### PR TITLE
ci: add on-demand Claude reviewer and CODEOWNERS gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @inflexa-ai/maintainers

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,57 @@
+name: Claude Code
+
+# On-demand Claude. Mention `@claude` in a PR/issue comment, a PR review, or an
+# issue body/title and Claude runs against that context (reviews the diff,
+# answers a question, drafts a fix). It does nothing unless invoked, so it costs
+# nothing on ordinary pushes.
+#
+# NOTE: Claude posts as `github-actions[bot]`. A bot review does NOT count toward
+# a required human approval — this complements branch protection, it never
+# bypasses it.
+#
+# Requires a `CLAUDE_CODE_OAUTH_TOKEN` repo secret. Generate it with
+# `claude setup-token` (uses a Claude Pro/Max subscription), or run
+# `/install-github-app` which sets it up for you
+# (Settings -> Secrets and variables -> Actions).
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run when someone actually mentions @claude.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history so Claude can diff the PR's whole commit range.
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # This repo is an independent-subsystem monorepo (cli/, harness/, ...).
+          # Review each changed subsystem against its own CLAUDE.md conventions.
+          prompt: |
+            This is the inflexa-ai/inf-cli monorepo of independent subsystems
+            (cli/, harness/, skills/, templates/, images/). Each subsystem is
+            self-contained with its own CLAUDE.md — review changed code against
+            the conventions of the subsystem it lives in. Focus on correctness
+            bugs, security issues, and missing tests; skip style nits.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,13 +1,11 @@
 name: DCO
 
-# Enforces the Developer Certificate of Origin: every commit in a PR must carry
-# a `Signed-off-by:` trailer matching its author (see CONTRIBUTING.md).
-#
-# The allowlist is applied per commit by author, not by the PR actor: bots such
-# as Dependabot cannot add a sign-off trailer, so their own commits are exempt
-# while human commits in the same PR are still checked. Because the job always
-# runs (never skipped via `if:`), it reports a real success/failure and so works
-# correctly as a required status check.
+# Enforces the Developer Certificate of Origin via KineticCafe/actions-dco:
+# every commit in a PR must carry a `Signed-off-by:` trailer matching its
+# author (see CONTRIBUTING.md). The action skips merge commits automatically,
+# and the bot allowlist exempts Dependabot, whose commits cannot carry a
+# sign-off trailer. Because the job always runs, it reports a real
+# success/failure and so works correctly as a required status check.
 on:
   pull_request:
     branches: [main]
@@ -19,46 +17,9 @@ jobs:
   dco:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: KineticCafe/actions-dco@v3.1.0
         with:
-          # Full history so the PR's whole commit range is reachable.
-          fetch-depth: 0
-
-      - name: Verify Signed-off-by on every commit
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-
-          # Commit authors exempt from the sign-off requirement. Add more bots
-          # here as needed. Quoted patterns keep the brackets in "[bot]" literal
-          # rather than treating them as a glob character class.
-          is_allowlisted() {
-            case "$1" in
-              "dependabot[bot]") return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          status=0
-          for sha in $(git rev-list "$BASE..$HEAD"); do
-            # Merge commits introduce no authored change of their own; skip them.
-            if [ "$(git rev-list --parents -n 1 "$sha" | wc -w)" -gt 2 ]; then
-              continue
-            fi
-            name=$(git show -s --format='%an' "$sha")
-            email=$(git show -s --format='%ae' "$sha")
-            if is_allowlisted "$name"; then
-              echo "skip  $sha (allowlisted author: $name)"
-              continue
-            fi
-            trailer="Signed-off-by: ${name} <${email}>"
-            if git show -s --format='%B' "$sha" | grep -qiF "$trailer"; then
-              echo "ok    $sha"
-            else
-              echo "::error::commit $sha is missing a sign-off matching its author ($trailer)"
-              status=1
-            fi
-          done
-          exit "$status"
+          config: |
+            [bot]
+            policy = "allowlist"
+            allow = ["dependabot[bot]"]


### PR DESCRIPTION
## What

- **`.github/workflows/claude.yml`** — on-demand Claude reviewer using `anthropics/claude-code-action@v1`. Runs only when someone mentions `@claude` in a PR/issue comment, a PR review, or an issue body/title. Authenticated via a `CLAUDE_CODE_OAUTH_TOKEN` repo secret.
- **`.github/CODEOWNERS`** — assigns all paths to `@inflexa-ai/maintainers`.

## Follow-up (manual, needs repo/org admin)

1. Add the **`CLAUDE_CODE_OAUTH_TOKEN`** secret (Settings → Secrets and variables → Actions). Generate with `claude setup-token` or `/install-github-app`.
2. Ensure the **`@inflexa-ai/maintainers`** team exists and has **write** access to this repo.
3. On the `main` branch protection rule, enable **Require a pull request before merging**, **Require approvals (1)**, and **Require review from Code Owners** — this is what forces a maintainer approval before merge.

## Notes

- The `@claude` bot review is advisory; it does **not** satisfy a required human approval.
- Do **not** add this workflow as a required status check — it only runs when mentioned, so it would block PRs waiting for a run that never fires.