### PR TITLE
Add tamper-evidence to provenance: Ed25519 hash-chain signatures

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "PreToolUse": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ todos/
 .auth/
 tech-debt/
 .superpowers/
+
+.old_ideas/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@inflexa-ai:registry=https://npm.pkg.github.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ Format: `// TODO(<tag>): <reason>`. Never use a bare `// TODO`.
 | `slop` | Works but should be extracted / cleaned up | Duplicated logic across two modules |
 | `robustness` | Missing hardening for stress conditions | No retry/backoff on a flaky external call |
 
+### Local state can desync from the database — never hard-fail on it
+
+The SQLite database is a file on the **user's own machine**: they may delete it, restore an old copy, or hand-edit it at will, and they are entitled to. Meanwhile other state lives **outside** it and persists independently — on-disk anchor markers (`.inflexa/id`), output folders, config. So the two stores routinely disagree: a marker (or a row's foreign key) can reference an id the database no longer has.
+
+**Treat "the referenced row is gone" as a normal, recoverable condition — never a hard error.** When code reads an id/marker/path from one store and looks it up in another, a miss must **heal** (reconstruct from the authoritative source — e.g. re-establish an anchor row from its on-disk marker, but only on a *deliberate* action, never a passive read — see the no-litter policy) or **degrade gracefully** (resolve to `null`/a sensible fallback and carry on), so the user still gets a working command. Returning a `query_failed`/`DbError` for a routine desync is a bug: it turns "your DB and your folders disagree" into a crash the user can't escape without surgery.
+
+Concretely: a lookup that can legitimately miss returns `T | null` (the miss is in-band), not an error; the caller picks a fallback. Reserve the error channel for genuine faults (the query itself failed). See `resolveAnchor` (`modules/anchor/anchor.ts`): a marker pointing at a deleted anchor resolves to `null`, and bare `inflexa` then offers to start fresh in that folder rather than dying with `unknown anchor <id>`.
+
 ### Resolving an id-or-name reference
 
 When a command resolves a user-supplied reference that may be **either an id or a human name/slug** (`inflexa resume <x>`, `--analysis <x>`, …):
@@ -171,9 +179,23 @@ A module under `src/modules/<domain>/` groups everything about one domain: its l
 
 Reach for an extension only when a helper is genuinely cross-cutting; keep single-caller helpers in their owning file per the Coding rules.
 
+## Event bus — single bus, typed events
+
+There is **one bus** (`Bus` in `src/lib/bus.ts`), shared by every domain — session, provenance, and any future concern. Domain separation is by event `type` string, not by bus instance. **Never add a second bus** to separate concerns; if the current event contract feels wrong, the fix is better types, not more buses.
+
+- **One event type per domain action.** Each `BusEvent` member carries exactly the fields its action needs. Never pack multiple sub-actions into a single event discriminated by an interior field with nullable companions — that defeats TypeScript's narrowing and forces consumers to guard against impossible states. E.g. provenance has `prov.analysis_created`, `prov.input_added`, `prov.input_removed` — not one `prov.recorded` with a nullable `input`.
+- **Event types live in `src/types/events.ts`** — the `BusEvent` discriminated union is the contract. Session-scoped events carry `sessionId`; analysis-scoped events carry `analysisId`. Consumers filter by `type`.
+- **Design rationale:** a dedicated bus per domain only earns its keep when that domain needs its own subscriber lifecycle, backpressure, or error isolation. inflexa's bus is a fire-and-forget notification channel with one subscriber per concern — multiplying buses adds wiring overhead for no structural gain. (Validated against OpenCode, which routes ~80+ event types across all domains through a single typed bus.)
+
 ## Solid + opentui (TUI)
 
 The TUI is Solid (`solid-js`) rendered to the terminal via `@opentui/solid`. Solid is not React: components run once, reactivity lives in signals/stores, and there are no re-renders.
+
+### Design gallery
+
+**Before writing or changing TUI code, consult the design gallery** (`src/tui/layout/design_gallery.tsx`, opened via the "Design gallery" command-palette entry) — the read-only showcase of every existing block/widget and its states. Reuse what it shows; match its patterns.
+
+**If a task needs something the gallery doesn't cover** (a new block, state, or visual pattern), STOP and talk to the user about adding it to the design system / extending the gallery — don't invent ad-hoc UI off to the side. New surfaces become part of the gallery so it stays the single source of truth.
 
 ### Launch and exit
 
@@ -205,10 +227,12 @@ The remedy: **any fixed chrome row placed directly below a `flexGrow` scrollbox 
 
 **Verifying layout.** `@opentui/solid`'s `testRender` + `captureCharFrame()` renders any component tree to a text frame at a fixed `{width, height}` with no TTY; `mockInput.pressKeys` drives scrolling, and a renderable's `.x/.y/.width/.height` + `yogaNode.getComputedLayout()` expose the computed boxes. Sweep a range of heights — these bugs are size-dependent and a single size hides them.
 
-### Event bus
+### Event bus (TUI consumption)
 
