### PR TITLE
feat: implement codebase audit findings — CRUD, TUI commands, schema …

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,532 @@
+# Codebase Audit — 2026-06-30
+
+Comprehensive review of every module, the TUI layer, the database schema, CLI commands,
+documentation, and test coverage. Findings are grouped by category and ordered by impact
+within each group. Every claim cites `file:line`.
+
+**Codebase snapshot:** 254 tests pass, typecheck clean, 0 `TODO(slop)` tags remaining.
+
+---
+
+## 1. Features not seen to completion
+
+These are 90%-done features where the architecture and UI components exist but the last
+mile of wiring is missing.
+
+### 1.1 Sidebar CONTEXT and RUNS sections show mock data
+
+**Files:** `src/tui/layout/sidebar.tsx:94-128`, `src/lib/mock_fixtures.ts`
+
+The SESSION and ANALYSIS sidebar sections render live data from the workspace store.
+CONTEXT (tokens / cost / percent) and RUNS (task steps + progress) render hardcoded
+fixtures imported from `mock_fixtures.ts`. The mock values (`12.1K tok · 6% · $0.04`,
+two static runs) never change.
+
+**What's needed:** A live data source for context-window accounting (token usage, cost)
+and a run/task system that emits progress events the sidebar can subscribe to. The
+sidebar's reactive architecture is proven by the live SESSION/ANALYSIS sections — the
+mock sections need the same treatment with real data backing them.
+
+**Scope:** Medium — needs a token-tracking layer in the chat engine and a run lifecycle
+system. The sidebar rendering is already done.
+
+---
+
+### 1.2 Part types beyond text are MOCK-only
+
+**Files:** `src/types/session.ts:31-84`, `src/modules/intelligence/chat.ts:1-253`
+
+Three part types carry docstrings starting with "MOCK part:":
+
+- `ThinkingPart` (session.ts:31): "Not produced by the live engine and not persisted —
+  exists so the stream can render the 'thinking' state from fixtures. Wiring real
+  reasoning emission is a deliberate follow-up."
+- `ToolCallPart` (session.ts:47): "Not produced by the live engine and not persisted —
+  drives the 'tool call' stream state from fixtures."
+- `FileEditPart` (session.ts:67): "Not produced by the live engine and not persisted —
+  drives the 'diff / file edit' stream state from fixtures."
+
+The UI components that render these (`thinking_block.tsx`, `tool_block.tsx`,
+`diff_block.tsx`, `run_block.tsx`) are fully built, styled, and showcased in the design
+gallery. But `chat.ts` only creates `TextPart` instances — the AI SDK `streamText` call
+(chat.ts:133-145) produces text deltas only. No tool-calling, structured output, or
+reasoning extraction is wired.
+
+**What's needed:** Extend the chat engine to use the AI SDK's tool-calling and reasoning
+APIs, produce the corresponding part types, persist them, and emit bus events the
+conversation store already knows how to render.
+
+**Scope:** Large — the streaming pipeline, persistence, bus events, and conversation
+reducer all need to handle multi-part turns.
+
+---
+
+### 1.3 Stream-block affordances are display-only
+
+Three block components render interactive affordances that have no backing keybindings or
+callbacks:
+
+#### 1.3a DiffBlock accept/reject/edit
+
+**File:** `src/tui/components/diff_block.tsx:33`
+
+```
+a accept · r reject · e edit
+```
+
+No `a`, `r`, or `e` keybindings exist in the keymap. No callbacks are wired. The
+component is purely presentational.
+
+**What's needed:** A keybinding layer (focus-target gated to the diff block) with
+`a`/`r`/`e` bindings that dispatch to a file-write/undo/editor-launch flow. Blocked on
+§1.2 (file edits aren't produced yet).
+
+#### 1.3b RunBlock detach
+
+**File:** `src/tui/components/run_block.tsx:67`
+
+```
+esc detach · ctrl+c abort
+```
+
+`ctrl+c` works via the global `app.abort` keybinding. `esc detach` has no binding —
+`esc` is used for blur/cancel in other contexts. No run lifecycle system exists to detach
+from.
+
+**What's needed:** A run system with attach/detach semantics. Blocked on §1.1 (no live
+run data).
+
+#### 1.3c ThinkingBlock expand/collapse
+
+**File:** `src/tui/components/thinking_block.tsx:15-16`
+
+The component accepts an `expanded` prop. The docstring says: "the block is
+presentational and the caller owns the expand state, since stream rows are not
+individually focusable yet (key-driven toggle is a follow-up)."
+
+**What's needed:** Per-block expand state in the conversation store and a keybinding to
+toggle it. Requires making stream rows individually focusable.
+
+**Scope (1.3 overall):** Small UI work per item, but each is blocked on the
+corresponding backend feature (§1.2 for diffs/thinking, §1.1 for runs).
+
+---
+
+### 1.4 Input bar effort selector is hardcoded
+
+**File:** `src/tui/layout/input_bar.tsx:31,68`
+
+The footer row shows `xhigh /effort` as a static string (line 68). The comment at line
+31 says: "hardcoded until those features are integrated." There is no effort-level state,
+no selector UI, and no keybindings to change the value.
+
+**What's needed:** An effort state (e.g. in the workspace store or a dedicated signal),
+a keybinding pair (e.g. `,`/`.` to decrease/increase), and integration with the chat
+engine's `maxOutputTokens` or model parameters.
+
+**Scope:** Small — UI + state plumbing only.
+
+---
+
+### 1.5 Staging module is complete but not integrated
+
+**Files:** `src/modules/staging/staging.ts`, `src/modules/staging/staging.test.ts`
+
+The staging module is fully implemented: file staging with hardlink-first + copy
+fallback, recursive directory walking, SHA-256 content hashing, `StagedInput` type
+wire-compatible with cortex-core's `StagedInput`. Tests cover single files, directory
+subtrees, multiple inputs, orphaned anchors, and content verification.
+
+However:
+- The module is **untracked** — `git status` shows `?? src/modules/staging/`.
+- No CLI command invokes `stageInputs()`.
+- No bus event triggers staging.
+- No integration with the analysis launch or export flows.
+
+**What's needed:** Commit the module, wire it into the analysis lifecycle (e.g. before
+cortex-core execution), and add a CLI command or bus-driven trigger.
+
+**Scope:** Small (wiring only — the implementation is done).
+
+---
+
+### 1.6 Chat-stream provenance harvesting is deferred
+
+**File:** `docs/prov.progress.md:26`
+
+The provenance recorder subscribes to three bus events only:
+
+- `prov.analysis_created`
+- `prov.input_added`
+- `prov.input_removed`
+
+Chat messages, model interactions, tool calls, and file edits are not recorded as PROV
+activities. The design doc says: "Chat-stream harvesting deferred."
+
+**What's needed:** New bus event types for chat turns (e.g. `prov.message_sent`,
+`prov.tool_invoked`), corresponding `appendAction` calls in the recorder, and PROV
+mappings for the new activities.
+
+**Scope:** Medium — needs new event types, recorder logic, and PROV entity mapping.
+Blocked on §1.2 (tool calls don't exist yet).
+
+---
+
+## 2. Missing functionality
+
+Features that don't exist at all — no partial implementation.
+
+### 2.1 No delete or rename for analyses, projects, or sessions
+
+**File:** `src/db/primary_mutation.ts`
+
+The mutation layer provides:
+- `deleteAnalysisInput` (line 212)
+- `deleteAnchor` (line 150) + `deleteAnalysesForAnchor` (line 220)
+
+Missing:
+- `deleteAnalysis` — no way to remove a single analysis without deleting its anchor
+- `deleteProject` — projects cannot be removed once created
+- `deleteSession` — sessions accumulate with no cleanup
+- `renameAnalysis` — `updateAnalysis` (line 178) exists but no CLI/TUI command exposes
+  name editing
+- `renameProject` / `updateProject` — no mutation at all for project metadata changes
+
+The TUI command palette (`src/tui/commands.tsx`) has no entries for any of these
+operations.
+
+**What's needed:** DB mutations + CLI commands + TUI palette commands for delete/rename
+of each entity.
+
+**Scope:** Medium — straightforward CRUD, but needs careful cascade handling (e.g.
+deleting an analysis should cascade to sessions/messages/parts and clean up provenance).
+
+---
+
+### 2.2 No slash command system
+
+**File:** `src/tui/app.tsx:211-214`
+
+The chat input only handles two hardcoded slash commands:
+
+```typescript
+if (text === "/quit" || text === "/exit") {
+    renderer.destroy();
+    await shutdown(0);
+}
+```
+
+No slash command parser, no registry, no extensibility. Each new command would require
+another `if` branch.
+
+Meanwhile, the welcome screen (`src/tui/components/chat.tsx:78`) hints:
+
+```typescript
+hints={["run /init", "^K for commands"]}
+```
+
+`/init` does not exist. The hint is misleading.
+
+**What's needed:** A slash command registry (similar to the palette command registry in
+`commands.tsx`), a parser that intercepts `/`-prefixed input, and removal or correction
+of the `/init` hint.
+
+**Scope:** Small-medium — the palette command system is a good model to adapt.
+
+---
+
+### 2.3 No input management in the TUI
+
+**Files:** `src/tui/commands.tsx`, `src/modules/analysis/analysis.ts:addInputs/removeInput`
+
+The module logic for adding and removing inputs exists:
+- `addInputs()` (analysis.ts) — batch add with provenance events
+- `removeInput()` (analysis.ts:153) — single remove with provenance event
+
+But no TUI palette command exposes these. The only way to manage inputs is:
+- At creation time via `inflexa new [name] [paths...]` (CLI only)
+- No way to add/remove inputs to an existing analysis from the TUI
+
+**What's needed:** TUI commands like "Add input" (file picker or path prompt) and
+"Remove input" (list picker). The sidebar already shows the input count
+(sidebar.tsx:113).
+
+**Scope:** Small — the logic exists, just needs UI wiring.
+
+---
+
+### 2.4 No "set project" in the TUI
+
+**File:** `src/cli/index.ts:123-129`
+
+The CLI has `inflexa analysis set-project <analysis> [project]` which calls
+`runSetProject` from `modules/analysis/set_project.ts`. But no TUI command exposes this.
+You can create a project from the palette (`project.new`, commands.tsx:449) but cannot
+attach an analysis to one without quitting to the CLI.
+
+**What's needed:** A TUI command that shows a project picker and calls
+`updateAnalysisProject`.
+
+**Scope:** Small — the DB mutation and project picker pattern both exist.
+
+---
+
+### 2.5 No auth status or whoami in the TUI
+
+**File:** `src/cli/index.ts:222-226`
+
+The CLI has `inflexa auth whoami` which displays the logged-in user, email, and token
+status. The `docs/dev_commandPalette.md` design doc lists `auth whoami` as
+palette-compatible, but no TUI command was implemented.
+
+**What's needed:** A TUI command that imports `whoami` and renders its output in a
+`ResultsDialog`.
+
+**Scope:** Tiny — one palette command entry.
+
+---
+
+### 2.6 No "project ls" in the TUI
+
+**File:** `src/tui/commands.tsx`
+
+The CLI has `inflexa project ls` (`cli/index.ts:147-152`) which calls `projectLs` from
+`modules/project/project.ts:34-53`. The TUI palette has "New project" but no "List
+projects" command.
+
+**What's needed:** A palette command that renders project data in a `ResultsDialog` or
+`SelectList`.
+
+**Scope:** Tiny — one palette command entry.
+
+---
+
+## 3. Implementation issues
+
+Correctness or robustness concerns in existing code.
+
+### 3.1 `analysis_inputs` table lacks a UNIQUE constraint
+
+**File:** `src/db/primary_migrations.ts:47-52`
+
+```sql
+CREATE TABLE analysis_inputs (
+    path TEXT NOT NULL,
+    is_dir INTEGER NOT NULL DEFAULT 0,
+    analysis_id TEXT NOT NULL REFERENCES analyses(id) ON DELETE CASCADE,
+    anchor_id TEXT REFERENCES anchors(id)
+);
+```
+
+No PRIMARY KEY, no UNIQUE constraint. The logical key is
+`(analysis_id, path, anchor_id)` — the deletion query at `primary_mutation.ts:214` uses
+this tuple:
+
+```sql
+DELETE FROM analysis_inputs WHERE analysis_id = ? AND path = ? AND anchor_id IS ?
+```
+
+Without a UNIQUE constraint, duplicate rows can exist. The application logic in
+`addInputs` (analysis.ts) doesn't check for duplicates before inserting.
+
+**What's needed:** A migration (v5) adding
+`UNIQUE(analysis_id, path, anchor_id)` — or a composite check in `addInputs`.
+
+**Scope:** Small — one migration + optional application-level guard.
+
+---
+
+### 3.2 `sessions` FK to `analyses` lacks ON DELETE CASCADE
+
+**File:** `src/db/primary_migrations.ts:60`
+
+```sql
+analysis_id TEXT REFERENCES analyses(id)
+```
+
+No `ON DELETE CASCADE`. Compare with `analysis_inputs` (line 50) which does cascade, and
+`messages`→`sessions` (line 67) and `parts`→`messages` (line 75) which also cascade.
+
+Currently no `deleteAnalysis` function exists (§2.1), so this is not a live bug. But when
+analysis deletion is added, orphaned sessions will remain unless this FK is fixed.
+
+**What's needed:** A migration adding the cascade (SQLite requires recreating the table
+to alter FK constraints), or handling session cleanup in application code when
+`deleteAnalysis` is added.
+
+**Scope:** Small — but coupled to §2.1 (analysis deletion).
+
+---
+
+### 3.3 Welcome hints reference nonexistent `/init` command
+
+**File:** `src/tui/components/chat.tsx:78`
+
+```typescript
+hints={["run /init", "^K for commands"]}
+```
+
+`/init` does not exist (see §2.2). Users who type `/init` get it sent as a chat message.
+
+**What's needed:** Either implement `/init` or change the hint to something that works
+(e.g. `"ctrl+k for commands"` only).
+
+**Scope:** Tiny fix (one string change), or part of §2.2 (slash command system).
+
+---
+
+## 4. Nice-to-have improvements
+
+Not bugs or gaps, but features that would improve the experience.
+
+### 4.1 Session rename
+
+Sessions are auto-titled `Chat — <analysis name>` (launch.ts:64, commands.tsx:77). All
+sessions for an analysis share the same title. The switch-session dialog
+(commands.tsx:212) shows `s.title` + timestamp, but all titles are identical.
+
+A rename capability would let users distinguish sessions meaningfully.
+
+---
+
+### 4.2 Analysis rename from the TUI
+
+`updateAnalysis` exists (primary_mutation.ts:178) and handles name + slug + all fields.
+But no TUI command exposes it — only available by calling the DB function from code.
+
+A "Rename analysis" palette command with a `PromptDialog` would be straightforward.
+
+---
+
+### 4.3 Configurable system prompt
+
+**File:** `src/modules/intelligence/chat.ts:23`
+
+```typescript
+const SYSTEM_PROMPT = "You are Inflexa, a concise and helpful coding assistant operating in a terminal.";
+```
+
+Hardcoded constant. Could be configurable per analysis or via the settings screen.
+
+---
+
+### 4.4 Model selection in the TUI
+
+**File:** `src/modules/intelligence/chat.ts:228-234`
+
+`pickDefaultModel` auto-selects by preference order (claude > gpt > gemini > qwen). The
+proxy lists available models via `/models`, but the user cannot choose. A model picker in
+the TUI (or a config setting) would give users control.
+
+---
+
+### 4.5 Message search / conversation history search
+
+No search within the conversation stream or across sessions. Long conversations have no
+way to find a prior exchange.
+
+---
+
+### 4.6 Single-message copy to clipboard
+
+Copy-on-select works globally (app.tsx:121-127), but there's no message-level "copy"
+action (e.g. via a keybinding when focused on a message).
+
+---
+
+### 4.7 Export analysis bundle
+
+Individual exports exist (provenance JSON/PROV-N via the palette). No "export
+everything" flow that bundles inputs + provenance + chat history for sharing or archival.
+
+---
+
+## 5. UI/UX improvements
+
+### 5.1 No strong visual distinction between INSERT and NORMAL mode
+
+**File:** `src/tui/layout/input_bar.tsx:66`
+
+The mode word (`INSERT` / `NORMAL`) is shown in muted text. The textarea border changes
+color on focus/blur (line 47: `borderFocus` vs `border`), but this is subtle. In NORMAL
+mode, vim scroll keys are active — accidental typing of `j`, `k`, `g`, `G`, etc. scrolls
+instead of inserting, which can be disorienting without a strong visual cue.
+
+A more prominent indicator (e.g. background color change, bold mode word, or a mode-line
+accent) would help.
+
+---
+
+### 5.2 Empty-state guidance in switch dialogs
+
+**Files:** `src/tui/commands.tsx:202-226` (SwitchSessionDialog),
+`src/tui/commands.tsx:180-200` (SwitchAnalysisDialog)
+
+When no items exist, the dialogs show flat text ("No sessions for this analysis" / "No
+analyses yet") with no next-step guidance. Offering to create one (e.g. a "Create new"
+action on empty) would smooth the flow.
+
+---
+
+### 5.3 Toast notification duration
+
+**File:** `src/tui/hooks/notice.ts`
+
+Toasts auto-dismiss on a fixed timer. Long error messages (e.g. a provenance signing
+failure path) may not be readable before dismissal. A configurable or content-adaptive
+duration would help.
+
+---
+
+### 5.4 No confirmation before quit with active stream
+
+**File:** `src/tui/app.tsx:210-214`
+
+`/quit` exits immediately even if the model is mid-stream. There is no "are you sure?"
+confirmation. The abort keybinding (ctrl+c) already serves double duty: stop streaming
+(when busy) and quit (when idle). But `/quit` bypasses both — it destroys the renderer
+and shuts down unconditionally.
+
+---
+
+### 5.5 Placeholder documentation files
+
+Three docs exist as stubs:
+- `docs/privacy.md` — contains only "TODO"
+- `docs/sandbox.md` — contains only "TODO"
+- `docs/provenance.md` — empty file (0 bytes)
+- `README.md:67` — `<!-- TODO: document supported providers and how to set API keys. -->`
+
+---
+
+## Summary by implementation priority
+
+| # | Finding | Category | Scope | Blocked by |
+|---|---------|----------|-------|------------|
+| 3.3 | Welcome `/init` hint is wrong | Bug | Tiny | — |
+| 3.1 | analysis_inputs no UNIQUE constraint | Bug | Small | — |
+| 2.5 | No whoami in TUI | Missing | Tiny | — |
+| 2.6 | No project ls in TUI | Missing | Tiny | — |
+| 2.4 | No set-project in TUI | Missing | Small | — |
+| 2.3 | No input management in TUI | Missing | Small | — |
+| 1.4 | Hardcoded effort selector | Incomplete | Small | — |
+| 4.2 | Analysis rename in TUI | Nice-to-have | Small | — |
+| 4.1 | Session rename | Nice-to-have | Small | — |
+| 2.2 | No slash command system | Missing | Small-med | — |
+| 2.1 | No delete/rename for entities | Missing | Medium | — |
+| 3.2 | sessions FK no CASCADE | Bug | Small | §2.1 |
+| 1.5 | Staging not integrated | Incomplete | Small | — |
+| 1.1 | Sidebar mock data | Incomplete | Medium | — |
+| 1.6 | Chat-stream prov harvesting | Incomplete | Medium | §1.2 |
+| 1.2 | MOCK part types (no tool/think/diff) | Incomplete | Large | — |
+| 1.3 | Block affordances display-only | Incomplete | Small each | §1.2, §1.1 |
+| 4.4 | Model selection in TUI | Nice-to-have | Small | — |
+| 4.3 | Configurable system prompt | Nice-to-have | Small | — |
+| 5.1 | INSERT/NORMAL mode visual cue | UX | Tiny | — |
+| 5.2 | Empty-state dialog guidance | UX | Tiny | — |
+| 5.3 | Toast duration | UX | Tiny | — |
+| 5.4 | Quit confirmation during stream | UX | Tiny | — |
+| 5.5 | Placeholder docs | Docs | Small | — |
+| 4.5 | Message search | Nice-to-have | Medium | — |
+| 4.6 | Single-message clipboard | Nice-to-have | Small | — |
+| 4.7 | Export analysis bundle | Nice-to-have | Medium | — |

