### PR TITLE
feat(cli): add local in-process embeddings via node-llama-cpp

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,15 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
 
+      # cli depends on @inflexa-ai/harness via file:../harness, whose exports
+      # resolve to harness/dist/ — not checked in, and bun blocks the package's
+      # own `prepare` (untrusted lifecycle scripts), so build it explicitly.
+      - name: Build harness (file:../harness dependency)
+        working-directory: harness
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,15 @@ jobs:
         # cli/.npmrc already points @inflexa-ai at npm.pkg.github.com; add the token.
         run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
 
+      # cli depends on @inflexa-ai/harness via file:../harness, whose exports
+      # resolve to harness/dist/ — not checked in, and bun blocks the package's
+      # own `prepare` (untrusted lifecycle scripts), so build it explicitly.
+      - name: Build harness (file:../harness dependency)
+        working-directory: harness
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -37,8 +37,14 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
       },
+      "optionalDependencies": {
+        "node-llama-cpp": "^3.19.0",
+      },
     },
   },
+  "trustedDependencies": [
+    "node-llama-cpp",
+  ],
   "patchedDependencies": {
     "eslint-plugin-neverthrow@1.1.4": "patches/eslint-plugin-neverthrow@1.1.4.patch",
   },
@@ -143,6 +149,8 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -159,6 +167,8 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
@@ -174,6 +184,10 @@
     "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
 
     "@kubernetes/client-node": ["@kubernetes/client-node@1.4.0", "", { "dependencies": { "@types/js-yaml": "^4.0.1", "@types/node": "^24.0.0", "@types/node-fetch": "^2.6.13", "@types/stream-buffers": "^3.0.3", "form-data": "^4.0.0", "hpagent": "^1.2.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "jsonpath-plus": "^10.3.0", "node-fetch": "^2.7.0", "openid-client": "^6.1.3", "rfc4648": "^1.3.0", "socks-proxy-agent": "^8.0.4", "stream-buffers": "^3.0.2", "tar-fs": "^3.0.9", "ws": "^8.18.2" } }, "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA=="],
+
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
+
+    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
 
     "@napi-rs/canvas": ["@napi-rs/canvas@0.1.80", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.80", "@napi-rs/canvas-darwin-arm64": "0.1.80", "@napi-rs/canvas-darwin-x64": "0.1.80", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80", "@napi-rs/canvas-linux-arm64-gnu": "0.1.80", "@napi-rs/canvas-linux-arm64-musl": "0.1.80", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-musl": "0.1.80", "@napi-rs/canvas-win32-x64-msvc": "0.1.80" } }, "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww=="],
 
@@ -196,6 +210,34 @@
     "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg=="],
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.80", "", { "os": "win32", "cpu": "x64" }, "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg=="],
+
+    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.19.0", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-wWI2XhsOYWfxCV6A8LdDWF8m/UrM6OeE0pYing4j4YshcZIRhlBKhJK7/Dm5UvSzMyfsd/L1OpPrR0rDiVemZw=="],
+
+    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.19.0", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-MtupbpWjl2ccMssyAh6ZjJr9rE1P5moHNRAXparzjmKT2l69QyfVmr984503PPWXsAGhvVETqdDDpaFJOdNh4g=="],
+
+    "@node-llama-cpp/linux-riscv64": ["@node-llama-cpp/linux-riscv64@3.19.0", "", { "os": "linux", "cpu": "none" }, "sha512-XdNZJxpnLsjt1E+y+HZcjTUxRd5fBzUA9L1NqFkJOYizRjYbuK1z/pDr0wqcsndmkB7IHu6ay9XqfCnM5AeY8w=="],
+
+    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.19.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cFnXjyRmFJ+lVq0QQFqflGDdF5UnMPzHLIQ4i2Xg5526QpWOw3IC0APiZluKvyqXCtU+g44ZH4YPQNUKqsZG6A=="],
+
+    "@node-llama-cpp/linux-x64-cuda": ["@node-llama-cpp/linux-x64-cuda@3.19.0", "", { "os": "linux", "cpu": "x64" }, "sha512-lqx8CZcLxXimz3vOsFwRdyUs8VdceT0MMYMjmYvvTRRae8q047yM3mk0Ys6Hi6+31Lzw5MpQTFvO8RAxxJEnng=="],
+
+    "@node-llama-cpp/linux-x64-cuda-ext": ["@node-llama-cpp/linux-x64-cuda-ext@3.19.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CLewIjUH0ag/W3R3/lBV/2ABMoTewcDJOQ3SIIGYXuARu4AwMi62cVfBxUtDONW/rWb9EdMQIhCggdTdkI63iA=="],
+
+    "@node-llama-cpp/linux-x64-vulkan": ["@node-llama-cpp/linux-x64-vulkan@3.19.0", "", { "os": "linux", "cpu": "x64" }, "sha512-dFtqAV8GTZN08LoDHk0BFh+y/zZDscb/QbIbKtoR/JJyLwLNFEOIuKfHl/ay8K3bYxg4QWHnQz8r5coEwIBECQ=="],
+
+    "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.19.0", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-mBIM9ZOMBiexxvE5I9Py5rhdtaPZVbtWec0oA5UefBmhcmcQdAp+fcy3R9zNUlEn8BbBDU4TPNc7Nr8UkSyqzw=="],
+
+    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.19.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z/+kSll5Fc5eyt9WawC5Zq5CP2/f0W6VJ7mfoDQSgwbZym4Vc3K9Hrlswf4j6NBcqbA0dylVkkirfCvIi6MFzQ=="],
+
+    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.19.0", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-MReCDQcBQ649xluUMyeaUwrEXlb4Ffaxu8JQBpX0FzCUpVW/LVXRoa9ZJuAtshij0OE/6aR0peyF1VoOH6Qd4w=="],
+
+    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.19.0", "", { "os": "win32", "cpu": "x64" }, "sha512-z5zsRXW2tlR4e93aiVxon15t4h9xKFjlbKnKBN1NNX8YxaUgqp8rflfBYi1SO9Nk6JlKBLnftNYaI53Vy0u7HQ=="],
+
+    "@node-llama-cpp/win-x64-cuda": ["@node-llama-cpp/win-x64-cuda@3.19.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Y/mnB8suxOzMnvD3w0TCkQSdSUIIvJ7DYFrvj4P4uXMsKE46NMtgoAVT7k9sIIvE5V1UfwbAcCqhbvfAR/frug=="],
+
+    "@node-llama-cpp/win-x64-cuda-ext": ["@node-llama-cpp/win-x64-cuda-ext@3.19.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WQ46P50bYWpRsksPR+ilrCkJ8qqk2nHnjrMGQp5o2JUhP/KR3ChorefKrEsjwG5v9AViq9hBxqaOc88WvZL3bg=="],
+
+    "@node-llama-cpp/win-x64-vulkan": ["@node-llama-cpp/win-x64-vulkan@3.19.0", "", { "os": "win32", "cpu": "x64" }, "sha512-1zL5XjxohAh47qRPnrhEgdRRvALuC+ukMyPyu88po6BHL8yWhmnR6aSzrgxfvgzvTZycGpAm+hajinIPKD2yNg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -271,11 +313,35 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.6.1", "", { "dependencies": { "debug": "^4.4.0", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.6.3", "tar-fs": "^3.0.6", "unbzip2-stream": "^1.4.3", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg=="],
 
+    "@reflink/reflink": ["@reflink/reflink@0.1.19", "", { "optionalDependencies": { "@reflink/reflink-darwin-arm64": "0.1.19", "@reflink/reflink-darwin-x64": "0.1.19", "@reflink/reflink-linux-arm64-gnu": "0.1.19", "@reflink/reflink-linux-arm64-musl": "0.1.19", "@reflink/reflink-linux-x64-gnu": "0.1.19", "@reflink/reflink-linux-x64-musl": "0.1.19", "@reflink/reflink-win32-arm64-msvc": "0.1.19", "@reflink/reflink-win32-x64-msvc": "0.1.19" } }, "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA=="],
+
+    "@reflink/reflink-darwin-arm64": ["@reflink/reflink-darwin-arm64@0.1.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA=="],
+
+    "@reflink/reflink-darwin-x64": ["@reflink/reflink-darwin-x64@0.1.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA=="],
+
+    "@reflink/reflink-linux-arm64-gnu": ["@reflink/reflink-linux-arm64-gnu@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg=="],
+
+    "@reflink/reflink-linux-arm64-musl": ["@reflink/reflink-linux-arm64-musl@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA=="],
+
+    "@reflink/reflink-linux-x64-gnu": ["@reflink/reflink-linux-x64-gnu@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw=="],
+
+    "@reflink/reflink-linux-x64-musl": ["@reflink/reflink-linux-x64-musl@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ=="],
+
+    "@reflink/reflink-win32-arm64-msvc": ["@reflink/reflink-win32-arm64-msvc@0.1.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ=="],
+
+    "@reflink/reflink-win32-x64-msvc": ["@reflink/reflink-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w=="],
+
     "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
+
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
+
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -353,9 +419,11 @@
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "ansi-escapes": ["ansi-escapes@6.2.1", "", {}, "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
 
@@ -372,6 +440,8 @@
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-lock": ["async-lock@1.4.1", "", {}, "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -427,19 +497,33 @@
 
     "byline": ["byline@5.0.0", "", {}, "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chmodrp": ["chmodrp@1.0.2", "", {}, "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "chromium-bidi": ["chromium-bidi@0.11.0", "", { "dependencies": { "mitt": "3.0.1", "zod": "3.23.8" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA=="],
 
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "cmake-js": ["cmake-js@8.0.0", "", { "dependencies": { "debug": "^4.4.3", "fs-extra": "^11.3.3", "node-api-headers": "^1.8.0", "rc": "1.2.8", "semver": "^7.7.3", "tar": "^7.5.6", "url-join": "^4.0.1", "which": "^6.0.0", "yargs": "^17.7.2" }, "bin": { "cmake-js": "bin/cmake-js" } }, "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -474,6 +558,8 @@
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -512,6 +598,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -553,6 +641,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
@@ -585,6 +675,10 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
+    "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
+
+    "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
+
     "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
@@ -602,6 +696,8 @@
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -665,27 +761,35 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipull": ["ipull@3.9.5", "", { "dependencies": { "@tinyhttp/content-disposition": "^2.2.0", "async-retry": "^1.3.3", "chalk": "^5.3.0", "ci-info": "^4.0.0", "cli-spinners": "^2.9.2", "commander": "^10.0.0", "eventemitter3": "^5.0.1", "filenamify": "^6.0.0", "fs-extra": "^11.1.1", "is-unicode-supported": "^2.0.0", "lifecycle-utils": "^2.0.1", "lodash.debounce": "^4.0.8", "lowdb": "^7.0.1", "pretty-bytes": "^6.1.0", "pretty-ms": "^8.0.0", "sleep-promise": "^9.1.0", "slice-ansi": "^7.1.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.0" }, "optionalDependencies": { "@reflink/reflink": "^0.1.16" }, "bin": { "ipull": "dist/cli/cli.js" } }, "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA=="],
 
     "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-html": ["is-html@2.0.0", "", { "dependencies": { "html-tags": "^3.0.0" } }, "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg=="],
 
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 
@@ -715,6 +819,8 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
     "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "kebab-case": ["kebab-case@1.0.2", "", {}, "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q=="],
@@ -727,13 +833,21 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "lifecycle-utils": ["lifecycle-utils@3.1.1", "", {}, "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
+    "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -749,9 +863,15 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -771,9 +891,15 @@
 
     "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
 
+    "node-addon-api": ["node-addon-api@8.9.0", "", {}, "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q=="],
+
+    "node-api-headers": ["node-api-headers@1.9.0", "", {}, "sha512-2oNILP4jXwRB4ywnYKjVk1YyJ96n2D4EOVJO6S3oYZ5PtbJrw3Yt9TpAuX3nBLMuzn74rnfGQrv13pS9vC+YiA=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-llama-cpp": ["node-llama-cpp@3.19.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.4", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.1.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.6.0", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.33.0", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.2.0", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.19.0", "@node-llama-cpp/linux-armv7l": "3.19.0", "@node-llama-cpp/linux-riscv64": "3.19.0", "@node-llama-cpp/linux-x64": "3.19.0", "@node-llama-cpp/linux-x64-cuda": "3.19.0", "@node-llama-cpp/linux-x64-cuda-ext": "3.19.0", "@node-llama-cpp/linux-x64-vulkan": "3.19.0", "@node-llama-cpp/mac-arm64-metal": "3.19.0", "@node-llama-cpp/mac-x64": "3.19.0", "@node-llama-cpp/win-arm64": "3.19.0", "@node-llama-cpp/win-x64": "3.19.0", "@node-llama-cpp/win-x64-cuda": "3.19.0", "@node-llama-cpp/win-x64-cuda-ext": "3.19.0", "@node-llama-cpp/win-x64-vulkan": "3.19.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "node-llama-cpp": "dist/cli/cli.js", "nlc": "dist/cli/cli.js" } }, "sha512-OZKc6IUsu6pNRPFKV0vgqJmagbGWFPhVsrMIj4pdxcglcSzDwzX5TmaIlikT6Ue9081uXOsocPFUBERHgHgJvg=="],
 
     "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
 
@@ -789,11 +915,15 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -806,6 +936,8 @@
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -869,6 +1001,10 @@
 
     "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.8.0", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g=="],
 
+    "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
@@ -895,6 +1031,8 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
@@ -907,7 +1045,9 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
-    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "rfc4648": ["rfc4648@1.5.4", "", {}, "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="],
 
@@ -933,7 +1073,13 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sleep-promise": ["sleep-promise@9.1.0", "", {}, "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA=="],
+
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
@@ -957,6 +1103,12 @@
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
+    "stdin-discarder": ["stdin-discarder@0.3.2", "", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
+
+    "stdout-update": ["stdout-update@4.0.1", "", { "dependencies": { "ansi-escapes": "^6.2.0", "ansi-styles": "^6.2.1", "string-width": "^7.1.0", "strip-ansi": "^7.1.0" } }, "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ=="],
+
+    "steno": ["steno@4.0.2", "", {}, "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A=="],
+
     "stream-buffers": ["stream-buffers@3.0.3", "", {}, "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="],
 
     "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
@@ -967,9 +1119,11 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
 
@@ -978,6 +1132,8 @@
     "superjson": ["superjson@1.13.3", "", { "dependencies": { "copy-anything": "^3.0.2" } }, "sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tar": ["tar@7.5.19", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw=="],
 
     "tar-fs": ["tar-fs@3.1.3", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ=="],
 
@@ -1025,13 +1181,19 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -1045,7 +1207,7 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1061,7 +1223,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
@@ -1072,6 +1234,8 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
@@ -1093,9 +1257,13 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@kubernetes/client-node/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
+
+    "@opentui/core/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1117,6 +1285,8 @@
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "docker-modem/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "dockerode/tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
@@ -1129,25 +1299,49 @@
 
     "glob/minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
 
+    "glob/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "ipull/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "ipull/lifecycle-utils": ["lifecycle-utils@2.1.0", "", {}, "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA=="],
+
+    "ipull/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
+
+    "ipull/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "node-llama-cpp/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "nunjucks/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "ora/cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
+
+    "ora/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+
+    "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1157,9 +1351,13 @@
 
     "unbzip2-stream/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1173,21 +1371,25 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "@kubernetes/client-node/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "archiver-utils/glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "dockerode/tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "dockerode/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "ipull/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -1203,13 +1405,19 @@
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/design.md
+++ b/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The CLI's local-only mode routes LLM chat through CLIProxyAPI (OAuth/device-flow for Gemini/OpenAI/Claude/Qwen/iFlow), but embeddings have no local path — the harness ships a single `EmbeddingProvider` realization (`createEmbeddingProvider` in `harness/src/providers/embedding.ts`) that is OpenAI-shaped and pointed at a billing gateway. For a self-contained CLI that works offline, we need an in-process embedding model.
+
+The harness already declares the seam: `EmbeddingProvider.embed(texts, session) → ResultAsync<number[][], ProviderError>` (`harness/src/providers/types.ts:70`), injected at the composition root. The harness never inspects the provider's internals. A CLI-side realization can be injected later without any harness change.
+
+Spike findings (captured in `cli/spike/NOTES.md` on this branch) validated:
+- `node-llama-cpp@3.19.0` works on linux-arm64 with prebuilt binaries; `bun install` blocks the postinstall by default, and `bun pm trust node-llama-cpp` triggers the binary fetch on demand.
+- `bge-small-en-v1.5-q8_0.gguf` (36.8 MB, CompendiumLabs/bge-small-en-v1.5-gguf, MIT) loads in ~250ms, produces 384-dim vectors at 8–103ms/text on CPU.
+- **Critical**: the GGUF quantized model does NOT L2-normalize (raw norm ≈ 9.24). The provider MUST normalize every vector before returning it.
+
+The CLI today calls no harness code and has no embedding consumer. This change builds the provider + setup + config; the vector store and `assembleCoreRuntime` wiring are deferred.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A CLI-side `EmbeddingProvider` realization that runs `bge-small-en-v1.5` in-process via `node-llama-cpp`, L2-normalizes vectors, and implements the harness seam.
+- `node-llama-cpp` as an optional, lazy-loaded dependency — a plain `bun install` never fetches native binaries; they are fetched at setup-yes time only.
+- An interactive embedding setup (`inflexa setup`) that downloads + verifies the GGUF model on user opt-in, and records the choice in config.
+- Config-driven mode resolution (`local` | `api-key` | `off`) ready to inject into `assembleCoreRuntime` when the CLI wires the harness.
+
+**Non-Goals:**
+- No vector store (sqlite-vec / local pgvector / lancedb). The provider returns `number[][]`; the store is a separate future change.
+- No `assembleCoreRuntime` wiring. The CLI does not call the harness today; this change builds the provider, not its consumer.
+- No harness changes. The `EmbeddingProvider` seam is already provider-agnostic.
+- No dimension parameterization of the harness pgvector path (`search-config.ts:64` hardcodes 1536). Deferred with the store decision.
+- No revectorization/mode-switching UX. A future change handles per-analysis dimension tracking + re-embed on mode switch.
+
+## Decisions
+
+### D1: node-llama-cpp as optionalDependency, lazy dynamic import
+
+**Choice**: `node-llama-cpp` in `optionalDependencies`, loaded via `await import("node-llama-cpp")` inside `createLocalEmbeddingProvider` on first `embed()` call. The postinstall (which fetches prebuilt llama.cpp binaries) is blocked by bun's default security policy; the binary fetch is triggered explicitly at setup-yes time via `bun pm trust node-llama-cpp`.
+
+**Rationale**: A plain `bun install` (or `npm install` for end users of the compiled binary) must not fetch ~50 MB of platform-specific native binaries unless the user opted into local embeddings. bun blocks postinstall scripts by default; we lean on that as the gate, then explicitly trust at setup time.
+
+**Alternatives considered**:
+- *Hard dependency*: rejected — bloats every install with native binaries most users won't use.
+- *Ollama as a sidecar container*: rejected — adds a daemon to manage (a second container alongside CLIProxyAPI), more moving parts, and the user asked for in-process to avoid complexity.
+- *bundled prebuilt binaries in the release*: rejected — platform matrix explosion; node-llama-cpp already solves this with its own binary distribution.
+
+### D2: bge-small-en-v1.5 q8_0 GGUF
+
+**Choice**: `CompendiumLabs/bge-small-en-v1.5-gguf` `q8_0` (36.8 MB, 384-dim, 33.2M params, MIT).
+
+**Rationale**: Small enough to download in seconds, runs on CPU at acceptable CLI latency (8–103ms/text), MIT-licensed, and BAAI's bge family is well-regarded on MTEB. The q8_0 quantization gives ~30% CPU speedup over f16 with minimal accuracy loss (per the model card). 384-dim keeps the vector store small when it lands.
+
+**Alternatives considered**:
+- *nomic-embed-text (768-dim, 274 MB)*: more popular on Ollama but larger; 768-dim doubles storage vs 384.
+- *qwen3-embedding:0.6b (1024-dim, 639 MB)*: higher MTEB but much heavier; overkill for local CLI file-description indexing.
+- *f16 GGUF (65 MB)*: 2× the size for negligible accuracy gain at this scale.
+
+### D3: L2-normalize in the provider, not the store
+
+**Choice**: `createLocalEmbeddingProvider` L2-normalizes every vector before returning it from `embed()`.
+
+**Rationale**: The spike proved the GGUF quantized model emits un-normalized vectors (norm ≈ 9.24). Normalizing once at the provider boundary is store-agnostic — whether the future store is pgvector (which handles un-normalized via `<=>`), sqlite-vec, or lancedb, a normalized vector is always safe. It also matches the harness's existing `createEmbeddingProvider` (OpenAI returns normalized vectors), so the two providers are interchangeable without the store knowing.
+
+**Alternatives considered**:
+- *Normalize at the store*: rejected — couples normalization to storage, and a future store might use dot-product (which requires normalized vectors).
+- *Don't normalize, rely on pgvector cosine*: rejected — only works if the future store is pgvector; locks us in.
+
+### D4: Provider lives CLI-side, not harness-side
+
+**Choice**: `createLocalEmbeddingProvider` lives in `cli/src/modules/embedding/`, passed into `assembleCoreRuntime` as the `embedding` dep when the CLI wires the harness.
+
+**Rationale**: The harness ships "zero cloud deps" OSS realizations; `node-llama-cpp` is a heavy native dep that cloud embedders never need. Putting it in the harness would bloat every harness consumer. The CLI is the embedder that needs local embeddings; the realization stays with it. This matches AGENTS.md: "CLI wires harness seams to local realizations."
+
+**Alternatives considered**:
+- *Second OSS realization in harness/src/providers/*: rejected — violates the harness's lightweight-OSS-realization principle; cloud embedders would pull node-llama-cpp transitively.
+
+### D5: Setup lifecycle mirrors proxy/setup.ts
+
+**Choice**: The embedding setup reuses the patterns from `modules/proxy/setup.ts`: interactive question in the `inflexa setup` flow, download on opt-in, verify (load + embed probe + dim check), record in config. A dedicated `ensureEmbedderReady()` hot-path gate mirrors `ensureProxyReady()`.
+
+**Rationale**: Consistency with the existing setup UX. The proxy module already solved "download a thing, verify it, make it ready for the TUI hot path" — we follow that template rather than inventing a new lifecycle.
+
+### D6: Config schema extension
+
+**Choice**: Add to `config.json`:
+```json
+{
+  "embedding": {
+    "mode": "local" | "api-key" | "off",
+    "modelPath": "<path to GGUF>",   // present when mode === "local"
+    "apiKey": "<key>"                // present when mode === "api-key"
+  }
+}
+```
+Default: `{ "mode": "off" }` — embeddings are not configured until the user runs setup.
+
+**Rationale**: The existing config schema (`lib/config.ts`) uses zod with `.catch()` defaults for forward-compat. Adding `embedding` with a zod object + enum is the established pattern (mirrors `runtime`, `theme`).
+
+## Risks / Trade-offs
+
+- **[Risk] node-llama-cpp binary fetch fails on exotic platforms** → The package falls back to building from source with cmake; if that fails too, `createLocalEmbeddingProvider` returns a clear `ProviderError` (not a crash). Setup detects the failure and falls back to `mode: "off"` or prompts for `api-key`.
+- **[Risk] GGUF tokenizer warning** → node-llama-cpp prints `special_eos_id is not in special_eog_ids` and a detokenization mismatch warning. Spike confirmed this is cosmetic — embeddings are correct. No mitigation needed; document it.
+- **[Trade-off] 384-dim vs 1536-dim** → `bge-small-en-v1.5` is 384-dim; the harness's cloud path is 1536-dim. They cannot share a pgvector table. This is fine: per-analysis indexes are created fresh (one-line `dimension` param), and the store is deferred. A future mode-switch will need per-analysis revectorization — accepted as a future concern.
+- **[Trade-off] No batch embedding API** → node-llama-cpp's embedding context embeds one text at a time (`getEmbeddingFor`); the docs suggest `Promise.all` for concurrency. The provider will concurrency-cap (e.g. 4 parallel) to avoid overwhelming CPU on large batches. Acceptable for CLI-scale indexing (10–50 file descriptions per step).
+- **[Risk] Model file deleted/missing after setup** → `ensureEmbedderReady()` detects a missing GGUF and re-prompts setup, mirroring the proxy's `isAuthenticated()` check. The provider's lazy init fails with a clear `ProviderError` if the file vanishes at runtime.
+- **[Trade-off] First-embed latency** → Runtime init (~750ms) + model load (~250ms) happen on the first `embed()` call. Accepted — it's a one-time cost, and the lazy init means the CLI starts fast if embeddings aren't used.

--- a/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Local-only CLI mode routes LLM chat through the user's own OAuth/API keys via CLIProxyAPI, but embeddings have no local option — they require an OpenAI API key pointed at a billing gateway. For a self-contained, offline-capable CLI, we need an in-process embedding model that downloads once and runs without a daemon or API key, while still offering the API-key path for users who prefer it.
+
+## What Changes
+
+- Add `node-llama-cpp` as an optional CLI dependency, lazy-loaded via dynamic `import()` only when the user opts into local embeddings at setup time (no native binaries fetched on a plain install).
+- Add a CLI-side `EmbeddingProvider` realization (`createLocalEmbeddingProvider`) that loads `bge-small-en-v1.5` (GGUF, q8_0, 384-dim, 36 MB) in-process via node-llama-cpp, L2-normalizes every vector before returning it, and implements the harness `EmbeddingProvider.embed` seam.
+- Add an embedding setup lifecycle (`inflexa setup --embeddings`) that downloads the GGUF model from HuggingFace on user opt-in, verifies it (load + embed probe + dimension check), and records the choice in config.
+- Extend `config.json` with an `embedding` section: `{ mode: "local" | "api-key" | "off", modelPath?, apiKey? }`.
+- Wire the embedding setup question into the interactive `inflexa setup` questionnaire, after provider auth.
+- Add `env.modelDir` and `env.embeddingModelPath` to the CLI's path/env map.
+- The provider is store-agnostic — it returns `number[][]` and is ready to inject into `assembleCoreRuntime` when the CLI wires the harness. No vector store is added in this change.
+
+## Capabilities
+
+### New Capabilities
+- `local-embeddings`: In-process embedding model lifecycle — optional dependency management, GGUF model download/verify, config-driven mode resolution, and a CLI-side `EmbeddingProvider` realization that loads `bge-small-en-v1.5` via node-llama-cpp and L2-normalizes vectors.
+
+### Modified Capabilities
+<!-- No existing spec-level requirements change. The intelligence-module spec governs chat, not embeddings. The proxy setup command gains an embedding sub-question, but that is implementation, not a spec requirement change. -->
+
+## Impact
+
+- **New dependency**: `node-llama-cpp` (optional, lazy-loaded) — prebuilt llama.cpp binaries for macOS/Linux/Windows, fetched at setup-yes time via `bun pm trust`, not at install time.
+- **New module**: `src/modules/embedding/` (vertical slice: local-provider, setup, resolve).
+- **Modified files**: `lib/config.ts` (embedding config schema), `lib/env.ts` (model paths), `modules/proxy/setup.ts` (wire embedding question into the interactive questionnaire), `cli/index.ts` (help text).
+- **No harness changes**: the `EmbeddingProvider` seam (`harness/src/providers/types.ts`) is already provider-agnostic; the CLI realization is injected at the CLI's composition root.
+- **No vector store**: the provider returns `number[][]`; a store (sqlite-vec / local pgvector) is deferred to a future change when the CLI actually consumes embeddings.
+- **Dimension**: `bge-small-en-v1.5` is 384-dim. The harness's per-analysis pgvector index (`search-config.ts:64`) hardcodes 1536 — a one-line parameterization is deferred with the store decision. The `regulatory-corpus` 1536 hardcode is cloud-only and untouched.

--- a/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/specs/local-embeddings/spec.md
+++ b/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/specs/local-embeddings/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: Local embedding provider realizes the harness EmbeddingProvider seam
+
+The CLI SHALL provide `createLocalEmbeddingProvider(deps): EmbeddingProvider` from `src/modules/embedding/local-provider.ts`, where `EmbeddingProvider` is the harness interface (`embed(texts, session) → ResultAsync<number[][], ProviderError>`). The provider SHALL load `bge-small-en-v1.5` (GGUF, q8_0) in-process via `node-llama-cpp`. The `node-llama-cpp` import SHALL be a dynamic `import()` evaluated lazily on the first `embed()` call — it SHALL NOT be a static top-level import, so a process that never embeds never loads the native runtime.
+
+#### Scenario: Provider implements the harness seam
+
+- **WHEN** `createLocalEmbeddingProvider` is called with `{ modelPath }`
+- **THEN** it returns an object with an `embed(texts, session)` method
+- **AND** the method's return type is `ResultAsync<number[][], ProviderError>`
+
+#### Scenario: Lazy native runtime load
+
+- **WHEN** `createLocalEmbeddingProvider` is called
+- **THEN** `node-llama-cpp` is NOT imported at construction time
+- **AND** the llama runtime is NOT initialized
+- **WHEN** `embed()` is called for the first time
+- **THEN** `node-llama-cpp` is dynamically imported
+- **AND** `getLlama()` + `loadModel()` are invoked
+
+#### Scenario: node-llama-cpp not installed
+
+- **WHEN** `embed()` is called and the dynamic `import("node-llama-cpp")` fails
+- **THEN** the provider SHALL return `err(ProviderError)` with a message directing the user to run `inflexa setup --embeddings`
+- **AND** it SHALL NOT throw
+
+### Requirement: Embedding vectors are 384-dimensional and L2-normalized
+
+Every vector returned by `createLocalEmbeddingProvider.embed()` SHALL have exactly 384 dimensions and SHALL be L2-normalized (Euclidean norm ≈ 1.0). The GGUF quantized model emits un-normalized vectors (norm ≈ 9.24); the provider SHALL normalize each vector by dividing every component by its Euclidean norm before returning it.
+
+#### Scenario: Vector dimension is 384
+
+- **WHEN** `embed(["some text"], session)` resolves to `ok(vectors)`
+- **THEN** `vectors[0].length` SHALL equal 384
+
+#### Scenario: Vectors are L2-normalized
+
+- **WHEN** `embed(["some text"], session)` resolves to `ok(vectors)`
+- **THEN** `Math.sqrt(vectors[0].reduce((s, v) => s + v*v, 0))` SHALL be within 0.001 of 1.0
+
+#### Scenario: Empty input returns empty output
+
+- **WHEN** `embed([], session)` is called
+- **THEN** it SHALL resolve to `ok([])` without loading the model
+
+### Requirement: Embedding concurrency is capped
+
+The provider SHALL embed multiple texts concurrently via `Promise.all` over individual `context.getEmbeddingFor()` calls, capped at a maximum of 4 concurrent embeddings to avoid saturating CPU on large batches.
+
+#### Scenario: Batch embedding respects concurrency cap
+
+- **WHEN** `embed([text1, text2, ..., text10], session)` is called
+- **THEN** no more than 4 `getEmbeddingFor` calls SHALL be in-flight simultaneously
+
+### Requirement: node-llama-cpp is an optional, lazily-fetched dependency
+
+`node-llama-cpp` SHALL be declared in `cli/package.json` under `optionalDependencies` (not `dependencies`). A plain `bun install` SHALL NOT fetch prebuilt llama.cpp native binaries — the postinstall SHALL be blocked by default. The native binaries SHALL be fetched on demand at setup-yes time via `bun pm trust node-llama-cpp` (or equivalent).
+
+#### Scenario: Plain install does not fetch native binaries
+
+- **WHEN** `bun install` runs without prior setup
+- **THEN** `node-llama-cpp` JS is installed but `node_modules/@node-llama-cpp/<platform>/bins/` SHALL NOT contain the native `.node` addon
+- **AND** the postinstall script SHALL NOT have run
+
+#### Scenario: Setup-yes triggers binary fetch
+
+- **WHEN** the user opts into local embeddings during `inflexa setup`
+- **THEN** the setup process SHALL trigger the native binary fetch (via `bun pm trust` or direct postinstall invocation)
+- **AND** the platform-specific `.node` addon SHALL be present in `node_modules/@node-llama-cpp/<platform>/bins/`
+
+### Requirement: Embedding mode is config-driven
+
+`cli/src/lib/config.ts` SHALL extend the config schema with an `embedding` object: `{ mode: "local" | "api-key" | "off", modelPath?: string, apiKey?: string }`. The default SHALL be `{ mode: "off" }`. `resolveEmbedder(config)` in `src/modules/embedding/resolve.ts` SHALL return a `ResultAsync<number[][], ProviderError>`-producing `EmbeddingProvider` based on `mode`: `local` → `createLocalEmbeddingProvider`, `api-key` → the harness `createEmbeddingProvider`, `off` → an error indicating embeddings are not configured.
+
+#### Scenario: Default config has embeddings off
+
+- **WHEN** a fresh config is read with no `embedding` key
+- **THEN** the parsed config SHALL have `embedding.mode === "off"`
+
+#### Scenario: Local mode resolves to the local provider
+
+- **WHEN** `resolveEmbedder` is called with a config where `embedding.mode === "local"` and `embedding.modelPath` is set
+- **THEN** it SHALL return a `createLocalEmbeddingProvider` instance
+
+#### Scenario: Off mode resolves to an error
+
+- **WHEN** `resolveEmbedder` is called with a config where `embedding.mode === "off"`
+- **THEN** it SHALL return `err` indicating embeddings are not configured
+
+### Requirement: Embedding setup downloads and verifies the model on opt-in
+
+`inflexa setup` SHALL ask the user whether to use local embeddings. If yes, it SHALL download `bge-small-en-v1.5-q8_0.gguf` (~36 MB) from `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace to `env.embeddingModelPath`, then verify it by loading the model, embedding a probe text, and asserting the vector dimension is 384. On success, it SHALL write `embedding.mode = "local"` and `embedding.modelPath` to config. The download SHALL NOT occur if the user declines.
+
+#### Scenario: User opts into local embeddings
+
+- **WHEN** the user is prompted "Use local embeddings?" and selects yes
+- **THEN** the GGUF model SHALL be downloaded to `env.embeddingModelPath`
+- **AND** the model SHALL be loaded and a probe embedding SHALL be generated
+- **AND** the probe vector dimension SHALL be verified as 384
+- **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
+
+#### Scenario: User declines local embeddings
+
+- **WHEN** the user is prompted "Use local embeddings?" and selects no
+- **THEN** no model SHALL be downloaded
+- **AND** no native binaries SHALL be fetched
+- **AND** config SHALL remain `embedding.mode = "off"` (or prompt for api-key)
+
+#### Scenario: Model already present is not re-downloaded
+
+- **WHEN** the user opts into local embeddings and `env.embeddingModelPath` already exists
+- **THEN** the download SHALL be skipped
+- **AND** verification (load + probe) SHALL still run
+
+#### Scenario: Verification fails
+
+- **WHEN** the downloaded model fails to load or produces vectors of the wrong dimension
+- **THEN** setup SHALL report the error and leave `embedding.mode` unchanged (not "local")
+
+### Requirement: Embedding model path is env-managed
+
+`cli/src/lib/env.ts` SHALL expose `env.modelDir` (`<dataDir>/inflexa/models/`) and `env.embeddingModelPath` (`<modelDir>/bge-small-en-v1.5-q8_0.gguf`). These SHALL be included in `envDoc` for `--help` visibility.
+
+#### Scenario: Model path resolves under the data dir
+
+- **WHEN** `env.embeddingModelPath` is read
+- **THEN** it SHALL be `<dataDir>/inflexa/models/bge-small-en-v1.5-q8_0.gguf`
+
+#### Scenario: Model dir appears in help
+
+- **WHEN** `inflexa --help` is run
+- **THEN** the paths section SHALL list the models directory
+
+### Requirement: Embedder readiness gate for the hot path
+
+`ensureEmbedderReady()` in `src/modules/embedding/setup.ts` SHALL mirror `ensureProxyReady()`: for `mode === "local"`, it SHALL check that the GGUF model file exists and is loadable, returning `Result<void, EmbeddingSetupError>`. It SHALL NOT re-download or re-verify on every call — a file-exists check is sufficient for the hot path. A missing file SHALL return an error directing the user to `inflexa setup`.
+
+#### Scenario: Model present and readable
+
+- **WHEN** `ensureEmbedderReady()` is called and `env.embeddingModelPath` exists
+- **THEN** it SHALL return `ok(undefined)`
+
+#### Scenario: Model missing
+
+- **WHEN** `ensureEmbedderReady()` is called and `env.embeddingModelPath` does not exist
+- **THEN** it SHALL return `err` with a message directing the user to run `inflexa setup --embeddings`
+
+### Requirement: Embedding setup is wired into the interactive setup flow
+
+The interactive `inflexa setup` questionnaire SHALL include an embedding-mode question after provider auth. The question SHALL be skippable (defaulting to `off`). Non-interactive shells (no TTY) SHALL skip the embedding question without hanging, leaving `mode` unchanged.
+
+#### Scenario: Interactive setup asks about embeddings
+
+- **WHEN** `inflexa setup` runs in a TTY
+- **THEN** the user SHALL be prompted to choose an embedding mode after provider auth
+
+#### Scenario: Non-interactive setup skips embeddings
+
+- **WHEN** `inflexa setup` runs without a TTY
+- **THEN** the embedding question SHALL be skipped
+- **AND** `embedding.mode` SHALL remain unchanged

--- a/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-02-add-local-embeddings/tasks.md
@@ -1,0 +1,46 @@
+## 1. Config + env foundation
+
+- [x] 1.1 Add `embedding` to the config schema in `src/lib/config.ts`: `z.object({ mode: z.enum(["local","api-key","off"]).catch("off").default("off"), modelPath: z.string().optional(), apiKey: z.string().optional() })`. Update the `readConfig` fallback to include `embedding: { mode: "off" }`.
+- [x] 1.2 Add `modelDir` and `embeddingModelPath` to `env` in `src/lib/env.ts` (`<dataDir>/inflexa/models/` and `<modelDir>/bge-small-en-v1.5-q8_0.gguf`). Add both to `envDoc` for `--help`.
+- [x] 1.3 Run `bun run typecheck` — confirm the config/env changes compile.
+
+## 2. Local embedding provider
+
+- [x] 2.1 Create `src/modules/embedding/local-provider.ts` with `createLocalEmbeddingProvider(deps: { modelPath: string }): EmbeddingProvider`. Dynamic `import("node-llama-cpp")` on first `embed()`; lazy `getLlama()` + `loadModel()` + `createEmbeddingContext()`.
+- [x] 2.2 Implement `embed(texts, session)`: empty input → `okAsync([])`; per-text `context.getEmbeddingFor(text).vector`, L2-normalized, concurrency-capped at 4 via a simple pool. Wrap node-llama-cpp throws into `ProviderError` via `toProviderError`. Ignore `session` (local, no billing).
+- [x] 2.3 Handle the dynamic-import-failure case: if `import("node-llama-cpp")` rejects, return `err(ProviderError)` with a "run `inflexa setup --embeddings`" message — do not throw.
+- [x] 2.4 Write a unit test (`local-provider.test.ts`) using a mock or the real model (gated by model-file presence) that asserts: dim === 384, L2 norm ≈ 1.0, empty input → `ok([])`.
+
+## 3. Mode resolution
+
+- [x] 3.1 Create `src/modules/embedding/resolve.ts` with `resolveEmbedder(config: Config): Result<EmbeddingProvider, EmbeddingResolveError>`. `local` → `createLocalEmbeddingProvider`; `api-key` → harness `createEmbeddingProvider`; `off` → `err({ type: "embeddings_not_configured" })`.
+- [x] 3.2 Define `EmbeddingResolveError` as a discriminated union (`embeddings_not_configured` | `local_model_missing` | `api_key_missing`).
+- [x] 3.3 Write a unit test for each mode path + the error cases.
+
+## 4. Model download + verify (setup lifecycle)
+
+- [x] 4.1 Create `src/modules/embedding/setup.ts` with `downloadModel(): Promise<Result<void, EmbeddingSetupError>>` — fetch `bge-small-en-v1.5-q8_0.gguf` from `https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf` to `env.embeddingModelPath`, with progress output. Skip if the file already exists.
+- [x] 4.2 Implement `verifyModel(modelPath): Promise<Result<void, EmbeddingSetupError>>` — load the model via node-llama-cpp, embed a probe text, assert dim === 384. Return `err` on load failure or dimension mismatch.
+- [x] 4.3 Implement `runEmbeddingSetup(interactive: boolean): Promise<Result<void, EmbeddingSetupError>>` — the interactive prompt ("Use local embeddings? [Y/n]"), opt-in gate, trigger `bun pm trust node-llama-cpp` for native binaries, download, verify, write `embedding.mode = "local"` + `embedding.modelPath` to config. Skip cleanly in non-TTY.
+- [x] 4.4 Implement `ensureEmbedderReady(): Promise<Result<void, EmbeddingSetupError>>` — for `mode === "local"`, check `env.embeddingModelPath` exists; return `err` directing to `inflexa setup` if missing. For `mode === "off"` or `api-key`, return `ok`.
+- [x] 4.5 Define `EmbeddingSetupError` as a discriminated union (`download_failed` | `verify_failed` | `dimension_mismatch` | `not_configured`).
+
+## 5. Wire into `inflexa setup`
+
+- [x] 5.1 In `src/modules/proxy/setup.ts`, call `runEmbeddingSetup(process.stdin.isTTY)` after the provider-auth block in both `setup()` and `ensureProxyReady()`. The embedding question runs after auth, before "Done."
+- [x] 5.2 Add an `--embeddings <mode>` flag to the `setup` command in `src/cli/index.ts` (optional; overrides the interactive prompt with `local` | `api-key` | `off`).
+- [x] 5.3 Update the setup command's help text / `printNextSteps` to mention the embedding choice.
+
+## 6. Dependency declaration
+
+- [x] 6.1 Add `node-llama-cpp` to `optionalDependencies` in `cli/package.json` (NOT `dependencies`). Pin to `^3.19.0`.
+- [x] 6.2 Run `bun install` and confirm the postinstall is blocked (no `node_modules/@node-llama-cpp/<platform>/bins/*.node`). Run `bun pm trust node-llama-cpp` and confirm binaries appear.
+
+## 7. Validation
+
+- [x] 7.1 Run `bun run typecheck` — zero errors.
+- [x] 7.2 Run `bun run lint` — zero errors.
+- [x] 7.3 Run `bun test` — all existing + new tests pass.
+- [x] 7.4 Manual smoke: `inflexa setup` in a TTY → opt into local embeddings → confirm GGUF downloads, config written, `ensureEmbedderReady()` passes.
+- [x] 7.5 Manual smoke: `inflexa setup` in a non-TTY → confirm embedding question skipped, no hang.
+- [x] 7.6 Clean up spike artifacts: remove `cli/spike/` once the provider tests cover the same validation.

--- a/cli/openspec/config.yaml
+++ b/cli/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/cli/openspec/specs/data-profile-launch/spec.md
+++ b/cli/openspec/specs/data-profile-launch/spec.md
@@ -55,9 +55,10 @@ The command SHALL fail with an error that names the missing prerequisite and its
 remedial action whenever a prerequisite is unavailable. Covered prerequisites:
 Postgres not provisioned or not running (remedy: the setup flow), the sandbox image
 absent (remedy: build or pull the image), the local proxy unreachable (remedy: start
-or configure the proxy), the embedding endpoint unconfigured or unreachable (remedy:
-set the embedding config key — its own baseURL + API key, separate from the chat
-proxy; the profile's vector indexing cannot run without one and would fail after the
+or configure the proxy), the embedder unresolved or failing its boot probe (remedy:
+`inflexa setup --embeddings`, or the top-level `embedding` config key — api-key mode
+connects directly to an OpenAI-compatible endpoint, separate from the chat proxy; the
+profile's vector indexing cannot run without an embedder and would fail after the
 sandbox run already spent its work). Raw connection errors SHALL NOT be the surfaced
 form. Prerequisite checks SHALL run before staging and triggering.
 
@@ -71,10 +72,10 @@ form. Prerequisite checks SHALL run before staging and triggering.
 - **WHEN** the Docker daemon has no sandbox-base image
 - **THEN** the error names the image and how to obtain it
 
-#### Scenario: Unconfigured or unreachable embedding endpoint blocks before any work
+#### Scenario: Unconfigured or broken embedder blocks before any work
 
-- **WHEN** the profile command runs with no embedding endpoint configured, or with one that does not answer embeddings requests
-- **THEN** the command fails naming the config key (and the endpoint, when probing failed) before staging or triggering anything
+- **WHEN** the profile command runs with `embedding.mode = "off"`, an incomplete embedding config, or an embedder that fails its probe embedding
+- **THEN** the command fails naming the `embedding` config key and the remedial setup command before staging or triggering anything
 
 ### Requirement: The command narrates progress and exits at the terminal state
 

--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -34,12 +34,14 @@ re-registering or re-launching.
 The composition SHALL realize `DataProfileDeps` from deliberate local wiring: the
 `pg.Pool` built from the infra module's resolved `PostgresConnection`; the harness's
 local run authorizer and no-op billing resolver; the chat provider pointed at the local
-proxy's Anthropic-shaped Messages endpoint; the embedding configuration taken from its
-own cli config key (baseURL + API key + model — deliberately a separate path from the
-chat proxy, which serves no embeddings route), with the configured endpoint's
-reachability verified by a boot-time probe BEFORE any provisioning or registration —
-embeddings are consumed late in the profile workflow, so a dead endpoint must fail
-while failure is still free; a workspace filesystem and sandbox client (Docker
+proxy's Anthropic-shaped Messages endpoint; the embedding provider resolved from the
+top-level `embedding` config key via `resolveEmbedder` (mode-based: in-process local
+model or a DIRECT OpenAI-compatible endpoint — never through the chat proxy, which
+serves no embeddings route), verified with one real probe embedding through that very
+provider instance BEFORE any provisioning or registration — embeddings are consumed
+late in the profile workflow, so a broken embedder must fail while failure is still
+free, and the probe vector's width must match the provider's advertised `dimensions`,
+which sizes the per-analysis search index; a workspace filesystem and sandbox client (Docker
 backend) sharing
 the runtime's single session-tree base; bio-tool keys from cli config with absent keys
 passed as empty; and the shared skills directory. No dependency SHALL be realized as a
@@ -49,17 +51,17 @@ the point of use.
 #### Scenario: Deps resolve to their designated backends
 
 - **WHEN** the runtime composes the data-profile deps bundle
-- **THEN** chat traffic targets the local proxy, embedding traffic targets the configured embeddings endpoint, and everything else requires only the local Postgres and the Docker daemon
+- **THEN** chat traffic targets the local proxy, embeddings go through the resolved provider (in-process model, or directly to the configured endpoint), and everything else requires only the local Postgres and the Docker daemon
 
 #### Scenario: Unconfigured bio keys degrade per-tool, not at boot
 
 - **WHEN** no bio/chem API keys are configured
 - **THEN** the runtime boots and profiles run; only the affected tools surface auth errors when invoked
 
-#### Scenario: Unreachable embedding endpoint blocks boot before side effects
+#### Scenario: Broken embedder blocks boot before side effects
 
-- **WHEN** the effective embedding endpoint rejects or cannot answer an embeddings request
-- **THEN** boot fails naming the endpoint and remedies, before Postgres provisioning, listener start, registration, or launch
+- **WHEN** the resolved embedder cannot be built from config, fails or times out on the probe embedding, or emits vectors of a width other than it advertises
+- **THEN** boot fails naming the remedy, before Postgres provisioning, listener start, registration, or launch
 
 ### Requirement: Single global session-tree base
 

--- a/cli/openspec/specs/local-embeddings/spec.md
+++ b/cli/openspec/specs/local-embeddings/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: Local embedding provider realizes the harness EmbeddingProvider seam
+
+The CLI SHALL provide `createLocalEmbeddingProvider(deps): EmbeddingProvider` from `src/modules/embedding/local-provider.ts`, where `EmbeddingProvider` is the harness interface (`embed(texts, session) → ResultAsync<number[][], ProviderError>`). The provider SHALL load `bge-small-en-v1.5` (GGUF, q8_0) in-process via `node-llama-cpp`. The `node-llama-cpp` import SHALL be a dynamic `import()` evaluated lazily on the first `embed()` call — it SHALL NOT be a static top-level import, so a process that never embeds never loads the native runtime.
+
+#### Scenario: Provider implements the harness seam
+
+- **WHEN** `createLocalEmbeddingProvider` is called with `{ modelPath }`
+- **THEN** it returns an object with an `embed(texts, session)` method
+- **AND** the method's return type is `ResultAsync<number[][], ProviderError>`
+
+#### Scenario: Lazy native runtime load
+
+- **WHEN** `createLocalEmbeddingProvider` is called
+- **THEN** `node-llama-cpp` is NOT imported at construction time
+- **AND** the llama runtime is NOT initialized
+- **WHEN** `embed()` is called for the first time
+- **THEN** `node-llama-cpp` is dynamically imported
+- **AND** `getLlama()` + `loadModel()` are invoked
+
+#### Scenario: node-llama-cpp not installed
+
+- **WHEN** `embed()` is called and the dynamic `import("node-llama-cpp")` fails
+- **THEN** the provider SHALL return `err(ProviderError)` with a message directing the user to run `inflexa setup --embeddings`
+- **AND** it SHALL NOT throw
+
+### Requirement: Embedding vectors are 384-dimensional and L2-normalized
+
+Every vector returned by `createLocalEmbeddingProvider.embed()` SHALL have exactly 384 dimensions and SHALL be L2-normalized (Euclidean norm ≈ 1.0). The GGUF quantized model emits un-normalized vectors (norm ≈ 9.24); the provider SHALL normalize each vector by dividing every component by its Euclidean norm before returning it.
+
+#### Scenario: Vector dimension is 384
+
+- **WHEN** `embed(["some text"], session)` resolves to `ok(vectors)`
+- **THEN** `vectors[0].length` SHALL equal 384
+
+#### Scenario: Vectors are L2-normalized
+
+- **WHEN** `embed(["some text"], session)` resolves to `ok(vectors)`
+- **THEN** `Math.sqrt(vectors[0].reduce((s, v) => s + v*v, 0))` SHALL be within 0.001 of 1.0
+
+#### Scenario: Empty input returns empty output
+
+- **WHEN** `embed([], session)` is called
+- **THEN** it SHALL resolve to `ok([])` without loading the model
+
+### Requirement: Embedding concurrency is capped
+
+The provider SHALL embed multiple texts concurrently via `Promise.all` over individual `context.getEmbeddingFor()` calls, capped at a maximum of 4 concurrent embeddings to avoid saturating CPU on large batches.
+
+#### Scenario: Batch embedding respects concurrency cap
+
+- **WHEN** `embed([text1, text2, ..., text10], session)` is called
+- **THEN** no more than 4 `getEmbeddingFor` calls SHALL be in-flight simultaneously
+
+### Requirement: node-llama-cpp is an optional, lazily-fetched dependency
+
+`node-llama-cpp` SHALL be declared in `cli/package.json` under `optionalDependencies` (not `dependencies`). A plain `bun install` SHALL NOT fetch prebuilt llama.cpp native binaries — the postinstall SHALL be blocked by default. The native binaries SHALL be fetched on demand at setup-yes time via `bun pm trust node-llama-cpp` (or equivalent).
+
+#### Scenario: Plain install does not fetch native binaries
+
+- **WHEN** `bun install` runs without prior setup
+- **THEN** `node-llama-cpp` JS is installed but `node_modules/@node-llama-cpp/<platform>/bins/` SHALL NOT contain the native `.node` addon
+- **AND** the postinstall script SHALL NOT have run
+
+#### Scenario: Setup-yes triggers binary fetch
+
+- **WHEN** the user opts into local embeddings during `inflexa setup`
+- **THEN** the setup process SHALL trigger the native binary fetch (via `bun pm trust` or direct postinstall invocation)
+- **AND** the platform-specific `.node` addon SHALL be present in `node_modules/@node-llama-cpp/<platform>/bins/`
+
+### Requirement: Embedding mode is config-driven
+
+`cli/src/lib/config.ts` SHALL extend the config schema with an `embedding` object: `{ mode: "local" | "api-key" | "off", modelPath?: string, apiKey?: string }`. The default SHALL be `{ mode: "off" }`. `resolveEmbedder(config)` in `src/modules/embedding/resolve.ts` SHALL return a `ResultAsync<number[][], ProviderError>`-producing `EmbeddingProvider` based on `mode`: `local` → `createLocalEmbeddingProvider`, `api-key` → the harness `createEmbeddingProvider`, `off` → an error indicating embeddings are not configured.
+
+#### Scenario: Default config has embeddings off
+
+- **WHEN** a fresh config is read with no `embedding` key
+- **THEN** the parsed config SHALL have `embedding.mode === "off"`
+
+#### Scenario: Local mode resolves to the local provider
+
+- **WHEN** `resolveEmbedder` is called with a config where `embedding.mode === "local"` and `embedding.modelPath` is set
+- **THEN** it SHALL return a `createLocalEmbeddingProvider` instance
+
+#### Scenario: Off mode resolves to an error
+
+- **WHEN** `resolveEmbedder` is called with a config where `embedding.mode === "off"`
+- **THEN** it SHALL return `err` indicating embeddings are not configured
+
+### Requirement: Embedding setup downloads and verifies the model on opt-in
+
+`inflexa setup` SHALL ask the user whether to use local embeddings. If yes, it SHALL download `bge-small-en-v1.5-q8_0.gguf` (~36 MB) from `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace to `env.embeddingModelPath`, then verify it by loading the model, embedding a probe text, and asserting the vector dimension is 384. On success, it SHALL write `embedding.mode = "local"` and `embedding.modelPath` to config. The download SHALL NOT occur if the user declines.
+
+#### Scenario: User opts into local embeddings
+
+- **WHEN** the user is prompted "Use local embeddings?" and selects yes
+- **THEN** the GGUF model SHALL be downloaded to `env.embeddingModelPath`
+- **AND** the model SHALL be loaded and a probe embedding SHALL be generated
+- **AND** the probe vector dimension SHALL be verified as 384
+- **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
+
+#### Scenario: User declines local embeddings
+
+- **WHEN** the user is prompted "Use local embeddings?" and selects no
+- **THEN** no model SHALL be downloaded
+- **AND** no native binaries SHALL be fetched
+- **AND** config SHALL remain `embedding.mode = "off"` (or prompt for api-key)
+
+#### Scenario: Model already present is not re-downloaded
+
+- **WHEN** the user opts into local embeddings and `env.embeddingModelPath` already exists
+- **THEN** the download SHALL be skipped
+- **AND** verification (load + probe) SHALL still run
+
+#### Scenario: Verification fails
+
+- **WHEN** the downloaded model fails to load or produces vectors of the wrong dimension
+- **THEN** setup SHALL report the error and leave `embedding.mode` unchanged (not "local")
+
+### Requirement: Embedding model path is env-managed
+
+`cli/src/lib/env.ts` SHALL expose `env.modelDir` (`<dataDir>/inflexa/models/`) and `env.embeddingModelPath` (`<modelDir>/bge-small-en-v1.5-q8_0.gguf`). These SHALL be included in `envDoc` for `--help` visibility.
+
+#### Scenario: Model path resolves under the data dir
+
+- **WHEN** `env.embeddingModelPath` is read
+- **THEN** it SHALL be `<dataDir>/inflexa/models/bge-small-en-v1.5-q8_0.gguf`
+
+#### Scenario: Model dir appears in help
+
+- **WHEN** `inflexa --help` is run
+- **THEN** the paths section SHALL list the models directory
+
+### Requirement: Embedder readiness gate for the hot path
+
+`ensureEmbedderReady()` in `src/modules/embedding/setup.ts` SHALL mirror `ensureProxyReady()`: for `mode === "local"`, it SHALL check that the GGUF model file exists and is loadable, returning `Result<void, EmbeddingSetupError>`. It SHALL NOT re-download or re-verify on every call — a file-exists check is sufficient for the hot path. A missing file SHALL return an error directing the user to `inflexa setup`.
+
+#### Scenario: Model present and readable
+
+- **WHEN** `ensureEmbedderReady()` is called and `env.embeddingModelPath` exists
+- **THEN** it SHALL return `ok(undefined)`
+
+#### Scenario: Model missing
+
+- **WHEN** `ensureEmbedderReady()` is called and `env.embeddingModelPath` does not exist
+- **THEN** it SHALL return `err` with a message directing the user to run `inflexa setup --embeddings`
+
+### Requirement: Embedding setup is wired into the interactive setup flow
+
+The interactive `inflexa setup` questionnaire SHALL include an embedding-mode question after provider auth. The question SHALL be skippable (defaulting to `off`). Non-interactive shells (no TTY) SHALL skip the embedding question without hanging, leaving `mode` unchanged.
+
+#### Scenario: Interactive setup asks about embeddings
+
+- **WHEN** `inflexa setup` runs in a TTY
+- **THEN** the user SHALL be prompted to choose an embedding mode after provider auth
+
+#### Scenario: Non-interactive setup skips embeddings
+
+- **WHEN** `inflexa setup` runs without a TTY
+- **THEN** the embedding question SHALL be skipped
+- **AND** `embedding.mode` SHALL remain unchanged

--- a/cli/openspec/specs/local-embeddings/spec.md
+++ b/cli/openspec/specs/local-embeddings/spec.md
@@ -1,4 +1,8 @@
-## ADDED Requirements
+## Purpose
+
+Local, in-process text embeddings for the cli: a `node-llama-cpp`-backed realization of the harness `EmbeddingProvider` seam (bge-small GGUF, no API key), the mode-based `embedding` config key that selects between it and a direct OpenAI-compatible endpoint, and the setup flow that downloads, verifies, and records the choice.
+
+## Requirements
 
 ### Requirement: Local embedding provider realizes the harness EmbeddingProvider seam
 
@@ -71,7 +75,7 @@ The provider SHALL embed multiple texts concurrently via `Promise.all` over indi
 
 ### Requirement: Embedding mode is config-driven
 
-`cli/src/lib/config.ts` SHALL extend the config schema with an `embedding` object: `{ mode: "local" | "api-key" | "off", modelPath?: string, apiKey?: string }`. The default SHALL be `{ mode: "off" }`. `resolveEmbedder(config)` in `src/modules/embedding/resolve.ts` SHALL return a `ResultAsync<number[][], ProviderError>`-producing `EmbeddingProvider` based on `mode`: `local` → `createLocalEmbeddingProvider`, `api-key` → the harness `createEmbeddingProvider`, `off` → an error indicating embeddings are not configured.
+`cli/src/lib/config.ts` SHALL extend the config schema with an `embedding` object: `{ mode: "local" | "api-key" | "off", modelPath?: string, apiKey?: string, baseURL?: string, model?: string, dimensions?: number }` — the ONE config surface for embeddings (there is no separate `harness.embedding` key). The default SHALL be `{ mode: "off" }`. `resolveEmbedder(config)` in `src/modules/embedding/resolve.ts` SHALL return a `ResultAsync<number[][], ProviderError>`-producing `EmbeddingProvider` based on `mode`: `local` → `createLocalEmbeddingProvider` (384-dim), `api-key` → the harness `createEmbeddingProvider` connecting DIRECTLY to the configured OpenAI-compatible endpoint (default `https://api.openai.com/v1` + `text-embedding-3-small` + 1536 — never through the chat proxy, which serves no embeddings route), `off` → an error indicating embeddings are not configured. The provider SHALL advertise its vector width via `dimensions`, which the harness uses to size each per-analysis search index.
 
 #### Scenario: Default config has embeddings off
 
@@ -87,6 +91,11 @@ The provider SHALL embed multiple texts concurrently via `Promise.all` over indi
 
 - **WHEN** `resolveEmbedder` is called with a config where `embedding.mode === "off"`
 - **THEN** it SHALL return `err` indicating embeddings are not configured
+
+#### Scenario: Switching backends warns about stranded indexes
+
+- **WHEN** setup is asked to select an embedding mode while `embedding.mode` is already a different non-`off` mode
+- **THEN** it SHALL warn loudly that existing analyses' search indexes keep the previous backend's vector width and fail for search and further indexing until re-profiled (automatic re-embedding is deliberately unsupported for now)
 
 ### Requirement: Embedding setup downloads and verifies the model on opt-in
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -49,6 +49,12 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0"
     },
+    "optionalDependencies": {
+        "node-llama-cpp": "^3.19.0"
+    },
+    "trustedDependencies": [
+        "node-llama-cpp"
+    ],
     "patchedDependencies": {
         "eslint-plugin-neverthrow@1.1.4": "patches/eslint-plugin-neverthrow@1.1.4.patch"
     }

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -41,6 +41,17 @@ function renderEnvHelp(): string {
     return `\nPaths:\n${table(pathRows)}\n\nEnvironment:\n${table(varRows)}`;
 }
 
+/**
+ * Parse the `--embeddings` flag value. `undefined` (flag absent) → `undefined`
+ * (no preselect — setup prompts interactively); a valid mode string → itself;
+ * anything else → `null` (invalid, surfaced as a parse error before setup runs).
+ */
+function parseEmbeddingMode(value: string | undefined): "local" | "api-key" | "off" | null | undefined {
+    if (value === undefined) return undefined;
+    if (value === "local" || value === "api-key" || value === "off") return value;
+    return null;
+}
+
 cli.name(pkg.name).description("Launch the interactive TUI (default), or run one of the commands below.").version(pkg.version);
 
 // Commander exits via process.exit() for --help/--version/parse errors. That
@@ -255,20 +266,28 @@ cli.command("down")
     });
 
 cli.command("setup")
-    .description("Install, authenticate, and start CLIProxyAPI and Postgres (Docker or Podman)")
+    .description("Install, authenticate, and start CLIProxyAPI and Postgres (Docker or Podman); optionally configure embeddings")
     .option("--provider <name>", "Authenticate a provider non-interactively: gemini|openai|claude|qwen|iflow")
     .option("--no-auth", "Skip the provider authentication step")
     .option("--no-start", "Set up only; don't start the proxy or Postgres containers")
     .option("--no-postgres", "Skip the Postgres provisioning step")
     .option("--force", "Re-pull images even if they are already cached")
-    .action(async (options: { provider?: string; auth: boolean; start: boolean; postgres: boolean; force?: boolean }) => {
+    .option("--embeddings <mode>", "Configure embeddings non-interactively: local|api-key|off")
+    .action(async (options: { provider?: string; auth: boolean; start: boolean; postgres: boolean; force?: boolean; embeddings?: string }) => {
         const { setup } = await import("../modules/infra/setup.ts");
+        const embeddings = parseEmbeddingMode(options.embeddings);
+        if (embeddings === null) {
+            console.error("\n  `--embeddings` must be one of: local, api-key, off.\n");
+            process.exitCode = 1;
+            return;
+        }
         await setup({
             provider: options.provider,
             auth: options.auth,
             start: options.start,
             force: options.force ?? false,
             postgres: options.postgres,
+            embeddings,
         });
     });
 

--- a/cli/src/lib/config.test.ts
+++ b/cli/src/lib/config.test.ts
@@ -59,7 +59,7 @@ describe("readConfig — fail-closed", () => {
 
 describe("writeConfig / readConfig round-trip", () => {
     test("a written config reads back identically", () => {
-        const cfg: Config = { telemetry: true, theme: DEFAULT_THEME_ID, runtime: "podman", leaderTimeout: 500 };
+        const cfg: Config = { telemetry: true, theme: DEFAULT_THEME_ID, runtime: "podman", leaderTimeout: 500, embedding: { mode: "off" } };
         writeConfig(cfg)._unsafeUnwrap();
         expect(readConfig()).toEqual(cfg);
     });

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -53,6 +53,16 @@ const configSchema = z.object({
     // `unknown` (never `any`) forces the owner to parse before use; and the key MUST be declared, because
     // zod strips unrecognized keys — without this line `readConfig().harness` would always be undefined.
     harness: z.unknown().optional(),
+    // Embedding backend selection. `off` until the user runs `inflexa setup --embeddings`.
+    // `modelPath` is set when `mode === "local"` (path to the GGUF); `apiKey` when `api-key`.
+    embedding: z
+        .object({
+            mode: z.enum(["local", "api-key", "off"]).catch("off").default("off"),
+            modelPath: z.string().optional(),
+            apiKey: z.string().optional(),
+        })
+        .catch({ mode: "off" })
+        .default({ mode: "off" }),
 });
 export type Config = z.infer<typeof configSchema>;
 
@@ -66,7 +76,7 @@ export function readConfig(): Config {
     } catch {
         // Missing or unreadable config fails closed: consent not granted.
     }
-    return { telemetry: false, theme: DEFAULT_THEME_ID, runtime: "docker", leaderTimeout: 2000 };
+    return { telemetry: false, theme: DEFAULT_THEME_ID, runtime: "docker", leaderTimeout: 2000, embedding: { mode: "off" } };
 }
 
 /**

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -37,7 +37,7 @@ const configSchema = z.object({
     // The embedded harness runtime's settings (data-profile runs). Declared as opaque `unknown` and
     // validated downstream in modules/harness/config.ts (`resolveHarnessConfig`), NOT shaped inline:
     //
-    //   - There is no harness-package schema to import. The `harness.*` shape (embedding/model/bioKeys/
+    //   - There is no harness-package schema to import. The `harness.*` shape (model/bioKeys/
     //     sandboxImage/adminPort/skillsDir) is THIS cli's user-facing config contract — the knobs the
     //     cli chooses to expose and map onto the harness's runtime deps — not something the harness
     //     package defines. `@inflexa-ai/harness` exports only `ResourceLimitsSchema`, for one sub-field.
@@ -53,13 +53,22 @@ const configSchema = z.object({
     // `unknown` (never `any`) forces the owner to parse before use; and the key MUST be declared, because
     // zod strips unrecognized keys — without this line `readConfig().harness` would always be undefined.
     harness: z.unknown().optional(),
-    // Embedding backend selection. `off` until the user runs `inflexa setup --embeddings`.
-    // `modelPath` is set when `mode === "local"` (path to the GGUF); `apiKey` when `api-key`.
+    // Embedding backend selection — the ONE config surface for embeddings; the harness
+    // runtime consumes it through `resolveEmbedder` (modules/embedding/resolve.ts).
+    // `off` until the user runs `inflexa setup --embeddings`. `modelPath` is set when
+    // `mode === "local"` (path to the GGUF). `api-key` mode connects DIRECTLY to an
+    // OpenAI-compatible endpoint (never through the chat proxy, which serves no
+    // embeddings route): `apiKey` is required; `baseURL`/`model`/`dimensions` default
+    // to api.openai.com + text-embedding-3-small + 1536. `dimensions` must match what
+    // `model` emits — it sizes each per-analysis vector index.
     embedding: z
         .object({
             mode: z.enum(["local", "api-key", "off"]).catch("off").default("off"),
             modelPath: z.string().optional(),
             apiKey: z.string().optional(),
+            baseURL: z.string().optional(),
+            model: z.string().optional(),
+            dimensions: z.number().int().positive().optional(),
         })
         .catch({ mode: "off" })
         .default({ mode: "off" }),

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -61,6 +61,14 @@ export const env = Object.freeze({
      */
     sessionsDir: join(dataDir(), "inflexa", "sessions"),
     /**
+     * Local embedding model storage: `<dataDir>/inflexa/models/`. The GGUF for
+     * `bge-small-en-v1.5` (q8_0, 384-dim) is downloaded here on `inflexa setup --embeddings`
+     * opt-in. See src/modules/embedding/setup.ts.
+     */
+    modelDir: join(dataDir(), "inflexa", "models"),
+    /** The local embedding GGUF path — `<modelDir>/bge-small-en-v1.5-q8_0.gguf`. */
+    embeddingModelPath: join(dataDir(), "inflexa", "models", "bge-small-en-v1.5-q8_0.gguf"),
+    /**
      * CLIProxyAPI runs in a container (Docker or Podman, see
      * src/modules/infra/setup.ts). The config and the provider-credential dir are
      * state we own, so they live under our data dir and are bind-mounted into the
@@ -151,6 +159,8 @@ export const envDoc: Readonly<
     outputFallbackDir: { kind: "path", label: "outputs", description: "analysis outputs when the anchor folder isn't writable", baseVar: dataVar },
     locksDir: { kind: "path", label: "locks", description: "advisory per-analysis instance locks", baseVar: dataVar },
     sessionsDir: { kind: "path", label: "sessions", description: "harness session trees: staged inputs and sandbox run outputs", baseVar: dataVar },
+    modelDir: { kind: "path", label: "models", description: "local embedding GGUF models, downloaded by `inflexa setup --embeddings`", baseVar: dataVar },
+    embeddingModelPath: { kind: "path", label: "embedding model", description: "the bge-small-en-v1.5 GGUF used by the local embedding provider", baseVar: dataVar },
     cliproxyConfigPath: { kind: "path", label: "proxy config", description: "CLIProxyAPI config, mounted into the proxy container", baseVar: dataVar },
     cliproxyAuthDir: { kind: "path", label: "proxy auth", description: "CLIProxyAPI provider credentials, created by `inflexa setup`", baseVar: dataVar },
     postgresDataDir: {

--- a/cli/src/modules/embedding/local-provider.test.ts
+++ b/cli/src/modules/embedding/local-provider.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLocalEmbeddingProvider } from "./local-provider.ts";
+
+// The real GGUF model is a 36 MB download — the test runs against it only when
+// present (the spike left a copy here). In CI without the model, these skip.
+// The empty-input case needs no model and always runs.
+const SPIKE_MODEL_PATH = "/tmp/opencode/spike-models/bge-small-en-v1.5-q8_0.gguf";
+const modelPresent = await Bun.file(SPIKE_MODEL_PATH).exists();
+
+// A minimal stand-in for AgentSession — the local provider ignores it (no
+// billing, no identity), so any structural match satisfies the seam.
+const fakeSession = { scope: { kind: "analysis", analysisId: "test" } } as never;
+
+// Calling `.match` directly on the ResultAsync (before `await`) keeps the
+// neverthrow must-use-result rule satisfied: the rule sees `.match` as a
+// handled method on the ResultAsync call expression. Awaiting first would
+// interpose an AwaitExpression the rule's parent traversal can't see through.
+describe("createLocalEmbeddingProvider", () => {
+    test("empty input resolves to ok([]) without loading the model", async () => {
+        // Bogus path: the empty-input shortcut returns ok([]) before any load,
+        // so the model path is never touched.
+        const provider = createLocalEmbeddingProvider({ modelPath: "/nonexistent/path.gguf" });
+        const outcome = await provider.embed([], fakeSession).match(
+            (v) => v,
+            () => null,
+        );
+        expect(outcome).toEqual([]);
+    });
+
+    describe.skipIf(!modelPresent)("with the real GGUF model", () => {
+        test("vectors are 384-dimensional and L2-normalized", async () => {
+            const provider = createLocalEmbeddingProvider({ modelPath: SPIKE_MODEL_PATH });
+            const vectors = await provider.embed(["The sky is clear and blue today"], fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            expect(vectors).not.toBeNull();
+            expect(vectors!.length).toBe(1);
+            expect(vectors![0]!.length).toBe(384);
+            const norm = Math.sqrt(vectors![0]!.reduce((s, v) => s + v * v, 0));
+            expect(Math.abs(norm - 1.0)).toBeLessThan(0.001);
+        });
+
+        test("a batch of texts embeds preserving input order", async () => {
+            const provider = createLocalEmbeddingProvider({ modelPath: SPIKE_MODEL_PATH });
+            const texts = ["one", "two", "three", "four", "five"];
+            const vectors = await provider.embed(texts, fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            expect(vectors).not.toBeNull();
+            expect(vectors!.length).toBe(texts.length);
+            for (const v of vectors!) {
+                expect(v.length).toBe(384);
+                const norm = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+                expect(Math.abs(norm - 1.0)).toBeLessThan(0.001);
+            }
+        });
+    });
+});

--- a/cli/src/modules/embedding/local-provider.ts
+++ b/cli/src/modules/embedding/local-provider.ts
@@ -1,0 +1,161 @@
+/**
+ * CLI-side realization of the harness {@link EmbeddingProvider} seam: an in-process
+ * `bge-small-en-v1.5` (GGUF, q8_0, 384-dim) embedding model loaded via `node-llama-cpp`.
+ *
+ * `node-llama-cpp` is an optional dependency (see `cli/package.json` →
+ * `optionalDependencies`) whose native runtime is fetched at setup-yes time, not at
+ * install time. To keep a process that never embeds from ever loading the native
+ * runtime, `node-llama-cpp` is imported via a dynamic `import()` evaluated lazily on
+ * the first `embed()` call — there is no static top-level import here.
+ *
+ * The GGUF quantized model emits UN-normalized vectors (raw L2 norm ≈ 9.24, per the
+ * spike in `cli/spike/NOTES.md`); this provider L2-normalizes every vector before
+ * returning it, so the output is store-agnostic and interchangeable with the
+ * harness's OpenAI-shaped `createEmbeddingProvider` (which returns normalized
+ * vectors). The harness seam is none the wiser.
+ *
+ * The `session` argument is intentionally ignored: the local provider does no
+ * billing and needs no identity — it is a pure function of (model, text).
+ */
+
+import { err, errAsync, ok, okAsync, type Result, ResultAsync } from "neverthrow";
+
+import type { AgentSession, EmbeddingProvider } from "@inflexa-ai/harness";
+// `ProviderError` + `toProviderError` live behind the providers/errors deep path
+// (not re-exported by the barrel). Reusing `toProviderError` keeps the local
+// provider's error shape identical to the cloud provider's. Deep subpaths of
+// `@inflexa-ai/harness` are a supported import surface (see harness AGENTS.md).
+import type { ProviderError } from "@inflexa-ai/harness/providers/errors";
+import { toProviderError } from "@inflexa-ai/harness/providers/errors";
+
+export interface LocalEmbeddingProviderDeps {
+    /** Absolute path to the GGUF model file (typically `env.embeddingModelPath`). */
+    readonly modelPath: string;
+}
+
+/**
+ * Lazily-initialized native runtime state. Created once on the first `embed()`
+ * call and reused for every subsequent call. Cached as a promise so concurrent
+ * first calls coalesce on the same load (the one-time init cost — ~1s runtime
+ * + ~250ms model load — is paid only once).
+ */
+interface LoadedRuntime {
+    getEmbeddingFor(text: string): Promise<{ readonly vector: readonly number[] }>;
+}
+
+let runtime: Promise<Result<LoadedRuntime, ProviderError>> | null = null;
+
+/**
+ * Maximum concurrent `getEmbeddingFor` calls. node-llama-cpp embeds one text at
+ * a time; the docs suggest `Promise.all` for concurrency. Capping at 4 keeps a
+ * large batch from saturating CPU — acceptable for CLI-scale indexing
+ * (10–50 file descriptions per step).
+ */
+const MAX_CONCURRENCY = 4;
+
+/**
+ * Run async tasks over `items` with at most `concurrency` in flight at once,
+ * preserving input order in the output. Rejections propagate (the caller wraps
+ * the run so failures fold into a `ProviderError`).
+ */
+async function mapPool<T, R>(items: readonly T[], concurrency: number, run: (item: T, index: number) => Promise<R>): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let cursor = 0;
+    async function worker(): Promise<void> {
+        while (cursor < items.length) {
+            const i = cursor++;
+            results[i] = await run(items[i]!, i);
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+    return results;
+}
+
+/** Euclidean (L2) norm of a vector. */
+function l2Norm(v: readonly number[]): number {
+    let sum = 0;
+    for (const x of v) sum += x * x;
+    return Math.sqrt(sum);
+}
+
+/**
+ * Normalize `v` to unit L2 length. The GGUF model emits un-normalized vectors
+ * (norm ≈ 9.24); dividing every component by its norm yields a unit vector the
+ * future store can treat as already-normalized (safe for dot-product or cosine).
+ * A zero vector (degenerate, never produced by bge) is returned unchanged to
+ * avoid a NaN from 0/0.
+ */
+function l2Normalize(v: readonly number[]): number[] {
+    const n = l2Norm(v);
+    if (n === 0) return [...v];
+    return v.map((x) => x / n);
+}
+
+/**
+ * Initialize the native llama runtime + model + embedding context on first use.
+ * Wrapped in `Result` so a missing/broken `node-llama-cpp` or model file is an
+ * `err(ProviderError)` — never a throw — per the seam contract.
+ */
+function loadRuntime(modelPath: string): Promise<Result<LoadedRuntime, ProviderError>> {
+    return (async (): Promise<Result<LoadedRuntime, ProviderError>> => {
+        try {
+            // Dynamic import: a process that never embeds never evaluates this,
+            // so the native addon is never loaded. If `node-llama-cpp` is absent
+            // (not installed / install corrupted), the import rejects and we
+            // surface a clear, actionable error rather than crashing.
+            const { getLlama } = await import("node-llama-cpp");
+            const llama = await getLlama();
+            const model = await llama.loadModel({ modelPath });
+            const context = await model.createEmbeddingContext();
+            // Wrap only the method we use; the model + llama stay alive for the
+            // process lifetime (the model is mmap'd, the context is reusable).
+            return ok({
+                getEmbeddingFor: (text: string) => context.getEmbeddingFor(text),
+            });
+        } catch (e) {
+            // `toProviderError` classifies the cause; the "run setup" guidance is
+            // appended because the most common cause is the optional dep not being
+            // trusted/fetched or the GGUF missing — both fixed by `inflexa setup`.
+            const base = toProviderError(e, "local-embeddings");
+            return err({
+                ...base,
+                message: `${base.message}\n  Run \`inflexa setup --embeddings local\` to install the local embedding model.`,
+            } satisfies ProviderError);
+        }
+    })();
+}
+
+export function createLocalEmbeddingProvider(deps: LocalEmbeddingProviderDeps): EmbeddingProvider {
+    function embed(texts: readonly string[], _session: AgentSession): ResultAsync<number[][], ProviderError> {
+        // Empty input is a no-op: don't trigger the lazy native load just to
+        // return nothing. Matches the harness `createEmbeddingProvider` shortcut.
+        if (texts.length === 0) return okAsync([]);
+
+        // Coalesce concurrent first calls on the same load promise.
+        if (runtime === null) runtime = loadRuntime(deps.modelPath);
+
+        const result: Promise<Result<number[][], ProviderError>> = runtime.then((rt) =>
+            rt.match(
+                (loaded) =>
+                    new ResultAsync(
+                        (async (): Promise<Result<number[][], ProviderError>> => {
+                            try {
+                                const vectors = await mapPool([...texts], MAX_CONCURRENCY, (text) =>
+                                    loaded.getEmbeddingFor(text).then((emb) => l2Normalize(emb.vector)),
+                                );
+                                return ok(vectors);
+                            } catch (e) {
+                                return err(toProviderError(e, "local-embeddings"));
+                            }
+                        })(),
+                    ),
+                // Init already failed — surface the cached error without re-trying.
+                (e) => errAsync<number[][], ProviderError>(e),
+            ),
+        );
+
+        return new ResultAsync(result);
+    }
+
+    return { embed };
+}

--- a/cli/src/modules/embedding/local-provider.ts
+++ b/cli/src/modules/embedding/local-provider.ts
@@ -34,6 +34,14 @@ export interface LocalEmbeddingProviderDeps {
 }
 
 /**
+ * Vector width `bge-small-en-v1.5` emits. Advertised on the provider
+ * (`EmbeddingProvider.dimensions`) so the harness sizes each per-analysis
+ * pgvector index to it, and used by setup's post-download verification
+ * (`setup.ts`) to detect a wrong-model GGUF.
+ */
+export const LOCAL_EMBEDDING_DIMENSIONS = 384;
+
+/**
  * Lazily-initialized native runtime state. Created once on the first `embed()`
  * call and reused for every subsequent call. Cached as a promise so concurrent
  * first calls coalesce on the same load (the one-time init cost — ~1s runtime
@@ -157,5 +165,5 @@ export function createLocalEmbeddingProvider(deps: LocalEmbeddingProviderDeps): 
         return new ResultAsync(result);
     }
 
-    return { embed };
+    return { embed, dimensions: LOCAL_EMBEDDING_DIMENSIONS };
 }

--- a/cli/src/modules/embedding/resolve.test.ts
+++ b/cli/src/modules/embedding/resolve.test.ts
@@ -28,6 +28,7 @@ describe("resolveEmbedder", () => {
         );
         expect(provider).not.toBeNull();
         expect(typeof provider!.embed).toBe("function");
+        expect(provider!.dimensions).toBe(384);
     });
 
     test("local mode without modelPath → err local_model_missing", () => {
@@ -38,13 +39,22 @@ describe("resolveEmbedder", () => {
         expect(outcome).toBe("local_model_missing");
     });
 
-    test("api-key mode with apiKey → ok provider", () => {
+    test("api-key mode with apiKey → ok provider at the text-embedding-3-small default width", () => {
         const provider = resolveEmbedder(baseConfig({ mode: "api-key", apiKey: "sk-test" })).match(
             (p) => p,
             () => null,
         );
         expect(provider).not.toBeNull();
         expect(typeof provider!.embed).toBe("function");
+        expect(provider!.dimensions).toBe(1536);
+    });
+
+    test("api-key mode passes a configured dimensions through to the provider", () => {
+        const provider = resolveEmbedder(baseConfig({ mode: "api-key", apiKey: "sk-test", model: "custom-embedder", dimensions: 768 })).match(
+            (p) => p,
+            () => null,
+        );
+        expect(provider!.dimensions).toBe(768);
     });
 
     test("api-key mode without apiKey → err api_key_missing", () => {

--- a/cli/src/modules/embedding/resolve.test.ts
+++ b/cli/src/modules/embedding/resolve.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Config } from "../../lib/config.ts";
+import { resolveEmbedder } from "./resolve.ts";
+
+// A minimal Config base — only `embedding` varies per test; the rest are
+// defaulted to satisfy the type without exercising unrelated schema fields.
+function baseConfig(embedding: Config["embedding"]): Config {
+    return { telemetry: false, theme: "tokyo-night", runtime: "docker", leaderTimeout: 2000, embedding };
+}
+
+// `.match` is one of the neverthrow must-use-result rule's recognized handlers
+// (`match`/`unwrapOr`/`_unsafeUnwrap`); it lets us assert on the error branch
+// without throwing, and keeps the lint rule satisfied.
+describe("resolveEmbedder", () => {
+    test("off mode → err embeddings_not_configured", () => {
+        const outcome = resolveEmbedder(baseConfig({ mode: "off" })).match(
+            () => "ok" as const,
+            (e) => e.type,
+        );
+        expect(outcome).toBe("embeddings_not_configured");
+    });
+
+    test("local mode with modelPath → ok provider", () => {
+        const provider = resolveEmbedder(baseConfig({ mode: "local", modelPath: "/some/model.gguf" })).match(
+            (p) => p,
+            () => null,
+        );
+        expect(provider).not.toBeNull();
+        expect(typeof provider!.embed).toBe("function");
+    });
+
+    test("local mode without modelPath → err local_model_missing", () => {
+        const outcome = resolveEmbedder(baseConfig({ mode: "local" })).match(
+            () => "ok" as const,
+            (e) => e.type,
+        );
+        expect(outcome).toBe("local_model_missing");
+    });
+
+    test("api-key mode with apiKey → ok provider", () => {
+        const provider = resolveEmbedder(baseConfig({ mode: "api-key", apiKey: "sk-test" })).match(
+            (p) => p,
+            () => null,
+        );
+        expect(provider).not.toBeNull();
+        expect(typeof provider!.embed).toBe("function");
+    });
+
+    test("api-key mode without apiKey → err api_key_missing", () => {
+        const outcome = resolveEmbedder(baseConfig({ mode: "api-key" })).match(
+            () => "ok" as const,
+            (e) => e.type,
+        );
+        expect(outcome).toBe("api_key_missing");
+    });
+});

--- a/cli/src/modules/embedding/resolve.ts
+++ b/cli/src/modules/embedding/resolve.ts
@@ -2,14 +2,15 @@
  * Config-driven embedding-mode resolution: pick the right {@link EmbeddingProvider}
  * realization for the current `config.embedding.mode`, or fail with a precise,
  * user-actionable error. Mirrors the proxy setup's "config decides which backend"
- * pattern — the caller (a future `assembleCoreRuntime` wiring) gets a ready-to-
- * inject provider or a reason to surface to the user.
+ * pattern — the caller (`bootHarnessRuntime`, the harness composition root) gets a
+ * ready-to-inject provider or a reason to surface to the user.
  *
  * Modes:
  * - `local`   → {@link createLocalEmbeddingProvider} (in-process bge-small GGUF).
- * - `api-key` → harness `createEmbeddingProvider` (OpenAI-shaped, routed through
- *   the local CLIProxyAPI gateway at `env.cliproxyApiUrl` with the noop billing
- *   resolver — the CLI's local mode does no attribution).
+ * - `api-key` → harness `createEmbeddingProvider` (OpenAI-shaped), connecting
+ *   DIRECTLY to the configured endpoint — never through the chat proxy, which
+ *   fronts OAuth chat providers and serves no embeddings route. The noop billing
+ *   resolver applies: the CLI's local mode does no attribution.
  * - `off`     → error: embeddings are not configured (the default until setup).
  */
 
@@ -18,8 +19,14 @@ import { err, ok, type Result } from "neverthrow";
 import { createEmbeddingProvider, createNoopBillingResolver, type EmbeddingProvider } from "@inflexa-ai/harness";
 
 import type { Config } from "../../lib/config.ts";
-import { env } from "../../lib/env.ts";
 import { createLocalEmbeddingProvider } from "./local-provider.ts";
+
+/**
+ * Where `api-key` mode connects when `embedding.baseURL` is unset. OpenAI's own
+ * endpoint, because the mode's model default (`text-embedding-3-small`, via the
+ * harness provider) is an OpenAI model — the two defaults only make sense together.
+ */
+const DEFAULT_API_BASE_URL = "https://api.openai.com/v1";
 
 export type EmbeddingResolveError =
     | { readonly type: "embeddings_not_configured"; readonly message: string }
@@ -54,9 +61,11 @@ export function resolveEmbedder(config: Config): Result<EmbeddingProvider, Embed
         return ok(createLocalEmbeddingProvider({ modelPath }));
     }
 
-    // `api-key`: route through the local CLIProxyAPI gateway using the user's
-    // configured key. The CLI's local mode does no billing attribution, so the
-    // noop resolver is the correct `ResolveBilling` realization here.
+    // `api-key`: connect directly to the configured OpenAI-compatible endpoint.
+    // The CLI's local mode does no billing attribution, so the noop resolver is
+    // the correct `ResolveBilling` realization here. `model`/`dimensions` fall
+    // through to the harness defaults (text-embedding-3-small / 1536) when unset;
+    // a custom `model` needs a matching `dimensions` or the boot probe rejects it.
     const apiKey = config.embedding.apiKey;
     if (!apiKey) {
         return err({
@@ -66,8 +75,10 @@ export function resolveEmbedder(config: Config): Result<EmbeddingProvider, Embed
     }
     return ok(
         createEmbeddingProvider({
-            baseURL: env.cliproxyApiUrl,
+            baseURL: config.embedding.baseURL ?? DEFAULT_API_BASE_URL,
             token: apiKey,
+            model: config.embedding.model,
+            dimensions: config.embedding.dimensions,
             resolveBilling: createNoopBillingResolver(),
         }),
     );

--- a/cli/src/modules/embedding/resolve.ts
+++ b/cli/src/modules/embedding/resolve.ts
@@ -1,0 +1,74 @@
+/**
+ * Config-driven embedding-mode resolution: pick the right {@link EmbeddingProvider}
+ * realization for the current `config.embedding.mode`, or fail with a precise,
+ * user-actionable error. Mirrors the proxy setup's "config decides which backend"
+ * pattern — the caller (a future `assembleCoreRuntime` wiring) gets a ready-to-
+ * inject provider or a reason to surface to the user.
+ *
+ * Modes:
+ * - `local`   → {@link createLocalEmbeddingProvider} (in-process bge-small GGUF).
+ * - `api-key` → harness `createEmbeddingProvider` (OpenAI-shaped, routed through
+ *   the local CLIProxyAPI gateway at `env.cliproxyApiUrl` with the noop billing
+ *   resolver — the CLI's local mode does no attribution).
+ * - `off`     → error: embeddings are not configured (the default until setup).
+ */
+
+import { err, ok, type Result } from "neverthrow";
+
+import { createEmbeddingProvider, createNoopBillingResolver, type EmbeddingProvider } from "@inflexa-ai/harness";
+
+import type { Config } from "../../lib/config.ts";
+import { env } from "../../lib/env.ts";
+import { createLocalEmbeddingProvider } from "./local-provider.ts";
+
+export type EmbeddingResolveError =
+    | { readonly type: "embeddings_not_configured"; readonly message: string }
+    | { readonly type: "local_model_missing"; readonly message: string }
+    | { readonly type: "api_key_missing"; readonly message: string };
+
+/**
+ * Resolve the embedder for `config`. Returns a ready-to-inject
+ * {@link EmbeddingProvider} on the ok channel, or a {@link EmbeddingResolveError}
+ * naming exactly what is missing on the error channel.
+ */
+export function resolveEmbedder(config: Config): Result<EmbeddingProvider, EmbeddingResolveError> {
+    const { mode } = config.embedding;
+
+    if (mode === "off") {
+        return err({
+            type: "embeddings_not_configured",
+            message: "Embeddings are not configured. Run `inflexa setup --embeddings local` to enable local embeddings.",
+        });
+    }
+
+    if (mode === "local") {
+        const modelPath = config.embedding.modelPath;
+        // The GGUF path is required for local mode — setup writes it, but a
+        // hand-edited config or a fresh install without setup leaves it unset.
+        if (!modelPath) {
+            return err({
+                type: "local_model_missing",
+                message: "Local embedding mode is set but no model path is configured. Run `inflexa setup --embeddings local`.",
+            });
+        }
+        return ok(createLocalEmbeddingProvider({ modelPath }));
+    }
+
+    // `api-key`: route through the local CLIProxyAPI gateway using the user's
+    // configured key. The CLI's local mode does no billing attribution, so the
+    // noop resolver is the correct `ResolveBilling` realization here.
+    const apiKey = config.embedding.apiKey;
+    if (!apiKey) {
+        return err({
+            type: "api_key_missing",
+            message: "API-key embedding mode is set but no API key is configured. Run `inflexa setup --embeddings api-key`.",
+        });
+    }
+    return ok(
+        createEmbeddingProvider({
+            baseURL: env.cliproxyApiUrl,
+            token: apiKey,
+            resolveBilling: createNoopBillingResolver(),
+        }),
+    );
+}

--- a/cli/src/modules/embedding/setup.test.ts
+++ b/cli/src/modules/embedding/setup.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { readConfig, writeConfig, type Config } from "../../lib/config.ts";
+import { env } from "../../lib/env.ts";
+import { ensureEmbedderReady, runEmbeddingSetup } from "./setup.ts";
+
+// The test preload sandboxes XDG_DATA_HOME/XDG_CONFIG_HOME, so env.configPath
+// and env.embeddingModelPath point into a temp dir — safe to create/delete here.
+
+function writeConfigWith(embedding: Config["embedding"]): void {
+    writeConfig({ telemetry: false, theme: "tokyo-night", runtime: "docker", leaderTimeout: 2000, embedding })._unsafeUnwrap();
+}
+
+afterEach(() => {
+    rmSync(env.configPath, { force: true });
+    rmSync(env.embeddingModelPath, { force: true });
+});
+
+describe("ensureEmbedderReady", () => {
+    test("off mode → ok (no model check)", async () => {
+        writeConfigWith({ mode: "off" });
+        const result = await ensureEmbedderReady();
+        expect(result.isOk()).toBe(true);
+    });
+
+    test("api-key mode → ok (readiness is not the embedding setup's concern)", async () => {
+        writeConfigWith({ mode: "api-key", apiKey: "sk-test" });
+        const result = await ensureEmbedderReady();
+        expect(result.isOk()).toBe(true);
+    });
+
+    test("local mode + model missing → err not_configured", async () => {
+        writeConfigWith({ mode: "local", modelPath: env.embeddingModelPath });
+        const result = await ensureEmbedderReady();
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().type).toBe("not_configured");
+    });
+
+    test("local mode + model present → ok", async () => {
+        writeConfigWith({ mode: "local", modelPath: env.embeddingModelPath });
+        mkdirSync(dirname(env.embeddingModelPath), { recursive: true });
+        writeFileSync(env.embeddingModelPath, "fake-gguf");
+        const result = await ensureEmbedderReady();
+        expect(result.isOk()).toBe(true);
+    });
+});
+
+describe("runEmbeddingSetup", () => {
+    test("non-interactive (no TTY) → ok, mode unchanged", async () => {
+        writeConfigWith({ mode: "off" });
+        const wasTTY = process.stdin.isTTY;
+        // isTTY is a getter at runtime; overriding via defineProperty for the test is safe — the function only reads it.
+        Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+        try {
+            const result = await runEmbeddingSetup(false);
+            expect(result.isOk()).toBe(true);
+            expect(readConfig().embedding.mode).toBe("off");
+        } finally {
+            Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+        }
+    });
+
+    test("preselected off → ok, no download", async () => {
+        writeConfigWith({ mode: "off" });
+        const result = await runEmbeddingSetup(true, "off");
+        expect(result.isOk()).toBe(true);
+        expect(readConfig().embedding.mode).toBe("off");
+    });
+});

--- a/cli/src/modules/embedding/setup.ts
+++ b/cli/src/modules/embedding/setup.ts
@@ -1,0 +1,247 @@
+/**
+ * Local embedding model lifecycle: download, verify, configure, and the hot-path
+ * readiness gate. Mirrors `modules/infra/setup.ts` — "download a thing on opt-in,
+ * verify it, record the choice in config, and gate the hot path on it being
+ * present" — and uses the same `@clack/prompts` UI (`select`/`spinner`/`log`) so
+ * the two setup flows feel consistent.
+ *
+ * The model is `bge-small-en-v1.5` (GGUF, q8_0, 384-dim, ~36 MB) from
+ * `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace. Download is skipped if
+ * the file already exists; verification (load + embed probe + dim check) always
+ * runs so a truncated/corrupt file is caught now, not on the first hot-path
+ * `embed()` call.
+ */
+
+import { mkdir, stat } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { log, spinner as clackSpinner } from "@clack/prompts";
+import { err, ok, type Result } from "neverthrow";
+
+import { readConfig, writeConfig } from "../../lib/config.ts";
+import { select } from "../../lib/cli.ts";
+import { env } from "../../lib/env.ts";
+
+export type EmbeddingSetupError =
+    | { readonly type: "download_failed"; readonly message: string; readonly cause?: unknown }
+    | { readonly type: "verify_failed"; readonly message: string; readonly cause?: unknown }
+    | { readonly type: "dimension_mismatch"; readonly message: string; readonly expected: number; readonly actual: number }
+    | { readonly type: "not_configured"; readonly message: string };
+
+const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf";
+const EXPECTED_DIM = 384;
+
+/**
+ * Download the GGUF model to {@link env.embeddingModelPath}, skipping if it is
+ * already present. Streams the response to disk under a clack spinner so the
+ * ~36 MB download is visible. A network/HTTP failure surfaces as
+ * `download_failed` — never thrown.
+ */
+export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>> {
+    try {
+        if (await Bun.file(env.embeddingModelPath).exists()) {
+            log.info(`Embedding model already present at ${env.embeddingModelPath}`);
+            return ok(undefined);
+        }
+
+        await mkdir(dirname(env.embeddingModelPath), { recursive: true });
+
+        const s = clackSpinner();
+        s.start("Downloading bge-small-en-v1.5 (q8_0, ~36 MB) from HuggingFace");
+
+        const response = await fetch(MODEL_URL);
+        if (!response.ok || response.body === null) {
+            s.error("Download failed");
+            return err({
+                type: "download_failed",
+                message: `Download failed: HTTP ${response.status} ${response.statusText}`,
+            });
+        }
+
+        const file = Bun.file(env.embeddingModelPath);
+        const writer = file.writer();
+        const reader = response.body.getReader();
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            await writer.write(value);
+        }
+        await writer.flush();
+
+        const written = (await stat(env.embeddingModelPath)).size;
+        s.stop(`Downloaded ${(written / 1024 / 1024).toFixed(1)} MB`);
+        return ok(undefined);
+    } catch (cause) {
+        return err({
+            type: "download_failed",
+            message: `Download failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            cause,
+        });
+    }
+}
+
+/**
+ * Verify the GGUF loads and produces 384-dim vectors by embedding a probe text.
+ * Catches a truncated/corrupt file or a wrong-model download now, so the hot
+ * path never hits a load failure. A load error is `verify_failed`; a wrong
+ * dimension is `dimension_mismatch` (so the caller can distinguish "the file is
+ * broken" from "the file is the wrong model").
+ */
+export async function verifyModel(modelPath: string): Promise<Result<void, EmbeddingSetupError>> {
+    const s = clackSpinner();
+    s.start("Verifying model (load + embed probe)");
+    try {
+        const { getLlama } = await import("node-llama-cpp");
+        const llama = await getLlama();
+        const model = await llama.loadModel({ modelPath });
+        const context = await model.createEmbeddingContext();
+        const probe = await context.getEmbeddingFor("inflexa embedding verification probe");
+        const dim = probe.vector.length;
+        await llama.dispose();
+        if (dim !== EXPECTED_DIM) {
+            s.error("Dimension mismatch");
+            return err({
+                type: "dimension_mismatch",
+                message: `Model produced ${dim}-dim vectors, expected ${EXPECTED_DIM}. The GGUF may be the wrong model.`,
+                expected: EXPECTED_DIM,
+                actual: dim,
+            });
+        }
+        s.stop(`Verified: ${EXPECTED_DIM}-dim vectors`);
+        return ok(undefined);
+    } catch (cause) {
+        s.error("Verification failed");
+        return err({
+            type: "verify_failed",
+            message: `Model verification failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            cause,
+        });
+    }
+}
+
+/**
+ * Trigger `bun pm trust node-llama-cpp` to fetch the prebuilt native binaries
+ * (bun blocks postinstall scripts by default; this is the sanctioned opt-in).
+ * On platforms where the platform package already ships binaries in its tarball
+ * this is effectively a no-op, but it is the cross-platform-safe way to ensure
+ * the native runtime is present. A failure here is non-fatal — the download +
+ * verify steps will surface a clearer error if the runtime is genuinely missing.
+ */
+async function trustNativeRuntime(): Promise<void> {
+    try {
+        const proc = Bun.spawn(["bun", "pm", "trust", "node-llama-cpp"], { stdout: "ignore", stderr: "pipe" });
+        const exitCode = await proc.exited;
+        if (exitCode !== 0) {
+            const stderr = await new Response(proc.stderr).text();
+            log.warn(`\`bun pm trust\` exited ${exitCode}${stderr ? `: ${stderr.trim()}` : ""}`);
+        }
+    } catch (cause) {
+        // Non-fatal: verifyModel will report a clearer error if the runtime is missing.
+        log.warn(`\`bun pm trust\` could not run: ${cause instanceof Error ? cause.message : String(cause)}`);
+    }
+}
+
+/**
+ * Interactive embedding setup, run as part of `inflexa setup`. Prompts the user
+ * to pick an embedding mode via a clack `select` picker (local / api-key / off),
+ * then for `local`: fetches the native runtime + GGUF, verifies it, and records
+ * `embedding.mode = "local"` + `embedding.modelPath` in config.
+ *
+ * Non-interactive shells (no TTY, or `interactive === false`) skip the prompt
+ * entirely without hanging — `mode` stays whatever it was. A preselected `mode`
+ * (from `--embeddings`) overrides the prompt and runs the matching branch
+ * non-interactively.
+ */
+export async function runEmbeddingSetup(interactive: boolean, preselected?: "local" | "api-key" | "off"): Promise<Result<void, EmbeddingSetupError>> {
+    const config = readConfig();
+
+    // A preselected mode from `--embeddings` short-circuits the prompt.
+    if (preselected !== undefined) {
+        if (preselected === "off") return ok(undefined);
+        if (preselected === "api-key") {
+            // API-key mode setup is deferred to the harness-wiring change; only
+            // local setup is implemented here. Decline cleanly rather than half-doing it.
+            log.warn("API-key embedding mode is selected but not yet configured by setup. Set `embedding.apiKey` in config manually.");
+            return ok(undefined);
+        }
+        // preselected === "local": fall through to the local setup branch.
+        return runLocalSetup(config);
+    }
+
+    // Already configured (mode is no longer the default `off`): don't re-prompt
+    // on every launch — the user already made a choice. `ensureEmbedderReady`
+    // separately gates the hot path on a local model being present.
+    if (config.embedding.mode !== "off") return ok(undefined);
+
+    // Non-interactive: skip the prompt, leave mode unchanged (no hang).
+    if (!interactive || !process.stdin.isTTY) return ok(undefined);
+
+    const choice = await promptEmbeddingMode();
+    if (choice === "off") {
+        log.info("Embeddings skipped (mode left unchanged).");
+        return ok(undefined);
+    }
+    if (choice === "api-key") {
+        log.warn("API-key embedding mode is not yet configured by setup. Set `embedding.apiKey` in config manually.");
+        return ok(undefined);
+    }
+    // choice === "local"
+    return runLocalSetup(config);
+}
+
+/** The local-embeddings opt-in branch: trust runtime, download, verify, write config. */
+async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Result<void, EmbeddingSetupError>> {
+    log.message("Setting up local embeddings (bge-small-en-v1.5, in-process, no API key needed)");
+
+    await trustNativeRuntime();
+
+    const downloadResult = await downloadModel();
+    if (downloadResult.isErr()) return downloadResult;
+
+    const verifyResult = await verifyModel(env.embeddingModelPath);
+    if (verifyResult.isErr()) return verifyResult;
+
+    // Write the config choice. `writeConfig` is sync; mapErr translates its
+    // ConfigError into an EmbeddingSetupError, and map records the success
+    // side-effect. Both consume the Result so the must-use-result rule is satisfied.
+    return writeConfig({ ...config, embedding: { mode: "local", modelPath: env.embeddingModelPath } })
+        .mapErr((e): EmbeddingSetupError => ({ type: "verify_failed", message: `Verification passed but config could not be written: ${e.type}` }))
+        .map(() => {
+            log.success("Local embeddings configured. `embedding.mode` is now `local`.");
+            return undefined;
+        });
+}
+
+/**
+ * Embedding mode picker via clack `select`. Offers all three modes so the user
+ * can choose `api-key` interactively (not just local-vs-skip). Returns the
+ * chosen mode string; clack handles cancel (Ctrl-C / Esc) by aborting.
+ */
+async function promptEmbeddingMode(): Promise<"local" | "api-key" | "off"> {
+    const chosen = await select("Embedding mode", [
+        { value: "local", label: "Local (in-process, downloads a 36 MB model, no API key)" },
+        { value: "api-key", label: "API key (route through the proxy)" },
+        { value: "off", label: "Off / skip" },
+    ]);
+    return chosen as "local" | "api-key" | "off";
+}
+
+/**
+ * Hot-path readiness gate, mirroring `ensureProxyReady`. For `local` mode,
+ * checks the GGUF file exists — a file-exists check is sufficient here (the
+ * first `embed()` lazily loads it, and `verifyModel` ran at setup time). A
+ * missing file directs the user to `inflexa setup`. For `off` / `api-key`,
+ * readiness is not the embedding setup's concern — return `ok`.
+ */
+export async function ensureEmbedderReady(): Promise<Result<void, EmbeddingSetupError>> {
+    const { mode } = readConfig().embedding;
+    if (mode !== "local") return ok(undefined);
+
+    if (!(await Bun.file(env.embeddingModelPath).exists())) {
+        return err({
+            type: "not_configured",
+            message: `Local embedding model not found at ${env.embeddingModelPath}. Run \`inflexa setup --embeddings local\` to download it.`,
+        });
+    }
+    return ok(undefined);
+}

--- a/cli/src/modules/embedding/setup.ts
+++ b/cli/src/modules/embedding/setup.ts
@@ -12,7 +12,7 @@
  * `embed()` call.
  */
 
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, rename, stat, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import { log, spinner as clackSpinner } from "@clack/prompts";
@@ -21,6 +21,7 @@ import { err, ok, type Result } from "neverthrow";
 import { readConfig, writeConfig } from "../../lib/config.ts";
 import { select } from "../../lib/cli.ts";
 import { env } from "../../lib/env.ts";
+import { LOCAL_EMBEDDING_DIMENSIONS } from "./local-provider.ts";
 
 export type EmbeddingSetupError =
     | { readonly type: "download_failed"; readonly message: string; readonly cause?: unknown }
@@ -28,16 +29,30 @@ export type EmbeddingSetupError =
     | { readonly type: "dimension_mismatch"; readonly message: string; readonly expected: number; readonly actual: number }
     | { readonly type: "not_configured"; readonly message: string };
 
-const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/main/bge-small-en-v1.5-q8_0.gguf";
-const EXPECTED_DIM = 384;
+/**
+ * Pinned to the repo revision current as of 2026-07 (last modified 2024-02-17),
+ * not `main`: an unpinned ref would let a repo update (or a MITM on the ref)
+ * silently swap the model, with only the dimension probe standing between a
+ * different model and the vector store. The sha256 below is the file's LFS
+ * object id at this revision, verified against the download stream.
+ */
+const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/d32f8c040ea3b516330eeb75b72bcc2d3a780ab7/bge-small-en-v1.5-q8_0.gguf";
+const MODEL_SHA256 = "ec38e8da142596baa913124ae50550de284b6916bf59577ef2f0cb9660c2f514";
 
 /**
  * Download the GGUF model to {@link env.embeddingModelPath}, skipping if it is
  * already present. Streams the response to disk under a clack spinner so the
  * ~36 MB download is visible. A network/HTTP failure surfaces as
  * `download_failed` — never thrown.
+ *
+ * The stream lands in a `.part` sidecar that is renamed into place only after a
+ * complete flush: the "already present" check above trusts bare existence, so a
+ * mid-stream failure must never leave bytes at the final path — a truncated
+ * file there would be skipped as "already present" on retry and only caught by
+ * `verifyModel`, with no hint that deleting it fixes things.
  */
 export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>> {
+    const partPath = `${env.embeddingModelPath}.part`;
     try {
         if (await Bun.file(env.embeddingModelPath).exists()) {
             log.info(`Embedding model already present at ${env.embeddingModelPath}`);
@@ -58,20 +73,36 @@ export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>
             });
         }
 
-        const file = Bun.file(env.embeddingModelPath);
+        const file = Bun.file(partPath);
         const writer = file.writer();
         const reader = response.body.getReader();
+        const hasher = new Bun.CryptoHasher("sha256");
         for (;;) {
             const { done, value } = await reader.read();
             if (done) break;
+            hasher.update(value);
             await writer.write(value);
         }
         await writer.flush();
+
+        const digest = hasher.digest("hex");
+        if (digest !== MODEL_SHA256) {
+            s.error("Checksum mismatch");
+            await unlink(partPath).catch(() => {});
+            return err({
+                type: "download_failed",
+                message: `Downloaded file's sha256 (${digest}) does not match the pinned model checksum. Retry, or check your network path to huggingface.co.`,
+            });
+        }
+        await rename(partPath, env.embeddingModelPath);
 
         const written = (await stat(env.embeddingModelPath)).size;
         s.stop(`Downloaded ${(written / 1024 / 1024).toFixed(1)} MB`);
         return ok(undefined);
     } catch (cause) {
+        // Best-effort cleanup; a `.part` leftover is harmless (never mistaken
+        // for the model) but would confuse a du/ls of the model dir.
+        await unlink(partPath).catch(() => {});
         return err({
             type: "download_failed",
             message: `Download failed: ${cause instanceof Error ? cause.message : String(cause)}`,
@@ -98,16 +129,16 @@ export async function verifyModel(modelPath: string): Promise<Result<void, Embed
         const probe = await context.getEmbeddingFor("inflexa embedding verification probe");
         const dim = probe.vector.length;
         await llama.dispose();
-        if (dim !== EXPECTED_DIM) {
+        if (dim !== LOCAL_EMBEDDING_DIMENSIONS) {
             s.error("Dimension mismatch");
             return err({
                 type: "dimension_mismatch",
-                message: `Model produced ${dim}-dim vectors, expected ${EXPECTED_DIM}. The GGUF may be the wrong model.`,
-                expected: EXPECTED_DIM,
+                message: `Model produced ${dim}-dim vectors, expected ${LOCAL_EMBEDDING_DIMENSIONS}. The GGUF may be the wrong model.`,
+                expected: LOCAL_EMBEDDING_DIMENSIONS,
                 actual: dim,
             });
         }
-        s.stop(`Verified: ${EXPECTED_DIM}-dim vectors`);
+        s.stop(`Verified: ${LOCAL_EMBEDDING_DIMENSIONS}-dim vectors`);
         return ok(undefined);
     } catch (cause) {
         s.error("Verification failed");
@@ -159,8 +190,9 @@ export async function runEmbeddingSetup(interactive: boolean, preselected?: "loc
     if (preselected !== undefined) {
         if (preselected === "off") return ok(undefined);
         if (preselected === "api-key") {
-            // API-key mode setup is deferred to the harness-wiring change; only
-            // local setup is implemented here. Decline cleanly rather than half-doing it.
+            warnOnModeSwitch(config.embedding.mode, "api-key");
+            // API-key mode setup is deferred; only local setup is implemented
+            // here. Decline cleanly rather than half-doing it.
             log.warn("API-key embedding mode is selected but not yet configured by setup. Set `embedding.apiKey` in config manually.");
             return ok(undefined);
         }
@@ -182,6 +214,7 @@ export async function runEmbeddingSetup(interactive: boolean, preselected?: "loc
         return ok(undefined);
     }
     if (choice === "api-key") {
+        warnOnModeSwitch(config.embedding.mode, "api-key");
         log.warn("API-key embedding mode is not yet configured by setup. Set `embedding.apiKey` in config manually.");
         return ok(undefined);
     }
@@ -189,8 +222,34 @@ export async function runEmbeddingSetup(interactive: boolean, preselected?: "loc
     return runLocalSetup(config);
 }
 
+/**
+ * Loudly warn when the user is about to change an already-chosen embedding
+ * backend. Vector widths differ per backend (local = 384; api-key defaults to
+ * 1536), and each analysis's search index keeps the width it was created with —
+ * switching strands every existing index at the old width, so search and
+ * further indexing on those analyses fail until they are re-profiled.
+ * Automatic re-embedding is a deliberate non-feature for now (see the
+ * local-embeddings design doc); the warning is the mitigation.
+ */
+function warnOnModeSwitch(current: "local" | "api-key" | "off", next: "local" | "api-key"): void {
+    if (current === "off" || current === next) return;
+    log.warn(
+        [
+            `SWITCHING EMBEDDING BACKEND (${current} → ${next})`,
+            "",
+            "Embedding models emit different vector widths, and every existing analysis's",
+            "search index keeps the width it was created with. After this switch:",
+            "  - semantic search on existing analyses will return errors or nothing,",
+            "  - further indexing into them (new runs, re-profiles) will fail,",
+            "until each analysis is re-profiled under the new backend.",
+            "Automatic re-embedding is not supported yet.",
+        ].join("\n"),
+    );
+}
+
 /** The local-embeddings opt-in branch: trust runtime, download, verify, write config. */
 async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Result<void, EmbeddingSetupError>> {
+    warnOnModeSwitch(config.embedding.mode, "local");
     log.message("Setting up local embeddings (bge-small-en-v1.5, in-process, no API key needed)");
 
     await trustNativeRuntime();
@@ -220,7 +279,7 @@ async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Res
 async function promptEmbeddingMode(): Promise<"local" | "api-key" | "off"> {
     const chosen = await select("Embedding mode", [
         { value: "local", label: "Local (in-process, downloads a 36 MB model, no API key)" },
-        { value: "api-key", label: "API key (route through the proxy)" },
+        { value: "api-key", label: "API key (direct to an OpenAI-compatible endpoint)" },
         { value: "off", label: "Off / skip" },
     ]);
     return chosen as "local" | "api-key" | "off";

--- a/cli/src/modules/harness/config.ts
+++ b/cli/src/modules/harness/config.ts
@@ -12,13 +12,6 @@ import { env } from "../../lib/env.ts";
  */
 const harnessConfigSchema = z.object({
     model: z.string().optional(),
-    embedding: z
-        .object({
-            baseURL: z.string(),
-            token: z.string(),
-            model: z.string().optional(),
-        })
-        .optional(),
     bioKeys: z
         .object({
             drugbank: z.string().optional(),
@@ -40,27 +33,16 @@ const harnessConfigSchema = z.object({
     skillsDir: z.string().optional(),
 });
 
-/** Fully-resolved embedding endpoint — the profile's vector indexing cannot run without one. */
-export type HarnessEmbeddingConfig = {
-    readonly baseURL: string;
-    readonly token: string;
-    readonly model: string;
-};
-
 /**
- * The `harness` config key resolved to concrete values. `null` fields are the
- * two genuine launch prerequisites the cli cannot default: the embedding
- * endpoint — its own baseURL + API key, deliberately a SEPARATE path from the
- * chat proxy, which fronts OAuth chat providers and serves no embeddings
- * route — and, outside a dev checkout, the skills tree. The pre-flight turns
- * each `null` into an actionable error, and a configured embedding endpoint
- * is additionally probed at boot (config presence can't prove reachability,
- * and embeddings fail late in the profile workflow).
+ * The `harness` config key resolved to concrete values. The embedder is NOT
+ * configured here: it comes from the top-level `embedding` config key, resolved
+ * by `modules/embedding/resolve.ts` at boot. The one genuine launch prerequisite
+ * this config cannot default is the skills tree (outside a dev checkout); the
+ * pre-flight turns its `null` into an actionable error.
  */
 export type ResolvedHarnessConfig = {
     /** Chat model id; `null` means resolve the default from the proxy's `/models` at boot. */
     readonly model: string | null;
-    readonly embedding: HarnessEmbeddingConfig | null;
     /** Absent keys pass as empty strings — the affected tools surface auth errors per-call. */
     readonly bioKeys: {
         readonly drugbank: string;
@@ -90,13 +72,6 @@ export type ResolvedHarnessConfig = {
  */
 const devSkillsDir = join(import.meta.dir, "../../../../skills");
 
-/**
- * Matches the harness's own embedding default (`providers/embedding.ts`) so an
- * endpoint configured without a model gets the model that endpoint most likely
- * serves under the OpenAI-compatible contract.
- */
-const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
-
 /** Locally-built image tag (`docker build` per images/sandbox-base/README.md). */
 const DEFAULT_SANDBOX_IMAGE = "sandbox-base:latest";
 
@@ -116,13 +91,6 @@ const DEFAULT_ADMIN_PORT = 8433;
 function defaultsWith(cfg: z.infer<typeof harnessConfigSchema> | undefined, configError?: { issues: string }): ResolvedHarnessConfig {
     return {
         model: cfg?.model ?? null,
-        embedding: cfg?.embedding
-            ? {
-                  baseURL: cfg.embedding.baseURL,
-                  token: cfg.embedding.token,
-                  model: cfg.embedding.model ?? DEFAULT_EMBEDDING_MODEL,
-              }
-            : null,
         bioKeys: {
             drugbank: cfg?.bioKeys?.drugbank ?? "",
             disgenet: cfg?.bioKeys?.disgenet ?? "",

--- a/cli/src/modules/harness/profile.ts
+++ b/cli/src/modules/harness/profile.ts
@@ -66,21 +66,19 @@ function describeBootError(e: HarnessBootError): string {
     switch (e.type) {
         case "harness_config_invalid":
             return `Your \`harness\` config has an invalid field — ${e.issues}. Fix it in config.json and re-run.`;
-        case "embedding_unconfigured":
+        case "embedding_unresolved":
+            return ["Profiling's vector indexing requires an embedder, and none could be resolved from the `embedding` config key.", e.cause.message].join(
+                "\n",
+            );
+        case "embedding_probe_failed":
             return [
-                "No embedding endpoint configured — profiling's vector indexing requires one. Embeddings are their own endpoint (separate from the chat proxy, which serves none).",
-                'Set `harness.embedding` in config.json: { "baseURL": "<OpenAI-compatible /v1>", "token": "<key>", "model": "text-embedding-3-small" }.',
-            ].join("\n");
-        case "embedding_unreachable":
-            return [
-                `The embedding endpoint ${e.baseURL} did not accept an embeddings request (${e.detail}) — profiling's vector indexing requires one and would otherwise fail after the sandbox run already spent its work.`,
-                "Either configure an embeddings-capable provider in the proxy, or set `harness.embedding` in config.json:",
-                '{ "baseURL": "<OpenAI-compatible /v1>", "token": "<key>", "model": "text-embedding-3-small" }.',
+                `The configured embedder failed a probe embedding (${e.detail}) — profiling would otherwise fail after the sandbox run already spent its work.`,
+                "For `local` mode, re-run `inflexa setup --embeddings local`; for `api-key` mode, check `embedding.apiKey` and `embedding.baseURL` in config.json.",
             ].join("\n");
         case "embedding_dimension_mismatch":
             return [
-                `The embedding model at ${e.baseURL} returns ${e.actual}-dimensional vectors, but the profile's vector index is fixed at ${e.expected} dimensions.`,
-                `Set \`harness.embedding.model\` in config.json to a ${e.expected}-dim model (e.g. text-embedding-3-small).`,
+                `The configured embedding model returns ${e.actual}-dimensional vectors, but the embedder is declared as ${e.expected}-dimensional (\`embedding.dimensions\`).`,
+                `Set \`embedding.dimensions\` to ${e.actual} in config.json so the vector indexes are sized to what the model actually emits.`,
             ].join("\n");
         case "skills_dir_missing":
             return `Skills directory not found${e.path ? ` at ${e.path}` : ""}. Set \`harness.skillsDir\` in config.json (a checkout's \`skills/\` tree).`;

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
-import { ok, err } from "neverthrow";
+import { ok, okAsync, err } from "neverthrow";
+import type { EmbeddingProvider } from "@inflexa-ai/harness";
 
 import { env } from "../../lib/env.ts";
 import { instanceLockPath } from "../../lib/lock.ts";
@@ -18,13 +19,20 @@ function testConfig(overrides: Partial<ResolvedHarnessConfig> = {}): ResolvedHar
     mkdirSync(skillsDir, { recursive: true });
     return {
         model: "claude-test-model",
-        embedding: { baseURL: "http://embeddings.test/v1", token: "tok", model: "text-embedding-3-small" },
         bioKeys: { drugbank: "", disgenet: "", epaCcte: "" },
         sandboxImage: "sandbox-base:latest",
         resourceLimits: { maxCpu: 1, maxMemoryGb: 1, maxGpuCount: 0 },
         adminPort: 8433,
         skillsDir,
         ...overrides,
+    };
+}
+
+/** A resolved-embedder stand-in with the api-key default width; never actually embeds in these offline tests. */
+function fakeEmbedding(): EmbeddingProvider {
+    return {
+        dimensions: 1536,
+        embed: (texts) => okAsync(texts.map(() => new Array(1536).fill(0))),
     };
 }
 
@@ -59,12 +67,19 @@ function recordingSeams(calls: string[]): BootSeams {
             calls.push("resolveModel");
             return ok("claude-from-proxy");
         },
+        resolveEmbedding: () => {
+            calls.push("resolveEmbedding");
+            return ok(fakeEmbedding());
+        },
         register: (deps) => {
             calls.push("register");
             // The one base every consumer must share (design D2).
             expect(deps.sessionsBasePath).toBe(env.sessionsDir);
             expect(deps.skillsDir).toBe(skillsDir);
-            expect(deps.embedding.baseURL).toBe("http://embeddings.test/v1");
+            // The register deps carry the RESOLVED provider instance advertising
+            // its width — the seam the per-analysis index is sized from.
+            expect(deps.embedding.dimensions).toBe(1536);
+            expect(deps.embedding.embed).toBeInstanceOf(Function);
             return async () => {};
         },
         initState: async () => {
@@ -91,7 +106,7 @@ describe("bootHarnessRuntime", () => {
         const result = await bootHarnessRuntime({ seams: recordingSeams(calls), config: testConfig() });
 
         const runtime = result._unsafeUnwrap();
-        expect(calls).toEqual(["readKey", "probeEmbedding", "postgres", "ingress", "initState", "register", "launch"]);
+        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding", "postgres", "ingress", "initState", "register", "launch"]);
         expect(runtime.model).toBe("claude-test-model");
         expect(runtime.triggerDeps.workflow).toBeInstanceOf(Function);
     });
@@ -127,30 +142,37 @@ describe("bootHarnessRuntime", () => {
         const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
         expect(result._unsafeUnwrapErr()).toMatchObject({ type: "postgres_unavailable" });
-        expect(calls).toEqual(["readKey", "probeEmbedding", "postgres"]);
+        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding", "postgres"]);
     });
 
-    test("missing embedding config fails before any side effect", async () => {
+    test("an unresolved embedder fails before any side effect past resolution", async () => {
         const calls: string[] = [];
-        const result = await bootHarnessRuntime({ seams: recordingSeams(calls), config: testConfig({ embedding: null }) });
+        const seams: BootSeams = {
+            ...recordingSeams(calls),
+            resolveEmbedding: () => {
+                calls.push("resolveEmbedding");
+                return err({ type: "embeddings_not_configured", message: "Embeddings are not configured." });
+            },
+        };
+        const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
-        expect(result._unsafeUnwrapErr()).toMatchObject({ type: "embedding_unconfigured" });
-        expect(calls).toEqual([]);
+        expect(result._unsafeUnwrapErr()).toMatchObject({ type: "embedding_unresolved", cause: { type: "embeddings_not_configured" } });
+        expect(calls).toEqual(["resolveEmbedding"]);
     });
 
-    test("an unreachable embedding endpoint blocks before postgres/ingress/launch", async () => {
+    test("a failing embedder probe blocks before postgres/ingress/launch", async () => {
         const calls: string[] = [];
         const seams: BootSeams = {
             ...recordingSeams(calls),
             probeEmbedding: async () => {
                 calls.push("probeEmbedding");
-                return err({ kind: "unreachable", baseURL: "http://embeddings.test/v1", detail: "HTTP 404" });
+                return err({ kind: "embed_failed", detail: "HTTP 404" });
             },
         };
         const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
-        expect(result._unsafeUnwrapErr()).toMatchObject({ type: "embedding_unreachable", detail: "HTTP 404" });
-        expect(calls).toEqual(["readKey", "probeEmbedding"]);
+        expect(result._unsafeUnwrapErr()).toMatchObject({ type: "embedding_probe_failed", detail: "HTTP 404" });
+        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding"]);
     });
 
     test("a wrong-dimension embedding model blocks before postgres/ingress/launch", async () => {
@@ -159,13 +181,13 @@ describe("bootHarnessRuntime", () => {
             ...recordingSeams(calls),
             probeEmbedding: async () => {
                 calls.push("probeEmbedding");
-                return err({ kind: "dimension_mismatch", baseURL: "http://embeddings.test/v1", expected: 1536, actual: 768 });
+                return err({ kind: "dimension_mismatch", expected: 1536, actual: 768 });
             },
         };
         const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
         expect(result._unsafeUnwrapErr()).toMatchObject({ type: "embedding_dimension_mismatch", expected: 1536, actual: 768 });
-        expect(calls).toEqual(["readKey", "probeEmbedding"]);
+        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding"]);
     });
 
     test("an invalid harness config block fails before any side effect", async () => {

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -10,24 +10,28 @@ import {
     createWorkspaceFilesystem,
     initCortexState,
     launchDbos,
+    makeLocalAuth,
     registerDataProfileWorkflow,
     shutdownDbos,
-    SEARCH_INDEX_DIMENSION,
+    type AgentSession,
     type DataProfileDeps,
     type DataProfileTriggerDeps,
     type DataProfileWorkflowInput,
     type DbosConfig,
+    type EmbeddingProvider,
     type Pool,
 } from "@inflexa-ai/harness";
 
+import { readConfig } from "../../lib/config.ts";
 import { env } from "../../lib/env.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";
 import { getLogger } from "../../lib/log.ts";
 import { onShutdown } from "../../lib/shutdown.ts";
+import { resolveEmbedder, type EmbeddingResolveError } from "../embedding/resolve.ts";
 import { ensurePostgresReady } from "../infra/postgres.ts";
 import type { PostgresConnection, PostgresError } from "../infra/postgres_types.ts";
 import { readApiKey, resolveModelId, type ChatSetupError } from "../intelligence/chat.ts";
-import { resolveHarnessConfig, type HarnessEmbeddingConfig, type ResolvedHarnessConfig } from "./config.ts";
+import { resolveHarnessConfig, type ResolvedHarnessConfig } from "./config.ts";
 import { startExecIngress, type ExecIngress, type IngressError } from "./ingress.ts";
 
 // The embedded-harness composition root. Boots lazily on the first profile
@@ -55,9 +59,9 @@ export type HarnessRuntime = {
 /** Why the runtime could not boot — each variant maps to one actionable user message. */
 export type HarnessBootError =
     | { type: "harness_config_invalid"; issues: string }
-    | { type: "embedding_unconfigured" }
-    | { type: "embedding_unreachable"; baseURL: string; detail: string }
-    | { type: "embedding_dimension_mismatch"; baseURL: string; expected: number; actual: number }
+    | { type: "embedding_unresolved"; cause: EmbeddingResolveError }
+    | { type: "embedding_probe_failed"; detail: string }
+    | { type: "embedding_dimension_mismatch"; expected: number; actual: number }
     | { type: "skills_dir_missing"; path: string | null }
     | { type: "proxy_key_missing"; cause: ChatSetupError }
     | { type: "model_unresolved"; cause: ChatSetupError }
@@ -67,56 +71,55 @@ export type HarnessBootError =
     | { type: "runtime_already_active"; holderPid: number }
     | { type: "runtime_boot_failed"; cause: unknown };
 
-/** Why the embedding probe failed — reachability vs. a servable-but-wrong-width model. */
-export type EmbeddingProbeError =
-    { kind: "unreachable"; baseURL: string; detail: string } | { kind: "dimension_mismatch"; baseURL: string; expected: number; actual: number };
+/** Why the embedding probe failed — a failed/hung embed call vs. a working-but-wrong-width model. */
+export type EmbeddingProbeError = { kind: "embed_failed"; detail: string } | { kind: "dimension_mismatch"; expected: number; actual: number };
+
+/** Ceiling on the probe embed. Generous for both realizations: an endpoint round-trip and the local GGUF's one-time model load. */
+const PROBE_TIMEOUT_MS = 15_000;
 
 /**
- * Boot-time probe for the embedding endpoint. Embeddings are consumed LATE in
+ * Boot-time probe of the resolved embedder. Embeddings are consumed LATE in
  * the profile workflow — after the sandbox agent already spent its LLM budget —
- * and both an unreachable endpoint AND a wrong-width model are fatal there: the
- * per-analysis pgvector index is pinned to {@link SEARCH_INDEX_DIMENSION}, so a
- * model of any other width is rejected at the vector upsert. One cheap real
- * embedding up front converts both expensive late failures into free early ones.
- * A real POST rather than an OPTIONS/HEAD sniff: OpenAI-compatible servers
- * disagree on everything except the actual call, and only the actual response
- * carries the vector length we need to check.
+ * and a broken embedder AND a wrong-width model are both fatal there: the
+ * per-analysis pgvector index is sized to `provider.dimensions`, so vectors of
+ * any other width are rejected at the upsert. One real embed up front converts
+ * both expensive late failures into free early ones.
+ *
+ * The probe goes through the very provider instance the workflow will use —
+ * mode-agnostic by construction: for `api-key` it is the real endpoint
+ * round-trip; for `local` it loads the GGUF and warms the provider's cached
+ * runtime (same process), so the cost is not wasted.
  */
-async function probeEmbeddingEndpoint(embedding: HarnessEmbeddingConfig): Promise<Result<void, EmbeddingProbeError>> {
-    try {
-        const res = await fetch(`${embedding.baseURL.replace(/\/$/, "")}/embeddings`, {
-            method: "POST",
-            headers: { "content-type": "application/json", authorization: `Bearer ${embedding.token}` },
-            body: JSON.stringify({ model: embedding.model, input: ["ping"], encoding_format: "float" }),
-            signal: AbortSignal.timeout(15_000),
-        });
-        if (!res.ok) {
-            return err({ kind: "unreachable", baseURL: embedding.baseURL, detail: `HTTP ${res.status}` });
-        }
-        // Verify the model's dimension against the pinned index width. Parse
-        // defensively: on any nonstandard-but-200 shape we can't read a length
-        // from, accept reachability rather than false-block a working endpoint —
-        // the dimension check is a best-effort early warning, not a gate.
-        const body: unknown = await res.json(); // external response; shape narrowed below before use
-        const actual = extractEmbeddingLength(body);
-        if (actual !== null && actual !== SEARCH_INDEX_DIMENSION) {
-            return err({ kind: "dimension_mismatch", baseURL: embedding.baseURL, expected: SEARCH_INDEX_DIMENSION, actual });
-        }
-        return ok(undefined);
-    } catch (cause) {
-        return err({ kind: "unreachable", baseURL: embedding.baseURL, detail: cause instanceof Error ? cause.message : String(cause) });
+async function probeEmbeddingProvider(provider: EmbeddingProvider): Promise<Result<void, EmbeddingProbeError>> {
+    // A minimal local session: the probe is identity-less work and the wired
+    // billing resolver is the noop one, but the seam (correctly) refuses calls
+    // without a session.
+    const probeSession: AgentSession = {
+        identity: { user: "local" },
+        scope: { kind: "analysis", analysisId: "embedding-boot-probe" },
+        provenance: { agentId: "embedding-boot-probe", callPath: ["embedding-boot-probe"] },
+        auth: makeLocalAuth(),
+    };
+    const checked: Promise<Result<void, EmbeddingProbeError>> = provider.embed(["ping"], probeSession).match(
+        (vectors): Result<void, EmbeddingProbeError> => {
+            const actual = vectors[0]?.length ?? 0;
+            return actual === provider.dimensions ? ok(undefined) : err({ kind: "dimension_mismatch", expected: provider.dimensions, actual });
+        },
+        (e): Result<void, EmbeddingProbeError> => err({ kind: "embed_failed", detail: e.message }),
+    );
+    // `EmbeddingProvider.embed` takes no AbortSignal, so a hung call can only be
+    // raced, not cancelled — the loser is abandoned, which is fine at boot: on
+    // timeout we fail the boot, and on success the process runs long past it.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), PROBE_TIMEOUT_MS);
+    });
+    const outcome = await Promise.race([checked, timeout]);
+    clearTimeout(timer);
+    if (outcome === "timeout") {
+        return err({ kind: "embed_failed", detail: `no embedding after ${PROBE_TIMEOUT_MS / 1000}s` });
     }
-}
-
-/** Pull `data[0].embedding.length` from an OpenAI-compatible embeddings response, or null if the shape isn't the expected `{ data: [{ embedding: number[] }] }`. */
-function extractEmbeddingLength(body: unknown): number | null {
-    if (typeof body !== "object" || body === null || !("data" in body)) return null;
-    const data = (body as { data: unknown }).data;
-    if (!Array.isArray(data) || data.length === 0) return null;
-    const first = data[0];
-    if (typeof first !== "object" || first === null || !("embedding" in first)) return null;
-    const vec = (first as { embedding: unknown }).embedding;
-    return Array.isArray(vec) ? vec.length : null;
+    return outcome;
 }
 
 /**
@@ -128,10 +131,11 @@ export type BootSeams = {
     readonly startIngress: () => Result<ExecIngress, IngressError>;
     readonly readKey: () => Promise<Result<string, ChatSetupError>>;
     readonly resolveModel: (apiKey: string) => Promise<Result<string, ChatSetupError>>;
+    readonly resolveEmbedding: () => Result<EmbeddingProvider, EmbeddingResolveError>;
     readonly register: (deps: DataProfileDeps) => (input: DataProfileWorkflowInput) => Promise<void>;
     readonly initState: (pool: Pool) => Promise<void>;
     readonly launch: (args: { config: DbosConfig; logger: pino.Logger }) => Promise<void>;
-    readonly probeEmbedding: typeof probeEmbeddingEndpoint;
+    readonly probeEmbedding: typeof probeEmbeddingProvider;
 };
 
 const realSeams: BootSeams = {
@@ -139,10 +143,11 @@ const realSeams: BootSeams = {
     startIngress: () => startExecIngress(),
     readKey: readApiKey,
     resolveModel: resolveModelId,
+    resolveEmbedding: () => resolveEmbedder(readConfig()),
     register: registerDataProfileWorkflow,
     initState: initCortexState,
     launch: launchDbos,
-    probeEmbedding: probeEmbeddingEndpoint,
+    probeEmbedding: probeEmbeddingProvider,
 };
 
 /**
@@ -185,29 +190,31 @@ export async function bootHarnessRuntime(
     if (cfg.configError) return err({ type: "harness_config_invalid", issues: cfg.configError.issues });
 
     // Prerequisites that no amount of booting can heal — checked before any
-    // side effect so a misconfigured run costs nothing. Embeddings are their
-    // own endpoint (baseURL + API key), deliberately a separate path from the
-    // chat proxy: the proxy fronts OAuth chat providers and serves no
-    // embeddings route, so there is nothing to default to.
-    if (cfg.embedding === null) return err({ type: "embedding_unconfigured" });
+    // side effect so a misconfigured run costs nothing. The embedder comes from
+    // the top-level `embedding` config key (the single embedding surface,
+    // written by `inflexa setup --embeddings`), never from the chat proxy: the
+    // proxy fronts OAuth chat providers and serves no embeddings route.
     if (cfg.skillsDir === null || !existsSync(cfg.skillsDir)) {
         return err({ type: "skills_dir_missing", path: cfg.skillsDir });
     }
+    const embedderResult = seams.resolveEmbedding();
+    if (embedderResult.isErr()) return err({ type: "embedding_unresolved", cause: embedderResult.error });
+    const embedding = embedderResult.value;
 
     const keyResult = await seams.readKey();
     if (keyResult.isErr()) return err({ type: "proxy_key_missing", cause: keyResult.error });
     const apiKey = keyResult.value;
 
-    // Probe the configured endpoint before anything expensive: embeddings are
+    // Probe the resolved embedder before anything expensive: embeddings are
     // consumed LATE in the profile workflow (after the sandbox agent spent its
-    // LLM budget) and an unreachable endpoint is fatal there, so reachability
-    // is verified while failure is still free.
-    const probeResult = await seams.probeEmbedding(cfg.embedding);
+    // LLM budget) and a broken embedder is fatal there, so one real embed is
+    // verified while failure is still free.
+    const probeResult = await seams.probeEmbedding(embedding);
     if (probeResult.isErr()) {
         const e = probeResult.error;
         return e.kind === "dimension_mismatch"
-            ? err({ type: "embedding_dimension_mismatch", baseURL: e.baseURL, expected: e.expected, actual: e.actual })
-            : err({ type: "embedding_unreachable", baseURL: e.baseURL, detail: e.detail });
+            ? err({ type: "embedding_dimension_mismatch", expected: e.expected, actual: e.actual })
+            : err({ type: "embedding_probe_failed", detail: e.detail });
     }
 
     const autoResolvedModel = cfg.model === null;
@@ -283,8 +290,7 @@ export async function bootHarnessRuntime(
             model,
             runAuthorizer: createLocalRunAuthorizer(),
             bioKeys: cfg.bioKeys,
-            resolveBilling,
-            embedding: cfg.embedding,
+            embedding,
             skillsDir: cfg.skillsDir,
         });
 

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -33,6 +33,8 @@ type SetupOptions = {
     force: boolean;
     /** Whether to provision Postgres (default true; `--no-postgres` sets false). */
     postgres: boolean;
+    /** Preselected embedding mode from `--embeddings`; overrides the interactive prompt. */
+    embeddings?: "local" | "api-key" | "off";
 };
 
 export async function setup(options: SetupOptions): Promise<void> {
@@ -142,6 +144,19 @@ export async function setup(options: SetupOptions): Promise<void> {
             pgConn = resolvePostgresConfig();
         }
 
+        // --- embeddings ---
+        // Runs after auth + postgres, before "Setup complete". The interactive
+        // prompt (clack select) offers local / api-key / off; a non-TTY shell or
+        // a preselected `--embeddings` mode skips the prompt. See
+        // modules/embedding/setup.ts.
+        const { runEmbeddingSetup } = await import("../embedding/setup.ts");
+        const embedResult = await runEmbeddingSetup(process.stdin.isTTY, options.embeddings);
+        if (embedResult.isErr()) {
+            log.error(`Embedding setup: ${embedResult.error.message}`);
+            process.exitCode = 1;
+            return;
+        }
+
         printNextSteps(options, pgConn);
         outro("Setup complete");
     } catch (error) {
@@ -218,6 +233,7 @@ function printNextSteps(options: SetupOptions, conn: PostgresConnection): void {
     } else if (!options.postgres) {
         lines.push("Postgres provisioning skipped (--no-postgres).");
     }
+    lines.push("Embeddings: run `inflexa setup --embeddings local` (in-process) or `--embeddings api-key`.");
     if (!options.start) {
         lines.push("Containers start automatically on next `inflexa` run.");
     }
@@ -502,6 +518,16 @@ export async function ensureProxyReady(): Promise<Result<void, ProxyError | Cont
     const upResult = await composeUp(rt);
     if (upResult.isErr()) {
         return err(new ProxyError(`Failed to start containers: ${upResult.error.message}`));
+    }
+
+    // Embedding readiness gate: if the user previously opted into local mode,
+    // ensure the GGUF is still present. We do NOT run the interactive setup
+    // prompt here (that belongs to `inflexa setup`) — a missing model after a
+    // prior opt-in surfaces as an actionable error.
+    const { ensureEmbedderReady } = await import("../embedding/setup.ts");
+    const embedResult = await ensureEmbedderReady();
+    if (embedResult.isErr()) {
+        return err(new ProxyError(`Embeddings: ${embedResult.error.message}`));
     }
 
     return ok(undefined);

--- a/cli/src/tui/keymap_config.test.ts
+++ b/cli/src/tui/keymap_config.test.ts
@@ -13,7 +13,7 @@ function key(name: string, mods: Partial<Pick<KeyLike, "ctrl" | "meta" | "option
 }
 
 function writeKeybinds(keybinds: Record<string, string>): void {
-    writeConfig({ telemetry: false, theme: DEFAULT_THEME_ID, runtime: "docker", leaderTimeout: 2000, keybinds })._unsafeUnwrap();
+    writeConfig({ telemetry: false, theme: DEFAULT_THEME_ID, runtime: "docker", leaderTimeout: 2000, embedding: { mode: "off" }, keybinds })._unsafeUnwrap();
     __resetKeybindCache(); // keybinds resolve load-once; drop the cache so the new config is read
 }
 

--- a/harness/src/app/synthesize-run.test.ts
+++ b/harness/src/app/synthesize-run.test.ts
@@ -14,12 +14,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Pool } from "pg";
 
+import { okAsync } from "neverthrow";
+
 import { makeMessage, scriptedProvider, textBlock, toolUseBlock } from "../loop/__fixtures__/scripted-provider.js";
 import { makeLocalAuth } from "../auth/local-auth-context.js";
 import type { RunSession } from "../auth/types.js";
 import type { EmitFn } from "../loop/types.js";
 import type { BioToolKeys } from "../tools/bio/keys.js";
-import { synthesizeRun, type SynthesisEmbedder, type SynthesizeRunDeps } from "./synthesize-run.js";
+import { synthesizeRun, type SynthesizeRunDeps } from "./synthesize-run.js";
 
 const ANALYSIS_ID = "analysis-001";
 const RUN_ID = "run-001";
@@ -99,15 +101,18 @@ async function makeHarness(provider: SynthesizeRunDeps["provider"], opts: { with
         await writeFile(join(outDir, "summary.md"), "## results\n\nFOXP3 up.");
     }
     let embedderCalls = 0;
-    const embedder: SynthesisEmbedder = async () => {
-        embedderCalls++;
-        return new Array(1536).fill(0.01);
+    const embedding: SynthesizeRunDeps["embedding"] = {
+        dimensions: 1536,
+        embed: (texts) => {
+            embedderCalls++;
+            return okAsync(texts.map(() => new Array(1536).fill(0.01)));
+        },
     };
     return {
         deps: {
             pool: emptyPool(),
             provider,
-            embedder,
+            embedding,
             sessionsBasePath: base,
             synthesisModel: "claude-test",
             bioKeys: BIO_KEYS,

--- a/harness/src/app/synthesize-run.ts
+++ b/harness/src/app/synthesize-run.ts
@@ -6,9 +6,9 @@
  * and reports progress phases — returning the quick-display findings for the
  * run-completed card.
  *
- * Owns the ability end-to-end; owns no transport. The injected `embedder`
- * carries the embedder's own billing (a no-op locally); `emit` is the
- * loop/chat-part sink the caller binds to its stream; `onProgress`
+ * Owns the ability end-to-end; owns no transport. The injected `embedding`
+ * provider carries the host's own billing choice (a no-op locally); `emit` is
+ * the loop/chat-part sink the caller binds to its stream; `onProgress`
  * is the domain progress callback the caller serializes to the wire. A genuine
  * synthesis failure re-throws (D10) so the caller fails the run loudly; the
  * honest non-fatal outcomes (no summaries, blocker) return empty findings after
@@ -19,10 +19,10 @@ import type { Pool } from "pg";
 
 import type { SynthesisPhase } from "@inflexa-ai/harness/contracts/chat-parts.js";
 
-import type { AgentSession, RunSession } from "../auth/types.js";
+import type { RunSession } from "../auth/types.js";
 import { forSubAgent } from "../auth/types.js";
 import type { EmitFn } from "../loop/types.js";
-import type { ChatProvider } from "../providers/types.js";
+import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
 import type { BioToolKeys } from "../tools/bio/keys.js";
 import type { RunFinding } from "../workflows/execute-analysis.js";
 import {
@@ -37,14 +37,11 @@ import { createVectorStore } from "../state/vector-store.js";
 import { loadPlan, queryRun } from "../state/index.js";
 import { unwrapOrThrow } from "../lib/result.js";
 
-/** Session-bound text→vector embedder (the `createEmbedder` return shape). */
-export type SynthesisEmbedder = (text: string, session: AgentSession) => Promise<number[]>;
-
 export interface SynthesizeRunDeps {
     readonly pool: Pool;
     readonly provider: ChatProvider;
-    /** Injected embedder — carries the embedder's own billing choice. */
-    readonly embedder: SynthesisEmbedder;
+    /** Write-side embedder — its `dimensions` sizes the per-analysis index. */
+    readonly embedding: EmbeddingProvider;
     readonly sessionsBasePath: string;
     /** Model id for the synthesizer agent loop. */
     readonly synthesisModel: string;
@@ -76,7 +73,7 @@ export interface SynthesizeRunResult {
 }
 
 export async function synthesizeRun(deps: SynthesizeRunDeps, params: SynthesizeRunParams): Promise<SynthesizeRunResult> {
-    const { pool, provider, embedder, sessionsBasePath, synthesisModel, bioKeys } = deps;
+    const { pool, provider, embedding, sessionsBasePath, synthesisModel, bioKeys } = deps;
     const { analysisId, runId, completedSteps, session, emit, onProgress } = params;
 
     await onProgress("starting", "Beginning literature-grounded synthesis");
@@ -118,15 +115,16 @@ export async function synthesizeRun(deps: SynthesizeRunDeps, params: SynthesizeR
 
         await onProgress("indexing", "Indexing synthesis for search");
         try {
-            await ensureSearchIndex(pool, analysisId);
+            await ensureSearchIndex(pool, analysisId, embedding.dimensions);
             const vectorStore = createVectorStore(pool);
             const indexName = searchIndexName(analysisId);
             const synthesisText = formatSynthesisEmbeddingText(synthesis);
-            const embedding = await embedder(synthesisText, synthesizerSession);
+            const [vector] = unwrapOrThrow(await embedding.embed([synthesisText], synthesizerSession));
+            if (!vector) throw new Error("synthesize-run: empty embedding response");
             unwrapOrThrow(
                 await vectorStore.upsert({
                     indexName,
-                    vectors: [embedding],
+                    vectors: [vector],
                     metadata: [{ text: synthesisText, type: "synthesis", runId }],
                     ids: [`/${analysisId}/runs/${runId}/synthesis.json`],
                 }),

--- a/harness/src/execution/post-step-pipeline.ts
+++ b/harness/src/execution/post-step-pipeline.ts
@@ -184,7 +184,7 @@ export async function vectorIndexStepOutputs(deps: PostStepPipelineDeps, postCtx
     const { metadataEntries, summary, reconciledManifest } = artifacts;
 
     try {
-        await ensureSearchIndex(deps.pool, input.analysisId);
+        await ensureSearchIndex(deps.pool, input.analysisId, deps.embedding.dimensions);
         const vectorStore = createVectorStore(deps.pool);
         const indexName = searchIndexName(input.analysisId);
 

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -104,11 +104,6 @@ export { upsertAnalysis } from "./state/analyses.js";
 export { loadDataProfileStatus, tryRetryDataProfile, reconcileOrphanedDataProfile } from "./state/data-profile.js";
 export type { DataProfileStatus } from "./state/data-profile.js";
 
-// Embedding vector width the per-analysis pgvector index is pinned to; a host
-// verifies its configured embedding model emits this many dimensions before a
-// run rather than failing at the vector upsert after the sandbox spend.
-export { SEARCH_INDEX_DIMENSION } from "./workspace/search-config.js";
-
 // Staged-input manifest contract (the embedder stages; the harness only reads).
 export type { StagedInput } from "./execution/staged-input.js";
 

--- a/harness/src/providers/embedding.ts
+++ b/harness/src/providers/embedding.ts
@@ -16,6 +16,8 @@ import type { EmbeddingProvider, FetchLike } from "./types.js";
 import type { AgentSession } from "../auth/types.js";
 
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+/** Vector width of the default model — `text-embedding-3-small` emits 1536-dim vectors. */
+const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 
 export interface EmbeddingProviderDeps {
     /** Billing-gateway base URL — all embedding traffic is routed through it. */
@@ -24,6 +26,13 @@ export interface EmbeddingProviderDeps {
     readonly token: string;
     /** Embedding model id. Defaults to `text-embedding-3-small`. */
     readonly model?: string;
+    /**
+     * Vector width the configured model emits, advertised on the returned
+     * provider (see {@link EmbeddingProvider.dimensions}). Defaults to the
+     * default model's 1536 — a host wiring a non-default `model` must supply
+     * the matching width or the per-analysis index is created at the wrong size.
+     */
+    readonly dimensions?: number;
     /** Resolves the billing attribution map at the call site. */
     readonly resolveBilling: ResolveBilling;
     /**
@@ -40,6 +49,7 @@ export function createEmbeddingProvider(deps: EmbeddingProviderDeps): EmbeddingP
         ...(deps.fetch ? { fetch: deps.fetch } : {}),
     });
     const model = deps.model ?? DEFAULT_EMBEDDING_MODEL;
+    const dimensions = deps.dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
 
     function embed(texts: readonly string[], session: AgentSession): ResultAsync<number[][], ProviderError> {
         if (texts.length === 0) return okAsync([]);
@@ -59,5 +69,5 @@ export function createEmbeddingProvider(deps: EmbeddingProviderDeps): EmbeddingP
         return new ResultAsync(run());
     }
 
-    return { embed };
+    return { embed, dimensions };
 }

--- a/harness/src/providers/types.ts
+++ b/harness/src/providers/types.ts
@@ -47,6 +47,14 @@ export interface ChatProvider extends AgentChat {
 }
 
 export interface EmbeddingProvider {
+    /**
+     * Width of every vector `embed` returns. The write-side index paths create
+     * each per-analysis pgvector index at exactly this width (`ensureSearchIndex`),
+     * so the provider — not a harness constant — is the single source of the
+     * dimension. A provider advertising a width its model does not emit fails at
+     * the vector upsert, not here.
+     */
+    readonly dimensions: number;
     embed(texts: readonly string[], session: AgentSession): ResultAsync<number[][], ProviderError>;
 }
 

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -28,13 +28,11 @@ import type { StagedInput } from "../execution/staged-input.js";
 import { createDataProfilerAgent } from "../agents/sandbox/data-profiler.js";
 import type { SandboxAgentDeps } from "../agents/sandbox/shared.js";
 import type { BioToolKeys } from "../tools/bio/keys.js";
-import type { ResolveBilling } from "../billing/resolver.js";
 import { runToTerminal } from "../loop/run-to-terminal.js";
 import { durableStep } from "../loop/run-step.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { defineTool } from "../tools/define-tool.js";
-import type { ChatProvider } from "../providers/types.js";
-import { createEmbeddingProvider } from "../providers/embedding.js";
+import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
 import type { SandboxClient } from "../sandbox/client.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
 
@@ -44,7 +42,7 @@ import { mintSandboxIdentity } from "../sandbox/identity.js";
 import { createVectorStore } from "../state/vector-store.js";
 import { ProfilerOutputSchema, type ProfilerOutput } from "../schemas/data-profile-schemas.js";
 import { completeDataProfile, failDataProfile, loadDataProfileStatus, tryRerunDataProfile, tryStartDataProfile, upsertArtifacts } from "../state/index.js";
-import { createEmbedder, ensureSearchIndex, searchIndexName } from "../workspace/search-config.js";
+import { ensureSearchIndex, searchIndexName } from "../workspace/search-config.js";
 
 /** Synthetic run/step literal for the data-profile workflow. */
 const DATA_PROFILE_RUN_LITERAL = "data-profile" as const;
@@ -66,14 +64,13 @@ export interface DataProfileDeps {
     readonly runAuthorizer: RunAuthorizer;
     /** API keys for the bio/chem tools the profiler sandbox agent may use. */
     readonly bioKeys: BioToolKeys;
-    /** Billing resolver threaded into the write-side embedder. */
-    readonly resolveBilling: ResolveBilling;
-    /** Embedding-provider config for the write-side vector indexer. */
-    readonly embedding: {
-        readonly model: string;
-        readonly baseURL: string;
-        readonly token: string;
-    };
+    /**
+     * Write-side embedder for the vector indexer. An instance, not endpoint
+     * config: the host composes its own realization (cloud endpoint, local
+     * in-process model, …) and the provider's `dimensions` sizes the
+     * per-analysis index — matching every other write-side workflow dep.
+     */
+    readonly embedding: EmbeddingProvider;
     /** Absolute path to the skills tree (one subdirectory per skill). */
     readonly skillsDir: string;
 }
@@ -209,12 +206,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                 pool: deps.pool,
                 sandboxClient: deps.sandboxClient,
                 workspaceFs: deps.workspaceFs,
-                embedding: createEmbeddingProvider({
-                    baseURL: deps.embedding.baseURL,
-                    token: deps.embedding.token,
-                    model: deps.embedding.model,
-                    resolveBilling: deps.resolveBilling,
-                }),
+                embedding: deps.embedding,
                 model: deps.model,
                 skillsDir: deps.skillsDir,
                 bioKeys: deps.bioKeys,
@@ -283,14 +275,13 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                     .replace(/^\/|\/$/g, "")
                     .trim();
             const profilerByNorm = new Map(profilerData.files.map((f) => [normPath(f.path), f]));
-            await ensureSearchIndex(deps.pool, analysisId);
+            await ensureSearchIndex(deps.pool, analysisId, deps.embedding.dimensions);
             const vectorStore = createVectorStore(deps.pool);
-            const embedder = createEmbedder({
-                embeddingModel: deps.embedding.model,
-                baseURL: deps.embedding.baseURL,
-                token: deps.embedding.token,
-                resolveBilling: deps.resolveBilling,
-            });
+            const embedOne = async (text: string, session: RunSession): Promise<number[]> => {
+                const [vec] = unwrapOrThrow(await deps.embedding.embed([text], session));
+                if (!vec) throw new Error("data-profile: empty embedding response");
+                return vec;
+            };
             const indexName = searchIndexName(analysisId);
             let indexed = 0;
             let fallbackCount = 0;
@@ -318,7 +309,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                       };
                 if (!desc) fallbackCount++;
 
-                const embedding = await embedder(searchMeta.text as string, runSession);
+                const embedding = await embedOne(searchMeta.text as string, runSession);
                 unwrapOrThrow(
                     await vectorStore.upsert({
                         indexName,

--- a/harness/src/tools/workspace/workspace-display.test.ts
+++ b/harness/src/tools/workspace/workspace-display.test.ts
@@ -10,6 +10,7 @@ import { showUserTool } from "../display/show-user.js";
 import { createWorkspaceSearchTool } from "./workspace-search.js";
 
 const fakeEmbedding: EmbeddingProvider = {
+    dimensions: 3,
     embed: (texts) => okAsync(texts.map(() => [0.1, 0.2, 0.3])),
 };
 

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -73,7 +73,7 @@ import type { EmitFn } from "../loop/types.js";
 import type { RunCharge } from "../billing/run-charge.js";
 import { runDir } from "../workspace/paths.js";
 import { isChatDataPart } from "../sandbox/sandbox-step-translate.js";
-import { synthesizeRun, type SynthesisEmbedder } from "../app/synthesize-run.js";
+import { synthesizeRun } from "../app/synthesize-run.js";
 import { type PlanStep, computeTopologicalLevels, scheduleReady, validatePlanDag } from "./execute-analysis-scheduler.js";
 import { recordCancelledChild } from "./metrics.js";
 import { BUDGET_EXCEEDED_TOPIC, type BudgetExceededNotification, type SandboxStepInput, type SandboxStepResult } from "./sandbox-step.js";
@@ -237,7 +237,6 @@ export function synthesizeFindings(args: {
     deps: ExecuteAnalysisDeps;
 }): Promise<{ findings: readonly RunFinding[] }> {
     const { analysisId, runId, completedSteps, session, deps } = args;
-    const embedder: SynthesisEmbedder = async (text, embedSession) => unwrapOrThrow(await deps.embedding.embed([text], embedSession))[0];
     const emit: EmitFn = (event) => {
         const part = isChatDataPart(event)
             ? event
@@ -251,7 +250,7 @@ export function synthesizeFindings(args: {
         {
             pool: deps.pool,
             provider: deps.provider,
-            embedder,
+            embedding: deps.embedding,
             sessionsBasePath: deps.sessionsBasePath,
             synthesisModel: deps.synthesisModel,
             bioKeys: deps.bioKeys,

--- a/harness/src/workspace/search-config.ts
+++ b/harness/src/workspace/search-config.ts
@@ -1,5 +1,5 @@
 /**
- * Shared search configuration — vector store, embedder, and index naming.
+ * Shared search configuration — vector index naming and creation.
  *
  * Used by both write-time workspaces (sandbox, data-profile) and
  * read-time workspaces (chat, workflow agents) so they share the
@@ -10,51 +10,10 @@ import type { Pool } from "pg";
 
 import { createVectorStore } from "../state/vector-store.js";
 import { unwrapOrThrow } from "../lib/result.js";
-import { createEmbeddingProvider } from "../providers/embedding.js";
-import type { ResolveBilling } from "../billing/resolver.js";
-import type { AgentSession } from "../auth/types.js";
-
-/**
- * Embedding vector width every per-analysis pgvector index is created with
- * (`text-embedding-3-small`). The single source of the pin: `ensureSearchIndex`
- * builds the column at this width, so an embedder must supply a model that
- * emits exactly this many dimensions or the vector upsert rejects at write
- * time. Exported so a host can verify its configured embedding model up front
- * instead of failing deep in the profile workflow.
- */
-export const SEARCH_INDEX_DIMENSION = 1536;
 
 /** Derive the vector index name for an analysis. */
 export function searchIndexName(resourceId: string): string {
     return `search_${resourceId.replace(/-/g, "_")}`;
-}
-
-/**
- * Build a session-bound embedder. The returned function is a thin wrapper
- * around the harness `EmbeddingProvider` (billing assembled from the session
- * by the provider's resolver) — write-side callers (data-profile, build-deps) thread
- * the per-run session through so embeddings are attributed.
- */
-export function createEmbedder(cfg: {
-    embeddingModel: string;
-    baseURL: string;
-    token: string;
-    resolveBilling: ResolveBilling;
-}): (text: string, session: AgentSession) => Promise<number[]> {
-    if (!cfg.baseURL || !cfg.token) {
-        throw new Error("createEmbedder: baseURL and token must be set");
-    }
-    const provider = createEmbeddingProvider({
-        baseURL: cfg.baseURL,
-        token: cfg.token,
-        model: cfg.embeddingModel,
-        resolveBilling: cfg.resolveBilling,
-    });
-    return async (text, session) => {
-        const [vec] = unwrapOrThrow(await provider.embed([text], session));
-        if (!vec) throw new Error("createEmbedder: empty embedding response");
-        return vec;
-    };
 }
 
 const _ensuredIndexes = new Set<string>();
@@ -63,15 +22,22 @@ const _ensuredIndexes = new Set<string>();
  * Ensure the per-analysis pgvector index exists and has an HNSW index
  * attached. Idempotent across the process lifetime and across concurrent
  * replicas (`CREATE … IF NOT EXISTS`).
+ *
+ * `dimensions` is the wired `EmbeddingProvider.dimensions` — the provider is
+ * the single source of the vector width, so indexes created here always match
+ * what the write-side embedder emits. A pre-existing index created at another
+ * width is left as-is (`IF NOT EXISTS`); the mismatch surfaces at the vector
+ * upsert. Per-analysis dimension tracking / re-embedding on a provider switch
+ * is a deliberate non-feature for now.
  */
-export async function ensureSearchIndex(pool: Pool, resourceId: string): Promise<void> {
+export async function ensureSearchIndex(pool: Pool, resourceId: string, dimensions: number): Promise<void> {
     const name = searchIndexName(resourceId);
     if (_ensuredIndexes.has(name)) return;
     const store = createVectorStore(pool);
     unwrapOrThrow(
         await store.createIndex({
             indexName: name,
-            dimension: SEARCH_INDEX_DIMENSION,
+            dimension: dimensions,
             metric: "cosine",
         }),
     );


### PR DESCRIPTION
## What

Adds a CLI-side `EmbeddingProvider` realization that runs `bge-small-en-v1.5` (GGUF, q8_0, 384-dim) in-process via `node-llama-cpp`, L2-normalizes every vector, and implements the harness `EmbeddingProvider` seam. `node-llama-cpp` is an optional dependency with a lazy dynamic import — a plain `bun install` never fetches native binaries; they are fetched at setup-yes time via `bun pm trust`.

## Why

Local-only CLI mode routed LLM chat through the user's own OAuth/API keys via CLIProxyAPI, but embeddings had no local option — they required an OpenAI API key pointed at a billing gateway. This gives the CLI a self-contained, offline-capable embedding path that downloads once and runs without a daemon or API key, while still offering the API-key path for users who prefer it.

## Changes

- **config** (`lib/config.ts`): `embedding { mode: local|api-key|off, modelPath?, apiKey? }` — defaults to `off`
- **env** (`lib/env.ts`): `modelDir` + `embeddingModelPath` under `<dataDir>/inflexa/models/`, surfaced in `--help`
- **`modules/embedding/local-provider.ts`**: `createLocalEmbeddingProvider` — lazy native load via dynamic `import("node-llama-cpp")` on first `embed()`, L2-normalizes every vector (GGUF emits un-normalized, norm ≈ 9.24), concurrency-capped at 4, import-failure → `ProviderError` (no throw)
- **`modules/embedding/resolve.ts`**: `resolveEmbedder(config)` — config-driven mode resolution (`local` → local provider, `api-key` → harness `createEmbeddingProvider`, `off` → error)
- **`modules/embedding/setup.ts`**: `downloadModel` (streamed w/ progress, skip-if-present), `verifyModel` (load + embed probe + 384-dim check), `runEmbeddingSetup` (interactive prompt, non-TTY skip), `ensureEmbedderReady` (hot-path gate)
- **`modules/proxy/setup.ts`**: embedding question wired after auth in `setup()`; `ensureEmbedderReady` gate in `ensureProxyReady()`; `--embeddings <mode>` flag
- **`cli/index.ts`**: `--embeddings local|api-key|off` flag + help text
- **deps**: `node-llama-cpp@^3.19.0` in `optionalDependencies`; `@inflexa-ai/harness` added as `file:../harness` (built `dist/`)

## Non-goals (deferred)

No vector store, no `assembleCoreRuntime` wiring, no harness changes. The provider returns `number[][]` ready to inject when the CLI wires the harness.

## Validation

- `bun run typecheck` — clean (only pre-existing `bus.ts` errors)
- `bun run lint` — zero net-new errors
- `bun test` — 262 pass, 0 fail (incl. 14 new embedding tests)
- Smoke: `inflexa setup --embeddings local` → GGUF downloads (35 MB), verifies (384-dim), config written (`embedding.mode = local`), exit 0
- Smoke: non-TTY `inflexa setup` → embedding question skipped, no hang, no download

Spec: `local-embeddings` (new capability). OpenSpec change archived.