-- UI state updates flow from `Bus` events: subscribe in component setup with `Bus.on("inflexa", handler)` and always pair with `onCleanup(() => Bus.off("inflexa", handler))`.
-- Handlers must filter events by `sessionId` before applying them.
+The bus contract and design rationale live in [Event bus — single bus, typed events](#event-bus--single-bus-typed-events) above. TUI-specific rules:
+
+- Subscribe in component setup with `Bus.on("inflexa", handler)` and always pair with `onCleanup(() => Bus.off("inflexa", handler))`.
+- Handlers must filter events by `sessionId` before applying them (provenance events carry `analysisId` and should be ignored).
 
 ### Colors
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.50",
         "@clack/prompts": "^1.5.1",
+        "@inflexa-ai/tsprov": "0.1.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",
@@ -132,6 +133,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.1.1", "https://npm.pkg.github.com/download/@inflexa-ai/tsprov/0.1.1/73988290dbc76fe7b4900f268a4c386b4bb35fe0", { "dependencies": { "luxon": "^3.7.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HXiXKSbFe934/tdMqIhcF2/sL39rTw1eI/sx0eKg1vp3g8coZRGs7lgTn/xS8ItAWQfin0teO8Lvt7aw7o+KMg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -392,6 +395,8 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,13 @@
-preload = ["@opentui/solid/preload", "@opentui/solid/runtime-plugin-support"]
+# NOTE: top-level preload deliberately OMITS "@opentui/solid/runtime-plugin-support".
+# That preload registers @opentui/core's createRuntimePlugin globally (via Bun's
+# plugin() API), whose catch-all `onResolve({ filter: /.*/ })` calls import.meta.resolve
+# — which re-enters that same handler inside any Bun.build, recursing until the stack
+# overflows ("Maximum call stack size exceeded"). Because a global plugin participates in
+# every Bun.build in the process, it intermittently crashed `bun scripts/build.ts`. We
+# don't load external runtime plugins, so the support shim buys us nothing here; the JSX
+# transform (./preload) is all the dev runtime needs. It stays in [test] below because
+# render tests rely on it and never bundle. See opentui-issue-runtime-plugin-recursion.md.
+preload = ["@opentui/solid/preload"]
 
 # `bun test` uses [test].preload INSTEAD OF the top-level preload (it does not merge them), so the
 # opentui preloads are repeated here to keep render tests working — plus the env sandbox that points

--- a/openspec/changes/archive/2026-06-29-prov-integrity/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/archive/2026-06-29-prov-integrity/design.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The provenance module (`src/modules/prov/`) records W3C PROV documents (via `@inflexa-ai/tsprov`) as PROV-JSON blobs on `analyses.provenance` — a plain TEXT column in SQLite. Recording is bus-driven: analysis mutations emit typed `prov.*` events, the recorder appends to an in-memory `ProvDocument`, and a coalesced async flush (+ sync exit backstop) persists the serialized JSON to the column.
+
+There is currently no integrity mechanism. The SQLite file is a user-local file; anyone (or a bug) can edit the provenance column and the system cannot detect it. For provenance to serve reproducibility claims, audit trails, or regulatory compliance, it must be tamper-evident.
+
+A prior research spike (`prov.research.old.md`) evaluated a full Merkle tree transparency log (Go + PostgreSQL, Trillian/Tessera patterns, compact ranges, subtree tiles, witness protocol). That approach was rejected as disproportionate for a single-user local CLI tool — it targets multi-party server environments with billions of entries and mutual distrust between the log operator and its clients. We retain the hash-chain and signing concepts.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tamper-evidence: any modification to stored provenance after recording is detectable.
+- Non-repudiation: a third party with the public key can independently verify that the provenance was produced by the holder of the signing key.
+- A `verify` command (CLI + TUI) that checks integrity and reports pass/fail with detail.
+- Graceful degradation: missing keypair does not block recording — provenance is still captured unsigned.
+- Zero new dependencies: uses Bun's built-in `crypto.subtle` (WebCrypto Ed25519).
+
+**Non-Goals:**
+- Distributed transparency log (Merkle tree, witnesses, inclusion/consistency proofs).
+- Cross-analysis global ordering or a process-wide append-only log.
+- Key management ceremony (HSM, KMS, key rotation protocol) — first-use generation is sufficient for local use.
+- Encrypting provenance at rest — tamper-evidence, not confidentiality.
+- Backward-compatible verification of provenance recorded before this change (pre-existing unsigned documents verify as "unsigned", not "tampered").
+
+## Decisions
+
+### D1: Ed25519 via WebCrypto — no new dependencies
+
+**Decision:** use `crypto.subtle.generateKey`, `crypto.subtle.sign`, `crypto.subtle.verify` with the `Ed25519` algorithm (supported in Bun's WebCrypto).
+
+**Alternatives considered:**
+- `tweetnacl` / `@noble/ed25519`: adds a dependency; Bun's native WebCrypto is faster and already available.
+- HMAC-only (no asymmetric key): detects tampering but provides no non-repudiation — a third party cannot verify because the secret is shared. Rejected because export + third-party verification is a goal.
+- RSA / ECDSA P-256: larger signatures, no advantage for this use case. Ed25519 is deterministic (no nonce-reuse risk), produces 64-byte signatures, and is the dominant choice in the transparency-dev ecosystem.
+
+### D2: Sign the chain state at flush time, not per action
+
+**Decision:** the signing unit is the flush — after serializing the `ProvDocument` to PROV-JSON, compute `SHA-256(prev_chain_hash || prov_json)` and sign the resulting chain hash. One signature per flush, not per `appendCreation`/`appendInputAdded`/`appendInputRemoved`.
+
+**Rationale:** a flush is the persistence boundary — the PROV-JSON blob on the column is the canonical serialization of all actions. Signing the blob after `unified().serialize("json")` covers everything that was appended since the last flush. Signing per action would require a separate persistence layer for intermediate signatures and would not add integrity (the actions exist only in memory between flushes; the column is the attack surface).
+
+**The chain hash links flushes:** `H_n = SHA-256(H_{n-1} || prov_json_n)`. The initial `H_0` is `SHA-256("")` (the empty-tree convention from RFC 6962). This chain makes insertion, deletion, or reordering of flush states detectable — a modified `prov_json` at any point in the chain cascades through all subsequent hashes.
+
+### D3: Two new columns on `analyses` — not a sibling table
+
+**Decision:** add `provenance_chain_hash TEXT` and `provenance_signature TEXT` to the `analyses` table in migration v3. Both are hex-encoded strings (chain hash: 64 hex chars; signature: 128 hex chars). `NULL` until first signed flush.
+
+**Alternatives considered:**
+- Sibling `prov_integrity` table with a row per flush (full audit trail of every chain state): provides a historical log of every intermediate hash, but the PROV document itself already contains the full history (it is append-only — `unified()` never drops records). The chain hash and signature of the *latest* flush are sufficient to verify the *current* document, which is the goal. A historical log would add write amplification for no additional tamper-evidence.
+- Embed in the PROV-JSON itself (as a custom `inflexa:` attribute): pollutes the W3C PROV document with non-PROV metadata; harder to strip for interop. Keeping integrity metadata in SQL columns keeps the PROV document clean.
+
+### D4: Keypair lifecycle — generate on first sign, store as JWK
+
+**Decision:** on the first flush that would produce a signature, if no keypair file exists at `env.provKeyPath`, generate an Ed25519 keypair via `crypto.subtle.generateKey`, export both keys as JWK, and write them to `<configDir>/inflexa/prov_key.json`. Subsequent loads import from the file.
+
+**Format:** JWK (JSON Web Key) — the WebCrypto native export format. The file contains `{ publicKey: JWK, privateKey: JWK }`. The public key is also what gets included in an export bundle for third-party verification.
+
+**Missing keypair = unsigned:** if the keypair file cannot be read (permissions, deleted, first run before any flush), the flush still writes `provenance` but leaves `provenance_chain_hash` and `provenance_signature` as `NULL`. The `verify` command reports "unsigned" for these analyses.
+
+### D5: Verification recomputes, does not trust stored chain hash
+
+**Decision:** `inflexa prov verify <analysis>` does NOT trust the stored `provenance_chain_hash`. It recomputes `SHA-256("" || prov_json)` from the stored `provenance` column (for the current single-flush model, `H_0 || prov_json` where `H_0 = SHA-256("")`), then verifies the stored `provenance_signature` against the recomputed hash using the public key. This means even if someone tampers with both the PROV-JSON and the chain hash, the signature check catches it (they don't have the private key).
+
+**Verification result states:**
+- `valid`: chain hash recomputes correctly AND signature verifies against the public key.
+- `unsigned`: no signature stored (pre-integrity provenance or missing keypair at recording time).
+- `tampered`: chain hash or signature does not verify — provenance was modified after signing.
+- `no-key`: signature exists but the public key file is missing — cannot verify (distinct from tampered).
+- `empty`: no provenance recorded yet.
+
+### D6: Export includes a verification bundle
+
+**Decision:** `inflexa prov export` gains an optional `--signed` flag (or always includes when available) that writes a sidecar `provenance.<format>.sig.json` file containing `{ chainHash, signature, publicKey }`. A third party can verify the exported PROV document against this bundle without access to the original database.
+
+## Risks / Trade-offs
+
+- **[Key compromise]** → If the private key file is stolen, an attacker can sign forged provenance. **Mitigation:** the keypair file lives in the user's config directory (same trust boundary as their auth tokens); a compromised local machine defeats all local-only integrity. Future: support hardware keys or external signers.
+- **[Key loss]** → If the keypair file is deleted, existing signed provenance becomes `no-key` (signature exists but can't be verified). **Mitigation:** `verify` distinguishes `no-key` from `tampered`; the user knows the key is missing vs. the data was modified. Future: key backup/export command.
+- **[Async flush window]** → Between a bus event and the next flush, in-memory appends are unsigned. A crash in this window loses the un-flushed tail (existing accepted trade-off from the A decision). The integrity mechanism does not change this — it signs what reaches the column. **Mitigation:** the sync exit backstop (`process.on("exit", flushProvenance)`) covers clean quits.
+- **[Performance]** → SHA-256 + Ed25519 sign on every flush. SHA-256 of a typical PROV-JSON (~1-10 KB) is sub-microsecond; Ed25519 sign is ~50 μs on modern hardware. Negligible compared to the SQLite write.
+- **[Migration v3 on existing DBs]** → `ALTER TABLE analyses ADD COLUMN` is SQLite-safe (no table rebuild). Existing rows get `NULL` for both columns — correctly treated as "unsigned" by the verification logic.

--- a/openspec/changes/archive/2026-06-29-prov-integrity/proposal.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The provenance module records W3C PROV documents as PROV-JSON blobs on `analyses.provenance` (a plain TEXT column in SQLite). Nothing prevents editing the database file directly — the system cannot detect that provenance was altered after the fact. For provenance to be meaningful (reproducibility claims, audit trails, regulatory compliance), it must be tamper-evident: any modification after recording must be detectable, and a verification command must let the user (or a third party) confirm integrity.
+
+## What Changes
+
+- **Ed25519 signing keypair** generated on first use, stored in the user's config directory. Used to sign provenance chain state at each flush.
+- **Hash-chain integrity** at flush time: each flush computes `SHA-256(prev_chain_hash || serialized_prov_json)`, producing a rolling chain hash that makes insertion, deletion, or reordering of flush states detectable.
+- **Ed25519 signature** over the chain hash, stored alongside the provenance. Proves the chain hash was produced by the holder of the private key — non-repudiation for third-party verification.
+- **`inflexa prov verify <analysis>`** CLI + TUI command: recomputes the chain hash from the stored PROV-JSON, verifies the Ed25519 signature, and reports integrity status (pass/fail with detail).
+- **Export includes integrity metadata**: `inflexa prov export` emits the signature and chain hash so a recipient with the public key can verify independently.
+- **Graceful degradation**: missing keypair does not block recording — provenance is still captured, but unsigned. `verify` reports "unsigned" rather than failing.
+
+## Capabilities
+
+### New Capabilities
+- `prov-signing`: Ed25519 keypair lifecycle (generation, storage, loading) and the sign/verify operations over provenance chain hashes.
+- `prov-chain`: Hash-chain computation at flush time — rolling SHA-256 digest linking each flush state to its predecessor, plus the DB columns that persist chain hash and signature.
+- `prov-verify`: The verification command (CLI `inflexa prov verify <analysis>` + TUI palette entry) that recomputes the chain, checks the signature, and reports integrity status.
+
+### Modified Capabilities
+- `cli-core`: New `prov verify` subcommand under the existing `prov` command group.
+- `data-model-storage`: New columns on `analyses` for chain hash and signature (migration v3).
+- `command-palette`: New "Verify provenance" TUI command entry.
+
+## Impact
+
+- **DB schema**: migration v3 adds `provenance_chain_hash TEXT` and `provenance_signature TEXT` columns to `analyses`.
+- **Config directory**: new `prov_key.json` file at `<configDir>/inflexa/`.
+- **`src/modules/prov/`**: new signing/chain logic alongside existing recorder and document modules.
+- **`src/lib/env.ts`**: new `provKeyPath` entry for the keypair file path.
+- **`src/cli/index.ts`**: `prov verify` subcommand registration.
+- **`src/tui/commands.tsx`**: "Verify provenance" palette entry.
+- **`src/modules/prov/export.ts`**: extended to include chain hash + signature in output.
+- **Dependencies**: none — uses Bun's built-in `crypto.subtle` (WebCrypto Ed25519).

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/cli-core/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/cli-core/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: inflexa prov verify checks provenance integrity
+
+The system SHALL register `inflexa prov verify <analysis>` under the existing `prov` command group that resolves the analysis by id-or-name, runs the verification logic, and prints the result. The action SHALL live in `src/modules/prov/verify.ts` and be lazy-imported from `src/cli/index.ts`.
+
+#### Scenario: Verify subcommand is registered
+
+- **WHEN** `inflexa prov --help` is run
+- **THEN** the `verify` subcommand is listed alongside the existing `export` subcommand
+
+#### Scenario: Verify runs and reports
+
+- **WHEN** `inflexa prov verify my-analysis` is run
+- **THEN** the analysis is resolved, verification is performed, and the result is printed to stdout
+
+### Requirement: inflexa prov verify-file checks an exported provenance file
+
+The system SHALL register `inflexa prov verify-file <path>` under the existing `prov` command group that reads a provenance file and its `.sig.json` sidecar from disk, runs file-based verification, and prints the result. No database or analysis row is required. The action SHALL live in `src/modules/prov/verify.ts` and be lazy-imported from `src/cli/index.ts`.
+
+#### Scenario: Verify-file subcommand is registered
+
+- **WHEN** `inflexa prov --help` is run
+- **THEN** the `verify-file` subcommand is listed
+
+#### Scenario: Verify-file runs on exported files
+
+- **WHEN** `inflexa prov verify-file ./provenance.json` is run with a valid sidecar alongside
+- **THEN** the file and sidecar are read, verification is performed, and the result is printed to stdout

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/command-palette/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/command-palette/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Verify provenance command in palette
+
+The system SHALL add a "Verify provenance" entry to the command palette with `id: "prov.verify"`, `category: "Analysis"`, enabled when `ctx.analysis !== null`. The action SHALL lazy-import the verification module, run the check, and display the result via `notify`.
+
+#### Scenario: Verify command appears when analysis is open
+
+- **WHEN** the command palette is opened with an analysis active
+- **THEN** "Verify provenance" is listed in the Analysis category
+
+#### Scenario: Verify command is hidden without an analysis
+
+- **WHEN** the command palette is opened with no analysis active
+- **THEN** "Verify provenance" does not appear
+
+#### Scenario: Verify result is shown as a notice
+
+- **WHEN** the user selects "Verify provenance"
+- **THEN** a notice is displayed: info for valid/unsigned/empty, warn for no-key, error for tampered

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/data-model-storage/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/data-model-storage/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Migration v3 adds provenance integrity columns
+
+The system SHALL define a `version: 3` migration in `src/db/primary_migrations.ts` that adds `provenance_chain_hash TEXT` and `provenance_signature TEXT` columns to the `analyses` table via `ALTER TABLE`. Existing rows receive `NULL`, treated as "unsigned".
+
+#### Scenario: Migration v3 is applied after v2
+
+- **WHEN** the migration runner executes against a database at version 2
+- **THEN** version 3 is applied
+- **AND** `analyses` gains `provenance_chain_hash` and `provenance_signature` columns
+
+#### Scenario: Column ordering follows house convention
+
+- **WHEN** the migration adds columns
+- **THEN** `provenance_chain_hash` and `provenance_signature` are added after `provenance` (core data, not FK columns)
+
+### Requirement: DB accessors for integrity columns
+
+The system SHALL provide `getAnalysisIntegrity(id): Result<{ chainHash: string | null, signature: string | null }, DbError>` in `src/db/primary_query.ts` and extend `updateAnalysisProvenance` in `src/db/primary_mutation.ts` to accept optional `chainHash` and `signature` parameters, writing all three columns in a single `UPDATE`.
+
+#### Scenario: Read integrity columns
+
+- **WHEN** `getAnalysisIntegrity(id)` is called for an analysis with stored integrity data
+- **THEN** it returns the `provenance_chain_hash` and `provenance_signature` values
+
+#### Scenario: Write provenance with integrity
+
+- **WHEN** `updateAnalysisProvenance(id, prov, chainHash, signature)` is called
+- **THEN** `provenance`, `provenance_chain_hash`, and `provenance_signature` are updated in one statement

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-chain/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-chain/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Hash chain computation at flush time
+
+The system SHALL compute a chain hash on each provenance flush as `SHA-256(prev_chain_hash_bytes || prov_json_bytes)` where `prev_chain_hash_bytes` is the previously stored `provenance_chain_hash` decoded from hex (or `SHA-256("")` for the initial flush when no prior chain hash exists). The result SHALL be hex-encoded and stored in `analyses.provenance_chain_hash`.
+
+#### Scenario: Initial flush computes chain hash from the empty seed
+
+- **WHEN** the recorder flushes provenance for an analysis with no prior `provenance_chain_hash`
+- **THEN** the chain hash is `SHA-256(SHA-256("") || prov_json_bytes)`
+- **AND** the hex-encoded result is stored in `provenance_chain_hash`
+
+#### Scenario: Subsequent flush chains from the previous hash
+
+- **WHEN** the recorder flushes provenance for an analysis that already has a `provenance_chain_hash`
+- **THEN** the new chain hash is `SHA-256(prev_chain_hash_bytes || prov_json_bytes)`
+- **AND** the stored `provenance_chain_hash` is updated to the new value
+
+#### Scenario: Chain hash cascades on modification
+
+- **WHEN** the PROV-JSON at any point in an analysis's flush history is modified
+- **THEN** recomputing the chain hash from the current PROV-JSON produces a different value than the stored `provenance_chain_hash`
+
+### Requirement: Signature stored alongside chain hash
+
+The system SHALL sign the chain hash with the Ed25519 private key (per `prov-signing`) after computing it, and store the hex-encoded signature in `analyses.provenance_signature`. Both columns SHALL be updated atomically in the same `UPDATE` statement as `provenance`.
+
+#### Scenario: Flush writes provenance, chain hash, and signature together
+
+- **WHEN** the recorder flushes and a signing keypair is available
+- **THEN** `provenance`, `provenance_chain_hash`, and `provenance_signature` are all updated in a single SQL statement
+
+#### Scenario: Flush without keypair writes provenance only
+
+- **WHEN** the recorder flushes and no signing keypair is available
+- **THEN** `provenance` is updated
+- **AND** `provenance_chain_hash` and `provenance_signature` remain `NULL`
+
+### Requirement: DB migration v3 adds integrity columns
+
+The system SHALL add a migration `version: 3` in `src/db/primary_migrations.ts` that executes:
+```sql
+ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT;
+ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;
+```
+Existing rows receive `NULL` for both columns, correctly treated as "unsigned" by the verification logic.
+
+#### Scenario: Migration v3 adds columns to existing database
+
+- **WHEN** the migration runner applies version 3 to a database at version 2
+- **THEN** the `analyses` table gains `provenance_chain_hash` and `provenance_signature` columns
+- **AND** existing rows have `NULL` for both
+
+#### Scenario: Fresh database gets all migrations
+
+- **WHEN** the migration runner executes against a fresh database
+- **THEN** migrations 1, 2, and 3 are all applied
+- **AND** `analyses` has `provenance`, `provenance_chain_hash`, and `provenance_signature` columns

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-signing/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-signing/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Ed25519 keypair generation on first use
+
+The system SHALL generate an Ed25519 keypair via `crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"])` on the first provenance flush that would produce a signature, if no keypair file exists at `env.provKeyPath`. The keypair SHALL be exported as JWK and written to `<configDir>/inflexa/prov_key.json` as `{ publicKey: JsonWebKey, privateKey: JsonWebKey }`.
+
+#### Scenario: First flush generates keypair
+
+- **WHEN** the provenance recorder flushes for the first time and no `prov_key.json` exists
+- **THEN** an Ed25519 keypair is generated and written to `prov_key.json`
+- **AND** the flush proceeds to sign the chain hash with the new key
+
+#### Scenario: Existing keypair is loaded
+
+- **WHEN** the provenance recorder flushes and `prov_key.json` already exists
+- **THEN** the existing keypair is loaded via `crypto.subtle.importKey` and reused
+
+#### Scenario: Unparseable keypair file is replaced with a fresh keypair
+
+- **WHEN** `prov_key.json` exists but cannot be parsed as JSON
+- **THEN** the system generates a fresh keypair and overwrites the file
+- **AND** the flush proceeds to sign with the new key
+
+#### Scenario: Structurally valid but wrong JWK degrades to unsigned
+
+- **WHEN** `prov_key.json` parses as JSON but the JWK cannot be imported (wrong algorithm, missing fields)
+- **THEN** the flush still writes the `provenance` column
+- **AND** `provenance_chain_hash` and `provenance_signature` remain `NULL`
+- **AND** a warning is logged
+
+### Requirement: Signing operation over chain hash
+
+The system SHALL sign a chain hash (a 32-byte SHA-256 digest, hex-encoded) using `crypto.subtle.sign("Ed25519", privateKey, chainHashBytes)` and produce a hex-encoded 64-byte Ed25519 signature.
+
+#### Scenario: Sign produces a deterministic signature
+
+- **WHEN** the same chain hash is signed with the same private key twice
+- **THEN** both signatures are identical (Ed25519 is deterministic — no nonce)
+
+### Requirement: Verification operation over chain hash and signature
+
+The system SHALL verify a signature against a chain hash using `crypto.subtle.verify("Ed25519", publicKey, signatureBytes, chainHashBytes)`, returning a boolean.
+
+#### Scenario: Valid signature verifies
+
+- **WHEN** a chain hash is verified against the signature that signed it and the corresponding public key
+- **THEN** verification returns `true`
+
+#### Scenario: Tampered chain hash fails verification
+
+- **WHEN** a chain hash is verified against a signature produced for a different hash
+- **THEN** verification returns `false`
+
+### Requirement: Keypair path in env
+
+The system SHALL expose `env.provKeyPath` (at `<configDir>/inflexa/prov_key.json`) in `src/lib/env.ts`, following the existing pattern for `authPath` and `configPath`.
+
+#### Scenario: provKeyPath is derived from configDir
+
+- **WHEN** `env.provKeyPath` is read
+- **THEN** it returns `<configDir>/inflexa/prov_key.json`

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-verify/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-verify/spec.md
@@ -99,7 +99,7 @@ The system SHALL extend `inflexa prov export` to write a sidecar file `provenanc
 {
   "payloadType": "application/json; profile=prov-json",
   "payloadDigestAlgorithm": "SHA-256",
-  "payloadDigest": "<hex-encoded SHA-256 chain hash>",
+  "payloadDigest": "<hex-encoded SHA-256 content digest>",
   "payloadDigestMethod": "verbatim",
   "signatureAlgorithm": "Ed25519",
   "signature": "<hex-encoded Ed25519 signature over the digest>",
@@ -123,6 +123,6 @@ The system SHALL extend `inflexa prov export` to write a sidecar file `provenanc
 
 - **WHEN** a third party has `provenance.json` and `provenance.json.sig.json`
 - **THEN** they read `payloadDigestAlgorithm` and `signatureAlgorithm` from the sidecar
-- **AND** they compute `SHA-256(SHA-256("") || file_contents)` over the provenance file bytes
+- **AND** they compute `SHA-256(file_contents)` over the provenance file bytes
 - **AND** they compare the result to `payloadDigest`
 - **AND** they verify the `signature` against the `payloadDigest` bytes using the `publicKey` with `Ed25519`

--- a/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-verify/spec.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/specs/prov-verify/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: CLI verify command
+
+The system SHALL register `inflexa prov verify <analysis>` that resolves the analysis by id-or-name (per the existing resolver pattern), recomputes the chain hash from the stored PROV-JSON, verifies the stored signature against the public key, and prints the verification result.
+
+#### Scenario: Valid signed provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with a valid signature
+- **THEN** it prints a success message indicating the provenance chain is intact and the signature is valid
+
+#### Scenario: Tampered provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis whose `provenance` column was modified after signing
+- **THEN** it prints a failure message indicating the provenance has been tampered with
+- **AND** the exit code is non-zero
+
+#### Scenario: Unsigned provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with `NULL` chain hash and signature
+- **THEN** it prints a message indicating the provenance is unsigned (recorded before integrity was enabled or without a keypair)
+
+#### Scenario: Missing public key
+
+- **WHEN** `inflexa prov verify my-analysis` runs with a stored signature but the `prov_key.json` file is absent
+- **THEN** it prints a message indicating the signature exists but cannot be verified without the key
+
+#### Scenario: No provenance recorded
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with `NULL` provenance
+- **THEN** it prints a message indicating no provenance has been recorded yet
+
+#### Scenario: Unknown analysis
+
+- **WHEN** `inflexa prov verify nonexistent` runs
+- **THEN** it prints an error that no analysis matches the reference
+
+### Requirement: File-based verification command
+
+The system SHALL register `inflexa prov verify-file <path>` that verifies a provenance file against its sidecar without requiring a local database or analysis row. It SHALL locate the sidecar at `<path>.sig.json`, read the provenance file bytes and the sidecar JSON, recompute the chain hash from the file bytes, and verify the signature using the public key from the sidecar.
+
+#### Scenario: Valid signed provenance file
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and `provenance.json.sig.json` exists with a valid signature
+- **THEN** it prints a success message indicating the provenance file is intact and the signature is valid
+
+#### Scenario: Tampered provenance file
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and the file contents do not match the sidecar's `payloadDigest`
+- **THEN** it prints a failure message indicating the file has been tampered with
+- **AND** the exit code is non-zero
+
+#### Scenario: Missing sidecar
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and `provenance.json.sig.json` does not exist
+- **THEN** it prints a message indicating no sidecar was found and the file cannot be verified
+
+#### Scenario: Missing provenance file
+
+- **WHEN** `inflexa prov verify-file nonexistent.json` runs and the file does not exist
+- **THEN** it prints an error that the file was not found
+
+### Requirement: Verification result type
+
+The system SHALL define a discriminated union `VerifyResult` with the following variants:
+- `{ status: "valid" }` — chain hash recomputes correctly AND signature verifies.
+- `{ status: "unsigned" }` — no signature stored.
+- `{ status: "tampered"; detail: string }` — chain hash or signature does not verify.
+- `{ status: "no-key" }` — signature exists but public key is missing.
+- `{ status: "empty" }` — no provenance recorded.
+
+#### Scenario: Each verification outcome maps to exactly one variant
+
+- **WHEN** verification is performed
+- **THEN** the result is exactly one of the five `VerifyResult` variants
+
+### Requirement: Verification logic is pure and testable
+
+The verification logic SHALL be a pure function that takes the stored PROV-JSON, stored chain hash, stored signature, and public key (or null), and returns a `VerifyResult`. It SHALL NOT perform DB queries or file I/O itself — the caller provides the inputs.
+
+#### Scenario: Verification function is testable without DB
+
+- **WHEN** the verify function is called with in-memory inputs (prov JSON, chain hash, signature, public key)
+- **THEN** it returns a `VerifyResult` without touching the database or filesystem
+
+### Requirement: TUI verify command
+
+The system SHALL add a "Verify provenance" entry to the command palette (category "Analysis"), enabled when an analysis is open, that runs the verification logic and displays the result as a notice.
+
+#### Scenario: TUI verify shows result as notice
+
+- **WHEN** the user selects "Verify provenance" from the command palette
+- **THEN** a notice is displayed with the verification status (valid/unsigned/tampered/no-key/empty)
+
+### Requirement: Export includes a self-describing verification sidecar
+
+The system SHALL extend `inflexa prov export` to write a sidecar file `provenance.<format>.sig.json` alongside the provenance document when a signature is available. The sidecar SHALL be a self-describing envelope containing all the metadata a third party needs to verify independently:
+```json
+{
+  "payloadType": "application/json; profile=prov-json",
+  "payloadDigestAlgorithm": "SHA-256",
+  "payloadDigest": "<hex-encoded SHA-256 chain hash>",
+  "payloadDigestMethod": "verbatim",
+  "signatureAlgorithm": "Ed25519",
+  "signature": "<hex-encoded Ed25519 signature over the digest>",
+  "publicKey": { "kty": "OKP", "crv": "Ed25519", ... }
+}
+```
+`payloadDigestMethod: "verbatim"` declares the digest was computed over the exact stored bytes (not a canonicalized form). This aligns with DSSE's approach of treating the payload as an opaque blob to avoid canonicalization.
+
+#### Scenario: Export with signature writes sidecar
+
+- **WHEN** `inflexa prov export my-analysis --format json` runs and the analysis has a stored signature and the public key is available
+- **THEN** it writes `provenance.json` and `provenance.json.sig.json` to the output directory
+- **AND** the sidecar contains `payloadType`, `payloadDigestAlgorithm`, `payloadDigest`, `payloadDigestMethod`, `signatureAlgorithm`, `signature`, and `publicKey`
+
+#### Scenario: Export without signature writes no sidecar
+
+- **WHEN** `inflexa prov export my-analysis` runs and the analysis has no stored signature
+- **THEN** it writes only `provenance.json` (no `.sig.json` sidecar)
+
+#### Scenario: Third-party verification with sidecar
+
+- **WHEN** a third party has `provenance.json` and `provenance.json.sig.json`
+- **THEN** they read `payloadDigestAlgorithm` and `signatureAlgorithm` from the sidecar
+- **AND** they compute `SHA-256(SHA-256("") || file_contents)` over the provenance file bytes
+- **AND** they compare the result to `payloadDigest`
+- **AND** they verify the `signature` against the `payloadDigest` bytes using the `publicKey` with `Ed25519`

--- a/openspec/changes/archive/2026-06-29-prov-integrity/tasks.md
+++ b/openspec/changes/archive/2026-06-29-prov-integrity/tasks.md
@@ -1,0 +1,43 @@
+## 1. Infrastructure — keypair and env
+
+- [x] 1.1 Add `provKeyPath` to `env` in `src/lib/env.ts` (`<configDir>/inflexa/prov_key.json`) and to `envDoc` for `--help`
+- [x] 1.2 Create `src/modules/prov/signing.ts` — keypair generation (`crypto.subtle.generateKey("Ed25519")`), load-or-generate lifecycle, JWK file read/write, sign and verify functions over raw bytes
+- [x] 1.3 Write tests for signing: keypair round-trip (generate → export → import → sign → verify), tampered data fails verification, missing key file returns null gracefully
+
+## 2. DB schema — integrity columns
+
+- [x] 2.1 Add migration v3 to `src/db/primary_migrations.ts`: `ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT; ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;`
+- [x] 2.2 Add `getAnalysisIntegrity(id)` to `src/db/primary_query.ts` returning `{ chainHash: string | null, signature: string | null }`
+- [x] 2.3 Extend `updateAnalysisProvenance` in `src/db/primary_mutation.ts` to accept optional `chainHash` and `signature`, writing all three columns in one `UPDATE`
+- [x] 2.4 Update `src/db/primary_migrations.test.ts` to assert the new columns exist after migration v3
+
+## 3. Chain computation — hash and sign at flush
+
+- [x] 3.1 Create chain hash function in `src/modules/prov/signing.ts`: `computeChainHash(prevChainHashHex: string | null, provJson: string): Promise<string>` — returns hex-encoded `SHA-256(prevBytes || provJsonBytes)` with `SHA-256("")` as the seed when prev is null
+- [x] 3.2 Wire chain hash + sign into `flushProvenance()` in `src/modules/prov/prov.ts`: after `doc.unified().serialize("json")`, compute chain hash from stored prev + new JSON, sign it, pass all three to `updateAnalysisProvenance`
+- [x] 3.3 Handle missing keypair gracefully in flush: if signing fails or keypair is absent, still write `provenance` but leave integrity columns `NULL`, log a warning
+- [x] 3.4 Write integration test: emit bus events → flush → read back integrity columns → verify signature matches chain hash of stored PROV-JSON
+
+## 4. Verification command
+
+- [x] 4.1 Define `VerifyResult` type in `src/types/prov.ts`: discriminated union with `valid | unsigned | tampered | no-key | empty`
+- [x] 4.2 Create `src/modules/prov/verify.ts` — pure `verifyProvenance(provJson, chainHash, signature, publicKey)` function returning `VerifyResult`, plus the CLI action `runVerifyProvenance(ref)` that loads inputs from DB and calls it
+- [x] 4.3 Write unit tests for `verifyProvenance`: all five result variants (valid, unsigned, tampered, no-key, empty)
+- [x] 4.4 Register `prov verify <analysis>` in `src/cli/index.ts` under the existing `prov` command group, lazy-importing `verify.ts`
+
+## 5. TUI integration
+
+- [x] 5.1 Add "Verify provenance" command to `src/tui/commands.tsx` (`id: "prov.verify"`, category "Analysis", enabled when analysis is open), lazy-importing verify module, displaying result as notice
+- [x] 5.2 Test manually: open TUI, run verify from palette, confirm notice shows for valid/unsigned/empty states
+
+## 6. Export — verification bundle
+
+- [x] 6.1 Extend `src/modules/prov/export.ts` to write a sidecar `.sig.json` file alongside the provenance document when a signature is stored and the public key is available
+- [x] 6.2 Extend the TUI `exportProvenanceToFile` in `src/tui/commands.tsx` to write the sidecar alongside the provenance file
+- [x] 6.3 Write test: export with signed provenance produces both `.json` and `.json.sig.json`; export without signature produces only `.json`
+
+## 7. Cleanup and format
+
+- [x] 7.1 Run `bun run typecheck` and `bun run lint` — fix any issues
+- [x] 7.2 Run `bun run format:file` on all changed `src/` files
+- [x] 7.3 Run full test suite (`bun test`) — all tests pass

--- a/openspec/specs/cli-core/spec.md
+++ b/openspec/specs/cli-core/spec.md
@@ -107,3 +107,31 @@ The commands SHALL be registered on the commander root in `src/cli/index.ts`, ea
 - **WHEN** a confirm/pick is reached with a non-interactive stdin
 - **THEN** the prompt layer declines rather than hanging
 
+### Requirement: inflexa prov verify checks provenance integrity
+
+The system SHALL register `inflexa prov verify <analysis>` under the existing `prov` command group that resolves the analysis by id-or-name, runs the verification logic, and prints the result. The action SHALL live in `src/modules/prov/verify.ts` and be lazy-imported from `src/cli/index.ts`.
+
+#### Scenario: Verify subcommand is registered
+
+- **WHEN** `inflexa prov --help` is run
+- **THEN** the `verify` subcommand is listed alongside the existing `export` subcommand
+
+#### Scenario: Verify runs and reports
+
+- **WHEN** `inflexa prov verify my-analysis` is run
+- **THEN** the analysis is resolved, verification is performed, and the result is printed to stdout
+
+### Requirement: inflexa prov verify-file checks an exported provenance file
+
+The system SHALL register `inflexa prov verify-file <path>` under the existing `prov` command group that reads a provenance file and its `.sig.json` sidecar from disk, runs file-based verification, and prints the result. No database or analysis row is required. The action SHALL live in `src/modules/prov/verify.ts` and be lazy-imported from `src/cli/index.ts`.
+
+#### Scenario: Verify-file subcommand is registered
+
+- **WHEN** `inflexa prov --help` is run
+- **THEN** the `verify-file` subcommand is listed
+
+#### Scenario: Verify-file runs on exported files
+
+- **WHEN** `inflexa prov verify-file ./provenance.json` is run with a valid sidecar alongside
+- **THEN** the file and sidecar are read, verification is performed, and the result is printed to stdout
+

--- a/openspec/specs/command-palette/spec.md
+++ b/openspec/specs/command-palette/spec.md
@@ -165,3 +165,22 @@ Building on the reactive chat screen (see the `chat-wiring` capability), the pal
 - **WHEN** "Switch analysis" runs and there are no other analyses
 - **THEN** the picker shows an empty-state message rather than a blank list
 
+### Requirement: Verify provenance command in palette
+
+The system SHALL add a "Verify provenance" entry to the command palette with `id: "prov.verify"`, `category: "Analysis"`, enabled when `ctx.analysis !== null`. The action SHALL lazy-import the verification module, run the check, and display the result via `notify`.
+
+#### Scenario: Verify command appears when analysis is open
+
+- **WHEN** the command palette is opened with an analysis active
+- **THEN** "Verify provenance" is listed in the Analysis category
+
+#### Scenario: Verify command is hidden without an analysis
+
+- **WHEN** the command palette is opened with no analysis active
+- **THEN** "Verify provenance" does not appear
+
+#### Scenario: Verify result is shown as a notice
+
+- **WHEN** the user selects "Verify provenance"
+- **THEN** a notice is displayed: info for valid/unsigned/empty, warn for no-key, error for tampered
+

--- a/openspec/specs/data-model-storage/spec.md
+++ b/openspec/specs/data-model-storage/spec.md
@@ -83,3 +83,32 @@ The migration SHALL create the indexes `idx_analyses_project` on `analyses(proje
 - **WHEN** the migration has been applied
 - **THEN** all seven named indexes exist over their stated columns
 
+### Requirement: Migration v3 adds provenance integrity columns
+
+The system SHALL define a `version: 3` migration in `src/db/primary_migrations.ts` that adds `provenance_chain_hash TEXT` and `provenance_signature TEXT` columns to the `analyses` table via `ALTER TABLE`. Existing rows receive `NULL`, treated as "unsigned".
+
+#### Scenario: Migration v3 is applied after v2
+
+- **WHEN** the migration runner executes against a database at version 2
+- **THEN** version 3 is applied
+- **AND** `analyses` gains `provenance_chain_hash` and `provenance_signature` columns
+
+#### Scenario: Column ordering follows house convention
+
+- **WHEN** the migration adds columns
+- **THEN** `provenance_chain_hash` and `provenance_signature` are added after `provenance` (core data, not FK columns)
+
+### Requirement: DB accessors for integrity columns
+
+The system SHALL provide `getAnalysisIntegrity(id): Result<{ chainHash: string | null, signature: string | null }, DbError>` in `src/db/primary_query.ts` and extend `updateAnalysisProvenance` in `src/db/primary_mutation.ts` to accept optional `chainHash` and `signature` parameters, writing all three columns in a single `UPDATE`.
+
+#### Scenario: Read integrity columns
+
+- **WHEN** `getAnalysisIntegrity(id)` is called for an analysis with stored integrity data
+- **THEN** it returns the `provenance_chain_hash` and `provenance_signature` values
+
+#### Scenario: Write provenance with integrity
+
+- **WHEN** `updateAnalysisProvenance(id, prov, chainHash, signature)` is called
+- **THEN** `provenance`, `provenance_chain_hash`, and `provenance_signature` are updated in one statement
+

--- a/openspec/specs/prov-chain/spec.md
+++ b/openspec/specs/prov-chain/spec.md
@@ -1,0 +1,61 @@
+# prov-chain Specification
+
+## Purpose
+The SHA-256 hash chain that binds each provenance flush to its predecessor and the Ed25519 signature stored alongside it — the runtime integrity layer that makes tampering detectable. Depends on `prov-signing` for the cryptographic primitives and `data-model-storage` for the migration that adds the integrity columns.
+## Requirements
+### Requirement: Hash chain computation at flush time
+
+The system SHALL compute a chain hash on each provenance flush as `SHA-256(prev_chain_hash_bytes || prov_json_bytes)` where `prev_chain_hash_bytes` is the previously stored `provenance_chain_hash` decoded from hex (or `SHA-256("")` for the initial flush when no prior chain hash exists). The result SHALL be hex-encoded and stored in `analyses.provenance_chain_hash`.
+
+#### Scenario: Initial flush computes chain hash from the empty seed
+
+- **WHEN** the recorder flushes provenance for an analysis with no prior `provenance_chain_hash`
+- **THEN** the chain hash is `SHA-256(SHA-256("") || prov_json_bytes)`
+- **AND** the hex-encoded result is stored in `provenance_chain_hash`
+
+#### Scenario: Subsequent flush chains from the previous hash
+
+- **WHEN** the recorder flushes provenance for an analysis that already has a `provenance_chain_hash`
+- **THEN** the new chain hash is `SHA-256(prev_chain_hash_bytes || prov_json_bytes)`
+- **AND** the stored `provenance_chain_hash` is updated to the new value
+
+#### Scenario: Chain hash cascades on modification
+
+- **WHEN** the PROV-JSON at any point in an analysis's flush history is modified
+- **THEN** recomputing the chain hash from the current PROV-JSON produces a different value than the stored `provenance_chain_hash`
+
+### Requirement: Signature stored alongside chain hash
+
+The system SHALL sign the chain hash with the Ed25519 private key (per `prov-signing`) after computing it, and store the hex-encoded signature in `analyses.provenance_signature`. Both columns SHALL be updated atomically in the same `UPDATE` statement as `provenance`.
+
+#### Scenario: Flush writes provenance, chain hash, and signature together
+
+- **WHEN** the recorder flushes and a signing keypair is available
+- **THEN** `provenance`, `provenance_chain_hash`, and `provenance_signature` are all updated in a single SQL statement
+
+#### Scenario: Flush without keypair writes provenance only
+
+- **WHEN** the recorder flushes and no signing keypair is available
+- **THEN** `provenance` is updated
+- **AND** `provenance_chain_hash` and `provenance_signature` remain `NULL`
+
+### Requirement: DB migration v3 adds integrity columns
+
+The system SHALL add a migration `version: 3` in `src/db/primary_migrations.ts` that executes:
+```sql
+ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT;
+ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;
+```
+Existing rows receive `NULL` for both columns, correctly treated as "unsigned" by the verification logic.
+
+#### Scenario: Migration v3 adds columns to existing database
+
+- **WHEN** the migration runner applies version 3 to a database at version 2
+- **THEN** the `analyses` table gains `provenance_chain_hash` and `provenance_signature` columns
+- **AND** existing rows have `NULL` for both
+
+#### Scenario: Fresh database gets all migrations
+
+- **WHEN** the migration runner executes against a fresh database
+- **THEN** migrations 1, 2, and 3 are all applied
+- **AND** `analyses` has `provenance`, `provenance_chain_hash`, and `provenance_signature` columns

--- a/openspec/specs/prov-signing/spec.md
+++ b/openspec/specs/prov-signing/spec.md
@@ -1,0 +1,64 @@
+# prov-signing Specification
+
+## Purpose
+Ed25519 keypair lifecycle (generate-on-first-use, JWK persistence at `env.provKeyPath`) and the sign/verify primitives over SHA-256 chain hashes — the cryptographic foundation for provenance integrity. Lives in `src/modules/prov/signing.ts`.
+## Requirements
+### Requirement: Ed25519 keypair generation on first use
+
+The system SHALL generate an Ed25519 keypair via `crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"])` on the first provenance flush that would produce a signature, if no keypair file exists at `env.provKeyPath`. The keypair SHALL be exported as JWK and written to `<configDir>/inflexa/prov_key.json` as `{ publicKey: JsonWebKey, privateKey: JsonWebKey }`.
+
+#### Scenario: First flush generates keypair
+
+- **WHEN** the provenance recorder flushes for the first time and no `prov_key.json` exists
+- **THEN** an Ed25519 keypair is generated and written to `prov_key.json`
+- **AND** the flush proceeds to sign the chain hash with the new key
+
+#### Scenario: Existing keypair is loaded
+
+- **WHEN** the provenance recorder flushes and `prov_key.json` already exists
+- **THEN** the existing keypair is loaded via `crypto.subtle.importKey` and reused
+
+#### Scenario: Unparseable keypair file is replaced with a fresh keypair
+
+- **WHEN** `prov_key.json` exists but cannot be parsed as JSON
+- **THEN** the system generates a fresh keypair and overwrites the file
+- **AND** the flush proceeds to sign with the new key
+
+#### Scenario: Structurally valid but wrong JWK degrades to unsigned
+
+- **WHEN** `prov_key.json` parses as JSON but the JWK cannot be imported (wrong algorithm, missing fields)
+- **THEN** the flush still writes the `provenance` column
+- **AND** `provenance_chain_hash` and `provenance_signature` remain `NULL`
+- **AND** a warning is logged
+
+### Requirement: Signing operation over chain hash
+
+The system SHALL sign a chain hash (a 32-byte SHA-256 digest, hex-encoded) using `crypto.subtle.sign("Ed25519", privateKey, chainHashBytes)` and produce a hex-encoded 64-byte Ed25519 signature.
+
+#### Scenario: Sign produces a deterministic signature
+
+- **WHEN** the same chain hash is signed with the same private key twice
+- **THEN** both signatures are identical (Ed25519 is deterministic — no nonce)
+
+### Requirement: Verification operation over chain hash and signature
+
+The system SHALL verify a signature against a chain hash using `crypto.subtle.verify("Ed25519", publicKey, signatureBytes, chainHashBytes)`, returning a boolean.
+
+#### Scenario: Valid signature verifies
+
+- **WHEN** a chain hash is verified against the signature that signed it and the corresponding public key
+- **THEN** verification returns `true`
+
+#### Scenario: Tampered chain hash fails verification
+
+- **WHEN** a chain hash is verified against a signature produced for a different hash
+- **THEN** verification returns `false`
+
+### Requirement: Keypair path in env
+
+The system SHALL expose `env.provKeyPath` (at `<configDir>/inflexa/prov_key.json`) in `src/lib/env.ts`, following the existing pattern for `authPath` and `configPath`.
+
+#### Scenario: provKeyPath is derived from configDir
+
+- **WHEN** `env.provKeyPath` is read
+- **THEN** it returns `<configDir>/inflexa/prov_key.json`

--- a/openspec/specs/prov-verify/spec.md
+++ b/openspec/specs/prov-verify/spec.md
@@ -1,0 +1,131 @@
+# prov-verify Specification
+
+## Purpose
+The verification surface for provenance integrity — the pure `verifyProvenance` function, the `VerifyResult` discriminated union, the `prov verify` and `prov verify-file` CLI commands, the TUI palette entry, and the self-describing DSSE-style export sidecar. Lives in `src/modules/prov/verify.ts` (logic + CLI actions) and `src/modules/prov/export.ts` (sidecar writing).
+## Requirements
+### Requirement: CLI verify command
+
+The system SHALL register `inflexa prov verify <analysis>` that resolves the analysis by id-or-name (per the existing resolver pattern), recomputes the chain hash from the stored PROV-JSON, verifies the stored signature against the public key, and prints the verification result.
+
+#### Scenario: Valid signed provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with a valid signature
+- **THEN** it prints a success message indicating the provenance chain is intact and the signature is valid
+
+#### Scenario: Tampered provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis whose `provenance` column was modified after signing
+- **THEN** it prints a failure message indicating the provenance has been tampered with
+- **AND** the exit code is non-zero
+
+#### Scenario: Unsigned provenance
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with `NULL` chain hash and signature
+- **THEN** it prints a message indicating the provenance is unsigned (recorded before integrity was enabled or without a keypair)
+
+#### Scenario: Missing public key
+
+- **WHEN** `inflexa prov verify my-analysis` runs with a stored signature but the `prov_key.json` file is absent
+- **THEN** it prints a message indicating the signature exists but cannot be verified without the key
+
+#### Scenario: No provenance recorded
+
+- **WHEN** `inflexa prov verify my-analysis` runs against an analysis with `NULL` provenance
+- **THEN** it prints a message indicating no provenance has been recorded yet
+
+#### Scenario: Unknown analysis
+
+- **WHEN** `inflexa prov verify nonexistent` runs
+- **THEN** it prints an error that no analysis matches the reference
+
+### Requirement: File-based verification command
+
+The system SHALL register `inflexa prov verify-file <path>` that verifies a provenance file against its sidecar without requiring a local database or analysis row. It SHALL locate the sidecar at `<path>.sig.json`, read the provenance file bytes and the sidecar JSON, recompute the chain hash from the file bytes, and verify the signature using the public key from the sidecar.
+
+#### Scenario: Valid signed provenance file
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and `provenance.json.sig.json` exists with a valid signature
+- **THEN** it prints a success message indicating the provenance file is intact and the signature is valid
+
+#### Scenario: Tampered provenance file
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and the file contents do not match the sidecar's `payloadDigest`
+- **THEN** it prints a failure message indicating the file has been tampered with
+- **AND** the exit code is non-zero
+
+#### Scenario: Missing sidecar
+
+- **WHEN** `inflexa prov verify-file provenance.json` runs and `provenance.json.sig.json` does not exist
+- **THEN** it prints a message indicating no sidecar was found and the file cannot be verified
+
+#### Scenario: Missing provenance file
+
+- **WHEN** `inflexa prov verify-file nonexistent.json` runs and the file does not exist
+- **THEN** it prints an error that the file was not found
+
+### Requirement: Verification result type
+
+The system SHALL define a discriminated union `VerifyResult` with the following variants:
+- `{ status: "valid" }` — chain hash recomputes correctly AND signature verifies.
+- `{ status: "unsigned" }` — no signature stored.
+- `{ status: "tampered"; detail: string }` — chain hash or signature does not verify.
+- `{ status: "no-key" }` — signature exists but public key is missing.
+- `{ status: "empty" }` — no provenance recorded.
+
+#### Scenario: Each verification outcome maps to exactly one variant
+
+- **WHEN** verification is performed
+- **THEN** the result is exactly one of the five `VerifyResult` variants
+
+### Requirement: Verification logic is pure and testable
+
+The verification logic SHALL be a pure function that takes the stored PROV-JSON, stored chain hash, stored signature, and public key (or null), and returns a `VerifyResult`. It SHALL NOT perform DB queries or file I/O itself — the caller provides the inputs.
+
+#### Scenario: Verification function is testable without DB
+
+- **WHEN** the verify function is called with in-memory inputs (prov JSON, chain hash, signature, public key)
+- **THEN** it returns a `VerifyResult` without touching the database or filesystem
+
+### Requirement: TUI verify command
+
+The system SHALL add a "Verify provenance" entry to the command palette (category "Analysis"), enabled when an analysis is open, that runs the verification logic and displays the result as a notice.
+
+#### Scenario: TUI verify shows result as notice
+
+- **WHEN** the user selects "Verify provenance" from the command palette
+- **THEN** a notice is displayed with the verification status (valid/unsigned/tampered/no-key/empty)
+
+### Requirement: Export includes a self-describing verification sidecar
+
+The system SHALL extend `inflexa prov export` to write a sidecar file `provenance.<format>.sig.json` alongside the provenance document when a signature is available. The sidecar SHALL be a self-describing envelope containing all the metadata a third party needs to verify independently:
+```json
+{
+  "payloadType": "application/json; profile=prov-json",
+  "payloadDigestAlgorithm": "SHA-256",
+  "payloadDigest": "<hex-encoded SHA-256 chain hash>",
+  "payloadDigestMethod": "verbatim",
+  "signatureAlgorithm": "Ed25519",
+  "signature": "<hex-encoded Ed25519 signature over the digest>",
+  "publicKey": { "kty": "OKP", "crv": "Ed25519", ... }
+}
+```
+`payloadDigestMethod: "verbatim"` declares the digest was computed over the exact stored bytes (not a canonicalized form). This aligns with DSSE's approach of treating the payload as an opaque blob to avoid canonicalization.
+
+#### Scenario: Export with signature writes sidecar
+
+- **WHEN** `inflexa prov export my-analysis --format json` runs and the analysis has a stored signature and the public key is available
+- **THEN** it writes `provenance.json` and `provenance.json.sig.json` to the output directory
+- **AND** the sidecar contains `payloadType`, `payloadDigestAlgorithm`, `payloadDigest`, `payloadDigestMethod`, `signatureAlgorithm`, `signature`, and `publicKey`
+
+#### Scenario: Export without signature writes no sidecar
+
+- **WHEN** `inflexa prov export my-analysis` runs and the analysis has no stored signature
+- **THEN** it writes only `provenance.json` (no `.sig.json` sidecar)
+
+#### Scenario: Third-party verification with sidecar
+
+- **WHEN** a third party has `provenance.json` and `provenance.json.sig.json`
+- **THEN** they read `payloadDigestAlgorithm` and `signatureAlgorithm` from the sidecar
+- **AND** they compute `SHA-256(SHA-256("") || file_contents)` over the provenance file bytes
+- **AND** they compare the result to `payloadDigest`
+- **AND** they verify the `signature` against the `payloadDigest` bytes using the `publicKey` with `Ed25519`

--- a/openspec/specs/prov-verify/spec.md
+++ b/openspec/specs/prov-verify/spec.md
@@ -102,7 +102,7 @@ The system SHALL extend `inflexa prov export` to write a sidecar file `provenanc
 {
   "payloadType": "application/json; profile=prov-json",
   "payloadDigestAlgorithm": "SHA-256",
-  "payloadDigest": "<hex-encoded SHA-256 chain hash>",
+  "payloadDigest": "<hex-encoded SHA-256 content digest>",
   "payloadDigestMethod": "verbatim",
   "signatureAlgorithm": "Ed25519",
   "signature": "<hex-encoded Ed25519 signature over the digest>",
@@ -126,6 +126,6 @@ The system SHALL extend `inflexa prov export` to write a sidecar file `provenanc
 
 - **WHEN** a third party has `provenance.json` and `provenance.json.sig.json`
 - **THEN** they read `payloadDigestAlgorithm` and `signatureAlgorithm` from the sidecar
-- **AND** they compute `SHA-256(SHA-256("") || file_contents)` over the provenance file bytes
+- **AND** they compute `SHA-256(file_contents)` over the provenance file bytes
 - **AND** they compare the result to `payloadDigest`
 - **AND** they verify the `signature` against the `payloadDigest` bytes using the `publicKey` with `Ed25519`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.50",
         "@clack/prompts": "^1.5.1",
+        "@inflexa-ai/tsprov": "0.1.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -125,8 +125,7 @@ for (const target of targets) {
     // Windows uses the B:\~BUN\root root with backslashes; that mapping is unverified (cross targets
     // aren't smoke-tested), so highlighting may degrade gracefully there (warmGrammars swallows a
     // worker failure) — text still renders, just unstyled.
-    const workerBunfsPath =
-        target.os === "windows" ? `B:\\~BUN\\root\\${workerRelToRoot.split("/").join("\\")}` : `/$bunfs/root/${workerRelToRoot}`;
+    const workerBunfsPath = target.os === "windows" ? `B:\\~BUN\\root\\${workerRelToRoot.split("/").join("\\")}` : `/$bunfs/root/${workerRelToRoot}`;
     const targetDefine: Record<string, string> = {
         ...define,
         OTUI_TREE_SITTER_WORKER_PATH: JSON.stringify(workerBunfsPath),
@@ -223,6 +222,7 @@ function collectThirdPartyLicenses(rootDir: string): ThirdPartyPackage[] {
     function readMatchingText(pkgDir: string, matcher: RegExp): string | null {
         let entries: string[];
         try {
+            // TODO(slop): neverthrow
             entries = readdirSync(pkgDir);
         } catch {
             return null;
@@ -234,6 +234,7 @@ function collectThirdPartyLicenses(rootDir: string): ThirdPartyPackage[] {
             .sort()
             .map((entry) => {
                 try {
+                    // TODO(slop): neverthrow
                     return readFileSync(join(pkgDir, entry), "utf8").trim();
                 } catch {
                     return "";

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -39,6 +39,14 @@ function bakedVarNames(source: string): string[] {
     return names;
 }
 
+// Bake the exact source commit so a release binary can report what it was built from (the
+// provenance `system` actor stamps it). Left empty if this is not a git checkout, which the
+// bakedEnv missing-guard below then rejects with a clear error.
+process.env.INFLEXA_GIT_COMMIT = await $`git rev-parse HEAD`
+    .text()
+    .then((sha) => sha.trim())
+    .catch(() => "");
+
 const bakedVars = bakedVarNames(await Bun.file(ENV_TS).text());
 
 const define: Record<string, string> = {};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -151,6 +151,31 @@ project
         projectLs();
     });
 
+const prov = cli.command("prov").description("Provenance — the recorded history of an analysis's inputs and actions");
+
+prov.command("export <analysis>")
+    .description("Export an analysis's provenance document as PROV (writes into its .inflexa output folder by default)")
+    .option("--format <format>", "json (PROV-JSON) or provn (PROV-N)", "json")
+    .option("--output <file>", "Write to this file instead of the analysis output folder")
+    .action(async (analysisRef: string, options: { format?: string; output?: string }) => {
+        const { runExportProvenance } = await import("../modules/prov/export.ts");
+        await runExportProvenance(analysisRef, { format: options.format, output: options.output });
+    });
+
+prov.command("verify <analysis>")
+    .description("Verify the integrity of an analysis's provenance chain and signature")
+    .action(async (analysisRef: string) => {
+        const { runVerifyProvenance } = await import("../modules/prov/verify.ts");
+        await runVerifyProvenance(analysisRef);
+    });
+
+prov.command("verify-file <path>")
+    .description("Verify an exported provenance file against its .sig.json sidecar (no database needed)")
+    .action(async (path: string) => {
+        const { runVerifyFile } = await import("../modules/prov/verify.ts");
+        await runVerifyFile(path);
+    });
+
 // Anchor move-backstop: the manual fallback for folder moves that the automatic
 // reconciliation in `resolveAnchor` cannot settle on its own. All addressed by path.
 cli.command("repair [path]")

--- a/src/db/primary_migrations.test.ts
+++ b/src/db/primary_migrations.test.ts
@@ -40,19 +40,27 @@ describe("runMigrations", () => {
         expect(columns).toContain("provenance_signature");
     });
 
+    test("migration 4 adds the prev chain hash column for multi-flush verification", () => {
+        const columns = migratedMemoryDb()
+            .query<{ name: string }, []>("PRAGMA table_info(analyses)")
+            .all()
+            .map((c) => c.name);
+        expect(columns).toContain("provenance_prev_chain_hash");
+    });
+
     test("records the applied version in the _migrations ledger", () => {
         const versions = migratedMemoryDb()
             .query<{ version: number }, []>("SELECT version FROM _migrations ORDER BY version")
             .all()
             .map((r) => r.version);
-        expect(versions).toEqual([1, 2, 3]);
+        expect(versions).toEqual([1, 2, 3, 4]);
     });
 
     test("is idempotent: re-running applies nothing new", () => {
         const db = migratedMemoryDb();
         runMigrations(db, migrations)._unsafeUnwrap(); // second run
         const count = db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM _migrations").get();
-        expect(count?.n).toBe(3);
+        expect(count?.n).toBe(4);
     });
 
     test("declares the analyses foreign keys to anchors and projects", () => {

--- a/src/db/primary_migrations.test.ts
+++ b/src/db/primary_migrations.test.ts
@@ -23,19 +23,36 @@ describe("runMigrations", () => {
         }
     });
 
+    test("migration 2 adds the provenance column to analyses (not a separate table)", () => {
+        const columns = migratedMemoryDb()
+            .query<{ name: string }, []>("PRAGMA table_info(analyses)")
+            .all()
+            .map((c) => c.name);
+        expect(columns).toContain("provenance");
+    });
+
+    test("migration 3 adds integrity columns for tamper-evident provenance", () => {
+        const columns = migratedMemoryDb()
+            .query<{ name: string }, []>("PRAGMA table_info(analyses)")
+            .all()
+            .map((c) => c.name);
+        expect(columns).toContain("provenance_chain_hash");
+        expect(columns).toContain("provenance_signature");
+    });
+
     test("records the applied version in the _migrations ledger", () => {
         const versions = migratedMemoryDb()
             .query<{ version: number }, []>("SELECT version FROM _migrations ORDER BY version")
             .all()
             .map((r) => r.version);
-        expect(versions).toEqual([1]);
+        expect(versions).toEqual([1, 2, 3]);
     });
 
     test("is idempotent: re-running applies nothing new", () => {
         const db = migratedMemoryDb();
         runMigrations(db, migrations)._unsafeUnwrap(); // second run
         const count = db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM _migrations").get();
-        expect(count?.n).toBe(1);
+        expect(count?.n).toBe(3);
     });
 
     test("declares the analyses foreign keys to anchors and projects", () => {

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -78,6 +78,29 @@ export const migrations: Migration[] = [
             CREATE INDEX idx_parts_session ON parts(session_id);
         `,
     },
+    {
+        // Provenance lives 1:1 with the analysis as the PROV-JSON serialization of its provenance
+        // document — built incrementally in memory (tsprov) from typed `prov.*` bus events and flushed
+        // here. It is read and written whole (export serializes it; reopening deserializes it back),
+        // never filtered or joined by an interior field, so it is one opaque column rather than a
+        // columnar event log — matching how sessions/messages/parts store their JSON blob. `NULL`
+        // until the first action is recorded (treated as an empty document).
+        version: 2,
+        up: `
+            ALTER TABLE analyses ADD COLUMN provenance TEXT;
+        `,
+    },
+    {
+        // Integrity columns for tamper-evident provenance: the chain hash links each flush state
+        // to its predecessor (SHA-256 rolling digest), and the Ed25519 signature proves the chain
+        // hash was produced by the holder of the signing key. Both are hex-encoded strings. NULL
+        // until the first signed flush — treated as "unsigned" by the verification logic.
+        version: 3,
+        up: `
+            ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT;
+            ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;
+        `,
+    },
 ];
 
 export function runMigrations(db: Database, migrations: Migration[]): Result<void, DbError> {

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -101,6 +101,15 @@ export const migrations: Migration[] = [
             ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;
         `,
     },
+    {
+        // The verifier needs the PREVIOUS chain hash to recompute the current one:
+        // H_n = SHA-256(H_{n-1} || json_n). Without it, verification after a second flush
+        // always reports "tampered" because the verifier seeds from SHA-256("") instead of H_{n-1}.
+        version: 4,
+        up: `
+            ALTER TABLE analyses ADD COLUMN provenance_prev_chain_hash TEXT;
+        `,
+    },
 ];
 
 export function runMigrations(db: Database, migrations: Migration[]): Result<void, DbError> {

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -250,14 +250,16 @@ export function relocateRawInputPrefix(fromPrefix: string, toPrefix: string): Re
 // --- Data model: provenance ---
 
 /**
- * Persists the PROV-JSON serialization of an analysis's provenance document, plus the optional
- * integrity columns. The UPDATE atomically rotates the chain: the current `provenance_chain_hash`
- * becomes `provenance_prev_chain_hash` before the new values land, so the verifier can always
- * recompute `chainHash = SHA-256(prevChainHash || provJson)` from stored data alone. Deliberately
- * does NOT bump `updated_at`: provenance is recorded metadata flushed asynchronously, not a user
- * data-edit — the same reasoning as `touchAnchor` leaving `updatedAt` alone. Returns rows changed.
+ * Persists the PROV-JSON serialization of an analysis's provenance document and its integrity
+ * columns. All three are required — unsigned provenance is never written (the signing key is
+ * generated on first use, so absence is a hard fault, not a graceful-degradation case). The
+ * UPDATE atomically rotates the chain: the current `provenance_chain_hash` becomes
+ * `provenance_prev_chain_hash` before the new values land, so the verifier can always recompute
+ * `chainHash = SHA-256(prevChainHash || provJson)` from stored data alone. Deliberately does NOT
+ * bump `updated_at`: provenance is recorded metadata flushed asynchronously, not a user data-edit
+ * — the same reasoning as `touchAnchor` leaving `updatedAt` alone. Returns rows changed.
  */
-export function updateAnalysisProvenance(id: string, provenance: string, chainHash?: string | null, signature?: string | null): Result<number, DbError> {
+export function updateAnalysisProvenance(id: string, provenance: string, chainHash: string, signature: string): Result<number, DbError> {
     return tryMutation("updateAnalysisProvenance", (conn) => {
         return conn
             .query(
@@ -268,6 +270,6 @@ export function updateAnalysisProvenance(id: string, provenance: string, chainHa
                      provenance_signature = ?
                  WHERE id = ?`,
             )
-            .run(provenance, chainHash ?? null, signature ?? null, id).changes;
+            .run(provenance, chainHash, signature, id).changes;
     });
 }

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -251,15 +251,23 @@ export function relocateRawInputPrefix(fromPrefix: string, toPrefix: string): Re
 
 /**
  * Persists the PROV-JSON serialization of an analysis's provenance document, plus the optional
- * integrity columns (chain hash and Ed25519 signature). All three are written in a single UPDATE
- * so the column never disagrees with its signature. Deliberately does NOT bump `updated_at`:
- * provenance is recorded metadata flushed asynchronously, not a user data-edit — the same
- * reasoning as `touchAnchor` leaving `updatedAt` alone. Returns rows changed.
+ * integrity columns. The UPDATE atomically rotates the chain: the current `provenance_chain_hash`
+ * becomes `provenance_prev_chain_hash` before the new values land, so the verifier can always
+ * recompute `chainHash = SHA-256(prevChainHash || provJson)` from stored data alone. Deliberately
+ * does NOT bump `updated_at`: provenance is recorded metadata flushed asynchronously, not a user
+ * data-edit — the same reasoning as `touchAnchor` leaving `updatedAt` alone. Returns rows changed.
  */
 export function updateAnalysisProvenance(id: string, provenance: string, chainHash?: string | null, signature?: string | null): Result<number, DbError> {
     return tryMutation("updateAnalysisProvenance", (conn) => {
         return conn
-            .query("UPDATE analyses SET provenance = ?, provenance_chain_hash = ?, provenance_signature = ? WHERE id = ?")
+            .query(
+                `UPDATE analyses
+                 SET provenance = ?,
+                     provenance_prev_chain_hash = provenance_chain_hash,
+                     provenance_chain_hash = ?,
+                     provenance_signature = ?
+                 WHERE id = ?`,
+            )
             .run(provenance, chainHash ?? null, signature ?? null, id).changes;
     });
 }

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -204,6 +204,18 @@ export function insertAnalysisInput(input: AnalysisInput): Result<AnalysisInput,
     });
 }
 
+/**
+ * Removes a single input ref, matched by its identity (owning analysis + path + source anchor).
+ * `anchor_id` is matched with `IS` so a `null` (raw path) ref compares equal. Returns rows
+ * deleted — `0` when no such ref exists.
+ */
+export function deleteAnalysisInput(input: AnalysisInput): Result<number, DbError> {
+    return tryMutation("deleteAnalysisInput", (conn) => {
+        return conn.query("DELETE FROM analysis_inputs WHERE analysis_id = ? AND path = ? AND anchor_id IS ?").run(input.analysisId, input.path, input.anchorId)
+            .changes;
+    });
+}
+
 /** Deletes every analysis homed at an anchor (their input refs cascade via the analysis FK). Used by `prune` before dropping a dead anchor, since the analyses→anchors FK has no ON DELETE CASCADE. Returns rows deleted. */
 export function deleteAnalysesForAnchor(anchorId: string): Result<number, DbError> {
     return tryMutation("deleteAnalysesForAnchor", (conn) => {
@@ -232,5 +244,22 @@ export function relocateRawInputPrefix(fromPrefix: string, toPrefix: string): Re
             }
         }
         return rewritten;
+    });
+}
+
+// --- Data model: provenance ---
+
+/**
+ * Persists the PROV-JSON serialization of an analysis's provenance document, plus the optional
+ * integrity columns (chain hash and Ed25519 signature). All three are written in a single UPDATE
+ * so the column never disagrees with its signature. Deliberately does NOT bump `updated_at`:
+ * provenance is recorded metadata flushed asynchronously, not a user data-edit — the same
+ * reasoning as `touchAnchor` leaving `updatedAt` alone. Returns rows changed.
+ */
+export function updateAnalysisProvenance(id: string, provenance: string, chainHash?: string | null, signature?: string | null): Result<number, DbError> {
+    return tryMutation("updateAnalysisProvenance", (conn) => {
+        return conn
+            .query("UPDATE analyses SET provenance = ?, provenance_chain_hash = ?, provenance_signature = ? WHERE id = ?")
+            .run(provenance, chainHash ?? null, signature ?? null, id).changes;
     });
 }

--- a/src/db/primary_query.ts
+++ b/src/db/primary_query.ts
@@ -302,18 +302,31 @@ export function getAnalysisProvenance(id: string): Result<string | null, DbError
     });
 }
 
-/** The integrity columns (chain hash + Ed25519 signature) for an analysis's provenance. Both are `null` when unsigned. */
-export type AnalysisIntegrity = { provenance: string | null; chainHash: string | null; signature: string | null };
+/** The integrity columns for an analysis's provenance. All are `null` when unsigned. */
+export type AnalysisIntegrity = {
+    provenance: string | null;
+    prevChainHash: string | null;
+    chainHash: string | null;
+    signature: string | null;
+};
 
 /** Read provenance + integrity columns in one query — the verifier's single DB round-trip. */
 export function getAnalysisIntegrity(id: string): Result<AnalysisIntegrity | null, DbError> {
     return tryQuery("getAnalysisIntegrity", (conn) => {
-        const row = conn.query("SELECT provenance, provenance_chain_hash, provenance_signature FROM analyses WHERE id = ?").get(id) as {
+        const row = conn
+            .query("SELECT provenance, provenance_prev_chain_hash, provenance_chain_hash, provenance_signature FROM analyses WHERE id = ?")
+            .get(id) as {
             provenance: string | null;
+            provenance_prev_chain_hash: string | null;
             provenance_chain_hash: string | null;
             provenance_signature: string | null;
         } | null;
         if (!row) return null;
-        return { provenance: row.provenance, chainHash: row.provenance_chain_hash, signature: row.provenance_signature };
+        return {
+            provenance: row.provenance,
+            prevChainHash: row.provenance_prev_chain_hash,
+            chainHash: row.provenance_chain_hash,
+            signature: row.provenance_signature,
+        };
     });
 }

--- a/src/db/primary_query.ts
+++ b/src/db/primary_query.ts
@@ -291,3 +291,29 @@ export function listAnalysisInputs(analysisId: string): Result<AnalysisInput[], 
         }));
     });
 }
+
+// --- Data model: provenance ---
+
+/** The stored PROV-JSON serialization of an analysis's provenance document; `null` when nothing has been recorded yet (treated as an empty document). */
+export function getAnalysisProvenance(id: string): Result<string | null, DbError> {
+    return tryQuery("getAnalysisProvenance", (conn) => {
+        const row = conn.query("SELECT provenance FROM analyses WHERE id = ?").get(id) as { provenance: string | null } | null;
+        return row?.provenance ?? null;
+    });
+}
+
+/** The integrity columns (chain hash + Ed25519 signature) for an analysis's provenance. Both are `null` when unsigned. */
+export type AnalysisIntegrity = { provenance: string | null; chainHash: string | null; signature: string | null };
+
+/** Read provenance + integrity columns in one query — the verifier's single DB round-trip. */
+export function getAnalysisIntegrity(id: string): Result<AnalysisIntegrity | null, DbError> {
+    return tryQuery("getAnalysisIntegrity", (conn) => {
+        const row = conn.query("SELECT provenance, provenance_chain_hash, provenance_signature FROM analyses WHERE id = ?").get(id) as {
+            provenance: string | null;
+            provenance_chain_hash: string | null;
+            provenance_signature: string | null;
+        } | null;
+        if (!row) return null;
+        return { provenance: row.provenance, chainHash: row.provenance_chain_hash, signature: row.provenance_signature };
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,12 @@ import { CommanderError } from "commander";
 
 import { cli } from "./cli/index.ts";
 import { releaseHeldAnalysisLock } from "./modules/analysis/lock.ts";
-import { initProvenanceRecording, flushProvenance } from "./modules/prov/prov.ts";
+import { initProvenanceRecording, flushProvenanceAsync } from "./modules/prov/prov.ts";
 import { initBusLogging } from "./lib/bus.ts";
 import { readConfig } from "./lib/config.ts";
 import { addLogStream, flushLogsSync, getLogger } from "./lib/log.ts";
 import { createOtelLogStream, initOtel } from "./lib/otel.ts";
-import { shutdown } from "./lib/shutdown.ts";
+import { onShutdown, shutdown } from "./lib/shutdown.ts";
 
 if (initOtel(readConfig().telemetry)) {
     addLogStream(createOtelLogStream());
@@ -20,17 +20,17 @@ initBusLogging();
 // runs before the TUI opens). The eager import pulls tsprov into startup for every command — accepted
 // as the simple, correct choice now that the package builds; lazy-load the recorder if that cost bites.
 initProvenanceRecording();
+// Flush un-persisted provenance (with signing) during shutdown — registered as a hook so the
+// dependency direction stays correct (module → lib, never lib → module).
+onShutdown(flushProvenanceAsync);
 
 // Commands that exit by event-loop drain (sessions, telemetry) never call
 // shutdown() themselves; beforeExit catches them. It does not fire on the
 // TUI's explicit shutdown()/process.exit() path.
-process.on("beforeExit", () => {
-    void shutdown(typeof process.exitCode === "number" ? process.exitCode : 0);
+process.on("beforeExit", (exitCode) => {
+    void shutdown(exitCode);
 });
 process.on("exit", flushLogsSync);
-// Persist any un-flushed provenance synchronously on exit (the backstop to the recorder's async
-// flush). Safe here because nothing closes the DB before exit (primary.ts has no exit-time closeDb).
-process.on("exit", flushProvenance);
 // Release this instance's analysis lock on any exit. This single sync hook covers the graceful TUI
 // quit too (App.quit → shutdown → process.exit), so no separate release in App.quit() is needed.
 // SIGKILL bypasses it; that stale lock is reclaimed by the pid check on the next open.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { CommanderError } from "commander";
 
 import { cli } from "./cli/index.ts";
 import { releaseHeldAnalysisLock } from "./modules/analysis/lock.ts";
+import { initProvenanceRecording, flushProvenance } from "./modules/prov/prov.ts";
 import { initBusLogging } from "./lib/bus.ts";
 import { readConfig } from "./lib/config.ts";
 import { addLogStream, flushLogsSync, getLogger } from "./lib/log.ts";
@@ -15,6 +16,10 @@ if (initOtel(readConfig().telemetry)) {
     addLogStream(createOtelLogStream());
 }
 initBusLogging();
+// Subscribe the provenance recorder before any command can emit a `prov.*` event (createAnalysis
+// runs before the TUI opens). The eager import pulls tsprov into startup for every command — accepted
+// as the simple, correct choice now that the package builds; lazy-load the recorder if that cost bites.
+initProvenanceRecording();
 
 // Commands that exit by event-loop drain (sessions, telemetry) never call
 // shutdown() themselves; beforeExit catches them. It does not fire on the
@@ -23,6 +28,9 @@ process.on("beforeExit", () => {
     void shutdown(typeof process.exitCode === "number" ? process.exitCode : 0);
 });
 process.on("exit", flushLogsSync);
+// Persist any un-flushed provenance synchronously on exit (the backstop to the recorder's async
+// flush). Safe here because nothing closes the DB before exit (primary.ts has no exit-time closeDb).
+process.on("exit", flushProvenance);
 // Release this instance's analysis lock on any exit. This single sync hook covers the graceful TUI
 // quit too (App.quit → shutdown → process.exit), so no separate release in App.quit() is needed.
 // SIGKILL bypasses it; that stale lock is reclaimed by the pid check on the next open.

--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -67,6 +67,12 @@ function eventFields(event: StampedEvent): Record<string, unknown> {
             };
         case "session.error":
             return { sessionId: event.sessionId, error: event.error };
+        case "prov.analysis_created":
+            return { analysisId: event.analysisId, actorKind: event.actor.kind };
+        case "prov.input_added":
+            return { analysisId: event.analysisId, actorKind: event.actor.kind, inputPath: event.input.path };
+        case "prov.input_removed":
+            return { analysisId: event.analysisId, actorKind: event.actor.kind, inputPath: event.input.path };
     }
 }
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -88,7 +88,9 @@ function resolveGitCommit(): string {
         throw new Error("INFLEXA_GIT_COMMIT is not set on production environment. This means the binary was not built correctly.");
 
     // Dev-only path: resolve from the working tree's HEAD.
-    return Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim();
+    const sha = Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim();
+    if (!sha) throw new Error("Could not resolve git HEAD — are you running outside a git checkout?");
+    return sha;
 }
 
 export const bakedEnv = Object.freeze({

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -76,12 +76,29 @@ export const env = Object.freeze({
  * just add its dot access here — scripts/build.ts derives the baked-var list
  * from this block, so there is nothing else to keep in sync.
  */
+// Deferred so the spawnSync only runs when the value is first read (provenance actor, --version),
+// not on every CLI startup. In release builds --define inlines process.env.INFLEXA_GIT_COMMIT as a
+// string literal, so the fallback is dead code. The fallback is dev-only: resolve from git. If
+// neither source produces a commit, the binary was not built correctly — crash rather than silently
+// stamping provenance with garbage.
+let _gitCommit: string | undefined;
+function resolveGitCommit(): string {
+    if (process.env.INFLEXA_GIT_COMMIT) return process.env.INFLEXA_GIT_COMMIT;
+    if (process.env.NODE_ENV === "production")
+        throw new Error("INFLEXA_GIT_COMMIT is not set on production environment. This means the binary was not built correctly.");
+
+    // Dev-only path: resolve from the working tree's HEAD.
+    return Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim();
+}
+
 export const bakedEnv = Object.freeze({
     auth0Domain: process.env.INFLEXA_AUTH0_DOMAIN,
     auth0ClientId: process.env.INFLEXA_AUTH0_CLIENT_ID,
     auth0Audience: process.env.INFLEXA_AUTH0_AUDIENCE,
-    // Falls back to a live `git rev-parse` in dev; release builds inline the value via --define.
-    gitCommit: process.env.INFLEXA_GIT_COMMIT ?? Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim(),
+    get gitCommit(): string {
+        if (_gitCommit === undefined) _gitCommit = resolveGitCommit();
+        return _gitCommit;
+    },
 });
 
 export type EnvDocEntry = { kind: "path"; label: string; description: string; baseVar: string } | { kind: "var"; name: string; description: string };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -53,6 +53,7 @@ export const env = Object.freeze({
     cliproxyAuthDir: join(dataDir(), "inflexa", "cliproxy", "auth"),
     configPath: join(configDir(), "inflexa", "config.json"),
     authPath: join(configDir(), "inflexa", "auth.json"),
+    provKeyPath: join(configDir(), "inflexa", "prov_key.json"),
     logLevel: process.env[logLevelVar],
     otelEndpoint: process.env[otelEndpointVar],
     /**
@@ -79,6 +80,8 @@ export const bakedEnv = Object.freeze({
     auth0Domain: process.env.INFLEXA_AUTH0_DOMAIN,
     auth0ClientId: process.env.INFLEXA_AUTH0_CLIENT_ID,
     auth0Audience: process.env.INFLEXA_AUTH0_AUDIENCE,
+    // Falls back to a live `git rev-parse` in dev; release builds inline the value via --define.
+    gitCommit: process.env.INFLEXA_GIT_COMMIT ?? Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim(),
 });
 
 export type EnvDocEntry = { kind: "path"; label: string; description: string; baseVar: string } | { kind: "var"; name: string; description: string };
@@ -93,6 +96,7 @@ export const envDoc: Readonly<Record<Exclude<keyof typeof env, "cliproxyPort" | 
     cliproxyAuthDir: { kind: "path", label: "proxy auth", description: "CLIProxyAPI provider credentials, created by `inflexa setup`", baseVar: dataVar },
     configPath: { kind: "path", label: "config", description: "settings (telemetry consent)", baseVar: configVar },
     authPath: { kind: "path", label: "auth", description: "Auth0 session tokens, created by `inflexa auth login`", baseVar: configVar },
+    provKeyPath: { kind: "path", label: "provenance key", description: "Ed25519 keypair for signing provenance chain hashes", baseVar: configVar },
     logLevel: { kind: "var", name: logLevelVar, description: "log verbosity: trace|debug|info|warn|error|fatal (default: info)" },
     otelEndpoint: { kind: "var", name: otelEndpointVar, description: "OTLP endpoint for log export; requires telemetry enabled via `inflexa config`" },
 });

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -3,6 +3,14 @@ import { shutdownOtel } from "./otel.ts";
 
 let shuttingDown = false;
 
+/** Async cleanup hooks registered by modules (e.g. provenance flush). Runs alongside log/telemetry flush. */
+const asyncHooks: (() => Promise<void>)[] = [];
+
+/** Register an async cleanup function to run during shutdown — keeps the dependency direction correct (module → lib, never lib → module). */
+export function onShutdown(hook: () => Promise<void>): void {
+    asyncHooks.push(hook);
+}
+
 /**
  * Flush logs and telemetry, then exit. The CLI is short-lived — without this,
  * the final batch of records is silently dropped on `process.exit()`.
@@ -10,7 +18,7 @@ let shuttingDown = false;
 export async function shutdown(code: number): Promise<never> {
     if (!shuttingDown) {
         shuttingDown = true;
-        await Promise.allSettled([flushLogs(), shutdownOtel()]);
+        await Promise.allSettled([...asyncHooks.map((h) => h()), flushLogs(), shutdownOtel()]);
     }
     process.exit(code);
 }

--- a/src/lib/wg.ts
+++ b/src/lib/wg.ts
@@ -4,8 +4,6 @@
  * (`allSettled`) — callers handle errors inside their work functions, not at the barrier.
  */
 export class WaitGroup {
-    constructor() {}
-
     private work: Promise<unknown>[] = [];
 
     /** Track a single in-flight promise. */

--- a/src/lib/wg.ts
+++ b/src/lib/wg.ts
@@ -1,0 +1,32 @@
+/**
+ * A lightweight concurrency barrier modelled after Go's `sync.WaitGroup`: collect async work with
+ * {@link go}/{@link goMany}, then {@link wait} for all of it to settle. Failures are swallowed
+ * (`allSettled`) — callers handle errors inside their work functions, not at the barrier.
+ */
+export class WaitGroup {
+    constructor() {}
+
+    private work: Promise<unknown>[] = [];
+
+    /** Track a single in-flight promise. */
+    public go(p: Promise<unknown>) {
+        this.work.push(p);
+    }
+
+    /** Fan out `workFn` over every item, tracking each returned promise. */
+    public goMany<T>(items: T[], workFn: (item: T) => Promise<unknown>) {
+        for (const item of items) {
+            this.work.push(workFn(item));
+        }
+    }
+
+    /** Block until every tracked promise settles (resolve or reject). Drains the internal list so the group is reusable. */
+    public async wait(): Promise<void> {
+        if (this.work.length === 0) return;
+
+        const work = this.work;
+        this.work = [];
+
+        void (await Promise.allSettled(work));
+    }
+}

--- a/src/modules/analysis/analysis.test.ts
+++ b/src/modules/analysis/analysis.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { join, sep } from "node:path";
 
-import { makeBaseSlug } from "./analysis.ts";
+import { makeBaseSlug, matchOutputPrefix, detectSourceAnalysis } from "./analysis.ts";
+import { defaultOutputSubdir } from "./output.ts";
+import { freshDb } from "../../test_support/db.ts";
+import { insertAnchor, insertAnalysis } from "../../db/primary_mutation.ts";
+import { asStr256 } from "../../lib/types.ts";
+import type { Analysis } from "../../types/analysis.ts";
+import type { AnalysisInput } from "../../types/analysis.ts";
 
 describe("makeBaseSlug", () => {
     test("lowercases and kebab-cases a name", () => {
@@ -17,5 +24,63 @@ describe("makeBaseSlug", () => {
 
     test("falls back to a generated handle when the name slugs to empty", () => {
         expect(makeBaseSlug("!!!")).toMatch(/^analysis-[0-9a-f]{6}$/);
+    });
+});
+
+describe("matchOutputPrefix", () => {
+    const candidates = [
+        { id: "A", dir: join(sep, "data", "out-a") },
+        { id: "B", dir: join(sep, "data", "out-b") },
+    ];
+
+    test("matches a path inside (or equal to) a candidate's output dir", () => {
+        expect(matchOutputPrefix(join(sep, "data", "out-a", "r.csv"), candidates)).toBe("A");
+        expect(matchOutputPrefix(join(sep, "data", "out-b"), candidates)).toBe("B");
+    });
+
+    test("requires a path boundary — a sibling prefix is not a match", () => {
+        expect(matchOutputPrefix(join(sep, "data", "out-a-extra"), candidates)).toBeNull();
+    });
+
+    test("null when under no candidate", () => {
+        expect(matchOutputPrefix(join(sep, "elsewhere"), candidates)).toBeNull();
+    });
+});
+
+describe("detectSourceAnalysis", () => {
+    beforeEach(() => {
+        freshDb();
+    });
+
+    function row(id: string, slug: string, anchorId: string, outputDirectory: string | null = null): Analysis {
+        return { id, createdAt: 1, updatedAt: 1, name: asStr256(slug), slug, outputDirectory, anchorId, projectId: null };
+    }
+    function seedAnchor(id: string): void {
+        insertAnchor({ id, createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+    }
+    function input(partial: Partial<AnalysisInput> & Pick<AnalysisInput, "path" | "analysisId">): AnalysisInput {
+        return { isDir: false, anchorId: null, ...partial };
+    }
+
+    test("links an anchor-relative input under a sibling's DEFAULT output to that analysis", () => {
+        seedAnchor("anc");
+        insertAnalysis(row("SRC", "src", "anc"))._unsafeUnwrap();
+        const dst = insertAnalysis(row("DST", "dst", "anc"))._unsafeUnwrap();
+        const i = input({ path: join(defaultOutputSubdir("src"), "result.csv"), analysisId: dst.id, anchorId: "anc" });
+        expect(detectSourceAnalysis(i, dst.id)._unsafeUnwrap()).toBe("SRC");
+    });
+
+    test("links a raw absolute input under an analysis's EXPLICIT outputDirectory", () => {
+        seedAnchor("anc");
+        insertAnalysis(row("SRC", "src", "anc", join(sep, "custom", "out")))._unsafeUnwrap();
+        const i = input({ path: join(sep, "custom", "out", "r.csv"), analysisId: "OTHER" });
+        expect(detectSourceAnalysis(i, "OTHER")._unsafeUnwrap()).toBe("SRC");
+    });
+
+    test("null when the input is no analysis's output", () => {
+        seedAnchor("anc");
+        const dst = insertAnalysis(row("DST", "dst", "anc"))._unsafeUnwrap();
+        const i = input({ path: join("some", "other", "file.csv"), analysisId: dst.id, anchorId: "anc" });
+        expect(detectSourceAnalysis(i, dst.id)._unsafeUnwrap()).toBeNull();
     });
 });

--- a/src/modules/analysis/analysis.ts
+++ b/src/modules/analysis/analysis.ts
@@ -1,15 +1,17 @@
 import { randomUUIDv7 } from "bun";
-import { resolve } from "node:path";
+import { resolve, sep } from "node:path";
 import { ok, err, Result } from "neverthrow";
 import type { Analysis, AnalysisInput } from "../../types/analysis.ts";
 import type { Str256, IdOrName } from "../../lib/types.ts";
 import type { DbError } from "../../db/errors.ts";
 import { findAnalysesByRef, listAnalyses, listAnalysesByAnchor, listAnalysesByProject, listAnalysisInputs } from "../../db/primary_query.ts";
-import { insertAnalysis, insertAnalysisInput, updateAnalysis } from "../../db/primary_mutation.ts";
+import { insertAnalysis, insertAnalysisInput, deleteAnalysisInput, updateAnalysis } from "../../db/primary_mutation.ts";
+import { currentUserActor } from "../prov/prov.ts";
+import { Bus } from "../../lib/bus.ts";
 import { getOrCreateAnchorForCwd } from "../anchor/anchor.ts";
 import { findMarkerUpwards } from "../anchor/marker.ts";
 import { classifyInputPath } from "./input.ts";
-import { resolveOutputDir } from "./output.ts";
+import { resolveOutputDir, defaultOutputSubdir } from "./output.ts";
 import { env } from "../../lib/env.ts";
 
 /** Args for {@link createAnalysis}. `name` is validated to {@link Str256} at the CLI boundary. */
@@ -59,6 +61,49 @@ function refKey(input: AnalysisInput): string {
     return `${input.anchorId ?? ""}|${input.path}`;
 }
 
+/** The first analysis in `candidates` whose output dir contains `path` (a true path-boundary match), or null. */
+export function matchOutputPrefix(path: string, candidates: { id: string; dir: string }[]): string | null {
+    for (const c of candidates) {
+        // Boundary match only: `dir` exactly, or `dir` followed by a separator — so `…/a-extra` does
+        // not match output dir `…/a` (the same guard relocateRawInputPrefix uses).
+        if (path === c.dir || path.startsWith(c.dir + sep)) return c.id;
+    }
+    return null;
+}
+
+/**
+ * Detect whether `input` is itself another inflexa analysis's output, returning that analysis's id
+ * (to record as `derivedFromAnalysisId`, linking the two provenance documents) or null.
+ *
+ * Side-effect-FREE by design: uses only pure reads (`listAnalysesByAnchor`/`listAnalyses`), never
+ * `resolveOutputDir`/`resolveAnchor` — whose Step-1 `touchAnchor` would bump every other anchor's
+ * `last_seen` on each add, a false "sighting" that corrupts the heartbeat. Two cases are provable
+ * from stored data alone:
+ *  - an anchor-relative input under a sibling's DEFAULT output (`<anchor>/.inflexa/analyses/<slug>/`):
+ *    same anchor, so its stored relpath is prefixed by that analysis's default output subdir;
+ *  - a raw absolute input under some analysis's EXPLICIT `outputDirectory`.
+ * Not detected (best-effort, per the "if possible" spec): XDG-fallback outputs, and a default output
+ * reached from a different anchor than the input's own.
+ */
+export function detectSourceAnalysis(input: AnalysisInput, excludeAnalysisId: string): Result<string | null, DbError> {
+    if (input.anchorId !== null) {
+        const anchorId = input.anchorId;
+        return listAnalysesByAnchor(anchorId).map((siblings) =>
+            matchOutputPrefix(
+                input.path,
+                siblings.filter((a) => a.id !== excludeAnalysisId && a.outputDirectory === null).map((a) => ({ id: a.id, dir: defaultOutputSubdir(a.slug) })),
+            ),
+        );
+    }
+    return listAnalyses().map((all) =>
+        matchOutputPrefix(
+            input.path,
+            // Only analyses that pinned an explicit (absolute) output dir; a raw input's path is absolute too.
+            all.flatMap((a) => (a.id !== excludeAnalysisId && a.outputDirectory !== null ? [{ id: a.id, dir: a.outputDirectory }] : [])),
+        ),
+    );
+}
+
 /**
  * Classify each raw path, de-dup (batch + existing), and reject a non-existent path with a
  * clear error rather than storing a dangling ref.
@@ -76,9 +121,45 @@ export function addInputs(analysisId: string, rawPaths: string[], cwd: string): 
                 seen.add(key);
                 toInsert.push(input);
             }
-            return Result.combine(toInsert.map((input) => insertAnalysisInput(input))).map(() => toInsert);
+            // Emit each add onto the provenance chain (actor resolved once for the batch); the recorder
+            // appends it to the analysis's PROV document. When an input is itself another analysis's
+            // output, `derivedFromAnalysisId` links the two documents (detection is side-effect-free —
+            // see detectSourceAnalysis).
+            const actor = currentUserActor();
+            return Result.combine(
+                toInsert.map((input) =>
+                    insertAnalysisInput(input).andThen(() =>
+                        detectSourceAnalysis(input, analysisId).map((sourceId) => {
+                            Bus.emit("inflexa", {
+                                type: "prov.input_added",
+                                analysisId: input.analysisId,
+                                actor,
+                                input,
+                                derivedFromAnalysisId: sourceId,
+                            });
+                        }),
+                    ),
+                ),
+            ).map(() => toInsert);
         }),
     );
+}
+
+/**
+ * Remove a single input ref and record the removal in the analysis's provenance chain. Returns the
+ * removed input, or `null` when no matching ref existed (nothing removed, nothing to record).
+ */
+export function removeInput(input: AnalysisInput): Result<AnalysisInput | null, DbError> {
+    return deleteAnalysisInput(input).map((changed) => {
+        if (changed === 0) return null;
+        Bus.emit("inflexa", {
+            type: "prov.input_removed",
+            analysisId: input.analysisId,
+            actor: currentUserActor(),
+            input,
+        });
+        return input;
+    });
 }
 
 /**
@@ -101,19 +182,30 @@ export function createAnalysis(opts: CreateAnalysisInput): Result<Analysis, DbEr
                 updatedAt: now,
             };
             const inputPaths = opts.inputPaths && opts.inputPaths.length > 0 ? opts.inputPaths : [anchor.cachedPath];
-            return insertAnalysis(analysis)
-                .andThen((created) => addInputs(created.id, inputPaths, opts.cwd).map(() => created))
-                .andThen((created) =>
-                    resolveOutputDir(created).andThen((outDir) => {
-                        // Persist only the XDG fallback (case 3); a writable-anchor path (case 2)
-                        // stays null = derived, and an override is already absolute on the row.
-                        if (created.outputDirectory === null && outDir.startsWith(env.outputFallbackDir)) {
-                            const persisted: Analysis = { ...created, outputDirectory: outDir };
-                            return updateAnalysis(persisted).map(() => persisted);
-                        }
+            return (
+                insertAnalysis(analysis)
+                    // Seed the provenance document with the creation event before any input events.
+                    .andThen((created) => {
+                        Bus.emit("inflexa", {
+                            type: "prov.analysis_created",
+                            analysisId: created.id,
+                            actor: currentUserActor(),
+                        });
                         return ok(created);
-                    }),
-                );
+                    })
+                    .andThen((created) => addInputs(created.id, inputPaths, opts.cwd).map(() => created))
+                    .andThen((created) =>
+                        resolveOutputDir(created).andThen((outDir) => {
+                            // Persist only the XDG fallback (case 3); a writable-anchor path (case 2)
+                            // stays null = derived, and an override is already absolute on the row.
+                            if (created.outputDirectory === null && outDir.startsWith(env.outputFallbackDir)) {
+                                const persisted: Analysis = { ...created, outputDirectory: outDir };
+                                return updateAnalysis(persisted).map(() => persisted);
+                            }
+                            return ok(created);
+                        }),
+                    )
+            );
         }),
     );
 }

--- a/src/modules/analysis/context.ts
+++ b/src/modules/analysis/context.ts
@@ -5,7 +5,7 @@ import type { IdOrName } from "../../lib/types.ts";
 import type { DbError } from "../../db/errors.ts";
 import { findProjectByRef } from "../../db/primary_query.ts";
 import { findMarkerUpwards } from "../anchor/marker.ts";
-import { classifyMarkerSighting, resolveAnchor } from "../anchor/anchor.ts";
+import { classifyMarkerSighting, resolveAnchor, resolvedPathOrCached } from "../anchor/anchor.ts";
 import { findAnalysis, listAnalysesForAnchorAt, listRecentAnalyses } from "./analysis.ts";
 
 /** What bare `inflexa` resolves to, by the spec's precedence. Pure data — the picker/prompts/printing live in the CLI/TUI layer. */
@@ -34,7 +34,7 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
             return resolveAnchor(analysis.anchorId).map((resolved) => ({
                 kind: "analysis",
                 analysis,
-                anchorPath: resolved ? (resolved.path ?? resolved.anchor.cachedPath) : cwd,
+                anchorPath: resolvedPathOrCached(resolved) ?? cwd,
             }));
         });
     }
@@ -63,7 +63,7 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
         // carry on — listAnalysesForAnchorAt returns nothing, so this resolves to an empty anchor the
         // user can start an analysis in (which re-establishes the row from the marker).
         return resolveAnchor(marker.anchorId).andThen((resolved) => {
-            const anchorPath = resolved ? (resolved.path ?? resolved.anchor.cachedPath) : found.dir;
+            const anchorPath = resolvedPathOrCached(resolved) ?? found.dir;
             return listAnalysesForAnchorAt(cwd).map((analyses): ResolvedContext => {
                 const [only] = analyses;
                 if (analyses.length === 1 && only) return { kind: "analysis", analysis: only, anchorPath };

--- a/src/modules/analysis/context.ts
+++ b/src/modules/analysis/context.ts
@@ -48,6 +48,7 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
     // 2. The folder (or an ancestor) is an anchor.
     let found: ReturnType<typeof findMarkerUpwards>;
     try {
+        // TODO(slop): neverthrow
         found = findMarkerUpwards(cwd);
     } catch (cause) {
         return err({ type: "query_failed", op: "resolveContext:marker", cause });

--- a/src/modules/analysis/context.ts
+++ b/src/modules/analysis/context.ts
@@ -29,10 +29,12 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
         return findAnalysis(flags.analysis).andThen((analysis): Result<ResolvedContext, DbError> => {
             // Unmatched flag: surface recent analyses so the command can report the mismatch.
             if (!analysis) return listRecentAnalyses().map((analyses) => ({ kind: "pick", analyses }));
-            return resolveAnchor(analysis.anchorId).map(({ anchor, path }) => ({
+            // The analysis's anchor row may be gone (user edited the DB) — fall back to cwd for display
+            // rather than failing; the analysis is still openable.
+            return resolveAnchor(analysis.anchorId).map((resolved) => ({
                 kind: "analysis",
                 analysis,
-                anchorPath: path ?? anchor.cachedPath,
+                anchorPath: resolved ? (resolved.path ?? resolved.anchor.cachedPath) : cwd,
             }));
         });
     }
@@ -56,8 +58,12 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
     return classifyMarkerSighting(found.dir, marker).andThen((sighting): Result<ResolvedContext, DbError> => {
         // Copy guard: never auto-resolve a copied folder — let the command prompt.
         if (sighting === "copy") return ok({ kind: "copy", cwd, marker });
-        return resolveAnchor(marker.anchorId).andThen(({ anchor, path }) => {
-            const anchorPath = path ?? anchor.cachedPath;
+        // A marker on disk whose anchor row the DB no longer has (e.g. the user deleted the DB) is a
+        // routine desync, not an error: fall back to the marker's own directory for the anchor path and
+        // carry on — listAnalysesForAnchorAt returns nothing, so this resolves to an empty anchor the
+        // user can start an analysis in (which re-establishes the row from the marker).
+        return resolveAnchor(marker.anchorId).andThen((resolved) => {
+            const anchorPath = resolved ? (resolved.path ?? resolved.anchor.cachedPath) : found.dir;
             return listAnalysesForAnchorAt(cwd).map((analyses): ResolvedContext => {
                 const [only] = analyses;
                 if (analyses.length === 1 && only) return { kind: "analysis", analysis: only, anchorPath };

--- a/src/modules/analysis/input.ts
+++ b/src/modules/analysis/input.ts
@@ -53,5 +53,6 @@ export function classifyInputPath(analysisId: string, rawPath: string, cwd: stri
  */
 export function resolveInputPath(input: AnalysisInput): Result<string | null, DbError> {
     if (input.anchorId === null) return ok(input.path);
-    return resolveAnchor(input.anchorId).map(({ path }) => (path === null ? null : join(path, input.path)));
+    // A missing anchor row (null resolved) or unlocated folder (null path) both mean "can't resolve".
+    return resolveAnchor(input.anchorId).map((resolved) => (resolved?.path == null ? null : join(resolved.path, input.path)));
 }

--- a/src/modules/analysis/launch.ts
+++ b/src/modules/analysis/launch.ts
@@ -1,6 +1,6 @@
 import { findProjectByRef, getSession, listSessionsByAnalysis } from "../../db/primary_query.ts";
 import { createSession } from "../../db/primary_mutation.ts";
-import { recoverAnchors, resolveAnchor } from "../anchor/anchor.ts";
+import { recoverAnchors, resolveAnchor, resolvedPathOrCached } from "../anchor/anchor.ts";
 import { confirm, dieOn, fail, promptText, select } from "../../lib/cli.ts";
 import { getLogger } from "../../lib/log.ts";
 import { str256, type Str256, type IdOrName } from "../../lib/types.ts";
@@ -34,7 +34,7 @@ export type ChatTarget = {
 function resolveChatTarget(opts: { analysis: Analysis; resumeSessionId?: string }): ChatTarget {
     const analysis = opts.analysis;
     const workingDir = resolveAnchor(analysis.anchorId).match(
-        (resolved) => (resolved ? (resolved.path ?? resolved.anchor.cachedPath) : process.cwd()),
+        (resolved) => resolvedPathOrCached(resolved) ?? process.cwd(),
         () => process.cwd(),
     );
 

--- a/src/modules/analysis/launch.ts
+++ b/src/modules/analysis/launch.ts
@@ -34,7 +34,7 @@ export type ChatTarget = {
 function resolveChatTarget(opts: { analysis: Analysis; resumeSessionId?: string }): ChatTarget {
     const analysis = opts.analysis;
     const workingDir = resolveAnchor(analysis.anchorId).match(
-        ({ anchor, path }) => path ?? anchor.cachedPath,
+        (resolved) => (resolved ? (resolved.path ?? resolved.anchor.cachedPath) : process.cwd()),
         () => process.cwd(),
     );
 

--- a/src/modules/analysis/output.ts
+++ b/src/modules/analysis/output.ts
@@ -8,6 +8,15 @@ import { isDirWritable } from "../anchor/marker.ts";
 import { resolveAnchor } from "../anchor/anchor.ts";
 
 /**
+ * An analysis's default output sub-path under its anchor: `.inflexa/analyses/<slug>`. The single
+ * source of this layout — shared by {@link resolveOutputDir} and provenance source-analysis
+ * detection (which matches a stored input ref against it without resolving the anchor).
+ */
+export function defaultOutputSubdir(slug: string): string {
+    return join(".inflexa", "analyses", slug);
+}
+
+/**
  * Decide an analysis's output dir (does not create it). Three cases, in order:
  * 1. explicit override / prior fallback already recorded on the analysis;
  * 2. anchor resolves and is writable → beside the data under `.inflexa/`;
@@ -16,9 +25,12 @@ import { resolveAnchor } from "../anchor/anchor.ts";
 export function resolveOutputDir(analysis: Analysis): Result<string, DbError> {
     if (analysis.outputDirectory !== null) return ok(analysis.outputDirectory);
 
-    return resolveAnchor(analysis.anchorId).map(({ path }) => {
+    // A missing/unlocatable anchor (null resolved, or null path) falls through to managed storage —
+    // the same path as a non-writable anchor folder, so outputs always have somewhere to go.
+    return resolveAnchor(analysis.anchorId).map((resolved) => {
+        const path = resolved?.path ?? null;
         if (path !== null && isDirWritable(path)) {
-            return join(path, ".inflexa", "analyses", analysis.slug);
+            return join(path, defaultOutputSubdir(analysis.slug));
         }
         return join(env.outputFallbackDir, analysis.slug);
     });

--- a/src/modules/anchor/anchor.test.ts
+++ b/src/modules/anchor/anchor.test.ts
@@ -41,7 +41,14 @@ describe("resolveAnchor", () => {
         const dir = tmp();
         writeMarker(dir, "A1");
         insertAnchorRow("A1", dir);
-        expect(resolveAnchor("A1", { searchRoots: [dir] })._unsafeUnwrap().path).toBe(dir);
+        expect(resolveAnchor("A1", { searchRoots: [dir] })._unsafeUnwrap()?.path).toBe(dir);
+    });
+
+    test("missing row — resolves to null (a marker/DB desync is not an error)", () => {
+        // No anchor row: the user deleted/edited their local DB while a marker still references it.
+        // resolveAnchor must degrade to null, NOT a query_failed error, or bare `inflexa` crashes.
+        // _unsafeUnwrap throws on an Err, so a null return proves both "is ok" and "value is null".
+        expect(resolveAnchor("ghost", { searchRoots: [tmp()] })._unsafeUnwrap()).toBeNull();
     });
 
     test("step 2 — self-heals to a search root that holds the marker after a move", () => {
@@ -51,7 +58,7 @@ describe("resolveAnchor", () => {
         insertAnchorRow("A1", stale);
 
         const result = resolveAnchor("A1", { searchRoots: [moved] })._unsafeUnwrap();
-        expect(result.path).toBe(canonicalPath(moved));
+        expect(result?.path).toBe(canonicalPath(moved));
         // The drifted cached path was healed to the new (canonical) location.
         expect(getAnchor("A1")._unsafeUnwrap()?.cachedPath).toBe(canonicalPath(moved));
     });
@@ -62,7 +69,7 @@ describe("resolveAnchor", () => {
         rmSync(gone, { recursive: true, force: true }); // cached path gone, no marker anywhere
         const elsewhere = tmp(); // a search root with no matching marker
 
-        expect(resolveAnchor("A1", { searchRoots: [elsewhere] })._unsafeUnwrap().path).toBeNull();
+        expect(resolveAnchor("A1", { searchRoots: [elsewhere] })._unsafeUnwrap()?.path).toBeNull();
     });
 });
 

--- a/src/modules/anchor/anchor.ts
+++ b/src/modules/anchor/anchor.ts
@@ -105,6 +105,11 @@ function ancestorsOf(dir: string): string[] {
 /** A resolved anchor and its current on-disk path (`null` when the folder can't be located). */
 export type ResolvedAnchor = { anchor: Anchor; path: string | null };
 
+/** Best-effort path: the resolved on-disk path, falling back to the anchor's cached path, or `null` when the anchor row is missing. */
+export function resolvedPathOrCached(r: ResolvedAnchor | null): string | null {
+    return r ? (r.path ?? r.anchor.cachedPath) : null;
+}
+
 function selfHeal(anchor: Anchor, anchorId: string, dir: string): Result<ResolvedAnchor, DbError> {
     const canonical = canonicalPath(dir);
     const healed: Anchor = { ...anchor, cachedPath: canonical };

--- a/src/modules/anchor/anchor.ts
+++ b/src/modules/anchor/anchor.ts
@@ -58,7 +58,7 @@ export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
     const writable = isDirWritable(abs);
     if (writable) {
         try {
-            writeMarker(abs, anchorId);
+            writeMarker(abs, anchorId); // TODO(slop): this will be refactored to return result, no need for catch
         } catch (cause) {
             return err({ type: "mutation_failed", op: "getOrCreateAnchorForCwd:writeMarker", cause });
         }
@@ -72,6 +72,7 @@ export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
  */
 function markerMatches(dir: string, anchorId: string): boolean {
     try {
+        // TODO(slop): same here, try catch without reason
         return readMarker(dir)?.anchorId === anchorId;
     } catch {
         return false;
@@ -84,6 +85,7 @@ function markerMatches(dir: string, anchorId: string): boolean {
  */
 function findMatchingMarkerUpwards(startDir: string, anchorId: string): string | null {
     try {
+        // TODO(slop): neverthrow
         const found = findMarkerUpwards(startDir);
         return found && found.marker.anchorId === anchorId ? found.dir : null;
     } catch {

--- a/src/modules/anchor/anchor.ts
+++ b/src/modules/anchor/anchor.ts
@@ -102,7 +102,10 @@ function ancestorsOf(dir: string): string[] {
     }
 }
 
-function selfHeal(anchor: Anchor, anchorId: string, dir: string): Result<{ anchor: Anchor; path: string | null }, DbError> {
+/** A resolved anchor and its current on-disk path (`null` when the folder can't be located). */
+export type ResolvedAnchor = { anchor: Anchor; path: string | null };
+
+function selfHeal(anchor: Anchor, anchorId: string, dir: string): Result<ResolvedAnchor, DbError> {
     const canonical = canonicalPath(dir);
     const healed: Anchor = { ...anchor, cachedPath: canonical };
     return updateAnchorCachedPath(anchorId, canonical).map(() => ({ anchor: healed, path: canonical }));
@@ -111,10 +114,17 @@ function selfHeal(anchor: Anchor, anchorId: string, dir: string): Result<{ ancho
 /**
  * Resolve a UUID to its current path, reconciling the cached path lazily. See the spec
  * (Folder identity & moves): cached-path check → cwd/ancestor self-heal → bounded search.
+ *
+ * Returns `null` when the DB has no row for `anchorId`. That is a NORMAL condition, not an error:
+ * the database is the user's local file and they may delete or edit it freely, while on-disk markers
+ * (and analyses that reference an anchor) persist independently — so a reference to a missing anchor
+ * is a routine desync. We degrade rather than hard-fail; the deliberate `getOrCreateAnchorForCwd`
+ * re-establishes the row from the on-disk marker when the user next acts (we never write on this
+ * passive resolve — the no-litter policy). See CLAUDE.md → "Local state can desync from the database".
  */
-export function resolveAnchor(anchorId: string, opts?: { searchRoots?: string[] }): Result<{ anchor: Anchor; path: string | null }, DbError> {
-    return getAnchor(anchorId).andThen((anchor): Result<{ anchor: Anchor; path: string | null }, DbError> => {
-        if (!anchor) return err({ type: "query_failed", op: "resolveAnchor", cause: new Error(`unknown anchor ${anchorId}`) });
+export function resolveAnchor(anchorId: string, opts?: { searchRoots?: string[] }): Result<ResolvedAnchor | null, DbError> {
+    return getAnchor(anchorId).andThen((anchor): Result<ResolvedAnchor | null, DbError> => {
+        if (!anchor) return ok(null);
 
         // Step 1: the cached path still holds our marker — cheapest, highest-hit case.
         if (markerMatches(anchor.cachedPath, anchorId)) {
@@ -130,7 +140,7 @@ export function resolveAnchor(anchorId: string, opts?: { searchRoots?: string[] 
         }
 
         // Step 3: bounded search over roots (+ ancestors) and known anchor cached paths.
-        return listAnchors().andThen((anchors): Result<{ anchor: Anchor; path: string | null }, DbError> => {
+        return listAnchors().andThen((anchors): Result<ResolvedAnchor, DbError> => {
             const candidates = new Set<string>();
             for (const root of roots) for (const d of ancestorsOf(root)) candidates.add(d);
             for (const a of anchors) candidates.add(resolve(a.cachedPath));
@@ -169,7 +179,9 @@ export function classifyMarkerSighting(dir: string, marker: AnchorMarker): Resul
  */
 export function recoverAnchors(searchRoots: string[] = [process.cwd()]): Result<{ recovered: number; unresolved: number }, DbError> {
     return listAnchors().andThen((anchors) =>
-        Result.combine(anchors.map((a) => resolveAnchor(a.id, { searchRoots }).map((r) => r.path))).map((paths) => {
+        // Every id comes from listAnchors, so the row always exists (r is non-null); the guard is
+        // only to satisfy resolveAnchor's nullable contract — a null would count as unresolved anyway.
+        Result.combine(anchors.map((a) => resolveAnchor(a.id, { searchRoots }).map((r) => r?.path ?? null))).map((paths) => {
             const unresolved = paths.filter((p) => p === null).length;
             return { recovered: paths.length - unresolved, unresolved };
         }),

--- a/src/modules/anchor/backstop.ts
+++ b/src/modules/anchor/backstop.ts
@@ -19,6 +19,7 @@ import { resolveAnchor } from "./anchor.ts";
 /** Read a marker, treating corruption as "absent" — these commands only need presence/identity. */
 function readMarkerSafe(dir: string): AnchorMarker | null {
     try {
+        // TODO(slop): neverthrow
         return readMarker(dir);
     } catch {
         return null;
@@ -35,6 +36,7 @@ export function runRepair(path?: string): void {
 
     let marker: AnchorMarker | null;
     try {
+        // TODO(slop): neverthrow
         marker = readMarker(dir);
     } catch (cause) {
         fail(`Could not read the marker at ${dir} (corrupt?):`, cause);

--- a/src/modules/anchor/backstop.ts
+++ b/src/modules/anchor/backstop.ts
@@ -145,7 +145,7 @@ export async function runPrune(): Promise<void> {
         if (!a.markerWritten) return false;
         if (existsSync(a.cachedPath)) return false;
         const refound = resolveAnchor(a.id).match(
-            (r) => r.path,
+            (r) => r?.path ?? null,
             () => null,
         );
         return refound === null;

--- a/src/modules/anchor/marker.ts
+++ b/src/modules/anchor/marker.ts
@@ -16,6 +16,7 @@ export function markerPath(dir: string): string {
  */
 export function canonicalPath(p: string): string {
     try {
+        // TODO(slop): neverthrow
         return realpathSync(p);
     } catch {
         return resolve(p);
@@ -42,12 +43,12 @@ export function readMarker(dir: string): AnchorMarker | null {
     const path = markerPath(dir);
     if (!existsSync(path)) return null;
 
-    const raw = readFileSync(path, "utf8");
+    const raw = readFileSync(path, "utf8"); // TODO(slop): make a wrapper that returns result - since I guess this throws
     // A present-but-invalid marker is corruption, not absence. JSON.parseWith returns null
     // for both a parse error and a schema mismatch, so the existsSync gate above is what
     // separates "no marker" (null, fine) from "broken marker" (throw, never silently re-minted).
     const marker = JSON.parseWith(raw, anchorMarkerSchema);
-    if (!marker) throw new Error(`corrupt anchor marker at ${path}: ${raw}`);
+    if (!marker) throw new Error(`corrupt anchor marker at ${path}: ${raw}`); // TODO(slop): don't throw, return result
     return marker;
 }
 
@@ -62,8 +63,8 @@ export function writeMarker(dir: string, anchorId: AnchorId): AnchorMarker {
     if (existing) return existing;
 
     const marker: AnchorMarker = { schemaVersion: 1, anchorId: anchorId };
-    mkdirSync(join(dir, ".inflexa"), { recursive: true });
-    writeFileSync(markerPath(dir), `${JSON.stringify(marker, null, 2)}\n`, "utf8");
+    mkdirSync(join(dir, ".inflexa"), { recursive: true }); // TODO(slop): Make wrapper - don't throw
+    writeFileSync(markerPath(dir), `${JSON.stringify(marker, null, 2)}\n`, "utf8"); // TODO(slop): make wrapper - don't throw
     return marker;
 }
 
@@ -74,6 +75,7 @@ export function writeMarker(dir: string, anchorId: AnchorId): AnchorMarker {
  */
 export function isDirWritable(dir: string): boolean {
     try {
+        // TODO(slop): neverthrow
         accessSync(dir, constants.W_OK);
         return true;
     } catch {
@@ -92,7 +94,7 @@ export function findMarkerUpwards(startDir: string): { dir: string; marker: Anch
     for (;;) {
         const marker = readMarker(dir);
         if (marker) return { dir, marker };
-        const parent = dirname(dir);
+        const parent = dirname(dir); // TODO(slop): make a wrapper that returns result and change the call.
         if (parent === dir) return null; // reached filesystem root
         dir = parent;
     }

--- a/src/modules/prov/document.ts
+++ b/src/modules/prov/document.ts
@@ -1,0 +1,146 @@
+import { randomUUIDv7 } from "bun";
+import { type Result } from "neverthrow";
+import { ProvDocument, type BuiltinProvFormat } from "@inflexa-ai/tsprov";
+import type { Analysis } from "../../types/analysis.ts";
+import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
+import type { IdOrName } from "../../lib/types.ts";
+import type { DbError } from "../../db/errors.ts";
+import { getAnalysisProvenance, findAnalysesByRef } from "../../db/primary_query.ts";
+
+// The tsprov-facing layer: seeding, appending to, and serializing an analysis's PROV document. The
+// `@inflexa-ai/tsprov` dependency is confined to this file — the recorder (`prov.ts`) and the export
+// action drive provenance through these functions, so a tsprov fault is contained to provenance.
+//
+// The document is built INCREMENTALLY (one append per recorded action) rather than projected in a
+// batch: it lives in memory while an analysis is open and is reloaded from its serialized form on
+// reopen. Records that recur across actions (the same agent, the same input across add+remove) are
+// deliberately NOT de-duplicated at append time — tsprov's `_idMap` tolerates duplicate identifiers
+// and the caller collapses them with `unified()` at serialize time (see prov.ts flush + B decision).
+
+/** The namespace every inflexa-minted PROV identifier lives under. */
+const NS_PREFIX = "inflexa";
+const NS_URI = "https://inflexa.ai/prov#";
+
+/** Replace every character a PROV qualified-name localpart disallows, so any string can seed an identifier. */
+function qnameSafe(s: string): string {
+    return s.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+/** The analysis's PROV subject-entity QName — the document's subject, related to by every action. */
+function analysisQName(analysisId: string): string {
+    return `${NS_PREFIX}:analysis-${analysisId}`;
+}
+
+/** A stable input-entity QName keyed by (source anchor, path), so an add and its later removal touch the same entity. */
+function inputQName(input: ProvInputRef): string {
+    const key = `${input.anchorId ?? ""}|${input.path}`;
+    return `${NS_PREFIX}:input-${Bun.hash(key).toString(36)}`;
+}
+
+/** Declare (re-declare) the responsible agent on `doc`, returning its QName. Re-declaration is fine — `unified()` collapses it later. */
+function appendAgent(doc: ProvDocument, actor: ProvActor): string {
+    switch (actor.kind) {
+        case "user": {
+            const qn = `${NS_PREFIX}:agent-user-${qnameSafe(actor.email)}`;
+            doc.agent(qn, { "prov:type": "prov:Person", "inflexa:email": actor.email });
+            return qn;
+        }
+        case "anonymous": {
+            const qn = `${NS_PREFIX}:agent-anonymous`;
+            doc.agent(qn, { "prov:type": "prov:Person", "prov:label": "Anonymous user" });
+            return qn;
+        }
+        case "system": {
+            const qn = `${NS_PREFIX}:agent-system`;
+            doc.agent(qn, {
+                "prov:type": "prov:SoftwareAgent",
+                "prov:label": "inflexa cli",
+                "inflexa:version": actor.version,
+                "inflexa:commit": actor.commit,
+            });
+            return qn;
+        }
+        default: {
+            // Exhaustiveness: a new actor kind must declare its agent here.
+            const never: never = actor;
+            throw new Error(`unhandled actor kind: ${String(never)}`);
+        }
+    }
+}
+
+/** Declare (re-declare) an input entity on `doc`, returning its QName. */
+function appendInput(doc: ProvDocument, input: ProvInputRef): string {
+    const qn = inputQName(input);
+    doc.entity(qn, { "prov:type": "inflexa:Input", "inflexa:path": input.path, "inflexa:isDir": input.isDir });
+    return qn;
+}
+
+/** A fresh provenance document for an analysis: the namespace plus the subject entity. Actions append onto this; reopening deserializes the stored form instead. */
+export function freshDocument(analysis: Analysis): ProvDocument {
+    const doc = new ProvDocument();
+    doc.addNamespace(NS_PREFIX, NS_URI);
+    doc.entity(analysisQName(analysis.id), { "prov:type": "inflexa:Analysis", "inflexa:name": analysis.name, "inflexa:slug": analysis.slug });
+    return doc;
+}
+
+/** Reconstruct an analysis's live document from its stored PROV-JSON, or seed a fresh one when nothing is stored yet. */
+export function loadDocument(analysis: Analysis, storedJson: string | null): ProvDocument {
+    return storedJson ? ProvDocument.deserialize(storedJson, "json") : freshDocument(analysis);
+}
+
+// Each append function mints a fresh activity, stamps it at append time (the action's occurrence),
+// and declares the agent. The analysis subject is assumed already present (declared by
+// freshDocument or carried in the deserialized document). Shared preamble lives in startAction.
+
+function startAction(
+    doc: ProvDocument,
+    analysisId: string,
+    activityType: string,
+    actor: ProvActor,
+): { analysisQn: string; actionQn: string; time: string; agentQn: string } {
+    const analysisQn = analysisQName(analysisId);
+    const actionQn = `${NS_PREFIX}:action-${randomUUIDv7()}`;
+    const time = new Date().toISOString();
+    const agentQn = appendAgent(doc, actor);
+    doc.activity(actionQn, time, time, { "prov:type": activityType });
+    doc.wasAssociatedWith(actionQn, agentQn);
+    return { analysisQn, actionQn, time, agentQn };
+}
+
+/** Append the PROV records for an analysis creation: the subject was generated by and attributed to the actor. */
+export function appendCreation(doc: ProvDocument, analysisId: string, actor: ProvActor): void {
+    const { analysisQn, actionQn, time, agentQn } = startAction(doc, analysisId, "inflexa:CreateAnalysis", actor);
+    doc.wasGeneratedBy(analysisQn, actionQn, time);
+    doc.wasAttributedTo(analysisQn, agentQn);
+}
+
+/** Append the PROV records for an input addition: the action used the input, and the analysis derives from it. */
+export function appendInputAdded(doc: ProvDocument, analysisId: string, actor: ProvActor, input: ProvInputRef, derivedFromAnalysisId: string | null): void {
+    const { analysisQn, actionQn, time, agentQn } = startAction(doc, analysisId, "inflexa:AddInput", actor);
+    const inputQn = appendInput(doc, input);
+    doc.used(actionQn, inputQn, time);
+    doc.wasAttributedTo(inputQn, agentQn);
+    doc.wasDerivedFrom(analysisQn, inputQn);
+    if (derivedFromAnalysisId) doc.wasDerivedFrom(inputQn, analysisQName(derivedFromAnalysisId));
+}
+
+/** Append the PROV records for an input removal: the input was invalidated by the action. */
+export function appendInputRemoved(doc: ProvDocument, analysisId: string, actor: ProvActor, input: ProvInputRef): void {
+    const { actionQn, time } = startAction(doc, analysisId, "inflexa:RemoveInput", actor);
+    const inputQn = appendInput(doc, input);
+    doc.wasInvalidatedBy(inputQn, actionQn, time);
+}
+
+/** Build and serialize an analysis's provenance document from its stored PROV-JSON (or a fresh doc), in a tsprov built-in format (`"json"` | `"provn"`). Same-identifier records are unified first. */
+export function serializeProvenance(analysis: Analysis, format: BuiltinProvFormat): Result<string, DbError> {
+    return getAnalysisProvenance(analysis.id).map((json) => loadDocument(analysis, json).unified().serialize(format));
+}
+
+/**
+ * Resolve an id-or-name ref to one analysis for export, via the db resolver (id-first ordering) —
+ * keeping ref resolution inside the prov module so `export.ts` need not import `analysis`'s own
+ * `findAnalysis`. `null` when none match.
+ */
+export function findAnalysisForProv(ref: IdOrName): Result<Analysis | null, DbError> {
+    return findAnalysesByRef(ref).map((rows) => rows[0] ?? null);
+}

--- a/src/modules/prov/document.ts
+++ b/src/modules/prov/document.ts
@@ -131,9 +131,19 @@ export function appendInputRemoved(doc: ProvDocument, analysisId: string, actor:
     doc.wasInvalidatedBy(inputQn, actionQn, time);
 }
 
-/** Build and serialize an analysis's provenance document from its stored PROV-JSON (or a fresh doc), in a tsprov built-in format (`"json"` | `"provn"`). Same-identifier records are unified first. */
+/**
+ * Serialize an analysis's provenance for export. For JSON format, returns the **exact stored bytes**
+ * from the DB column — the same bytes the chain hash was computed over, so the export is verifiable
+ * against the sidecar. For other formats (PROV-N), deserializes and re-serializes into the target
+ * format; this is a lossy conversion that cannot be verified against the chain hash (which is
+ * always over the JSON form).
+ */
 export function serializeProvenance(analysis: Analysis, format: BuiltinProvFormat): Result<string, DbError> {
-    return getAnalysisProvenance(analysis.id).map((json) => loadDocument(analysis, json).unified().serialize(format));
+    return getAnalysisProvenance(analysis.id).map((json) => {
+        if (json === null) return loadDocument(analysis, null).unified().serialize(format);
+        if (format === "json") return json;
+        return loadDocument(analysis, json).unified().serialize(format);
+    });
 }
 
 /**

--- a/src/modules/prov/export.ts
+++ b/src/modules/prov/export.ts
@@ -1,0 +1,76 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
+import { findAnalysisForProv, serializeProvenance } from "./document.ts";
+import { exportPublicKeyJwk } from "./signing.ts";
+import { getAnalysisIntegrity } from "../../db/primary_query.ts";
+import { ensureOutputDir } from "../analysis/output.ts";
+import { dieOn, fail } from "../../lib/cli.ts";
+
+// The export action lives in the `prov` module. Its one cross-module import is `analysis/output.ts`
+// for the default destination (the analysis's own `.inflexa` output folder); `output.ts` imports
+// `anchor`/`env`, NOT `prov`, so this opens no dependency cycle back into `prov`.
+
+/**
+ * `inflexa prov export <analysis> [--format json|provn] [--output <file>]` — serialize an analysis's
+ * provenance document. By DEFAULT writes `provenance.<format>` into the analysis's output folder
+ * (under `.inflexa/`, created if needed); `--output <file>` overrides the destination. When a
+ * signature is available and the public key can be read, a sidecar `.sig.json` is written alongside.
+ */
+export async function runExportProvenance(ref: string, opts: { format?: string; output?: string }): Promise<void> {
+    const format = parseFormat(opts.format);
+    const analysis = findAnalysisForProv(ref).match((a) => a, dieOn("Failed to resolve analysis"));
+    if (!analysis) fail(`No analysis found matching "${ref}".`);
+
+    const document = serializeProvenance(analysis, format).match((s) => s, dieOn("Failed to build provenance"));
+
+    const dest = opts.output ?? ensureOutputDir(analysis).match((dir) => join(dir, `provenance.${format}`), dieOn("Failed to resolve output directory"));
+    try {
+        writeFileSync(dest, document);
+    } catch (cause) {
+        fail(`Failed to write ${dest}`, cause);
+    }
+    console.log(`Wrote ${format} provenance for "${analysis.name}" to ${dest}`);
+
+    await writeSidecar(analysis.id, dest);
+}
+
+/**
+ * Write the verification sidecar (`<dest>.sig.json`) when the analysis has a stored signature
+ * and the public key is available. Silently skipped when either is absent.
+ */
+async function writeSidecar(analysisId: string, provDest: string): Promise<void> {
+    const integrity = getAnalysisIntegrity(analysisId).match(
+        (i) => i,
+        () => null,
+    );
+    if (!integrity?.chainHash || !integrity.signature) return;
+
+    const publicKey = await exportPublicKeyJwk();
+    if (!publicKey) return;
+
+    const sidecar = {
+        payloadType: "application/json; profile=prov-json",
+        payloadDigestAlgorithm: "SHA-256",
+        payloadDigest: integrity.chainHash,
+        payloadDigestMethod: "verbatim",
+        signatureAlgorithm: "Ed25519",
+        signature: integrity.signature,
+        publicKey,
+    };
+    const sigDest = `${provDest}.sig.json`;
+    try {
+        writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
+        console.log(`Wrote verification sidecar to ${sigDest}`);
+    } catch {
+        // Non-fatal: the provenance file was already written successfully.
+        console.warn(`Warning: could not write sidecar to ${sigDest}`);
+    }
+}
+
+/** Validate the `--format` flag against tsprov's built-in formats, defaulting to `json`. */
+function parseFormat(raw: string | undefined): BuiltinProvFormat {
+    const f = (raw ?? "json").toLowerCase();
+    if (f === "json" || f === "provn") return f;
+    fail(`Unknown format "${raw}". Use "json" or "provn".`);
+}

--- a/src/modules/prov/export.ts
+++ b/src/modules/prov/export.ts
@@ -32,7 +32,11 @@ export async function runExportProvenance(ref: string, opts: { format?: string; 
     }
     console.log(`Wrote ${format} provenance for "${analysis.name}" to ${dest}`);
 
-    await writeSidecar(document, dest);
+    // Sidecar is only meaningful for JSON exports — the payloadType claim must match the actual
+    // format, and PROV-N is a lossy re-serialization unverifiable against the chain hash.
+    if (format === "json") {
+        await writeSidecar(document, dest);
+    }
 }
 
 /**

--- a/src/modules/prov/export.ts
+++ b/src/modules/prov/export.ts
@@ -39,17 +39,15 @@ export async function runExportProvenance(ref: string, opts: { format?: string; 
     }
 }
 
-/**
- * Write the verification sidecar (`<dest>.sig.json`) by computing a content digest of the
- * exported provenance and signing it. Silently skipped when no signing key is available.
- */
+/** Write the verification sidecar (`<dest>.sig.json`) alongside the exported provenance file. */
 async function writeSidecar(provJson: string, provDest: string): Promise<void> {
-    const sidecar = await buildSidecar(provJson);
-    if (!sidecar) return;
-
+    const result = await buildSidecar(provJson);
+    if (result.isErr()) {
+        fail(`Signing failed (${result.error.type}) — provenance is never exported unsigned.`);
+    }
     const sigDest = `${provDest}.sig.json`;
     try {
-        writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
+        writeFileSync(sigDest, JSON.stringify(result.value, null, 2));
         console.log(`Wrote verification sidecar to ${sigDest}`);
     } catch {
         // Non-fatal: the provenance file was already written successfully.

--- a/src/modules/prov/export.ts
+++ b/src/modules/prov/export.ts
@@ -2,9 +2,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
 import { findAnalysisForProv, serializeProvenance } from "./document.ts";
-import { exportPublicKeyJwk } from "./signing.ts";
-import { getAnalysisIntegrity } from "../../db/primary_query.ts";
-import type { Sidecar } from "./verify.ts";
+import { buildSidecar } from "./verify.ts";
 import { ensureOutputDir } from "../analysis/output.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
 
@@ -16,7 +14,8 @@ import { dieOn, fail } from "../../lib/cli.ts";
  * `inflexa prov export <analysis> [--format json|provn] [--output <file>]` — serialize an analysis's
  * provenance document. By DEFAULT writes `provenance.<format>` into the analysis's output folder
  * (under `.inflexa/`, created if needed); `--output <file>` overrides the destination. When a
- * signature is available and the public key can be read, a sidecar `.sig.json` is written alongside.
+ * signing key is available, a sidecar `.sig.json` is written alongside with a content digest and
+ * Ed25519 signature for third-party verification.
  */
 export async function runExportProvenance(ref: string, opts: { format?: string; output?: string }): Promise<void> {
     const format = parseFormat(opts.format);
@@ -33,32 +32,17 @@ export async function runExportProvenance(ref: string, opts: { format?: string; 
     }
     console.log(`Wrote ${format} provenance for "${analysis.name}" to ${dest}`);
 
-    await writeSidecar(analysis.id, dest);
+    await writeSidecar(document, dest);
 }
 
 /**
- * Write the verification sidecar (`<dest>.sig.json`) when the analysis has a stored signature
- * and the public key is available. Silently skipped when either is absent.
+ * Write the verification sidecar (`<dest>.sig.json`) by computing a content digest of the
+ * exported provenance and signing it. Silently skipped when no signing key is available.
  */
-async function writeSidecar(analysisId: string, provDest: string): Promise<void> {
-    const integrity = getAnalysisIntegrity(analysisId).match(
-        (i) => i,
-        () => null,
-    );
-    if (!integrity?.chainHash || !integrity.signature) return;
+async function writeSidecar(provJson: string, provDest: string): Promise<void> {
+    const sidecar = await buildSidecar(provJson);
+    if (!sidecar) return;
 
-    const publicKey = await exportPublicKeyJwk();
-    if (!publicKey) return;
-
-    const sidecar: Sidecar = {
-        payloadType: "application/json; profile=prov-json",
-        payloadDigestAlgorithm: "SHA-256",
-        payloadDigest: integrity.chainHash,
-        payloadDigestMethod: "verbatim",
-        signatureAlgorithm: "Ed25519",
-        signature: integrity.signature,
-        publicKey,
-    };
     const sigDest = `${provDest}.sig.json`;
     try {
         writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));

--- a/src/modules/prov/export.ts
+++ b/src/modules/prov/export.ts
@@ -4,6 +4,7 @@ import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
 import { findAnalysisForProv, serializeProvenance } from "./document.ts";
 import { exportPublicKeyJwk } from "./signing.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
+import type { Sidecar } from "./verify.ts";
 import { ensureOutputDir } from "../analysis/output.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
 
@@ -49,7 +50,7 @@ async function writeSidecar(analysisId: string, provDest: string): Promise<void>
     const publicKey = await exportPublicKeyJwk();
     if (!publicKey) return;
 
-    const sidecar = {
+    const sidecar: Sidecar = {
         payloadType: "application/json; profile=prov-json",
         payloadDigestAlgorithm: "SHA-256",
         payloadDigest: integrity.chainHash,

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -11,7 +11,7 @@ import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
 import { appendCreation, appendInputAdded, appendInputRemoved, freshDocument, serializeProvenance } from "./document.ts";
 import { initProvenanceRecording, flushProvenance, flushProvenanceAsync, resetProvenanceRecorderForTests } from "./prov.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
-import { computeChainHash, computePayloadDigest, verifyChainHash, resetSigningForTests, loadOrGenerateKeypair } from "./signing.ts";
+import { computeChainHash, computePayloadDigest, verifyHexDigest, resetSigningForTests, loadOrGenerateKeypair } from "./signing.ts";
 import { verifyProvenance, verifyPayload } from "./verify.ts";
 
 const analysis: Analysis = {
@@ -180,7 +180,7 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
 
         // Verify the Ed25519 signature.
         const kp = await loadOrGenerateKeypair();
-        const ok = await verifyChainHash(kp!.publicKey, integrity!.signature!, integrity!.chainHash!);
+        const ok = await verifyHexDigest(kp!.publicKey, integrity!.signature!, integrity!.chainHash!);
         expect(ok).toBe(true);
 
         resetSigningForTests(null);
@@ -229,7 +229,7 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
 
         // The signature still verifies against the new chain hash.
         const kp = await loadOrGenerateKeypair();
-        const ok = await verifyChainHash(kp!.publicKey, second!.signature!, second!.chainHash!);
+        const ok = await verifyHexDigest(kp!.publicKey, second!.signature!, second!.chainHash!);
         expect(ok).toBe(true);
 
         // verifyProvenance must report "valid" after multi-flush — this was the #CRT-1 bug:

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -9,7 +9,7 @@ import { asStr256 } from "../../lib/types.ts";
 import type { Analysis } from "../../types/analysis.ts";
 import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
 import { appendCreation, appendInputAdded, appendInputRemoved, freshDocument, serializeProvenance } from "./document.ts";
-import { initProvenanceRecording, flushProvenance, flushProvenanceAsync, resetProvenanceRecorderForTests } from "./prov.ts";
+import { initProvenanceRecording, flushProvenanceAsync, resetProvenanceRecorderForTests } from "./prov.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { computeChainHash, computePayloadDigest, verifyHexDigest, resetSigningForTests, loadOrGenerateKeypair } from "./signing.ts";
 import { verifyProvenance, verifyPayload } from "./verify.ts";
@@ -89,14 +89,23 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
     beforeEach(() => {
         freshDb();
         resetProvenanceRecorderForTests();
+        resetSigningForTests(null);
         initProvenanceRecording(); // idempotent: subscribes once across the whole test run
     });
 
-    test("emitted events accumulate in memory and flush to the analyses.provenance column", () => {
+    test("emitted events accumulate in memory and flush to the analyses.provenance column", async () => {
+        const { mkdirSync, rmSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        const tmpDir = join(tmpdir(), `prov-accum-test-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
         insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
         insertAnalysis(analysis)._unsafeUnwrap();
 
-        // No provenance until something is recorded.
         expect(getAnalysisProvenance("a1")._unsafeUnwrap()).toBeNull();
 
         Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
@@ -107,29 +116,38 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
             input: { path: "data.csv", isDir: false, anchorId: "anchor1" },
             derivedFromAnalysisId: null,
         });
-        // Drive the flush synchronously rather than waiting on the coalesced timer.
-        flushProvenance();
+        await flushProvenanceAsync();
 
         const stored = getAnalysisProvenance("a1")._unsafeUnwrap();
         expect(stored).not.toBeNull();
-        // Stored form is valid PROV-JSON that deserializes back into a document holding both agents.
         const doc = ProvDocument.deserialize(stored!, "json");
         const provn = doc.serialize("provn");
         expect(provn).toContain("entity(inflexa:analysis-a1");
         expect(provn).toContain("agent(inflexa:agent-system");
         expect(provn).toContain("agent(inflexa:agent-user-alice_example_org");
 
-        // serializeProvenance reads the same column back for export.
         const exported = serializeProvenance(analysis, "provn")._unsafeUnwrap();
         expect(exported).toContain("used(inflexa:action-");
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    test("reopening deserializes the stored doc and appends onto it", () => {
+    test("reopening deserializes the stored doc and appends onto it", async () => {
+        const { mkdirSync, rmSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        const tmpDir = join(tmpdir(), `prov-reopen-test-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
         insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
         insertAnalysis(analysis)._unsafeUnwrap();
 
         Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
-        flushProvenance();
+        await flushProvenanceAsync();
 
         // Simulate a new process: drop in-memory state so the next event rebuilds from the column.
         resetProvenanceRecorderForTests();
@@ -141,12 +159,14 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
             input: { path: "later.csv", isDir: false, anchorId: "anchor1" },
             derivedFromAnalysisId: null,
         });
-        flushProvenance();
+        await flushProvenanceAsync();
 
-        // The reloaded document retains the creation action AND the later add.
         const provn = serializeProvenance(analysis, "provn")._unsafeUnwrap();
         expect(provn).toContain("inflexa:CreateAnalysis");
         expect(provn).toContain("later.csv");
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
     });
 
     test("async flush signs provenance and the signature verifies against the chain hash", async () => {
@@ -304,23 +324,6 @@ describe("export sidecar (writeSidecar via the full export path)", () => {
 
         resetSigningForTests(null);
         rmSync(tmpDir, { recursive: true, force: true });
-    });
-
-    test("unsigned provenance produces no sidecar", () => {
-        freshDb();
-        resetProvenanceRecorderForTests();
-
-        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
-        insertAnalysis(analysis)._unsafeUnwrap();
-
-        // Sync flush (no signing) leaves integrity columns NULL.
-        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
-        flushProvenance();
-
-        const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
-        expect(integrity!.chainHash).toBeNull();
-        expect(integrity!.signature).toBeNull();
-        // The sidecar writer skips when chainHash/signature are null — no file to check.
     });
 });
 

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ProvDocument } from "@inflexa-ai/tsprov";
+
+import { freshDb } from "../../test_support/db.ts";
+import { insertAnchor, insertAnalysis } from "../../db/primary_mutation.ts";
+import { getAnalysisProvenance } from "../../db/primary_query.ts";
+import { Bus } from "../../lib/bus.ts";
+import { asStr256 } from "../../lib/types.ts";
+import type { Analysis } from "../../types/analysis.ts";
+import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
+import { appendCreation, appendInputAdded, appendInputRemoved, freshDocument, serializeProvenance } from "./document.ts";
+import { initProvenanceRecording, flushProvenance, flushProvenanceAsync, resetProvenanceRecorderForTests } from "./prov.ts";
+import { getAnalysisIntegrity } from "../../db/primary_query.ts";
+import { computeChainHash, verifyChainHash, resetSigningForTests, loadOrGenerateKeypair, exportPublicKeyJwk } from "./signing.ts";
+import { verifyProvenance } from "./verify.ts";
+
+const analysis: Analysis = {
+    id: "a1",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    name: asStr256("My Analysis"),
+    slug: "my-analysis",
+    outputDirectory: null,
+    anchorId: "anchor1",
+    projectId: null,
+};
+
+const user: ProvActor = { kind: "user", email: "alice@example.org" };
+const system: ProvActor = { kind: "system", version: "0.0.1", commit: "abc1234" };
+const anon: ProvActor = { kind: "anonymous" };
+
+function inputRef(path: string): ProvInputRef {
+    return { path, isDir: false, anchorId: "anchor1" };
+}
+
+describe("PROV document building (appendCreation / appendInputAdded / appendInputRemoved)", () => {
+    test("appends each action's PROV records", () => {
+        const doc = freshDocument(analysis);
+        appendCreation(doc, "a1", system);
+        appendInputAdded(doc, "a1", user, inputRef("data.csv"), null);
+        appendInputRemoved(doc, "a1", anon, inputRef("data.csv"));
+        const provn = doc.unified().serialize("provn");
+
+        expect(provn).toContain("entity(inflexa:analysis-a1");
+        expect(provn).toContain("agent(inflexa:agent-system");
+        // qnameSafe replaces every non-[A-Za-z0-9_-] char — so both `@` and `.` become `_`.
+        expect(provn).toContain("agent(inflexa:agent-user-alice_example_org");
+        expect(provn).toContain("agent(inflexa:agent-anonymous");
+        expect(provn).toContain("0.0.1"); // system agent's version
+        expect(provn).toContain("abc1234"); // system agent's source commit (inflexa:commit)
+        expect(provn).toContain("used(inflexa:action-"); // add → used
+        expect(provn).toContain("wasInvalidatedBy(inflexa:input-"); // remove → wasInvalidatedBy
+    });
+
+    test("the same input is one entity across add and remove", () => {
+        const doc = freshDocument(analysis);
+        appendInputAdded(doc, "a1", user, inputRef("data.csv"), null);
+        appendInputRemoved(doc, "a1", user, inputRef("data.csv"));
+        const ids = doc
+            .unified()
+            .getRecords()
+            .map((r) => r.identifier?.toString() ?? "")
+            .filter((id) => id.startsWith("inflexa:input-"));
+        expect(new Set(ids).size).toBe(1);
+    });
+
+    test("unified() collapses an agent re-declared across actions (the B decision)", () => {
+        const doc = freshDocument(analysis);
+        appendInputAdded(doc, "a1", user, inputRef("a.csv"), null);
+        appendInputAdded(doc, "a1", user, inputRef("b.csv"), null);
+        const agents = doc
+            .unified()
+            .getRecords()
+            .map((r) => r.identifier?.toString() ?? "")
+            .filter((id) => id === "inflexa:agent-user-alice_example_org");
+        expect(agents.length).toBe(1);
+    });
+
+    test("round-trips losslessly through PROV-JSON (deserialize is the reload path)", () => {
+        const doc = freshDocument(analysis);
+        appendCreation(doc, "a1", system);
+        const unified = doc.unified();
+        const parsed = ProvDocument.deserialize(unified.serialize("json"), "json");
+        expect(unified.equals(parsed)).toBe(true);
+    });
+});
+
+describe("provenance recorder (bus → in-memory doc → column)", () => {
+    beforeEach(() => {
+        freshDb();
+        resetProvenanceRecorderForTests();
+        initProvenanceRecording(); // idempotent: subscribes once across the whole test run
+    });
+
+    test("emitted events accumulate in memory and flush to the analyses.provenance column", () => {
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        // No provenance until something is recorded.
+        expect(getAnalysisProvenance("a1")._unsafeUnwrap()).toBeNull();
+
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        Bus.emit("inflexa", {
+            type: "prov.input_added",
+            analysisId: "a1",
+            actor: user,
+            input: { path: "data.csv", isDir: false, anchorId: "anchor1" },
+            derivedFromAnalysisId: null,
+        });
+        // Drive the flush synchronously rather than waiting on the coalesced timer.
+        flushProvenance();
+
+        const stored = getAnalysisProvenance("a1")._unsafeUnwrap();
+        expect(stored).not.toBeNull();
+        // Stored form is valid PROV-JSON that deserializes back into a document holding both agents.
+        const doc = ProvDocument.deserialize(stored!, "json");
+        const provn = doc.serialize("provn");
+        expect(provn).toContain("entity(inflexa:analysis-a1");
+        expect(provn).toContain("agent(inflexa:agent-system");
+        expect(provn).toContain("agent(inflexa:agent-user-alice_example_org");
+
+        // serializeProvenance reads the same column back for export.
+        const exported = serializeProvenance(analysis, "provn")._unsafeUnwrap();
+        expect(exported).toContain("used(inflexa:action-");
+    });
+
+    test("reopening deserializes the stored doc and appends onto it", () => {
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        flushProvenance();
+
+        // Simulate a new process: drop in-memory state so the next event rebuilds from the column.
+        resetProvenanceRecorderForTests();
+
+        Bus.emit("inflexa", {
+            type: "prov.input_added",
+            analysisId: "a1",
+            actor: user,
+            input: { path: "later.csv", isDir: false, anchorId: "anchor1" },
+            derivedFromAnalysisId: null,
+        });
+        flushProvenance();
+
+        // The reloaded document retains the creation action AND the later add.
+        const provn = serializeProvenance(analysis, "provn")._unsafeUnwrap();
+        expect(provn).toContain("inflexa:CreateAnalysis");
+        expect(provn).toContain("later.csv");
+    });
+
+    test("async flush signs provenance and the signature verifies against the chain hash", async () => {
+        const { mkdirSync, rmSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        // Use a temp dir for the signing keypair so this test doesn't touch the real config.
+        const tmpDir = join(tmpdir(), `prov-int-test-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        await flushProvenanceAsync();
+
+        const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        expect(integrity).not.toBeNull();
+        expect(integrity!.provenance).not.toBeNull();
+        expect(integrity!.chainHash).not.toBeNull();
+        expect(integrity!.signature).not.toBeNull();
+
+        // Recompute the chain hash from the stored PROV-JSON and verify it matches.
+        const recomputed = await computeChainHash(null, integrity!.provenance!);
+        // Non-null assertions safe: the three `.not.toBeNull()` checks above guard them.
+        expect(recomputed).toBe(integrity!.chainHash!);
+
+        // Verify the Ed25519 signature.
+        const kp = await loadOrGenerateKeypair();
+        const ok = await verifyChainHash(kp!.publicKey, integrity!.signature!, integrity!.chainHash!);
+        expect(ok).toBe(true);
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("second signed flush chains from the first flush's chain hash", async () => {
+        const { mkdirSync, rmSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        const tmpDir = join(tmpdir(), `prov-chain-test-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        // First flush: creation event.
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        await flushProvenanceAsync();
+        const first = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        expect(first!.chainHash).not.toBeNull();
+
+        // Second flush: an input-added event appends to the same document.
+        Bus.emit("inflexa", {
+            type: "prov.input_added",
+            analysisId: "a1",
+            actor: user,
+            input: { path: "extra.csv", isDir: false, anchorId: "anchor1" },
+            derivedFromAnalysisId: null,
+        });
+        await flushProvenanceAsync();
+        const second = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        expect(second!.chainHash).not.toBeNull();
+
+        // The second chain hash must differ from the first (the PROV-JSON grew).
+        expect(second!.chainHash).not.toBe(first!.chainHash);
+
+        // The second chain hash must chain from the first: H2 = SHA-256(H1 || json2).
+        const recomputed = await computeChainHash(first!.chainHash!, second!.provenance!);
+        expect(recomputed).toBe(second!.chainHash!);
+
+        // The signature still verifies against the new chain hash.
+        const kp = await loadOrGenerateKeypair();
+        const ok = await verifyChainHash(kp!.publicKey, second!.signature!, second!.chainHash!);
+        expect(ok).toBe(true);
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+});
+
+describe("export sidecar (writeSidecar via the full export path)", () => {
+    test("signed provenance produces a .sig.json sidecar with the correct shape", async () => {
+        const { mkdirSync, rmSync, existsSync, readFileSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        freshDb();
+        resetProvenanceRecorderForTests();
+        initProvenanceRecording();
+
+        const tmpDir = join(tmpdir(), `prov-sidecar-test-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        await flushProvenanceAsync();
+
+        // Write provenance file, then call the sidecar writer via the export module.
+        const provDest = join(tmpDir, "provenance.json");
+        const provJson = serializeProvenance(analysis, "json")._unsafeUnwrap();
+        const { writeFileSync: wf } = await import("node:fs");
+        wf(provDest, provJson);
+
+        // Import and call the export module's sidecar path indirectly by checking the integrity data.
+        const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        expect(integrity!.chainHash).not.toBeNull();
+        expect(integrity!.signature).not.toBeNull();
+
+        const pubKey = await exportPublicKeyJwk();
+        expect(pubKey).not.toBeNull();
+
+        // Write the sidecar manually (mirrors export.ts:writeSidecar logic) to verify the self-describing shape.
+        const sidecar = {
+            payloadType: "application/json; profile=prov-json",
+            payloadDigestAlgorithm: "SHA-256",
+            payloadDigest: integrity!.chainHash,
+            payloadDigestMethod: "verbatim",
+            signatureAlgorithm: "Ed25519",
+            signature: integrity!.signature,
+            publicKey: pubKey,
+        };
+        const sigDest = `${provDest}.sig.json`;
+        wf(sigDest, JSON.stringify(sidecar, null, 2));
+
+        expect(existsSync(sigDest)).toBe(true);
+        const parsed = JSON.parse(readFileSync(sigDest, "utf-8"));
+        // Self-describing envelope fields.
+        expect(parsed.payloadType).toBe("application/json; profile=prov-json");
+        expect(parsed.payloadDigestAlgorithm).toBe("SHA-256");
+        expect(parsed.payloadDigestMethod).toBe("verbatim");
+        expect(parsed.signatureAlgorithm).toBe("Ed25519");
+        expect(parsed.payloadDigest).toBe(integrity!.chainHash);
+        expect(parsed.signature).toBe(integrity!.signature);
+        expect(parsed.publicKey).toHaveProperty("kty", "OKP");
+        expect(parsed.publicKey).toHaveProperty("crv", "Ed25519");
+
+        // Third-party verification: recompute chain hash from the file, verify the signature with the sidecar public key.
+        const recomputedHash = await computeChainHash(null, provJson);
+        expect(recomputedHash).toBe(parsed.payloadDigest);
+        const importedPub = await crypto.subtle.importKey("jwk", parsed.publicKey, "Ed25519", true, ["verify"]);
+        const ok = await verifyChainHash(importedPub, parsed.signature, parsed.payloadDigest);
+        expect(ok).toBe(true);
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("unsigned provenance produces no sidecar", () => {
+        freshDb();
+        resetProvenanceRecorderForTests();
+
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        // Sync flush (no signing) leaves integrity columns NULL.
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        flushProvenance();
+
+        const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        expect(integrity!.chainHash).toBeNull();
+        expect(integrity!.signature).toBeNull();
+        // The sidecar writer skips when chainHash/signature are null — no file to check.
+    });
+});
+
+describe("verifyProvenance end-to-end (bus → flush → verify)", () => {
+    test("signed provenance round-trips through verifyProvenance as valid", async () => {
+        const { mkdirSync, rmSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        const { tmpdir } = await import("node:os");
+        const { randomUUIDv7: uuid } = await import("bun");
+
+        freshDb();
+        resetProvenanceRecorderForTests();
+        initProvenanceRecording();
+
+        const tmpDir = join(tmpdir(), `prov-e2e-verify-${uuid()}`);
+        mkdirSync(tmpDir, { recursive: true });
+        resetSigningForTests(join(tmpDir, "prov_key.json"));
+
+        insertAnchor({ id: "anchor1", createdAt: 1, updatedAt: 1, cachedPath: "/tmp/x", markerWritten: true, lastSeen: 1 })._unsafeUnwrap();
+        insertAnalysis(analysis)._unsafeUnwrap();
+
+        Bus.emit("inflexa", { type: "prov.analysis_created", analysisId: "a1", actor: system });
+        await flushProvenanceAsync();
+
+        const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
+        const { loadPublicKey } = await import("./signing.ts");
+        const pubKey = await loadPublicKey();
+        const result = await verifyProvenance(integrity!.provenance, integrity!.chainHash, integrity!.signature, pubKey);
+        expect(result.status).toBe("valid");
+
+        resetSigningForTests(null);
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+});

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -11,8 +11,8 @@ import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
 import { appendCreation, appendInputAdded, appendInputRemoved, freshDocument, serializeProvenance } from "./document.ts";
 import { initProvenanceRecording, flushProvenance, flushProvenanceAsync, resetProvenanceRecorderForTests } from "./prov.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
-import { computeChainHash, verifyChainHash, resetSigningForTests, loadOrGenerateKeypair, exportPublicKeyJwk } from "./signing.ts";
-import { verifyProvenance } from "./verify.ts";
+import { computeChainHash, computePayloadDigest, verifyChainHash, resetSigningForTests, loadOrGenerateKeypair } from "./signing.ts";
+import { verifyProvenance, verifyPayload } from "./verify.ts";
 
 const analysis: Analysis = {
     id: "a1",
@@ -172,7 +172,8 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
         expect(integrity!.chainHash).not.toBeNull();
         expect(integrity!.signature).not.toBeNull();
 
-        // Recompute the chain hash from the stored PROV-JSON and verify it matches.
+        // First flush: prevChainHash is null, so recompute seeds from SHA-256("").
+        expect(integrity!.prevChainHash).toBeNull();
         const recomputed = await computeChainHash(null, integrity!.provenance!);
         // Non-null assertions safe: the three `.not.toBeNull()` checks above guard them.
         expect(recomputed).toBe(integrity!.chainHash!);
@@ -219,6 +220,8 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
 
         // The second chain hash must differ from the first (the PROV-JSON grew).
         expect(second!.chainHash).not.toBe(first!.chainHash);
+        // The stored prevChainHash must be the first flush's chain hash.
+        expect(second!.prevChainHash).toBe(first!.chainHash);
 
         // The second chain hash must chain from the first: H2 = SHA-256(H1 || json2).
         const recomputed = await computeChainHash(first!.chainHash!, second!.provenance!);
@@ -228,6 +231,11 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
         const kp = await loadOrGenerateKeypair();
         const ok = await verifyChainHash(kp!.publicKey, second!.signature!, second!.chainHash!);
         expect(ok).toBe(true);
+
+        // verifyProvenance must report "valid" after multi-flush — this was the #CRT-1 bug:
+        // the verifier needs prevChainHash to recompute the rolling hash correctly.
+        const result = await verifyProvenance(second!.provenance, second!.prevChainHash, second!.chainHash, second!.signature, kp!.publicKey);
+        expect(result.status).toBe("valid");
 
         resetSigningForTests(null);
         rmSync(tmpDir, { recursive: true, force: true });
@@ -261,24 +269,16 @@ describe("export sidecar (writeSidecar via the full export path)", () => {
         const { writeFileSync: wf } = await import("node:fs");
         wf(provDest, provJson);
 
-        // Import and call the export module's sidecar path indirectly by checking the integrity data.
+        // The flush should have written integrity columns.
         const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
         expect(integrity!.chainHash).not.toBeNull();
         expect(integrity!.signature).not.toBeNull();
 
-        const pubKey = await exportPublicKeyJwk();
-        expect(pubKey).not.toBeNull();
+        // Build the sidecar via the shared builder (mirrors the export path).
+        const { buildSidecar } = await import("./verify.ts");
+        const sidecar = await buildSidecar(provJson);
+        expect(sidecar).not.toBeNull();
 
-        // Write the sidecar manually (mirrors export.ts:writeSidecar logic) to verify the self-describing shape.
-        const sidecar = {
-            payloadType: "application/json; profile=prov-json",
-            payloadDigestAlgorithm: "SHA-256",
-            payloadDigest: integrity!.chainHash,
-            payloadDigestMethod: "verbatim",
-            signatureAlgorithm: "Ed25519",
-            signature: integrity!.signature,
-            publicKey: pubKey,
-        };
         const sigDest = `${provDest}.sig.json`;
         wf(sigDest, JSON.stringify(sidecar, null, 2));
 
@@ -289,17 +289,18 @@ describe("export sidecar (writeSidecar via the full export path)", () => {
         expect(parsed.payloadDigestAlgorithm).toBe("SHA-256");
         expect(parsed.payloadDigestMethod).toBe("verbatim");
         expect(parsed.signatureAlgorithm).toBe("Ed25519");
-        expect(parsed.payloadDigest).toBe(integrity!.chainHash);
-        expect(parsed.signature).toBe(integrity!.signature);
         expect(parsed.publicKey).toHaveProperty("kty", "OKP");
         expect(parsed.publicKey).toHaveProperty("crv", "Ed25519");
 
-        // Third-party verification: recompute chain hash from the file, verify the signature with the sidecar public key.
-        const recomputedHash = await computeChainHash(null, provJson);
-        expect(recomputedHash).toBe(parsed.payloadDigest);
+        // The sidecar's payloadDigest is a simple SHA-256(provJson), not the chain hash.
+        const contentDigest = await computePayloadDigest(provJson);
+        expect(parsed.payloadDigest).toBe(contentDigest);
+        expect(parsed.payloadDigest).not.toBe(integrity!.chainHash);
+
+        // Third-party verification: recompute digest from the file, verify the signature.
         const importedPub = await crypto.subtle.importKey("jwk", parsed.publicKey, "Ed25519", true, ["verify"]);
-        const ok = await verifyChainHash(importedPub, parsed.signature, parsed.payloadDigest);
-        expect(ok).toBe(true);
+        const result = await verifyPayload(provJson, parsed.payloadDigest, parsed.signature, importedPub);
+        expect(result.status).toBe("valid");
 
         resetSigningForTests(null);
         rmSync(tmpDir, { recursive: true, force: true });
@@ -347,7 +348,7 @@ describe("verifyProvenance end-to-end (bus → flush → verify)", () => {
         const integrity = getAnalysisIntegrity("a1")._unsafeUnwrap();
         const { loadPublicKey } = await import("./signing.ts");
         const pubKey = await loadPublicKey();
-        const result = await verifyProvenance(integrity!.provenance, integrity!.chainHash, integrity!.signature, pubKey);
+        const result = await verifyProvenance(integrity!.provenance, integrity!.prevChainHash, integrity!.chainHash, integrity!.signature, pubKey);
         expect(result.status).toBe("valid");
 
         resetSigningForTests(null);

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -199,9 +199,9 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
         expect(recomputed).toBe(integrity!.chainHash!);
 
         // Verify the Ed25519 signature.
-        const kp = await loadOrGenerateKeypair();
-        const ok = await verifyHexDigest(kp!.publicKey, integrity!.signature!, integrity!.chainHash!);
-        expect(ok).toBe(true);
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
+        const sigOk = await verifyHexDigest(kp.publicKey, integrity!.signature!, integrity!.chainHash!);
+        expect(sigOk).toBe(true);
 
         resetSigningForTests(null);
         rmSync(tmpDir, { recursive: true, force: true });
@@ -248,13 +248,13 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
         expect(recomputed).toBe(second!.chainHash!);
 
         // The signature still verifies against the new chain hash.
-        const kp = await loadOrGenerateKeypair();
-        const ok = await verifyHexDigest(kp!.publicKey, second!.signature!, second!.chainHash!);
-        expect(ok).toBe(true);
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
+        const sigOk = await verifyHexDigest(kp.publicKey, second!.signature!, second!.chainHash!);
+        expect(sigOk).toBe(true);
 
         // verifyProvenance must report "valid" after multi-flush — this was the #CRT-1 bug:
         // the verifier needs prevChainHash to recompute the rolling hash correctly.
-        const result = await verifyProvenance(second!.provenance, second!.prevChainHash, second!.chainHash, second!.signature, kp!.publicKey);
+        const result = await verifyProvenance(second!.provenance, second!.prevChainHash, second!.chainHash, second!.signature, kp.publicKey);
         expect(result.status).toBe("valid");
 
         resetSigningForTests(null);
@@ -296,8 +296,9 @@ describe("export sidecar (writeSidecar via the full export path)", () => {
 
         // Build the sidecar via the shared builder (mirrors the export path).
         const { buildSidecar } = await import("./verify.ts");
-        const sidecar = await buildSidecar(provJson);
-        expect(sidecar).not.toBeNull();
+        const sidecarResult = await buildSidecar(provJson);
+        expect(sidecarResult.isOk()).toBe(true);
+        const sidecar = sidecarResult._unsafeUnwrap();
 
         const sigDest = `${provDest}.sig.json`;
         wf(sigDest, JSON.stringify(sidecar, null, 2));

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -1,0 +1,202 @@
+import type { ProvDocument } from "@inflexa-ai/tsprov";
+import type { StampedEvent } from "../../types/events.ts";
+import type { ProvActor } from "../../types/prov.ts";
+import { Bus } from "../../lib/bus.ts";
+import { bakedEnv } from "../../lib/env.ts";
+import { getLogger } from "../../lib/log.ts";
+import { findAnalysesByRef, getAnalysisIntegrity } from "../../db/primary_query.ts";
+import { updateAnalysisProvenance } from "../../db/primary_mutation.ts";
+import { appendCreation, appendInputAdded, appendInputRemoved, loadDocument } from "./document.ts";
+import { loadOrGenerateKeypair, computeChainHash, signChainHash } from "./signing.ts";
+import { loadAuth } from "../auth/auth.ts";
+import { decodeIdTokenClaims } from "../auth/whoami.ts";
+import pkg from "../../../package.json";
+
+// The provenance recorder: a process-global bus subscriber that keeps each open analysis's PROV
+// document in memory (append-only) and persists it to `analyses.provenance`. Recording is decoupled
+// from the analysis mutations that drive it — they emit typed `prov.*` events and forget; this listens.
+
+// --- Actors ---
+
+/**
+ * The agent responsible for a user-initiated action: the logged-in user's email, or an anonymous
+ * person when unauthenticated. Absence rides the ok channel — a failed/empty auth means anonymous,
+ * never an error (the action still happened and must be recorded).
+ */
+export function currentUserActor(): ProvActor {
+    return loadAuth()
+        .map((auth) => decodeIdTokenClaims(auth.idToken)?.email)
+        .match<ProvActor>(
+            (email) => (email ? { kind: "user", email } : { kind: "anonymous" }),
+            () => ({ kind: "anonymous" }),
+        );
+}
+
+/** The agent for a change inflexa makes autonomously: the CLI itself, stamped with its version and source commit. */
+export function systemActor(): ProvActor {
+    return { kind: "system", version: pkg.version, commit: bakedEnv.gitCommit };
+}
+
+// --- Recorder ---
+
+const log = getLogger("prov");
+
+// One live document per analysis touched this process. The analysis lock means a process drives a
+// single analysis interactively, but keying by id keeps the recorder correct without relying on that.
+const liveDocs = new Map<string, ProvDocument>();
+// Last known chain hash per analysis — loaded from the DB on first touch, updated after each signed
+// flush so subsequent flushes chain correctly without a re-read.
+const chainHashes = new Map<string, string | null>();
+// Analyses whose live doc has appends not yet written to the column, awaiting the next flush.
+const dirty = new Set<string>();
+let flushScheduled = false;
+let subscribed = false;
+
+/**
+ * Subscribe the recorder to the bus. Explicit init (not an import side effect), mirroring
+ * `initBusLogging` — importing this module never starts recording. Must run before any analysis
+ * mutation can emit (so it is wired at CLI startup, alongside `initBusLogging`). Idempotent.
+ */
+export function initProvenanceRecording(): void {
+    if (subscribed) return;
+    subscribed = true;
+    Bus.on("inflexa", onEvent);
+}
+
+function onEvent(event: StampedEvent): void {
+    switch (event.type) {
+        case "prov.analysis_created": {
+            const doc = liveDocForAnalysis(event.analysisId);
+            if (!doc) return;
+            appendCreation(doc, event.analysisId, event.actor);
+            dirty.add(event.analysisId);
+            scheduleFlush();
+            break;
+        }
+        case "prov.input_added": {
+            const doc = liveDocForAnalysis(event.analysisId);
+            if (!doc) return;
+            appendInputAdded(doc, event.analysisId, event.actor, event.input, event.derivedFromAnalysisId);
+            dirty.add(event.analysisId);
+            scheduleFlush();
+            break;
+        }
+        case "prov.input_removed": {
+            const doc = liveDocForAnalysis(event.analysisId);
+            if (!doc) return;
+            appendInputRemoved(doc, event.analysisId, event.actor, event.input);
+            dirty.add(event.analysisId);
+            scheduleFlush();
+            break;
+        }
+        // Non-prov.* events are ignored.
+        default:
+            break;
+    }
+}
+
+/** The analysis's live document — cached, else rebuilt from its stored PROV-JSON, else seeded fresh. `null` only when the analysis row has vanished. */
+function liveDocForAnalysis(analysisId: string): ProvDocument | null {
+    const cached = liveDocs.get(analysisId);
+    if (cached) return cached;
+
+    // First touch this process: the Analysis row supplies the subject entity's name/slug when seeding
+    // a fresh document; the integrity columns supply the prior chain hash for chaining subsequent flushes.
+    const analysis = findAnalysesByRef(analysisId).match(
+        (rows) => rows[0] ?? null,
+        () => null,
+    );
+    if (!analysis) {
+        log.warn({ analysisId }, "prov event for unknown analysis; skipping");
+        return null;
+    }
+    const integrity = getAnalysisIntegrity(analysisId).match(
+        (i) => i,
+        () => null,
+    );
+    const doc = loadDocument(analysis, integrity?.provenance ?? null);
+    liveDocs.set(analysisId, doc);
+    // Seed the chain hash from the stored value so the next flush chains correctly.
+    if (integrity?.chainHash) chainHashes.set(analysisId, integrity.chainHash);
+    return doc;
+}
+
+// Coalesce a burst of appends (e.g. create + N inputs) into one async flush. The in-memory document
+// is authoritative between flushes; a crash in that window loses the un-flushed tail — the accepted
+// trade-off for keeping recording off the synchronous mutation path (the A decision).
+function scheduleFlush(): void {
+    if (flushScheduled) return;
+    flushScheduled = true;
+    setTimeout(() => {
+        flushScheduled = false;
+        void flushProvenanceAsync();
+    }, 0);
+}
+
+/**
+ * Async flush: serialize, compute chain hash, sign, then persist all three columns. This is the
+ * normal path (called from the coalesced `setTimeout`). A signing failure degrades to unsigned —
+ * the provenance is still written, just without integrity columns.
+ */
+async function flushProvenanceAsync(): Promise<void> {
+    for (const analysisId of [...dirty]) {
+        const doc = liveDocs.get(analysisId);
+        if (!doc) {
+            dirty.delete(analysisId);
+            continue;
+        }
+        const json = doc.unified().serialize("json");
+
+        let chainHash: string | null = null;
+        let signature: string | null = null;
+        try {
+            const kp = await loadOrGenerateKeypair();
+            if (kp) {
+                const prev = chainHashes.get(analysisId) ?? null;
+                chainHash = await computeChainHash(prev, json);
+                signature = await signChainHash(kp.privateKey, chainHash);
+            }
+        } catch (cause) {
+            log.warn({ analysisId, cause }, "signing failed; persisting provenance unsigned");
+        }
+
+        updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
+            () => {
+                dirty.delete(analysisId);
+                if (chainHash) chainHashes.set(analysisId, chainHash);
+            },
+            (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
+        );
+    }
+}
+
+/**
+ * Sync exit backstop: persist provenance WITHOUT signing. `process.on("exit")` handlers must be
+ * synchronous — WebCrypto is async, so we cannot sign here. An unsigned flush is strictly better
+ * than losing the un-flushed tail: the data is preserved and `verify` reports "unsigned" rather
+ * than "empty" or stale.
+ */
+export function flushProvenance(): void {
+    for (const analysisId of [...dirty]) {
+        const doc = liveDocs.get(analysisId);
+        if (!doc) {
+            dirty.delete(analysisId);
+            continue;
+        }
+        updateAnalysisProvenance(analysisId, doc.unified().serialize("json")).match(
+            () => dirty.delete(analysisId),
+            (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
+        );
+    }
+}
+
+/** Test-only: drop all in-memory live documents, chain hashes, and pending flushes so a fresh DB starts from a clean recorder. */
+export function resetProvenanceRecorderForTests(): void {
+    liveDocs.clear();
+    chainHashes.clear();
+    dirty.clear();
+    flushScheduled = false;
+}
+
+/** Async flush exposed for tests that need signing (the sync `flushProvenance` skips it). */
+export { flushProvenanceAsync };

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -155,12 +155,14 @@ async function flushProvenanceAsync(): Promise<void> {
         }
         const json = doc.unified().serialize("json");
 
+        const kpResult = await loadOrGenerateKeypair();
+        if (kpResult.isErr()) {
+            log.error({ analysisId, err: kpResult.error.type }, "signing key unavailable; provenance not persisted");
+            return;
+        }
+        const kp = kpResult.value;
+
         try {
-            const kp = await loadOrGenerateKeypair();
-            if (!kp) {
-                log.error({ analysisId }, "no signing key available; provenance not persisted");
-                return;
-            }
             const prev = chainHashes.get(analysisId) ?? null;
             const chainHash = await computeChainHash(prev, json);
             const signature = await signHexDigest(kp.privateKey, chainHash);

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -160,6 +160,8 @@ async function flushProvenanceAsync(): Promise<void> {
             log.warn({ analysisId, cause }, "signing failed; persisting provenance unsigned");
         }
 
+        // The UPDATE atomically rotates provenance_chain_hash → provenance_prev_chain_hash
+        // before writing the new chainHash, so the caller doesn't need to pass prev.
         updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
             () => {
                 dirty.delete(analysisId);

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -106,7 +106,10 @@ function liveDocForAnalysis(analysisId: string): ProvDocument | null {
     // a fresh document; the integrity columns supply the prior chain hash for chaining subsequent flushes.
     const analysis = findAnalysesByRef(analysisId).match(
         (rows) => rows[0] ?? null,
-        () => null,
+        (e) => {
+            log.error({ analysisId, err: e.type, cause: e.cause }, "failed to look up analysis row");
+            return null;
+        },
     );
     if (!analysis) {
         log.warn({ analysisId }, "prov event for unknown analysis; skipping");
@@ -114,7 +117,10 @@ function liveDocForAnalysis(analysisId: string): ProvDocument | null {
     }
     const integrity = getAnalysisIntegrity(analysisId).match(
         (i) => i,
-        () => null,
+        (e) => {
+            log.warn({ analysisId, err: e.type }, "failed to read integrity columns; starting fresh chain");
+            return null;
+        },
     );
     const doc = loadDocument(analysis, integrity?.provenance ?? null);
     liveDocs.set(analysisId, doc);
@@ -145,7 +151,7 @@ function scheduleFlush(): void {
  * analysis signs independently (the keypair is process-cached, so there is no lock contention),
  * and `allSettled` ensures one failure doesn't block the others.
  */
-async function flushProvenanceAsync(): Promise<void> {
+export async function flushProvenanceAsync(): Promise<void> {
     const wg = new WaitGroup();
     wg.goMany([...dirty], async (analysisId) => {
         const doc = liveDocs.get(analysisId);
@@ -191,5 +197,3 @@ export function resetProvenanceRecorderForTests(): void {
     flushTimer = null;
     flushScheduled = false;
 }
-
-export { flushProvenanceAsync };

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -7,7 +7,7 @@ import { getLogger } from "../../lib/log.ts";
 import { findAnalysesByRef, getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { updateAnalysisProvenance } from "../../db/primary_mutation.ts";
 import { appendCreation, appendInputAdded, appendInputRemoved, loadDocument } from "./document.ts";
-import { loadOrGenerateKeypair, computeChainHash, signChainHash } from "./signing.ts";
+import { loadOrGenerateKeypair, computeChainHash, signHexDigest } from "./signing.ts";
 import { loadAuth } from "../auth/auth.ts";
 import { decodeIdTokenClaims } from "../auth/whoami.ts";
 import pkg from "../../../package.json";
@@ -154,7 +154,7 @@ async function flushProvenanceAsync(): Promise<void> {
             if (kp) {
                 const prev = chainHashes.get(analysisId) ?? null;
                 chainHash = await computeChainHash(prev, json);
-                signature = await signChainHash(kp.privateKey, chainHash);
+                signature = await signHexDigest(kp.privateKey, chainHash);
             }
         } catch (cause) {
             log.warn({ analysisId, cause }, "signing failed; persisting provenance unsigned");

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -11,6 +11,7 @@ import { loadOrGenerateKeypair, computeChainHash, signHexDigest } from "./signin
 import { loadAuth } from "../auth/auth.ts";
 import { decodeIdTokenClaims } from "../auth/whoami.ts";
 import pkg from "../../../package.json";
+import { WaitGroup } from "@/lib/wg.ts";
 
 // The provenance recorder: a process-global bus subscriber that keeps each open analysis's PROV
 // document in memory (append-only) and persists it to `analyses.provenance`. Recording is decoupled
@@ -50,6 +51,7 @@ const chainHashes = new Map<string, string | null>();
 // Analyses whose live doc has appends not yet written to the column, awaiting the next flush.
 const dirty = new Set<string>();
 let flushScheduled = false;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let subscribed = false;
 
 /**
@@ -127,69 +129,55 @@ function liveDocForAnalysis(analysisId: string): ProvDocument | null {
 function scheduleFlush(): void {
     if (flushScheduled) return;
     flushScheduled = true;
-    setTimeout(() => {
+    flushTimer = setTimeout(() => {
         flushScheduled = false;
+        flushTimer = null;
         void flushProvenanceAsync();
     }, 0);
 }
 
 /**
- * Async flush: serialize, compute chain hash, sign, then persist all three columns. This is the
- * normal path (called from the coalesced `setTimeout`). A signing failure degrades to unsigned —
- * the provenance is still written, just without integrity columns.
+ * Async flush: serialize, compute chain hash, sign, then persist all three columns atomically.
+ * Every flush is signed — unsigned provenance is never written. A signing failure skips the
+ * persist entirely (the dirty set retains the analysis so the next flush retries). Shutdown
+ * registers this via {@link onShutdown} so un-flushed provenance is signed and persisted before
+ * `process.exit()`. Dirty analyses are flushed concurrently via a {@link WaitGroup} — each
+ * analysis signs independently (the keypair is process-cached, so there is no lock contention),
+ * and `allSettled` ensures one failure doesn't block the others.
  */
 async function flushProvenanceAsync(): Promise<void> {
-    for (const analysisId of [...dirty]) {
+    const wg = new WaitGroup();
+    wg.goMany([...dirty], async (analysisId) => {
         const doc = liveDocs.get(analysisId);
         if (!doc) {
             dirty.delete(analysisId);
-            continue;
+            return;
         }
         const json = doc.unified().serialize("json");
 
-        let chainHash: string | null = null;
-        let signature: string | null = null;
         try {
             const kp = await loadOrGenerateKeypair();
-            if (kp) {
-                const prev = chainHashes.get(analysisId) ?? null;
-                chainHash = await computeChainHash(prev, json);
-                signature = await signHexDigest(kp.privateKey, chainHash);
+            if (!kp) {
+                log.error({ analysisId }, "no signing key available; provenance not persisted");
+                return;
             }
+            const prev = chainHashes.get(analysisId) ?? null;
+            const chainHash = await computeChainHash(prev, json);
+            const signature = await signHexDigest(kp.privateKey, chainHash);
+
+            updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
+                () => {
+                    dirty.delete(analysisId);
+                    chainHashes.set(analysisId, chainHash);
+                },
+                (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
+            );
         } catch (cause) {
-            log.warn({ analysisId, cause }, "signing failed; persisting provenance unsigned");
+            log.error({ analysisId, cause }, "signing failed; provenance not persisted");
         }
+    });
 
-        // The UPDATE atomically rotates provenance_chain_hash → provenance_prev_chain_hash
-        // before writing the new chainHash, so the caller doesn't need to pass prev.
-        updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
-            () => {
-                dirty.delete(analysisId);
-                if (chainHash) chainHashes.set(analysisId, chainHash);
-            },
-            (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
-        );
-    }
-}
-
-/**
- * Sync exit backstop: persist provenance WITHOUT signing. `process.on("exit")` handlers must be
- * synchronous — WebCrypto is async, so we cannot sign here. An unsigned flush is strictly better
- * than losing the un-flushed tail: the data is preserved and `verify` reports "unsigned" rather
- * than "empty" or stale.
- */
-export function flushProvenance(): void {
-    for (const analysisId of [...dirty]) {
-        const doc = liveDocs.get(analysisId);
-        if (!doc) {
-            dirty.delete(analysisId);
-            continue;
-        }
-        updateAnalysisProvenance(analysisId, doc.unified().serialize("json")).match(
-            () => dirty.delete(analysisId),
-            (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
-        );
-    }
+    await wg.wait();
 }
 
 /** Test-only: drop all in-memory live documents, chain hashes, and pending flushes so a fresh DB starts from a clean recorder. */
@@ -197,8 +185,9 @@ export function resetProvenanceRecorderForTests(): void {
     liveDocs.clear();
     chainHashes.clear();
     dirty.clear();
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = null;
     flushScheduled = false;
 }
 
-/** Async flush exposed for tests that need signing (the sync `flushProvenance` skips it). */
 export { flushProvenanceAsync };

--- a/src/modules/prov/signing.test.ts
+++ b/src/modules/prov/signing.test.ts
@@ -28,8 +28,8 @@ afterEach(() => {
 describe("keypair lifecycle", () => {
     test("generates a keypair on first call and persists it", async () => {
         const dir = useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const result = await loadOrGenerateKeypair();
+        expect(result.isOk()).toBe(true);
         const raw = Bun.file(join(dir, "prov_key.json"));
         expect(await raw.exists()).toBe(true);
         const stored = await raw.json();
@@ -39,16 +39,16 @@ describe("keypair lifecycle", () => {
 
     test("loads an existing keypair from disk", async () => {
         useTempKeyDir();
-        const kp1 = await loadOrGenerateKeypair();
-        expect(kp1).not.toBeNull();
+        const r1 = await loadOrGenerateKeypair();
+        expect(r1.isOk()).toBe(true);
         // Drop the in-memory cache, keep the file path, reload from disk.
         resetSigningForTests(join(tempDir!, "prov_key.json"));
-        const kp2 = await loadOrGenerateKeypair();
-        expect(kp2).not.toBeNull();
+        const r2 = await loadOrGenerateKeypair();
+        expect(r2.isOk()).toBe(true);
         // Both keypairs sign the same data to the same signature (Ed25519 is deterministic).
         const hash = await computeChainHash(null, "test");
-        const sig1 = await signHexDigest(kp1!.privateKey, hash);
-        const sig2 = await signHexDigest(kp2!.privateKey, hash);
+        const sig1 = await signHexDigest(r1._unsafeUnwrap().privateKey, hash);
+        const sig2 = await signHexDigest(r2._unsafeUnwrap().privateKey, hash);
         expect(sig1).toBe(sig2);
     });
 
@@ -57,19 +57,20 @@ describe("keypair lifecycle", () => {
         writeFileSync(join(dir, "prov_key.json"), "not json");
         // readKeypairFile returns null for unparseable JSON, so loadOrGenerateKeypair falls
         // through to generate a fresh one — the user gets signing rather than silent degradation.
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const result = await loadOrGenerateKeypair();
+        expect(result.isOk()).toBe(true);
         // The file on disk now contains a valid keypair.
         const stored = await Bun.file(join(dir, "prov_key.json")).json();
         expect(stored.publicKey.kty).toBe("OKP");
     });
 
-    test("structurally valid but wrong JWK degrades to null", async () => {
+    test("structurally valid but wrong JWK returns keypair_corrupt error", async () => {
         const dir = useTempKeyDir();
-        // A file that parses as JSON but has bogus JWK contents — importKey will throw.
+        // A file that parses as JSON but has bogus JWK contents — importKey will fail.
         writeFileSync(join(dir, "prov_key.json"), JSON.stringify({ publicKey: { kty: "BAD" }, privateKey: { kty: "BAD" } }));
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).toBeNull();
+        const result = await loadOrGenerateKeypair();
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().type).toBe("keypair_corrupt");
     });
 
     test("loadPublicKey returns null when no file exists", async () => {
@@ -102,33 +103,30 @@ describe("chain hash computation", () => {
 describe("sign and verify", () => {
     test("round-trip: sign then verify succeeds", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
         const hash = await computeChainHash(null, '{"provenance":"data"}');
-        const sig = await signHexDigest(kp!.privateKey, hash);
+        const sig = await signHexDigest(kp.privateKey, hash);
         expect(sig).toHaveLength(128);
-        const ok = await verifyHexDigest(kp!.publicKey, sig, hash);
-        expect(ok).toBe(true);
+        const valid = await verifyHexDigest(kp.publicKey, sig, hash);
+        expect(valid).toBe(true);
     });
 
     test("tampered chain hash fails verification", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
         const hash = await computeChainHash(null, "original");
-        const sig = await signHexDigest(kp!.privateKey, hash);
+        const sig = await signHexDigest(kp.privateKey, hash);
         const tampered = await computeChainHash(null, "modified");
-        const ok = await verifyHexDigest(kp!.publicKey, sig, tampered);
-        expect(ok).toBe(false);
+        const valid = await verifyHexDigest(kp.publicKey, sig, tampered);
+        expect(valid).toBe(false);
     });
 
     test("Ed25519 signature is deterministic", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
         const hash = await computeChainHash(null, "deterministic");
-        const sig1 = await signHexDigest(kp!.privateKey, hash);
-        const sig2 = await signHexDigest(kp!.privateKey, hash);
+        const sig1 = await signHexDigest(kp.privateKey, hash);
+        const sig2 = await signHexDigest(kp.privateKey, hash);
         expect(sig1).toBe(sig2);
     });
 });

--- a/src/modules/prov/signing.test.ts
+++ b/src/modules/prov/signing.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUIDv7 } from "bun";
+
+import { loadOrGenerateKeypair, loadPublicKey, computeChainHash, signChainHash, verifyChainHash, resetSigningForTests } from "./signing.ts";
+
+let tempDir: string | null = null;
+
+function useTempKeyDir(): string {
+    const dir = join(tmpdir(), `prov-signing-test-${randomUUIDv7()}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "prov_key.json");
+    resetSigningForTests(path);
+    tempDir = dir;
+    return dir;
+}
+
+afterEach(() => {
+    resetSigningForTests(null);
+    if (tempDir) {
+        rmSync(tempDir, { recursive: true, force: true });
+        tempDir = null;
+    }
+});
+
+describe("keypair lifecycle", () => {
+    test("generates a keypair on first call and persists it", async () => {
+        const dir = useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+        const raw = Bun.file(join(dir, "prov_key.json"));
+        expect(await raw.exists()).toBe(true);
+        const stored = await raw.json();
+        expect(stored.publicKey.kty).toBe("OKP");
+        expect(stored.publicKey.crv).toBe("Ed25519");
+    });
+
+    test("loads an existing keypair from disk", async () => {
+        useTempKeyDir();
+        const kp1 = await loadOrGenerateKeypair();
+        expect(kp1).not.toBeNull();
+        // Drop the in-memory cache, keep the file path, reload from disk.
+        resetSigningForTests(join(tempDir!, "prov_key.json"));
+        const kp2 = await loadOrGenerateKeypair();
+        expect(kp2).not.toBeNull();
+        // Both keypairs sign the same data to the same signature (Ed25519 is deterministic).
+        const hash = await computeChainHash(null, "test");
+        const sig1 = await signChainHash(kp1!.privateKey, hash);
+        const sig2 = await signChainHash(kp2!.privateKey, hash);
+        expect(sig1).toBe(sig2);
+    });
+
+    test("corrupt keypair file is replaced with a fresh keypair", async () => {
+        const dir = useTempKeyDir();
+        writeFileSync(join(dir, "prov_key.json"), "not json");
+        // readKeypairFile returns null for unparseable JSON, so loadOrGenerateKeypair falls
+        // through to generate a fresh one — the user gets signing rather than silent degradation.
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+        // The file on disk now contains a valid keypair.
+        const stored = await Bun.file(join(dir, "prov_key.json")).json();
+        expect(stored.publicKey.kty).toBe("OKP");
+    });
+
+    test("structurally valid but wrong JWK degrades to null", async () => {
+        const dir = useTempKeyDir();
+        // A file that parses as JSON but has bogus JWK contents — importKey will throw.
+        writeFileSync(join(dir, "prov_key.json"), JSON.stringify({ publicKey: { kty: "BAD" }, privateKey: { kty: "BAD" } }));
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).toBeNull();
+    });
+
+    test("loadPublicKey returns null when no file exists", async () => {
+        useTempKeyDir();
+        expect(await loadPublicKey()).toBeNull();
+    });
+});
+
+describe("chain hash computation", () => {
+    test("initial chain hash uses SHA-256 of empty as the seed", async () => {
+        const h = await computeChainHash(null, "hello");
+        expect(h).toHaveLength(64);
+        expect(await computeChainHash(null, "hello")).toBe(h);
+    });
+
+    test("different provenance JSON produces a different chain hash", async () => {
+        const h1 = await computeChainHash(null, '{"a":1}');
+        const h2 = await computeChainHash(null, '{"a":2}');
+        expect(h1).not.toBe(h2);
+    });
+
+    test("chaining from a previous hash differs from the initial seed", async () => {
+        const h1 = await computeChainHash(null, "first");
+        const h2 = await computeChainHash(h1, "second");
+        const hAlt = await computeChainHash(null, "second");
+        expect(h2).not.toBe(hAlt);
+    });
+});
+
+describe("sign and verify", () => {
+    test("round-trip: sign then verify succeeds", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+        const hash = await computeChainHash(null, '{"provenance":"data"}');
+        const sig = await signChainHash(kp!.privateKey, hash);
+        expect(sig).toHaveLength(128);
+        const ok = await verifyChainHash(kp!.publicKey, sig, hash);
+        expect(ok).toBe(true);
+    });
+
+    test("tampered chain hash fails verification", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+        const hash = await computeChainHash(null, "original");
+        const sig = await signChainHash(kp!.privateKey, hash);
+        const tampered = await computeChainHash(null, "modified");
+        const ok = await verifyChainHash(kp!.publicKey, sig, tampered);
+        expect(ok).toBe(false);
+    });
+
+    test("Ed25519 signature is deterministic", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+        const hash = await computeChainHash(null, "deterministic");
+        const sig1 = await signChainHash(kp!.privateKey, hash);
+        const sig2 = await signChainHash(kp!.privateKey, hash);
+        expect(sig1).toBe(sig2);
+    });
+});

--- a/src/modules/prov/signing.test.ts
+++ b/src/modules/prov/signing.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
-import { loadOrGenerateKeypair, loadPublicKey, computeChainHash, signChainHash, verifyChainHash, resetSigningForTests } from "./signing.ts";
+import { loadOrGenerateKeypair, loadPublicKey, computeChainHash, signHexDigest, verifyHexDigest, resetSigningForTests } from "./signing.ts";
 
 let tempDir: string | null = null;
 
@@ -47,8 +47,8 @@ describe("keypair lifecycle", () => {
         expect(kp2).not.toBeNull();
         // Both keypairs sign the same data to the same signature (Ed25519 is deterministic).
         const hash = await computeChainHash(null, "test");
-        const sig1 = await signChainHash(kp1!.privateKey, hash);
-        const sig2 = await signChainHash(kp2!.privateKey, hash);
+        const sig1 = await signHexDigest(kp1!.privateKey, hash);
+        const sig2 = await signHexDigest(kp2!.privateKey, hash);
         expect(sig1).toBe(sig2);
     });
 
@@ -105,9 +105,9 @@ describe("sign and verify", () => {
         const kp = await loadOrGenerateKeypair();
         expect(kp).not.toBeNull();
         const hash = await computeChainHash(null, '{"provenance":"data"}');
-        const sig = await signChainHash(kp!.privateKey, hash);
+        const sig = await signHexDigest(kp!.privateKey, hash);
         expect(sig).toHaveLength(128);
-        const ok = await verifyChainHash(kp!.publicKey, sig, hash);
+        const ok = await verifyHexDigest(kp!.publicKey, sig, hash);
         expect(ok).toBe(true);
     });
 
@@ -116,9 +116,9 @@ describe("sign and verify", () => {
         const kp = await loadOrGenerateKeypair();
         expect(kp).not.toBeNull();
         const hash = await computeChainHash(null, "original");
-        const sig = await signChainHash(kp!.privateKey, hash);
+        const sig = await signHexDigest(kp!.privateKey, hash);
         const tampered = await computeChainHash(null, "modified");
-        const ok = await verifyChainHash(kp!.publicKey, sig, tampered);
+        const ok = await verifyHexDigest(kp!.publicKey, sig, tampered);
         expect(ok).toBe(false);
     });
 
@@ -127,8 +127,8 @@ describe("sign and verify", () => {
         const kp = await loadOrGenerateKeypair();
         expect(kp).not.toBeNull();
         const hash = await computeChainHash(null, "deterministic");
-        const sig1 = await signChainHash(kp!.privateKey, hash);
-        const sig2 = await signChainHash(kp!.privateKey, hash);
+        const sig1 = await signHexDigest(kp!.privateKey, hash);
+        const sig2 = await signHexDigest(kp!.privateKey, hash);
         expect(sig1).toBe(sig2);
     });
 });

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -119,9 +119,12 @@ export async function loadPublicKey(): Promise<CryptoKey | null> {
 
 /**
  * Export the public key as JWK for inclusion in an export sidecar — lets a third party verify
- * without access to the keypair file. Returns `null` when no keypair is available.
+ * without access to the keypair file. Prefers the in-memory cached key (avoiding a file re-read
+ * that could race with another process writing a different keypair); falls back to disk when the
+ * keypair hasn't been loaded yet. Returns `null` when no keypair is available.
  */
 export async function exportPublicKeyJwk(): Promise<JWK | null> {
+    if (cached) return crypto.subtle.exportKey("jwk", cached.publicKey);
     const stored = readKeypairFile();
     return stored?.publicKey ?? null;
 }

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -158,6 +158,12 @@ export async function computeChainHash(prevChainHashHex: string | null, provJson
     return bytesToHex(hash);
 }
 
+/** Simple `SHA-256(provJson)` — the self-contained content digest used in the export sidecar. */
+export async function computePayloadDigest(provJson: string): Promise<string> {
+    const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(provJson)));
+    return bytesToHex(hash);
+}
+
 // --- Sign / Verify ---
 
 /** Sign a hex-encoded chain hash with the private key, returning a hex-encoded 64-byte Ed25519 signature. */

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -1,0 +1,181 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { env } from "../../lib/env.ts";
+import { getLogger } from "../../lib/log.ts";
+
+/**
+ * Ed25519 provenance signing: keypair lifecycle (generate-on-first-use, JWK persistence) and the
+ * sign/verify/chain-hash operations the recorder and verifier call. Confined to this file so a
+ * WebCrypto fault is contained to provenance integrity, not recording.
+ *
+ * The keypair lives at `env.provKeyPath` as `{ publicKey: JWK, privateKey: JWK }`. Missing or
+ * corrupt file degrades to unsigned — the caller (flush) still writes provenance, just without
+ * integrity columns.
+ */
+
+const log = getLogger("prov:signing");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- WebCrypto's JsonWebKey is a loose object; we serialize it as-is without inspecting fields.
+type JWK = any;
+
+/** The on-disk JWK keypair shape. */
+type StoredKeypair = { publicKey: JWK; privateKey: JWK };
+
+/** In-memory imported keypair — cached for the process lifetime to avoid re-importing on every flush. */
+export type ImportedKeypair = { publicKey: CryptoKey; privateKey: CryptoKey };
+
+let cached: ImportedKeypair | null = null;
+
+/** Resolve the keypair file path — tests override via `keyPathOverride`; production uses `env.provKeyPath`. */
+let keyPathOverride: string | null = null;
+
+function keyPath(): string {
+    return keyPathOverride ?? env.provKeyPath;
+}
+
+// --- Keypair lifecycle ---
+
+async function generateKeypair(): Promise<CryptoKeyPair> {
+    return crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]) as Promise<CryptoKeyPair>;
+}
+
+async function exportKeypair(kp: CryptoKeyPair): Promise<StoredKeypair> {
+    const [publicKey, privateKey] = await Promise.all([crypto.subtle.exportKey("jwk", kp.publicKey), crypto.subtle.exportKey("jwk", kp.privateKey)]);
+    return { publicKey, privateKey };
+}
+
+async function importKeypair(stored: StoredKeypair): Promise<ImportedKeypair> {
+    const [publicKey, privateKey] = await Promise.all([
+        crypto.subtle.importKey("jwk", stored.publicKey, "Ed25519", true, ["verify"]),
+        crypto.subtle.importKey("jwk", stored.privateKey, "Ed25519", true, ["sign"]),
+    ]);
+    return { publicKey, privateKey };
+}
+
+function readKeypairFile(): StoredKeypair | null {
+    try {
+        return JSON.parse(readFileSync(keyPath(), "utf-8")) as StoredKeypair;
+    } catch {
+        return null;
+    }
+}
+
+function writeKeypairFile(stored: StoredKeypair): void {
+    mkdirSync(dirname(keyPath()), { recursive: true });
+    writeFileSync(keyPath(), JSON.stringify(stored, null, 2));
+}
+
+/**
+ * Load the signing keypair from disk, or generate and persist one on first use. Returns `null`
+ * when the file is corrupt and cannot be re-generated (should not happen in practice — generate
+ * is infallible on supported runtimes). Cached for the process lifetime.
+ */
+export async function loadOrGenerateKeypair(): Promise<ImportedKeypair | null> {
+    if (cached) return cached;
+
+    const stored = readKeypairFile();
+    if (stored) {
+        try {
+            cached = await importKeypair(stored);
+            return cached;
+        } catch (cause) {
+            log.warn({ cause }, "corrupt provenance keypair file; provenance will be unsigned");
+            return null;
+        }
+    }
+
+    try {
+        const kp = await generateKeypair();
+        const exported = await exportKeypair(kp);
+        writeKeypairFile(exported);
+        cached = { publicKey: kp.publicKey, privateKey: kp.privateKey };
+        log.info("generated provenance signing keypair");
+        return cached;
+    } catch (cause) {
+        log.warn({ cause }, "failed to generate provenance keypair; provenance will be unsigned");
+        return null;
+    }
+}
+
+/**
+ * Load only the public key (for verification when the private key is not needed). Returns `null`
+ * when the file is missing or corrupt.
+ */
+export async function loadPublicKey(): Promise<CryptoKey | null> {
+    if (cached) return cached.publicKey;
+    const stored = readKeypairFile();
+    if (!stored) return null;
+    try {
+        return await crypto.subtle.importKey("jwk", stored.publicKey, "Ed25519", true, ["verify"]);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Export the public key as JWK for inclusion in an export sidecar — lets a third party verify
+ * without access to the keypair file. Returns `null` when no keypair is available.
+ */
+export async function exportPublicKeyJwk(): Promise<JWK | null> {
+    const stored = readKeypairFile();
+    return stored?.publicKey ?? null;
+}
+
+// --- Chain hash ---
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+    }
+    return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let hex = "";
+    for (const b of bytes) {
+        hex += b.toString(16).padStart(2, "0");
+    }
+    return hex;
+}
+
+/** The seed for the initial flush's chain hash: `SHA-256("")`, matching the RFC 6962 empty-tree convention. */
+async function emptySeed(): Promise<Uint8Array> {
+    return new Uint8Array(await crypto.subtle.digest("SHA-256", new Uint8Array(0)));
+}
+
+/**
+ * Compute the chain hash: `SHA-256(prevBytes || provJsonBytes)`. When `prevChainHashHex` is null
+ * (first flush), the seed is `SHA-256("")`.
+ */
+export async function computeChainHash(prevChainHashHex: string | null, provJson: string): Promise<string> {
+    const prev = prevChainHashHex ? hexToBytes(prevChainHashHex) : await emptySeed();
+    const jsonBytes = new TextEncoder().encode(provJson);
+    const combined = new Uint8Array(prev.length + jsonBytes.length);
+    combined.set(prev, 0);
+    combined.set(jsonBytes, prev.length);
+    const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", combined));
+    return bytesToHex(hash);
+}
+
+// --- Sign / Verify ---
+
+/** Sign a hex-encoded chain hash with the private key, returning a hex-encoded 64-byte Ed25519 signature. */
+export async function signChainHash(privateKey: CryptoKey, chainHashHex: string): Promise<string> {
+    const data = hexToBytes(chainHashHex);
+    const sig = await crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer);
+    return bytesToHex(new Uint8Array(sig));
+}
+
+/** Verify a hex-encoded signature against a hex-encoded chain hash and a public key. */
+export async function verifyChainHash(publicKey: CryptoKey, signatureHex: string, chainHashHex: string): Promise<boolean> {
+    const sig = hexToBytes(signatureHex);
+    const data = hexToBytes(chainHashHex);
+    return crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer);
+}
+
+/** Reset the cached keypair and optionally override the key path — test-only. */
+export function resetSigningForTests(overridePath?: string | null): void {
+    cached = null;
+    keyPathOverride = overridePath ?? null;
+}

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -25,6 +25,9 @@ type StoredKeypair = { publicKey: JWK; privateKey: JWK };
 export type ImportedKeypair = { publicKey: CryptoKey; privateKey: CryptoKey };
 
 let cached: ImportedKeypair | null = null;
+// Set after a parseable-but-unimportable JWK is encountered, so we don't re-read the file and
+// retry crypto.subtle.importKey on every flush cycle for the rest of the process.
+let importFailed = false;
 
 /** Resolve the keypair file path — tests override via `keyPathOverride`; production uses `env.provKeyPath`. */
 let keyPathOverride: string | null = null;
@@ -72,6 +75,7 @@ function writeKeypairFile(stored: StoredKeypair): void {
  */
 export async function loadOrGenerateKeypair(): Promise<ImportedKeypair | null> {
     if (cached) return cached;
+    if (importFailed) return null;
 
     const stored = readKeypairFile();
     if (stored) {
@@ -79,6 +83,7 @@ export async function loadOrGenerateKeypair(): Promise<ImportedKeypair | null> {
             cached = await importKeypair(stored);
             return cached;
         } catch (cause) {
+            importFailed = true;
             log.warn({ cause }, "corrupt provenance keypair file; provenance will be unsigned");
             return null;
         }
@@ -166,22 +171,23 @@ export async function computePayloadDigest(provJson: string): Promise<string> {
 
 // --- Sign / Verify ---
 
-/** Sign a hex-encoded chain hash with the private key, returning a hex-encoded 64-byte Ed25519 signature. */
-export async function signChainHash(privateKey: CryptoKey, chainHashHex: string): Promise<string> {
-    const data = hexToBytes(chainHashHex);
+/** Sign a hex-encoded digest with the Ed25519 private key, returning a hex-encoded 64-byte signature. */
+export async function signHexDigest(privateKey: CryptoKey, digestHex: string): Promise<string> {
+    const data = hexToBytes(digestHex);
     const sig = await crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer);
     return bytesToHex(new Uint8Array(sig));
 }
 
-/** Verify a hex-encoded signature against a hex-encoded chain hash and a public key. */
-export async function verifyChainHash(publicKey: CryptoKey, signatureHex: string, chainHashHex: string): Promise<boolean> {
+/** Verify a hex-encoded Ed25519 signature against a hex-encoded digest and a public key. */
+export async function verifyHexDigest(publicKey: CryptoKey, signatureHex: string, digestHex: string): Promise<boolean> {
     const sig = hexToBytes(signatureHex);
-    const data = hexToBytes(chainHashHex);
+    const data = hexToBytes(digestHex);
     return crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer);
 }
 
 /** Reset the cached keypair and optionally override the key path — test-only. */
 export function resetSigningForTests(overridePath?: string | null): void {
     cached = null;
+    importFailed = false;
     keyPathOverride = overridePath ?? null;
 }

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -235,6 +235,7 @@ export async function computePayloadDigest(provJson: string): Promise<string> {
 /** Sign a hex-encoded digest with the Ed25519 private key, returning a hex-encoded 64-byte signature. */
 export async function signHexDigest(privateKey: CryptoKey, digestHex: string): Promise<string> {
     const data = hexToBytes(digestHex);
+    // Safe: hexToBytes allocates a fresh Uint8Array, so .buffer starts at offset 0 and is not shared.
     const sig = await crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer);
     return bytesToHex(new Uint8Array(sig));
 }
@@ -243,6 +244,7 @@ export async function signHexDigest(privateKey: CryptoKey, digestHex: string): P
 export async function verifyHexDigest(publicKey: CryptoKey, signatureHex: string, digestHex: string): Promise<boolean> {
     const sig = hexToBytes(signatureHex);
     const data = hexToBytes(digestHex);
+    // Safe: both Uint8Arrays are freshly allocated by hexToBytes — offset 0, not shared.
     return crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer);
 }
 

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, linkSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
+import { type Result, ok, err } from "neverthrow";
 import { env } from "../../lib/env.ts";
 import { getLogger } from "../../lib/log.ts";
 
@@ -8,9 +9,9 @@ import { getLogger } from "../../lib/log.ts";
  * sign/verify/chain-hash operations the recorder and verifier call. Confined to this file so a
  * WebCrypto fault is contained to provenance integrity, not recording.
  *
- * The keypair lives at `env.provKeyPath` as `{ publicKey: JWK, privateKey: JWK }`. Missing or
- * corrupt file degrades to unsigned — the caller (flush) still writes provenance, just without
- * integrity columns.
+ * The keypair lives at `env.provKeyPath` as `{ publicKey: JWK, privateKey: JWK }`. Provenance is
+ * never written unsigned — every failure to obtain the keypair surfaces as a `SigningError` on
+ * the err channel, forcing the caller to handle or propagate rather than silently skip signing.
  */
 
 const log = getLogger("prov:signing");
@@ -23,6 +24,13 @@ type StoredKeypair = { publicKey: JWK; privateKey: JWK };
 
 /** In-memory imported keypair — cached for the process lifetime to avoid re-importing on every flush. */
 export type ImportedKeypair = { publicKey: CryptoKey; privateKey: CryptoKey };
+
+/** Why a signing operation could not obtain the keypair. Every variant is a hard failure — provenance is never written unsigned. */
+export type SigningError =
+    | { type: "keypair_corrupt"; cause?: unknown }
+    | { type: "keypair_generation_failed"; cause: unknown }
+    | { type: "keypair_race_lost" }
+    | { type: "public_key_export_failed" };
 
 let cached: ImportedKeypair | null = null;
 // Set after a parseable-but-unimportable JWK is encountered, so we don't re-read the file and
@@ -63,42 +71,92 @@ function readKeypairFile(): StoredKeypair | null {
     }
 }
 
-function writeKeypairFile(stored: StoredKeypair): void {
-    mkdirSync(dirname(keyPath()), { recursive: true });
-    writeFileSync(keyPath(), JSON.stringify(stored, null, 2));
+/**
+ * Atomically persist the keypair: write to a PID-stamped temp file, then hard-link to the
+ * target path. `linkSync` fails with EEXIST if another process already created the file,
+ * so the winner's key is never overwritten. Returns `"created"` if this process won,
+ * `"exists"` if a valid keypair already occupies the path. If the existing file is corrupt
+ * (unparseable — e.g. leftover from a crash), removes it and retries the link once.
+ */
+function writeKeypairFileExclusive(stored: StoredKeypair): "created" | "exists" {
+    const target = keyPath();
+    mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+    const tmp = `${target}.${process.pid}.tmp`;
+    try {
+        writeFileSync(tmp, JSON.stringify(stored, null, 2), { mode: 0o600 });
+        // Hard-link is atomic and exclusive — fails EEXIST if target was created between
+        // our readKeypairFile() miss and now, preventing the second process from silently
+        // clobbering the first's key.
+        try {
+            linkSync(tmp, target);
+            return "created";
+        } catch (e: unknown) {
+            if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+            // Target exists — check if it's a valid keypair from a concurrent winner, or
+            // corrupt debris (e.g. a crash left partial JSON). If corrupt, remove and retry
+            // the link once; a concurrent process that wins the retry will have a valid file.
+            if (readKeypairFile()) return "exists";
+            try {
+                unlinkSync(target);
+                linkSync(tmp, target);
+                return "created";
+            } catch (retryErr: unknown) {
+                if ((retryErr as NodeJS.ErrnoException).code === "EEXIST") return "exists";
+                throw retryErr;
+            }
+        }
+    } finally {
+        try {
+            unlinkSync(tmp);
+        } catch {
+            // temp may not exist if writeFileSync failed before creating it
+        }
+    }
 }
 
 /**
- * Load the signing keypair from disk, or generate and persist one on first use. Returns `null`
- * when the file is corrupt and cannot be re-generated (should not happen in practice — generate
- * is infallible on supported runtimes). Cached for the process lifetime.
+ * Load the signing keypair from disk, or generate and persist one on first use. Returns
+ * `err(SigningError)` when the keypair cannot be obtained — provenance is never written unsigned.
+ * Cached for the process lifetime.
+ *
+ * Race-safe: if two processes both miss the read and generate concurrently, the exclusive write
+ * ensures exactly one wins; the loser adopts the winner's key from disk.
  */
-export async function loadOrGenerateKeypair(): Promise<ImportedKeypair | null> {
-    if (cached) return cached;
-    if (importFailed) return null;
+export async function loadOrGenerateKeypair(): Promise<Result<ImportedKeypair, SigningError>> {
+    if (cached) return ok(cached);
+    if (importFailed) return err({ type: "keypair_corrupt" });
 
     const stored = readKeypairFile();
     if (stored) {
         try {
             cached = await importKeypair(stored);
-            return cached;
+            return ok(cached);
         } catch (cause) {
             importFailed = true;
-            log.warn({ cause }, "corrupt provenance keypair file; provenance will be unsigned");
-            return null;
+            return err({ type: "keypair_corrupt", cause });
         }
     }
 
     try {
         const kp = await generateKeypair();
         const exported = await exportKeypair(kp);
-        writeKeypairFile(exported);
+        if (writeKeypairFileExclusive(exported) === "exists") {
+            const winner = readKeypairFile();
+            if (!winner) return err({ type: "keypair_race_lost" });
+            try {
+                cached = await importKeypair(winner);
+            } catch (cause) {
+                importFailed = true;
+                return err({ type: "keypair_corrupt", cause });
+            }
+            log.info("adopted provenance signing keypair from concurrent process");
+            return ok(cached);
+        }
         cached = { publicKey: kp.publicKey, privateKey: kp.privateKey };
         log.info("generated provenance signing keypair");
-        return cached;
+        return ok(cached);
     } catch (cause) {
-        log.warn({ cause }, "failed to generate provenance keypair; provenance will be unsigned");
-        return null;
+        return err({ type: "keypair_generation_failed", cause });
     }
 }
 

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -43,59 +43,55 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 
     test("valid: correct chain hash and signature (first flush, prevChainHash = null)", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, provJson);
-        const signature = await signHexDigest(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp.privateKey, chainHash);
 
-        const result = await verifyProvenance(provJson, null, chainHash, signature, kp!.publicKey);
+        const result = await verifyProvenance(provJson, null, chainHash, signature, kp.publicKey);
         expect(result.status).toBe("valid");
     });
 
     test("valid: correct chain hash and signature (second flush, prevChainHash set)", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const firstJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const firstHash = await computeChainHash(null, firstJson);
 
         const secondJson = '{"entity":{"inflexa:analysis-a1":{"extra":true}}}';
         const secondHash = await computeChainHash(firstHash, secondJson);
-        const signature = await signHexDigest(kp!.privateKey, secondHash);
+        const signature = await signHexDigest(kp.privateKey, secondHash);
 
-        const result = await verifyProvenance(secondJson, firstHash, secondHash, signature, kp!.publicKey);
+        const result = await verifyProvenance(secondJson, firstHash, secondHash, signature, kp.publicKey);
         expect(result.status).toBe("valid");
     });
 
     test("tampered: modified PROV-JSON produces chain hash mismatch", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, originalJson);
-        const signature = await signHexDigest(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp.privateKey, chainHash);
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
-        const result = await verifyProvenance(tamperedJson, null, chainHash, signature, kp!.publicKey);
+        const result = await verifyProvenance(tamperedJson, null, chainHash, signature, kp.publicKey);
         expect(result.status).toBe("tampered");
         expect(result.status === "tampered" && result.detail).toContain("chain hash mismatch");
     });
 
     test("tampered: modified signature fails Ed25519 verification", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, provJson);
-        const signature = await signHexDigest(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp.privateKey, chainHash);
         const flipped = signature.slice(0, -2) + (signature.slice(-2) === "00" ? "01" : "00");
 
-        const result = await verifyProvenance(provJson, null, chainHash, flipped, kp!.publicKey);
+        const result = await verifyProvenance(provJson, null, chainHash, flipped, kp.publicKey);
         expect(result.status).toBe("tampered");
         expect(result.status === "tampered" && result.detail).toContain("signature verification failed");
     });
@@ -104,28 +100,26 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 describe("verifyPayload (file-path, simple content digest)", () => {
     test("valid: correct digest and signature", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const digest = await computePayloadDigest(provJson);
-        const signature = await signHexDigest(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp.privateKey, digest);
 
-        const result = await verifyPayload(provJson, digest, signature, kp!.publicKey);
+        const result = await verifyPayload(provJson, digest, signature, kp.publicKey);
         expect(result.status).toBe("valid");
     });
 
     test("tampered: modified file produces digest mismatch", async () => {
         useTempKeyDir();
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const digest = await computePayloadDigest(originalJson);
-        const signature = await signHexDigest(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp.privateKey, digest);
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
-        const result = await verifyPayload(tamperedJson, digest, signature, kp!.publicKey);
+        const result = await verifyPayload(tamperedJson, digest, signature, kp.publicKey);
         expect(result.status).toBe("tampered");
         expect(result.status === "tampered" && result.detail).toContain("payload digest mismatch");
     });
@@ -133,12 +127,11 @@ describe("verifyPayload (file-path, simple content digest)", () => {
 
 describe("runVerifyFile (file-based verification, no DB)", () => {
     async function writeSignedProvFile(dir: string): Promise<{ provPath: string; provJson: string }> {
-        const kp = await loadOrGenerateKeypair();
-        expect(kp).not.toBeNull();
+        const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-file-test":{}}}';
         const digest = await computePayloadDigest(provJson);
-        const signature = await signHexDigest(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp.privateKey, digest);
 
         const { exportPublicKeyJwk } = await import("./signing.ts");
         const publicKey = await exportPublicKeyJwk();

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
-import { verifyProvenance, runVerifyFile } from "./verify.ts";
-import { computeChainHash, signChainHash, loadOrGenerateKeypair, exportPublicKeyJwk, resetSigningForTests } from "./signing.ts";
+import { verifyProvenance, verifyPayload, runVerifyFile } from "./verify.ts";
+import { computeChainHash, computePayloadDigest, signChainHash, loadOrGenerateKeypair, resetSigningForTests } from "./signing.ts";
 
 let tempDir: string | null = null;
 
@@ -25,23 +25,23 @@ afterEach(() => {
     }
 });
 
-describe("verifyProvenance (pure function, all five result variants)", () => {
+describe("verifyProvenance (DB-path, chain hash verification)", () => {
     test("empty: null provenance → status empty", async () => {
-        const result = await verifyProvenance(null, null, null, null);
+        const result = await verifyProvenance(null, null, null, null, null);
         expect(result.status).toBe("empty");
     });
 
     test("unsigned: provenance present but no chain hash or signature", async () => {
-        const result = await verifyProvenance('{"some":"prov"}', null, null, null);
+        const result = await verifyProvenance('{"some":"prov"}', null, null, null, null);
         expect(result.status).toBe("unsigned");
     });
 
     test("no-key: signature exists but no public key provided", async () => {
-        const result = await verifyProvenance('{"some":"prov"}', "abcd".repeat(16), "ef01".repeat(32), null);
+        const result = await verifyProvenance('{"some":"prov"}', null, "abcd".repeat(16), "ef01".repeat(32), null);
         expect(result.status).toBe("no-key");
     });
 
-    test("valid: correct chain hash and signature", async () => {
+    test("valid: correct chain hash and signature (first flush, prevChainHash = null)", async () => {
         useTempKeyDir();
         const kp = await loadOrGenerateKeypair();
         expect(kp).not.toBeNull();
@@ -50,7 +50,23 @@ describe("verifyProvenance (pure function, all five result variants)", () => {
         const chainHash = await computeChainHash(null, provJson);
         const signature = await signChainHash(kp!.privateKey, chainHash);
 
-        const result = await verifyProvenance(provJson, chainHash, signature, kp!.publicKey);
+        const result = await verifyProvenance(provJson, null, chainHash, signature, kp!.publicKey);
+        expect(result.status).toBe("valid");
+    });
+
+    test("valid: correct chain hash and signature (second flush, prevChainHash set)", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const firstJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const firstHash = await computeChainHash(null, firstJson);
+
+        const secondJson = '{"entity":{"inflexa:analysis-a1":{"extra":true}}}';
+        const secondHash = await computeChainHash(firstHash, secondJson);
+        const signature = await signChainHash(kp!.privateKey, secondHash);
+
+        const result = await verifyProvenance(secondJson, firstHash, secondHash, signature, kp!.publicKey);
         expect(result.status).toBe("valid");
     });
 
@@ -64,7 +80,7 @@ describe("verifyProvenance (pure function, all five result variants)", () => {
         const signature = await signChainHash(kp!.privateKey, chainHash);
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
-        const result = await verifyProvenance(tamperedJson, chainHash, signature, kp!.publicKey);
+        const result = await verifyProvenance(tamperedJson, null, chainHash, signature, kp!.publicKey);
         expect(result.status).toBe("tampered");
         expect(result.status === "tampered" && result.detail).toContain("chain hash mismatch");
     });
@@ -76,13 +92,42 @@ describe("verifyProvenance (pure function, all five result variants)", () => {
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, provJson);
-        // Sign the correct hash, then flip a byte in the signature.
         const signature = await signChainHash(kp!.privateKey, chainHash);
         const flipped = signature.slice(0, -2) + (signature.slice(-2) === "00" ? "01" : "00");
 
-        const result = await verifyProvenance(provJson, chainHash, flipped, kp!.publicKey);
+        const result = await verifyProvenance(provJson, null, chainHash, flipped, kp!.publicKey);
         expect(result.status).toBe("tampered");
         expect(result.status === "tampered" && result.detail).toContain("signature verification failed");
+    });
+});
+
+describe("verifyPayload (file-path, simple content digest)", () => {
+    test("valid: correct digest and signature", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const digest = await computePayloadDigest(provJson);
+        const signature = await signChainHash(kp!.privateKey, digest);
+
+        const result = await verifyPayload(provJson, digest, signature, kp!.publicKey);
+        expect(result.status).toBe("valid");
+    });
+
+    test("tampered: modified file produces digest mismatch", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const digest = await computePayloadDigest(originalJson);
+        const signature = await signChainHash(kp!.privateKey, digest);
+
+        const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
+        const result = await verifyPayload(tamperedJson, digest, signature, kp!.publicKey);
+        expect(result.status).toBe("tampered");
+        expect(result.status === "tampered" && result.detail).toContain("payload digest mismatch");
     });
 });
 
@@ -92,8 +137,10 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         expect(kp).not.toBeNull();
 
         const provJson = '{"entity":{"inflexa:analysis-file-test":{}}}';
-        const chainHash = await computeChainHash(null, provJson);
-        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const digest = await computePayloadDigest(provJson);
+        const signature = await signChainHash(kp!.privateKey, digest);
+
+        const { exportPublicKeyJwk } = await import("./signing.ts");
         const publicKey = await exportPublicKeyJwk();
 
         const provPath = join(dir, "provenance.json");
@@ -102,7 +149,7 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         const sidecar = {
             payloadType: "application/json; profile=prov-json",
             payloadDigestAlgorithm: "SHA-256",
-            payloadDigest: chainHash,
+            payloadDigest: digest,
             payloadDigestMethod: "verbatim",
             signatureAlgorithm: "Ed25519",
             signature,
@@ -116,7 +163,6 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         useTempKeyDir();
         const { provPath } = await writeSignedProvFile(tempDir!);
 
-        // Capture stdout to check the output.
         const origLog = console.log;
         let output = "";
         console.log = (msg: string) => {
@@ -132,7 +178,6 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         useTempKeyDir();
         const { provPath } = await writeSignedProvFile(tempDir!);
 
-        // Tamper with the provenance file after signing.
         writeFileSync(provPath, '{"entity":{"inflexa:analysis-file-test":{"tampered":true}}}');
 
         const origLog = console.log;
@@ -153,7 +198,6 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         useTempKeyDir();
         const provPath = join(tempDir!, "no-sidecar.json");
         writeFileSync(provPath, '{"entity":{}}');
-        // No .sig.json written.
 
         const origLog = console.log;
         let output = "";

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -125,6 +125,26 @@ describe("verifyPayload (file-path, simple content digest)", () => {
     });
 });
 
+/**
+ * Run `fn` with console.log captured into a string. Restores console.log and process.exitCode
+ * on exit (even if `fn` throws), so one test's side effects don't leak into the next.
+ */
+async function captureConsole(fn: () => Promise<void>): Promise<{ output: string; exitCode: typeof process.exitCode }> {
+    const origLog = console.log;
+    const origExitCode = process.exitCode;
+    let output = "";
+    console.log = (msg: string) => {
+        output += msg;
+    };
+    try {
+        await fn();
+        return { output, exitCode: process.exitCode };
+    } finally {
+        console.log = origLog;
+        process.exitCode = origExitCode;
+    }
+}
+
 describe("runVerifyFile (file-based verification, no DB)", () => {
     async function writeSignedProvFile(dir: string): Promise<{ provPath: string; provJson: string }> {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
@@ -156,14 +176,7 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         useTempKeyDir();
         const { provPath } = await writeSignedProvFile(tempDir!);
 
-        const origLog = console.log;
-        let output = "";
-        console.log = (msg: string) => {
-            output += msg;
-        };
-        await runVerifyFile(provPath);
-        console.log = origLog;
-
+        const { output } = await captureConsole(() => runVerifyFile(provPath));
         expect(output).toContain("verified");
     });
 
@@ -173,21 +186,9 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
 
         writeFileSync(provPath, '{"entity":{"inflexa:analysis-file-test":{"tampered":true}}}');
 
-        const origLog = console.log;
-        let output = "";
-        console.log = (msg: string) => {
-            output += msg;
-        };
-        try {
-            await runVerifyFile(provPath);
-
-            expect(output).toContain("FAILED");
-            expect(process.exitCode).toBe(1);
-        } finally {
-            console.log = origLog;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- restore exitCode so a throw above doesn't poison the runner's exit status
-            (process as any).exitCode = 0;
-        }
+        const { output, exitCode } = await captureConsole(() => runVerifyFile(provPath));
+        expect(output).toContain("FAILED");
+        expect(exitCode).toBe(1);
     });
 
     test("missing sidecar: reports that verification is not possible", async () => {
@@ -195,14 +196,7 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         const provPath = join(tempDir!, "no-sidecar.json");
         writeFileSync(provPath, '{"entity":{}}');
 
-        const origLog = console.log;
-        let output = "";
-        console.log = (msg: string) => {
-            output += msg;
-        };
-        await runVerifyFile(provPath);
-        console.log = origLog;
-
+        const { output } = await captureConsole(() => runVerifyFile(provPath));
         expect(output).toContain("No sidecar found");
     });
 });

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUIDv7 } from "bun";
+
+import { verifyProvenance, runVerifyFile } from "./verify.ts";
+import { computeChainHash, signChainHash, loadOrGenerateKeypair, exportPublicKeyJwk, resetSigningForTests } from "./signing.ts";
+
+let tempDir: string | null = null;
+
+function useTempKeyDir(): string {
+    const dir = join(tmpdir(), `prov-verify-test-${randomUUIDv7()}`);
+    mkdirSync(dir, { recursive: true });
+    resetSigningForTests(join(dir, "prov_key.json"));
+    tempDir = dir;
+    return dir;
+}
+
+afterEach(() => {
+    resetSigningForTests(null);
+    if (tempDir) {
+        rmSync(tempDir, { recursive: true, force: true });
+        tempDir = null;
+    }
+});
+
+describe("verifyProvenance (pure function, all five result variants)", () => {
+    test("empty: null provenance → status empty", async () => {
+        const result = await verifyProvenance(null, null, null, null);
+        expect(result.status).toBe("empty");
+    });
+
+    test("unsigned: provenance present but no chain hash or signature", async () => {
+        const result = await verifyProvenance('{"some":"prov"}', null, null, null);
+        expect(result.status).toBe("unsigned");
+    });
+
+    test("no-key: signature exists but no public key provided", async () => {
+        const result = await verifyProvenance('{"some":"prov"}', "abcd".repeat(16), "ef01".repeat(32), null);
+        expect(result.status).toBe("no-key");
+    });
+
+    test("valid: correct chain hash and signature", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const chainHash = await computeChainHash(null, provJson);
+        const signature = await signChainHash(kp!.privateKey, chainHash);
+
+        const result = await verifyProvenance(provJson, chainHash, signature, kp!.publicKey);
+        expect(result.status).toBe("valid");
+    });
+
+    test("tampered: modified PROV-JSON produces chain hash mismatch", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const chainHash = await computeChainHash(null, originalJson);
+        const signature = await signChainHash(kp!.privateKey, chainHash);
+
+        const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
+        const result = await verifyProvenance(tamperedJson, chainHash, signature, kp!.publicKey);
+        expect(result.status).toBe("tampered");
+        expect(result.status === "tampered" && result.detail).toContain("chain hash mismatch");
+    });
+
+    test("tampered: modified signature fails Ed25519 verification", async () => {
+        useTempKeyDir();
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
+        const chainHash = await computeChainHash(null, provJson);
+        // Sign the correct hash, then flip a byte in the signature.
+        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const flipped = signature.slice(0, -2) + (signature.slice(-2) === "00" ? "01" : "00");
+
+        const result = await verifyProvenance(provJson, chainHash, flipped, kp!.publicKey);
+        expect(result.status).toBe("tampered");
+        expect(result.status === "tampered" && result.detail).toContain("signature verification failed");
+    });
+});
+
+describe("runVerifyFile (file-based verification, no DB)", () => {
+    async function writeSignedProvFile(dir: string): Promise<{ provPath: string; provJson: string }> {
+        const kp = await loadOrGenerateKeypair();
+        expect(kp).not.toBeNull();
+
+        const provJson = '{"entity":{"inflexa:analysis-file-test":{}}}';
+        const chainHash = await computeChainHash(null, provJson);
+        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const publicKey = await exportPublicKeyJwk();
+
+        const provPath = join(dir, "provenance.json");
+        writeFileSync(provPath, provJson);
+
+        const sidecar = {
+            payloadType: "application/json; profile=prov-json",
+            payloadDigestAlgorithm: "SHA-256",
+            payloadDigest: chainHash,
+            payloadDigestMethod: "verbatim",
+            signatureAlgorithm: "Ed25519",
+            signature,
+            publicKey,
+        };
+        writeFileSync(`${provPath}.sig.json`, JSON.stringify(sidecar, null, 2));
+        return { provPath, provJson };
+    }
+
+    test("valid: provenance file + sidecar verify successfully", async () => {
+        useTempKeyDir();
+        const { provPath } = await writeSignedProvFile(tempDir!);
+
+        // Capture stdout to check the output.
+        const origLog = console.log;
+        let output = "";
+        console.log = (msg: string) => {
+            output += msg;
+        };
+        await runVerifyFile(provPath);
+        console.log = origLog;
+
+        expect(output).toContain("verified");
+    });
+
+    test("tampered: modified provenance file is detected", async () => {
+        useTempKeyDir();
+        const { provPath } = await writeSignedProvFile(tempDir!);
+
+        // Tamper with the provenance file after signing.
+        writeFileSync(provPath, '{"entity":{"inflexa:analysis-file-test":{"tampered":true}}}');
+
+        const origLog = console.log;
+        let output = "";
+        console.log = (msg: string) => {
+            output += msg;
+        };
+        await runVerifyFile(provPath);
+        console.log = origLog;
+
+        expect(output).toContain("FAILED");
+        expect(process.exitCode).toBe(1);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- resetting exitCode to 0 after the tampered test so it doesn't leak into the test runner's exit status
+        (process as any).exitCode = 0;
+    });
+
+    test("missing sidecar: reports that verification is not possible", async () => {
+        useTempKeyDir();
+        const provPath = join(tempDir!, "no-sidecar.json");
+        writeFileSync(provPath, '{"entity":{}}');
+        // No .sig.json written.
+
+        const origLog = console.log;
+        let output = "";
+        console.log = (msg: string) => {
+            output += msg;
+        };
+        await runVerifyFile(provPath);
+        console.log = origLog;
+
+        expect(output).toContain("No sidecar found");
+    });
+});

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
 import { verifyProvenance, verifyPayload, runVerifyFile } from "./verify.ts";
-import { computeChainHash, computePayloadDigest, signChainHash, loadOrGenerateKeypair, resetSigningForTests } from "./signing.ts";
+import { computeChainHash, computePayloadDigest, signHexDigest, loadOrGenerateKeypair, resetSigningForTests } from "./signing.ts";
 
 let tempDir: string | null = null;
 
@@ -48,7 +48,7 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, provJson);
-        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp!.privateKey, chainHash);
 
         const result = await verifyProvenance(provJson, null, chainHash, signature, kp!.publicKey);
         expect(result.status).toBe("valid");
@@ -64,7 +64,7 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 
         const secondJson = '{"entity":{"inflexa:analysis-a1":{"extra":true}}}';
         const secondHash = await computeChainHash(firstHash, secondJson);
-        const signature = await signChainHash(kp!.privateKey, secondHash);
+        const signature = await signHexDigest(kp!.privateKey, secondHash);
 
         const result = await verifyProvenance(secondJson, firstHash, secondHash, signature, kp!.publicKey);
         expect(result.status).toBe("valid");
@@ -77,7 +77,7 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, originalJson);
-        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp!.privateKey, chainHash);
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
         const result = await verifyProvenance(tamperedJson, null, chainHash, signature, kp!.publicKey);
@@ -92,7 +92,7 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const chainHash = await computeChainHash(null, provJson);
-        const signature = await signChainHash(kp!.privateKey, chainHash);
+        const signature = await signHexDigest(kp!.privateKey, chainHash);
         const flipped = signature.slice(0, -2) + (signature.slice(-2) === "00" ? "01" : "00");
 
         const result = await verifyProvenance(provJson, null, chainHash, flipped, kp!.publicKey);
@@ -109,7 +109,7 @@ describe("verifyPayload (file-path, simple content digest)", () => {
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const digest = await computePayloadDigest(provJson);
-        const signature = await signChainHash(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp!.privateKey, digest);
 
         const result = await verifyPayload(provJson, digest, signature, kp!.publicKey);
         expect(result.status).toBe("valid");
@@ -122,7 +122,7 @@ describe("verifyPayload (file-path, simple content digest)", () => {
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
         const digest = await computePayloadDigest(originalJson);
-        const signature = await signChainHash(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp!.privateKey, digest);
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
         const result = await verifyPayload(tamperedJson, digest, signature, kp!.publicKey);
@@ -138,7 +138,7 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
 
         const provJson = '{"entity":{"inflexa:analysis-file-test":{}}}';
         const digest = await computePayloadDigest(provJson);
-        const signature = await signChainHash(kp!.privateKey, digest);
+        const signature = await signHexDigest(kp!.privateKey, digest);
 
         const { exportPublicKeyJwk } = await import("./signing.ts");
         const publicKey = await exportPublicKeyJwk();

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -185,13 +185,16 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         console.log = (msg: string) => {
             output += msg;
         };
-        await runVerifyFile(provPath);
-        console.log = origLog;
+        try {
+            await runVerifyFile(provPath);
 
-        expect(output).toContain("FAILED");
-        expect(process.exitCode).toBe(1);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- resetting exitCode to 0 after the tampered test so it doesn't leak into the test runner's exit status
-        (process as any).exitCode = 0;
+            expect(output).toContain("FAILED");
+            expect(process.exitCode).toBe(1);
+        } finally {
+            console.log = origLog;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- restore exitCode so a throw above doesn't poison the runner's exit status
+            (process as any).exitCode = 0;
+        }
     });
 
     test("missing sidecar: reports that verification is not possible", async () => {

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -5,6 +5,7 @@ import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { findAnalysisForProv } from "./document.ts";
 import { type Result, ok, err } from "neverthrow";
+import { getLogger } from "../../lib/log.ts";
 import {
     computeChainHash,
     computePayloadDigest,
@@ -16,6 +17,8 @@ import {
     type SigningError,
 } from "./signing.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
+
+const log = getLogger("prov:verify");
 
 /**
  * DB-path verification: recompute the rolling chain hash from `prevChainHash` and the stored
@@ -41,8 +44,8 @@ export async function verifyProvenance(
         return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
     }
 
-    const ok = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
-    if (!ok) {
+    const sigOk = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
+    if (!sigOk) {
         return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
     }
 
@@ -60,8 +63,8 @@ export async function verifyPayload(provJson: string, storedDigest: string, stor
         return { status: "tampered", detail: "payload digest mismatch: the provenance file has been modified since it was signed" };
     }
 
-    const ok = await verifyHexDigest(publicKey, storedSignature, storedDigest);
-    if (!ok) {
+    const sigOk = await verifyHexDigest(publicKey, storedSignature, storedDigest);
+    if (!sigOk) {
         return { status: "tampered", detail: "signature verification failed: the digest or signature has been modified" };
     }
 
@@ -96,7 +99,10 @@ export function formatVerifyResult(result: VerifyResult): string {
 export async function verifyAnalysisIntegrity(analysisId: string): Promise<VerifyResult | null> {
     const integrity = getAnalysisIntegrity(analysisId).match(
         (i) => i,
-        () => null,
+        (e) => {
+            log.error({ analysisId, err: e.type, cause: e.cause }, "failed to read integrity columns");
+            return null;
+        },
     );
     if (!integrity) return null;
 

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -4,7 +4,17 @@ import type { VerifyResult } from "../../types/prov.ts";
 import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { findAnalysisForProv } from "./document.ts";
-import { computeChainHash, computePayloadDigest, verifyHexDigest, loadPublicKey, loadOrGenerateKeypair, exportPublicKeyJwk, signHexDigest } from "./signing.ts";
+import { type Result, ok, err } from "neverthrow";
+import {
+    computeChainHash,
+    computePayloadDigest,
+    verifyHexDigest,
+    loadPublicKey,
+    loadOrGenerateKeypair,
+    exportPublicKeyJwk,
+    signHexDigest,
+    type SigningError,
+} from "./signing.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
 
 /**
@@ -138,21 +148,22 @@ export type Sidecar = z.infer<typeof sidecarSchema>;
 
 /**
  * Build a sidecar for an exported provenance file. Computes `SHA-256(provJson)` as the content
- * digest and signs it with the Ed25519 private key. Returns `null` when no signing key is
- * available. The sidecar is self-contained — a recipient verifies with just the file and the
- * sidecar, no chain history or database access needed.
+ * digest and signs it with the Ed25519 private key. Returns `err(SigningError)` when the signing
+ * key is unavailable — provenance is never exported unsigned. The sidecar is self-contained — a
+ * recipient verifies with just the file and the sidecar, no chain history or database access needed.
  */
-export async function buildSidecar(provJson: string): Promise<Sidecar | null> {
-    const kp = await loadOrGenerateKeypair();
-    if (!kp) return null;
+export async function buildSidecar(provJson: string): Promise<Result<Sidecar, SigningError>> {
+    const kpResult = await loadOrGenerateKeypair();
+    if (kpResult.isErr()) return err(kpResult.error);
+    const kp = kpResult.value;
 
     const publicKeyJwk = await exportPublicKeyJwk();
-    if (!publicKeyJwk) return null;
+    if (!publicKeyJwk) return err({ type: "public_key_export_failed" });
 
     const digest = await computePayloadDigest(provJson);
     const signature = await signHexDigest(kp.privateKey, digest);
 
-    return {
+    return ok({
         payloadType: "application/json; profile=prov-json",
         payloadDigestAlgorithm: "SHA-256",
         payloadDigest: digest,
@@ -160,7 +171,7 @@ export async function buildSidecar(provJson: string): Promise<Sidecar | null> {
         signatureAlgorithm: "Ed25519",
         signature,
         publicKey: publicKeyJwk as Record<string, unknown>,
-    };
+    });
 }
 
 /** Parse a `.sig.json` sidecar file, returning `null` on missing/corrupt/malformed. */
@@ -199,7 +210,12 @@ export async function verifyExportFile(provPath: string): Promise<VerifyResult |
         return { status: "invalid-key" };
     }
 
-    const provJson = readFileSync(provPath, "utf-8");
+    let provJson: string;
+    try {
+        provJson = readFileSync(provPath, "utf-8");
+    } catch {
+        return { status: "tampered", detail: `provenance file at ${provPath} is missing or unreadable` };
+    }
     return verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
 }
 

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -1,0 +1,126 @@
+import { readFileSync, existsSync } from "node:fs";
+import type { VerifyResult } from "../../types/prov.ts";
+import type { IdOrName } from "../../lib/types.ts";
+import { getAnalysisIntegrity } from "../../db/primary_query.ts";
+import { findAnalysisForProv } from "./document.ts";
+import { computeChainHash, verifyChainHash, loadPublicKey } from "./signing.ts";
+import { dieOn, fail } from "../../lib/cli.ts";
+
+/**
+ * Pure verification: recompute the chain hash from the stored PROV-JSON and check the signature.
+ * All inputs are passed in — no DB or file I/O here, so the function is directly unit-testable.
+ */
+export async function verifyProvenance(
+    provJson: string | null,
+    storedChainHash: string | null,
+    storedSignature: string | null,
+    publicKey: CryptoKey | null,
+): Promise<VerifyResult> {
+    if (provJson === null) return { status: "empty" };
+    if (storedChainHash === null || storedSignature === null) return { status: "unsigned" };
+    if (publicKey === null) return { status: "no-key" };
+
+    const recomputed = await computeChainHash(null, provJson);
+    if (recomputed !== storedChainHash) {
+        return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
+    }
+
+    const ok = await verifyChainHash(publicKey, storedSignature, storedChainHash);
+    if (!ok) {
+        return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
+    }
+
+    return { status: "valid" };
+}
+
+/** Format a {@link VerifyResult} as a human-readable line for CLI output or TUI notice. */
+export function formatVerifyResult(result: VerifyResult): string {
+    switch (result.status) {
+        case "valid":
+            return "Provenance integrity verified: chain hash and signature are valid.";
+        case "unsigned":
+            return "Provenance is unsigned (recorded before integrity was enabled, or without a signing key).";
+        case "tampered":
+            return `Provenance integrity FAILED: ${result.detail}`;
+        case "no-key":
+            return "Cannot verify: a signature exists but the signing key file is missing.";
+        case "empty":
+            return "No provenance has been recorded for this analysis.";
+    }
+}
+
+/**
+ * CLI action for `inflexa prov verify <analysis>`: resolve the analysis, load integrity data
+ * from the DB, load the public key, run verification, and print the result.
+ */
+export async function runVerifyProvenance(ref: string): Promise<void> {
+    const analysis = findAnalysisForProv(ref as IdOrName).match((a) => a, dieOn("Failed to resolve analysis"));
+    if (!analysis) fail(`No analysis found matching "${ref}".`);
+
+    const integrity = getAnalysisIntegrity(analysis.id).match((i) => i, dieOn("Failed to read provenance"));
+    if (!integrity) fail(`No analysis row for "${ref}".`);
+
+    const publicKey = await loadPublicKey();
+    const result = await verifyProvenance(integrity.provenance, integrity.chainHash, integrity.signature, publicKey);
+    console.log(formatVerifyResult(result));
+
+    if (result.status === "tampered") process.exitCode = 1;
+}
+
+/** The self-describing sidecar shape written by export.ts. */
+type Sidecar = {
+    payloadType: string;
+    payloadDigestAlgorithm: string;
+    payloadDigest: string;
+    payloadDigestMethod: string;
+    signatureAlgorithm: string;
+    signature: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JWK is a loose object from the sidecar file; we pass it straight to crypto.subtle.importKey which validates it.
+    publicKey: any;
+};
+
+function readSidecar(sigPath: string): Sidecar | null {
+    try {
+        return JSON.parse(readFileSync(sigPath, "utf-8")) as Sidecar;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * CLI action for `inflexa prov verify-file <path>`: verify an exported provenance file against
+ * its `.sig.json` sidecar. No database or analysis row needed — a colleague who receives the
+ * exported files can run this to confirm integrity.
+ */
+export async function runVerifyFile(path: string): Promise<void> {
+    if (!existsSync(path)) fail(`File not found: ${path}`);
+
+    const sigPath = `${path}.sig.json`;
+    if (!existsSync(sigPath)) {
+        console.log("No sidecar found: the provenance file cannot be verified without a .sig.json sidecar.");
+        return;
+    }
+
+    const sidecar = readSidecar(sigPath);
+    if (!sidecar?.payloadDigest || !sidecar.signature || !sidecar.publicKey) {
+        fail(`Sidecar at ${sigPath} is missing required fields.`);
+    }
+
+    // TODO(robustness): the public key is trusted solely because it travels in the sidecar — an
+    // attacker who replaces both the provenance file and the sidecar (with their own key) passes
+    // verification. For teammate-to-teammate sharing over trusted channels this is fine; for stronger
+    // trust, support key pinning: the verifier registers the signer's public key once, then future
+    // verify-file calls check the sidecar's key against the pinned one.
+    let publicKey: CryptoKey;
+    try {
+        publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
+    } catch {
+        fail("The public key in the sidecar is invalid or unsupported.");
+    }
+
+    const provJson = readFileSync(path, "utf-8");
+    const result = await verifyProvenance(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
+    console.log(formatVerifyResult(result));
+
+    if (result.status === "tampered") process.exitCode = 1;
+}

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from "node:fs";
+import { z } from "zod";
 import type { VerifyResult } from "../../types/prov.ts";
 import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
@@ -67,21 +68,28 @@ export async function runVerifyProvenance(ref: string): Promise<void> {
     if (result.status === "tampered") process.exitCode = 1;
 }
 
-/** The self-describing sidecar shape written by export.ts. */
-type Sidecar = {
-    payloadType: string;
-    payloadDigestAlgorithm: string;
-    payloadDigest: string;
-    payloadDigestMethod: string;
-    signatureAlgorithm: string;
-    signature: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JWK is a loose object from the sidecar file; we pass it straight to crypto.subtle.importKey which validates it.
-    publicKey: any;
-};
+/**
+ * The self-describing sidecar envelope. Zod-validated on read so a corrupt or
+ * hand-edited `.sig.json` surfaces a clear "invalid sidecar" error instead of
+ * a downstream type confusion. The same schema is used to construct the sidecar
+ * at export time, keeping the two sides in sync.
+ */
+export const sidecarSchema = z.object({
+    payloadType: z.string(),
+    payloadDigestAlgorithm: z.string(),
+    payloadDigest: z.string(),
+    payloadDigestMethod: z.string(),
+    signatureAlgorithm: z.string(),
+    signature: z.string(),
+    publicKey: z.record(z.string(), z.unknown()),
+});
+
+/** The validated sidecar shape — inferred from the schema so the type never drifts. */
+export type Sidecar = z.infer<typeof sidecarSchema>;
 
 function readSidecar(sigPath: string): Sidecar | null {
     try {
-        return JSON.parse(readFileSync(sigPath, "utf-8")) as Sidecar;
+        return JSON.parseWith(readFileSync(sigPath, "utf-8"), sidecarSchema);
     } catch {
         return null;
     }
@@ -102,8 +110,8 @@ export async function runVerifyFile(path: string): Promise<void> {
     }
 
     const sidecar = readSidecar(sigPath);
-    if (!sidecar?.payloadDigest || !sidecar.signature || !sidecar.publicKey) {
-        fail(`Sidecar at ${sigPath} is missing required fields.`);
+    if (!sidecar) {
+        fail(`Sidecar at ${sigPath} is invalid or missing required fields.`);
     }
 
     // TODO(robustness): the public key is trusted solely because it travels in the sidecar — an

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -4,7 +4,7 @@ import type { VerifyResult } from "../../types/prov.ts";
 import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { findAnalysisForProv } from "./document.ts";
-import { computeChainHash, computePayloadDigest, verifyChainHash, loadPublicKey, loadOrGenerateKeypair, exportPublicKeyJwk, signChainHash } from "./signing.ts";
+import { computeChainHash, computePayloadDigest, verifyHexDigest, loadPublicKey, loadOrGenerateKeypair, exportPublicKeyJwk, signHexDigest } from "./signing.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
 
 /**
@@ -31,7 +31,7 @@ export async function verifyProvenance(
         return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
     }
 
-    const ok = await verifyChainHash(publicKey, storedSignature, storedChainHash);
+    const ok = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
     if (!ok) {
         return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
     }
@@ -50,7 +50,7 @@ export async function verifyPayload(provJson: string, storedDigest: string, stor
         return { status: "tampered", detail: "payload digest mismatch: the provenance file has been modified since it was signed" };
     }
 
-    const ok = await verifyChainHash(publicKey, storedSignature, storedDigest);
+    const ok = await verifyHexDigest(publicKey, storedSignature, storedDigest);
     if (!ok) {
         return { status: "tampered", detail: "signature verification failed: the digest or signature has been modified" };
     }
@@ -146,7 +146,7 @@ export async function buildSidecar(provJson: string): Promise<Sidecar | null> {
     if (!publicKeyJwk) return null;
 
     const digest = await computePayloadDigest(provJson);
-    const signature = await signChainHash(kp.privateKey, digest);
+    const signature = await signHexDigest(kp.privateKey, digest);
 
     return {
         payloadType: "application/json; profile=prov-json",

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -4,15 +4,20 @@ import type { VerifyResult } from "../../types/prov.ts";
 import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { findAnalysisForProv } from "./document.ts";
-import { computeChainHash, verifyChainHash, loadPublicKey } from "./signing.ts";
+import { computeChainHash, computePayloadDigest, verifyChainHash, loadPublicKey, loadOrGenerateKeypair, exportPublicKeyJwk, signChainHash } from "./signing.ts";
 import { dieOn, fail } from "../../lib/cli.ts";
 
 /**
- * Pure verification: recompute the chain hash from the stored PROV-JSON and check the signature.
- * All inputs are passed in — no DB or file I/O here, so the function is directly unit-testable.
+ * DB-path verification: recompute the rolling chain hash from `prevChainHash` and the stored
+ * PROV-JSON, then check the Ed25519 signature over it. Used by `prov verify` (the internal
+ * command that reads integrity columns from the database).
+ *
+ * `prevChainHash` is the chain hash from the PREVIOUS flush — needed to recompute the current one
+ * (`H_n = SHA-256(H_{n-1} || json_n)`). `null` on the first flush, where the seed is SHA-256("").
  */
 export async function verifyProvenance(
     provJson: string | null,
+    prevChainHash: string | null,
     storedChainHash: string | null,
     storedSignature: string | null,
     publicKey: CryptoKey | null,
@@ -21,7 +26,7 @@ export async function verifyProvenance(
     if (storedChainHash === null || storedSignature === null) return { status: "unsigned" };
     if (publicKey === null) return { status: "no-key" };
 
-    const recomputed = await computeChainHash(null, provJson);
+    const recomputed = await computeChainHash(prevChainHash, provJson);
     if (recomputed !== storedChainHash) {
         return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
     }
@@ -29,6 +34,25 @@ export async function verifyProvenance(
     const ok = await verifyChainHash(publicKey, storedSignature, storedChainHash);
     if (!ok) {
         return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
+    }
+
+    return { status: "valid" };
+}
+
+/**
+ * File-path verification: check a simple `SHA-256(provJson)` content digest and its Ed25519
+ * signature. Used by `prov verify-file` and the TUI "Verify provenance (export)" command —
+ * the sidecar is self-contained, no chain mechanics needed.
+ */
+export async function verifyPayload(provJson: string, storedDigest: string, storedSignature: string, publicKey: CryptoKey): Promise<VerifyResult> {
+    const recomputed = await computePayloadDigest(provJson);
+    if (recomputed !== storedDigest) {
+        return { status: "tampered", detail: "payload digest mismatch: the provenance file has been modified since it was signed" };
+    }
+
+    const ok = await verifyChainHash(publicKey, storedSignature, storedDigest);
+    if (!ok) {
+        return { status: "tampered", detail: "signature verification failed: the digest or signature has been modified" };
     }
 
     return { status: "valid" };
@@ -51,6 +75,22 @@ export function formatVerifyResult(result: VerifyResult): string {
 }
 
 /**
+ * Verify an analysis's stored provenance from its DB integrity columns: load the integrity data,
+ * load the public key, and run {@link verifyProvenance}. Returns `null` only when the analysis
+ * row does not exist. Shared by the CLI `prov verify` action and the TUI palette command.
+ */
+export async function verifyAnalysisIntegrity(analysisId: string): Promise<VerifyResult | null> {
+    const integrity = getAnalysisIntegrity(analysisId).match(
+        (i) => i,
+        () => null,
+    );
+    if (!integrity) return null;
+
+    const publicKey = await loadPublicKey();
+    return verifyProvenance(integrity.provenance, integrity.prevChainHash, integrity.chainHash, integrity.signature, publicKey);
+}
+
+/**
  * CLI action for `inflexa prov verify <analysis>`: resolve the analysis, load integrity data
  * from the DB, load the public key, run verification, and print the result.
  */
@@ -58,36 +98,69 @@ export async function runVerifyProvenance(ref: string): Promise<void> {
     const analysis = findAnalysisForProv(ref as IdOrName).match((a) => a, dieOn("Failed to resolve analysis"));
     if (!analysis) fail(`No analysis found matching "${ref}".`);
 
-    const integrity = getAnalysisIntegrity(analysis.id).match((i) => i, dieOn("Failed to read provenance"));
-    if (!integrity) fail(`No analysis row for "${ref}".`);
+    const result = await verifyAnalysisIntegrity(analysis.id);
+    if (!result) fail(`No analysis row for "${ref}".`);
 
-    const publicKey = await loadPublicKey();
-    const result = await verifyProvenance(integrity.provenance, integrity.chainHash, integrity.signature, publicKey);
     console.log(formatVerifyResult(result));
-
     if (result.status === "tampered") process.exitCode = 1;
 }
 
 /**
- * The self-describing sidecar envelope. Zod-validated on read so a corrupt or
- * hand-edited `.sig.json` surfaces a clear "invalid sidecar" error instead of
- * a downstream type confusion. The same schema is used to construct the sidecar
- * at export time, keeping the two sides in sync.
+ * The self-describing export sidecar. A recipient verifies integrity with just the provenance
+ * file and this sidecar — no database, no chain history, no internal state needed.
+ *
+ * Zod-validated on read so a corrupt or hand-edited `.sig.json` surfaces a clear "invalid
+ * sidecar" error instead of a downstream type confusion.
  */
 export const sidecarSchema = z.object({
-    payloadType: z.string(),
-    payloadDigestAlgorithm: z.string(),
+    /** MIME type of the payload file. */
+    payloadType: z.literal("application/json; profile=prov-json"),
+    /** Hash algorithm used to compute {@link payloadDigest}. */
+    payloadDigestAlgorithm: z.literal("SHA-256"),
+    /** `SHA-256(file bytes)` — the recipient recomputes this from the file and compares. */
     payloadDigest: z.string(),
-    payloadDigestMethod: z.string(),
-    signatureAlgorithm: z.string(),
+    /** How the digest input was derived — "verbatim" means exact file bytes, no canonicalization. */
+    payloadDigestMethod: z.literal("verbatim"),
+    /** Signature algorithm. */
+    signatureAlgorithm: z.literal("Ed25519"),
+    /** Ed25519 signature over the {@link payloadDigest} — proves it was produced by the key holder. */
     signature: z.string(),
+    /** The signer's public key as JWK — lets the recipient verify without the keypair file. */
     publicKey: z.record(z.string(), z.unknown()),
 });
 
 /** The validated sidecar shape — inferred from the schema so the type never drifts. */
 export type Sidecar = z.infer<typeof sidecarSchema>;
 
-function readSidecar(sigPath: string): Sidecar | null {
+/**
+ * Build a sidecar for an exported provenance file. Computes `SHA-256(provJson)` as the content
+ * digest and signs it with the Ed25519 private key. Returns `null` when no signing key is
+ * available. The sidecar is self-contained — a recipient verifies with just the file and the
+ * sidecar, no chain history or database access needed.
+ */
+export async function buildSidecar(provJson: string): Promise<Sidecar | null> {
+    const kp = await loadOrGenerateKeypair();
+    if (!kp) return null;
+
+    const publicKeyJwk = await exportPublicKeyJwk();
+    if (!publicKeyJwk) return null;
+
+    const digest = await computePayloadDigest(provJson);
+    const signature = await signChainHash(kp.privateKey, digest);
+
+    return {
+        payloadType: "application/json; profile=prov-json",
+        payloadDigestAlgorithm: "SHA-256",
+        payloadDigest: digest,
+        payloadDigestMethod: "verbatim",
+        signatureAlgorithm: "Ed25519",
+        signature,
+        publicKey: publicKeyJwk as Record<string, unknown>,
+    };
+}
+
+/** Parse a `.sig.json` sidecar file, returning `null` on missing/corrupt/malformed. */
+export function readSidecar(sigPath: string): Sidecar | null {
     try {
         return JSON.parseWith(readFileSync(sigPath, "utf-8"), sidecarSchema);
     } catch {
@@ -127,7 +200,7 @@ export async function runVerifyFile(path: string): Promise<void> {
     }
 
     const provJson = readFileSync(path, "utf-8");
-    const result = await verifyProvenance(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
+    const result = await verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
     console.log(formatVerifyResult(result));
 
     if (result.status === "tampered") process.exitCode = 1;

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -71,6 +71,10 @@ export function formatVerifyResult(result: VerifyResult): string {
             return "Cannot verify: a signature exists but the signing key file is missing.";
         case "empty":
             return "No provenance has been recorded for this analysis.";
+        case "invalid-sidecar":
+            return `Invalid sidecar: ${result.detail}`;
+        case "invalid-key":
+            return "The public key in the sidecar is invalid or unsupported.";
     }
 }
 
@@ -168,12 +172,12 @@ export function readSidecar(sigPath: string): Sidecar | null {
     }
 }
 
-// TODO(slop): why does this throw? Why don't you use neverthrow?
 /**
  * Verify an exported provenance file against its `.sig.json` sidecar. Shared by the CLI
  * `prov verify-file` action and the TUI "Verify provenance (export)" command — both need the same
- * read-sidecar → import-key → verify-payload pipeline. Returns `null` when no sidecar exists;
- * throws on a corrupt sidecar or invalid public key (the caller decides error UX).
+ * read-sidecar → import-key → verify-payload pipeline. Returns `null` when no sidecar exists.
+ * Corrupt sidecars and invalid keys are returned as `VerifyResult` statuses, not thrown — callers
+ * handle them the same way as any other verification outcome.
  *
  * // TODO(robustness): the public key is trusted solely because it travels in the sidecar — an
  * // attacker who replaces both the provenance file and the sidecar (with their own key) passes
@@ -186,13 +190,13 @@ export async function verifyExportFile(provPath: string): Promise<VerifyResult |
     if (!existsSync(sigPath)) return null;
 
     const sidecar = readSidecar(sigPath);
-    if (!sidecar) throw new Error(`Sidecar at ${sigPath} is invalid or missing required fields.`);
+    if (!sidecar) return { status: "invalid-sidecar", detail: `sidecar at ${sigPath} is invalid or missing required fields` };
 
     let publicKey: CryptoKey;
     try {
         publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
     } catch {
-        throw new Error("The public key in the sidecar is invalid or unsupported.");
+        return { status: "invalid-key" };
     }
 
     const provJson = readFileSync(provPath, "utf-8");
@@ -207,15 +211,11 @@ export async function verifyExportFile(provPath: string): Promise<VerifyResult |
 export async function runVerifyFile(path: string): Promise<void> {
     if (!existsSync(path)) fail(`File not found: ${path}`);
 
-    try {
-        const result = await verifyExportFile(path);
-        if (!result) {
-            console.log("No sidecar found: the provenance file cannot be verified without a .sig.json sidecar.");
-            return;
-        }
-        console.log(formatVerifyResult(result));
-        if (result.status === "tampered") process.exitCode = 1;
-    } catch (e) {
-        fail(e instanceof Error ? e.message : String(e));
+    const result = await verifyExportFile(path);
+    if (!result) {
+        console.log("No sidecar found: the provenance file cannot be verified without a .sig.json sidecar.");
+        return;
     }
+    console.log(formatVerifyResult(result));
+    if (result.status === "tampered" || result.status === "invalid-sidecar" || result.status === "invalid-key") process.exitCode = 1;
 }

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -168,6 +168,37 @@ export function readSidecar(sigPath: string): Sidecar | null {
     }
 }
 
+// TODO(slop): why does this throw? Why don't you use neverthrow?
+/**
+ * Verify an exported provenance file against its `.sig.json` sidecar. Shared by the CLI
+ * `prov verify-file` action and the TUI "Verify provenance (export)" command — both need the same
+ * read-sidecar → import-key → verify-payload pipeline. Returns `null` when no sidecar exists;
+ * throws on a corrupt sidecar or invalid public key (the caller decides error UX).
+ *
+ * // TODO(robustness): the public key is trusted solely because it travels in the sidecar — an
+ * // attacker who replaces both the provenance file and the sidecar (with their own key) passes
+ * // verification. For teammate-to-teammate sharing over trusted channels this is fine; for stronger
+ * // trust, support key pinning: the verifier registers the signer's public key once, then future
+ * // verify calls check the sidecar's key against the pinned one.
+ */
+export async function verifyExportFile(provPath: string): Promise<VerifyResult | null> {
+    const sigPath = `${provPath}.sig.json`;
+    if (!existsSync(sigPath)) return null;
+
+    const sidecar = readSidecar(sigPath);
+    if (!sidecar) throw new Error(`Sidecar at ${sigPath} is invalid or missing required fields.`);
+
+    let publicKey: CryptoKey;
+    try {
+        publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
+    } catch {
+        throw new Error("The public key in the sidecar is invalid or unsupported.");
+    }
+
+    const provJson = readFileSync(provPath, "utf-8");
+    return verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
+}
+
 /**
  * CLI action for `inflexa prov verify-file <path>`: verify an exported provenance file against
  * its `.sig.json` sidecar. No database or analysis row needed — a colleague who receives the
@@ -176,32 +207,15 @@ export function readSidecar(sigPath: string): Sidecar | null {
 export async function runVerifyFile(path: string): Promise<void> {
     if (!existsSync(path)) fail(`File not found: ${path}`);
 
-    const sigPath = `${path}.sig.json`;
-    if (!existsSync(sigPath)) {
-        console.log("No sidecar found: the provenance file cannot be verified without a .sig.json sidecar.");
-        return;
-    }
-
-    const sidecar = readSidecar(sigPath);
-    if (!sidecar) {
-        fail(`Sidecar at ${sigPath} is invalid or missing required fields.`);
-    }
-
-    // TODO(robustness): the public key is trusted solely because it travels in the sidecar — an
-    // attacker who replaces both the provenance file and the sidecar (with their own key) passes
-    // verification. For teammate-to-teammate sharing over trusted channels this is fine; for stronger
-    // trust, support key pinning: the verifier registers the signer's public key once, then future
-    // verify-file calls check the sidecar's key against the pinned one.
-    let publicKey: CryptoKey;
     try {
-        publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
-    } catch {
-        fail("The public key in the sidecar is invalid or unsupported.");
+        const result = await verifyExportFile(path);
+        if (!result) {
+            console.log("No sidecar found: the provenance file cannot be verified without a .sig.json sidecar.");
+            return;
+        }
+        console.log(formatVerifyResult(result));
+        if (result.status === "tampered") process.exitCode = 1;
+    } catch (e) {
+        fail(e instanceof Error ? e.message : String(e));
     }
-
-    const provJson = readFileSync(path, "utf-8");
-    const result = await verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
-    console.log(formatVerifyResult(result));
-
-    if (result.status === "tampered") process.exitCode = 1;
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -279,7 +279,7 @@ export function App(props: AppProps) {
                                     // text's single-line length and then clips the overflow (hiding a long export
                                     // path mid-string). Size to the text so short toasts stay snug, capped so a long
                                     // path wraps within the cap. +6 = border (2) + padding (2) + glyph and its space (2).
-                                    width={Math.min(Math.min(60, dims().width - 6), n.text.length + 6)}
+                                    width={Math.min(60, dims().width - 6, n.text.length + 6)}
                                     backgroundColor={theme().bgRaised}
                                     border
                                     borderColor={noticeColor(n.kind)}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -117,7 +117,7 @@ export function App(props: AppProps) {
 
     // Copy-on-select (see TEXT-SELECTION-CLIPBOARD-REPORT.md): OpenTUI owns the selection, we just read,
     // write, toast, clear. On the root box so a release anywhere copies.
-    // ponytail: unconditional — the report's Windows explicit-copy flag can be a config knob if asked.
+    // Unconditional for now — the report's Windows explicit-copy flag can become a config knob if asked.
     function copySelection(): void {
         const text = renderer.getSelection()?.getSelectedText();
         if (!text) return; // empty → a plain click, not a drag
@@ -274,7 +274,12 @@ export function App(props: AppProps) {
                                     top={1}
                                     right={2}
                                     zIndex={zIndex.toast}
-                                    maxWidth={Math.min(60, dims().width - 6)}
+                                    // A DEFINITE width (not maxWidth) so a long line wraps instead of clipping —
+                                    // opentui only wraps text whose box has a resolved width; maxWidth sizes to the
+                                    // text's single-line length and then clips the overflow (hiding a long export
+                                    // path mid-string). Size to the text so short toasts stay snug, capped so a long
+                                    // path wraps within the cap. +6 = border (2) + padding (2) + glyph and its space (2).
+                                    width={Math.min(Math.min(60, dims().width - 6), n.text.length + 6)}
                                     backgroundColor={theme().bgRaised}
                                     border
                                     borderColor={noticeColor(n.kind)}

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 // Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
@@ -20,7 +20,7 @@ import { str256 } from "../lib/types.ts";
 import { createAnalysis, listRecentAnalyses } from "../modules/analysis/analysis.ts";
 import { resolveContext, describeContext } from "../modules/analysis/context.ts";
 import { openOutputDir } from "../modules/analysis/open.ts";
-import { resolveAnchor } from "../modules/anchor/anchor.ts";
+import { resolveAnchor, resolvedPathOrCached } from "../modules/anchor/anchor.ts";
 import { createProject, createSession } from "../db/primary_mutation.ts";
 import { listSessionsByAnalysis } from "../db/primary_query.ts";
 import type { Analysis } from "../types/analysis.ts";
@@ -58,7 +58,7 @@ export type Command = {
 // Resolve an analysis's live working directory from its anchor (falling back to cwd).
 function workingDirFor(a: Analysis): string {
     return resolveAnchor(a.anchorId).match(
-        (resolved) => (resolved ? (resolved.path ?? resolved.anchor.cachedPath) : process.cwd()),
+        (resolved) => resolvedPathOrCached(resolved) ?? process.cwd(),
         () => process.cwd(),
     );
 }
@@ -425,30 +425,16 @@ export const commands: Command[] = [
                 return;
             }
 
-            const sigPath = `${provPath}.sig.json`;
-            if (!existsSync(sigPath)) {
-                notify({ kind: "warn", text: "No .sig.json sidecar found. The export may be unsigned." });
-                return;
-            }
-
-            const sidecar = verify.readSidecar(sigPath);
-            if (!sidecar) {
-                notify({ kind: "error", text: "The .sig.json sidecar is invalid or missing required fields." });
-                return;
-            }
-
-            let publicKey: CryptoKey;
             try {
-                publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
-            } catch {
-                notify({ kind: "error", text: "The public key in the sidecar is invalid." });
-                return;
+                const result = await verify.verifyExportFile(provPath);
+                if (!result) {
+                    notify({ kind: "warn", text: "No .sig.json sidecar found. The export may be unsigned." });
+                    return;
+                }
+                notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
+            } catch (e) {
+                notify({ kind: "error", text: e instanceof Error ? e.message : String(e) });
             }
-
-            const provJson = readFileSync(provPath, "utf-8");
-            const result = await verify.verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
-
-            notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
         },
     },
     {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -298,15 +298,17 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
     }
 
     // Provenance + sidecar are one logical export: both must succeed before we report success.
-    const sidecar = await verify.buildSidecar(text);
-    if (sidecar) {
-        const sigDest = `${dest}.sig.json`;
-        try {
-            writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
-        } catch (cause) {
-            notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
-            return;
-        }
+    const sidecarResult = await verify.buildSidecar(text);
+    if (sidecarResult.isErr()) {
+        notify({ kind: "error", text: `Signing failed (${sidecarResult.error.type}) — provenance is never exported unsigned.` });
+        return;
+    }
+    const sigDest = `${dest}.sig.json`;
+    try {
+        writeFileSync(sigDest, JSON.stringify(sidecarResult.value, null, 2));
+    } catch (cause) {
+        notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
+        return;
     }
 
     notify({ kind: "info", text: `Wrote ${format} provenance to ${dest}` });

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 // Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
-import type { Sidecar } from "../modules/prov/verify.ts";
+import type { VerifyResult } from "../types/prov.ts";
 
 import { PromptDialog } from "./components/prompt_dialog.tsx";
 import { ResultsDialog } from "./components/results_dialog.tsx";
@@ -82,6 +82,20 @@ function openAnalysis(ws: Workspace, a: Analysis): void {
         return;
     }
     ws.openSession(session.id, workingDirFor(a), a);
+}
+
+/** Map a {@link VerifyResult} status to the appropriate notice severity. */
+function noticeKindFor(result: VerifyResult): "info" | "warn" | "error" {
+    switch (result.status) {
+        case "valid":
+        case "unsigned":
+        case "empty":
+            return "info";
+        case "no-key":
+            return "warn";
+        case "tampered":
+            return "error";
+    }
 }
 
 function ThemePicker(): JSX.Element {
@@ -244,13 +258,11 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
 
     let prov: typeof import("../modules/prov/document.ts");
     let output: typeof import("../modules/analysis/output.ts");
-    let query: typeof import("../db/primary_query.ts");
-    let signing: typeof import("../modules/prov/signing.ts");
+    let verify: typeof import("../modules/prov/verify.ts");
     try {
         prov = await import("../modules/prov/document.ts");
         output = await import("../modules/analysis/output.ts");
-        query = await import("../db/primary_query.ts");
-        signing = await import("../modules/prov/signing.ts");
+        verify = await import("../modules/prov/verify.ts");
     } catch {
         notify({ kind: "error", text: "Provenance export is unavailable (the tsprov library failed to load)." });
         return;
@@ -284,29 +296,14 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
     }
 
     // Provenance + sidecar are one logical export: both must succeed before we report success.
-    const integrity = query.getAnalysisIntegrity(a.id).match(
-        (i) => i,
-        () => null,
-    );
-    if (integrity?.chainHash && integrity.signature) {
-        const pubKey = await signing.exportPublicKeyJwk();
-        if (pubKey) {
-            const sidecar: Sidecar = {
-                payloadType: "application/json; profile=prov-json",
-                payloadDigestAlgorithm: "SHA-256",
-                payloadDigest: integrity.chainHash,
-                payloadDigestMethod: "verbatim",
-                signatureAlgorithm: "Ed25519",
-                signature: integrity.signature,
-                publicKey: pubKey,
-            };
-            const sigDest = `${dest}.sig.json`;
-            try {
-                writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
-            } catch (cause) {
-                notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
-                return;
-            }
+    const sidecar = await verify.buildSidecar(text);
+    if (sidecar) {
+        const sigDest = `${dest}.sig.json`;
+        try {
+            writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
+        } catch (cause) {
+            notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
+            return;
         }
     }
 
@@ -377,45 +374,20 @@ export const commands: Command[] = [
             if (!a) return;
 
             let verify: typeof import("../modules/prov/verify.ts");
-            let query: typeof import("../db/primary_query.ts");
-            let signing: typeof import("../modules/prov/signing.ts");
             try {
                 verify = await import("../modules/prov/verify.ts");
-                query = await import("../db/primary_query.ts");
-                signing = await import("../modules/prov/signing.ts");
             } catch {
                 notify({ kind: "error", text: "Provenance verification is unavailable." });
                 return;
             }
 
-            const integrity = query.getAnalysisIntegrity(a.id).match(
-                (i) => i,
-                () => null,
-            );
-            if (!integrity) {
+            const result = await verify.verifyAnalysisIntegrity(a.id);
+            if (!result) {
                 notify({ kind: "error", text: "Could not read provenance data." });
                 return;
             }
 
-            const publicKey = await signing.loadPublicKey();
-            const result = await verify.verifyProvenance(integrity.provenance, integrity.chainHash, integrity.signature, publicKey);
-            const text = verify.formatVerifyResult(result);
-
-            switch (result.status) {
-                case "valid":
-                    notify({ kind: "info", text });
-                    break;
-                case "unsigned":
-                case "empty":
-                    notify({ kind: "info", text });
-                    break;
-                case "no-key":
-                    notify({ kind: "warn", text });
-                    break;
-                case "tampered":
-                    notify({ kind: "error", text });
-                    break;
-            }
+            notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
         },
     },
     {
@@ -459,15 +431,7 @@ export const commands: Command[] = [
                 return;
             }
 
-            let sidecarSchema: typeof import("../modules/prov/verify.ts").sidecarSchema;
-            try {
-                sidecarSchema = (await import("../modules/prov/verify.ts")).sidecarSchema;
-            } catch {
-                notify({ kind: "error", text: "Provenance verification is unavailable." });
-                return;
-            }
-
-            const sidecar = JSON.parseWith(readFileSync(sigPath, "utf-8"), sidecarSchema);
+            const sidecar = verify.readSidecar(sigPath);
             if (!sidecar) {
                 notify({ kind: "error", text: "The .sig.json sidecar is invalid or missing required fields." });
                 return;
@@ -482,24 +446,9 @@ export const commands: Command[] = [
             }
 
             const provJson = readFileSync(provPath, "utf-8");
-            const result = await verify.verifyProvenance(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
-            const text = verify.formatVerifyResult(result);
+            const result = await verify.verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
 
-            switch (result.status) {
-                case "valid":
-                    notify({ kind: "info", text });
-                    break;
-                case "unsigned":
-                case "empty":
-                    notify({ kind: "info", text });
-                    break;
-                case "no-key":
-                    notify({ kind: "warn", text });
-                    break;
-                case "tampered":
-                    notify({ kind: "error", text });
-                    break;
-            }
+            notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
         },
     },
     {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -1,8 +1,9 @@
 import type { JSX } from "solid-js";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-// Type-only — erased at compile time, so it does NOT pull tsprov into the TUI's startup path.
+// Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
+import type { Sidecar } from "../modules/prov/verify.ts";
 
 import { PromptDialog } from "./components/prompt_dialog.tsx";
 import { ResultsDialog } from "./components/results_dialog.tsx";
@@ -264,47 +265,52 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
         return;
     }
 
-    prov.serializeProvenance(a, format).match(
-        (text) => {
-            const dest = join(dir, `provenance.${format}`);
+    const text = prov.serializeProvenance(a, format).match(
+        (t) => t,
+        (e) => {
+            notify({ kind: "error", text: `Failed to build provenance: ${e.type}` });
+            return null;
+        },
+    );
+    if (!text) return;
+
+    const dest = join(dir, `provenance.${format}`);
+    try {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(dest, text);
+    } catch (cause) {
+        notify({ kind: "error", text: `Failed to write provenance: ${String(cause)}` });
+        return;
+    }
+
+    // Provenance + sidecar are one logical export: both must succeed before we report success.
+    const integrity = query.getAnalysisIntegrity(a.id).match(
+        (i) => i,
+        () => null,
+    );
+    if (integrity?.chainHash && integrity.signature) {
+        const pubKey = await signing.exportPublicKeyJwk();
+        if (pubKey) {
+            const sidecar: Sidecar = {
+                payloadType: "application/json; profile=prov-json",
+                payloadDigestAlgorithm: "SHA-256",
+                payloadDigest: integrity.chainHash,
+                payloadDigestMethod: "verbatim",
+                signatureAlgorithm: "Ed25519",
+                signature: integrity.signature,
+                publicKey: pubKey,
+            };
+            const sigDest = `${dest}.sig.json`;
             try {
-                mkdirSync(dir, { recursive: true });
-                writeFileSync(dest, text);
-                notify({ kind: "info", text: `Wrote ${format} provenance to ${dest}` });
+                writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
             } catch (cause) {
-                notify({ kind: "error", text: `Failed to write provenance: ${String(cause)}` });
+                notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
                 return;
             }
+        }
+    }
 
-            // Write the sidecar when a signature is stored and the public key is available.
-            const integrity = query.getAnalysisIntegrity(a.id).match(
-                (i) => i,
-                () => null,
-            );
-            if (integrity?.chainHash && integrity.signature) {
-                void signing.exportPublicKeyJwk().then((pubKey) => {
-                    if (!pubKey) return;
-                    const sidecar = {
-                        payloadType: "application/json; profile=prov-json",
-                        payloadDigestAlgorithm: "SHA-256",
-                        payloadDigest: integrity.chainHash,
-                        payloadDigestMethod: "verbatim",
-                        signatureAlgorithm: "Ed25519",
-                        signature: integrity.signature,
-                        publicKey: pubKey,
-                    };
-                    const sigDest = `${dest}.sig.json`;
-                    try {
-                        writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
-                        notify({ kind: "info", text: `Wrote verification sidecar to ${sigDest}` });
-                    } catch {
-                        // Non-fatal.
-                    }
-                });
-            }
-        },
-        (e) => notify({ kind: "error", text: `Failed to build provenance: ${e.type}` }),
-    );
+    notify({ kind: "info", text: `Wrote ${format} provenance to ${dest}` });
 }
 
 export const commands: Command[] = [
@@ -362,8 +368,8 @@ export const commands: Command[] = [
     },
     {
         id: "prov.verify",
-        title: "Verify provenance",
-        description: "Check the integrity of this analysis's provenance chain and signature",
+        title: "Verify provenance (internal)",
+        description: "Check the integrity of the database provenance record",
         category: "Analysis",
         enabled: (ctx) => ctx.analysis !== null,
         run: async (ctx) => {
@@ -393,6 +399,90 @@ export const commands: Command[] = [
 
             const publicKey = await signing.loadPublicKey();
             const result = await verify.verifyProvenance(integrity.provenance, integrity.chainHash, integrity.signature, publicKey);
+            const text = verify.formatVerifyResult(result);
+
+            switch (result.status) {
+                case "valid":
+                    notify({ kind: "info", text });
+                    break;
+                case "unsigned":
+                case "empty":
+                    notify({ kind: "info", text });
+                    break;
+                case "no-key":
+                    notify({ kind: "warn", text });
+                    break;
+                case "tampered":
+                    notify({ kind: "error", text });
+                    break;
+            }
+        },
+    },
+    {
+        id: "prov.verify-export",
+        title: "Verify provenance (export)",
+        description: "Check the integrity of the exported provenance files on disk",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: async (ctx) => {
+            const a = ctx.analysis;
+            if (!a) return;
+
+            let verify: typeof import("../modules/prov/verify.ts");
+            let output: typeof import("../modules/analysis/output.ts");
+            try {
+                verify = await import("../modules/prov/verify.ts");
+                output = await import("../modules/analysis/output.ts");
+            } catch {
+                notify({ kind: "error", text: "Provenance verification is unavailable." });
+                return;
+            }
+
+            const dir = output.resolveOutputDir(a).match(
+                (d) => d,
+                () => null,
+            );
+            if (!dir) {
+                notify({ kind: "error", text: "Could not resolve this analysis's output directory." });
+                return;
+            }
+
+            const provPath = join(dir, "provenance.json");
+            if (!existsSync(provPath)) {
+                notify({ kind: "warn", text: "No exported provenance.json found. Export provenance first." });
+                return;
+            }
+
+            const sigPath = `${provPath}.sig.json`;
+            if (!existsSync(sigPath)) {
+                notify({ kind: "warn", text: "No .sig.json sidecar found. The export may be unsigned." });
+                return;
+            }
+
+            let sidecarSchema: typeof import("../modules/prov/verify.ts").sidecarSchema;
+            try {
+                sidecarSchema = (await import("../modules/prov/verify.ts")).sidecarSchema;
+            } catch {
+                notify({ kind: "error", text: "Provenance verification is unavailable." });
+                return;
+            }
+
+            const sidecar = JSON.parseWith(readFileSync(sigPath, "utf-8"), sidecarSchema);
+            if (!sidecar) {
+                notify({ kind: "error", text: "The .sig.json sidecar is invalid or missing required fields." });
+                return;
+            }
+
+            let publicKey: CryptoKey;
+            try {
+                publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
+            } catch {
+                notify({ kind: "error", text: "The public key in the sidecar is invalid." });
+                return;
+            }
+
+            const provJson = readFileSync(provPath, "utf-8");
+            const result = await verify.verifyProvenance(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
             const text = verify.formatVerifyResult(result);
 
             switch (result.status) {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -1,4 +1,8 @@
 import type { JSX } from "solid-js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+// Type-only — erased at compile time, so it does NOT pull tsprov into the TUI's startup path.
+import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
 
 import { PromptDialog } from "./components/prompt_dialog.tsx";
 import { ResultsDialog } from "./components/results_dialog.tsx";
@@ -53,7 +57,7 @@ export type Command = {
 // Resolve an analysis's live working directory from its anchor (falling back to cwd).
 function workingDirFor(a: Analysis): string {
     return resolveAnchor(a.anchorId).match(
-        ({ anchor, path }) => path ?? anchor.cachedPath,
+        (resolved) => (resolved ? (resolved.path ?? resolved.anchor.cachedPath) : process.cwd()),
         () => process.cwd(),
     );
 }
@@ -229,6 +233,80 @@ function SettingsDialog(): JSX.Element {
 
 /** The single source of truth. Add a command = add an entry here. Ordered by category so the
  *  unfiltered palette groups contiguously. */
+// Serialize the active analysis's provenance and write it into its output folder, then notify the
+// path. The PROV-building module (`prov/document.ts`) is imported LAZILY inside the action — it
+// depends on `@inflexa-ai/tsprov`, so a static import here would pull that into the TUI's startup
+// path; deferring it both keeps launch lean and contains any tsprov load failure to this action.
+async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat): Promise<void> {
+    const a = ws.analysis;
+    if (!a) return;
+
+    let prov: typeof import("../modules/prov/document.ts");
+    let output: typeof import("../modules/analysis/output.ts");
+    let query: typeof import("../db/primary_query.ts");
+    let signing: typeof import("../modules/prov/signing.ts");
+    try {
+        prov = await import("../modules/prov/document.ts");
+        output = await import("../modules/analysis/output.ts");
+        query = await import("../db/primary_query.ts");
+        signing = await import("../modules/prov/signing.ts");
+    } catch {
+        notify({ kind: "error", text: "Provenance export is unavailable (the tsprov library failed to load)." });
+        return;
+    }
+
+    const dir = output.resolveOutputDir(a).match(
+        (d) => d,
+        () => null,
+    );
+    if (!dir) {
+        notify({ kind: "error", text: "Could not resolve this analysis's output directory." });
+        return;
+    }
+
+    prov.serializeProvenance(a, format).match(
+        (text) => {
+            const dest = join(dir, `provenance.${format}`);
+            try {
+                mkdirSync(dir, { recursive: true });
+                writeFileSync(dest, text);
+                notify({ kind: "info", text: `Wrote ${format} provenance to ${dest}` });
+            } catch (cause) {
+                notify({ kind: "error", text: `Failed to write provenance: ${String(cause)}` });
+                return;
+            }
+
+            // Write the sidecar when a signature is stored and the public key is available.
+            const integrity = query.getAnalysisIntegrity(a.id).match(
+                (i) => i,
+                () => null,
+            );
+            if (integrity?.chainHash && integrity.signature) {
+                void signing.exportPublicKeyJwk().then((pubKey) => {
+                    if (!pubKey) return;
+                    const sidecar = {
+                        payloadType: "application/json; profile=prov-json",
+                        payloadDigestAlgorithm: "SHA-256",
+                        payloadDigest: integrity.chainHash,
+                        payloadDigestMethod: "verbatim",
+                        signatureAlgorithm: "Ed25519",
+                        signature: integrity.signature,
+                        publicKey: pubKey,
+                    };
+                    const sigDest = `${dest}.sig.json`;
+                    try {
+                        writeFileSync(sigDest, JSON.stringify(sidecar, null, 2));
+                        notify({ kind: "info", text: `Wrote verification sidecar to ${sigDest}` });
+                    } catch {
+                        // Non-fatal.
+                    }
+                });
+            }
+        },
+        (e) => notify({ kind: "error", text: `Failed to build provenance: ${e.type}` }),
+    );
+}
+
 export const commands: Command[] = [
     {
         id: "analysis.switch",
@@ -264,6 +342,74 @@ export const commands: Command[] = [
                 (d) => notify({ kind: "info", text: `Opened ${d}` }),
                 (e) => notify({ kind: "error", text: `Failed to open: ${e.type}` }),
             );
+        },
+    },
+    {
+        id: "prov.export-json",
+        title: "Export provenance (JSON)",
+        description: "Write this analysis's PROV-JSON provenance to its output folder",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => exportProvenanceToFile(ctx, "json"),
+    },
+    {
+        id: "prov.export-provn",
+        title: "Export provenance (PROV-N)",
+        description: "Write this analysis's PROV-N provenance to its output folder",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => exportProvenanceToFile(ctx, "provn"),
+    },
+    {
+        id: "prov.verify",
+        title: "Verify provenance",
+        description: "Check the integrity of this analysis's provenance chain and signature",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: async (ctx) => {
+            const a = ctx.analysis;
+            if (!a) return;
+
+            let verify: typeof import("../modules/prov/verify.ts");
+            let query: typeof import("../db/primary_query.ts");
+            let signing: typeof import("../modules/prov/signing.ts");
+            try {
+                verify = await import("../modules/prov/verify.ts");
+                query = await import("../db/primary_query.ts");
+                signing = await import("../modules/prov/signing.ts");
+            } catch {
+                notify({ kind: "error", text: "Provenance verification is unavailable." });
+                return;
+            }
+
+            const integrity = query.getAnalysisIntegrity(a.id).match(
+                (i) => i,
+                () => null,
+            );
+            if (!integrity) {
+                notify({ kind: "error", text: "Could not read provenance data." });
+                return;
+            }
+
+            const publicKey = await signing.loadPublicKey();
+            const result = await verify.verifyProvenance(integrity.provenance, integrity.chainHash, integrity.signature, publicKey);
+            const text = verify.formatVerifyResult(result);
+
+            switch (result.status) {
+                case "valid":
+                    notify({ kind: "info", text });
+                    break;
+                case "unsigned":
+                case "empty":
+                    notify({ kind: "info", text });
+                    break;
+                case "no-key":
+                    notify({ kind: "warn", text });
+                    break;
+                case "tampered":
+                    notify({ kind: "error", text });
+                    break;
+            }
         },
     },
     {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -94,6 +94,8 @@ function noticeKindFor(result: VerifyResult): "info" | "warn" | "error" {
         case "no-key":
             return "warn";
         case "tampered":
+        case "invalid-sidecar":
+        case "invalid-key":
             return "error";
     }
 }
@@ -425,16 +427,12 @@ export const commands: Command[] = [
                 return;
             }
 
-            try {
-                const result = await verify.verifyExportFile(provPath);
-                if (!result) {
-                    notify({ kind: "warn", text: "No .sig.json sidecar found. The export may be unsigned." });
-                    return;
-                }
-                notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
-            } catch (e) {
-                notify({ kind: "error", text: e instanceof Error ? e.message : String(e) });
+            const result = await verify.verifyExportFile(provPath);
+            if (!result) {
+                notify({ kind: "warn", text: "No .sig.json sidecar found. The export may be unsigned." });
+                return;
             }
+            notify({ kind: noticeKindFor(result), text: verify.formatVerifyResult(result) });
         },
     },
     {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,9 +1,14 @@
 import type { Message, Part } from "./session.ts";
+import type { AnalysisId } from "./analysis.ts";
+import type { ProvActor, ProvInputRef } from "./prov.ts";
 
 /**
- * The cross-process event contract: the intelligence module's chat engine emits
- * these and the TUI consumes them through the bus. Carries session-domain shapes,
- * so it lives in the shared type layer rather than inside the intelligence module.
+ * The cross-process event contract. Session-scoped events carry `sessionId`;
+ * provenance events carry `analysisId` and are ignored by session-scoped consumers.
+ *
+ * One event type per domain action — never a single "recorded" event discriminated
+ * by an interior `action` field with nullable companions. Each member carries exactly
+ * the fields its action needs, no more (see "Single bus, typed events" in CLAUDE.md).
  */
 export type BusEvent =
     | { type: "session.status"; sessionId: string; status: "idle" | "busy" | "error" }
@@ -11,7 +16,17 @@ export type BusEvent =
     | { type: "message.updated"; message: Message }
     | { type: "part.updated"; part: Part }
     | { type: "part.delta"; sessionId: string; messageId: string; partId: string; delta: string }
-    | { type: "session.error"; sessionId: string; error: string };
+    | { type: "session.error"; sessionId: string; error: string }
+    | { type: "prov.analysis_created"; analysisId: AnalysisId; actor: ProvActor }
+    | {
+          type: "prov.input_added";
+          analysisId: AnalysisId;
+          actor: ProvActor;
+          input: ProvInputRef;
+          /** Set when the input is itself another analysis's output — links the two PROV subjects. */
+          derivedFromAnalysisId: string | null;
+      }
+    | { type: "prov.input_removed"; analysisId: AnalysisId; actor: ProvActor; input: ProvInputRef };
 
 /** A {@link BusEvent} stamped with a unique id by the bus on emit (for telemetry correlation). */
 export type StampedEvent = BusEvent & { __infId: string };

--- a/src/types/prov.ts
+++ b/src/types/prov.ts
@@ -41,4 +41,11 @@ export type ProvInputRef = {
  * The outcome of `inflexa prov verify`: one of five mutually exclusive states, each with enough
  * detail for the CLI/TUI to render a clear message.
  */
-export type VerifyResult = { status: "valid" } | { status: "unsigned" } | { status: "tampered"; detail: string } | { status: "no-key" } | { status: "empty" };
+export type VerifyResult =
+    | { status: "valid" }
+    | { status: "unsigned" }
+    | { status: "tampered"; detail: string }
+    | { status: "no-key" }
+    | { status: "empty" }
+    | { status: "invalid-sidecar"; detail: string }
+    | { status: "invalid-key" };

--- a/src/types/prov.ts
+++ b/src/types/prov.ts
@@ -1,0 +1,44 @@
+/**
+ * The provenance domain model: the kinds of tracked actions and the agent responsible for one.
+ * These outlive any single storage choice — an analysis's provenance is a PROV document
+ * (serialized as PROV-JSON onto `analyses.provenance`), built incrementally by the recorder in
+ * `modules/prov/prov.ts` from the typed `prov.*` bus events that carry these shapes.
+ */
+
+/**
+ * Who is responsible for an action. `user` is a logged-in person (their email), `anonymous` an
+ * unauthenticated person, `system` the inflexa CLI itself acting autonomously (carries its version).
+ */
+export type ProvActorKind = "user" | "anonymous" | "system";
+
+/**
+ * The resolved responsible agent for an action — a discriminated union so the call site states
+ * *which* kind it is recording, and so the document builder reads the right fields per kind.
+ */
+export type ProvActor =
+    | { kind: "user"; email: string }
+    | { kind: "anonymous" }
+    | {
+          kind: "system";
+          /** The CLI's package version. */
+          version: string;
+          /** The exact source commit — baked at build time, resolved from git in dev. */
+          commit: string;
+      };
+
+/**
+ * The subset of an analysis input that provenance records: the identity fields for the PROV
+ * entity (stable QName from anchor+path) and the attributes written onto it. The owning
+ * `analysisId` is not needed — the analysis subject is already in the document.
+ */
+export type ProvInputRef = {
+    path: string;
+    isDir: boolean;
+    anchorId: string | null;
+};
+
+/**
+ * The outcome of `inflexa prov verify`: one of five mutually exclusive states, each with enough
+ * detail for the CLI/TUI to render a clear message.
+ */
+export type VerifyResult = { status: "valid" } | { status: "unsigned" } | { status: "tampered"; detail: string } | { status: "no-key" } | { status: "empty" };


### PR DESCRIPTION
Provenance documents (W3C PROV-JSON) were stored as plain text — anyone with SQLite access could silently modify the recorded history. This adds a cryptographic integrity layer that makes tampering detectable.

== Signing infrastructure (src/modules/prov/signing.ts) ==

Ed25519 keypair generated on first use via WebCrypto (zero new deps), persisted as JWK at <configDir>/inflexa/prov_key.json. The keypair is loaded once per process and cached. Corrupt key files are handled gracefully: unparseable JSON regenerates a fresh keypair; structurally valid but wrong JWK degrades to unsigned (provenance still recorded, just without integrity). env.provKeyPath added to src/lib/env.ts.

== Hash chain (src/modules/prov/prov.ts flush path) ==

Each provenance flush computes SHA-256(prev_chain_hash || prov_json) — seeded from SHA-256("") on the first flush — then signs the result with the Ed25519 private key. Both the chain hash and signature are written atomically alongside the provenance in a single UPDATE. Two flush paths:

  - flushProvenanceAsync(): normal path, signs the chain hash
  - flushProvenance(): sync exit backstop (process.on("exit") handlers must be synchronous, WebCrypto is async), writes unsigned provenance

== Database (migration v3) ==

ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT; ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;

Existing rows get NULL, correctly treated as "unsigned" by verification. getAnalysisIntegrity() reads all three provenance columns in one query; updateAnalysisProvenance() extended to write all three atomically.

== Verification (src/modules/prov/verify.ts) ==

Pure verifyProvenance() function: recomputes chain hash from stored PROV-JSON, compares to stored hash, verifies Ed25519 signature. Returns a VerifyResult discriminated union (valid|unsigned|tampered|no-key|empty).

Two CLI commands:
  - `inflexa prov verify <analysis>`: DB-based, resolves by id-or-name
  - `inflexa prov verify-file <path>`: file-based, reads .sig.json sidecar — no DB needed, so a colleague who receives exported files can confirm integrity without having run the analysis themselves

TUI command palette entry "Verify provenance" (category: Analysis), enabled when an analysis is open, displays result as a notice.

== Self-describing export sidecar (src/modules/prov/export.ts) ==

Export now writes a .sig.json sidecar alongside the provenance file, containing everything needed for third-party verification:

  { payloadType, payloadDigestAlgorithm, payloadDigest,
    payloadDigestMethod, signatureAlgorithm, signature, publicKey }

payloadDigestMethod: "verbatim" declares the digest was computed over exact stored bytes — no canonicalization (PROV-JSON has no canonical form; this aligns with DSSE's opaque-payload approach).

== bunfig.toml ==

Removed @opentui/solid/runtime-plugin-support from top-level preload. That plugin's catch-all onResolve({ filter: /.*/ }) re-enters itself via import.meta.resolve during Bun.build, intermittently blowing the stack. Kept in [test] preload where it's needed for render tests (test runner never bundles). See opentui-issue-runtime-plugin-recursion.md.

== Specs ==

OpenSpec change prov-integrity archived (6 delta specs, 23 tasks). Three new main specs created: prov-signing, prov-chain, prov-verify. Delta requirements merged into cli-core, command-palette, and data-model-storage main specs.

== Tests ==

signing.test.ts: 11 tests (keypair lifecycle, chain hash determinism,
  sign/verify round-trip, tamper detection, Ed25519 determinism)
verify.test.ts: 9 tests (all 5 VerifyResult variants, file-based
  verification: valid + tampered + missing sidecar)
prov.test.ts: +4 tests (signed flush, multi-flush chaining, sidecar
  shape, e2e verify round-trip)
primary_migrations.test.ts: updated for migration v3

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (default no network egress, working-directory-only mounts, resource limits); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented), and `docs/provenance.md` is updated.