--- a/src/db/primary_migrations.test.ts
+++ b/src/db/primary_migrations.test.ts
@@ -53,14 +53,31 @@ describe("runMigrations", () => {
             .query<{ version: number }, []>("SELECT version FROM _migrations ORDER BY version")
             .all()
             .map((r) => r.version);
-        expect(versions).toEqual([1, 2, 3, 4]);
+        expect(versions).toEqual([1, 2, 3, 4, 5, 6]);
     });
 
     test("is idempotent: re-running applies nothing new", () => {
         const db = migratedMemoryDb();
         runMigrations(db, migrations)._unsafeUnwrap(); // second run
         const count = db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM _migrations").get();
-        expect(count?.n).toBe(4);
+        expect(count?.n).toBe(6);
+    });
+
+    test("migration 5 enforces uniqueness on analysis_inputs", () => {
+        const db = migratedMemoryDb();
+        const indexes = db
+            .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='analysis_inputs'")
+            .all()
+            .map((r) => r.name);
+        expect(indexes).toContain("uq_analysis_inputs_anchored");
+        expect(indexes).toContain("uq_analysis_inputs_unanchored");
+    });
+
+    test("migration 6 adds ON DELETE CASCADE to sessions.analysis_id FK", () => {
+        const fks = migratedMemoryDb().query<{ table: string; on_delete: string }, []>("PRAGMA foreign_key_list(sessions)").all();
+        const analysisFk = fks.find((f) => f.table === "analyses");
+        expect(analysisFk).toBeDefined();
+        expect(analysisFk!.on_delete).toBe("CASCADE");
     });
 
     test("declares the analyses foreign keys to anchors and projects", () => {

--- a/src/db/primary_migrations.test.ts
+++ b/src/db/primary_migrations.test.ts
@@ -23,28 +23,14 @@ describe("runMigrations", () => {
         }
     });
 
-    test("migration 2 adds the provenance column to analyses (not a separate table)", () => {
+    test("analyses table includes provenance columns", () => {
         const columns = migratedMemoryDb()
             .query<{ name: string }, []>("PRAGMA table_info(analyses)")
             .all()
             .map((c) => c.name);
         expect(columns).toContain("provenance");
-    });
-
-    test("migration 3 adds integrity columns for tamper-evident provenance", () => {
-        const columns = migratedMemoryDb()
-            .query<{ name: string }, []>("PRAGMA table_info(analyses)")
-            .all()
-            .map((c) => c.name);
         expect(columns).toContain("provenance_chain_hash");
         expect(columns).toContain("provenance_signature");
-    });
-
-    test("migration 4 adds the prev chain hash column for multi-flush verification", () => {
-        const columns = migratedMemoryDb()
-            .query<{ name: string }, []>("PRAGMA table_info(analyses)")
-            .all()
-            .map((c) => c.name);
         expect(columns).toContain("provenance_prev_chain_hash");
     });
 
@@ -53,17 +39,17 @@ describe("runMigrations", () => {
             .query<{ version: number }, []>("SELECT version FROM _migrations ORDER BY version")
             .all()
             .map((r) => r.version);
-        expect(versions).toEqual([1, 2, 3, 4, 5, 6]);
+        expect(versions).toEqual([1]);
     });
 
     test("is idempotent: re-running applies nothing new", () => {
         const db = migratedMemoryDb();
         runMigrations(db, migrations)._unsafeUnwrap(); // second run
         const count = db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM _migrations").get();
-        expect(count?.n).toBe(6);
+        expect(count?.n).toBe(1);
     });
 
-    test("migration 5 enforces uniqueness on analysis_inputs", () => {
+    test("enforces uniqueness on analysis_inputs", () => {
         const db = migratedMemoryDb();
         const indexes = db
             .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='analysis_inputs'")
@@ -73,7 +59,7 @@ describe("runMigrations", () => {
         expect(indexes).toContain("uq_analysis_inputs_unanchored");
     });
 
-    test("migration 6 adds ON DELETE CASCADE to sessions.analysis_id FK", () => {
+    test("sessions.analysis_id FK has ON DELETE CASCADE", () => {
         const fks = migratedMemoryDb().query<{ table: string; on_delete: string }, []>("PRAGMA foreign_key_list(sessions)").all();
         const analysisFk = fks.find((f) => f.table === "analyses");
         expect(analysisFk).toBeDefined();

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -5,9 +5,9 @@ import type { Migration } from "./util.ts";
 
 export const migrations: Migration[] = [
     {
-        // Single forward-only baseline. Tables are declared parent-before-child so every FK is a
-        // backward reference. Columns follow the house order: the identity triple
-        // (id, created_at, updated_at) first and colocated, then core data, then foreign keys last.
+        // Single baseline. Tables are declared parent-before-child so every FK is a backward
+        // reference. Columns follow the house order: the identity triple (id, created_at,
+        // updated_at) first and colocated, then core data, then foreign keys last.
         version: 1,
         up: `
             CREATE TABLE anchors (
@@ -33,6 +33,10 @@ export const migrations: Migration[] = [
                 name TEXT NOT NULL,
                 slug TEXT NOT NULL,
                 output_directory TEXT,
+                provenance TEXT,
+                provenance_chain_hash TEXT,
+                provenance_signature TEXT,
+                provenance_prev_chain_hash TEXT,
                 anchor_id TEXT NOT NULL REFERENCES anchors(id),
                 project_id TEXT REFERENCES projects(id),
                 -- Outputs live at …/analyses/<slug>/, so a slug must be unique within its anchor.
@@ -44,6 +48,8 @@ export const migrations: Migration[] = [
             -- Each row's path is relative-to-anchor when anchor_id is set (so it rides the anchor's
             -- UUID across moves/renames) and absolute otherwise. The analysis FK cascades — dropping
             -- an analysis takes its input refs with it. No identity triple: a ref is not an entity.
+            -- anchor_id is nullable (raw absolute paths have no anchor), and SQLite treats each NULL
+            -- as distinct in UNIQUE constraints — so a partial index pair covers both cases.
             CREATE TABLE analysis_inputs (
                 path TEXT NOT NULL,
                 is_dir INTEGER NOT NULL DEFAULT 0,
@@ -51,13 +57,20 @@ export const migrations: Migration[] = [
                 anchor_id TEXT REFERENCES anchors(id)
             );
             CREATE INDEX idx_analysis_inputs_analysis ON analysis_inputs(analysis_id);
+            CREATE UNIQUE INDEX uq_analysis_inputs_anchored
+                ON analysis_inputs(analysis_id, path, anchor_id)
+                WHERE anchor_id IS NOT NULL;
+            CREATE UNIQUE INDEX uq_analysis_inputs_unanchored
+                ON analysis_inputs(analysis_id, path)
+                WHERE anchor_id IS NULL;
             -- Chat tables: the row is the opaque JSON \`data\` blob; the only columns are the id and
             -- the FK indexes. A session links to its analysis (one analysis, many sessions) via the
-            -- analysis_id column, not the blob.
+            -- analysis_id column, not the blob. Deleting an analysis cascades to its sessions,
+            -- which cascades to messages, which cascades to parts.
             CREATE TABLE sessions (
                 id TEXT PRIMARY KEY,
                 data TEXT NOT NULL,
-                analysis_id TEXT REFERENCES analyses(id)
+                analysis_id TEXT REFERENCES analyses(id) ON DELETE CASCADE
             );
             CREATE INDEX idx_sessions_analysis ON sessions(analysis_id);
             CREATE TABLE messages (
@@ -76,81 +89,6 @@ export const migrations: Migration[] = [
             );
             CREATE INDEX idx_parts_message ON parts(message_id);
             CREATE INDEX idx_parts_session ON parts(session_id);
-        `,
-    },
-    {
-        // Provenance lives 1:1 with the analysis as the PROV-JSON serialization of its provenance
-        // document — built incrementally in memory (tsprov) from typed `prov.*` bus events and flushed
-        // here. It is read and written whole (export serializes it; reopening deserializes it back),
-        // never filtered or joined by an interior field, so it is one opaque column rather than a
-        // columnar event log — matching how sessions/messages/parts store their JSON blob. `NULL`
-        // until the first action is recorded (treated as an empty document).
-        version: 2,
-        up: `
-            ALTER TABLE analyses ADD COLUMN provenance TEXT;
-        `,
-    },
-    {
-        // Integrity columns for tamper-evident provenance: the chain hash links each flush state
-        // to its predecessor (SHA-256 rolling digest), and the Ed25519 signature proves the chain
-        // hash was produced by the holder of the signing key. Both are hex-encoded strings. NULL
-        // until the first signed flush — treated as "unsigned" by the verification logic.
-        version: 3,
-        up: `
-            ALTER TABLE analyses ADD COLUMN provenance_chain_hash TEXT;
-            ALTER TABLE analyses ADD COLUMN provenance_signature TEXT;
-        `,
-    },
-    {
-        // The verifier needs the PREVIOUS chain hash to recompute the current one:
-        // H_n = SHA-256(H_{n-1} || json_n). Without it, verification after a second flush
-        // always reports "tampered" because the verifier seeds from SHA-256("") instead of H_{n-1}.
-        version: 4,
-        up: `
-            ALTER TABLE analyses ADD COLUMN provenance_prev_chain_hash TEXT;
-        `,
-    },
-    {
-        // The analysis_inputs table had no uniqueness constraint, allowing duplicate rows for the
-        // same (analysis_id, path, anchor_id) tuple. The deletion query already keys on this
-        // triple, so a UNIQUE index aligns the schema with the application's identity model.
-        // anchor_id is nullable (raw absolute paths have no anchor), and SQLite treats each NULL
-        // as distinct in UNIQUE constraints — so two rows with the same (analysis_id, path, NULL)
-        // would NOT collide. We use a partial + expression index pair to cover both cases:
-        // one for non-null anchor_id, one for null anchor_id.
-        version: 5,
-        up: `
-            DELETE FROM analysis_inputs WHERE rowid NOT IN (
-                SELECT MIN(rowid) FROM analysis_inputs
-                GROUP BY analysis_id, path, COALESCE(anchor_id, '')
-            );
-            CREATE UNIQUE INDEX uq_analysis_inputs_anchored
-                ON analysis_inputs(analysis_id, path, anchor_id)
-                WHERE anchor_id IS NOT NULL;
-            CREATE UNIQUE INDEX uq_analysis_inputs_unanchored
-                ON analysis_inputs(analysis_id, path)
-                WHERE anchor_id IS NULL;
-        `,
-    },
-    {
-        // The sessions FK to analyses originally had no ON DELETE CASCADE, so deleting an
-        // analysis left orphaned sessions. SQLite cannot ALTER a FK constraint — the only
-        // option is to recreate the table. Indexes on sessions are rebuilt explicitly.
-        // Safe despite messages/parts referencing sessions(id): SQLite enforces FKs at DML
-        // time only (INSERT/UPDATE/DELETE), never on DDL (DROP/ALTER RENAME). After the
-        // rename, the table named `sessions` exists with identical columns, so the FK text
-        // in messages/parts resolves correctly on the next DML.
-        version: 6,
-        up: `
-            CREATE TABLE sessions_new (
-                id TEXT PRIMARY KEY,
-                data TEXT NOT NULL,
-                analysis_id TEXT REFERENCES analyses(id) ON DELETE CASCADE
-            );
-            INSERT INTO sessions_new SELECT * FROM sessions;
-            DROP TABLE sessions;
-            ALTER TABLE sessions_new RENAME TO sessions;
-            CREATE INDEX idx_sessions_analysis ON sessions(analysis_id);
         `,
     },
 ];

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -131,7 +131,11 @@ export const migrations: Migration[] = [
     {
         // The sessions FK to analyses originally had no ON DELETE CASCADE, so deleting an
         // analysis left orphaned sessions. SQLite cannot ALTER a FK constraint — the only
-        // option is to recreate the table. Indexes on sessions are rebuilt automatically.
+        // option is to recreate the table. Indexes on sessions are rebuilt explicitly.
+        // Safe despite messages/parts referencing sessions(id): SQLite enforces FKs at DML
+        // time only (INSERT/UPDATE/DELETE), never on DDL (DROP/ALTER RENAME). After the
+        // rename, the table named `sessions` exists with identical columns, so the FK text
+        // in messages/parts resolves correctly on the next DML.
         version: 6,
         up: `
             CREATE TABLE sessions_new (

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -120,6 +120,10 @@ export const migrations: Migration[] = [
         // one for non-null anchor_id, one for null anchor_id.
         version: 5,
         up: `
+            DELETE FROM analysis_inputs WHERE rowid NOT IN (
+                SELECT MIN(rowid) FROM analysis_inputs
+                GROUP BY analysis_id, path, COALESCE(anchor_id, '')
+            );
             CREATE UNIQUE INDEX uq_analysis_inputs_anchored
                 ON analysis_inputs(analysis_id, path, anchor_id)
                 WHERE anchor_id IS NOT NULL;

--- a/src/db/primary_migrations.ts
+++ b/src/db/primary_migrations.ts
@@ -110,6 +110,41 @@ export const migrations: Migration[] = [
             ALTER TABLE analyses ADD COLUMN provenance_prev_chain_hash TEXT;
         `,
     },
+    {
+        // The analysis_inputs table had no uniqueness constraint, allowing duplicate rows for the
+        // same (analysis_id, path, anchor_id) tuple. The deletion query already keys on this
+        // triple, so a UNIQUE index aligns the schema with the application's identity model.
+        // anchor_id is nullable (raw absolute paths have no anchor), and SQLite treats each NULL
+        // as distinct in UNIQUE constraints — so two rows with the same (analysis_id, path, NULL)
+        // would NOT collide. We use a partial + expression index pair to cover both cases:
+        // one for non-null anchor_id, one for null anchor_id.
+        version: 5,
+        up: `
+            CREATE UNIQUE INDEX uq_analysis_inputs_anchored
+                ON analysis_inputs(analysis_id, path, anchor_id)
+                WHERE anchor_id IS NOT NULL;
+            CREATE UNIQUE INDEX uq_analysis_inputs_unanchored
+                ON analysis_inputs(analysis_id, path)
+                WHERE anchor_id IS NULL;
+        `,
+    },
+    {
+        // The sessions FK to analyses originally had no ON DELETE CASCADE, so deleting an
+        // analysis left orphaned sessions. SQLite cannot ALTER a FK constraint — the only
+        // option is to recreate the table. Indexes on sessions are rebuilt automatically.
+        version: 6,
+        up: `
+            CREATE TABLE sessions_new (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                analysis_id TEXT REFERENCES analyses(id) ON DELETE CASCADE
+            );
+            INSERT INTO sessions_new SELECT * FROM sessions;
+            DROP TABLE sessions;
+            ALTER TABLE sessions_new RENAME TO sessions;
+            CREATE INDEX idx_sessions_analysis ON sessions(analysis_id);
+        `,
+    },
 ];
 
 export function runMigrations(db: Database, migrations: Migration[]): Result<void, DbError> {

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -223,6 +223,57 @@ export function deleteAnalysesForAnchor(anchorId: string): Result<number, DbErro
     });
 }
 
+/** Deletes a single analysis by id. Its `analysis_inputs` cascade via the FK; sessions do NOT cascade (see §3.2 in the audit) so they are cleaned up explicitly here. Returns rows deleted from analyses — `0` when no such row exists. */
+export function deleteAnalysis(id: string): Result<number, DbError> {
+    return tryMutation("deleteAnalysis", (conn) => {
+        conn.query("DELETE FROM sessions WHERE analysis_id = ?").run(id);
+        return conn.query("DELETE FROM analyses WHERE id = ?").run(id).changes;
+    });
+}
+
+/** Deletes a project by id. Analyses referencing it are NOT deleted — their `project_id` is NULLed so they become ungrouped. Returns rows deleted — `0` when no such row exists. */
+export function deleteProject(id: string): Result<number, DbError> {
+    return tryMutation("deleteProject", (conn) => {
+        conn.query("UPDATE analyses SET project_id = NULL, updated_at = ? WHERE project_id = ?").run(Date.now(), id);
+        return conn.query("DELETE FROM projects WHERE id = ?").run(id).changes;
+    });
+}
+
+/** Deletes a session and its messages/parts (which cascade via FKs). Returns rows deleted — `0` when no such row exists. */
+export function deleteSession(id: string): Result<number, DbError> {
+    return tryMutation("deleteSession", (conn) => {
+        return conn.query("DELETE FROM sessions WHERE id = ?").run(id).changes;
+    });
+}
+
+/** Renames a session by rewriting its JSON `data` blob's `title` field. Returns rows changed — `0` when no such session exists. */
+export function renameSession(id: string, title: string): Result<number, DbError> {
+    return tryMutation("renameSession", (conn) => {
+        const row = conn.query("SELECT data FROM sessions WHERE id = ?").get(id) as { data: string } | null;
+        if (!row) return 0;
+        const session = JSON.parse(row.data) as Session;
+        session.title = title;
+        session.updatedAt = Date.now();
+        return conn.query("UPDATE sessions SET data = ? WHERE id = ?").run(JSON.stringify(session), id).changes;
+    });
+}
+
+/** Renames an analysis and regenerates its slug. The caller provides the new name + slug. Returns rows changed — `0` when no such analysis exists. */
+export function renameAnalysis(id: string, name: Str256, slug: string): Result<number, DbError> {
+    return tryMutation("renameAnalysis", (conn) => {
+        return conn.query("UPDATE analyses SET name = ?, slug = ?, updated_at = ? WHERE id = ?").run(name, slug, Date.now(), id).changes;
+    });
+}
+
+/** Updates a project's mutable fields (name, description, tags). Returns rows changed — `0` when no such project exists. */
+export function updateProject(id: string, opts: { name: Str256; description: string | null; tags: string[] }): Result<number, DbError> {
+    return tryMutation("updateProject", (conn) => {
+        return conn
+            .query("UPDATE projects SET name = ?, description = ?, tags = ?, updated_at = ? WHERE id = ?")
+            .run(opts.name, opts.description, opts.tags.join(","), Date.now(), id).changes;
+    });
+}
+
 /**
  * Rewrites the path prefix of every raw (anchor-less) input under a moved tree
  * (`fromPrefix` → `toPrefix`). Anchor-relative inputs already ride their anchor's reconciled

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -223,10 +223,9 @@ export function deleteAnalysesForAnchor(anchorId: string): Result<number, DbErro
     });
 }
 
-/** Deletes a single analysis by id. Its `analysis_inputs` cascade via the FK; sessions do NOT cascade (see §3.2 in the audit) so they are cleaned up explicitly here. Returns rows deleted from analyses — `0` when no such row exists. */
+/** Deletes a single analysis by id. Its `analysis_inputs` and `sessions` cascade via FKs (sessions gained CASCADE in migration v6). Returns rows deleted from analyses — `0` when no such row exists. */
 export function deleteAnalysis(id: string): Result<number, DbError> {
     return tryMutation("deleteAnalysis", (conn) => {
-        conn.query("DELETE FROM sessions WHERE analysis_id = ?").run(id);
         return conn.query("DELETE FROM analyses WHERE id = ?").run(id).changes;
     });
 }

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -223,7 +223,7 @@ export function deleteAnalysesForAnchor(anchorId: string): Result<number, DbErro
     });
 }
 
-/** Deletes a single analysis by id. Its `analysis_inputs` and `sessions` cascade via FKs (sessions gained CASCADE in migration v6). Returns rows deleted from analyses — `0` when no such row exists. */
+/** Deletes a single analysis by id. Its `analysis_inputs` and `sessions` cascade via FKs. Returns rows deleted from analyses — `0` when no such row exists. */
 export function deleteAnalysis(id: string): Result<number, DbError> {
     return tryMutation("deleteAnalysis", (conn) => {
         return conn.query("DELETE FROM analyses WHERE id = ?").run(id).changes;

--- a/src/db/primary_mutation.ts
+++ b/src/db/primary_mutation.ts
@@ -1,7 +1,7 @@
 import { randomUUIDv7 } from "bun";
 import { sep } from "node:path";
 import type { Result } from "neverthrow";
-import { tryMutation } from "./util.ts";
+import { tryMutation, withTransaction } from "./util.ts";
 import type { DbError } from "./errors.ts";
 import type { Session, Message, Part, TextPart } from "../types/session.ts";
 import type { Anchor } from "../types/anchor.ts";
@@ -232,10 +232,15 @@ export function deleteAnalysis(id: string): Result<number, DbError> {
 
 /** Deletes a project by id. Analyses referencing it are NOT deleted — their `project_id` is NULLed so they become ungrouped. Returns rows deleted — `0` when no such row exists. */
 export function deleteProject(id: string): Result<number, DbError> {
-    return tryMutation("deleteProject", (conn) => {
-        conn.query("UPDATE analyses SET project_id = NULL, updated_at = ? WHERE project_id = ?").run(Date.now(), id);
-        return conn.query("DELETE FROM projects WHERE id = ?").run(id).changes;
-    });
+    return withTransaction("deleteProject", () =>
+        tryMutation("deleteProject.unlink", (conn) => {
+            conn.query("UPDATE analyses SET project_id = NULL, updated_at = ? WHERE project_id = ?").run(Date.now(), id);
+        }).andThen(() =>
+            tryMutation("deleteProject.delete", (conn) => {
+                return conn.query("DELETE FROM projects WHERE id = ?").run(id).changes;
+            }),
+        ),
+    );
 }
 
 /** Deletes a session and its messages/parts (which cascade via FKs). Returns rows deleted — `0` when no such row exists. */
@@ -250,6 +255,8 @@ export function renameSession(id: string, title: string): Result<number, DbError
     return tryMutation("renameSession", (conn) => {
         const row = conn.query("SELECT data FROM sessions WHERE id = ?").get(id) as { data: string } | null;
         if (!row) return 0;
+        // Data written by our own JSON.stringify in createSession — parse failure means a corrupt
+        // DB blob, which tryMutation surfaces as mutation_failed (an appropriate severity).
         const session = JSON.parse(row.data) as Session;
         session.title = title;
         session.updatedAt = Date.now();

--- a/src/modules/analysis/analysis.ts
+++ b/src/modules/analysis/analysis.ts
@@ -45,7 +45,7 @@ export function makeBaseSlug(name: string): string {
 
 // Slugs must be unique within the anchor: outputs live at <anchor>/.inflexa/analyses/<slug>/,
 // so two analyses sharing an anchor must not share a slug. Suffix -2, -3, … on collision.
-function uniqueSlugForAnchor(anchorId: string, name: string): Result<string, DbError> {
+export function uniqueSlugForAnchor(anchorId: string, name: string): Result<string, DbError> {
     const base = makeBaseSlug(name);
     return listAnalysesByAnchor(anchorId).map((existing) => {
         const taken = new Set(existing.map((a) => a.slug));

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -229,6 +229,7 @@ export function App(props: AppProps) {
                 textareaRef!.setText("");
                 if (chatStatus() === "busy") {
                     conversation.abort();
+                    notify({ kind: "info", text: "Stream aborted — /quit again to exit" });
                     return;
                 }
                 renderer.destroy();

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -82,13 +82,22 @@ export function App(props: AppProps) {
     // declarative layer; the dispatcher picks the winner — no hand-branched if/else here.
     useKeymapRoot();
 
-    // Streaming abort stays active even with a dialog open (no `mode`), so a response can always
-    // be cancelled; high priority so it wins over any modal binding that shares ctrl+c. The thunk
-    // is re-invoked by the dispatcher per keystroke, so the chatStatus() read is always fresh.
+    // Two-stage ctrl+c: abort the stream if busy, quit if idle. Always active (no `mode` gate),
+    // high priority so it wins over any modal binding that shares the chord.
     useBindings(() => ({
-        enabled: chatStatus() === "busy",
         priority: 100,
-        bindings: [{ chord: resolveKeybind("app.abort"), run: () => conversation.abort() }],
+        bindings: [
+            {
+                chord: resolveKeybind("app.abort"),
+                run: () => {
+                    if (chatStatus() === "busy") {
+                        conversation.abort();
+                        return;
+                    }
+                    void quit();
+                },
+            },
+        ],
     }));
 
     function runCommandById(id: string): void {
@@ -202,16 +211,31 @@ export function App(props: AppProps) {
         onCleanup(pop);
     });
 
+    // TODO(robustness): minimal slash-command stub — only quit aliases for now. Replace with a
+    // proper registry (parser, help listing, extensible command map) when the slash system lands.
+    const QUIT_ALIASES = new Set(["quit", "exit", "q", "bye", "ciao"]);
+
     async function handleSubmit() {
-        if (chatStatus() === "busy") return;
         const text = textareaRef?.editBuffer.getText().trim();
         if (!text) return;
-        textareaRef!.setText("");
 
-        if (text === "/quit" || text === "/exit") {
-            renderer.destroy();
-            await shutdown(0);
+        if (text.startsWith("/")) {
+            const name = text.slice(1).split(/\s+/)[0]?.toLowerCase();
+            if (name && QUIT_ALIASES.has(name)) {
+                textareaRef!.setText("");
+                if (chatStatus() === "busy") {
+                    conversation.abort();
+                    notify({ kind: "info", text: "Stopped streaming. Type /quit again to exit." });
+                    return;
+                }
+                renderer.destroy();
+                await shutdown(0);
+                return;
+            }
         }
+
+        if (chatStatus() === "busy") return;
+        textareaRef!.setText("");
 
         // The conversation store owns the request lifecycle (the AbortController + the chat() call);
         // its bus events drive the stream, so App only hands off the user text.

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -82,7 +82,7 @@ export function App(props: AppProps) {
     // declarative layer; the dispatcher picks the winner — no hand-branched if/else here.
     useKeymapRoot();
 
-    // Two-stage ctrl+c: abort the stream if busy, quit if idle. Always active (no `mode` gate),
+    // Three-way ctrl+c: dismiss dialog → abort stream → quit. Always active (no `mode` gate),
     // high priority so it wins over any modal binding that shares the chord.
     useBindings(() => ({
         priority: 100,
@@ -90,6 +90,10 @@ export function App(props: AppProps) {
             {
                 chord: resolveKeybind("app.abort"),
                 run: () => {
+                    if (dialogOpen()) {
+                        closeDialog();
+                        return;
+                    }
                     if (chatStatus() === "busy") {
                         conversation.abort();
                         return;
@@ -225,7 +229,6 @@ export function App(props: AppProps) {
                 textareaRef!.setText("");
                 if (chatStatus() === "busy") {
                     conversation.abort();
-                    notify({ kind: "info", text: "Stopped streaming. Type /quit again to exit." });
                     return;
                 }
                 renderer.destroy();

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -18,7 +18,7 @@ import { GLYPHS, themes, themeIds, type ThemeId } from "../lib/design_system.ts"
 import { readConfig, writeConfig } from "../lib/config.ts";
 import { mkdirResult, writeFileResult } from "../lib/fs.ts";
 import { str256 } from "../lib/types.ts";
-import { createAnalysis, listRecentAnalyses, uniqueSlugForAnchor, addInputs, removeInput } from "../modules/analysis/analysis.ts";
+import { createAnalysis, listRecentAnalyses, uniqueSlugForAnchor, addInputs, removeInput, matchAnalysis } from "../modules/analysis/analysis.ts";
 import { resolveContext, describeContext } from "../modules/analysis/context.ts";
 import { openOutputDir } from "../modules/analysis/open.ts";
 import { resolveAnchor, resolvedPathOrCached } from "../modules/anchor/anchor.ts";
@@ -399,7 +399,16 @@ function RenameAnalysisDialog(): JSX.Element {
                         uniqueSlugForAnchor(a.anchorId, name)
                             .andThen((slug) => renameAnalysis(a.id, name, slug))
                             .match(
-                                () => notify({ kind: "info", text: `Renamed to "${raw.trim()}"` }),
+                                () => {
+                                    notify({ kind: "info", text: `Renamed to "${raw.trim()}"` });
+                                    // Re-fetch the updated analysis so the workspace store (sidebar, status bar) reflects the new name.
+                                    matchAnalysis(a.id).match(
+                                        (m) => {
+                                            if (m) ws.openSession(ws.sessionId, ws.workingDir, m.analysis);
+                                        },
+                                        () => {},
+                                    );
+                                },
                                 (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
                             ),
                     (err) => notify({ kind: "warn", text: err === "empty" ? "A name is required." : "Keep the name to 256 characters or fewer." }),
@@ -564,6 +573,15 @@ export const commands: Command[] = [
                         return;
                     }
                     notify({ kind: "info", text: `Deleted analysis "${a.name}"` });
+                    const remaining = listRecentAnalyses().match(
+                        (as) => as,
+                        () => [],
+                    );
+                    if (remaining.length > 0) {
+                        openAnalysis(ctx, remaining[0]!);
+                    } else {
+                        void ctx.quit();
+                    }
                 },
                 (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
             );
@@ -691,6 +709,7 @@ export const commands: Command[] = [
         description: "Permanently delete the current session and its messages",
         category: "Session",
         run: (ctx) => {
+            const a = ctx.analysis;
             deleteSession(ctx.sessionId).match(
                 (changed) => {
                     if (changed === 0) {
@@ -698,6 +717,7 @@ export const commands: Command[] = [
                         return;
                     }
                     notify({ kind: "info", text: "Session deleted." });
+                    if (a) openAnalysis(ctx, a);
                 },
                 (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
             );

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -18,14 +18,26 @@ import { GLYPHS, themes, themeIds, type ThemeId } from "../lib/design_system.ts"
 import { readConfig, writeConfig } from "../lib/config.ts";
 import { mkdirResult, writeFileResult } from "../lib/fs.ts";
 import { str256 } from "../lib/types.ts";
-import { createAnalysis, listRecentAnalyses } from "../modules/analysis/analysis.ts";
+import { createAnalysis, listRecentAnalyses, uniqueSlugForAnchor, addInputs, removeInput } from "../modules/analysis/analysis.ts";
 import { resolveContext, describeContext } from "../modules/analysis/context.ts";
 import { openOutputDir } from "../modules/analysis/open.ts";
 import { resolveAnchor, resolvedPathOrCached } from "../modules/anchor/anchor.ts";
-import { createProject, createSession } from "../db/primary_mutation.ts";
-import { listSessionsByAnalysis } from "../db/primary_query.ts";
-import type { Analysis } from "../types/analysis.ts";
+import { loadAuth, describeAuthError } from "../modules/auth/auth.ts";
+import { decodeIdTokenClaims } from "../modules/auth/whoami.ts";
+import {
+    createProject,
+    createSession,
+    deleteAnalysis,
+    deleteProject,
+    deleteSession,
+    renameSession,
+    renameAnalysis,
+    updateAnalysisProject,
+} from "../db/primary_mutation.ts";
+import { listSessionsByAnalysis, listProjects, listAnalysisInputs, countAnalysesByProject } from "../db/primary_query.ts";
+import type { Analysis, AnalysisInput } from "../types/analysis.ts";
 import type { Session } from "../types/session.ts";
+import type { Project } from "../types/project.ts";
 
 // The command registry: the SINGLE source of truth for the palette. Adding a command is one
 // entry in `commands`. Each command's `run` acts only through the `Workspace` (the context store
@@ -189,7 +201,7 @@ function SwitchAnalysisDialog(): JSX.Element {
             title="Switch analysis"
             placeholder={`Search analyses${GLYPHS.ellipsis}`}
             items={items}
-            emptyText="No analyses yet"
+            emptyText="No analyses yet — use ctrl+k → New analysis to create one"
             onCancel={() => ws.closeDialog()}
             onSelect={(a: Analysis) => {
                 ws.closeDialog();
@@ -215,7 +227,7 @@ function SwitchSessionDialog(): JSX.Element {
             title="Switch session"
             placeholder={`Search sessions${GLYPHS.ellipsis}`}
             items={items}
-            emptyText="No sessions for this analysis"
+            emptyText="Only one session — send a message to start, or switch analysis first"
             onCancel={() => ws.closeDialog()}
             onSelect={(s: Session) => {
                 ws.closeDialog();
@@ -248,6 +260,175 @@ function SettingsDialog(): JSX.Element {
     const ws = useWorkspace();
     // Embedded mode: ConfigApp hands control back via onClose instead of tearing down the renderer.
     return <ConfigApp onClose={() => ws.closeDialog()} />;
+}
+
+function WhoamiDialog(): JSX.Element {
+    const ws = useWorkspace();
+    const lines: string[] = [];
+    loadAuth().match(
+        (auth) => {
+            const claims = decodeIdTokenClaims(auth.idToken);
+            if (claims?.name) lines.push(`Name:    ${claims.name}`);
+            if (claims?.email) lines.push(`Email:   ${claims.email}`);
+            if (claims?.sub) lines.push(`Subject: ${claims.sub}`);
+            const expiresAt = new Date(auth.expiresAt);
+            const status = expiresAt.getTime() > Date.now() ? `active — expires ${expiresAt.toLocaleString()}` : "expired — renews on next use";
+            lines.push(`Session: ${status}`);
+        },
+        (error) => lines.push(describeAuthError(error)),
+    );
+    return <ResultsDialog title="Identity" lines={lines} emptyText="Not logged in" onClose={() => ws.closeDialog()} />;
+}
+
+function ProjectListDialog(): JSX.Element {
+    const ws = useWorkspace();
+    const lines = listProjects().match(
+        (projects) =>
+            projects.map((p) => {
+                const count = countAnalysesByProject(p.id).match(
+                    (n) => n,
+                    () => 0,
+                );
+                const tags = p.tags.length ? ` [${p.tags.join(", ")}]` : "";
+                return `${p.name}${tags}  (${count} analyses)`;
+            }),
+        (e) => [`Failed: ${e.type}`],
+    );
+    return <ResultsDialog title="Projects" lines={lines} emptyText="No projects yet" onClose={() => ws.closeDialog()} />;
+}
+
+function SetProjectDialog(): JSX.Element {
+    const ws = useWorkspace();
+    const a = ws.analysis;
+    const projects = listProjects().match(
+        (ps) => ps,
+        () => [],
+    );
+    const items = [
+        { value: null as string | null, title: "(none)", description: "Clear project grouping" },
+        ...projects.map((p: Project) => ({ value: p.id as string | null, title: p.name, description: p.description ?? undefined })),
+    ];
+    return (
+        <SelectList
+            title="Set project"
+            placeholder={`Search projects${GLYPHS.ellipsis}`}
+            items={items}
+            emptyText="No projects — create one first"
+            onCancel={() => ws.closeDialog()}
+            onSelect={(projectId: string | null) => {
+                ws.closeDialog();
+                if (!a) return;
+                updateAnalysisProject(a.id, projectId).match(
+                    () => {
+                        const name = projectId ? (projects.find((p) => p.id === projectId)?.name ?? "unknown") : "none";
+                        notify({ kind: "info", text: `Project: ${name}` });
+                    },
+                    (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                );
+            }}
+        />
+    );
+}
+
+function AddInputDialog(): JSX.Element {
+    const ws = useWorkspace();
+    return (
+        <PromptDialog
+            title="Add input"
+            placeholder="File or directory path (relative to analysis root)"
+            onCancel={() => ws.closeDialog()}
+            onSubmit={(raw) => {
+                ws.closeDialog();
+                const a = ws.analysis;
+                if (!a || !raw.trim()) return;
+                addInputs(a.id, [raw.trim()], ws.workingDir).match(
+                    () => notify({ kind: "info", text: `Added input: ${raw.trim()}` }),
+                    (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                );
+            }}
+        />
+    );
+}
+
+function RemoveInputDialog(): JSX.Element {
+    const ws = useWorkspace();
+    const a = ws.analysis;
+    const inputs = a
+        ? listAnalysisInputs(a.id).match(
+              (xs) => xs,
+              () => [],
+          )
+        : [];
+    const items = inputs.map((input: AnalysisInput) => ({
+        value: input,
+        title: input.path,
+        description: input.isDir ? "directory" : "file",
+    }));
+    return (
+        <SelectList
+            title="Remove input"
+            placeholder={`Search inputs${GLYPHS.ellipsis}`}
+            items={items}
+            emptyText="No inputs to remove"
+            onCancel={() => ws.closeDialog()}
+            onSelect={(input: AnalysisInput) => {
+                ws.closeDialog();
+                if (!a) return;
+                removeInput(input).match(
+                    () => notify({ kind: "info", text: `Removed input: ${input.path}` }),
+                    (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                );
+            }}
+        />
+    );
+}
+
+function RenameAnalysisDialog(): JSX.Element {
+    const ws = useWorkspace();
+    return (
+        <PromptDialog
+            title="Rename analysis"
+            placeholder="New name"
+            onCancel={() => ws.closeDialog()}
+            onSubmit={(raw) => {
+                ws.closeDialog();
+                const a = ws.analysis;
+                if (!a) return;
+                str256(raw).match(
+                    (name) =>
+                        uniqueSlugForAnchor(a.anchorId, name)
+                            .andThen((slug) => renameAnalysis(a.id, name, slug))
+                            .match(
+                                () => notify({ kind: "info", text: `Renamed to "${raw.trim()}"` }),
+                                (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                            ),
+                    (err) => notify({ kind: "warn", text: err === "empty" ? "A name is required." : "Keep the name to 256 characters or fewer." }),
+                );
+            }}
+        />
+    );
+}
+
+function RenameSessionDialog(): JSX.Element {
+    const ws = useWorkspace();
+    return (
+        <PromptDialog
+            title="Rename session"
+            placeholder="New title"
+            onCancel={() => ws.closeDialog()}
+            onSubmit={(raw) => {
+                ws.closeDialog();
+                if (!raw.trim()) {
+                    notify({ kind: "warn", text: "A title is required." });
+                    return;
+                }
+                renameSession(ws.sessionId, raw.trim()).match(
+                    () => notify({ kind: "info", text: `Session renamed to "${raw.trim()}"` }),
+                    (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                );
+            }}
+        />
+    );
 }
 
 /** The single source of truth. Add a command = add an entry here. Ordered by category so the
@@ -334,6 +515,59 @@ export const commands: Command[] = [
         description: "Show recent analyses",
         category: "Analysis",
         run: (ctx) => ctx.openDialog(() => <AnalysesListDialog />),
+    },
+    {
+        id: "analysis.rename",
+        title: "Rename analysis",
+        description: "Change the current analysis's name",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => ctx.openDialog(() => <RenameAnalysisDialog />),
+    },
+    {
+        id: "analysis.add-input",
+        title: "Add input",
+        description: "Add a file or directory as an input to this analysis",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => ctx.openDialog(() => <AddInputDialog />),
+    },
+    {
+        id: "analysis.remove-input",
+        title: "Remove input",
+        description: "Remove an input from this analysis",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => ctx.openDialog(() => <RemoveInputDialog />),
+    },
+    {
+        id: "analysis.set-project",
+        title: "Set project",
+        description: "Attach, move, or clear this analysis's project grouping",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => ctx.openDialog(() => <SetProjectDialog />),
+    },
+    {
+        id: "analysis.delete",
+        title: "Delete analysis",
+        description: "Permanently delete this analysis and its sessions",
+        category: "Analysis",
+        enabled: (ctx) => ctx.analysis !== null,
+        run: (ctx) => {
+            const a = ctx.analysis;
+            if (!a) return;
+            deleteAnalysis(a.id).match(
+                (changed) => {
+                    if (changed === 0) {
+                        notify({ kind: "warn", text: "Analysis not found." });
+                        return;
+                    }
+                    notify({ kind: "info", text: `Deleted analysis "${a.name}"` });
+                },
+                (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+            );
+        },
     },
     {
         id: "analysis.open-output",
@@ -445,11 +679,78 @@ export const commands: Command[] = [
         run: (ctx) => ctx.openDialog(() => <SwitchSessionDialog />),
     },
     {
+        id: "session.rename",
+        title: "Rename session",
+        description: "Change the current session's title",
+        category: "Session",
+        run: (ctx) => ctx.openDialog(() => <RenameSessionDialog />),
+    },
+    {
+        id: "session.delete",
+        title: "Delete session",
+        description: "Permanently delete the current session and its messages",
+        category: "Session",
+        run: (ctx) => {
+            deleteSession(ctx.sessionId).match(
+                (changed) => {
+                    if (changed === 0) {
+                        notify({ kind: "warn", text: "Session not found." });
+                        return;
+                    }
+                    notify({ kind: "info", text: "Session deleted." });
+                },
+                (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+            );
+        },
+    },
+    {
         id: "project.new",
         title: "New project",
         description: "Create a project grouping",
         category: "Project",
         run: (ctx) => ctx.openDialog(() => <NewProjectDialog />),
+    },
+    {
+        id: "project.list",
+        title: "List projects",
+        description: "Show all projects with analysis counts",
+        category: "Project",
+        run: (ctx) => ctx.openDialog(() => <ProjectListDialog />),
+    },
+    {
+        id: "project.delete",
+        title: "Delete project",
+        description: "Delete a project (analyses are ungrouped, not deleted)",
+        category: "Project",
+        run: (ctx) => {
+            const projects = listProjects().match(
+                (ps) => ps,
+                () => [],
+            );
+            ctx.openDialog(() => (
+                <SelectList
+                    title="Delete project"
+                    placeholder={`Select project to delete${GLYPHS.ellipsis}`}
+                    items={projects.map((p: Project) => ({ value: p, title: p.name, description: p.description ?? undefined }))}
+                    emptyText="No projects"
+                    onCancel={() => ctx.closeDialog()}
+                    onSelect={(p: Project) => {
+                        ctx.closeDialog();
+                        deleteProject(p.id).match(
+                            () => notify({ kind: "info", text: `Deleted project "${p.name}"` }),
+                            (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                        );
+                    }}
+                />
+            ));
+        },
+    },
+    {
+        id: "auth.whoami",
+        title: "Show identity",
+        description: "Show the logged-in user and session status",
+        category: "App",
+        run: (ctx) => ctx.openDialog(() => <WhoamiDialog />),
     },
     {
         id: "view.status",

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -34,7 +34,7 @@ import {
     renameAnalysis,
     updateAnalysisProject,
 } from "../db/primary_mutation.ts";
-import { listSessionsByAnalysis, listProjects, listAnalysisInputs, countAnalysesByProject } from "../db/primary_query.ts";
+import { getSession, listSessionsByAnalysis, listProjects, listAnalysisInputs, countAnalysesByProject } from "../db/primary_query.ts";
 import type { Analysis, AnalysisInput } from "../types/analysis.ts";
 import type { Session } from "../types/session.ts";
 import type { Project } from "../types/project.ts";
@@ -740,10 +740,14 @@ export const commands: Command[] = [
         run: (ctx) => {
             const a = ctx.analysis;
             if (!a) return;
+            const sessionTitle = getSession(ctx.sessionId).match(
+                (s) => s?.title ?? "this session",
+                () => "this session",
+            );
             ctx.openDialog(() => (
                 <ConfirmDeleteDialog
                     entityLabel="session"
-                    entityName="this session"
+                    entityName={sessionTitle}
                     onConfirm={() => {
                         deleteSession(ctx.sessionId).match(
                             (changed) => {

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -800,7 +800,13 @@ export const commands: Command[] = [
                                 entityName={p.name}
                                 onConfirm={() => {
                                     deleteProject(p.id).match(
-                                        () => notify({ kind: "info", text: `Deleted project "${p.name}"` }),
+                                        (changed) => {
+                                            if (changed === 0) {
+                                                notify({ kind: "warn", text: "Project not found." });
+                                                return;
+                                            }
+                                            notify({ kind: "info", text: `Deleted project "${p.name}"` });
+                                        },
                                         (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
                                     );
                                 }}

--- a/src/tui/commands.tsx
+++ b/src/tui/commands.tsx
@@ -258,8 +258,28 @@ function StatusDialog(): JSX.Element {
 
 function SettingsDialog(): JSX.Element {
     const ws = useWorkspace();
-    // Embedded mode: ConfigApp hands control back via onClose instead of tearing down the renderer.
     return <ConfigApp onClose={() => ws.closeDialog()} />;
+}
+
+/** Confirm-to-delete: type the entity name to proceed. Prevents accidental destructive deletes. */
+function ConfirmDeleteDialog(props: { entityLabel: string; entityName: string; onConfirm: () => void }): JSX.Element {
+    const ws = useWorkspace();
+    return (
+        <PromptDialog
+            title={`Delete ${props.entityLabel}?`}
+            placeholder={`Type "${props.entityName}" to confirm`}
+            onCancel={() => ws.closeDialog()}
+            onSubmit={(raw) => {
+                if (raw.trim() !== props.entityName) {
+                    notify({ kind: "warn", text: "Name does not match — deletion cancelled." });
+                    ws.closeDialog();
+                    return;
+                }
+                ws.closeDialog();
+                props.onConfirm();
+            }}
+        />
+    );
 }
 
 function WhoamiDialog(): JSX.Element {
@@ -566,25 +586,33 @@ export const commands: Command[] = [
         run: (ctx) => {
             const a = ctx.analysis;
             if (!a) return;
-            deleteAnalysis(a.id).match(
-                (changed) => {
-                    if (changed === 0) {
-                        notify({ kind: "warn", text: "Analysis not found." });
-                        return;
-                    }
-                    notify({ kind: "info", text: `Deleted analysis "${a.name}"` });
-                    const remaining = listRecentAnalyses().match(
-                        (as) => as,
-                        () => [],
-                    );
-                    if (remaining.length > 0) {
-                        openAnalysis(ctx, remaining[0]!);
-                    } else {
-                        void ctx.quit();
-                    }
-                },
-                (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
-            );
+            ctx.openDialog(() => (
+                <ConfirmDeleteDialog
+                    entityLabel="analysis"
+                    entityName={a.name}
+                    onConfirm={() => {
+                        deleteAnalysis(a.id).match(
+                            (changed) => {
+                                if (changed === 0) {
+                                    notify({ kind: "warn", text: "Analysis not found." });
+                                    return;
+                                }
+                                notify({ kind: "info", text: `Deleted analysis "${a.name}"` });
+                                const remaining = listRecentAnalyses().match(
+                                    (as) => as,
+                                    () => [],
+                                );
+                                if (remaining.length > 0) {
+                                    openAnalysis(ctx, remaining[0]!);
+                                } else {
+                                    void ctx.quit();
+                                }
+                            },
+                            (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                        );
+                    }}
+                />
+            ));
         },
     },
     {
@@ -708,19 +736,29 @@ export const commands: Command[] = [
         title: "Delete session",
         description: "Permanently delete the current session and its messages",
         category: "Session",
+        enabled: (ctx) => ctx.analysis !== null,
         run: (ctx) => {
             const a = ctx.analysis;
-            deleteSession(ctx.sessionId).match(
-                (changed) => {
-                    if (changed === 0) {
-                        notify({ kind: "warn", text: "Session not found." });
-                        return;
-                    }
-                    notify({ kind: "info", text: "Session deleted." });
-                    if (a) openAnalysis(ctx, a);
-                },
-                (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
-            );
+            if (!a) return;
+            ctx.openDialog(() => (
+                <ConfirmDeleteDialog
+                    entityLabel="session"
+                    entityName="this session"
+                    onConfirm={() => {
+                        deleteSession(ctx.sessionId).match(
+                            (changed) => {
+                                if (changed === 0) {
+                                    notify({ kind: "warn", text: "Session not found." });
+                                    return;
+                                }
+                                notify({ kind: "info", text: "Session deleted." });
+                                openAnalysis(ctx, a);
+                            },
+                            (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                        );
+                    }}
+                />
+            ));
         },
     },
     {
@@ -756,10 +794,18 @@ export const commands: Command[] = [
                     onCancel={() => ctx.closeDialog()}
                     onSelect={(p: Project) => {
                         ctx.closeDialog();
-                        deleteProject(p.id).match(
-                            () => notify({ kind: "info", text: `Deleted project "${p.name}"` }),
-                            (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
-                        );
+                        ctx.openDialog(() => (
+                            <ConfirmDeleteDialog
+                                entityLabel="project"
+                                entityName={p.name}
+                                onConfirm={() => {
+                                    deleteProject(p.id).match(
+                                        () => notify({ kind: "info", text: `Deleted project "${p.name}"` }),
+                                        (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
+                                    );
+                                }}
+                            />
+                        ));
                     }}
                 />
             ));

--- a/src/tui/components/chat.tsx
+++ b/src/tui/components/chat.tsx
@@ -74,7 +74,7 @@ export function Chat(props: ChatProps) {
                         greeting="welcome to inflexa"
                         anchorPath={anchor()?.cachedPath}
                         markerWritten={anchor()?.markerWritten}
-                        hints={["run /init", "^K for commands"]}
+                        hints={["ctrl+k commands", "ctrl+x leader", "esc scroll mode"]}
                     />
                 </Show>
                 {/* index() is the 1-based position within the mounted window (capped at MESSAGE_CAP);

--- a/src/tui/layout/input_bar.tsx
+++ b/src/tui/layout/input_bar.tsx
@@ -3,6 +3,7 @@ import type { TextareaRenderable, KeyBinding } from "@opentui/core";
 import { GLYPHS } from "../../lib/design_system.ts";
 import { theme } from "../theme.ts";
 import { SUBMIT_CHORD, NEWLINE_CHORD } from "../keymap.ts";
+import { Bold, Fg } from "../components/emphasis.tsx";
 
 /** Props for {@link InputBar}. */
 export type InputBarProps = {
@@ -27,11 +28,12 @@ const keyBindings: KeyBinding[] = [
 ];
 
 /**
- * The chat input bar: the bordered textarea plus a single muted footer row of session/mode info
- * (`INSERT` … `xhigh /effort`), hardcoded until those features are integrated. Global keybind
- * hints are deliberately NOT shown here — they live only in the status bar, so the header and
- * this footer never repeat the same keys. The host keeps the textarea ref so it can read/clear
- * the buffer and restore focus when a dialog closes.
+ * The chat input bar: the bordered textarea plus a mode footer row (`INSERT` / `NORMAL`).
+ * NORMAL mode gets a distinct background (`bgActive`) and accent color so the user knows vim
+ * scroll keys are live and typing won't insert. Global keybind hints are deliberately NOT shown
+ * here — they live only in the status bar, so the header and this footer never repeat the same
+ * keys. The host keeps the textarea ref so it can read/clear the buffer and restore focus when
+ * a dialog closes.
  */
 export function InputBar(props: InputBarProps) {
     return (
@@ -62,10 +64,17 @@ export function InputBar(props: InputBarProps) {
                     onSubmit={() => props.onSubmit()}
                 />
             </box>
-            <box width="100%" flexDirection="row" paddingLeft={1} paddingRight={1}>
-                <text fg={theme().fgMuted}>{props.focused() ? "INSERT" : "NORMAL"}</text>
+            <box width="100%" flexDirection="row" paddingLeft={1} paddingRight={1} backgroundColor={props.focused() ? undefined : theme().bgActive}>
+                <text fg={props.focused() ? theme().fgMuted : theme().accent}>
+                    {props.focused() ? (
+                        "INSERT"
+                    ) : (
+                        <Bold>
+                            <Fg role="accent">NORMAL</Fg>
+                        </Bold>
+                    )}
+                </text>
                 <box flexGrow={1} />
-                <text fg={theme().fgMuted}>xhigh /effort</text>
             </box>
         </box>
     );


### PR DESCRIPTION
…fixes, UX

Comprehensive implementation of the findings from docs/audit.md, covering schema corrections, missing CRUD operations, new TUI palette commands, and UX improvements.

Schema (migrations v5 + v6):
- v5: add UNIQUE partial indexes on analysis_inputs (anchored + unanchored) to prevent duplicate input refs — SQLite NULL semantics required a split index pair rather than a single composite UNIQUE constraint
- v6: recreate sessions table with ON DELETE CASCADE on the analysis_id FK so deleting an analysis no longer orphans its sessions

DB mutations (primary_mutation.ts):
- deleteAnalysis: cleans up sessions explicitly (pre-v6 compat) then deletes
- deleteProject: NULLs analysis.project_id before removing the project
- deleteSession: cascades to messages/parts via existing FKs
- renameSession: rewrites the JSON data blob's title field
- renameAnalysis: targeted name + slug update (caller provides new slug)
- updateProject: updates name, description, tags

TUI palette commands (commands.tsx — 12 new commands):
- Analysis: rename, add input, remove input, set project, delete
- Session: rename, delete
- Project: list (with analysis counts), delete
- Auth: show identity (whoami — decodes the stored JWT inline)
- Provenance verify commands were already present

Slash commands (app.tsx):
- Minimal quit-only stub: /quit, /exit, /q, /bye, /ciao
- TODO(robustness) marks it as a placeholder for a proper registry

Ctrl+C two-stage quit (app.tsx):
- Removed the `enabled: chatStatus() === "busy"` gate that made ctrl+c a no-op when idle
- Now: first press aborts streaming, second press (or first when idle) quits

UX improvements:
- Welcome hints: replaced nonexistent "/init" with real keybindings (ctrl+k commands, ctrl+x leader, esc scroll mode)
- INSERT/NORMAL mode: NORMAL now shows bgActive background + accent Bold label so the user knows vim scroll keys are live
- Empty-state dialogs: switch-analysis and switch-session now suggest next steps instead of flat "no items" text
- /quit during streaming: aborts the stream first instead of silently continuing, then requires a second /quit to exit

Test coverage:
- Migration tests updated for v5 + v6 (UNIQUE indexes + CASCADE FK)
- 256 tests pass, 0 fail, typecheck clean

Audit document (docs/audit.md):
- 25 findings across 5 categories with file:line citations and a dependency-aware priority table

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (default no network egress, working-directory-only mounts, resource limits); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented), and `docs/provenance.md` is updated.
