### PR TITLE
Enforce neverthrow-first error handling across the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ bun run format       # Format all of src/
 - **At CLI boundaries:** `result.match(v => v, dieOn("context"))` — print and exit.
 - **In module logic:** `.andThen` / `.map` to chain, `.mapErr` to translate error types across layers.
 - **In the TUI:** the presentation layer may `.match` to render success/error states.
-- **Never `.unwrap()` or `._unsafeUnwrap()`.** These defeat the purpose. If you need the value and want to crash on error, you're at a CLI boundary — use `dieOn`.
+- **Never `.unwrap()` or `._unsafeUnwrap()` in production code.** These defeat the purpose. If you need the value and want to crash on error, you're at a CLI boundary — use `dieOn`. **Exception:** test files (`*.test.ts`) may use `._unsafeUnwrap()` to extract values where an unexpected `Err` is itself a test failure.
 
 ### Migrating existing `throw` → `Result`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,37 @@ bun run format       # Format all of src/
 
 - **Don't extract single-caller helpers or sub-components into separate files.** Keep them in the same file as their caller. A new file is justified only when multiple callers exist — that's when a real reusable pattern emerges.
 
+## Error handling — neverthrow first
+
+**`Result<T, E>` from `neverthrow` is the default error channel.** Every function that can fail returns `Result` (sync) or `ResultAsync` (async). The `eslint-plugin-neverthrow` `must-use-result` rule is set to `error` — an unconsumed `Result` is a build failure.
+
+### The rule
+
+1. **Return `Result`, don't `throw`.** A function's failure mode is part of its signature. If it can fail, the return type says so (`Result<T, SomeError>`). Callers handle both branches with `.match`, `.andThen`, `.map`, `.mapErr`, etc.
+2. **`throw` requires explicit user approval.** Before writing a `throw`, get confirmation. The only pre-approved exceptions are:
+   - **Exhaustive-switch defaults** — `throw new Error("unhandled: ...")` (or `never`-typed) in a `default:` branch that the compiler should make unreachable. This is a programmer bug, not a runtime failure.
+   - **Top-level entry-point bail-outs** — `fail()` / `dieOn()` in `lib/cli.ts` at the CLI boundary, where the process is about to exit anyway.
+   - **`throw` inside `bun:sqlite` transactions** — bun's `transaction()` API uses throw-to-rollback; the `TxAbort` pattern in `db/util.ts` bridges this into `Result`.
+3. **Wrap throwing stdlib / external calls at the boundary.** When a function you don't control throws (`readFileSync`, `mkdirSync`, `writeFileSync`, `JSON.parse`, `crypto.*`, `Bun.spawn`, etc.), wrap it in a function that returns `Result`. The wrapper lives beside its callers (in `lib/` if cross-cutting, in the module if local). Existing examples: `tryQuery`/`tryMutation` in `db/util.ts`, `JSON.parseWith` in `extensions/json.ext.ts`.
+4. **`try/catch` is only for bridging throws into `Result`.** A `try/catch` that doesn't produce a `Result` is a code smell — it means either the caught function should return `Result` itself, or the catch block should.
+
+### Error types
+
+- **Domain errors are discriminated unions** — `type FooError = { type: "x"; ... } | { type: "y"; ... }`, not `Error` subclasses. This gives exhaustive `switch` and zero prototype overhead.
+- **`DbError`** (in `db/errors.ts`) is the storage-layer error. Absence is `T | null` on the `ok` channel, never an error.
+- **Keep error types as narrow as the function needs.** A function that can only fail one way returns `Result<T, { type: "io_failed"; cause: unknown }>`, not `Result<T, AllErrors>`.
+
+### Consuming Results
+
+- **At CLI boundaries:** `result.match(v => v, dieOn("context"))` — print and exit.
+- **In module logic:** `.andThen` / `.map` to chain, `.mapErr` to translate error types across layers.
+- **In the TUI:** the presentation layer may `.match` to render success/error states.
+- **Never `.unwrap()` or `._unsafeUnwrap()`.** These defeat the purpose. If you need the value and want to crash on error, you're at a CLI boundary — use `dieOn`.
+
+### Migrating existing `throw` → `Result`
+
+The codebase has legacy `throw`/`try-catch` sites being migrated. When touching a function that throws, convert it to return `Result` if the change is contained (the function + its direct callers). Don't leave a half-migrated state where a function both throws AND returns `Result`. Mark sites you notice but can't convert in-scope with `// TODO(slop): neverthrow`.
+
 ## Code Comments
 
 Comment the why, not the what.
@@ -48,7 +79,7 @@ Document the decisions you made.
 
 Document what is NOT there.
 
