### PR TITLE
chore: regenerate bun.lock after TypeScript 6 upgrade

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "globals": "^17.6.0",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.8.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
       },
     },
@@ -504,7 +504,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.62.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.1", "@typescript-eslint/parser": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/utils": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw=="],
 


### PR DESCRIPTION
## Summary

- Regenerates `bun.lock` after Dependabot PR #6 (TypeScript 5.9.3 → 6.0.3) was merged
- Dependabot doesn't support bun lockfiles, so manual regeneration is needed
- Installs TypeScript 6.0.3 as intended by the package.json range `^6.0.3`

## Verification

- `bun run typecheck` — clean
- `bun test` — 248 pass, 0 fail
- `bun run lint` — clean

## Note

`@inflexa-ai/tsprov` peer dep warning (`typescript: ^5` excludes 6.x) is tracked in inflexa-ai/tsprov#1.