-- Flag shortcuts and unhandled cases explicitly rather than leaving them silent. Use `throw new Error("not implemented")` (or a `// TODO:` with an issue link) instead of a stub that returns a fake value.
+- Flag shortcuts and unhandled cases explicitly rather than leaving them silent. Use `err({ type: "not_implemented" })` when the function returns `Result`, or `throw new Error("not implemented")` only in exhaustive-switch defaults and pre-approved boundary sites (see [Error handling](#error-handling--neverthrow-first)), instead of a stub that returns a fake value.
 - In exhaustive `switch`/discriminated-union handling, use a `never`-typed default branch so the compiler flags any case you forgot — this documents "everything is handled" and breaks the build when it stops being true.
 - Note future optimization opportunities and the deliberate absence of an implementation (e.g., why a method is intentionally not provided, why a type guard is omitted).
 

--- a/docs/neverthrow-audit.md
+++ b/docs/neverthrow-audit.md
@@ -1,5 +1,7 @@
 # neverthrow migration audit
 
+> **Status: IMPLEMENTED.** All items below were migrated in commit `f4345b2` + follow-up fix. This file is now a reference for what was done and why.
+
 Comprehensive catalog of every `try/catch`, `throw`, and error-handling site in `src/`.
 Organized by verdict: what to convert, what to keep, and what stdlib calls need wrappers.
 
@@ -24,7 +26,7 @@ These modules/functions already return `Result<T, E>` and use `tryQuery`/`tryMut
 | `modules/prov/signing.ts` | `loadOrGenerateKeypair` | Returns `Promise<Result<ImportedKeypair, SigningError>>` |
 | `modules/prov/document.ts` | `serializeProvenance`, `findAnalysisForProv` | Return `Result<T, DbError>` |
 | `modules/prov/verify.ts` | `buildSidecar` | Returns `Promise<Result<Sidecar, SigningError>>` |
-| `modules/staging/staging.ts` | `stageInputs` | Returns `Result<Promise<StagedInput[]>, DbError>` |
+| `modules/staging/staging.ts` | `stageInputs` | Returns `Promise<Result<StagedInput[], DbError \| StagingError>>` (was `Result<Promise<...>>`, restructured) |
 
 ---
 

--- a/docs/neverthrow-audit.md
+++ b/docs/neverthrow-audit.md
@@ -1,0 +1,249 @@
+# neverthrow migration audit
+
+Comprehensive catalog of every `try/catch`, `throw`, and error-handling site in `src/`.
+Organized by verdict: what to convert, what to keep, and what stdlib calls need wrappers.
+
+## 1. Already neverthrow-wrapped (no action needed)
+
+These modules/functions already return `Result<T, E>` and use `tryQuery`/`tryMutation`/`Result.fromThrowable` to bridge throws.
+
+| Layer / File | Functions | Notes |
+|---|---|---|
+| `db/util.ts` | `tryQuery`, `tryMutation`, `withTransaction` | The bridge layer — all legitimate try/catch wrapping bun:sqlite throws |
+| `db/primary.ts` | `db()` | Connection bootstrap, wraps `new Database()` throws as `connection_failed` |
+| `db/primary_migrations.ts` | `runMigrations` | Wraps DDL throws as `migration_failed` |
+| `db/primary_query.ts` | All 18 query functions | Delegate to `tryQuery` — zero try/catch in this file |
+| `db/primary_mutation.ts` | All 19 mutation functions | Delegate to `tryMutation` — zero try/catch in this file |
+| `lib/config.ts` | `writeConfig` | Uses `Result.fromThrowable` for `mkdirSync`/`writeFileSync` |
+| `modules/auth/auth.ts` | `loadAuth`, `saveAuth`, `deleteAuth`, `resolveAuth0Config`, `requestDeviceCode`, `pollForToken`, `refreshAccessToken`, `getValidAccessToken`, `revokeRefreshToken`, `tokenWireToStoredAuth`, `acquireRefreshLock` | Fully Result-based with `AuthError` union |
+| `modules/anchor/anchor.ts` | `getOrCreateAnchorForCwd`, `resolveAnchor`, `classifyMarkerSighting`, `recoverAnchors` | Already return `Result<T, DbError>` |
+| `modules/analysis/analysis.ts` | `createAnalysis`, `uniqueSlugForAnchor`, `listAnalysesForAnchorAt`, `matchAnalysis`, etc. | Already return `Result<T, DbError>` |
+| `modules/analysis/input.ts` | `classifyInputPath`, `resolveInputPath` | Already return `Result<T, DbError>` |
+| `modules/analysis/context.ts` | `resolveContext` | Returns `Result<ResolvedContext, DbError>` |
+| `modules/intelligence/chat.ts` | `chat` | Returns `Promise<Result<void, DbError>>` |
+| `modules/prov/signing.ts` | `loadOrGenerateKeypair` | Returns `Promise<Result<ImportedKeypair, SigningError>>` |
+| `modules/prov/document.ts` | `serializeProvenance`, `findAnalysisForProv` | Return `Result<T, DbError>` |
+| `modules/prov/verify.ts` | `buildSidecar` | Returns `Promise<Result<Sidecar, SigningError>>` |
+| `modules/staging/staging.ts` | `stageInputs` | Returns `Result<Promise<StagedInput[]>, DbError>` |
+
+---
+
+## 2. Functions that throw and SHOULD return `Result` (convert)
+
+### Priority 1 — Root-cause throwers (converting these collapses downstream try/catch)
+
+#### `modules/anchor/marker.ts`
+
+| Function | Currently | Target | Downstream impact |
+|---|---|---|---|
+| `readMarker(dir)` | Returns `AnchorMarker \| null`, throws on corrupt marker & via `readFileSync` | `Result<AnchorMarker \| null, MarkerError>` | Collapses 7 try/catch blocks in `anchor.ts`, `backstop.ts`, `context.ts`, `analysis.ts`, `input.ts` |
+| `writeMarker(dir, anchorId)` | Returns `AnchorMarker`, throws via `readMarker` + `mkdirSync` + `writeFileSync` | `Result<AnchorMarker, MarkerError>` | Collapses try/catch in `anchor.ts:60-63` |
+| `findMarkerUpwards(startDir)` | Returns `{dir, marker} \| null`, throws via `readMarker` | `Result<{dir, marker} \| null, MarkerError>` | Collapses try/catch in `context.ts:50-55`, `analysis.ts:216-220`, `input.ts:33-36` |
+
+**Stdlib calls needing wrappers inside `marker.ts`:** `readFileSync`, `mkdirSync`, `writeFileSync`
+
+**Error type to define:**
+```ts
+type MarkerError =
+    | { type: "marker_read_failed"; path: string; cause: unknown }
+    | { type: "marker_corrupt"; path: string; raw: string }
+    | { type: "marker_write_failed"; path: string; cause: unknown };
+```
+
+**Note:** `canonicalPath` (catches `realpathSync`, falls back to `resolve`) and `isDirWritable` (catches `accessSync`, returns boolean) are fine as-is — these are boolean/fallback predicates, not error channels. The `TODO(slop)` on `marker.ts:97` (`dirname`) is a false alarm — `dirname` is pure and never throws.
+
+#### `modules/prov/signing.ts` — crypto primitives
+
+| Function | Currently | Target |
+|---|---|---|
+| `signHexDigest(key, digest)` | `Promise<string>`, rejects via `crypto.subtle.sign` | `ResultAsync<string, SigningError>` |
+| `computeChainHash(prev, json)` | `Promise<string>`, rejects via `crypto.subtle.digest` | `ResultAsync<string, SigningError>` |
+| `computePayloadDigest(json)` | `Promise<string>`, rejects via `crypto.subtle.digest` | `ResultAsync<string, SigningError>` |
+| `verifyHexDigest(key, digest, sig)` | `Promise<boolean>`, rejects via `crypto.subtle.verify` | `ResultAsync<boolean, SigningError>` |
+| `exportPublicKeyJwk(kp)` | `Promise<JWK \| null>`, **uncaught** `crypto.subtle.exportKey` rejection | `ResultAsync<JWK \| null, SigningError>` |
+
+Converting these removes the try/catch at `prov.ts:171-185` and fixes the **uncaught rejection** in `verify.ts:buildSidecar` (lines 166-170 call `computePayloadDigest`/`signHexDigest`/`exportPublicKeyJwk` without catch, bypassing the `Result` return type).
+
+#### `lib/container.ts`
+
+| Function | Currently | Target |
+|---|---|---|
+| `ensureReady(rt)` | `Promise<void>`, throws `ContainerRuntimeError` | `ResultAsync<void, ContainerRuntimeError>` |
+
+Two well-defined failure modes (`not_found`, `not_ready`) that map to a discriminated union. Converting removes the 2 try/catch blocks in `proxy/setup.ts` (`setup:67-75`, `ensureProxyReadyOrExit:371-381`).
+
+#### `lib/hash.ts`
+
+| Function | Currently | Target |
+|---|---|---|
+| `sha256File(path)` | `Promise<string>`, rejects on stream error | `ResultAsync<string, HashError>` |
+
+Callers (`staging.ts`) currently have no try/catch — an I/O error is an unhandled rejection. Converting makes the failure visible.
+
+#### `modules/intelligence/chat.ts`
+
+| Function | Currently | Target |
+|---|---|---|
+| `readApiKey()` | `Promise<string>`, throws on missing key | `ResultAsync<string, ChatSetupError>` |
+| `resolveModelId(apiKey)` | `Promise<string>`, throws on HTTP error / no models | `ResultAsync<string, ChatSetupError>` |
+
+These throw inside the try/catch at `chat.ts:111-136`. Converting them would let the error channel stay in `Result` rather than flowing through `streamError`.
+
+#### `modules/proxy/setup.ts`
+
+| Function | Currently | Target |
+|---|---|---|
+| `resolveProvider(options)` | throws `ProxyError` on invalid provider | Return `Result<Provider \| undefined, ProxyError>` |
+| `pullImage(rt, force)` | throws `ProxyError` on pull failure | Return `ResultAsync<void, ProxyError>` |
+| `recreateContainer(rt)` | throws `ProxyError` on start failure | Return `ResultAsync<void, ProxyError>` |
+| `ensureContainerRunning(rt)` | throws `ProxyError` on start failure | Return `ResultAsync<void, ProxyError>` |
+| `ensureProxyReady()` | throws `ProxyError`/`ContainerRuntimeError` | Return `ResultAsync<void, ProxyError \| ContainerRuntimeError>` |
+
+These are all internal to the `setup` command flow. `ensureProxyReady` is the public surface consumed by the TUI. Converting it removes the catch in `ensureProxyReadyOrExit` and makes the failure explicit in the type.
+
+---
+
+## 3. try/catch blocks that collapse once their throwing functions are converted
+
+These are consumers of the throwing functions listed above. Once the source functions return `Result`, these try/catch blocks become `.andThen()`/`.map()`/`.match()` chains.
+
+| File | Lines | Catches | Becomes |
+|---|---|---|---|
+| `anchor/anchor.ts` | 33-38 | `readMarker` throw → `err(query_failed)` | `readMarker(abs).andThen(...)` |
+| `anchor/anchor.ts` | 60-63 | `writeMarker` throw → `err(mutation_failed)` | `writeMarker(abs, anchorId).andThen(...)` |
+| `anchor/anchor.ts` | 74-78 | `readMarker` throw → `false` | `readMarker(dir).map(...).unwrapOr(false)` |
+| `anchor/anchor.ts` | 87-93 | `findMarkerUpwards` throw → `null` | `findMarkerUpwards(startDir).map(...).unwrapOr(null)` |
+| `anchor/backstop.ts` | 21-26 | `readMarker` throw → `null` | `readMarker(dir).unwrapOr(null)` |
+| `anchor/backstop.ts` | 38-42 | `readMarker` throw → `fail()` | `readMarker(dir).match(ok, dieOn(...))` |
+| `analysis/context.ts` | 50-55 | `findMarkerUpwards` throw → `err(query_failed)` | `findMarkerUpwards(cwd).mapErr(...)` |
+| `analysis/analysis.ts` | 216-220 | `findMarkerUpwards` throw → `err(query_failed)` | `findMarkerUpwards(dir).mapErr(...)` |
+| `analysis/input.ts` | 22-26 | `statSync` throw → `err(query_failed)` | `statResult(target).mapErr(...)` |
+| `analysis/input.ts` | 33-36 | `findMarkerUpwards` throw → `err(query_failed)` | `findMarkerUpwards(abs).mapErr(...)` |
+| `prov/prov.ts` | 171-185 | crypto primitives reject → log error | `signHexDigest(...).andThen(...)` |
+| `proxy/setup.ts` | 36-75 | `ensureProxyReady` path → `process.exitCode=1` | `setup` returns `ResultAsync`, `.match()` at boundary |
+| `proxy/setup.ts` | 371-381 | `ensureProxyReady` throw → `process.exit(1)` | `ensureProxyReady().match(...)` |
+| `intelligence/chat.ts` | 111-136 | `readApiKey`/`resolveModelId` throw → `streamError` | `.andThen(...)` chain |
+
+---
+
+## 4. Legitimate try/catch (keep as-is)
+
+These catch blocks are correct and should NOT be converted:
+
+| File | Lines | Reason |
+|---|---|---|
+| `db/util.ts` | 8-12, 17-22, 31-52, 95-99 | Bridge layer: wraps bun:sqlite throws into `Result`. `TxAbort` throw-to-rollback. `ensureDir` best-effort. |
+| `db/primary.ts` | 14-24 | Wraps `new Database()` constructor throws |
+| `db/primary_migrations.ts` | 116-138 | Wraps DDL throws |
+| `lib/config.ts` | 26-31 | Fail-closed to safe default on missing/corrupt config |
+| `lib/log.ts` | 17-28, 33-36, 89-93 | Log infrastructure — must never crash the app |
+| `lib/otel.ts` | 51-74, 87-108 | Telemetry — must never crash the app |
+| `lib/clipboard.ts` | 50-57 | Best-effort clipboard write, logged |
+| `index.ts` | 41-68 | Process entry point — Commander uses throw-based control flow |
+| `extensions/json.ext.ts` | 16-22 | Global extension absorbs `JSON.parse` throws into `T\|null` |
+| `extensions/response.ext.ts` | 18-24 | Global extension absorbs `Response.json()` throws into `T\|null` |
+| `tui/grammars/register.ts` | 67-88 | Fire-and-forget grammar warming |
+| `tui/commands.tsx` | 264-270, 381-385, 409-414 | Dynamic `import()` is inherently throwing |
+| `analysis/lock.ts` | 30-35, 45-50, 65-75, 90-100 | Advisory lock: PID-probe + O_EXCL are throw-based by design, fail-open semantics. `LockOutcome` is intentionally not `Result`. |
+| `auth/auth.ts` | 147-152, 185-193, 225-241, 279-287, 323-333, 338-345, 381-388, 408-412, 423-427 | Bridging `fetch`/`readFileSync`/`writeFileSync`/`statSync` throws into `Result<T, AuthError>` |
+| `prov/export.ts` | 28-31, 49-55 | CLI action — `fail()` / best-effort sidecar write |
+| `prov/verify.ts` | 213-216, 219-222 | Bridging `crypto.subtle.importKey` + `readFileSync` into `VerifyResult` status |
+| `prov/signing.ts` | 67-71, 85-115, 131-137, 140-160, 171-175 | Bridging FS + WebCrypto into `Result<T, SigningError>` (except the crypto primitives — see §2) |
+| `staging/staging.ts` | 49-53 | Hardlink fallback to copy — catch is the intentional fallback, not an error |
+
+---
+
+## 5. Legitimate throw (keep as-is, pre-approved by policy)
+
+| File | Line | What | Justification |
+|---|---|---|---|
+| `lib/env.ts` | 88, 92 | Crash on misconfigured build | Invariant assertion — silently stamping provenance with garbage is worse |
+| `prov/document.ts` | 67 | Exhaustive-switch default (`never`-branch) | Compiler bug guard |
+| `tui/contexts/workspace.ts` | 105 | Context provider missing | React/Solid framework convention — programmer bug |
+| `db/util.ts` | 43 | `TxAbort` throw-to-rollback | Internal bridge, never escapes `withTransaction` |
+| `prov/signing.ts` | 94, 104 | Re-throw non-EEXIST `linkSync` errors | Propagates to outer catch that wraps in `Result` |
+| `lib/cli.ts` | `fail()`, `dieOn()` | CLI boundary exit (`never` return) | Top-level bail-out, the process is terminating |
+
+---
+
+## 6. Stdlib wrappers needed
+
+Functions the codebase calls that throw, needing `Result`-returning wrappers:
+
+| Stdlib function | Where called (unwrapped) | Wrapper location |
+|---|---|---|
+| `readFileSync(path, "utf8")` | `marker.ts:46` | `lib/fs.ts` (new: `readFileResult`) |
+| `writeFileSync(path, data, opts?)` | `marker.ts:67`, `commands.tsx:295,309` | `lib/fs.ts` (`writeFileResult`) |
+| `mkdirSync(path, opts?)` | `marker.ts:66`, `commands.tsx:294` | `lib/fs.ts` (`mkdirResult`) |
+| `statSync(path)` | `input.ts:23` | `lib/fs.ts` (`statResult`) |
+| `crypto.subtle.sign(...)` | `signing.ts:239` | wrap inline with `ResultAsync.fromPromise` |
+| `crypto.subtle.verify(...)` | `signing.ts:248` | wrap inline with `ResultAsync.fromPromise` |
+| `crypto.subtle.digest(...)` | `signing.ts:210,223,229` | wrap inline with `ResultAsync.fromPromise` |
+| `crypto.subtle.exportKey(...)` | `signing.ts:185` | wrap inline with `ResultAsync.fromPromise` |
+| `createReadStream` (via reject) | `hash.ts:12` | wrap `sha256File` itself |
+
+**Note:** `JSON.parse` is already wrapped by `JSON.parseWith` (extension). `readFileSync`/`writeFileSync` in `auth.ts` and `config.ts` are already bridged into `Result` at their call sites — but a shared `lib/fs.ts` wrapper would DRY those.
+
+---
+
+## 7. TODO(slop) tags — all 13
+
+| File | Line | Tag text | Action |
+|---|---|---|---|
+| `anchor/marker.ts` | 19 | `neverthrow` (on `canonicalPath`'s `realpathSync` catch) | Keep as-is — fallback predicate, not an error channel |
+| `anchor/marker.ts` | 46 | `make a wrapper that returns result` (on `readFileSync`) | Convert `readMarker` to return `Result` |
+| `anchor/marker.ts` | 51 | `don't throw, return result` (on corrupt marker throw) | Convert to `err({ type: "marker_corrupt" })` |
+| `anchor/marker.ts` | 66 | `Make wrapper - don't throw` (on `mkdirSync`) | Use `mkdirResult` wrapper |
+| `anchor/marker.ts` | 67 | `make wrapper - don't throw` (on `writeFileSync`) | Use `writeFileResult` wrapper |
+| `anchor/marker.ts` | 78 | `neverthrow` (on `isDirWritable`'s `accessSync` catch) | Keep as-is — boolean predicate, not an error channel |
+| `anchor/marker.ts` | 97 | `make a wrapper that returns result` (on `dirname`) | Remove — `dirname` is pure and never throws |
+| `anchor/anchor.ts` | 61 | `this will be refactored to return result` (on `writeMarker` catch) | Collapses once `writeMarker` returns `Result` |
+| `anchor/anchor.ts` | 75 | `same here, try catch without reason` (on `readMarker` catch) | Collapses once `readMarker` returns `Result` |
+| `anchor/anchor.ts` | 88 | `neverthrow` (on `findMarkerUpwards` catch) | Collapses once `findMarkerUpwards` returns `Result` |
+| `anchor/backstop.ts` | 22 | `neverthrow` (on `readMarkerSafe`'s `readMarker` catch) | Collapses once `readMarker` returns `Result` |
+| `anchor/backstop.ts` | 39 | `neverthrow` (on `runRepair`'s `readMarker` catch) | Collapses once `readMarker` returns `Result` |
+| `analysis/context.ts` | 51 | `neverthrow` (on `findMarkerUpwards` catch) | Collapses once `findMarkerUpwards` returns `Result` |
+
+---
+
+## 8. Uncaught rejection bugs (fix during migration)
+
+| File | Lines | Bug | Fix |
+|---|---|---|---|
+| `prov/verify.ts` | 166-170 (`buildSidecar`) | Calls `exportPublicKeyJwk`, `computePayloadDigest`, `signHexDigest` without try/catch. These can reject, bypassing `buildSidecar`'s `Result` return. | Convert the 3 functions to `ResultAsync` (§2), then chain with `.andThen` |
+| `prov/document.ts` | 88 | `ProvDocument.deserialize(storedJson)` can throw on corrupt stored JSON. Propagates uncaught through `prov.ts`'s recorder. | Wrap in `Result.fromThrowable` at the call site |
+
+---
+
+## 9. Suggested migration order
+
+1. **`lib/fs.ts`** — create `readFileResult`, `writeFileResult`, `mkdirResult`, `statResult` wrappers using `Result.fromThrowable`
+2. **`modules/anchor/marker.ts`** — convert `readMarker`, `writeMarker`, `findMarkerUpwards` to return `Result<T, MarkerError>`; remove 3 TODO(slop) tags; update `marker.test.ts`
+3. **`modules/anchor/anchor.ts`** — replace 4 try/catch blocks with `.andThen()`/`.unwrapOr()`; remove 3 TODO(slop) tags
+4. **`modules/anchor/backstop.ts`** — replace 2 try/catch blocks with `.match()`; remove 2 TODO(slop) tags
+5. **Downstream consumers** — `analysis/context.ts`, `analysis/analysis.ts`, `analysis/input.ts` — replace try/catch with `.andThen()`; remove 1 TODO(slop) tag
+6. **`modules/prov/signing.ts`** — convert 5 crypto primitives to `ResultAsync`
+7. **`modules/prov/prov.ts`** + **`modules/prov/verify.ts`** — replace try/catch with `.andThen()`, fix uncaught rejections
+8. **`lib/container.ts`** — convert `ensureReady` to `ResultAsync`
+9. **`modules/proxy/setup.ts`** — convert internal functions + `ensureProxyReady` to `ResultAsync`
+10. **`modules/intelligence/chat.ts`** — convert `readApiKey`, `resolveModelId` to `ResultAsync`
+11. **`lib/hash.ts`** — convert `sha256File` to `ResultAsync`
+12. **`tui/commands.tsx`** — replace `mkdirSync`/`writeFileSync` try/catch with wrappers
+
+---
+
+## 10. Uncaught throws inside `Result` `.map()` chains (will bypass the error channel)
+
+These are calls to throwing stdlib functions inside `.map()`/`.andThen()` callbacks that do NOT have their own try/catch. If they throw, the exception bypasses the `Result` error channel entirely, becoming an unhandled exception/rejection.
+
+| File | Function | Line | Throwing call | Risk |
+|---|---|---|---|---|
+| `analysis/output.ts` | `ensureOutputDir` | 45 | `mkdirSync` inside `.map()` | Permission denied blows up past `DbError` |
+| `analysis/open.ts` | `openOutputDir` | 33 | `Bun.spawn` inside `.map()` | Missing opener binary blows up |
+| `staging/staging.ts` | `stageFile` | 48 | `mkdirSync` | Permission denied |
+| `staging/staging.ts` | `stageFile` | 52 | `copyFileSync` (fallback after `linkSync` catch) | Cross-fs + copy failure |
+| `staging/staging.ts` | `stageSingleFile` | 84 | `statSync` | File vanished between stage and stat |
+| `staging/staging.ts` | `walkFiles` | 63 | `readdirSync` | Permission denied |
+| `staging/staging.ts` | `stageSingleFile` | 83 | `sha256File` | Async rejection inside Promise |
+
+**Staging structural gap:** `stageInputs` returns `Result<Promise<StagedInput[]>, DbError>` — the DB-read phase is Result-wrapped, but the entire filesystem I/O phase runs inside the unwrapped `Promise`. Any FS error during staging becomes an unhandled rejection rather than flowing through Result. The fix is to change the return type to `ResultAsync<StagedInput[], DbError | StagingError>` so the I/O phase is also Result-wrapped.

--- a/docs/neverthrow-audit.md
+++ b/docs/neverthrow-audit.md
@@ -26,7 +26,7 @@ These modules/functions already return `Result<T, E>` and use `tryQuery`/`tryMut
 | `modules/prov/signing.ts` | `loadOrGenerateKeypair` | Returns `Promise<Result<ImportedKeypair, SigningError>>` |
 | `modules/prov/document.ts` | `serializeProvenance`, `findAnalysisForProv` | Return `Result<T, DbError>` |
 | `modules/prov/verify.ts` | `buildSidecar` | Returns `Promise<Result<Sidecar, SigningError>>` |
-| `modules/staging/staging.ts` | `stageInputs` | Returns `Promise<Result<StagedInput[], DbError \| StagingError>>` (was `Result<Promise<...>>`, restructured) |
+| `modules/staging/staging.ts` | `stageInputs` | Returns `Promise<Result<StagedInput[], DbError \| StagingError>>` (was `Result<Promise<...>>`, restructured). **Downstream fork only** — this module does not exist in inf-cli yet. |
 
 ---
 
@@ -80,7 +80,7 @@ Two well-defined failure modes (`not_found`, `not_ready`) that map to a discrimi
 |---|---|---|
 | `sha256File(path)` | `Promise<string>`, rejects on stream error | `ResultAsync<string, HashError>` |
 
-Callers (`staging.ts`) currently have no try/catch — an I/O error is an unhandled rejection. Converting makes the failure visible.
+Callers (`staging.ts`, downstream fork only) currently have no try/catch — an I/O error is an unhandled rejection. Converting makes the failure visible.
 
 #### `modules/intelligence/chat.ts`
 
@@ -151,7 +151,7 @@ These catch blocks are correct and should NOT be converted:
 | `prov/export.ts` | 28-31, 49-55 | CLI action — `fail()` / best-effort sidecar write |
 | `prov/verify.ts` | 213-216, 219-222 | Bridging `crypto.subtle.importKey` + `readFileSync` into `VerifyResult` status |
 | `prov/signing.ts` | 67-71, 85-115, 131-137, 140-160, 171-175 | Bridging FS + WebCrypto into `Result<T, SigningError>` (except the crypto primitives — see §2) |
-| `staging/staging.ts` | 49-53 | Hardlink fallback to copy — catch is the intentional fallback, not an error |
+| `staging/staging.ts` | 49-53 | Hardlink fallback to copy — catch is the intentional fallback, not an error (**downstream fork only**) |
 
 ---
 
@@ -242,10 +242,10 @@ These are calls to throwing stdlib functions inside `.map()`/`.andThen()` callba
 |---|---|---|---|---|
 | `analysis/output.ts` | `ensureOutputDir` | 45 | `mkdirSync` inside `.map()` | Permission denied blows up past `DbError` |
 | `analysis/open.ts` | `openOutputDir` | 33 | `Bun.spawn` inside `.map()` | Missing opener binary blows up |
-| `staging/staging.ts` | `stageFile` | 48 | `mkdirSync` | Permission denied |
-| `staging/staging.ts` | `stageFile` | 52 | `copyFileSync` (fallback after `linkSync` catch) | Cross-fs + copy failure |
-| `staging/staging.ts` | `stageSingleFile` | 84 | `statSync` | File vanished between stage and stat |
-| `staging/staging.ts` | `walkFiles` | 63 | `readdirSync` | Permission denied |
-| `staging/staging.ts` | `stageSingleFile` | 83 | `sha256File` | Async rejection inside Promise |
+| `staging/staging.ts` | `stageFile` | 48 | `mkdirSync` | Permission denied (**downstream fork only**) |
+| `staging/staging.ts` | `stageFile` | 52 | `copyFileSync` (fallback after `linkSync` catch) | Cross-fs + copy failure (**downstream fork only**) |
+| `staging/staging.ts` | `stageSingleFile` | 84 | `statSync` | File vanished between stage and stat (**downstream fork only**) |
+| `staging/staging.ts` | `walkFiles` | 63 | `readdirSync` | Permission denied (**downstream fork only**) |
+| `staging/staging.ts` | `stageSingleFile` | 83 | `sha256File` | Async rejection inside Promise (**downstream fork only**) |
 
-**Staging structural gap:** `stageInputs` returns `Result<Promise<StagedInput[]>, DbError>` — the DB-read phase is Result-wrapped, but the entire filesystem I/O phase runs inside the unwrapped `Promise`. Any FS error during staging becomes an unhandled rejection rather than flowing through Result. The fix is to change the return type to `ResultAsync<StagedInput[], DbError | StagingError>` so the I/O phase is also Result-wrapped.
+**Staging structural gap (downstream fork only — module does not exist in inf-cli yet):** `stageInputs` returns `Result<Promise<StagedInput[]>, DbError>` — the DB-read phase is Result-wrapped, but the entire filesystem I/O phase runs inside the unwrapped `Promise`. Any FS error during staging becomes an unhandled rejection rather than flowing through Result. The fix is to change the return type to `ResultAsync<StagedInput[], DbError | StagingError>` so the I/O phase is also Result-wrapped.

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -5,6 +5,8 @@
 // config-reading resolver (`activeRuntime`) therefore lives in lib/config.ts, not
 // here. The proxy module is today's only caller of the spawn core.
 
+import { type Result, ok, err } from "neverthrow";
+
 /**
  * Ordered id list — single source of truth for the picker order, the
  * `ContainerRuntimeId` union, and the config zod enum. Docker is first: it is the
@@ -91,14 +93,15 @@ export async function inherit(rt: ContainerRuntime, args: string[]): Promise<num
 }
 
 /**
- * Verify the runtime is installed and usable before issuing commands. Throws a
- * {@link ContainerRuntimeError} with runtime-specific guidance: `notFoundHint`
- * when the binary is absent, `notReadyHint` when `info` fails (daemon down /
- * Podman machine not started).
+ * Verify the runtime is installed and usable before issuing commands. Returns
+ * a {@link ContainerRuntimeError} on the error channel with runtime-specific
+ * guidance: `notFoundHint` when the binary is absent, `notReadyHint` when
+ * `info` fails (daemon down / Podman machine not started).
  */
-export async function ensureReady(rt: ContainerRuntime): Promise<void> {
-    if (!Bun.which(rt.bin)) throw new ContainerRuntimeError(rt.notFoundHint);
+export async function ensureReady(rt: ContainerRuntime): Promise<Result<void, ContainerRuntimeError>> {
+    if (!Bun.which(rt.bin)) return err(new ContainerRuntimeError(rt.notFoundHint));
     // `info` exits non-zero when the runtime is installed but not reachable.
     const { code } = await capture(rt, ["info"]);
-    if (code !== 0) throw new ContainerRuntimeError(rt.notReadyHint);
+    if (code !== 0) return err(new ContainerRuntimeError(rt.notReadyHint));
+    return ok(undefined);
 }

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, readFileSync, statSync, writeFileSync, type Stats } from "node:fs";
+import { type Result, ok, err } from "neverthrow";
+
+/**
+ * Filesystem error for operations that can fail with an OS-level I/O error.
+ * `op` names the logical operation so callers can distinguish "which read
+ * failed" without inspecting the cause.
+ */
+export type FsError = { type: "io_failed"; op: string; cause: unknown };
+
+/** Read a UTF-8 text file, wrapping `readFileSync` throws into `Result`. */
+export function readFileResult(path: string, op: string): Result<string, FsError> {
+    try {
+        return ok(readFileSync(path, "utf8"));
+    } catch (cause) {
+        return err({ type: "io_failed", op, cause });
+    }
+}
+
+/** Write a text file, wrapping `writeFileSync` throws into `Result`. */
+export function writeFileResult(path: string, data: string, op: string, opts?: Parameters<typeof writeFileSync>[2]): Result<void, FsError> {
+    try {
+        writeFileSync(path, data, opts);
+        return ok(undefined);
+    } catch (cause) {
+        return err({ type: "io_failed", op, cause });
+    }
+}
+
+/** Create directories recursively, wrapping `mkdirSync` throws into `Result`. */
+export function mkdirResult(path: string, op: string): Result<void, FsError> {
+    try {
+        mkdirSync(path, { recursive: true });
+        return ok(undefined);
+    } catch (cause) {
+        return err({ type: "io_failed", op, cause });
+    }
+}
+
+/** Stat a path, wrapping `statSync` throws into `Result`. */
+export function statResult(path: string, op: string): Result<Stats, FsError> {
+    try {
+        return ok(statSync(path));
+    } catch (cause) {
+        return err({ type: "io_failed", op, cause });
+    }
+}

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { ResultAsync } from "neverthrow";
+import type { FsError } from "./fs.ts";
+
+/** SHA-256 hash a file by streaming its content. Returns the hex-encoded digest. */
+export function sha256File(path: string): ResultAsync<string, FsError> {
+    return ResultAsync.fromPromise(
+        new Promise<string>((resolve, reject) => {
+            const hash = createHash("sha256");
+            const stream = createReadStream(path);
+            stream.on("data", (chunk) => hash.update(chunk));
+            stream.on("end", () => resolve(hash.digest("hex")));
+            stream.on("error", reject);
+        }),
+        (cause): FsError => ({ type: "io_failed", op: "sha256File", cause }),
+    );
+}

--- a/src/modules/analysis/analysis.ts
+++ b/src/modules/analysis/analysis.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7 } from "bun";
 import { resolve, sep } from "node:path";
-import { ok, err, Result } from "neverthrow";
+import { ok, Result } from "neverthrow";
 import type { Analysis, AnalysisInput } from "../../types/analysis.ts";
 import type { Str256, IdOrName } from "../../lib/types.ts";
 import type { DbError } from "../../db/errors.ts";
@@ -212,14 +212,9 @@ export function createAnalysis(opts: CreateAnalysisInput): Result<Analysis, DbEr
 
 /** Analyses anchored at the nearest marker for `dir`; empty when there is no marker. */
 export function listAnalysesForAnchorAt(dir: string): Result<Analysis[], DbError> {
-    let found: ReturnType<typeof findMarkerUpwards>;
-    try {
-        found = findMarkerUpwards(dir);
-    } catch (cause) {
-        return err({ type: "query_failed", op: "listAnalysesForAnchorAt:marker", cause });
-    }
-    if (!found) return ok([]);
-    return listAnalysesByAnchor(found.marker.anchorId);
+    return findMarkerUpwards(dir)
+        .mapErr((cause): DbError => ({ type: "query_failed", op: "listAnalysesForAnchorAt:marker", cause }))
+        .andThen((found) => (found ? listAnalysesByAnchor(found.marker.anchorId) : ok([])));
 }
 
 /** All analyses, or those for `opts.projectId` when given — most-recent-first. */

--- a/src/modules/analysis/context.ts
+++ b/src/modules/analysis/context.ts
@@ -46,13 +46,9 @@ export function resolveContext(cwd: string, flags: ContextFlags): Result<Resolve
     }
 
     // 2. The folder (or an ancestor) is an anchor.
-    let found: ReturnType<typeof findMarkerUpwards>;
-    try {
-        // TODO(slop): neverthrow
-        found = findMarkerUpwards(cwd);
-    } catch (cause) {
-        return err({ type: "query_failed", op: "resolveContext:marker", cause });
-    }
+    const markerResult = findMarkerUpwards(cwd);
+    if (markerResult.isErr()) return err({ type: "query_failed", op: "resolveContext:marker", cause: markerResult.error });
+    const found = markerResult.value;
     if (!found) return ok({ kind: "empty", cwd }); // 3. Nothing here.
 
     const marker = found.marker;

--- a/src/modules/analysis/input.ts
+++ b/src/modules/analysis/input.ts
@@ -1,9 +1,9 @@
-import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { ok, err, type Result } from "neverthrow";
 import type { AnalysisInput } from "../../types/analysis.ts";
 import type { DbError } from "../../db/errors.ts";
+import { statResult } from "../../lib/fs.ts";
 import { canonicalPath, findMarkerUpwards } from "../anchor/marker.ts";
 import { resolveAnchor } from "../anchor/anchor.ts";
 
@@ -18,23 +18,17 @@ export function classifyInputPath(analysisId: string, rawPath: string, cwd: stri
 
     // `isDir` comes from a real stat. A non-existent path cannot honestly produce `isDir`, so
     // surface it (op marks it not-found) rather than defaulting — the caller rejects it.
-    let isDir: boolean;
-    try {
-        isDir = statSync(target).isDirectory();
-    } catch (cause) {
-        return err({ type: "query_failed", op: "classifyInputPath:notFound", cause });
-    }
+    const stat = statResult(target, "classifyInputPath:notFound");
+    if (stat.isErr()) return err({ type: "query_failed", op: "classifyInputPath:notFound", cause: stat.error.cause });
+    const isDir = stat.value.isDirectory();
 
     // Canonicalize now that we know it exists, so anchor membership and the stored relpath are
     // computed against symlink-resolved paths (consistent with the anchor's cachedPath).
     const abs = canonicalPath(target);
 
-    let found: { dir: string; marker: { anchorId: string } } | null;
-    try {
-        found = findMarkerUpwards(abs);
-    } catch (cause) {
-        return err({ type: "query_failed", op: "classifyInputPath:marker", cause });
-    }
+    const markerResult = findMarkerUpwards(abs);
+    if (markerResult.isErr()) return err({ type: "query_failed", op: "classifyInputPath:marker", cause: markerResult.error });
+    const found = markerResult.value;
 
     if (found) {
         const rel = relative(found.dir, abs);

--- a/src/modules/analysis/open.ts
+++ b/src/modules/analysis/open.ts
@@ -30,7 +30,11 @@ export function openerArgv(dir: string, platform: NodeJS.Platform = process.plat
 export function openOutputDir(analysis: Analysis): Result<string, DbError> {
     // ensure (not just resolve) — the directory must exist to be opened.
     return ensureOutputDir(analysis).map((dir) => {
-        Bun.spawn(openerArgv(dir), { stdout: "inherit", stderr: "inherit" });
+        try {
+            Bun.spawn(openerArgv(dir), { stdout: "inherit", stderr: "inherit" });
+        } catch {
+            // Fire-and-forget: a missing opener (ENOENT) is not worth crashing for.
+        }
         return dir;
     });
 }

--- a/src/modules/analysis/output.ts
+++ b/src/modules/analysis/output.ts
@@ -1,9 +1,9 @@
-import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { ok, type Result } from "neverthrow";
 import type { Analysis } from "../../types/analysis.ts";
 import type { DbError } from "../../db/errors.ts";
 import { env } from "../../lib/env.ts";
+import { mkdirResult } from "../../lib/fs.ts";
 import { isDirWritable } from "../anchor/marker.ts";
 import { resolveAnchor } from "../anchor/anchor.ts";
 
@@ -41,8 +41,9 @@ export function resolveOutputDir(analysis: Analysis): Result<string, DbError> {
  * (the write boundary); nothing here touches source data.
  */
 export function ensureOutputDir(analysis: Analysis): Result<string, DbError> {
-    return resolveOutputDir(analysis).map((dir) => {
-        mkdirSync(dir, { recursive: true });
-        return dir;
-    });
+    return resolveOutputDir(analysis).andThen((dir) =>
+        mkdirResult(dir, "ensureOutputDir")
+            .map(() => dir)
+            .mapErr((e): DbError => ({ type: "mutation_failed", op: "ensureOutputDir", cause: e.cause })),
+    );
 }

--- a/src/modules/anchor/anchor.ts
+++ b/src/modules/anchor/anchor.ts
@@ -6,7 +6,12 @@ import type { Anchor, AnchorMarker } from "../../types/anchor.ts";
 import type { DbError } from "../../db/errors.ts";
 import { getAnchor, listAnchors } from "../../db/primary_query.ts";
 import { insertAnchor, touchAnchor, updateAnchorCachedPath } from "../../db/primary_mutation.ts";
-import { canonicalPath, findMarkerUpwards, isDirWritable, readMarker, writeMarker } from "./marker.ts";
+import { canonicalPath, findMarkerUpwards, isDirWritable, readMarker, writeMarker, type MarkerError } from "./marker.ts";
+
+/** Bridge a marker-layer failure into the db-layer error type so callers that return `Result<T, DbError>` can propagate it without widening their error union. */
+function markerToDbError(op: string, e: MarkerError): DbError {
+    return { type: "query_failed", op, cause: e };
+}
 
 /**
  * `id` is the marker UUID (from the on-disk marker or freshly minted), stored as the
@@ -29,13 +34,9 @@ function makeAnchor(id: string, dir: string, markerWritten: boolean): Anchor {
 export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
     const abs = canonicalPath(dir);
 
-    let marker: AnchorMarker | null;
-    try {
-        marker = readMarker(abs);
-    } catch (cause) {
-        // Corrupt on-disk marker surfaces through the Result channel, not as a throw.
-        return err({ type: "query_failed", op: "getOrCreateAnchorForCwd:readMarker", cause });
-    }
+    const markerResult = readMarker(abs);
+    if (markerResult.isErr()) return err(markerToDbError("getOrCreateAnchorForCwd:readMarker", markerResult.error));
+    const marker = markerResult.value;
 
     if (marker) {
         const anchorId = marker.anchorId;
@@ -57,11 +58,8 @@ export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
     const anchorId = randomUUIDv7();
     const writable = isDirWritable(abs);
     if (writable) {
-        try {
-            writeMarker(abs, anchorId); // TODO(slop): this will be refactored to return result, no need for catch
-        } catch (cause) {
-            return err({ type: "mutation_failed", op: "getOrCreateAnchorForCwd:writeMarker", cause });
-        }
+        const writeResult = writeMarker(abs, anchorId);
+        if (writeResult.isErr()) return err(markerToDbError("getOrCreateAnchorForCwd:writeMarker", writeResult.error));
     }
     return insertAnchor(makeAnchor(anchorId, abs, writable));
 }
@@ -71,12 +69,9 @@ export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
  * treated as non-matching here: resolution must not abort on an unrelated corrupt marker.
  */
 function markerMatches(dir: string, anchorId: string): boolean {
-    try {
-        // TODO(slop): same here, try catch without reason
-        return readMarker(dir)?.anchorId === anchorId;
-    } catch {
-        return false;
-    }
+    return readMarker(dir)
+        .map((m) => m?.anchorId === anchorId)
+        .unwrapOr(false);
 }
 
 /**
@@ -84,13 +79,9 @@ function markerMatches(dir: string, anchorId: string): boolean {
  * marker on the walk falls through to the bounded search rather than aborting resolution).
  */
 function findMatchingMarkerUpwards(startDir: string, anchorId: string): string | null {
-    try {
-        // TODO(slop): neverthrow
-        const found = findMarkerUpwards(startDir);
-        return found && found.marker.anchorId === anchorId ? found.dir : null;
-    } catch {
-        return null;
-    }
+    return findMarkerUpwards(startDir)
+        .map((found) => (found && found.marker.anchorId === anchorId ? found.dir : null))
+        .unwrapOr(null);
 }
 
 function ancestorsOf(dir: string): string[] {

--- a/src/modules/anchor/anchor.ts
+++ b/src/modules/anchor/anchor.ts
@@ -9,8 +9,8 @@ import { insertAnchor, touchAnchor, updateAnchorCachedPath } from "../../db/prim
 import { canonicalPath, findMarkerUpwards, isDirWritable, readMarker, writeMarker, type MarkerError } from "./marker.ts";
 
 /** Bridge a marker-layer failure into the db-layer error type so callers that return `Result<T, DbError>` can propagate it without widening their error union. */
-function markerToDbError(op: string, e: MarkerError): DbError {
-    return { type: "query_failed", op, cause: e };
+function markerToDbError(op: string, e: MarkerError, kind: "query_failed" | "mutation_failed" = "query_failed"): DbError {
+    return { type: kind, op, cause: e };
 }
 
 /**
@@ -59,7 +59,7 @@ export function getOrCreateAnchorForCwd(dir: string): Result<Anchor, DbError> {
     const writable = isDirWritable(abs);
     if (writable) {
         const writeResult = writeMarker(abs, anchorId);
-        if (writeResult.isErr()) return err(markerToDbError("getOrCreateAnchorForCwd:writeMarker", writeResult.error));
+        if (writeResult.isErr()) return err(markerToDbError("getOrCreateAnchorForCwd:writeMarker", writeResult.error, "mutation_failed"));
     }
     return insertAnchor(makeAnchor(anchorId, abs, writable));
 }

--- a/src/modules/anchor/backstop.ts
+++ b/src/modules/anchor/backstop.ts
@@ -18,12 +18,7 @@ import { resolveAnchor } from "./anchor.ts";
 
 /** Read a marker, treating corruption as "absent" — these commands only need presence/identity. */
 function readMarkerSafe(dir: string): AnchorMarker | null {
-    try {
-        // TODO(slop): neverthrow
-        return readMarker(dir);
-    } catch {
-        return null;
-    }
+    return readMarker(dir).unwrapOr(null);
 }
 
 /**
@@ -34,13 +29,9 @@ function readMarkerSafe(dir: string): AnchorMarker | null {
 export function runRepair(path?: string): void {
     const dir = canonicalPath(path ?? process.cwd());
 
-    let marker: AnchorMarker | null;
-    try {
-        // TODO(slop): neverthrow
-        marker = readMarker(dir);
-    } catch (cause) {
-        fail(`Could not read the marker at ${dir} (corrupt?):`, cause);
-    }
+    const markerResult = readMarker(dir);
+    if (markerResult.isErr()) fail(`Could not read the marker at ${dir} (corrupt?):`, markerResult.error);
+    const marker = markerResult.value;
     if (!marker) fail(`No marker at ${dir}. Nothing to repair.`);
     const anchorId = marker.anchorId;
 

--- a/src/modules/anchor/marker.test.ts
+++ b/src/modules/anchor/marker.test.ts
@@ -24,34 +24,41 @@ afterEach(() => {
 });
 
 describe("readMarker", () => {
-    test("returns null when there is no marker (the normal not-an-anchor case)", () => {
-        expect(readMarker(tmp())).toBeNull();
+    test("returns ok(null) when there is no marker (the normal not-an-anchor case)", () => {
+        const result = readMarker(tmp());
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap()).toBeNull();
     });
 
-    test("returns the marker when present and valid", () => {
+    test("returns ok(marker) when present and valid", () => {
         const dir = tmp();
         writeMarker(dir, "anchor-1");
-        expect(readMarker(dir)).toEqual({ schemaVersion: 1, anchorId: "anchor-1" });
+        const result = readMarker(dir);
+        expect(result._unsafeUnwrap()).toEqual({ schemaVersion: 1, anchorId: "anchor-1" });
     });
 
-    test("throws on a present-but-corrupt marker (malformed JSON) — never silently re-minted", () => {
+    test("returns err on a present-but-corrupt marker (malformed JSON) — never silently re-minted", () => {
         const dir = tmp();
         writeRawMarker(dir, "{ not json");
-        expect(() => readMarker(dir)).toThrow();
+        const result = readMarker(dir);
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().type).toBe("marker_corrupt");
     });
 
-    test("throws on a marker that fails the schema (wrong schemaVersion)", () => {
+    test("returns err on a marker that fails the schema (wrong schemaVersion)", () => {
         const dir = tmp();
         writeRawMarker(dir, JSON.stringify({ schemaVersion: 2, anchorId: "x" }));
-        expect(() => readMarker(dir)).toThrow();
+        const result = readMarker(dir);
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().type).toBe("marker_corrupt");
     });
 });
 
 describe("writeMarker", () => {
     test("creates the marker file when absent", () => {
         const dir = tmp();
-        const marker = writeMarker(dir, "anchor-1");
-        expect(marker).toEqual({ schemaVersion: 1, anchorId: "anchor-1" });
+        const result = writeMarker(dir, "anchor-1");
+        expect(result._unsafeUnwrap()).toEqual({ schemaVersion: 1, anchorId: "anchor-1" });
         expect(existsSync(markerPath(dir))).toBe(true);
     });
 
@@ -59,13 +66,14 @@ describe("writeMarker", () => {
         const dir = tmp();
         writeMarker(dir, "first-uuid");
         const result = writeMarker(dir, "second-uuid");
-        expect(result.anchorId).toBe("first-uuid");
+        expect(result._unsafeUnwrap().anchorId).toBe("first-uuid");
     });
 
-    test("throws on a corrupt existing marker rather than clobbering it", () => {
+    test("returns err on a corrupt existing marker rather than clobbering it", () => {
         const dir = tmp();
         writeRawMarker(dir, "{ not json");
-        expect(() => writeMarker(dir, "anchor-1")).toThrow();
+        const result = writeMarker(dir, "anchor-1");
+        expect(result.isErr()).toBe(true);
     });
 });
 
@@ -73,7 +81,8 @@ describe("findMarkerUpwards", () => {
     test("finds a marker in the start directory itself", () => {
         const dir = tmp();
         writeMarker(dir, "anchor-1");
-        const found = findMarkerUpwards(dir);
+        const result = findMarkerUpwards(dir);
+        const found = result._unsafeUnwrap();
         expect(found?.dir).toBe(dir);
         expect(found?.marker.anchorId).toBe("anchor-1");
     });
@@ -83,12 +92,15 @@ describe("findMarkerUpwards", () => {
         writeMarker(dir, "anchor-1");
         const deep = join(dir, "a", "b", "c");
         mkdirSync(deep, { recursive: true });
-        const found = findMarkerUpwards(deep);
+        const result = findMarkerUpwards(deep);
+        const found = result._unsafeUnwrap();
         expect(found?.dir).toBe(dir);
         expect(found?.marker.anchorId).toBe("anchor-1");
     });
 
-    test("returns null when no ancestor holds a marker", () => {
-        expect(findMarkerUpwards(tmp())).toBeNull();
+    test("returns ok(null) when no ancestor holds a marker", () => {
+        const result = findMarkerUpwards(tmp());
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap()).toBeNull();
     });
 });

--- a/src/modules/anchor/marker.ts
+++ b/src/modules/anchor/marker.ts
@@ -1,7 +1,15 @@
-import { accessSync, constants, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { accessSync, constants, existsSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { type Result, ok, err } from "neverthrow";
 import { z } from "zod";
 import type { AnchorMarker, AnchorId } from "../../types/anchor.ts";
+import { readFileResult, writeFileResult, mkdirResult } from "../../lib/fs.ts";
+
+/** Marker-layer failure. Covers I/O (FS read/write) and data integrity (corrupt marker file). */
+export type MarkerError =
+    | { type: "marker_read_failed"; path: string; cause: unknown }
+    | { type: "marker_corrupt"; path: string; raw: string }
+    | { type: "marker_write_failed"; path: string; cause: unknown };
 
 /** The on-disk marker for a folder: <dir>/.inflexa/id (write-once identity file). */
 export function markerPath(dir: string): string {
@@ -16,7 +24,6 @@ export function markerPath(dir: string): string {
  */
 export function canonicalPath(p: string): string {
     try {
-        // TODO(slop): neverthrow
         return realpathSync(p);
     } catch {
         return resolve(p);
@@ -34,38 +41,47 @@ const anchorMarkerSchema = z.object({
 }) satisfies z.ZodType<AnchorMarker>;
 
 /**
- * Reads & validates <dir>/.inflexa/id. Returns null when the file is absent (the normal
- * "not an anchor yet" case). Throws on malformed JSON or a marker that fails the schema:
+ * Reads & validates <dir>/.inflexa/id. Returns `ok(null)` when the file is absent (the normal
+ * "not an anchor yet" case). Returns `err` on I/O failure or a marker that fails the schema:
  * corruption is surfaced so the caller can repair it, never silently re-minted (which
  * would orphan the existing identity and duplicate its analyses).
  */
-export function readMarker(dir: string): AnchorMarker | null {
+export function readMarker(dir: string): Result<AnchorMarker | null, MarkerError> {
     const path = markerPath(dir);
-    if (!existsSync(path)) return null;
+    if (!existsSync(path)) return ok(null);
 
-    const raw = readFileSync(path, "utf8"); // TODO(slop): make a wrapper that returns result - since I guess this throws
-    // A present-but-invalid marker is corruption, not absence. JSON.parseWith returns null
-    // for both a parse error and a schema mismatch, so the existsSync gate above is what
-    // separates "no marker" (null, fine) from "broken marker" (throw, never silently re-minted).
+    const read = readFileResult(path, "readMarker");
+    if (read.isErr()) return err({ type: "marker_read_failed", path, cause: read.error.cause });
+
+    const raw = read.value;
     const marker = JSON.parseWith(raw, anchorMarkerSchema);
-    if (!marker) throw new Error(`corrupt anchor marker at ${path}: ${raw}`); // TODO(slop): don't throw, return result
-    return marker;
+    if (!marker) return err({ type: "marker_corrupt", path, raw });
+    return ok(marker);
 }
 
 /**
  * Write-once: if a valid marker already exists it is returned unchanged (the folder
  * already has identity, so its UUID wins over the passed one and the file is never
- * rewritten — the marker records no mutable state). A corrupt existing marker throws
- * rather than being clobbered. Only an absent marker is created.
+ * rewritten — the marker records no mutable state). A corrupt existing marker returns
+ * an error rather than being clobbered. Only an absent marker is created.
  */
-export function writeMarker(dir: string, anchorId: AnchorId): AnchorMarker {
-    const existing = readMarker(dir); // throws if corrupt — do not overwrite corruption
-    if (existing) return existing;
+export function writeMarker(dir: string, anchorId: AnchorId): Result<AnchorMarker, MarkerError> {
+    return readMarker(dir).andThen((existing) => {
+        if (existing) return ok(existing);
 
-    const marker: AnchorMarker = { schemaVersion: 1, anchorId: anchorId };
-    mkdirSync(join(dir, ".inflexa"), { recursive: true }); // TODO(slop): Make wrapper - don't throw
-    writeFileSync(markerPath(dir), `${JSON.stringify(marker, null, 2)}\n`, "utf8"); // TODO(slop): make wrapper - don't throw
-    return marker;
+        const marker: AnchorMarker = { schemaVersion: 1, anchorId: anchorId };
+        const dotDir = join(dir, ".inflexa");
+        const path = markerPath(dir);
+
+        return mkdirResult(dotDir, "writeMarker:mkdir")
+            .mapErr((e): MarkerError => ({ type: "marker_write_failed", path, cause: e.cause }))
+            .andThen(() =>
+                writeFileResult(path, `${JSON.stringify(marker, null, 2)}\n`, "writeMarker:write").mapErr(
+                    (e): MarkerError => ({ type: "marker_write_failed", path, cause: e.cause }),
+                ),
+            )
+            .map(() => marker);
+    });
 }
 
 /**
@@ -75,7 +91,6 @@ export function writeMarker(dir: string, anchorId: AnchorId): AnchorMarker {
  */
 export function isDirWritable(dir: string): boolean {
     try {
-        // TODO(slop): neverthrow
         accessSync(dir, constants.W_OK);
         return true;
     } catch {
@@ -89,13 +104,14 @@ export function isDirWritable(dir: string): boolean {
  * instead of looping. A corrupt marker mid-walk propagates via readMarker — corruption
  * at a candidate anchor is a real error, not something to skip past.
  */
-export function findMarkerUpwards(startDir: string): { dir: string; marker: AnchorMarker } | null {
+export function findMarkerUpwards(startDir: string): Result<{ dir: string; marker: AnchorMarker } | null, MarkerError> {
     let dir = resolve(startDir);
     for (;;) {
-        const marker = readMarker(dir);
-        if (marker) return { dir, marker };
-        const parent = dirname(dir); // TODO(slop): make a wrapper that returns result and change the call.
-        if (parent === dir) return null; // reached filesystem root
+        const result = readMarker(dir);
+        if (result.isErr()) return err(result.error);
+        if (result.value) return ok({ dir, marker: result.value });
+        const parent = dirname(dir);
+        if (parent === dir) return ok(null);
         dir = parent;
     }
 }

--- a/src/modules/intelligence/chat.ts
+++ b/src/modules/intelligence/chat.ts
@@ -111,37 +111,45 @@ export async function chat(opts: ChatOptions): Promise<Result<void, DbError>> {
     // and the user sees a blank reply with no clue why. Capture it and surface it below, the same
     // as a thrown setup failure.
     let streamError: unknown;
-    const keyResult = await readApiKey();
-    if (keyResult.isErr()) {
-        streamError = keyResult.error;
-    } else {
-        const modelResult = await resolveModelId(keyResult.value);
-        if (modelResult.isErr()) {
-            streamError = modelResult.error;
-        } else {
-            try {
-                const provider = createOpenAICompatible({ name: "cliproxy", baseURL: env.cliproxyApiUrl, apiKey: keyResult.value });
-                const result = streamText({
-                    model: provider(modelResult.value),
-                    system: SYSTEM_PROMPT,
-                    messages: modelMessages,
-                    abortSignal: abort,
-                    // Anthropic requires an explicit max_tokens; the proxy passes the
-                    // OpenAI-format value through when translating to Claude, so set a
-                    // generous cap to make Claude work out of the box.
-                    maxOutputTokens: 8192,
-                    onError: ({ error }) => {
-                        streamError = error;
-                    },
-                });
-                for await (const delta of result.textStream) {
-                    accumulated += delta;
-                    Bus.emit("inflexa", { type: "part.delta", sessionId, messageId: assistantMsg.id, partId: assistantPart.id, delta });
-                }
-            } catch (error) {
-                // Streaming failures from the AI SDK that surface as exceptions (not via onError).
-                streamError = error;
+    const apiKey = (await readApiKey()).match(
+        (k) => k,
+        (e) => {
+            streamError = e;
+            return null;
+        },
+    );
+    const modelId = apiKey
+        ? (await resolveModelId(apiKey)).match(
+              (m) => m,
+              (e) => {
+                  streamError = e;
+                  return null;
+              },
+          )
+        : null;
+    if (apiKey && modelId) {
+        try {
+            const provider = createOpenAICompatible({ name: "cliproxy", baseURL: env.cliproxyApiUrl, apiKey });
+            const result = streamText({
+                model: provider(modelId),
+                system: SYSTEM_PROMPT,
+                messages: modelMessages,
+                abortSignal: abort,
+                // Anthropic requires an explicit max_tokens; the proxy passes the
+                // OpenAI-format value through when translating to Claude, so set a
+                // generous cap to make Claude work out of the box.
+                maxOutputTokens: 8192,
+                onError: ({ error }) => {
+                    streamError = error;
+                },
+            });
+            for await (const delta of result.textStream) {
+                accumulated += delta;
+                Bus.emit("inflexa", { type: "part.delta", sessionId, messageId: assistantMsg.id, partId: assistantPart.id, delta });
             }
+        } catch (error) {
+            // Streaming failures from the AI SDK that surface as exceptions (not via onError).
+            streamError = error;
         }
     }
     // A user abort is not an error — it just stops and keeps whatever streamed so far.
@@ -222,6 +230,19 @@ export function pickDefaultModel(ids: string[]): string {
 
 function describe(cause: unknown): string {
     if (cause instanceof Error) return cause.message;
-    if (typeof cause === "object" && cause !== null && "type" in cause) return (cause as { type: string }).type;
+    if (typeof cause === "object" && cause !== null && "type" in cause) {
+        // ChatSetupError carries a discriminated `type` — map it to actionable guidance.
+        const typed = cause as ChatSetupError;
+        switch (typed.type) {
+            case "proxy_key_missing":
+                return "could not read the proxy API key — run `inflexa setup`";
+            case "proxy_unreachable":
+                return `the proxy returned ${typed.detail} listing models`;
+            case "no_models":
+                return "the proxy reported no models — is a provider authenticated? run `inflexa setup`";
+            default:
+                return (cause as { type: string }).type;
+        }
+    }
     return String(cause);
 }

--- a/src/modules/intelligence/chat.ts
+++ b/src/modules/intelligence/chat.ts
@@ -39,6 +39,9 @@ export type ChatOptions = {
     abort?: AbortSignal;
 };
 
+/** Setup failures surfaced before streaming begins — the proxy key is missing, unreachable, or reports no models. */
+export type ChatSetupError = { type: "proxy_key_missing" } | { type: "proxy_unreachable"; detail: string } | { type: "no_models" };
+
 export async function chat(opts: ChatOptions): Promise<Result<void, DbError>> {
     const { sessionId, userText, abort } = opts;
 
@@ -108,31 +111,38 @@ export async function chat(opts: ChatOptions): Promise<Result<void, DbError>> {
     // and the user sees a blank reply with no clue why. Capture it and surface it below, the same
     // as a thrown setup failure.
     let streamError: unknown;
-    try {
-        const apiKey = await readApiKey();
-        const modelId = await resolveModelId(apiKey);
-        const provider = createOpenAICompatible({ name: "cliproxy", baseURL: env.cliproxyApiUrl, apiKey });
-        const result = streamText({
-            model: provider(modelId),
-            system: SYSTEM_PROMPT,
-            messages: modelMessages,
-            abortSignal: abort,
-            // Anthropic requires an explicit max_tokens; the proxy passes the
-            // OpenAI-format value through when translating to Claude, so set a
-            // generous cap to make Claude work out of the box.
-            maxOutputTokens: 8192,
-            onError: ({ error }) => {
+    const keyResult = await readApiKey();
+    if (keyResult.isErr()) {
+        streamError = keyResult.error;
+    } else {
+        const modelResult = await resolveModelId(keyResult.value);
+        if (modelResult.isErr()) {
+            streamError = modelResult.error;
+        } else {
+            try {
+                const provider = createOpenAICompatible({ name: "cliproxy", baseURL: env.cliproxyApiUrl, apiKey: keyResult.value });
+                const result = streamText({
+                    model: provider(modelResult.value),
+                    system: SYSTEM_PROMPT,
+                    messages: modelMessages,
+                    abortSignal: abort,
+                    // Anthropic requires an explicit max_tokens; the proxy passes the
+                    // OpenAI-format value through when translating to Claude, so set a
+                    // generous cap to make Claude work out of the box.
+                    maxOutputTokens: 8192,
+                    onError: ({ error }) => {
+                        streamError = error;
+                    },
+                });
+                for await (const delta of result.textStream) {
+                    accumulated += delta;
+                    Bus.emit("inflexa", { type: "part.delta", sessionId, messageId: assistantMsg.id, partId: assistantPart.id, delta });
+                }
+            } catch (error) {
+                // Streaming failures from the AI SDK that surface as exceptions (not via onError).
                 streamError = error;
-            },
-        });
-        for await (const delta of result.textStream) {
-            accumulated += delta;
-            Bus.emit("inflexa", { type: "part.delta", sessionId, messageId: assistantMsg.id, partId: assistantPart.id, delta });
+            }
         }
-    } catch (error) {
-        // Synchronous/setup failures (readApiKey, resolveModelId) throw here; streaming failures
-        // arrive via onError above. Funnel both through the single session.error emit below.
-        streamError = error;
     }
     // A user abort is not an error — it just stops and keeps whatever streamed so far.
     if (streamError && !abort?.aborted) {
@@ -179,25 +189,23 @@ export function toModelMessages(stored: StoredMessage[]): ModelMessage[] {
 }
 
 /** The proxy requires the client API key we generated into its config at setup. */
-async function readApiKey(): Promise<string> {
+async function readApiKey(): Promise<Result<string, ChatSetupError>> {
     const text = await Bun.file(env.cliproxyConfigPath)
         .text()
         .catch(() => "");
     const key = text.match(/^api-keys:\s*\n\s*-\s*"([^"]+)"/m)?.[1];
-    if (!key) throw new Error("could not read the proxy API key — run `inflexa setup`");
-    return key;
+    if (!key) return err({ type: "proxy_key_missing" });
+    return ok(key);
 }
 
-async function resolveModelId(apiKey: string): Promise<string> {
-    if (cachedModelId) return cachedModelId;
+async function resolveModelId(apiKey: string): Promise<Result<string, ChatSetupError>> {
+    if (cachedModelId) return ok(cachedModelId);
     const res = await fetch(`${env.cliproxyApiUrl}/models`, { headers: { Authorization: `Bearer ${apiKey}` } });
-    if (!res.ok) throw new Error(`the proxy returned ${res.status} listing models`);
+    if (!res.ok) return err({ type: "proxy_unreachable", detail: `HTTP ${res.status}` });
     const models = await res.jsonWith(modelsSchema);
-    if (!models || models.data.length === 0) {
-        throw new Error("the proxy reported no models — is a provider authenticated? run `inflexa setup`");
-    }
+    if (!models || models.data.length === 0) return err({ type: "no_models" });
     cachedModelId = pickDefaultModel(models.data.map((m) => m.id));
-    return cachedModelId;
+    return ok(cachedModelId);
 }
 
 /**
@@ -213,5 +221,7 @@ export function pickDefaultModel(ids: string[]): string {
 }
 
 function describe(cause: unknown): string {
-    return cause instanceof Error ? cause.message : String(cause);
+    if (cause instanceof Error) return cause.message;
+    if (typeof cause === "object" && cause !== null && "type" in cause) return (cause as { type: string }).type;
+    return String(cause);
 }

--- a/src/modules/intelligence/chat.ts
+++ b/src/modules/intelligence/chat.ts
@@ -208,7 +208,12 @@ async function readApiKey(): Promise<Result<string, ChatSetupError>> {
 
 async function resolveModelId(apiKey: string): Promise<Result<string, ChatSetupError>> {
     if (cachedModelId) return ok(cachedModelId);
-    const res = await fetch(`${env.cliproxyApiUrl}/models`, { headers: { Authorization: `Bearer ${apiKey}` } });
+    let res: Response;
+    try {
+        res = await fetch(`${env.cliproxyApiUrl}/models`, { headers: { Authorization: `Bearer ${apiKey}` } });
+    } catch (cause) {
+        return err({ type: "proxy_unreachable", detail: cause instanceof Error ? cause.message : String(cause) });
+    }
     if (!res.ok) return err({ type: "proxy_unreachable", detail: `HTTP ${res.status}` });
     const models = await res.jsonWith(modelsSchema);
     if (!models || models.data.length === 0) return err({ type: "no_models" });

--- a/src/modules/prov/document.ts
+++ b/src/modules/prov/document.ts
@@ -1,5 +1,5 @@
 import { randomUUIDv7 } from "bun";
-import { type Result } from "neverthrow";
+import { type Result, ok, err } from "neverthrow";
 import { ProvDocument, type BuiltinProvFormat } from "@inflexa-ai/tsprov";
 import type { Analysis } from "../../types/analysis.ts";
 import type { ProvActor, ProvInputRef } from "../../types/prov.ts";
@@ -84,8 +84,13 @@ export function freshDocument(analysis: Analysis): ProvDocument {
 }
 
 /** Reconstruct an analysis's live document from its stored PROV-JSON, or seed a fresh one when nothing is stored yet. */
-export function loadDocument(analysis: Analysis, storedJson: string | null): ProvDocument {
-    return storedJson ? ProvDocument.deserialize(storedJson, "json") : freshDocument(analysis);
+export function loadDocument(analysis: Analysis, storedJson: string | null): Result<ProvDocument, { type: "prov_corrupt"; cause: unknown }> {
+    if (!storedJson) return ok(freshDocument(analysis));
+    try {
+        return ok(ProvDocument.deserialize(storedJson, "json"));
+    } catch (cause) {
+        return err({ type: "prov_corrupt" as const, cause });
+    }
 }
 
 // Each append function mints a fresh activity, stamps it at append time (the action's occurrence),
@@ -139,10 +144,11 @@ export function appendInputRemoved(doc: ProvDocument, analysisId: string, actor:
  * always over the JSON form).
  */
 export function serializeProvenance(analysis: Analysis, format: BuiltinProvFormat): Result<string, DbError> {
-    return getAnalysisProvenance(analysis.id).map((json) => {
-        if (json === null) return loadDocument(analysis, null).unified().serialize(format);
-        if (format === "json") return json;
-        return loadDocument(analysis, json).unified().serialize(format);
+    return getAnalysisProvenance(analysis.id).andThen((json): Result<string, DbError> => {
+        if (format === "json" && json !== null) return ok(json);
+        return loadDocument(analysis, json)
+            .map((doc) => doc.unified().serialize(format))
+            .mapErr((e): DbError => ({ type: "query_failed", op: "serializeProvenance:deserialize", cause: e.cause }));
     });
 }
 

--- a/src/modules/prov/prov.test.ts
+++ b/src/modules/prov/prov.test.ts
@@ -194,13 +194,13 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
 
         // First flush: prevChainHash is null, so recompute seeds from SHA-256("").
         expect(integrity!.prevChainHash).toBeNull();
-        const recomputed = await computeChainHash(null, integrity!.provenance!);
+        const recomputed = (await computeChainHash(null, integrity!.provenance!))._unsafeUnwrap();
         // Non-null assertions safe: the three `.not.toBeNull()` checks above guard them.
         expect(recomputed).toBe(integrity!.chainHash!);
 
         // Verify the Ed25519 signature.
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
-        const sigOk = await verifyHexDigest(kp.publicKey, integrity!.signature!, integrity!.chainHash!);
+        const sigOk = (await verifyHexDigest(kp.publicKey, integrity!.signature!, integrity!.chainHash!))._unsafeUnwrap();
         expect(sigOk).toBe(true);
 
         resetSigningForTests(null);
@@ -244,12 +244,12 @@ describe("provenance recorder (bus → in-memory doc → column)", () => {
         expect(second!.prevChainHash).toBe(first!.chainHash);
 
         // The second chain hash must chain from the first: H2 = SHA-256(H1 || json2).
-        const recomputed = await computeChainHash(first!.chainHash!, second!.provenance!);
+        const recomputed = (await computeChainHash(first!.chainHash!, second!.provenance!))._unsafeUnwrap();
         expect(recomputed).toBe(second!.chainHash!);
 
         // The signature still verifies against the new chain hash.
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
-        const sigOk = await verifyHexDigest(kp.publicKey, second!.signature!, second!.chainHash!);
+        const sigOk = (await verifyHexDigest(kp.publicKey, second!.signature!, second!.chainHash!))._unsafeUnwrap();
         expect(sigOk).toBe(true);
 
         // verifyProvenance must report "valid" after multi-flush — this was the #CRT-1 bug:
@@ -314,7 +314,7 @@ describe("export sidecar (writeSidecar via the full export path)", () => {
         expect(parsed.publicKey).toHaveProperty("crv", "Ed25519");
 
         // The sidecar's payloadDigest is a simple SHA-256(provJson), not the chain hash.
-        const contentDigest = await computePayloadDigest(provJson);
+        const contentDigest = (await computePayloadDigest(provJson))._unsafeUnwrap();
         expect(parsed.payloadDigest).toBe(contentDigest);
         expect(parsed.payloadDigest).not.toBe(integrity!.chainHash);
 

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -6,7 +6,7 @@ import { bakedEnv } from "../../lib/env.ts";
 import { getLogger } from "../../lib/log.ts";
 import { findAnalysesByRef, getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { updateAnalysisProvenance } from "../../db/primary_mutation.ts";
-import { appendCreation, appendInputAdded, appendInputRemoved, loadDocument } from "./document.ts";
+import { appendCreation, appendInputAdded, appendInputRemoved, freshDocument, loadDocument } from "./document.ts";
 import { loadOrGenerateKeypair, computeChainHash, signHexDigest } from "./signing.ts";
 import { loadAuth } from "../auth/auth.ts";
 import { decodeIdTokenClaims } from "../auth/whoami.ts";
@@ -122,7 +122,14 @@ function liveDocForAnalysis(analysisId: string): ProvDocument | null {
             return null;
         },
     );
-    const doc = loadDocument(analysis, integrity?.provenance ?? null);
+    const docResult = loadDocument(analysis, integrity?.provenance ?? null);
+    if (docResult.isErr()) {
+        log.error({ analysisId, cause: docResult.error.cause }, "stored provenance is corrupt; starting fresh document");
+        const fresh = freshDocument(analysis);
+        liveDocs.set(analysisId, fresh);
+        return fresh;
+    }
+    const doc = docResult.value;
     liveDocs.set(analysisId, doc);
     // Seed the chain hash from the stored value so the next flush chains correctly.
     if (integrity?.chainHash) chainHashes.set(analysisId, integrity.chainHash);

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -168,21 +168,22 @@ export async function flushProvenanceAsync(): Promise<void> {
         }
         const kp = kpResult.value;
 
-        try {
-            const prev = chainHashes.get(analysisId) ?? null;
-            const chainHash = await computeChainHash(prev, json);
-            const signature = await signHexDigest(kp.privateKey, chainHash);
-
-            updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
-                () => {
-                    dirty.delete(analysisId);
-                    chainHashes.set(analysisId, chainHash);
-                },
-                (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
-            );
-        } catch (cause) {
-            log.error({ analysisId, cause }, "signing failed; provenance not persisted");
+        const prev = chainHashes.get(analysisId) ?? null;
+        const result = await computeChainHash(prev, json).andThen((chainHash) =>
+            signHexDigest(kp.privateKey, chainHash).map((signature) => ({ chainHash, signature })),
+        );
+        if (result.isErr()) {
+            log.error({ analysisId, err: result.error }, "signing failed; provenance not persisted");
+            return;
         }
+        const { chainHash, signature } = result.value;
+        updateAnalysisProvenance(analysisId, json, chainHash, signature).match(
+            () => {
+                dirty.delete(analysisId);
+                chainHashes.set(analysisId, chainHash);
+            },
+            (e) => log.error({ analysisId, err: e.type }, "failed to persist provenance"),
+        );
     });
 
     await wg.wait();

--- a/src/modules/prov/prov.ts
+++ b/src/modules/prov/prov.ts
@@ -125,6 +125,9 @@ function liveDocForAnalysis(analysisId: string): ProvDocument | null {
     const docResult = loadDocument(analysis, integrity?.provenance ?? null);
     if (docResult.isErr()) {
         log.error({ analysisId, cause: docResult.error.cause }, "stored provenance is corrupt; starting fresh document");
+        // Clear the stale chain hash so the next flush starts a new chain instead
+        // of chaining from the old (now-disconnected) hash.
+        chainHashes.delete(analysisId);
         const fresh = freshDocument(analysis);
         liveDocs.set(analysisId, fresh);
         return fresh;

--- a/src/modules/prov/signing.test.ts
+++ b/src/modules/prov/signing.test.ts
@@ -41,32 +41,26 @@ describe("keypair lifecycle", () => {
         useTempKeyDir();
         const r1 = await loadOrGenerateKeypair();
         expect(r1.isOk()).toBe(true);
-        // Drop the in-memory cache, keep the file path, reload from disk.
         resetSigningForTests(join(tempDir!, "prov_key.json"));
         const r2 = await loadOrGenerateKeypair();
         expect(r2.isOk()).toBe(true);
-        // Both keypairs sign the same data to the same signature (Ed25519 is deterministic).
-        const hash = await computeChainHash(null, "test");
-        const sig1 = await signHexDigest(r1._unsafeUnwrap().privateKey, hash);
-        const sig2 = await signHexDigest(r2._unsafeUnwrap().privateKey, hash);
+        const hash = (await computeChainHash(null, "test"))._unsafeUnwrap();
+        const sig1 = (await signHexDigest(r1._unsafeUnwrap().privateKey, hash))._unsafeUnwrap();
+        const sig2 = (await signHexDigest(r2._unsafeUnwrap().privateKey, hash))._unsafeUnwrap();
         expect(sig1).toBe(sig2);
     });
 
     test("corrupt keypair file is replaced with a fresh keypair", async () => {
         const dir = useTempKeyDir();
         writeFileSync(join(dir, "prov_key.json"), "not json");
-        // readKeypairFile returns null for unparseable JSON, so loadOrGenerateKeypair falls
-        // through to generate a fresh one — the user gets signing rather than silent degradation.
         const result = await loadOrGenerateKeypair();
         expect(result.isOk()).toBe(true);
-        // The file on disk now contains a valid keypair.
         const stored = await Bun.file(join(dir, "prov_key.json")).json();
         expect(stored.publicKey.kty).toBe("OKP");
     });
 
     test("structurally valid but wrong JWK returns keypair_corrupt error", async () => {
         const dir = useTempKeyDir();
-        // A file that parses as JSON but has bogus JWK contents — importKey will fail.
         writeFileSync(join(dir, "prov_key.json"), JSON.stringify({ publicKey: { kty: "BAD" }, privateKey: { kty: "BAD" } }));
         const result = await loadOrGenerateKeypair();
         expect(result.isErr()).toBe(true);
@@ -81,21 +75,21 @@ describe("keypair lifecycle", () => {
 
 describe("chain hash computation", () => {
     test("initial chain hash uses SHA-256 of empty as the seed", async () => {
-        const h = await computeChainHash(null, "hello");
+        const h = (await computeChainHash(null, "hello"))._unsafeUnwrap();
         expect(h).toHaveLength(64);
-        expect(await computeChainHash(null, "hello")).toBe(h);
+        expect((await computeChainHash(null, "hello"))._unsafeUnwrap()).toBe(h);
     });
 
     test("different provenance JSON produces a different chain hash", async () => {
-        const h1 = await computeChainHash(null, '{"a":1}');
-        const h2 = await computeChainHash(null, '{"a":2}');
+        const h1 = (await computeChainHash(null, '{"a":1}'))._unsafeUnwrap();
+        const h2 = (await computeChainHash(null, '{"a":2}'))._unsafeUnwrap();
         expect(h1).not.toBe(h2);
     });
 
     test("chaining from a previous hash differs from the initial seed", async () => {
-        const h1 = await computeChainHash(null, "first");
-        const h2 = await computeChainHash(h1, "second");
-        const hAlt = await computeChainHash(null, "second");
+        const h1 = (await computeChainHash(null, "first"))._unsafeUnwrap();
+        const h2 = (await computeChainHash(h1, "second"))._unsafeUnwrap();
+        const hAlt = (await computeChainHash(null, "second"))._unsafeUnwrap();
         expect(h2).not.toBe(hAlt);
     });
 });
@@ -104,29 +98,29 @@ describe("sign and verify", () => {
     test("round-trip: sign then verify succeeds", async () => {
         useTempKeyDir();
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
-        const hash = await computeChainHash(null, '{"provenance":"data"}');
-        const sig = await signHexDigest(kp.privateKey, hash);
+        const hash = (await computeChainHash(null, '{"provenance":"data"}'))._unsafeUnwrap();
+        const sig = (await signHexDigest(kp.privateKey, hash))._unsafeUnwrap();
         expect(sig).toHaveLength(128);
-        const valid = await verifyHexDigest(kp.publicKey, sig, hash);
+        const valid = (await verifyHexDigest(kp.publicKey, sig, hash))._unsafeUnwrap();
         expect(valid).toBe(true);
     });
 
     test("tampered chain hash fails verification", async () => {
         useTempKeyDir();
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
-        const hash = await computeChainHash(null, "original");
-        const sig = await signHexDigest(kp.privateKey, hash);
-        const tampered = await computeChainHash(null, "modified");
-        const valid = await verifyHexDigest(kp.publicKey, sig, tampered);
+        const hash = (await computeChainHash(null, "original"))._unsafeUnwrap();
+        const sig = (await signHexDigest(kp.privateKey, hash))._unsafeUnwrap();
+        const tampered = (await computeChainHash(null, "modified"))._unsafeUnwrap();
+        const valid = (await verifyHexDigest(kp.publicKey, sig, tampered))._unsafeUnwrap();
         expect(valid).toBe(false);
     });
 
     test("Ed25519 signature is deterministic", async () => {
         useTempKeyDir();
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
-        const hash = await computeChainHash(null, "deterministic");
-        const sig1 = await signHexDigest(kp.privateKey, hash);
-        const sig2 = await signHexDigest(kp.privateKey, hash);
+        const hash = (await computeChainHash(null, "deterministic"))._unsafeUnwrap();
+        const sig1 = (await signHexDigest(kp.privateKey, hash))._unsafeUnwrap();
+        const sig2 = (await signHexDigest(kp.privateKey, hash))._unsafeUnwrap();
         expect(sig1).toBe(sig2);
     });
 });

--- a/src/modules/prov/signing.ts
+++ b/src/modules/prov/signing.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync, linkSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
-import { type Result, ok, err } from "neverthrow";
+import { type Result, ResultAsync, ok, err } from "neverthrow";
 import { env } from "../../lib/env.ts";
 import { getLogger } from "../../lib/log.ts";
 
@@ -25,12 +25,13 @@ type StoredKeypair = { publicKey: JWK; privateKey: JWK };
 /** In-memory imported keypair — cached for the process lifetime to avoid re-importing on every flush. */
 export type ImportedKeypair = { publicKey: CryptoKey; privateKey: CryptoKey };
 
-/** Why a signing operation could not obtain the keypair. Every variant is a hard failure — provenance is never written unsigned. */
+/** Why a signing/crypto operation failed. Every variant is a hard failure — provenance is never written unsigned. */
 export type SigningError =
     | { type: "keypair_corrupt"; cause?: unknown }
     | { type: "keypair_generation_failed"; cause: unknown }
     | { type: "keypair_race_lost" }
-    | { type: "public_key_export_failed" };
+    | { type: "public_key_export_failed" }
+    | { type: "crypto_failed"; op: string; cause: unknown };
 
 let cached: ImportedKeypair | null = null;
 // Set after a parseable-but-unimportable JWK is encountered, so we don't re-read the file and
@@ -181,10 +182,15 @@ export async function loadPublicKey(): Promise<CryptoKey | null> {
  * that could race with another process writing a different keypair); falls back to disk when the
  * keypair hasn't been loaded yet. Returns `null` when no keypair is available.
  */
-export async function exportPublicKeyJwk(): Promise<JWK | null> {
-    if (cached) return crypto.subtle.exportKey("jwk", cached.publicKey);
+export function exportPublicKeyJwk(): ResultAsync<JWK | null, SigningError> {
+    if (cached) {
+        return ResultAsync.fromPromise(
+            crypto.subtle.exportKey("jwk", cached.publicKey),
+            (cause): SigningError => ({ type: "crypto_failed", op: "exportPublicKeyJwk", cause }),
+        );
+    }
     const stored = readKeypairFile();
-    return stored?.publicKey ?? null;
+    return ResultAsync.fromSafePromise(Promise.resolve(stored?.publicKey ?? null));
 }
 
 // --- Chain hash ---
@@ -214,38 +220,50 @@ async function emptySeed(): Promise<Uint8Array> {
  * Compute the chain hash: `SHA-256(prevBytes || provJsonBytes)`. When `prevChainHashHex` is null
  * (first flush), the seed is `SHA-256("")`.
  */
-export async function computeChainHash(prevChainHashHex: string | null, provJson: string): Promise<string> {
-    const prev = prevChainHashHex ? hexToBytes(prevChainHashHex) : await emptySeed();
-    const jsonBytes = new TextEncoder().encode(provJson);
-    const combined = new Uint8Array(prev.length + jsonBytes.length);
-    combined.set(prev, 0);
-    combined.set(jsonBytes, prev.length);
-    const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", combined));
-    return bytesToHex(hash);
+export function computeChainHash(prevChainHashHex: string | null, provJson: string): ResultAsync<string, SigningError> {
+    return ResultAsync.fromPromise(
+        (async () => {
+            const prev = prevChainHashHex ? hexToBytes(prevChainHashHex) : await emptySeed();
+            const jsonBytes = new TextEncoder().encode(provJson);
+            const combined = new Uint8Array(prev.length + jsonBytes.length);
+            combined.set(prev, 0);
+            combined.set(jsonBytes, prev.length);
+            const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", combined));
+            return bytesToHex(hash);
+        })(),
+        (cause): SigningError => ({ type: "crypto_failed", op: "computeChainHash", cause }),
+    );
 }
 
 /** Simple `SHA-256(provJson)` — the self-contained content digest used in the export sidecar. */
-export async function computePayloadDigest(provJson: string): Promise<string> {
-    const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(provJson)));
-    return bytesToHex(hash);
+export function computePayloadDigest(provJson: string): ResultAsync<string, SigningError> {
+    return ResultAsync.fromPromise(
+        crypto.subtle.digest("SHA-256", new TextEncoder().encode(provJson)).then((buf) => bytesToHex(new Uint8Array(buf))),
+        (cause): SigningError => ({ type: "crypto_failed", op: "computePayloadDigest", cause }),
+    );
 }
 
 // --- Sign / Verify ---
 
 /** Sign a hex-encoded digest with the Ed25519 private key, returning a hex-encoded 64-byte signature. */
-export async function signHexDigest(privateKey: CryptoKey, digestHex: string): Promise<string> {
+export function signHexDigest(privateKey: CryptoKey, digestHex: string): ResultAsync<string, SigningError> {
     const data = hexToBytes(digestHex);
     // Safe: hexToBytes allocates a fresh Uint8Array, so .buffer starts at offset 0 and is not shared.
-    const sig = await crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer);
-    return bytesToHex(new Uint8Array(sig));
+    return ResultAsync.fromPromise(
+        crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer).then((sig) => bytesToHex(new Uint8Array(sig))),
+        (cause): SigningError => ({ type: "crypto_failed", op: "signHexDigest", cause }),
+    );
 }
 
 /** Verify a hex-encoded Ed25519 signature against a hex-encoded digest and a public key. */
-export async function verifyHexDigest(publicKey: CryptoKey, signatureHex: string, digestHex: string): Promise<boolean> {
+export function verifyHexDigest(publicKey: CryptoKey, signatureHex: string, digestHex: string): ResultAsync<boolean, SigningError> {
     const sig = hexToBytes(signatureHex);
     const data = hexToBytes(digestHex);
     // Safe: both Uint8Arrays are freshly allocated by hexToBytes — offset 0, not shared.
-    return crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer);
+    return ResultAsync.fromPromise(
+        crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer),
+        (cause): SigningError => ({ type: "crypto_failed", op: "verifyHexDigest", cause }),
+    );
 }
 
 /** Reset the cached keypair and optionally override the key path — test-only. */

--- a/src/modules/prov/verify.test.ts
+++ b/src/modules/prov/verify.test.ts
@@ -46,8 +46,8 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const chainHash = await computeChainHash(null, provJson);
-        const signature = await signHexDigest(kp.privateKey, chainHash);
+        const chainHash = (await computeChainHash(null, provJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, chainHash))._unsafeUnwrap();
 
         const result = await verifyProvenance(provJson, null, chainHash, signature, kp.publicKey);
         expect(result.status).toBe("valid");
@@ -58,11 +58,11 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const firstJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const firstHash = await computeChainHash(null, firstJson);
+        const firstHash = (await computeChainHash(null, firstJson))._unsafeUnwrap();
 
         const secondJson = '{"entity":{"inflexa:analysis-a1":{"extra":true}}}';
-        const secondHash = await computeChainHash(firstHash, secondJson);
-        const signature = await signHexDigest(kp.privateKey, secondHash);
+        const secondHash = (await computeChainHash(firstHash, secondJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, secondHash))._unsafeUnwrap();
 
         const result = await verifyProvenance(secondJson, firstHash, secondHash, signature, kp.publicKey);
         expect(result.status).toBe("valid");
@@ -73,8 +73,8 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const chainHash = await computeChainHash(null, originalJson);
-        const signature = await signHexDigest(kp.privateKey, chainHash);
+        const chainHash = (await computeChainHash(null, originalJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, chainHash))._unsafeUnwrap();
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
         const result = await verifyProvenance(tamperedJson, null, chainHash, signature, kp.publicKey);
@@ -87,8 +87,8 @@ describe("verifyProvenance (DB-path, chain hash verification)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const chainHash = await computeChainHash(null, provJson);
-        const signature = await signHexDigest(kp.privateKey, chainHash);
+        const chainHash = (await computeChainHash(null, provJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, chainHash))._unsafeUnwrap();
         const flipped = signature.slice(0, -2) + (signature.slice(-2) === "00" ? "01" : "00");
 
         const result = await verifyProvenance(provJson, null, chainHash, flipped, kp.publicKey);
@@ -103,8 +103,8 @@ describe("verifyPayload (file-path, simple content digest)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const digest = await computePayloadDigest(provJson);
-        const signature = await signHexDigest(kp.privateKey, digest);
+        const digest = (await computePayloadDigest(provJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, digest))._unsafeUnwrap();
 
         const result = await verifyPayload(provJson, digest, signature, kp.publicKey);
         expect(result.status).toBe("valid");
@@ -115,8 +115,8 @@ describe("verifyPayload (file-path, simple content digest)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const originalJson = '{"entity":{"inflexa:analysis-a1":{}}}';
-        const digest = await computePayloadDigest(originalJson);
-        const signature = await signHexDigest(kp.privateKey, digest);
+        const digest = (await computePayloadDigest(originalJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, digest))._unsafeUnwrap();
 
         const tamperedJson = '{"entity":{"inflexa:analysis-a1":{"tampered":true}}}';
         const result = await verifyPayload(tamperedJson, digest, signature, kp.publicKey);
@@ -150,11 +150,11 @@ describe("runVerifyFile (file-based verification, no DB)", () => {
         const kp = (await loadOrGenerateKeypair())._unsafeUnwrap();
 
         const provJson = '{"entity":{"inflexa:analysis-file-test":{}}}';
-        const digest = await computePayloadDigest(provJson);
-        const signature = await signHexDigest(kp.privateKey, digest);
+        const digest = (await computePayloadDigest(provJson))._unsafeUnwrap();
+        const signature = (await signHexDigest(kp.privateKey, digest))._unsafeUnwrap();
 
         const { exportPublicKeyJwk } = await import("./signing.ts");
-        const publicKey = await exportPublicKeyJwk();
+        const publicKey = (await exportPublicKeyJwk())._unsafeUnwrap();
 
         const provPath = join(dir, "provenance.json");
         writeFileSync(provPath, provJson);

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -4,7 +4,7 @@ import type { VerifyResult } from "../../types/prov.ts";
 import type { IdOrName } from "../../lib/types.ts";
 import { getAnalysisIntegrity } from "../../db/primary_query.ts";
 import { findAnalysisForProv } from "./document.ts";
-import { type Result, ok, err } from "neverthrow";
+import { type Result, err } from "neverthrow";
 import { getLogger } from "../../lib/log.ts";
 import {
     computeChainHash,
@@ -39,13 +39,23 @@ export async function verifyProvenance(
     if (storedChainHash === null || storedSignature === null) return { status: "unsigned" };
     if (publicKey === null) return { status: "no-key" };
 
-    const recomputed = await computeChainHash(prevChainHash, provJson);
-    if (recomputed !== storedChainHash) {
+    const hashResult = await computeChainHash(prevChainHash, provJson);
+    if (hashResult.isErr())
+        return {
+            status: "tampered",
+            detail: `chain hash computation failed: ${String("cause" in hashResult.error ? hashResult.error.cause : hashResult.error.type)}`,
+        };
+    if (hashResult.value !== storedChainHash) {
         return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
     }
 
-    const sigOk = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
-    if (!sigOk) {
+    const sigResult = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
+    if (sigResult.isErr())
+        return {
+            status: "tampered",
+            detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
+        };
+    if (!sigResult.value) {
         return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
     }
 
@@ -58,13 +68,23 @@ export async function verifyProvenance(
  * the sidecar is self-contained, no chain mechanics needed.
  */
 export async function verifyPayload(provJson: string, storedDigest: string, storedSignature: string, publicKey: CryptoKey): Promise<VerifyResult> {
-    const recomputed = await computePayloadDigest(provJson);
-    if (recomputed !== storedDigest) {
+    const digestResult = await computePayloadDigest(provJson);
+    if (digestResult.isErr())
+        return {
+            status: "tampered",
+            detail: `payload digest computation failed: ${String("cause" in digestResult.error ? digestResult.error.cause : digestResult.error.type)}`,
+        };
+    if (digestResult.value !== storedDigest) {
         return { status: "tampered", detail: "payload digest mismatch: the provenance file has been modified since it was signed" };
     }
 
-    const sigOk = await verifyHexDigest(publicKey, storedSignature, storedDigest);
-    if (!sigOk) {
+    const sigResult = await verifyHexDigest(publicKey, storedSignature, storedDigest);
+    if (sigResult.isErr())
+        return {
+            status: "tampered",
+            detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
+        };
+    if (!sigResult.value) {
         return { status: "tampered", detail: "signature verification failed: the digest or signature has been modified" };
     }
 
@@ -163,21 +183,22 @@ export async function buildSidecar(provJson: string): Promise<Result<Sidecar, Si
     if (kpResult.isErr()) return err(kpResult.error);
     const kp = kpResult.value;
 
-    const publicKeyJwk = await exportPublicKeyJwk();
+    const pubKeyResult = await exportPublicKeyJwk();
+    if (pubKeyResult.isErr()) return err(pubKeyResult.error);
+    const publicKeyJwk = pubKeyResult.value;
     if (!publicKeyJwk) return err({ type: "public_key_export_failed" });
 
-    const digest = await computePayloadDigest(provJson);
-    const signature = await signHexDigest(kp.privateKey, digest);
-
-    return ok({
-        payloadType: "application/json; profile=prov-json",
-        payloadDigestAlgorithm: "SHA-256",
-        payloadDigest: digest,
-        payloadDigestMethod: "verbatim",
-        signatureAlgorithm: "Ed25519",
-        signature,
-        publicKey: publicKeyJwk as Record<string, unknown>,
-    });
+    return computePayloadDigest(provJson).andThen((digest) =>
+        signHexDigest(kp.privateKey, digest).map((signature) => ({
+            payloadType: "application/json; profile=prov-json" as const,
+            payloadDigestAlgorithm: "SHA-256" as const,
+            payloadDigest: digest,
+            payloadDigestMethod: "verbatim" as const,
+            signatureAlgorithm: "Ed25519" as const,
+            signature,
+            publicKey: publicKeyJwk as Record<string, unknown>,
+        })),
+    );
 }
 
 /** Parse a `.sig.json` sidecar file, returning `null` on missing/corrupt/malformed. */

--- a/src/modules/prov/verify.ts
+++ b/src/modules/prov/verify.ts
@@ -42,7 +42,7 @@ export async function verifyProvenance(
     const hashResult = await computeChainHash(prevChainHash, provJson);
     if (hashResult.isErr())
         return {
-            status: "tampered",
+            status: "verify-error",
             detail: `chain hash computation failed: ${String("cause" in hashResult.error ? hashResult.error.cause : hashResult.error.type)}`,
         };
     if (hashResult.value !== storedChainHash) {
@@ -52,7 +52,7 @@ export async function verifyProvenance(
     const sigResult = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
     if (sigResult.isErr())
         return {
-            status: "tampered",
+            status: "verify-error",
             detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
         };
     if (!sigResult.value) {
@@ -71,7 +71,7 @@ export async function verifyPayload(provJson: string, storedDigest: string, stor
     const digestResult = await computePayloadDigest(provJson);
     if (digestResult.isErr())
         return {
-            status: "tampered",
+            status: "verify-error",
             detail: `payload digest computation failed: ${String("cause" in digestResult.error ? digestResult.error.cause : digestResult.error.type)}`,
         };
     if (digestResult.value !== storedDigest) {
@@ -81,7 +81,7 @@ export async function verifyPayload(provJson: string, storedDigest: string, stor
     const sigResult = await verifyHexDigest(publicKey, storedSignature, storedDigest);
     if (sigResult.isErr())
         return {
-            status: "tampered",
+            status: "verify-error",
             detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
         };
     if (!sigResult.value) {
@@ -108,6 +108,8 @@ export function formatVerifyResult(result: VerifyResult): string {
             return `Invalid sidecar: ${result.detail}`;
         case "invalid-key":
             return "The public key in the sidecar is invalid or unsupported.";
+        case "verify-error":
+            return `Verification could not complete (internal error): ${result.detail}`;
     }
 }
 
@@ -142,7 +144,7 @@ export async function runVerifyProvenance(ref: string): Promise<void> {
     if (!result) fail(`No analysis row for "${ref}".`);
 
     console.log(formatVerifyResult(result));
-    if (result.status === "tampered") process.exitCode = 1;
+    if (result.status === "tampered" || result.status === "verify-error") process.exitCode = 1;
 }
 
 /**
@@ -260,5 +262,6 @@ export async function runVerifyFile(path: string): Promise<void> {
         return;
     }
     console.log(formatVerifyResult(result));
-    if (result.status === "tampered" || result.status === "invalid-sidecar" || result.status === "invalid-key") process.exitCode = 1;
+    if (result.status === "tampered" || result.status === "invalid-sidecar" || result.status === "invalid-key" || result.status === "verify-error")
+        process.exitCode = 1;
 }

--- a/src/modules/proxy/setup.ts
+++ b/src/modules/proxy/setup.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline/promises";
 
+import { type Result, ok, err } from "neverthrow";
 import { activeRuntime } from "../../lib/config.ts";
 import { capture, ensureReady, inherit, ContainerRuntimeError, type ContainerRuntime } from "../../lib/container.ts";
 import { env } from "../../lib/env.ts";
@@ -33,53 +34,64 @@ type SetupOptions = {
 };
 
 export async function setup(options: SetupOptions): Promise<void> {
-    try {
-        const provider = resolveProvider(options);
-        const rt = activeRuntime();
-
-        await ensureReady(rt);
-
-        const { created, apiKey } = await writeProxyConfig();
-        if (created) {
-            console.log(`\n  Wrote ${env.cliproxyConfigPath}`);
-            if (apiKey) console.log(`  Client API key (use this to call the proxy): ${apiKey}`);
-        } else {
-            console.log(`\n  Keeping existing config at ${env.cliproxyConfigPath}`);
-        }
-
-        await pullImage(rt, options.force);
-
-        if (options.auth) {
-            // Credentials persist in the mounted auth dir, so re-running setup
-            // shouldn't force a re-login. Skip the prompt when already signed in;
-            // an explicit --provider still triggers a fresh login to add/switch.
-            if (provider === undefined && (await isAuthenticated())) {
-                console.log("  Already authenticated — skipping login (use `--provider <name>` to add or switch).");
-            } else {
-                const authed = await authenticate(rt, provider);
-                if (!authed) console.log("  No provider authenticated yet — re-run `inflexa setup` to sign in.");
-            }
-        }
-
-        if (options.start) await startProxy(rt);
-
-        printNextSteps(options);
-    } catch (error) {
-        if (error instanceof ProxyError || error instanceof ContainerRuntimeError) {
-            console.error(`\n  ${error.message}\n`);
-        } else {
-            console.error("\n  Setup failed unexpectedly:", error, "\n");
-        }
+    const providerResult = resolveProvider(options);
+    if (providerResult.isErr()) {
+        console.error(`\n  ${providerResult.error.message}\n`);
         process.exitCode = 1;
+        return;
     }
+    const provider = providerResult.value;
+    const rt = activeRuntime();
+
+    const readyResult = await ensureReady(rt);
+    if (readyResult.isErr()) {
+        console.error(`\n  ${readyResult.error.message}\n`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const { created, apiKey } = await writeProxyConfig();
+    if (created) {
+        console.log(`\n  Wrote ${env.cliproxyConfigPath}`);
+        if (apiKey) console.log(`  Client API key (use this to call the proxy): ${apiKey}`);
+    } else {
+        console.log(`\n  Keeping existing config at ${env.cliproxyConfigPath}`);
+    }
+
+    const pullResult = await pullImage(rt, options.force);
+    if (pullResult.isErr()) {
+        console.error(`\n  ${pullResult.error.message}\n`);
+        process.exitCode = 1;
+        return;
+    }
+
+    if (options.auth) {
+        if (provider === undefined && (await isAuthenticated())) {
+            console.log("  Already authenticated — skipping login (use `--provider <name>` to add or switch).");
+        } else {
+            const authed = await authenticate(rt, provider);
+            if (!authed) console.log("  No provider authenticated yet — re-run `inflexa setup` to sign in.");
+        }
+    }
+
+    if (options.start) {
+        const startResult = await startProxy(rt);
+        if (startResult.isErr()) {
+            console.error(`\n  ${startResult.error.message}\n`);
+            process.exitCode = 1;
+            return;
+        }
+    }
+
+    printNextSteps(options);
 }
 
-function resolveProvider(options: SetupOptions): Provider | undefined {
-    if (options.provider === undefined) return undefined;
+function resolveProvider(options: SetupOptions): Result<Provider | undefined, ProxyError> {
+    if (options.provider === undefined) return ok(undefined);
     if (!isProvider(options.provider)) {
-        throw new ProxyError(`Unknown provider '${options.provider}'. Choose one of: ${PROVIDERS.join(", ")}.`);
+        return err(new ProxyError(`Unknown provider '${options.provider}'. Choose one of: ${PROVIDERS.join(", ")}.`));
     }
-    return options.provider;
+    return ok(options.provider);
 }
 
 function printNextSteps(options: SetupOptions): void {
@@ -152,10 +164,11 @@ async function imageExists(rt: ContainerRuntime): Promise<boolean> {
     return (await capture(rt, ["image", "inspect", IMAGE])).code === 0;
 }
 
-async function pullImage(rt: ContainerRuntime, force: boolean): Promise<void> {
-    if (!force && (await imageExists(rt))) return;
+async function pullImage(rt: ContainerRuntime, force: boolean): Promise<Result<void, ProxyError>> {
+    if (!force && (await imageExists(rt))) return ok(undefined);
     console.log(`  Pulling ${IMAGE}…`);
-    if ((await inherit(rt, ["pull", IMAGE])) !== 0) throw new ProxyError(`Failed to pull ${IMAGE}.`);
+    if ((await inherit(rt, ["pull", IMAGE])) !== 0) return err(new ProxyError(`Failed to pull ${IMAGE}.`));
+    return ok(undefined);
 }
 
 /**
@@ -188,7 +201,7 @@ async function removeContainer(rt: ContainerRuntime): Promise<void> {
  * (Re)create the long-running proxy container. Recreating (vs reusing) applies
  * the current image and mount flags every time setup runs.
  */
-async function recreateContainer(rt: ContainerRuntime): Promise<void> {
+async function recreateContainer(rt: ContainerRuntime): Promise<Result<void, ProxyError>> {
     await removeContainer(rt);
     const args = [
         "run",
@@ -206,26 +219,29 @@ async function recreateContainer(rt: ContainerRuntime): Promise<void> {
         IMAGE,
     ];
     const { code, stderr } = await capture(rt, args);
-    if (code !== 0) throw new ProxyError(`Failed to start the proxy container.${stderr ? `\n  ${stderr.trim()}` : ""}`);
+    if (code !== 0) return err(new ProxyError(`Failed to start the proxy container.${stderr ? `\n  ${stderr.trim()}` : ""}`));
+    return ok(undefined);
 }
 
-async function startProxy(rt: ContainerRuntime): Promise<void> {
-    await recreateContainer(rt);
+async function startProxy(rt: ContainerRuntime): Promise<Result<void, ProxyError>> {
+    const result = await recreateContainer(rt);
+    if (result.isErr()) return result;
     console.log(`\n  CLIProxyAPI is running on ${env.cliproxyBaseUrl}`);
+    return ok(undefined);
 }
 
 /**
  * Bring the container up without forcing a recreate: reuse a running one, start
  * a stopped one, or create it if absent. Used on the TUI hot path.
  */
-async function ensureContainerRunning(rt: ContainerRuntime): Promise<void> {
-    if (await isProxyRunning(rt)) return;
+async function ensureContainerRunning(rt: ContainerRuntime): Promise<Result<void, ProxyError>> {
+    if (await isProxyRunning(rt)) return ok(undefined);
     if ((await containerId(rt, true)) !== null) {
         const { code, stderr } = await capture(rt, ["start", CONTAINER_NAME]);
-        if (code !== 0) throw new ProxyError(`Failed to start the proxy container.${stderr ? `\n  ${stderr.trim()}` : ""}`);
-        return;
+        if (code !== 0) return err(new ProxyError(`Failed to start the proxy container.${stderr ? `\n  ${stderr.trim()}` : ""}`));
+        return ok(undefined);
     }
-    await recreateContainer(rt);
+    return recreateContainer(rt);
 }
 
 // --- config ----------------------------------------------------------------
@@ -342,23 +358,27 @@ async function authenticate(rt: ContainerRuntime, preselected: Provider | undefi
  * ContainerRuntimeError with actionable guidance when it can't proceed (e.g.
  * the runtime isn't ready, or auth is needed in a non-interactive shell).
  */
-export async function ensureProxyReady(): Promise<void> {
+export async function ensureProxyReady(): Promise<Result<void, ProxyError | ContainerRuntimeError>> {
     const rt = activeRuntime();
-    await ensureReady(rt);
+    const readyResult = await ensureReady(rt);
+    if (readyResult.isErr()) return readyResult;
+
     await writeProxyConfig();
-    await pullImage(rt, false);
+
+    const pullResult = await pullImage(rt, false);
+    if (pullResult.isErr()) return pullResult;
 
     if (!(await isAuthenticated())) {
         if (!process.stdin.isTTY) {
-            throw new ProxyError("CLIProxyAPI isn't authenticated yet.\n  Run `inflexa setup` to sign in to a provider before starting the TUI.");
+            return err(new ProxyError("CLIProxyAPI isn't authenticated yet.\n  Run `inflexa setup` to sign in to a provider before starting the TUI."));
         }
         console.log("\n  CLIProxyAPI isn't authenticated yet — let's sign in.");
         if (!(await authenticate(rt, undefined))) {
-            throw new ProxyError("Authentication didn't complete.\n  Run `inflexa setup` to finish signing in, then try again.");
+            return err(new ProxyError("Authentication didn't complete.\n  Run `inflexa setup` to finish signing in, then try again."));
         }
     }
 
-    await ensureContainerRunning(rt);
+    return ensureContainerRunning(rt);
 }
 
 /**
@@ -368,14 +388,9 @@ export async function ensureProxyReady(): Promise<void> {
  * BEFORE render().
  */
 export async function ensureProxyReadyOrExit(): Promise<void> {
-    try {
-        await ensureProxyReady();
-    } catch (error) {
-        if (error instanceof ProxyError || error instanceof ContainerRuntimeError) {
-            console.error(`\n  ${error.message}\n`);
-        } else {
-            console.error("\n  Could not start CLIProxyAPI:", error, "\n");
-        }
+    const result = await ensureProxyReady();
+    if (result.isErr()) {
+        console.error(`\n  ${result.error.message}\n`);
         process.exit(1);
     }
 }

--- a/src/modules/proxy/setup.ts
+++ b/src/modules/proxy/setup.ts
@@ -361,16 +361,24 @@ async function authenticate(rt: ContainerRuntime, preselected: Provider | undefi
 
 /**
  * Make the proxy ready to serve the TUI: runtime up, image present, config
- * written, authenticated, container running. Throws ProxyError /
- * ContainerRuntimeError with actionable guidance when it can't proceed (e.g.
- * the runtime isn't ready, or auth is needed in a non-interactive shell).
+ * written, authenticated, container running. Returns a {@link ProxyError} or
+ * {@link ContainerRuntimeError} on the error channel with actionable guidance
+ * when it can't proceed (e.g. the runtime isn't ready, or auth is needed in a
+ * non-interactive shell).
  */
 export async function ensureProxyReady(): Promise<Result<void, ProxyError | ContainerRuntimeError>> {
     const rt = activeRuntime();
     const readyResult = await ensureReady(rt);
     if (readyResult.isErr()) return readyResult;
 
-    await writeProxyConfig();
+    // writeProxyConfig and authenticate are not yet Result-wrapped — catch their
+    // rejections so they flow through the Result channel instead of escaping as
+    // unhandled rejections (the caller has no try/catch).
+    try {
+        await writeProxyConfig();
+    } catch (cause) {
+        return err(new ProxyError(`Failed to write proxy config: ${cause instanceof Error ? cause.message : String(cause)}`));
+    }
 
     const pullResult = await pullImage(rt, false);
     if (pullResult.isErr()) return pullResult;
@@ -380,8 +388,12 @@ export async function ensureProxyReady(): Promise<Result<void, ProxyError | Cont
             return err(new ProxyError("CLIProxyAPI isn't authenticated yet.\n  Run `inflexa setup` to sign in to a provider before starting the TUI."));
         }
         console.log("\n  CLIProxyAPI isn't authenticated yet — let's sign in.");
-        if (!(await authenticate(rt, undefined))) {
-            return err(new ProxyError("Authentication didn't complete.\n  Run `inflexa setup` to finish signing in, then try again."));
+        try {
+            if (!(await authenticate(rt, undefined))) {
+                return err(new ProxyError("Authentication didn't complete.\n  Run `inflexa setup` to finish signing in, then try again."));
+            }
+        } catch (cause) {
+            return err(new ProxyError(`Authentication failed: ${cause instanceof Error ? cause.message : String(cause)}`));
         }
     }
 

--- a/src/modules/proxy/setup.ts
+++ b/src/modules/proxy/setup.ts
@@ -50,40 +50,47 @@ export async function setup(options: SetupOptions): Promise<void> {
         return;
     }
 
-    const { created, apiKey } = await writeProxyConfig();
-    if (created) {
-        console.log(`\n  Wrote ${env.cliproxyConfigPath}`);
-        if (apiKey) console.log(`  Client API key (use this to call the proxy): ${apiKey}`);
-    } else {
-        console.log(`\n  Keeping existing config at ${env.cliproxyConfigPath}`);
-    }
-
-    const pullResult = await pullImage(rt, options.force);
-    if (pullResult.isErr()) {
-        console.error(`\n  ${pullResult.error.message}\n`);
-        process.exitCode = 1;
-        return;
-    }
-
-    if (options.auth) {
-        if (provider === undefined && (await isAuthenticated())) {
-            console.log("  Already authenticated — skipping login (use `--provider <name>` to add or switch).");
+    // writeProxyConfig, isAuthenticated, and authenticate are not yet Result-wrapped — a catch-all
+    // ensures their rejections still produce friendly output instead of a raw stack trace.
+    try {
+        const { created, apiKey } = await writeProxyConfig();
+        if (created) {
+            console.log(`\n  Wrote ${env.cliproxyConfigPath}`);
+            if (apiKey) console.log(`  Client API key (use this to call the proxy): ${apiKey}`);
         } else {
-            const authed = await authenticate(rt, provider);
-            if (!authed) console.log("  No provider authenticated yet — re-run `inflexa setup` to sign in.");
+            console.log(`\n  Keeping existing config at ${env.cliproxyConfigPath}`);
         }
-    }
 
-    if (options.start) {
-        const startResult = await startProxy(rt);
-        if (startResult.isErr()) {
-            console.error(`\n  ${startResult.error.message}\n`);
+        const pullResult = await pullImage(rt, options.force);
+        if (pullResult.isErr()) {
+            console.error(`\n  ${pullResult.error.message}\n`);
             process.exitCode = 1;
             return;
         }
-    }
 
-    printNextSteps(options);
+        if (options.auth) {
+            if (provider === undefined && (await isAuthenticated())) {
+                console.log("  Already authenticated — skipping login (use `--provider <name>` to add or switch).");
+            } else {
+                const authed = await authenticate(rt, provider);
+                if (!authed) console.log("  No provider authenticated yet — re-run `inflexa setup` to sign in.");
+            }
+        }
+
+        if (options.start) {
+            const startResult = await startProxy(rt);
+            if (startResult.isErr()) {
+                console.error(`\n  ${startResult.error.message}\n`);
+                process.exitCode = 1;
+                return;
+            }
+        }
+
+        printNextSteps(options);
+    } catch (error) {
+        console.error("\n  Setup failed unexpectedly:", error, "\n");
+        process.exitCode = 1;
+    }
 }
 
 function resolveProvider(options: SetupOptions): Result<Provider | undefined, ProxyError> {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 // Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
@@ -16,6 +16,7 @@ import { keybindLabel } from "./keymap.ts";
 import { useWorkspace, type Workspace } from "./contexts/workspace.ts";
 import { GLYPHS, themes, themeIds, type ThemeId } from "../lib/design_system.ts";
 import { readConfig, writeConfig } from "../lib/config.ts";
+import { mkdirResult, writeFileResult } from "../lib/fs.ts";
 import { str256 } from "../lib/types.ts";
 import { createAnalysis, listRecentAnalyses } from "../modules/analysis/analysis.ts";
 import { resolveContext, describeContext } from "../modules/analysis/context.ts";
@@ -289,11 +290,9 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
     if (!text) return;
 
     const dest = join(dir, `provenance.${format}`);
-    try {
-        mkdirSync(dir, { recursive: true });
-        writeFileSync(dest, text);
-    } catch (cause) {
-        notify({ kind: "error", text: `Failed to write provenance: ${String(cause)}` });
+    const writeResult = mkdirResult(dir, "exportProvenance:mkdir").andThen(() => writeFileResult(dest, text, "exportProvenance:write"));
+    if (writeResult.isErr()) {
+        notify({ kind: "error", text: `Failed to write provenance: ${String(writeResult.error.cause)}` });
         return;
     }
 
@@ -304,10 +303,9 @@ async function exportProvenanceToFile(ws: Workspace, format: BuiltinProvFormat):
         return;
     }
     const sigDest = `${dest}.sig.json`;
-    try {
-        writeFileSync(sigDest, JSON.stringify(sidecarResult.value, null, 2));
-    } catch (cause) {
-        notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(cause)}` });
+    const sidecarWrite = writeFileResult(sigDest, JSON.stringify(sidecarResult.value, null, 2), "exportProvenance:sidecar");
+    if (sidecarWrite.isErr()) {
+        notify({ kind: "error", text: `Wrote provenance but sidecar failed: ${String(sidecarWrite.error.cause)}` });
         return;
     }
 

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -97,6 +97,7 @@ function noticeKindFor(result: VerifyResult): "info" | "warn" | "error" {
         case "tampered":
         case "invalid-sidecar":
         case "invalid-key":
+        case "verify-error":
             return "error";
     }
 }

--- a/src/types/prov.ts
+++ b/src/types/prov.ts
@@ -48,4 +48,5 @@ export type VerifyResult =
     | { status: "no-key" }
     | { status: "empty" }
     | { status: "invalid-sidecar"; detail: string }
-    | { status: "invalid-key" };
+    | { status: "invalid-key" }
+    | { status: "verify-error"; detail: string };

--- a/src/types/prov.ts
+++ b/src/types/prov.ts
@@ -38,7 +38,7 @@ export type ProvInputRef = {
 };
 
 /**
- * The outcome of `inflexa prov verify`: one of five mutually exclusive states, each with enough
+ * The outcome of `inflexa prov verify`: one of several mutually exclusive states, each with enough
  * detail for the CLI/TUI to render a clear message.
  */
 export type VerifyResult =


### PR DESCRIPTION
Replace throw/try-catch with neverthrow Result types throughout:
- Add lib/fs.ts with readFileResult/writeFileResult/mkdirResult/statResult wrappers
- Convert marker.ts readMarker/writeMarker/findMarkerUpwards to Result<T, MarkerError>
- Collapse 7 downstream try/catch blocks in anchor.ts, backstop.ts, context.ts, analysis.ts, input.ts
- Convert 5 prov crypto primitives (signHexDigest, computeChainHash, etc.) to ResultAsync
- Fix 2 uncaught rejection bugs in verify.ts buildSidecar and prov.ts flushProvenanceAsync
- Convert container.ts ensureReady and proxy/setup.ts chain to Result
- Convert chat.ts readApiKey/resolveModelId with ChatSetupError type
- Convert hash.ts sha256File to ResultAsync
- Fix uncaught throws in output.ts ensureOutputDir and staging.ts structural gap
- Add neverthrow-first policy to CLAUDE.md

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (default no network egress, working-directory-only mounts, resource limits); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented), and `docs/provenance.md` is updated.
