### PR TITLE
Add library-validator smoke-test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ dist-ssr
 # TypeScript incremental build info
 *.tsbuildinfo
 
+# Python bytecode cache (e.g. from cli/scripts/lib-validator/*.py smoke tests)
+__pycache__/
+*.py[cod]
+
 # Guard against tsc emitting alongside source. the harness builds to harness/dist (ignored
 # above); these catch an accidental in-place emit. Scoped to core, NOT blanket
 # **/src — cli/src ships a hand-written assets.d.ts that must stay tracked.

--- a/cli/scripts/lib-validator/ALDEx2.R
+++ b/cli/scripts/lib-validator/ALDEx2.R
@@ -1,0 +1,106 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ALDEx2` package (ANOVA-Like Differential Expression /
+# CLR-based compositional differential abundance).
+#
+# Fully self-contained: no input files, no network, no packages beyond ALDEx2
+# itself. The reads matrix is simulated with a fixed seed; ALDEx2's Monte-Carlo
+# instances make exact values non-deterministic, so every check is structural
+# (table shape, required columns, one row per feature) rather than exact
+# floating-point equality. Exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript ALDEx2.R
+#
+# FLAG (orientation): ALDEx2 expects the reads matrix as FEATURES (rows) x
+# SAMPLES (columns) -- the transpose of most tidy count tables -- and the
+# conditions vector aligns with the COLUMNS. This is the classic ALDEx2
+# footgun; the fixture below is oriented that way on purpose.
+
+if (!requireNamespace("ALDEx2", quietly = TRUE)) {
+  cat("FAIL: package 'ALDEx2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ALDEx2))
+cat(sprintf("ALDEx2 version: %s\n", as.character(packageVersion("ALDEx2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: 100 features (rows) x 10 samples (columns) of Poisson counts, two
+# conditions of 5 samples each. A modest number of Monte-Carlo instances keeps
+# the run fast while still exercising the full CLR pipeline.
+set.seed(1)
+n_features <- 100L
+n_samples <- 10L
+reads <- matrix(
+  rpois(n_features * n_samples, lambda = 20),
+  nrow = n_features,
+  ncol = n_samples,
+  dimnames = list(sprintf("f%03d", seq_len(n_features)),
+                  sprintf("s%02d", seq_len(n_samples)))
+)
+conds <- c(rep("A", n_samples / 2L), rep("B", n_samples / 2L))
+mc <- 8L
+
+# aldex.clr's per-instance sampling prints a progress line per Monte-Carlo
+# draw; suppressMessages keeps the log clean. Genuine errors still propagate.
+build_clr <- function() {
+  suppressMessages(ALDEx2::aldex.clr(reads, conds, mc.samples = mc, verbose = FALSE))
+}
+
+run_test("aldex.clr: builds a CLR object over the feature x sample matrix", function() {
+  x <- build_clr()
+  stopifnot(!is.null(x))
+  # numFeatures / numMCInstances are the documented accessors on the clr object.
+  stopifnot(ALDEx2::numFeatures(x) == n_features)
+  stopifnot(ALDEx2::numMCInstances(x) == mc)
+})
+
+run_test("aldex.ttest: t-test table has we.ep / wi.ep, one row per feature", function() {
+  x <- build_clr()
+  tt <- ALDEx2::aldex.ttest(x)
+  stopifnot(is.data.frame(tt))
+  stopifnot(nrow(tt) == n_features)
+  stopifnot(all(c("we.ep", "we.eBH", "wi.ep", "wi.eBH") %in% colnames(tt)))
+  # p-values are bounded in [0, 1].
+  stopifnot(all(tt$we.ep >= 0 & tt$we.ep <= 1))
+  stopifnot(all(tt$wi.ep >= 0 & tt$wi.ep <= 1))
+})
+
+run_test("aldex.effect: effect table has effect / diff.btw, one row per feature", function() {
+  x <- build_clr()
+  ef <- ALDEx2::aldex.effect(x)
+  stopifnot(is.data.frame(ef))
+  stopifnot(nrow(ef) == n_features)
+  stopifnot(all(c("effect", "diff.btw", "diff.win") %in% colnames(ef)))
+  stopifnot(all(is.finite(ef$effect)))
+})
+
+run_test("aldex: one-shot wrapper returns a combined per-feature table", function() {
+  res <- suppressMessages(
+    ALDEx2::aldex(reads, conds, mc.samples = mc, test = "t", effect = TRUE,
+                  verbose = FALSE)
+  )
+  stopifnot(is.data.frame(res))
+  stopifnot(nrow(res) == n_features)
+  # The combined table merges the t-test and effect columns.
+  stopifnot(all(c("we.ep", "wi.ep", "effect", "diff.btw") %in% colnames(res)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ALDEx2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/ANCOMBC.R
+++ b/cli/scripts/lib-validator/ANCOMBC.R
@@ -1,0 +1,139 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ANCOMBC` package (Analysis of Compositions of
+# Microbiomes with Bias Correction).
+#
+# Fully self-contained: no input files, no network, no packages beyond ANCOMBC
+# itself. ANCOMBC accepts input in three shapes -- a phyloseq object, a
+# (Tree)SummarizedExperiment, or a generic feature matrix + sample-metadata
+# data.frame -- and the last form needs none of those container packages, so
+# the differential-abundance run below is exercised on a plain integer matrix
+# with a fixed seed. All checks are structural / tolerance-based (a planted
+# signal recovered by name, q-values bounded), never exact floating-point
+# equality. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript ANCOMBC.R
+
+if (!requireNamespace("ANCOMBC", quietly = TRUE)) {
+  cat("FAIL: package 'ANCOMBC' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ANCOMBC))
+cat(sprintf("ANCOMBC version: %s\n", as.character(packageVersion("ANCOMBC"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: a 20-taxon x 12-sample count matrix (taxa in rows), two groups of
+# 6. Baseline counts are Poisson around a moderate mean; the first 5 taxa (the
+# planted differentially-abundant set) get a strong +60 up-shift in group "b",
+# so there is a known effect to recover. Taxon names are zero-padded so the
+# result tables' taxon ordering is unambiguous. meta_data carries a sampleid
+# column alongside the grouping variable: a single-column metadata frame is
+# collapsed and ANCOMBC then reports the formula variable as missing.
+set.seed(1)
+n_taxa <- 20L
+n_samp <- 12L
+n_de <- 5L
+counts <- matrix(
+  rpois(n_taxa * n_samp, lambda = 20),
+  nrow = n_taxa,
+  ncol = n_samp,
+  dimnames = list(sprintf("t%02d", seq_len(n_taxa)),
+                  sprintf("s%02d", seq_len(n_samp)))
+)
+grp <- rep(c("a", "b"), each = n_samp / 2L)
+counts[seq_len(n_de), grp == "b"] <- counts[seq_len(n_de), grp == "b"] + 60L
+meta <- data.frame(
+  sampleid = colnames(counts),
+  group = grp,
+  row.names = colnames(counts),
+  stringsAsFactors = FALSE
+)
+planted <- sprintf("t%02d", seq_len(n_de))
+
+# capture.output + suppressWarnings/Messages silence ANCOMBC's sanity-check
+# and progress chatter (and the "< 3 categories" note for a two-group design);
+# genuine errors still propagate to run_test's tryCatch.
+run_ancombc <- function() {
+  out <- NULL
+  invisible(capture.output(suppressWarnings(suppressMessages(
+    out <- ancombc(
+      data = counts, taxa_are_rows = TRUE, meta_data = meta,
+      formula = "group", group = "group", p_adj_method = "holm",
+      prv_cut = 0.10, lib_cut = 0, struc_zero = FALSE, neg_lb = FALSE,
+      tol = 1e-5, max_iter = 100, conserve = TRUE, alpha = 0.05,
+      global = FALSE
+    )
+  ))))
+  out
+}
+
+run_test("core API functions are exported and callable", function() {
+  stopifnot(is.function(ancombc))
+  stopifnot(is.function(ancombc2))
+  stopifnot(is.function(ancom))
+  stopifnot(is.function(secom_linear))
+  stopifnot(is.function(secom_dist))
+})
+
+run_test("ancombc runs on a plain matrix + metadata and returns a result list", function() {
+  out <- run_ancombc()
+  stopifnot(is.list(out))
+  stopifnot("res" %in% names(out))
+  r <- out$res
+  stopifnot(is.list(r))
+  # ANCOM-BC primary result: one data.frame per statistic, all taxon-indexed.
+  stopifnot(all(c("lfc", "se", "W", "p_val", "q_val", "diff_abn") %in% names(r)))
+  for (comp in c("lfc", "se", "W", "p_val", "q_val", "diff_abn")) {
+    stopifnot(is.data.frame(r[[comp]]))
+  }
+})
+
+run_test("result tables are taxon-aligned with the group effect column", function() {
+  r <- run_ancombc()$res
+  # No prevalence/library filtering removes any taxon here (Poisson lambda 20
+  # makes zero counts effectively impossible), so every taxon survives.
+  nrows <- vapply(r[c("lfc", "se", "W", "p_val", "q_val", "diff_abn")], nrow, integer(1))
+  stopifnot(length(unique(nrows)) == 1L, unname(nrows[1]) == n_taxa)
+  stopifnot("taxon" %in% colnames(r$lfc))
+  # Two-group design -> an intercept plus one "groupb" effect column.
+  stopifnot("groupb" %in% colnames(r$lfc))
+  stopifnot("groupb" %in% colnames(r$q_val))
+  stopifnot("groupb" %in% colnames(r$diff_abn))
+  stopifnot(is.logical(r$diff_abn$groupb))
+})
+
+run_test("q-values are bounded and the planted signal is recovered", function() {
+  r <- run_ancombc()$res
+  q <- r$q_val$groupb
+  stopifnot(all(is.finite(q)), all(q >= 0), all(q <= 1))
+  # The 5 planted taxa must all be flagged differentially abundant, and their
+  # group effect must be clearly larger than the null taxa's. Match by taxon
+  # name rather than assuming row order.
+  flagged_planted <- r$diff_abn$groupb[match(planted, r$diff_abn$taxon)]
+  stopifnot(all(flagged_planted))
+  lfc_planted <- r$lfc$groupb[match(planted, r$lfc$taxon)]
+  null_taxa <- setdiff(r$lfc$taxon, planted)
+  lfc_null <- r$lfc$groupb[match(null_taxa, r$lfc$taxon)]
+  stopifnot(median(lfc_planted) > 0.5)
+  stopifnot(median(lfc_planted) > median(lfc_null))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ANCOMBC smoke tests passed\n")

--- a/cli/scripts/lib-validator/AnnotationDbi.R
+++ b/cli/scripts/lib-validator/AnnotationDbi.R
@@ -1,0 +1,68 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `AnnotationDbi` (Bioconductor) package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# AnnotationDbi + its deps. Exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript AnnotationDbi.R
+#
+# ============================ SCOPE =========================================
+# AnnotationDbi is an INTERFACE package: it defines the SQLite-backed
+# annotation query API (select/keys/columns/keytypes/mapIds) but ships NO
+# annotation database of its own. A real select()/mapIds() query needs a
+# concrete AnnotationDbi object -- e.g. an org.*.eg.db package -- so the
+# END-TO-END behaviour of these generics is exercised in the org.*.eg.db
+# validator scripts (which carry an actual SQLite DB), NOT here.
+#
+# This test validates the OFFLINE, data-free surface: that the core mapping
+# GENERICS are present and registered as S4 generics.
+# ============================================================================
+
+if (!requireNamespace("AnnotationDbi", quietly = TRUE)) {
+  cat("FAIL: package 'AnnotationDbi' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(AnnotationDbi))
+cat(sprintf("AnnotationDbi version: %s\n", as.character(packageVersion("AnnotationDbi"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core mapping functions are exported by AnnotationDbi", function() {
+  # These five are the public annotation query surface. `::` resolves the
+  # exported generic function objects directly.
+  stopifnot(is.function(AnnotationDbi::select))
+  stopifnot(is.function(AnnotationDbi::keys))
+  stopifnot(is.function(AnnotationDbi::columns))
+  stopifnot(is.function(AnnotationDbi::keytypes))
+  stopifnot(is.function(AnnotationDbi::mapIds))
+})
+
+run_test("mapping functions are registered as S4 generics", function() {
+  # Each is an S4 generic dispatching on the annotation object; after
+  # library(AnnotationDbi) they are visible on the search path.
+  stopifnot(isGeneric("select"))
+  stopifnot(isGeneric("keys"))
+  stopifnot(isGeneric("columns"))
+  stopifnot(isGeneric("keytypes"))
+  stopifnot(isGeneric("mapIds"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all AnnotationDbi smoke tests passed\n")

--- a/cli/scripts/lib-validator/AnnotationHub.R
+++ b/cli/scripts/lib-validator/AnnotationHub.R
@@ -1,0 +1,70 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `AnnotationHub` (Bioconductor) package.
+#
+# Fully self-contained: no input files, no packages beyond AnnotationHub + its
+# deps. Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript AnnotationHub.R
+#
+# ============================ NETWORK / SCOPE ================================
+# AnnotationHub's PRIMARY function -- discovering and downloading annotation
+# resources -- is NETWORK-DEPENDENT: constructing a live hub with
+# AnnotationHub() contacts the Bioconductor hub server (and caches downloads).
+# Those hub queries are OUT OF SCOPE for an offline smoke test and are NOT
+# exercised here. This test only validates the OFFLINE surface: that the
+# package loads and its core constructor / query generic / metadata accessor
+# are present as callable functions.
+# ============================================================================
+
+if (!requireNamespace("AnnotationHub", quietly = TRUE)) {
+  cat("FAIL: package 'AnnotationHub' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(AnnotationHub))
+cat(sprintf("AnnotationHub version: %s\n", as.character(packageVersion("AnnotationHub"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("AnnotationHub constructor is an exported function", function() {
+  # NOTE: only checks the constructor EXISTS -- calling AnnotationHub() would
+  # contact the network, which is deliberately out of scope here.
+  stopifnot(is.function(AnnotationHub::AnnotationHub))
+})
+
+run_test("query generic for searching a hub is exported", function() {
+  # query() filters an in-memory hub by keywords; the generic itself is offline.
+  stopifnot(is.function(AnnotationHub::query))
+})
+
+run_test("hub resource metadata is accessed via S4Vectors::mcols", function() {
+  # Hub metadata (title, species, provider, ...) is surfaced as mcols() on hub
+  # objects. S4Vectors is a hard dependency of AnnotationHub, so it is present.
+  stopifnot(requireNamespace("S4Vectors", quietly = TRUE))
+  stopifnot(is.function(S4Vectors::mcols))
+})
+
+run_test("hub configuration is readable via getAnnotationHubOption", function() {
+  # getAnnotationHubOption() reads local option state only (no network); we
+  # assert the accessor exists rather than depending on any configured value.
+  stopifnot(is.function(AnnotationHub::getAnnotationHubOption))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all AnnotationHub smoke tests passed\n")

--- a/cli/scripts/lib-validator/Azimuth.R
+++ b/cli/scripts/lib-validator/Azimuth.R
@@ -1,0 +1,72 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Azimuth` package (reference-based scRNA annotation).
+#
+# Install: remotes::install_github("satijalab/azimuth")
+#
+# Fully self-contained and OFFLINE: no input files, no network. Azimuth's core
+# entry point, RunAzimuth(query, reference = ...), needs a DOWNLOADED reference
+# (a network fetch) plus a full Seurat query object -- both out of scope here --
+# so this validator exercises only the side-effect-free surface: that the public
+# entry points load and are exported as functions. Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript Azimuth.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once Azimuth is
+# available:
+#   - RunAzimuth() is the annotation workhorse: RunAzimuth(query, reference =).
+#     It maps a Seurat query onto a reference and REQUIRES a downloaded reference
+#     bundle (network) -- the reference is fetched/loaded, not bundled -- so a
+#     real annotation run cannot be validated offline. Only its existence as a
+#     function is checked here.
+#   - LoadReference() reads a reference directory/bundle from disk (again, a real
+#     reference must be downloaded first). Checked only as an exported function.
+#   - AzimuthApp() launches the interactive Shiny mapping app; it cannot run
+#     headless/offline. Checked only as an exported function.
+#   - EXPORT SURFACE. If any of these three names is not exported by the installed
+#     build (renamed / moved), the corresponding is.function() check will fail --
+#     re-confirm the public API names against the installed package.
+# ============================================================================
+
+if (!requireNamespace("Azimuth", quietly = TRUE)) {
+  cat("FAIL: package 'Azimuth' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Azimuth))
+cat(sprintf("Azimuth version: %s\n", as.character(packageVersion("Azimuth"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("RunAzimuth is an exported function", function() {
+  # The annotation workhorse. A real call needs a downloaded reference (network)
+  # and a Seurat query -- out of scope offline; existence is all we can assert.
+  stopifnot(is.function(RunAzimuth))
+})
+
+run_test("LoadReference is an exported function", function() {
+  stopifnot(is.function(LoadReference))
+})
+
+run_test("AzimuthApp is an exported function", function() {
+  stopifnot(is.function(AzimuthApp))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Azimuth smoke tests passed\n")

--- a/cli/scripts/lib-validator/BayesSpace.R
+++ b/cli/scripts/lib-validator/BayesSpace.R
@@ -1,0 +1,121 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `BayesSpace` package.
+#
+# Fully self-contained: no input files, no network. Builds a small synthetic
+# SingleCellExperiment (genes x spots) with spatial coordinates in colData, then
+# exercises only the LIGHT preprocessing surface. BayesSpace's core is a slow
+# MCMC spatial-clustering step (spatialCluster / qTune) -- that is deliberately
+# NOT run. Checks are structural (function existence, SCE class, spatial colData
+# columns, a PCA reducedDim after preprocessing) -- never numeric. Exits 0 only
+# if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript BayesSpace.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm once BayesSpace is available:
+#   - REQUIRED colData COLUMNS. BayesSpace keys off per-spot array coordinates
+#     `row` and `col` (and pixel coordinates `imagerow`/`imagecol`); all four are
+#     supplied. Re-confirm the exact names/spelling BayesSpace expects.
+#   - spatialPreprocess() SIGNATURE. Assumes
+#       spatialPreprocess(sce, platform = "ST", n.PCs = 5, n.HVGs = <= n_genes,
+#                         log.normalize = TRUE)
+#     returns an SCE carrying a "PCA" reducedDim with n.PCs columns. `n.HVGs`
+#     defaults to 2000, which EXCEEDS the 100 synthetic genes and would error --
+#     it is lowered here; re-check the argument name and default.
+#   - HEAVY SURFACE NOT EXERCISED. spatialCluster() and qTune() run long MCMC
+#     chains and are only checked for existence (is.function), never invoked.
+#     Their signatures (q, platform, d, nrep, burn.in, ...) are entirely
+#     UNVERIFIED here and must be validated separately.
+# ============================================================================
+
+if (!requireNamespace("BayesSpace", quietly = TRUE)) {
+  cat("FAIL: package 'BayesSpace' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(BayesSpace))
+cat(sprintf("BayesSpace version: %s\n", as.character(packageVersion("BayesSpace"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic spatial data: 100 genes x 40 spots laid out on an 8x5 grid. colData
+# carries the array coordinates (row/col) and pixel coordinates
+# (imagerow/imagecol) BayesSpace consumes. Namespace-qualified constructors are
+# used because BayesSpace imports SingleCellExperiment/S4Vectors without
+# attaching them.
+set.seed(1)
+n_genes <- 100L
+grid_rows <- 8L
+grid_cols <- 5L
+n_spots <- grid_rows * grid_cols
+
+counts <- matrix(rpois(n_genes * n_spots, lambda = 5), nrow = n_genes, ncol = n_spots)
+rownames(counts) <- paste0("gene", seq_len(n_genes))
+colnames(counts) <- paste0("spot", seq_len(n_spots))
+
+grid <- expand.grid(row = seq_len(grid_rows), col = seq_len(grid_cols))
+col_data <- S4Vectors::DataFrame(
+  row = grid$row,
+  col = grid$col,
+  imagerow = grid$row * 100,
+  imagecol = grid$col * 100,
+  row.names = colnames(counts)
+)
+
+make_sce <- function() {
+  SingleCellExperiment::SingleCellExperiment(
+    assays = list(counts = counts),
+    colData = col_data
+  )
+}
+
+run_test("prep + clustering entry points are exported functions", function() {
+  stopifnot(is.function(spatialPreprocess))
+  stopifnot(is.function(spatialCluster))
+  stopifnot(is.function(qTune))
+})
+
+run_test("synthetic SCE carries the spatial colData columns", function() {
+  sce <- make_sce()
+  stopifnot(inherits(sce, "SingleCellExperiment"))
+  stopifnot(ncol(sce) == n_spots)
+  stopifnot(nrow(sce) == n_genes)
+  cd_cols <- colnames(SummarizedExperiment::colData(sce))
+  stopifnot(all(c("row", "col", "imagerow", "imagecol") %in% cd_cols))
+  stopifnot("counts" %in% SummarizedExperiment::assayNames(sce))
+})
+
+run_test("spatialPreprocess yields a PCA reducedDim", function() {
+  sce <- make_sce()
+  # n.HVGs held to <= n_genes (default 2000 would exceed the 100 synthetic
+  # genes). Preprocessing does log-normalisation + HVG selection + PCA; it
+  # chatters, so silence warnings/messages. spatialCluster is NOT run.
+  sce <- suppressWarnings(suppressMessages(
+    spatialPreprocess(sce, platform = "ST", n.PCs = 5, n.HVGs = 50,
+                      log.normalize = TRUE)
+  ))
+  stopifnot(inherits(sce, "SingleCellExperiment"))
+  rd <- SingleCellExperiment::reducedDimNames(sce)
+  stopifnot("PCA" %in% rd)
+  pca <- SingleCellExperiment::reducedDim(sce, "PCA")
+  stopifnot(nrow(pca) == n_spots, ncol(pca) == 5L)
+  stopifnot(all(is.finite(pca)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all BayesSpace smoke tests passed\n")

--- a/cli/scripts/lib-validator/BiocGenerics.R
+++ b/cli/scripts/lib-validator/BiocGenerics.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `BiocGenerics` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# BiocGenerics itself (and the base packages it attaches). BiocGenerics is the
+# S4 generics hub for Bioconductor, so this exercises that a representative set
+# of generics exist, are true S4 generics, and dispatch to their base-vector
+# default methods with the expected values. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript BiocGenerics.R
+
+if (!requireNamespace("BiocGenerics", quietly = TRUE)) {
+  cat("FAIL: package 'BiocGenerics' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(BiocGenerics))
+cat(sprintf("BiocGenerics version: %s\n", as.character(packageVersion("BiocGenerics"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("set-operation generics exist", function() {
+  stopifnot(isGeneric("union"), isGeneric("intersect"), isGeneric("setdiff"))
+  stopifnot(existsFunction("combine"))
+})
+
+run_test("union/intersect/setdiff dispatch on base vectors", function() {
+  stopifnot(identical(BiocGenerics::union(c(1, 2), c(2, 3)), c(1, 2, 3)))
+  stopifnot(identical(BiocGenerics::intersect(c(1, 2, 3), c(2, 3, 4)), c(2, 3)))
+  stopifnot(identical(BiocGenerics::setdiff(c(1, 2, 3), c(2)), c(1, 3)))
+})
+
+run_test("rbind/cbind are generics", function() {
+  stopifnot(isGeneric("rbind"), isGeneric("cbind"))
+  stopifnot(is.function(BiocGenerics::rbind), is.function(BiocGenerics::cbind))
+  m <- BiocGenerics::rbind(c(1L, 2L), c(3L, 4L))
+  stopifnot(is.matrix(m), identical(dim(m), c(2L, 2L)))
+  stopifnot(identical(as.vector(m), c(1L, 3L, 2L, 4L)))
+})
+
+run_test("unique and duplicated generics", function() {
+  stopifnot(isGeneric("unique"), isGeneric("duplicated"))
+  stopifnot(identical(BiocGenerics::unique(c(1L, 1L, 2L, 3L, 3L)), c(1L, 2L, 3L)))
+  stopifnot(identical(BiocGenerics::duplicated(c(1L, 1L, 2L)), c(FALSE, TRUE, FALSE)))
+})
+
+run_test("table generic tallies base vectors", function() {
+  stopifnot(isGeneric("table"))
+  tab <- BiocGenerics::table(c("a", "a", "b"))
+  stopifnot(identical(as.integer(tab[["a"]]), 2L), identical(as.integer(tab[["b"]]), 1L))
+})
+
+run_test("apply-family generics are exported", function() {
+  stopifnot(existsFunction("lapply"), existsFunction("sapply"), existsFunction("mapply"))
+  stopifnot(isGeneric("lapply"), isGeneric("sapply"))
+})
+
+run_test("nrow/ncol generics exist and dispatch", function() {
+  stopifnot(isGeneric("nrow"), isGeneric("ncol"))
+  m <- matrix(1:6, nrow = 2, ncol = 3)
+  stopifnot(BiocGenerics::nrow(m) == 2L, BiocGenerics::ncol(m) == 3L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all BiocGenerics smoke tests passed\n")

--- a/cli/scripts/lib-validator/BiocManager.R
+++ b/cli/scripts/lib-validator/BiocManager.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `BiocManager` package.
+#
+# Fully self-contained and OFFLINE: no input files, no network. Only the
+# side-effect-free, non-networked surface is exercised -- `version()` plus
+# function-existence/class checks. Networked entry points (`install()`,
+# `available()`, `valid()`, `repositories()`) are deliberately NOT called.
+# Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript BiocManager.R
+
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  cat("FAIL: package 'BiocManager' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(BiocManager))
+cat(sprintf("BiocManager version: %s\n", as.character(packageVersion("BiocManager"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("version() returns a valid Bioconductor version >= 3.0", function() {
+  v <- BiocManager::version()
+  # package_version objects carry class c("package_version", "numeric_version").
+  stopifnot(inherits(v, "numeric_version"))
+  stopifnot(length(v) == 1L)
+  stopifnot(v >= "3.0")
+})
+
+run_test("version() is round-trippable through character", function() {
+  v <- BiocManager::version()
+  chr <- as.character(v)
+  stopifnot(is.character(chr), nzchar(chr))
+  stopifnot(numeric_version(chr) == v)
+})
+
+run_test("install is a function", function() {
+  stopifnot(is.function(BiocManager::install))
+})
+
+run_test("valid is a function", function() {
+  stopifnot(is.function(BiocManager::valid))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all BiocManager smoke tests passed\n")

--- a/cli/scripts/lib-validator/BiocParallel.R
+++ b/cli/scripts/lib-validator/BiocParallel.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `BiocParallel` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# BiocParallel itself. Uses SerialParam() ONLY: it runs everything in-process
+# with no forked/socket workers, so results are deterministic and there is no
+# reliance on the host's parallel backend. Exercises the core apply family
+# (bplapply, bpmapply, bpvec) and asserts exact values. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript BiocParallel.R
+
+if (!requireNamespace("BiocParallel", quietly = TRUE)) {
+  cat("FAIL: package 'BiocParallel' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(BiocParallel))
+cat(sprintf("BiocParallel version: %s\n", as.character(packageVersion("BiocParallel"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("SerialParam is a param object with one worker", function() {
+  p <- SerialParam()
+  stopifnot(is(p, "SerialParam"), is(p, "BiocParallelParam"))
+  stopifnot(bpnworkers(p) == 1L)
+})
+
+run_test("bplapply maps over a vector", function() {
+  res <- bplapply(1:5, function(i) i^2, BPPARAM = SerialParam())
+  stopifnot(is.list(res), length(res) == 5L)
+  stopifnot(identical(res, list(1, 4, 9, 16, 25)))
+})
+
+run_test("bpmapply zips multiple vectors", function() {
+  res <- bpmapply(function(a, b) a + b, 1:3, 4:6, BPPARAM = SerialParam())
+  stopifnot(identical(res, c(5L, 7L, 9L)))
+})
+
+run_test("bpvec applies over vector chunks", function() {
+  res <- bpvec(1:10, function(x) x * 2L, BPPARAM = SerialParam())
+  stopifnot(identical(res, (1:10) * 2L))
+})
+
+run_test("bplapply preserves names", function() {
+  res <- bplapply(c(a = 2L, b = 3L), function(i) i + 1L, BPPARAM = SerialParam())
+  stopifnot(identical(names(res), c("a", "b")))
+  stopifnot(identical(res[["a"]], 3L), identical(res[["b"]], 4L))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all BiocParallel smoke tests passed\n")

--- a/cli/scripts/lib-validator/Biostrings.R
+++ b/cli/scripts/lib-validator/Biostrings.R
@@ -1,0 +1,108 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `Biostrings` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond
+# Biostrings itself. Every object is a small, literal, in-memory DNA/amino-acid
+# sequence, so the checks are DETERMINISTIC and use exact equality — no random
+# data, no tolerance needed. Exercises the core XString / XStringSet API
+# (construction, reverse-complement, alphabet counting, pattern matching,
+# translation, subsetting) and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript Biostrings.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# All assertions are on fixed literal sequences with hand-computed expected
+# values, so they should hold on any healthy Biostrings install. Points worth a
+# glance once a build is available:
+#   - reverseComplement("AAGCTT") == "AAGCTT" (HindIII site is its own
+#     reverse-complement); reverseComplement("AAGC") == "GCTT".
+#   - translate() uses the Standard Genetic Code by default: ATG->M, GCC->A.
+#   - alphabetFrequency(x, baseOnly=TRUE) yields the A/C/G/T/other 5-vector.
+# ============================================================================
+
+if (!requireNamespace("Biostrings", quietly = TRUE)) {
+  cat("FAIL: package 'Biostrings' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Biostrings))
+cat(sprintf("Biostrings version: %s\n", as.character(packageVersion("Biostrings"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("DNAString construction and round-trip", function() {
+  d <- DNAString("AAGCTT")
+  stopifnot(inherits(d, "DNAString"))
+  stopifnot(length(d) == 6L)
+  stopifnot(identical(as.character(d), "AAGCTT"))
+})
+
+run_test("reverseComplement of a palindrome (HindIII site)", function() {
+  d <- DNAString("AAGCTT")
+  # complement AAGCTT -> TTCGAA, reversed -> AAGCTT (self reverse-complement).
+  stopifnot(identical(as.character(reverseComplement(d)), "AAGCTT"))
+})
+
+run_test("reverseComplement / complement / reverse of a non-palindrome", function() {
+  d <- DNAString("AAGC")
+  # complement AAGC -> TTCG; reverse of that -> GCTT.
+  stopifnot(identical(as.character(reverseComplement(d)), "GCTT"))
+  stopifnot(identical(as.character(complement(d)), "TTCG"))
+  stopifnot(identical(as.character(reverse(d)), "CGAA"))
+})
+
+run_test("alphabetFrequency counts each base", function() {
+  af <- alphabetFrequency(DNAString("AACGT"), baseOnly = TRUE)
+  stopifnot(af[["A"]] == 2, af[["C"]] == 1, af[["G"]] == 1, af[["T"]] == 1)
+  stopifnot(af[["other"]] == 0)
+  stopifnot(sum(af) == 5)
+})
+
+run_test("DNAStringSet holds two sequences with correct widths", function() {
+  dss <- DNAStringSet(c("ACGT", "TTTT"))
+  stopifnot(inherits(dss, "DNAStringSet"))
+  stopifnot(length(dss) == 2L)
+  stopifnot(identical(as.integer(width(dss)), c(4L, 4L)))
+  stopifnot(identical(as.character(dss[[1]]), "ACGT"))
+})
+
+run_test("matchPattern finds all occurrences", function() {
+  m <- matchPattern("CG", DNAString("ACGCG"))
+  # 'CG' occurs at positions 2-3 and 4-5.
+  stopifnot(length(m) == 2L)
+  stopifnot(identical(as.integer(start(m)), c(2L, 4L)))
+  stopifnot(identical(as.integer(end(m)), c(3L, 5L)))
+})
+
+run_test("translate uses the standard genetic code", function() {
+  aa <- translate(DNAString("ATGGCC"))
+  stopifnot(inherits(aa, "AAString"))
+  # ATG -> Met (M), GCC -> Ala (A).
+  stopifnot(identical(as.character(aa), "MA"))
+})
+
+run_test("subseq and letterFrequency", function() {
+  d <- DNAString("AACGT")
+  stopifnot(identical(as.character(subseq(d, start = 2, end = 4)), "ACG"))
+  # 'CG' collapses to a single G+C count.
+  stopifnot(as.integer(letterFrequency(d, "CG")) == 2L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Biostrings smoke tests passed\n")

--- a/cli/scripts/lib-validator/CAMERA.R
+++ b/cli/scripts/lib-validator/CAMERA.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `CAMERA` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond CAMERA
+# itself. CAMERA annotates xcms peak-detection results (isotopes, adducts, pseudo
+# -spectra), so its real work needs an upstream xcmsSet / XCMSnExp -- itself
+# derived from raw LC-MS files -- which is OUT OF SCOPE offline. This validator
+# is therefore deliberately MODEST: it confirms the package loads, its annotation
+# container class is defined, and its core annotation functions exist. Exits 0
+# only if every check passes:
+#
+#   Rscript CAMERA.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# CAMERA is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - FLAG: real annotation (groupFWHM/groupCorr/findIsotopes/findAdducts run on
+#     an xsAnnotate built from an xcmsSet) is OUT OF SCOPE offline -- it needs an
+#     xcms result. Only class + function existence is asserted here.
+#   - getClass("xsAnnotate") is defined; the annotation functions are exported
+#     under the names asserted below.
+# ============================================================================
+
+if (!requireNamespace("CAMERA", quietly = TRUE)) {
+  cat("FAIL: package 'CAMERA' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(CAMERA))
+cat(sprintf("CAMERA version: %s\n", as.character(packageVersion("CAMERA"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("annotation container class is defined", function() {
+  stopifnot(!is.null(methods::getClassDef("xsAnnotate")))
+})
+
+run_test("core annotation functions exist", function() {
+  stopifnot(is.function(annotate))
+  stopifnot(is.function(groupFWHM))
+  stopifnot(is.function(groupCorr))
+  stopifnot(is.function(findIsotopes))
+  stopifnot(is.function(findAdducts))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all CAMERA smoke tests passed\n")

--- a/cli/scripts/lib-validator/CARNIVAL.R
+++ b/cli/scripts/lib-validator/CARNIVAL.R
@@ -1,0 +1,66 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `CARNIVAL` package (CAusal Reasoning for Network
+# identification via Integer VALue programming).
+#
+# Fully self-contained: no input files, no network, no packages beyond CARNIVAL
+# and a bundled ILP solver. CARNIVAL solves an integer linear program to infer
+# signed causal networks, so a genuine run needs an ILP backend; the free,
+# always-available fallback is lpSolve (vs. commercial cbc/CPLEX/Gurobi). This
+# test stays deliberately MODEST -- it verifies the package loads, its entry
+# point is callable, and the lpSolve fallback solver is present -- rather than
+# blind-driving a full ILP optimisation. Exits 0 only if every check passes, so
+# it can be used as a pass/fail library validator:
+#
+#   Rscript CARNIVAL.R
+#
+# FLAG (unverified on this machine -- CARNIVAL is NOT installed here, heavily
+# flagged): the entry-point name runCARNIVAL, the lpSolve solver option, and
+# the result-list field names (weightedSIF / nodesAttributes) are taken from
+# the documented CARNIVAL API and MUST be re-checked against the installed
+# version -- CARNIVAL's solver interface changed noticeably between v1 and v2.
+
+if (!requireNamespace("CARNIVAL", quietly = TRUE)) {
+  cat("FAIL: package 'CARNIVAL' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(CARNIVAL))
+cat(sprintf("CARNIVAL version: %s\n", as.character(packageVersion("CARNIVAL"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core entry point runCARNIVAL is exported and callable", function() {
+  stopifnot(exists("runCARNIVAL"))
+  stopifnot(is.function(runCARNIVAL))
+})
+
+run_test("runCARNIVAL exposes a solver option", function() {
+  # The solver is selected by a formal argument; assert it exists so a caller
+  # can request the free lpSolve backend explicitly.
+  fmls <- names(formals(runCARNIVAL))
+  stopifnot("solver" %in% fmls || "solverPath" %in% fmls || "carnivalOptions" %in% fmls)
+})
+
+run_test("lpSolve fallback ILP solver is available", function() {
+  # lpSolve is the free, no-license fallback backend CARNIVAL falls back to
+  # when no commercial solver (CPLEX / cbc / Gurobi) is configured.
+  stopifnot(requireNamespace("lpSolve", quietly = TRUE))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all CARNIVAL smoke tests passed\n")

--- a/cli/scripts/lib-validator/CATALYST.R
+++ b/cli/scripts/lib-validator/CATALYST.R
@@ -1,0 +1,133 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `CATALYST` package.
+#
+# Fully self-contained: no input files, NO network. Builds a synthetic CyTOF
+# experiment entirely in memory (two flowFrames of Gaussian marker intensities
+# assembled into a flowSet, plus the panel + metadata data.frames CATALYST
+# requires) and drives it through `prepData()` to obtain a SingleCellExperiment.
+# Checks are STRUCTURAL (class + dims relating markers/cells + assay presence);
+# NO clustering is run. Exits 0 only if every check passes, so it can be used as
+# a pass/fail library validator:
+#
+#   Rscript CATALYST.R
+#
+# ======================= ASSUMPTIONS TO RE-CHECK (FIDDLY) ====================
+# The `prepData()` contract is intricate and was written from the CATALYST
+# source (HelenaLC/CATALYST, R/prepData.R) rather than a live install -- RE-
+# VERIFY ALL OF THIS once a build is available:
+#
+#  * SIGNATURE / column names (verified against source):
+#      prepData(x, panel, md, features = NULL, ...)
+#      panel_cols default: channel="fcs_colname", antigen="antigen",
+#                          class="marker_class"
+#      md_cols default:    file="file_name", id="sample_id",
+#                          factors=c("condition","patient_id")
+#    So `panel` MUST have columns  fcs_colname / antigen / marker_class,
+#    and `md` MUST have columns    file_name / sample_id / condition / patient_id.
+#
+#  * marker_class values must be one of "type" / "state" / "none" (validated;
+#    anything else errors "Invalid marker classes detected").
+#
+#  * flowSet <-> md matching (THE fiddly bit): prepData matches
+#    `fsApply(fs, identifier)` (tried first) or `keyword(fs, "FILENAME")`
+#    against `md[[file_name]]`, then reorders. We therefore set each frame's
+#    identifier() EXPLICITLY to the md file_name, so the identifier path matches.
+#
+#  * `features = NULL` keeps every panel channel, so nrow(sce) == nrow(panel)
+#    (markers) and ncol(sce) == total events across the two frames (cells).
+#    RE-CONFIRM these dims and that "exprs"/"counts" assays are present.
+#
+# flowCore is a hard dependency of CATALYST, so it is guaranteed installed
+# whenever the guard below passes; we attach it to build the flowFrames.
+# ============================================================================
+
+if (!requireNamespace("CATALYST", quietly = TRUE)) {
+  cat("FAIL: package 'CATALYST' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(CATALYST))
+suppressPackageStartupMessages(library(flowCore))
+cat(sprintf("CATALYST version: %s\n", as.character(packageVersion("CATALYST"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# ---- synthetic CyTOF experiment -------------------------------------------
+# Two samples of Gaussian marker intensities (kept positive-ish so the default
+# arcsinh transform in prepData is exercised on realistic values). Channel
+# names M1..M5 are what the panel's fcs_colname must reference.
+markers <- paste0("M", 1:5)
+n1 <- 1000L
+n2 <- 500L
+
+set.seed(1)
+mat1 <- matrix(rnorm(n1 * 5, 5), ncol = 5, dimnames = list(NULL, markers))
+set.seed(2)
+mat2 <- matrix(rnorm(n2 * 5, 5), ncol = 5, dimnames = list(NULL, markers))
+
+ff1 <- flowFrame(mat1)
+ff2 <- flowFrame(mat2)
+# The frame identifier is what prepData matches against md$file_name (the
+# identifier path is tried before the FILENAME keyword). Set it explicitly.
+identifier(ff1) <- "sample1.fcs"
+identifier(ff2) <- "sample2.fcs"
+fs <- flowSet(list(sample1.fcs = ff1, sample2.fcs = ff2))
+sampleNames(fs) <- c("sample1.fcs", "sample2.fcs")
+
+# panel: one row per channel. Column names are the prepData defaults.
+panel <- data.frame(
+  fcs_colname  = markers,
+  antigen      = paste0("antigen", 1:5),
+  marker_class = c("type", "type", "type", "state", "state"),
+  stringsAsFactors = FALSE
+)
+
+# md: one row per sample. file_name MUST match the frame identifiers above.
+md <- data.frame(
+  file_name  = c("sample1.fcs", "sample2.fcs"),
+  sample_id  = c("s1", "s2"),
+  condition  = c("A", "B"),
+  patient_id = c("p1", "p2"),
+  stringsAsFactors = FALSE
+)
+
+run_test("prepData builds a SingleCellExperiment from the flowSet", function() {
+  sce <- suppressMessages(suppressWarnings(
+    prepData(fs, panel = panel, md = md, features = NULL)))
+  stopifnot(inherits(sce, "SingleCellExperiment"))
+})
+
+run_test("SCE dims relate to markers (rows) and cells (cols)", function() {
+  sce <- suppressMessages(suppressWarnings(
+    prepData(fs, panel = panel, md = md, features = NULL)))
+  # rows == panel channels (all kept because features = NULL)
+  stopifnot(nrow(sce) == nrow(panel))
+  # cols == total events pooled across both samples
+  stopifnot(ncol(sce) == n1 + n2)
+})
+
+run_test("SCE carries the expression assays", function() {
+  sce <- suppressMessages(suppressWarnings(
+    prepData(fs, panel = panel, md = md, features = NULL)))
+  an <- SummarizedExperiment::assayNames(sce)
+  # prepData stores raw "counts" and, with transform = TRUE (default), "exprs".
+  stopifnot("counts" %in% an)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all CATALYST smoke tests passed\n")

--- a/cli/scripts/lib-validator/CVXR.R
+++ b/cli/scripts/lib-validator/CVXR.R
@@ -1,0 +1,84 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `CVXR` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# CVXR itself. Solves small convex problems with known analytic optima and
+# exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript CVXR.R
+
+if (!requireNamespace("CVXR", quietly = TRUE)) {
+  cat("FAIL: package 'CVXR' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(CVXR))
+cat(sprintf("CVXR version: %s\n", as.character(packageVersion("CVXR"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("least squares recovers analytic solution", function() {
+  # A %*% c(1, 2) == b exactly, so the optimum is 0 attained at x = (1, 2).
+  A <- rbind(c(1, 0), c(0, 1), c(1, 1))
+  b <- c(1, 2, 3)
+  x <- Variable(2)
+  prob <- Problem(Minimize(sum_squares(A %*% x - b)))
+  # suppressMessages: CVXR prints a once-per-session future-API notice;
+  # suppressWarnings: solver/deprecation chatter. Errors still propagate.
+  res <- suppressMessages(suppressWarnings(solve(prob)))
+  stopifnot(identical(res$status, "optimal"))
+  stopifnot(is.finite(res$value))
+  stopifnot(isTRUE(all.equal(res$value, 0, tolerance = 1e-4)))
+  xhat <- as.numeric(suppressWarnings(res$getValue(x)))
+  stopifnot(isTRUE(all.equal(xhat, c(1, 2), tolerance = 1e-4)))
+})
+
+run_test("constrained LP hits known vertex optimum", function() {
+  # minimize x1 + 2*x2 over the simplex {x >= 0, sum(x) == 1}:
+  # the optimum is the vertex x = (1, 0) with value 1.
+  y <- Variable(2)
+  cost <- c(1, 2)
+  prob <- Problem(Minimize(t(cost) %*% y), list(y >= 0, sum(y) == 1))
+  # suppressMessages: CVXR prints a once-per-session future-API notice;
+  # suppressWarnings: solver/deprecation chatter. Errors still propagate.
+  res <- suppressMessages(suppressWarnings(solve(prob)))
+  stopifnot(identical(res$status, "optimal"))
+  stopifnot(is.finite(res$value))
+  stopifnot(isTRUE(all.equal(res$value, 1, tolerance = 1e-4)))
+  yhat <- as.numeric(suppressWarnings(res$getValue(y)))
+  stopifnot(isTRUE(all.equal(yhat, c(1, 0), tolerance = 1e-4)))
+})
+
+run_test("nonnegative QP with an active constraint", function() {
+  # minimize ||x - (3, -2)||^2 s.t. x >= 0: the projection onto the
+  # nonnegative orthant is x = (3, 0) with value (-2)^2 = 4.
+  z <- Variable(2)
+  prob <- Problem(Minimize(sum_squares(z - c(3, -2))), list(z >= 0))
+  # suppressMessages: CVXR prints a once-per-session future-API notice;
+  # suppressWarnings: solver/deprecation chatter. Errors still propagate.
+  res <- suppressMessages(suppressWarnings(solve(prob)))
+  stopifnot(identical(res$status, "optimal"))
+  stopifnot(is.finite(res$value))
+  stopifnot(isTRUE(all.equal(res$value, 4, tolerance = 1e-4)))
+  zhat <- as.numeric(suppressWarnings(res$getValue(z)))
+  stopifnot(isTRUE(all.equal(zhat, c(3, 0), tolerance = 1e-4)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all CVXR smoke tests passed\n")

--- a/cli/scripts/lib-validator/ChAMP.R
+++ b/cli/scripts/lib-validator/ChAMP.R
@@ -1,0 +1,70 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ChAMP` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. ChAMP is a full Illumina
+# 450K/EPIC methylation pipeline: champ.load() reads per-sample .idat files, and
+# every downstream step (normalization, DMP/DMR calling) leans on the array's
+# annotation and manifest data packages. We have NEITHER IDATs/beta matrices NOR
+# a chosen array annotation here, so a real pipeline run is OUT OF SCOPE OFFLINE.
+# This test therefore verifies only what is checkable without any array files or
+# annotation choice: that the package loads and that its pipeline entry points
+# are present. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript ChAMP.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# This test is FUNCTION-EXISTENCE-DOMINATED. Even the beta-matrix entry points
+# (champ.norm/champ.DMP/champ.DMR) require array annotation data (450K vs EPIC)
+# to map probes to genome positions/genes, so none can be exercised offline on a
+# synthetic matrix without pulling annotation. The checks below pass on any
+# healthy install; VERIFY ONCE INSTALLED that these remain the pipeline's public
+# entry points:
+#   - champ.load()  : read IDATs -> beta matrix + pheno (needs IDAT files).
+#   - champ.filter(): probe/sample QC filtering.
+#   - champ.norm()  : normalization (BMIQ/etc.; needs array annotation).
+#   - champ.DMP()   : differentially methylated positions.
+#   - champ.DMR()   : differentially methylated regions.
+# ============================================================================
+
+if (!requireNamespace("ChAMP", quietly = TRUE)) {
+  cat("FAIL: package 'ChAMP' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ChAMP))
+cat(sprintf("ChAMP version: %s\n", as.character(packageVersion("ChAMP"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("data-loading / filtering entry points are exported functions", function() {
+  stopifnot(exists("champ.load"), is.function(champ.load))
+  stopifnot(exists("champ.filter"), is.function(champ.filter))
+})
+
+run_test("normalization entry point is an exported function", function() {
+  stopifnot(exists("champ.norm"), is.function(champ.norm))
+})
+
+run_test("differential-methylation entry points are exported functions", function() {
+  stopifnot(exists("champ.DMP"), is.function(champ.DMP))
+  stopifnot(exists("champ.DMR"), is.function(champ.DMR))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ChAMP smoke tests passed\n")

--- a/cli/scripts/lib-validator/ComplexHeatmap.R
+++ b/cli/scripts/lib-validator/ComplexHeatmap.R
@@ -1,0 +1,66 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ComplexHeatmap` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# ComplexHeatmap and its implied deps. All data is a small synthetic Gaussian
+# matrix built with a fixed seed; checks are structural (object class of the
+# BUILT heatmap / annotation / list) rather than numeric-equality on anything
+# random. Crucially it exercises only heatmap CONSTRUCTION -- building a Heatmap
+# stores its layout parameters and does NOT draw to a graphics device, so no
+# device is opened (draw() is never called). Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript ComplexHeatmap.R
+#
+# NOTE (needs re-check once installed): ComplexHeatmap objects are S4; the class
+# checks use inherits() on the concrete classes Heatmap / HeatmapAnnotation /
+# HeatmapList. draw()/rendering is intentionally NOT exercised (it requires a
+# live graphics device) -- re-confirm these class names once a build is
+# available.
+
+if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
+  cat("FAIL: package 'ComplexHeatmap' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ComplexHeatmap))
+cat(sprintf("ComplexHeatmap version: %s\n", as.character(packageVersion("ComplexHeatmap"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic matrix: 10 x 10, i.i.d. normal.
+set.seed(1)
+m <- matrix(rnorm(100), nrow = 10, ncol = 10)
+
+run_test("Heatmap() builds a Heatmap object without drawing", function() {
+  ht <- suppressWarnings(suppressMessages(Heatmap(m)))
+  stopifnot(inherits(ht, "Heatmap"))
+})
+
+run_test("HeatmapAnnotation() builds an annotation object", function() {
+  anno <- suppressWarnings(suppressMessages(HeatmapAnnotation(foo = 1:10)))
+  stopifnot(inherits(anno, "HeatmapAnnotation"))
+})
+
+run_test("Heatmap + Heatmap composes into a HeatmapList", function() {
+  hl <- suppressWarnings(suppressMessages(Heatmap(m) + Heatmap(m)))
+  stopifnot(inherits(hl, "HeatmapList"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ComplexHeatmap smoke tests passed\n")

--- a/cli/scripts/lib-validator/ComplexUpset.R
+++ b/cli/scripts/lib-validator/ComplexUpset.R
@@ -1,0 +1,65 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ComplexUpset` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# ComplexUpset itself (it builds on ggplot2/patchwork, its core dependencies).
+# Exercises the core API surface by INSPECTING the built plot object and the
+# intersection data structure -- it never opens an interactive device -- and
+# exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript ComplexUpset.R
+
+if (!requireNamespace("ComplexUpset", quietly = TRUE)) {
+  cat("FAIL: package 'ComplexUpset' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ComplexUpset))
+suppressPackageStartupMessages(library(ggplot2))
+cat(sprintf("ComplexUpset version: %s\n", as.character(packageVersion("ComplexUpset"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+membership_df <- function() {
+  set.seed(7)
+  n <- 20L
+  data.frame(
+    A = sample(c(TRUE, FALSE), n, replace = TRUE),
+    B = sample(c(TRUE, FALSE), n, replace = TRUE),
+    C = sample(c(TRUE, FALSE), n, replace = TRUE)
+  )
+}
+
+run_test("upset builds a ggplot object", function() {
+  df <- membership_df()
+  plt <- ComplexUpset::upset(df, intersect = c("A", "B", "C"))
+  # ComplexUpset composes its panels with patchwork, so the result is a ggplot.
+  stopifnot(inherits(plt, "ggplot"))
+})
+
+run_test("upset_data returns the intersection structure", function() {
+  df <- membership_df()
+  ud <- ComplexUpset::upset_data(df, intersect = c("A", "B", "C"))
+  stopifnot(is.list(ud), length(ud) > 0L)
+  # The intersection membership matrix is carried on $with_sizes / $sizes.
+  stopifnot(!is.null(ud$sizes) || !is.null(ud$with_sizes))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ComplexUpset smoke tests passed\n")

--- a/cli/scripts/lib-validator/ConsensusClusterPlus.R
+++ b/cli/scripts/lib-validator/ConsensusClusterPlus.R
@@ -1,0 +1,121 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ConsensusClusterPlus` package.
+#
+# Fully self-contained: no input files, NO network. Runs consensus clustering on
+# a small synthetic feature-by-sample matrix (fixed seed) and inspects the
+# per-k result structure. ConsensusClusterPlus DRAWS diagnostic plots as a side
+# effect, so every call is wrapped in a throwaway pdf() null device (opened on a
+# tempfile, closed + unlinked on exit) and its file output is directed at a temp
+# dir that is removed on exit -- no interactive device is opened, nothing is left
+# behind. Checks are STRUCTURAL (list length, per-k class labels + consensus
+# matrix dims) rather than numeric equality on the random resampling. Exits 0
+# only if every check passes, so it can be used as a pass/fail validator:
+#
+#   Rscript ConsensusClusterPlus.R
+#
+# ======================= ASSUMPTIONS TO RE-CHECK ============================
+# Written from the ConsensusClusterPlus contract rather than a live install:
+#
+#  * SIGNATURE: ConsensusClusterPlus(d, maxK, reps, pItem, pFeature, title,
+#    plot=NULL, seed, verbose). `d` is FEATURES x SAMPLES. `title` is a directory
+#    for file output. plot=NULL draws to the CURRENT device (hence the null pdf
+#    wrapper); plot="pdf"/"png" would instead write image files under `title`.
+#
+#  * RETURN: a list of length maxK. Element [[1]] (k=1) is an empty placeholder;
+#    element [[k]] for k>=2 is a list with:
+#       $consensusMatrix -- numeric matrix, (n samples) x (n samples)
+#       $consensusClass  -- integer cluster labels, length == n samples, in 1..k
+#    RE-VERIFY these element names and that [[1]] is the empty slot once a build
+#    is available.
+# ============================================================================
+
+if (!requireNamespace("ConsensusClusterPlus", quietly = TRUE)) {
+  cat("FAIL: package 'ConsensusClusterPlus' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ConsensusClusterPlus))
+cat(sprintf("ConsensusClusterPlus version: %s\n",
+            as.character(packageVersion("ConsensusClusterPlus"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic data: 20 features x 40 samples. ConsensusClusterPlus expects the
+# matrix oriented features-in-rows, samples-in-columns.
+n_samples <- 40L
+maxK <- 4L
+
+run_test("ConsensusClusterPlus returns a per-k consensus result list", function() {
+  set.seed(1)
+  d <- matrix(rnorm(20 * n_samples), nrow = 20, ncol = n_samples)
+
+  title_dir <- tempfile("ccp-")
+  null_dev <- tempfile("ccp-null-", fileext = ".pdf")
+  # Swallow ALL of ConsensusClusterPlus's drawing into a throwaway pdf device,
+  # and clean up both the device file and any title-dir output on exit.
+  grDevices::pdf(null_dev)
+  on.exit({
+    grDevices::dev.off()
+    unlink(null_dev)
+    unlink(title_dir, recursive = TRUE)
+  }, add = TRUE)
+
+  res <- suppressWarnings(suppressMessages(
+    ConsensusClusterPlus(d, maxK = maxK, reps = 10, pItem = 0.8,
+                         pFeature = 1, title = title_dir,
+                         plot = NULL, seed = 1, verbose = FALSE)))
+
+  stopifnot(is.list(res), length(res) == maxK)
+})
+
+run_test("each k>=2 carries consensusClass + consensusMatrix of right dims", function() {
+  set.seed(1)
+  d <- matrix(rnorm(20 * n_samples), nrow = 20, ncol = n_samples)
+
+  title_dir <- tempfile("ccp-")
+  null_dev <- tempfile("ccp-null-", fileext = ".pdf")
+  grDevices::pdf(null_dev)
+  on.exit({
+    grDevices::dev.off()
+    unlink(null_dev)
+    unlink(title_dir, recursive = TRUE)
+  }, add = TRUE)
+
+  res <- suppressWarnings(suppressMessages(
+    ConsensusClusterPlus(d, maxK = maxK, reps = 10, pItem = 0.8,
+                         pFeature = 1, title = title_dir,
+                         plot = NULL, seed = 1, verbose = FALSE)))
+
+  for (k in 2:maxK) {
+    ck <- res[[k]]
+    stopifnot(is.list(ck))
+    stopifnot(!is.null(ck$consensusClass))
+    stopifnot(length(ck$consensusClass) == n_samples)
+    # k clusters -> labels fall within 1..k
+    stopifnot(all(ck$consensusClass >= 1L), all(ck$consensusClass <= k))
+    stopifnot(!is.null(ck$consensusMatrix))
+    cm <- ck$consensusMatrix
+    stopifnot(is.matrix(cm))
+    stopifnot(nrow(cm) == n_samples, ncol(cm) == n_samples)
+    # consensus values are proportions in [0, 1]
+    stopifnot(all(cm >= 0), all(cm <= 1))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ConsensusClusterPlus smoke tests passed\n")

--- a/cli/scripts/lib-validator/CytoNorm.R
+++ b/cli/scripts/lib-validator/CytoNorm.R
@@ -1,0 +1,180 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `CytoNorm` package.
+#
+# Fully self-contained: no input files, NO network. CytoNorm is a CyTOF/flow
+# batch-normalization method (FlowSOM clustering + per-cluster quantile
+# normalization). This test stays MODEST: it (1) asserts the key train/normalize
+# entry points are exported functions, (2) builds a synthetic two-batch
+# flowCore::flowSet (with a planted per-batch shift) and checks its shape, then
+# (3) runs a SOFT lower-level QuantileNorm.train -> QuantileNorm.normalize
+# round-trip and, only if it is constructible offline, asserts the normalized
+# output keeps its dims and that the between-batch mean gap SHRINKS. Checks are
+# STRUCTURAL/tolerance (object shape, dims, an inequality on the batch gap)
+# rather than numeric equality on random data. Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript CytoNorm.R
+#
+# Install (GitHub-hosted, not on CRAN/Bioconductor):
+#   remotes::install_github("saeyslab/CytoNorm")
+#
+# ======================= ASSUMPTIONS TO RE-CHECK (FIDDLY) ====================
+# Written from the CytoNorm source (saeyslab/CytoNorm) rather than a live
+# install. The train/normalize signatures + the transformList contract are the
+# easy-to-get-wrong parts -- RE-VERIFY every one of these:
+#
+#  * HIGH-LEVEL pipeline (heavily version-sensitive):
+#      CytoNorm.train(files, labels, channels, transformList,
+#                     FlowSOM.params = list(nCells=, xdim=, ydim=, nClus=, ...),
+#                     normMethod.train = QuantileNorm.train, seed=, ...)
+#      CytoNorm.normalize(model, files, labels, transformList,
+#                         transformList.reverse, outputDir=, prefix=, ...)
+#    - `files` is a flowSet (or a character vector of FCS paths); `labels` is a
+#      per-FILE batch label vector; `channels` are the channels to normalize.
+#    - transformList is REQUIRED for real CyTOF data: intensities must be
+#      asinh-transformed (typical cofactor 5) BEFORE clustering/normalization,
+#      and transformList.reverse un-does it on the written output. Passing the
+#      wrong (or no) transform silently corrupts results. CytoNorm.normalize
+#      WRITES normalized FCS files to `outputDir` (disk I/O) and returns paths.
+#    - We DO NOT run the high-level FlowSOM pipeline here (too much surface to
+#      pin offline); we only assert CytoNorm.train / CytoNorm.normalize EXIST.
+#
+#  * LOWER-LEVEL quantile normalization (what the soft round-trip exercises):
+#      QuantileNorm.train(files, labels, channels, transformList,
+#                         nQ = 101, goal = "mean", ...)
+#      QuantileNorm.normalize(model, files, labels, transformList,
+#                             transformList.reverse, outputDir=, prefix=,
+#                             write = TRUE, ...)
+#    - transformList MAY be NULL here (data assumed already on the analysis
+#      scale) -- so the soft round-trip passes NULL and feeds already-modest
+#      synthetic values, sidestepping the asinh/reverse-asinh pair entirely.
+#    - `goal = "mean"` aligns every batch to the pooled mean quantiles; it can
+#      also be a batch label or an explicit goal-quantile matrix.
+#    - QuantileNorm.normalize WRITES FCS to outputDir and returns the written
+#      paths; the round-trip reads them back with flowCore::read.flowSet. This
+#      exact 3-plus-arg signature + file-writing behaviour is UNVERIFIED here,
+#      so the whole round-trip is best-effort: if it will not construct offline
+#      it SOFT-SKIPS (no failure); only once it produces output do the dims /
+#      finiteness / gap-shrinks assertions become HARD.
+#
+#  * flowCore is a hard dependency of CytoNorm, so it is guaranteed installed
+#    whenever CytoNorm is; the synthetic flowSet is built with flowCore.
+# ============================================================================
+
+if (!requireNamespace("CytoNorm", quietly = TRUE)) {
+  cat("FAIL: package 'CytoNorm' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(CytoNorm))
+cat(sprintf("CytoNorm version: %s\n", as.character(packageVersion("CytoNorm"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# ---- synthetic two-batch data --------------------------------------------
+# Two batches of 2000 cells x 5 markers. Batch 2 carries a planted +2 shift on
+# every marker (the "batch effect" quantile normalization should remove). Values
+# are already on a modest scale, so no transformList is needed (see NOTE above).
+set.seed(1)
+markers <- paste0("M", 1:5)
+n_cells <- 2000L
+mat_b1 <- matrix(rnorm(n_cells * length(markers), mean = 0, sd = 1),
+                 ncol = length(markers), dimnames = list(NULL, markers))
+mat_b2 <- matrix(rnorm(n_cells * length(markers), mean = 2, sd = 1),
+                 ncol = length(markers), dimnames = list(NULL, markers))
+
+# Uncorrected between-batch mean gap (planted ~2 on each marker).
+gap_before <- mean(abs(colMeans(mat_b1) - colMeans(mat_b2)))
+
+# One flowFrame per batch -> a 2-sample flowSet, one label per sample.
+synthetic_flowset <- function() {
+  ff1 <- flowCore::flowFrame(mat_b1)
+  ff2 <- flowCore::flowFrame(mat_b2)
+  fs <- flowCore::flowSet(ff1, ff2)
+  flowCore::sampleNames(fs) <- c("batch1", "batch2")
+  fs
+}
+
+# SOFT: full QuantileNorm.train -> normalize -> read-back round-trip. Throws if
+# it cannot be constructed offline (uncertain signature / disk I/O); the caller
+# turns that throw into a soft-skip.
+quantile_roundtrip <- function() {
+  stopifnot(requireNamespace("flowCore", quietly = TRUE))
+  fs <- synthetic_flowset()
+  labels <- c("batch1", "batch2")   # one batch label per file/sample
+
+  model <- QuantileNorm.train(
+    files = fs, labels = labels, channels = markers,
+    transformList = NULL, nQ = 101, goal = "mean")
+
+  out_dir <- file.path(tempdir(), sprintf("cytonorm-smoke-%d", as.integer(Sys.time())))
+  dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+  on.exit(unlink(out_dir, recursive = TRUE), add = TRUE)
+
+  written <- QuantileNorm.normalize(
+    model = model, files = fs, labels = labels,
+    transformList = NULL, transformList.reverse = NULL,
+    outputDir = out_dir, prefix = "Norm_", write = TRUE)
+
+  normed <- flowCore::read.flowSet(files = as.character(written))
+  after1 <- flowCore::exprs(normed[[1]])[, markers, drop = FALSE]
+  after2 <- flowCore::exprs(normed[[2]])[, markers, drop = FALSE]
+  list(
+    n = n_cells,
+    after1 = after1,
+    after2 = after2,
+    gap_after = mean(abs(colMeans(after1) - colMeans(after2)))
+  )
+}
+
+run_test("train/normalize entry points are exported functions", function() {
+  stopifnot(is.function(CytoNorm.train))
+  stopifnot(is.function(CytoNorm.normalize))
+  stopifnot(is.function(QuantileNorm.train))
+  stopifnot(is.function(QuantileNorm.normalize))
+})
+
+run_test("synthetic 2-batch flowSet has the expected shape", function() {
+  stopifnot(requireNamespace("flowCore", quietly = TRUE))
+  fs <- synthetic_flowset()
+  stopifnot(is(fs, "flowSet"))
+  stopifnot(length(fs) == 2L)                       # two batches
+  stopifnot(all(markers %in% flowCore::colnames(fs)))
+  stopifnot(nrow(flowCore::exprs(fs[[1]])) == n_cells)
+  stopifnot(nrow(flowCore::exprs(fs[[2]])) == n_cells)
+})
+
+run_test("QuantileNorm round-trip (soft): dims preserved & batch gap shrinks", function() {
+  res <- tryCatch(
+    suppressWarnings(suppressMessages(quantile_roundtrip())),
+    error = function(e) {
+      cat(sprintf("       (soft-skip: round-trip not constructible offline: %s)\n",
+                  conditionMessage(e)))
+      NULL
+    })
+  if (is.null(res)) return(invisible(NULL))  # soft-skip: nothing to assert
+  # Round-trip produced output -> assertions are now HARD.
+  stopifnot(nrow(res$after1) == res$n, nrow(res$after2) == res$n)
+  stopifnot(all(is.finite(res$after1)), all(is.finite(res$after2)))
+  # Quantile normalization aligns the batches: the mean gap must not grow, and
+  # in practice shrinks well below the planted ~2 (tolerance, not equality).
+  stopifnot(res$gap_after <= gap_before + 1e-8)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all CytoNorm smoke tests passed\n")

--- a/cli/scripts/lib-validator/DBI.R
+++ b/cli/scripts/lib-validator/DBI.R
@@ -1,0 +1,84 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `DBI` package.
+#
+# Fully self-contained: no input files, no network. DBI is an interface,
+# so its generics are exercised through the RSQLite driver against
+# in-memory databases only (nothing touches disk). Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript DBI.R
+
+if (!requireNamespace("DBI", quietly = TRUE)) {
+  cat("FAIL: package 'DBI' is not installed\n")
+  quit(save = "no", status = 1)
+}
+if (!requireNamespace("RSQLite", quietly = TRUE)) {
+  cat("FAIL: package 'RSQLite' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DBI))
+cat(sprintf("DBI version: %s\n", as.character(packageVersion("DBI"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("connect, dbWriteTable, count", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbWriteTable(con, "t", data.frame(id = 1:3, v = c("a", "b", "c"), stringsAsFactors = FALSE))
+  stopifnot(dbGetQuery(con, "SELECT COUNT(*) AS n FROM t")$n == 3)
+})
+
+run_test("dbListTables and dbExistsTable", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbWriteTable(con, "t", data.frame(id = 1:3))
+  stopifnot("t" %in% dbListTables(con))
+  stopifnot(isTRUE(dbExistsTable(con, "t")))
+  stopifnot(isFALSE(dbExistsTable(con, "missing")))
+})
+
+run_test("dbReadTable roundtrips the frame", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  df <- data.frame(id = 1:3, v = c("a", "b", "c"), stringsAsFactors = FALSE)
+  dbWriteTable(con, "t", df)
+  back <- dbReadTable(con, "t")
+  stopifnot(nrow(back) == 3L, identical(names(back), c("id", "v")))
+  stopifnot(all(back$id == 1:3))
+  stopifnot(identical(as.character(back$v), c("a", "b", "c")))
+})
+
+run_test("dbExecute reports affected rows", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbExecute(con, "CREATE TABLE t (id INTEGER, v TEXT)")
+  stopifnot(dbExecute(con, "INSERT INTO t VALUES (1, 'a'), (2, 'b')") == 2)
+  stopifnot(dbExecute(con, "UPDATE t SET v = 'z' WHERE id = 1") == 1)
+  stopifnot(identical(as.character(dbGetQuery(con, "SELECT v FROM t WHERE id = 1")$v), "z"))
+})
+
+run_test("dbDisconnect invalidates the connection", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  stopifnot(isTRUE(dbIsValid(con)))
+  dbDisconnect(con)
+  stopifnot(isFALSE(dbIsValid(con)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DBI smoke tests passed\n")

--- a/cli/scripts/lib-validator/DEP.R
+++ b/cli/scripts/lib-validator/DEP.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `DEP` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond DEP itself
+# (a proteomics differential-enrichment package built on SummarizedExperiment).
+# All data is DEP's OWN bundled example -- the UbiLength proteinGroups table and
+# its experimental design -- loaded via data(); no external files are read. The
+# heavy end-to-end DE model (test_diff/add_rejections) is left to function
+# existence, while the make_unique -> make_se construction (which yields a real
+# SummarizedExperiment) is exercised. Exits 0 only if every check passes:
+#
+#   Rscript DEP.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# DEP is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - data(UbiLength) loads a proteinGroups data.frame with "Protein.IDs" /
+#     "Gene.names" columns and several "LFQ.intensity.*" quantitative columns;
+#     data(UbiLength_ExpDesign) loads its label/condition/replicate design.
+#   - FLAG (arg names): make_unique(df, names_col, ids_col, delim=";") then
+#     make_se(unique_df, <LFQ column indices>, expdesign) returns a
+#     SummarizedExperiment with one column per LFQ sample.
+#   - FLAG: the actual DE test (test_diff) and thresholding (add_rejections) are
+#     left as function-existence only -- their statistical output is NOT checked.
+# ============================================================================
+
+if (!requireNamespace("DEP", quietly = TRUE)) {
+  cat("FAIL: package 'DEP' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DEP))
+cat(sprintf("DEP version: %s\n", as.character(packageVersion("DEP"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core workflow functions exist", function() {
+  stopifnot(is.function(make_unique))
+  stopifnot(is.function(make_se))
+  stopifnot(is.function(make_se_parse))
+  stopifnot(is.function(test_diff))
+  stopifnot(is.function(add_rejections))
+  stopifnot(is.function(plot_volcano))
+})
+
+run_test("bundled example data loads (UbiLength)", function() {
+  data("UbiLength", package = "DEP", envir = environment())
+  stopifnot(is.data.frame(UbiLength))
+  stopifnot(all(c("Protein.IDs", "Gene.names") %in% colnames(UbiLength)))
+  # The LFQ intensity columns are the quantitative payload the workflow consumes.
+  stopifnot(length(grep("^LFQ\\.", colnames(UbiLength))) > 0L)
+})
+
+run_test("make_unique + make_se build a SummarizedExperiment", function() {
+  data("UbiLength", package = "DEP", envir = environment())
+  data("UbiLength_ExpDesign", package = "DEP", envir = environment())
+  du <- make_unique(UbiLength, "Gene.names", "Protein.IDs", delim = ";")
+  lfq <- grep("^LFQ\\.", colnames(du))
+  stopifnot(length(lfq) > 0L)
+  se <- make_se(du, lfq, UbiLength_ExpDesign)
+  stopifnot(inherits(se, "SummarizedExperiment"))
+  # One assay column per LFQ sample; features carried across.
+  stopifnot(ncol(se) == length(lfq))
+  stopifnot(nrow(se) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DEP smoke tests passed\n")

--- a/cli/scripts/lib-validator/DESeq2.R
+++ b/cli/scripts/lib-validator/DESeq2.R
@@ -1,0 +1,116 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `DESeq2` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# DESeq2 itself (and the dependencies it implies, e.g. SummarizedExperiment /
+# S4Vectors). All data is simulated with a fixed seed; differential-expression
+# checks are structural / tolerance-based, never exact floating-point
+# equality. Exercises the core API surface and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript DESeq2.R
+
+if (!requireNamespace("DESeq2", quietly = TRUE)) {
+  cat("FAIL: package 'DESeq2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DESeq2))
+cat(sprintf("DESeq2 version: %s\n", as.character(packageVersion("DESeq2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate a 200-gene x 6-sample count matrix: two conditions, 3 vs 3.
+# Baseline counts are Poisson around a moderate mean; the first 20 genes
+# (the planted DE set) get a strong ~8x up-shift in condition B, so there is
+# a known effect to recover. The remaining 180 genes are null (same mean in
+# both conditions).
+set.seed(1)
+n_genes <- 200L
+n_per <- 3L
+n_de <- 20L
+base_mu <- 100
+counts <- matrix(
+  rpois(n_genes * 2L * n_per, lambda = base_mu),
+  nrow = n_genes,
+  ncol = 2L * n_per
+)
+b_cols <- (n_per + 1L):(2L * n_per) # columns 4:6 == condition B
+counts[1:n_de, b_cols] <- rpois(n_de * n_per, lambda = base_mu * 8)
+rownames(counts) <- sprintf("gene%03d", seq_len(n_genes))
+colnames(counts) <- sprintf("s%d", seq_len(2L * n_per))
+cond <- factor(rep(c("A", "B"), each = n_per))
+de_idx <- 1:n_de
+null_idx <- (n_de + 1L):n_genes
+
+# suppressMessages silences DESeq()'s progress chatter ("estimating size
+# factors", ...); genuine errors still propagate to run_test's tryCatch.
+run_deseq <- function() {
+  dds <- DESeqDataSetFromMatrix(
+    countData = counts,
+    colData = DataFrame(cond = cond),
+    design = ~cond
+  )
+  suppressMessages(DESeq(dds))
+}
+
+run_test("DESeqDataSetFromMatrix + DESeq: object class and dims", function() {
+  dds <- run_deseq()
+  stopifnot(inherits(dds, "DESeqDataSet"))
+  stopifnot(nrow(dds) == n_genes, ncol(dds) == 2L * n_per)
+  stopifnot(identical(as.character(colnames(dds)), colnames(counts)))
+})
+
+run_test("results: table shape and required columns", function() {
+  dds <- run_deseq()
+  res <- results(dds)
+  stopifnot(inherits(res, "DESeqResults"))
+  stopifnot(nrow(res) == n_genes)
+  stopifnot(all(c("log2FoldChange", "pvalue", "padj") %in% colnames(res)))
+})
+
+run_test("results: planted DE genes recovered with correct sign", function() {
+  dds <- run_deseq()
+  # Contrast B vs A: the up-shifted genes must show positive LFC; the null
+  # genes must sit near zero. Aggregate medians, not per-gene equality.
+  res <- results(dds, contrast = c("cond", "B", "A"))
+  lfc <- res$log2FoldChange
+  stopifnot(median(lfc[de_idx], na.rm = TRUE) > 2)
+  stopifnot(abs(median(lfc[null_idx], na.rm = TRUE)) < 0.5)
+})
+
+run_test("results: DE genes have smaller adjusted p than null genes", function() {
+  dds <- run_deseq()
+  res <- results(dds, contrast = c("cond", "B", "A"))
+  padj <- res$padj
+  # The planted set is strongly significant; the null set is not. Compare
+  # medians rather than asserting a per-gene threshold.
+  stopifnot(median(padj[de_idx], na.rm = TRUE) < 0.01)
+  stopifnot(median(padj[null_idx], na.rm = TRUE) > 0.1)
+})
+
+run_test("counts and sizeFactors accessors", function() {
+  dds <- run_deseq()
+  cm <- counts(dds)
+  stopifnot(is.matrix(cm), identical(dim(cm), c(n_genes, 2L * n_per)))
+  sf <- sizeFactors(dds)
+  stopifnot(length(sf) == 2L * n_per, all(is.finite(sf)), all(sf > 0))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DESeq2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/DMRcate.R
+++ b/cli/scripts/lib-validator/DMRcate.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `DMRcate` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. DMRcate calls differentially
+# methylated regions (DMRs): cpg.annotate() turns per-CpG statistics into an
+# annotated object using the array's annotation package (450K/EPIC) or a
+# sequencing annotation, and dmrcate() then agglomerates neighbouring CpGs into
+# regions. We have NEITHER per-CpG stats NOR a chosen array annotation here, so a
+# real cpg.annotate() -> dmrcate() -> extractRanges() run is OUT OF SCOPE
+# OFFLINE. This test therefore verifies only what is checkable without any
+# annotation: that the package loads and that its DMR-calling entry points are
+# present. Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript DMRcate.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# This test is FUNCTION-EXISTENCE-DOMINATED. A real run needs annotated CpG
+# statistics (from an array annotation package such as
+# IlluminaHumanMethylation450kanno.* / EPIC, or a bisulfite-seq annotation),
+# which we cannot construct or fetch offline. The checks below pass on any
+# healthy install; VERIFY ONCE INSTALLED that these remain the public entry
+# points:
+#   - cpg.annotate()  : per-CpG stats + array annotation -> annotated object.
+#   - dmrcate()       : agglomerate annotated CpGs into candidate regions.
+#   - extractRanges() : pull the called DMRs out as a GRanges.
+# ============================================================================
+
+if (!requireNamespace("DMRcate", quietly = TRUE)) {
+  cat("FAIL: package 'DMRcate' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DMRcate))
+cat(sprintf("DMRcate version: %s\n", as.character(packageVersion("DMRcate"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("cpg.annotate entry point is an exported function", function() {
+  stopifnot(exists("cpg.annotate"), is.function(cpg.annotate))
+})
+
+run_test("dmrcate DMR-calling entry point is an exported function", function() {
+  stopifnot(exists("dmrcate"), is.function(dmrcate))
+})
+
+run_test("extractRanges result-extraction entry point is an exported function", function() {
+  stopifnot(exists("extractRanges"), is.function(extractRanges))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DMRcate smoke tests passed\n")

--- a/cli/scripts/lib-validator/DSS.R
+++ b/cli/scripts/lib-validator/DSS.R
@@ -1,0 +1,120 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `DSS` package.
+#
+# Fully self-contained: no input files, NO network. DSS calls differentially
+# methylated loci (DML) and regions (DMR) from a `bsseq::BSseq` object. We build
+# a synthetic two-group BSseq (mirroring the dmrseq build: one chromosome of CpG
+# loci with methylation + coverage matrices and a planted differential block),
+# run `DMLtest`, then `callDML`/`callDMR`. Exits 0 only if every check passes, so
+# it works as a pass/fail validator:
+#
+#   Rscript DSS.R
+#
+# ============================ HEAVILY FLAGGED — RE-CHECK =====================
+# Written blind (package not installed here). The LOAD-BEARING checks are the
+# safe ones: (a) DMLtest()/callDML()/callDMR() exist, and (b) a synthetic BSseq
+# is CONSTRUCTIBLE. VERIFY ONCE INSTALLED:
+#   * BSseq CONSTRUCTION: assumed `bsseq::BSseq(chr=, pos=, M=, Cov=, ...)`
+#     (M = methylated counts, Cov = total coverage). Mirrors the dmrseq build.
+#   * DMLtest GROUP-ARG FORM: assumed `DSS::DMLtest(BSobj, group1=, group2=)`
+#     where group1/group2 are vectors of SAMPLE NAMES present in the BSseq. If
+#     DSS expects indices or a different arg form, test 3 fails at the call.
+#   * OUTPUT SHAPE: assumed DMLtest() -> data.frame with at least chr/pos/stat/
+#     pval; callDML() -> data.frame; callDMR() -> data.frame OR NULL (it returns
+#     NULL when no region passes). The actual DMLtest run (test 3) is SOFT: it
+#     warns and passes if DSS cannot complete on this minimal set, asserting the
+#     data.frame contract only on success. If it runs reliably, PROMOTE to hard.
+# ============================================================================
+
+if (!requireNamespace("DSS", quietly = TRUE)) {
+  cat("FAIL: package 'DSS' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DSS))
+cat(sprintf("DSS version: %s\n", as.character(packageVersion("DSS"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Deterministic synthetic BSseq with a planted differential block (mirrors the
+# dmrseq build). Coverage is positive at every locus/sample.
+nLoci <- 400L
+nPerGroup <- 3L
+sampleIds <- sprintf("S%02d", seq_len(2L * nPerGroup))
+group1 <- sampleIds[seq_len(nPerGroup)]                       # "A"
+group2 <- sampleIds[nPerGroup + seq_len(nPerGroup)]           # "B"
+
+build_bs <- function() {
+  set.seed(3)
+  nSample <- 2L * nPerGroup
+  condition <- factor(rep(c("A", "B"), each = nPerGroup))
+
+  pos <- sort(sample.int(1e6L, nLoci))  # unique, strictly increasing positions
+  cov <- matrix(sample(10:30, nLoci * nSample, replace = TRUE),
+                nrow = nLoci, ncol = nSample)
+
+  prob <- matrix(0.5, nrow = nLoci, ncol = nSample)
+  block <- 150:200
+  prob[block, condition == "B"] <- 0.85
+  prob[block, condition == "A"] <- 0.15
+  meth <- matrix(rbinom(nLoci * nSample, size = as.vector(cov), prob = as.vector(prob)),
+                 nrow = nLoci, ncol = nSample)
+
+  bsseq::BSseq(chr = rep("chr1", nLoci), pos = pos,
+               M = meth, Cov = cov, sampleNames = sampleIds)
+}
+
+run_test("DMLtest, callDML and callDMR are exported functions", function() {
+  stopifnot(is.function(DSS::DMLtest))
+  stopifnot(is.function(DSS::callDML))
+  stopifnot(is.function(DSS::callDMR))
+})
+
+run_test("synthetic BSseq object is constructible with the expected shape", function() {
+  bs <- build_bs()
+  stopifnot(methods::is(bs, "BSseq"))
+  stopifnot(nrow(bs) == nLoci, ncol(bs) == 2L * nPerGroup)
+  stopifnot(all(c(group1, group2) %in% bsseq::sampleNames(bs)))
+})
+
+run_test("DMLtest -> callDML/callDMR return data frames (SOFT -- see header)", function() {
+  bs <- build_bs()
+  dml <- tryCatch({
+    out <- NULL
+    invisible(utils::capture.output(suppressWarnings(suppressMessages(
+      out <- DSS::DMLtest(bs, group1 = group1, group2 = group2)))))
+    out
+  }, error = function(e) e)
+  if (inherits(dml, "error")) {
+    cat(sprintf("  note DMLtest() did not complete on the synthetic set: %s\n",
+                conditionMessage(dml)))
+    return(invisible(NULL))
+  }
+  stopifnot(is.data.frame(dml), nrow(dml) > 0L)
+  stopifnot(all(c("chr", "pos", "stat", "pval") %in% names(dml)))
+
+  calls <- suppressWarnings(suppressMessages(DSS::callDML(dml)))
+  stopifnot(is.data.frame(calls))
+
+  # callDMR() returns NULL when no region passes the thresholds — both are fine.
+  dmr <- suppressWarnings(suppressMessages(DSS::callDMR(dml)))
+  stopifnot(is.null(dmr) || is.data.frame(dmr))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DSS smoke tests passed\n")

--- a/cli/scripts/lib-validator/DelayedArray.R
+++ b/cli/scripts/lib-validator/DelayedArray.R
@@ -1,0 +1,75 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `DelayedArray` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# DelayedArray and the Bioconductor/CRAN base packages it attaches (Matrix,
+# BiocGenerics, MatrixGenerics, S4Vectors, IRanges, S4Arrays, SparseArray).
+# Wraps a synthetic in-memory matrix in a DelayedArray, then asserts that the
+# delayed ops realize to the same values as the equivalent base-matrix
+# computation (elementwise arithmetic, row/col sums, subsetting). Exits 0 only
+# if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript DelayedArray.R
+
+if (!requireNamespace("DelayedArray", quietly = TRUE)) {
+  cat("FAIL: package 'DelayedArray' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DelayedArray))
+cat(sprintf("DelayedArray version: %s\n", as.character(packageVersion("DelayedArray"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("DelayedArray construction dims", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  da <- DelayedArray(m)
+  stopifnot(is(da, "DelayedArray"))
+  stopifnot(identical(dim(da), c(3L, 4L)))
+})
+
+run_test("elementwise arithmetic realizes correctly", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  da <- DelayedArray(m)
+  stopifnot(identical(as.matrix(da * 2L), m * 2L))
+  stopifnot(identical(as.matrix(da + 1L), m + 1L))
+})
+
+run_test("rowSums / colSums match base", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  da <- DelayedArray(m)
+  stopifnot(isTRUE(all.equal(rowSums(da), rowSums(m))))
+  stopifnot(isTRUE(all.equal(colSums(da), colSums(m))))
+})
+
+run_test("subsetting realizes the expected block", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  da <- DelayedArray(m)
+  stopifnot(identical(as.matrix(da[1:2, 1:2]), m[1:2, 1:2]))
+  stopifnot(identical(as.matrix(da[2:3, , drop = FALSE]), m[2:3, , drop = FALSE]))
+})
+
+run_test("single-element access realizes a scalar", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  da <- DelayedArray(m)
+  stopifnot(as.vector(da[1, 1]) == 1L)
+  stopifnot(as.vector(da[3, 4]) == 12L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DelayedArray smoke tests passed\n")

--- a/cli/scripts/lib-validator/DescTools.R
+++ b/cli/scripts/lib-validator/DescTools.R
@@ -1,0 +1,80 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `DescTools` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# DescTools itself. Exercises pure helpers with deterministic expected
+# values and exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript DescTools.R
+
+if (!requireNamespace("DescTools", quietly = TRUE)) {
+  cat("FAIL: package 'DescTools' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DescTools))
+cat(sprintf("DescTools version: %s\n", as.character(packageVersion("DescTools"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("Mode of a small vector", function() {
+  m <- Mode(c(1, 1, 2, 3))
+  stopifnot(as.numeric(m) == 1)
+  stopifnot(attr(m, "freq") == 2L)
+})
+
+run_test("Gini: equality and concentration", function() {
+  stopifnot(isTRUE(all.equal(Gini(c(1, 1, 1, 1)), 0)))
+  # Closed form for c(0, 0, 0, 10): sum|xi-xj| / (2 n^2 mu) = 60/80 = 0.75.
+  stopifnot(isTRUE(all.equal(Gini(c(0, 0, 0, 10), unbiased = FALSE), 0.75, tolerance = 1e-8)))
+  # The default (unbiased) estimator scales by n/(n-1); still heavily concentrated.
+  stopifnot(Gini(c(0, 0, 0, 10)) > 0.7)
+})
+
+run_test("Winsorize clamps the tails", function() {
+  w <- Winsorize(1:10, val = c(2, 9))
+  stopifnot(isTRUE(all.equal(as.numeric(w), c(2, 2, 3, 4, 5, 6, 7, 8, 9, 9))))
+})
+
+run_test("%like% and %nin% operators", function() {
+  stopifnot(identical(c("apple", "banana") %like% "%an%", c(FALSE, TRUE)))
+  stopifnot(identical(c(1, 2) %nin% c(2, 3), c(TRUE, FALSE)))
+})
+
+run_test("AUC matches the trapezoid area", function() {
+  # y = x on [0, 2]: area = 2. Constant y = 1 on [0, 1]: area = 1.
+  stopifnot(isTRUE(all.equal(AUC(c(0, 1, 2), c(0, 1, 2)), 2)))
+  stopifnot(isTRUE(all.equal(AUC(c(0, 1), c(1, 1)), 1)))
+})
+
+run_test("CramerV on contingency tables", function() {
+  perfect <- matrix(c(10, 0, 0, 10), nrow = 2)
+  stopifnot(isTRUE(all.equal(CramerV(perfect), 1)))
+  independent <- matrix(c(5, 5, 5, 5), nrow = 2)
+  stopifnot(isTRUE(all.equal(CramerV(independent), 0)))
+})
+
+run_test("Recode relabels factor levels", function() {
+  r <- Recode(factor(c("a", "b", "c")), lo = c("a", "b"), hi = "c")
+  stopifnot(identical(as.character(r), c("lo", "lo", "hi")))
+  stopifnot(identical(levels(r), c("lo", "hi")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DescTools smoke tests passed\n")

--- a/cli/scripts/lib-validator/DiffBind.R
+++ b/cli/scripts/lib-validator/DiffBind.R
@@ -1,0 +1,90 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `DiffBind` package (ChIP/ATAC differential
+# binding).
+#
+# NO network and no truly-external files. A real DiffBind run needs peaksets +
+# BAM files wired through a sample sheet, which is heavier than a smoke test
+# should be; instead this validates the public API surface and — when the
+# package ships its bundled example DBA object — a real `DBA` object built from
+# that data. Everything comes from DiffBind's own installation (its exported
+# functions and its bundled data()); no user data is touched. Checks are
+# STRUCTURAL (functions exist; the example object, if present, is a DBA with
+# the expected accessors). Exits 0 only if every check passes, so it can be used
+# as a pass/fail library validator:
+#
+#   Rscript DiffBind.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# DiffBind is the HEAVIEST package to validate offline — a genuine analysis
+# needs a sample sheet + aligned reads. RE-CHECK once a build is available:
+#   - Exported entry points: dba, dba.count, dba.contrast, dba.analyze,
+#     dba.normalize, dba.report (these are the load-bearing API assertions and
+#     should hold on any install).
+#   - The bundled example dataset name: this script tries data("tamoxifen_counts")
+#     and expects it to materialise a `tamoxifen` object of class DBA. The
+#     dataset name / object name have varied across DiffBind versions, so the
+#     block is GUARDED — it is skipped (without failing) if that dataset is not
+#     listed by data(package="DiffBind"). If skipped, only the API-surface
+#     checks run. Re-confirm the current example-data name and object name.
+# ============================================================================
+
+if (!requireNamespace("DiffBind", quietly = TRUE)) {
+  cat("FAIL: package 'DiffBind' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(DiffBind))
+cat(sprintf("DiffBind version: %s\n", as.character(packageVersion("DiffBind"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core differential-binding API is exported", function() {
+  stopifnot(is.function(DiffBind::dba))
+  stopifnot(is.function(DiffBind::dba.count))
+  stopifnot(is.function(DiffBind::dba.contrast))
+  stopifnot(is.function(DiffBind::dba.analyze))
+  stopifnot(is.function(DiffBind::dba.normalize))
+  stopifnot(is.function(DiffBind::dba.report))
+})
+
+run_test("bundled example DBA object loads (if shipped)", function() {
+  # DiffBind ships example objects via data(); the classic one is
+  # 'tamoxifen_counts', which materialises a `tamoxifen` DBA object. The name
+  # has drifted across versions, so guard on it actually being present.
+  ds <- data(package = "DiffBind")$results
+  available <- if (is.null(ds)) character(0) else ds[, "Item"]
+  if (!("tamoxifen_counts" %in% available)) {
+    # Example data not shipped under this name; skip without failing. The
+    # API-surface test above still covers the load.
+    return(invisible(NULL))
+  }
+  e <- new.env(parent = emptyenv())
+  suppressWarnings(suppressMessages(
+    data("tamoxifen_counts", package = "DiffBind", envir = e)
+  ))
+  stopifnot(exists("tamoxifen", envir = e, inherits = FALSE))
+  obj <- get("tamoxifen", envir = e)
+  stopifnot(inherits(obj, "DBA"))
+  # A counted DBA carries a sample table; dba.show() returns one row per sample.
+  info <- suppressMessages(dba.show(obj))
+  stopifnot(is.data.frame(info))
+  stopifnot(nrow(info) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all DiffBind smoke tests passed\n")

--- a/cli/scripts/lib-validator/EnhancedVolcano.R
+++ b/cli/scripts/lib-validator/EnhancedVolcano.R
@@ -1,0 +1,88 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `EnhancedVolcano` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network, NO graphics device opened.
+# EnhancedVolcano builds a ggplot volcano plot from a differential-expression
+# results table; this test SIMULATES such a table (log2 fold changes + p-values
+# with gene rownames) and asserts the returned object is a ggplot WITHOUT ever
+# printing/drawing it (construction alone is the smoke test). Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript EnhancedVolcano.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed:
+#
+#   * EnhancedVolcano(toptable, lab, x, y, ...) is assumed -- `toptable` is the
+#     results data.frame, `lab` the point labels (here rownames), `x`/`y` the
+#     COLUMN NAMES holding log2FC and (raw) p-value. The function RETURNS a
+#     ggplot object; it does not draw unless printed.
+#
+#   * The returned object is asserted to inherit "ggplot" (and "gg"). Optional
+#     args pCutoff / FCcutoff / title are exercised in the last test; re-check
+#     those names if the extended call errors.
+# ============================================================================
+
+if (!requireNamespace("EnhancedVolcano", quietly = TRUE)) {
+  cat("FAIL: package 'EnhancedVolcano' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(EnhancedVolcano))
+cat(sprintf("EnhancedVolcano version: %s\n", as.character(packageVersion("EnhancedVolcano"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic DE results: 500 genes, rownames "g1".."g500". A subset is pushed to
+# large |log2FC| and tiny p-values so the plot has genuine "hits" to render.
+set.seed(123)
+n <- 500L
+gene_ids <- paste0("g", seq_len(n))
+lfc <- rnorm(n, sd = 1.5)
+pval <- runif(n, min = 1e-8, max = 1)
+hits <- 1:25
+lfc[hits] <- sample(c(-1, 1), length(hits), replace = TRUE) * runif(length(hits), 3, 6)
+pval[hits] <- 10^(-runif(length(hits), 6, 12))
+res <- data.frame(
+  log2FoldChange = lfc,
+  pvalue = pval,
+  row.names = gene_ids,
+  stringsAsFactors = FALSE
+)
+
+run_test("EnhancedVolcano returns a ggplot object", function() {
+  p <- suppressWarnings(suppressMessages(EnhancedVolcano::EnhancedVolcano(
+    res, lab = rownames(res), x = "log2FoldChange", y = "pvalue")))
+  stopifnot(inherits(p, "ggplot"), inherits(p, "gg"))
+})
+
+run_test("the plot carries at least one drawn layer", function() {
+  p <- suppressWarnings(suppressMessages(EnhancedVolcano::EnhancedVolcano(
+    res, lab = rownames(res), x = "log2FoldChange", y = "pvalue")))
+  stopifnot(is.list(p$layers), length(p$layers) > 0L)
+})
+
+run_test("explicit cutoffs and title still yield a ggplot", function() {
+  p <- suppressWarnings(suppressMessages(EnhancedVolcano::EnhancedVolcano(
+    res, lab = rownames(res), x = "log2FoldChange", y = "pvalue",
+    pCutoff = 1e-5, FCcutoff = 2, title = "smoke")))
+  stopifnot(inherits(p, "ggplot"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all EnhancedVolcano smoke tests passed\n")

--- a/cli/scripts/lib-validator/EnsDb.Hsapiens.v86.R
+++ b/cli/scripts/lib-validator/EnsDb.Hsapiens.v86.R
@@ -1,0 +1,88 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `EnsDb.Hsapiens.v86` (Bioconductor) data package.
+#
+# Fully self-contained: no input files, NO network. EnsDb.Hsapiens.v86 is a
+# DATA package -- it ships the Ensembl v86 human annotation as a local SQLite
+# database, so every query is deterministic and offline once installed. It
+# attaches ensembldb (a Depends) which supplies the query API. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript EnsDb.Hsapiens.v86.R
+#
+# ============================ API TO RE-CHECK ===============================
+# FLAG the following once installed:
+#   * KEYTYPE NAME: this looks up genes by name using keytype "GENENAME"
+#     (EnsDb also exposes "SYMBOL"). The script auto-selects whichever the
+#     installed db advertises via keytypes(), but CONFIRM the intended one.
+#   * organism(edb) is asserted to be exactly "Homo sapiens".
+#   * HARD-CODED ENSEMBL ID: BRCA1 is asserted to resolve to gene id
+#     "ENSG00000012048". This is the well-known BRCA1 Ensembl gene id, but it
+#     is a specific literal -- RE-CHECK it. The shape check (^ENSG[0-9]+$) is
+#     the robust primary assertion; the exact id is the secondary one.
+# ============================================================================
+
+if (!requireNamespace("EnsDb.Hsapiens.v86", quietly = TRUE)) {
+  cat("FAIL: package 'EnsDb.Hsapiens.v86' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(EnsDb.Hsapiens.v86))
+cat(sprintf("EnsDb.Hsapiens.v86 version: %s\n", as.character(packageVersion("EnsDb.Hsapiens.v86"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The package exports an EnsDb object bound to its own name.
+edb <- EnsDb.Hsapiens.v86
+
+run_test("package object is an EnsDb", function() {
+  stopifnot(is(edb, "EnsDb"))
+})
+
+run_test("organism is Homo sapiens", function() {
+  stopifnot(identical(organism(edb), "Homo sapiens"))
+})
+
+run_test("genes() returns a non-empty GRanges", function() {
+  g <- genes(edb)
+  stopifnot(is(g, "GRanges"))
+  stopifnot(length(g) > 0L)
+})
+
+run_test("BRCA1 resolves to an Ensembl gene id via select()", function() {
+  # Pick the gene-name keytype the installed db advertises (GENENAME preferred,
+  # SYMBOL as a fallback) -- see API TO RE-CHECK note in the header.
+  kt <- keytypes(edb)
+  gene_kt <- if ("GENENAME" %in% kt) {
+    "GENENAME"
+  } else if ("SYMBOL" %in% kt) {
+    "SYMBOL"
+  } else {
+    stop("EnsDb exposes neither a GENENAME nor a SYMBOL keytype")
+  }
+  res <- select(edb, keys = "BRCA1", keytype = gene_kt, columns = c("GENEID"))
+  stopifnot(is.data.frame(res), nrow(res) > 0L)
+  stopifnot("GENEID" %in% colnames(res))
+  ids <- res$GENEID
+  # ROBUST primary assertion: at least one non-empty ENSG-shaped id.
+  stopifnot(any(grepl("^ENSG[0-9]+$", ids)))
+  # SECONDARY assertion: the specific, well-known BRCA1 gene id (FLAGGED above).
+  stopifnot("ENSG00000012048" %in% ids)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all EnsDb.Hsapiens.v86 smoke tests passed\n")

--- a/cli/scripts/lib-validator/EnsDb.Mmusculus.v79.R
+++ b/cli/scripts/lib-validator/EnsDb.Mmusculus.v79.R
@@ -1,0 +1,89 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `EnsDb.Mmusculus.v79` (Bioconductor) data package.
+#
+# Fully self-contained: no input files, NO network. EnsDb.Mmusculus.v79 is a
+# DATA package -- it ships the Ensembl v79 mouse annotation as a local SQLite
+# database, so every query is deterministic and offline once installed. It
+# attaches ensembldb (a Depends) which supplies the query API. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript EnsDb.Mmusculus.v79.R
+#
+# ============================ API TO RE-CHECK ===============================
+# FLAG the following once installed:
+#   * KEYTYPE NAME: this looks up genes by name using keytype "GENENAME"
+#     (EnsDb also exposes "SYMBOL"). The script auto-selects whichever the
+#     installed db advertises via keytypes(), but CONFIRM the intended one.
+#   * organism(edb) is asserted to be exactly "Mus musculus".
+#   * HARD-CODED ENSEMBL ID: Trp53 is asserted to resolve to gene id
+#     "ENSMUSG00000059552". This is the well-known mouse Trp53 Ensembl gene id,
+#     but it is a specific literal -- RE-CHECK it. The shape check
+#     (^ENSMUSG[0-9]+$) is the robust primary assertion; the exact id is
+#     secondary.
+# ============================================================================
+
+if (!requireNamespace("EnsDb.Mmusculus.v79", quietly = TRUE)) {
+  cat("FAIL: package 'EnsDb.Mmusculus.v79' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(EnsDb.Mmusculus.v79))
+cat(sprintf("EnsDb.Mmusculus.v79 version: %s\n", as.character(packageVersion("EnsDb.Mmusculus.v79"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The package exports an EnsDb object bound to its own name.
+edb <- EnsDb.Mmusculus.v79
+
+run_test("package object is an EnsDb", function() {
+  stopifnot(is(edb, "EnsDb"))
+})
+
+run_test("organism is Mus musculus", function() {
+  stopifnot(identical(organism(edb), "Mus musculus"))
+})
+
+run_test("genes() returns a non-empty GRanges", function() {
+  g <- genes(edb)
+  stopifnot(is(g, "GRanges"))
+  stopifnot(length(g) > 0L)
+})
+
+run_test("Trp53 resolves to an Ensembl gene id via select()", function() {
+  # Pick the gene-name keytype the installed db advertises (GENENAME preferred,
+  # SYMBOL as a fallback) -- see API TO RE-CHECK note in the header.
+  kt <- keytypes(edb)
+  gene_kt <- if ("GENENAME" %in% kt) {
+    "GENENAME"
+  } else if ("SYMBOL" %in% kt) {
+    "SYMBOL"
+  } else {
+    stop("EnsDb exposes neither a GENENAME nor a SYMBOL keytype")
+  }
+  res <- select(edb, keys = "Trp53", keytype = gene_kt, columns = c("GENEID"))
+  stopifnot(is.data.frame(res), nrow(res) > 0L)
+  stopifnot("GENEID" %in% colnames(res))
+  ids <- res$GENEID
+  # ROBUST primary assertion: at least one non-empty ENSMUSG-shaped id.
+  stopifnot(any(grepl("^ENSMUSG[0-9]+$", ids)))
+  # SECONDARY assertion: the specific mouse Trp53 gene id (FLAGGED above).
+  stopifnot("ENSMUSG00000059552" %in% ids)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all EnsDb.Mmusculus.v79 smoke tests passed\n")

--- a/cli/scripts/lib-validator/EpiDISH.R
+++ b/cli/scripts/lib-validator/EpiDISH.R
@@ -1,0 +1,126 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `EpiDISH` package.
+#
+# Fully self-contained: no input files, NO network. EpiDISH estimates cell-type
+# fractions from a methylation (or expression) mixture given a reference profile
+# — a task that is GENUINELY testable OFFLINE with synthetic matrices, because
+# the answer is planted by construction. We build a random reference `ref`
+# (CpGs x cell types), draw known mixing proportions `trueF` (cell types x
+# samples), form the observed mixture `beta = ref %*% trueF` (+ tiny noise), run
+# the deconvolution, and check the recovered fractions against what we planted.
+# Exits 0 only if every check passes, so it works as a pass/fail validator:
+#
+#   Rscript EpiDISH.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# Written blind (package not installed here). VERIFY ONCE INSTALLED:
+#   * epidish() ARG NAMES: assumed `beta.m` (mixture) and `ref.m` (reference),
+#     with `method %in% {"RPC","CBS","CP"}`. If these names changed, the RPC
+#     test below fails at the call site — that is the signal to re-check.
+#   * estF ORIENTATION: assumed `out$estF` is a matrix of SAMPLES (rows) x
+#     CELL TYPES (cols). The shape assertion pins this; if EpiDISH transposed
+#     it, that assertion fails. The correlation test aligns by dimnames so it
+#     is robust to column/row reordering but NOT to a full transpose.
+#   * method="CBS" (CIBERSORT-style nu-SVR) needs `e1071`; kept SOFT so a
+#     missing optional dep only warns, never false-fails a healthy install.
+# ============================================================================
+
+if (!requireNamespace("EpiDISH", quietly = TRUE)) {
+  cat("FAIL: package 'EpiDISH' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(EpiDISH))
+cat(sprintf("EpiDISH version: %s\n", as.character(packageVersion("EpiDISH"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Deterministic synthetic deconvolution problem with a KNOWN answer.
+# Rebuilt identically on each call (fixed seed) so every test shares one truth.
+build_mix <- function() {
+  set.seed(1)
+  nCpG <- 200L
+  cellTypes <- c("CT1", "CT2", "CT3")
+  nCT <- length(cellTypes)
+  nSample <- 5L
+  cpgIds <- sprintf("cg%05d", seq_len(nCpG))
+  sampleIds <- sprintf("S%02d", seq_len(nSample))
+
+  # Reference: CpGs x cell types, methylation-beta values in [0, 1].
+  ref <- matrix(runif(nCpG * nCT), nrow = nCpG, ncol = nCT,
+                dimnames = list(cpgIds, cellTypes))
+
+  # Planted proportions: cell types x samples, each SAMPLE column sums to 1.
+  raw <- matrix(runif(nCT * nSample), nrow = nCT, ncol = nSample,
+                dimnames = list(cellTypes, sampleIds))
+  trueF <- sweep(raw, 2, colSums(raw), "/")
+
+  # Observed mixture = exact linear combination of the reference + small noise,
+  # clamped back into [0, 1] as a real methylation beta matrix would be.
+  beta <- ref %*% trueF + matrix(rnorm(nCpG * nSample, sd = 0.01), nrow = nCpG)
+  beta <- pmin(pmax(beta, 0), 1)
+  dimnames(beta) <- list(cpgIds, sampleIds)
+
+  list(beta = beta, ref = ref, trueF = trueF)
+}
+
+run_test("RPC deconvolution returns an estF matrix of the right shape", function() {
+  d <- build_mix()
+  out <- EpiDISH::epidish(beta.m = d$beta, ref.m = d$ref, method = "RPC")
+  stopifnot(is.list(out), !is.null(out$estF))
+  est <- out$estF
+  # SAMPLES x CELL TYPES — see header ASSUMPTIONS.
+  stopifnot(is.matrix(est))
+  stopifnot(nrow(est) == ncol(d$beta), ncol(est) == ncol(d$ref))
+})
+
+run_test("estF fractions lie in [0,1] and sum to ~1 per sample", function() {
+  d <- build_mix()
+  est <- EpiDISH::epidish(beta.m = d$beta, ref.m = d$ref, method = "RPC")$estF
+  stopifnot(all(est >= -1e-8), all(est <= 1 + 1e-8))
+  # RPC constrains each estimate to non-negative fractions that renormalize to 1.
+  stopifnot(max(abs(rowSums(est) - 1)) < 1e-2)
+})
+
+run_test("recovered fractions correlate with the planted proportions", function() {
+  d <- build_mix()
+  est <- EpiDISH::epidish(beta.m = d$beta, ref.m = d$ref, method = "RPC")$estF
+  planted <- t(d$trueF)  # samples x cell types, matching estF orientation
+  # Align by name so the check survives any column/row reordering.
+  est <- est[rownames(planted), colnames(planted), drop = FALSE]
+  r <- cor(as.vector(est), as.vector(planted))
+  # Exact linear mixture + tiny noise => near-perfect recovery; 0.7 is a floor.
+  stopifnot(is.finite(r), r > 0.7)
+})
+
+run_test("CBS method also runs and returns a well-shaped estF (SOFT)", function() {
+  d <- build_mix()
+  res <- tryCatch(
+    EpiDISH::epidish(beta.m = d$beta, ref.m = d$ref, method = "CBS"),
+    error = function(e) e)
+  if (inherits(res, "error")) {
+    # e1071 (nu-SVR backend) may be absent offline — warn, do NOT fail.
+    cat(sprintf("  note CBS did not run (optional dep?): %s\n", conditionMessage(res)))
+    return(invisible(NULL))
+  }
+  est <- res$estF
+  stopifnot(is.matrix(est), nrow(est) == ncol(d$beta), ncol(est) == ncol(d$ref))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all EpiDISH smoke tests passed\n")

--- a/cli/scripts/lib-validator/FlowSOM.R
+++ b/cli/scripts/lib-validator/FlowSOM.R
@@ -1,0 +1,115 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `FlowSOM` package.
+#
+# Fully self-contained: no input files, NO network. Feeds a small synthetic
+# marker matrix (built with a fixed seed) straight into the FlowSOM() one-shot
+# wrapper and inspects the resulting self-organizing map + metaclustering.
+# Checks are STRUCTURAL/tolerance (object shape, codebook dims, per-cell vs
+# per-node assignment lengths) rather than numeric equality on the random SOM.
+# Exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript FlowSOM.R
+#
+# ======================= ASSUMPTIONS TO RE-CHECK (FIDDLY) ====================
+# Written from the FlowSOM source (SofieVG/FlowSOM) rather than a live install.
+# The FlowSOM object shape changed across major versions -- RE-VERIFY:
+#
+#  * FlowSOM() one-shot: FlowSOM(input, colsToUse, nClus, xdim, ydim, seed, ...).
+#    - v2.x returns the FlowSOM object DIRECTLY.
+#    - v1.x returned list(FlowSOM = <obj>, metaclustering = <per-node factor>).
+#    We UNWRAP either shape via `res$FlowSOM %||% res`.
+#
+#  * Field names (v2.x, verified against source):
+#      fsom$map$codes   -- matrix, (xdim*ydim) SOM nodes x length(colsToUse)
+#      fsom$map$mapping -- matrix, one row PER CELL: [node_id, distance]
+#      fsom$metaclustering -- factor of length n_nodes (PER NODE, NOT per cell!)
+#    So `fsom$metaclustering` is per-node; PER-CELL metaclusters come from
+#    GetMetaclusters(fsom) (length == n cells). We assert both, deriving the
+#    per-cell vector defensively if the accessor signature differs by version.
+#
+#  * A raw matrix is accepted as input (via ReadInput), so this test needs no
+#    flowFrame and does not depend on flowCore being attached.
+# ============================================================================
+
+if (!requireNamespace("FlowSOM", quietly = TRUE)) {
+  cat("FAIL: package 'FlowSOM' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(FlowSOM))
+cat(sprintf("FlowSOM version: %s\n", as.character(packageVersion("FlowSOM"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic input: 1000 cells x 5 markers of Gaussian intensities. A raw matrix
+# with column names is a valid FlowSOM input. xdim*ydim = 25 SOM nodes.
+set.seed(1)
+mat <- matrix(rnorm(1000 * 5, 5), ncol = 5, dimnames = list(NULL, paste0("M", 1:5)))
+n_cells <- nrow(mat)
+n_nodes <- 25L
+n_clus <- 5L
+
+# Unwrap a v1.x list(FlowSOM=, metaclustering=) to the bare FlowSOM object.
+unwrap <- function(res) if (!is.null(res$FlowSOM)) res$FlowSOM else res
+
+run_test("FlowSOM builds a SOM codebook of the expected shape", function() {
+  res <- suppressWarnings(FlowSOM(mat, colsToUse = 1:5, nClus = n_clus,
+                                  xdim = 5, ydim = 5, seed = 1))
+  fsom <- unwrap(res)
+  stopifnot(is.list(fsom))
+  stopifnot(!is.null(fsom$map), !is.null(fsom$map$codes))
+  codes <- fsom$map$codes
+  stopifnot(is.matrix(codes))
+  stopifnot(nrow(codes) == n_nodes)  # xdim*ydim SOM nodes
+  stopifnot(ncol(codes) == 5L)       # one column per marker in colsToUse
+})
+
+run_test("per-node metaclustering labels every SOM node", function() {
+  res <- suppressWarnings(FlowSOM(mat, colsToUse = 1:5, nClus = n_clus,
+                                  xdim = 5, ydim = 5, seed = 1))
+  fsom <- unwrap(res)
+  mcl <- fsom$metaclustering
+  stopifnot(!is.null(mcl))
+  # metaclustering is PER NODE (length n_nodes), each node -> one of nClus.
+  stopifnot(length(mcl) == n_nodes)
+  stopifnot(length(unique(as.integer(mcl))) <= n_clus)
+})
+
+run_test("per-cell node + metacluster assignments span all cells", function() {
+  res <- suppressWarnings(FlowSOM(mat, colsToUse = 1:5, nClus = n_clus,
+                                  xdim = 5, ydim = 5, seed = 1))
+  fsom <- unwrap(res)
+  # mapping has exactly one row per cell: [assigned node, distance].
+  stopifnot(is.matrix(fsom$map$mapping))
+  stopifnot(nrow(fsom$map$mapping) == n_cells)
+  stopifnot(all(fsom$map$mapping[, 1] >= 1L),
+            all(fsom$map$mapping[, 1] <= n_nodes))
+  # Per-cell metaclusters via the accessor; fall back across version signatures,
+  # ultimately deriving cell -> node -> node-metacluster by hand.
+  mc <- tryCatch(
+    FlowSOM::GetMetaclusters(res),
+    error = function(e) tryCatch(
+      FlowSOM::GetMetaclusters(fsom),
+      error = function(e2) fsom$metaclustering[fsom$map$mapping[, 1]]))
+  stopifnot(length(mc) == n_cells)
+  stopifnot(length(unique(as.integer(mc))) <= n_clus)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all FlowSOM smoke tests passed\n")

--- a/cli/scripts/lib-validator/GSVA.R
+++ b/cli/scripts/lib-validator/GSVA.R
@@ -1,0 +1,105 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `GSVA` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. GSVA scores gene-set
+# activity per sample from an expression matrix; this test SIMULATES a small
+# expression matrix plus a user-supplied named list of gene sets, so nothing
+# reaches an online annotation source. Exits 0 only if every check passes, so
+# it can be used as a pass/fail library validator:
+#
+#   Rscript GSVA.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed -- the GSVA entry-point API changed at 1.50:
+#
+#   * CURRENT (GSVA >= 1.50): a PARAM-OBJECT API. You build a parameter object
+#       par <- gsvaParam(exprData, geneSets)   # (also ssgseaParam / plageParam)
+#     and then call the generic
+#       es  <- gsva(par)
+#     This script is written for that API.
+#
+#   * LEGACY (GSVA < 1.50): gsva() was called directly on the data --
+#       es <- gsva(exprData, geneSets, method = "gsva")
+#     If the installed version predates 1.50, `gsvaParam` will be missing and
+#     the first test errors; switch to the legacy signature above.
+#
+# Also verify: the S4 class name is assumed to be "gsvaParam", and gsva() on a
+# plain matrix is assumed to RETURN a plain matrix (rows = gene sets, cols =
+# samples). Both hold for current GSVA; re-check if the shape assertions fail.
+# ============================================================================
+
+if (!requireNamespace("GSVA", quietly = TRUE)) {
+  cat("FAIL: package 'GSVA' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(GSVA))
+cat(sprintf("GSVA version: %s\n", as.character(packageVersion("GSVA"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Deterministic synthetic inputs: a 100-gene x 6-sample expression matrix with
+# rownames "g1".."g100" and a named list of three gene sets over those genes.
+set.seed(42)
+n_genes <- 100L
+n_samples <- 6L
+gene_ids <- paste0("g", seq_len(n_genes))
+sample_ids <- paste0("s", seq_len(n_samples))
+expr <- matrix(
+  rnorm(n_genes * n_samples),
+  nrow = n_genes,
+  ncol = n_samples,
+  dimnames = list(gene_ids, sample_ids)
+)
+gene_sets <- list(
+  setA = gene_ids[1:20],
+  setB = gene_ids[30:50],
+  setC = gene_ids[60:80]
+)
+
+run_test("gsvaParam constructs a parameter object (>= 1.50 API)", function() {
+  par <- GSVA::gsvaParam(expr, gene_sets)
+  # S4 param object; class name assumed "gsvaParam" (see API UNCERTAINTY).
+  stopifnot(methods::is(par, "gsvaParam"))
+})
+
+run_test("gsva(param) returns a (nsets x nsamples) matrix", function() {
+  par <- GSVA::gsvaParam(expr, gene_sets)
+  es <- suppressWarnings(suppressMessages(GSVA::gsva(par)))
+  stopifnot(is.matrix(es))
+  stopifnot(nrow(es) == length(gene_sets), ncol(es) == ncol(expr))
+})
+
+run_test("enrichment scores are finite numerics", function() {
+  par <- GSVA::gsvaParam(expr, gene_sets)
+  es <- suppressWarnings(suppressMessages(GSVA::gsva(par)))
+  stopifnot(is.numeric(es))
+  stopifnot(all(is.finite(es)))
+})
+
+run_test("scores carry the gene-set and sample dimnames", function() {
+  par <- GSVA::gsvaParam(expr, gene_sets)
+  es <- suppressWarnings(suppressMessages(GSVA::gsva(par)))
+  # rows may be reordered by size filtering; compare as sets. Sample columns
+  # are preserved in input order.
+  stopifnot(setequal(rownames(es), names(gene_sets)))
+  stopifnot(identical(colnames(es), colnames(expr)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all GSVA smoke tests passed\n")

--- a/cli/scripts/lib-validator/GenomicAlignments.R
+++ b/cli/scripts/lib-validator/GenomicAlignments.R
@@ -1,0 +1,82 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `GenomicAlignments` package.
+#
+# NO network and no truly-external files: it reads only the example BAM that
+# ships INSIDE Rsamtools' own installation (system.file(..., package=
+# "Rsamtools")) — Rsamtools is a hard dependency of GenomicAlignments and is
+# therefore always present alongside it. Checks are STRUCTURAL (class, non-empty
+# length, CIGAR type, finite coordinates, coverage class) with no numeric
+# tolerance needed. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript GenomicAlignments.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# RE-CHECK once a build is available:
+#   - The bundled BAM lives at system.file("extdata", "ex1.bam", package=
+#     "Rsamtools"). GenomicAlignments has no example BAM of its own, so it
+#     borrows Rsamtools' — Rsamtools MUST be installed (it is a dependency, so
+#     this holds whenever GenomicAlignments itself is installed).
+#   - readGAlignments(bam) returns a GAlignments; coverage() returns an RleList.
+# ============================================================================
+
+if (!requireNamespace("GenomicAlignments", quietly = TRUE)) {
+  cat("FAIL: package 'GenomicAlignments' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(GenomicAlignments))
+cat(sprintf("GenomicAlignments version: %s\n", as.character(packageVersion("GenomicAlignments"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Package-bundled example alignment (ships inside Rsamtools/extdata; Rsamtools is
+# a dependency of GenomicAlignments so it is always installed alongside it).
+bam_path <- system.file("extdata", "ex1.bam", package = "Rsamtools")
+
+run_test("bundled example BAM is reachable", function() {
+  stopifnot(nzchar(bam_path), file.exists(bam_path))
+})
+
+run_test("readGAlignments returns a non-empty GAlignments", function() {
+  ga <- readGAlignments(bam_path)
+  stopifnot(inherits(ga, "GAlignments"))
+  stopifnot(length(ga) > 0L)
+})
+
+run_test("CIGAR strings and coordinates are well-formed", function() {
+  ga <- readGAlignments(bam_path)
+  cg <- cigar(ga)
+  stopifnot(is.character(cg))
+  stopifnot(length(cg) == length(ga))
+  st <- start(ga)
+  wd <- width(ga)
+  stopifnot(length(st) == length(ga), length(wd) == length(ga))
+  stopifnot(all(is.finite(st)), all(is.finite(wd)))
+  stopifnot(all(wd > 0))
+})
+
+run_test("coverage returns an RleList", function() {
+  ga <- readGAlignments(bam_path)
+  cov <- coverage(ga)
+  stopifnot(inherits(cov, "RleList"))
+  stopifnot(length(cov) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all GenomicAlignments smoke tests passed\n")

--- a/cli/scripts/lib-validator/GenomicRanges.R
+++ b/cli/scripts/lib-validator/GenomicRanges.R
@@ -1,0 +1,85 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `GenomicRanges` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# GenomicRanges and the Bioconductor base packages it attaches (BiocGenerics,
+# S4Vectors, IRanges, GenomeInfoDb). Builds small in-memory GRanges /
+# GRangesList objects and asserts exact results for the accessors and core
+# range operations (shift, flank, findOverlaps). Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript GenomicRanges.R
+
+if (!requireNamespace("GenomicRanges", quietly = TRUE)) {
+  cat("FAIL: package 'GenomicRanges' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(GenomicRanges))
+cat(sprintf("GenomicRanges version: %s\n", as.character(packageVersion("GenomicRanges"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("GRanges construction and range accessors", function() {
+  gr <- GRanges("chr1", IRanges(1:3, width = 10), strand = "+")
+  stopifnot(length(gr) == 3L)
+  stopifnot(identical(start(gr), c(1L, 2L, 3L)))
+  stopifnot(identical(end(gr), c(10L, 11L, 12L)))
+  stopifnot(identical(width(gr), c(10L, 10L, 10L)))
+})
+
+run_test("seqnames and strand", function() {
+  gr <- GRanges("chr1", IRanges(1:3, width = 10), strand = "+")
+  stopifnot(identical(as.character(seqnames(gr)), rep("chr1", 3)))
+  stopifnot(identical(as.character(strand(gr)), rep("+", 3)))
+})
+
+run_test("GRangesList groups GRanges", function() {
+  gr <- GRanges("chr1", IRanges(1:3, width = 10), strand = "+")
+  grl <- GRangesList(a = gr, b = gr[1:2])
+  stopifnot(length(grl) == 2L)
+  stopifnot(identical(names(grl), c("a", "b")))
+  stopifnot(identical(unname(lengths(grl)), c(3L, 2L)))
+})
+
+run_test("shift moves ranges by the offset", function() {
+  gr <- GRanges("chr1", IRanges(1:3, width = 10), strand = "+")
+  s <- shift(gr, 5)
+  stopifnot(identical(start(s), c(6L, 7L, 8L)))
+  stopifnot(identical(end(s), c(15L, 16L, 17L)))
+})
+
+run_test("flank yields upstream ranges on + strand", function() {
+  gr <- GRanges("chr1", IRanges(1:3, width = 10), strand = "+")
+  fl <- flank(gr, 3)
+  stopifnot(identical(width(fl), c(3L, 3L, 3L)))
+  stopifnot(identical(start(fl), c(-2L, -1L, 0L)))
+  stopifnot(identical(end(fl), c(0L, 1L, 2L)))
+})
+
+run_test("findOverlaps / countOverlaps across GRanges", function() {
+  q <- GRanges("chr1", IRanges(c(1, 20), width = 5))
+  s <- GRanges("chr1", IRanges(c(3, 100), width = 5))
+  ov <- findOverlaps(q, s)
+  stopifnot(length(ov) == 1L)
+  stopifnot(identical(queryHits(ov), 1L), identical(subjectHits(ov), 1L))
+  stopifnot(identical(countOverlaps(q, s), c(1L, 0L)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all GenomicRanges smoke tests passed\n")

--- a/cli/scripts/lib-validator/HDF5Array.R
+++ b/cli/scripts/lib-validator/HDF5Array.R
@@ -1,0 +1,78 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `HDF5Array` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# HDF5Array and the packages it attaches (DelayedArray, rhdf5). The one bit of
+# I/O is a private, per-test temporary `.h5` file that this script creates AND
+# removes via on.exit(unlink(...)) — no pre-existing/external file is read and
+# nothing is left behind. Exercises the HDF5 write/read roundtrip through the
+# bundled rhdf5 backend and asserts the realized values match the source
+# matrix. Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript HDF5Array.R
+
+if (!requireNamespace("HDF5Array", quietly = TRUE)) {
+  cat("FAIL: package 'HDF5Array' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(HDF5Array))
+cat(sprintf("HDF5Array version: %s\n", as.character(packageVersion("HDF5Array"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("writeHDF5Array returns an HDF5-backed DelayedArray", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  p <- tempfile(fileext = ".h5")
+  on.exit(unlink(p), add = TRUE)
+  ha <- writeHDF5Array(m, filepath = p, name = "m")
+  stopifnot(is(ha, "HDF5Array"))
+  stopifnot(is(ha, "DelayedArray"))
+  stopifnot(identical(dim(ha), c(3L, 4L)))
+})
+
+run_test("HDF5 write/read roundtrip preserves values", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  p <- tempfile(fileext = ".h5")
+  on.exit(unlink(p), add = TRUE)
+  writeHDF5Array(m, filepath = p, name = "m")
+  back <- HDF5Array(p, "m")
+  stopifnot(is(back, "HDF5Array"))
+  stopifnot(identical(dim(back), c(3L, 4L)))
+  stopifnot(identical(as.matrix(back), m))
+})
+
+run_test("realized values match the source at write time", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  p <- tempfile(fileext = ".h5")
+  on.exit(unlink(p), add = TRUE)
+  ha <- writeHDF5Array(m, filepath = p, name = "m")
+  stopifnot(identical(as.matrix(ha), m))
+})
+
+run_test("delayed arithmetic on an HDF5-backed array", function() {
+  m <- matrix(1:12, nrow = 3, ncol = 4)
+  p <- tempfile(fileext = ".h5")
+  on.exit(unlink(p), add = TRUE)
+  ha <- writeHDF5Array(m, filepath = p, name = "m")
+  stopifnot(identical(as.matrix(ha * 2L), m * 2L))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all HDF5Array smoke tests passed\n")

--- a/cli/scripts/lib-validator/IRanges.R
+++ b/cli/scripts/lib-validator/IRanges.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `IRanges` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond IRanges
+# and the Bioconductor base packages it attaches (BiocGenerics, S4Vectors).
+# Builds small in-memory IRanges objects and asserts exact integer results for
+# the construction accessors and the core range algebra (reduce, disjoin,
+# shift, findOverlaps/countOverlaps). Exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript IRanges.R
+
+if (!requireNamespace("IRanges", quietly = TRUE)) {
+  cat("FAIL: package 'IRanges' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(IRanges))
+cat(sprintf("IRanges version: %s\n", as.character(packageVersion("IRanges"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("IRanges construction and accessors", function() {
+  ir <- IRanges(start = c(1, 10, 20), end = c(5, 15, 25))
+  stopifnot(length(ir) == 3L)
+  stopifnot(identical(start(ir), c(1L, 10L, 20L)))
+  stopifnot(identical(end(ir), c(5L, 15L, 25L)))
+  stopifnot(identical(width(ir), c(5L, 6L, 6L)))
+})
+
+run_test("shift moves ranges by the offset", function() {
+  ir <- IRanges(start = c(1, 10, 20), end = c(5, 15, 25))
+  s <- shift(ir, 5)
+  stopifnot(identical(start(s), c(6L, 15L, 25L)))
+  stopifnot(identical(end(s), c(10L, 20L, 30L)))
+  stopifnot(identical(width(s), c(5L, 6L, 6L)))
+})
+
+run_test("reduce merges overlapping ranges", function() {
+  ir <- IRanges(start = c(1, 3, 10), end = c(5, 8, 15))
+  red <- reduce(ir)
+  stopifnot(length(red) == 2L)
+  stopifnot(identical(start(red), c(1L, 10L)))
+  stopifnot(identical(end(red), c(8L, 15L)))
+})
+
+run_test("disjoin splits into non-overlapping pieces", function() {
+  ir <- IRanges(start = c(1, 3, 10), end = c(5, 8, 15))
+  dj <- disjoin(ir)
+  stopifnot(length(dj) == 4L)
+  stopifnot(identical(start(dj), c(1L, 3L, 6L, 10L)))
+  stopifnot(identical(end(dj), c(2L, 5L, 8L, 15L)))
+})
+
+run_test("findOverlaps / countOverlaps", function() {
+  q <- IRanges(start = c(1, 10), end = c(5, 15))
+  s <- IRanges(start = c(3, 12, 20), end = c(8, 18, 25))
+  ov <- findOverlaps(q, s)
+  stopifnot(length(ov) == 2L)
+  stopifnot(identical(queryHits(ov), c(1L, 2L)))
+  stopifnot(identical(subjectHits(ov), c(1L, 2L)))
+  stopifnot(identical(countOverlaps(q, s), c(1L, 1L)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all IRanges smoke tests passed\n")

--- a/cli/scripts/lib-validator/Jinja2.py
+++ b/cli/scripts/lib-validator/Jinja2.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `Jinja2` package (import name: jinja2).
+
+Fully self-contained: no input files, no network, no packages beyond Jinja2
+(and its implied deps). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 Jinja2.py
+
+Install: pip install Jinja2   (import name: jinja2)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import jinja2
+except ImportError:
+    print("FAIL: package 'Jinja2' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"Jinja2 version: {_version(jinja2, 'Jinja2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_simple_variable_substitution():
+    out = jinja2.Template("Hello {{ name }}!").render(name="X")
+    assert out == "Hello X!"
+
+
+def test_environment_loop_and_filter():
+    env = jinja2.Environment()
+    tmpl = env.from_string("{{ items | join(', ') }}")
+    assert tmpl.render(items=["a", "b", "c"]) == "a, b, c"
+    loop = env.from_string("{% for i in xs %}{{ i }}{% endfor %}")
+    assert loop.render(xs=[1, 2, 3]) == "123"
+
+
+def test_autoescape_behavior():
+    # autoescape ON: HTML-special characters are entity-escaped.
+    on = jinja2.Environment(autoescape=True)
+    assert on.from_string("{{ v }}").render(v="<b>") == "&lt;b&gt;"
+    # autoescape OFF (the default): the value passes through verbatim.
+    off = jinja2.Environment(autoescape=False)
+    assert off.from_string("{{ v }}").render(v="<b>") == "<b>"
+
+
+def test_conditional_and_default_filter():
+    env = jinja2.Environment()
+    cond = env.from_string("{% if n > 1 %}many{% else %}one{% endif %}")
+    assert cond.render(n=5) == "many"
+    assert cond.render(n=1) == "one"
+    dflt = env.from_string("{{ missing | default('fallback') }}")
+    assert dflt.render() == "fallback"
+
+
+run_test("simple variable substitution", test_simple_variable_substitution)
+run_test("Environment loop + join filter", test_environment_loop_and_filter)
+run_test("autoescape on/off behavior", test_autoescape_behavior)
+run_test("conditional + default filter", test_conditional_and_default_filter)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all Jinja2 smoke tests passed")

--- a/cli/scripts/lib-validator/KEGGREST.R
+++ b/cli/scripts/lib-validator/KEGGREST.R
@@ -1,0 +1,69 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `KEGGREST` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond KEGGREST
+# itself.
+#
+# NOTE ON SCOPE: KEGGREST is a thin client for the KEGG REST web API — every
+# data-returning function (keggGet, keggList, keggFind, ...) performs a live
+# HTTP request to https://rest.kegg.jp. That network-dependent behavior is
+# intentionally OUT OF SCOPE for an offline smoke test: an offline validator
+# cannot and must not call it. This test therefore only verifies that the
+# package loads and that its public query functions exist with the expected
+# signatures. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript KEGGREST.R
+
+if (!requireNamespace("KEGGREST", quietly = TRUE)) {
+  cat("FAIL: package 'KEGGREST' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(KEGGREST))
+cat(sprintf("KEGGREST version: %s\n", as.character(packageVersion("KEGGREST"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core REST query functions are exported", function() {
+  stopifnot(is.function(KEGGREST::keggGet))
+  stopifnot(is.function(KEGGREST::keggList))
+  stopifnot(is.function(KEGGREST::keggFind))
+  stopifnot(is.function(KEGGREST::keggConv))
+  stopifnot(is.function(KEGGREST::keggLink))
+})
+
+run_test("info helper is exported", function() {
+  stopifnot(is.function(KEGGREST::keggInfo))
+})
+
+run_test("keggGet has a dbentries argument", function() {
+  stopifnot("dbentries" %in% names(formals(KEGGREST::keggGet)))
+})
+
+run_test("keggList has a database argument", function() {
+  stopifnot("database" %in% names(formals(KEGGREST::keggList)))
+})
+
+run_test("keggConv/keggLink take target and source", function() {
+  stopifnot(all(c("target", "source") %in% names(formals(KEGGREST::keggConv))))
+  stopifnot(all(c("target", "source") %in% names(formals(KEGGREST::keggLink))))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all KEGGREST smoke tests passed\n")

--- a/cli/scripts/lib-validator/MSnbase.R
+++ b/cli/scripts/lib-validator/MSnbase.R
@@ -1,0 +1,104 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `MSnbase` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond MSnbase
+# itself (a Bioconductor MS package that attaches Biobase / ProtGenerics /
+# BiocGenerics). All data is built in memory: a hand-specified MS2 spectrum and
+# a small fixed-seed expression matrix wrapped in an MSnSet. Checks are
+# structural / exact on the values we put in, never on anything the package
+# derives stochastically. Exits 0 only if every check passes, so it can be used
+# as a pass/fail library validator:
+#
+#   Rscript MSnbase.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# MSnbase is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - new("Spectrum2", mz=, intensity=, rt=) accepts these slot names and keeps
+#     the peaks in the supplied order (mz must be sorted ascending, as here).
+#   - mz()/intensity()/peaksCount()/msLevel()/rtime() accessors behave as
+#     asserted; peaksCount() == length(mz); Spectrum2's default msLevel == 2.
+#   - Total ion current is checked as sum(intensity(sp)) (== 60), which is
+#     robust. NOTE: tic(sp) returns the @tic HEADER slot (0 for a hand-built
+#     spectrum -- only populated when importing raw files), so do NOT swap this
+#     assertion to tic(sp) without re-verifying.
+#   - The MSnSet(exprs=, fData=, pData=) constructor arg names and its validity
+#     rule that fData/pData rownames match the expression matrix dimnames.
+# ============================================================================
+
+if (!requireNamespace("MSnbase", quietly = TRUE)) {
+  cat("FAIL: package 'MSnbase' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(MSnbase))
+cat(sprintf("MSnbase version: %s\n", as.character(packageVersion("MSnbase"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# A 5-feature x 4-sample expression matrix (fixed seed). Row/column names are
+# needed because MSnSet's validity ties fData/pData rownames to the dimnames.
+set.seed(1)
+m <- matrix(rnorm(20), nrow = 5, ncol = 4)
+rownames(m) <- paste0("feat", 1:5)
+colnames(m) <- paste0("samp", 1:4)
+
+run_test("Spectrum2 constructs and round-trips its peaks", function() {
+  sp <- new("Spectrum2", mz = c(100, 150, 200), intensity = c(10, 20, 30), rt = 10.0)
+  stopifnot(inherits(sp, "Spectrum2"))
+  stopifnot(identical(mz(sp), c(100, 150, 200)))
+  stopifnot(identical(intensity(sp), c(10, 20, 30)))
+})
+
+run_test("Spectrum2 peak count, ion current, level and rt", function() {
+  sp <- new("Spectrum2", mz = c(100, 150, 200), intensity = c(10, 20, 30), rt = 10.0)
+  stopifnot(peaksCount(sp) == 3L)
+  # Total ion current == sum of intensities. Read off intensity() so the check
+  # is independent of the header-only @tic slot (see ASSUMPTIONS above).
+  stopifnot(sum(intensity(sp)) == 60)
+  stopifnot(msLevel(sp) == 2L)
+  stopifnot(rtime(sp) == 10.0)
+})
+
+run_test("MSnSet wraps an expression matrix with matching shape", function() {
+  ms <- MSnSet(
+    exprs = m,
+    fData = data.frame(row.names = rownames(m), feature = rownames(m)),
+    pData = data.frame(row.names = colnames(m), group = rep(c("a", "b"), 2))
+  )
+  stopifnot(inherits(ms, "MSnSet"))
+  stopifnot(nrow(ms) == 5L, ncol(ms) == 4L)
+  stopifnot(identical(featureNames(ms), rownames(m)))
+  stopifnot(identical(sampleNames(ms), colnames(m)))
+})
+
+run_test("MSnSet exprs() round-trips the matrix", function() {
+  ms <- MSnSet(
+    exprs = m,
+    fData = data.frame(row.names = rownames(m), feature = rownames(m)),
+    pData = data.frame(row.names = colnames(m), group = rep(c("a", "b"), 2))
+  )
+  back <- exprs(ms)
+  stopifnot(is.matrix(back), identical(dim(back), c(5L, 4L)))
+  # exprs stores the values verbatim; equality is legitimate (the matrix is not
+  # re-randomised, just wrapped and read back).
+  stopifnot(isTRUE(all.equal(back, m)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all MSnbase smoke tests passed\n")

--- a/cli/scripts/lib-validator/MSstats.R
+++ b/cli/scripts/lib-validator/MSstats.R
@@ -1,0 +1,70 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `MSstats` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond MSstats
+# itself (a proteomics statistical package for label-based / label-free MS). All
+# data is MSstats's OWN bundled example (SRMRawData) loaded via data(); no
+# external files are read. The full quantification pipeline (dataProcess ->
+# groupComparison) is HEAVY (fits per-protein models) and its output shape has
+# drifted across versions, so it is left to function existence while the bundled
+# input table's structure is verified. Exits 0 only if every check passes:
+#
+#   Rscript MSstats.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# MSstats is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - data(SRMRawData) loads a long-format data.frame with the MSstats columns
+#     asserted below (ProteinName, PeptideSequence, Condition, BioReplicate,
+#     Run, Intensity, ...).
+#   - FLAG (output shape): dataProcess(SRMRawData) is NOT run here. Its result is
+#     a list whose component names changed across versions -- newer MSstats emits
+#     ProteinLevelData / FeatureLevelData, older emits RunlevelData. Re-verify
+#     the exact component names before asserting on them.
+#   - FLAG (contrast form): groupComparison(contrast.matrix, quant) needs a
+#     contrast matrix whose columns match the conditions and returns a
+#     $ComparisonResult table (log2FC / pvalue / adj.pvalue). Not exercised here.
+# ============================================================================
+
+if (!requireNamespace("MSstats", quietly = TRUE)) {
+  cat("FAIL: package 'MSstats' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(MSstats))
+cat(sprintf("MSstats version: %s\n", as.character(packageVersion("MSstats"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core quantification / comparison functions exist", function() {
+  stopifnot(is.function(dataProcess))
+  stopifnot(is.function(groupComparison))
+  stopifnot(is.function(dataProcessPlots))
+  stopifnot(is.function(groupComparisonPlots))
+})
+
+run_test("bundled SRM example data loads with MSstats columns", function() {
+  data("SRMRawData", package = "MSstats", envir = environment())
+  stopifnot(is.data.frame(SRMRawData))
+  need <- c("ProteinName", "PeptideSequence", "Condition", "BioReplicate", "Run", "Intensity")
+  stopifnot(all(need %in% colnames(SRMRawData)))
+  stopifnot(nrow(SRMRawData) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all MSstats smoke tests passed\n")

--- a/cli/scripts/lib-validator/MSstatsTMT.R
+++ b/cli/scripts/lib-validator/MSstatsTMT.R
@@ -1,0 +1,69 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `MSstatsTMT` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond MSstatsTMT
+# itself (TMT-labelled proteomics statistics, built on MSstats). All data is the
+# package's OWN bundled example loaded via data(); no external files are read.
+# The full TMT pipeline (converter -> proteinSummarization -> groupComparisonTMT)
+# is HEAVY and input-format sensitive, so this validator is deliberately MODEST:
+# it confirms the package loads, its core functions exist, and a bundled example
+# input table loads with a sane shape. Exits 0 only if every check passes:
+#
+#   Rscript MSstatsTMT.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# MSstatsTMT is NOT installed in this environment, so the bodies below are
+# written correct-by-review and could NOT be executed. Re-confirm once a build
+# exists:
+#   - FLAG (converter / input format): the real workflow starts from a
+#     search-engine export run through a converter such as PDtoMSstatsTMTFormat
+#     (Proteome Discoverer) / MaxQtoMSstatsTMTFormat. Converter arg names and the
+#     required raw/annotation columns are NOT exercised here.
+#   - FLAG (example object name): the bundled MSstats-TMT-format table is loaded
+#     as data(input.pd). Re-verify the exact dataset name and its columns
+#     (ProteinName, PeptideSequence, Channel, Run, Mixture, Condition,
+#     BioReplicate, Intensity, ...) against the installed version.
+#   - proteinSummarization() and groupComparisonTMT() are asserted by existence
+#     only; their summarization / comparison output is NOT checked offline.
+# ============================================================================
+
+if (!requireNamespace("MSstatsTMT", quietly = TRUE)) {
+  cat("FAIL: package 'MSstatsTMT' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(MSstatsTMT))
+cat(sprintf("MSstatsTMT version: %s\n", as.character(packageVersion("MSstatsTMT"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core TMT functions exist", function() {
+  stopifnot(is.function(proteinSummarization))
+  stopifnot(is.function(groupComparisonTMT))
+  # A search-engine converter into MSstatsTMT format.
+  stopifnot(is.function(PDtoMSstatsTMTFormat))
+})
+
+run_test("bundled PD example input loads", function() {
+  data("input.pd", package = "MSstatsTMT", envir = environment())
+  stopifnot(is.data.frame(input.pd))
+  stopifnot(nrow(input.pd) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all MSstatsTMT smoke tests passed\n")

--- a/cli/scripts/lib-validator/Maaslin2.R
+++ b/cli/scripts/lib-validator/Maaslin2.R
@@ -1,0 +1,113 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Maaslin2` package (multivariable association between
+# microbiome features and sample metadata).
+#
+# Fully self-contained: no input files, no network, no packages beyond Maaslin2
+# itself. Abundance and metadata tables are simulated with a fixed seed; the
+# only filesystem use is a temp output directory, created under tempdir() and
+# removed on exit. Checks are structural (the results data.frame shape and
+# required columns), never exact floating-point equality. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript Maaslin2.R
+#
+# FLAG (unverified on this machine -- Maaslin2 is NOT installed here):
+#   * ARG NAMES: input_data / input_metadata / output / fixed_effects and the
+#     plot_heatmap = FALSE / plot_scatter = FALSE toggles are taken from the
+#     documented Maaslin2() signature and should be re-checked.
+#   * ORIENTATION: Maaslin2 expects samples in ROWS -- both input_data
+#     (samples x features) and input_metadata (samples x covariates) are keyed
+#     by the same sample row names.
+#   * The results table lives at fit$results with columns
+#     metadata/feature/coef/pval/qval.
+
+if (!requireNamespace("Maaslin2", quietly = TRUE)) {
+  cat("FAIL: package 'Maaslin2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Maaslin2))
+cat(sprintf("Maaslin2 version: %s\n", as.character(packageVersion("Maaslin2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: 30 samples x 20 features of Poisson abundances (samples in rows),
+# plus a metadata frame with a two-level "group" covariate keyed by the same
+# sample names. A +30 shift on the first 4 features in group "b" plants a
+# recoverable association.
+set.seed(1)
+n_samp <- 30L
+n_feat <- 20L
+samp_ids <- sprintf("s%02d", seq_len(n_samp))
+feat_ids <- sprintf("f%02d", seq_len(n_feat))
+abund_mat <- matrix(
+  rpois(n_samp * n_feat, lambda = 20),
+  nrow = n_samp,
+  ncol = n_feat,
+  dimnames = list(samp_ids, feat_ids)
+)
+group <- rep(c("a", "b"), length.out = n_samp)
+abund_mat[group == "b", 1:4] <- abund_mat[group == "b", 1:4] + 30L
+abund <- as.data.frame(abund_mat)
+meta <- data.frame(group = group, row.names = samp_ids, stringsAsFactors = FALSE)
+
+# Maaslin2() writes a full set of TSVs/plots to `output`; keep it inside
+# tempdir() and remove it afterwards. capture.output + suppressMessages silence
+# the fitting log; genuine errors still propagate to run_test's tryCatch.
+run_maaslin <- function() {
+  out <- tempfile("maaslin2-smoke-", tmpdir = tempdir())
+  on.exit(unlink(out, recursive = TRUE), add = TRUE)
+  fit <- NULL
+  invisible(capture.output(suppressMessages(
+    fit <- Maaslin2::Maaslin2(
+      input_data = abund,
+      input_metadata = meta,
+      output = out,
+      fixed_effects = c("group"),
+      plot_heatmap = FALSE,
+      plot_scatter = FALSE
+    )
+  )))
+  fit
+}
+
+run_test("Maaslin2: fit object exposes a results data.frame", function() {
+  fit <- run_maaslin()
+  stopifnot(is.list(fit))
+  stopifnot("results" %in% names(fit))
+  stopifnot(is.data.frame(fit$results))
+  stopifnot(nrow(fit$results) >= 1L)
+})
+
+run_test("Maaslin2: results table has the association columns", function() {
+  fit <- run_maaslin()
+  res <- fit$results
+  stopifnot(all(c("metadata", "feature", "coef", "pval", "qval") %in% colnames(res)))
+})
+
+run_test("Maaslin2: p/q values are bounded and finite", function() {
+  fit <- run_maaslin()
+  res <- fit$results
+  stopifnot(all(is.finite(res$pval)), all(res$pval >= 0), all(res$pval <= 1))
+  stopifnot(all(is.finite(res$qval)), all(res$qval >= 0), all(res$qval <= 1))
+  # Every association is against the single tested covariate.
+  stopifnot(all(res$metadata == "group"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Maaslin2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/MendelianRandomization.R
+++ b/cli/scripts/lib-validator/MendelianRandomization.R
@@ -1,0 +1,99 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `MendelianRandomization` package.
+#
+# Fully self-contained: no input files, no network. Simulates summary-level
+# two-sample MR data (per-SNP exposure and outcome associations with standard
+# errors) for a known causal effect with a fixed seed, then runs the standard
+# estimators. Checks are structural / tolerance-based: the IVW point estimate
+# must recover the simulated effect within a generous band, standard errors are
+# finite-positive, p-values live in [0, 1]. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript MendelianRandomization.R
+#
+# NOTE (needs re-check once installed): MendelianRandomization's result objects
+# are S4 classes (MRInput / IVW / Egger / MRAll), so estimates are read via
+# `@` slot access -- NOT `$` (which errors on S4). Slot names (Estimate,
+# StdError, Pvalue, Intercept, Values) were taken from the documented API and
+# each is guarded by a `slotNames()` membership check before it is read, so a
+# renamed slot fails that one test cleanly rather than crashing. Re-confirm the
+# slot names and the exact class of `mr_ivw` output (IVW vs WeightedIVW) once a
+# build is available.
+
+if (!requireNamespace("MendelianRandomization", quietly = TRUE)) {
+  cat("FAIL: package 'MendelianRandomization' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(MendelianRandomization))
+cat(sprintf(
+  "MendelianRandomization version: %s\n",
+  as.character(packageVersion("MendelianRandomization"))
+))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate 20 independent instruments for a true causal effect theta = 0.3.
+# Genetic-exposure associations bx are moderate; outcome associations by follow
+# the causal model by = theta * bx + small balanced pleiotropy noise. Standard
+# errors are drawn from a tight uniform band so the instruments are "strong".
+set.seed(1)
+n_snps <- 20L
+theta <- 0.3
+bx <- runif(n_snps, 0.10, 0.50)
+bxse <- runif(n_snps, 0.02, 0.05)
+by <- theta * bx + rnorm(n_snps, 0, 0.02)
+byse <- runif(n_snps, 0.02, 0.05)
+
+run_test("mr_input builds an MRInput object", function() {
+  input <- mr_input(bx = bx, bxse = bxse, by = by, byse = byse)
+  stopifnot(inherits(input, "MRInput"))
+})
+
+run_test("mr_ivw recovers the causal effect", function() {
+  input <- mr_input(bx = bx, bxse = bxse, by = by, byse = byse)
+  res <- mr_ivw(input)
+  stopifnot(inherits(res, "IVW") || inherits(res, "WeightedIVW"))
+  stopifnot(all(c("Estimate", "StdError", "Pvalue") %in% slotNames(res)))
+  est <- res@Estimate
+  se <- res@StdError
+  pv <- res@Pvalue
+  stopifnot(is.finite(est), abs(est - theta) < 0.2) # generous recovery band
+  stopifnot(is.finite(se), se > 0)
+  stopifnot(is.finite(pv), pv >= 0, pv <= 1)
+})
+
+run_test("mr_egger returns an Egger fit with an intercept", function() {
+  input <- mr_input(bx = bx, bxse = bxse, by = by, byse = byse)
+  res <- mr_egger(input)
+  stopifnot(inherits(res, "Egger"))
+  stopifnot(all(c("Estimate", "Intercept") %in% slotNames(res)))
+  stopifnot(is.finite(res@Estimate), is.finite(res@Intercept))
+})
+
+run_test("mr_allmethods runs and returns a table", function() {
+  input <- mr_input(bx = bx, bxse = bxse, by = by, byse = byse)
+  res <- mr_allmethods(input, method = "main")
+  stopifnot(inherits(res, "MRAll"))
+  stopifnot("Values" %in% slotNames(res))
+  vals <- res@Values
+  stopifnot(is.data.frame(vals), nrow(vals) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all MendelianRandomization smoke tests passed\n")

--- a/cli/scripts/lib-validator/OptimalCutpoints.R
+++ b/cli/scripts/lib-validator/OptimalCutpoints.R
@@ -1,0 +1,114 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `OptimalCutpoints` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# OptimalCutpoints itself. Data is simulated with a fixed seed (a continuous
+# marker that separates a binary disease status). Exercises the core
+# cutpoint-selection API and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript OptimalCutpoints.R
+#
+# NOTE (needs re-check once installed): the nested result structure
+# (`oc$Youden$Global$optimal.cutoff$cutoff` / `$Se` / `$Sp`) and the
+# "optimal.cutpoints" class name were written from the documented API and NOT
+# verified against an installed build -- re-confirm the accessor path when the
+# package is available. Selected cutoffs and Se/Sp are floating point, so checks
+# assert structural/robust properties (class, finiteness, in-range,
+# probabilities in [0, 1]) -- never exact equality.
+
+if (!requireNamespace("OptimalCutpoints", quietly = TRUE)) {
+  cat("FAIL: package 'OptimalCutpoints' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(OptimalCutpoints))
+cat(sprintf("OptimalCutpoints version: %s\n",
+            as.character(packageVersion("OptimalCutpoints"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared simulated diagnostic dataset: diseased subjects (status == 1) carry a
+# higher marker, so a Youden-optimal cutoff should sit between the two means.
+make_data <- function() {
+  set.seed(1)
+  n <- 300L
+  status <- rbinom(n, 1L, 0.5)
+  marker <- rnorm(n, mean = ifelse(status == 1L, 2.5, 0), sd = 1)
+  data.frame(marker = marker, status = status)
+}
+
+run_test("optimal.cutpoints fits with the Youden method", function() {
+  df <- make_data()
+  oc <- optimal.cutpoints(X = "marker", status = "status",
+                          tag.healthy = 0, methods = "Youden", data = df)
+  stopifnot(inherits(oc, "optimal.cutpoints"))
+  # the requested method is present in the result
+  stopifnot("Youden" %in% names(oc))
+})
+
+run_test("Youden optimal cutoff is finite and within marker range", function() {
+  df <- make_data()
+  oc <- optimal.cutpoints(X = "marker", status = "status",
+                          tag.healthy = 0, methods = "Youden", data = df)
+  cutoff <- as.numeric(oc$Youden$Global$optimal.cutoff$cutoff)
+  stopifnot(length(cutoff) >= 1L)
+  stopifnot(all(is.finite(cutoff)))
+  rng <- range(df$marker)
+  stopifnot(all(cutoff >= rng[1]), all(cutoff <= rng[2]))
+  # a well-separated marker -> cutoff sits between the two group means (0 & 2.5)
+  stopifnot(any(cutoff > -1 & cutoff < 3.5))
+})
+
+run_test("sensitivity and specificity are valid probabilities", function() {
+  df <- make_data()
+  oc <- optimal.cutpoints(X = "marker", status = "status",
+                          tag.healthy = 0, methods = "Youden", data = df)
+  se <- as.numeric(oc$Youden$Global$optimal.cutoff$Se)
+  sp <- as.numeric(oc$Youden$Global$optimal.cutoff$Sp)
+  se <- se[is.finite(se)]
+  sp <- sp[is.finite(sp)]
+  stopifnot(length(se) >= 1L, length(sp) >= 1L)
+  stopifnot(all(se >= 0), all(se <= 1))
+  stopifnot(all(sp >= 0), all(sp <= 1))
+  # a separable marker should yield decent discrimination at the optimum
+  stopifnot(max(se) > 0.6, max(sp) > 0.6)
+})
+
+run_test("multiple methods can be requested together", function() {
+  df <- make_data()
+  oc <- optimal.cutpoints(X = "marker", status = "status", tag.healthy = 0,
+                          methods = c("Youden", "MaxSpSe"), data = df)
+  stopifnot(inherits(oc, "optimal.cutpoints"))
+  stopifnot(all(c("Youden", "MaxSpSe") %in% names(oc)))
+  for (m in c("Youden", "MaxSpSe")) {
+    cut_m <- as.numeric(oc[[m]]$Global$optimal.cutoff$cutoff)
+    stopifnot(length(cut_m) >= 1L, all(is.finite(cut_m)))
+  }
+})
+
+run_test("summary of the fit is produced without error", function() {
+  df <- make_data()
+  oc <- optimal.cutpoints(X = "marker", status = "status",
+                          tag.healthy = 0, methods = "Youden", data = df)
+  s <- summary(oc)
+  stopifnot(!is.null(s))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all OptimalCutpoints smoke tests passed\n")

--- a/cli/scripts/lib-validator/PKPDsim.R
+++ b/cli/scripts/lib-validator/PKPDsim.R
@@ -1,0 +1,123 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `PKPDsim` package.
+#
+# Install: remotes::install_github("InsightRX/PKPDsim")
+#
+# Fully self-contained: no input files, no network, no packages beyond PKPDsim
+# itself -- BUT `new_ode_model()` compiles an ODE model to C++ via Rcpp, so a
+# working C++ toolchain is required at run time (that is intrinsic to PKPDsim,
+# not a network dependency). Exercises the compile -> dose -> simulate path for a
+# one-compartment IV-bolus PK model and exits 0 only if every check passes, so
+# it can be used as a pass/fail library validator:
+#
+#   Rscript PKPDsim.R
+#
+# NOTE (needs re-check once installed): the entry points were written from the
+# documented API and NOT verified against an installed build. Re-confirm:
+#   * new_ode_model("pk_1cmt_iv") -- the bundled library-model name and the
+#     class of the returned object (asserted only non-null here).
+#   * new_regimen(amt=, n=, interval=, type="bolus") -- the exact argument names
+#     and that a single IV bolus is expressed this way.
+#   * sim(ode=, parameters=list(CL=, V=), regimen=, t_obs=, only_obs=TRUE) -- the
+#     argument names and the returned long-format columns (time in `t`, the
+#     dependent/observation variable in `y`); these column names are guarded by
+#     membership checks so a rename fails one test cleanly rather than crashing.
+# Simulated concentrations are floating point, so checks assert structural/robust
+# properties (class, finiteness, non-negativity, monotone decay after the dose)
+# -- never exact equality.
+
+if (!requireNamespace("PKPDsim", quietly = TRUE)) {
+  cat("FAIL: package 'PKPDsim' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(PKPDsim))
+cat(sprintf("PKPDsim version: %s\n", as.character(packageVersion("PKPDsim"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# One-compartment IV-bolus model from the bundled PKPDsim library: first-order
+# elimination (CL) from a single central compartment of volume V. new_ode_model
+# compiles the model to a shared object once; the parameters are supplied per
+# sim() call. A single 100-unit bolus is observed at 1..24 h -- every sample
+# falls after the t=0 dose, so concentration should decay monotonically.
+params <- list(CL = 5, V = 50)
+t_obs <- c(1, 2, 4, 8, 24)
+make_model <- function() {
+  new_ode_model("pk_1cmt_iv")
+}
+make_regimen <- function(amt) {
+  new_regimen(amt = amt, n = 1, interval = 24, type = "bolus")
+}
+simulate <- function(amt) {
+  sim(
+    ode = make_model(),
+    parameters = params,
+    regimen = make_regimen(amt),
+    t_obs = t_obs,
+    only_obs = TRUE
+  )
+}
+
+run_test("new_ode_model compiles the library model", function() {
+  mod <- make_model()
+  stopifnot(!is.null(mod))
+})
+
+run_test("new_regimen builds a single IV bolus", function() {
+  reg <- make_regimen(100)
+  stopifnot(!is.null(reg))
+})
+
+run_test("sim returns a data.frame of observations", function() {
+  df <- simulate(100)
+  stopifnot(is.data.frame(df), nrow(df) > 1L)
+  # PKPDsim returns long-format output: time in `t`, dependent variable in `y`
+  stopifnot("t" %in% names(df))
+  stopifnot("y" %in% names(df))
+})
+
+run_test("concentrations are finite and non-negative", function() {
+  df <- simulate(100)
+  y <- df$y
+  stopifnot(all(is.finite(y)))
+  stopifnot(all(y >= -1e-9))
+  # the dose actually put drug in the system
+  stopifnot(max(y) > 0)
+})
+
+run_test("concentration decays monotonically after the bolus", function() {
+  df <- simulate(100)
+  ord <- df[order(df$t), ]
+  y <- ord$y
+  # all observation times are post-dose, so on a one-compartment IV model the
+  # concentration must not rise between successive samples
+  stopifnot(all(diff(y) <= 1e-6))
+  # first-order elimination -> concentration falls over the horizon
+  stopifnot(y[length(y)] < y[1])
+})
+
+run_test("larger dose scales the exposure", function() {
+  lo <- simulate(100)$y
+  hi <- simulate(200)$y
+  # a linear one-compartment model: doubling the dose raises peak concentration
+  stopifnot(max(hi) > max(lo))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all PKPDsim smoke tests passed\n")

--- a/cli/scripts/lib-validator/Pillow.py
+++ b/cli/scripts/lib-validator/Pillow.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `Pillow` package (imported as `PIL`).
+
+Fully self-contained: no input files, no network, no packages beyond Pillow
+(and its implied deps). Exercises the core imaging API and exits 0 only if
+every check passes, so it can be used as a pass/fail library validator:
+
+    python3 Pillow.py
+
+Install: pip install Pillow   (import name: PIL)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import PIL
+    from PIL import Image
+except ImportError:
+    print("FAIL: package 'Pillow' is not installed")
+    sys.exit(1)
+
+import tempfile
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata.
+
+    The dist name is `Pillow`, the import name is `PIL`; when `PIL.__version__`
+    is absent this falls back to the installed-distribution metadata for Pillow.
+    """
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"Pillow version: {_version(PIL, 'Pillow')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_new_image_size_mode_pixel():
+    img = Image.new("RGB", (16, 8), (255, 0, 0))
+    assert img.size == (16, 8)
+    assert img.mode == "RGB"
+    assert img.getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_grayscale_conversion():
+    img = Image.new("RGB", (16, 8), (255, 0, 0))
+    grey = img.convert("L")
+    assert grey.mode == "L"
+    assert grey.size == (16, 8)
+    # Pure red maps to luminance 0.299*255 ≈ 76 under ITU-R 601-2 (Pillow's L).
+    px = grey.getpixel((0, 0))
+    assert isinstance(px, int)
+    assert 70 <= px <= 82
+
+
+def test_resize():
+    img = Image.new("RGB", (16, 8), (255, 0, 0))
+    small = img.resize((8, 4))
+    assert small.size == (8, 4)
+
+
+def test_rotate_expand():
+    img = Image.new("RGB", (16, 8), (255, 0, 0))
+    rotated = img.rotate(90, expand=True)
+    # A 90-degree rotation with expand swaps width and height.
+    assert rotated.size == (8, 16)
+
+
+def test_save_and_reopen_png():
+    img = Image.new("RGB", (16, 8), (0, 128, 255))
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    try:
+        img.save(path)
+        assert os.path.getsize(path) > 0
+        with Image.open(path) as reopened:
+            assert reopened.size == (16, 8)
+            assert reopened.mode == "RGB"
+    finally:
+        os.remove(path)
+
+
+run_test("new image size/mode/pixel", test_new_image_size_mode_pixel)
+run_test("grayscale conversion", test_grayscale_conversion)
+run_test("resize", test_resize)
+run_test("rotate with expand", test_rotate_expand)
+run_test("save and reopen PNG", test_save_and_reopen_png)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all Pillow smoke tests passed")

--- a/cli/scripts/lib-validator/ProjecTILs.R
+++ b/cli/scripts/lib-validator/ProjecTILs.R
@@ -1,0 +1,78 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ProjecTILs` package.
+#
+# Fully self-contained: no input files, no network. ProjecTILs projects a query
+# single-cell dataset onto a curated reference atlas of T-cell states --
+# Run.ProjecTILs(query, ref = ...) embeds a Seurat query into a reference map,
+# and ProjecTILs.classifier(query, ref = ...) labels cells against it. That
+# end-to-end path is OUT OF SCOPE offline: it needs a reference atlas (normally
+# fetched by load.reference.map(), which DOWNLOADS the map) plus a Seurat query,
+# and Seurat is not installed here. This test therefore stays deliberately
+# MODEST -- it asserts the package loads and that its core exported entry points
+# exist as functions. Checks are structural (function presence) only -- never
+# numeric. Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript ProjecTILs.R
+#
+# Install: remotes::install_github("carmonalab/ProjecTILs")
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL (ProjecTILs and its Seurat dependency are both
+# absent here) -- confirm every item below once ProjecTILs is available:
+#   - REFERENCE-ATLAS DEPENDENCY. Run.ProjecTILs() / ProjecTILs.classifier()
+#     both require a reference map object (ref = ...). A real reference is
+#     normally obtained via load.reference.map(), which DOWNLOADS the atlas --
+#     out of scope for an offline validator, so projection/classification are
+#     NOT exercised; only is.function(...) is checked on the entry points.
+#   - Run.ProjecTILs() / ProjecTILs.classifier() ARGUMENTS. Assumed calls are
+#     Run.ProjecTILs(query = <Seurat obj>, ref = <reference map>) and
+#     ProjecTILs.classifier(query = <Seurat obj>, ref = <reference map>).
+#     Re-confirm the argument names and return shapes once installed.
+#   - make.reference() builds a custom reference from a Seurat object; existence
+#     is checked, but it is NOT called (needs a Seurat object).
+#   - load.reference.map() is deliberately NOT called (it downloads a reference).
+# ============================================================================
+
+if (!requireNamespace("ProjecTILs", quietly = TRUE)) {
+  cat("FAIL: package 'ProjecTILs' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ProjecTILs))
+cat(sprintf("ProjecTILs version: %s\n", as.character(packageVersion("ProjecTILs"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core projection entry points are exported functions", function() {
+  stopifnot(is.function(Run.ProjecTILs))
+  stopifnot(is.function(ProjecTILs.classifier))
+})
+
+run_test("reference construction helper is an exported function", function() {
+  stopifnot(is.function(make.reference))
+})
+
+run_test("reference loader is exported (not invoked -- it downloads the atlas)", function() {
+  # Existence only; load.reference.map() would hit the network, so it is never
+  # called (see the RE-CHECK note in the header block above).
+  stopifnot(is.function(load.reference.map))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ProjecTILs smoke tests passed\n")

--- a/cli/scripts/lib-validator/PyWGCNA.py
+++ b/cli/scripts/lib-validator/PyWGCNA.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `PyWGCNA` package (weighted gene co-expression).
+
+Fully self-contained: no input files, no network. Deliberately MODEST — see the
+note below — so it can be used as a pass/fail library validator:
+
+    python3 PyWGCNA.py
+
+Install: pip install PyWGCNA   (import name: PyWGCNA)
+
+DESIGN NOTE (why this validator is intentionally shallow): PyWGCNA is a heavy
+co-expression pipeline whose `WGCNA(...)` object is normally built from a file
+path (`geneExpPath`) or an AnnData, and whose real work (`preprocess`,
+`findModules`, `runWGCNA`) writes plots/objects to an output directory. A
+network-free, file-free smoke test therefore cannot exercise the pipeline
+end-to-end without side effects, so this validator asserts only the public
+API surface: the `WGCNA` class, its headline methods, and the
+expression-input parameters of its constructor (verified by introspection, so
+no `WGCNA` object is constructed and nothing touches disk).
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import PyWGCNA
+except ImportError:
+    print("FAIL: package 'PyWGCNA' is not installed")
+    sys.exit(1)
+
+import inspect
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"PyWGCNA version: {_version(PyWGCNA, 'PyWGCNA')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_wgcna_class_exists():
+    # The headline entry point of the library is the WGCNA class.
+    assert hasattr(PyWGCNA, "WGCNA")
+    assert inspect.isclass(PyWGCNA.WGCNA)
+
+
+def test_wgcna_core_methods():
+    cls = PyWGCNA.WGCNA
+    # The core co-expression pipeline steps are exposed as instance methods.
+    for meth in ("preprocess", "findModules", "runWGCNA"):
+        assert callable(getattr(cls, meth, None)), f"missing method: {meth}"
+
+
+def test_constructor_accepts_expression_input():
+    # Confirm the documented expression-input API via introspection only —
+    # constructing a WGCNA object can create output dirs / read files, which a
+    # file-free smoke test must avoid.
+    sig = inspect.signature(PyWGCNA.WGCNA.__init__)
+    params = set(sig.parameters)
+    assert "name" in params
+    # At least one in-memory / path expression-input channel must be offered.
+    assert params & {"geneExp", "geneExpPath", "anndata"}
+
+
+run_test("WGCNA class exists", test_wgcna_class_exists)
+run_test("WGCNA core methods present", test_wgcna_core_methods)
+run_test("constructor expression-input API", test_constructor_accepts_expression_input)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all PyWGCNA smoke tests passed")

--- a/cli/scripts/lib-validator/RSQLite.R
+++ b/cli/scripts/lib-validator/RSQLite.R
@@ -1,0 +1,88 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `RSQLite` package.
+#
+# Fully self-contained: no input files, no network, in-memory databases
+# only (nothing touches disk). RSQLite is driven through the DBI generics
+# (DBI is a hard dependency of RSQLite). Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript RSQLite.R
+
+if (!requireNamespace("RSQLite", quietly = TRUE)) {
+  cat("FAIL: package 'RSQLite' is not installed\n")
+  quit(save = "no", status = 1)
+}
+if (!requireNamespace("DBI", quietly = TRUE)) {
+  cat("FAIL: package 'DBI' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(RSQLite))
+suppressPackageStartupMessages(library(DBI))
+cat(sprintf("RSQLite version: %s\n", as.character(packageVersion("RSQLite"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("create, insert, parameterized query", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbExecute(con, "CREATE TABLE t (id INTEGER, v TEXT)")
+  stopifnot(dbExecute(con, "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')") == 3)
+  hit <- dbGetQuery(con, "SELECT v FROM t WHERE id = ?", params = list(2L))
+  stopifnot(nrow(hit) == 1L, identical(as.character(hit$v), "b"))
+})
+
+run_test("prepared statement: dbSendQuery/dbBind/dbFetch", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbExecute(con, "CREATE TABLE t (id INTEGER, v TEXT)")
+  dbExecute(con, "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+  res <- dbSendQuery(con, "SELECT v FROM t WHERE id = ?")
+  on.exit(dbClearResult(res), add = TRUE, after = FALSE)
+  dbBind(res, list(3L))
+  row <- dbFetch(res)
+  stopifnot(nrow(row) == 1L, identical(as.character(row$v), "c"))
+})
+
+run_test("transactions: commit persists, rollback discards", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  dbExecute(con, "CREATE TABLE t (id INTEGER)")
+  dbBegin(con)
+  dbExecute(con, "INSERT INTO t VALUES (1)")
+  dbCommit(con)
+  stopifnot(dbGetQuery(con, "SELECT COUNT(*) AS n FROM t")$n == 1)
+  dbBegin(con)
+  dbExecute(con, "INSERT INTO t VALUES (2)")
+  dbRollback(con)
+  stopifnot(dbGetQuery(con, "SELECT COUNT(*) AS n FROM t")$n == 1)
+})
+
+run_test("SQLite scalar functions evaluate", function() {
+  con <- dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+  out <- dbGetQuery(con, "SELECT abs(-5) AS a, lower('ABC') AS l, length('hello') AS n")
+  stopifnot(out$a == 5)
+  stopifnot(identical(as.character(out$l), "abc"))
+  stopifnot(out$n == 5)
+  ver <- dbGetQuery(con, "SELECT sqlite_version() AS v")$v
+  stopifnot(is.character(ver), nzchar(ver))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all RSQLite smoke tests passed\n")

--- a/cli/scripts/lib-validator/Rcpp.R
+++ b/cli/scripts/lib-validator/Rcpp.R
@@ -1,0 +1,71 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Rcpp` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# Rcpp itself. Exercises the core API surface -- including inline C++
+# compilation, which needs a working R build toolchain (a C++ compiler) --
+# and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript Rcpp.R
+
+if (!requireNamespace("Rcpp", quietly = TRUE)) {
+  cat("FAIL: package 'Rcpp' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Rcpp))
+cat(sprintf("Rcpp version: %s\n", as.character(packageVersion("Rcpp"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("evalCpp arithmetic", function() {
+  stopifnot(Rcpp::evalCpp("1 + 1") == 2)
+  stopifnot(Rcpp::evalCpp("2 * 21") == 42)
+})
+
+run_test("cppFunction compiles and runs (scalar)", function() {
+  Rcpp::cppFunction("int add(int a, int b) { return a + b; }")
+  stopifnot(add(2L, 3L) == 5L)
+  stopifnot(add(-4L, 4L) == 0L)
+})
+
+run_test("cppFunction with NumericVector", function() {
+  Rcpp::cppFunction("
+    double vsum(NumericVector x) {
+      double total = 0.0;
+      for (int i = 0; i < x.size(); ++i) total += x[i];
+      return total;
+    }
+  ")
+  stopifnot(isTRUE(all.equal(vsum(c(1, 2, 3, 4)), 10)))
+  stopifnot(isTRUE(all.equal(vsum(as.numeric(1:100)), 5050)))
+})
+
+run_test("sourceCpp from literal code", function() {
+  Rcpp::sourceCpp(code = "
+    #include <Rcpp.h>
+    using namespace Rcpp;
+    // [[Rcpp::export]]
+    int mult(int a, int b) { return a * b; }
+  ")
+  stopifnot(mult(6L, 7L) == 42L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Rcpp smoke tests passed\n")

--- a/cli/scripts/lib-validator/RcppArmadillo.R
+++ b/cli/scripts/lib-validator/RcppArmadillo.R
@@ -1,0 +1,76 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `RcppArmadillo` package.
+#
+# Fully self-contained: no input files, no network. Exercises the core API
+# surface -- including inline C++ compilation against the Armadillo headers,
+# which needs a working R build toolchain (a C++ compiler). `Rcpp::sourceCpp`
+# is available because RcppArmadillo hard-depends on Rcpp. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript RcppArmadillo.R
+
+if (!requireNamespace("RcppArmadillo", quietly = TRUE)) {
+  cat("FAIL: package 'RcppArmadillo' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(RcppArmadillo))
+cat(sprintf("RcppArmadillo version: %s\n", as.character(packageVersion("RcppArmadillo"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("armadillo_version reports major/minor/patch", function() {
+  v <- RcppArmadillo::armadillo_version(single = FALSE)
+  stopifnot(all(c("major", "minor", "patch") %in% names(v)))
+  stopifnot(as.integer(v[["major"]]) >= 1L)
+})
+
+run_test("sourceCpp with Armadillo: matrix multiply", function() {
+  Rcpp::sourceCpp(code = "
+    // [[Rcpp::depends(RcppArmadillo)]]
+    #include <RcppArmadillo.h>
+    using namespace Rcpp;
+    // [[Rcpp::export]]
+    arma::mat mat_mult(const arma::mat& a, const arma::mat& b) {
+      return a * b;
+    }
+  ")
+  a <- matrix(c(1, 2, 3, 4), 2, 2)
+  b <- matrix(c(5, 6, 7, 8), 2, 2)
+  stopifnot(isTRUE(all.equal(mat_mult(a, b), a %*% b, tolerance = 1e-9)))
+})
+
+run_test("sourceCpp with Armadillo: solve linear system", function() {
+  Rcpp::sourceCpp(code = "
+    // [[Rcpp::depends(RcppArmadillo)]]
+    #include <RcppArmadillo.h>
+    using namespace Rcpp;
+    // [[Rcpp::export]]
+    arma::vec arma_solve(const arma::mat& A, const arma::vec& b) {
+      return arma::solve(A, b);
+    }
+  ")
+  # A = diag(2, 4); solving A x = (2, 8) gives x = (1, 2).
+  A <- matrix(c(2, 0, 0, 4), 2, 2)
+  b <- c(2, 8)
+  x <- arma_solve(A, b)
+  stopifnot(isTRUE(all.equal(as.numeric(x), c(1, 2), tolerance = 1e-9)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all RcppArmadillo smoke tests passed\n")

--- a/cli/scripts/lib-validator/Rfast.R
+++ b/cli/scripts/lib-validator/Rfast.R
@@ -1,0 +1,125 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Rfast` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# Rfast itself and its implied dependencies (Rcpp et al.). Checks Rfast's
+# fast linear-algebra / stats routines against their base R equivalents on
+# fixed-seed data, and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript Rfast.R
+
+if (!requireNamespace("Rfast", quietly = TRUE)) {
+  cat("FAIL: package 'Rfast' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Rfast))
+cat(sprintf("Rfast version: %s\n", as.character(packageVersion("Rfast"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("colmeans matches base colMeans", function() {
+  set.seed(42)
+  x <- matrix(rnorm(50 * 4), 50, 4)
+  cm <- Rfast::colmeans(x)
+  stopifnot(length(cm) == 4L)
+  stopifnot(isTRUE(all.equal(as.numeric(cm), as.numeric(colMeans(x)),
+                             tolerance = 1e-6)))
+})
+
+run_test("colVars matches apply(x, 2, var)", function() {
+  set.seed(43)
+  x <- matrix(rnorm(50 * 4), 50, 4)
+  # Rfast::colVars defaults to the SAMPLE variance (n - 1 denominator),
+  # i.e. base var(); `std = TRUE` would return standard deviations instead.
+  cv <- Rfast::colVars(x)
+  stopifnot(isTRUE(all.equal(as.numeric(cv),
+                             as.numeric(apply(x, 2, var)),
+                             tolerance = 1e-6)))
+})
+
+run_test("rowmeans matches base rowMeans", function() {
+  set.seed(44)
+  x <- matrix(rnorm(50 * 4), 50, 4)
+  stopifnot(isTRUE(all.equal(as.numeric(Rfast::rowmeans(x)),
+                             as.numeric(rowMeans(x)),
+                             tolerance = 1e-6)))
+})
+
+run_test("colMedians matches apply(x, 2, median)", function() {
+  set.seed(45)
+  x <- matrix(rnorm(51 * 4), 51, 4)
+  stopifnot(isTRUE(all.equal(as.numeric(Rfast::colMedians(x)),
+                             as.numeric(apply(x, 2, median)),
+                             tolerance = 1e-6)))
+})
+
+run_test("Dist matches base dist", function() {
+  set.seed(46)
+  x <- matrix(rnorm(20 * 3), 20, 3)
+  d <- Rfast::Dist(x)
+  stopifnot(is.matrix(d), identical(dim(d), c(20L, 20L)))
+  stopifnot(all(abs(diag(d)) < 1e-12))
+  stopifnot(isTRUE(all.equal(d, t(d), tolerance = 1e-12))) # symmetric
+  stopifnot(isTRUE(all.equal(as.numeric(d),
+                             as.numeric(as.matrix(dist(x))),
+                             tolerance = 1e-6)))
+})
+
+run_test("colSort sorts every column", function() {
+  set.seed(47)
+  x <- matrix(rnorm(50 * 4), 50, 4)
+  s <- Rfast::colSort(x)
+  stopifnot(identical(dim(s), dim(x)))
+  stopifnot(all(apply(s, 2, function(col) all(diff(col) >= 0))))
+  stopifnot(isTRUE(all.equal(as.numeric(s),
+                             as.numeric(apply(x, 2, sort)),
+                             tolerance = 1e-12)))
+})
+
+run_test("med and Var match base median/var", function() {
+  set.seed(48)
+  # Odd length: the median is an actual sample point, so no midpoint
+  # convention can differ between implementations.
+  v <- rnorm(101)
+  stopifnot(isTRUE(all.equal(as.numeric(Rfast::med(v)), median(v),
+                             tolerance = 1e-6)))
+  stopifnot(isTRUE(all.equal(as.numeric(Rfast::Var(v)), var(v),
+                             tolerance = 1e-6)))
+})
+
+run_test("lmfit matches base lm.fit", function() {
+  set.seed(49)
+  x <- matrix(rnorm(50 * 4), 50, 4)
+  X <- cbind(1, x) # lmfit takes the full design matrix: intercept is explicit
+  beta_true <- c(2, 1, -1, 0.5, 3)
+  y <- as.numeric(X %*% beta_true + rnorm(50, sd = 0.1))
+  fit <- Rfast::lmfit(X, y)
+  base_fit <- lm.fit(X, y)
+  stopifnot(isTRUE(all.equal(as.numeric(fit$be),
+                             as.numeric(base_fit$coefficients),
+                             tolerance = 1e-6)))
+  stopifnot(length(fit$residuals) == 50L)
+  stopifnot(isTRUE(all.equal(as.numeric(fit$residuals),
+                             as.numeric(base_fit$residuals),
+                             tolerance = 1e-6)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Rfast smoke tests passed\n")

--- a/cli/scripts/lib-validator/Rsamtools.R
+++ b/cli/scripts/lib-validator/Rsamtools.R
@@ -1,0 +1,107 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `Rsamtools` package.
+#
+# NO network and no truly-external files: it reads only the example BAM/FASTA
+# that ship INSIDE Rsamtools' own installation (via system.file(..., package=
+# "Rsamtools")), which are part of the package, not user data. Checks are
+# STRUCTURAL (class, header targets, a positive record count) with no numeric
+# tolerance needed. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript Rsamtools.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assumption is the exact bundled example filenames. RE-CHECK
+# these once a build is available:
+#   - system.file("extdata", "ex1.bam", package="Rsamtools") exists (the classic
+#     samtools example alignment; reference seqs "seq1"/"seq2").
+#   - system.file("extdata", "ex1.fa", package="Rsamtools") exists (matching
+#     FASTA). scanFa() needs a ".fai" index — the index-dependent FaFile test is
+#     GUARDED on ex1.fa.fai existing and skipped (still passes) if absent.
+#   - idxstatsBam() needs a ".bai" index — GUARDED on ex1.bam.bai existing and
+#     skipped if absent (no index is written; writing into the package dir would
+#     be an external side effect).
+# ============================================================================
+
+if (!requireNamespace("Rsamtools", quietly = TRUE)) {
+  cat("FAIL: package 'Rsamtools' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Rsamtools))
+cat(sprintf("Rsamtools version: %s\n", as.character(packageVersion("Rsamtools"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Package-bundled example alignment (ships inside Rsamtools/extdata).
+bam_path <- system.file("extdata", "ex1.bam", package = "Rsamtools")
+
+run_test("bundled example BAM is present", function() {
+  stopifnot(nzchar(bam_path), file.exists(bam_path))
+})
+
+run_test("BamFile opens the alignment", function() {
+  bf <- BamFile(bam_path)
+  stopifnot(inherits(bf, "BamFile"))
+  stopifnot(identical(normalizePath(path(bf)), normalizePath(bam_path)))
+})
+
+run_test("countBam reports a positive record count", function() {
+  cb <- countBam(bam_path)
+  stopifnot(is.data.frame(cb))
+  stopifnot("records" %in% colnames(cb))
+  stopifnot(sum(cb$records) > 0)
+})
+
+run_test("scanBamHeader exposes reference targets", function() {
+  hdr <- scanBamHeader(bam_path)
+  stopifnot(is.list(hdr), "targets" %in% names(hdr))
+  targets <- hdr$targets
+  stopifnot(length(targets) > 0L)
+  # Target lengths are named positive integers.
+  stopifnot(!is.null(names(targets)), all(targets > 0))
+})
+
+run_test("idxstatsBam summarises per-reference counts (if .bai present)", function() {
+  bai <- paste0(bam_path, ".bai")
+  if (!file.exists(bai)) {
+    # No bundled index; skip without failing (writing one would touch the
+    # package directory — an external side effect we forbid).
+    return(invisible(NULL))
+  }
+  st <- idxstatsBam(bam_path)
+  stopifnot(is.data.frame(st))
+  stopifnot(all(c("seqnames", "seqlength", "mapped", "unmapped") %in% colnames(st)))
+  stopifnot(nrow(st) > 0L)
+})
+
+run_test("FaFile/scanFa reads the bundled FASTA (if .fai present)", function() {
+  fa_path <- system.file("extdata", "ex1.fa", package = "Rsamtools")
+  fai <- paste0(fa_path, ".fai")
+  if (!nzchar(fa_path) || !file.exists(fa_path) || !file.exists(fai)) {
+    # Missing FASTA or its index; skip without failing (scanFa needs the .fai
+    # and we must not write one into the package dir).
+    return(invisible(NULL))
+  }
+  seqs <- scanFa(FaFile(fa_path))
+  stopifnot(inherits(seqs, "DNAStringSet"))
+  stopifnot(length(seqs) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Rsamtools smoke tests passed\n")

--- a/cli/scripts/lib-validator/S4Vectors.R
+++ b/cli/scripts/lib-validator/S4Vectors.R
@@ -1,0 +1,85 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `S4Vectors` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# S4Vectors and the Bioconductor base packages it attaches (BiocGenerics).
+# Builds small in-memory Rle / DataFrame / SimpleList / Hits objects and
+# asserts their structure and exact values. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript S4Vectors.R
+
+if (!requireNamespace("S4Vectors", quietly = TRUE)) {
+  cat("FAIL: package 'S4Vectors' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(S4Vectors))
+cat(sprintf("S4Vectors version: %s\n", as.character(packageVersion("S4Vectors"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("Rle run-length encoding", function() {
+  x <- Rle(c(1, 1, 2, 2, 2))
+  stopifnot(length(x) == 5L)
+  stopifnot(identical(runLength(x), c(2L, 3L)))
+  stopifnot(identical(runValue(x), c(1, 2)))
+  stopifnot(nrun(x) == 2L)
+})
+
+run_test("Rle decodes back to a plain vector", function() {
+  x <- Rle(c(1, 1, 2, 2, 2))
+  stopifnot(identical(as.vector(x), c(1, 1, 2, 2, 2)))
+  stopifnot(identical(as.numeric(x), c(1, 1, 2, 2, 2)))
+})
+
+run_test("DataFrame construction and column access", function() {
+  df <- DataFrame(a = 1:3, b = letters[1:3])
+  stopifnot(inherits(df, "DataFrame"))
+  stopifnot(nrow(df) == 3L, ncol(df) == 2L)
+  stopifnot(identical(colnames(df), c("a", "b")))
+  stopifnot(identical(df$a, 1:3))
+  stopifnot(identical(df$b, c("a", "b", "c")))
+  stopifnot(identical(df[["a"]], 1:3))
+})
+
+run_test("DataFrame row subsetting", function() {
+  df <- DataFrame(a = 1:3, b = letters[1:3])
+  sub <- df[1:2, ]
+  stopifnot(nrow(sub) == 2L, identical(sub$a, 1:2))
+  stopifnot(identical(df[, "a"], 1:3))
+})
+
+run_test("SimpleList holds named elements", function() {
+  sl <- SimpleList(a = 1:3, b = letters[1:2])
+  stopifnot(inherits(sl, "SimpleList"))
+  stopifnot(length(sl) == 2L)
+  stopifnot(identical(names(sl), c("a", "b")))
+  stopifnot(identical(sl$a, 1:3))
+  stopifnot(identical(sl[["b"]], c("a", "b")))
+})
+
+run_test("Hits and queryHits/subjectHits", function() {
+  h <- Hits(from = c(1L, 1L, 2L), to = c(1L, 2L, 3L), nLnode = 2L, nRnode = 3L)
+  stopifnot(length(h) == 3L)
+  stopifnot(identical(queryHits(h), c(1L, 1L, 2L)))
+  stopifnot(identical(subjectHits(h), c(1L, 2L, 3L)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all S4Vectors smoke tests passed\n")

--- a/cli/scripts/lib-validator/STACAS.R
+++ b/cli/scripts/lib-validator/STACAS.R
@@ -1,0 +1,73 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `STACAS` package.
+#
+# Fully self-contained: no input files, no network. STACAS performs anchor-based
+# integration of single-cell datasets (TILslope / semi-supervised) on Seurat
+# objects -- Run.STACAS(object_list, ...) finds anchors, builds a sample tree,
+# and integrates a LIST of >= 2 Seurat objects into one. That end-to-end path
+# is OUT OF SCOPE offline: it needs multiple Seurat objects, and Seurat is not
+# installed here. This test therefore stays deliberately MODEST -- it asserts
+# the package loads and that its core exported entry points exist as functions.
+# Checks are structural (function presence) only -- never numeric. Exits 0 only
+# if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript STACAS.R
+#
+# Install: remotes::install_github("carmonalab/STACAS")
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL (STACAS and its Seurat dependency are both
+# absent here) -- confirm every item below once STACAS is available:
+#   - Run.STACAS() ARGUMENTS / PIPELINE. The assumed core call is
+#     Run.STACAS(object_list = <list of >= 2 Seurat objects>, ...), returning an
+#     integrated Seurat object. NOT exercised (needs Seurat objects); only
+#     is.function(Run.STACAS) is checked. Re-confirm the argument names and the
+#     FindAnchors.STACAS / SampleTree.STACAS / IntegrateData.STACAS staging once
+#     installed.
+#   - STANDARDIZATION HELPER NAME. This test asserts an exported gene-symbol
+#     standardization helper named `StandardizeGeneSymbols`. If the installed
+#     build names it differently, update the is.function() assertion below.
+# ============================================================================
+
+if (!requireNamespace("STACAS", quietly = TRUE)) {
+  cat("FAIL: package 'STACAS' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(STACAS))
+cat(sprintf("STACAS version: %s\n", as.character(packageVersion("STACAS"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core integration entry points are exported functions", function() {
+  stopifnot(is.function(Run.STACAS))
+  stopifnot(is.function(FindAnchors.STACAS))
+})
+
+run_test("anchor pipeline helpers are exported functions", function() {
+  stopifnot(is.function(SampleTree.STACAS))
+  stopifnot(is.function(IntegrateData.STACAS))
+})
+
+run_test("gene-symbol standardization helper is exported", function() {
+  # Name unverified offline -- see the RE-CHECK note in the header block above.
+  stopifnot(is.function(StandardizeGeneSymbols))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all STACAS smoke tests passed\n")

--- a/cli/scripts/lib-validator/Seurat.R
+++ b/cli/scripts/lib-validator/Seurat.R
@@ -1,0 +1,104 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Seurat` package.
+#
+# Fully self-contained: no input files, no network. Builds a small synthetic
+# Poisson counts matrix with a fixed seed and runs the standard early scRNA-seq
+# pipeline (NormalizeData -> FindVariableFeatures -> ScaleData -> RunPCA) on it.
+# Small-data statistical chatter is silenced with suppressWarnings/Messages, but
+# real errors propagate. Checks are structural (class per step, non-empty
+# variable features, PCA embedding dimensions) -- never numeric equality on the
+# stochastic fit. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript Seurat.R
+#
+# NOTE (needs re-check once installed): RunPCA on a 100-gene x 20-cell toy
+# matrix is at the edge of what PCA tolerates -- npcs is held to 5 and
+# approx = FALSE forces the exact (non-irlba) solver, but the exact embedding
+# column count and any small-data guard rails should be re-confirmed against an
+# installed build. The pipeline entry points (NormalizeData/FindVariableFeatures/
+# ScaleData/RunPCA) and the Embeddings/VariableFeatures accessors were written
+# from the documented API.
+
+if (!requireNamespace("Seurat", quietly = TRUE)) {
+  cat("FAIL: package 'Seurat' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Seurat))
+cat(sprintf("Seurat version: %s\n", as.character(packageVersion("Seurat"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 20 cells, integer Poisson draws (same toy design
+# as the SeuratObject smoke test). Fixed seed keeps the object reproducible; the
+# downstream fits are still stochastic, so all assertions stay structural.
+set.seed(1)
+m <- matrix(rpois(100 * 20, 5), nrow = 100, ncol = 20)
+rownames(m) <- paste0("gene", 1:100)
+colnames(m) <- paste0("cell", 1:20)
+
+# Build once, reuse the same object across the pipeline stages. Each stage
+# mutates and returns a Seurat object, so we thread it forward.
+make_obj <- function() {
+  suppressWarnings(suppressMessages(CreateSeuratObject(counts = m)))
+}
+
+run_test("NormalizeData returns a Seurat object", function() {
+  obj <- make_obj()
+  obj <- suppressWarnings(suppressMessages(NormalizeData(obj, verbose = FALSE)))
+  stopifnot(inherits(obj, "Seurat"))
+})
+
+run_test("FindVariableFeatures flags variable genes", function() {
+  obj <- make_obj()
+  obj <- suppressWarnings(suppressMessages(NormalizeData(obj, verbose = FALSE)))
+  obj <- suppressWarnings(suppressMessages(FindVariableFeatures(obj, verbose = FALSE)))
+  stopifnot(inherits(obj, "Seurat"))
+  vf <- VariableFeatures(obj)
+  stopifnot(length(vf) > 0L, all(vf %in% rownames(m)))
+})
+
+run_test("ScaleData returns a Seurat object", function() {
+  obj <- make_obj()
+  obj <- suppressWarnings(suppressMessages(NormalizeData(obj, verbose = FALSE)))
+  obj <- suppressWarnings(suppressMessages(FindVariableFeatures(obj, verbose = FALSE)))
+  obj <- suppressWarnings(suppressMessages(ScaleData(obj, verbose = FALSE)))
+  stopifnot(inherits(obj, "Seurat"))
+})
+
+run_test("RunPCA yields a pca embedding of the expected shape", function() {
+  obj <- make_obj()
+  obj <- suppressWarnings(suppressMessages(NormalizeData(obj, verbose = FALSE)))
+  obj <- suppressWarnings(suppressMessages(FindVariableFeatures(obj, verbose = FALSE)))
+  obj <- suppressWarnings(suppressMessages(ScaleData(obj, verbose = FALSE)))
+  # npcs kept small for a 20-cell matrix; approx=FALSE avoids irlba, which is
+  # unstable at this size. verbose off to suppress the loadings printout.
+  obj <- suppressWarnings(suppressMessages(
+    RunPCA(obj, npcs = 5, approx = FALSE, verbose = FALSE)
+  ))
+  stopifnot(inherits(obj, "Seurat"))
+  stopifnot("pca" %in% Reductions(obj))
+  emb <- Embeddings(obj, "pca")
+  # One row per cell, one column per requested principal component.
+  stopifnot(nrow(emb) == 20L, ncol(emb) == 5L)
+  stopifnot(all(is.finite(emb)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Seurat smoke tests passed\n")

--- a/cli/scripts/lib-validator/SeuratDisk.R
+++ b/cli/scripts/lib-validator/SeuratDisk.R
@@ -1,0 +1,86 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `SeuratDisk` package (h5Seurat / .h5ad conversion).
+#
+# Install: remotes::install_github("mojaveazure/seurat-disk")
+#
+# Fully self-contained and OFFLINE: no input files, no network. A real round-trip
+# -- SaveH5Seurat(object, filename) -> LoadH5Seurat(filename), or Convert(source,
+# dest) between .h5Seurat and .h5ad -- needs a Seurat object (full Seurat, not
+# blind-installable), the hdf5r backend, and a tempfile on disk, all out of scope
+# here. So this validator exercises only the side-effect-free surface: that the
+# public entry points and the R6 class generators load and are exported. Exits 0
+# only if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript SeuratDisk.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once SeuratDisk
+# is available:
+#   - SaveH5Seurat(object, filename) / LoadH5Seurat(filename) are the on-disk
+#     round-trip. A real round-trip needs a Seurat object + hdf5r + a tempfile --
+#     out of scope offline; only existence as functions is checked here.
+#   - Convert(source, dest) converts between .h5Seurat and .h5ad (AnnData). Same
+#     dependency chain (hdf5r + real files); checked only as an exported function.
+#   - R6 CLASS GENERATORS. SeuratDisk exports `scdisk` (the abstract HDF5-backed
+#     base) and `h5Seurat` (the concrete .h5Seurat handle) as R6ClassGenerator
+#     objects. The check below tolerates either being absent from the export list
+#     (older/renamed builds) -- re-confirm both the names and that they are
+#     exported R6 generators (class "R6ClassGenerator") against the installed
+#     package before relying on the class assertions.
+# ============================================================================
+
+if (!requireNamespace("SeuratDisk", quietly = TRUE)) {
+  cat("FAIL: package 'SeuratDisk' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(SeuratDisk))
+cat(sprintf("SeuratDisk version: %s\n", as.character(packageVersion("SeuratDisk"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("SaveH5Seurat is an exported function", function() {
+  # A real SaveH5Seurat(object, filename) needs a Seurat object + hdf5r + a
+  # tempfile -- out of scope offline; existence is all we can assert.
+  stopifnot(is.function(SaveH5Seurat))
+})
+
+run_test("LoadH5Seurat is an exported function", function() {
+  stopifnot(is.function(LoadH5Seurat))
+})
+
+run_test("Convert is an exported function", function() {
+  # .h5Seurat <-> .h5ad conversion; same hdf5r + real-file dependency.
+  stopifnot(is.function(Convert))
+})
+
+run_test("h5Seurat / scdisk R6 class generators are exported", function() {
+  # Both are exported as R6ClassGenerator objects (scdisk is the abstract base,
+  # h5Seurat the concrete handle). Export status is version-dependent (see the
+  # R6 CLASS GENERATORS note above), so pull each via getExportedValue() and only
+  # assert its class when the name is actually exported.
+  exports <- getNamespaceExports("SeuratDisk")
+  stopifnot("h5Seurat" %in% exports || "scdisk" %in% exports)
+  for (nm in intersect(c("h5Seurat", "scdisk"), exports)) {
+    gen <- getExportedValue("SeuratDisk", nm)
+    stopifnot(inherits(gen, "R6ClassGenerator"))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all SeuratDisk smoke tests passed\n")

--- a/cli/scripts/lib-validator/SeuratObject.R
+++ b/cli/scripts/lib-validator/SeuratObject.R
@@ -1,0 +1,94 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `SeuratObject` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# SeuratObject itself (and the Matrix dependency it implies). All data is a
+# small synthetic Poisson counts matrix built with a fixed seed; checks are
+# structural (class, dimensions, cell/feature accessors, layer round-trip,
+# metadata) rather than numeric-equality on anything random. Exercises the
+# core data-structure API and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript SeuratObject.R
+#
+# NOTE (needs re-check once installed): SeuratObject v5 moved assay storage
+# from `slot=`-addressed slots to named `layer=`s, so counts access is written
+# to try `LayerData(obj, layer="counts")` first and fall back to
+# `GetAssayData(obj, slot="counts")` for v4 -- re-confirm the accessor and the
+# returned class (dgCMatrix vs matrix) once a build is available.
+
+if (!requireNamespace("SeuratObject", quietly = TRUE)) {
+  cat("FAIL: package 'SeuratObject' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(SeuratObject))
+cat(sprintf("SeuratObject version: %s\n", as.character(packageVersion("SeuratObject"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 20 cells, integer Poisson draws. With lambda 5
+# over 20 cells every gene is non-empty with overwhelming probability, so the
+# default CreateSeuratObject filters (min.cells = 0, min.features = 0) drop
+# nothing and the object keeps all 100 x 20 entries.
+set.seed(1)
+m <- matrix(rpois(100 * 20, 5), nrow = 100, ncol = 20)
+rownames(m) <- paste0("gene", 1:100)
+colnames(m) <- paste0("cell", 1:20)
+
+run_test("CreateSeuratObject builds a Seurat object", function() {
+  obj <- CreateSeuratObject(counts = m)
+  stopifnot(inherits(obj, "Seurat"))
+  stopifnot(ncol(obj) == 20L, nrow(obj) == 100L)
+})
+
+run_test("Cells and Features accessors", function() {
+  obj <- CreateSeuratObject(counts = m)
+  cells <- Cells(obj)
+  feats <- Features(obj)
+  stopifnot(length(cells) == 20L, length(feats) == 100L)
+  # Names are preserved from the input matrix dimnames.
+  stopifnot(all(cells %in% colnames(m)), all(feats %in% rownames(m)))
+})
+
+run_test("counts layer round-trips the input matrix", function() {
+  obj <- CreateSeuratObject(counts = m)
+  # v5: LayerData(layer=); v4: GetAssayData(slot=). Prefer v5, fall back.
+  counts_back <- tryCatch(
+    LayerData(obj, layer = "counts"),
+    error = function(e) GetAssayData(obj, slot = "counts")
+  )
+  cm <- as.matrix(counts_back)
+  stopifnot(nrow(cm) == 100L, ncol(cm) == 20L)
+  # Align by name in case the assay reorders, then compare exactly: counts are
+  # integers stored verbatim, so equality is legitimate here (not floats).
+  stopifnot(all(cm[rownames(m), colnames(m)] == m))
+})
+
+run_test("per-cell metadata is populated and positive", function() {
+  obj <- CreateSeuratObject(counts = m)
+  nc <- obj$nCount_RNA
+  nf <- obj$nFeature_RNA
+  stopifnot(!is.null(nc), length(nc) == 20L, all(is.finite(nc)), all(nc > 0))
+  stopifnot(!is.null(nf), length(nf) == 20L, all(nf > 0))
+  # nCount_RNA is the per-cell total UMI count == column sums of the counts.
+  stopifnot(all(as.numeric(nc) == colSums(m)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all SeuratObject smoke tests passed\n")

--- a/cli/scripts/lib-validator/Signac.R
+++ b/cli/scripts/lib-validator/Signac.R
@@ -1,0 +1,125 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `Signac` package (scATAC-seq analysis on Seurat).
+#
+# Install: remotes::install_github("stuart-lab/signac@1.16.0")  — 1.17.0 removed
+# RunChromVAR (chromVAR dropped from Bioc 3.23) but Azimuth still imports it, so
+# this validator pins the last release that still ships RunChromVAR.
+#
+# Fully self-contained: no input files, no network. Builds a small synthetic
+# peak x cell counts matrix with a fixed seed (peak ids like "chr1-1-100", cell
+# ids as columns) and constructs a ChromatinAssay from it. Only the surface that
+# touches Signac + SeuratObject (+ GenomicRanges) is exercised: the full LSI
+# pipeline (RunTFIDF -> FindTopFeatures -> RunSVD) runs on a *Seurat* object,
+# which is out of scope offline, so those entry points are asserted to EXIST as
+# functions rather than driven end to end. Checks are structural (class, dims,
+# parsed ranges) -- never numeric. Exits 0 only if every check passes, so it can
+# be used as a pass/fail library validator:
+#
+#   Rscript Signac.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once Signac is
+# available:
+#   - CreateChromatinAssay() ARG NAMES + `sep`. This test relies on
+#     `counts = <matrix>` and `sep = c("-", "-")`, which splits a "chr1-1-100"
+#     row name into (seqname="chr1", start=1, end=100): the FIRST separator sits
+#     between seqname and start, the SECOND between start and end. Re-confirm the
+#     `sep` semantics and whether a `genome`/`ranges` arg is required (here the
+#     ranges are inferred from the row names alone, no genome supplied).
+#   - ChromatinAssay CLASS NAME. Asserted via inherits(x, "ChromatinAssay") and
+#     the granges() accessor returning a GRanges of one range per peak -- confirm
+#     both the class string and that granges() is re-exported by Signac.
+#   - FEATURE/CELL FILTERING. CreateChromatinAssay may drop peaks/cells via
+#     min.cells / min.features. The synthetic matrix is dense (Poisson lambda 2
+#     over 20 cells, so ~every peak is detected in most cells), so nothing is
+#     EXPECTED to be filtered and all 50 peaks x 20 cells should survive -- but
+#     the exact default filtering must be re-confirmed against an installed build.
+#   - LSI PIPELINE. RunTFIDF() / FindTopFeatures() / RunSVD() are only checked to
+#     be exported functions here; a real RunTFIDF(obj) -> FindTopFeatures(obj) ->
+#     RunSVD(obj) chain needs a Seurat object (full Seurat, not blind-installable)
+#     and returns a Seurat object -- out of scope offline.
+#   - RunChromVAR presence is the whole reason for the @1.16.0 pin; it is checked
+#     as an exported function below so the pin is self-documenting.
+# ============================================================================
+
+if (!requireNamespace("Signac", quietly = TRUE)) {
+  cat("FAIL: package 'Signac' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Signac))
+cat(sprintf("Signac version: %s\n", as.character(packageVersion("Signac"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic peak x cell counts: 50 peaks x 20 cells, integer Poisson draws.
+# Peaks are non-overlapping windows on chr1 named "chr1-<start>-<end>" so the
+# sep = c("-","-") parser can recover their genomic coordinates; cells are the
+# columns. Poisson(lambda = 2) over 20 cells keeps every peak well detected, so
+# the default construction filters drop nothing.
+set.seed(1)
+n_peaks <- 50L
+n_cells <- 20L
+starts <- seq(1L, by = 200L, length.out = n_peaks)
+ends <- starts + 100L
+peak_ids <- paste0("chr1-", starts, "-", ends)
+cell_ids <- paste0("cell", seq_len(n_cells))
+peaks <- matrix(
+  rpois(n_peaks * n_cells, lambda = 2),
+  nrow = n_peaks, ncol = n_cells,
+  dimnames = list(peak_ids, cell_ids)
+)
+
+run_test("core LSI / TF-IDF entry points are exported functions", function() {
+  stopifnot(is.function(CreateChromatinAssay))
+  stopifnot(is.function(RunTFIDF))
+  stopifnot(is.function(FindTopFeatures))
+  stopifnot(is.function(RunSVD))
+})
+
+run_test("RunChromVAR is present (the @1.16.0 pin retains it)", function() {
+  # 1.17.0 dropped this with chromVAR; the pin exists so Azimuth's import of it
+  # keeps resolving. If this fails, the wrong Signac version is installed.
+  stopifnot(is.function(RunChromVAR))
+})
+
+run_test("CreateChromatinAssay builds a ChromatinAssay from a peak x cell matrix", function() {
+  chrom <- suppressWarnings(suppressMessages(
+    CreateChromatinAssay(counts = peaks, sep = c("-", "-"))
+  ))
+  stopifnot(inherits(chrom, "ChromatinAssay"))
+  # Nothing is expected to be filtered from the dense synthetic matrix (see the
+  # FEATURE/CELL FILTERING note in the assumptions block above).
+  stopifnot(ncol(chrom) == n_cells)
+  stopifnot(nrow(chrom) == n_peaks)
+})
+
+run_test("sep parses peak ids into one genomic range per peak", function() {
+  chrom <- suppressWarnings(suppressMessages(
+    CreateChromatinAssay(counts = peaks, sep = c("-", "-"))
+  ))
+  # granges() (re-exported by Signac from GenomicRanges) is the proof the sep
+  # argument parsed the "chr1-<start>-<end>" row names into coordinates.
+  gr <- suppressWarnings(Signac::granges(chrom))
+  stopifnot(inherits(gr, "GRanges"))
+  stopifnot(length(gr) == nrow(chrom))
+  stopifnot(all(as.character(GenomicRanges::seqnames(gr)) == "chr1"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Signac smoke tests passed\n")

--- a/cli/scripts/lib-validator/SingleCellExperiment.R
+++ b/cli/scripts/lib-validator/SingleCellExperiment.R
@@ -1,0 +1,107 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `SingleCellExperiment` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# SingleCellExperiment and the Bioconductor deps it attaches (SummarizedExperiment
+# / S4Vectors -- from which `DataFrame` reaches the search path). All data is a
+# small synthetic Poisson counts matrix built with a fixed seed; checks are
+# structural (class, dimensions, assay/reducedDim/altExp round-trips, colData)
+# rather than numeric-equality on anything random. Exercises the core
+# data-structure API and exits 0 only if every check passes, so it can be used
+# as a pass/fail library validator:
+#
+#   Rscript SingleCellExperiment.R
+#
+# NOTE (needs re-check once installed): `DataFrame` is expected on the search
+# path because SingleCellExperiment attaches S4Vectors transitively (via
+# SummarizedExperiment -> GenomicRanges -> S4Vectors); if a future packaging
+# change stops attaching it, qualify as `S4Vectors::DataFrame`. reducedDim<- /
+# altExp<- store an embedding / an alternative experiment whose column count
+# must match the parent (20 cells) -- re-confirm the accessor names once a build
+# is available.
+
+if (!requireNamespace("SingleCellExperiment", quietly = TRUE)) {
+  cat("FAIL: package 'SingleCellExperiment' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(SingleCellExperiment))
+cat(sprintf("SingleCellExperiment version: %s\n", as.character(packageVersion("SingleCellExperiment"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 20 cells, integer Poisson draws, fully named.
+# colData tags cells with an alternating a/b condition (10 each).
+set.seed(1)
+counts <- matrix(rpois(100 * 20, 5), nrow = 100, ncol = 20)
+rownames(counts) <- paste0("gene", seq_len(100))
+colnames(counts) <- paste0("cell", seq_len(20))
+coldata <- DataFrame(cond = rep(c("a", "b"), 10))
+
+run_test("SingleCellExperiment() builds an SCE of the right shape", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  stopifnot(inherits(sce, "SingleCellExperiment"))
+  stopifnot(identical(dim(sce), c(100L, 20L)))
+})
+
+run_test("counts() round-trips the input assay", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  back <- counts(sce)
+  stopifnot(nrow(back) == 100L, ncol(back) == 20L)
+  # Counts are integers stored verbatim, so equality is legitimate (not floats).
+  stopifnot(all(back == counts))
+  stopifnot(identical(rownames(back), rownames(counts)))
+})
+
+run_test("logcounts() assign and read back", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  logcounts(sce) <- log1p(counts)
+  stopifnot("logcounts" %in% assayNames(sce))
+  lc <- logcounts(sce)
+  stopifnot(nrow(lc) == 100L, ncol(lc) == 20L)
+  stopifnot(isTRUE(all.equal(lc, log1p(counts))))
+})
+
+run_test("reducedDim() stores and names an embedding", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  pca <- matrix(rnorm(20 * 2), nrow = 20, ncol = 2)  # one row per cell
+  reducedDim(sce, "PCA") <- pca
+  stopifnot("PCA" %in% reducedDimNames(sce))
+  rd <- reducedDim(sce, "PCA")
+  stopifnot(nrow(rd) == 20L, ncol(rd) == 2L)
+})
+
+run_test("altExp() stores an alternative experiment", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  # An altExp must share the cell axis (20 columns) with its parent.
+  spike <- SingleCellExperiment(
+    assays = list(counts = matrix(rpois(5 * 20, 2), nrow = 5, ncol = 20)))
+  altExp(sce, "spike") <- spike
+  stopifnot("spike" %in% altExpNames(sce))
+  ae <- altExp(sce, "spike")
+  stopifnot(inherits(ae, "SingleCellExperiment"), ncol(ae) == 20L)
+})
+
+run_test("colData carries the per-cell annotation", function() {
+  sce <- SingleCellExperiment(assays = list(counts = counts), colData = coldata)
+  cond <- colData(sce)$cond
+  stopifnot(length(cond) == 20L, all(cond %in% c("a", "b")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all SingleCellExperiment smoke tests passed\n")

--- a/cli/scripts/lib-validator/Spectra.R
+++ b/cli/scripts/lib-validator/Spectra.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `Spectra` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond Spectra
+# itself (a Bioconductor MS package that attaches ProtGenerics / S4Vectors /
+# BiocGenerics). All data is built in memory: two synthetic MS2 spectra described
+# as an S4Vectors DataFrame with scalar spectra variables plus per-peak list
+# columns. Checks are structural / exact on the values we put in. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript Spectra.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# Spectra is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - The DataFrame-backend construction path: a DataFrame with scalar columns
+#     (msLevel, rtime) plus LIST columns `mz`/`intensity` (one numeric vector
+#     per spectrum), passed straight to Spectra(spd), yields a 2-spectrum object
+#     backed by the in-memory backend. This is the load-bearing API to verify.
+#   - mz()/intensity() return a list-like (NumericList) indexable with [[ ]] and
+#     answering lengths(); msLevel()/rtime() return plain per-spectrum vectors.
+# ============================================================================
+
+if (!requireNamespace("Spectra", quietly = TRUE)) {
+  cat("FAIL: package 'Spectra' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(Spectra))
+cat(sprintf("Spectra version: %s\n", as.character(packageVersion("Spectra"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Two synthetic MS2 spectra. Scalar spectra variables (msLevel, rtime) are plain
+# columns; the peaks are LIST columns holding one numeric vector per spectrum.
+# This DataFrame is Spectra's documented in-memory construction input.
+spd <- S4Vectors::DataFrame(msLevel = c(2L, 2L), rtime = c(10.1, 10.5))
+spd$mz <- list(c(100.1, 150.2, 200.3), c(110.0, 220.0))
+spd$intensity <- list(c(10, 20, 30), c(5, 15))
+
+run_test("Spectra builds from a DataFrame backend", function() {
+  sp <- Spectra(spd)
+  stopifnot(inherits(sp, "Spectra"))
+  stopifnot(length(sp) == 2L)
+})
+
+run_test("scalar spectra variables round-trip (msLevel, rtime)", function() {
+  sp <- Spectra(spd)
+  stopifnot(identical(msLevel(sp), c(2L, 2L)))
+  stopifnot(isTRUE(all.equal(rtime(sp), c(10.1, 10.5))))
+})
+
+run_test("mz peak lists round-trip", function() {
+  sp <- Spectra(spd)
+  mzs <- mz(sp)
+  stopifnot(length(mzs) == 2L)
+  stopifnot(identical(as.integer(lengths(mzs)), c(3L, 2L)))
+  stopifnot(isTRUE(all.equal(as.numeric(mzs[[1]]), c(100.1, 150.2, 200.3))))
+  stopifnot(isTRUE(all.equal(as.numeric(mzs[[2]]), c(110.0, 220.0))))
+})
+
+run_test("intensity peak lists round-trip", function() {
+  sp <- Spectra(spd)
+  ints <- intensity(sp)
+  stopifnot(length(ints) == 2L)
+  stopifnot(identical(as.integer(lengths(ints)), c(3L, 2L)))
+  stopifnot(isTRUE(all.equal(as.numeric(ints[[1]]), c(10, 20, 30))))
+  stopifnot(isTRUE(all.equal(as.numeric(ints[[2]]), c(5, 15))))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all Spectra smoke tests passed\n")

--- a/cli/scripts/lib-validator/SummarizedExperiment.R
+++ b/cli/scripts/lib-validator/SummarizedExperiment.R
@@ -1,0 +1,82 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `SummarizedExperiment` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# SummarizedExperiment and the Bioconductor base packages it attaches
+# (GenomicRanges, S4Vectors, MatrixGenerics, Biobase, ...). Builds a small
+# in-memory SummarizedExperiment from a synthetic assay matrix plus colData and
+# asserts its dimensions, assay roundtrip, column-metadata access, and
+# subsetting. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript SummarizedExperiment.R
+
+if (!requireNamespace("SummarizedExperiment", quietly = TRUE)) {
+  cat("FAIL: package 'SummarizedExperiment' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(SummarizedExperiment))
+cat(sprintf("SummarizedExperiment version: %s\n", as.character(packageVersion("SummarizedExperiment"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+make_se <- function() {
+  SummarizedExperiment(
+    assays = list(counts = matrix(1:12, nrow = 3, ncol = 4)),
+    colData = DataFrame(cond = factor(c("a", "a", "b", "b")))
+  )
+}
+
+run_test("SummarizedExperiment construction dims", function() {
+  se <- make_se()
+  stopifnot(is(se, "SummarizedExperiment"))
+  stopifnot(identical(dim(se), c(3L, 4L)))
+  stopifnot(nrow(se) == 3L, ncol(se) == 4L)
+})
+
+run_test("assay names and matrix roundtrip", function() {
+  se <- make_se()
+  stopifnot(identical(assayNames(se), "counts"))
+  stopifnot(identical(assay(se, "counts"), matrix(1:12, nrow = 3, ncol = 4)))
+  stopifnot(identical(assay(se), matrix(1:12, nrow = 3, ncol = 4)))
+})
+
+run_test("colData column access", function() {
+  se <- make_se()
+  cond <- colData(se)$cond
+  stopifnot(is.factor(cond))
+  stopifnot(identical(as.character(cond), c("a", "a", "b", "b")))
+})
+
+run_test("row subsetting keeps assay layout", function() {
+  se <- make_se()
+  sub <- se[1:2, 1:2]
+  stopifnot(identical(dim(sub), c(2L, 2L)))
+  stopifnot(identical(assay(sub, "counts"), matrix(1:12, nrow = 3, ncol = 4)[1:2, 1:2]))
+})
+
+run_test("column subsetting narrows colData", function() {
+  se <- make_se()
+  sub <- se[, 1:2]
+  stopifnot(ncol(sub) == 2L)
+  stopifnot(identical(as.character(colData(sub)$cond), c("a", "a")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all SummarizedExperiment smoke tests passed\n")

--- a/cli/scripts/lib-validator/TwoSampleMR.R
+++ b/cli/scripts/lib-validator/TwoSampleMR.R
@@ -1,0 +1,126 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `TwoSampleMR` package.
+#
+# Install: remotes::install_github("MRCIEU/TwoSampleMR")
+#
+# Fully self-contained: no input files, no network. TwoSampleMR's data-retrieval
+# functions (extract_instruments, extract_outcome_data, available_outcomes) hit
+# the OpenGWAS API and require an auth token -- those are NETWORK-dependent and
+# deliberately OUT OF SCOPE here. This test instead builds a harmonised
+# summary-statistics data.frame locally (with a fixed seed and a planted causal
+# effect) and exercises the offline harmonised-data -> estimator path. Checks are
+# structural / tolerance-based: the IVW point estimate must recover the simulated
+# effect within a generous band, standard errors are finite-positive, p-values
+# live in [0, 1]. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript TwoSampleMR.R
+#
+# NOTE (needs re-check once installed): the offline API surface was written from
+# the documented interface and NOT verified against an installed build.
+# Re-confirm:
+#   * The harmonised-data columns mr() requires: SNP, id.exposure, id.outcome,
+#     exposure, outcome, mr_keep, beta.exposure/se.exposure, beta.outcome/
+#     se.outcome and the effect_allele/other_allele pairs for both sides.
+#   * mr(dat) returns a data.frame whose columns include method/nsnp/b/se/pval,
+#     and that the IVW row is labelled "Inverse variance weighted".
+#   * mr_ivw() / mr_egger_regression() take (b_exp, b_out, se_exp, se_out) vectors
+#     and return a list keyed b/se/pval (parameters defaults to
+#     default_parameters()).
+# Simulated associations are floating point, so checks assert structural/robust
+# properties -- never exact equality.
+
+if (!requireNamespace("TwoSampleMR", quietly = TRUE)) {
+  cat("FAIL: package 'TwoSampleMR' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(TwoSampleMR))
+cat(sprintf("TwoSampleMR version: %s\n", as.character(packageVersion("TwoSampleMR"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate 30 independent instruments for a true causal effect theta = 0.3.
+# Genetic-exposure associations beta.exposure are moderate and "strong" (tight
+# standard errors); outcome associations follow the causal model
+# beta.outcome = theta * beta.exposure + small balanced-pleiotropy noise. The
+# result is assembled into the harmonised long-format frame mr() consumes:
+# one row per SNP, mr_keep = TRUE, matched effect/other alleles on both sides.
+set.seed(1)
+n_snps <- 30L
+theta <- 0.3
+beta.exposure <- runif(n_snps, 0.10, 0.30)
+se.exposure <- runif(n_snps, 0.02, 0.04)
+beta.outcome <- theta * beta.exposure + rnorm(n_snps, 0, 0.005)
+se.outcome <- runif(n_snps, 0.02, 0.04)
+
+dat <- data.frame(
+  SNP = paste0("rs", seq_len(n_snps)),
+  exposure = "X",
+  outcome = "Y",
+  id.exposure = "exp",
+  id.outcome = "out",
+  effect_allele.exposure = "A",
+  other_allele.exposure = "G",
+  effect_allele.outcome = "A",
+  other_allele.outcome = "G",
+  beta.exposure = beta.exposure,
+  se.exposure = se.exposure,
+  beta.outcome = beta.outcome,
+  se.outcome = se.outcome,
+  mr_keep = TRUE,
+  stringsAsFactors = FALSE
+)
+
+run_test("mr_method_list returns the available methods", function() {
+  ml <- mr_method_list()
+  stopifnot(is.data.frame(ml), nrow(ml) > 0L)
+  stopifnot("obj" %in% names(ml))
+  stopifnot("mr_ivw" %in% ml$obj)
+})
+
+run_test("mr_ivw on summary vectors recovers the effect", function() {
+  res <- mr_ivw(dat$beta.exposure, dat$beta.outcome, dat$se.exposure, dat$se.outcome)
+  stopifnot(is.list(res))
+  stopifnot(all(c("b", "se", "pval") %in% names(res)))
+  stopifnot(is.finite(res$b), abs(res$b - theta) < 0.2) # generous recovery band
+  stopifnot(is.finite(res$se), res$se > 0)
+  stopifnot(is.finite(res$pval), res$pval >= 0, res$pval <= 1)
+})
+
+run_test("mr_egger_regression returns a list with b/se/pval", function() {
+  res <- mr_egger_regression(dat$beta.exposure, dat$beta.outcome, dat$se.exposure, dat$se.outcome)
+  stopifnot(is.list(res))
+  stopifnot(all(c("b", "se", "pval") %in% names(res)))
+  stopifnot(is.finite(res$b), is.finite(res$se), res$se > 0)
+  stopifnot(is.finite(res$pval), res$pval >= 0, res$pval <= 1)
+})
+
+run_test("mr() on the harmonised frame recovers the causal effect", function() {
+  res <- mr(dat)
+  stopifnot(is.data.frame(res), nrow(res) > 0L)
+  stopifnot(all(c("method", "nsnp", "b", "se", "pval") %in% names(res)))
+  ivw <- res[grepl("Inverse variance weighted", res$method), ]
+  stopifnot(nrow(ivw) >= 1L)
+  stopifnot(ivw$nsnp[1] == n_snps)
+  stopifnot(is.finite(ivw$b[1]), abs(ivw$b[1] - theta) < 0.2)
+  stopifnot(is.finite(ivw$pval[1]), ivw$pval[1] >= 0, ivw$pval[1] <= 1)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all TwoSampleMR smoke tests passed\n")

--- a/cli/scripts/lib-validator/UCell.R
+++ b/cli/scripts/lib-validator/UCell.R
@@ -1,0 +1,98 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `UCell` package.
+#
+# Fully self-contained: no input files, no network. Simulates a small scRNA-seq
+# counts matrix (genes x cells) with a fixed seed, defines one marker-gene
+# signature, and scores every cell with ScoreSignatures_UCell(). UCell scores
+# are rank-based Mann-Whitney U statistics normalised to [0, 1], so checks are
+# structural / bound-based (matrix shape, signature column present, values in
+# range) -- never exact numeric equality. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript UCell.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm once UCell is available:
+#   - ScoreSignatures_UCell() OUTPUT ORIENTATION. This test assumes the result
+#     is a CELLS-x-SIGNATURES matrix: one ROW per cell (nrow == n_cells) and one
+#     COLUMN per signature. If UCell instead returns signatures-x-cells, the
+#     nrow/ncol assertions must be transposed.
+#   - COLUMN NAMING. Assumes each signature column is named "<sig>_UCell" (the
+#     default `name = "_UCell"` suffix), i.e. "sigA_UCell" here.
+#   - INPUT TYPE. UCell prefers a sparse matrix; the counts are coerced to a
+#     dgCMatrix (via the Matrix package, a UCell dependency) before scoring.
+#     A plain dense matrix is also accepted, so the coercion is a convenience,
+#     not a hard requirement -- re-confirm the accepted input classes.
+# ============================================================================
+
+if (!requireNamespace("UCell", quietly = TRUE)) {
+  cat("FAIL: package 'UCell' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(UCell))
+cat(sprintf("UCell version: %s\n", as.character(packageVersion("UCell"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 200 genes x 30 cells, integer Poisson draws. Named rows/cols
+# are required so the signature (a set of gene names) can be resolved against the
+# matrix. Coerced to a sparse dgCMatrix -- UCell's preferred input type.
+set.seed(1)
+n_genes <- 200L
+n_cells <- 30L
+counts <- matrix(rpois(n_genes * n_cells, lambda = 3), nrow = n_genes, ncol = n_cells)
+rownames(counts) <- paste0("Gene", seq_len(n_genes))
+colnames(counts) <- paste0("Cell", seq_len(n_cells))
+counts_sparse <- suppressWarnings(as(counts, "dgCMatrix"))
+
+# One signature: the first 20 genes. Expected scored column: "sigA_UCell".
+sigs <- list(sigA = paste0("Gene", 1:20))
+sig_col <- "sigA_UCell"
+
+run_test("ScoreSignatures_UCell returns a numeric matrix", function() {
+  scores <- suppressWarnings(suppressMessages(
+    ScoreSignatures_UCell(counts_sparse, features = sigs)
+  ))
+  stopifnot(is.matrix(scores) || is.data.frame(scores))
+  stopifnot(is.numeric(as.matrix(scores)))
+})
+
+run_test("scores are cells x signatures with the named signature column", function() {
+  scores <- suppressWarnings(suppressMessages(
+    ScoreSignatures_UCell(counts_sparse, features = sigs)
+  ))
+  # One row per cell (see ORIENTATION note in the header block above).
+  stopifnot(nrow(scores) == n_cells)
+  stopifnot(sig_col %in% colnames(scores))
+  # Every cell is scored -- rownames should match the input cells.
+  stopifnot(all(rownames(scores) %in% colnames(counts)))
+})
+
+run_test("UCell scores are finite and bounded in [0, 1]", function() {
+  scores <- suppressWarnings(suppressMessages(
+    ScoreSignatures_UCell(counts_sparse, features = sigs)
+  ))
+  vals <- as.numeric(scores[, sig_col])
+  stopifnot(length(vals) == n_cells)
+  stopifnot(all(is.finite(vals)))
+  stopifnot(all(vals >= 0 & vals <= 1))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all UCell smoke tests passed\n")

--- a/cli/scripts/lib-validator/VariantAnnotation.R
+++ b/cli/scripts/lib-validator/VariantAnnotation.R
@@ -1,0 +1,91 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `VariantAnnotation` package.
+#
+# NO network and no truly-external files: it reads only the example VCF that
+# ships INSIDE VariantAnnotation's own installation (system.file(..., package=
+# "VariantAnnotation")) — part of the package, not user data. Checks are
+# STRUCTURAL (VCF class, non-empty rows, rowRanges is a GRanges, info/geno
+# accessible, named samples) with no numeric tolerance needed. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript VariantAnnotation.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assumptions are the bundled filename and the genome tag.
+# RE-CHECK once a build is available:
+#   - system.file("extdata", "chr22.vcf.gz", package="VariantAnnotation") exists
+#     (the classic 1000-Genomes chr22 example slice).
+#   - readVcf(vf, "hg19") parses it — "hg19" is the genome label attached to the
+#     result, not a lookup, so any string works, but hg19 matches the example.
+#   - The result is a CollapsedVCF (extends VCF); rowRanges() -> GRanges;
+#     info()/geno() are accessible; samples(header(vcf)) is non-empty.
+# ============================================================================
+
+if (!requireNamespace("VariantAnnotation", quietly = TRUE)) {
+  cat("FAIL: package 'VariantAnnotation' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(VariantAnnotation))
+cat(sprintf("VariantAnnotation version: %s\n", as.character(packageVersion("VariantAnnotation"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Package-bundled example VCF (ships inside VariantAnnotation/extdata).
+vcf_path <- system.file("extdata", "chr22.vcf.gz", package = "VariantAnnotation")
+
+run_test("bundled example VCF is present", function() {
+  stopifnot(nzchar(vcf_path), file.exists(vcf_path))
+})
+
+run_test("readVcf parses a non-empty VCF object", function() {
+  vcf <- suppressWarnings(readVcf(vcf_path, "hg19"))
+  stopifnot(inherits(vcf, "VCF"))
+  stopifnot(inherits(vcf, "CollapsedVCF"))
+  stopifnot(nrow(vcf) > 0L)
+})
+
+run_test("rowRanges is a GRanges over the variants", function() {
+  vcf <- suppressWarnings(readVcf(vcf_path, "hg19"))
+  rr <- rowRanges(vcf)
+  stopifnot(inherits(rr, "GRanges"))
+  stopifnot(length(rr) == nrow(vcf))
+  # REF alleles come back as a DNAStringSet, one per variant.
+  stopifnot(inherits(ref(vcf), "DNAStringSet"))
+  stopifnot(length(ref(vcf)) == nrow(vcf))
+})
+
+run_test("info and geno matrices are accessible", function() {
+  vcf <- suppressWarnings(readVcf(vcf_path, "hg19"))
+  inf <- info(vcf)
+  stopifnot(inherits(inf, "DataFrame"))
+  stopifnot(nrow(inf) == nrow(vcf))
+  gn <- geno(vcf)
+  # geno is a SimpleList of per-genotype matrices (GT, etc.).
+  stopifnot(length(gn) > 0L)
+})
+
+run_test("header exposes named samples", function() {
+  vcf <- suppressWarnings(readVcf(vcf_path, "hg19"))
+  smp <- samples(header(vcf))
+  stopifnot(is.character(smp))
+  stopifnot(length(smp) > 0L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all VariantAnnotation smoke tests passed\n")

--- a/cli/scripts/lib-validator/WGCNA.R
+++ b/cli/scripts/lib-validator/WGCNA.R
@@ -1,0 +1,93 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `WGCNA` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond WGCNA
+# and its implied deps. All data is a small synthetic Gaussian expression
+# matrix built with a fixed seed (samples x genes); checks are structural
+# (dimensions, symmetry) and tolerance-based (value ranges, finiteness) rather
+# than numeric-equality on anything random. Exercises the core network-
+# construction API and exits 0 only if every check passes, so it can be used as
+# a pass/fail library validator:
+#
+#   Rscript WGCNA.R
+#
+# WGCNA is chatty (connectivity progress, soft-threshold tables): every noisy
+# call is wrapped in suppressMessages()/suppressWarnings(). The heavy
+# blockwiseModules() module-detection step is deliberately SKIPPED -- it is slow
+# and stochastic; adjacency() / TOMsimilarity() / pickSoftThreshold() cover the
+# core surface without it.
+#
+# NOTE (needs re-check once installed): WGCNA masks stats::cor with its own
+# WGCNA::cor, so the correlation checks qualify WGCNA::cor / WGCNA::bicor
+# explicitly. adjacency() defaults to type="unsigned" (abs(cor)^power, values in
+# [0,1] with a unit diagonal); pickSoftThreshold() returns a `fitIndices`
+# data.frame whose columns are assumed to include Power / SFT.R.sq / slope --
+# re-confirm the default network type and those column names once a build is
+# available.
+
+if (!requireNamespace("WGCNA", quietly = TRUE)) {
+  cat("FAIL: package 'WGCNA' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(WGCNA))
+cat(sprintf("WGCNA version: %s\n", as.character(packageVersion("WGCNA"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic expression: 30 samples (rows) x 100 genes (columns), i.i.d. normal.
+# WGCNA expects genes in columns, so adjacency / TOM are gene-by-gene 100 x 100.
+set.seed(1)
+datExpr <- matrix(rnorm(30 * 100), nrow = 30, ncol = 100)
+colnames(datExpr) <- paste0("gene", seq_len(100))
+rownames(datExpr) <- paste0("sample", seq_len(30))
+
+run_test("adjacency() is 100x100, symmetric, in [0,1] with unit diagonal", function() {
+  adj <- suppressWarnings(suppressMessages(adjacency(datExpr, power = 6)))
+  stopifnot(is.matrix(adj), nrow(adj) == 100L, ncol(adj) == 100L)
+  stopifnot(max(abs(adj - t(adj))) < 1e-8)             # symmetric
+  stopifnot(all(adj >= -1e-8 & adj <= 1 + 1e-8))       # unsigned range [0,1]
+  stopifnot(all(abs(diag(adj) - 1) < 1e-8))            # self-adjacency == 1
+})
+
+run_test("TOMsimilarity() is 100x100, symmetric, in [0,1]", function() {
+  adj <- suppressWarnings(suppressMessages(adjacency(datExpr, power = 6)))
+  TOM <- suppressWarnings(suppressMessages(TOMsimilarity(adj)))
+  stopifnot(is.matrix(TOM), nrow(TOM) == 100L, ncol(TOM) == 100L)
+  stopifnot(all(TOM >= -1e-8 & TOM <= 1 + 1e-8))
+  stopifnot(max(abs(TOM - t(TOM))) < 1e-8)
+})
+
+run_test("pickSoftThreshold() returns a fitIndices table over the powers", function() {
+  sft <- suppressWarnings(suppressMessages(
+    pickSoftThreshold(datExpr, powerVector = c(1, 4, 6), verbose = 0)))
+  fi <- sft$fitIndices
+  stopifnot(is.data.frame(fi), nrow(fi) == 3L)
+  stopifnot(all(c("Power", "SFT.R.sq", "slope") %in% names(fi)))
+  stopifnot(all(fi$Power == c(1, 4, 6)))
+})
+
+run_test("WGCNA::cor and WGCNA::bicor are finite 100x100 matrices", function() {
+  cmat <- suppressWarnings(WGCNA::cor(datExpr))
+  bmat <- suppressWarnings(WGCNA::bicor(datExpr))
+  stopifnot(is.matrix(cmat), nrow(cmat) == 100L, ncol(cmat) == 100L, all(is.finite(cmat)))
+  stopifnot(is.matrix(bmat), nrow(bmat) == 100L, ncol(bmat) == 100L, all(is.finite(bmat)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all WGCNA smoke tests passed\n")

--- a/cli/scripts/lib-validator/XML.R
+++ b/cli/scripts/lib-validator/XML.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `XML` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# XML itself. Parses an inline XML string and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript XML.R
+
+if (!requireNamespace("XML", quietly = TRUE)) {
+  cat("FAIL: package 'XML' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(XML))
+cat(sprintf("XML version: %s\n", as.character(packageVersion("XML"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+SAMPLE <- "<root><item id='1'>a</item><item id='2'>b</item></root>"
+
+run_test("parse inline XML and inspect the root", function() {
+  doc <- xmlParse(SAMPLE, asText = TRUE)
+  root <- xmlRoot(doc)
+  stopifnot(identical(xmlName(root), "root"))
+  stopifnot(xmlSize(root) == 2L)
+})
+
+run_test("xpathSApply extracts values and attributes", function() {
+  doc <- xmlParse(SAMPLE, asText = TRUE)
+  stopifnot(identical(xpathSApply(doc, "//item", xmlValue), c("a", "b")))
+  stopifnot(identical(xpathSApply(doc, "//item", xmlGetAttr, "id"), c("1", "2")))
+})
+
+run_test("getNodeSet selects by predicate", function() {
+  doc <- xmlParse(SAMPLE, asText = TRUE)
+  ns <- getNodeSet(doc, "//item[@id='2']")
+  stopifnot(length(ns) == 1L)
+  stopifnot(identical(xmlValue(ns[[1]]), "b"))
+})
+
+run_test("child access via [[ and xmlChildren", function() {
+  doc <- xmlParse(SAMPLE, asText = TRUE)
+  root <- xmlRoot(doc)
+  first <- root[[1]]
+  stopifnot(identical(xmlName(first), "item"))
+  stopifnot(identical(xmlValue(first), "a"))
+  stopifnot(length(xmlChildren(root)) == 2L)
+})
+
+run_test("build a node tree and serialize with saveXML", function() {
+  top <- newXMLNode("top")
+  newXMLNode("kid", "hello", parent = top)
+  out <- saveXML(top)
+  stopifnot(grepl("<kid>hello</kid>", out, fixed = TRUE))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all XML smoke tests passed\n")

--- a/cli/scripts/lib-validator/adjustText.py
+++ b/cli/scripts/lib-validator/adjustText.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `adjustText` package.
+
+Fully self-contained: no input files, no network, no packages beyond adjustText
+(and its implied deps: matplotlib + numpy). Forces the headless Agg backend
+before importing, so it never opens a window. Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 adjustText.py
+
+Install: pip install adjustText   (import name: adjustText)
+
+NOTE — deliberately MODEST coverage: adjustText's one job is to iteratively
+reposition overlapping matplotlib text labels, and its `adjust_text` return
+value has varied across releases (iteration count vs None). So the checks assert
+the callable surface plus that a real scatter + a few text handles can be run
+through `adjust_text` without error, rather than pinning exact coordinates.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+# Force the non-interactive Agg backend BEFORE adjustText (which pulls in
+# pyplot): headless run, must never pop a window. matplotlib is a hard
+# dependency of adjustText, so importing it here is safe when the package is
+# present.
+import matplotlib
+
+matplotlib.use("Agg")
+
+try:
+    import adjustText
+except ImportError:
+    print("FAIL: package 'adjustText' is not installed")
+    sys.exit(1)
+
+import matplotlib.pyplot as plt
+from adjustText import adjust_text
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"adjustText version: {_version(adjustText, 'adjustText')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_adjust_text_is_callable():
+    assert callable(adjust_text)
+    assert adjustText.adjust_text is adjust_text
+
+
+def test_adjust_text_runs_on_scatter():
+    fig, ax = plt.subplots()
+    try:
+        xs = [0.1, 0.15, 0.2, 0.22, 0.8]
+        ys = [0.1, 0.12, 0.5, 0.52, 0.9]
+        labels = ["a", "b", "c", "d", "e"]
+        ax.scatter(xs, ys)
+        texts = [ax.text(x, y, s) for x, y, s in zip(xs, ys, labels)]
+        assert len(texts) == 5
+        # Return type varies by version (iteration count or None); either way a
+        # clean call over real Text handles is the smoke signal we want.
+        result = adjust_text(texts, ax=ax)
+        assert result is None or isinstance(result, int)
+    finally:
+        plt.close(fig)
+
+
+run_test("adjust_text is callable", test_adjust_text_is_callable)
+run_test("adjust_text runs on scatter", test_adjust_text_runs_on_scatter)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all adjustText smoke tests passed")

--- a/cli/scripts/lib-validator/affy.R
+++ b/cli/scripts/lib-validator/affy.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `affy` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. affy reads Affymetrix
+# 3'-IVT arrays from per-array CEL files and needs the matching chip-definition
+# (CDF) environment package to map probes to probesets. We have NEITHER the raw
+# CEL files NOR a CDF package here, so a real ReadAffy() -> rma() is OUT OF SCOPE
+# OFFLINE. This test therefore verifies only what is checkable without any array
+# files: that the package loads and that its core reader / preprocessing entry
+# points and central S4 classes are present. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript affy.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# This test is FUNCTION/CLASS-EXISTENCE-DOMINATED because the real workflow needs
+# CEL files plus a CDF environment package that we cannot construct or fetch
+# offline. Constructing a bare AffyBatch is deliberately NOT attempted: a valid
+# object still points at a cdfName whose CDF env must be resolvable for any
+# downstream method, so class existence + FLAG is the honest offline check. The
+# assertions below pass on any healthy install; VERIFY ONCE INSTALLED:
+#   - ReadAffy() is the CEL reader; rma()/expresso()/justRMA() are the summarizers
+#     (all need CEL files + a CDF env package).
+#   - AffyBatch is a concrete (non-virtual) class extending Biobase's eSet.
+#   - ProbeSet is affy's per-probeset PM/MM container class.
+# ============================================================================
+
+if (!requireNamespace("affy", quietly = TRUE)) {
+  cat("FAIL: package 'affy' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(affy))
+cat(sprintf("affy version: %s\n", as.character(packageVersion("affy"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core reader / preprocessing functions are exported", function() {
+  stopifnot(exists("ReadAffy"), is.function(ReadAffy))
+  stopifnot(exists("rma"), is.function(rma))
+  stopifnot(exists("expresso"), is.function(expresso))
+})
+
+run_test("justRMA one-shot entry point is present", function() {
+  stopifnot(exists("justRMA"), is.function(justRMA))
+})
+
+run_test("AffyBatch S4 class is defined and non-virtual", function() {
+  cls <- getClass("AffyBatch")
+  stopifnot(!is.null(cls))
+  # AffyBatch is instantiable (holds CEL intensities); it must not be virtual.
+  stopifnot(!isVirtualClass("AffyBatch"))
+})
+
+run_test("AffyBatch extends Biobase eSet", function() {
+  # Structural inheritance is fixed by the class definition, so it is safe to
+  # assert hard (no array data needed): AffyBatch -> eSet -> VersionedBiobase.
+  stopifnot(extends("AffyBatch", "eSet"))
+})
+
+run_test("ProbeSet S4 class is defined", function() {
+  stopifnot(!is.null(getClass("ProbeSet")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all affy smoke tests passed\n")

--- a/cli/scripts/lib-validator/anndata.py
+++ b/cli/scripts/lib-validator/anndata.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `anndata` package.
+
+Fully self-contained: no input files, no network, no packages beyond anndata
+(and its implied deps — numpy, pandas, h5py). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 anndata.py
+
+Install: pip install anndata   (import name: anndata)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import anndata as ad
+except ImportError:
+    print("FAIL: package 'anndata' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"anndata version: {_version(ad, 'anndata')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_adata():
+    """A seeded 50x20 count matrix with labelled obs/var — the shared fixture."""
+    rng = np.random.default_rng(0)
+    X = rng.poisson(5, (50, 20)).astype(float)
+    obs = pd.DataFrame(
+        {"cell_type": ["A" if i % 2 == 0 else "B" for i in range(50)]},
+        index=[f"cell{i}" for i in range(50)],
+    )
+    var = pd.DataFrame(
+        {"gene_symbol": [f"g{j}" for j in range(20)]},
+        index=[f"gene{j}" for j in range(20)],
+    )
+    return ad.AnnData(X=X, obs=obs, var=var)
+
+
+def test_construct_shape_and_counts():
+    adata = _make_adata()
+    assert adata.shape == (50, 20)
+    assert adata.n_obs == 50
+    assert adata.n_vars == 20
+    assert adata.X.shape == (50, 20)
+
+
+def test_obs_var_column_access():
+    adata = _make_adata()
+    assert list(adata.obs["cell_type"][:4]) == ["A", "B", "A", "B"]
+    assert adata.var["gene_symbol"].iloc[0] == "g0"
+    assert adata.var["gene_symbol"].iloc[-1] == "g19"
+    assert list(adata.obs_names[:2]) == ["cell0", "cell1"]
+    assert list(adata.var_names[:2]) == ["gene0", "gene1"]
+
+
+def test_layers_roundtrip():
+    adata = _make_adata()
+    adata.layers["counts"] = adata.X.copy()
+    adata.layers["doubled"] = adata.X * 2.0
+    assert "counts" in adata.layers
+    assert adata.layers["counts"].shape == (50, 20)
+    assert np.allclose(adata.layers["counts"], adata.X)
+    assert np.allclose(adata.layers["doubled"], adata.X * 2.0)
+
+
+def test_obsm_pca_roundtrip():
+    adata = _make_adata()
+    pca = np.random.default_rng(1).standard_normal((50, 5))
+    adata.obsm["X_pca"] = pca
+    assert adata.obsm["X_pca"].shape == (50, 5)
+    assert np.allclose(adata.obsm["X_pca"], pca)
+
+
+def test_subset_view_shape():
+    adata = _make_adata()
+    sub = adata[:10, :5]
+    assert sub.shape == (10, 5)
+    assert sub.n_obs == 10
+    assert sub.n_vars == 5
+    assert np.allclose(sub.X, adata.X[:10, :5])
+
+
+def test_h5ad_write_read_roundtrip():
+    import tempfile
+
+    adata = _make_adata()
+    adata.layers["counts"] = adata.X.copy()
+    adata.obsm["X_pca"] = np.random.default_rng(2).standard_normal((50, 4))
+    fd, path = tempfile.mkstemp(suffix=".h5ad")
+    os.close(fd)
+    try:
+        adata.write_h5ad(path)
+        back = ad.read_h5ad(path)
+        assert back.shape == (50, 20)
+        assert np.allclose(back.X, adata.X)
+        assert np.allclose(back.layers["counts"], adata.layers["counts"])
+        assert np.allclose(back.obsm["X_pca"], adata.obsm["X_pca"])
+        assert list(back.obs["cell_type"]) == list(adata.obs["cell_type"])
+    finally:
+        os.remove(path)
+
+
+run_test("construct: shape / n_obs / n_vars", test_construct_shape_and_counts)
+run_test("obs/var column access", test_obs_var_column_access)
+run_test("layers assignment + readback", test_layers_roundtrip)
+run_test("obsm X_pca roundtrip", test_obsm_pca_roundtrip)
+run_test("subset [:10, :5] shape", test_subset_view_shape)
+run_test("h5ad tempfile write/read round-trip", test_h5ad_write_read_roundtrip)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all anndata smoke tests passed")

--- a/cli/scripts/lib-validator/babelgene.R
+++ b/cli/scripts/lib-validator/babelgene.R
@@ -1,0 +1,80 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `babelgene` package.
+#
+# Fully self-contained: no input files, NO network. babelgene is a DATA
+# package -- it ships pre-computed human<->model-organism ortholog tables, so
+# every lookup is deterministic and offline. Exercises the ortholog-mapping
+# API and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript babelgene.R
+#
+# Because the bundled data is fixed, checks are structural/exact (column
+# presence, row counts, a known TP53 -> Trp53 mapping).
+#
+# API TO RE-CHECK ONCE INSTALLED: the exact orthologs() output column names.
+# This asserts `human_symbol` (the queried human gene) and `symbol` (the model
+# organism ortholog). If those names differ in the installed version, update
+# the column assertions below.
+
+if (!requireNamespace("babelgene", quietly = TRUE)) {
+  cat("FAIL: package 'babelgene' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(babelgene))
+cat(sprintf("babelgene version: %s\n", as.character(packageVersion("babelgene"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("orthologs maps human genes to mouse orthologs", function() {
+  # human = TRUE: the input genes are HUMAN symbols; `symbol` holds the mouse
+  # ortholog. TP53 -> Trp53 and BRCA1 -> Brca1 are stable, canonical mappings.
+  res <- babelgene::orthologs(genes = c("TP53", "BRCA1"),
+                              species = "mouse", human = TRUE)
+  stopifnot(is.data.frame(res), nrow(res) > 0L)
+  stopifnot("human_symbol" %in% names(res))
+  stopifnot("symbol" %in% names(res))
+  # every returned human_symbol comes from the query set
+  stopifnot(all(res$human_symbol %in% c("TP53", "BRCA1")))
+  # TP53's mouse ortholog symbol is Trp53
+  tp53_rows <- res[res$human_symbol == "TP53", , drop = FALSE]
+  stopifnot(nrow(tp53_rows) > 0L)
+  stopifnot("Trp53" %in% tp53_rows$symbol)
+})
+
+run_test("orthologs recovers the BRCA1 -> Brca1 mapping", function() {
+  res <- babelgene::orthologs(genes = "BRCA1", species = "mouse", human = TRUE)
+  stopifnot(is.data.frame(res), nrow(res) > 0L)
+  stopifnot(all(res$human_symbol == "BRCA1"))
+  stopifnot("Brca1" %in% res$symbol)
+})
+
+run_test("species() returns the supported-species table", function() {
+  sp <- babelgene::species()
+  stopifnot(is.data.frame(sp), nrow(sp) > 0L)
+  # mouse must be listed. Column names vary across versions, so scan every
+  # character column for the scientific name rather than assuming a column.
+  has_mouse <- any(vapply(sp, function(col) {
+    is.character(col) && any(grepl("musculus", col, ignore.case = TRUE))
+  }, logical(1)))
+  stopifnot(has_mouse)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all babelgene smoke tests passed\n")

--- a/cli/scripts/lib-validator/batchelor.R
+++ b/cli/scripts/lib-validator/batchelor.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `batchelor` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond batchelor
+# and the Bioconductor deps it attaches. Two synthetic Gaussian batches are built
+# with a fixed seed, sharing gene names but offset by a constant batch shift;
+# checks are structural (return class, corrected slot present, batch labels) and
+# tolerance-based (shape, finiteness) rather than numeric-equality on anything
+# random. Exercises the batch-integration API and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript batchelor.R
+#
+# ============================ SIGNATURES TO RE-CHECK ========================
+# FLAG (verify once installed):
+#   - INPUT FORM: fastMNN() / rescaleBatches() are called here with two BARE
+#     MATRICES (genes x cells), one positional argument per batch, sharing
+#     rownames. The alternative forms -- a list of SCEs, or a single object with
+#     `batch=` -- are NOT exercised; confirm the multi-matrix positional form
+#     still resolves each argument to a separate batch.
+#   - fastMNN() returns a SingleCellExperiment carrying reducedDim(., "corrected")
+#     (cells x d) and a colData `batch` column. `d`/`k` are pinned small (d=10,
+#     k=10) so the internal PCA never requests more components than the low-rank
+#     40-100 cell data supports -- re-confirm the arg names and the "corrected"
+#     reducedDim name once a build is available.
+#   - rescaleBatches() returns an SCE with a `corrected` ASSAY (genes x cells)
+#     and a `batch` column.
+# ============================================================================
+
+if (!requireNamespace("batchelor", quietly = TRUE)) {
+  cat("FAIL: package 'batchelor' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(batchelor))
+cat(sprintf("batchelor version: %s\n", as.character(packageVersion("batchelor"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Two batches: 100 genes x 30 cells each, i.i.d. normal, with batch 2 shifted by
+# a constant so there is a batch effect to correct. Shared gene names are
+# required for fastMNN/rescaleBatches to align the batches.
+set.seed(1)
+ngenes <- 100L
+ncells <- 30L
+total <- 2L * ncells
+b1 <- matrix(rnorm(ngenes * ncells), nrow = ngenes, ncol = ncells)
+b2 <- matrix(rnorm(ngenes * ncells) + 1, nrow = ngenes, ncol = ncells)  # batch shift
+rownames(b1) <- rownames(b2) <- paste0("gene", seq_len(ngenes))
+colnames(b1) <- paste0("b1_cell", seq_len(ncells))
+colnames(b2) <- paste0("b2_cell", seq_len(ncells))
+
+run_test("fastMNN() returns an SCE with a corrected embedding + batch labels", function() {
+  mnn <- suppressWarnings(suppressMessages(fastMNN(b1, b2, d = 10, k = 10)))
+  stopifnot(inherits(mnn, "SingleCellExperiment"))
+  stopifnot("corrected" %in% reducedDimNames(mnn))
+  corr <- reducedDim(mnn, "corrected")
+  stopifnot(nrow(corr) == total, ncol(corr) == 10L, all(is.finite(corr)))
+  stopifnot("batch" %in% colnames(colData(mnn)))
+  stopifnot(length(mnn$batch) == total)
+})
+
+run_test("rescaleBatches() returns a corrected assay across both batches", function() {
+  rb <- suppressWarnings(suppressMessages(rescaleBatches(b1, b2)))
+  stopifnot(inherits(rb, "SingleCellExperiment"))
+  stopifnot("corrected" %in% assayNames(rb))
+  stopifnot(nrow(rb) == ngenes, ncol(rb) == total)
+  stopifnot("batch" %in% colnames(colData(rb)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all batchelor smoke tests passed\n")

--- a/cli/scripts/lib-validator/bioframe.py
+++ b/cli/scripts/lib-validator/bioframe.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `bioframe` package.
+
+Fully self-contained: no input files, no network, no packages beyond bioframe
+and its implied deps (numpy, pandas). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 bioframe.py
+
+Install: pip install bioframe   (import name: bioframe)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import bioframe
+except ImportError:
+    print("FAIL: package 'bioframe' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"bioframe version: {_version(bioframe, 'bioframe')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _df(rows):
+    import pandas as pd
+
+    return pd.DataFrame(rows, columns=["chrom", "start", "end"])
+
+
+def test_overlap():
+    df1 = _df([["chr1", 0, 10], ["chr1", 20, 30], ["chr2", 0, 10]])
+    df2 = _df([["chr1", 5, 15], ["chr1", 25, 35]])
+    ov = bioframe.overlap(df1, df2, how="inner", suffixes=("", "_"))
+    # (0,10)∩(5,15) and (20,30)∩(25,35) overlap; (chr2,0,10) has no partner.
+    assert len(ov) == 2
+    assert set(ov["chrom"]) == {"chr1"}
+
+
+def test_cluster():
+    # (0,10) and (5,15) touch → one cluster; (40,50) stands alone → another.
+    df = _df([["chr1", 0, 10], ["chr1", 5, 15], ["chr1", 40, 50]])
+    clustered = bioframe.cluster(df)
+    assert "cluster" in clustered.columns
+    assert clustered["cluster"].nunique() == 2
+
+
+def test_merge():
+    df = _df([["chr1", 0, 10], ["chr1", 5, 15], ["chr1", 40, 50]])
+    merged = bioframe.merge(df).sort_values("start").reset_index(drop=True)
+    # Overlapping (0,10)+(5,15) collapse into (0,15); (40,50) survives intact.
+    assert len(merged) == 2
+    assert int(merged.loc[0, "start"]) == 0
+    assert int(merged.loc[0, "end"]) == 15
+    assert int(merged.loc[1, "start"]) == 40
+    assert int(merged.loc[1, "end"]) == 50
+
+
+def test_closest():
+    df1 = _df([["chr1", 0, 10]])
+    df2 = _df([["chr1", 20, 30], ["chr1", 100, 110]])
+    closest = bioframe.closest(df1, df2, suffixes=("", "_"))
+    assert len(closest) == 1
+    # The nearer downstream feature is (20,30); its distance from (0,10) is 10.
+    assert int(closest.iloc[0]["distance"]) == 10
+
+
+run_test("overlap", test_overlap)
+run_test("cluster", test_cluster)
+run_test("merge", test_merge)
+run_test("closest", test_closest)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all bioframe smoke tests passed")

--- a/cli/scripts/lib-validator/biom-format.py
+++ b/cli/scripts/lib-validator/biom-format.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `biom-format` package (import name: biom).
+
+Fully self-contained: no input files, no network, no packages beyond
+biom-format and its implied deps (numpy, scipy). Exercises the core API surface
+and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 biom-format.py
+
+Install: pip install biom-format   (import name: biom)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import biom
+except ImportError:
+    print("FAIL: package 'biom-format' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"biom-format version: {_version(biom, 'biom-format')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# A small dense feature table shared across the checks below: 3 observations
+# (OTUs/features) x 2 samples. biom.Table takes data as [observation, sample].
+_DATA = None
+_OBS = ["O1", "O2", "O3"]
+_SAMPLES = ["S1", "S2"]
+
+
+def _make_table():
+    import numpy as np
+
+    global _DATA
+    _DATA = np.array(
+        [
+            [1.0, 3.0],
+            [0.0, 2.0],
+            [4.0, 5.0],
+        ]
+    )
+    return biom.Table(_DATA, _OBS, _SAMPLES)
+
+
+def test_construct_shape_and_ids():
+    t = _make_table()
+    # biom reports shape as (num_observations, num_samples).
+    assert t.shape == (3, 2)
+    assert list(t.ids("observation")) == _OBS
+    assert list(t.ids("sample")) == _SAMPLES
+
+
+def test_sums_per_sample():
+    import numpy as np
+
+    t = _make_table()
+    # Per-sample totals: column sums of the observation-by-sample matrix.
+    per_sample = t.sum("sample")
+    assert np.allclose(per_sample, np.array([5.0, 10.0]))
+    # Grand total of all counts.
+    assert abs(float(t.sum()) - 15.0) < 1e-9
+
+
+def test_to_dataframe_roundtrip():
+    import numpy as np
+
+    t = _make_table()
+    df = t.to_dataframe(dense=True)
+    # DataFrame is observation-indexed with sample columns.
+    assert list(df.index) == _OBS
+    assert list(df.columns) == _SAMPLES
+    assert np.allclose(df.to_numpy(), _DATA)
+
+
+def test_hdf5_tempfile_roundtrip():
+    import tempfile
+
+    # biom's native on-disk format is HDF5 (needs h5py). Skip cleanly if h5py
+    # is absent so the check reflects biom itself, not an optional backend.
+    try:
+        import h5py  # noqa: F401
+    except ImportError:
+        return
+
+    import numpy as np
+
+    t = _make_table()
+    fd, path = tempfile.mkstemp(suffix=".biom")
+    os.close(fd)
+    try:
+        with h5py.File(path, "w") as fh:
+            t.to_hdf5(fh, generated_by="lib-validator smoke test")
+        back = biom.load_table(path)
+        assert back.shape == (3, 2)
+        assert list(back.ids("observation")) == _OBS
+        assert list(back.ids("sample")) == _SAMPLES
+        assert np.allclose(back.sum("sample"), np.array([5.0, 10.0]))
+    finally:
+        os.remove(path)
+
+
+run_test("Table construct: shape + ids", test_construct_shape_and_ids)
+run_test("per-sample sums", test_sums_per_sample)
+run_test("to_dataframe roundtrip", test_to_dataframe_roundtrip)
+run_test("HDF5 tempfile roundtrip (if h5py)", test_hdf5_tempfile_roundtrip)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all biom-format smoke tests passed")

--- a/cli/scripts/lib-validator/biomaRt.R
+++ b/cli/scripts/lib-validator/biomaRt.R
@@ -1,0 +1,60 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `biomaRt` (Bioconductor) package.
+#
+# Fully self-contained: no input files, no packages beyond biomaRt + its deps.
+# Exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript biomaRt.R
+#
+# ============================ NETWORK / SCOPE ================================
+# biomaRt's PRIMARY function -- querying Ensembl BioMart -- is
+# NETWORK-DEPENDENT: useMart()/useEnsembl() open a connection to a BioMart web
+# service and getBM()/getLDS() issue live queries over HTTP. Those BioMart
+# queries are OUT OF SCOPE for an offline smoke test and are NOT exercised
+# here. This test only validates the OFFLINE surface: that the package loads
+# and its core connection / query functions are present as callable functions.
+# ============================================================================
+
+if (!requireNamespace("biomaRt", quietly = TRUE)) {
+  cat("FAIL: package 'biomaRt' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(biomaRt))
+cat(sprintf("biomaRt version: %s\n", as.character(packageVersion("biomaRt"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("mart-connection functions are exported", function() {
+  # NOTE: existence only -- calling any of these contacts a BioMart server,
+  # which is deliberately out of scope for this offline test.
+  stopifnot(is.function(biomaRt::useMart))
+  stopifnot(is.function(biomaRt::useEnsembl))
+  stopifnot(is.function(biomaRt::listMarts))
+})
+
+run_test("query functions are exported", function() {
+  # getBM() retrieves attributes from a mart; getLDS() links two datasets --
+  # both issue live network queries, so we only assert they exist.
+  stopifnot(is.function(biomaRt::getBM))
+  stopifnot(is.function(biomaRt::getLDS))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all biomaRt smoke tests passed\n")

--- a/cli/scripts/lib-validator/biopython.py
+++ b/cli/scripts/lib-validator/biopython.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `biopython` package (import name: Bio).
+
+Fully self-contained: no input files, no network, no packages beyond biopython
+(and its implied deps: numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 biopython.py
+
+Install: pip install biopython   (import name: Bio)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import Bio
+except ImportError:
+    print("FAIL: package 'biopython' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"biopython version: {_version(Bio, 'biopython')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_seq_basic_operations():
+    from Bio.Seq import Seq
+
+    s = Seq("ATGGCC")
+    assert len(s) == 6
+    # complement A<->T, G<->C: ATGGCC -> TACCGG
+    assert str(s.complement()) == "TACCGG"
+    # reverse of the complement
+    assert str(s.reverse_complement()) == "GGCCAT"
+    # ATG=Met(M), GCC=Ala(A)
+    assert str(s.translate()) == "MA"
+    assert s.count("G") == 2
+
+
+def test_gc_fraction():
+    from Bio.Seq import Seq
+    from Bio.SeqUtils import gc_fraction
+
+    # ATGGCC has 4 G/C out of 6 bases -> 0.6667 (gc_fraction returns a fraction,
+    # not a percentage).
+    frac = gc_fraction(Seq("ATGGCC"))
+    assert abs(frac - (4.0 / 6.0)) < 1e-9
+
+
+def test_seqrecord():
+    from Bio.Seq import Seq
+    from Bio.SeqRecord import SeqRecord
+
+    rec = SeqRecord(Seq("ACGTACGT"), id="rec1", description="demo record")
+    assert rec.id == "rec1"
+    assert str(rec.seq) == "ACGTACGT"
+    assert len(rec) == 8
+    assert rec.description == "demo record"
+
+
+def test_seqio_parse_inline_fasta():
+    import io
+
+    from Bio import SeqIO
+
+    # Parse an in-memory FASTA string via StringIO — no external file touched.
+    handle = io.StringIO(">x description here\nACGT\nTTGG\n")
+    records = list(SeqIO.parse(handle, "fasta"))
+    assert len(records) == 1
+    assert records[0].id == "x"
+    assert str(records[0].seq) == "ACGTTTGG"
+
+
+def test_pairwise_aligner():
+    import math
+
+    from Bio.Align import PairwiseAligner
+
+    aligner = PairwiseAligner()
+    # Default global aligner: match=1, mismatch/gap=0. Identical 4-mers -> 4.0.
+    alignments = aligner.align("ACGT", "ACGT")
+    assert math.isfinite(alignments.score)
+    assert alignments.score == 4.0
+    # A single-mismatch pair must score strictly lower than the perfect match.
+    mismatched = aligner.align("ACGT", "ACGA")
+    assert mismatched.score < alignments.score
+
+
+run_test("Seq complement/reverse_complement/translate/count", test_seq_basic_operations)
+run_test("GC content via gc_fraction", test_gc_fraction)
+run_test("SeqRecord id + seq", test_seqrecord)
+run_test("SeqIO.parse inline FASTA (StringIO)", test_seqio_parse_inline_fasta)
+run_test("PairwiseAligner score is finite + exact", test_pairwise_aligner)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all biopython smoke tests passed")

--- a/cli/scripts/lib-validator/cell2location.py
+++ b/cli/scripts/lib-validator/cell2location.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `cell2location` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 cell2location.py
+
+Install: pip install cell2location   (import name: cell2location)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: cell2location maps cell types onto spatial transcriptomics via
+a Bayesian model (scvi-tools / PyTorch / Pyro). Training is heavy and needs a
+reference signature plus spatial AnnData, so this only asserts the package
+imports and exposes its documented entry points (models, the Cell2location
+model class, run_colocation); it does NOT train a model. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import cell2location
+except ImportError:
+    print("FAIL: package 'cell2location' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"cell2location version: {_version(cell2location, 'cell2location')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_models_namespace():
+    assert hasattr(cell2location, "models")
+    # Cell2location is the spatial mapping model class.
+    assert hasattr(cell2location.models, "Cell2location")
+
+
+def test_exposes_run_colocation():
+    assert hasattr(cell2location, "run_colocation")
+
+
+run_test("exposes cell2location.models.Cell2location", test_exposes_models_namespace)
+run_test("exposes run_colocation", test_exposes_run_colocation)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all cell2location smoke tests passed")

--- a/cli/scripts/lib-validator/cellrank.py
+++ b/cli/scripts/lib-validator/cellrank.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `cellrank` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 cellrank.py
+
+Install: pip install "cellrank>=2"   (import name: cellrank)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: CellRank is fate mapping on an AnnData. The v1 and v2 APIs
+differ sharply (hence the >=2 pin), and a real run needs a preprocessed AnnData
+with a transition kernel, so this only asserts the package imports and exposes
+its documented v2 namespaces (kernels, estimators, tl); it does NOT run fate
+mapping. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import cellrank
+except ImportError:
+    print("FAIL: package 'cellrank' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"cellrank version: {_version(cellrank, 'cellrank')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_v2_namespaces():
+    # kernels + estimators are the CellRank v2 building blocks; their presence
+    # confirms the >=2 API rather than the legacy v1 tl.* surface.
+    assert hasattr(cellrank, "kernels")
+    assert hasattr(cellrank, "estimators")
+
+
+def test_exposes_tl_namespace():
+    assert hasattr(cellrank, "tl")
+
+
+run_test("exposes cellrank.kernels / cellrank.estimators", test_exposes_v2_namespaces)
+run_test("exposes cellrank.tl", test_exposes_tl_namespace)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all cellrank smoke tests passed")

--- a/cli/scripts/lib-validator/celltypist.py
+++ b/cli/scripts/lib-validator/celltypist.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `celltypist` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 celltypist.py
+
+Install: pip install celltypist   (import name: celltypist)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: celltypist.annotate needs a pretrained model, which is
+DOWNLOADED over the network on first use — NOT done here. This only asserts the
+package imports and exposes its documented entry points (Model, annotate,
+train); it does NOT fetch a model or annotate anything. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import celltypist
+except ImportError:
+    print("FAIL: package 'celltypist' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"celltypist version: {_version(celltypist, 'celltypist')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_model_class():
+    assert hasattr(celltypist, "Model")
+
+
+def test_exposes_annotate_and_train():
+    assert hasattr(celltypist, "annotate")
+    assert callable(celltypist.annotate)
+    assert hasattr(celltypist, "train")
+    assert callable(celltypist.train)
+
+
+run_test("exposes celltypist.Model", test_exposes_model_class)
+run_test("exposes annotate / train entry points", test_exposes_annotate_and_train)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all celltypist smoke tests passed")

--- a/cli/scripts/lib-validator/cli.R
+++ b/cli/scripts/lib-validator/cli.R
@@ -1,0 +1,90 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `cli` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# cli itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript cli.R
+
+if (!requireNamespace("cli", quietly = TRUE)) {
+  cat("FAIL: package 'cli' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(cli))
+cat(sprintf("cli version: %s\n", as.character(packageVersion("cli"))))
+
+# Force ANSI color support on: Rscript runs without a TTY, where cli would
+# otherwise disable styling and the styled-string tests would be vacuous.
+options(cli.num_colors = 256L)
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("inline interpolation (format_inline)", function() {
+  out <- cli::format_inline("value is {toupper('abc')} ok")
+  stopifnot(identical(as.character(out), "value is ABC ok"))
+  n <- 4L
+  stopifnot(identical(as.character(cli::format_inline("got {n} rows")), "got 4 rows"))
+})
+
+run_test("ANSI styling + strip roundtrip", function() {
+  styled <- cli::col_red("hello")
+  # Styling must actually add escape codes, and stripping must recover the text.
+  stopifnot(cli::ansi_has_any(styled))
+  stopifnot(base::nchar(styled) > 5L)
+  stopifnot(identical(as.character(cli::ansi_strip(styled)), "hello"))
+  bolded <- cli::style_bold("wide text")
+  stopifnot(identical(as.character(cli::ansi_strip(bolded)), "wide text"))
+})
+
+run_test("pluralization", function() {
+  stopifnot(identical(as.character(cli::pluralize("{1} file{?s}")), "1 file"))
+  stopifnot(identical(as.character(cli::pluralize("{3} file{?s}")), "3 files"))
+  n <- 0L
+  stopifnot(identical(as.character(cli::pluralize("{n} file{?s}")), "0 files"))
+})
+
+run_test("ansi_nchar vs base nchar on styled string", function() {
+  styled <- cli::col_red("hello")
+  stopifnot(identical(cli::ansi_nchar(styled), 5L))
+  stopifnot(base::nchar(styled) > cli::ansi_nchar(styled))
+  # Unstyled strings agree between the two.
+  stopifnot(identical(cli::ansi_nchar("plain"), base::nchar("plain")))
+})
+
+run_test("ansi_align pads to width", function() {
+  left <- cli::ansi_align("ab", width = 6)
+  stopifnot(identical(as.character(left), "ab    "))
+  right <- cli::ansi_align("ab", width = 6, align = "right")
+  stopifnot(identical(as.character(right), "    ab"))
+})
+
+run_test("cli_fmt captures cli output", function() {
+  out <- cli::cli_fmt(cli::cli_text("count is {2 + 2}"))
+  stopifnot(identical(as.character(cli::ansi_strip(out)), "count is 4"))
+})
+
+run_test("cli_vec collapsing", function() {
+  v <- cli::cli_vec(c("a", "b", "c"), style = list("vec-last" = " and "))
+  out <- cli::format_inline("{v}")
+  stopifnot(identical(as.character(cli::ansi_strip(out)), "a, b and c"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all cli smoke tests passed\n")

--- a/cli/scripts/lib-validator/clusterProfiler.R
+++ b/cli/scripts/lib-validator/clusterProfiler.R
@@ -1,0 +1,110 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `clusterProfiler` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. clusterProfiler can reach
+# online annotation (GO / KEGG / OrgDb) -- this test DELIBERATELY AVOIDS all of
+# that by driving the generic `enricher()` / `GSEA()` entry points with a
+# user-supplied TERM2GENE mapping. Everything runs OFFLINE against synthetic
+# terms and genes. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript clusterProfiler.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed -- the generic-enrichment argument names:
+#
+#   * enricher(gene, TERM2GENE, pvalueCutoff, qvalueCutoff, ...) is assumed;
+#     `gene` is a character vector, `TERM2GENE` a 2-column data.frame (term,
+#     gene). Cutoffs are set to 1 so every tested term is returned. Result class
+#     assumed "enrichResult"; the reported term ids live in as.data.frame(res)$ID.
+#
+#   * GSEA(geneList, TERM2GENE, pvalueCutoff, ...) is assumed; `geneList` is a
+#     DECREASING-sorted NAMED numeric vector. Result class assumed "gseaResult".
+#
+# TERM2GENE column *names* are ignored by clusterProfiler (position matters:
+# col1 = term, col2 = gene), so only the arg names / class names above are the
+# things to re-verify.
+# ============================================================================
+
+if (!requireNamespace("clusterProfiler", quietly = TRUE)) {
+  cat("FAIL: package 'clusterProfiler' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(clusterProfiler))
+cat(sprintf("clusterProfiler version: %s\n", as.character(packageVersion("clusterProfiler"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic, fully offline annotation: 200 genes partitioned into three terms.
+# TERM_A is the planted term; the query gene list is exactly TERM_A's members,
+# so the over-representation test must surface TERM_A.
+set.seed(42)
+gene_ids <- paste0("g", seq_len(200))
+term2gene <- rbind(
+  data.frame(term = "TERM_A", gene = gene_ids[1:30], stringsAsFactors = FALSE),
+  data.frame(term = "TERM_B", gene = gene_ids[50:80], stringsAsFactors = FALSE),
+  data.frame(term = "TERM_C", gene = gene_ids[100:140], stringsAsFactors = FALSE)
+)
+query_genes <- gene_ids[1:30]
+
+# Ranked list for GSEA: TERM_A genes shifted up so the term enriches at the top.
+scores <- rnorm(200)
+names(scores) <- gene_ids
+scores[gene_ids[1:30]] <- scores[gene_ids[1:30]] + 2
+gene_list <- sort(scores, decreasing = TRUE)
+
+run_test("enricher over a user TERM2GENE returns an enrichResult", function() {
+  res <- suppressMessages(clusterProfiler::enricher(
+    gene = query_genes, TERM2GENE = term2gene,
+    pvalueCutoff = 1, qvalueCutoff = 1))
+  stopifnot(inherits(res, "enrichResult"))
+})
+
+run_test("planted term appears in the enricher output", function() {
+  res <- suppressMessages(clusterProfiler::enricher(
+    gene = query_genes, TERM2GENE = term2gene,
+    pvalueCutoff = 1, qvalueCutoff = 1))
+  df <- as.data.frame(res)
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot("ID" %in% names(df))
+  stopifnot("TERM_A" %in% df$ID)
+})
+
+run_test("GSEA over a ranked geneList returns a gseaResult", function() {
+  res <- suppressWarnings(suppressMessages(clusterProfiler::GSEA(
+    geneList = gene_list, TERM2GENE = term2gene,
+    minGSSize = 5, pvalueCutoff = 1, verbose = FALSE)))
+  stopifnot(inherits(res, "gseaResult"))
+})
+
+run_test("GSEA result frame carries an ID column", function() {
+  res <- suppressWarnings(suppressMessages(clusterProfiler::GSEA(
+    geneList = gene_list, TERM2GENE = term2gene,
+    minGSSize = 5, pvalueCutoff = 1, verbose = FALSE)))
+  df <- as.data.frame(res)
+  stopifnot(is.data.frame(df), "ID" %in% names(df))
+  # SOFT: the planted term is expected to enrich, but leave it a note (not a
+  # failure) so multilevel RNG variation can't false-fail a healthy install.
+  if (!("TERM_A" %in% df$ID)) {
+    cat("  note TERM_A not reported by GSEA (verify enrichment once installed)\n")
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all clusterProfiler smoke tests passed\n")

--- a/cli/scripts/lib-validator/conorm.py
+++ b/cli/scripts/lib-validator/conorm.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `conorm` package.
+
+Fully self-contained: no input files, no network, no packages beyond conorm
+(and its implied deps: numpy + pandas). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 conorm.py
+
+Install: pip install conorm   (import name: conorm)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import conorm
+except ImportError:
+    print("FAIL: package 'conorm' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"conorm version: {_version(conorm, 'conorm')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _counts():
+    """A seeded genes x samples RNA-seq count matrix (rows=genes, cols=samples)."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(1, 1000, size=(50, 4))
+    return pd.DataFrame(
+        data,
+        index=[f"gene{i}" for i in range(50)],
+        columns=["s1", "s2", "s3", "s4"],
+    )
+
+
+def test_cpm_columns_sum_to_million():
+    counts = _counts()
+    cpm = conorm.cpm(counts)
+    assert isinstance(cpm, pd.DataFrame)
+    assert cpm.shape == counts.shape
+    # Counts-per-million: every sample (column) is scaled to sum to 1e6.
+    assert np.allclose(cpm.sum(axis=0).values, 1e6, rtol=1e-6)
+
+
+def test_tmm_preserves_shape():
+    counts = _counts()
+    tmm = conorm.tmm(counts)
+    assert isinstance(tmm, pd.DataFrame)
+    assert tmm.shape == counts.shape
+    assert list(tmm.columns) == list(counts.columns)
+    assert list(tmm.index) == list(counts.index)
+    # Normalized counts stay finite and non-negative.
+    assert np.isfinite(tmm.values).all()
+    assert (tmm.values >= 0).all()
+
+
+def test_tmm_norm_factors_center_on_one():
+    counts = _counts()
+    nf = conorm.tmm_norm_factors(counts)
+    assert len(nf) == counts.shape[1]
+    # TMM normalization factors are scaled to have a geometric mean of 1.
+    assert np.isclose(np.exp(np.log(np.asarray(nf).ravel()).mean()), 1.0, rtol=1e-6)
+
+
+run_test("cpm columns sum to 1e6", test_cpm_columns_sum_to_million)
+run_test("tmm preserves shape/labels", test_tmm_preserves_shape)
+run_test("tmm_norm_factors center on 1", test_tmm_norm_factors_center_on_one)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all conorm smoke tests passed")

--- a/cli/scripts/lib-validator/cooler.py
+++ b/cli/scripts/lib-validator/cooler.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `cooler` package.
+
+Fully self-contained: no input files, no network, no packages beyond cooler
+and its implied deps (numpy, pandas, h5py, scipy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 cooler.py
+
+Install: pip install cooler   (import name: cooler)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAG: cooler stores Hi-C contact matrices in a `.cool` (HDF5) file.
+Building a valid cooler is non-trivial — `cooler.create_cooler(path, bins,
+pixels)` demands a bins DataFrame with columns (chrom, start, end) and a pixels
+DataFrame with columns (bin1_id, bin2_id, count) whose bin ids index into the
+bins table. The create-then-reopen check below encodes that schema exactly; if
+the create API drifts, this is the check to revisit first.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import cooler
+except ImportError:
+    print("FAIL: package 'cooler' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"cooler version: {_version(cooler, 'cooler')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _toy_bins_pixels():
+    """A minimal 4-bin single-chromosome contact set (chr1, 10bp binsize)."""
+    import pandas as pd
+
+    bins = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1", "chr1"],
+            "start": [0, 10, 20, 30],
+            "end": [10, 20, 30, 40],
+        }
+    )
+    # Upper-triangle pixels (bin1_id <= bin2_id) with integer counts.
+    pixels = pd.DataFrame(
+        {
+            "bin1_id": [0, 0, 1, 2, 3],
+            "bin2_id": [0, 1, 1, 2, 3],
+            "count": [5, 3, 7, 4, 6],
+        }
+    )
+    return bins, pixels
+
+
+def test_create_and_reopen_cool_tempfile():
+    import tempfile
+
+    bins, pixels = _toy_bins_pixels()
+    fd, path = tempfile.mkstemp(suffix=".cool")
+    os.close(fd)
+    try:
+        cooler.create_cooler(path, bins, pixels)
+        c = cooler.Cooler(path)
+        # Four bins on a single chromosome.
+        assert c.chromnames == ["chr1"]
+        assert c.binsize == 10
+        assert c.bins().shape[0] == 4
+        # A dense 4x4 contact matrix reconstructed from the sparse pixels.
+        mat = c.matrix(balance=False)[:]
+        assert mat.shape == (4, 4)
+        # Diagonal (0,0) pixel had count 5; matrix is symmetric.
+        assert mat[0, 0] == 5
+        assert mat[0, 1] == 3
+        assert mat[1, 0] == 3
+    finally:
+        os.remove(path)
+
+
+def test_bins_and_pixels_accessors():
+    import tempfile
+
+    bins, pixels = _toy_bins_pixels()
+    fd, path = tempfile.mkstemp(suffix=".cool")
+    os.close(fd)
+    try:
+        cooler.create_cooler(path, bins, pixels)
+        c = cooler.Cooler(path)
+        bdf = c.bins()[:]
+        assert list(bdf.columns[:3]) == ["chrom", "start", "end"]
+        assert int(bdf.iloc[1]["start"]) == 10
+        pdf = c.pixels()[:]
+        assert "count" in pdf.columns
+        # Five stored (upper-triangle) contacts.
+        assert len(pdf) == 5
+    finally:
+        os.remove(path)
+
+
+run_test("create_cooler + reopen matrix", test_create_and_reopen_cool_tempfile)
+run_test("bins/pixels accessors", test_bins_and_pixels_accessors)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all cooler smoke tests passed")

--- a/cli/scripts/lib-validator/cooltools.py
+++ b/cli/scripts/lib-validator/cooltools.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `cooltools` package.
+
+Fully self-contained: no input files, no network, no packages beyond cooltools
+and its implied deps (cooler, numpy, pandas, scipy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 cooltools.py
+
+Install: pip install cooltools   (import name: cooltools)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAG: cooltools runs genome-scale analyses (expected, insulation,
+compartment eigenvectors) on real `cooler` objects — a proper end-to-end run
+needs a populated `.cool` with genome-wide coverage, which is heavier than a
+smoke test should build. So this validator asserts the package imports and
+that its headline analysis entry points are exposed and callable, WITHOUT
+running them against a real matrix. The dependency on `cooler` is implicit;
+if cooler is missing, cooltools import itself will fail.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import cooltools
+except ImportError:
+    print("FAIL: package 'cooltools' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"cooltools version: {_version(cooltools, 'cooltools')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_analysis_entry_points_exposed():
+    # The headline analyses. We assert they are present and callable, but do
+    # NOT invoke them — each needs a real, genome-wide cooler to be meaningful.
+    for attr in ("expected_cis", "insulation", "eigs_cis"):
+        assert hasattr(cooltools, attr), f"cooltools.{attr} missing"
+        assert callable(getattr(cooltools, attr)), f"cooltools.{attr} not callable"
+
+
+def test_cooler_dependency_importable():
+    # cooltools operates on cooler objects; its own import implies cooler is
+    # present, but assert it explicitly so a broken dep surfaces clearly.
+    import cooler
+
+    assert hasattr(cooler, "Cooler")
+
+
+run_test("analysis entry points exposed (not run)", test_analysis_entry_points_exposed)
+run_test("cooler dependency importable", test_cooler_dependency_importable)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all cooltools smoke tests passed")

--- a/cli/scripts/lib-validator/copykat.R
+++ b/cli/scripts/lib-validator/copykat.R
@@ -1,0 +1,102 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `copykat` package.
+#
+# Fully self-contained and OFFLINE: no input files, no network. copykat calls
+# aneuploid (malignant) vs diploid (normal) cells from a genes x cells raw scRNA
+# UMI count matrix. The full `copykat()` pipeline is deliberately NOT run: it
+# REQUIRES a large gene-symbol-rownamed UMI matrix, is slow (per-chromosome
+# segmentation + KS clustering), and WRITES result files (predictions, CNA
+# matrix, heatmap) into the working directory -- all out of scope for an offline
+# validator. Instead the test asserts the package loads and exposes its entry
+# point, checks the documented `copykat()` argument names, and builds (but does
+# NOT score) a small synthetic UMI matrix of the shape copykat expects. Exits 0
+# only if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript copykat.R
+#
+# Install (GitHub-hosted, not on CRAN/Bioconductor):
+#   remotes::install_github("navinlabcode/copykat")
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- copykat is NOT installed here, so confirm
+# all of the following once a build is available:
+#   - copykat() SIGNATURE. The formals check below asserts the documented
+#     arguments (rawmat, id.type, ngene.chr, win.size, KS.cut, sam.name,
+#     n.cores) are present. If a version renames/removes any, update the check.
+#   - RETURN SHAPE. A real copykat() run returns a list with `prediction` (a
+#     data.frame of aneuploid/diploid calls per cell) and `CNAmat` (the copy-
+#     number matrix). This is NOT exercised here (the pipeline is not run);
+#     re-confirm the list element names before relying on them.
+#   - INPUT ORIENTATION. copykat expects GENES as rows (gene-symbol rownames)
+#     and CELLS as columns of a raw UMI count matrix; id.type="S" selects gene
+#     symbols. The synthetic matrix is built to that shape but never scored.
+# ============================================================================
+
+if (!requireNamespace("copykat", quietly = TRUE)) {
+  cat("FAIL: package 'copykat' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(copykat))
+cat(sprintf("copykat version: %s\n", as.character(packageVersion("copykat"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic raw UMI matrix: 100 genes x 20 cells, integer Poisson draws with
+# gene-symbol rownames -- the shape copykat's `rawmat` expects (genes as rows,
+# cells as columns, id.type="S"). Built only to exercise a cheap structural
+# check; it is NEVER passed to copykat() (the full pipeline is slow and writes
+# output files, out of scope offline -- see the header note).
+set.seed(42)
+n_genes <- 100L
+n_cells <- 20L
+gene_symbols <- sprintf("GENE%03d", seq_len(n_genes))
+cell_ids <- paste0("cell", seq_len(n_cells))
+rawmat <- matrix(
+  rpois(n_genes * n_cells, lambda = 5),
+  nrow = n_genes, ncol = n_cells,
+  dimnames = list(gene_symbols, cell_ids)
+)
+
+run_test("copykat entry point is an exported function", function() {
+  stopifnot(is.function(copykat))
+})
+
+run_test("copykat() exposes its documented arguments", function() {
+  args <- names(formals(copykat))
+  # Core documented arguments (see the SIGNATURE note in the header block).
+  # Subset check: extra args in a newer version are fine; a rename is the case
+  # the header flags for re-confirmation.
+  expected <- c("rawmat", "id.type", "ngene.chr", "win.size", "KS.cut",
+                "sam.name", "n.cores")
+  stopifnot(all(expected %in% args))
+})
+
+run_test("synthetic raw UMI matrix has the copykat-expected shape", function() {
+  # genes x cells, non-negative integer counts, named rows/cols -- what `rawmat`
+  # needs. This never touches copykat(); it only guards the construction above.
+  stopifnot(is.matrix(rawmat))
+  stopifnot(nrow(rawmat) == n_genes, ncol(rawmat) == n_cells)
+  stopifnot(!is.null(rownames(rawmat)), !is.null(colnames(rawmat)))
+  stopifnot(all(rawmat >= 0), all(rawmat == round(rawmat)))
+  # id.type="S" resolves rownames as gene SYMBOLS -- they must be non-empty.
+  stopifnot(all(nzchar(rownames(rawmat))))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all copykat smoke tests passed\n")

--- a/cli/scripts/lib-validator/corrplot.R
+++ b/cli/scripts/lib-validator/corrplot.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `corrplot` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# corrplot itself (plus its implied deps). corrplot always draws, so every
+# call is routed to a throwaway pdf null device (opened on a tempfile, closed
+# and unlinked on exit) -- no interactive device is ever opened. Exits 0 only
+# if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript corrplot.R
+
+if (!requireNamespace("corrplot", quietly = TRUE)) {
+  cat("FAIL: package 'corrplot' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(corrplot))
+cat(sprintf("corrplot version: %s\n", as.character(packageVersion("corrplot"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("corrplot returns the reordered correlation matrix", function() {
+  set.seed(42)
+  M <- cor(matrix(rnorm(100), 20, 5))
+  path <- tempfile("corrplot-smoke-", fileext = ".pdf")
+  grDevices::pdf(path)
+  on.exit({ grDevices::dev.off(); unlink(path) }, add = TRUE)
+  res <- corrplot::corrplot(M)
+  # Older corrplot returns the (reordered) matrix; newer versions wrap it in a
+  # list with a $corr element -- accept either so the check tracks the API.
+  cm <- if (is.matrix(res)) res else res$corr
+  stopifnot(is.matrix(cm), nrow(cm) == 5L, ncol(cm) == 5L)
+  stopifnot(all(abs(diag(cm) - 1) < 1e-8))
+})
+
+run_test("corrplot.mixed runs on the null device", function() {
+  set.seed(42)
+  M <- cor(matrix(rnorm(100), 20, 5))
+  path <- tempfile("corrplot-mixed-", fileext = ".pdf")
+  grDevices::pdf(path)
+  on.exit({ grDevices::dev.off(); unlink(path) }, add = TRUE)
+  res <- corrplot::corrplot.mixed(M)
+  cm <- if (is.matrix(res)) res else res$corr
+  stopifnot(is.matrix(cm), nrow(cm) == 5L, ncol(cm) == 5L)
+})
+
+run_test("hclust reordering runs on the null device", function() {
+  set.seed(42)
+  M <- cor(matrix(rnorm(100), 20, 5))
+  path <- tempfile("corrplot-order-", fileext = ".pdf")
+  grDevices::pdf(path)
+  on.exit({ grDevices::dev.off(); unlink(path) }, add = TRUE)
+  res <- corrplot::corrplot(M, order = "hclust")
+  cm <- if (is.matrix(res)) res else res$corr
+  stopifnot(is.matrix(cm), nrow(cm) == 5L, ncol(cm) == 5L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all corrplot smoke tests passed\n")

--- a/cli/scripts/lib-validator/cowplot.R
+++ b/cli/scripts/lib-validator/cowplot.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `cowplot` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# cowplot itself (ggplot2 is its core dependency, used to build the panels).
+# Exercises the core API surface by INSPECTING the composed grid/theme objects
+# -- it never opens an interactive device -- and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript cowplot.R
+
+if (!requireNamespace("cowplot", quietly = TRUE)) {
+  cat("FAIL: package 'cowplot' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(cowplot))
+suppressPackageStartupMessages(library(ggplot2))
+cat(sprintf("cowplot version: %s\n", as.character(packageVersion("cowplot"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("plot_grid returns a ggplot/gg object", function() {
+  p1 <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  p2 <- ggplot(mtcars, aes(hp, qsec)) + geom_point()
+  g <- plot_grid(p1, p2, ncol = 2)
+  # cowplot draws its grid onto a ggdraw canvas, so the result is a ggplot.
+  stopifnot(inherits(g, "gg"))
+  stopifnot(inherits(g, "ggplot"))
+})
+
+run_test("theme_cowplot is a ggplot theme", function() {
+  th <- theme_cowplot()
+  stopifnot(inherits(th, "theme"))
+  stopifnot(inherits(th, "gg"))
+})
+
+run_test("get_legend extracts a legend grob", function() {
+  p <- ggplot(mtcars, aes(mpg, wt, colour = factor(cyl))) + geom_point()
+  leg <- get_legend(p)
+  # The legend comes back as a grid grob/gtable, not NULL.
+  stopifnot(!is.null(leg))
+  stopifnot(inherits(leg, "gtable") || inherits(leg, "grob"))
+})
+
+run_test("ggdraw yields a drawable ggplot canvas", function() {
+  canvas <- ggdraw()
+  stopifnot(inherits(canvas, "ggplot"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all cowplot smoke tests passed\n")

--- a/cli/scripts/lib-validator/cyCombine.R
+++ b/cli/scripts/lib-validator/cyCombine.R
@@ -1,0 +1,142 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `cyCombine` package.
+#
+# Fully self-contained: no input files, NO network. cyCombine corrects batch
+# effects in high-dimensional cytometry data (SOM clustering + per-cluster
+# ComBat). It works on a TIDY data frame/tibble where rows = cells and columns
+# = markers plus a `batch` (and optional `sample`) column. This test runs a
+# GENUINE offline correction: it builds a synthetic 2000-cell x 10-marker tibble
+# with a planted per-batch shift, calls batch_correct(), and asserts the
+# corrected tibble keeps its row count + marker columns, stays finite, and that
+# the between-batch mean gap SHRINKS versus the uncorrected data. Checks are
+# STRUCTURAL/tolerance (shape, finiteness, an inequality on the batch gap)
+# rather than numeric equality on random data. Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript cyCombine.R
+#
+# Install (GitHub-hosted, not on CRAN/Bioconductor):
+#   remotes::install_github("biosurf/cyCombine")
+#
+# ======================= ASSUMPTIONS TO RE-CHECK (FIDDLY) ====================
+# Written from the cyCombine source (biosurf/cyCombine) rather than a live
+# install. The batch_correct() argument names + the tibble column contract are
+# the easy-to-get-wrong parts -- RE-VERIFY every one of these:
+#
+#  * batch_correct(df, markers = <chr>, batch = "batch", covar = NULL,
+#                  seed = , xdim = 8, ydim = 8, rlen = 10,
+#                  norm_method = "scale", ...):
+#      - `df` is a tibble/data.frame: one ROW per cell, one COLUMN per marker,
+#        PLUS a batch column and (optionally) a `sample` column. covar names an
+#        optional biological covariate to preserve during ComBat.
+#      - The `batch =` ARGUMENT NAME is UNVERIFIED. Some versions do NOT take a
+#        `batch =` parameter and instead HARD-CODE a column literally named
+#        "batch". We hedge by naming the column "batch" regardless -- so the
+#        data is correct whether batch_correct reads the arg or the column. If a
+#        given version rejects `batch =` ("unused argument"), DROP it from the
+#        call; the "batch" column already carries the grouping.
+#      - The `sample` column is OPTIONAL (used for anchoring / covariates); we
+#        include it for realism, but correction keys on `batch`.
+#
+#  * RETURN VALUE: a corrected tibble on the NORMALIZED scale. It preserves the
+#    marker columns and the row count, and typically ADDS helper columns (e.g.
+#    `id`, `label` = SOM node). So we assert marker columns are a SUBSET of the
+#    result's columns (not column-set equality) and compare the batch gap on the
+#    CORRECTED values vs the UNCORRECTED planted gap as an INEQUALITY, never an
+#    exact numeric target.
+#
+#  * DEPENDENCIES: the SOM comes from kohonen and the correction from sva/ComBat
+#    -- both are cyCombine dependencies, present whenever cyCombine is installed.
+#    batch_correct() is seeded, so with a fixed `seed` the run is deterministic.
+# ============================================================================
+
+if (!requireNamespace("cyCombine", quietly = TRUE)) {
+  cat("FAIL: package 'cyCombine' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(cyCombine))
+cat(sprintf("cyCombine version: %s\n", as.character(packageVersion("cyCombine"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# ---- synthetic tidy cytometry table ---------------------------------------
+# 2000 cells x 10 markers across two batches (A, B), two samples per batch.
+# Batch B carries a planted +3 shift on every marker -- the batch effect that
+# correction should remove. rows = cells; columns = markers + batch + sample.
+set.seed(1)
+n_cells   <- 2000L
+n_markers <- 10L
+markers   <- paste0("M", sprintf("%02d", seq_len(n_markers)))
+
+sample <- rep(c("S1", "S2", "S3", "S4"), each = n_cells / 4L)
+batch  <- ifelse(sample %in% c("S1", "S2"), "A", "B")
+shift  <- ifelse(batch == "B", 3, 0)
+
+expr <- matrix(rnorm(n_cells * n_markers), nrow = n_cells, ncol = n_markers)
+expr <- expr + shift
+colnames(expr) <- markers
+
+df <- as.data.frame(expr, stringsAsFactors = FALSE)
+df$batch  <- batch
+df$sample <- sample
+if (requireNamespace("tibble", quietly = TRUE)) df <- tibble::as_tibble(df)
+
+# Uncorrected between-batch mean gap, averaged over markers (planted ~3).
+batch_gap <- function(mat, grp) {
+  mean(abs(colMeans(mat[grp == "A", , drop = FALSE]) -
+           colMeans(mat[grp == "B", , drop = FALSE])))
+}
+gap_before <- batch_gap(expr, batch)
+
+run_test("batch_correct + helpers are exported functions", function() {
+  stopifnot(is.function(cyCombine::batch_correct))
+  stopifnot(is.function(cyCombine::normalize))
+  stopifnot(is.function(cyCombine::create_som))
+  stopifnot(is.function(cyCombine::correct_data))
+})
+
+run_test("synthetic tidy tibble has the expected shape", function() {
+  stopifnot(nrow(df) == n_cells)
+  stopifnot(all(markers %in% colnames(df)))
+  stopifnot("batch" %in% colnames(df))
+  stopifnot(setequal(unique(df$batch), c("A", "B")))
+  # planted effect is real: the uncorrected gap is large.
+  stopifnot(gap_before > 1)
+})
+
+run_test("batch_correct preserves shape, stays finite, shrinks the batch gap", function() {
+  corrected <- suppressWarnings(suppressMessages(
+    cyCombine::batch_correct(df, markers = markers, batch = "batch", seed = 1)))
+  # same number of cells (one corrected row per input cell)
+  stopifnot(nrow(corrected) == n_cells)
+  # marker columns survive the correction (result may ADD helper columns)
+  stopifnot(all(markers %in% colnames(corrected)))
+  cm <- as.matrix(corrected[, markers])
+  stopifnot(all(is.finite(cm)))
+  # corrected batch labels, aligned row-for-row (batch_correct keeps row order)
+  bvec <- as.character(corrected[["batch"]])
+  stopifnot(length(bvec) == n_cells)
+  # ComBat removes the planted shift: the between-batch mean gap must shrink
+  # well below the uncorrected gap (tolerance/inequality, never equality).
+  gap_after <- batch_gap(cm, bvec)
+  stopifnot(gap_after < gap_before)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all cyCombine smoke tests passed\n")

--- a/cli/scripts/lib-validator/cyvcf2.py
+++ b/cli/scripts/lib-validator/cyvcf2.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `cyvcf2` package.
+
+Fully self-contained: no input files, no network, no packages beyond cyvcf2
+(and its implied deps: numpy). The VCF fixture is synthesized into a tempfile
+at runtime and deleted afterwards. Exercises the core API surface and exits 0
+only if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 cyvcf2.py
+
+Install: pip install cyvcf2   (import name: cyvcf2)
+
+NOTE: cyvcf2 is a thin Cython wrapper over htslib; the wheel bundles htslib, but
+a source build needs htslib (libhts) present at build time. If import fails on a
+freshly built cyvcf2, that is usually a missing/mismatched htslib.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import cyvcf2
+except ImportError:
+    print("FAIL: package 'cyvcf2' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"cyvcf2 version: {_version(cyvcf2, 'cyvcf2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# A minimal but valid VCF v4.2: header + contig/FORMAT lines + two records with
+# one genotyped sample. First record is a heterozygote (0/1), second is
+# homozygous-alt (1/1).
+_VCF_TEXT = (
+    "##fileformat=VCFv4.2\n"
+    "##contig=<ID=chr1,length=1000>\n"
+    '##FILTER=<ID=PASS,Description="All filters passed">\n'
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE1\n"
+    "chr1\t100\t.\tA\tT\t50\tPASS\t.\tGT\t0/1\n"
+    "chr1\t200\trs2\tG\tC\t60\tPASS\t.\tGT\t1/1\n"
+)
+
+
+def _write_vcf():
+    """Materialize the fixture VCF into a tempfile; caller deletes it."""
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as fh:
+        fh.write(_VCF_TEXT)
+    return path
+
+
+def test_read_variants_and_fields():
+    path = _write_vcf()
+    try:
+        vcf = cyvcf2.VCF(path)
+        try:
+            assert vcf.samples == ["SAMPLE1"]
+            variants = list(vcf)
+            assert len(variants) == 2
+
+            v0 = variants[0]
+            assert v0.CHROM == "chr1"
+            assert v0.POS == 100  # cyvcf2 exposes POS as 1-based
+            assert v0.REF == "A"
+            assert v0.ALT == ["T"]
+
+            v1 = variants[1]
+            assert v1.POS == 200
+            assert v1.REF == "G"
+            assert v1.ALT == ["C"]
+            assert v1.ID == "rs2"
+        finally:
+            vcf.close()
+    finally:
+        os.remove(path)
+
+
+def test_genotype_types():
+    # gts012=True fixes the encoding to HOM_REF=0, HET=1, HOM_ALT=2, UNKNOWN=3,
+    # which is stable to assert against (the default encoding differs).
+    path = _write_vcf()
+    try:
+        vcf = cyvcf2.VCF(path, gts012=True)
+        try:
+            variants = list(vcf)
+            # gt_types is a numpy int array, one entry per sample.
+            assert list(variants[0].gt_types) == [1]  # 0/1 -> HET
+            assert list(variants[1].gt_types) == [2]  # 1/1 -> HOM_ALT
+        finally:
+            vcf.close()
+    finally:
+        os.remove(path)
+
+
+run_test("read variants + CHROM/POS/REF/ALT", test_read_variants_and_fields)
+run_test("genotype types (gt_types)", test_genotype_types)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all cyvcf2 smoke tests passed")

--- a/cli/scripts/lib-validator/dask.py
+++ b/cli/scripts/lib-validator/dask.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `dask` package.
+
+Fully self-contained: no input files, no network, no packages beyond dask
+(and its implied deps: numpy, pandas for the array/dataframe collections).
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 dask.py
+
+Install: pip install "dask[array,dataframe]"   (import name: dask)
+
+The [array,dataframe] extras pull in numpy/pandas so dask.array and
+dask.dataframe are usable — the bare `dask` install ships only the core
+scheduler.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import dask
+except ImportError:
+    print("FAIL: package 'dask' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"dask version: {_version(dask, 'dask')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_array_compute_equals_numpy():
+    import dask.array as da
+    import numpy as np
+
+    source = np.arange(100, dtype="float64").reshape(10, 10)
+    d = da.from_array(source, chunks=(5, 5))
+    assert d.shape == (10, 10)
+    assert np.allclose(d.compute(), source)
+    assert abs(float(d.sum().compute()) - float(source.sum())) < 1e-9
+
+
+def test_dataframe_groupby_mean():
+    import dask.dataframe as dd
+    import pandas as pd
+
+    pdf = pd.DataFrame({"g": ["a", "a", "b", "b", "b"], "v": [1.0, 3.0, 2.0, 4.0, 6.0]})
+    ddf = dd.from_pandas(pdf, npartitions=2)
+    means = ddf.groupby("g")["v"].mean().compute()
+    assert abs(means.loc["a"] - 2.0) < 1e-9
+    assert abs(means.loc["b"] - 4.0) < 1e-9
+
+
+run_test("dask.array compute equals numpy", test_array_compute_equals_numpy)
+run_test("dask.dataframe groupby mean", test_dataframe_groupby_mean)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all dask smoke tests passed")

--- a/cli/scripts/lib-validator/data.table.R
+++ b/cli/scripts/lib-validator/data.table.R
@@ -1,0 +1,127 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `data.table` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# data.table itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript data.table.R
+
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  cat("FAIL: package 'data.table' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(data.table))
+cat(sprintf("data.table version: %s\n", as.character(packageVersion("data.table"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("create and subset", function() {
+  dt <- data.table(id = 1:5, x = c(10, 20, 30, 40, 50))
+  stopifnot(is.data.table(dt), nrow(dt) == 5L)
+  stopifnot(identical(dt[id > 3, x], c(40, 50)))
+  stopifnot(identical(dt[2:3, sum(x)], 50))
+})
+
+run_test("update by reference (:=)", function() {
+  dt <- data.table(a = 1:3)
+  dt[, b := a * 2L]
+  dt[a == 2L, b := 100L]
+  stopifnot(identical(dt$b, c(2L, 100L, 6L)))
+  dt[, b := NULL]
+  stopifnot(identical(names(dt), "a"))
+})
+
+run_test("grouped aggregation", function() {
+  dt <- data.table(grp = c("a", "a", "b", "b", "b"), v = c(1, 3, 2, 4, 6))
+  agg <- dt[, .(n = .N, total = sum(v), avg = mean(v)), by = grp][order(grp)]
+  stopifnot(identical(agg$n, c(2L, 3L)))
+  stopifnot(identical(agg$total, c(4, 12)))
+  stopifnot(identical(agg$avg, c(2, 4)))
+})
+
+run_test("keys and joins", function() {
+  left <- data.table(id = c(1L, 2L, 3L), x = c("a", "b", "c"))
+  right <- data.table(id = c(2L, 3L, 4L), y = c(20, 30, 40))
+  setkey(left, id)
+  stopifnot(identical(key(left), "id"))
+  joined <- right[left, on = "id"]
+  stopifnot(nrow(joined) == 3L)
+  stopifnot(identical(joined$y, c(NA, 20, 30)))
+  inner <- merge(left, right, by = "id")
+  stopifnot(identical(inner$id, c(2L, 3L)))
+})
+
+run_test("fwrite/fread roundtrip", function() {
+  dt <- data.table(i = 1:4, f = c(1.5, 2.5, NA, 4.5), s = c("w", "x", "y", "z"))
+  path <- tempfile("dt-smoke-", fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+  fwrite(dt, path)
+  back <- fread(path)
+  stopifnot(all.equal(dt, back, check.attributes = FALSE))
+})
+
+run_test("fread from literal text", function() {
+  dt <- fread("a,b\n1,x\n2,y\n")
+  stopifnot(identical(dt$a, c(1L, 2L)), identical(dt$b, c("x", "y")))
+})
+
+run_test("melt and dcast", function() {
+  wide <- data.table(id = 1:2, m1 = c(10, 20), m2 = c(30, 40))
+  long <- melt(wide, id.vars = "id", variable.name = "metric", value.name = "val")
+  stopifnot(nrow(long) == 4L, identical(sort(long$val), c(10, 20, 30, 40)))
+  wide2 <- dcast(long, id ~ metric, value.var = "val")
+  stopifnot(identical(wide2$m1, wide$m1), identical(wide2$m2, wide$m2))
+})
+
+run_test("rbindlist", function() {
+  combined <- rbindlist(list(
+    data.table(a = 1L, b = "x"),
+    data.table(b = "y", a = 2L)
+  ), use.names = TRUE)
+  stopifnot(identical(combined$a, c(1L, 2L)), identical(combined$b, c("x", "y")))
+})
+
+run_test(".SD with .SDcols", function() {
+  dt <- data.table(g = c("a", "a", "b"), x = c(1, 2, 3), y = c(4, 5, 6))
+  sums <- dt[, lapply(.SD, sum), by = g, .SDcols = c("x", "y")][order(g)]
+  stopifnot(identical(sums$x, c(3, 3)), identical(sums$y, c(9, 6)))
+})
+
+run_test("setorder and setnames", function() {
+  dt <- data.table(a = c(3L, 1L, 2L), b = c("c", "a", "b"))
+  setorder(dt, a)
+  stopifnot(identical(dt$b, c("a", "b", "c")))
+  setnames(dt, "b", "label")
+  stopifnot(identical(names(dt), c("a", "label")))
+})
+
+run_test("utilities: shift, fifelse, uniqueN", function() {
+  x <- c(1L, 2L, 2L, 3L)
+  stopifnot(identical(shift(x), c(NA_integer_, 1L, 2L, 2L)))
+  stopifnot(identical(fifelse(x > 1L, "hi", "lo"), c("lo", "hi", "hi", "hi")))
+  stopifnot(uniqueN(x) == 3L)
+})
+
+run_test("threading is sane", function() {
+  stopifnot(getDTthreads() >= 1L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all data.table smoke tests passed\n")

--- a/cli/scripts/lib-validator/datamol.py
+++ b/cli/scripts/lib-validator/datamol.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `datamol` package.
+
+Fully self-contained: no input files, no network, no packages beyond datamol
+and its implied deps (rdkit, numpy, pandas). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 datamol.py
+
+Install: pip install datamol   (import name: datamol)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAG: datamol is a thin, ergonomic wrapper over RDKit — it cannot
+function without rdkit installed, and most of its surface delegates straight to
+`rdkit.Chem`. The checks below stick to datamol's own top-level convenience API
+(to_mol / to_smiles / sanitize_mol / descriptors) on a trivial molecule.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import datamol
+except ImportError:
+    print("FAIL: package 'datamol' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"datamol version: {_version(datamol, 'datamol')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_to_mol_and_smiles_roundtrip():
+    mol = datamol.to_mol("CCO")
+    assert mol is not None
+    # Ethanol: three heavy atoms.
+    assert mol.GetNumAtoms() == 3
+    smi = datamol.to_smiles(mol)
+    assert isinstance(smi, str)
+    # Round-tripping the canonical SMILES yields the same molecule.
+    assert datamol.to_smiles(datamol.to_mol(smi)) == smi
+
+
+def test_sanitize_mol():
+    mol = datamol.to_mol("CCO", sanitize=False)
+    sane = datamol.sanitize_mol(mol)
+    assert sane is not None
+    assert sane.GetNumAtoms() == 3
+
+
+def test_descriptors():
+    mol = datamol.to_mol("CCO")
+    desc = datamol.descriptors.compute_many_descriptors(mol)
+    assert isinstance(desc, dict)
+    # Molecular weight of ethanol ≈ 46.07; datamol exposes it as "mw".
+    assert "mw" in desc
+    assert abs(float(desc["mw"]) - 46.07) < 0.1
+
+
+run_test("to_mol + to_smiles roundtrip", test_to_mol_and_smiles_roundtrip)
+run_test("sanitize_mol", test_sanitize_mol)
+run_test("descriptors (ethanol mw ~46.07)", test_descriptors)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all datamol smoke tests passed")

--- a/cli/scripts/lib-validator/decoupler.py
+++ b/cli/scripts/lib-validator/decoupler.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `decoupler` package.
+
+Fully self-contained: no input files, no network, no packages beyond decoupler
+(and its implied deps — anndata, numpy, pandas, scipy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 decoupler.py
+
+Install: pip install "decoupler[full]>=2.1.2"   (import name: decoupler)
+
+FLAG — 1.x vs 2.x API split (this is the big one). decoupler 2.x RENAMED the
+public surface:
+  * 1.x: `dc.run_ulm(mat, net, source=..., target=..., weight=...)`, and the
+    activities land in `mat.obsm['ulm_estimate']` (or a returned estimate/pvals
+    tuple for a DataFrame input).
+  * 2.x: methods live under `dc.mt.*` (e.g. `dc.mt.ulm(data, net)`), the net
+    columns are the fixed names `source`/`target`/`weight`, and for an AnnData
+    the scores land in `adata.obsm['score_ulm']` (p-values in `padj_ulm`).
+Because the install note pins >=2.1.2, the body below targets the 2.x API.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import decoupler as dc
+except ImportError:
+    print("FAIL: package 'decoupler' is not installed")
+    sys.exit(1)
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"decoupler version: {_version(dc, 'decoupler')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_data_and_net():
+    """A 5-sample x 20-gene AnnData plus a 3-source regulatory net.
+
+    Sources s0/s1/s2 each regulate a disjoint block of genes with unit weights —
+    a toy but structurally valid `net` (columns source/target/weight).
+    """
+    rng = np.random.default_rng(0)
+    genes = [f"g{j}" for j in range(20)]
+    samples = [f"s{i}" for i in range(5)]
+    mat = pd.DataFrame(
+        rng.normal(size=(5, 20)), index=samples, columns=genes
+    )
+    adata = ad.AnnData(mat)
+
+    rows = []
+    for src, block in {"s0": genes[0:6], "s1": genes[6:12], "s2": genes[12:20]}.items():
+        for g in block:
+            rows.append({"source": src, "target": g, "weight": 1.0})
+    net = pd.DataFrame(rows, columns=["source", "target", "weight"])
+    return adata, net
+
+
+def test_net_shape_and_columns():
+    _, net = _make_data_and_net()
+    assert list(net.columns) == ["source", "target", "weight"]
+    assert set(net["source"].unique()) == {"s0", "s1", "s2"}
+    assert len(net) == 20
+
+
+def test_ulm_activities_shape():
+    # 2.x API: dc.mt.ulm mutates the AnnData in place, writing per-source scores
+    # into adata.obsm['score_ulm'] with shape (n_samples, n_sources).
+    adata, net = _make_data_and_net()
+    dc.mt.ulm(data=adata, net=net, tmin=3)
+    scores = adata.obsm["score_ulm"]
+    assert scores.shape == (5, 3)
+    assert list(scores.columns) == ["s0", "s1", "s2"]
+    assert np.isfinite(scores.to_numpy()).all()
+
+
+run_test("net DataFrame shape/columns (source/target/weight)", test_net_shape_and_columns)
+run_test("dc.mt.ulm activities shape (2.x API)", test_ulm_activities_shape)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all decoupler smoke tests passed")

--- a/cli/scripts/lib-validator/deepchem.py
+++ b/cli/scripts/lib-validator/deepchem.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `deepchem` package.
+
+Fully self-contained: no input files, no network. deepchem is a large library
+whose deep-learning models sit behind optional backends (jax / torch /
+tensorflow); this validator deliberately touches only the backend-free surface
+— featurizers (which need rdkit) and the in-memory dataset container — so it
+can pass without any DL framework installed. Exits 0 only if every check
+passes, so it can be used as a pass/fail library validator:
+
+    python3 deepchem.py
+
+Install: pip install "deepchem[jax]"   (import name: deepchem)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAG (heavily): deepchem is huge and its model classes require one of
+jax / pytorch / tensorflow — none of which this smoke test assumes. The
+featurizer check below needs rdkit (deepchem's chem featurizers wrap it). We
+therefore assert the top-level subpackages exist, run one lightweight
+featurizer, and build a NumpyDataset — no model training, no backend import.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import deepchem
+except ImportError:
+    print("FAIL: package 'deepchem' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"deepchem version: {_version(deepchem, 'deepchem')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_subpackages_present():
+    # The three pillars of the API surface. Import lazily so a broken optional
+    # backend in one doesn't mask the others.
+    import deepchem.data as dcdata
+    import deepchem.feat as dcfeat
+    import deepchem.models as dcmodels  # noqa: F401 - existence check only
+
+    assert hasattr(dcfeat, "CircularFingerprint")
+    assert hasattr(dcdata, "NumpyDataset")
+
+
+def test_circular_fingerprint_featurize():
+    import numpy as np
+    import deepchem.feat as dcfeat
+
+    feat = dcfeat.CircularFingerprint(size=1024, radius=2)
+    # Featurizing ethanol's SMILES yields a (n_mols, size) bit array (via rdkit).
+    X = feat.featurize(["CCO"])
+    X = np.asarray(X)
+    assert X.shape[0] == 1
+    # One featurized molecule with a non-trivial feature vector.
+    assert X.shape[-1] == 1024
+    assert np.isfinite(X).all()
+
+
+def test_numpy_dataset_container():
+    import numpy as np
+    import deepchem.data as dcdata
+
+    X = np.arange(12, dtype="float64").reshape(3, 4)
+    y = np.array([0.0, 1.0, 0.0])
+    ds = dcdata.NumpyDataset(X=X, y=y)
+    assert ds.X.shape == (3, 4)
+    assert ds.y.shape == (3,)
+    assert len(ds) == 3
+    assert np.allclose(ds.X, X)
+
+
+run_test("data/feat/models subpackages present", test_subpackages_present)
+run_test("CircularFingerprint featurize (needs rdkit)", test_circular_fingerprint_featurize)
+run_test("NumpyDataset container", test_numpy_dataset_container)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all deepchem smoke tests passed")

--- a/cli/scripts/lib-validator/devtools.R
+++ b/cli/scripts/lib-validator/devtools.R
@@ -1,0 +1,53 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `devtools` package.
+#
+# Fully self-contained and OFFLINE: no input files, no network. devtools is
+# mostly a network / package-development workflow toolkit, so only its
+# offline, side-effect-free surface is exercised -- the existence of the key
+# workflow functions and `session_info()`, which merely inspects the loaded
+# namespaces. Nothing is installed, checked, or built. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript devtools.R
+
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  cat("FAIL: package 'devtools' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(devtools))
+cat(sprintf("devtools version: %s\n", as.character(packageVersion("devtools"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core workflow functions exist", function() {
+  stopifnot(is.function(devtools::install))
+  stopifnot(is.function(devtools::check))
+  stopifnot(is.function(devtools::test))
+  stopifnot(is.function(devtools::load_all))
+  stopifnot(is.function(devtools::document))
+})
+
+run_test("session_info() returns a session_info object", function() {
+  si <- devtools::session_info()
+  stopifnot(inherits(si, "session_info"))
+  stopifnot(all(c("platform", "packages") %in% names(si)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all devtools smoke tests passed\n")

--- a/cli/scripts/lib-validator/diffcyt.R
+++ b/cli/scripts/lib-validator/diffcyt.R
@@ -1,0 +1,140 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `diffcyt` package.
+#
+# Fully self-contained: no input files, NO network. diffcyt is a heavy CyTOF
+# differential-discovery pipeline; this test stays MODEST. It (1) asserts the
+# key pipeline entry points are exported functions, then (2) runs the early
+# pipeline stages -- prepareData -> transformData -> generateClusters -- on a
+# tiny synthetic two-sample dataset and checks the intermediate structure. It
+# does NOT run the statistical tests (testDA/testDS). Checks are STRUCTURAL
+# (class, dims relating cells/markers, per-cell cluster labels) rather than
+# numeric equality on the random data. Exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript diffcyt.R
+#
+# ======================= ASSUMPTIONS TO RE-CHECK (FIDDLY) ====================
+# Written from the diffcyt source (lmweber/diffcyt) rather than a live install.
+# The prepareData input contract is easy to get wrong -- RE-VERIFY:
+#
+#  * prepareData(d_input, experiment_info, marker_info, ...):
+#      - d_input: a flowSet OR a list of matrices (one per sample); each matrix
+#        is CELLS x MARKERS with matching column names across samples.
+#      - experiment_info: data.frame, one row per sample, MUST contain a
+#        `sample_id` column (we also add `group_id`).
+#      - marker_info: data.frame, one row per MARKER (== ncol of each matrix),
+#        MUST contain `marker_name` and `marker_class`; marker_class is a factor
+#        with levels "type"/"state"/"none". At least one "type" marker is
+#        required for generateClusters (its default clusters on type markers).
+#
+#  * RETURNED d_se is a SummarizedExperiment with ROWS = cells (concatenated
+#    across samples) and COLUMNS = markers. So nrow(d_se) == total cells,
+#    ncol(d_se) == n markers. rowData holds per-cell sample_id/group_id.
+#
+#  * generateClusters(d_se, xdim, ydim, seed_clustering, ...): runs FlowSOM and
+#    adds `rowData(d_se)$cluster_id` -- one label PER CELL, in 1..(xdim*ydim)
+#    when meta_clustering = FALSE (the default). FlowSOM is a hard dep of
+#    diffcyt, so it is present whenever diffcyt is installed.
+#
+# If the pipeline setup proves wrong on a real install, the function-existence
+# test still exercises the package's exported surface; each run_test is isolated.
+# ============================================================================
+
+if (!requireNamespace("diffcyt", quietly = TRUE)) {
+  cat("FAIL: package 'diffcyt' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(diffcyt))
+cat(sprintf("diffcyt version: %s\n", as.character(packageVersion("diffcyt"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# ---- tiny synthetic two-sample experiment ---------------------------------
+markers <- paste0("M", 1:5)
+n_per_sample <- 500L
+n_samples <- 2L
+total_cells <- n_per_sample * n_samples
+xdim <- 5L
+ydim <- 5L
+n_nodes <- xdim * ydim
+
+make_sample <- function(n) {
+  m <- matrix(rnorm(n * length(markers), 5), ncol = length(markers))
+  colnames(m) <- markers
+  m
+}
+
+set.seed(1)
+d_input <- list(sample1 = make_sample(n_per_sample),
+                sample2 = make_sample(n_per_sample))
+
+experiment_info <- data.frame(
+  sample_id = factor(c("sample1", "sample2")),
+  group_id  = factor(c("group1", "group2")),
+  stringsAsFactors = FALSE
+)
+
+marker_info <- data.frame(
+  marker_name  = markers,
+  marker_class = factor(c("type", "type", "type", "state", "state"),
+                        levels = c("type", "state", "none")),
+  stringsAsFactors = FALSE
+)
+
+run_test("core pipeline entry points are exported functions", function() {
+  stopifnot(is.function(prepareData))
+  stopifnot(is.function(transformData))
+  stopifnot(is.function(generateClusters))
+  stopifnot(is.function(calcCounts))
+  stopifnot(is.function(calcMedians))
+  stopifnot(is.function(testDA_edgeR))
+  stopifnot(is.function(testDS_limma))
+})
+
+run_test("prepareData builds a cells-x-markers SummarizedExperiment", function() {
+  d_se <- suppressMessages(suppressWarnings(
+    prepareData(d_input, experiment_info, marker_info)))
+  stopifnot(inherits(d_se, "SummarizedExperiment"))
+  # rows == cells (concatenated across samples); cols == markers.
+  stopifnot(nrow(d_se) == total_cells)
+  stopifnot(ncol(d_se) == length(markers))
+  # per-cell sample assignment lives in rowData.
+  rd <- SummarizedExperiment::rowData(d_se)
+  stopifnot("sample_id" %in% colnames(rd))
+  stopifnot(length(rd$sample_id) == total_cells)
+})
+
+run_test("transformData preserves shape and generateClusters labels cells", function() {
+  d_se <- suppressMessages(suppressWarnings(
+    prepareData(d_input, experiment_info, marker_info)))
+  d_se <- suppressMessages(suppressWarnings(transformData(d_se, cofactor = 5)))
+  stopifnot(inherits(d_se, "SummarizedExperiment"))
+  stopifnot(nrow(d_se) == total_cells, ncol(d_se) == length(markers))
+
+  d_se <- suppressMessages(suppressWarnings(
+    generateClusters(d_se, xdim = xdim, ydim = ydim, seed_clustering = 123)))
+  cid <- SummarizedExperiment::rowData(d_se)$cluster_id
+  stopifnot(!is.null(cid))
+  # one cluster label per cell, within 1..(xdim*ydim) (no meta-clustering).
+  stopifnot(length(cid) == total_cells)
+  stopifnot(all(as.integer(cid) >= 1L), all(as.integer(cid) <= n_nodes))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all diffcyt smoke tests passed\n")

--- a/cli/scripts/lib-validator/dmrseq.R
+++ b/cli/scripts/lib-validator/dmrseq.R
@@ -1,0 +1,118 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `dmrseq` package.
+#
+# Fully self-contained: no input files, NO network. dmrseq detects differentially
+# methylated regions (DMRs) from a `bsseq::BSseq` object. We build a synthetic
+# BSseq (a single chromosome of CpG loci with methylation + coverage matrices and
+# a two-level `condition` in pData), then attempt a DMR scan. Exits 0 only if
+# every check passes, so it works as a pass/fail validator:
+#
+#   Rscript dmrseq.R
+#
+# ============================ HEAVILY FLAGGED — RE-CHECK =====================
+# Written blind (package not installed here). The LOAD-BEARING checks are the
+# safe ones: (a) dmrseq()/BSseq() exist as functions, and (b) a synthetic BSseq
+# is CONSTRUCTIBLE with the expected shape. VERIFY ONCE INSTALLED:
+#   * BSseq CONSTRUCTION: assumed `bsseq::BSseq(chr=, pos=, M=, Cov=, ...,
+#     pData=)` where M = methylated-read counts, Cov = total coverage, and
+#     `pData` carries the `condition` column dmrseq keys on. If the constructor
+#     signature differs, test 2 fails.
+#   * dmrseq REQUIREMENTS: dmrseq needs the test covariate to VARY, every locus
+#     covered in EVERY sample (Cov >= 1 everywhere — arranged here), and enough
+#     loci for smoothing. Whether this particular minimal set satisfies dmrseq's
+#     internal thresholds cannot be confirmed blind, so the actual scan (test 3)
+#     is SOFT: it warns and passes if dmrseq() cannot complete, and only asserts
+#     the GRanges + metadata-column contract (`stat`,`pval`,`qval`) on success.
+#     If it turns out to run reliably, PROMOTE test 3 to a hard assertion.
+# ============================================================================
+
+if (!requireNamespace("dmrseq", quietly = TRUE)) {
+  cat("FAIL: package 'dmrseq' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(dmrseq))
+cat(sprintf("dmrseq version: %s\n", as.character(packageVersion("dmrseq"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Deterministic synthetic BSseq with a planted hyper-methylated block in group B.
+# Coverage is positive at every locus/sample (dmrseq requires full coverage).
+nLoci <- 400L
+nPerGroup <- 3L
+
+build_bs <- function() {
+  set.seed(2)
+  nSample <- 2L * nPerGroup
+  sampleIds <- sprintf("S%02d", seq_len(nSample))
+  condition <- factor(rep(c("A", "B"), each = nPerGroup))
+
+  pos <- sort(sample.int(1e6L, nLoci))  # unique, strictly increasing positions
+  cov <- matrix(sample(10:30, nLoci * nSample, replace = TRUE),
+                nrow = nLoci, ncol = nSample)
+
+  # Baseline methylation ~0.5; loci 150:200 flip strongly between groups.
+  prob <- matrix(0.5, nrow = nLoci, ncol = nSample)
+  block <- 150:200
+  prob[block, condition == "B"] <- 0.85
+  prob[block, condition == "A"] <- 0.15
+  meth <- matrix(rbinom(nLoci * nSample, size = as.vector(cov), prob = as.vector(prob)),
+                 nrow = nLoci, ncol = nSample)
+
+  pd <- S4Vectors::DataFrame(condition = condition, row.names = sampleIds)
+  bsseq::BSseq(chr = rep("chr1", nLoci), pos = pos,
+               M = meth, Cov = cov, sampleNames = sampleIds, pData = pd)
+}
+
+run_test("dmrseq and BSseq are exported functions", function() {
+  stopifnot(is.function(dmrseq::dmrseq))
+  stopifnot(is.function(bsseq::BSseq))
+})
+
+run_test("synthetic BSseq object is constructible with the expected shape", function() {
+  bs <- build_bs()
+  stopifnot(methods::is(bs, "BSseq"))
+  stopifnot(nrow(bs) == nLoci, ncol(bs) == 2L * nPerGroup)
+  stopifnot("condition" %in% names(bsseq::pData(bs)))
+})
+
+run_test("dmrseq detects DMRs and returns a GRanges (SOFT -- see header)", function() {
+  bs <- build_bs()
+  res <- tryCatch({
+    out <- NULL
+    # dmrseq is chatty (progress + BiocParallel notes); swallow it all.
+    invisible(utils::capture.output(suppressWarnings(suppressMessages(
+      out <- dmrseq::dmrseq(bs = bs, testCovariate = "condition")))))
+    out
+  }, error = function(e) e)
+  if (inherits(res, "error")) {
+    cat(sprintf("  note dmrseq() did not complete on the synthetic set: %s\n",
+                conditionMessage(res)))
+    return(invisible(NULL))
+  }
+  stopifnot(methods::is(res, "GRanges"))
+  # A run can legitimately find zero DMRs; only check the metadata contract when
+  # there are rows to carry it.
+  if (length(res) > 0L) {
+    mc <- names(S4Vectors::mcols(res))
+    stopifnot(all(c("stat", "pval", "qval") %in% mc))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all dmrseq smoke tests passed\n")

--- a/cli/scripts/lib-validator/dplyr.R
+++ b/cli/scripts/lib-validator/dplyr.R
@@ -1,0 +1,103 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `dplyr` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# dplyr itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript dplyr.R
+
+if (!requireNamespace("dplyr", quietly = TRUE)) {
+  cat("FAIL: package 'dplyr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(dplyr))
+cat(sprintf("dplyr version: %s\n", as.character(packageVersion("dplyr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("filter, select, mutate, arrange", function() {
+  df <- data.frame(id = c(3L, 1L, 2L), v = c(30, 10, 20))
+  out <- df |>
+    filter(v > 10) |>
+    mutate(v2 = v * 2) |>
+    arrange(id) |>
+    select(id, v2)
+  stopifnot(identical(names(out), c("id", "v2")))
+  stopifnot(identical(out$id, c(2L, 3L)))
+  stopifnot(identical(out$v2, c(40, 60)))
+})
+
+run_test("group_by + summarise on mtcars", function() {
+  agg <- mtcars |>
+    group_by(cyl) |>
+    summarise(m = mean(mpg))
+  stopifnot(identical(nrow(agg), 3L))
+  stopifnot(identical(agg$cyl, c(4, 6, 8)))
+  expected <- c(26.66364, 19.74286, 15.1)
+  stopifnot(all(abs(agg$m - expected) < 1e-4))
+})
+
+run_test("left_join and inner_join", function() {
+  left <- data.frame(id = c(1L, 2L, 3L), x = c("a", "b", "c"))
+  right <- data.frame(id = c(2L, 3L, 4L), y = c(20, 30, 40))
+  lj <- left_join(left, right, by = "id")
+  stopifnot(identical(nrow(lj), 3L))
+  stopifnot(identical(lj$y, c(NA, 20, 30)))
+  ij <- inner_join(left, right, by = "id")
+  stopifnot(identical(ij$id, c(2L, 3L)))
+  stopifnot(identical(ij$x, c("b", "c")))
+  stopifnot(identical(ij$y, c(20, 30)))
+})
+
+run_test("count, distinct, slice", function() {
+  df <- data.frame(g = c("a", "a", "b"), v = c(1, 1, 2))
+  cnt <- count(df, g)
+  stopifnot(identical(cnt$g, c("a", "b")))
+  stopifnot(identical(cnt$n, c(2L, 1L)))
+  d <- distinct(df)
+  stopifnot(identical(nrow(d), 2L))
+  stopifnot(identical(d$g, c("a", "b")))
+  s <- slice(df, 2)
+  stopifnot(identical(nrow(s), 1L))
+  stopifnot(identical(s$v, 1))
+})
+
+run_test("case_when", function() {
+  x <- c(1, 5, 10)
+  out <- case_when(
+    x < 3 ~ "low",
+    x < 8 ~ "mid",
+    TRUE ~ "high"
+  )
+  stopifnot(identical(out, c("low", "mid", "high")))
+})
+
+run_test("across in grouped summarise", function() {
+  df <- data.frame(g = c("a", "a", "b"), x = c(1, 2, 3), y = c(4, 5, 6))
+  agg <- df |>
+    group_by(g) |>
+    summarise(across(c(x, y), mean))
+  stopifnot(identical(agg$g, c("a", "b")))
+  stopifnot(identical(agg$x, c(1.5, 3)))
+  stopifnot(identical(agg$y, c(4.5, 6)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all dplyr smoke tests passed\n")

--- a/cli/scripts/lib-validator/edgeR.R
+++ b/cli/scripts/lib-validator/edgeR.R
@@ -1,0 +1,118 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `edgeR` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# edgeR itself (and the dependencies it implies, e.g. limma). All data is
+# simulated with a fixed seed; differential-expression checks are structural /
+# tolerance-based, never exact floating-point equality. Exercises the core
+# API surface and exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript edgeR.R
+
+if (!requireNamespace("edgeR", quietly = TRUE)) {
+  cat("FAIL: package 'edgeR' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(edgeR))
+cat(sprintf("edgeR version: %s\n", as.character(packageVersion("edgeR"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate a 200-gene x 6-sample count matrix: two groups, 3 vs 3. Baseline
+# counts are Poisson around a moderate mean; the first 20 genes (the planted
+# DE set) get a strong ~8x up-shift in group B. The remaining 180 genes are
+# null. gene001..gene020 are the planted set; used by rank/sign checks below.
+set.seed(1)
+n_genes <- 200L
+n_per <- 3L
+n_de <- 20L
+base_mu <- 100
+counts <- matrix(
+  rpois(n_genes * 2L * n_per, lambda = base_mu),
+  nrow = n_genes,
+  ncol = 2L * n_per
+)
+b_cols <- (n_per + 1L):(2L * n_per) # columns 4:6 == group B
+counts[1:n_de, b_cols] <- rpois(n_de * n_per, lambda = base_mu * 8)
+rownames(counts) <- sprintf("gene%03d", seq_len(n_genes))
+colnames(counts) <- sprintf("s%d", seq_len(2L * n_per))
+grp <- factor(rep(c("A", "B"), each = n_per))
+de_names <- sprintf("gene%03d", 1:n_de)
+
+# Run the full QL pipeline. suppressMessages/suppressWarnings silence benign
+# estimator chatter only; genuine errors still propagate to run_test.
+fit_edger <- function() {
+  suppressMessages(suppressWarnings({
+    y <- DGEList(counts = counts, group = grp)
+    y <- calcNormFactors(y)
+    design <- model.matrix(~grp)
+    y <- estimateDisp(y, design)
+    fit <- glmQLFit(y, design)
+    qlf <- glmQLFTest(fit) # tests the last coef, grpB
+    list(y = y, design = design, fit = fit, qlf = qlf)
+  }))
+}
+
+run_test("DGEList: object class and dims", function() {
+  y <- DGEList(counts = counts, group = grp)
+  stopifnot(inherits(y, "DGEList"))
+  stopifnot(identical(dim(y), c(n_genes, 2L * n_per)))
+  stopifnot(nrow(y$counts) == n_genes, ncol(y$counts) == 2L * n_per)
+  stopifnot(length(y$samples$group) == 2L * n_per)
+})
+
+run_test("calcNormFactors + estimateDisp: norm factors and dispersion", function() {
+  y <- suppressWarnings(calcNormFactors(DGEList(counts = counts, group = grp)))
+  nf <- y$samples$norm.factors
+  stopifnot(length(nf) == 2L * n_per, all(is.finite(nf)), all(nf > 0))
+  design <- model.matrix(~grp)
+  y <- suppressWarnings(estimateDisp(y, design))
+  stopifnot(is.finite(y$common.dispersion), y$common.dispersion > 0)
+  stopifnot(length(y$tagwise.dispersion) == n_genes)
+})
+
+run_test("glmQLFit + glmQLFTest + topTags: table shape and columns", function() {
+  res <- fit_edger()
+  tt <- topTags(res$qlf, n = Inf)
+  stopifnot(nrow(tt$table) == n_genes)
+  stopifnot(all(c("logFC", "PValue", "FDR") %in% colnames(tt$table)))
+})
+
+run_test("topTags: planted genes rank near the top with correct sign", function() {
+  res <- fit_edger()
+  tab <- topTags(res$qlf, n = Inf)$table
+  # topTags sorts by significance; the strong planted set should dominate the
+  # most-significant end of the table.
+  top50 <- rownames(tab)[1:50]
+  stopifnot(sum(de_names %in% top50) >= 15L)
+  # grpB is the tested coefficient, so positive logFC == higher in group B.
+  stopifnot(median(tab[de_names, "logFC"]) > 2)
+})
+
+run_test("topTags: null genes are not significant on average", function() {
+  res <- fit_edger()
+  tab <- topTags(res$qlf, n = Inf)$table
+  null_names <- sprintf("gene%03d", (n_de + 1L):n_genes)
+  stopifnot(abs(median(tab[null_names, "logFC"])) < 0.5)
+  stopifnot(median(tab[null_names, "FDR"]) > 0.1)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all edgeR smoke tests passed\n")

--- a/cli/scripts/lib-validator/energy.R
+++ b/cli/scripts/lib-validator/energy.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `energy` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# energy itself. Uses fixed seeds and range/tolerance assertions (never
+# exact p-values) and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript energy.R
+
+if (!requireNamespace("energy", quietly = TRUE)) {
+  cat("FAIL: package 'energy' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(energy))
+cat(sprintf("energy version: %s\n", as.character(packageVersion("energy"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("dcor: perfect dependence is 1, independence is small", function() {
+  set.seed(1)
+  x <- rnorm(50)
+  y <- rnorm(50)
+  stopifnot(isTRUE(all.equal(dcor(x, x), 1, tolerance = 1e-8)))
+  # A noiseless linear map is total dependence: dcor stays 1.
+  stopifnot(isTRUE(all.equal(dcor(x, 2 * x + 3), 1, tolerance = 1e-8)))
+  d <- dcor(x, y)
+  stopifnot(is.finite(d), d >= 0, d < 0.4)
+})
+
+run_test("dcov.test returns a sane htest", function() {
+  set.seed(2)
+  x <- rnorm(30)
+  y <- rnorm(30)
+  t <- dcov.test(x, y, R = 199)
+  stopifnot(inherits(t, "htest"))
+  stopifnot(is.finite(as.numeric(t$statistic)))
+  stopifnot(t$p.value >= 0, t$p.value <= 1)
+})
+
+run_test("edist on two separated samples", function() {
+  set.seed(3)
+  m <- rbind(matrix(rnorm(40), 20, 2), matrix(rnorm(40, mean = 3), 20, 2))
+  e <- edist(m, c(20, 20))
+  stopifnot(inherits(e, "dist"))
+  ev <- as.numeric(e)
+  stopifnot(length(ev) == 1L, is.finite(ev), ev > 0)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all energy smoke tests passed\n")

--- a/cli/scripts/lib-validator/ensembldb.R
+++ b/cli/scripts/lib-validator/ensembldb.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ensembldb` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond
+# ensembldb + its deps. Exits 0 only if every check passes, so it can be used
+# as a pass/fail library validator:
+#
+#   Rscript ensembldb.R
+#
+# ensembldb queries EnsDb annotation databases, but its FILTER-CONSTRUCTION
+# surface is fully OFFLINE and DETERMINISTIC: building a GeneNameFilter etc.
+# needs no database. Those filter constructors (re-exported from the
+# AnnotationFilter package) are the substance of this test. Live EnsDb queries
+# (genes()/transcripts()/select() against a real DB) are exercised by the
+# EnsDb.* data-package validators; here we only assert those generics EXIST.
+#
+# ============================ API TO RE-CHECK ===============================
+# FLAG the following names once installed:
+#   * FILTER CLASS NAMES: `GeneNameFilter`, `SeqNameFilter`, `TxBiotypeFilter`,
+#     `AnnotationFilterList` and their shared super-class `AnnotationFilter`
+#     (defined in the AnnotationFilter package, re-exported by ensembldb).
+#   * The `value()` accessor returning the filter's stored value verbatim.
+#   * The exported query generics `genes` / `transcripts` / `exons` and the
+#     AnnotationDbi generics `select` / `keys`.
+# ============================================================================
+
+if (!requireNamespace("ensembldb", quietly = TRUE)) {
+  cat("FAIL: package 'ensembldb' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ensembldb))
+cat(sprintf("ensembldb version: %s\n", as.character(packageVersion("ensembldb"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("GeneNameFilter constructs an AnnotationFilter carrying its value", function() {
+  gnf <- GeneNameFilter("BRCA1")
+  # class identity: the concrete filter and its shared abstract super-class.
+  stopifnot(is(gnf, "GeneNameFilter"))
+  stopifnot(is(gnf, "AnnotationFilter"))
+  # value() round-trips the stored query value verbatim (offline, deterministic).
+  stopifnot(identical(AnnotationFilter::value(gnf), "BRCA1"))
+})
+
+run_test("SeqNameFilter and TxBiotypeFilter construct offline", function() {
+  snf <- SeqNameFilter("1")
+  stopifnot(is(snf, "SeqNameFilter"), is(snf, "AnnotationFilter"))
+  stopifnot(identical(AnnotationFilter::value(snf), "1"))
+
+  tbf <- TxBiotypeFilter("protein_coding")
+  stopifnot(is(tbf, "TxBiotypeFilter"), is(tbf, "AnnotationFilter"))
+  stopifnot(identical(AnnotationFilter::value(tbf), "protein_coding"))
+})
+
+run_test("AnnotationFilterList combines multiple filters", function() {
+  afl <- AnnotationFilterList(GeneNameFilter("BRCA1"), SeqNameFilter("1"))
+  stopifnot(is(afl, "AnnotationFilterList"))
+  stopifnot(length(afl) == 2L)
+})
+
+run_test("EnsDb query generics are exported and callable", function() {
+  # Existence only -- a live query needs an EnsDb database (see EnsDb.* scripts).
+  stopifnot(existsFunction("genes"))
+  stopifnot(existsFunction("transcripts"))
+  stopifnot(existsFunction("exons"))
+  stopifnot(existsFunction("select"))
+  stopifnot(existsFunction("keys"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ensembldb smoke tests passed\n")

--- a/cli/scripts/lib-validator/fgsea.R
+++ b/cli/scripts/lib-validator/fgsea.R
@@ -1,0 +1,106 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `fgsea` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. fgsea runs preranked gene
+# set enrichment analysis; this test SIMULATES a named ranked statistic vector
+# and a list of gene sets (pathways), planting one strongly-enriched pathway so
+# the outcome is deterministic. Nothing reaches an online pathway database.
+# Exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript fgsea.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed:
+#
+#   * COLUMN NAMES: fgsea() returns a data.table whose columns are assumed to
+#     be pathway / pval / padj / log2err / ES / NES / size / leadingEdge. The
+#     load-bearing assertions check pathway/pval/padj/ES/NES presence -- if a
+#     future release renames any of these the shape test flags it.
+#
+#   * ENTRY POINT: fgsea() dispatches to the multilevel algorithm in current
+#     releases; fgseaMultilevel(pathways=, stats=, ...) is the explicit form and
+#     is interchangeable here. Both take `pathways` (named list) and `stats`
+#     (named numeric vector); size gating via minSize/maxSize.
+#
+# The enrichment RANK/SIGN checks are robust (a +3 SD shift on 30/500 genes),
+# not exact p-values, so BiocParallel RNG variation cannot false-fail them.
+# ============================================================================
+
+if (!requireNamespace("fgsea", quietly = TRUE)) {
+  cat("FAIL: package 'fgsea' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(fgsea))
+cat(sprintf("fgsea version: %s\n", as.character(packageVersion("fgsea"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Deterministic ranked statistics over 500 genes. The 30 genes of the planted
+# pathway get a strong positive shift so they cluster at the top of the ranking
+# -> the planted pathway must earn the largest |NES| with a positive sign.
+set.seed(1)
+n_genes <- 500L
+gene_ids <- paste0("g", seq_len(n_genes))
+stats <- rnorm(n_genes)
+names(stats) <- gene_ids
+planted_genes <- gene_ids[1:30]
+stats[planted_genes] <- stats[planted_genes] + 3
+stats <- sort(stats, decreasing = TRUE)
+
+pathways <- list(
+  planted = planted_genes,
+  decoyA = sample(gene_ids, 25),
+  decoyB = sample(gene_ids, 40)
+)
+
+run_test("fgsea returns the expected result columns", function() {
+  res <- suppressWarnings(fgsea::fgsea(
+    pathways = pathways, stats = stats, minSize = 5, maxSize = 200))
+  stopifnot(is.data.frame(res))
+  stopifnot(all(c("pathway", "pval", "padj", "ES", "NES") %in% colnames(res)))
+})
+
+run_test("one result row per size-eligible pathway", function() {
+  res <- suppressWarnings(fgsea::fgsea(
+    pathways = pathways, stats = stats, minSize = 5, maxSize = 200))
+  # all three pathways fall inside [5, 200], so none are dropped
+  stopifnot(nrow(res) == length(pathways))
+  stopifnot(setequal(res$pathway, names(pathways)))
+})
+
+run_test("p-values and NES are valid numerics", function() {
+  res <- suppressWarnings(fgsea::fgsea(
+    pathways = pathways, stats = stats, minSize = 5, maxSize = 200))
+  stopifnot(all(is.finite(res$NES)))
+  stopifnot(all(res$pval >= 0 & res$pval <= 1))
+  stopifnot(all(res$padj >= 0 & res$padj <= 1))
+})
+
+run_test("planted pathway has the largest |NES|, positive sign", function() {
+  res <- suppressWarnings(fgsea::fgsea(
+    pathways = pathways, stats = stats, minSize = 5, maxSize = 200))
+  top <- res$pathway[which.max(abs(res$NES))]
+  stopifnot(identical(top, "planted"))
+  nes_planted <- res$NES[res$pathway == "planted"]
+  stopifnot(length(nes_planted) == 1L, nes_planted > 0)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all fgsea smoke tests passed\n")

--- a/cli/scripts/lib-validator/flowCore.R
+++ b/cli/scripts/lib-validator/flowCore.R
@@ -1,0 +1,119 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `flowCore` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond flowCore
+# itself (a Bioconductor package). All data is a small synthetic expression
+# matrix built with a fixed seed and wrapped in flowCore's core data structures
+# (flowFrame / flowSet); checks are structural (class, dimensions, marker names,
+# matrix round-trip) plus a transform-changes-values check, never numeric
+# equality on anything random. Exercises the core data-structure + transform API
+# and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript flowCore.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL and should hold on any healthy
+# flowCore install. Points to re-confirm once a build is available:
+#   - flowFrame(mat) constructs directly from a matrix with column dimnames
+#     becoming the parameter (marker) names; nrow/ncol/colnames/exprs accessors
+#     behave as asserted.
+#   - flowSet(list(a=ff, b=ff2)) builds a 2-frame set; fsApply(fs, nrow) returns
+#     one row-count per frame.
+#   - arcsinhTransform()/logicleTransform() return transform functions that can
+#     be applied via transform(ff, transformList(...)) and shift the values.
+# ============================================================================
+
+if (!requireNamespace("flowCore", quietly = TRUE)) {
+  cat("FAIL: package 'flowCore' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(flowCore))
+cat(sprintf("flowCore version: %s\n", as.character(packageVersion("flowCore"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic expression: 1000 events x 5 markers, Gaussian around 5 (kept
+# positive-ish so the arcsinh/logicle transforms are exercised on realistic
+# cytometry-like intensities). Column names become the flowFrame parameters.
+set.seed(1)
+mat <- matrix(rnorm(1000 * 5, 5), ncol = 5, dimnames = list(NULL, paste0("M", 1:5)))
+
+run_test("flowFrame builds from a matrix with correct shape + names", function() {
+  ff <- flowFrame(mat)
+  stopifnot(inherits(ff, "flowFrame"))
+  stopifnot(nrow(ff) == 1000L, ncol(ff) == 5L)
+  stopifnot(identical(colnames(ff), paste0("M", 1:5)))
+})
+
+run_test("exprs() round-trips the input matrix within storage precision", function() {
+  ff <- flowFrame(mat)
+  back <- exprs(ff)
+  stopifnot(is.matrix(back), nrow(back) == 1000L, ncol(back) == 5L)
+  # exprs() returns the channel names as a *named* character vector (the names
+  # are the $Pn keyword ids), so compare unnamed.
+  stopifnot(identical(unname(colnames(back)), colnames(mat)))
+  # flowFrame stores intensities in single precision (FCS $DATATYPE F), so the
+  # readback differs from the double-precision input by ~1e-7 — assert equality
+  # within that storage tolerance, not bit-exact identity.
+  stopifnot(isTRUE(all.equal(unname(back), unname(mat),
+                             tolerance = 1e-4, check.attributes = FALSE)))
+})
+
+run_test("flowSet composes two frames and fsApply maps over them", function() {
+  ff <- flowFrame(mat)
+  # A second, distinct frame so the set genuinely holds two members.
+  set.seed(2)
+  mat2 <- matrix(rnorm(500 * 5, 5), ncol = 5, dimnames = list(NULL, paste0("M", 1:5)))
+  ff2 <- flowFrame(mat2)
+  fs <- flowSet(list(a = ff, b = ff2))
+  stopifnot(inherits(fs, "flowSet"))
+  stopifnot(length(fs) == 2L)
+  # fsApply returns one value per frame; here the per-frame event counts.
+  counts <- fsApply(fs, nrow)
+  stopifnot(sort(as.integer(counts)) == c(500L, 1000L))
+})
+
+run_test("arcsinhTransform applies and changes the values", function() {
+  ff <- flowFrame(mat)
+  tf <- arcsinhTransform(transformationId = "asinh", a = 1, b = 1, c = 0)
+  stopifnot(is.function(tf))
+  tl <- transformList(colnames(ff), tf)
+  ff_t <- transform(ff, tl)
+  stopifnot(inherits(ff_t, "flowFrame"))
+  after <- exprs(ff_t)
+  stopifnot(nrow(after) == 1000L, ncol(after) == 5L)
+  # The transform is monotone but nonlinear, so it must shift essentially every
+  # value; require the columnwise means to differ appreciably from the input.
+  stopifnot(all(abs(colMeans(after) - colMeans(mat)) > 1e-6))
+})
+
+run_test("logicleTransform applies and changes the values", function() {
+  ff <- flowFrame(mat)
+  lt <- logicleTransform()
+  stopifnot(is.function(lt))
+  tl <- transformList(colnames(ff), lt)
+  ff_t <- transform(ff, tl)
+  after <- exprs(ff_t)
+  stopifnot(nrow(after) == 1000L, ncol(after) == 5L)
+  stopifnot(all(abs(colMeans(after) - colMeans(mat)) > 1e-6))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all flowCore smoke tests passed\n")

--- a/cli/scripts/lib-validator/formulaic.py
+++ b/cli/scripts/lib-validator/formulaic.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `formulaic` package.
+
+Fully self-contained: no input files, no network, no packages beyond formulaic
+and its implied deps (numpy, pandas). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 formulaic.py
+
+Install: pip install formulaic   (import name: formulaic)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import formulaic
+except ImportError:
+    print("FAIL: package 'formulaic' is not installed")
+    sys.exit(1)
+
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"formulaic version: {_version(formulaic, 'formulaic')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_two_sided_model_matrix():
+    from formulaic import model_matrix
+
+    df = pd.DataFrame(
+        {
+            "y": [1.0, 2.0, 3.0, 4.0],
+            "x1": [0.0, 1.0, 2.0, 3.0],
+            "x2": [1.0, 0.0, 1.0, 0.0],
+        }
+    )
+    # A two-sided formula yields a structured result with .lhs / .rhs.
+    mm = model_matrix("y ~ x1 + x2", df)
+    y = mm.lhs
+    X = mm.rhs
+    # RHS carries an implicit intercept plus the two named terms.
+    assert list(X.columns) == ["Intercept", "x1", "x2"]
+    assert (X["Intercept"] == 1.0).all()
+    assert X.shape == (4, 3)
+    assert list(y.columns) == ["y"]
+    assert y.shape == (4, 1)
+    # formulaic attaches the derivation spec to every produced matrix.
+    assert hasattr(X, "model_spec")
+
+
+def test_categorical_expansion():
+    from formulaic import model_matrix
+
+    df = pd.DataFrame(
+        {
+            "y": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "g": ["a", "b", "c", "a", "b", "c"],
+        }
+    )
+    X = model_matrix("y ~ g", df).rhs
+    # Treatment coding drops the reference level "a"; b and c get contrast cols.
+    assert "Intercept" in X.columns
+    assert "g[T.b]" in X.columns
+    assert "g[T.c]" in X.columns
+    assert "g[T.a]" not in X.columns
+    assert X.shape == (6, 3)
+
+
+def test_model_matrix_type_surface():
+    from formulaic import ModelMatrix, model_matrix
+
+    # The library exposes the ModelMatrix type as its public structure.
+    assert ModelMatrix is not None
+    df = pd.DataFrame({"z": [1.0, 2.0, 3.0]})
+    # A one-sided formula yields a single design matrix (intercept + z).
+    X = model_matrix("~ z", df)
+    assert list(X.columns) == ["Intercept", "z"]
+    assert X.shape == (3, 2)
+
+
+run_test("two-sided model_matrix lhs/rhs", test_two_sided_model_matrix)
+run_test("categorical treatment expansion", test_categorical_expansion)
+run_test("ModelMatrix type + one-sided", test_model_matrix_type_surface)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all formulaic smoke tests passed")

--- a/cli/scripts/lib-validator/fs.R
+++ b/cli/scripts/lib-validator/fs.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `fs` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# fs itself. Filesystem access is confined to a unique temp directory that
+# the script creates and always deletes. Exercises the core API surface and
+# exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript fs.R
+
+if (!requireNamespace("fs", quietly = TRUE)) {
+  cat("FAIL: package 'fs' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(fs))
+cat(sprintf("fs version: %s\n", as.character(packageVersion("fs"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("path composition", function() {
+  p <- fs::path("a", "b", "c")
+  stopifnot(inherits(p, "fs_path"))
+  stopifnot(identical(as.character(p), "a/b/c"))
+  stopifnot(identical(as.character(fs::path("a", "b", ext = "txt")), "a/b.txt"))
+})
+
+run_test("path_ext / path_ext_set", function() {
+  stopifnot(identical(as.character(fs::path_ext("archive.tar.gz")), "gz"))
+  stopifnot(identical(as.character(fs::path_ext_set("notes.txt", "md")), "notes.md"))
+  stopifnot(identical(as.character(fs::path_ext("no_extension")), ""))
+})
+
+run_test("path_file / path_dir / path_norm", function() {
+  stopifnot(identical(as.character(fs::path_file("/x/y/z.csv")), "z.csv"))
+  stopifnot(identical(as.character(fs::path_dir("/x/y/z.csv")), "/x/y"))
+  stopifnot(identical(as.character(fs::path_norm("a/../b/./c")), "b/c"))
+})
+
+run_test("path_rel / path_abs", function() {
+  stopifnot(identical(as.character(fs::path_rel("/a/b/c", "/a")), "b/c"))
+  stopifnot(identical(as.character(fs::path_abs("b", "/a")), "/a/b"))
+})
+
+run_test("path_split / path_join roundtrip", function() {
+  parts <- fs::path_split("/a/b/c")[[1]]
+  stopifnot(identical(as.character(parts), c("/", "a", "b", "c")))
+  stopifnot(identical(as.character(fs::path_join(parts)), "/a/b/c"))
+})
+
+run_test("create/exists/list/delete cycle in tempdir", function() {
+  # tempfile() mints a unique, not-yet-existing path under the session tempdir.
+  d <- fs::path(tempfile("fs-smoke-"))
+  on.exit(if (fs::dir_exists(d)) fs::dir_delete(d), add = TRUE)
+
+  fs::dir_create(d)
+  stopifnot(fs::dir_exists(d), fs::is_dir(d))
+
+  f <- fs::path(d, "a.txt")
+  fs::file_create(f)
+  stopifnot(fs::file_exists(f), fs::is_file(f), !fs::is_dir(f))
+
+  listed <- fs::dir_ls(d)
+  stopifnot(length(listed) == 1L)
+  stopifnot(identical(as.character(fs::path_file(listed)), "a.txt"))
+
+  fs::dir_delete(d)
+  stopifnot(!fs::dir_exists(d), !fs::file_exists(f))
+})
+
+run_test("is_dir / is_file on known paths", function() {
+  stopifnot(identical(unname(as.logical(fs::is_dir(tempdir()))), TRUE))
+  stopifnot(identical(unname(as.logical(fs::is_file(tempdir()))), FALSE))
+  ghost <- fs::path(tempfile("fs-smoke-ghost-"))
+  stopifnot(identical(unname(as.logical(fs::file_exists(ghost))), FALSE))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all fs smoke tests passed\n")

--- a/cli/scripts/lib-validator/fsspec.py
+++ b/cli/scripts/lib-validator/fsspec.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `fsspec` package.
+
+Fully self-contained: no input files, no network, no packages beyond fsspec.
+Exercises the core API surface against the built-in in-memory filesystem (no
+disk, no network) and exits 0 only if every check passes, so it can be used as
+a pass/fail library validator:
+
+    python3 fsspec.py
+
+Install: pip install fsspec   (import name: fsspec)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import fsspec
+except ImportError:
+    print("FAIL: package 'fsspec' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"fsspec version: {_version(fsspec, 'fsspec')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_memory_write_read():
+    fs = fsspec.filesystem("memory")
+    path = "/smoke/data.bin"
+    payload = b"hello fsspec"
+    with fs.open(path, "wb") as fh:
+        fh.write(payload)
+    assert fs.exists(path)
+    with fs.open(path, "rb") as fh:
+        assert fh.read() == payload
+    # Clean up so repeat runs start empty (the memory store is process-global).
+    fs.rm(path)
+
+
+def test_memory_ls():
+    fs = fsspec.filesystem("memory")
+    for name in ("a.txt", "b.txt"):
+        with fs.open(f"/lsdir/{name}", "wb") as fh:
+            fh.write(b"x")
+    listing = fs.ls("/lsdir", detail=False)
+    basenames = sorted(p.rsplit("/", 1)[-1] for p in listing)
+    assert basenames == ["a.txt", "b.txt"]
+    fs.rm("/lsdir", recursive=True)
+
+
+def test_open_convenience_helper():
+    # fsspec.open() resolves the protocol from the URL and returns an OpenFile.
+    with fsspec.open("memory://top/greeting.txt", "wb") as fh:
+        fh.write(b"hi")
+    with fsspec.open("memory://top/greeting.txt", "rb") as fh:
+        assert fh.read() == b"hi"
+    fsspec.filesystem("memory").rm("/top/greeting.txt")
+
+
+run_test("memory FS write/read", test_memory_write_read)
+run_test("memory FS ls", test_memory_ls)
+run_test("fsspec.open convenience helper", test_open_convenience_helper)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all fsspec smoke tests passed")

--- a/cli/scripts/lib-validator/geopandas.py
+++ b/cli/scripts/lib-validator/geopandas.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `geopandas` package.
+
+Fully self-contained: no input files, no network. Builds geometries in-memory
+with shapely and exercises the core GeoDataFrame API, exiting 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 geopandas.py
+
+Install: pip install geopandas   (import name: geopandas)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review): geopandas layers on a stack of native libraries —
+shapely/GEOS for geometry, pyproj/PROJ for CRS reprojection (`.to_crs`), and
+fiona/pyogrio (GDAL) for file I/O. The CRS test below needs pyproj; none of the
+checks touch disk, so no GDAL file drivers are required here.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import geopandas
+    from shapely.geometry import Point, Polygon
+except ImportError:
+    print("FAIL: package 'geopandas' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"geopandas version: {_version(geopandas, 'geopandas')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _sample_gdf():
+    """Two unit-side squares plus an attribute column."""
+    polys = [
+        Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        Polygon([(2, 2), (4, 2), (4, 4), (2, 4)]),
+    ]
+    return geopandas.GeoDataFrame({"name": ["a", "b"], "geometry": polys})
+
+
+def test_construct_geometry_and_area():
+    gdf = _sample_gdf()
+    assert list(gdf["name"]) == ["a", "b"]
+    assert isinstance(gdf.geometry, geopandas.GeoSeries)
+    assert list(gdf.geometry.geom_type) == ["Polygon", "Polygon"]
+    # Each square is 2 x 2 = area 4.
+    assert list(gdf.area) == [4.0, 4.0]
+
+
+def test_bounds():
+    gdf = _sample_gdf()
+    bounds = gdf.bounds
+    assert list(bounds.columns) == ["minx", "miny", "maxx", "maxy"]
+    first = bounds.iloc[0]
+    assert (first.minx, first.miny, first.maxx, first.maxy) == (0.0, 0.0, 2.0, 2.0)
+    # Total extent spans both squares.
+    assert tuple(gdf.total_bounds) == (0.0, 0.0, 4.0, 4.0)
+
+
+def test_spatial_predicate_contains():
+    gdf = _sample_gdf()
+    mask = gdf.contains(Point(1, 1))
+    # Only the first square encloses (1, 1).
+    assert list(mask) == [True, False]
+
+
+def test_set_and_reproject_crs():
+    gdf = _sample_gdf()
+    gdf = gdf.set_crs("EPSG:4326")
+    assert gdf.crs is not None
+    assert gdf.crs.to_epsg() == 4326
+    # .to_crs needs pyproj/PROJ to reproject the coordinates.
+    web = gdf.to_crs("EPSG:3857")
+    assert web.crs.to_epsg() == 3857
+    assert not web.geometry.iloc[0].equals(gdf.geometry.iloc[0])
+
+
+def test_dissolve_by_group():
+    polys = [
+        Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+        Polygon([(0, 2), (1, 2), (1, 3), (0, 3)]),
+    ]
+    gdf = geopandas.GeoDataFrame({"grp": ["x", "x", "y"], "geometry": polys})
+    merged = gdf.dissolve(by="grp")
+    assert set(merged.index) == {"x", "y"}
+    # The two "x" unit squares dissolve into a single area-2 geometry.
+    assert abs(float(merged.loc["x"].geometry.area) - 2.0) < 1e-9
+
+
+run_test("construct GeoDataFrame + area", test_construct_geometry_and_area)
+run_test("bounds / total_bounds", test_bounds)
+run_test("spatial predicate: contains", test_spatial_predicate_contains)
+run_test("set_crs + to_crs reprojection", test_set_and_reproject_crs)
+run_test("dissolve by group", test_dissolve_by_group)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all geopandas smoke tests passed")

--- a/cli/scripts/lib-validator/ggplot2.R
+++ b/cli/scripts/lib-validator/ggplot2.R
@@ -1,0 +1,114 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ggplot2` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# ggplot2 itself (plus its implied deps). Exercises the core API surface by
+# INSPECTING plot objects and their computed layer data -- it never opens an
+# interactive device -- and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript ggplot2.R
+
+if (!requireNamespace("ggplot2", quietly = TRUE)) {
+  cat("FAIL: package 'ggplot2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ggplot2))
+cat(sprintf("ggplot2 version: %s\n", as.character(packageVersion("ggplot2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("build a plot object", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  stopifnot(inherits(p, "ggplot"))
+  stopifnot(length(p$layers) == 1L)
+})
+
+run_test("computed point-layer data", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  # ggplot_build / layer_data expose the COMPUTED aesthetics without rendering.
+  ld <- layer_data(p, 1)
+  stopifnot(is.data.frame(ld), nrow(ld) == nrow(mtcars))
+  stopifnot(all(c("x", "y") %in% names(ld)))
+  stopifnot(all(is.finite(ld$x)), all(is.finite(ld$y)))
+  stopifnot(identical(ld$x, mtcars$mpg), identical(ld$y, mtcars$wt))
+})
+
+run_test("default labels resolve from aes mapping", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  # In ggplot2 4.x the default (mapping-derived) labels are resolved lazily:
+  # p$labels$x is NULL until set explicitly, so use get_labs() to read them.
+  labs_resolved <- get_labs(p)
+  stopifnot(identical(labs_resolved$x, "mpg"))
+  stopifnot(identical(labs_resolved$y, "wt"))
+})
+
+run_test("labs() roundtrip sets explicit labels", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point() +
+    labs(x = "Miles per gallon", y = "Weight")
+  stopifnot(identical(p$labels$x, "Miles per gallon"))
+  stopifnot(identical(p$labels$y, "Weight"))
+})
+
+run_test("stat_smooth computes a fitted line", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point() +
+    stat_smooth(method = "lm", formula = y ~ x, se = FALSE)
+  smooth <- layer_data(p, 2)
+  stopifnot(is.data.frame(smooth), nrow(smooth) > 0L)
+  stopifnot(all(c("x", "y") %in% names(smooth)))
+  stopifnot(all(is.finite(smooth$x)), all(is.finite(smooth$y)))
+  # A negative mpg~wt slope: the fitted y at min x exceeds y at max x.
+  stopifnot(smooth$y[which.min(smooth$x)] > smooth$y[which.max(smooth$x)])
+})
+
+run_test("geom_histogram bins the data", function() {
+  p <- ggplot(mtcars, aes(mpg)) + geom_histogram(bins = 10)
+  hist <- layer_data(p, 1)
+  stopifnot(all(c("count", "x", "xmin", "xmax") %in% names(hist)))
+  stopifnot(all(is.finite(hist$count)))
+  # Every observation lands in exactly one bin.
+  stopifnot(sum(hist$count) == nrow(mtcars))
+})
+
+run_test("scale_color_manual maps discrete colours", function() {
+  p <- ggplot(mtcars, aes(mpg, wt, colour = factor(cyl))) + geom_point() +
+    scale_color_manual(values = c("4" = "red", "6" = "green", "8" = "blue"))
+  ld <- layer_data(p, 1)
+  stopifnot("colour" %in% names(ld))
+  stopifnot(setequal(unique(ld$colour), c("red", "green", "blue")))
+})
+
+run_test("aesthetic mapping is captured", function() {
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  stopifnot(all(c("x", "y") %in% names(p$mapping)))
+})
+
+run_test("render to a null pdf device", function() {
+  # Prefer object inspection above; this exercises the full render path once,
+  # writing to a throwaway pdf so no interactive device is needed.
+  p <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
+  path <- tempfile("ggplot-smoke-", fileext = ".pdf")
+  grDevices::pdf(path)
+  on.exit({ grDevices::dev.off(); unlink(path) }, add = TRUE)
+  print(p)
+  stopifnot(file.exists(path))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ggplot2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/ggrepel.R
+++ b/cli/scripts/lib-validator/ggrepel.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ggrepel` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# ggrepel and its hard dependency ggplot2. ggrepel adds repelling text/label
+# geoms to ggplot2, so every check builds a plot object and inspects its
+# structure -- no graphics device is ever opened. Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript ggrepel.R
+#
+# Checks are STRUCTURAL (layer classes, required aesthetics, built layer data)
+# rather than pixel/geometry assertions: the actual label repelling happens in
+# the grid draw step at render time, which we deliberately never trigger.
+
+if (!requireNamespace("ggrepel", quietly = TRUE)) {
+  cat("FAIL: package 'ggrepel' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+# ggplot2 is a hard dependency of ggrepel (Imports), so it is guaranteed to be
+# present whenever ggrepel is; attach it for ggplot()/aes()/geom_point().
+suppressPackageStartupMessages({
+  library(ggrepel)
+  library(ggplot2)
+})
+cat(sprintf("ggrepel version: %s\n", as.character(packageVersion("ggrepel"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared fixture: a tiny labelled scatter. Deterministic, no randomness needed.
+df <- data.frame(
+  x = c(1, 2, 3, 4, 5),
+  y = c(2, 1, 4, 3, 5),
+  lab = c("alpha", "beta", "gamma", "delta", "epsilon")
+)
+
+run_test("geom_text_repel builds a repel layer", function() {
+  p <- ggplot(df, aes(x = x, y = y)) +
+    geom_point() +
+    geom_text_repel(aes(label = lab))
+  stopifnot(inherits(p, "ggplot"))
+  stopifnot(length(p$layers) == 2L)
+  # the second layer's geom is ggrepel's GeomTextRepel (subclass of GeomText)
+  stopifnot(inherits(p$layers[[2]]$geom, "GeomTextRepel"))
+})
+
+run_test("geom_label_repel builds a repel layer", function() {
+  p <- ggplot(df, aes(x = x, y = y)) +
+    geom_label_repel(aes(label = lab))
+  stopifnot(inherits(p, "ggplot"))
+  stopifnot(length(p$layers) == 1L)
+  stopifnot(inherits(p$layers[[1]]$geom, "GeomLabelRepel"))
+})
+
+run_test("repel geom requires a label aesthetic", function() {
+  p <- ggplot(df, aes(x = x, y = y)) +
+    geom_text_repel(aes(label = lab))
+  # GeomTextRepel$required_aes == c("x", "y", "label")
+  req <- p$layers[[1]]$geom$required_aes
+  stopifnot(is.character(req))
+  stopifnot(all(c("x", "y", "label") %in% req))
+})
+
+run_test("ggplot_build computes layer data without a device", function() {
+  p <- ggplot(df, aes(x = x, y = y)) +
+    geom_point() +
+    geom_text_repel(aes(label = lab))
+  b <- ggplot_build(p)
+  # b$data is one built data.frame per layer, regardless of ggplot2 version
+  stopifnot(is.list(b$data), length(b$data) == 2L)
+  built <- b$data[[2]] # the repel layer
+  stopifnot(is.data.frame(built))
+  stopifnot(nrow(built) == nrow(df))
+  # the label column survives the build; labels match the source data
+  stopifnot("label" %in% names(built))
+  stopifnot(setequal(as.character(built$label), df$lab))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ggrepel smoke tests passed\n")

--- a/cli/scripts/lib-validator/glmGamPoi.R
+++ b/cli/scripts/lib-validator/glmGamPoi.R
@@ -1,0 +1,109 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `glmGamPoi` package.
+#
+# Fully self-contained: no input files, no network. Simulates a small Poisson
+# count matrix (genes x samples) with a fixed seed and a two-group design, fits
+# a Gamma-Poisson GLM with glm_gp(), then runs a differential-expression test
+# with test_de(). Checks are structural / tolerance-based (object class, matrix
+# shapes, finite non-negative overdispersions, probability ranges) -- never
+# exact floating-point equality on the fit. Exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript glmGamPoi.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm once glmGamPoi is available:
+#   - glm_gp() SIGNATURE. Assumes glm_gp(data, design = <matrix or formula>)
+#     returns an S3 object of class "glmGamPoi" whose elements include:
+#       * $Beta            -- coefficient matrix, (n_genes x n_coef)
+#       * $overdispersions -- length-(n_genes) numeric, finite & >= 0
+#       * $Mu              -- fitted means, same dim as the count matrix
+#   - test_de() SIGNATURE. Assumes test_de(fit, contrast = "<coef name>")
+#     returns a data.frame with (at least) columns `pval`, `adj_pval`, `lfc`,
+#     one row per gene. The contrast is passed as the STRING name of the
+#     non-intercept design coefficient ("groupb"); if the coefficient-naming
+#     convention differs, adjust the contrast argument.
+# ============================================================================
+
+if (!requireNamespace("glmGamPoi", quietly = TRUE)) {
+  cat("FAIL: package 'glmGamPoi' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(glmGamPoi))
+cat(sprintf("glmGamPoi version: %s\n", as.character(packageVersion("glmGamPoi"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 10 samples, integer Poisson draws. A balanced
+# two-group design (5 "a" + 5 "b"); model.matrix gives coefficients named
+# "(Intercept)" and "groupb", the latter being the contrast tested below.
+set.seed(1)
+n_genes <- 100L
+n_samples <- 10L
+counts <- matrix(rpois(n_genes * n_samples, lambda = 8), nrow = n_genes, ncol = n_samples)
+group <- factor(rep(c("a", "b"), each = 5))
+design <- model.matrix(~group)
+n_coef <- ncol(design)
+
+run_test("glm_gp returns a glmGamPoi fit", function() {
+  fit <- suppressWarnings(suppressMessages(glm_gp(counts, design = design)))
+  stopifnot(inherits(fit, "glmGamPoi"))
+})
+
+run_test("Beta is a (genes x coef) coefficient matrix", function() {
+  fit <- suppressWarnings(suppressMessages(glm_gp(counts, design = design)))
+  stopifnot(is.matrix(fit$Beta))
+  stopifnot(identical(dim(fit$Beta), c(n_genes, n_coef)))
+  stopifnot(all(is.finite(fit$Beta)))
+})
+
+run_test("overdispersions are finite and non-negative, one per gene", function() {
+  fit <- suppressWarnings(suppressMessages(glm_gp(counts, design = design)))
+  od <- fit$overdispersions
+  stopifnot(length(od) == n_genes)
+  stopifnot(all(is.finite(od)))
+  stopifnot(all(od >= 0))
+})
+
+run_test("Mu (fitted means) matches the count-matrix shape", function() {
+  fit <- suppressWarnings(suppressMessages(glm_gp(counts, design = design)))
+  stopifnot(identical(dim(fit$Mu), dim(counts)))
+  stopifnot(all(is.finite(fit$Mu)))
+  # Fitted Poisson/GP means are strictly positive.
+  stopifnot(all(fit$Mu > 0))
+})
+
+run_test("test_de returns a per-gene DE table with pval/adj_pval/lfc", function() {
+  fit <- suppressWarnings(suppressMessages(glm_gp(counts, design = design)))
+  res <- suppressWarnings(suppressMessages(test_de(fit, contrast = "groupb")))
+  stopifnot(is.data.frame(res))
+  stopifnot(all(c("pval", "adj_pval", "lfc") %in% names(res)))
+  stopifnot(nrow(res) == n_genes)
+  # p-values and adjusted p-values are probabilities (allow NA for degenerate
+  # genes, but every non-NA value must lie in [0, 1]).
+  pv <- res$pval[is.finite(res$pval)]
+  ap <- res$adj_pval[is.finite(res$adj_pval)]
+  stopifnot(all(pv >= 0 & pv <= 1))
+  stopifnot(all(ap >= 0 & ap <= 1))
+  # log fold-changes are finite where defined.
+  stopifnot(all(is.finite(res$lfc[!is.na(res$lfc)])))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all glmGamPoi smoke tests passed\n")

--- a/cli/scripts/lib-validator/glmnet.R
+++ b/cli/scripts/lib-validator/glmnet.R
@@ -1,0 +1,113 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `glmnet` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# glmnet itself (and the dependencies it implies, e.g. Matrix). All data
+# is simulated with fixed seeds; model-fit checks are structural /
+# tolerance-based, never exact floating-point equality. Exercises the
+# core API surface and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript glmnet.R
+
+if (!requireNamespace("glmnet", quietly = TRUE)) {
+  cat("FAIL: package 'glmnet' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(glmnet))
+cat(sprintf("glmnet version: %s\n", as.character(packageVersion("glmnet"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Sparse gaussian design: only the first 3 of 20 predictors carry signal.
+set.seed(1234)
+n <- 100L
+p <- 20L
+X <- matrix(rnorm(n * p), n, p)
+beta_true <- c(3, -2, 1.5, rep(0, p - 3L))
+y <- as.numeric(X %*% beta_true + rnorm(n))
+
+# Separate seed for the binomial response so the two simulations stay
+# independently reproducible; strong effects (+1.5 / -1.5) on X1 and X2.
+set.seed(4321)
+ybin <- rbinom(n, 1L, plogis(1.5 * X[, 1] - 1.5 * X[, 2]))
+
+run_test("gaussian lasso: fit object and lambda path", function() {
+  fit <- glmnet(X, y)
+  stopifnot(inherits(fit, "glmnet"))
+  stopifnot(length(fit$lambda) > 1L)
+  stopifnot(all(is.finite(fit$lambda)), all(fit$lambda > 0))
+  # The regularization path is a strictly decreasing lambda sequence.
+  stopifnot(all(diff(fit$lambda) < 0))
+  stopifnot(identical(dim(fit$beta), c(p, length(fit$lambda))))
+})
+
+run_test("coef and predict shapes at a fixed lambda", function() {
+  fit <- glmnet(X, y)
+  s_mid <- fit$lambda[min(10L, length(fit$lambda))]
+  cf <- as.numeric(coef(fit, s = s_mid))
+  stopifnot(length(cf) == p + 1L, all(is.finite(cf)))
+  pr <- as.numeric(predict(fit, X, s = s_mid))
+  stopifnot(length(pr) == n, all(is.finite(pr)))
+})
+
+run_test("lasso recovers the sparse signal", function() {
+  fit <- glmnet(X, y)
+  # At the smallest path lambda the fit is nearly unpenalized, so the
+  # three true effects should show the right sign and rough magnitude.
+  cf <- as.numeric(coef(fit, s = min(fit$lambda)))
+  stopifnot(cf[2] > 0, cf[3] < 0, cf[4] > 0)
+  stopifnot(abs(cf[2] - 3) < 1, abs(cf[3] - (-2)) < 1, abs(cf[4] - 1.5) < 1)
+  # The 17 true-zero predictors stay small (noise-level estimates only).
+  stopifnot(max(abs(cf[5:(p + 1L)])) < 0.75)
+})
+
+run_test("cv.glmnet: cross-validation object", function() {
+  set.seed(1234) # fold assignment is random; pin it for determinism
+  cvfit <- cv.glmnet(X, y)
+  stopifnot(inherits(cvfit, "cv.glmnet"))
+  stopifnot(is.finite(cvfit$lambda.min), cvfit$lambda.min > 0)
+  stopifnot(is.finite(cvfit$lambda.1se), cvfit$lambda.1se >= cvfit$lambda.min)
+  stopifnot(length(cvfit$cvm) == length(cvfit$lambda))
+  stopifnot(all(is.finite(cvfit$cvm)))
+})
+
+run_test("cv predictions track the simulated response", function() {
+  set.seed(1234)
+  cvfit <- cv.glmnet(X, y)
+  pr <- as.numeric(predict(cvfit, newx = X, s = "lambda.min"))
+  stopifnot(length(pr) == n, all(is.finite(pr)))
+  # Signal-to-noise is ~15:1, so in-sample correlation must be high.
+  stopifnot(cor(pr, y) > 0.8)
+})
+
+run_test("binomial lasso: logistic fit and probabilities", function() {
+  fit <- glmnet(X, ybin, family = "binomial")
+  stopifnot(inherits(fit, "glmnet"))
+  cf <- as.numeric(coef(fit, s = min(fit$lambda)))
+  stopifnot(length(cf) == p + 1L, all(is.finite(cf)))
+  # True effects: +1.5 on X1, -1.5 on X2 -- signs must be recovered.
+  stopifnot(cf[2] > 0, cf[3] < 0)
+  pr <- as.numeric(predict(fit, X, s = min(fit$lambda), type = "response"))
+  stopifnot(length(pr) == n, all(is.finite(pr)))
+  stopifnot(all(pr >= 0 & pr <= 1))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all glmnet smoke tests passed\n")

--- a/cli/scripts/lib-validator/glue.R
+++ b/cli/scripts/lib-validator/glue.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `glue` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# glue itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript glue.R
+
+if (!requireNamespace("glue", quietly = TRUE)) {
+  cat("FAIL: package 'glue' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(glue))
+cat(sprintf("glue version: %s\n", as.character(packageVersion("glue"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("basic interpolation with local variables", function() {
+  name <- "world"
+  n <- 2L
+  stopifnot(identical(as.character(glue("hello {name}!")), "hello world!"))
+  stopifnot(identical(as.character(glue("{n} + {n} = {n + n}")), "2 + 2 = 4"))
+})
+
+run_test("interpolation via .envir", function() {
+  e <- new.env(parent = emptyenv())
+  assign("x", 42L, envir = e)
+  assign("who", "env", envir = e)
+  stopifnot(identical(as.character(glue("x is {x} from {who}", .envir = e)), "x is 42 from env"))
+})
+
+run_test("vectorized interpolation and recycling", function() {
+  v <- c("a", "b", "c")
+  stopifnot(identical(as.character(glue("{v}-{1:3}")), c("a-1", "b-2", "c-3")))
+  # length-1 recycles against length-2
+  stopifnot(identical(as.character(glue("{c('x', 'y')}{1L}")), c("x1", "y1")))
+})
+
+run_test("glue_data over a list and a data.frame", function() {
+  d <- list(a = "foo", b = 1:2)
+  stopifnot(identical(as.character(glue_data(d, "{a}{b}")), c("foo1", "foo2")))
+  df <- data.frame(x = c("p", "q"), y = c(1L, 2L), stringsAsFactors = FALSE)
+  stopifnot(identical(as.character(glue_data(df, "{x}={y}")), c("p=1", "q=2")))
+})
+
+run_test("glue_collapse with sep and last", function() {
+  stopifnot(identical(
+    as.character(glue_collapse(c("a", "b", "c"), sep = ", ", last = " and ")),
+    "a, b and c"
+  ))
+  stopifnot(identical(as.character(glue_collapse(1:4, sep = "-")), "1-2-3-4"))
+})
+
+run_test("literal braces and custom delimiters", function() {
+  a <- 1L
+  stopifnot(identical(as.character(glue("{{a}} = {a}")), "{a} = 1"))
+  stopifnot(identical(
+    as.character(glue("<x> + <y> = {kept}", x = 1L, y = 2L, .open = "<", .close = ">")),
+    "1 + 2 = {kept}"
+  ))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all glue smoke tests passed\n")

--- a/cli/scripts/lib-validator/grpcio-tools.py
+++ b/cli/scripts/lib-validator/grpcio-tools.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `grpcio-tools` package.
+
+Fully self-contained: no input files, no network, no packages beyond
+grpcio-tools (and its implied deps: grpcio, protobuf). Exercises the core API
+surface — compiling a tiny inline .proto written to a scratch tempdir — and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 grpcio-tools.py
+
+Install: pip install "grpcio-tools>=1.60"   (import name: grpc_tools)
+
+Pin note: orbax-checkpoint otherwise resolves grpcio-tools 1.30.0, whose
+setup.py imports the now-unavailable pkg_resources and fails to build — so pin
+grpcio-tools >= 1.60.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import grpc_tools
+    from grpc_tools import protoc
+except ImportError:
+    print("FAIL: package 'grpcio-tools' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+# grpc_tools has no __version__; _version falls back to installed metadata.
+print(f"grpcio-tools version: {_version(grpc_tools, 'grpcio-tools')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+_PROTO = """syntax = "proto3";
+
+package smoke;
+
+message Ping {
+  string id = 1;
+  int32 seq = 2;
+}
+
+service Echo {
+  rpc Send (Ping) returns (Ping);
+}
+"""
+
+
+def _compile(tmpdir):
+    """Run protoc over the inline .proto in tmpdir; return its exit code.
+
+    grpc_tools bundles the well-known-type .proto includes; --proto_path points
+    protoc at their location so imports resolve without a system protoc.
+    """
+    import pkg_resources
+
+    proto_path = os.path.join(tmpdir, "smoke.proto")
+    with open(proto_path, "w") as fh:
+        fh.write(_PROTO)
+    well_known = pkg_resources.resource_filename("grpc_tools", "_proto")
+    return protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"--proto_path={tmpdir}",
+            f"--proto_path={well_known}",
+            f"--python_out={tmpdir}",
+            f"--grpc_python_out={tmpdir}",
+            proto_path,
+        ]
+    )
+
+
+def test_protoc_returns_zero_and_emits_python():
+    import tempfile
+
+    tmpdir = tempfile.mkdtemp(prefix="grpc-smoke-")
+    try:
+        code = _compile(tmpdir)
+        assert code == 0, f"protoc exited {code}"
+        pb2 = os.path.join(tmpdir, "smoke_pb2.py")
+        grpc_pb2 = os.path.join(tmpdir, "smoke_pb2_grpc.py")
+        assert os.path.exists(pb2), "smoke_pb2.py not generated"
+        assert os.path.exists(grpc_pb2), "smoke_pb2_grpc.py not generated"
+    finally:
+        import shutil
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+run_test("protoc compiles inline .proto to python", test_protoc_returns_zero_and_emits_python)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all grpcio-tools smoke tests passed")

--- a/cli/scripts/lib-validator/gseapy.py
+++ b/cli/scripts/lib-validator/gseapy.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `gseapy` package.
+
+Fully self-contained: no input files, no network, no packages beyond gseapy
+(and its implied deps — numpy, pandas, scipy). Exercises the core API surface
+and exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 gseapy.py
+
+Install: pip install "gseapy>=1.1.11"   (import name: gseapy)
+
+FLAG — no network. This test uses ONLY `gseapy.prerank` with an in-memory
+`gene_sets` dict and an in-memory ranked pandas Series. `gseapy.enrichr` (and
+any gene-set download) hits the network and is deliberately NOT exercised — the
+validator must stay offline.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import gseapy as gp
+except ImportError:
+    print("FAIL: package 'gseapy' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"gseapy version: {_version(gp, 'gseapy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_rank_and_sets():
+    """A 200-gene ranked Series + two in-memory gene sets (no downloads).
+
+    GENE0..GENE9 are pushed to the top of the ranking and form SET_TOP, so that
+    set should enrich positively; SET_RANDOM is a scattered control.
+    """
+    rng = np.random.default_rng(0)
+    genes = [f"GENE{i}" for i in range(200)]
+    scores = rng.normal(size=200)
+    scores[:10] += 5.0  # lift the SET_TOP members to the head of the ranking
+    rnk = pd.Series(scores, index=genes).sort_values(ascending=False)
+
+    gene_sets = {
+        "SET_TOP": [f"GENE{i}" for i in range(10)],
+        "SET_RANDOM": [f"GENE{i}" for i in range(50, 65)],
+    }
+    return rnk, gene_sets
+
+
+def test_ranked_series_and_sets():
+    rnk, gene_sets = _make_rank_and_sets()
+    assert rnk.shape == (200,)
+    assert rnk.is_monotonic_decreasing
+    assert set(gene_sets.keys()) == {"SET_TOP", "SET_RANDOM"}
+    assert len(gene_sets["SET_TOP"]) == 10
+
+
+def test_prerank_res2d():
+    # In-memory prerank: gene_sets is a dict, rnk is a Series — no network.
+    rnk, gene_sets = _make_rank_and_sets()
+    pre = gp.prerank(
+        rnk=rnk,
+        gene_sets=gene_sets,
+        min_size=5,
+        max_size=100,
+        permutation_num=100,
+        seed=0,
+        no_plot=True,
+        outdir=None,
+    )
+    res = pre.res2d
+    assert isinstance(res, pd.DataFrame)
+    assert len(res) >= 1
+    for col in ("Term", "NES"):
+        assert col in res.columns
+    # A p-value column exists under one of gseapy's spellings across versions.
+    assert any(c in res.columns for c in ("pval", "NOM p-val", "FDR q-val"))
+
+
+run_test("ranked Series + in-memory gene sets", test_ranked_series_and_sets)
+run_test("prerank res2d (offline, no enrichr)", test_prerank_res2d)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all gseapy smoke tests passed")

--- a/cli/scripts/lib-validator/h5py.py
+++ b/cli/scripts/lib-validator/h5py.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `h5py` package.
+
+Fully self-contained: no input files, no network, no packages beyond h5py
+(and its implied deps: numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 h5py.py
+
+Install: pip install h5py   (import name: h5py)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import h5py
+except ImportError:
+    print("FAIL: package 'h5py' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"h5py version: {_version(h5py, 'h5py')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_in_memory_dataset_and_attrs():
+    import numpy as np
+
+    # driver="core" with backing_store=False keeps the whole file in RAM — no
+    # disk touched, so this check needs no tempfile cleanup.
+    f = h5py.File("mem.h5", "w", driver="core", backing_store=False)
+    try:
+        payload = np.arange(6, dtype="int64").reshape(2, 3)
+        dset = f.create_dataset("data", data=payload)
+        dset.attrs["units"] = "counts"
+        assert np.array_equal(f["data"][...], payload)
+        assert f["data"][1, 2] == 5
+        assert f["data"].attrs["units"] == "counts"
+        assert f["data"].shape == (2, 3)
+    finally:
+        f.close()
+
+
+def test_groups_tempfile():
+    import numpy as np
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".h5")
+    os.close(fd)
+    try:
+        with h5py.File(path, "w") as f:
+            grp = f.create_group("group_a")
+            grp.create_dataset("vec", data=np.array([1.5, 2.5, 3.5]))
+            f.attrs["root_note"] = "top-level"
+        with h5py.File(path, "r") as f:
+            assert list(f.keys()) == ["group_a"]
+            assert list(f["group_a"].keys()) == ["vec"]
+            assert np.allclose(f["group_a/vec"][...], [1.5, 2.5, 3.5])
+            assert f.attrs["root_note"] == "top-level"
+    finally:
+        os.remove(path)
+
+
+run_test("in-memory dataset + attribute", test_in_memory_dataset_and_attrs)
+run_test("groups via tempfile", test_groups_tempfile)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all h5py smoke tests passed")

--- a/cli/scripts/lib-validator/harmonypy.py
+++ b/cli/scripts/lib-validator/harmonypy.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `harmonypy` package.
+
+Fully self-contained: no input files, no network, no packages beyond harmonypy
+(and its implied deps: numpy, pandas). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 harmonypy.py
+
+Install: pip install harmonypy   (import name: harmonypy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+harmonypy is genuinely offline-shaped: batch integration runs entirely in
+memory. run_harmony takes a cells-by-dims embedding, a metadata DataFrame, and
+the batch column name(s) via vars_use; it returns a Harmony object whose
+`.Z_corr` is the corrected embedding shaped (dims, cells). Checks are seeded and
+structural / tolerance-based. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import harmonypy
+except ImportError:
+    print("FAIL: package 'harmonypy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"harmonypy version: {_version(harmonypy, 'harmonypy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_run_harmony():
+    assert hasattr(harmonypy, "run_harmony")
+    assert callable(harmonypy.run_harmony)
+
+
+def test_run_harmony_corrects_embedding():
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(0)
+    n_cells, n_dims = 60, 5
+    # A PCA-like embedding with an injected per-batch offset, so there is a
+    # batch effect for Harmony to remove.
+    batch = np.array(["A", "B"] * (n_cells // 2))
+    data_mat = rng.standard_normal((n_cells, n_dims))
+    data_mat[batch == "B"] += 3.0
+    meta_data = pd.DataFrame({"batch": batch})
+
+    ho = harmonypy.run_harmony(data_mat, meta_data, vars_use=["batch"])
+
+    # Z_corr is the corrected embedding, transposed to (dims, cells).
+    assert ho.Z_corr.shape == (n_dims, n_cells)
+    assert np.all(np.isfinite(np.asarray(ho.Z_corr)))
+
+
+run_test("exposes run_harmony", test_exposes_run_harmony)
+run_test("run_harmony returns Z_corr of shape (dims, cells)", test_run_harmony_corrects_embedding)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all harmonypy smoke tests passed")

--- a/cli/scripts/lib-validator/httr2.R
+++ b/cli/scripts/lib-validator/httr2.R
@@ -1,0 +1,138 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `httr2` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond
+# httr2 itself and its implied dependencies. Requests are only BUILT and
+# INSPECTED, never performed: the one serialization check goes through
+# req_dry_run(), which renders the request without sending it to the
+# target host. Exercises the core API surface and exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript httr2.R
+
+if (!requireNamespace("httr2", quietly = TRUE)) {
+  cat("FAIL: package 'httr2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(httr2))
+cat(sprintf("httr2 version: %s\n", as.character(packageVersion("httr2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("request construction", function() {
+  req <- request("https://example.com/api")
+  stopifnot(inherits(req, "httr2_request"))
+  stopifnot(identical(req$url, "https://example.com/api"))
+})
+
+run_test("req_url_path_append composes the URL path", function() {
+  req <- request("https://example.com/api")
+  users <- req_url_path_append(req, "users")
+  stopifnot(identical(users$url, "https://example.com/api/users"))
+  nested <- req_url_path_append(req, "users", "42")
+  stopifnot(identical(nested$url, "https://example.com/api/users/42"))
+})
+
+run_test("req_url_query adds query parameters", function() {
+  req <- req_url_query(request("https://example.com/api"), a = 1, b = "x")
+  stopifnot(grepl("?a=1&b=x", req$url, fixed = TRUE))
+  stopifnot(identical(req$url, "https://example.com/api?a=1&b=x"))
+})
+
+run_test("req_headers sets headers", function() {
+  req <- req_headers(request("https://example.com/api"),
+                     Authorization = "Bearer t", `X-Smoke` = "1")
+  # httr2 >= 1.2 stores headers in an S7 `httr2_headers` object and OBFUSCATES
+  # secret headers (Authorization) — reading `req$headers$Authorization`
+  # directly yields a weakref. Read through the public accessor with
+  # `redacted = "reveal"` to get the plain values.
+  h <- as.list(req_get_headers(req, redacted = "reveal"))
+  stopifnot(identical(h$Authorization, "Bearer t"))
+  stopifnot(identical(h[["X-Smoke"]], "1"))
+})
+
+run_test("req_method overrides the method", function() {
+  req <- req_method(request("https://example.com/api"), "POST")
+  stopifnot(identical(req$method, "POST"))
+})
+
+run_test("req_body_json attaches a JSON body", function() {
+  req <- req_body_json(request("https://example.com/api"), list(k = "v"))
+  stopifnot(!is.null(req$body))
+  stopifnot(identical(req$body$data, list(k = "v")))
+})
+
+run_test("requests are immutable values", function() {
+  base <- request("https://example.com/api")
+  derived <- req_url_query(base, a = 1)
+  stopifnot(identical(base$url, "https://example.com/api"))
+  stopifnot(!identical(derived$url, base$url))
+})
+
+run_test("req_dry_run serializes without sending", function() {
+  stopifnot(is.function(req_dry_run))
+  # Some httr2 versions fake the transport through the *suggested* `httpuv`
+  # package; when it is absent, settle for the structural check above rather
+  # than failing the validator over an optional dependency. Either way,
+  # nothing ever leaves the machine: the dry run never contacts example.com.
+  if (!requireNamespace("httpuv", quietly = TRUE)) return(invisible(NULL))
+  get_req <- req_headers(request("https://example.com/api"), `X-Smoke` = "1")
+  out <- capture.output(info <- req_dry_run(get_req))
+  stopifnot(length(out) > 0)
+  stopifnot(identical(toupper(info$method), "GET"))
+  post_req <- req_body_json(request("https://example.com/api"), list(k = "v"))
+  post_info <- req_dry_run(post_req, quiet = TRUE)
+  # A JSON body flips the *effective* method to POST even though req$method
+  # stays NULL until the request is rendered.
+  stopifnot(identical(toupper(post_info$method), "POST"))
+})
+
+run_test("url_parse extracts components", function() {
+  u <- url_parse("https://u:p@host:8080/a/b?x=1#frag")
+  stopifnot(identical(u$scheme, "https"))
+  stopifnot(identical(u$hostname, "host"))
+  stopifnot(identical(u$username, "u"))
+  stopifnot(identical(u$password, "p"))
+  # Port is a string in some httr2 versions and an integer in others;
+  # as.character() makes the assertion hold for both.
+  stopifnot(identical(as.character(u$port), "8080"))
+  stopifnot(identical(u$path, "/a/b"))
+  stopifnot(identical(u$query, list(x = "1")))
+  stopifnot(identical(u$fragment, "frag"))
+})
+
+run_test("url_build roundtrips url_parse", function() {
+  for (raw in c("https://u:p@host:8080/a/b?x=1#frag",
+                "https://example.com/api?a=1&b=x")) {
+    stopifnot(identical(url_build(url_parse(raw)), raw))
+  }
+})
+
+run_test("url_modify updates components (when available)", function() {
+  # url_modify() arrived in httr2 1.1.0; treat its absence as a skip, not a
+  # failure, so the validator also passes on older httr2 installs.
+  if (!exists("url_modify", envir = asNamespace("httr2"), inherits = FALSE)) {
+    return(invisible(NULL))
+  }
+  stopifnot(identical(url_modify("https://example.com/a", path = "/b"),
+                      "https://example.com/b"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all httr2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/igraph.R
+++ b/cli/scripts/lib-validator/igraph.R
@@ -1,0 +1,97 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `igraph` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# igraph itself. Graphs are tiny hand-built structures (a triangle, a ring)
+# or fixed-seed random graphs. Exercises the core graph-construction, metric,
+# and path API, and exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript igraph.R
+#
+# Structural quantities (vertex/edge counts, degrees, hop distances, component
+# sizes) are integers, checked EXACTLY; centralities are floating-point,
+# checked for finiteness and sign only.
+
+if (!requireNamespace("igraph", quietly = TRUE)) {
+  cat("FAIL: package 'igraph' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(igraph))
+cat(sprintf("igraph version: %s\n", as.character(packageVersion("igraph"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("graph_from_literal builds a connected triangle", function() {
+  g <- igraph::graph_from_literal(A - B, B - C, C - A)
+  stopifnot(igraph::vcount(g) == 3L)
+  stopifnot(igraph::ecount(g) == 3L)
+  # every vertex of a triangle has degree 2
+  stopifnot(all(igraph::degree(g) == 2L))
+  stopifnot(isTRUE(igraph::is_connected(g)))
+})
+
+run_test("distances on a triangle are all one hop", function() {
+  g <- igraph::graph_from_literal(A - B, B - C, C - A)
+  d <- igraph::distances(g)
+  stopifnot(is.matrix(d), identical(dim(d), c(3L, 3L)))
+  stopifnot(all(diag(d) == 0))
+  # off-diagonal geodesics are exactly 1 in a complete triangle
+  stopifnot(all(d[upper.tri(d)] == 1))
+})
+
+run_test("make_ring gives predictable hop distances", function() {
+  ring <- igraph::make_ring(5)
+  stopifnot(igraph::vcount(ring) == 5L, igraph::ecount(ring) == 5L)
+  d <- igraph::distances(ring)
+  stopifnot(d[1, 2] == 1) # adjacent
+  stopifnot(d[1, 3] == 2) # two hops around the ring
+  stopifnot(max(d) == 2) # diameter of a 5-ring is floor(5 / 2) = 2
+})
+
+run_test("shortest_paths returns a path of the expected length", function() {
+  ring <- igraph::make_ring(5)
+  sp <- igraph::shortest_paths(ring, from = 1, to = 3)
+  vpath <- sp$vpath[[1]]
+  # a shortest 1 -> 3 path on the ring visits 3 vertices (2 hops)
+  stopifnot(length(vpath) == 3L)
+})
+
+run_test("sample_gnp with a seed has stable structure", function() {
+  set.seed(7)
+  g <- igraph::sample_gnp(n = 50, p = 0.1)
+  stopifnot(igraph::vcount(g) == 50L)
+  stopifnot(igraph::ecount(g) >= 0L, is.finite(igraph::ecount(g)))
+  comp <- igraph::components(g)
+  stopifnot(comp$no >= 1L)
+  # every vertex belongs to exactly one component
+  stopifnot(sum(comp$csize) == 50L)
+  stopifnot(length(comp$membership) == 50L)
+})
+
+run_test("betweenness and closeness are finite on a connected graph", function() {
+  ring <- igraph::make_ring(5)
+  bt <- igraph::betweenness(ring)
+  stopifnot(length(bt) == 5L, all(is.finite(bt)), all(bt >= 0))
+  cl <- igraph::closeness(ring)
+  stopifnot(length(cl) == 5L, all(is.finite(cl)), all(cl > 0))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all igraph smoke tests passed\n")

--- a/cli/scripts/lib-validator/immunarch.R
+++ b/cli/scripts/lib-validator/immunarch.R
@@ -1,0 +1,88 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `immunarch` package (immune repertoire / AIRR analysis).
+#
+# NOTE: immunarch is an R package (repo immunomind/immunarch), NOT a Python
+# package. Despite appearing in a Python dependency list it has no PyPI
+# distribution (the Python analogue is scirpy), so this validator is written as
+# an R smoke test — like data.table.R — to exercise the REAL package.
+#
+# Install: install.packages("immunarch")  OR  remotes::install_github("immunomind/immunarch")
+#
+# Fully self-contained: no input files, no network. immunarch ships an example
+# immune-repertoire dataset via data(immdata); this test loads it and exercises
+# the core repertoire-statistics API. Exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript immunarch.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK =======================
+# UNVERIFIABLE WITHOUT AN INSTALL — confirm the following once immunarch is
+# available:
+#   - immdata STRUCTURE. Assumed immdata$data is a NAMED LIST of per-sample
+#     repertoire data.frames and immdata$meta is a metadata data.frame (one row
+#     per sample). Re-confirm if the checks below fail.
+#   - FUNCTION NAMES / METHOD STRINGS. Assumed repExplore(.data, "volume"),
+#     repDiversity(.data, "chao1"), and repClonality(.data, "homeo") — each
+#     taking the list of repertoires as the first arg and a method string as the
+#     second, and returning a data.frame / immunr_* object with >= 1 row.
+#     Re-confirm the method spellings ("volume"/"chao1"/"homeo") against the
+#     installed help.
+# ============================================================================
+
+if (!requireNamespace("immunarch", quietly = TRUE)) {
+  cat("FAIL: package 'immunarch' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(immunarch))
+cat(sprintf("immunarch version: %s\n", as.character(packageVersion("immunarch"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("bundled immdata loads with $data (list of data.frames) and $meta", function() {
+  data(immdata)
+  stopifnot(exists("immdata"))
+  stopifnot(is.list(immdata$data), length(immdata$data) > 0L)
+  stopifnot(all(vapply(immdata$data, is.data.frame, logical(1L))))
+  stopifnot(is.data.frame(immdata$meta))
+  stopifnot(nrow(immdata$meta) >= 1L)
+})
+
+run_test("repExplore volume returns a data.frame", function() {
+  data(immdata)
+  vol <- repExplore(immdata$data, "volume")
+  stopifnot(is.data.frame(vol))
+  stopifnot(nrow(vol) >= 1L)
+})
+
+run_test("repDiversity chao1", function() {
+  data(immdata)
+  div <- repDiversity(immdata$data, "chao1")
+  stopifnot(!is.null(div))
+  stopifnot(NROW(div) >= 1L)
+})
+
+run_test("repClonality homeo", function() {
+  data(immdata)
+  clon <- repClonality(immdata$data, "homeo")
+  stopifnot(!is.null(clon))
+  stopifnot(NROW(clon) >= 1L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all immunarch smoke tests passed\n")

--- a/cli/scripts/lib-validator/immunedeconv.R
+++ b/cli/scripts/lib-validator/immunedeconv.R
@@ -1,0 +1,131 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `immunedeconv` package (a unified wrapper over many
+# immune-cell deconvolution methods: MCP-counter, quanTIseq, EPIC, xCell, ...).
+#
+# Install: remotes::install_github("omnideconv/immunedeconv")
+#
+# Fully self-contained: no input files, no network. The method-registry surface
+# is tested HARD (deconvolution_methods is a non-empty named vector exposing the
+# expected method keys; deconvolute() is a function). An actual deconvolution is
+# attempted on a small synthetic TPM matrix whose rownames are REAL HGNC gene
+# symbols (including MCP-counter marker genes), but only as a SOFT check: the
+# marker-based methods rely on specific signature genes mapping onto the input,
+# and a synthetic matrix may legitimately fail to map, so a run error there is
+# reported and tolerated -- never counted as a failure. Exits 0 only if every
+# HARD check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript immunedeconv.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm once immunedeconv is available:
+#   - deconvolution_methods SHAPE. Assumed to be a named character vector whose
+#     entries (as names OR values) include the free, self-contained method keys
+#     "mcp_counter", "quantiseq", and "epic". Some methods (CIBERSORT, TIMER)
+#     need extra setup/licensing and are intentionally not required here.
+#   - METHOD-KEY SPELLING. The `method=` argument keys are assumed spelled
+#     "mcp_counter" / "quantiseq" / "epic". Re-confirm against the installed
+#     `deconvolution_methods`.
+#   - deconvolute() OUTPUT SHAPE. When the soft run succeeds it is assumed to
+#     return a data.frame/tibble of cell types x samples with a first column
+#     named "cell_type". Re-confirm the column name and orientation.
+#   - GENE-SYMBOL / MARKER DEPENDENCY (the reason the run is SOFT). Marker-based
+#     methods map their signature genes onto the input rownames; the synthetic
+#     symbols here may not cover enough markers to produce non-NA fractions.
+#     Re-run deconvolute() on a REAL TPM matrix once installed.
+# ============================================================================
+
+if (!requireNamespace("immunedeconv", quietly = TRUE)) {
+  cat("FAIL: package 'immunedeconv' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(immunedeconv))
+cat(sprintf("immunedeconv version: %s\n", as.character(packageVersion("immunedeconv"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic bulk RNA-seq expression: REAL HGNC symbols as rownames (a spread of
+# MCP-counter T-cell / B-cell / monocyte / NK / endothelial / fibroblast markers
+# plus common housekeeping/oncogenes), 6 samples. Values are drawn lognormal
+# then column-normalised to TPM (each sample sums to 1e6) so the matrix is
+# genuinely TPM-like. Real symbols give the marker-based methods a chance to map.
+set.seed(2024)
+genes <- c(
+  "CD8A", "CD8B", "CD3D", "CD3E", "CD3G", "CD2", "CD5", "CD28",           # T cells
+  "CD19", "MS4A1", "CD79A", "CD79B", "TCL1A",                              # B cells
+  "CD14", "CD68", "CSF1R", "FCGR3A", "LYZ",                                # monocytic
+  "NCAM1", "KLRD1", "KLRF1", "NKG7", "GNLY", "PRF1", "GZMB",               # NK / cytotoxic
+  "PECAM1", "VWF", "CDH5", "CLDN5",                                        # endothelial
+  "COL1A1", "COL3A1", "DCN", "PDGFRB", "THY1", "LUM",                      # fibroblast
+  "PTPRC", "CD4", "FOXP3", "IL2RA", "CTLA4",                               # immune-general
+  "ACTB", "GAPDH", "B2M", "TP53", "EGFR", "KRAS", "MYC", "VIM"            # housekeeping / onco
+)
+n_genes <- length(genes)
+n_samples <- 6L
+expr <- matrix(
+  rlnorm(n_genes * n_samples, meanlog = 3, sdlog = 1),
+  nrow = n_genes, ncol = n_samples,
+  dimnames = list(genes, paste0("Sample", seq_len(n_samples)))
+)
+# Column-normalise to TPM (each sample sums to 1e6).
+expr <- sweep(expr, 2L, colSums(expr), "/") * 1e6
+
+run_test("deconvolution_methods is a non-empty named vector", function() {
+  dm <- deconvolution_methods
+  stopifnot(is.character(dm))
+  stopifnot(length(dm) > 0L)
+  stopifnot(!is.null(names(dm)))
+})
+
+run_test("deconvolution_methods exposes expected method keys", function() {
+  dm <- deconvolution_methods
+  # Accept the key appearing as a value OR a name -- immunedeconv maps display
+  # names to method keys and the orientation has varied across versions.
+  known <- c(unname(dm), names(dm))
+  for (m in c("mcp_counter", "quantiseq", "epic")) {
+    stopifnot(m %in% known)
+  }
+})
+
+run_test("deconvolute is an exported function", function() {
+  stopifnot(exists("deconvolute"))
+  stopifnot(is.function(deconvolute))
+})
+
+run_test("deconvolute(method='mcp_counter') on synthetic TPM (soft)", function() {
+  # SOFT: marker genes may not map onto the synthetic symbols, so a run error is
+  # tolerated (reported, not failed). If it DOES run, sanity-check the shape.
+  res <- tryCatch(
+    suppressWarnings(suppressMessages(
+      deconvolute(expr, method = "mcp_counter")
+    )),
+    error = function(e) e
+  )
+  if (inherits(res, "error")) {
+    cat(sprintf("       (soft) mcp_counter did not run on synthetic data: %s\n",
+                conditionMessage(res)))
+    return(invisible(NULL))
+  }
+  stopifnot(is.data.frame(res))
+  stopifnot("cell_type" %in% colnames(res))
+  # One column per sample beside the cell_type label column.
+  stopifnot(ncol(res) >= 2L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all immunedeconv smoke tests passed\n")

--- a/cli/scripts/lib-validator/infercnv.R
+++ b/cli/scripts/lib-validator/infercnv.R
@@ -1,0 +1,156 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `infercnv` package.
+#
+# Fully self-contained: no input files, no network. Builds a small synthetic
+# scRNA-seq counts matrix (genes x cells) with a fixed seed, plus the two
+# in-memory metadata frames infercnv needs -- a per-cell group annotation
+# (with a reference group) and a per-gene genomic-order table -- and constructs
+# an infercnv object. Only the OBJECT-CONSTRUCTION surface is exercised: the
+# heavy `infercnv::run()` HMM/Bayesian step is deliberately NOT called (it is
+# extremely slow and pulls in rjags/JAGS). Checks are structural (S4 class,
+# populated slots, aligned dimensions) -- never numeric. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript infercnv.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once infercnv
+# is available:
+#   - CreateInfercnvObject() ARG NAMES. This test relies on the documented
+#     in-memory path where `raw_counts_matrix` takes a matrix and BOTH
+#     `annotations_file` and `gene_order_file` accept in-memory data.frames
+#     (not only file paths). Arg spelling: raw_counts_matrix, annotations_file,
+#     gene_order_file, ref_group_names.
+#   - The annotations data.frame shape: rownames = cell ids, first column = the
+#     group label; the gene_order data.frame shape: rownames = gene ids, three
+#     columns interpreted as (chr, start, stop).
+#   - Retained dims. CreateInfercnvObject filters cells by total counts
+#     (min_max_counts_per_cell default c(100, +Inf)) and drops genes on excluded
+#     chromosomes (chr_exclude default chrX/chrY/chrM). The synthetic data is
+#     built to survive both (chr1/chr2 only, ~300 counts/cell), so all 60 genes
+#     and 20 cells are EXPECTED to remain -- but the exact filtering behaviour
+#     must be re-confirmed against an installed build.
+#   - rjags / JAGS DEPENDENCY. infercnv Imports rjags, which links the external
+#     libjags library at load time. On a machine without libjags, loading
+#     infercnv (and hence the requireNamespace guard below) can itself fail --
+#     an install-only miss and a missing-libjags miss both fire the guard.
+# ============================================================================
+
+if (!requireNamespace("infercnv", quietly = TRUE)) {
+  cat("FAIL: package 'infercnv' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(infercnv))
+cat(sprintf("infercnv version: %s\n", as.character(packageVersion("infercnv"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic design: 60 genes x 20 cells. Genes live only on chr1/chr2 so none
+# are dropped by the default chr_exclude; Poisson(mean=5) gives ~300 counts per
+# cell, comfortably above the default min-counts filter (100). Ten reference
+# ("normal") cells and ten observation ("tumor") cells.
+set.seed(42)
+n_genes <- 60L
+n_cells <- 20L
+genes <- paste0("gene", seq_len(n_genes))
+cells <- paste0("cell", seq_len(n_cells))
+
+counts <- matrix(
+  rpois(n_genes * n_cells, lambda = 5),
+  nrow = n_genes, ncol = n_cells,
+  dimnames = list(genes, cells)
+)
+
+# gene_order: rownames = gene ids; three columns read as chr/start/stop. Half
+# the genes on chr1, half on chr2, each with a monotonically increasing start.
+gene_order_df <- data.frame(
+  chr = rep(c("chr1", "chr2"), each = n_genes / 2L),
+  start = rep(seq_len(n_genes / 2L) * 1000L, times = 2L),
+  stop = rep(seq_len(n_genes / 2L) * 1000L, times = 2L) + 500L,
+  row.names = genes
+)
+
+# annotations: rownames = cell ids; first column = group. "normal" is the
+# reference group, "tumor" the observation group.
+annot_df <- data.frame(
+  group = rep(c("normal", "tumor"), each = n_cells / 2L),
+  row.names = cells
+)
+
+# Build once; object construction is the whole surface under test. infercnv
+# chatters through a logging framework, so silence warnings/messages here.
+make_obj <- function() {
+  suppressWarnings(suppressMessages(
+    CreateInfercnvObject(
+      raw_counts_matrix = counts,
+      annotations_file = annot_df,
+      gene_order_file = gene_order_df,
+      ref_group_names = c("normal")
+    )
+  ))
+}
+
+run_test("CreateInfercnvObject returns an infercnv S4 object", function() {
+  obj <- make_obj()
+  stopifnot(inherits(obj, "infercnv"))
+  stopifnot(isVirtualClass("infercnv") == FALSE)
+})
+
+run_test("count.data slot is populated with the expected dimensions", function() {
+  obj <- make_obj()
+  cd <- obj@count.data
+  stopifnot(!is.null(cd))
+  # dense matrix or a Matrix-package sparse matrix, depending on infercnv version
+  stopifnot(is.matrix(cd) || inherits(cd, "Matrix"))
+  stopifnot(nrow(cd) > 0L, ncol(cd) > 0L)
+  # All synthetic cells clear the count filter and all genes survive chr_exclude,
+  # so nothing should be dropped. (Re-check: filtering behaviour is version-
+  # dependent -- see the ASSUMPTIONS block above.)
+  stopifnot(ncol(cd) == n_cells)
+  stopifnot(nrow(cd) == n_genes)
+  stopifnot(all(colnames(cd) %in% cells))
+  stopifnot(all(rownames(cd) %in% genes))
+})
+
+run_test("gene_order slot is populated and aligned with count.data", function() {
+  obj <- make_obj()
+  go <- obj@gene_order
+  stopifnot(is.data.frame(go))
+  # infercnv renames the three columns to chr/start/stop internally.
+  stopifnot(all(c("chr", "start", "stop") %in% colnames(go)))
+  # count.data and gene_order describe the same genes, in the same order.
+  stopifnot(nrow(go) == nrow(obj@count.data))
+  stopifnot(identical(rownames(go), rownames(obj@count.data)))
+})
+
+run_test("reference and observation groups are recorded", function() {
+  obj <- make_obj()
+  ref_idx <- obj@reference_grouped_cell_indices
+  obs_idx <- obj@observation_grouped_cell_indices
+  stopifnot(is.list(ref_idx), is.list(obs_idx))
+  stopifnot("normal" %in% names(ref_idx))
+  stopifnot("tumor" %in% names(obs_idx))
+  # Every reference index points at a real column of the count matrix.
+  ref_cols <- ref_idx[["normal"]]
+  stopifnot(length(ref_cols) > 0L)
+  stopifnot(all(ref_cols >= 1L & ref_cols <= ncol(obj@count.data)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all infercnv smoke tests passed\n")

--- a/cli/scripts/lib-validator/jax.py
+++ b/cli/scripts/lib-validator/jax.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `jax` package.
+
+Fully self-contained: no input files, no network, no packages beyond jax
+(and its implied deps: jaxlib, numpy). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 jax.py
+
+Install: pip install "jax<0.10"   (import name: jax)
+
+Pin note: JAX 0.10.0 removed xla_pmap_p from jax.extend.core.primitives, but
+numpyro (a transitive dependency of pertpy) still imports it — so pin jax below
+0.10 until that import is fixed upstream.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import jax
+except ImportError:
+    print("FAIL: package 'jax' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"jax version: {_version(jax, 'jax')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_jnp_array_ops():
+    import jax.numpy as jnp
+
+    a = jnp.array([1.0, 2.0, 3.0])
+    assert a.shape == (3,)
+    assert float(jnp.sum(a)) == 6.0
+    assert jnp.allclose(a * 2.0, jnp.array([2.0, 4.0, 6.0]))
+
+
+def test_grad():
+    # d/dx x**2 at x=3 == 6.
+    g = jax.grad(lambda x: x**2)
+    assert abs(float(g(3.0)) - 6.0) < 1e-5
+
+
+def test_jit():
+    import jax.numpy as jnp
+
+    f = jax.jit(lambda x: jnp.sum(x**2))
+    x = jnp.array([1.0, 2.0, 3.0])
+    assert abs(float(f(x)) - 14.0) < 1e-5
+
+
+def test_vmap():
+    import jax.numpy as jnp
+
+    batched = jax.vmap(lambda x: x * 2.0)
+    out = batched(jnp.array([1.0, 2.0, 3.0]))
+    assert jnp.allclose(out, jnp.array([2.0, 4.0, 6.0]))
+
+
+run_test("jnp array ops", test_jnp_array_ops)
+run_test("grad of x**2 at 3 == 6", test_grad)
+run_test("jit", test_jit)
+run_test("vmap", test_vmap)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all jax smoke tests passed")

--- a/cli/scripts/lib-validator/joblib.py
+++ b/cli/scripts/lib-validator/joblib.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `joblib` package.
+
+Fully self-contained: no input files, no network, no packages beyond joblib.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 joblib.py
+
+Install: pip install joblib   (import name: joblib)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import joblib
+except ImportError:
+    print("FAIL: package 'joblib' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"joblib version: {_version(joblib, 'joblib')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _square(i):
+    """Top-level so it stays picklable for any multiprocessing backend."""
+    return i * i
+
+
+def test_parallel_delayed():
+    from joblib import Parallel, delayed
+
+    # n_jobs=1 keeps it single-process and deterministic — no worker pool.
+    out = Parallel(n_jobs=1)(delayed(_square)(i) for i in range(6))
+    assert out == [0, 1, 4, 9, 16, 25]
+
+
+def test_dump_load_tempfile():
+    import tempfile
+
+    obj = {"weights": [1.0, 2.0, 3.0], "label": "model", "nested": {"k": [4, 5]}}
+    fd, path = tempfile.mkstemp(suffix=".joblib")
+    os.close(fd)
+    try:
+        joblib.dump(obj, path)
+        back = joblib.load(path)
+        assert back == obj
+    finally:
+        os.remove(path)
+
+
+def test_hash_is_stable():
+    # joblib.hash is deterministic for equal inputs — used for memo cache keys.
+    assert joblib.hash([1, 2, 3]) == joblib.hash([1, 2, 3])
+    assert joblib.hash([1, 2, 3]) != joblib.hash([1, 2, 4])
+
+
+run_test("Parallel/delayed (n_jobs=1)", test_parallel_delayed)
+run_test("dump/load tempfile roundtrip", test_dump_load_tempfile)
+run_test("hash is stable", test_hash_is_stable)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all joblib smoke tests passed")

--- a/cli/scripts/lib-validator/jsonlite.R
+++ b/cli/scripts/lib-validator/jsonlite.R
@@ -1,0 +1,94 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `jsonlite` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# jsonlite itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript jsonlite.R
+
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  cat("FAIL: package 'jsonlite' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(jsonlite))
+cat(sprintf("jsonlite version: %s\n", as.character(packageVersion("jsonlite"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("toJSON/fromJSON data.frame roundtrip (dataframe=\"rows\")", function() {
+  df <- data.frame(id = 1:2, name = c("a", "b"), stringsAsFactors = FALSE)
+  json <- toJSON(df, dataframe = "rows")
+  stopifnot(identical(as.character(json), '[{"id":1,"name":"a"},{"id":2,"name":"b"}]'))
+  back <- fromJSON(as.character(json))
+  stopifnot(is.data.frame(back), nrow(back) == 2L)
+  stopifnot(identical(back$id, c(1L, 2L)))
+  stopifnot(identical(back$name, c("a", "b")))
+})
+
+run_test("auto_unbox scalar behavior", function() {
+  stopifnot(identical(as.character(toJSON("hi")), '["hi"]'))
+  stopifnot(identical(as.character(toJSON("hi", auto_unbox = TRUE)), '"hi"'))
+  stopifnot(identical(
+    as.character(toJSON(list(name = "x", n = 1L), auto_unbox = TRUE)),
+    '{"name":"x","n":1}'
+  ))
+  stopifnot(identical(
+    as.character(toJSON(list(name = "x", n = 1L))),
+    '{"name":["x"],"n":[1]}'
+  ))
+})
+
+run_test("fromJSON literal string into list", function() {
+  x <- fromJSON('{"a": 1, "b": [1, 2, 3], "c": "x"}')
+  stopifnot(is.list(x), identical(names(x), c("a", "b", "c")))
+  stopifnot(identical(x$a, 1L))
+  stopifnot(identical(x$b, c(1L, 2L, 3L)))
+  stopifnot(identical(x$c, "x"))
+  y <- fromJSON('{"a": 1, "b": [1, 2, 3]}', simplifyVector = FALSE)
+  stopifnot(identical(y, list(a = 1L, b = list(1L, 2L, 3L))))
+})
+
+run_test("prettify and minify", function() {
+  json <- '{"a": 1, "b": [true, null], "c": "x"}'
+  stopifnot(identical(as.character(minify(json)), '{"a":1,"b":[true,null],"c":"x"}'))
+  pretty <- prettify(json)
+  stopifnot(grepl("\n", as.character(pretty), fixed = TRUE))
+  stopifnot(identical(as.character(minify(pretty)), as.character(minify(json))))
+})
+
+run_test("serializeJSON/unserializeJSON roundtrip", function() {
+  obj <- list(x = 1:3, y = "hello", z = c(TRUE, FALSE), w = c(1.5, NA))
+  back <- unserializeJSON(serializeJSON(obj))
+  stopifnot(identical(back, obj))
+  df <- data.frame(a = 1:2, b = c("p", "q"), stringsAsFactors = FALSE)
+  stopifnot(identical(unserializeJSON(serializeJSON(df)), df))
+})
+
+run_test("null and NA handling", function() {
+  stopifnot(is.null(fromJSON("null")))
+  # default NA encoding for bare vectors is the string "NA"; na = "null" opts into JSON null
+  stopifnot(identical(as.character(toJSON(c(1L, NA, 3L))), '[1,"NA",3]'))
+  stopifnot(identical(as.character(toJSON(c(1L, NA, 3L), na = "null")), "[1,null,3]"))
+  stopifnot(identical(fromJSON("[1, null, 3]"), c(1L, NA, 3L)))
+  stopifnot(identical(fromJSON("[true, null]"), c(TRUE, NA)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all jsonlite smoke tests passed\n")

--- a/cli/scripts/lib-validator/jupytext.py
+++ b/cli/scripts/lib-validator/jupytext.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `jupytext` package.
+
+Fully self-contained: no input files, no network, no packages beyond jupytext
+(and its implied deps: nbformat). Exercises the core API surface and exits 0
+only if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 jupytext.py
+
+Install: pip install jupytext   (import name: jupytext)
+
+NOTE — jupytext format names: text formats are `py:percent` / `py:light` /
+`md` (+ `md:myst`); the JSON notebook format is `ipynb` (the jupytext CLI also
+accepts the `notebook` alias for it). These checks read the `py:percent`
+representation and round-trip through both `py:percent` and `ipynb`.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import jupytext
+except ImportError:
+    print("FAIL: package 'jupytext' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"jupytext version: {_version(jupytext, 'jupytext')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_reads_percent_script_to_notebook():
+    nb = jupytext.reads("# %%\nprint(1)\n", fmt="py:percent")
+    # A notebook node exposes .cells; a single percent cell -> one code cell.
+    assert hasattr(nb, "cells")
+    assert len(nb.cells) == 1
+    assert nb.cells[0].cell_type == "code"
+    assert nb.cells[0].source == "print(1)"
+
+
+def test_writes_percent_roundtrip():
+    nb = jupytext.reads("# %%\nprint(1)\n", fmt="py:percent")
+    text = jupytext.writes(nb, fmt="py:percent")
+    assert isinstance(text, str)
+    assert "print(1)" in text
+    # Re-reading the emitted text reproduces the same single code cell.
+    nb2 = jupytext.reads(text, fmt="py:percent")
+    assert len(nb2.cells) == 1
+    assert nb2.cells[0].source == "print(1)"
+
+
+def test_writes_ipynb_roundtrip():
+    nb = jupytext.reads("# %%\nprint(1)\n", fmt="py:percent")
+    ipynb = jupytext.writes(nb, fmt="ipynb")
+    assert isinstance(ipynb, str)
+    # The ipynb form is JSON text.
+    assert ipynb.lstrip().startswith("{")
+    back = jupytext.reads(ipynb, fmt="ipynb")
+    assert len(back.cells) == 1
+    assert back.cells[0].source == "print(1)"
+
+
+def test_multi_cell_percent_script():
+    src = "# %% [markdown]\n# a heading\n\n# %%\nx = 2\nprint(x)\n"
+    nb = jupytext.reads(src, fmt="py:percent")
+    assert len(nb.cells) == 2
+    assert nb.cells[0].cell_type == "markdown"
+    assert nb.cells[1].cell_type == "code"
+    assert "print(x)" in nb.cells[1].source
+
+
+run_test("reads py:percent -> notebook", test_reads_percent_script_to_notebook)
+run_test("writes py:percent roundtrip", test_writes_percent_roundtrip)
+run_test("writes ipynb roundtrip", test_writes_ipynb_roundtrip)
+run_test("multi-cell percent script", test_multi_cell_percent_script)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all jupytext smoke tests passed")

--- a/cli/scripts/lib-validator/kaleido.py
+++ b/cli/scripts/lib-validator/kaleido.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `kaleido` package.
+
+Fully self-contained: no input files, no network, no packages beyond kaleido
+itself. kaleido is plotly's static-image exporter and needs BOTH plotly and a
+bundled Chromium backend to actually render an image — so this smoke test is
+deliberately MODEST: it only asserts the package imports and exposes its
+version and exporter surface. It never exports an image (that would spawn
+Chromium). Exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 kaleido.py
+
+Install: pip install kaleido   (import name: kaleido)
+
+FLAG — Chromium: real image export (`fig.to_image` / `fig.write_image` via
+plotly, or kaleido's own exporter) launches the bundled Chromium; this test
+intentionally does not do that, so a green run does NOT prove image export
+works end-to-end — only that the package is importable.
+
+FLAG — version API: kaleido's public API changed across major versions. The
+0.x line exposed a scope-based exporter (`kaleido.scopes.plotly.PlotlyScope` /
+a `Scope` object); the 1.x rewrite moved to a `Kaleido` class plus top-level
+`calc_fig`/`write_fig` helpers. The API-surface check below accepts EITHER
+shape rather than pinning one.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import kaleido
+except ImportError:
+    print("FAIL: package 'kaleido' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"kaleido version: {_version(kaleido, 'kaleido')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_module_imports_and_names_itself():
+    assert kaleido.__name__ == "kaleido"
+
+
+def test_version_string_present():
+    v = _version(kaleido, "kaleido")
+    assert isinstance(v, str)
+    assert v and v != "unknown"
+
+
+def test_exposes_known_exporter_surface():
+    # Accept either the legacy scope-based API or the 1.x Kaleido/calc_fig API
+    # (see the module docstring's version FLAG). We assert only that an
+    # exporter surface EXISTS — we never invoke it, because a real export needs
+    # plotly + the bundled Chromium, which this smoke test deliberately avoids.
+    legacy = hasattr(kaleido, "scopes") or hasattr(kaleido, "Scope")
+    modern = (
+        hasattr(kaleido, "Kaleido")
+        or hasattr(kaleido, "calc_fig")
+        or hasattr(kaleido, "calc_fig_sync")
+        or hasattr(kaleido, "write_fig")
+        or hasattr(kaleido, "write_fig_sync")
+    )
+    assert legacy or modern
+
+
+run_test("module imports and names itself", test_module_imports_and_names_itself)
+run_test("version string present", test_version_string_present)
+run_test("exposes known exporter surface", test_exposes_known_exporter_surface)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all kaleido smoke tests passed")

--- a/cli/scripts/lib-validator/leidenalg.py
+++ b/cli/scripts/lib-validator/leidenalg.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `leidenalg` package.
+
+Fully self-contained: no input files, no network, no packages beyond leidenalg
+(and its implied dep — python-igraph). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 leidenalg.py
+
+Install: pip install leidenalg   (import name: leidenalg)
+
+FLAG — igraph dependency. leidenalg operates on `igraph.Graph` objects and does
+NOT vendor igraph; the test imports `igraph` too. If igraph is missing the
+relevant checks fail (isolated by the harness) rather than crashing.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import leidenalg
+except ImportError:
+    print("FAIL: package 'leidenalg' is not installed")
+    sys.exit(1)
+
+import math
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"leidenalg version: {_version(leidenalg, 'leidenalg')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_partition_zachary():
+    # FLAG: needs python-igraph. Zachary's karate club is a fixed 34-node graph.
+    import igraph
+
+    g = igraph.Graph.Famous("Zachary")
+    assert g.vcount() == 34
+    part = leidenalg.find_partition(g, leidenalg.RBConfigurationVertexPartition, seed=0)
+    assert len(part.membership) == 34
+    assert math.isfinite(part.modularity)
+    assert len(set(part.membership)) >= 2
+
+
+def test_modularity_partition_flavour():
+    import igraph
+
+    g = igraph.Graph.Famous("Zachary")
+    part = leidenalg.find_partition(g, leidenalg.ModularityVertexPartition, seed=0)
+    assert len(part.membership) == 34
+    assert math.isfinite(part.modularity)
+    assert part.modularity > 0.0
+
+
+run_test("find_partition on Zachary (RBConfiguration, needs igraph)", test_partition_zachary)
+run_test("ModularityVertexPartition modularity finite", test_modularity_partition_flavour)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all leidenalg smoke tests passed")

--- a/cli/scripts/lib-validator/liana.py
+++ b/cli/scripts/lib-validator/liana.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `liana` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 liana.py
+
+Install: pip install "liana[extras]"   (import name: liana)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: liana is ligand-receptor / cell-cell communication. Running
+rank_aggregate needs an AnnData with cell-type labels, and resource fetching
+(the ligand-receptor database) may hit the network — NEITHER is done here.
+This only asserts the package imports and exposes its documented method entry
+points (mt.rank_aggregate, the method namespace); it does NOT run the full
+method or fetch a resource. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import liana
+except ImportError:
+    print("FAIL: package 'liana' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"liana version: {_version(liana, 'liana')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_method_and_mt_namespaces():
+    assert hasattr(liana, "mt")
+    assert hasattr(liana, "method")
+
+
+def test_exposes_rank_aggregate():
+    # rank_aggregate is liana's consensus multi-method entry point.
+    assert hasattr(liana.mt, "rank_aggregate")
+
+
+run_test("exposes liana.mt / liana.method", test_exposes_method_and_mt_namespaces)
+run_test("exposes mt.rank_aggregate", test_exposes_rank_aggregate)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all liana smoke tests passed")

--- a/cli/scripts/lib-validator/lifelines.py
+++ b/cli/scripts/lib-validator/lifelines.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `lifelines` package.
+
+Fully self-contained: no input files, no network, no packages beyond lifelines
+and its implied deps (numpy, pandas, scipy). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 lifelines.py
+
+Install: pip install lifelines   (import name: lifelines)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import lifelines
+except ImportError:
+    print("FAIL: package 'lifelines' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"lifelines version: {_version(lifelines, 'lifelines')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_kaplan_meier_monotone_from_one():
+    from lifelines import KaplanMeierFitter
+
+    rng = np.random.default_rng(0)
+    durations = rng.exponential(scale=10.0, size=200)
+    events = rng.integers(0, 2, size=200)  # 0/1 censoring indicator
+    kmf = KaplanMeierFitter()
+    kmf.fit(durations, event_observed=events)
+    vals = kmf.survival_function_.values.ravel()
+    # Survival curve starts at 1, is non-increasing, and stays within [0, 1].
+    assert np.isclose(vals[0], 1.0)
+    assert np.all(np.diff(vals) <= 1e-9)
+    assert np.all((vals >= -1e-9) & (vals <= 1.0 + 1e-9))
+    assert kmf.median_survival_time_ > 0.0
+
+
+def test_cox_ph_summary_and_concordance():
+    from lifelines import CoxPHFitter
+
+    rng = np.random.default_rng(1)
+    n = 300
+    x = rng.normal(size=n)
+    # Higher x raises the hazard, so it shortens the simulated survival time.
+    baseline = rng.exponential(scale=10.0, size=n)
+    T = baseline * np.exp(-0.8 * x)
+    E = np.ones(n, dtype=int)  # every subject observed (uncensored)
+    df = pd.DataFrame({"T": T, "E": E, "x": x})
+    cph = CoxPHFitter()
+    cph.fit(df, duration_col="T", event_col="E")
+    summ = cph.summary
+    assert isinstance(summ, pd.DataFrame)
+    assert "coef" in summ.columns and "p" in summ.columns
+    # A hazard-raising covariate yields a positive Cox coefficient.
+    assert float(summ.loc["x", "coef"]) > 0.0
+    c = cph.concordance_index_
+    assert 0.0 <= c <= 1.0
+    # A real prognostic signal discriminates better than a coin flip.
+    assert c > 0.5
+
+
+run_test("Kaplan-Meier monotone from 1", test_kaplan_meier_monotone_from_one)
+run_test("CoxPH summary + concordance", test_cox_ph_summary_and_concordance)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all lifelines smoke tests passed")

--- a/cli/scripts/lib-validator/limma.R
+++ b/cli/scripts/lib-validator/limma.R
@@ -1,0 +1,110 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `limma` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# limma itself. All data is simulated with a fixed seed; differential-
+# expression checks are structural / tolerance-based, never exact floating-
+# point equality. Exercises the core API surface and exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript limma.R
+
+if (!requireNamespace("limma", quietly = TRUE)) {
+  cat("FAIL: package 'limma' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(limma))
+cat(sprintf("limma version: %s\n", as.character(packageVersion("limma"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate a 200-gene x 12-sample log-expression matrix: two groups, 6 vs 6.
+# Baseline expression ~ N(6, 1); the first 20 genes (the planted DE set) get
+# a strong +3 shift in group B. The remaining 180 genes are null.
+# The effect size (+3 SD) and replication (6/group) are chosen so the planted
+# genes clear a BH-adjusted 0.05 threshold across all 200 genes with margin —
+# a smaller effect / 3-per-group leaves the recovery below the assertions after
+# multiple-testing correction, which is a property of the test setup, not limma.
+set.seed(1)
+n_genes <- 200L
+n_per <- 6L
+n_de <- 20L
+expr <- matrix(
+  rnorm(n_genes * 2L * n_per, mean = 6, sd = 1),
+  nrow = n_genes,
+  ncol = 2L * n_per
+)
+b_cols <- (n_per + 1L):(2L * n_per) # group B columns
+expr[1:n_de, b_cols] <- expr[1:n_de, b_cols] + 3
+rownames(expr) <- sprintf("gene%03d", seq_len(n_genes))
+colnames(expr) <- sprintf("s%d", seq_len(2L * n_per))
+grp <- factor(rep(c("A", "B"), each = n_per))
+de_names <- sprintf("gene%03d", 1:n_de)
+
+# Design has an intercept + a grpB coefficient (coef 2 is the group effect).
+fit_limma <- function() {
+  design <- model.matrix(~grp)
+  eBayes(lmFit(expr, design))
+}
+
+run_test("lmFit + eBayes: MArrayLM object and coefficient shape", function() {
+  fit <- fit_limma()
+  stopifnot(inherits(fit, "MArrayLM"))
+  stopifnot(nrow(fit$coefficients) == n_genes)
+  stopifnot(ncol(fit$coefficients) == 2L)
+  stopifnot(!is.null(fit$t), !is.null(fit$p.value))
+})
+
+run_test("topTable: table shape and required columns", function() {
+  fit <- fit_limma()
+  tt <- topTable(fit, coef = 2, number = Inf)
+  stopifnot(nrow(tt) == n_genes)
+  stopifnot(all(c("logFC", "P.Value", "adj.P.Val") %in% colnames(tt)))
+})
+
+run_test("topTable: planted genes detected with correct sign", function() {
+  fit <- fit_limma()
+  tt <- topTable(fit, coef = 2, number = Inf)
+  # Planted genes are +2 in group B, so the grpB logFC must be positive and
+  # they should dominate the most-significant end of the table.
+  stopifnot(median(tt[de_names, "logFC"]) > 1.5)
+  top50 <- rownames(tt)[1:50]
+  stopifnot(sum(de_names %in% top50) >= 15L)
+  stopifnot(median(tt[de_names, "adj.P.Val"]) < 0.05)
+})
+
+run_test("topTable: null genes are not significant on average", function() {
+  fit <- fit_limma()
+  tt <- topTable(fit, coef = 2, number = Inf)
+  null_names <- sprintf("gene%03d", (n_de + 1L):n_genes)
+  stopifnot(abs(median(tt[null_names, "logFC"])) < 0.5)
+  stopifnot(median(tt[null_names, "adj.P.Val"]) > 0.1)
+})
+
+run_test("decideTests: planted genes flagged up in group B", function() {
+  fit <- fit_limma()
+  dt <- decideTests(fit)
+  stopifnot(inherits(dt, "TestResults"))
+  # Column 2 is the grpB coefficient; a +1 call == significantly up.
+  calls <- as.numeric(dt[, 2])
+  stopifnot(sum(calls[1:n_de] == 1) >= 15L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all limma smoke tests passed\n")

--- a/cli/scripts/lib-validator/lme4.R
+++ b/cli/scripts/lib-validator/lme4.R
@@ -1,0 +1,135 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `lme4` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# lme4 itself (and the dependencies it implies). Uses the bundled
+# `sleepstudy` dataset plus data simulated with fixed seeds; model-fit
+# checks are structural / tolerance-based, never exact floating-point
+# equality. Exercises the core API surface and exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript lme4.R
+
+if (!requireNamespace("lme4", quietly = TRUE)) {
+  cat("FAIL: package 'lme4' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(lme4))
+cat(sprintf("lme4 version: %s\n", as.character(packageVersion("lme4"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Bundled dataset: 18 subjects x 10 days of reaction times.
+data(sleepstudy, package = "lme4")
+
+# suppressMessages/suppressWarnings silence benign optimizer/convergence
+# chatter only -- real errors still propagate to run_test's tryCatch.
+fit_sleepstudy_lmm <- function() {
+  suppressMessages(suppressWarnings(
+    lmer(Reaction ~ Days + (Days | Subject), data = sleepstudy)
+  ))
+}
+
+# Simulated logistic GLMM: 24 groups x 15 obs, random intercepts (sd 0.8),
+# true fixed effects intercept -0.4 and slope +1.2.
+simulate_glmm_data <- function() {
+  set.seed(42)
+  n_grp <- 24L
+  n_per <- 15L
+  g <- factor(rep(seq_len(n_grp), each = n_per))
+  x <- rnorm(n_grp * n_per)
+  b <- rnorm(n_grp, sd = 0.8)
+  eta <- -0.4 + 1.2 * x + b[as.integer(g)]
+  data.frame(y = rbinom(length(eta), 1L, plogis(eta)), x = x, g = g)
+}
+
+fit_sim_glmm <- function(d) {
+  suppressMessages(suppressWarnings(
+    glmer(y ~ x + (1 | g), data = d, family = binomial)
+  ))
+}
+
+run_test("lmer: model class and fixed-effect recovery", function() {
+  fit <- fit_sleepstudy_lmm()
+  stopifnot(inherits(fit, "merMod"), inherits(fit, "lmerMod"))
+  fe <- fixef(fit)
+  stopifnot(length(fe) == 2L)
+  stopifnot(identical(names(fe), c("(Intercept)", "Days")))
+  stopifnot(all(is.finite(fe)))
+  # Days slope is positive and near the well-known ~10.47 ms/day estimate.
+  stopifnot(fe[["Days"]] > 0)
+  stopifnot(abs(fe[["Days"]] - 10.47) < 3)
+})
+
+run_test("lmer: log-likelihood and residual scale are finite", function() {
+  fit <- fit_sleepstudy_lmm()
+  ll <- as.numeric(logLik(fit))
+  stopifnot(length(ll) == 1L, is.finite(ll))
+  stopifnot(is.finite(sigma(fit)), sigma(fit) > 0)
+})
+
+run_test("lmer: fitted values and predictions", function() {
+  fit <- fit_sleepstudy_lmm()
+  fv <- fitted(fit)
+  stopifnot(length(fv) == nrow(sleepstudy), all(is.finite(fv)))
+  pr <- predict(fit, newdata = sleepstudy[1:5, ])
+  stopifnot(length(pr) == 5L, all(is.finite(pr)))
+})
+
+run_test("lmer: random-effect structure (VarCorr, ranef)", function() {
+  fit <- fit_sleepstudy_lmm()
+  vc <- VarCorr(fit)
+  stopifnot(!is.null(vc))
+  vcd <- as.data.frame(vc)
+  stopifnot(nrow(vcd) >= 3L, all(is.finite(vcd$vcov)))
+  # Both random-effect standard deviations are strictly positive.
+  sd_subj <- attr(vc$Subject, "stddev")
+  stopifnot(length(sd_subj) == 2L, all(sd_subj > 0))
+  re <- ranef(fit)
+  stopifnot(!is.null(re$Subject))
+  stopifnot(nrow(re$Subject) == nlevels(sleepstudy$Subject))
+  stopifnot(ncol(re$Subject) == 2L)
+})
+
+run_test("glmer: binomial GLMM recovers the simulated slope", function() {
+  d <- simulate_glmm_data()
+  fit <- fit_sim_glmm(d)
+  stopifnot(inherits(fit, "merMod"), inherits(fit, "glmerMod"))
+  fe <- fixef(fit)
+  stopifnot(length(fe) == 2L, all(is.finite(fe)))
+  # True slope is +1.2; require the right sign and a generous tolerance.
+  stopifnot(fe[["x"]] > 0)
+  stopifnot(abs(fe[["x"]] - 1.2) < 0.8)
+  stopifnot(is.finite(as.numeric(logLik(fit))))
+  stopifnot(is.finite(deviance(fit)))
+})
+
+run_test("glmer: fitted probabilities and per-group effects", function() {
+  d <- simulate_glmm_data()
+  fit <- fit_sim_glmm(d)
+  p <- fitted(fit)
+  stopifnot(length(p) == nrow(d), all(is.finite(p)))
+  stopifnot(all(p >= 0 & p <= 1))
+  re <- ranef(fit)
+  stopifnot(nrow(re$g) == nlevels(d$g))
+  stopifnot(all(is.finite(re$g[["(Intercept)"]])))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all lme4 smoke tests passed\n")

--- a/cli/scripts/lib-validator/louvain.py
+++ b/cli/scripts/lib-validator/louvain.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `louvain` package.
+
+Fully self-contained: no input files, no network, no packages beyond louvain
+(and its implied dep — python-igraph). Exercises the core API surface and exits
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 louvain.py
+
+Install: pip install louvain   (import name: louvain)
+
+FLAG — igraph dependency. louvain operates on `igraph.Graph` objects and does
+NOT vendor igraph; the test imports `igraph` too. If igraph is missing the
+relevant checks fail (isolated by the harness) rather than crashing.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import louvain
+except ImportError:
+    print("FAIL: package 'louvain' is not installed")
+    sys.exit(1)
+
+import math
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"louvain version: {_version(louvain, 'louvain')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_partition_zachary():
+    # FLAG: needs python-igraph. Zachary's karate club is a fixed 34-node graph.
+    import igraph
+
+    g = igraph.Graph.Famous("Zachary")
+    assert g.vcount() == 34
+    part = louvain.find_partition(g, louvain.ModularityVertexPartition, seed=0)
+    assert len(part.membership) == 34
+    assert math.isfinite(part.modularity)
+    assert part.modularity > 0.0
+    assert len(set(part.membership)) >= 2
+
+
+def test_rbconfiguration_flavour():
+    import igraph
+
+    g = igraph.Graph.Famous("Zachary")
+    part = louvain.find_partition(g, louvain.RBConfigurationVertexPartition, seed=0)
+    assert len(part.membership) == 34
+    assert math.isfinite(part.modularity)
+
+
+run_test("find_partition on Zachary (Modularity, needs igraph)", test_partition_zachary)
+run_test("RBConfigurationVertexPartition modularity finite", test_rbconfiguration_flavour)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all louvain smoke tests passed")

--- a/cli/scripts/lib-validator/matchms.py
+++ b/cli/scripts/lib-validator/matchms.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `matchms` package.
+
+Fully self-contained: no input files, no network, no packages beyond matchms
+(and its implied deps: numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 matchms.py
+
+Install: pip install matchms   (import name: matchms)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import matchms
+except ImportError:
+    print("FAIL: package 'matchms' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"matchms version: {_version(matchms, 'matchms')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# matchms is genuinely offline-shaped: a Spectrum is built from in-memory
+# arrays, and its filters/similarities are deterministic. m/z must be sorted
+# ascending, which it is here.
+def _spectrum():
+    import numpy as np
+
+    return matchms.Spectrum(
+        mz=np.array([100.0, 150.0, 200.0]),
+        intensities=np.array([0.1, 1.0, 0.5]),
+        metadata={"precursor_mz": 250.0},
+    )
+
+
+def test_spectrum_construct_and_metadata():
+    import numpy as np
+
+    spec = _spectrum()
+    assert np.array_equal(spec.peaks.mz, np.array([100.0, 150.0, 200.0]))
+    assert np.array_equal(spec.peaks.intensities, np.array([0.1, 1.0, 0.5]))
+    assert abs(float(spec.get("precursor_mz")) - 250.0) < 1e-9
+
+
+def test_normalize_intensities_max_is_one():
+    from matchms.filtering import normalize_intensities
+
+    normalized = normalize_intensities(_spectrum())
+    assert abs(float(normalized.peaks.intensities.max()) - 1.0) < 1e-9
+
+
+def test_cosine_greedy_self_similarity():
+    from matchms.similarity import CosineGreedy
+
+    spec = _spectrum()
+    score = CosineGreedy().pair(spec, spec)
+    # A spectrum's cosine similarity with itself is 1.0.
+    assert abs(float(score["score"]) - 1.0) < 1e-6
+
+
+run_test("Spectrum construct + metadata", test_spectrum_construct_and_metadata)
+run_test("normalize_intensities -> max 1.0", test_normalize_intensities_max_is_one)
+run_test("CosineGreedy self-similarity ~1.0", test_cosine_greedy_self_similarity)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all matchms smoke tests passed")

--- a/cli/scripts/lib-validator/matplotlib-venn.py
+++ b/cli/scripts/lib-validator/matplotlib-venn.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `matplotlib-venn` package (import name: matplotlib_venn).
+
+Fully self-contained: no input files, no network, no packages beyond
+matplotlib-venn (and its implied dep: matplotlib). Forces the headless Agg
+backend before importing the package, so it never opens a window. Exercises the
+core API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 matplotlib-venn.py
+
+Install: pip install matplotlib-venn   (import name: matplotlib_venn)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+# Force the non-interactive Agg backend BEFORE matplotlib_venn (which imports
+# pyplot at module load): this test runs headless (CI, no DISPLAY), must never
+# pop a window, and Agg renders to memory. matplotlib is a hard dependency of
+# matplotlib-venn, so importing it here is safe whenever the package is present.
+import matplotlib
+
+matplotlib.use("Agg")
+
+try:
+    import matplotlib_venn
+except ImportError:
+    print("FAIL: package 'matplotlib-venn' is not installed")
+    sys.exit(1)
+
+import matplotlib.pyplot as plt
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"matplotlib-venn version: {_version(matplotlib_venn, 'matplotlib-venn')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_venn2_diagram_and_labels():
+    fig, ax = plt.subplots()
+    try:
+        v = matplotlib_venn.venn2(subsets=(3, 2, 1), ax=ax)
+        assert v is not None
+        # Region "10" is "in A only"; its subset size (3) becomes the label text.
+        label = v.get_label_by_id("10")
+        assert label is not None
+        assert label.get_text() == "3"
+        # Every region also carries a drawable patch.
+        assert v.get_patch_by_id("10") is not None
+    finally:
+        plt.close(fig)
+
+
+def test_venn3_diagram_and_labels():
+    fig, ax = plt.subplots()
+    try:
+        v = matplotlib_venn.venn3(subsets=(1, 2, 3, 4, 5, 6, 7), ax=ax)
+        assert v is not None
+        # Region "100" is "in A only" -> first subset value (1).
+        label = v.get_label_by_id("100")
+        assert label is not None
+        assert label.get_text() == "1"
+        assert v.get_patch_by_id("111") is not None
+    finally:
+        plt.close(fig)
+
+
+run_test("venn2 diagram + labels", test_venn2_diagram_and_labels)
+run_test("venn3 diagram + labels", test_venn3_diagram_and_labels)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all matplotlib-venn smoke tests passed")

--- a/cli/scripts/lib-validator/matplotlib.py
+++ b/cli/scripts/lib-validator/matplotlib.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `matplotlib` package.
+
+Fully self-contained: no input files, no network, no packages beyond
+matplotlib (and its implied deps). Forces the headless Agg backend before any
+pyplot import, so it never opens a window. Exercises the core plotting API and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 matplotlib.py
+
+Install: pip install matplotlib   (import name: matplotlib)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import matplotlib
+except ImportError:
+    print("FAIL: package 'matplotlib' is not installed")
+    sys.exit(1)
+
+# Force the non-interactive Agg backend BEFORE importing pyplot: this test runs
+# headless (CI, no DISPLAY), must never pop a window, and Agg renders to memory
+# / PNG. Selecting the backend after pyplot is imported is a no-op, so it has to
+# come first.
+matplotlib.use("Agg")
+import tempfile
+
+import matplotlib.pyplot as plt
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"matplotlib version: {_version(matplotlib, 'matplotlib')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_line_plot_data_roundtrips():
+    fig, ax = plt.subplots()
+    try:
+        (line,) = ax.plot([0, 1, 2, 3], [0, 1, 4, 9])
+        assert len(ax.lines) == 1
+        assert ax.lines[0] is line
+        assert [int(v) for v in line.get_xdata()] == [0, 1, 2, 3]
+        assert [int(v) for v in line.get_ydata()] == [0, 1, 4, 9]
+    finally:
+        plt.close(fig)
+
+
+def test_title_set_and_get():
+    fig, ax = plt.subplots()
+    try:
+        ax.set_title("smoke test")
+        assert ax.get_title() == "smoke test"
+    finally:
+        plt.close(fig)
+
+
+def test_savefig_png_to_tempfile():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 4, 9])
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    try:
+        fig.savefig(path)
+        assert os.path.getsize(path) > 0
+    finally:
+        os.remove(path)
+        plt.close(fig)
+
+
+def test_colormap_lookup():
+    cmap = matplotlib.colormaps["viridis"]
+    assert cmap.N == 256
+    rgba = cmap(0.0)
+    assert len(rgba) == 4
+    # RGBA channels are normalized floats in [0, 1].
+    assert all(0.0 <= float(c) <= 1.0 for c in rgba)
+
+
+def test_figure_dimensions():
+    fig = plt.figure()
+    try:
+        fig.set_size_inches(4, 3)
+        w, h = fig.get_size_inches()
+        assert abs(float(w) - 4.0) < 1e-9
+        assert abs(float(h) - 3.0) < 1e-9
+        assert abs(fig.get_figwidth() - 4.0) < 1e-9
+        assert abs(fig.get_figheight() - 3.0) < 1e-9
+    finally:
+        plt.close(fig)
+
+
+run_test("line plot data roundtrips", test_line_plot_data_roundtrips)
+run_test("axes title set/get", test_title_set_and_get)
+run_test("savefig PNG to tempfile", test_savefig_png_to_tempfile)
+run_test("colormap lookup", test_colormap_lookup)
+run_test("figure dimensions", test_figure_dimensions)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all matplotlib smoke tests passed")

--- a/cli/scripts/lib-validator/matrixStats.R
+++ b/cli/scripts/lib-validator/matrixStats.R
@@ -1,0 +1,76 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `matrixStats` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# matrixStats itself. Each check builds a fixed, seeded matrix and asserts
+# that the matrixStats routine agrees with its base-R equivalent within
+# tolerance. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript matrixStats.R
+
+if (!requireNamespace("matrixStats", quietly = TRUE)) {
+  cat("FAIL: package 'matrixStats' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(matrixStats))
+cat(sprintf("matrixStats version: %s\n", as.character(packageVersion("matrixStats"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# A fresh, deterministic matrix per test keeps the checks order-independent.
+make_x <- function() {
+  set.seed(1)
+  matrix(rnorm(50 * 4), 50, 4)
+}
+
+run_test("rowMedians matches base median", function() {
+  x <- make_x()
+  stopifnot(isTRUE(all.equal(matrixStats::rowMedians(x), apply(x, 1, median), tolerance = 1e-9)))
+})
+
+run_test("colVars and colSds match base", function() {
+  x <- make_x()
+  stopifnot(isTRUE(all.equal(matrixStats::colVars(x), apply(x, 2, var), tolerance = 1e-9)))
+  stopifnot(isTRUE(all.equal(matrixStats::colSds(x), apply(x, 2, sd), tolerance = 1e-9)))
+})
+
+run_test("rowSums2 and colSums2 match base", function() {
+  x <- make_x()
+  stopifnot(isTRUE(all.equal(matrixStats::rowSums2(x), rowSums(x), tolerance = 1e-9)))
+  stopifnot(isTRUE(all.equal(matrixStats::colSums2(x), colSums(x), tolerance = 1e-9)))
+})
+
+run_test("colMaxs and colMins match base", function() {
+  x <- make_x()
+  stopifnot(isTRUE(all.equal(matrixStats::colMaxs(x), apply(x, 2, max), tolerance = 1e-9)))
+  stopifnot(isTRUE(all.equal(matrixStats::colMins(x), apply(x, 2, min), tolerance = 1e-9)))
+})
+
+run_test("colQuantiles shape and endpoints", function() {
+  x <- make_x()
+  q <- matrixStats::colQuantiles(x, probs = c(0, 0.5, 1))
+  stopifnot(is.matrix(q), nrow(q) == 4L, ncol(q) == 3L)
+  stopifnot(isTRUE(all.equal(unname(q[, 1]), apply(x, 2, min), tolerance = 1e-9)))
+  stopifnot(isTRUE(all.equal(unname(q[, 2]), apply(x, 2, median), tolerance = 1e-9)))
+  stopifnot(isTRUE(all.equal(unname(q[, 3]), apply(x, 2, max), tolerance = 1e-9)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all matrixStats smoke tests passed\n")

--- a/cli/scripts/lib-validator/methylclock.R
+++ b/cli/scripts/lib-validator/methylclock.R
@@ -1,0 +1,86 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `methylclock` package.
+#
+# Fully self-contained: no input files, NO network. methylclock computes
+# epigenetic ("DNA-methylation") age from a beta matrix using published clocks
+# (Horvath, Hannum, ...). This test is deliberately MODEST: a real age
+# computation is NOT meaningfully testable offline with synthetic data (see
+# FLAGS), so we assert the package loads and its core API surface is present.
+# Exits 0 only if every check passes, so it works as a pass/fail validator:
+#
+#   Rscript methylclock.R
+#
+# ============================ WHY MODEST — RE-CHECK =========================
+# What a FULL test would need but CANNOT be done blind/offline here:
+#   * DNAmAge(x) expects a beta matrix/data.frame whose ROWNAMES are real CpG
+#     probe ids that MATCH each clock's coefficient set (the Horvath/Hannum/...
+#     CpGs). Synthetic random `cg########` ids match NOTHING, so no clock can be
+#     evaluated and the result is empty/meaningless. A genuine test needs a real
+#     beta matrix covering the clock CpGs.
+#   * The clock COEFFICIENTS ship in a companion data package (`methylclockData`)
+#     that DNAmAge pulls from; if absent, a full run cannot proceed offline.
+# So the checks below are EXISTENCE + type of the exported entry points, plus a
+# SOFT inventory of any datasets bundled with the package. If DNAmAge/checkClocks
+# were renamed, the corresponding `::` lookup fails — that is the signal.
+# ============================================================================
+
+if (!requireNamespace("methylclock", quietly = TRUE)) {
+  cat("FAIL: package 'methylclock' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(methylclock))
+cat(sprintf("methylclock version: %s\n", as.character(packageVersion("methylclock"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("DNAmAge is an exported function", function() {
+  stopifnot(is.function(methylclock::DNAmAge))
+})
+
+run_test("checkClocks is an exported function", function() {
+  stopifnot(is.function(methylclock::checkClocks))
+})
+
+run_test("DNAmAge takes a data input as its first argument (SOFT)", function() {
+  # Structural sanity only — DNAmAge's first formal is the methylation beta
+  # object. Kept SOFT because the exact formal name varies across versions.
+  fmls <- tryCatch(names(formals(methylclock::DNAmAge)), error = function(e) character(0))
+  if (length(fmls) == 0L) {
+    cat("  note could not introspect DNAmAge() formals\n")
+    return(invisible(NULL))
+  }
+  cat(sprintf("  note DNAmAge() first arg is `%s` (feed a beta matrix keyed by clock CpGs)\n",
+              fmls[[1]]))
+})
+
+run_test("bundled datasets inventory (SOFT)", function() {
+  # If the package (or a loaded companion) ships example/coefficient objects
+  # offline, report them; do NOT guess names or assert on contents.
+  ds <- tryCatch(utils::data(package = "methylclock")$results, error = function(e) NULL)
+  n <- if (is.null(ds)) 0L else nrow(ds)
+  if (n == 0L) {
+    cat("  note no datasets bundled with methylclock itself (coefficients likely in methylclockData)\n")
+  } else {
+    cat(sprintf("  note methylclock bundles %d dataset(s): %s\n",
+                n, paste(utils::head(ds[, "Item"], 5L), collapse = ", ")))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all methylclock smoke tests passed\n")

--- a/cli/scripts/lib-validator/mgcv.R
+++ b/cli/scripts/lib-validator/mgcv.R
@@ -1,0 +1,111 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `mgcv` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond mgcv
+# itself (and its implied deps). Data is simulated with a fixed seed (either by
+# hand or via `mgcv::gamSim`). Exercises the core generalized-additive-model
+# API and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript mgcv.R
+#
+# Modeling outputs are floating-point, so checks assert structural/robust
+# properties (classes, lengths, finiteness, goodness-of-fit ranges) rather than
+# exact coefficient equality on the fitted smooths.
+
+if (!requireNamespace("mgcv", quietly = TRUE)) {
+  cat("FAIL: package 'mgcv' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(mgcv))
+cat(sprintf("mgcv version: %s\n", as.character(packageVersion("mgcv"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("gam smooth recovers a sine signal (simulated)", function() {
+  set.seed(42)
+  n <- 200L
+  x <- sort(runif(n))
+  y <- sin(2 * pi * x) + rnorm(n, sd = 0.2)
+  fit <- gam(y ~ s(x))
+  stopifnot(inherits(fit, "gam"))
+  s <- summary(fit)
+  stopifnot(is.finite(s$r.sq))
+  # a low-noise sine is captured well by a spline smooth
+  stopifnot(s$r.sq > 0.5)
+  # a genuinely nonlinear smooth was fit -> effective df above the linear (1)
+  stopifnot(sum(fit$edf) > 1)
+})
+
+run_test("predict from a fitted gam", function() {
+  set.seed(42)
+  n <- 200L
+  x <- sort(runif(n))
+  y <- sin(2 * pi * x) + rnorm(n, sd = 0.2)
+  fit <- gam(y ~ s(x))
+  p <- predict(fit)
+  stopifnot(length(p) == n, all(is.finite(p)))
+  # prediction on fresh data returns one finite value per new row
+  nd <- data.frame(x = c(0.1, 0.25, 0.5, 0.75, 0.9))
+  pn <- predict(fit, newdata = nd)
+  stopifnot(length(pn) == nrow(nd), all(is.finite(pn)))
+})
+
+run_test("parametric gam term runs", function() {
+  set.seed(11)
+  n <- 150L
+  x <- runif(n)
+  y <- 2 + 3 * x + rnorm(n, sd = 0.1)
+  fit <- gam(y ~ x)
+  stopifnot(inherits(fit, "gam"))
+  cf <- coef(fit)
+  stopifnot(length(cf) == 2L, all(is.finite(cf)))
+  # strong positive linear trend -> positive slope
+  stopifnot(cf["x"] > 0)
+})
+
+run_test("gam with multiple smooths on gamSim data", function() {
+  set.seed(7)
+  sim <- gamSim(1, n = 400, verbose = FALSE)
+  fit <- gam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = sim)
+  stopifnot(inherits(fit, "gam"))
+  s <- summary(fit)
+  stopifnot(is.finite(s$r.sq), is.finite(s$dev.expl))
+  # the gamSim(1) surface is well explained by four additive smooths
+  stopifnot(s$r.sq > 0.5, s$dev.expl > 0.5)
+  # one smooth term per s(...) in the formula
+  stopifnot(length(fit$smooth) == 4L)
+})
+
+run_test("gam summary exposes the expected components", function() {
+  set.seed(7)
+  sim <- gamSim(1, n = 200, verbose = FALSE)
+  fit <- gam(y ~ s(x0) + s(x2), data = sim)
+  s <- summary(fit)
+  stopifnot(!is.null(s$p.table), !is.null(s$s.table))
+  # p.table has the parametric intercept row; s.table has one row per smooth
+  stopifnot(nrow(s$p.table) >= 1L)
+  stopifnot(nrow(s$s.table) == 2L)
+  # smooth-term p-values are valid probabilities
+  spv <- s$s.table[, "p-value"]
+  stopifnot(all(is.finite(spv)), all(spv >= 0), all(spv <= 1))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all mgcv smoke tests passed\n")

--- a/cli/scripts/lib-validator/mia.R
+++ b/cli/scripts/lib-validator/mia.R
@@ -1,0 +1,126 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `mia` package (Microbiome Analysis on the
+# TreeSummarizedExperiment / SummarizedExperiment container).
+#
+# Fully self-contained: no input files, no network, no packages beyond mia and
+# its container dependency (TreeSummarizedExperiment). A synthetic counts assay
+# with taxonomy rowData and grouping colData is assembled with a fixed seed;
+# checks are structural (new assays appear, a diversity column lands in
+# colData, agglomeration reduces the feature count) with tolerance/range
+# assertions on numeric outputs, never exact floating-point equality. Exits 0
+# only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript mia.R
+#
+# FLAG (unverified on this machine -- mia is NOT installed here): mia's function
+# names have been RENAMED repeatedly across releases and MUST be re-checked --
+#   * transformAssay() (older: transformCounts / transformSamples)
+#   * addAlpha() (older: estimateDiversity / estimateAlpha)
+#   * agglomerateByRank()
+# and the TreeSummarizedExperiment() constructor + assay.type/name argument
+# spellings likewise.
+
+if (!requireNamespace("mia", quietly = TRUE)) {
+  cat("FAIL: package 'mia' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(mia))
+cat(sprintf("mia version: %s\n", as.character(packageVersion("mia"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: 40 taxa x 12 samples of Poisson counts assembled into a
+# TreeSummarizedExperiment. rowData carries a two-column taxonomy (Phylum,
+# Genus) so agglomeration by rank has something to collapse; colData carries a
+# two-level grouping factor. Genus is intentionally lower-cardinality than the
+# raw taxa so agglomerateByRank reduces the feature count.
+set.seed(1)
+n_taxa <- 40L
+n_samp <- 12L
+taxa_ids <- sprintf("t%02d", seq_len(n_taxa))
+samp_ids <- sprintf("s%02d", seq_len(n_samp))
+counts <- matrix(
+  rpois(n_taxa * n_samp, lambda = 10),
+  nrow = n_taxa,
+  ncol = n_samp,
+  dimnames = list(taxa_ids, samp_ids)
+)
+row_data <- S4Vectors::DataFrame(
+  Phylum = rep(c("P1", "P2"), length.out = n_taxa),
+  Genus = rep(sprintf("G%02d", 1:8), length.out = n_taxa),
+  row.names = taxa_ids
+)
+col_data <- S4Vectors::DataFrame(
+  group = rep(c("a", "b"), length.out = n_samp),
+  row.names = samp_ids
+)
+
+build_tse <- function() {
+  TreeSummarizedExperiment::TreeSummarizedExperiment(
+    assays = list(counts = counts),
+    rowData = row_data,
+    colData = col_data
+  )
+}
+
+run_test("TreeSummarizedExperiment fixture builds with expected dims", function() {
+  tse <- build_tse()
+  stopifnot(inherits(tse, "TreeSummarizedExperiment"))
+  stopifnot(nrow(tse) == n_taxa, ncol(tse) == n_samp)
+  stopifnot("counts" %in% SummarizedExperiment::assayNames(tse))
+})
+
+run_test("transformAssay adds a relative-abundance assay", function() {
+  tse <- build_tse()
+  tse <- mia::transformAssay(tse, assay.type = "counts", method = "relabundance")
+  stopifnot("relabundance" %in% SummarizedExperiment::assayNames(tse))
+  ra <- SummarizedExperiment::assay(tse, "relabundance")
+  stopifnot(identical(dim(ra), c(n_taxa, n_samp)))
+  # Relative abundances are non-negative and each sample sums to ~1.
+  stopifnot(all(ra >= 0))
+  stopifnot(all(abs(colSums(ra) - 1) < 1e-8))
+})
+
+run_test("addAlpha lands a Shannon diversity column in colData", function() {
+  tse <- build_tse()
+  tse <- mia::addAlpha(tse, assay.type = "counts", index = "shannon")
+  cd <- SummarizedExperiment::colData(tse)
+  # The new column carries the index name (exact spelling may vary by version);
+  # locate it by prefix rather than an exact match.
+  div_col <- grep("shannon", colnames(cd), ignore.case = TRUE, value = TRUE)
+  stopifnot(length(div_col) >= 1L)
+  vals <- cd[[div_col[1]]]
+  stopifnot(length(vals) == n_samp)
+  stopifnot(all(is.finite(vals)), all(vals >= 0))
+})
+
+run_test("agglomerateByRank collapses features to the Genus rank", function() {
+  tse <- build_tse()
+  agg <- mia::agglomerateByRank(tse, rank = "Genus")
+  stopifnot(inherits(agg, "TreeSummarizedExperiment"))
+  # 8 distinct Genus labels -> at most 8 agglomerated features, fewer than the
+  # 40 raw taxa.
+  stopifnot(nrow(agg) <= 8L)
+  stopifnot(nrow(agg) < n_taxa)
+  stopifnot(ncol(agg) == n_samp)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all mia smoke tests passed\n")

--- a/cli/scripts/lib-validator/miaViz.R
+++ b/cli/scripts/lib-validator/miaViz.R
@@ -1,0 +1,98 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `miaViz` package (ggplot2-based visualisation for mia /
+# TreeSummarizedExperiment microbiome data).
+#
+# Fully self-contained: no input files, no network, no packages beyond miaViz
+# and its container dependency (TreeSummarizedExperiment). miaViz builds ggplot
+# objects rather than drawing to a device, so this test stays MODEST: it checks
+# the plotting entry points are exported, and -- only if a TreeSummarizedExperiment
+# can be assembled cheaply here -- that plotAbundance() returns a ggplot object
+# WITHOUT opening any graphics device. Exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript miaViz.R
+#
+# Verified against miaViz 1.18.1 (Bioc 3.22): the plotting function names
+# (plotAbundance, plotAbundanceDensity, plotRowTree) and plotAbundance()'s
+# rank/assay.type arguments. Note miaViz has no plotColData (that is scater);
+# colData is plotted via plotColTile/plotColGraph.
+
+if (!requireNamespace("miaViz", quietly = TRUE)) {
+  cat("FAIL: package 'miaViz' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(miaViz))
+cat(sprintf("miaViz version: %s\n", as.character(packageVersion("miaViz"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core plotting functions are exported and callable", function() {
+  # NB: colData is visualised by plotColTile/plotColGraph in miaViz — there is no
+  # plotColData here (that name belongs to scater, a different package).
+  stopifnot(is.function(plotAbundance))
+  stopifnot(is.function(plotAbundanceDensity))
+  stopifnot(is.function(plotRowTree))
+})
+
+# Only attempt the render check when a TreeSummarizedExperiment can actually be
+# constructed on this machine; otherwise the exported-functions check above is
+# the whole smoke test (no failing assertion is added blind).
+if (requireNamespace("TreeSummarizedExperiment", quietly = TRUE)) {
+  set.seed(1)
+  n_taxa <- 30L
+  n_samp <- 8L
+  taxa_ids <- sprintf("t%02d", seq_len(n_taxa))
+  samp_ids <- sprintf("s%d", seq_len(n_samp))
+  counts <- matrix(
+    rpois(n_taxa * n_samp, lambda = 10),
+    nrow = n_taxa,
+    ncol = n_samp,
+    dimnames = list(taxa_ids, samp_ids)
+  )
+  row_data <- S4Vectors::DataFrame(
+    Phylum = rep(c("P1", "P2"), length.out = n_taxa),
+    row.names = taxa_ids
+  )
+  col_data <- S4Vectors::DataFrame(
+    group = rep(c("a", "b"), length.out = n_samp),
+    row.names = samp_ids
+  )
+  tse <- TreeSummarizedExperiment::TreeSummarizedExperiment(
+    assays = list(counts = counts),
+    rowData = row_data,
+    colData = col_data
+  )
+
+  run_test("plotAbundance returns a ggplot without drawing to a device", function() {
+    # ggplot construction touches no device; guard anyway so a stray draw can't
+    # spawn an Rplots.pdf in the working directory.
+    p <- plotAbundance(tse, assay.type = "counts", rank = "Phylum")
+    stopifnot(inherits(p, "ggplot"))
+  })
+
+  run_test("plotAbundanceDensity returns a ggplot without drawing to a device", function() {
+    p <- plotAbundanceDensity(tse, assay.type = "counts")
+    stopifnot(inherits(p, "ggplot"))
+  })
+} else {
+  cat("  note miaViz: TreeSummarizedExperiment unavailable; skipping render checks\n")
+}
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all miaViz smoke tests passed\n")

--- a/cli/scripts/lib-validator/minfi.R
+++ b/cli/scripts/lib-validator/minfi.R
@@ -1,0 +1,112 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `minfi` (Bioconductor) package.
+#
+# Fully self-contained: no input files, no network. minfi normally starts from
+# raw Illumina 450K/EPIC methylation arrays (per-sample .idat files) read into
+# an RGChannelSet -- which we do NOT have and must NOT fetch. But minfi's core
+# methylation math is checkable OFFLINE by constructing a MethylSet directly
+# from SYNTHETIC methylated/unmethylated intensity matrices (no IDATs, no array
+# annotation needed), then verifying the beta / M-value definitions against
+# their closed-form formulas. Exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript minfi.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# This is the richest offline test of the methylation set, but three minfi API
+# details are load-bearing and MUST be re-verified once installed:
+#   - CONSTRUCTOR: MethylSet(Meth = <matrix>, Unmeth = <matrix>) -- the two
+#     assay args are capitalized "Meth"/"Unmeth". If those names drift the
+#     "constructs" test fails first, flagging it.
+#   - getBeta() OFFSET: beta = Meth / (Meth + Unmeth + offset) with the DEFAULT
+#     offset = 100. The expected-beta below hardcodes 100; a changed default
+#     would fail the beta test.
+#   - getM() DEFAULT: assumed to be log2(Meth / Unmeth) for a raw MethylSet (the
+#     type="" branch), NOT logit2(getBeta(...)). If minfi's default changed to a
+#     beta-derived M, the M-value test fails -- re-confirm the definition.
+# The intensities are drawn strictly positive so beta is well-defined in (0,1)
+# and log2(Meth/Unmeth) is finite; checks are tolerance/structural, never
+# equality on anything sampled.
+# ============================================================================
+
+if (!requireNamespace("minfi", quietly = TRUE)) {
+  cat("FAIL: package 'minfi' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(minfi))
+cat(sprintf("minfi version: %s\n", as.character(packageVersion("minfi"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic methylation intensities: 50 CpG probes x 4 samples, strictly
+# positive (drawn in [200, 8000]) so beta in (0,1) and log2(Meth/Unmeth) finite.
+# Fixed seed -> deterministic; rownames are cg-style probe ids, colnames sample
+# ids, matching what a real MethylSet carries.
+set.seed(42)
+n_probes <- 50L
+n_samples <- 4L
+meth <- matrix(runif(n_probes * n_samples, 200, 8000), nrow = n_probes, ncol = n_samples)
+unmeth <- matrix(runif(n_probes * n_samples, 200, 8000), nrow = n_probes, ncol = n_samples)
+probe_ids <- sprintf("cg%08d", seq_len(n_probes))
+sample_ids <- paste0("sample", seq_len(n_samples))
+rownames(meth) <- rownames(unmeth) <- probe_ids
+colnames(meth) <- colnames(unmeth) <- sample_ids
+
+# The offset getBeta() uses by default -- see ASSUMPTIONS block above.
+beta_offset <- 100
+
+run_test("MethylSet constructs from Meth/Unmeth intensity matrices", function() {
+  ms <- MethylSet(Meth = meth, Unmeth = unmeth)
+  stopifnot(inherits(ms, "MethylSet"))
+  stopifnot(nrow(ms) == n_probes, ncol(ms) == n_samples)
+  stopifnot(identical(dim(ms), c(n_probes, n_samples)))
+})
+
+run_test("getMeth / getUnmeth round-trip the input intensities", function() {
+  ms <- MethylSet(Meth = meth, Unmeth = unmeth)
+  m_back <- as.matrix(getMeth(ms))
+  u_back <- as.matrix(getUnmeth(ms))
+  stopifnot(identical(dim(m_back), dim(meth)))
+  stopifnot(isTRUE(all.equal(m_back, meth, tolerance = 1e-8, check.attributes = FALSE)))
+  stopifnot(isTRUE(all.equal(u_back, unmeth, tolerance = 1e-8, check.attributes = FALSE)))
+  # Probe/sample names survive the round-trip.
+  stopifnot(identical(rownames(m_back), probe_ids))
+  stopifnot(identical(colnames(m_back), sample_ids))
+})
+
+run_test("getBeta returns [0,1] matching Meth/(Meth+Unmeth+offset)", function() {
+  ms <- MethylSet(Meth = meth, Unmeth = unmeth)
+  beta <- as.matrix(getBeta(ms))
+  stopifnot(identical(dim(beta), dim(meth)))
+  stopifnot(all(is.finite(beta)), all(beta >= 0), all(beta <= 1))
+  expected_beta <- meth / (meth + unmeth + beta_offset)
+  stopifnot(isTRUE(all.equal(beta, expected_beta, tolerance = 1e-8, check.attributes = FALSE)))
+})
+
+run_test("getM equals log2(Meth/Unmeth)", function() {
+  ms <- MethylSet(Meth = meth, Unmeth = unmeth)
+  mval <- as.matrix(getM(ms))
+  stopifnot(identical(dim(mval), dim(meth)))
+  stopifnot(all(is.finite(mval)))
+  expected_m <- log2(meth / unmeth)
+  stopifnot(isTRUE(all.equal(mval, expected_m, tolerance = 1e-6, check.attributes = FALSE)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all minfi smoke tests passed\n")

--- a/cli/scripts/lib-validator/minpack.lm.R
+++ b/cli/scripts/lib-validator/minpack.lm.R
@@ -1,0 +1,111 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `minpack.lm` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# minpack.lm itself (and the dependencies it implies). All data is
+# simulated with a fixed seed; model-fit checks are structural /
+# tolerance-based, never exact floating-point equality. Exercises the
+# core API surface and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript minpack.lm.R
+
+if (!requireNamespace("minpack.lm", quietly = TRUE)) {
+  cat("FAIL: package 'minpack.lm' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(minpack.lm))
+cat(sprintf("minpack.lm version: %s\n", as.character(packageVersion("minpack.lm"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Exponential growth y = a * exp(b * x) with true a = 2, b = 0.3 and
+# gaussian noise (sd 0.15) on 60 points over [0, 5].
+set.seed(99)
+a_true <- 2
+b_true <- 0.3
+x <- seq(0, 5, length.out = 60L)
+y <- a_true * exp(b_true * x) + rnorm(length(x), sd = 0.15)
+d <- data.frame(x = x, y = y)
+
+# Deliberately poor start (a = 1, b = 0.1) so the test exercises the
+# Levenberg-Marquardt optimizer, not just a no-op refinement.
+fit_exp <- function() {
+  suppressWarnings(
+    nlsLM(y ~ a * exp(b * x), data = d, start = list(a = 1, b = 0.1))
+  )
+}
+
+run_test("nlsLM: fit class", function() {
+  fit <- fit_exp()
+  stopifnot(inherits(fit, "nls"))
+})
+
+run_test("nlsLM: recovers the true parameters", function() {
+  fit <- fit_exp()
+  cf <- coef(fit)
+  stopifnot(length(cf) == 2L)
+  stopifnot(all(c("a", "b") %in% names(cf)))
+  stopifnot(all(is.finite(cf)))
+  # Generous tolerance: standard errors here are an order of magnitude
+  # smaller, so 0.15 leaves plenty of headroom across platforms.
+  stopifnot(abs(cf[["a"]] - a_true) < 0.15)
+  stopifnot(abs(cf[["b"]] - b_true) < 0.15)
+})
+
+run_test("nlsLM: fitted values and residuals", function() {
+  fit <- fit_exp()
+  fv <- fitted(fit)
+  stopifnot(length(fv) == length(y), all(is.finite(fv)))
+  res <- residuals(fit)
+  stopifnot(length(res) == length(y), all(is.finite(res)))
+  # Noise sd is 0.15 (variance ~0.0225); a sane fit keeps MSE well under 0.1.
+  stopifnot(mean(res^2) < 0.1)
+})
+
+run_test("nlsLM: summary structure", function() {
+  fit <- fit_exp()
+  cm <- coef(summary(fit))
+  stopifnot(is.matrix(cm))
+  stopifnot(nrow(cm) == 2L, ncol(cm) == 4L)
+  stopifnot(all(is.finite(cm)))
+  # Std. errors (column 2) must be strictly positive.
+  stopifnot(all(cm[, 2] > 0))
+})
+
+run_test("nlsLM: predictions on new data", function() {
+  fit <- fit_exp()
+  pr <- predict(fit, newdata = data.frame(x = c(0, 2.5, 5)))
+  stopifnot(length(pr) == 3L, all(is.finite(pr)))
+  # a > 0 and b > 0, so the fitted curve must be strictly increasing.
+  stopifnot(all(diff(pr) > 0))
+})
+
+run_test("nls.lm: low-level residual-function interface", function() {
+  resid_fn <- function(par, xx, obs) obs - par[["a"]] * exp(par[["b"]] * xx)
+  out <- nls.lm(par = list(a = 1, b = 0.1), fn = resid_fn, xx = x, obs = y)
+  stopifnot(inherits(out, "nls.lm"))
+  stopifnot(is.finite(out$deviance), out$deviance >= 0)
+  est <- unlist(out$par)
+  stopifnot(abs(est[["a"]] - a_true) < 0.15)
+  stopifnot(abs(est[["b"]] - b_true) < 0.15)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all minpack.lm smoke tests passed\n")

--- a/cli/scripts/lib-validator/missMethyl.R
+++ b/cli/scripts/lib-validator/missMethyl.R
@@ -1,0 +1,84 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `missMethyl` package.
+#
+# Fully self-contained: no input files, NO network. missMethyl provides GO/GSEA
+# enrichment for methylation arrays (`gometh`/`gsameth`) and SWAN normalization.
+# This test is deliberately MODEST: the load-bearing enrichment and
+# normalization paths are NOT meaningfully exercisable offline (see FLAGS), so
+# we assert the package loads and its core API surface is present. Exits 0 only
+# if every check passes, so it works as a pass/fail validator:
+#
+#   Rscript missMethyl.R
+#
+# ============================ WHY MODEST — RE-CHECK ==========================
+# What a FULL test would need but CANNOT be done blind/offline here:
+#   * gometh()/gsameth() need a 450K/EPIC array-annotation package
+#     (IlluminaHumanMethylation450kanno.* / ...EPICanno.*) to map CpG probe ids
+#     to genes, PLUS a gene universe (`all.cpg`) of real probe ids. Synthetic
+#     `cg########` ids won't map, so any enrichment result is meaningless.
+#   * SWAN() normalizes a MethylSet/RGChannelSet (minfi objects) built from IDAT
+#     intensities or a bundled minfi example dataset — out of scope offline.
+# So the checks below are EXISTENCE + type of the exported entry points. If any
+# were renamed, the corresponding `::` lookup fails — that is the signal.
+# ============================================================================
+
+if (!requireNamespace("missMethyl", quietly = TRUE)) {
+  cat("FAIL: package 'missMethyl' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(missMethyl))
+cat(sprintf("missMethyl version: %s\n", as.character(packageVersion("missMethyl"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("gometh is an exported function", function() {
+  stopifnot(is.function(missMethyl::gometh))
+})
+
+run_test("gsameth is an exported function", function() {
+  stopifnot(is.function(missMethyl::gsameth))
+})
+
+run_test("SWAN is an exported function/generic", function() {
+  # SWAN is exported as an S4 generic in recent versions; both is.function and
+  # existsMethod-style dispatch resolve `SWAN` — treat either as present.
+  stopifnot(is.function(missMethyl::SWAN) ||
+              methods::existsFunction("SWAN", where = asNamespace("missMethyl")))
+})
+
+run_test("getMappedEntrezIDs is an exported function", function() {
+  stopifnot(is.function(missMethyl::getMappedEntrezIDs))
+})
+
+run_test("gometh exposes the array-type / collection knobs (SOFT)", function() {
+  # Structural sanity on the signature; kept SOFT because argument names can
+  # drift across versions and this is not a load-bearing correctness check.
+  fmls <- tryCatch(names(formals(missMethyl::gometh)), error = function(e) character(0))
+  if (length(fmls) == 0L) {
+    cat("  note could not introspect gometh() formals\n")
+    return(invisible(NULL))
+  }
+  if (!("array.type" %in% fmls)) {
+    cat(sprintf("  note gometh() has no `array.type` arg (formals: %s) -- verify\n",
+                paste(fmls, collapse = ", ")))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all missMethyl smoke tests passed\n")

--- a/cli/scripts/lib-validator/mixOmics.R
+++ b/cli/scripts/lib-validator/mixOmics.R
@@ -1,0 +1,94 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `mixOmics` package (multivariate / integrative omics).
+#
+# Fully self-contained: no input files, no network, no packages beyond mixOmics
+# itself. Data is a small samples x variables matrix simulated with a fixed
+# seed, with a mean shift planted in the first variables of the second class so
+# a supervised model has real structure to fit. Checks are structural /
+# tolerance-based (object classes, component dimensions, variance-explained
+# bounds, that predict() runs), never exact floating-point equality. Exits 0
+# only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript mixOmics.R
+#
+# FLAG (unverified on this machine -- mixOmics is NOT installed here): the
+# result class strings ("pca", "mixo_plsda") and the accessor names
+# ($variates$X, $prop_expl_var$X, $loadings) are taken from the documented
+# mixOmics API and should be re-checked against the installed version.
+
+if (!requireNamespace("mixOmics", quietly = TRUE)) {
+  cat("FAIL: package 'mixOmics' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(mixOmics))
+cat(sprintf("mixOmics version: %s\n", as.character(packageVersion("mixOmics"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: 40 samples x 10 variables, two balanced classes. Baseline is
+# standard-normal noise; the first 3 variables get a +3 mean shift in class B,
+# giving PLS-DA a clear axis of separation to recover.
+set.seed(1)
+n <- 40L
+p <- 10L
+n_signal <- 3L
+X <- matrix(rnorm(n * p), nrow = n, ncol = p,
+            dimnames = list(sprintf("s%02d", seq_len(n)),
+                            sprintf("v%02d", seq_len(p))))
+Y <- factor(rep(c("A", "B"), each = n / 2L))
+X[Y == "B", seq_len(n_signal)] <- X[Y == "B", seq_len(n_signal)] + 3
+
+run_test("pca: object class, component dims, variance explained", function() {
+  pr <- mixOmics::pca(X, ncomp = 3)
+  stopifnot(inherits(pr, "pca"))
+  # $variates$X holds the sample scores: one row per sample, one column per
+  # requested component.
+  stopifnot(is.matrix(pr$variates$X))
+  stopifnot(identical(dim(pr$variates$X), c(n, 3L)))
+  # Proportion of variance explained: bounded in [0, 1] per component.
+  pev <- pr$prop_expl_var$X
+  stopifnot(length(pev) == 3L)
+  stopifnot(all(is.finite(pev)), all(pev >= 0), all(pev <= 1 + 1e-8))
+})
+
+run_test("pca: loadings shape", function() {
+  pr <- mixOmics::pca(X, ncomp = 2)
+  # Variable loadings: one row per input variable, one column per component.
+  stopifnot(identical(dim(pr$loadings$X), c(p, 2L)))
+})
+
+run_test("plsda: supervised model class and scores", function() {
+  pl <- mixOmics::plsda(X, Y, ncomp = 2)
+  stopifnot(inherits(pl, "mixo_plsda"))
+  stopifnot(identical(dim(pl$variates$X), c(n, 2L)))
+})
+
+run_test("plsda: predict runs and returns one class per sample", function() {
+  pl <- mixOmics::plsda(X, Y, ncomp = 2)
+  pred <- predict(pl, newdata = X)
+  # max.dist is the default distance; its per-component class assignments form
+  # a samples x ncomp matrix. Assert one prediction row per input sample.
+  cls <- pred$class$max.dist
+  stopifnot(nrow(cls) == n)
+  stopifnot(all(as.vector(cls) %in% levels(Y)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all mixOmics smoke tests passed\n")

--- a/cli/scripts/lib-validator/mofapy2.py
+++ b/cli/scripts/lib-validator/mofapy2.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `mofapy2` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 mofapy2.py
+
+Install: pip install mofapy2   (import name: mofapy2)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: mofapy2 is the MOFA+ multi-omics factor analysis TRAINING
+backend. A real fit — set_data_matrix(list-of-views) → set_model_options →
+set_train_options → build() → run() — is a heavy variational-inference
+optimisation, so this deliberately does NOT train a model. It only asserts the
+package imports, exposes its documented entry point
+(mofapy2.run.entry_point.entry_point), and that constructing an entry_point()
+is cheap (it just initialises the options container). RE-CHECK once installed:
+the entry_point module path and class name against the installed API.
+(correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import mofapy2
+except ImportError:
+    print("FAIL: package 'mofapy2' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"mofapy2 version: {_version(mofapy2, 'mofapy2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_entry_point():
+    import importlib
+
+    # entry_point lives at mofapy2.run.entry_point; import it lazily so a
+    # missing/renamed module is a test failure, not a top-level crash.
+    ep_mod = importlib.import_module("mofapy2.run.entry_point")
+    assert hasattr(ep_mod, "entry_point")
+    assert callable(ep_mod.entry_point)
+
+
+def test_entry_point_constructs_cheaply():
+    import importlib
+
+    ep_mod = importlib.import_module("mofapy2.run.entry_point")
+    # Constructing the entry point only initialises the options container; it
+    # touches no data and runs no inference, so this stays cheap and offline.
+    ep = ep_mod.entry_point()
+    assert isinstance(ep, ep_mod.entry_point)
+
+
+run_test("exposes mofapy2.run.entry_point.entry_point", test_exposes_entry_point)
+run_test("entry_point() constructs cheaply", test_entry_point_constructs_cheaply)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all mofapy2 smoke tests passed")

--- a/cli/scripts/lib-validator/mordred.py
+++ b/cli/scripts/lib-validator/mordred.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `mordred` package.
+
+Fully self-contained: no input files, no network, no packages beyond mordred
+and its implied deps (rdkit, numpy). Exercises the core API surface and exits 0
+only if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 mordred.py
+
+Install: pip install mordred   (import name: mordred)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAG: mordred is a molecular-descriptor calculator that runs ON TOP of
+RDKit — it needs rdkit installed and an rdkit Mol as input. It computes a large
+descriptor block (1000+ 2D/3D descriptors); the check below builds the 2D
+calculator (ignore_3D=True), runs it on ethanol, and asserts one well-known
+descriptor (molecular weight) is finite. NOTE: mordred is unmaintained and its
+Python 3.14 compatibility is uncertain (it historically pins older numpy and
+uses `networkx` internals); if import fails on a modern interpreter that is a
+known risk, not a defect in this validator.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import mordred
+    from mordred import Calculator, descriptors
+except ImportError:
+    print("FAIL: package 'mordred' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"mordred version: {_version(mordred, 'mordred')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_calculator_builds_large_descriptor_set():
+    calc = Calculator(descriptors, ignore_3D=True)
+    # The 2D descriptor block is large — hundreds of registered descriptors.
+    assert len(calc.descriptors) > 100
+
+
+def test_calc_ethanol_molecular_weight_finite():
+    import math
+    from rdkit import Chem
+
+    calc = Calculator(descriptors, ignore_3D=True)
+    mol = Chem.MolFromSmiles("CCO")
+    assert mol is not None
+    result = calc(mol)
+    # The Result maps descriptor -> value; molecular weight lives under "MW".
+    values = result.asdict()
+    assert "MW" in values
+    mw = float(values["MW"])
+    assert math.isfinite(mw)
+    # Ethanol MW ≈ 46.07 (mordred's MW is the full monoisotopic-ish mass; use a
+    # loose tolerance since the exact definition differs slightly from rdkit's).
+    assert 40.0 < mw < 52.0
+
+
+run_test("Calculator builds large descriptor set", test_calculator_builds_large_descriptor_set)
+run_test("calc(ethanol) MW is finite", test_calc_ethanol_molecular_weight_finite)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all mordred smoke tests passed")

--- a/cli/scripts/lib-validator/mrgsolve.R
+++ b/cli/scripts/lib-validator/mrgsolve.R
@@ -1,0 +1,113 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `mrgsolve` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond mrgsolve
+# itself -- BUT it compiles an ODE model from an inline code block, so a working
+# C++ toolchain is required at run time (that is intrinsic to mrgsolve, not a
+# network dependency). Exercises the compile -> dose -> simulate path for a
+# one-compartment IV-bolus PK model and exits 0 only if every check passes, so
+# it can be used as a pass/fail library validator:
+#
+#   Rscript mrgsolve.R
+#
+# NOTE (needs re-check once installed): the model-DSL block ($PARAM/$CMT/$ODE/
+# $CAPTURE) and the mcode/mrgsim/ev entry points were written from the
+# documented API and NOT verified against an installed build -- re-confirm the
+# DSL and simulation accessors when the package is available. Simulated
+# concentrations are floating point, so checks assert structural/robust
+# properties (class, finiteness, non-negativity, monotone decay after the dose)
+# -- never exact equality.
+
+if (!requireNamespace("mrgsolve", quietly = TRUE)) {
+  cat("FAIL: package 'mrgsolve' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(mrgsolve))
+cat(sprintf("mrgsolve version: %s\n", as.character(packageVersion("mrgsolve"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# One-compartment IV-bolus model: first-order elimination from a single central
+# compartment, capturing concentration CP = amount / volume. mrgsolve caches the
+# compiled shared object by model name, so repeated make_mod() calls recompile
+# only once.
+model_code <- paste(
+  "$PARAM CL=1, V=20",
+  "$CMT CENT",
+  "$ODE dxdt_CENT = -(CL/V)*CENT;",
+  "$CAPTURE CP=CENT/V",
+  sep = "\n"
+)
+make_mod <- function() {
+  mcode("onecmt_iv", model_code)
+}
+
+run_test("mcode compiles the ODE model", function() {
+  mod <- make_mod()
+  stopifnot(inherits(mod, "mrgmod"))
+})
+
+run_test("ev builds an event object", function() {
+  dose <- ev(amt = 100)
+  stopifnot(inherits(dose, "ev"))
+})
+
+run_test("mrgsim returns simulated output", function() {
+  mod <- make_mod()
+  out <- mrgsim(mod, events = ev(amt = 100), end = 24)
+  stopifnot(inherits(out, "mrgsims"))
+  df <- as.data.frame(out)
+  stopifnot(is.data.frame(df), nrow(df) > 1L)
+  # the captured concentration column is present
+  stopifnot("CP" %in% names(df))
+})
+
+run_test("concentrations are finite and non-negative", function() {
+  mod <- make_mod()
+  df <- as.data.frame(mrgsim(mod, events = ev(amt = 100), end = 24))
+  cp <- df$CP
+  stopifnot(all(is.finite(cp)))
+  stopifnot(all(cp >= -1e-9))
+  # the dose actually put drug in the system
+  stopifnot(max(cp) > 0)
+})
+
+run_test("concentration decays monotonically after the dose", function() {
+  mod <- make_mod()
+  df <- as.data.frame(mrgsim(mod, events = ev(amt = 100), end = 24))
+  cp <- df$CP
+  # the peak follows the bolus immediately; everything after it must not rise
+  peak <- which.max(cp)
+  stopifnot(peak <= 2L)
+  tail_cp <- cp[peak:length(cp)]
+  stopifnot(all(diff(tail_cp) <= 1e-6))
+  # first-order elimination -> concentration approaches zero by the horizon
+  stopifnot(tail_cp[length(tail_cp)] < max(cp))
+})
+
+run_test("larger dose scales the exposure", function() {
+  mod <- make_mod()
+  lo <- as.data.frame(mrgsim(mod, events = ev(amt = 100), end = 24))$CP
+  hi <- as.data.frame(mrgsim(mod, events = ev(amt = 200), end = 24))$CP
+  # a linear one-compartment model: doubling the dose raises peak concentration
+  stopifnot(max(hi) > max(lo))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all mrgsolve smoke tests passed\n")

--- a/cli/scripts/lib-validator/ms-deisotope.py
+++ b/cli/scripts/lib-validator/ms-deisotope.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `ms-deisotope` package.
+
+Fully self-contained: no input files, no network, no packages beyond
+ms-deisotope (and its implied deps: brainpy, ms_peak_picker). Exercises the
+core API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 ms-deisotope.py
+
+Install: pip install ms-deisotope   (import name: ms_deisotope)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import ms_deisotope
+except ImportError:
+    print("FAIL: package 'ms-deisotope' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"ms_deisotope version: {_version(ms_deisotope, 'ms-deisotope')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# NOTE: a full ms_deisotope.deconvolute_peaks run needs a real peak list, an
+# averagine model, and a scorer; MSFileLoader needs a real MS file. This
+# validator stays MODEST: it confirms the top-level surface, then exercises the
+# one genuinely offline piece — the averagine isotopic-pattern model. FLAG: no
+# deconvolution or file loading is performed.
+def test_top_level_surface():
+    assert callable(ms_deisotope.deconvolute_peaks)
+    assert callable(ms_deisotope.MSFileLoader)
+    from ms_deisotope import averagine
+
+    assert hasattr(averagine, "peptide")  # predefined peptide averagine model
+
+
+def test_averagine_isotopic_cluster():
+    from ms_deisotope import averagine
+
+    # The peptide averagine yields a normalized theoretical isotopic pattern —
+    # a purely offline computation that needs no peak list or MS file.
+    pattern = averagine.peptide.isotopic_cluster(1000.0, charge=2)
+    peaks = list(pattern)
+    assert len(peaks) > 0
+    total = sum(p.intensity for p in peaks)
+    assert abs(total - 1.0) < 1e-3  # pattern intensities are normalized to 1
+    assert all(p.mz > 0 for p in peaks)
+
+
+run_test("top-level surface present", test_top_level_surface)
+run_test("averagine isotopic cluster", test_averagine_isotopic_cluster)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all ms-deisotope smoke tests passed")

--- a/cli/scripts/lib-validator/msigdbr.R
+++ b/cli/scripts/lib-validator/msigdbr.R
@@ -1,0 +1,104 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `msigdbr` package.
+#
+# Fully self-contained: no input files, NO network. msigdbr is a DATA package
+# that vendors the MSigDB gene sets locally. Exercises the gene-set retrieval
+# API and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript msigdbr.R
+#
+# ============================ API UNCERTAINTY ================================
+# TWO things to RE-CHECK once installed:
+#
+# 1. ARG NAME: recent msigdbr (>= 10.0) RENAMED the collection argument from
+#    `category` to `collection` (and `subcategory` -> `subcollection`). This
+#    script auto-detects which name the installed version accepts via
+#    formals(); if neither is present the API changed further -- investigate.
+#
+# 2. DATA COMPANION: msigdbr >= 10.0 moved the gene-set payload into a separate
+#    `msigdbdf` package. If that companion is not installed, msigdbr() ERRORS
+#    with an install hint at call time -- which would surface here as a test
+#    FAILURE (not the not-installed guard). Older (7.x) msigdbr bundles the
+#    data itself. Note this if test bodies fail once msigdbr is present.
+# ============================================================================
+#
+# Gene-set contents are fixed, so checks are structural/known (column presence,
+# the HALLMARK_ naming convention, a known hallmark set name).
+
+if (!requireNamespace("msigdbr", quietly = TRUE)) {
+  cat("FAIL: package 'msigdbr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(msigdbr))
+cat(sprintf("msigdbr version: %s\n", as.character(packageVersion("msigdbr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fetch the Hallmark ("H") collection for human, tolerating either arg name.
+fetch_hallmark <- function() {
+  arg_names <- names(formals(msigdbr::msigdbr))
+  if ("collection" %in% arg_names) {
+    msigdbr::msigdbr(species = "Homo sapiens", collection = "H")
+  } else if ("category" %in% arg_names) {
+    # pre-10.0 API
+    msigdbr::msigdbr(species = "Homo sapiens", category = "H")
+  } else {
+    stop("msigdbr() exposes neither a `collection` nor a `category` argument")
+  }
+}
+
+run_test("hallmark collection retrieval yields gene-set rows", function() {
+  gs <- fetch_hallmark()
+  stopifnot(is.data.frame(gs), nrow(gs) > 0L)
+  # gs_name and gene_symbol are stable across msigdbr versions
+  stopifnot("gs_name" %in% names(gs))
+  stopifnot("gene_symbol" %in% names(gs))
+})
+
+run_test("hallmark set names follow the HALLMARK_ convention", function() {
+  gs <- fetch_hallmark()
+  # every gene set in collection "H" is named HALLMARK_*
+  stopifnot(all(grepl("^HALLMARK_", gs$gs_name)))
+  # a specific, long-standing hallmark set is present
+  stopifnot("HALLMARK_APOPTOSIS" %in% gs$gs_name)
+  # the canonical hallmark collection has 50 sets; assert a robust lower bound
+  # (exact 50 is expected but left loose in case MSigDB re-versions)
+  stopifnot(length(unique(gs$gs_name)) >= 45L)
+})
+
+run_test("gene_symbol values are non-empty character strings", function() {
+  gs <- fetch_hallmark()
+  syms <- gs$gene_symbol
+  stopifnot(is.character(syms))
+  stopifnot(all(!is.na(syms)), all(nzchar(syms)))
+})
+
+run_test("msigdbr_species returns a species table including human", function() {
+  sp <- msigdbr::msigdbr_species()
+  stopifnot(is.data.frame(sp), nrow(sp) > 0L)
+  # column names vary; scan every character column for the species name
+  has_human <- any(vapply(sp, function(col) {
+    is.character(col) && any(grepl("Homo sapiens", col, fixed = TRUE))
+  }, logical(1)))
+  stopifnot(has_human)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all msigdbr smoke tests passed\n")

--- a/cli/scripts/lib-validator/mudata.py
+++ b/cli/scripts/lib-validator/mudata.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `mudata` package.
+
+Fully self-contained: no input files, no network, no packages beyond mudata
+(and its implied deps — anndata, numpy, pandas, h5py). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 mudata.py
+
+Install: pip install mudata   (import name: mudata)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import mudata as md
+except ImportError:
+    print("FAIL: package 'mudata' is not installed")
+    sys.exit(1)
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"mudata version: {_version(md, 'mudata')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_mudata():
+    """Two modalities (rna 50x20, atac 50x30) over a shared 50-cell axis."""
+    rng = np.random.default_rng(0)
+    obs_names = [f"cell{i}" for i in range(50)]
+    rna = ad.AnnData(
+        X=rng.poisson(5, (50, 20)).astype(float),
+        obs=pd.DataFrame(index=obs_names),
+        var=pd.DataFrame(index=[f"gene{j}" for j in range(20)]),
+    )
+    atac = ad.AnnData(
+        X=rng.poisson(1, (50, 30)).astype(float),
+        obs=pd.DataFrame(index=obs_names),
+        var=pd.DataFrame(index=[f"peak{j}" for j in range(30)]),
+    )
+    return md.MuData({"rna": rna, "atac": atac})
+
+
+def test_construct_mods_and_shape():
+    mdata = _make_mudata()
+    assert set(mdata.mod.keys()) == {"rna", "atac"}
+    # Cells shared across modalities; features are the union of both var axes.
+    assert mdata.n_obs == 50
+    assert mdata.shape == (50, 50)
+    assert mdata["rna"].shape == (50, 20)
+    assert mdata["atac"].shape == (50, 30)
+
+
+def test_cross_modality_obs():
+    mdata = _make_mudata()
+    mdata.obs["batch"] = ["b0" if i % 2 == 0 else "b1" for i in range(50)]
+    assert list(mdata.obs["batch"][:4]) == ["b0", "b1", "b0", "b1"]
+    assert mdata["rna"].n_obs == mdata["atac"].n_obs == 50
+
+
+def test_h5mu_write_read_roundtrip():
+    import tempfile
+
+    mdata = _make_mudata()
+    fd, path = tempfile.mkstemp(suffix=".h5mu")
+    os.close(fd)
+    try:
+        mdata.write(path)
+        back = md.read(path)
+        assert set(back.mod.keys()) == {"rna", "atac"}
+        assert back.n_obs == 50
+        assert np.allclose(back["rna"].X, mdata["rna"].X)
+        assert np.allclose(back["atac"].X, mdata["atac"].X)
+    finally:
+        os.remove(path)
+
+
+run_test("construct: mods + shape", test_construct_mods_and_shape)
+run_test("cross-modality obs", test_cross_modality_obs)
+run_test("h5mu tempfile write/read round-trip", test_h5mu_write_read_roundtrip)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all mudata smoke tests passed")

--- a/cli/scripts/lib-validator/muon.py
+++ b/cli/scripts/lib-validator/muon.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `muon` package.
+
+Fully self-contained: no input files, no network, no packages beyond muon
+(and its implied deps — mudata, anndata, scanpy, numpy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 muon.py
+
+Install: pip install muon   (import name: muon)
+
+FLAG: muon vs mudata API overlap. muon re-exports the `MuData` container from
+the `mudata` package and layers multimodal *analysis* on top (`muon.pp`,
+`muon.tl` — e.g. MOFA+, WNN). The container tests here overlap with mudata.py by
+design; the analysis namespaces (mu.pp / mu.tl) are what muon adds.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import muon as mu
+except ImportError:
+    print("FAIL: package 'muon' is not installed")
+    sys.exit(1)
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"muon version: {_version(mu, 'muon')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_mudata():
+    """Two modalities (rna 60x40, atac 60x25) over a shared 60-cell axis."""
+    rng = np.random.default_rng(0)
+    obs_names = [f"cell{i}" for i in range(60)]
+    rna = ad.AnnData(
+        X=rng.poisson(4, (60, 40)).astype(np.float32),
+        obs=pd.DataFrame(index=obs_names),
+        var=pd.DataFrame(index=[f"gene{j}" for j in range(40)]),
+    )
+    atac = ad.AnnData(
+        X=rng.poisson(1, (60, 25)).astype(np.float32),
+        obs=pd.DataFrame(index=obs_names),
+        var=pd.DataFrame(index=[f"peak{j}" for j in range(25)]),
+    )
+    return mu.MuData({"rna": rna, "atac": atac})
+
+
+def test_mudata_container():
+    # FLAG: mu.MuData is the mudata container re-exported through muon.
+    mdata = _make_mudata()
+    assert set(mdata.mod.keys()) == {"rna", "atac"}
+    assert mdata.n_obs == 60
+    assert mdata["rna"].shape == (60, 40)
+    assert mdata["atac"].shape == (60, 25)
+
+
+def test_analysis_namespaces_present():
+    # What muon adds over mudata: multimodal preprocessing / tools.
+    assert hasattr(mu, "pp")
+    assert hasattr(mu, "tl")
+    assert callable(getattr(mu.pp, "intersect_obs", None)) or hasattr(mu.pp, "intersect_obs")
+
+
+def test_intersect_obs_ops():
+    mdata = _make_mudata()
+    # Drop a cell from one modality, then align the shared obs axis.
+    trimmed = mdata["rna"][: mdata.n_obs - 5].copy()
+    mdata.mod["rna"] = trimmed
+    mdata.update()
+    mu.pp.intersect_obs(mdata)
+    assert mdata["rna"].n_obs == mdata["atac"].n_obs
+    assert mdata.n_obs == 55
+
+
+run_test("MuData container (re-exported from mudata)", test_mudata_container)
+run_test("mu.pp / mu.tl analysis namespaces present", test_analysis_namespaces_present)
+run_test("mu.pp.intersect_obs aligns modalities", test_intersect_obs_ops)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all muon smoke tests passed")

--- a/cli/scripts/lib-validator/nbformat.py
+++ b/cli/scripts/lib-validator/nbformat.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `nbformat` package.
+
+Fully self-contained: no input files, no network, no packages beyond nbformat
+(and its implied deps). Builds a notebook entirely in memory, validates it, and
+roundtrips it through the JSON serializer. Exits 0 only if every check passes,
+so it can be used as a pass/fail library validator:
+
+    python3 nbformat.py
+
+Install: pip install nbformat   (import name: nbformat)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import nbformat
+except ImportError:
+    print("FAIL: package 'nbformat' is not installed")
+    sys.exit(1)
+
+from nbformat.v4 import new_code_cell, new_notebook
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"nbformat version: {_version(nbformat, 'nbformat')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _notebook():
+    """A minimal v4 notebook with a single code cell."""
+    nb = new_notebook()
+    nb.cells.append(new_code_cell("1+1"))
+    return nb
+
+
+def test_new_notebook_and_code_cell():
+    nb = _notebook()
+    assert nb.nbformat == 4
+    assert len(nb.cells) == 1
+    cell = nb.cells[0]
+    assert cell.cell_type == "code"
+    assert cell.source == "1+1"
+
+
+def test_validate_passes():
+    nb = _notebook()
+    # validate() raises ValidationError on a malformed notebook; a clean return
+    # (None) means the notebook conforms to the v4 schema.
+    assert nbformat.validate(nb) is None
+
+
+def test_writes_produces_json_string():
+    nb = _notebook()
+    s = nbformat.writes(nb)
+    assert isinstance(s, str)
+    import json
+
+    parsed = json.loads(s)
+    assert parsed["nbformat"] == 4
+    assert parsed["cells"][0]["source"] == "1+1"
+
+
+def test_reads_roundtrips_cell_source():
+    nb = _notebook()
+    s = nbformat.writes(nb)
+    back = nbformat.reads(s, as_version=4)
+    assert back.nbformat == 4
+    assert len(back.cells) == 1
+    assert back.cells[0].cell_type == "code"
+    assert back.cells[0].source == "1+1"
+
+
+run_test("new notebook and code cell", test_new_notebook_and_code_cell)
+run_test("validate passes", test_validate_passes)
+run_test("writes produces JSON string", test_writes_produces_json_string)
+run_test("reads roundtrips cell source", test_reads_roundtrips_cell_source)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all nbformat smoke tests passed")

--- a/cli/scripts/lib-validator/networkx.py
+++ b/cli/scripts/lib-validator/networkx.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `networkx` package.
+
+Fully self-contained: no input files, no network, no packages beyond networkx
+(and its implied deps — scipy for adjacency matrices). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 networkx.py
+
+Install: pip install networkx   (import name: networkx)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import math
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import networkx as nx
+except ImportError:
+    print("FAIL: package 'networkx' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"networkx version: {_version(nx, 'networkx')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_graph_construction():
+    g = nx.Graph()
+    g.add_nodes_from([1, 2, 3, 4])
+    g.add_edges_from([(1, 2), (2, 3), (3, 4)])
+    assert g.number_of_nodes() == 4
+    assert g.number_of_edges() == 3
+    assert g.degree(2) == 2
+    assert g.degree(1) == 1
+    assert set(g.neighbors(2)) == {1, 3}
+
+
+def test_from_edgelist_triangle():
+    # A triangle: three mutually-adjacent nodes, every degree exactly 2.
+    g = nx.from_edgelist([(0, 1), (1, 2), (2, 0)])
+    assert g.number_of_nodes() == 3
+    assert g.number_of_edges() == 3
+    assert all(d == 2 for _, d in g.degree())
+
+
+def test_shortest_path_length():
+    # Path graph 0-1-2-3-4: hop distance equals index gap.
+    g = nx.path_graph(5)
+    assert nx.shortest_path_length(g, 0, 4) == 4
+    assert nx.shortest_path_length(g, 1, 3) == 2
+    assert nx.shortest_path(g, 0, 4) == [0, 1, 2, 3, 4]
+
+
+def test_connected_components():
+    g = nx.Graph()
+    g.add_edges_from([(1, 2), (2, 3), (10, 11)])
+    comps = sorted(nx.connected_components(g), key=len, reverse=True)
+    assert nx.number_connected_components(g) == 2
+    assert comps[0] == {1, 2, 3}
+    assert comps[1] == {10, 11}
+
+
+def test_karate_club_shape():
+    g = nx.karate_club_graph()
+    assert g.number_of_nodes() == 34
+    assert g.number_of_edges() == 78
+
+
+def test_betweenness_and_pagerank_finite():
+    g = nx.karate_club_graph()
+    bc = nx.betweenness_centrality(g)
+    assert isinstance(bc, dict)
+    assert len(bc) == 34
+    assert all(math.isfinite(v) and v >= 0.0 for v in bc.values())
+    pr = nx.pagerank(g)
+    assert isinstance(pr, dict)
+    assert len(pr) == 34
+    assert all(math.isfinite(v) and v > 0.0 for v in pr.values())
+    # PageRank is a probability distribution over nodes: it must sum to 1.
+    assert math.isclose(sum(pr.values()), 1.0, rel_tol=1e-6)
+
+
+def test_adjacency_matrix_shape():
+    g = nx.path_graph(5)
+    A = nx.adjacency_matrix(g)
+    assert A.shape == (5, 5)
+    # 4 undirected edges → 8 stored nonzeros (symmetric matrix).
+    assert A.nnz == 8
+
+
+run_test("graph construction + degree", test_graph_construction)
+run_test("from_edgelist triangle", test_from_edgelist_triangle)
+run_test("shortest path length", test_shortest_path_length)
+run_test("connected components", test_connected_components)
+run_test("karate club shape (34/78)", test_karate_club_shape)
+run_test("betweenness + pagerank finite", test_betweenness_and_pagerank_finite)
+run_test("adjacency matrix shape", test_adjacency_matrix_shape)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all networkx smoke tests passed")

--- a/cli/scripts/lib-validator/nlme.R
+++ b/cli/scripts/lib-validator/nlme.R
@@ -1,0 +1,127 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `nlme` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond nlme
+# itself (and its implied deps). Data is either bundled with the package
+# (`Orthodont`, `Loblolly`) or simulated with a fixed seed. Exercises the core
+# mixed-effects modeling API and exits 0 only if every check passes, so it can
+# be used as a pass/fail library validator:
+#
+#   Rscript nlme.R
+#
+# Modeling outputs are floating-point, so checks assert structural/robust
+# properties (classes, lengths, finiteness, sign of effects) and recover known
+# effects only within a generous tolerance -- never exact coefficient equality.
+
+if (!requireNamespace("nlme", quietly = TRUE)) {
+  cat("FAIL: package 'nlme' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(nlme))
+cat(sprintf("nlme version: %s\n", as.character(packageVersion("nlme"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("lme random-intercept model on Orthodont", function() {
+  fit <- lme(distance ~ age, random = ~1 | Subject, data = Orthodont)
+  stopifnot(inherits(fit, "lme"))
+  fe <- fixef(fit)
+  stopifnot(length(fe) == 2L, identical(names(fe), c("(Intercept)", "age")))
+  stopifnot(all(is.finite(fe)))
+  # dental distance increases with age -> positive slope
+  stopifnot(fe["age"] > 0)
+  stopifnot(is.finite(as.numeric(logLik(fit))))
+  stopifnot(length(fitted(fit)) == nrow(Orthodont))
+  stopifnot(length(resid(fit)) == nrow(Orthodont))
+})
+
+run_test("lme fitted + residuals reconstruct the response", function() {
+  fit <- lme(distance ~ age, random = ~1 | Subject, data = Orthodont)
+  recon <- fitted(fit) + resid(fit)
+  # identity fitted + residual == observed, up to floating-point noise.
+  # compare raw numeric values -- the grouped-data response carries a `label`
+  # attribute that would trip all.equal's attribute comparison.
+  diff <- as.numeric(recon) - as.numeric(Orthodont$distance)
+  stopifnot(max(abs(diff)) < 1e-6)
+})
+
+run_test("lme recovers a known fixed effect (simulated)", function() {
+  set.seed(77)
+  ng <- 30L # groups
+  ni <- 8L  # observations per group
+  b0 <- 5
+  b1 <- 2.5
+  grp <- factor(rep(seq_len(ng), each = ni))
+  re <- rnorm(ng, sd = 1.5)[grp]
+  x <- rnorm(ng * ni)
+  y <- b0 + b1 * x + re + rnorm(ng * ni, sd = 0.5)
+  d <- data.frame(y = y, x = x, grp = grp)
+  fit <- lme(y ~ x, random = ~1 | grp, data = d)
+  fe <- fixef(fit)
+  stopifnot(all(is.finite(fe)))
+  # generous tolerances -- floating-point fit on simulated data
+  stopifnot(abs(fe["x"] - b1) < 0.3)
+  stopifnot(abs(fe["(Intercept)"] - b0) < 1.0)
+})
+
+run_test("gls fit on Orthodont", function() {
+  fit <- gls(distance ~ age, data = Orthodont)
+  stopifnot(inherits(fit, "gls"))
+  cf <- coef(fit)
+  stopifnot(length(cf) == 2L, all(is.finite(cf)))
+  stopifnot(cf["age"] > 0)
+  stopifnot(is.finite(as.numeric(logLik(fit))))
+  stopifnot(length(fitted(fit)) == nrow(Orthodont))
+})
+
+run_test("nlme nonlinear growth model on Loblolly", function() {
+  # self-starting logistic growth of pine height vs age, with a random
+  # asymptote per seed source. suppressWarnings guards benign convergence
+  # chatter, NOT genuine errors (a non-convergence error still propagates).
+  fit <- suppressWarnings(nlme(
+    height ~ SSlogis(age, Asym, xmid, scal),
+    data = Loblolly,
+    fixed = Asym + xmid + scal ~ 1,
+    random = Asym ~ 1 | Seed,
+    start = c(Asym = 103, xmid = 6, scal = 3)
+  ))
+  stopifnot(inherits(fit, "nlme"))
+  fe <- fixef(fit)
+  stopifnot(length(fe) == 3L)
+  stopifnot(identical(names(fe), c("Asym", "xmid", "scal")))
+  stopifnot(all(is.finite(fe)))
+  # the asymptotic height is a positive, physically plausible value
+  stopifnot(fe["Asym"] > 0)
+  stopifnot(is.finite(as.numeric(logLik(fit))))
+})
+
+run_test("corAR1 correlation structure fits", function() {
+  # lightly exercise a variance/correlation structure: an AR(1) within-subject
+  # correlation on the ordered Orthodont measurements.
+  fit <- gls(distance ~ age, data = Orthodont,
+             correlation = corAR1(form = ~1 | Subject))
+  stopifnot(inherits(fit, "gls"))
+  stopifnot(is.finite(as.numeric(logLik(fit))))
+  # the estimated AR(1) parameter is a valid correlation in (-1, 1)
+  phi <- coef(fit$modelStruct$corStruct, unconstrained = FALSE)
+  stopifnot(is.finite(phi), phi > -1, phi < 1)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all nlme smoke tests passed\n")

--- a/cli/scripts/lib-validator/nlmixr2.R
+++ b/cli/scripts/lib-validator/nlmixr2.R
@@ -1,0 +1,133 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `nlmixr2` package (population PK/PD NLME modeling).
+#
+# Fully self-contained: no input files, no network, no packages beyond nlmixr2
+# itself -- BUT nlmixr2 compiles models via rxode2, so a working C++ toolchain
+# is required at run time (intrinsic to nlmixr2, not a network dependency). The
+# test is deliberately MODEST: it defines a one-compartment model with the
+# nlmixr2 function/ini/model DSL, parses it into a model object, and runs ONE
+# small bounded fit on a fixed-seed simulated dataset. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript nlmixr2.R
+#
+# NOTE (needs re-check once installed): the nlmixr2 model DSL
+# (function(){ ini({...}); model({...}) }, linCmt(), add(...)), the parsed-model
+# class ("rxUi"), the fit class ("nlmixr2FitData"), and the fit accessors
+# (fixef, $objf) were written from the documented API and NOT verified against
+# an installed build -- re-confirm all of these when the package is available.
+# Fits are heavy and stochastic, so checks assert structural/robust properties
+# (classes, finiteness) with bounded iterations -- never exact estimates.
+
+if (!requireNamespace("nlmixr2", quietly = TRUE)) {
+  cat("FAIL: package 'nlmixr2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(nlmixr2))
+cat(sprintf("nlmixr2 version: %s\n", as.character(packageVersion("nlmixr2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# One-compartment first-order-absorption model in the nlmixr2 DSL: fixed effects
+# on log ka/cl/v, a per-subject random effect on each, additive residual error.
+one_cmt <- function() {
+  ini({
+    tka <- 0.45      # log ka
+    tcl <- 1.0       # log cl
+    tv  <- 3.45      # log v
+    add.sd <- 0.7    # additive residual sd
+    eta.ka ~ 0.1
+    eta.cl ~ 0.1
+    eta.v  ~ 0.1
+  })
+  model({
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v  <- exp(tv + eta.v)
+    linCmt() ~ add(add.sd)
+  })
+}
+
+# Fixed-seed simulated oral PK dataset (analytic one-compartment solution plus
+# subject-level and residual noise). Minimal nlmixr2 event format: an evid==1
+# dosing record per subject followed by evid==0 concentration observations.
+make_data <- function() {
+  set.seed(42)
+  n_id <- 6L
+  ka <- 1.5; cl <- 2.7; v <- 31.5; ke <- cl / v
+  dose <- 100
+  times <- c(0.5, 1, 2, 4, 8, 12, 24)
+  parts <- list()
+  for (id in seq_len(n_id)) {
+    dosing <- data.frame(id = id, time = 0, amt = dose, evid = 1L, dv = 0)
+    conc <- (dose * ka) / (v * (ka - ke)) * (exp(-ke * times) - exp(-ka * times))
+    conc <- conc * exp(rnorm(1L, 0, 0.1))             # between-subject variation
+    conc <- pmax(conc + rnorm(length(times), 0, 0.05), 1e-3) # residual, positive
+    obs <- data.frame(id = id, time = times, amt = 0, evid = 0L, dv = conc)
+    parts[[length(parts) + 1L]] <- rbind(dosing, obs)
+  }
+  do.call(rbind, parts)
+}
+
+run_test("model definition is a function", function() {
+  # a syntactically valid nlmixr2 model is an ordinary R function carrying the
+  # ini()/model() blocks; this validates the DSL parses at the R level
+  stopifnot(is.function(one_cmt))
+})
+
+run_test("nlmixr2 parses the model into a UI object", function() {
+  ui <- nlmixr2(one_cmt)
+  stopifnot(!is.null(ui))
+  # the parsed model is an rxode2 UI object
+  stopifnot(inherits(ui, "rxUi"))
+})
+
+run_test("parsed model exposes its fixed-effect names", function() {
+  ui <- nlmixr2(one_cmt)
+  ini_df <- ui$iniDf
+  stopifnot(is.data.frame(ini_df))
+  # the declared population parameters survive parsing
+  stopifnot(all(c("tka", "tcl", "tv") %in% ini_df$name))
+})
+
+run_test("simulated dataset has the expected event structure", function() {
+  dat <- make_data()
+  stopifnot(is.data.frame(dat))
+  stopifnot(all(c("id", "time", "amt", "evid", "dv") %in% names(dat)))
+  # exactly one dosing record per subject, plus observations
+  stopifnot(sum(dat$evid == 1L) == 6L)
+  stopifnot(sum(dat$evid == 0L) > 0L)
+  stopifnot(all(is.finite(dat$dv)), all(dat$dv[dat$evid == 0L] > 0))
+})
+
+run_test("a small bounded focei fit converges to finite estimates", function() {
+  dat <- make_data()
+  # bound the optimizer so the smoke test stays quick; silence progress output.
+  ctl <- foceiControl(print = 0L, maxOuterIterations = 20L,
+                      maxInnerIterations = 20L)
+  fit <- suppressWarnings(nlmixr2(one_cmt, dat, est = "focei", control = ctl))
+  stopifnot(inherits(fit, "nlmixr2FitData"))
+  fe <- fixef(fit)
+  stopifnot(length(fe) >= 3L, all(is.finite(fe)))
+  # the objective function value is a finite number
+  stopifnot(is.finite(as.numeric(fit$objf)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all nlmixr2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/numbat.R
+++ b/cli/scripts/lib-validator/numbat.R
@@ -1,0 +1,127 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `numbat` package.
+#
+# Fully self-contained and OFFLINE: no input files, no network. numbat calls
+# haplotype-aware copy-number variations and reconstructs tumor phylogenies from
+# single-cell data. Its full `run_numbat()` pipeline is deliberately NOT run: it
+# REQUIRES allele counts (`df_allele`), reference expression profiles
+# (`lambdas_ref`) and an external SNP phasing panel -- large inputs produced by
+# an upstream preprocessing/phasing step -- plus it writes many output files.
+# All of that is out of scope for an offline validator. Instead the test asserts
+# the package loads and exposes its core surface: the `run_numbat()` entry
+# point, the `Numbat` R6 class generator, and the get_bulk / aggregate_counts /
+# run_bulk helpers; plus it builds (but does NOT analyze) a small synthetic gene
+# x cell count matrix of the shape `count_mat` expects. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript numbat.R
+#
+# Install (GitHub-hosted):
+#   remotes::install_github("kharchenkolab/numbat")
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- numbat is NOT installed here, so confirm
+# all of the following once a build is available:
+#   - run_numbat() SIGNATURE. The formals check below asserts the documented
+#     arguments (count_mat, lambdas_ref, df_allele, genome) are present. If a
+#     version renames/removes any, update the check.
+#   - `Numbat` R6 CLASS. Assumed to be an exported R6ClassGenerator with a
+#     `$new()` constructor (the object wrapping a completed numbat result). If
+#     numbat changes the class system or the export name, update the check.
+#   - HELPER EXPORTS. get_bulk / aggregate_counts / run_bulk are checked SOFTLY
+#     (a missing one only notes, never fails) because the exact helper names
+#     drift between versions -- re-confirm the public helper set once installed.
+#   - INPUT SHAPE. count_mat is a GENES x CELLS raw count matrix; the synthetic
+#     matrix is built to that shape but is never passed to numbat.
+# ============================================================================
+
+if (!requireNamespace("numbat", quietly = TRUE)) {
+  cat("FAIL: package 'numbat' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(numbat))
+cat(sprintf("numbat version: %s\n", as.character(packageVersion("numbat"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic gene x cell raw count matrix: 80 genes x 24 cells, integer Poisson
+# draws with named rows/cols -- the shape numbat's `count_mat` expects (genes as
+# rows, cells as columns). Built only for a cheap structural check; it is NEVER
+# passed to run_numbat() (the full haplotype-aware pipeline needs allele +
+# expression + phasing inputs and writes output files, out of scope offline --
+# see the header note).
+set.seed(42)
+n_genes <- 80L
+n_cells <- 24L
+count_mat <- matrix(
+  rpois(n_genes * n_cells, lambda = 4),
+  nrow = n_genes, ncol = n_cells,
+  dimnames = list(sprintf("GENE%03d", seq_len(n_genes)),
+                  paste0("cell", seq_len(n_cells)))
+)
+
+run_test("run_numbat entry point is an exported function", function() {
+  stopifnot(is.function(run_numbat))
+})
+
+run_test("run_numbat() exposes its documented arguments", function() {
+  args <- names(formals(run_numbat))
+  # Core documented arguments (see the SIGNATURE note in the header block).
+  # Subset check: extra args in a newer version are fine; a rename is the case
+  # the header flags for re-confirmation.
+  expected <- c("count_mat", "lambdas_ref", "df_allele", "genome")
+  stopifnot(all(expected %in% args))
+})
+
+run_test("Numbat R6 class generator is exported", function() {
+  # numbat depends on R6; the result wrapper is an R6ClassGenerator whose
+  # $new() constructs the object around a completed numbat run.
+  stopifnot(inherits(Numbat, "R6ClassGenerator"))
+  stopifnot(is.function(Numbat$new))
+})
+
+run_test("core bulk/aggregation helpers are exported", function() {
+  exports <- getNamespaceExports("numbat")
+  # Softly checked (see HELPER EXPORTS note): helper names drift between
+  # versions, so a missing one only notes and must not false-fail a healthy
+  # install. get0() returns NULL rather than erroring when a name is absent.
+  for (fn in c("get_bulk", "aggregate_counts", "run_bulk")) {
+    present <- fn %in% exports &&
+      is.function(get0(fn, envir = asNamespace("numbat")))
+    if (!present) {
+      cat(sprintf(
+        "  note numbat helper '%s' not exported (verify helper set once installed)\n",
+        fn
+      ))
+    }
+  }
+})
+
+run_test("synthetic count matrix has the numbat-expected shape", function() {
+  # genes x cells, non-negative integer counts, named rows/cols -- what
+  # `count_mat` needs. This never touches run_numbat(); it only guards the
+  # construction above.
+  stopifnot(is.matrix(count_mat))
+  stopifnot(nrow(count_mat) == n_genes, ncol(count_mat) == n_cells)
+  stopifnot(!is.null(rownames(count_mat)), !is.null(colnames(count_mat)))
+  stopifnot(all(count_mat >= 0), all(count_mat == round(count_mat)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all numbat smoke tests passed\n")

--- a/cli/scripts/lib-validator/numpy.py
+++ b/cli/scripts/lib-validator/numpy.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `numpy` package.
+
+Fully self-contained: no input files, no network, no packages beyond numpy
+(and its implied deps). Exercises the core API surface and exits 0 only if
+every check passes, so it can be used as a pass/fail library validator:
+
+    python3 numpy.py
+
+Install: pip install numpy   (import name: numpy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import numpy as np
+except ImportError:
+    print("FAIL: package 'numpy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"numpy version: {_version(np, 'numpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_array_creation_and_dtype():
+    a = np.array([1, 2, 3], dtype=np.int64)
+    assert a.shape == (3,)
+    assert a.dtype == np.int64
+    assert a.sum() == 6
+    assert np.array_equal(a * 2, np.array([2, 4, 6]))
+
+
+def test_arange_reshape():
+    m = np.arange(12).reshape(3, 4)
+    assert m.shape == (3, 4)
+    assert m[2, 3] == 11
+    assert np.array_equal(m.T.shape, (4, 3))
+    assert np.array_equal(m.sum(axis=0), np.array([12, 15, 18, 21]))
+
+
+def test_broadcasting():
+    a = np.arange(3).reshape(3, 1)
+    b = np.arange(4).reshape(1, 4)
+    s = a + b
+    assert s.shape == (3, 4)
+    assert s[2, 3] == 5
+
+
+def test_linalg_solve():
+    A = np.array([[3.0, 2.0], [1.0, 2.0]])
+    b = np.array([5.0, 5.0])
+    x = np.linalg.solve(A, b)
+    assert np.allclose(A @ x, b)
+    assert np.isclose(np.linalg.det(A), 4.0)
+
+
+def test_boolean_indexing_and_reductions():
+    a = np.array([10, 20, 30, 40, 50])
+    assert np.array_equal(a[a > 25], np.array([30, 40, 50]))
+    assert np.isclose(a.mean(), 30.0)
+    assert np.isclose(a.std(), np.sqrt(200.0))
+
+
+def test_random_is_seeded_deterministic():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(5)
+    rng2 = np.random.default_rng(0)
+    assert np.allclose(x, rng2.standard_normal(5))
+
+
+run_test("array creation and dtype", test_array_creation_and_dtype)
+run_test("arange/reshape/transpose", test_arange_reshape)
+run_test("broadcasting", test_broadcasting)
+run_test("linalg solve + det", test_linalg_solve)
+run_test("boolean indexing and reductions", test_boolean_indexing_and_reductions)
+run_test("seeded RNG is deterministic", test_random_is_seeded_deterministic)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all numpy smoke tests passed")

--- a/cli/scripts/lib-validator/oligo.R
+++ b/cli/scripts/lib-validator/oligo.R
@@ -1,0 +1,82 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `oligo` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. oligo preprocesses
+# Affymetrix / NimbleGen microarrays whose raw intensities live in per-array
+# CEL / XYS files, and RMA additionally needs the matching platform-design
+# (pdInfo) package for the array. We have NEITHER the raw arrays NOR a pdInfo
+# package here, so a real read + normalize is OUT OF SCOPE OFFLINE. This test
+# therefore verifies only what is checkable without any array files: that the
+# package loads and that its core reader / preprocessing entry points and its
+# central S4 class are present. Exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript oligo.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# This test is FUNCTION/CLASS-EXISTENCE-DOMINATED because the real workflow
+# (read.celfiles() -> rma()) requires CEL/XYS files plus a pdInfoPackage that we
+# cannot construct or fetch offline. The checks below pass on any healthy
+# install; VERIFY ONCE INSTALLED that these are still the right names/shapes:
+#   - read.celfiles() / read.xysfiles() are the raw readers (need CEL/XYS files).
+#   - rma() is oligo's S4 generic; a real run needs a FeatureSet + a pdInfo pkg.
+#   - FeatureSet is the (virtual) base class for oligo's *FeatureSet objects
+#     (ExpressionFeatureSet, GeneFeatureSet, ...); getClass() must resolve it.
+# The generic-registration and virtual-class probes are kept SOFT (note, never
+# fail) so a reflection detail can't false-fail an otherwise healthy install.
+# ============================================================================
+
+if (!requireNamespace("oligo", quietly = TRUE)) {
+  cat("FAIL: package 'oligo' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(oligo))
+cat(sprintf("oligo version: %s\n", as.character(packageVersion("oligo"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("raw-array reader functions are exported", function() {
+  stopifnot(exists("read.celfiles"), is.function(read.celfiles))
+  stopifnot(exists("read.xysfiles"), is.function(read.xysfiles))
+})
+
+run_test("rma preprocessing entry point is present and callable", function() {
+  # A generic IS a function, so is.function(rma) holds whether rma is a plain
+  # function or (as expected) an S4 generic. That callable existence is the
+  # load-bearing check; the generic registration below is only a soft signal.
+  stopifnot(exists("rma"), is.function(rma))
+  if (!isGeneric("rma")) {
+    cat("  note rma is not registered as an S4 generic (verify once installed)\n")
+  }
+})
+
+run_test("FeatureSet S4 class is defined", function() {
+  # getClass() searches every loaded namespace; oligoClasses (loaded with oligo)
+  # defines FeatureSet, so this resolves without needing any array object.
+  cls <- getClass("FeatureSet")
+  stopifnot(!is.null(cls), isVirtualClass("FeatureSet") %in% c(TRUE, FALSE))
+  # FeatureSet is expected to be the VIRTUAL parent of the concrete *FeatureSet
+  # classes. Soft-note (do not fail) if the install reports otherwise.
+  if (!isVirtualClass("FeatureSet")) {
+    cat("  note FeatureSet is not a virtual class (verify once installed)\n")
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all oligo smoke tests passed\n")

--- a/cli/scripts/lib-validator/ontologyIndex.R
+++ b/cli/scripts/lib-validator/ontologyIndex.R
@@ -1,0 +1,117 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `ontologyIndex` package.
+#
+# Fully self-contained: no input files, NO network. ontologyIndex ships small
+# example ontologies as package data, so every check runs offline against
+# bundled objects. Exercises the ontology-traversal API and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript ontologyIndex.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed:
+#
+# 1. DATASET NAME: this uses the bundled `hpo` example ontology (ontologyIndex
+#    ships `hpo` and `go`). If data("hpo") is unavailable, adjust to the actual
+#    bundled dataset name.
+#
+# 2. VALIDATION FN: the consistency checker is called `check_ontology` in some
+#    versions and `check` in others -- this auto-detects whichever the
+#    namespace exports. If neither exists the API changed; investigate.
+#
+# 3. TERM IDS: rather than hardcoding term accessions, tests pick ids FROM the
+#    loaded ontology (roots, hpo$id[10]). One optional check uses HP:0000118
+#    only IF present. So the checks hold regardless of the bundled HPO release.
+# ============================================================================
+#
+# The bundled ontology is fixed, so checks are structural (class, field
+# presence, ancestor/descendant closure containing the query term).
+
+if (!requireNamespace("ontologyIndex", quietly = TRUE)) {
+  cat("FAIL: package 'ontologyIndex' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(ontologyIndex))
+cat(sprintf("ontologyIndex version: %s\n",
+            as.character(packageVersion("ontologyIndex"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared ontology, populated by the first test and reused by the rest.
+onto <- NULL
+
+run_test("bundled hpo example is a valid ontology_index", function() {
+  # load into this closure's environment, not the global env
+  data("hpo", package = "ontologyIndex", envir = environment())
+  stopifnot(exists("hpo"))
+  stopifnot(inherits(hpo, "ontology_index"))
+  # an ontology_index carries these core fields
+  stopifnot(all(c("id", "name", "parents", "children", "ancestors") %in% names(hpo)))
+  stopifnot(length(hpo$id) > 0L)
+  onto <<- hpo
+})
+
+run_test("get_ancestors returns a closure containing the term itself", function() {
+  stopifnot(!is.null(onto))
+  # pick a real term from the ontology rather than hardcoding an accession
+  term <- onto$id[[10]]
+  anc <- ontologyIndex::get_ancestors(onto, term)
+  stopifnot(is.character(anc), length(anc) >= 1L)
+  # a term is its own ancestor in ontologyIndex's closure convention
+  stopifnot(term %in% anc)
+})
+
+run_test("get_descendants from a root spans many terms", function() {
+  stopifnot(!is.null(onto))
+  # a root has no parents; its descendant closure covers a large subtree
+  root_ids <- onto$id[vapply(onto$parents, length, integer(1)) == 0L]
+  stopifnot(length(root_ids) >= 1L)
+  root <- root_ids[[1]]
+  desc <- ontologyIndex::get_descendants(onto, roots = root)
+  stopifnot(is.character(desc))
+  stopifnot(root %in% desc)
+  stopifnot(length(desc) > 1L)
+})
+
+run_test("optional HP:0000118 ancestor closure (if present)", function() {
+  stopifnot(!is.null(onto))
+  # "Phenotypic abnormality" -- assert only when the bundled release has it
+  if ("HP:0000118" %in% onto$id) {
+    anc <- ontologyIndex::get_ancestors(onto, "HP:0000118")
+    stopifnot("HP:0000118" %in% anc)
+  }
+})
+
+run_test("consistency checker validates the ontology", function() {
+  stopifnot(!is.null(onto))
+  ns <- asNamespace("ontologyIndex")
+  checker <- if (exists("check_ontology", envir = ns, inherits = FALSE)) {
+    get("check_ontology", envir = ns)
+  } else if (exists("check", envir = ns, inherits = FALSE)) {
+    get("check", envir = ns)
+  } else {
+    stop("no `check_ontology`/`check` function found in ontologyIndex")
+  }
+  # a consistent ontology returns cleanly; an inconsistent one errors
+  checker(onto)
+  invisible(TRUE)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all ontologyIndex smoke tests passed\n")

--- a/cli/scripts/lib-validator/openpyxl.py
+++ b/cli/scripts/lib-validator/openpyxl.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `openpyxl` package.
+
+Fully self-contained: no input files, no network, no packages beyond openpyxl
+(and its implied deps). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 openpyxl.py
+
+Install: pip install openpyxl   (import name: openpyxl)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import openpyxl
+except ImportError:
+    print("FAIL: package 'openpyxl' is not installed")
+    sys.exit(1)
+
+import tempfile
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"openpyxl version: {_version(openpyxl, 'openpyxl')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_workbook_write_and_read_cells():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "x"
+    ws["B2"] = 42
+    assert ws["A1"].value == "x"
+    assert ws["B2"].value == 42
+
+
+def test_formula_cell_stored_verbatim():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = 2
+    ws["A2"] = 3
+    ws["A3"] = "=SUM(A1:A2)"
+    # openpyxl stores the formula string (it does not evaluate it).
+    assert ws["A3"].value == "=SUM(A1:A2)"
+
+
+def test_save_reopen_roundtrip_tempfile():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "x"
+    ws["B2"] = 42
+    fd, path = tempfile.mkstemp(suffix=".xlsx")
+    os.close(fd)
+    try:
+        wb.save(path)
+        assert os.path.getsize(path) > 0
+        reopened = openpyxl.load_workbook(path)
+        rws = reopened.active
+        assert rws["A1"].value == "x"
+        assert rws["B2"].value == 42
+    finally:
+        os.remove(path)
+
+
+def test_append_rows_and_dimensions():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append([1, 2, 3])
+    ws.append([4, 5, 6])
+    assert ws.max_row == 2
+    assert ws.max_column == 3
+    assert ws["C2"].value == 6
+
+
+run_test("workbook write/read cells", test_workbook_write_and_read_cells)
+run_test("formula cell stored verbatim", test_formula_cell_stored_verbatim)
+run_test("save/reopen roundtrip tempfile", test_save_reopen_roundtrip_tempfile)
+run_test("append rows + dimensions", test_append_rows_and_dimensions)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all openpyxl smoke tests passed")

--- a/cli/scripts/lib-validator/openxlsx2.R
+++ b/cli/scripts/lib-validator/openxlsx2.R
@@ -1,0 +1,70 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `openxlsx2` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# openxlsx2 itself. Roundtrips a data frame through a tempfile workbook
+# (cleaned up on exit) and exits 0 only if every check passes, so it can
+# be used as a pass/fail library validator:
+#
+#   Rscript openxlsx2.R
+
+if (!requireNamespace("openxlsx2", quietly = TRUE)) {
+  cat("FAIL: package 'openxlsx2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(openxlsx2))
+cat(sprintf("openxlsx2 version: %s\n", as.character(packageVersion("openxlsx2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("workbook save/read_xlsx roundtrip via tempfile", function() {
+  df <- data.frame(a = 1:3, b = c("x", "y", "z"), stringsAsFactors = FALSE)
+  # openxlsx2's chaining API: wbWorkbook methods return the workbook.
+  wb <- wb_workbook()$add_worksheet("s1")$add_data(x = df)
+  tmp <- tempfile("openxlsx2-smoke-", fileext = ".xlsx")
+  on.exit(unlink(tmp), add = TRUE)
+  wb_save(wb, tmp)
+  stopifnot(file.exists(tmp), file.size(tmp) > 0)
+  back <- read_xlsx(tmp)
+  stopifnot(nrow(back) == 3L, ncol(back) == 2L)
+  stopifnot(identical(names(back), c("a", "b")))
+  stopifnot(isTRUE(all.equal(as.numeric(back$a), c(1, 2, 3))))
+  stopifnot(identical(as.character(back$b), c("x", "y", "z")))
+})
+
+run_test("wb_to_df reads back from the in-memory workbook", function() {
+  df <- data.frame(a = 1:3, b = c("x", "y", "z"), stringsAsFactors = FALSE)
+  # Same pipeline through the functional (non-chaining) API surface.
+  wb <- wb_workbook()
+  wb <- wb_add_worksheet(wb, "s1")
+  wb <- wb_add_data(wb, sheet = "s1", x = df)
+  back <- wb_to_df(wb, sheet = "s1")
+  stopifnot(nrow(back) == 3L, ncol(back) == 2L)
+  stopifnot(identical(names(back), c("a", "b")))
+  stopifnot(isTRUE(all.equal(as.numeric(back$a), c(1, 2, 3))))
+  stopifnot(identical(as.character(back$b), c("x", "y", "z")))
+})
+
+run_test("sheet names are tracked", function() {
+  wb <- wb_workbook()$add_worksheet("first")$add_worksheet("second")
+  stopifnot(identical(unname(wb_get_sheet_names(wb)), c("first", "second")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all openxlsx2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/optparse.R
+++ b/cli/scripts/lib-validator/optparse.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `optparse` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# optparse itself. Parsing runs against FIXED argument vectors (never the
+# process's real argv), so it is deterministic. Exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript optparse.R
+
+if (!requireNamespace("optparse", quietly = TRUE)) {
+  cat("FAIL: package 'optparse' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(optparse))
+cat(sprintf("optparse version: %s\n", as.character(packageVersion("optparse"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+make_parser <- function() {
+  option_list <- list(
+    optparse::make_option(c("-n", "--num"), type = "integer", default = 1L),
+    optparse::make_option(c("-v", "--verbose"), action = "store_true", default = FALSE)
+  )
+  optparse::OptionParser(option_list = option_list)
+}
+
+run_test("integer option and store_true flag parse", function() {
+  opts <- optparse::parse_args(make_parser(), args = c("--num", "5", "--verbose"))
+  stopifnot(identical(opts$num, 5L))
+  stopifnot(isTRUE(opts$verbose))
+})
+
+run_test("defaults applied when args are absent", function() {
+  opts <- optparse::parse_args(make_parser(), args = character(0))
+  stopifnot(identical(opts$num, 1L))
+  stopifnot(identical(opts$verbose, FALSE))
+})
+
+run_test("positional arguments captured alongside options", function() {
+  res <- optparse::parse_args(
+    make_parser(),
+    args = c("--num", "7", "file1.txt", "file2.txt"),
+    positional_arguments = TRUE
+  )
+  stopifnot(identical(res$options$num, 7L))
+  stopifnot(identical(res$args, c("file1.txt", "file2.txt")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all optparse smoke tests passed\n")

--- a/cli/scripts/lib-validator/optuna.py
+++ b/cli/scripts/lib-validator/optuna.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `optuna` package.
+
+Fully self-contained: no input files, no network, no storage backend (the
+default in-memory study), and no packages beyond optuna and its implied deps.
+The sampler is seeded so the search is reproducible. Exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 optuna.py
+
+Install: pip install optuna   (import name: optuna)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import optuna
+except ImportError:
+    print("FAIL: package 'optuna' is not installed")
+    sys.exit(1)
+
+# Keep the per-trial INFO chatter out of the validator output.
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"optuna version: {_version(optuna, 'optuna')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_minimization_converges():
+    sampler = optuna.samplers.TPESampler(seed=0)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(
+        lambda t: (t.suggest_float("x", -10.0, 10.0) - 2.0) ** 2, n_trials=25
+    )
+    assert len(study.trials) == 25
+    # (x-2)^2 bottoms out at 0 for x=2; a seeded TPE search should land near it.
+    # Tolerances are generous: |x-2| < 2 keeps the check robust across versions.
+    assert study.best_value < 2.0
+    assert abs(study.best_params["x"] - 2.0) < 2.0
+
+
+def test_study_records_trials_and_direction():
+    study = optuna.create_study(
+        direction="minimize", sampler=optuna.samplers.TPESampler(seed=1)
+    )
+    study.optimize(lambda t: abs(t.suggest_float("x", -5.0, 5.0)), n_trials=15)
+    assert len(study.trials) == 15
+    assert study.direction == optuna.study.StudyDirection.MINIMIZE
+    # best_value is exactly the smallest objective across completed trials.
+    values = [t.value for t in study.trials if t.value is not None]
+    assert study.best_value == min(values)
+
+
+run_test("minimization converges near x=2", test_minimization_converges)
+run_test("study records trials + direction", test_study_records_trials_and_direction)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all optuna smoke tests passed")

--- a/cli/scripts/lib-validator/org.Bt.eg.db.R
+++ b/cli/scripts/lib-validator/org.Bt.eg.db.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Bt.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Bt.eg.db is an OrgDb
+# annotation DATA package that vendors a cattle gene-annotation SQLite database
+# locally; once installed every query below runs fully OFFLINE. Exercises the
+# AnnotationDbi query API against the bundled DB and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Bt.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# No Entrez id is hardcoded here -- the round-trip alone proves DB integrity.
+# VERIFY ONCE INSTALLED:
+#   - gene symbol "TP53" is present in the cattle DB.
+#   - organism string expected "Bos taurus".
+# ============================================================================
+
+if (!requireNamespace("org.Bt.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Bt.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Bt.eg.db))
+cat(sprintf("org.Bt.eg.db version: %s\n", as.character(packageVersion("org.Bt.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "TP53"
+organism <- "Bos taurus"
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Bt.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Bt.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Bt.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Bt.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Bt.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Bt.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(identical(sp, organism))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Bt.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/org.Cf.eg.db.R
+++ b/cli/scripts/lib-validator/org.Cf.eg.db.R
@@ -1,0 +1,99 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Cf.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Cf.eg.db is an OrgDb
+# annotation DATA package that vendors a dog gene-annotation SQLite database
+# locally; once installed every query below runs fully OFFLINE. Exercises the
+# AnnotationDbi query API against the bundled DB and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Cf.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# No Entrez id is hardcoded here -- the round-trip alone proves DB integrity.
+# VERIFY ONCE INSTALLED:
+#   - gene symbol "TP53" is present in the dog DB.
+#   - organism string: newer builds report "Canis lupus familiaris", but OLDER
+#     builds report "Canis familiaris". The species check accepts EITHER; if the
+#     installed build uses a third spelling, tighten this once installed.
+# ============================================================================
+
+if (!requireNamespace("org.Cf.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Cf.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Cf.eg.db))
+cat(sprintf("org.Cf.eg.db version: %s\n", as.character(packageVersion("org.Cf.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "TP53"
+# Accept either the modern or legacy organism spelling (see header flag).
+organism_accepted <- c("Canis lupus familiaris", "Canis familiaris")
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Cf.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Cf.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Cf.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Cf.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Cf.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Cf.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(is.character(sp), length(sp) == 1L, sp %in% organism_accepted)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Cf.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/org.Dr.eg.db.R
+++ b/cli/scripts/lib-validator/org.Dr.eg.db.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Dr.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Dr.eg.db is an OrgDb
+# annotation DATA package that vendors a zebrafish gene-annotation SQLite
+# database locally; once installed every query below runs fully OFFLINE.
+# Exercises the AnnotationDbi query API against the bundled DB and exits 0 only
+# if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Dr.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# No Entrez id is hardcoded here -- the round-trip alone proves DB integrity.
+# VERIFY ONCE INSTALLED:
+#   - zebrafish gene symbols are lowercase; "tp53" is present in the DB.
+#   - organism string expected "Danio rerio".
+# ============================================================================
+
+if (!requireNamespace("org.Dr.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Dr.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Dr.eg.db))
+cat(sprintf("org.Dr.eg.db version: %s\n", as.character(packageVersion("org.Dr.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "tp53"
+organism <- "Danio rerio"
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Dr.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Dr.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Dr.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Dr.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Dr.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Dr.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(identical(sp, organism))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Dr.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/org.Hs.eg.db.R
+++ b/cli/scripts/lib-validator/org.Hs.eg.db.R
@@ -1,0 +1,103 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Hs.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Hs.eg.db is an OrgDb
+# annotation DATA package that vendors a human gene-annotation SQLite database
+# locally; once installed every query below runs fully OFFLINE. Exercises the
+# AnnotationDbi query API against the bundled DB and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Hs.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# One assertion is a hardcoded Entrez id, clearly flagged below and kept SOFT
+# (it only warns, never fails) so a slightly-off id can't false-fail a healthy
+# DB. VERIFY ONCE INSTALLED:
+#   - TP53 Entrez id commonly 7157.
+#   - organism string expected "Homo sapiens".
+# ============================================================================
+
+if (!requireNamespace("org.Hs.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Hs.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Hs.eg.db))
+cat(sprintf("org.Hs.eg.db version: %s\n", as.character(packageVersion("org.Hs.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "TP53"
+organism <- "Homo sapiens"
+entrez_expected <- "7157"  # VERIFY ONCE INSTALLED -- soft assertion only
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Hs.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Hs.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Hs.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Hs.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+  # SOFT known-id check: warn (do NOT fail) if the vendored id differs.
+  if (!identical(unname(id), entrez_expected)) {
+    cat(sprintf("  note %s ENTREZID is %s (expected %s -- verify once installed)\n",
+                gene, unname(id), entrez_expected))
+  }
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Hs.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Hs.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(identical(sp, organism))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Hs.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/org.Mm.eg.db.R
+++ b/cli/scripts/lib-validator/org.Mm.eg.db.R
@@ -1,0 +1,103 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Mm.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Mm.eg.db is an OrgDb
+# annotation DATA package that vendors a mouse gene-annotation SQLite database
+# locally; once installed every query below runs fully OFFLINE. Exercises the
+# AnnotationDbi query API against the bundled DB and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Mm.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# One assertion is a hardcoded Entrez id, clearly flagged below and kept SOFT
+# (it only warns, never fails) so a slightly-off id can't false-fail a healthy
+# DB. VERIFY ONCE INSTALLED:
+#   - Trp53 Entrez id commonly 22059.
+#   - organism string expected "Mus musculus".
+# ============================================================================
+
+if (!requireNamespace("org.Mm.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Mm.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Mm.eg.db))
+cat(sprintf("org.Mm.eg.db version: %s\n", as.character(packageVersion("org.Mm.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "Trp53"
+organism <- "Mus musculus"
+entrez_expected <- "22059"  # VERIFY ONCE INSTALLED -- soft assertion only
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Mm.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Mm.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Mm.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Mm.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+  # SOFT known-id check: warn (do NOT fail) if the vendored id differs.
+  if (!identical(unname(id), entrez_expected)) {
+    cat(sprintf("  note %s ENTREZID is %s (expected %s -- verify once installed)\n",
+                gene, unname(id), entrez_expected))
+  }
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Mm.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Mm.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(identical(sp, organism))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Mm.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/org.Rn.eg.db.R
+++ b/cli/scripts/lib-validator/org.Rn.eg.db.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `org.Rn.eg.db` package.
+#
+# Fully self-contained: no input files, NO network. org.Rn.eg.db is an OrgDb
+# annotation DATA package that vendors a rat gene-annotation SQLite database
+# locally; once installed every query below runs fully OFFLINE. Exercises the
+# AnnotationDbi query API against the bundled DB and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript org.Rn.eg.db.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# The load-bearing assertions are STRUCTURAL (columns/keytypes present, keys
+# nonempty) and the SYMBOL->ENTREZID->SYMBOL round-trip (a self-consistency
+# check that needs no hardcoded id). These pass on any healthy install.
+#
+# No Entrez id is hardcoded here -- the round-trip alone proves DB integrity.
+# VERIFY ONCE INSTALLED:
+#   - gene symbol "Tp53" is present in the rat DB.
+#   - organism string expected "Rattus norvegicus".
+# ============================================================================
+
+if (!requireNamespace("org.Rn.eg.db", quietly = TRUE)) {
+  cat("FAIL: package 'org.Rn.eg.db' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(org.Rn.eg.db))
+cat(sprintf("org.Rn.eg.db version: %s\n", as.character(packageVersion("org.Rn.eg.db"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# The OrgDb object is exported under the same name as the package.
+gene <- "Tp53"
+organism <- "Rattus norvegicus"
+
+run_test("OrgDb object is exported and well-typed", function() {
+  orgdb <- org.Rn.eg.db
+  stopifnot(inherits(orgdb, "OrgDb"))
+})
+
+run_test("columns and keytypes expose the core annotation fields", function() {
+  orgdb <- org.Rn.eg.db
+  cols <- AnnotationDbi::columns(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID", "ENSEMBL") %in% cols))
+  kts <- AnnotationDbi::keytypes(orgdb)
+  stopifnot(all(c("SYMBOL", "ENTREZID") %in% kts))
+})
+
+run_test("keys(keytype=SYMBOL) returns a nonempty character vector", function() {
+  orgdb <- org.Rn.eg.db
+  ks <- AnnotationDbi::keys(orgdb, keytype = "SYMBOL")
+  stopifnot(is.character(ks), length(ks) > 0L)
+})
+
+run_test("SYMBOL -> ENTREZID -> SYMBOL round-trips (DB integrity)", function() {
+  orgdb <- org.Rn.eg.db
+  id <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = gene, column = "ENTREZID", keytype = "SYMBOL"))
+  stopifnot(is.character(id), length(id) == 1L, !is.na(id), grepl("^[0-9]+$", id))
+  sym <- suppressMessages(AnnotationDbi::mapIds(
+    orgdb, keys = id, column = "SYMBOL", keytype = "ENTREZID"))
+  stopifnot(is.character(sym), length(sym) == 1L, !is.na(sym), identical(unname(sym), gene))
+})
+
+run_test("select() returns a data.frame with requested columns and rows", function() {
+  orgdb <- org.Rn.eg.db
+  df <- suppressMessages(AnnotationDbi::select(
+    orgdb, keys = gene, keytype = "SYMBOL", columns = c("ENTREZID", "ENSEMBL")))
+  stopifnot(is.data.frame(df), nrow(df) >= 1L)
+  stopifnot(all(c("ENTREZID", "ENSEMBL") %in% names(df)))
+})
+
+run_test("species metadata matches the organism", function() {
+  orgdb <- org.Rn.eg.db
+  sp <- AnnotationDbi::species(orgdb)
+  stopifnot(identical(sp, organism))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all org.Rn.eg.db smoke tests passed\n")

--- a/cli/scripts/lib-validator/orjson.py
+++ b/cli/scripts/lib-validator/orjson.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `orjson` package.
+
+Fully self-contained: no input files, no network, no packages beyond orjson
+(and its implied deps; the numpy check needs numpy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 orjson.py
+
+Install: pip install orjson   (import name: orjson)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import orjson
+except ImportError:
+    print("FAIL: package 'orjson' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"orjson version: {_version(orjson, 'orjson')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_dumps_returns_bytes():
+    out = orjson.dumps({"a": 1, "b": [1, 2]})
+    # Unlike stdlib json, orjson.dumps returns bytes, not str.
+    assert isinstance(out, bytes)
+    assert out == b'{"a":1,"b":[1,2]}'
+
+
+def test_roundtrip():
+    obj = {"a": 1, "b": [1, 2], "c": {"nested": True}, "d": None}
+    assert orjson.loads(orjson.dumps(obj)) == obj
+
+
+def test_sort_keys_option():
+    out = orjson.dumps({"b": 2, "a": 1}, option=orjson.OPT_SORT_KEYS)
+    assert out == b'{"a":1,"b":2}'
+
+
+def test_numpy_option():
+    import numpy as np
+
+    arr = np.array([[1, 2], [3, 4]], dtype=np.int64)
+    out = orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
+    assert orjson.loads(out) == [[1, 2], [3, 4]]
+
+
+def test_datetime_serialization():
+    import datetime
+
+    dt = datetime.datetime(2021, 1, 1, 12, 0, 0)
+    out = orjson.dumps(dt)
+    # orjson emits RFC 3339 / ISO 8601 timestamps natively.
+    assert out == b'"2021-01-01T12:00:00"'
+
+
+run_test("dumps returns bytes", test_dumps_returns_bytes)
+run_test("loads/dumps roundtrip", test_roundtrip)
+run_test("OPT_SORT_KEYS orders keys", test_sort_keys_option)
+run_test("OPT_SERIALIZE_NUMPY", test_numpy_option)
+run_test("datetime serialization", test_datetime_serialization)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all orjson smoke tests passed")

--- a/cli/scripts/lib-validator/otelsdk.R
+++ b/cli/scripts/lib-validator/otelsdk.R
@@ -1,0 +1,108 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `otelsdk` package (OpenTelemetry SDK for R).
+#
+# Fully self-contained and STRICTLY OFFLINE: no input files, no network, no
+# collector, no packages beyond otelsdk itself (and its `otel` API dependency).
+# The test only creates a tracer provider, obtains a tracer, and starts/ends a
+# span in-process; it never exports to any endpoint. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript otelsdk.R
+#
+# NOTE (needs re-check once installed): the otelsdk tracing API surface used
+# below (provider constructor, get_tracer / start_span / span$end) was written
+# from the documented OpenTelemetry-for-R design and NOT verified against an
+# installed build. Re-confirm the exact provider/tracer/span entry points and
+# class names when the package is available. Checks are deliberately modest and
+# structural (objects are non-null, of the expected class, and spans start/end
+# without error) precisely because of that uncertainty.
+
+if (!requireNamespace("otelsdk", quietly = TRUE)) {
+  cat("FAIL: package 'otelsdk' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(otelsdk))
+cat(sprintf("otelsdk version: %s\n", as.character(packageVersion("otelsdk"))))
+
+# Belt-and-braces: force the "none" exporter so no attempt is ever made to reach
+# a collector, regardless of ambient OTEL_* environment configuration.
+Sys.setenv(OTEL_TRACES_EXPORTER = "none")
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Construct an in-process tracer provider that does not export anywhere. The
+# memory/stdstream providers keep everything local; we prefer the memory one so
+# nothing is even written to a stream.
+make_provider <- function() {
+  tracer_provider_memory()
+}
+
+run_test("tracer provider constructs offline", function() {
+  tp <- make_provider()
+  stopifnot(!is.null(tp))
+  # providers are environment/R6-style objects exposing a get_tracer method
+  stopifnot(is.function(tp$get_tracer))
+})
+
+run_test("get_tracer returns a tracer object", function() {
+  tp <- make_provider()
+  tr <- tp$get_tracer("smoke-tracer")
+  stopifnot(!is.null(tr))
+  # a tracer exposes a span-creation method
+  stopifnot(is.function(tr$start_span))
+})
+
+run_test("start and end a span without error", function() {
+  tp <- make_provider()
+  tr <- tp$get_tracer("smoke-tracer")
+  sp <- tr$start_span("unit-of-work")
+  stopifnot(!is.null(sp))
+  # a live span should report that it is recording before it ends
+  stopifnot(isTRUE(sp$is_recording()))
+  sp$end()
+  # once ended, the span must no longer be recording
+  stopifnot(isFALSE(sp$is_recording()))
+})
+
+run_test("span accepts attributes", function() {
+  tp <- make_provider()
+  tr <- tp$get_tracer("smoke-tracer")
+  sp <- tr$start_span("attributed")
+  # setting attributes on an active span must not error
+  sp$set_attribute("component", "lib-validator")
+  sp$set_attribute("iteration", 1L)
+  sp$end()
+  stopifnot(isFALSE(sp$is_recording()))
+})
+
+run_test("nested spans start and end in order", function() {
+  tp <- make_provider()
+  tr <- tp$get_tracer("smoke-tracer")
+  outer <- tr$start_span("outer")
+  inner <- tr$start_span("inner")
+  stopifnot(isTRUE(inner$is_recording()))
+  inner$end()
+  stopifnot(isFALSE(inner$is_recording()))
+  stopifnot(isTRUE(outer$is_recording()))
+  outer$end()
+  stopifnot(isFALSE(outer$is_recording()))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all otelsdk smoke tests passed\n")

--- a/cli/scripts/lib-validator/pROC.R
+++ b/cli/scripts/lib-validator/pROC.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `pROC` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# pROC itself. Data is simulated with a fixed seed: a binary outcome plus a
+# predictor correlated with it. Exercises the core ROC / AUC API and exits 0
+# only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript pROC.R
+#
+# ROC/AUC/CI outputs are floating-point, so checks assert structural and
+# robust properties (classes, ranges, CI bracketing, monotone comparisons)
+# within generous tolerances -- never exact numeric equality.
+
+if (!requireNamespace("pROC", quietly = TRUE)) {
+  cat("FAIL: package 'pROC' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(pROC))
+cat(sprintf("pROC version: %s\n", as.character(packageVersion("pROC"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared fixture: a binary response and two predictors of differing strength.
+# direction "<" and explicit levels make the ROC deterministic and silence the
+# auto-direction message; quiet = TRUE suppresses the remaining console chatter.
+set.seed(1)
+n <- 300L
+response <- rbinom(n, size = 1, prob = 0.5)
+strong <- response + rnorm(n, sd = 0.6) # cases score higher -> strong signal
+weak <- response + rnorm(n, sd = 3.0) # noisier -> weaker signal
+
+roc_strong <- pROC::roc(response, strong,
+                        levels = c(0, 1), direction = "<", quiet = TRUE)
+roc_weak <- pROC::roc(response, weak,
+                      levels = c(0, 1), direction = "<", quiet = TRUE)
+
+run_test("roc object and AUC for a strong predictor", function() {
+  stopifnot(inherits(roc_strong, "roc"))
+  a <- as.numeric(pROC::auc(roc_strong))
+  # AUC lives in (0.5, 1]; a strong predictor clears 0.7 comfortably
+  stopifnot(a > 0.5, a <= 1)
+  stopifnot(a > 0.7)
+})
+
+run_test("ci.auc returns a 3-number CI bracketing the AUC", function() {
+  a <- as.numeric(pROC::auc(roc_strong))
+  ci <- as.numeric(pROC::ci.auc(roc_strong)) # DeLong CI: deterministic
+  stopifnot(length(ci) == 3L)
+  # element 2 is the AUC point estimate; 1 and 3 are the CI bounds
+  stopifnot(ci[1] <= ci[2], ci[2] <= ci[3])
+  stopifnot(abs(ci[2] - a) < 1e-6)
+  stopifnot(ci[1] >= 0, ci[3] <= 1)
+})
+
+run_test("coords(best) yields threshold/sensitivity/specificity", function() {
+  # transpose = FALSE returns a data.frame with named columns. NOTE: pre-1.16
+  # pROC returned a transposed named VECTOR by default -- flag on re-check.
+  co <- pROC::coords(roc_strong, x = "best",
+                     ret = c("threshold", "sensitivity", "specificity"),
+                     transpose = FALSE)
+  stopifnot(is.data.frame(co), nrow(co) >= 1L)
+  stopifnot(all(c("threshold", "sensitivity", "specificity") %in% names(co)))
+  stopifnot(all(co$sensitivity >= 0), all(co$sensitivity <= 1))
+  stopifnot(all(co$specificity >= 0), all(co$specificity <= 1))
+  stopifnot(all(is.finite(co$threshold)))
+})
+
+run_test("roc.test between two predictors returns a p-value", function() {
+  # paired DeLong test: both ROC curves share the same response vector
+  tst <- pROC::roc.test(roc_strong, roc_weak)
+  stopifnot(inherits(tst, "htest"))
+  stopifnot(is.finite(tst$p.value), tst$p.value >= 0, tst$p.value <= 1)
+  # the stronger predictor should out-AUC the weaker one
+  stopifnot(as.numeric(pROC::auc(roc_strong)) > as.numeric(pROC::auc(roc_weak)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all pROC smoke tests passed\n")

--- a/cli/scripts/lib-validator/palantir.py
+++ b/cli/scripts/lib-validator/palantir.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `palantir` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 palantir.py
+
+Install: pip install palantir   (import name: palantir)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: Palantir is a heavy trajectory/pseudotime stack (scanpy,
+anndata). Running a real trajectory needs a preprocessed AnnData and diffusion
+maps, so this only asserts the package imports and exposes its documented entry
+points — it does NOT run Palantir. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import palantir
+except ImportError:
+    print("FAIL: package 'palantir' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"palantir version: {_version(palantir, 'palantir')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_import_exposes_submodules():
+    import importlib
+
+    # utils/core are the workhorse submodules; import lazily so a missing one
+    # is a test failure, not a top-level crash.
+    assert importlib.import_module("palantir.utils") is not None
+    assert importlib.import_module("palantir.core") is not None
+
+
+def test_exposes_run_palantir_entry_point():
+    assert hasattr(palantir, "run_palantir")
+    assert callable(palantir.run_palantir)
+
+
+run_test("import exposes palantir.utils / palantir.core", test_import_exposes_submodules)
+run_test("exposes run_palantir entry point", test_exposes_run_palantir_entry_point)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all palantir smoke tests passed")

--- a/cli/scripts/lib-validator/pandas.py
+++ b/cli/scripts/lib-validator/pandas.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pandas` package.
+
+Fully self-contained: no input files, no network, no packages beyond pandas
+(and its implied deps). Exercises the core API surface and exits 0 only if
+every check passes, so it can be used as a pass/fail library validator:
+
+    python3 pandas.py
+
+Install: pip install pandas   (import name: pandas)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pandas as pd
+except ImportError:
+    print("FAIL: package 'pandas' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pandas version: {_version(pd, 'pandas')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_dataframe_construct_and_dtypes():
+    df = pd.DataFrame({"i": [1, 2, 3], "f": [1.5, 2.5, 3.5], "s": ["a", "b", "c"]})
+    assert df.shape == (3, 3)
+    assert list(df.columns) == ["i", "f", "s"]
+    assert df["i"].dtype == "int64"
+    assert df["f"].dtype == "float64"
+    assert df["s"].dtype == object
+    assert df["i"].sum() == 6
+
+
+def test_groupby_agg_exact_means():
+    df = pd.DataFrame({"g": ["a", "a", "b", "b", "b"], "v": [1.0, 3.0, 2.0, 4.0, 6.0]})
+    means = df.groupby("g")["v"].mean()
+    assert means.loc["a"] == 2.0
+    assert means.loc["b"] == 4.0
+    agg = df.groupby("g")["v"].agg(["sum", "count"])
+    assert agg.loc["a", "sum"] == 4.0
+    assert agg.loc["b", "sum"] == 12.0
+    assert int(agg.loc["b", "count"]) == 3
+
+
+def test_merge_join():
+    left = pd.DataFrame({"id": [1, 2, 3], "x": ["a", "b", "c"]})
+    right = pd.DataFrame({"id": [2, 3, 4], "y": [20, 30, 40]})
+    inner = left.merge(right, on="id", how="inner")
+    assert list(inner["id"]) == [2, 3]
+    assert list(inner["y"]) == [20, 30]
+    outer = left.merge(right, on="id", how="left")
+    assert list(outer["id"]) == [1, 2, 3]
+    assert pd.isna(outer["y"].iloc[0])
+
+
+def test_loc_iloc_selection():
+    df = pd.DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]}, index=["r0", "r1", "r2"])
+    assert df.loc["r1", "b"] == 50
+    assert df.iloc[2, 0] == 30
+    assert list(df.loc[df["a"] > 15, "a"]) == [20, 30]
+
+
+def test_to_dict_roundtrip():
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    d = df.to_dict(orient="list")
+    assert d == {"a": [1, 2], "b": ["x", "y"]}
+    back = pd.DataFrame(d)
+    assert back.equals(df)
+
+
+def test_csv_roundtrip_tempfile():
+    import tempfile
+
+    df = pd.DataFrame({"i": [1, 2, 3], "f": [1.5, 2.5, 3.5], "s": ["w", "x", "y"]})
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    try:
+        df.to_csv(path, index=False)
+        back = pd.read_csv(path)
+        assert list(back.columns) == ["i", "f", "s"]
+        assert list(back["i"]) == [1, 2, 3]
+        assert list(back["f"]) == [1.5, 2.5, 3.5]
+        assert list(back["s"]) == ["w", "x", "y"]
+    finally:
+        os.remove(path)
+
+
+run_test("DataFrame construct and dtypes", test_dataframe_construct_and_dtypes)
+run_test("groupby().agg exact means", test_groupby_agg_exact_means)
+run_test("merge/join", test_merge_join)
+run_test("loc/iloc selection", test_loc_iloc_selection)
+run_test("to_dict roundtrip", test_to_dict_roundtrip)
+run_test("CSV tempfile round-trip", test_csv_roundtrip_tempfile)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pandas smoke tests passed")

--- a/cli/scripts/lib-validator/patchwork.R
+++ b/cli/scripts/lib-validator/patchwork.R
@@ -1,0 +1,79 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `patchwork` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# patchwork itself (ggplot2 is its core dependency, used to build the panels).
+# Exercises the core API surface by INSPECTING the composed plot objects -- it
+# never opens an interactive device -- and exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript patchwork.R
+
+if (!requireNamespace("patchwork", quietly = TRUE)) {
+  cat("FAIL: package 'patchwork' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(patchwork))
+suppressPackageStartupMessages(library(ggplot2))
+cat(sprintf("patchwork version: %s\n", as.character(packageVersion("patchwork"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+make_plots <- function() {
+  list(
+    p1 = ggplot(mtcars, aes(mpg, wt)) + geom_point(),
+    p2 = ggplot(mtcars, aes(hp, qsec)) + geom_point()
+  )
+}
+
+run_test("side-by-side (|) composes a patchwork", function() {
+  pl <- make_plots()
+  combined <- pl$p1 | pl$p2
+  stopifnot(inherits(combined, "patchwork"))
+  # A patchwork is still a ggplot -- it can be treated as one downstream.
+  stopifnot(inherits(combined, "ggplot"))
+})
+
+run_test("addition (+) composes a patchwork", function() {
+  pl <- make_plots()
+  combined <- pl$p1 + pl$p2
+  stopifnot(inherits(combined, "patchwork"))
+  stopifnot(length(combined$patches$plots) == 1L)
+})
+
+run_test("plot_layout returns a patchwork", function() {
+  pl <- make_plots()
+  combined <- (pl$p1 + pl$p2) + plot_layout(ncol = 1)
+  stopifnot(inherits(combined, "patchwork"))
+})
+
+run_test("plot_annotation returns a patchwork", function() {
+  pl <- make_plots()
+  combined <- (pl$p1 | pl$p2) + plot_annotation(title = "smoke test")
+  stopifnot(inherits(combined, "patchwork"))
+})
+
+run_test("stacking (/) composes a patchwork", function() {
+  pl <- make_plots()
+  stacked <- pl$p1 / pl$p2
+  stopifnot(inherits(stacked, "patchwork"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all patchwork smoke tests passed\n")

--- a/cli/scripts/lib-validator/pertpy.py
+++ b/cli/scripts/lib-validator/pertpy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pertpy` package.
+
+Fully self-contained: no input files, no network, no packages beyond pertpy
+(and its implied deps — scanpy, anndata, and the model stack). Exercises the
+core API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pertpy.py
+
+Install: pip install pertpy   (import name: pertpy)
+
+FLAG — heavy import. pertpy transitively imports scanpy AND scvi-tools, which
+pulls in jax -> numpyro (this is why environments pin jax <0.10) plus torch.
+Importing pertpy alone is expensive, so this smoke test stays MODEST: it asserts
+the package imports and exposes its `pt.tl` / `pt.pp` / `pt.data` namespaces, and
+deliberately does NOT construct or train any model.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pertpy as pt
+except ImportError:
+    print("FAIL: package 'pertpy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pertpy version: {_version(pt, 'pertpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_namespaces_present():
+    # FLAG: heavy. We only assert the top-level API surface exists — importing
+    # pertpy already exercised the expensive scanpy/scvi/jax/torch stack.
+    assert hasattr(pt, "tl")
+    assert hasattr(pt, "pp")
+    assert hasattr(pt, "data")
+
+
+def test_tool_classes_exposed():
+    # A representative differential/perturbation tool should be exposed on pt.tl.
+    # Do NOT instantiate or run it — construction pulls the model backends.
+    assert any(hasattr(pt.tl, name) for name in ("Augur", "Mixscape", "Dialogue"))
+
+
+run_test("pt.tl / pt.pp / pt.data namespaces present", test_namespaces_present)
+run_test("pt.tl exposes perturbation tool classes (no model run)", test_tool_classes_exposed)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pertpy smoke tests passed")

--- a/cli/scripts/lib-validator/pharmpy-core.py
+++ b/cli/scripts/lib-validator/pharmpy-core.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pharmpy-core` package (population PK/PD modeling).
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pharmpy-core.py
+
+Install: pip install pharmpy-core   (import name: pharmpy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: pharmpy-core (import name `pharmpy`) is a population PK/PD
+model-handling toolkit. PARSING a real model (a NONMEM control stream, an
+mrgsolve/nlmixr model, …) needs an on-disk model file, so that path is
+deliberately NOT exercised here. This asserts the package imports and exposes
+its documented surface — the `pharmpy.Model` class and the large functional
+`pharmpy.modeling` API namespace — and, since it is cheap and file-free,
+constructs a minimal model via `pharmpy.modeling.create_basic_pk_model()` and
+asserts its type. RE-CHECK once installed (the modeling API is broad and
+version-sensitive): that `pharmpy.Model` is the top-level class name, that
+`create_basic_pk_model` exists in `pharmpy.modeling`, and that it constructs
+with no required dataset argument. (correct-by-review; the modeling API is
+FLAGGED.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pharmpy
+except ImportError:
+    print("FAIL: package 'pharmpy-core' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pharmpy version: {_version(pharmpy, 'pharmpy-core')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_model_and_modeling():
+    import importlib
+
+    # Model is the top-level model class; modeling is the functional API
+    # namespace (transforms, parameterisation, estimation setup, …). Import the
+    # namespace lazily so a rename is a test failure, not a top-level crash.
+    assert hasattr(pharmpy, "Model")
+    modeling = importlib.import_module("pharmpy.modeling")
+    assert callable(getattr(modeling, "create_basic_pk_model", None))
+
+
+def test_create_basic_pk_model_constructs():
+    from pharmpy.modeling import create_basic_pk_model
+
+    # create_basic_pk_model builds a minimal PK model with no dataset file —
+    # cheap, offline, and file-free (unlike parsing a real NONMEM control
+    # stream, which is deliberately not exercised here).
+    model = create_basic_pk_model()
+    assert isinstance(model, pharmpy.Model)
+
+
+run_test("exposes pharmpy.Model + pharmpy.modeling", test_exposes_model_and_modeling)
+run_test("create_basic_pk_model() constructs a Model", test_create_basic_pk_model_constructs)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pharmpy smoke tests passed")

--- a/cli/scripts/lib-validator/pheatmap.R
+++ b/cli/scripts/lib-validator/pheatmap.R
@@ -1,0 +1,66 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `pheatmap` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# pheatmap itself (plus its implied deps). Exercises the core API surface by
+# INSPECTING the returned gtable/clustering objects -- `silent = TRUE` returns
+# the layout WITHOUT drawing -- and exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript pheatmap.R
+
+if (!requireNamespace("pheatmap", quietly = TRUE)) {
+  cat("FAIL: package 'pheatmap' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(pheatmap))
+cat(sprintf("pheatmap version: %s\n", as.character(packageVersion("pheatmap"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("silent build returns a gtable + dendrograms", function() {
+  set.seed(1)
+  m <- matrix(rnorm(25), 5, 5)
+  # silent = TRUE builds the grid layout but does NOT draw to a device.
+  res <- pheatmap::pheatmap(m, silent = TRUE)
+  stopifnot(!is.null(res$tree_row), !is.null(res$tree_col), !is.null(res$gtable))
+  stopifnot(inherits(res$gtable, "gtable"))
+})
+
+run_test("row clustering is an hclust with 5 leaves", function() {
+  set.seed(1)
+  m <- matrix(rnorm(25), 5, 5)
+  res <- pheatmap::pheatmap(m, silent = TRUE)
+  stopifnot(inherits(res$tree_row, "hclust"))
+  stopifnot(length(res$tree_row$order) == 5L)
+  stopifnot(inherits(res$tree_col, "hclust"))
+  stopifnot(length(res$tree_col$order) == 5L)
+})
+
+run_test("clustering can be disabled", function() {
+  set.seed(1)
+  m <- matrix(rnorm(25), 5, 5)
+  res <- pheatmap::pheatmap(m, cluster_rows = FALSE, cluster_cols = FALSE,
+                            silent = TRUE)
+  # With clustering off the trees are absent but the gtable is still produced.
+  stopifnot(inherits(res$gtable, "gtable"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all pheatmap smoke tests passed\n")

--- a/cli/scripts/lib-validator/phyloseq.R
+++ b/cli/scripts/lib-validator/phyloseq.R
@@ -1,0 +1,105 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `phyloseq` package (microbiome census data containers +
+# analysis).
+#
+# Fully self-contained: no input files, no network, no packages beyond phyloseq
+# itself. A synthetic OTU table, sample data, and taxonomy table are assembled
+# with a fixed seed into a phyloseq object; checks are structural (component
+# dims, accessor round-trips, output classes) with tolerance/range assertions
+# on the numeric diversity + distance outputs, never exact floating-point
+# equality. Exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript phyloseq.R
+#
+# The phyloseq accessor names used here (otu_table, sample_data, tax_table,
+# ntaxa, nsamples, estimate_richness, distance) are long-stable public API.
+
+if (!requireNamespace("phyloseq", quietly = TRUE)) {
+  cat("FAIL: package 'phyloseq' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(phyloseq))
+cat(sprintf("phyloseq version: %s\n", as.character(packageVersion("phyloseq"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Fixture: 50 taxa (rows) x 8 samples of Poisson counts, taxa-are-rows layout.
+# Sample data carries a two-level grouping factor; the taxonomy table gives
+# every taxon a single Kingdom rank. Assembled once and reused across tests.
+set.seed(1)
+n_taxa <- 50L
+n_samp <- 8L
+taxa_ids <- sprintf("t%02d", seq_len(n_taxa))
+samp_ids <- sprintf("s%d", seq_len(n_samp))
+otu_mat <- matrix(
+  rpois(n_taxa * n_samp, lambda = 10),
+  nrow = n_taxa,
+  ncol = n_samp,
+  dimnames = list(taxa_ids, samp_ids)
+)
+
+build_ps <- function() {
+  otu <- phyloseq::otu_table(otu_mat, taxa_are_rows = TRUE)
+  sd <- phyloseq::sample_data(
+    data.frame(grp = rep(c("a", "b"), length.out = n_samp), row.names = samp_ids)
+  )
+  tax <- phyloseq::tax_table(
+    matrix("k__x", nrow = n_taxa, ncol = 1,
+           dimnames = list(taxa_ids, "Kingdom"))
+  )
+  phyloseq::phyloseq(otu, sd, tax)
+}
+
+run_test("phyloseq: assembles a container with expected dims", function() {
+  ps <- build_ps()
+  stopifnot(inherits(ps, "phyloseq"))
+  stopifnot(phyloseq::ntaxa(ps) == n_taxa)
+  stopifnot(phyloseq::nsamples(ps) == n_samp)
+})
+
+run_test("otu_table accessor round-trips the counts", function() {
+  ps <- build_ps()
+  back <- as(phyloseq::otu_table(ps), "matrix")
+  stopifnot(identical(dim(back), c(n_taxa, n_samp)))
+  stopifnot(all(back == otu_mat))
+})
+
+run_test("estimate_richness returns a per-sample data.frame", function() {
+  ps <- build_ps()
+  rich <- phyloseq::estimate_richness(ps, measures = c("Observed", "Shannon"))
+  stopifnot(is.data.frame(rich))
+  stopifnot(nrow(rich) == n_samp)
+  stopifnot("Shannon" %in% colnames(rich))
+  stopifnot(all(is.finite(rich$Shannon)), all(rich$Shannon >= 0))
+  # Observed richness cannot exceed the number of taxa.
+  stopifnot(all(rich$Observed >= 0), all(rich$Observed <= n_taxa))
+})
+
+run_test("bray-curtis distance is a valid dissimilarity over samples", function() {
+  ps <- build_ps()
+  d <- phyloseq::distance(ps, method = "bray")
+  stopifnot(inherits(d, "dist"))
+  stopifnot(attr(d, "Size") == n_samp)
+  v <- as.numeric(d)
+  stopifnot(all(is.finite(v)), all(v >= 0), all(v <= 1))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all phyloseq smoke tests passed\n")

--- a/cli/scripts/lib-validator/pingouin.py
+++ b/cli/scripts/lib-validator/pingouin.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pingouin` package.
+
+Fully self-contained: no input files, no network, no packages beyond pingouin
+and its implied deps (numpy, pandas, scipy). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 pingouin.py
+
+Install: pip install pingouin   (import name: pingouin)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pingouin as pg
+except ImportError:
+    print("FAIL: package 'pingouin' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pingouin version: {_version(pg, 'pingouin')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_ttest_columns_and_detects_difference():
+    rng = np.random.default_rng(0)
+    a = rng.normal(0.0, 1.0, size=40)
+    b = rng.normal(2.0, 1.0, size=40)  # clearly shifted mean
+    res = pg.ttest(a, b)
+    assert isinstance(res, pd.DataFrame)
+    for col in ("T", "p-val", "CI95%"):
+        assert col in res.columns
+    # A two-unit planted mean gap must register as significant.
+    assert float(res["p-val"].iloc[0]) < 0.01
+
+
+def test_corr_recovers_strong_relationship():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=120)
+    y = 2.0 * x + rng.normal(0.0, 0.1, size=120)  # strong positive link
+    res = pg.corr(x, y)
+    assert isinstance(res, pd.DataFrame)
+    assert "r" in res.columns and "p-val" in res.columns
+    assert float(res["r"].iloc[0]) > 0.9
+    assert float(res["p-val"].iloc[0]) < 1e-6
+
+
+def test_anova_between_groups():
+    rng = np.random.default_rng(2)
+    df = pd.DataFrame(
+        {
+            "y": np.concatenate(
+                [
+                    rng.normal(0.0, 1.0, 20),
+                    rng.normal(0.0, 1.0, 20),
+                    rng.normal(5.0, 1.0, 20),  # one group shifted far up
+                ]
+            ),
+            "group": (["a"] * 20) + (["b"] * 20) + (["c"] * 20),
+        }
+    )
+    aov = pg.anova(data=df, dv="y", between="group")
+    assert isinstance(aov, pd.DataFrame)
+    assert "F" in aov.columns and "p-unc" in aov.columns
+    assert float(aov["p-unc"].iloc[0]) < 0.01
+
+
+run_test("ttest columns + detects diff", test_ttest_columns_and_detects_difference)
+run_test("corr recovers relationship", test_corr_recovers_strong_relationship)
+run_test("anova between groups", test_anova_between_groups)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pingouin smoke tests passed")

--- a/cli/scripts/lib-validator/pksensi.R
+++ b/cli/scripts/lib-validator/pksensi.R
@@ -1,0 +1,134 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `pksensi` package.
+#
+# Fully self-contained: no input files, no network, no compiled model. Exercises
+# the global-sensitivity workflow on a simple analytic one-compartment oral PK
+# model instead of a compiled ODE: draw an eFAST parameter sample with
+# rfast99(), evaluate the closed-form concentration over the sample, feed the
+# responses back with tell2(), and inspect the sensitivity indices. Checks are
+# structural / range-based (object classes, finiteness, indices in a sane band)
+# -- never exact numeric equality on the stochastic sampler. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript pksensi.R
+#
+# NOTE (needs re-check once installed): this is the HIGH-UNCERTAINTY script of
+# the set. The eFAST sampler entry point (rfast99), the layout of its sample
+# array `x$a`, the shape tell2() expects for the response array
+# (c(evaluations, replications, times, outputs)), and the index slots
+# (x$mSI main / x$iSI interaction / x$tSI total) were written from the
+# documented API and NOT verified against an installed build. The model-over-
+# sample step locates the parameter dimension via `dimnames(x$a)` so it does not
+# hard-code which axis holds the parameters, and every stage is wrapped in
+# run_test() so a shape/name mismatch fails that one check cleanly instead of
+# crashing. Re-confirm rfast99 / tell2 / the index accessors when the package
+# is available.
+
+if (!requireNamespace("pksensi", quietly = TRUE)) {
+  cat("FAIL: package 'pksensi' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(pksensi))
+cat(sprintf("pksensi version: %s\n", as.character(packageVersion("pksensi"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# One-compartment oral PK model. Parameters: ka (absorption rate), ke
+# (elimination rate), V (volume of distribution). Uniform priors keep ka well
+# above ke over the whole box, so ka - ke never approaches zero and the
+# closed-form concentration stays finite and positive.
+params <- c("ka", "ke", "V")
+q <- "qunif"
+q.arg <- list(
+  list(min = 0.5, max = 1.5),   # ka
+  list(min = 0.05, max = 0.2),  # ke
+  list(min = 10, max = 30)      # V
+)
+
+# Analytic plasma concentration after a single oral dose (F = 1) at a fixed time.
+conc_1cpt <- function(ka, ke, V, dose = 100, t = 2) {
+  (dose * ka) / (V * (ka - ke)) * (exp(-ke * t) - exp(-ka * t))
+}
+
+# Draw the eFAST sample once; reuse it across the workflow tests.
+set.seed(1234)
+sample_obj <- rfast99(
+  params = params, n = 100, q = q, q.arg = q.arg, replicate = 1
+)
+
+run_test("rfast99 builds an eFAST sample", function() {
+  stopifnot(inherits(sample_obj, "rfast99"))
+  a <- sample_obj$a
+  stopifnot(is.array(a) || is.matrix(a))
+  stopifnot(all(is.finite(a)))
+  # The parameter axis must carry our three parameter names.
+  pdim <- which(vapply(
+    dimnames(a),
+    function(z) !is.null(z) && all(params %in% z),
+    logical(1)
+  ))
+  stopifnot(length(pdim) == 1L)
+  stopifnot(dim(a)[pdim] == length(params))
+})
+
+run_test("tell2 computes sensitivity indices from the model responses", function() {
+  x <- sample_obj
+  a <- x$a
+  d <- dim(a)
+
+  # Locate the parameter axis by name, move it last, and flatten the remaining
+  # (sample x replicate) axes into rows so each row is one full parameter set.
+  pdim <- which(vapply(
+    dimnames(a),
+    function(z) !is.null(z) && all(params %in% z),
+    logical(1)
+  ))
+  stopifnot(length(pdim) == 1L)
+  perm <- c(setdiff(seq_along(d), pdim), pdim)
+  A <- aperm(a, perm)
+  k <- d[pdim]
+  n_run <- prod(d[-pdim])
+  Amat <- matrix(A, nrow = n_run, ncol = k)
+  colnames(Amat) <- dimnames(a)[[pdim]]
+
+  # Evaluate the analytic model row-wise.
+  y_vec <- conc_1cpt(Amat[, "ka"], Amat[, "ke"], Amat[, "V"])
+  stopifnot(all(is.finite(y_vec)), all(y_vec > 0))
+
+  # tell2 expects the response as c(evaluations, replications, times, outputs);
+  # our single time / single output add two trailing length-1 axes. The row
+  # order of y_vec (sample fastest, then replicate) matches this fill order.
+  y <- array(y_vec, dim = c(d[-pdim], 1L, 1L))
+  x <- tell2(x, y)
+
+  # Main (first-order) and total sensitivity indices must be finite and land in
+  # a sane band: indices are variance fractions, nominally in [0, 1], but eFAST
+  # estimates can overshoot slightly on a small sample -- allow a margin.
+  stopifnot(!is.null(x$mSI), all(is.finite(x$mSI)))
+  stopifnot(!is.null(x$tSI), all(is.finite(x$tSI)))
+  stopifnot(all(x$mSI >= -0.1), all(x$mSI <= 1.5))
+  stopifnot(all(x$tSI >= -0.1), all(x$tSI <= 1.5))
+  # Interaction indices, when present, should also be finite.
+  if (!is.null(x$iSI)) {
+    stopifnot(all(is.finite(x$iSI)))
+  }
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all pksensi smoke tests passed\n")

--- a/cli/scripts/lib-validator/plotly.R
+++ b/cli/scripts/lib-validator/plotly.R
@@ -1,0 +1,71 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `plotly` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# plotly itself (plus its implied deps -- ggplot2 is one, used by ggplotly).
+# Exercises the core API surface by INSPECTING the built plot structure -- it
+# never opens a browser or interactive device -- and exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript plotly.R
+
+if (!requireNamespace("plotly", quietly = TRUE)) {
+  cat("FAIL: package 'plotly' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(plotly))
+cat(sprintf("plotly version: %s\n", as.character(packageVersion("plotly"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("build a plotly object", function() {
+  p <- plotly::plot_ly(x = 1:3, y = c(2, 1, 3), type = "scatter", mode = "markers")
+  stopifnot(inherits(p, "plotly"))
+})
+
+run_test("plotly_build roundtrips the data", function() {
+  p <- plotly::plot_ly(x = 1:3, y = c(2, 1, 3), type = "scatter", mode = "markers")
+  # plotly_build resolves the figure to its JSON-ish trace list without drawing.
+  built <- plotly::plotly_build(p)
+  stopifnot(length(built$x$data) >= 1L)
+  trace <- built$x$data[[1]]
+  stopifnot(identical(as.numeric(trace$x), c(1, 2, 3)))
+  stopifnot(identical(as.numeric(trace$y), c(2, 1, 3)))
+  stopifnot(identical(trace$type, "scatter"))
+  stopifnot(identical(trace$mode, "markers"))
+})
+
+run_test("add_trace appends a second trace", function() {
+  p <- plotly::plot_ly(x = 1:3, y = c(2, 1, 3), type = "scatter", mode = "markers")
+  p <- plotly::add_trace(p, y = c(3, 2, 1), mode = "lines")
+  built <- plotly::plotly_build(p)
+  stopifnot(length(built$x$data) == 2L)
+})
+
+run_test("ggplotly converts a ggplot to plotly", function() {
+  # ggplot2 is a plotly dependency; ggplotly is the bridge from a ggplot object.
+  gg <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) + ggplot2::geom_point()
+  pl <- plotly::ggplotly(gg)
+  stopifnot(inherits(pl, "plotly"))
+  built <- plotly::plotly_build(pl)
+  stopifnot(length(built$x$data) >= 1L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all plotly smoke tests passed\n")

--- a/cli/scripts/lib-validator/plotly.py
+++ b/cli/scripts/lib-validator/plotly.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `plotly` package.
+
+Fully self-contained: no input files, no network, no packages beyond plotly
+(and its implied deps — pandas for the express test). Builds figures purely as
+in-memory objects and serializes them to dict/JSON; it never renders to an
+image or opens a browser (rendering would need kaleido + a Chromium backend).
+Exercises the graph-object / express API and exits 0 only if every check
+passes, so it can be used as a pass/fail library validator:
+
+    python3 plotly.py
+
+Install: pip install plotly   (import name: plotly)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import plotly
+except ImportError:
+    print("FAIL: package 'plotly' is not installed")
+    sys.exit(1)
+
+import json
+
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"plotly version: {_version(plotly, 'plotly')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_scatter_trace_data_roundtrips():
+    fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6], mode="lines+markers"))
+    assert len(fig.data) == 1
+    trace = fig.data[0]
+    assert tuple(trace.x) == (1, 2, 3)
+    assert tuple(trace.y) == (4, 5, 6)
+    assert trace.type == "scatter"
+
+
+def test_to_dict_structure():
+    fig = go.Figure(data=go.Scatter(x=[0, 1], y=[10, 20]))
+    fig.update_layout(title="smoke")
+    d = fig.to_dict()
+    assert "data" in d and "layout" in d
+    assert d["data"][0]["type"] == "scatter"
+    assert tuple(d["data"][0]["x"]) == (0, 1)
+    assert tuple(d["data"][0]["y"]) == (10, 20)
+    assert d["layout"]["title"]["text"] == "smoke"
+
+
+def test_to_json_is_parseable():
+    fig = go.Figure(data=go.Scatter(x=[1, 2], y=[3, 4]))
+    s = fig.to_json()
+    assert isinstance(s, str)
+    parsed = json.loads(s)
+    assert parsed["data"][0]["type"] == "scatter"
+    assert list(parsed["data"][0]["x"]) == [1, 2]
+
+
+def test_express_scatter_returns_figure():
+    import pandas as pd
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+    fig = px.scatter(df, x="a", y="b")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 1
+    assert tuple(fig.data[0].x) == (1, 2, 3)
+    assert tuple(fig.data[0].y) == (3, 2, 1)
+
+
+def test_add_trace_accumulates():
+    fig = go.Figure()
+    fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]))
+    fig.add_trace(go.Scatter(x=["a", "b"], y=[2, 1]))
+    assert len(fig.data) == 2
+    assert fig.data[0].type == "bar"
+    assert fig.data[1].type == "scatter"
+
+
+run_test("scatter trace data roundtrips", test_scatter_trace_data_roundtrips)
+run_test("to_dict structure", test_to_dict_structure)
+run_test("to_json is parseable", test_to_json_is_parseable)
+run_test("express scatter returns Figure", test_express_scatter_returns_figure)
+run_test("add_trace accumulates", test_add_trace_accumulates)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all plotly smoke tests passed")

--- a/cli/scripts/lib-validator/purrr.R
+++ b/cli/scripts/lib-validator/purrr.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `purrr` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# purrr itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript purrr.R
+
+if (!requireNamespace("purrr", quietly = TRUE)) {
+  cat("FAIL: package 'purrr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(purrr))
+cat(sprintf("purrr version: %s\n", as.character(packageVersion("purrr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("map family with lambda shorthand", function() {
+  stopifnot(identical(map(1:3, ~ .x + 1), list(2, 3, 4)))
+  stopifnot(identical(map_dbl(1:3, ~ .x * 2), c(2, 4, 6)))
+  stopifnot(identical(map_chr(c("a", "b"), toupper), c("A", "B")))
+  stopifnot(identical(map_int(list(1:2, 1:5), length), c(2L, 5L)))
+})
+
+run_test("map2 and pmap", function() {
+  stopifnot(identical(map2(1:3, 4:6, `+`), list(5L, 7L, 9L)))
+  stopifnot(identical(map2_chr(c("a", "b"), c("x", "y"), paste0), c("ax", "by")))
+  stopifnot(identical(pmap_dbl(list(1:2, 3:4, 5:6), function(a, b, c) a + b + c), c(9, 12)))
+})
+
+run_test("reduce", function() {
+  stopifnot(identical(reduce(1:5, `+`), 15L))
+  stopifnot(identical(reduce(c("a", "b", "c"), paste0), "abc"))
+  stopifnot(identical(reduce(1:3, `+`, .init = 10L), 16L))
+})
+
+run_test("keep, discard, compact", function() {
+  stopifnot(identical(keep(1:5, ~ .x > 3), c(4L, 5L)))
+  stopifnot(identical(discard(1:5, ~ .x > 3), c(1L, 2L, 3L)))
+  stopifnot(identical(compact(list(a = 1, b = NULL, c = 2)), list(a = 1, c = 2)))
+})
+
+run_test("pluck into nested lists", function() {
+  x <- list(a = list(b = list(c = 42)))
+  stopifnot(identical(pluck(x, "a", "b", "c"), 42))
+  stopifnot(is.null(pluck(x, "a", "missing")))
+  stopifnot(identical(pluck(x, "a", "missing", .default = -1), -1))
+})
+
+run_test("list_rbind combines data frames", function() {
+  combined <- list_rbind(list(
+    data.frame(a = 1, b = "x"),
+    data.frame(a = 2, b = "y")
+  ))
+  stopifnot(identical(nrow(combined), 2L))
+  stopifnot(identical(combined$a, c(1, 2)))
+  stopifnot(identical(combined$b, c("x", "y")))
+})
+
+run_test("imap sees names", function() {
+  stopifnot(identical(
+    imap_chr(c(a = 1, b = 2), ~ paste0(.y, .x)),
+    c(a = "a1", b = "b2")
+  ))
+})
+
+run_test("possibly and safely wrap failures", function() {
+  safe_log <- safely(log)
+  bad <- safe_log("not a number")
+  stopifnot(is.null(bad$result), inherits(bad$error, "error"))
+  good <- safe_log(exp(1))
+  stopifnot(is.null(good$error), abs(good$result - 1) < 1e-12)
+  maybe_log <- possibly(log, otherwise = NA_real_)
+  stopifnot(identical(maybe_log("nope"), NA_real_))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all purrr smoke tests passed\n")

--- a/cli/scripts/lib-validator/pyBigWig.py
+++ b/cli/scripts/lib-validator/pyBigWig.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyBigWig` package.
+
+Fully self-contained: no input files, no network. Writes a tiny bigWig into a
+tempfile, reopens it for reading, and deletes it afterwards. Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pyBigWig.py
+
+Install: pip install pyBigWig   (import name: pyBigWig)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyBigWig
+except ImportError:
+    print("FAIL: package 'pyBigWig' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyBigWig version: {_version(pyBigWig, 'pyBigWig')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_write_then_read():
+    import math
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".bw")
+    os.close(fd)
+    try:
+        # --- write ---
+        bw = pyBigWig.open(path, "w")
+        try:
+            bw.addHeader([("chr1", 1000)])
+            # Three fixed-span intervals: [0,100)=1.0, [100,200)=2.0, [200,300)=3.0.
+            bw.addEntries(
+                "chr1",
+                [0, 100, 200],
+                values=[1.0, 2.0, 3.0],
+                span=100,
+                step=100,
+            )
+        finally:
+            bw.close()
+
+        # --- read back ---
+        bw = pyBigWig.open(path)
+        try:
+            assert bw.chroms("chr1") == 1000
+            # mean of [0,100) is 1.0; of [100,200) is 2.0.
+            assert abs(bw.stats("chr1", 0, 100)[0] - 1.0) < 1e-6
+            assert abs(bw.stats("chr1", 100, 200)[0] - 2.0) < 1e-6
+            # per-base values across the first three positions -> all 1.0.
+            vals = bw.values("chr1", 0, 3)
+            assert all(abs(v - 1.0) < 1e-6 for v in vals)
+            # a position past the last entry is unset -> NaN.
+            assert math.isnan(bw.values("chr1", 500, 501)[0])
+        finally:
+            bw.close()
+    finally:
+        os.remove(path)
+
+
+run_test("write bigWig tempfile then read stats/values", test_write_then_read)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyBigWig smoke tests passed")

--- a/cli/scripts/lib-validator/pyarrow.py
+++ b/cli/scripts/lib-validator/pyarrow.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyarrow` package.
+
+Fully self-contained: no input files, no network, no packages beyond pyarrow.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 pyarrow.py
+
+Install: pip install pyarrow   (import name: pyarrow)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyarrow as pa
+except ImportError:
+    print("FAIL: package 'pyarrow' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyarrow version: {_version(pa, 'pyarrow')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_array_and_table_construct():
+    arr = pa.array([1, 2, 3, 4])
+    assert len(arr) == 4
+    assert arr.to_pylist() == [1, 2, 3, 4]
+    table = pa.table({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+    assert table.num_rows == 3
+    assert table.num_columns == 2
+    assert table.column_names == ["a", "b"]
+
+
+def test_column_access_and_pydict_roundtrip():
+    data = {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+    table = pa.table(data)
+    assert table.column("a").to_pylist() == [1, 2, 3]
+    assert table.to_pydict() == data
+
+
+def test_compute_sum():
+    import pyarrow.compute as pc
+
+    table = pa.table({"a": [1, 2, 3, 4, 5]})
+    assert pc.sum(table.column("a")).as_py() == 15
+
+
+def test_parquet_roundtrip_tempfile():
+    import tempfile
+
+    import pyarrow.parquet as pq
+
+    table = pa.table({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+    fd, path = tempfile.mkstemp(suffix=".parquet")
+    os.close(fd)
+    try:
+        pq.write_table(table, path)
+        back = pq.read_table(path)
+        assert back.to_pydict() == table.to_pydict()
+    finally:
+        os.remove(path)
+
+
+def test_feather_roundtrip_tempfile():
+    import tempfile
+
+    import pyarrow.feather as feather
+
+    table = pa.table({"i": [10, 20, 30], "s": ["p", "q", "r"]})
+    fd, path = tempfile.mkstemp(suffix=".feather")
+    os.close(fd)
+    try:
+        feather.write_feather(table, path)
+        back = feather.read_table(path)
+        assert back.to_pydict() == table.to_pydict()
+    finally:
+        os.remove(path)
+
+
+run_test("array/table construct", test_array_and_table_construct)
+run_test("column access + to_pydict roundtrip", test_column_access_and_pydict_roundtrip)
+run_test("compute.sum", test_compute_sum)
+run_test("parquet tempfile round-trip", test_parquet_roundtrip_tempfile)
+run_test("feather tempfile round-trip", test_feather_roundtrip_tempfile)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyarrow smoke tests passed")

--- a/cli/scripts/lib-validator/pybedtools.py
+++ b/cli/scripts/lib-validator/pybedtools.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pybedtools` package.
+
+Fully self-contained: no input files, no network. Intervals are built from
+in-memory BED strings via `from_string=True`. Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 pybedtools.py
+
+Install: pip install pybedtools   (import name: pybedtools)
+
+RUNTIME NOTE: pybedtools is a wrapper around the standalone `bedtools` binary —
+it shells out to it for merge/intersect/etc. The `bedtools` executable must be
+installed and on PATH (e.g. `conda install -c bioconda bedtools`, or a system
+package); the Python package alone is not enough. A missing binary surfaces as a
+pybedtools helper/`OSError` at the first operation, not at import.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pybedtools
+except ImportError:
+    print("FAIL: package 'pybedtools' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pybedtools version: {_version(pybedtools, 'pybedtools')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_bedtool_from_string():
+    # BED is 0-based half-open; from_string accepts whitespace-separated fields.
+    bt = pybedtools.BedTool("chr1 10 20\nchr1 15 25\nchr1 40 50", from_string=True)
+    intervals = list(bt)
+    assert len(intervals) == 3
+    assert intervals[0].chrom == "chr1"
+    assert intervals[0].start == 10
+    assert intervals[0].end == 20
+
+
+def test_merge():
+    # Input is sorted; merge collapses book-ended/overlapping features.
+    bt = pybedtools.BedTool("chr1 10 20\nchr1 15 25\nchr1 40 50", from_string=True)
+    merged = list(bt.merge())
+    # [10,20) and [15,25) overlap -> [10,25); [40,50) stands alone.
+    assert len(merged) == 2
+    assert (merged[0].chrom, merged[0].start, merged[0].end) == ("chr1", 10, 25)
+    assert (merged[1].start, merged[1].end) == (40, 50)
+
+
+def test_intersect():
+    a = pybedtools.BedTool("chr1 10 20\nchr1 40 50", from_string=True)
+    b = pybedtools.BedTool("chr1 15 45", from_string=True)
+    inter = list(a.intersect(b))
+    # [10,20) & [15,45) -> [15,20); [40,50) & [15,45) -> [40,45).
+    assert len(inter) == 2
+    assert (inter[0].start, inter[0].end) == (15, 20)
+    assert (inter[1].start, inter[1].end) == (40, 45)
+
+
+run_test("BedTool from_string parse", test_bedtool_from_string)
+run_test("merge overlapping intervals", test_merge)
+run_test("intersect two BedTools", test_intersect)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pybedtools smoke tests passed")

--- a/cli/scripts/lib-validator/pydantic.py
+++ b/cli/scripts/lib-validator/pydantic.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pydantic` package.
+
+Fully self-contained: no input files, no network, no packages beyond pydantic
+(and its implied deps: pydantic-core, typing-extensions). Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pydantic.py
+
+Install: pip install pydantic   (import name: pydantic)
+
+Targets the pydantic v2 API (`model_dump`, `model_validate`, `ValidationError`
+raised from construction). pydantic v1 differs — `.dict()`/`.parse_obj()` and
+looser coercion — so this asserts against the v2 surface.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pydantic
+except ImportError:
+    print("FAIL: package 'pydantic' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pydantic version: {_version(pydantic, 'pydantic')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+from pydantic import BaseModel, ValidationError
+
+
+class Sample(BaseModel):
+    """A tiny typed model exercising fields, defaults, and coercion."""
+
+    name: str
+    count: int
+    ratio: float = 1.0
+    tags: list[str] = []
+
+
+def test_construct_and_field_values():
+    m = Sample(name="alpha", count=3, tags=["x", "y"])
+    assert m.name == "alpha"
+    assert m.count == 3
+    assert m.ratio == 1.0
+    assert m.tags == ["x", "y"]
+
+
+def test_type_coercion():
+    # pydantic v2 coerces a numeric string to int in lax mode.
+    m = Sample(name="beta", count="7")
+    assert m.count == 7
+    assert isinstance(m.count, int)
+
+
+def test_validation_error_on_bad_input():
+    raised = False
+    try:
+        Sample(name="gamma", count="not-a-number")
+    except ValidationError:
+        raised = True
+    assert raised
+
+
+def test_model_dump_validate_roundtrip():
+    m = Sample(name="delta", count=5, ratio=2.5, tags=["a"])
+    dumped = m.model_dump()
+    assert dumped == {"name": "delta", "count": 5, "ratio": 2.5, "tags": ["a"]}
+    back = Sample.model_validate(dumped)
+    assert back == m
+
+
+run_test("construct + field values", test_construct_and_field_values)
+run_test("type coercion", test_type_coercion)
+run_test("ValidationError on bad input", test_validation_error_on_bad_input)
+run_test("model_dump/model_validate roundtrip", test_model_dump_validate_roundtrip)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pydantic smoke tests passed")

--- a/cli/scripts/lib-validator/pydeseq2.py
+++ b/cli/scripts/lib-validator/pydeseq2.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pydeseq2` package.
+
+Fully self-contained: no input files, no network, no packages beyond pydeseq2
+(and its implied deps — numpy, pandas, scipy, anndata). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 pydeseq2.py
+
+Install: pip install "pydeseq2>=0.5.3"   (import name: pydeseq2)
+
+FLAG — design/arg names. pydeseq2 0.5.x takes a formula string via
+`design="~condition"` on DeseqDataSet; older releases used
+`design_factors="condition"`. The install note pins >=0.5.3, so the body uses
+the `design=` formula form. Results columns are log2FoldChange / pvalue / padj.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pydeseq2
+except ImportError:
+    print("FAIL: package 'pydeseq2' is not installed")
+    sys.exit(1)
+
+import numpy as np
+import pandas as pd
+from pydeseq2.dds import DeseqDataSet
+from pydeseq2.ds import DeseqStats
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pydeseq2 version: {_version(pydeseq2, 'pydeseq2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_counts_and_metadata():
+    """20 samples x 30 genes of negative-binomial-ish counts, two conditions.
+
+    Genes 0-4 are up-shifted in condition B so at least some signal exists; the
+    rest are null. Rows are samples, columns are genes (pydeseq2's orientation).
+    """
+    rng = np.random.default_rng(0)
+    n_samples, n_genes = 20, 30
+    samples = [f"sample{i}" for i in range(n_samples)]
+    genes = [f"gene{j}" for j in range(n_genes)]
+    condition = np.array(["A"] * 10 + ["B"] * 10)
+
+    base = rng.poisson(50, (n_samples, n_genes)).astype(int)
+    base[condition == "B", :5] += rng.poisson(80, (10, 5))
+    counts = pd.DataFrame(base, index=samples, columns=genes)
+    metadata = pd.DataFrame({"condition": condition}, index=samples)
+    return counts, metadata
+
+
+def test_counts_metadata_shape():
+    counts, metadata = _make_counts_and_metadata()
+    assert counts.shape == (20, 30)
+    assert list(metadata["condition"].unique()) == ["A", "B"]
+    assert (counts.to_numpy() >= 0).all()
+
+
+def test_deseq2_results():
+    counts, metadata = _make_counts_and_metadata()
+    dds = DeseqDataSet(counts=counts, metadata=metadata, design="~condition")
+    dds.deseq2()
+    stats = DeseqStats(dds)
+    stats.summary()
+    res = stats.results_df
+    assert res.shape[0] == 30
+    for col in ("log2FoldChange", "pvalue", "padj"):
+        assert col in res.columns
+    # p-values that exist are in [0, 1]; NaNs (filtered genes) are allowed.
+    pvals = res["pvalue"].dropna().to_numpy()
+    assert ((pvals >= 0.0) & (pvals <= 1.0)).all()
+
+
+run_test("counts/metadata shape", test_counts_metadata_shape)
+run_test("deseq2 + DeseqStats.summary results_df", test_deseq2_results)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pydeseq2 smoke tests passed")

--- a/cli/scripts/lib-validator/pyfaidx.py
+++ b/cli/scripts/lib-validator/pyfaidx.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyfaidx` package.
+
+Fully self-contained: no input files, no network, no packages beyond pyfaidx.
+The FASTA fixture is synthesized into a tempfile at runtime; both it and the
+`.fai` index pyfaidx builds beside it are deleted afterwards. Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pyfaidx.py
+
+Install: pip install pyfaidx   (import name: pyfaidx)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyfaidx
+except ImportError:
+    print("FAIL: package 'pyfaidx' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyfaidx version: {_version(pyfaidx, 'pyfaidx')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# chr1 is 20 bp (two wrapped 10-bp lines), chr2 is 10 bp.
+_FASTA_TEXT = ">chr1 first contig\nACGTACGTAC\nGTACGTACGT\n>chr2\nTTTTGGGGCC\n"
+
+
+def _write_fasta():
+    """Materialize the fixture FASTA into a tempfile; caller deletes it (+ .fai)."""
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".fa")
+    with os.fdopen(fd, "w") as fh:
+        fh.write(_FASTA_TEXT)
+    return path
+
+
+def test_indexed_fasta_access():
+    path = _write_fasta()
+    try:
+        fa = pyfaidx.Fasta(path)
+        try:
+            # keys() preserves record order from the file.
+            assert list(fa.keys()) == ["chr1", "chr2"]
+            # slice -> FastaRecord/Sequence; .seq is the base string.
+            assert fa["chr1"][0:4].seq == "ACGT"
+            assert len(fa["chr1"]) == 20
+            assert fa["chr2"][:].seq == "TTTTGGGGCC"
+            # 1-based description helper: last base of chr1.
+            assert fa["chr1"][-1:].seq == "T"
+        finally:
+            fa.close()
+    finally:
+        os.remove(path)
+        # pyfaidx writes a samtools-style <path>.fai index beside the FASTA.
+        fai = path + ".fai"
+        if os.path.exists(fai):
+            os.remove(fai)
+
+
+run_test("indexed FASTA slice/len/keys", test_indexed_fasta_access)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyfaidx smoke tests passed")

--- a/cli/scripts/lib-validator/pymzml.py
+++ b/cli/scripts/lib-validator/pymzml.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pymzml` package.
+
+Fully self-contained: no input files, no network, no packages beyond pymzml.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 pymzml.py
+
+Install: pip install pymzml   (import name: pymzml)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pymzml
+except ImportError:
+    print("FAIL: package 'pymzml' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pymzml version: {_version(pymzml, 'pymzml')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# NOTE: pymzml is an mzML reader — its real work needs an mzML file, and
+# synthesizing a valid mzML in a tempfile is brittle. This validator stays
+# MODEST: it confirms the package imports and exposes its reader/spectrum
+# classes. FLAG: no real spectrum file is parsed.
+def test_submodules_import():
+    import pymzml.run
+    import pymzml.spec
+
+    assert pymzml.run is not None
+    assert pymzml.spec is not None
+
+
+def test_reader_class_present():
+    from pymzml.run import Reader
+
+    assert isinstance(Reader, type)  # the mzML file reader class
+
+
+def test_spectrum_class_present():
+    from pymzml.spec import Spectrum
+
+    assert isinstance(Spectrum, type)  # the per-spectrum wrapper class
+
+
+run_test("run/spec submodules import", test_submodules_import)
+run_test("run.Reader class present", test_reader_class_present)
+run_test("spec.Spectrum class present", test_spectrum_class_present)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pymzml smoke tests passed")

--- a/cli/scripts/lib-validator/pypdf.py
+++ b/cli/scripts/lib-validator/pypdf.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pypdf` package.
+
+Fully self-contained: no input files, no network, no packages beyond pypdf (and
+its implied deps). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 pypdf.py
+
+Install: pip install pypdf   (import name: pypdf)
+
+NOTE — pypdf reads and manipulates PDFs, it is not a content-authoring library:
+there is no reportlab-style drawing API here. So these checks synthesize input
+with `PdfWriter.add_blank_page(width=..., height=...)` (points; 72pt = 1 inch),
+then read it back and merge, which is the whole read/write/merge surface without
+any external PDF file.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pypdf
+except ImportError:
+    print("FAIL: package 'pypdf' is not installed")
+    sys.exit(1)
+
+import io
+import tempfile
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pypdf version: {_version(pypdf, 'pypdf')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_blank_page_write_read_tempfile():
+    writer = pypdf.PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    fd, path = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+    try:
+        with open(path, "wb") as fh:
+            writer.write(fh)
+        assert os.path.getsize(path) > 0
+        reader = pypdf.PdfReader(path)
+        assert len(reader.pages) == 1
+        # add_blank_page dimensions are in points; the mediabox echoes them.
+        page = reader.pages[0]
+        assert float(page.mediabox.width) == 72.0
+        assert float(page.mediabox.height) == 72.0
+    finally:
+        os.remove(path)
+
+
+def test_write_to_bytesio_starts_with_pdf_magic():
+    writer = pypdf.PdfWriter()
+    writer.add_blank_page(width=100, height=120)
+    buf = io.BytesIO()
+    writer.write(buf)
+    data = buf.getvalue()
+    assert data[:4] == b"%PDF"
+    reader = pypdf.PdfReader(io.BytesIO(data))
+    assert len(reader.pages) == 1
+
+
+def test_merge_two_writers():
+    a = pypdf.PdfWriter()
+    a.add_blank_page(width=72, height=72)
+    b = pypdf.PdfWriter()
+    b.add_blank_page(width=72, height=72)
+
+    buf_a, buf_b = io.BytesIO(), io.BytesIO()
+    a.write(buf_a)
+    b.write(buf_b)
+    buf_a.seek(0)
+    buf_b.seek(0)
+
+    merged = pypdf.PdfWriter()
+    merged.append(pypdf.PdfReader(buf_a))
+    merged.append(pypdf.PdfReader(buf_b))
+    out = io.BytesIO()
+    merged.write(out)
+
+    reader = pypdf.PdfReader(io.BytesIO(out.getvalue()))
+    assert len(reader.pages) == 2
+
+
+run_test("blank page write/read tempfile", test_blank_page_write_read_tempfile)
+run_test("write to BytesIO (%PDF magic)", test_write_to_bytesio_starts_with_pdf_magic)
+run_test("merge two writers -> 2 pages", test_merge_two_writers)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pypdf smoke tests passed")

--- a/cli/scripts/lib-validator/pyranges.py
+++ b/cli/scripts/lib-validator/pyranges.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyranges` package.
+
+Fully self-contained: no input files, no network. Builds its intervals from
+in-memory pandas DataFrames. Exercises the core API surface and exits 0 only if
+every check passes, so it can be used as a pass/fail library validator:
+
+    python3 pyranges.py
+
+Install: pip install pyranges   (import name: pyranges; pulls in pandas)
+
+API NOTE (v0 vs v1): pyranges 1.x is a breaking rewrite. This script targets the
+CURRENT v1 API — a PyRanges IS a pandas.DataFrame subclass and overlapping
+intervals are collapsed with `.merge_overlaps()`. On the legacy v0.x API the
+constructor took keyword arrays (`pr.PyRanges(chromosomes=..., starts=...,
+ends=...)`) and the same operation was spelled `.merge()`. If you run this
+against a v0 install it will fail at `merge_overlaps` / column access — that is
+the API divergence, not a regression in the checks.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyranges
+except ImportError:
+    print("FAIL: package 'pyranges' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyranges version: {_version(pyranges, 'pyranges')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _gr(chroms, starts, ends):
+    """Build a PyRanges from parallel Chromosome/Start/End arrays (half-open)."""
+    import pandas as pd
+
+    return pyranges.PyRanges(
+        pd.DataFrame({"Chromosome": chroms, "Start": starts, "End": ends})
+    )
+
+
+def test_lengths():
+    # chr1: [1,10)=9, [5,15)=10, [20,30)=10  -> total 29 bp.
+    gr = _gr(["chr1", "chr1", "chr1"], [1, 5, 20], [10, 15, 30])
+    # Per-interval width via column arithmetic (works on the DataFrame subclass).
+    widths = list(gr.End - gr.Start)
+    assert widths == [9, 10, 10]
+    # `.length` is the total covered-by-rows base count (sum of widths).
+    assert gr.length == 29
+
+
+def test_overlap_and_intersect():
+    a = _gr(["chr1", "chr1", "chr1"], [1, 5, 20], [10, 15, 30])
+    b = _gr(["chr1"], [8], [22])
+
+    # overlap: rows of `a` that touch any interval of `b`. All three chr1 rows
+    # overlap [8,22): [1,10)->[8,10), [5,15)->[8,15), [20,30)->[20,22).
+    ov = a.overlap(b)
+    assert len(ov) == 3
+
+    # intersect: the clipped intersection intervals themselves.
+    inter = a.intersect(b)
+    clipped = sorted(zip(inter.Start, inter.End))
+    assert clipped == [(8, 10), (8, 15), (20, 22)]
+
+
+def test_merge_overlaps():
+    gr = _gr(["chr1", "chr1", "chr1"], [1, 5, 20], [10, 15, 30])
+    # [1,10) and [5,15) overlap -> [1,15); [20,30) stands alone.
+    merged = gr.merge_overlaps()
+    ranges = sorted(zip(merged.Start, merged.End))
+    assert ranges == [(1, 15), (20, 30)]
+
+
+run_test("interval lengths + total .length", test_lengths)
+run_test("overlap + intersect of two PyRanges", test_overlap_and_intersect)
+run_test("merge_overlaps collapses overlapping intervals", test_merge_overlaps)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyranges smoke tests passed")

--- a/cli/scripts/lib-validator/pyscenic.py
+++ b/cli/scripts/lib-validator/pyscenic.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyscenic` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 pyscenic.py
+
+Install: pip install pyscenic   (import name: pyscenic)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: pySCENIC is SCENIC gene-regulatory-network inference. The full
+pipeline (grn → prune against motif databases → aucell) needs downloaded ranking
+databases and motif annotations (network) — NOT done here. AUCell alone can run
+offline but requires ctxcore.genesig.GeneSignature objects; rather than couple
+to that internal, this asserts the package imports and exposes its documented
+step modules (aucell, grn, prune, utils). It does NOT run SCENIC.
+(correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyscenic
+except ImportError:
+    print("FAIL: package 'pyscenic' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyscenic version: {_version(pyscenic, 'pyscenic')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_step_modules():
+    import importlib
+
+    # The three SCENIC steps live in dedicated submodules; import lazily so a
+    # missing one is a test failure, not a top-level crash.
+    assert importlib.import_module("pyscenic.aucell") is not None
+    assert importlib.import_module("pyscenic.grn") is not None
+    assert importlib.import_module("pyscenic.prune") is not None
+
+
+def test_aucell_and_utils_callables():
+    import importlib
+
+    aucell_mod = importlib.import_module("pyscenic.aucell")
+    assert hasattr(aucell_mod, "aucell")
+    assert importlib.import_module("pyscenic.utils") is not None
+
+
+run_test("exposes pyscenic.aucell / grn / prune", test_exposes_step_modules)
+run_test("aucell callable + utils importable", test_aucell_and_utils_callables)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyscenic smoke tests passed")

--- a/cli/scripts/lib-validator/pyteomics.py
+++ b/cli/scripts/lib-validator/pyteomics.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pyteomics` package.
+
+Fully self-contained: no input files, no network, no packages beyond pyteomics.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 pyteomics.py
+
+Install: pip install pyteomics   (import name: pyteomics)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pyteomics
+except ImportError:
+    print("FAIL: package 'pyteomics' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyteomics version: {_version(pyteomics, 'pyteomics')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# pyteomics is pure-python and genuinely offline-testable: peptide masses and
+# in-silico digestion are deterministic, so these checks assert known values.
+def test_calculate_mass_peptide():
+    import math
+    from pyteomics import mass
+
+    m = mass.calculate_mass(sequence="PEPTIDE")
+    assert math.isfinite(m)
+    # Monoisotopic neutral mass of PEPTIDE is ~799.36 Da.
+    assert abs(m - 799.35994) < 0.02
+
+
+def test_fast_mass_matches_calculate_mass():
+    import math
+    from pyteomics import mass
+
+    fm = mass.fast_mass("PEPTIDE")
+    assert math.isfinite(fm)
+    assert abs(fm - 799.35994) < 0.02
+    # fast_mass is the optimized path; it must agree with calculate_mass.
+    assert abs(fm - mass.calculate_mass(sequence="PEPTIDE")) < 1e-3
+
+
+def test_cleave_trypsin_single():
+    from pyteomics import parser
+
+    peptides = parser.cleave("PEPTIDEK", "trypsin")
+    assert isinstance(peptides, set)
+    # A single K-terminated peptide yields exactly itself.
+    assert "PEPTIDEK" in peptides
+
+
+def test_cleave_trypsin_multiple():
+    from pyteomics import parser
+
+    # Trypsin cuts after K and after R -> two fully-digested peptides.
+    peptides = parser.cleave("AAKCCR", "trypsin")
+    assert peptides == {"AAK", "CCR"}
+
+
+run_test("mass.calculate_mass(PEPTIDE)", test_calculate_mass_peptide)
+run_test("mass.fast_mass matches calculate_mass", test_fast_mass_matches_calculate_mass)
+run_test("parser.cleave trypsin (single)", test_cleave_trypsin_single)
+run_test("parser.cleave trypsin (multiple)", test_cleave_trypsin_multiple)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyteomics smoke tests passed")

--- a/cli/scripts/lib-validator/python-docx.py
+++ b/cli/scripts/lib-validator/python-docx.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `python-docx` package (import name: docx).
+
+Fully self-contained: no input files, no network, no packages beyond python-docx
+(and its implied deps). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 python-docx.py
+
+Install: pip install python-docx   (import name: docx)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import docx
+except ImportError:
+    print("FAIL: package 'python-docx' is not installed")
+    sys.exit(1)
+
+import tempfile
+
+from docx import Document
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"python-docx version: {_version(docx, 'python-docx')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_add_heading_and_paragraph():
+    doc = Document()
+    doc.add_heading("Title", 0)
+    doc.add_paragraph("body")
+    # add_heading(level=0) and add_paragraph each append one paragraph.
+    assert len(doc.paragraphs) == 2
+    assert doc.paragraphs[0].text == "Title"
+    assert doc.paragraphs[1].text == "body"
+
+
+def test_paragraph_run_text():
+    doc = Document()
+    p = doc.add_paragraph("hello ")
+    p.add_run("world")
+    assert p.text == "hello world"
+    assert len(p.runs) == 2
+
+
+def test_save_reopen_roundtrip_tempfile():
+    doc = Document()
+    doc.add_heading("Persisted Title", 0)
+    doc.add_paragraph("first")
+    doc.add_paragraph("second")
+    fd, path = tempfile.mkstemp(suffix=".docx")
+    os.close(fd)
+    try:
+        doc.save(path)
+        assert os.path.getsize(path) > 0
+        reopened = Document(path)
+        assert len(reopened.paragraphs) == 3
+        assert reopened.paragraphs[0].text == "Persisted Title"
+        assert reopened.paragraphs[1].text == "first"
+        assert reopened.paragraphs[2].text == "second"
+    finally:
+        os.remove(path)
+
+
+run_test("add heading + paragraph", test_add_heading_and_paragraph)
+run_test("paragraph run text", test_paragraph_run_text)
+run_test("save/reopen roundtrip tempfile", test_save_reopen_roundtrip_tempfile)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all python-docx smoke tests passed")

--- a/cli/scripts/lib-validator/python-pptx.py
+++ b/cli/scripts/lib-validator/python-pptx.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `python-pptx` package (import name: pptx).
+
+Fully self-contained: no input files, no network, no packages beyond
+python-pptx (and its implied deps). Exercises the core API surface and exits 0
+only if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 python-pptx.py
+
+Install: pip install python-pptx   (import name: pptx)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pptx
+except ImportError:
+    print("FAIL: package 'python-pptx' is not installed")
+    sys.exit(1)
+
+import tempfile
+
+from pptx import Presentation
+from pptx.util import Inches
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"python-pptx version: {_version(pptx, 'python-pptx')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_new_presentation_is_empty():
+    prs = Presentation()
+    assert len(prs.slides) == 0
+    # The default template ships the standard 11 built-in slide layouts.
+    assert len(prs.slide_layouts) == 11
+
+
+def test_add_slide_and_set_title():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    assert len(prs.slides) == 1
+    # Layout 0 (title slide) seeds two placeholders: title + subtitle.
+    assert len(slide.shapes) == 2
+    slide.shapes.title.text = "Smoke Test Title"
+    assert slide.shapes.title.text == "Smoke Test Title"
+
+
+def test_add_textbox_grows_shape_count():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = "Deck"
+    box = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(4), Inches(1))
+    box.text_frame.text = "body text"
+    assert len(slide.shapes) == 3
+    assert box.text_frame.text == "body text"
+
+
+def test_save_reopen_roundtrip_tempfile():
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = "Persisted Title"
+    fd, path = tempfile.mkstemp(suffix=".pptx")
+    os.close(fd)
+    try:
+        prs.save(path)
+        assert os.path.getsize(path) > 0
+        reopened = Presentation(path)
+        assert len(reopened.slides) == 1
+        assert reopened.slides[0].shapes.title.text == "Persisted Title"
+    finally:
+        os.remove(path)
+
+
+run_test("new presentation is empty", test_new_presentation_is_empty)
+run_test("add slide + set title text", test_add_slide_and_set_title)
+run_test("add textbox grows shape count", test_add_textbox_grows_shape_count)
+run_test("save/reopen roundtrip tempfile", test_save_reopen_roundtrip_tempfile)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all python-pptx smoke tests passed")

--- a/cli/scripts/lib-validator/pytometry.py
+++ b/cli/scripts/lib-validator/pytometry.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `pytometry` package.
+
+Fully self-contained: no input files, no network, no packages beyond pytometry
+(and its implied deps: anndata, scanpy, numpy). Exercises the core API surface
+and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 pytometry.py
+
+Install: pip install pytometry   (import name: pytometry)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import pytometry as pm
+except ImportError:
+    print("FAIL: package 'pytometry' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pytometry version: {_version(pm, 'pytometry')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# NOTE: pytometry is a flow/mass-cytometry toolkit layered on AnnData. This
+# validator builds a tiny SYNTHETIC AnnData of marker intensities (no files, no
+# network) and exercises a tl transform. FLAG: real use needs anndata; kept
+# MODEST (surface + one transform).
+def test_submodules_present():
+    # pytometry mirrors scanpy's pp / tl / pl namespace layout.
+    for sub in ("pp", "tl", "pl"):
+        assert hasattr(pm, sub), f"pytometry.{sub} missing"
+
+
+def test_pp_surface_present():
+    # Preprocessing entrypoints (compensation / signal splitting).
+    assert hasattr(pm.pp, "split_signal") or hasattr(pm.pp, "compensate")
+
+
+def test_tl_arcsinh_transform_changes_values():
+    import numpy as np
+    import anndata as ad
+
+    rng = np.random.default_rng(0)
+    # 20 cells x 5 markers of raw positive intensities.
+    x = (rng.random((20, 5)) * 1000.0).astype("float32")
+    adata = ad.AnnData(X=x.copy())
+    adata.var_names = [f"marker{i}" for i in range(5)]
+
+    before = adata.X.copy()
+    # arcsinh normalization is the canonical cytometry variance stabilizer.
+    result = pm.tl.normalize_arcsinh(adata, cofactor=5)
+    # pytometry tools may transform in place (return None) or return a copy.
+    out = result if result is not None else adata
+    assert out.shape == (20, 5)  # shape preserved
+    assert not np.allclose(out.X, before)  # arcsinh actually transformed values
+
+
+run_test("scanpy-style submodules present", test_submodules_present)
+run_test("pp preprocessing surface present", test_pp_surface_present)
+run_test("tl arcsinh transform changes values", test_tl_arcsinh_transform_changes_values)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pytometry smoke tests passed")

--- a/cli/scripts/lib-validator/pyyaml.py
+++ b/cli/scripts/lib-validator/pyyaml.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `PyYAML` package.
+
+Fully self-contained: no input files, no network, no packages beyond PyYAML.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 pyyaml.py
+
+Install: pip install pyyaml   (import name: yaml)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL: package 'pyyaml' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"pyyaml version: {_version(yaml, 'pyyaml')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_safe_dump_load_roundtrip():
+    data = {
+        "name": "smoke",
+        "count": 3,
+        "nested": {"a": [1, 2, 3], "b": {"deep": True}},
+        "items": ["x", "y", "z"],
+    }
+    text = yaml.safe_dump(data)
+    assert isinstance(text, str)
+    back = yaml.safe_load(text)
+    assert back == data
+
+
+def test_safe_load_literal_multiline():
+    doc = """
+    name: project
+    version: 2
+    tags:
+      - alpha
+      - beta
+    config:
+      enabled: true
+      threshold: 0.5
+    """
+    parsed = yaml.safe_load(doc)
+    assert parsed["name"] == "project"
+    assert parsed["version"] == 2
+    assert parsed["tags"] == ["alpha", "beta"]
+    assert parsed["config"] == {"enabled": True, "threshold": 0.5}
+
+
+def test_type_coercion():
+    parsed = yaml.safe_load("i: 42\nf: 3.14\nb: yes\nn: null\nlst: [1, 2, 3]\n")
+    assert parsed["i"] == 42 and isinstance(parsed["i"], int)
+    assert abs(parsed["f"] - 3.14) < 1e-12 and isinstance(parsed["f"], float)
+    assert parsed["b"] is True
+    assert parsed["n"] is None
+    assert parsed["lst"] == [1, 2, 3]
+
+
+run_test("safe_dump/safe_load roundtrip", test_safe_dump_load_roundtrip)
+run_test("safe_load literal multi-line YAML", test_safe_load_literal_multiline)
+run_test("scalar type coercion", test_type_coercion)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all pyyaml smoke tests passed")

--- a/cli/scripts/lib-validator/quadprog.R
+++ b/cli/scripts/lib-validator/quadprog.R
@@ -1,0 +1,101 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `quadprog` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# quadprog itself. Solves small quadratic programs with known closed-form
+# optima (including the classic documented example from ?solve.QP) and
+# exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript quadprog.R
+
+if (!requireNamespace("quadprog", quietly = TRUE)) {
+  cat("FAIL: package 'quadprog' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(quadprog))
+cat(sprintf("quadprog version: %s\n", as.character(packageVersion("quadprog"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("classic ?solve.QP example", function() {
+  # minimize -d^T b + 1/2 b^T D b  subject to  A^T b >= b0
+  Dmat <- matrix(0, 3, 3)
+  diag(Dmat) <- 1
+  dvec <- c(0, 5, 0)
+  Amat <- matrix(c(-4, -3, 0, 2, 1, 0, 0, -2, 1), 3, 3)
+  bvec <- c(-8, 2, 0)
+  sol <- solve.QP(Dmat, dvec, Amat, bvec)
+  # Documented optimum: b = (10, 22, 44)/21, value = -50/21.
+  stopifnot(isTRUE(all.equal(sol$solution,
+                             c(0.4761905, 1.0476190, 2.0952381),
+                             tolerance = 1e-5)))
+  stopifnot(isTRUE(all.equal(sol$value, -2.380952, tolerance = 1e-5)))
+  # With D = I the unconstrained optimum of 1/2 b'b - d'b is b = dvec.
+  stopifnot(isTRUE(all.equal(sol$unconstrained.solution, dvec,
+                             tolerance = 1e-6)))
+  # Feasibility: every constraint holds at the solution (small slack for fp).
+  stopifnot(all(crossprod(Amat, sol$solution) - bvec >= -1e-8))
+  # Constraints 2 and 3 are active at the optimum, with multipliers 5/21
+  # and 44/21 (constraint 1 is slack, so its multiplier is 0).
+  stopifnot(length(sol$iact) == 2L, all(sort(sol$iact) == c(2, 3)))
+  stopifnot(isTRUE(all.equal(sol$Lagrangian, c(0, 5 / 21, 44 / 21),
+                             tolerance = 1e-5)))
+})
+
+run_test("inactive constraints recover the unconstrained optimum", function() {
+  # With D = I and a constraint far from the optimum, the QP reduces to
+  # minimizing 1/2 b'b - d'b, whose minimum is b = dvec.
+  Dmat <- diag(2)
+  dvec <- c(1, 2)
+  Amat <- matrix(c(1, 0), 2, 1) # b1 >= -100: never active
+  bvec <- -100
+  sol <- solve.QP(Dmat, dvec, Amat, bvec)
+  stopifnot(isTRUE(all.equal(sol$solution, c(1, 2), tolerance = 1e-6)))
+  stopifnot(isTRUE(all.equal(sol$value, -2.5, tolerance = 1e-6)))
+  stopifnot(isTRUE(all.equal(sol$unconstrained.solution, c(1, 2),
+                             tolerance = 1e-6)))
+})
+
+run_test("equality constraint via meq", function() {
+  # minimize 1/2 (b1^2 + b2^2)  subject to  b1 + b2 = 1  =>  b = (0.5, 0.5)
+  Dmat <- diag(2)
+  dvec <- c(0, 0)
+  Amat <- matrix(c(1, 1), 2, 1)
+  bvec <- 1
+  sol <- solve.QP(Dmat, dvec, Amat, bvec, meq = 1)
+  stopifnot(isTRUE(all.equal(sol$solution, c(0.5, 0.5), tolerance = 1e-6)))
+  stopifnot(isTRUE(all.equal(sol$value, 0.25, tolerance = 1e-6)))
+  stopifnot(abs(sum(sol$solution) - 1) < 1e-8) # equality holds exactly
+  stopifnot(isTRUE(all.equal(as.numeric(sol$Lagrangian), 0.5,
+                             tolerance = 1e-6)))
+})
+
+run_test("result structure and compact interface", function() {
+  sol <- solve.QP(diag(2), c(0, 0), matrix(c(1, 0), 2, 1), 0)
+  stopifnot(all(c("solution", "value", "unconstrained.solution",
+                  "iterations", "Lagrangian", "iact") %in% names(sol)))
+  stopifnot(all(abs(sol$solution) < 1e-8)) # optimum at the origin
+  # The sparse-storage variant exists too; the standard dense interface
+  # exercised above is the canonical API surface.
+  stopifnot(is.function(solve.QP.compact))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all quadprog smoke tests passed\n")

--- a/cli/scripts/lib-validator/rasterio.py
+++ b/cli/scripts/lib-validator/rasterio.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `rasterio` package.
+
+Fully self-contained: no external input files, no network. Writes a small
+in-memory array to a temporary GeoTIFF, reads it back, and verifies the
+round-trip, exiting 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 rasterio.py
+
+Install: pip install rasterio   (import name: rasterio)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review): rasterio is a Python binding over GDAL; the GeoTIFF
+("GTiff") driver used below comes from the bundled/native GDAL. Everything is
+written to and read from a tempfile that is removed in a `finally`, so no
+external raster data is required.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import rasterio
+    from rasterio.transform import from_origin
+except ImportError:
+    print("FAIL: package 'rasterio' is not installed")
+    sys.exit(1)
+
+# numpy is a hard dependency of rasterio, so it is importable whenever rasterio is.
+import numpy as np
+import tempfile
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"rasterio version: {_version(rasterio, 'rasterio')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_geotiff_write_read_roundtrip():
+    data = np.arange(64, dtype="float32").reshape(8, 8)
+    transform = from_origin(west=0, north=8, xsize=1, ysize=1)
+    fd, path = tempfile.mkstemp(suffix=".tif")
+    os.close(fd)
+    try:
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=8,
+            width=8,
+            count=1,
+            dtype="float32",
+            transform=transform,
+        ) as dst:
+            dst.write(data, 1)
+        with rasterio.open(path) as src:
+            back = src.read(1)
+            assert src.width == 8
+            assert src.height == 8
+            assert src.count == 1
+            assert src.dtypes[0] == "float32"
+            assert np.allclose(back, data)
+    finally:
+        os.remove(path)
+
+
+def test_profile_metadata_roundtrips():
+    data = np.arange(12, dtype="uint8").reshape(3, 4)
+    fd, path = tempfile.mkstemp(suffix=".tif")
+    os.close(fd)
+    try:
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=3,
+            width=4,
+            count=1,
+            dtype="uint8",
+        ) as dst:
+            dst.write(data, 1)
+        with rasterio.open(path) as src:
+            profile = src.profile
+            assert profile["driver"] == "GTiff"
+            assert profile["width"] == 4
+            assert profile["height"] == 3
+            assert profile["count"] == 1
+            assert str(profile["dtype"]) == "uint8"
+    finally:
+        os.remove(path)
+
+
+def test_multiband_write_read():
+    band1 = np.full((4, 4), 1, dtype="int16")
+    band2 = np.full((4, 4), 2, dtype="int16")
+    fd, path = tempfile.mkstemp(suffix=".tif")
+    os.close(fd)
+    try:
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=4,
+            width=4,
+            count=2,
+            dtype="int16",
+        ) as dst:
+            dst.write(band1, 1)
+            dst.write(band2, 2)
+        with rasterio.open(path) as src:
+            assert src.count == 2
+            stack = src.read()  # shape (bands, rows, cols)
+            assert stack.shape == (2, 4, 4)
+            assert np.all(stack[0] == 1)
+            assert np.all(stack[1] == 2)
+    finally:
+        os.remove(path)
+
+
+run_test("GeoTIFF write/read round-trip", test_geotiff_write_read_roundtrip)
+run_test("profile metadata roundtrips", test_profile_metadata_roundtrips)
+run_test("multi-band write/read", test_multiband_write_read)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all rasterio smoke tests passed")

--- a/cli/scripts/lib-validator/rdkit.py
+++ b/cli/scripts/lib-validator/rdkit.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `rdkit` package.
+
+Fully self-contained: no input files, no network, no packages beyond rdkit
+(which vends its own numpy-backed extensions). Exercises the core API surface
+and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 rdkit.py
+
+Install: pip install rdkit   (import name: rdkit)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import rdkit
+    from rdkit import Chem
+except ImportError:
+    print("FAIL: package 'rdkit' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"rdkit version: {_version(rdkit, 'rdkit')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_parse_and_atom_count():
+    mol = Chem.MolFromSmiles("CCO")
+    assert mol is not None
+    # Ethanol has three heavy atoms (C, C, O); implicit H are not counted here.
+    assert mol.GetNumAtoms() == 3
+
+
+def test_canonical_smiles_roundtrip():
+    mol = Chem.MolFromSmiles("OCC")
+    canon = Chem.MolToSmiles(mol)
+    # Round-tripping through the canonicalizer is idempotent.
+    remol = Chem.MolFromSmiles(canon)
+    assert remol is not None
+    assert Chem.MolToSmiles(remol) == canon
+    # "OCC" and "CCO" denote the same molecule → same canonical form.
+    assert canon == Chem.MolToSmiles(Chem.MolFromSmiles("CCO"))
+
+
+def test_molwt_descriptor():
+    from rdkit.Chem import Descriptors
+
+    mol = Chem.MolFromSmiles("CCO")
+    mw = Descriptors.MolWt(mol)
+    # Ethanol C2H6O ≈ 46.07 g/mol.
+    assert abs(mw - 46.07) < 0.1
+
+
+def test_morgan_fingerprint():
+    from rdkit.Chem import AllChem
+    from rdkit import DataStructs
+
+    m1 = Chem.MolFromSmiles("CCO")
+    m2 = Chem.MolFromSmiles("CCO")
+    m3 = Chem.MolFromSmiles("c1ccccc1")
+    fp1 = AllChem.GetMorganFingerprintAsBitVect(m1, radius=2, nBits=1024)
+    fp2 = AllChem.GetMorganFingerprintAsBitVect(m2, radius=2, nBits=1024)
+    fp3 = AllChem.GetMorganFingerprintAsBitVect(m3, radius=2, nBits=1024)
+    assert fp1.GetNumBits() == 1024
+    # Identical molecules → perfect Tanimoto similarity.
+    assert abs(DataStructs.TanimotoSimilarity(fp1, fp2) - 1.0) < 1e-9
+    # Ethanol vs benzene share no environments → dissimilar.
+    assert DataStructs.TanimotoSimilarity(fp1, fp3) < 1.0
+
+
+def test_embed_3d_optional():
+    # 3D embedding needs Hs and a conformer; treat inability to embed as a soft
+    # skip (some builds/platforms lack the coordinate generator) rather than a
+    # hard failure of the smoke test.
+    from rdkit.Chem import AllChem
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    rc = AllChem.EmbedMolecule(mol, randomSeed=0xF00D)
+    if rc != 0:
+        return
+    conf = mol.GetConformer()
+    assert conf.GetNumAtoms() == mol.GetNumAtoms()
+
+
+run_test("MolFromSmiles + heavy atom count", test_parse_and_atom_count)
+run_test("canonical SMILES roundtrip", test_canonical_smiles_roundtrip)
+run_test("MolWt descriptor (ethanol ~46.07)", test_molwt_descriptor)
+run_test("Morgan fingerprint + Tanimoto", test_morgan_fingerprint)
+run_test("3D embed (optional/soft-skip)", test_embed_3d_optional)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all rdkit smoke tests passed")

--- a/cli/scripts/lib-validator/readr.R
+++ b/cli/scripts/lib-validator/readr.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `readr` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# readr itself. All I/O is in-memory (literal strings via I()); exercises
+# the core API surface and exits 0 only if every check passes, so it can
+# be used as a pass/fail library validator:
+#
+#   Rscript readr.R
+
+if (!requireNamespace("readr", quietly = TRUE)) {
+  cat("FAIL: package 'readr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(readr))
+cat(sprintf("readr version: %s\n", as.character(packageVersion("readr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("read_csv from literal string", function() {
+  df <- suppressMessages(read_csv(I("a,b\n1,x\n2,y\n"), show_col_types = FALSE))
+  stopifnot(identical(names(df), c("a", "b")))
+  stopifnot(identical(nrow(df), 2L))
+  stopifnot(identical(df$a, c(1, 2)))
+  stopifnot(identical(df$b, c("x", "y")))
+})
+
+run_test("format_csv / read_csv roundtrip", function() {
+  df <- suppressMessages(read_csv(I("a,b\n1,x\n2,y\n"), show_col_types = FALSE))
+  csv <- format_csv(df)
+  stopifnot(identical(csv, "a,b\n1,x\n2,y\n"))
+  back <- suppressMessages(read_csv(I(csv), show_col_types = FALSE))
+  stopifnot(identical(back$a, df$a), identical(back$b, df$b))
+})
+
+run_test("read_tsv from literal string", function() {
+  df <- suppressMessages(read_tsv(I("a\tb\n1\tx\n2\ty\n"), show_col_types = FALSE))
+  stopifnot(identical(names(df), c("a", "b")))
+  stopifnot(identical(df$a, c(1, 2)))
+  stopifnot(identical(df$b, c("x", "y")))
+})
+
+run_test("parse_number strips formatting", function() {
+  stopifnot(identical(parse_number("$1,234.5"), 1234.5))
+  stopifnot(identical(parse_number(c("50%", "-3.5")), c(50, -3.5)))
+})
+
+run_test("parse_date and parse_logical", function() {
+  stopifnot(identical(parse_date("2020-01-02"), as.Date("2020-01-02")))
+  stopifnot(identical(parse_logical(c("TRUE", "FALSE", "T", "F")), c(TRUE, FALSE, TRUE, FALSE)))
+})
+
+run_test("explicit col_types are honored", function() {
+  df <- read_csv(I("a,b\n1,x\n2,y\n"), col_types = cols(a = col_integer(), b = col_character()))
+  stopifnot(identical(df$a, c(1L, 2L)))
+  stopifnot(identical(df$b, c("x", "y")))
+})
+
+run_test("type_convert re-guesses character columns", function() {
+  df <- data.frame(x = c("1", "2"), y = c("a", "b"), stringsAsFactors = FALSE)
+  tc <- suppressMessages(type_convert(df))
+  stopifnot(identical(tc$x, c(1, 2)))
+  stopifnot(identical(tc$y, c("a", "b")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all readr smoke tests passed\n")

--- a/cli/scripts/lib-validator/remotes.R
+++ b/cli/scripts/lib-validator/remotes.R
@@ -1,0 +1,73 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `remotes` package.
+#
+# Fully self-contained and OFFLINE: no input files, no network. Only the
+# pure spec parsers are exercised -- `parse_repo_spec()` -- which do string
+# parsing with no I/O. The networked surface (`install_*()`, `package_deps()`,
+# `dev_package_deps()`) is deliberately NOT called. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript remotes.R
+
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  cat("FAIL: package 'remotes' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(remotes))
+cat(sprintf("remotes version: %s\n", as.character(packageVersion("remotes"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# A field is "empty" when the spec did not supply it; parse_repo_spec fills
+# absent optional groups with either NA or an empty string across versions,
+# so treat both as blank.
+blank <- function(x) is.na(x) || !nzchar(as.character(x))
+
+run_test("parse_repo_spec: user/repo@branch", function() {
+  s <- remotes::parse_repo_spec("user/repo@branch")
+  stopifnot(is.list(s))
+  stopifnot(all(c("username", "repo", "ref") %in% names(s)))
+  stopifnot(identical(as.character(s$username), "user"))
+  stopifnot(identical(as.character(s$repo), "repo"))
+  stopifnot(identical(as.character(s$ref), "branch"))
+})
+
+run_test("parse_repo_spec: user/repo/subdir", function() {
+  s <- remotes::parse_repo_spec("user/repo/subdir")
+  stopifnot(identical(as.character(s$username), "user"))
+  stopifnot(identical(as.character(s$repo), "repo"))
+  stopifnot(identical(as.character(s$subdir), "subdir"))
+})
+
+run_test("parse_repo_spec: bare user/repo has no ref", function() {
+  s <- remotes::parse_repo_spec("user/repo")
+  stopifnot(identical(as.character(s$username), "user"))
+  stopifnot(identical(as.character(s$repo), "repo"))
+  stopifnot(blank(s$ref))
+})
+
+run_test("parse_repo_spec: pkgname=user/repo captures package name", function() {
+  s <- remotes::parse_repo_spec("mypkg=user/repo")
+  stopifnot(identical(as.character(s$package), "mypkg"))
+  stopifnot(identical(as.character(s$username), "user"))
+  stopifnot(identical(as.character(s$repo), "repo"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all remotes smoke tests passed\n")

--- a/cli/scripts/lib-validator/reshape2.R
+++ b/cli/scripts/lib-validator/reshape2.R
@@ -1,0 +1,70 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `reshape2` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# reshape2 itself (plus its implied deps). Exercises the core melt/cast API on
+# a small in-memory data frame and exits 0 only if every check passes, so it
+# can be used as a pass/fail library validator:
+#
+#   Rscript reshape2.R
+
+if (!requireNamespace("reshape2", quietly = TRUE)) {
+  cat("FAIL: package 'reshape2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(reshape2))
+cat(sprintf("reshape2 version: %s\n", as.character(packageVersion("reshape2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+wide_df <- function() {
+  data.frame(id = 1:3, x = c(10, 20, 30), y = c(40, 50, 60))
+}
+
+run_test("melt turns wide into long", function() {
+  df <- wide_df()
+  long <- reshape2::melt(df, id.vars = "id")
+  # n rows * measured columns: 3 ids * 2 measures (x, y) = 6.
+  stopifnot(nrow(long) == 3L * 2L)
+  stopifnot(all(c("id", "variable", "value") %in% names(long)))
+  stopifnot(setequal(as.character(unique(long$variable)), c("x", "y")))
+  stopifnot(setequal(long$value, c(10, 20, 30, 40, 50, 60)))
+})
+
+run_test("dcast reconstructs the wide frame exactly", function() {
+  df <- wide_df()
+  long <- reshape2::melt(df, id.vars = "id")
+  wide2 <- reshape2::dcast(long, id ~ variable, value.var = "value")
+  stopifnot(identical(wide2$id, df$id))
+  stopifnot(identical(wide2$x, df$x))
+  stopifnot(identical(wide2$y, df$y))
+  stopifnot(isTRUE(all.equal(df, wide2, check.attributes = FALSE)))
+})
+
+run_test("acast returns a matrix of the right dims", function() {
+  df <- wide_df()
+  long <- reshape2::melt(df, id.vars = "id")
+  m <- reshape2::acast(long, id ~ variable, value.var = "value")
+  stopifnot(is.matrix(m))
+  stopifnot(identical(dim(m), c(3L, 2L)))
+  stopifnot(setequal(colnames(m), c("x", "y")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all reshape2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/rjags.R
+++ b/cli/scripts/lib-validator/rjags.R
@@ -1,0 +1,144 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `rjags` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond rjags
+# itself. Data is simulated with a fixed seed. Exercises the core JAGS
+# interface -- compile a model, burn in, draw posterior samples -- and exits 0
+# only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript rjags.R
+#
+# rjags links the external JAGS library at load time; it will not even load
+# without a working libjags on the system, which is why an install-only miss
+# fires the guard below. MCMC output is stochastic, so checks assert
+# structural/robust properties (classes, dimensions, finiteness) and recover a
+# known posterior mean only within a generous tolerance -- never exact equality.
+
+if (!requireNamespace("rjags", quietly = TRUE)) {
+  cat("FAIL: package 'rjags' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(rjags))
+cat(sprintf("rjags version: %s\n", as.character(packageVersion("rjags"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# A tiny conjugate mean-estimation model shared by the tests: y_i ~ N(mu, 1/tau)
+# with vague priors on mu and tau. With enough data the posterior mean of mu
+# recovers the true data-generating mean.
+model_string <- "
+model {
+  for (i in 1:N) {
+    y[i] ~ dnorm(mu, tau)
+  }
+  mu ~ dnorm(0, 1.0E-4)
+  tau ~ dgamma(0.01, 0.01)
+}
+"
+
+run_test("jags.model compiles a model", function() {
+  set.seed(1)
+  y <- rnorm(200L, mean = 5, sd = 2)
+  jm <- jags.model(
+    textConnection(model_string),
+    data = list(y = y, N = length(y)),
+    n.chains = 2L,
+    quiet = TRUE
+  )
+  stopifnot(inherits(jm, "jags"))
+})
+
+run_test("update burns in without error", function() {
+  set.seed(2)
+  y <- rnorm(200L, mean = 5, sd = 2)
+  jm <- jags.model(
+    textConnection(model_string),
+    data = list(y = y, N = length(y)),
+    n.chains = 2L,
+    quiet = TRUE
+  )
+  update(jm, 500L, progress.bar = "none")
+  # update mutates the model in place; it should still be a live jags object
+  stopifnot(inherits(jm, "jags"))
+})
+
+run_test("coda.samples returns an mcmc.list with the monitored node", function() {
+  set.seed(3)
+  y <- rnorm(300L, mean = 5, sd = 2)
+  jm <- jags.model(
+    textConnection(model_string),
+    data = list(y = y, N = length(y)),
+    n.chains = 2L,
+    quiet = TRUE
+  )
+  update(jm, 500L, progress.bar = "none")
+  samp <- coda.samples(jm, variable.names = c("mu", "tau"),
+                       n.iter = 2000L, progress.bar = "none")
+  stopifnot(inherits(samp, "mcmc.list"))
+  # one mcmc matrix per chain
+  stopifnot(length(samp) == 2L)
+  stopifnot(all(vapply(samp, function(ch) inherits(ch, "mcmc"), logical(1))))
+  vn <- colnames(samp[[1]])
+  stopifnot(all(c("mu", "tau") %in% vn))
+  # each chain drew the requested number of iterations
+  stopifnot(all(vapply(samp, nrow, integer(1)) == 2000L))
+})
+
+run_test("posterior mean of mu recovers the known truth", function() {
+  set.seed(4)
+  true_mu <- 5
+  y <- rnorm(500L, mean = true_mu, sd = 2)
+  jm <- jags.model(
+    textConnection(model_string),
+    data = list(y = y, N = length(y)),
+    n.chains = 2L,
+    quiet = TRUE
+  )
+  update(jm, 1000L, progress.bar = "none")
+  samp <- coda.samples(jm, variable.names = "mu",
+                       n.iter = 3000L, progress.bar = "none")
+  # pool both chains' draws of mu
+  mu_draws <- unlist(lapply(samp, function(ch) as.numeric(ch[, "mu"])))
+  stopifnot(all(is.finite(mu_draws)))
+  post_mean <- mean(mu_draws)
+  stopifnot(is.finite(post_mean))
+  # generous tolerance -- stochastic MCMC estimate of the posterior mean
+  stopifnot(abs(post_mean - true_mu) < 0.4)
+  # posterior precision tau should be positive
+})
+
+run_test("tau posterior is strictly positive", function() {
+  set.seed(5)
+  y <- rnorm(300L, mean = 0, sd = 3)
+  jm <- jags.model(
+    textConnection(model_string),
+    data = list(y = y, N = length(y)),
+    n.chains = 1L,
+    quiet = TRUE
+  )
+  update(jm, 500L, progress.bar = "none")
+  samp <- coda.samples(jm, variable.names = "tau",
+                       n.iter = 2000L, progress.bar = "none")
+  tau_draws <- as.numeric(samp[[1]][, "tau"])
+  stopifnot(all(is.finite(tau_draws)), all(tau_draws > 0))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all rjags smoke tests passed\n")

--- a/cli/scripts/lib-validator/rlang.R
+++ b/cli/scripts/lib-validator/rlang.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `rlang` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# rlang itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript rlang.R
+
+if (!requireNamespace("rlang", quietly = TRUE)) {
+  cat("FAIL: package 'rlang' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(rlang))
+cat(sprintf("rlang version: %s\n", as.character(packageVersion("rlang"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("quo + eval_tidy", function() {
+  stopifnot(identical(rlang::eval_tidy(rlang::quo(1 + 2)), 3))
+  q <- rlang::quo(x * 10)
+  stopifnot(identical(rlang::eval_tidy(q, data = list(x = 4)), 40))
+})
+
+run_test("expr / sym / syms", function() {
+  e <- rlang::expr(a + b)
+  stopifnot(identical(e, quote(a + b)))
+  s <- rlang::sym("foo")
+  stopifnot(identical(s, quote(foo)))
+  stopifnot(identical(rlang::syms(c("a", "b")), list(quote(a), quote(b))))
+})
+
+run_test("!! injection with eval_tidy", function() {
+  col <- rlang::sym("foo")
+  e <- rlang::expr(!!col + 1)
+  stopifnot(identical(rlang::eval_tidy(e, data = list(foo = 41)), 42))
+  val <- 10
+  stopifnot(identical(rlang::eval_tidy(rlang::quo(!!val * 2)), 20))
+})
+
+run_test("set_names", function() {
+  named <- rlang::set_names(1:3, c("a", "b", "c"))
+  stopifnot(identical(named, c(a = 1L, b = 2L, c = 3L)))
+  self_named <- rlang::set_names(c("x", "y"))
+  stopifnot(identical(self_named, c(x = "x", y = "y")))
+})
+
+run_test("%||% null-default operator", function() {
+  stopifnot(identical(NULL %||% 5, 5))
+  stopifnot(identical("kept" %||% "fallback", "kept"))
+})
+
+run_test("type predicates", function() {
+  stopifnot(isTRUE(rlang::is_empty(list())))
+  stopifnot(isFALSE(rlang::is_empty(list(1))))
+  stopifnot(isTRUE(rlang::is_null(NULL)))
+  stopifnot(isFALSE(rlang::is_null(NA)))
+  stopifnot(isTRUE(rlang::is_string("one")))
+  stopifnot(isFALSE(rlang::is_string(c("two", "strings"))))
+  stopifnot(isFALSE(rlang::is_string(1)))
+})
+
+run_test("list2 with !!! splice via tidy dots", function() {
+  collect <- function(...) rlang::list2(...)
+  extras <- list(b = 2, c = 3)
+  got <- collect(a = 1, !!!extras)
+  stopifnot(identical(got, list(a = 1, b = 2, c = 3)))
+})
+
+run_test("inject and call2 build + evaluate", function() {
+  stopifnot(identical(rlang::inject(sum(!!!list(1, 2, 3))), 6))
+  cl <- rlang::call2("sum", 1, 2, 3)
+  stopifnot(identical(cl, quote(sum(1, 2, 3))))
+  stopifnot(identical(rlang::eval_tidy(cl), 6))
+  stopifnot(identical(rlang::exec("paste", "a", "b", sep = "-"), "a-b"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all rlang smoke tests passed\n")

--- a/cli/scripts/lib-validator/rpds-py.py
+++ b/cli/scripts/lib-validator/rpds-py.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `rpds-py` package.
+
+Fully self-contained: no input files, no network, no packages beyond rpds-py.
+Exercises the core API surface and exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 rpds-py.py
+
+Install: pip install rpds-py   (import name: rpds)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import rpds
+except ImportError:
+    print("FAIL: package 'rpds-py' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"rpds-py version: {_version(rpds, 'rpds-py')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_hash_trie_map_insert_is_immutable():
+    from rpds import HashTrieMap
+
+    m = HashTrieMap({"a": 1})
+    m2 = m.insert("b", 2)
+    # insert returns a NEW map; the original is untouched (persistent structure).
+    assert len(m) == 1 and len(m2) == 2
+    assert "b" not in m and "b" in m2
+    assert m.get("a") == 1 and m2.get("b") == 2
+    assert m.get("missing") is None
+    assert dict(m2.items()) == {"a": 1, "b": 2}
+    assert dict(m.items()) == {"a": 1}
+
+
+def test_hash_trie_map_equality():
+    from rpds import HashTrieMap
+
+    assert HashTrieMap({"a": 1, "b": 2}) == HashTrieMap({"b": 2, "a": 1})
+    assert HashTrieMap({"a": 1}) != HashTrieMap({"a": 2})
+
+
+def test_hash_trie_set_insert_discard_immutable():
+    from rpds import HashTrieSet
+
+    s = HashTrieSet([1, 2, 3])
+    s_ins = s.insert(4)
+    s_dis = s.discard(2)
+    # Both derivations leave the source set unchanged.
+    assert len(s) == 3
+    assert len(s_ins) == 4 and 4 in s_ins and 4 not in s
+    assert len(s_dis) == 2 and 2 not in s_dis and 2 in s
+
+
+def test_list_push_front_first_rest():
+    from rpds import List
+
+    li = List([1, 2, 3])
+    li2 = li.push_front(0)
+    # push_front prepends onto a NEW list; the original is unchanged.
+    assert len(li) == 3 and len(li2) == 4
+    assert li.first == 1 and li2.first == 0
+    assert list(li.rest) == [2, 3]
+    assert list(li) == [1, 2, 3]
+
+
+def test_list_equality_and_iteration():
+    from rpds import List
+
+    assert List([1, 2, 3]) == List([1, 2, 3])
+    assert List([1, 2, 3]) != List([1, 2])
+    assert list(List([1, 2, 3]).push_front(0)) == [0, 1, 2, 3]
+
+
+run_test("HashTrieMap insert is immutable", test_hash_trie_map_insert_is_immutable)
+run_test("HashTrieMap equality", test_hash_trie_map_equality)
+run_test("HashTrieSet insert/discard immutable", test_hash_trie_set_insert_discard_immutable)
+run_test("List push_front/first/rest", test_list_push_front_first_rest)
+run_test("List equality and iteration", test_list_equality_and_iteration)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all rpds-py smoke tests passed")

--- a/cli/scripts/lib-validator/rpy2.py
+++ b/cli/scripts/lib-validator/rpy2.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `rpy2` package.
+
+Fully self-contained: no input files, no network, no packages beyond rpy2.
+Needs a working R installation on PATH (rpy2 embeds the R interpreter), but no
+extra R packages beyond base R. Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 rpy2.py
+
+Install: pip install rpy2   (import name: rpy2)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import rpy2
+except ImportError:
+    print("FAIL: package 'rpy2' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"rpy2 version: {_version(rpy2, 'rpy2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_eval_arithmetic():
+    from rpy2.robjects import r
+
+    # r() evaluates R code and returns an R vector; [0] pulls the first element.
+    assert r("1 + 1")[0] == 2
+    assert abs(r("sqrt(2)")[0] - 2**0.5) < 1e-9
+
+
+def test_python_list_to_r_vector_and_back():
+    from rpy2.robjects import FloatVector
+
+    vec = FloatVector([1.0, 2.0, 3.0, 4.0])
+    assert len(vec) == 4
+    # Round-trip the values back into a Python list.
+    assert list(vec) == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_call_r_function():
+    from rpy2.robjects import FloatVector, r
+
+    r_sum = r["sum"]
+    total = r_sum(FloatVector([1.0, 2.0, 3.0, 4.0]))
+    assert total[0] == 10.0
+    r_mean = r["mean"]
+    assert r_mean(FloatVector([2.0, 4.0, 6.0]))[0] == 4.0
+
+
+run_test("evaluate R arithmetic", test_eval_arithmetic)
+run_test("python list -> R vector -> back", test_python_list_to_r_vector_and_back)
+run_test("call an R function", test_call_r_function)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all rpy2 smoke tests passed")

--- a/cli/scripts/lib-validator/rrvgo.R
+++ b/cli/scripts/lib-validator/rrvgo.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `rrvgo` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. rrvgo reduces redundancy in
+# a set of GO terms by clustering a semantic-similarity matrix. Exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript rrvgo.R
+#
+# ============================ SCOPE & DATA DEPENDENCY ========================
+# This test is DELIBERATELY MODEST -- function-existence + signature checks
+# only -- because rrvgo's real workload CANNOT run offline here:
+#
+#   * calculateSimMatrix(x, orgdb, ont, ...) needs a GO semantic-similarity
+#     database, which it builds from an OrgDb (e.g. org.Hs.eg.db) + GO.db via
+#     GOSemSim::godata(). None of those annotation packages are assumed present.
+#
+#   * reduceSimMatrix(simMatrix, scores, threshold, orgdb, ...) REQUIRES an
+#     `orgdb` argument even when `scores` are supplied -- it looks up per-term
+#     annotation sizes through the OrgDb. So it too cannot run without GO.db +
+#     an OrgDb, and is NOT invoked here.
+#
+# A full data-driven test therefore needs: GO.db, GOSemSim, and an OrgDb such as
+# org.Hs.eg.db installed. Until then, these checks confirm the package loads and
+# exposes its API with the expected argument names -- which is what proves an
+# install is healthy. RE-CHECK the `orgdb`/`ont` formal names once installed.
+# ============================================================================
+
+if (!requireNamespace("rrvgo", quietly = TRUE)) {
+  cat("FAIL: package 'rrvgo' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(rrvgo))
+cat(sprintf("rrvgo version: %s\n", as.character(packageVersion("rrvgo"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("calculateSimMatrix is exported and needs orgdb + ont", function() {
+  stopifnot(is.function(rrvgo::calculateSimMatrix))
+  fm <- names(formals(rrvgo::calculateSimMatrix))
+  # its OrgDb + ontology args are why a full run cannot be offline here
+  stopifnot("orgdb" %in% fm, "ont" %in% fm)
+})
+
+run_test("reduceSimMatrix is exported and requires orgdb", function() {
+  stopifnot(is.function(rrvgo::reduceSimMatrix))
+  fm <- names(formals(rrvgo::reduceSimMatrix))
+  stopifnot("simMatrix" %in% fm, "scores" %in% fm, "orgdb" %in% fm)
+})
+
+run_test("visualization helpers are exported functions", function() {
+  stopifnot(is.function(rrvgo::scatterPlot))
+  stopifnot(is.function(rrvgo::treemapPlot))
+  stopifnot(is.function(rrvgo::heatmapPlot))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all rrvgo smoke tests passed\n")

--- a/cli/scripts/lib-validator/rtracklayer.R
+++ b/cli/scripts/lib-validator/rtracklayer.R
@@ -1,0 +1,101 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `rtracklayer` package.
+#
+# Fully self-contained: NO network, no external annotation files. A small
+# in-memory GRanges is built, exported to a TEMPFILE (BED, then GFF3) and
+# re-imported; every temp path is unlinked on exit. Checks are STRUCTURAL
+# (class, length, seqnames) plus coordinate round-trip, accounting for BED's
+# 0-based half-open convention vs GFF/GRanges' 1-based closed convention.
+# Exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript rtracklayer.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# rtracklayer attaches GenomicRanges (Depends), so GRanges()/IRanges() are in
+# scope. Points to re-confirm once a build is available:
+#   - export(gr, path) dispatches on the ".bed"/".gff3" extension, and
+#     import(path) recovers a GRanges. rtracklayer internally converts BED's
+#     0-based starts back to 1-based on import, so start()/width() ROUND-TRIP
+#     to the original 1-based values (this is the load-bearing coordinate
+#     assumption — re-verify the convention did not change).
+#   - Minimal BED (no name/score) may import strand as "*", so strand is NOT
+#     asserted for the BED round-trip; GFF3 preserves it.
+# ============================================================================
+
+if (!requireNamespace("rtracklayer", quietly = TRUE)) {
+  cat("FAIL: package 'rtracklayer' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(rtracklayer))
+cat(sprintf("rtracklayer version: %s\n", as.character(packageVersion("rtracklayer"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Two 5bp features on chr1, forward strand. 1-based closed coordinates:
+# [10,14] and [50,54].
+make_gr <- function() {
+  GRanges(seqnames = "chr1",
+          ranges = IRanges(start = c(10, 50), width = 5),
+          strand = "+")
+}
+
+run_test("GRanges builds with expected shape", function() {
+  gr <- make_gr()
+  stopifnot(inherits(gr, "GRanges"))
+  stopifnot(length(gr) == 2L)
+  stopifnot(all(as.character(seqnames(gr)) == "chr1"))
+  stopifnot(identical(as.integer(start(gr)), c(10L, 50L)))
+  stopifnot(identical(as.integer(width(gr)), c(5L, 5L)))
+})
+
+run_test("BED export/import round-trips coordinates", function() {
+  gr <- make_gr()
+  tmp <- tempfile(fileext = ".bed")
+  on.exit(unlink(tmp), add = TRUE)
+  suppressWarnings(export(gr, tmp))
+  stopifnot(file.exists(tmp))
+  gr2 <- suppressWarnings(import(tmp))
+  stopifnot(inherits(gr2, "GRanges"))
+  stopifnot(length(gr2) == 2L)
+  stopifnot(all(as.character(seqnames(gr2)) == "chr1"))
+  # rtracklayer converts BED's 0-based starts back to 1-based on import, so the
+  # 1-based start/width recover exactly.
+  stopifnot(identical(as.integer(start(gr2)), c(10L, 50L)))
+  stopifnot(identical(as.integer(width(gr2)), c(5L, 5L)))
+})
+
+run_test("GFF3 export/import round-trips coordinates and strand", function() {
+  gr <- make_gr()
+  tmp <- tempfile(fileext = ".gff3")
+  on.exit(unlink(tmp), add = TRUE)
+  suppressWarnings(export(gr, tmp))
+  stopifnot(file.exists(tmp))
+  gr2 <- suppressWarnings(import(tmp))
+  stopifnot(inherits(gr2, "GRanges"))
+  stopifnot(length(gr2) == 2L)
+  stopifnot(all(as.character(seqnames(gr2)) == "chr1"))
+  # GFF is 1-based closed, matching GRanges directly.
+  stopifnot(identical(as.integer(start(gr2)), c(10L, 50L)))
+  stopifnot(identical(as.integer(width(gr2)), c(5L, 5L)))
+  stopifnot(all(as.character(strand(gr2)) == "+"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all rtracklayer smoke tests passed\n")

--- a/cli/scripts/lib-validator/run_all.py
+++ b/cli/scripts/lib-validator/run_all.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Run every library-validator smoke test in this directory and emit a report.
+
+Each sibling `<package>.py` / `<package>.R` in this folder is one self-contained
+smoke test that follows the house contract (see data.table.R / numpy.py):
+
+    PASS: all <pkg> smoke tests passed          -> exit 0   (installed & healthy)
+    FAIL: package '<pkg>' is not installed       -> exit 1   (absent; expected)
+    FAIL: N test(s) failed                       -> exit 1   (installed but BROKEN)
+
+This runner discovers them, executes each with the right interpreter
+(python3 for .py, Rscript for .R) in parallel, classifies the outcome from the
+script's final stdout line, and prints a grouped report:
+
+    python3 run_all.py                 # full report, all scripts
+    python3 run_all.py --lang py       # only Python validators
+    python3 run_all.py --filter scanpy # only scripts whose name contains "scanpy"
+    python3 run_all.py --json          # machine-readable results
+    python3 run_all.py --verbose       # include failing output for FAIL/ERROR
+
+Runner exit code: 0 when nothing is BROKEN — i.e. every installed library passed
+(absent libraries are skipped, not failures). Non-zero if any validator reports
+FAIL (installed but broken), ERROR (crashed/timed out), or if an interpreter is
+missing for scripts that need it.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import dataclasses
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SELF = Path(__file__).resolve().name
+
+# Outcome buckets. PASS/SKIP are healthy; FAIL/ERROR/NO_INTERP are actionable.
+PASS = "PASS"           # installed, all sub-tests passed
+SKIP = "NOT_INSTALLED"  # guard fired: library absent (expected, not a failure)
+FAIL = "FAIL"           # installed but one or more sub-tests failed
+ERROR = "ERROR"         # crashed, timed out, or emitted an unrecognized result
+NO_INTERP = "NO_INTERP"  # interpreter (python3/Rscript) unavailable
+
+_NOT_INSTALLED_RE = re.compile(r"^FAIL: package '.*' is not installed$")
+_TESTS_FAILED_RE = re.compile(r"^FAIL: \d+ test\(s\) failed$")
+_PASS_RE = re.compile(r"^PASS: all .* smoke tests passed$")
+_VERSION_RE = re.compile(r"version:\s*(.+)$", re.IGNORECASE)
+
+
+@dataclasses.dataclass
+class Result:
+    name: str          # package name (filename stem)
+    lang: str          # "py" or "R"
+    status: str        # one of the buckets above
+    exit_code: int | None
+    ok: int            # count of "  ok   ..." sub-test lines
+    failed: int        # count of "  FAIL ..." sub-test lines
+    version: str       # library version the script reported, if any
+    duration: float    # wall-clock seconds
+    detail: str        # short reason for FAIL/ERROR (tail of output)
+
+
+def _interp_for(path: Path) -> list[str] | None:
+    """Command prefix to run a script, or None if the interpreter is missing."""
+    if path.suffix == ".py":
+        return [sys.executable]
+    if path.suffix == ".R":
+        rscript = shutil.which("Rscript")
+        return [rscript] if rscript else None
+    return None
+
+
+def _classify(stdout: str, exit_code: int) -> tuple[str, int, int, str]:
+    """Map a script's stdout + exit code to (status, ok, failed, detail)."""
+    lines = [ln.rstrip() for ln in stdout.splitlines()]
+    non_empty = [ln for ln in lines if ln.strip()]
+    ok = sum(1 for ln in lines if ln.startswith("  ok   "))
+    failed = sum(1 for ln in lines if ln.startswith("  FAIL "))
+    last = non_empty[-1] if non_empty else ""
+
+    if _PASS_RE.match(last):
+        return PASS, ok, failed, ""
+    if _NOT_INSTALLED_RE.match(last):
+        return SKIP, ok, failed, ""
+    if _TESTS_FAILED_RE.match(last):
+        # Surface the individual failing sub-tests as the detail.
+        fails = [ln.strip() for ln in lines if ln.startswith("  FAIL ")]
+        return FAIL, ok, failed, "; ".join(fails) or last
+    # Anything else: a crash, a partial run, or an unexpected final line.
+    return ERROR, ok, failed, last or f"no recognizable result (exit {exit_code})"
+
+
+def _version_from(stdout: str) -> str:
+    for ln in stdout.splitlines():
+        m = _VERSION_RE.search(ln)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def run_one(path: Path, timeout: float) -> Result:
+    lang = "py" if path.suffix == ".py" else "R"
+    interp = _interp_for(path)
+    if interp is None:
+        return Result(path.stem, lang, NO_INTERP, None, 0, 0, "",
+                      0.0, "Rscript not found on PATH")
+
+    start = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            [*interp, str(path)],
+            cwd=str(HERE),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return Result(path.stem, lang, ERROR, None, 0, 0, "",
+                      time.perf_counter() - start, f"timed out after {timeout:.0f}s")
+    except Exception as e:  # noqa: BLE001 - report any launch failure as ERROR
+        return Result(path.stem, lang, ERROR, None, 0, 0, "",
+                      time.perf_counter() - start, f"failed to launch: {e}")
+
+    dur = time.perf_counter() - start
+    status, ok, failed, detail = _classify(proc.stdout, proc.returncode)
+    if status == ERROR and proc.stderr.strip():
+        # Prefer a stderr tail (traceback / R error) as the detail for crashes.
+        tail = [ln for ln in proc.stderr.splitlines() if ln.strip()][-3:]
+        detail = " / ".join(tail) or detail
+    return Result(path.stem, lang, status, proc.returncode, ok, failed,
+                  _version_from(proc.stdout), dur, detail)
+
+
+def discover(lang: str, name_filter: str | None) -> list[Path]:
+    paths: list[Path] = []
+    for p in sorted(HERE.iterdir(), key=lambda q: q.name.lower()):
+        if p.name == SELF or not p.is_file():
+            continue
+        if p.suffix == ".py":
+            if lang in ("all", "py"):
+                paths.append(p)
+        elif p.suffix == ".R":
+            if lang in ("all", "r"):
+                paths.append(p)
+        else:
+            continue
+    if name_filter:
+        needle = name_filter.lower()
+        paths = [p for p in paths if needle in p.stem.lower()]
+    return paths
+
+
+# ---- reporting ----------------------------------------------------------------
+
+def _c(text: str, code: str, use_color: bool) -> str:
+    return f"\033[{code}m{text}\033[0m" if use_color else text
+
+
+_STATUS_COLOR = {PASS: "32", SKIP: "90", FAIL: "31", ERROR: "1;31", NO_INTERP: "33"}
+_STATUS_LABEL = {
+    PASS: "PASS", SKIP: "skip (absent)", FAIL: "FAIL", ERROR: "ERROR",
+    NO_INTERP: "no interpreter",
+}
+
+
+def print_report(results: list[Result], elapsed: float, use_color: bool) -> None:
+    by_status: dict[str, list[Result]] = {}
+    for r in results:
+        by_status.setdefault(r.status, []).append(r)
+
+    total = len(results)
+    n_pass = len(by_status.get(PASS, []))
+    n_skip = len(by_status.get(SKIP, []))
+    n_fail = len(by_status.get(FAIL, []))
+    n_err = len(by_status.get(ERROR, []))
+    n_noi = len(by_status.get(NO_INTERP, []))
+
+    py = sum(1 for r in results if r.lang == "py")
+    rr = sum(1 for r in results if r.lang == "R")
+
+    bar = "=" * 72
+    print(bar)
+    print("  Library validator report")
+    print(f"  {datetime.now(timezone.utc).astimezone().strftime('%Y-%m-%d %H:%M:%S %Z')}"
+          f"  ·  {total} scripts ({py} py, {rr} R)  ·  {elapsed:.1f}s")
+    print(bar)
+    print(f"  {_c('PASS', _STATUS_COLOR[PASS], use_color)}         {n_pass:>4}   installed & healthy")
+    print(f"  {_c('FAIL', _STATUS_COLOR[FAIL], use_color)}         {n_fail:>4}   installed but a sub-test failed")
+    print(f"  {_c('ERROR', _STATUS_COLOR[ERROR], use_color)}        {n_err:>4}   crashed / timed out / unrecognized")
+    print(f"  {_c('skip', _STATUS_COLOR[SKIP], use_color)}         {n_skip:>4}   library not installed (expected)")
+    if n_noi:
+        print(f"  {_c('no-interp', _STATUS_COLOR[NO_INTERP], use_color)}    {n_noi:>4}   interpreter missing (Rscript)")
+    print(bar)
+
+    # Actionable first: everything that is not PASS/skip.
+    def _row(r: Result) -> str:
+        label = _c(_STATUS_LABEL[r.status].ljust(14), _STATUS_COLOR[r.status], use_color)
+        tests = f"{r.ok}/{r.ok + r.failed}" if (r.ok or r.failed) else "-"
+        return f"  {label} {r.name:<26} {r.lang:<3} {tests:>7}  {r.duration:5.1f}s"
+
+    actionable = sorted(
+        by_status.get(FAIL, []) + by_status.get(ERROR, []) + by_status.get(NO_INTERP, []),
+        key=lambda r: (r.status, r.name.lower()),
+    )
+    if actionable:
+        print("  NEEDS ATTENTION")
+        for r in actionable:
+            print(_row(r))
+            if r.detail:
+                print(f"       └─ {r.detail}")
+        print(bar)
+
+    passed = sorted(by_status.get(PASS, []), key=lambda r: r.name.lower())
+    if passed:
+        print(f"  PASSED ({len(passed)}) — installed libraries validated")
+        for r in passed:
+            ver = f"v{r.version}" if r.version else ""
+            tests = f"{r.ok}/{r.ok + r.failed}"
+            print(f"  {_c('ok'.ljust(6), _STATUS_COLOR[PASS], use_color)} "
+                  f"{r.name:<26} {r.lang:<3} {tests:>6} tests  {ver}")
+        print(bar)
+
+    skipped = sorted(by_status.get(SKIP, []), key=lambda r: r.name.lower())
+    if skipped:
+        print(f"  NOT INSTALLED ({len(skipped)}) — guard fired, nothing to validate")
+        names = [r.name for r in skipped]
+        # Compact multi-column list; these have no detail beyond "absent".
+        width = max((len(n) for n in names), default=0) + 2
+        per_row = max(1, 76 // max(width, 1))
+        for i in range(0, len(names), per_row):
+            print("    " + "".join(n.ljust(width) for n in names[i:i + per_row]))
+        print(bar)
+
+    verdict_broken = n_fail + n_err + n_noi
+    if verdict_broken == 0:
+        print(f"  VERDICT: {_c('OK', '32', use_color)} — "
+              f"{n_pass} installed librar{'y' if n_pass == 1 else 'ies'} healthy, "
+              f"{n_skip} absent.")
+    else:
+        print(f"  VERDICT: {_c('PROBLEMS', '1;31', use_color)} — "
+              f"{n_fail} broken, {n_err} errored"
+              + (f", {n_noi} unrunnable" if n_noi else "") + ".")
+    print(bar)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Run all library-validator smoke tests.")
+    ap.add_argument("--lang", choices=["all", "py", "r"], default="all",
+                    help="which validators to run (default: all)")
+    ap.add_argument("--filter", metavar="SUBSTR", default=None,
+                    help="only run scripts whose name contains SUBSTR")
+    ap.add_argument("--jobs", type=int, default=min(8, (os.cpu_count() or 4)),
+                    help="parallel workers (default: min(8, cpus))")
+    ap.add_argument("--timeout", type=float, default=300.0,
+                    help="per-script timeout in seconds (default: 300)")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a report")
+    ap.add_argument("--verbose", action="store_true",
+                    help="(reserved) include extra detail; FAIL/ERROR detail is always shown")
+    args = ap.parse_args()
+
+    scripts = discover(args.lang, args.filter)
+    if not scripts:
+        print("No validator scripts found matching the given filters.", file=sys.stderr)
+        return 2
+
+    start = time.perf_counter()
+    results: list[Result] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
+        futs = {ex.submit(run_one, p, args.timeout): p for p in scripts}
+        for fut in concurrent.futures.as_completed(futs):
+            results.append(fut.result())
+    elapsed = time.perf_counter() - start
+
+    results.sort(key=lambda r: r.name.lower())
+
+    if args.json:
+        payload = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "elapsed_seconds": round(elapsed, 3),
+            "counts": {
+                s: sum(1 for r in results if r.status == s)
+                for s in (PASS, FAIL, ERROR, SKIP, NO_INTERP)
+            },
+            "results": [dataclasses.asdict(r) for r in results],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        use_color = sys.stdout.isatty()
+        print_report(results, elapsed, use_color)
+
+    broken = sum(1 for r in results if r.status in (FAIL, ERROR, NO_INTERP))
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/scripts/lib-validator/scGate.R
+++ b/cli/scripts/lib-validator/scGate.R
@@ -1,0 +1,92 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `scGate` package.
+#
+# Fully self-contained: no input files, no network. scGate performs marker-based
+# purification / gating of cell types on a Seurat object -- scGate(data, model)
+# annotates each cell with an `is.pure` classification against a hierarchical
+# gating model. Both heavier paths need resources unavailable here (the Seurat
+# object path needs Seurat, which is not installed; get_scGateDB() fetches the
+# model database over the network), so this test exercises the one genuinely
+# OFFLINE, dependency-free piece -- building a gating model with gating_model()
+# -- plus existence checks on the core exported entry points. Checks are
+# structural (function presence, data.frame shape / column schema) -- never
+# numeric. Exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript scGate.R
+#
+# Install: remotes::install_github("carmonalab/scGate")
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL (scGate and its Seurat dependency are both
+# absent here) -- confirm every item below once scGate is available:
+#   - gating_model() COLUMN SCHEMA. This test asserts gating_model(name=,
+#     signature=) returns a data.frame whose columns include exactly
+#     c("levels", "use_as", "name", "signature"). If that column set or those
+#     names differ in the installed build, update the schema assertion.
+#   - scGate() SIGNATURE. The assumed core call is scGate(data = <Seurat obj>,
+#     model = <gating model>), which adds an `is.pure` classification to the
+#     object. This is NOT exercised (it needs a Seurat object); only
+#     is.function(scGate) is checked. Re-confirm the argument names / return
+#     shape once installed.
+#   - get_scGateDB() is deliberately NOT called (it downloads the model DB over
+#     the network) -- out of scope for an offline validator.
+# ============================================================================
+
+if (!requireNamespace("scGate", quietly = TRUE)) {
+  cat("FAIL: package 'scGate' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(scGate))
+cat(sprintf("scGate version: %s\n", as.character(packageVersion("scGate"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Expected column schema of a gating model data.frame (see RE-CHECK note above).
+gating_cols <- c("levels", "use_as", "name", "signature")
+
+run_test("core entry points are exported functions", function() {
+  stopifnot(is.function(scGate))
+  stopifnot(is.function(gating_model))
+})
+
+run_test("gating_model builds a gating-model data.frame with the expected schema", function() {
+  # Genuinely offline: gating_model() assembles a plain data.frame from the
+  # supplied name + signature, with no Seurat object or network access.
+  gm <- gating_model(name = "Tcell", signature = c("CD3D", "CD3E", "CD3G"))
+  stopifnot(is.data.frame(gm))
+  stopifnot(nrow(gm) >= 1L)
+  stopifnot(all(gating_cols %in% colnames(gm)))
+})
+
+run_test("gating_model records the supplied name and signature", function() {
+  gm <- gating_model(name = "Tcell", signature = c("CD3D", "CD3E", "CD3G"))
+  # The model must carry the name we gave it.
+  stopifnot("Tcell" %in% as.character(gm$name))
+  # The signature is stored as text; every supplied marker should appear in it.
+  sig_text <- paste(as.character(gm$signature), collapse = ";")
+  stopifnot(all(vapply(
+    c("CD3D", "CD3E", "CD3G"),
+    function(g) grepl(g, sig_text, fixed = TRUE),
+    logical(1)
+  )))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all scGate smoke tests passed\n")

--- a/cli/scripts/lib-validator/scanpy.py
+++ b/cli/scripts/lib-validator/scanpy.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scanpy` package.
+
+Fully self-contained: no input files, no network, no packages beyond scanpy
+(and its implied deps — anndata, numpy, scipy, scikit-learn). Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scanpy.py
+
+Install: pip install scanpy   (import name: scanpy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scanpy as sc
+except ImportError:
+    print("FAIL: package 'scanpy' is not installed")
+    sys.exit(1)
+
+import anndata as ad
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scanpy version: {_version(sc, 'scanpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_adata():
+    """A seeded 100x50 count matrix — enough cells/genes for PCA + a graph."""
+    rng = np.random.default_rng(0)
+    X = rng.poisson(3, (100, 50)).astype(np.float32)
+    return ad.AnnData(X=X)
+
+
+def test_normalize_and_log1p():
+    adata = _make_adata()
+    sc.pp.normalize_total(adata, target_sum=1e4)
+    sc.pp.log1p(adata)
+    assert adata.shape == (100, 50)
+    assert np.isfinite(np.asarray(adata.X)).all()
+
+
+def test_pca_shape():
+    adata = _make_adata()
+    sc.pp.normalize_total(adata, target_sum=1e4)
+    sc.pp.log1p(adata)
+    sc.pp.pca(adata, n_comps=10)
+    assert "X_pca" in adata.obsm
+    assert adata.obsm["X_pca"].shape == (100, 10)
+    assert np.isfinite(adata.obsm["X_pca"]).all()
+
+
+def test_neighbors_and_leiden():
+    # sc.tl.leiden needs the optional `leidenalg` (or igraph flavor) backend and
+    # may be absent — FLAG: this check exercises a dependency scanpy itself does
+    # not vendor. sc.tl.louvain likewise needs `louvain`.
+    adata = _make_adata()
+    sc.pp.normalize_total(adata, target_sum=1e4)
+    sc.pp.log1p(adata)
+    sc.pp.pca(adata, n_comps=10)
+    sc.pp.neighbors(adata, n_neighbors=10)
+    assert "neighbors" in adata.uns
+    sc.tl.leiden(adata, resolution=1.0, flavor="igraph", n_iterations=2)
+    assert "leiden" in adata.obs
+    assert str(adata.obs["leiden"].dtype) == "category"
+    assert adata.obs["leiden"].notna().all()
+
+
+def test_umap_shape():
+    # sc.tl.umap needs the `umap-learn` backend (numba-compiled, slow) — FLAG.
+    adata = _make_adata()
+    sc.pp.normalize_total(adata, target_sum=1e4)
+    sc.pp.log1p(adata)
+    sc.pp.pca(adata, n_comps=10)
+    sc.pp.neighbors(adata, n_neighbors=10)
+    sc.tl.umap(adata)
+    assert adata.obsm["X_umap"].shape == (100, 2)
+    assert np.isfinite(adata.obsm["X_umap"]).all()
+
+
+run_test("normalize_total + log1p finite", test_normalize_and_log1p)
+run_test("pca(n_comps=10) obsm shape", test_pca_shape)
+run_test("neighbors + leiden categorical (needs leidenalg)", test_neighbors_and_leiden)
+run_test("umap 2D embedding (needs umap-learn)", test_umap_shape)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scanpy smoke tests passed")

--- a/cli/scripts/lib-validator/scater.R
+++ b/cli/scripts/lib-validator/scater.R
@@ -1,0 +1,84 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `scater` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond scater
+# and the Bioconductor deps it attaches. scater `Depends:` SingleCellExperiment
+# and scuttle, so `SingleCellExperiment()`, `logNormCounts()` and
+# `perCellQCMetrics()` all reach the search path from a bare `library(scater)`.
+# All data is a small synthetic Poisson counts matrix built with a fixed seed;
+# checks are structural (assay populated, QC columns present, embedding shape)
+# and tolerance-based (finiteness) rather than numeric-equality on anything
+# random. Exercises the normalize -> QC -> PCA path and exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript scater.R
+#
+# ============================ SIGNATURES TO RE-CHECK ========================
+# FLAG (verify once installed):
+#   - logNormCounts() and perCellQCMetrics() are re-exported from *scuttle*
+#     (attached via scater's Depends). If a build no longer attaches scuttle,
+#     qualify them as `scuttle::logNormCounts` / `scuttle::perCellQCMetrics`.
+#   - perCellQCMetrics() is assumed to return a DataFrame with `sum` and
+#     `detected` columns, one row per cell.
+#   - runPCA() is scater's method with argument `ncomponents=`, writing an
+#     embedding into reducedDim(sce, "PCA"); confirm the arg name and slot.
+# runUMAP()/runTSNE() are intentionally NOT exercised (heavy, and runUMAP pulls
+# a Python/uwot backend on some installs).
+# ============================================================================
+
+if (!requireNamespace("scater", quietly = TRUE)) {
+  cat("FAIL: package 'scater' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(scater))
+cat(sprintf("scater version: %s\n", as.character(packageVersion("scater"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 20 cells, integer Poisson draws, fully named.
+set.seed(1)
+counts <- matrix(rpois(100 * 20, 5), nrow = 100, ncol = 20)
+rownames(counts) <- paste0("gene", seq_len(100))
+colnames(counts) <- paste0("cell", seq_len(20))
+sce0 <- SingleCellExperiment(assays = list(counts = counts))
+
+run_test("logNormCounts() populates the logcounts assay", function() {
+  sce <- suppressWarnings(suppressMessages(logNormCounts(sce0)))
+  stopifnot("logcounts" %in% assayNames(sce))
+  lc <- as.matrix(logcounts(sce))
+  stopifnot(nrow(lc) == 100L, ncol(lc) == 20L, all(is.finite(lc)))
+})
+
+run_test("perCellQCMetrics() returns sum/detected per cell", function() {
+  qc <- suppressWarnings(suppressMessages(perCellQCMetrics(sce0)))
+  stopifnot(nrow(qc) == 20L)                 # one row per cell
+  stopifnot(all(c("sum", "detected") %in% colnames(qc)))
+  stopifnot(all(qc$sum > 0), all(qc$detected > 0))
+})
+
+run_test("runPCA() writes a finite (cells x 5) embedding", function() {
+  sce <- suppressWarnings(suppressMessages(logNormCounts(sce0)))
+  sce <- suppressWarnings(suppressMessages(runPCA(sce, ncomponents = 5)))
+  stopifnot("PCA" %in% reducedDimNames(sce))
+  rd <- reducedDim(sce, "PCA")
+  stopifnot(nrow(rd) == 20L, ncol(rd) == 5L, all(is.finite(rd)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all scater smoke tests passed\n")

--- a/cli/scripts/lib-validator/scglue.py
+++ b/cli/scripts/lib-validator/scglue.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scglue` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scglue.py
+
+Install: pip install scglue   (import name: scglue)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: scGLUE is graph-linked multi-omics integration (GLUE) built on
+PyTorch. Training the GLUE model needs paired multi-omics AnnData plus a guidance
+graph and is heavy, so this only asserts the package imports and exposes its
+documented namespaces (models, data, genomics); it does NOT run GLUE.
+(correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scglue
+except ImportError:
+    print("FAIL: package 'scglue' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scglue version: {_version(scglue, 'scglue')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_models_and_data():
+    assert hasattr(scglue, "models")
+    assert hasattr(scglue, "data")
+
+
+def test_exposes_genomics():
+    assert hasattr(scglue, "genomics")
+
+
+run_test("exposes scglue.models / scglue.data", test_exposes_models_and_data)
+run_test("exposes scglue.genomics", test_exposes_genomics)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scglue smoke tests passed")

--- a/cli/scripts/lib-validator/scikit-bio.py
+++ b/cli/scripts/lib-validator/scikit-bio.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scikit-bio` package (import name: skbio).
+
+Fully self-contained: no input files, no network, no packages beyond
+scikit-bio and its implied deps (numpy, scipy, pandas). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scikit-bio.py
+
+Install: pip install scikit-bio   (import name: skbio)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import skbio
+except ImportError:
+    print("FAIL: package 'scikit-bio' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scikit-bio version: {_version(skbio, 'scikit-bio')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_dna_reverse_complement_and_gc():
+    seq = skbio.DNA("ACGT")
+    assert str(seq) == "ACGT"
+    assert len(seq) == 4
+    # ACGT is its own reverse complement.
+    assert str(seq.reverse_complement()) == "ACGT"
+    # Two of four bases (C, G) are G/C → 50%.
+    assert abs(float(seq.gc_content()) - 0.5) < 1e-9
+
+    seq2 = skbio.DNA("GGGGCCCC")
+    # All eight bases are G/C → 100%.
+    assert abs(float(seq2.gc_content()) - 1.0) < 1e-9
+    assert str(seq2.reverse_complement()) == "GGGGCCCC"
+
+
+def test_alpha_diversity_shannon():
+    from skbio.diversity.alpha import shannon
+    import numpy as np
+
+    counts = [10, 10, 10, 10]
+    h = shannon(counts)
+    assert np.isfinite(h)
+    # Four equally-abundant taxa → Shannon (log2) index of exactly 2 bits.
+    assert abs(float(h) - 2.0) < 1e-9
+    # A single-taxon community has zero diversity.
+    assert abs(float(shannon([42, 0, 0]))) < 1e-9
+
+
+def test_distance_matrix_condensed_form():
+    from skbio.stats.distance import DistanceMatrix
+    import numpy as np
+
+    square = np.array(
+        [
+            [0.0, 1.0, 2.0],
+            [1.0, 0.0, 3.0],
+            [2.0, 3.0, 0.0],
+        ]
+    )
+    dm = DistanceMatrix(square, ids=["a", "b", "c"])
+    assert dm.shape == (3, 3)
+    assert list(dm.ids) == ["a", "b", "c"]
+    # The condensed form is the upper triangle, row-major: (a,b), (a,c), (b,c).
+    assert np.allclose(dm.condensed_form(), np.array([1.0, 2.0, 3.0]))
+    assert abs(dm["a", "c"] - 2.0) < 1e-9
+
+
+def test_treenode_newick_parse():
+    from io import StringIO
+
+    tree = skbio.TreeNode.read(StringIO("((a,b),c);"))
+    tip_names = sorted(t.name for t in tree.tips())
+    assert tip_names == ["a", "b", "c"]
+    assert tree.count(tips=True) == 3
+    # a and b are siblings, so their LCA is not the whole-tree root.
+    lca = tree.lca(["a", "b"])
+    assert lca is not tree
+    assert sorted(t.name for t in lca.tips()) == ["a", "b"]
+
+
+run_test("DNA reverse_complement + gc_content", test_dna_reverse_complement_and_gc)
+run_test("alpha diversity shannon finite", test_alpha_diversity_shannon)
+run_test("DistanceMatrix condensed_form", test_distance_matrix_condensed_form)
+run_test("TreeNode newick parse", test_treenode_newick_parse)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scikit-bio smoke tests passed")

--- a/cli/scripts/lib-validator/scikit-learn.py
+++ b/cli/scripts/lib-validator/scikit-learn.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scikit-learn` package (import name: sklearn).
+
+Fully self-contained: no input files, no network, no packages beyond
+scikit-learn and its implied deps (numpy). Exercises the core API surface and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 scikit-learn.py
+
+Install: pip install scikit-learn   (import name: sklearn)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import sklearn
+except ImportError:
+    print("FAIL: package 'scikit-learn' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scikit-learn version: {_version(sklearn, 'scikit-learn')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_logistic_regression_learns():
+    from sklearn.datasets import make_classification
+    from sklearn.linear_model import LogisticRegression
+
+    X, y = make_classification(
+        n_samples=200, n_features=10, n_informative=5, random_state=0
+    )
+    clf = LogisticRegression(max_iter=1000).fit(X, y)
+    # A linearly-separable-ish planted signal must be learnable well above chance.
+    assert clf.score(X, y) > 0.7
+    preds = clf.predict(X)
+    assert preds.shape == (200,)
+    assert set(np.unique(preds)).issubset({0, 1})
+
+
+def test_random_forest_split_and_accuracy():
+    from sklearn.datasets import make_classification
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.metrics import accuracy_score
+    from sklearn.model_selection import train_test_split
+
+    X, y = make_classification(
+        n_samples=300, n_features=8, n_informative=5, random_state=1
+    )
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25, random_state=1)
+    assert Xtr.shape == (225, 8)
+    assert Xte.shape == (75, 8)
+    clf = RandomForestClassifier(n_estimators=50, random_state=0).fit(Xtr, ytr)
+    acc = accuracy_score(yte, clf.predict(Xte))
+    assert 0.0 <= acc <= 1.0
+    assert acc > 0.7
+
+
+def test_standard_scaler_standardizes():
+    from sklearn.preprocessing import StandardScaler
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(loc=5.0, scale=3.0, size=(500, 4))
+    Xs = StandardScaler().fit_transform(X)
+    # Standardized columns are centered (~0) with unit variance (~1).
+    assert np.allclose(Xs.mean(axis=0), 0.0, atol=1e-8)
+    assert np.allclose(Xs.std(axis=0), 1.0, atol=1e-6)
+
+
+def test_kmeans_recovers_k_clusters():
+    from sklearn.cluster import KMeans
+    from sklearn.datasets import make_blobs
+
+    X, _ = make_blobs(n_samples=300, centers=3, cluster_std=0.6, random_state=0)
+    km = KMeans(n_clusters=3, n_init=10, random_state=0).fit(X)
+    assert km.cluster_centers_.shape == (3, 2)
+    # Three well-separated blobs → three occupied labels.
+    assert len(np.unique(km.labels_)) == 3
+
+
+def test_pipeline_scale_then_classify():
+    from sklearn.datasets import make_classification
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    X, y = make_classification(n_samples=200, n_features=6, random_state=2)
+    pipe = Pipeline(
+        [
+            ("scale", StandardScaler()),
+            ("clf", LogisticRegression(max_iter=1000)),
+        ]
+    )
+    pipe.fit(X, y)
+    assert pipe.score(X, y) > 0.7
+    assert pipe.predict(X).shape == (200,)
+
+
+run_test("logistic regression learns signal", test_logistic_regression_learns)
+run_test("random forest split + accuracy", test_random_forest_split_and_accuracy)
+run_test("StandardScaler standardizes", test_standard_scaler_standardizes)
+run_test("KMeans recovers 3 clusters", test_kmeans_recovers_k_clusters)
+run_test("Pipeline scale->classify", test_pipeline_scale_then_classify)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scikit-learn smoke tests passed")

--- a/cli/scripts/lib-validator/scikit-misc.py
+++ b/cli/scripts/lib-validator/scikit-misc.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scikit-misc` package (import name: skmisc).
+
+Fully self-contained: no input files, no network, no packages beyond scikit-misc
+(and its implied dep — numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 scikit-misc.py
+
+Install: pip install scikit-misc   (import name: skmisc)
+
+scikit-misc provides `skmisc.loess.loess` — the local-regression smoother scanpy
+uses for `flavor="seurat_v3"` highly-variable-gene selection.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import skmisc
+except ImportError:
+    print("FAIL: package 'scikit-misc' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scikit-misc version: {_version(skmisc, 'scikit-misc')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_xy():
+    """Seeded noisy sine: x on [0, 2pi], y = sin(x) + small Gaussian noise."""
+    rng = np.random.default_rng(0)
+    x = np.linspace(0.0, 2.0 * np.pi, 120)
+    y = np.sin(x) + rng.normal(scale=0.1, size=x.shape)
+    return x, y
+
+
+def test_loess_fit_and_predict():
+    from skmisc.loess import loess
+
+    x, y = _make_xy()
+    lo = loess(x, y)
+    lo.fit()
+    pred = lo.predict(x)
+    values = pred.values
+    assert len(values) == len(x)
+    assert np.isfinite(values).all()
+    # The smoother should track the sine far better than a flat line.
+    assert np.mean((values - y) ** 2) < np.var(y)
+
+
+run_test("loess fit + predict finite, length matches", test_loess_fit_and_predict)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scikit-misc smoke tests passed")

--- a/cli/scripts/lib-validator/scikit-posthocs.py
+++ b/cli/scripts/lib-validator/scikit-posthocs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scikit-posthocs` package (import: scikit_posthocs).
+
+Fully self-contained: no input files, no network, no packages beyond
+scikit-posthocs and its implied deps (numpy, pandas, scipy). Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scikit-posthocs.py
+
+Install: pip install scikit-posthocs   (import name: scikit_posthocs)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scikit_posthocs
+except ImportError:
+    print("FAIL: package 'scikit-posthocs' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scikit-posthocs version: {_version(scikit_posthocs, 'scikit-posthocs')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_posthoc_dunn_square_symmetric_pvalues():
+    import scikit_posthocs as sp
+
+    rng = np.random.default_rng(0)
+    g1 = rng.normal(0.0, 1.0, 20)
+    g2 = rng.normal(0.0, 1.0, 20)
+    g3 = rng.normal(5.0, 1.0, 20)  # clearly shifted group
+    out = sp.posthoc_dunn([g1, g2, g3])
+    vals = out.values
+    assert out.shape == (3, 3)
+    # Self-comparison diagonal is 1.0; p-values live in [0, 1]; matrix is symmetric.
+    assert np.allclose(np.diag(vals), 1.0)
+    assert np.all((vals >= 0.0) & (vals <= 1.0))
+    assert np.allclose(vals, vals.T)
+    # Group 3 is far from group 1 → a small off-diagonal p-value.
+    assert out.iloc[0, 2] < 0.05
+
+
+def test_posthoc_conover_shape():
+    import scikit_posthocs as sp
+
+    rng = np.random.default_rng(1)
+    groups = [
+        rng.normal(0.0, 1.0, 15),
+        rng.normal(1.0, 1.0, 15),
+        rng.normal(2.0, 1.0, 15),
+        rng.normal(3.0, 1.0, 15),
+    ]
+    out = sp.posthoc_conover(groups)
+    vals = out.values
+    assert out.shape == (4, 4)
+    assert np.allclose(np.diag(vals), 1.0)
+    assert np.all((vals >= 0.0) & (vals <= 1.0))
+
+
+def test_posthoc_ttest_matrix():
+    import scikit_posthocs as sp
+
+    rng = np.random.default_rng(2)
+    groups = [
+        rng.normal(0.0, 1.0, 20),
+        rng.normal(0.0, 1.0, 20),
+        rng.normal(4.0, 1.0, 20),
+    ]
+    out = sp.posthoc_ttest(groups)
+    assert out.shape == (3, 3)
+    assert np.allclose(np.diag(out.values), 1.0)
+
+
+run_test("posthoc_dunn square/symmetric", test_posthoc_dunn_square_symmetric_pvalues)
+run_test("posthoc_conover shape", test_posthoc_conover_shape)
+run_test("posthoc_ttest matrix", test_posthoc_ttest_matrix)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scikit-posthocs smoke tests passed")

--- a/cli/scripts/lib-validator/scikit-survival.py
+++ b/cli/scripts/lib-validator/scikit-survival.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scikit-survival` package (import name: sksurv).
+
+Fully self-contained: no input files, no network, no packages beyond
+scikit-survival and its implied deps (numpy, scikit-learn). All data is
+simulated in-memory — the bundled `sksurv.datasets` loaders are deliberately
+NOT used (some fetch remote data). Exits 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 scikit-survival.py
+
+Install: pip install scikit-survival   (import name: sksurv)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import sksurv
+except ImportError:
+    print("FAIL: package 'scikit-survival' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scikit-survival version: {_version(sksurv, 'scikit-survival')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_surv_from_arrays_structured():
+    from sksurv.util import Surv
+
+    event = np.array([True, False, True, True, False])
+    time = np.array([5.0, 8.0, 2.0, 9.0, 3.0])
+    y = Surv.from_arrays(event, time)
+    # A structured array with an event-indicator field and a time field.
+    assert y.shape == (5,)
+    assert y.dtype.names == ("event", "time")
+    assert y["event"].dtype == np.bool_
+    assert np.allclose(y["time"], time)
+
+
+def test_coxph_fit_predict_concordance():
+    from sksurv.linear_model import CoxPHSurvivalAnalysis
+    from sksurv.metrics import concordance_index_censored
+    from sksurv.util import Surv
+
+    rng = np.random.default_rng(0)
+    n = 200
+    X = rng.normal(size=(n, 3))
+    beta = np.array([1.0, -0.5, 0.3])
+    # Linear predictor drives the hazard: larger X@beta → shorter survival.
+    lp = X @ beta
+    baseline = rng.exponential(scale=10.0, size=n)
+    time = baseline * np.exp(-lp)
+    event = np.ones(n, dtype=bool)  # all observed (uncensored)
+    y = Surv.from_arrays(event, time)
+
+    est = CoxPHSurvivalAnalysis().fit(X, y)
+    risk = est.predict(X)
+    assert risk.shape == (n,)
+    assert np.all(np.isfinite(risk))
+
+    cindex = concordance_index_censored(event, time, risk)[0]
+    assert 0.0 <= cindex <= 1.0
+    # Recovered risk ordering must beat random discrimination.
+    assert cindex > 0.5
+
+
+run_test("Surv.from_arrays structured", test_surv_from_arrays_structured)
+run_test("CoxPH fit/predict + c-index", test_coxph_fit_predict_concordance)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scikit-survival smoke tests passed")

--- a/cli/scripts/lib-validator/scipy.py
+++ b/cli/scripts/lib-validator/scipy.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scipy` package.
+
+Fully self-contained: no input files, no network, no packages beyond scipy
+(and its implied deps: numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 scipy.py
+
+Install: pip install scipy   (import name: scipy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scipy
+except ImportError:
+    print("FAIL: package 'scipy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scipy version: {_version(scipy, 'scipy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_linalg_solve_and_det():
+    import numpy as np
+    from scipy import linalg
+
+    A = np.array([[3.0, 2.0], [1.0, 2.0]])
+    b = np.array([5.0, 5.0])
+    x = linalg.solve(A, b)
+    assert np.allclose(A @ x, b)
+    assert abs(linalg.det(A) - 4.0) < 1e-9
+
+
+def test_stats_ttest_ind():
+    import numpy as np
+    from scipy import stats
+
+    rng = np.random.default_rng(0)
+    a = rng.normal(0.0, 1.0, 50)
+    b = rng.normal(0.5, 1.0, 50)
+    res = stats.ttest_ind(a, b)
+    assert np.isfinite(res.statistic)
+    assert 0.0 <= res.pvalue <= 1.0
+
+
+def test_stats_norm_cdf():
+    from scipy import stats
+
+    assert abs(stats.norm.cdf(0.0) - 0.5) < 1e-12
+
+
+def test_sparse_csr_roundtrip():
+    import numpy as np
+    from scipy import sparse
+
+    dense = np.array([[1, 0, 2], [0, 3, 0], [4, 0, 5]])
+    m = sparse.csr_matrix(dense)
+    assert m.shape == (3, 3)
+    assert m.nnz == 5
+    assert np.array_equal(m.toarray(), dense)
+
+
+def test_optimize_minimize_quadratic():
+    import numpy as np
+    from scipy import optimize
+
+    # Known minimum of (x-3)^2 + (y+1)^2 is at (3, -1).
+    res = optimize.minimize(lambda v: (v[0] - 3.0) ** 2 + (v[1] + 1.0) ** 2, [0.0, 0.0])
+    assert res.success
+    assert np.allclose(res.x, [3.0, -1.0], atol=1e-4)
+
+
+run_test("linalg solve + det", test_linalg_solve_and_det)
+run_test("stats ttest_ind on seeded samples", test_stats_ttest_ind)
+run_test("stats norm.cdf(0) == 0.5", test_stats_norm_cdf)
+run_test("sparse csr_matrix roundtrip", test_sparse_csr_roundtrip)
+run_test("optimize.minimize quadratic", test_optimize_minimize_quadratic)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scipy smoke tests passed")

--- a/cli/scripts/lib-validator/scirpy.py
+++ b/cli/scripts/lib-validator/scirpy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scirpy` package.
+
+Fully self-contained: no input files, no network (scirpy.datasets fetches are
+deliberately avoided), no packages beyond scirpy (and its implied deps:
+anndata, scanpy). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 scirpy.py
+
+Install: pip install scirpy   (import name: scirpy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scirpy as ir
+except ImportError:
+    print("FAIL: package 'scirpy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scirpy version: {_version(ir, 'scirpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# NOTE: scirpy operates on AnnData objects and its datasets fetch over the
+# network, so this validator stays MODEST: it confirms the package imports and
+# that the scanpy-style namespaces + the clonotype-pipeline entrypoints exist,
+# without building/processing a repertoire. FLAG: real use needs anndata.
+def test_submodules_present():
+    # scirpy mirrors scanpy's pp / tl / io / pl namespace layout.
+    for sub in ("pp", "tl", "io", "pl"):
+        assert hasattr(ir, sub), f"scirpy.{sub} missing"
+
+
+def test_pp_and_tl_functions_present():
+    # The workhorses of the clonotype pipeline: distance calc then clustering.
+    assert callable(ir.pp.ir_dist)
+    assert callable(ir.tl.define_clonotypes)
+    assert callable(ir.tl.define_clonotype_clusters)
+    assert callable(ir.tl.clonal_expansion)
+
+
+def test_io_reader_present():
+    # AIRR ingest entrypoints (no file is read here — MODEST surface check).
+    assert hasattr(ir.io, "read_airr") or hasattr(ir.io, "from_airr_cells")
+
+
+run_test("scanpy-style submodules present", test_submodules_present)
+run_test("pp/tl pipeline functions present", test_pp_and_tl_functions_present)
+run_test("io AIRR reader present", test_io_reader_present)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scirpy smoke tests passed")

--- a/cli/scripts/lib-validator/scran.R
+++ b/cli/scripts/lib-validator/scran.R
@@ -1,0 +1,89 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `scran` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond scran
+# and the Bioconductor deps it attaches / imports. All data is a small synthetic
+# Poisson counts matrix built with a fixed seed; checks are structural (per-gene
+# variance columns, HVG cardinality, cluster factor shape) and tolerance-based
+# (finiteness) rather than numeric-equality on anything random. Exercises the
+# mean-variance / HVG / clustering path and exits 0 only if every check passes,
+# so it can be used as a pass/fail library validator:
+#
+#   Rscript scran.R
+#
+# ============================ SIGNATURES TO RE-CHECK ========================
+# FLAG (verify once installed):
+#   - logNormCounts() is a *scuttle* function (a scran Import, NOT attached by
+#     library(scran)); it is qualified below as `scuttle::logNormCounts`.
+#   - modelGeneVar() returns a DataFrame (S4 DFrame, NOT a base data.frame -- so
+#     is.data.frame() is deliberately NOT asserted); assumed columns include
+#     `mean` / `total` / `bio`, one row per gene.
+#   - getTopHVGs(dec, n=) returns a character vector of gene ids (rownames).
+#   - clusterCells(x, use.dimred=) returns a factor of length ncol(x). We hand a
+#     small base-R prcomp() embedding as reducedDim "PCA" so clustering never
+#     runs its own PCA on a 20-cell matrix (avoids the low-rank SVD edge case);
+#     confirm the `use.dimred` arg name and the factor return once a build is
+#     available.
+# computeSumFactors()/pooledSizeFactors() are intentionally NOT exercised (they
+# want pre-computed clusters and add little to the smoke surface).
+# ============================================================================
+
+if (!requireNamespace("scran", quietly = TRUE)) {
+  cat("FAIL: package 'scran' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(scran))
+cat(sprintf("scran version: %s\n", as.character(packageVersion("scran"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic counts: 100 genes x 20 cells, integer Poisson draws, fully named,
+# then log-normalized so modelGeneVar()/clustering have a logcounts assay.
+set.seed(1)
+counts <- matrix(rpois(100 * 20, 5), nrow = 100, ncol = 20)
+rownames(counts) <- paste0("gene", seq_len(100))
+colnames(counts) <- paste0("cell", seq_len(20))
+sce <- SingleCellExperiment(assays = list(counts = counts))
+sce <- suppressWarnings(suppressMessages(scuttle::logNormCounts(sce)))
+
+run_test("modelGeneVar() returns per-gene mean/total/bio", function() {
+  dec <- suppressWarnings(suppressMessages(modelGeneVar(sce)))
+  stopifnot(nrow(dec) == 100L)               # one row per gene
+  stopifnot(all(c("mean", "total", "bio") %in% colnames(dec)))
+  stopifnot(all(is.finite(dec$total)))
+})
+
+run_test("getTopHVGs() returns at most n highly variable gene ids", function() {
+  dec <- suppressWarnings(suppressMessages(modelGeneVar(sce)))
+  hvg <- getTopHVGs(dec, n = 20)
+  stopifnot(is.character(hvg), length(hvg) >= 1L, length(hvg) <= 20L)
+  stopifnot(all(hvg %in% rownames(sce)))
+})
+
+run_test("clusterCells() over a PCA embedding is a factor of length ncells", function() {
+  # Precompute a deterministic 10-D embedding with base prcomp so clusterCells
+  # clusters that, rather than running its own SVD on a 20-cell matrix.
+  pcs <- prcomp(t(as.matrix(logcounts(sce))), center = TRUE, scale. = FALSE)$x
+  reducedDim(sce, "PCA") <- pcs[, seq_len(10), drop = FALSE]
+  cl <- suppressWarnings(suppressMessages(clusterCells(sce, use.dimred = "PCA")))
+  stopifnot(is.factor(cl), length(cl) == ncol(sce))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all scran smoke tests passed\n")

--- a/cli/scripts/lib-validator/scvelo.py
+++ b/cli/scripts/lib-validator/scvelo.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scvelo` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scvelo.py
+
+Install: pip install scvelo   (import name: scvelo)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: scVelo is RNA-velocity on top of scanpy/anndata. The bundled
+`scvelo.datasets` fetch over the network (NOT used here) and a full velocity
+graph is heavy, so this builds a tiny SEEDED synthetic AnnData with spliced /
+unspliced layers, runs only the light `pp.moments` step, and asserts the
+resulting layers/shapes. It does NOT compute the velocity graph.
+(correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scvelo
+except ImportError:
+    print("FAIL: package 'scvelo' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scvelo version: {_version(scvelo, 'scvelo')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_pp_tl_namespaces():
+    assert hasattr(scvelo, "pp")
+    assert hasattr(scvelo, "tl")
+    assert hasattr(scvelo.pp, "moments")
+
+
+def test_moments_on_synthetic_anndata():
+    import numpy as np
+    from anndata import AnnData
+
+    rng = np.random.default_rng(0)
+    n_obs, n_vars = 40, 12
+    counts = rng.poisson(5.0, size=(n_obs, n_vars)).astype(float)
+    spliced = rng.poisson(4.0, size=(n_obs, n_vars)).astype(float)
+    unspliced = rng.poisson(1.0, size=(n_obs, n_vars)).astype(float)
+    adata = AnnData(X=counts, layers={"spliced": spliced, "unspliced": unspliced})
+
+    scvelo.pp.moments(adata, n_neighbors=5, n_pcs=5)
+
+    # moments derives first-order Ms/Mu layers from the neighbor graph.
+    assert "Ms" in adata.layers and "Mu" in adata.layers
+    assert adata.layers["Ms"].shape == (n_obs, n_vars)
+    assert adata.layers["Mu"].shape == (n_obs, n_vars)
+
+
+run_test("exposes scvelo.pp / scvelo.tl", test_exposes_pp_tl_namespaces)
+run_test("pp.moments on synthetic spliced/unspliced AnnData", test_moments_on_synthetic_anndata)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scvelo smoke tests passed")

--- a/cli/scripts/lib-validator/scvi-tools.py
+++ b/cli/scripts/lib-validator/scvi-tools.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `scvi-tools` package (import name: scvi).
+
+Fully self-contained: no input files, no network, no packages beyond scvi-tools
+(and its implied deps — anndata, torch, lightning, numpy). Exercises the core
+API surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 scvi-tools.py
+
+Install: pip install scvi-tools   (import name: scvi)
+
+FLAG: heavy. scvi-tools pulls in PyTorch + Lightning and this smoke test trains
+a model (1 epoch on tiny synthetic data). It is slow to import and CPU-bound to
+run; keep the budget modest.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import scvi
+except ImportError:
+    print("FAIL: package 'scvi-tools' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"scvi-tools version: {_version(scvi, 'scvi-tools')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_synthetic_iid_is_anndata():
+    adata = scvi.data.synthetic_iid()
+    # synthetic_iid() yields a small labelled AnnData (counts in .X).
+    assert adata.n_obs > 0 and adata.n_vars > 0
+    assert adata.X is not None
+
+
+def test_setup_and_train_and_latent():
+    # FLAG: torch + training. One epoch on the tiny synthetic dataset keeps this
+    # cheap; we assert only structure (latent shape), never convergence.
+    scvi.settings.seed = 0
+    adata = scvi.data.synthetic_iid()
+    scvi.model.SCVI.setup_anndata(adata)
+    model = scvi.model.SCVI(adata, n_latent=5)
+    model.train(max_epochs=1)
+    latent = model.get_latent_representation()
+    assert latent.shape == (adata.n_obs, 5)
+    assert np.isfinite(latent).all()
+
+
+run_test("synthetic_iid returns AnnData", test_synthetic_iid_is_anndata)
+run_test("setup + 1-epoch train + latent shape (torch)", test_setup_and_train_and_latent)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all scvi-tools smoke tests passed")

--- a/cli/scripts/lib-validator/seaborn.py
+++ b/cli/scripts/lib-validator/seaborn.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `seaborn` package.
+
+Fully self-contained: no input files, no network, no packages beyond seaborn
+(and its implied deps — matplotlib, pandas, numpy). Forces the headless Agg
+backend before any pyplot import, so it never opens a window, and builds its
+own pandas DataFrames rather than calling `sns.load_dataset` (which downloads
+sample data over the network). Exercises the core statistical-plot API and
+exits 0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 seaborn.py
+
+Install: pip install seaborn   (import name: seaborn)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+# Force the non-interactive Agg backend BEFORE importing pyplot (and before
+# seaborn, which pulls pyplot in): this test runs headless and must never pop a
+# window. Selecting the backend after pyplot is imported is a no-op.
+import matplotlib
+
+matplotlib.use("Agg")
+
+try:
+    import seaborn as sns
+except ImportError:
+    print("FAIL: package 'seaborn' is not installed")
+    sys.exit(1)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"seaborn version: {_version(sns, 'seaborn')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _frame():
+    """A small deterministic DataFrame built in-process (no network download)."""
+    rng = np.random.default_rng(0)
+    n = 30
+    return pd.DataFrame(
+        {
+            "x": rng.standard_normal(n),
+            "y": rng.standard_normal(n),
+            "group": np.where(np.arange(n) % 2 == 0, "a", "b"),
+            "value": rng.uniform(0, 10, n),
+        }
+    )
+
+
+def test_scatterplot_returns_axes():
+    df = _frame()
+    ax = sns.scatterplot(data=df, x="x", y="y", hue="group")
+    try:
+        assert isinstance(ax, Axes)
+        # One PathCollection per hue level (two groups: "a", "b").
+        assert len(ax.collections) >= 1
+    finally:
+        plt.close("all")
+
+
+def test_boxplot_returns_axes():
+    df = _frame()
+    ax = sns.boxplot(data=df, x="group", y="value")
+    try:
+        assert isinstance(ax, Axes)
+        # Two categories on the x axis.
+        assert len(ax.get_xticks()) == 2
+    finally:
+        plt.close("all")
+
+
+def test_histplot_returns_axes():
+    df = _frame()
+    ax = sns.histplot(data=df, x="x", bins=5)
+    try:
+        assert isinstance(ax, Axes)
+        # Histogram bars are drawn as patches.
+        assert len(ax.patches) >= 1
+    finally:
+        plt.close("all")
+
+
+def test_color_palette_returns_n_rgb_tuples():
+    pal = sns.color_palette("deep", 4)
+    assert len(pal) == 4
+    for rgb in pal:
+        assert len(rgb) == 3
+        assert all(0.0 <= float(c) <= 1.0 for c in rgb)
+
+
+def test_heatmap_on_small_matrix():
+    mat = np.arange(9).reshape(3, 3).astype(float)
+    ax = sns.heatmap(mat)
+    try:
+        assert isinstance(ax, Axes)
+        # A heatmap draws a QuadMesh into the axes collections.
+        assert len(ax.collections) >= 1
+    finally:
+        plt.close("all")
+
+
+run_test("scatterplot returns Axes", test_scatterplot_returns_axes)
+run_test("boxplot returns Axes", test_boxplot_returns_axes)
+run_test("histplot returns Axes", test_histplot_returns_axes)
+run_test("color_palette returns n RGB tuples", test_color_palette_returns_n_rgb_tuples)
+run_test("heatmap on small matrix", test_heatmap_on_small_matrix)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all seaborn smoke tests passed")

--- a/cli/scripts/lib-validator/shap.py
+++ b/cli/scripts/lib-validator/shap.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `shap` package.
+
+Fully self-contained: no input files, no network, no packages beyond shap and
+its implied deps (numpy, scipy, numba). Data and the model are defined
+in-memory as a plain numpy function, and shap is exercised through its
+model-agnostic `shap.Explainer` + `shap.maskers.Independent` path.
+
+DESIGN NOTE: `shap.TreeExplainer` needs a fitted tree model from a *separate*
+library (scikit-learn / xgboost / lightgbm) that is not a shap dependency, so
+wiring it in would break self-containment. Instead we validate the core
+Shapley guarantee — additivity / local accuracy — model-agnostically, which
+exercises the same machinery and is the property TreeExplainer also asserts.
+
+    python3 shap.py
+
+Install: pip install shap   (import name: shap)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import shap
+except ImportError:
+    print("FAIL: package 'shap' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"shap version: {_version(shap, 'shap')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_explainer_class_surface():
+    # The headline explainer classes are part of shap's public API.
+    assert hasattr(shap, "Explainer")
+    assert hasattr(shap, "TreeExplainer")
+    assert hasattr(shap, "maskers")
+
+
+def test_linear_additivity_and_shape():
+    rng = np.random.default_rng(0)
+    n, d = 40, 4
+    background = rng.normal(size=(100, d))
+    X = rng.normal(size=(n, d))
+    w = np.array([1.0, -2.0, 0.5, 3.0])
+    b = 0.7
+
+    def f(x):
+        return x @ w + b
+
+    masker = shap.maskers.Independent(background, max_samples=100)
+    explainer = shap.Explainer(f, masker)
+    exp = explainer(X)
+    # One attribution per (sample, feature).
+    assert exp.values.shape == (n, d)
+    # Local accuracy: base value + summed attributions reconstruct the output.
+    recon = exp.base_values + exp.values.sum(axis=1)
+    assert np.allclose(recon, f(X), atol=1e-6)
+
+
+def test_nonlinear_efficiency_holds():
+    rng = np.random.default_rng(1)
+    n, d = 30, 3
+    background = rng.normal(size=(80, d))
+    X = rng.normal(size=(n, d))
+
+    def f(x):
+        # A nonlinear model: Shapley efficiency must still hold exactly.
+        return np.sin(x[:, 0]) + x[:, 1] * x[:, 2]
+
+    masker = shap.maskers.Independent(background, max_samples=80)
+    exp = shap.Explainer(f, masker)(X)
+    assert exp.values.shape == (n, d)
+    recon = exp.base_values + exp.values.sum(axis=1)
+    assert np.allclose(recon, f(X), atol=1e-6)
+
+
+run_test("Explainer class surface", test_explainer_class_surface)
+run_test("linear additivity + shape", test_linear_additivity_and_shape)
+run_test("nonlinear efficiency holds", test_nonlinear_efficiency_holds)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all shap smoke tests passed")

--- a/cli/scripts/lib-validator/shapely.py
+++ b/cli/scripts/lib-validator/shapely.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `shapely` package.
+
+Fully self-contained: no input files, no network, no packages beyond shapely
+(and its bundled GEOS). Exercises the core planar-geometry API and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 shapely.py
+
+Install: pip install shapely   (import name: shapely)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import math
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import shapely
+    from shapely.geometry import LineString, Point, Polygon
+except ImportError:
+    print("FAIL: package 'shapely' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"shapely version: {_version(shapely, 'shapely')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_point_buffer_area_approximates_pi():
+    circle = Point(0, 0).buffer(1)
+    # A buffer is a polygonal approximation of the disk (default 8 segments per
+    # quadrant), so its area is a touch under pi — allow a loose tolerance.
+    assert abs(circle.area - math.pi) < 0.05
+    assert circle.geom_type == "Polygon"
+
+
+def test_polygon_area_and_contains():
+    square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    assert abs(square.area - 1.0) < 1e-9
+    assert square.contains(Point(0.5, 0.5))
+    assert not square.contains(Point(2.0, 2.0))
+    assert abs(square.length - 4.0) < 1e-9
+
+
+def test_intersection_and_union():
+    a = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    b = Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)])
+    inter = a.intersection(b)
+    uni = a.union(b)
+    # Overlap is a 0.5 x 0.5 square (0.25); union is 1 + 1 - 0.25.
+    assert abs(inter.area - 0.25) < 1e-9
+    assert abs(uni.area - 1.75) < 1e-9
+
+
+def test_linestring_length():
+    line = LineString([(0, 0), (3, 4)])
+    # 3-4-5 right triangle: the hypotenuse length is exactly 5.
+    assert abs(line.length - 5.0) < 1e-9
+    assert line.geom_type == "LineString"
+
+
+run_test("Point.buffer area ~ pi", test_point_buffer_area_approximates_pi)
+run_test("Polygon area + contains", test_polygon_area_and_contains)
+run_test("intersection + union areas", test_intersection_and_union)
+run_test("LineString length", test_linestring_length)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all shapely smoke tests passed")

--- a/cli/scripts/lib-validator/singscore.R
+++ b/cli/scripts/lib-validator/singscore.R
@@ -1,0 +1,101 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `singscore` (Bioconductor) package.
+#
+# Fully self-contained: no input files, NO network. singscore computes a
+# rank-based, single-sample gene-set score; this test SIMULATES an expression
+# matrix (genes x samples) and a user-supplied up-regulated gene set, then
+# scores every sample. Nothing reaches an online annotation source. Exits 0
+# only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript singscore.R
+#
+# ============================ API UNCERTAINTY ================================
+# RE-CHECK once installed -- the two core signatures:
+#
+#   * rankGenes(expreMatrix) -> a per-sample rank matrix with the same dims as
+#     the input (genes x samples). Accepts a matrix / data.frame / DGEList.
+#
+#   * simpleScore(rankData, upSet, downSet = NULL, ...) -> a data.frame with one
+#     row per sample. `upSet` is assumed to accept a plain CHARACTER VECTOR of
+#     gene ids (it also accepts a GSEABase::GeneSet). The score column is
+#     assumed to be named "TotalScore".
+#
+#   * generateNull(upSet, rankData, B, ncores, seed, ...) -> a permutation null
+#     matrix with one column per sample and B rows. Signature/shape is the most
+#     likely thing to drift here -- flagged, and B is kept tiny (10).
+# ============================================================================
+
+if (!requireNamespace("singscore", quietly = TRUE)) {
+  cat("FAIL: package 'singscore' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(singscore))
+cat(sprintf("singscore version: %s\n", as.character(packageVersion("singscore"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Synthetic 200-gene x 10-sample expression matrix with named rows/cols, and an
+# up-regulated gene set drawn from the first 40 genes.
+set.seed(7)
+n_genes <- 200L
+n_samples <- 10L
+gene_ids <- paste0("g", seq_len(n_genes))
+sample_ids <- paste0("s", seq_len(n_samples))
+expr <- matrix(
+  rnorm(n_genes * n_samples),
+  nrow = n_genes,
+  ncol = n_samples,
+  dimnames = list(gene_ids, sample_ids)
+)
+up_set <- gene_ids[1:40]
+
+run_test("rankGenes yields a rank matrix matching expr dimensions", function() {
+  rank_data <- singscore::rankGenes(expr)
+  stopifnot(nrow(rank_data) == nrow(expr), ncol(rank_data) == ncol(expr))
+})
+
+run_test("simpleScore returns a per-sample frame with TotalScore", function() {
+  rank_data <- singscore::rankGenes(expr)
+  scores <- singscore::simpleScore(rank_data, upSet = up_set)
+  stopifnot(is.data.frame(scores))
+  stopifnot("TotalScore" %in% names(scores))
+  stopifnot(nrow(scores) == ncol(expr))
+})
+
+run_test("TotalScore values are finite numerics", function() {
+  rank_data <- singscore::rankGenes(expr)
+  scores <- singscore::simpleScore(rank_data, upSet = up_set)
+  stopifnot(is.numeric(scores$TotalScore))
+  stopifnot(all(is.finite(scores$TotalScore)))
+})
+
+run_test("generateNull produces a (B x nsamples) permutation null", function() {
+  rank_data <- singscore::rankGenes(expr)
+  null_mat <- singscore::generateNull(
+    upSet = up_set, rankData = rank_data,
+    B = 10L, ncores = 1L, seed = 1L)
+  # one column per sample, B permutation rows; all finite.
+  stopifnot(ncol(null_mat) == ncol(expr))
+  stopifnot(nrow(null_mat) == 10L)
+  stopifnot(all(is.finite(as.matrix(null_mat))))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all singscore smoke tests passed\n")

--- a/cli/scripts/lib-validator/snapatac2.py
+++ b/cli/scripts/lib-validator/snapatac2.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `snapatac2` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 snapatac2.py
+
+Install: pip install "snapatac2>=2.7"   (import name: snapatac2)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: SnapATAC2 is single-cell ATAC-seq analysis (Rust-backed). The
+bundled `snapatac2.datasets` fetch over the network (NOT used here) and the
+spectral/UMAP steps are heavy, so this only asserts the package imports and
+exposes its documented namespaces (pp, tl — e.g. tl.spectral); it does NOT run
+the heavy embedding steps. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import snapatac2
+except ImportError:
+    print("FAIL: package 'snapatac2' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"snapatac2 version: {_version(snapatac2, 'snapatac2')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_pp_tl_namespaces():
+    assert hasattr(snapatac2, "pp")
+    assert hasattr(snapatac2, "tl")
+
+
+def test_exposes_spectral():
+    # spectral embedding is SnapATAC2's dimensionality-reduction entry point.
+    assert hasattr(snapatac2.tl, "spectral")
+
+
+run_test("exposes snapatac2.pp / snapatac2.tl", test_exposes_pp_tl_namespaces)
+run_test("exposes tl.spectral", test_exposes_spectral)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all snapatac2 smoke tests passed")

--- a/cli/scripts/lib-validator/snfpy.py
+++ b/cli/scripts/lib-validator/snfpy.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `snf` package (Similarity Network Fusion).
+
+Fully self-contained: no input files, no network, no packages beyond snfpy
+(and its implied deps: numpy, scipy, scikit-learn). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 snfpy.py
+
+Install: pip install snfpy   (import name: snf)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+snf is genuinely offline-shaped: Similarity Network Fusion runs entirely in
+memory over synthetic matrices. make_affinity(data_list, K, mu) turns a list of
+(samples x features) views — same samples, different feature spaces (the
+canonical multi-omics setup) — into per-view sample-by-sample affinity
+matrices; snf(affinity_list, K) fuses them into ONE sample-by-sample network;
+get_n_clusters(fused) estimates the number of clusters via eigengap. Checks are
+seeded and structural / tolerance-based. (correct-by-review — genuinely
+offline-shaped.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import snf
+except ImportError:
+    print("FAIL: package 'snfpy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"snf version: {_version(snf, 'snfpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _two_views(seed):
+    """Two seeded views over the SAME 40 samples in DIFFERENT feature spaces."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    n_samples = 40
+    view1 = rng.standard_normal((n_samples, 15))
+    view2 = rng.standard_normal((n_samples, 25))
+    return n_samples, [view1, view2]
+
+
+def test_make_affinity_shapes():
+    import numpy as np
+
+    n_samples, views = _two_views(0)
+    affinities = snf.make_affinity(views, K=20, mu=0.5)
+    # A list in → a list of sample-by-sample affinity matrices out, one per view.
+    assert isinstance(affinities, list)
+    assert len(affinities) == 2
+    for aff in affinities:
+        assert aff.shape == (n_samples, n_samples)
+        assert np.all(np.isfinite(aff))
+
+
+def test_snf_fusion_is_square_symmetric_finite():
+    import numpy as np
+
+    n_samples, views = _two_views(0)
+    affinities = snf.make_affinity(views, K=20, mu=0.5)
+    fused = snf.snf(affinities, K=20)
+    assert fused.shape == (n_samples, n_samples)
+    assert np.all(np.isfinite(fused))
+    # SNF's final step symmetrises the fused network.
+    assert np.allclose(fused, fused.T, atol=1e-8)
+
+
+def test_get_n_clusters_returns_candidates():
+    n_samples, views = _two_views(1)
+    affinities = snf.make_affinity(views, K=20, mu=0.5)
+    fused = snf.snf(affinities, K=20)
+    candidates = snf.get_n_clusters(fused)
+    # get_n_clusters returns the top-two eigengap estimates of the cluster count.
+    assert len(candidates) == 2
+    assert all(int(c) >= 1 for c in candidates)
+
+
+run_test("make_affinity yields per-view sample x sample matrices", test_make_affinity_shapes)
+run_test("snf fuses to a square, symmetric, finite network", test_snf_fusion_is_square_symmetric_finite)
+run_test("get_n_clusters returns candidate cluster counts", test_get_n_clusters_returns_candidates)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all snf smoke tests passed")

--- a/cli/scripts/lib-validator/spacexr.R
+++ b/cli/scripts/lib-validator/spacexr.R
@@ -1,0 +1,177 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `spacexr` package (RCTD spatial-transcriptomics cell-type
+# deconvolution + CSIDE).
+#
+# Install: remotes::install_github("dmcable/spacexr")
+#
+# Fully self-contained: no input files, no network. Builds -- with a fixed seed
+# -- a synthetic single-cell REFERENCE (genes x cells, three cell types with
+# clear per-type marker blocks so differential-expression gene selection has
+# real markers to find) and a synthetic SpatialRNA puck (genes x pixels, each a
+# two-type mixture) over the SAME gene universe, then constructs the RCTD object.
+# Only the OBJECT-CONSTRUCTION surface is exercised: Reference(), SpatialRNA(),
+# and create.RCTD(). The heavy fit, run.RCTD(), is deliberately NOT called.
+# Checks are structural (S4 class, populated slots) -- never numeric. Exits 0
+# only if every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript spacexr.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once spacexr
+# is available:
+#   - CONSTRUCTOR ARG NAMES / ORDER. Assumed signatures:
+#       Reference(counts, cell_types, nUMI)   -- counts = genes x cells matrix
+#         (rownames = genes, colnames = cell barcodes); cell_types = a factor
+#         NAMED by cell barcode; nUMI = named numeric of per-cell totals.
+#       SpatialRNA(coords, counts, nUMI)      -- coords = data.frame with
+#         columns x/y and rownames = pixel ids; counts = genes x pixels; nUMI =
+#         named numeric of per-pixel totals.
+#       create.RCTD(spatialRNA, reference, max_cores = 1)
+#     Re-confirm the positional/argument spelling against the installed help.
+#   - S4 CLASS NAMES. Assumed "Reference", "SpatialRNA", and "RCTD"; and slot
+#     names @counts / @cell_types / @coords / @nUMI. Re-confirm if the inherits()
+#     / slotNames() checks below fail.
+#   - create.RCTD DEFAULT THRESHOLDS. The synthetic data is built to satisfy the
+#     documented defaults -- >= CELL_MIN_INSTANCE (25) cells per reference cell
+#     type (here 30), per-cell/per-pixel UMI comfortably above UMI_min (100) and
+#     UMI_min_sigma (300), and clear marker genes so DE selection is non-empty.
+#     These thresholds are version-dependent; if create.RCTD errors on an
+#     installed build, revisit the synthetic design (more cells / stronger
+#     markers / higher UMI) rather than assuming a package fault.
+#   - run.RCTD IS NOT TESTED (deliberately -- it is the expensive optimisation).
+#     The end-to-end fit must be re-verified separately once installed.
+# ============================================================================
+
+if (!requireNamespace("spacexr", quietly = TRUE)) {
+  cat("FAIL: package 'spacexr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(spacexr))
+cat(sprintf("spacexr version: %s\n", as.character(packageVersion("spacexr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# ---- Synthetic design ------------------------------------------------------
+# 150 genes: three 30-gene MARKER blocks (one per cell type) + 60 background
+# genes. For a cell of type k, its own marker block is highly expressed
+# (lambda 40), the other two blocks are near-silent (lambda 1), and background
+# genes are moderate (lambda 5) for everyone. That gives clear between-type
+# differential expression so create.RCTD's marker selection finds real markers.
+set.seed(7)
+cell_type_names <- c("typeA", "typeB", "typeC")
+n_types <- length(cell_type_names)
+n_markers_per_type <- 30L
+n_marker_genes <- n_markers_per_type * n_types    # 90
+n_bg_genes <- 60L
+n_genes <- n_marker_genes + n_bg_genes            # 150
+genes <- paste0("Gene", seq_len(n_genes))
+
+# lambda vector for a cell of the given type index.
+build_lambda <- function(type_idx) {
+  lam <- numeric(n_genes)
+  for (k in seq_len(n_types)) {
+    block <- ((k - 1L) * n_markers_per_type + 1L):(k * n_markers_per_type)
+    lam[block] <- if (k == type_idx) 40 else 1
+  }
+  lam[(n_marker_genes + 1L):n_genes] <- 5   # background genes
+  lam
+}
+
+# Reference: 30 cells per type -> 90 cells (>= CELL_MIN_INSTANCE default of 25).
+n_ref_per_type <- 30L
+n_ref_cells <- n_ref_per_type * n_types           # 90
+ref_type_vec <- rep(cell_type_names, each = n_ref_per_type)
+ref_cell_ids <- paste0("refcell", seq_len(n_ref_cells))
+ref_counts <- matrix(0, nrow = n_genes, ncol = n_ref_cells,
+                     dimnames = list(genes, ref_cell_ids))
+for (j in seq_len(n_ref_cells)) {
+  ti <- match(ref_type_vec[j], cell_type_names)
+  ref_counts[, j] <- rpois(n_genes, build_lambda(ti))
+}
+cell_types <- factor(ref_type_vec, levels = cell_type_names)
+names(cell_types) <- ref_cell_ids
+ref_nUMI <- colSums(ref_counts)
+
+# SpatialRNA: 100 pixels, each a random two-type mixture over the same genes.
+n_pixels <- 100L
+pixel_ids <- paste0("pixel", seq_len(n_pixels))
+spatial_counts <- matrix(0, nrow = n_genes, ncol = n_pixels,
+                         dimnames = list(genes, pixel_ids))
+for (j in seq_len(n_pixels)) {
+  pair <- sample.int(n_types, 2L)
+  lam <- (build_lambda(pair[1L]) + build_lambda(pair[2L])) / 2
+  spatial_counts[, j] <- rpois(n_genes, lam)
+}
+coords <- data.frame(
+  x = runif(n_pixels, 0, 100),
+  y = runif(n_pixels, 0, 100),
+  row.names = pixel_ids
+)
+spatial_nUMI <- colSums(spatial_counts)
+
+# Constructors are built via helpers so a construction error is recorded as a
+# test FAIL (not a top-level crash). create.RCTD is the heavy-ish step and is
+# invoked exactly once, inside its own test.
+make_reference <- function() {
+  suppressWarnings(suppressMessages(
+    Reference(ref_counts, cell_types, ref_nUMI)
+  ))
+}
+make_spatial <- function() {
+  suppressWarnings(suppressMessages(
+    SpatialRNA(coords, spatial_counts, spatial_nUMI)
+  ))
+}
+
+run_test("Reference() builds a Reference object", function() {
+  ref <- make_reference()
+  stopifnot(inherits(ref, "Reference"))
+  stopifnot("counts" %in% slotNames(ref))
+  stopifnot("cell_types" %in% slotNames(ref))
+  # Same gene universe we supplied; every retained cell keeps a type label.
+  stopifnot(nrow(ref@counts) > 0L, ncol(ref@counts) > 0L)
+  stopifnot(length(ref@cell_types) == ncol(ref@counts))
+})
+
+run_test("SpatialRNA() builds a SpatialRNA object", function() {
+  puck <- make_spatial()
+  stopifnot(inherits(puck, "SpatialRNA"))
+  stopifnot("coords" %in% slotNames(puck))
+  stopifnot("counts" %in% slotNames(puck))
+  # coords carries an x/y position per retained pixel.
+  stopifnot(all(c("x", "y") %in% colnames(puck@coords)))
+  stopifnot(nrow(puck@coords) == ncol(puck@counts))
+})
+
+run_test("create.RCTD is an exported function", function() {
+  stopifnot(exists("create.RCTD"))
+  stopifnot(is.function(create.RCTD))
+})
+
+run_test("create.RCTD() returns an RCTD object", function() {
+  # The synthetic reference/puck are built to clear create.RCTD's default
+  # thresholds (see ASSUMPTIONS). max_cores = 1 keeps it single-threaded.
+  rctd <- suppressWarnings(suppressMessages(
+    create.RCTD(make_spatial(), make_reference(), max_cores = 1)
+  ))
+  stopifnot(inherits(rctd, "RCTD"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all spacexr smoke tests passed\n")

--- a/cli/scripts/lib-validator/spatialdata-io.py
+++ b/cli/scripts/lib-validator/spatialdata-io.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `spatialdata-io` package.
+
+Fully self-contained: no input files, no network. `spatialdata-io` is a library
+of readers that turn on-disk spatial-omics platform outputs (Xenium, Visium,
+MERSCOPE, …) into `SpatialData` objects, so every reader needs a real data
+directory that this test deliberately does NOT provide. Instead it asserts the
+package imports and exposes its reader functions, exiting 0 only if every check
+passes, so it can be used as a pass/fail library validator:
+
+    python3 spatialdata-io.py
+
+Install: pip install spatialdata-io   (import name: spatialdata_io)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review, deliberately MODEST): the readers require real
+platform export directories (and pull in spatialdata + its element models), so
+this test does not invoke any reader — it only confirms the callable reader
+surface is present.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import spatialdata_io
+except ImportError:
+    print("FAIL: package 'spatialdata-io' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"spatialdata-io version: {_version(spatialdata_io, 'spatialdata-io')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_module_imports():
+    assert spatialdata_io is not None
+    # The package re-exports its readers at the top level.
+    assert hasattr(spatialdata_io, "__all__") or dir(spatialdata_io)
+
+
+def test_exposes_platform_readers():
+    # Core platform readers that every spatialdata-io release ships.
+    for reader in ("xenium", "visium", "merscope"):
+        assert hasattr(spatialdata_io, reader), f"missing reader: {reader}"
+        assert callable(getattr(spatialdata_io, reader)), f"not callable: {reader}"
+
+
+def test_at_least_one_extra_reader_present():
+    # Beyond the core three, the package exposes many more platform readers;
+    # assert the surface is broad without pinning a brittle exact set.
+    candidates = (
+        "visium_hd",
+        "cosmx",
+        "steinbock",
+        "curio",
+        "dbit",
+        "iss",
+        "mcmicro",
+    )
+    present = [c for c in candidates if callable(getattr(spatialdata_io, c, None))]
+    assert present, "expected at least one additional platform reader"
+
+
+run_test("module imports", test_module_imports)
+run_test("exposes core platform readers", test_exposes_platform_readers)
+run_test("exposes additional platform readers", test_at_least_one_extra_reader_present)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all spatialdata-io smoke tests passed")

--- a/cli/scripts/lib-validator/spatialdata-plot.py
+++ b/cli/scripts/lib-validator/spatialdata-plot.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `spatialdata-plot` package.
+
+Fully self-contained: no input files, no network. `spatialdata-plot` registers
+a matplotlib-backed `.pl` plotting accessor on `SpatialData`; importing it is
+the side effect under test. Forces the headless Agg backend before the import
+so nothing ever tries to open a window, and asserts the accessor is attached
+without rendering any real data, exiting 0 only if every check passes, so it
+can be used as a pass/fail library validator:
+
+    python3 spatialdata-plot.py
+
+Install: pip install spatialdata-plot   (import name: spatialdata_plot)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review, deliberately MODEST): actually rendering needs valid
+spatialdata elements + a matplotlib canvas, so this test only confirms that
+importing the package augments `SpatialData` with the `.pl` accessor and that
+the accessor exposes its render/show methods — it draws nothing.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    # Force the non-interactive Agg backend BEFORE spatialdata_plot pulls in
+    # pyplot: this test runs headless and must never open a window, and
+    # selecting the backend after pyplot is imported is a no-op. matplotlib is a
+    # hard dependency of spatialdata_plot, so importing it here cannot mask a
+    # missing spatialdata_plot.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import spatialdata_plot
+except ImportError:
+    print("FAIL: package 'spatialdata-plot' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"spatialdata-plot version: {_version(spatialdata_plot, 'spatialdata-plot')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_import_registers_pl_accessor():
+    from spatialdata import SpatialData
+
+    sdata = SpatialData()
+    # Importing spatialdata_plot registers the `.pl` accessor on SpatialData;
+    # every instance gains it as a side effect of the import above.
+    assert hasattr(sdata, "pl"), "spatialdata_plot did not register a .pl accessor"
+
+
+def test_pl_accessor_exposes_render_methods():
+    from spatialdata import SpatialData
+
+    sdata = SpatialData()
+    pl = sdata.pl
+    # The accessor is the plotting API surface: render_* builders plus show().
+    for method in ("render_images", "render_shapes", "render_points", "show"):
+        assert hasattr(pl, method), f"missing plotting method: {method}"
+        assert callable(getattr(pl, method)), f"not callable: {method}"
+
+
+def test_agg_backend_is_active():
+    # Confirms the headless guard above took effect (no interactive canvas).
+    assert matplotlib.get_backend().lower() == "agg"
+
+
+run_test("import registers .pl accessor", test_import_registers_pl_accessor)
+run_test(".pl accessor exposes render methods", test_pl_accessor_exposes_render_methods)
+run_test("Agg backend is active", test_agg_backend_is_active)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all spatialdata-plot smoke tests passed")

--- a/cli/scripts/lib-validator/spatialdata.py
+++ b/cli/scripts/lib-validator/spatialdata.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `spatialdata` package.
+
+Fully self-contained: no input files, no network. Builds a minimal synthetic
+`SpatialData` object entirely in memory and verifies it constructs and exposes
+its element containers, exiting 0 only if every check passes, so it can be used
+as a pass/fail library validator:
+
+    python3 spatialdata.py
+
+Install: pip install spatialdata   (import name: spatialdata)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review, deliberately MODEST): spatialdata's element models are
+intricate — images/labels are lazy xarray/dask arrays, points/shapes are
+parsed through `spatialdata.models.PointsModel.parse` / `ShapesModel.parse`,
+and tables are AnnData carrying a coordinate-transform + region annotation.
+This test only builds the simplest valid elements (a points frame and a table
+AnnData) to confirm the container composes and its `.points`/`.tables`/
+`.images`/`.labels`/`.shapes` accessors exist; it does not exercise coordinate
+systems, transforms, or on-disk (zarr) I/O.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import spatialdata
+except ImportError:
+    print("FAIL: package 'spatialdata' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"spatialdata version: {_version(spatialdata, 'spatialdata')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_empty_spatialdata_exposes_containers():
+    from spatialdata import SpatialData
+
+    sdata = SpatialData()
+    # The five element containers are the object's public surface; each is an
+    # (empty) mapping on a freshly-constructed object.
+    for attr in ("images", "labels", "points", "shapes", "tables"):
+        assert hasattr(sdata, attr)
+    assert len(sdata.points) == 0
+    assert len(sdata.tables) == 0
+
+
+def test_points_element_from_dataframe():
+    import numpy as np
+    import pandas as pd
+    from spatialdata import SpatialData
+    from spatialdata.models import PointsModel
+
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {"x": rng.random(5), "y": rng.random(5), "gene": ["g0", "g1", "g2", "g3", "g4"]}
+    )
+    # PointsModel.parse converts the frame into the lazy (dask) points element
+    # spatialdata expects, wiring in the coordinate columns.
+    points = PointsModel.parse(df, coordinates={"x": "x", "y": "y"})
+    sdata = SpatialData(points={"pts": points})
+    assert "pts" in sdata.points
+    assert len(sdata.points) == 1
+
+
+def test_table_element_from_anndata():
+    import anndata as ad
+    import numpy as np
+    from spatialdata import SpatialData
+    from spatialdata.models import TableModel
+
+    rng = np.random.default_rng(1)
+    adata = ad.AnnData(rng.random((6, 3)).astype("float32"))
+    table = TableModel.parse(adata)
+    sdata = SpatialData(tables={"table": table})
+    assert "table" in sdata.tables
+    assert sdata.tables["table"].shape == (6, 3)
+
+
+run_test("empty SpatialData exposes element containers", test_empty_spatialdata_exposes_containers)
+run_test("points element from DataFrame", test_points_element_from_dataframe)
+run_test("table element from AnnData", test_table_element_from_anndata)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all spatialdata smoke tests passed")

--- a/cli/scripts/lib-validator/spectrum-utils.py
+++ b/cli/scripts/lib-validator/spectrum-utils.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `spectrum-utils` package.
+
+Fully self-contained: no input files, no network, no packages beyond
+spectrum-utils (and its implied deps: numpy). Exercises the core API surface
+and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 spectrum-utils.py
+
+Install: pip install spectrum-utils   (import name: spectrum_utils)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import spectrum_utils
+except ImportError:
+    print("FAIL: package 'spectrum-utils' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"spectrum_utils version: {_version(spectrum_utils, 'spectrum-utils')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+# spectrum_utils is genuinely offline-shaped: an MsmsSpectrum is built from
+# in-memory arrays, and its transforms are deterministic and chainable (each
+# returns self).
+def _spectrum(mz=None, intensity=None):
+    import numpy as np
+    from spectrum_utils.spectrum import MsmsSpectrum
+
+    if mz is None:
+        mz = np.array([100.5, 150.2, 200.9, 250.1])
+    if intensity is None:
+        intensity = np.array([10.0, 40.0, 5.0, 25.0])
+    return MsmsSpectrum("spec1", 500.0, 2, mz, intensity)
+
+
+def test_construct_and_arrays():
+    import numpy as np
+
+    mz = np.array([100.5, 150.2, 200.9, 250.1])
+    intensity = np.array([10.0, 40.0, 5.0, 25.0])
+    spec = _spectrum(mz, intensity)
+    assert np.allclose(spec.mz, mz)
+    assert np.allclose(spec.intensity, intensity)
+    assert len(spec.mz) == 4
+
+
+def test_round_transform():
+    import numpy as np
+
+    mz = np.array([100.53, 150.27, 200.94, 250.11])
+    spec = _spectrum(mz, np.array([10.0, 40.0, 5.0, 25.0]))
+    spec.round(1)  # round m/z to 1 decimal, in place
+    assert np.allclose(spec.mz, np.round(mz, 1))
+
+
+def test_scale_intensity_changes_values():
+    import numpy as np
+
+    spec = _spectrum()
+    before = spec.intensity.copy()
+    spec.scale_intensity(scaling="root")
+    assert spec.intensity.shape == before.shape  # shape preserved
+    assert not np.allclose(spec.intensity, before)  # values transformed
+
+
+def test_filter_intensity_chainable():
+    from spectrum_utils.spectrum import MsmsSpectrum
+
+    # Transforms return self, so they chain: filter then scale.
+    result = _spectrum().filter_intensity(min_intensity=0.2, max_num_peaks=2).scale_intensity(
+        scaling="root"
+    )
+    assert isinstance(result, MsmsSpectrum)
+    assert len(result.mz) == len(result.intensity)  # arrays stay aligned
+    assert len(result.mz) <= 2  # capped by max_num_peaks
+
+
+run_test("MsmsSpectrum construct + arrays", test_construct_and_arrays)
+run_test("round() transform", test_round_transform)
+run_test("scale_intensity() changes values", test_scale_intensity_changes_values)
+run_test("filter_intensity() chainable", test_filter_intensity_chainable)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all spectrum-utils smoke tests passed")

--- a/cli/scripts/lib-validator/squidpy.py
+++ b/cli/scripts/lib-validator/squidpy.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `squidpy` package.
+
+Fully self-contained: no input files, no network. `squidpy.datasets` would
+fetch over the network, so this test instead builds a synthetic AnnData with
+`obsm["spatial"]` coordinates and runs the spatial-graph builder on it, exiting
+0 only if every check passes, so it can be used as a pass/fail library
+validator:
+
+    python3 squidpy.py
+
+Install: pip install squidpy   (import name: squidpy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+NOTE (correct-by-review, deliberately MODEST): squidpy sits on the scverse
+stack (anndata + scanpy), and its graph/enrichment tools mutate an AnnData in
+place. This test seeds its RNG for determinism and only exercises the
+graph-construction path (`gr.spatial_neighbors`) plus one enrichment
+(`gr.nhood_enrichment`); it does not fetch datasets, plot, or run image
+analysis.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import squidpy
+except ImportError:
+    print("FAIL: package 'squidpy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"squidpy version: {_version(squidpy, 'squidpy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _synthetic_adata(n=60, n_genes=8, seed=0):
+    """AnnData with a seeded expression matrix and 2-D spatial coordinates."""
+    import anndata as ad
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    X = rng.random((n, n_genes)).astype("float32")
+    adata = ad.AnnData(X)
+    # squidpy reads point coordinates from obsm["spatial"].
+    adata.obsm["spatial"] = rng.random((n, 2)) * 100.0
+    return adata
+
+
+def test_spatial_neighbors_builds_graph():
+    import numpy as np
+
+    adata = _synthetic_adata()
+    n = adata.n_obs
+    # "generic" coord_type treats obsm["spatial"] as arbitrary point coordinates.
+    squidpy.gr.spatial_neighbors(adata, coord_type="generic", n_neighs=6)
+    assert "spatial_connectivities" in adata.obsp
+    assert "spatial_distances" in adata.obsp
+    conn = adata.obsp["spatial_connectivities"]
+    assert conn.shape == (n, n)
+    # A neighbor graph must have at least one edge.
+    assert conn.nnz > 0
+    _ = np  # keep the deterministic-import contract explicit
+
+
+def test_nhood_enrichment_optional():
+    import numpy as np
+    import pandas as pd
+
+    adata = _synthetic_adata(seed=1)
+    rng = np.random.default_rng(2)
+    adata.obs["cluster"] = pd.Categorical(rng.choice(["a", "b", "c"], size=adata.n_obs))
+    squidpy.gr.spatial_neighbors(adata, coord_type="generic", n_neighs=6)
+    # Permutation-based enrichment; seed + small n_perms keep it fast and stable.
+    squidpy.gr.nhood_enrichment(
+        adata, cluster_key="cluster", seed=0, n_perms=20, show_progress_bar=False
+    )
+    assert "cluster_nhood_enrichment" in adata.uns
+    zscore = adata.uns["cluster_nhood_enrichment"]["zscore"]
+    # 3 clusters -> a 3x3 enrichment matrix.
+    assert zscore.shape == (3, 3)
+
+
+run_test("gr.spatial_neighbors builds a spatial graph", test_spatial_neighbors_builds_graph)
+run_test("gr.nhood_enrichment (optional)", test_nhood_enrichment_optional)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all squidpy smoke tests passed")

--- a/cli/scripts/lib-validator/statsmodels.py
+++ b/cli/scripts/lib-validator/statsmodels.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `statsmodels` package.
+
+Fully self-contained: no input files, no network, no packages beyond
+statsmodels and its implied deps (numpy, pandas, scipy). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 statsmodels.py
+
+Install: pip install "statsmodels>=0.14.5"   (import name: statsmodels)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import statsmodels
+    import statsmodels.api as sm
+except ImportError:
+    print("FAIL: package 'statsmodels' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"statsmodels version: {_version(statsmodels, 'statsmodels')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_ols_recovers_slope():
+    # Simulate y = 3 + 2*x + noise; OLS must recover intercept ~3, slope ~2.
+    rng = np.random.default_rng(0)
+    x = rng.uniform(0, 10, size=500)
+    y = 3.0 + 2.0 * x + rng.normal(0, 1.0, size=500)
+    X = sm.add_constant(x)
+    res = sm.OLS(y, X).fit()
+    assert res.params.shape == (2,)
+    assert np.isclose(res.params[0], 3.0, atol=0.3)
+    assert np.isclose(res.params[1], 2.0, atol=0.1)
+    # Strong linear signal → high R^2 and a highly-significant slope.
+    assert res.rsquared > 0.95
+    assert res.pvalues[1] < 1e-6
+
+
+def test_add_constant_shape():
+    x = np.arange(10.0).reshape(10, 1)
+    X = sm.add_constant(x)
+    assert X.shape == (10, 2)
+    # First column is the added intercept of all ones.
+    assert np.allclose(X[:, 0], 1.0)
+
+
+def test_summary_has_params_and_pvalues():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=200)
+    y = 1.0 - 0.5 * x + rng.normal(0, 0.5, size=200)
+    res = sm.OLS(y, sm.add_constant(x)).fit()
+    # Both inferential vectors are present and finite for every term.
+    assert len(res.params) == 2
+    assert len(res.pvalues) == 2
+    assert np.all(np.isfinite(res.pvalues))
+    text = str(res.summary())
+    assert "coef" in text and "P>|t|" in text
+
+
+def test_glm_binomial_logit():
+    # Logistic signal: higher x → higher P(y=1). GLM slope must be positive.
+    rng = np.random.default_rng(2)
+    x = rng.normal(size=400)
+    p = 1.0 / (1.0 + np.exp(-(0.5 + 2.0 * x)))
+    y = (rng.uniform(size=400) < p).astype(float)
+    X = sm.add_constant(x)
+    res = sm.GLM(y, X, family=sm.families.Binomial()).fit()
+    assert res.params.shape == (2,)
+    assert res.params[1] > 0.0
+    assert np.all(np.isfinite(res.fittedvalues))
+
+
+run_test("OLS recovers y=3+2x slope", test_ols_recovers_slope)
+run_test("add_constant adds intercept", test_add_constant_shape)
+run_test("summary has params + pvalues", test_summary_has_params_and_pvalues)
+run_test("GLM binomial (logit)", test_glm_binomial_logit)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all statsmodels smoke tests passed")

--- a/cli/scripts/lib-validator/stringr.R
+++ b/cli/scripts/lib-validator/stringr.R
@@ -1,0 +1,91 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `stringr` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# stringr itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript stringr.R
+
+if (!requireNamespace("stringr", quietly = TRUE)) {
+  cat("FAIL: package 'stringr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(stringr))
+cat(sprintf("stringr version: %s\n", as.character(packageVersion("stringr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("str_detect and str_extract", function() {
+  stopifnot(identical(str_detect(c("apple", "banana"), "an"), c(FALSE, TRUE)))
+  stopifnot(identical(str_extract("abc123def", "\\d+"), "123"))
+  stopifnot(identical(str_extract_all("a1b22c333", "\\d+")[[1]], c("1", "22", "333")))
+})
+
+run_test("str_replace and str_replace_all", function() {
+  stopifnot(identical(str_replace("aaa", "a", "b"), "baa"))
+  stopifnot(identical(str_replace_all("aaa", "a", "b"), "bbb"))
+  stopifnot(identical(str_replace_all("x1y2", "\\d", "#"), "x#y#"))
+})
+
+run_test("str_split returns a list", function() {
+  parts <- str_split("a,b,c", ",")
+  stopifnot(is.list(parts), identical(length(parts), 1L))
+  stopifnot(identical(parts[[1]], c("a", "b", "c")))
+  stopifnot(identical(str_split(c("a-b", "c-d-e"), "-"), list(c("a", "b"), c("c", "d", "e"))))
+})
+
+run_test("str_c and str_flatten", function() {
+  stopifnot(identical(str_c("a", "b", sep = "-"), "a-b"))
+  stopifnot(identical(str_c(c("x", "y"), 1:2), c("x1", "y2")))
+  stopifnot(identical(str_flatten(c("a", "b", "c"), collapse = "+"), "a+b+c"))
+})
+
+run_test("str_pad, str_trim, str_squish", function() {
+  stopifnot(identical(str_pad("7", 3, pad = "0"), "007"))
+  stopifnot(identical(str_pad("ab", 4, side = "right", pad = "."), "ab.."))
+  stopifnot(identical(str_trim("  x  "), "x"))
+  stopifnot(identical(str_squish("  a   b  "), "a b"))
+})
+
+run_test("case conversion and str_length", function() {
+  stopifnot(identical(str_to_upper("abc"), "ABC"))
+  stopifnot(identical(str_to_title("hello world"), "Hello World"))
+  stopifnot(identical(str_length(c("a", "abc", "")), c(1L, 3L, 0L)))
+})
+
+run_test("str_match captures regex groups", function() {
+  m <- str_match("2020-01-02", "(\\d{4})-(\\d{2})-(\\d{2})")
+  stopifnot(identical(dim(m), c(1L, 4L)))
+  stopifnot(identical(m[1, 1], "2020-01-02"))
+  stopifnot(identical(m[1, 2], "2020"))
+  stopifnot(identical(m[1, 3], "01"))
+  stopifnot(identical(m[1, 4], "02"))
+})
+
+run_test("str_sub extraction and negative indexing", function() {
+  stopifnot(identical(str_sub("abcdef", 2, 4), "bcd"))
+  stopifnot(identical(str_sub("abcdef", -3), "def"))
+  x <- "abcdef"
+  str_sub(x, 1, 1) <- "Z"
+  stopifnot(identical(x, "Zbcdef"))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all stringr smoke tests passed\n")

--- a/cli/scripts/lib-validator/survival.R
+++ b/cli/scripts/lib-validator/survival.R
@@ -1,0 +1,117 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `survival` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# survival itself (and its implied deps). Data is either bundled with the
+# package (`lung`) or simulated with a fixed seed. Exercises the core
+# survival-modeling API and exits 0 only if every check passes, so it can be
+# used as a pass/fail library validator:
+#
+#   Rscript survival.R
+#
+# Modeling outputs are floating-point, so checks assert structural/robust
+# properties (classes, lengths, finiteness, monotonicity) and recover known
+# effects only within a generous tolerance -- never exact coefficient equality.
+
+if (!requireNamespace("survival", quietly = TRUE)) {
+  cat("FAIL: package 'survival' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(survival))
+cat(sprintf("survival version: %s\n", as.character(packageVersion("survival"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("Surv object construction", function() {
+  s <- Surv(time = c(5, 10, 15, 20), event = c(1L, 0L, 1L, 1L))
+  stopifnot(inherits(s, "Surv"))
+  m <- as.matrix(s)
+  stopifnot(nrow(m) == 4L, ncol(m) == 2L)
+  # right-censored Surv exposes time + status columns
+  stopifnot(all(c("time", "status") %in% colnames(m)))
+  stopifnot(identical(as.integer(m[, "status"]), c(1L, 0L, 1L, 1L)))
+})
+
+run_test("coxph fit on bundled lung dataset", function() {
+  # `lung` is lazy-loaded by the package namespace; reference it directly.
+  fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+  stopifnot(inherits(fit, "coxph"))
+  cf <- coef(fit)
+  stopifnot(length(cf) == 2L, identical(names(cf), c("age", "sex")))
+  stopifnot(all(is.finite(cf)))
+  ll <- as.numeric(logLik(fit))
+  stopifnot(is.finite(ll))
+  stopifnot(is.finite(AIC(fit)))
+  # females (sex == 2) have lower hazard in lung -> negative sex coefficient
+  stopifnot(cf["sex"] < 0)
+})
+
+run_test("coxph recovers a known effect (simulated)", function() {
+  set.seed(123)
+  n <- 2000L
+  x <- rnorm(n)
+  beta <- 0.8
+  # exponential event times with hazard proportional to exp(beta * x)
+  event_time <- -log(runif(n)) / exp(beta * x)
+  cens_time <- runif(n, 0, 3)
+  obs <- pmin(event_time, cens_time)
+  status <- as.integer(event_time <= cens_time)
+  stopifnot(sum(status) > 0L, sum(status) < n) # some events, some censored
+  fit <- coxph(Surv(obs, status) ~ x)
+  est <- unname(coef(fit))
+  stopifnot(is.finite(est))
+  # generous tolerance -- floating-point fit on simulated data
+  stopifnot(abs(est - beta) < 0.15)
+})
+
+run_test("kaplan-meier survfit is a valid survival curve", function() {
+  sf <- survfit(Surv(time, status) ~ 1, data = lung)
+  stopifnot(inherits(sf, "survfit"))
+  surv <- sf$surv
+  stopifnot(length(surv) > 1L, all(is.finite(surv)))
+  # survival probabilities live in [0, 1], start at/near 1, never increase
+  stopifnot(all(surv >= 0), all(surv <= 1))
+  stopifnot(abs(surv[1] - 1) < 0.05)
+  stopifnot(all(diff(surv) <= 1e-9))
+  # a median survival estimate should be finite and positive
+  med <- summary(sf)$table["median"]
+  stopifnot(is.finite(med), med > 0)
+})
+
+run_test("log-rank survdiff between groups", function() {
+  sd <- survdiff(Surv(time, status) ~ sex, data = lung)
+  stopifnot(sd$chisq >= 0, is.finite(sd$chisq))
+  pval <- pchisq(sd$chisq, df = length(sd$n) - 1L, lower.tail = FALSE)
+  stopifnot(pval >= 0, pval <= 1)
+  # observed/expected counts line up with the two groups
+  stopifnot(length(sd$obs) == 2L, length(sd$exp) == 2L)
+})
+
+run_test("predict from a fitted coxph model", function() {
+  fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+  lp <- predict(fit, type = "lp")
+  rk <- predict(fit, type = "risk")
+  stopifnot(length(lp) == nrow(lung), all(is.finite(lp)))
+  stopifnot(length(rk) == nrow(lung), all(is.finite(rk)))
+  # relative-risk scores are strictly positive
+  stopifnot(all(rk > 0))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all survival smoke tests passed\n")

--- a/cli/scripts/lib-validator/survminer.R
+++ b/cli/scripts/lib-validator/survminer.R
@@ -1,0 +1,104 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `survminer` package.
+#
+# Fully self-contained: no input files, no network, no plotting device. Data is
+# the `lung` dataset bundled with `survival` (a survminer dependency); models
+# are fit with survival's `survfit`. Exercises survminer's survival-plot and
+# summary API and exits 0 only if every check passes, so it can be used as a
+# pass/fail library validator:
+#
+#   Rscript survminer.R
+#
+# ggsurvplot builds a ggplot object but is never drawn (no device is opened),
+# so checks assert structural properties (object classes, data-frame columns,
+# value ranges) rather than pixels -- and never exact floating-point equality.
+
+if (!requireNamespace("survminer", quietly = TRUE)) {
+  cat("FAIL: package 'survminer' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(survminer))
+suppressPackageStartupMessages(library(survival))
+cat(sprintf("survminer version: %s\n", as.character(packageVersion("survminer"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("ggsurvplot builds a ggsurvplot / ggplot object", function() {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- ggsurvplot(fit, data = lung)
+  stopifnot(inherits(p, "ggsurvplot"))
+  # the survival curve itself is a ggplot; it is built but never drawn
+  stopifnot(inherits(p$plot, "ggplot"))
+})
+
+run_test("ggsurvplot with risk table and p-value", function() {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE, pval = TRUE,
+                  conf.int = TRUE)
+  stopifnot(inherits(p, "ggsurvplot"))
+  stopifnot(inherits(p$plot, "ggplot"))
+  # requesting a risk table yields a second ggplot component
+  stopifnot(inherits(p$table, "ggplot"))
+})
+
+run_test("surv_summary returns a tidy data.frame", function() {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  ss <- surv_summary(fit, data = lung)
+  stopifnot(is.data.frame(ss))
+  stopifnot(nrow(ss) > 0L)
+  # the standard tidy survival-summary columns are present
+  stopifnot(all(c("time", "n.risk", "n.event", "surv", "strata") %in% names(ss)))
+  # survival probabilities are valid and non-increasing within each stratum
+  stopifnot(all(is.finite(ss$surv)), all(ss$surv >= 0), all(ss$surv <= 1))
+  for (st in unique(ss$strata)) {
+    s <- ss$surv[ss$strata == st]
+    stopifnot(all(diff(s) <= 1e-9))
+  }
+})
+
+run_test("surv_median returns per-stratum medians", function() {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  med <- surv_median(fit)
+  stopifnot(is.data.frame(med))
+  stopifnot("median" %in% names(med))
+  # one median row per stratum (sex has two levels)
+  stopifnot(nrow(med) == 2L)
+  stopifnot(all(is.finite(med$median)), all(med$median > 0))
+})
+
+run_test("pairwise_survdiff returns valid p-values", function() {
+  psd <- pairwise_survdiff(Surv(time, status) ~ sex, data = lung)
+  stopifnot(inherits(psd, "pairwise.htest"))
+  pv <- psd$p.value
+  finite_p <- pv[is.finite(pv)]
+  # at least one comparison, all p-values are proper probabilities
+  stopifnot(length(finite_p) >= 1L)
+  stopifnot(all(finite_p >= 0), all(finite_p <= 1))
+})
+
+run_test("surv_fit convenience wrapper fits a survfit", function() {
+  # survminer's surv_fit re-evaluates the formula against the data, keeping the
+  # call tidy for downstream ggsurvplot use.
+  fit <- surv_fit(Surv(time, status) ~ sex, data = lung)
+  stopifnot(inherits(fit, "survfit"))
+  stopifnot(length(fit$strata) == 2L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all survminer smoke tests passed\n")

--- a/cli/scripts/lib-validator/sva.R
+++ b/cli/scripts/lib-validator/sva.R
@@ -1,0 +1,115 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `sva` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# sva itself (and the dependencies it implies, e.g. mgcv / genefilter). All
+# data is simulated with a fixed seed; batch-correction checks are structural
+# / tolerance-based (inequalities on variance, never exact floating-point
+# equality). Exercises the core API surface and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript sva.R
+
+if (!requireNamespace("sva", quietly = TRUE)) {
+  cat("FAIL: package 'sva' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(sva))
+cat(sprintf("sva version: %s\n", as.character(packageVersion("sva"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate a 500-gene x 20-sample expression matrix with a PRIMARY condition
+# (A vs B, 10 each) AND a HIDDEN batch that is balanced within each condition
+# (5 batch-1 + 5 batch-2 per condition, so batch is not confounded with the
+# condition). The primary effect lives on the first 50 genes; the batch adds
+# a strong per-gene shift to every batch-2 sample -- unwanted variation that
+# sva should capture and ComBat should remove.
+set.seed(1)
+n_genes <- 500L
+n_per <- 10L
+n_samples <- 2L * n_per
+cond <- factor(rep(c("A", "B"), each = n_per))
+batch <- factor(rep(rep(c(1L, 2L), each = n_per %/% 2L), times = 2L))
+
+edata <- matrix(rnorm(n_genes * n_samples), nrow = n_genes, ncol = n_samples)
+edata[1:50, cond == "B"] <- edata[1:50, cond == "B"] + 3
+batch_shift <- rnorm(n_genes, mean = 0, sd = 2)
+edata[, batch == "2"] <- edata[, batch == "2"] + batch_shift
+rownames(edata) <- sprintf("gene%03d", seq_len(n_genes))
+colnames(edata) <- sprintf("s%02d", seq_len(n_samples))
+
+mod <- model.matrix(~cond)
+mod0 <- model.matrix(~1, data = data.frame(cond = cond))
+
+# sva() and ComBat() print progress via cat(); capture.output swallows it so
+# the harness output stays clean, while suppressMessages/suppressWarnings
+# silence benign chatter. Genuine errors still propagate to run_test.
+run_sva <- function(n.sv) {
+  svobj <- NULL
+  invisible(capture.output(
+    svobj <- suppressMessages(suppressWarnings(
+      sva(edata, mod, mod0, n.sv = n.sv)
+    ))
+  ))
+  svobj
+}
+run_combat <- function() {
+  adjusted <- NULL
+  invisible(capture.output(
+    adjusted <- suppressMessages(suppressWarnings(
+      ComBat(edata, batch = batch)
+    ))
+  ))
+  adjusted
+}
+
+run_test("num.sv: non-negative integer surrogate-variable count", function() {
+  n.sv <- num.sv(edata, mod)
+  stopifnot(length(n.sv) == 1L, is.finite(n.sv))
+  stopifnot(n.sv >= 0, n.sv == as.integer(n.sv))
+})
+
+run_test("sva: surrogate variables recovered with correct dims", function() {
+  n.sv <- num.sv(edata, mod)
+  # The strong planted batch guarantees at least one SV; guard so sva() is
+  # never asked to estimate zero surrogate variables.
+  if (n.sv < 1L) n.sv <- 1L
+  svobj <- run_sva(n.sv)
+  stopifnot(is.list(svobj))
+  stopifnot(svobj$n.sv >= 0, svobj$n.sv == as.integer(svobj$n.sv))
+  stopifnot(is.matrix(svobj$sv))
+  stopifnot(nrow(svobj$sv) == n_samples)
+  stopifnot(ncol(svobj$sv) == svobj$n.sv)
+  stopifnot(all(is.finite(svobj$sv)))
+})
+
+run_test("ComBat: shrinks between-batch variance", function() {
+  # Per-gene mean difference between the two batches, before correction.
+  before <- rowMeans(edata[, batch == "2"]) - rowMeans(edata[, batch == "1"])
+  adjusted <- run_combat()
+  stopifnot(is.matrix(adjusted), identical(dim(adjusted), dim(edata)))
+  after <- rowMeans(adjusted[, batch == "2"]) - rowMeans(adjusted[, batch == "1"])
+  # ComBat harmonizes batch means: the typical absolute between-batch gap
+  # must shrink substantially versus the uncorrected data (inequality only).
+  stopifnot(median(abs(after)) < median(abs(before)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all sva smoke tests passed\n")

--- a/cli/scripts/lib-validator/symphonypy.py
+++ b/cli/scripts/lib-validator/symphonypy.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `symphonypy` package.
+
+Fully self-contained: no input files, no network. Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 symphonypy.py
+
+Install: pip install symphonypy   (import name: symphonypy)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+
+MODEST + FLAGGED: symphonypy is Symphony reference mapping on top of scanpy.
+A real mapping needs a built reference AnnData plus a query, so this only
+asserts the package imports and exposes its documented pp / tl namespaces
+(e.g. tl.map_embedding); it does NOT run reference mapping. (correct-by-review.)
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import symphonypy
+except ImportError:
+    print("FAIL: package 'symphonypy' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"symphonypy version: {_version(symphonypy, 'symphonypy')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_exposes_pp_tl_namespaces():
+    assert hasattr(symphonypy, "pp")
+    assert hasattr(symphonypy, "tl")
+
+
+def test_exposes_map_embedding():
+    # map_embedding is Symphony's core query-onto-reference projection step.
+    assert hasattr(symphonypy.tl, "map_embedding")
+    assert callable(symphonypy.tl.map_embedding)
+
+
+run_test("exposes symphonypy.pp / symphonypy.tl", test_exposes_pp_tl_namespaces)
+run_test("exposes tl.map_embedding", test_exposes_map_embedding)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all symphonypy smoke tests passed")

--- a/cli/scripts/lib-validator/tibble.R
+++ b/cli/scripts/lib-validator/tibble.R
@@ -1,0 +1,93 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `tibble` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# tibble itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript tibble.R
+
+if (!requireNamespace("tibble", quietly = TRUE)) {
+  cat("FAIL: package 'tibble' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(tibble))
+cat(sprintf("tibble version: %s\n", as.character(packageVersion("tibble"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("tibble() with tidy eval across columns", function() {
+  t <- tibble(a = 1:3, b = a * 2)
+  stopifnot(inherits(t, "tbl_df"), inherits(t, "data.frame"))
+  stopifnot(identical(dim(t), c(3L, 2L)))
+  stopifnot(identical(names(t), c("a", "b")))
+  stopifnot(identical(t$a, 1:3))
+  stopifnot(identical(t$b, c(2, 4, 6)))
+})
+
+run_test("as_tibble from data.frame", function() {
+  df <- data.frame(x = 1:2, y = c("p", "q"))
+  t <- as_tibble(df)
+  stopifnot(inherits(t, "tbl_df"))
+  stopifnot(identical(t$x, 1:2))
+  stopifnot(identical(t$y, c("p", "q")))
+  stopifnot(is_tibble(t), !is_tibble(df))
+})
+
+run_test("tribble row-wise construction", function() {
+  t <- tribble(
+    ~x, ~y,
+    1, "a",
+    2, "b"
+  )
+  stopifnot(identical(names(t), c("x", "y")))
+  stopifnot(identical(t$x, c(1, 2)))
+  stopifnot(identical(t$y, c("a", "b")))
+  stopifnot(identical(nrow(t), 2L))
+})
+
+run_test("add_row and add_column", function() {
+  t <- tibble(a = c(1, 2), b = c("x", "y"))
+  t2 <- add_row(t, a = 3, b = "z")
+  stopifnot(identical(t2$a, c(1, 2, 3)))
+  stopifnot(identical(t2$b, c("x", "y", "z")))
+  t3 <- add_column(t, flag = c(TRUE, FALSE))
+  stopifnot(identical(names(t3), c("a", "b", "flag")))
+  stopifnot(identical(t3$flag, c(TRUE, FALSE)))
+})
+
+run_test("enframe/deframe roundtrip", function() {
+  v <- c(alpha = 1.5, beta = 2.5)
+  e <- enframe(v)
+  stopifnot(identical(names(e), c("name", "value")))
+  stopifnot(identical(e$name, c("alpha", "beta")))
+  stopifnot(identical(e$value, c(1.5, 2.5)))
+  stopifnot(identical(deframe(e), v))
+})
+
+run_test("single-bracket subsetting keeps tibble", function() {
+  t <- tibble(a = 1:3, b = c("x", "y", "z"))
+  one_col <- t["a"]
+  stopifnot(inherits(one_col, "tbl_df"))
+  stopifnot(identical(one_col$a, 1:3))
+  stopifnot(identical(t[[2]], c("x", "y", "z")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all tibble smoke tests passed\n")

--- a/cli/scripts/lib-validator/tidyr.R
+++ b/cli/scripts/lib-validator/tidyr.R
@@ -1,0 +1,103 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `tidyr` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# tidyr itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript tidyr.R
+
+if (!requireNamespace("tidyr", quietly = TRUE)) {
+  cat("FAIL: package 'tidyr' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(tidyr))
+cat(sprintf("tidyr version: %s\n", as.character(packageVersion("tidyr"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("pivot_longer/pivot_wider roundtrip", function() {
+  wide <- data.frame(id = 1:2, m1 = c(10, 20), m2 = c(30, 40))
+  long <- pivot_longer(wide, cols = c(m1, m2), names_to = "metric", values_to = "val")
+  stopifnot(identical(nrow(long), 4L))
+  stopifnot(identical(long$id, c(1L, 1L, 2L, 2L)))
+  stopifnot(identical(long$metric, c("m1", "m2", "m1", "m2")))
+  stopifnot(identical(long$val, c(10, 30, 20, 40)))
+  wide2 <- pivot_wider(long, names_from = metric, values_from = val)
+  stopifnot(identical(wide2$id, wide$id))
+  stopifnot(identical(wide2$m1, wide$m1))
+  stopifnot(identical(wide2$m2, wide$m2))
+})
+
+run_test("separate/unite roundtrip", function() {
+  df <- data.frame(x = c("a-1", "b-2"))
+  sep <- separate(df, x, into = c("l", "n"), sep = "-")
+  stopifnot(identical(names(sep), c("l", "n")))
+  stopifnot(identical(sep$l, c("a", "b")))
+  stopifnot(identical(sep$n, c("1", "2")))
+  back <- unite(sep, "x", l, n, sep = "-")
+  stopifnot(identical(back$x, c("a-1", "b-2")))
+})
+
+run_test("nest/unnest roundtrip", function() {
+  df <- data.frame(g = c("a", "a", "b"), v = 1:3)
+  n <- nest(df, data = c(v))
+  stopifnot(identical(nrow(n), 2L))
+  stopifnot(identical(n$g, c("a", "b")))
+  stopifnot(identical(n$data[[1]]$v, 1:2))
+  stopifnot(identical(n$data[[2]]$v, 3L))
+  un <- unnest(n, cols = data)
+  stopifnot(identical(un$g, c("a", "a", "b")))
+  stopifnot(identical(un$v, 1:3))
+})
+
+run_test("fill in both directions", function() {
+  df <- data.frame(x = c(1, NA, NA, 2))
+  stopifnot(identical(fill(df, x)$x, c(1, 1, 1, 2)))
+  stopifnot(identical(fill(df, x, .direction = "up")$x, c(1, 2, 2, 2)))
+})
+
+run_test("complete adds missing combinations", function() {
+  df <- data.frame(g = c("a", "a", "b"), t = c(1, 2, 1), v = c(10, 20, 30))
+  out <- complete(df, g, t)
+  stopifnot(identical(nrow(out), 4L))
+  stopifnot(identical(out$g, c("a", "a", "b", "b")))
+  stopifnot(identical(out$t, c(1, 2, 1, 2)))
+  stopifnot(identical(out$v, c(10, 20, 30, NA)))
+})
+
+run_test("drop_na", function() {
+  df <- data.frame(x = c(1, NA, 3), y = c("a", "b", NA))
+  all_complete <- drop_na(df)
+  stopifnot(identical(nrow(all_complete), 1L))
+  stopifnot(identical(all_complete$x, 1), identical(all_complete$y, "a"))
+  x_only <- drop_na(df, x)
+  stopifnot(identical(x_only$x, c(1, 3)))
+  stopifnot(identical(x_only$y, c("a", NA)))
+})
+
+run_test("expand_grid", function() {
+  grid <- expand_grid(x = 1:2, y = c("a", "b"))
+  stopifnot(identical(nrow(grid), 4L))
+  stopifnot(identical(grid$x, c(1L, 1L, 2L, 2L)))
+  stopifnot(identical(grid$y, c("a", "b", "a", "b")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all tidyr smoke tests passed\n")

--- a/cli/scripts/lib-validator/timeROC.R
+++ b/cli/scripts/lib-validator/timeROC.R
@@ -1,0 +1,107 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `timeROC` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond timeROC
+# itself. Data is simulated with a fixed seed (right-censored survival times
+# whose hazard rises with a continuous marker). Exercises the core
+# time-dependent ROC / AUC API and exits 0 only if every check passes, so it can
+# be used as a pass/fail library validator:
+#
+#   Rscript timeROC.R
+#
+# NOTE (needs re-check once installed): the "ipcwsurvivalROC" class name and the
+# `$AUC` / `$times` accessors were written from the documented API and NOT
+# verified against an installed build -- re-confirm when the package is
+# available. AUC estimates are floating point (and early/late time points can be
+# NA when at risk-set thins), so checks assert structural/robust properties
+# (class, length matching `times`, finite AUCs in [0, 1], discrimination above
+# chance) -- never exact equality.
+
+if (!requireNamespace("timeROC", quietly = TRUE)) {
+  cat("FAIL: package 'timeROC' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(timeROC))
+cat(sprintf("timeROC version: %s\n", as.character(packageVersion("timeROC"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared simulated survival dataset: higher marker -> higher hazard -> shorter
+# time, so the marker is genuinely prognostic and time-dependent AUC > 0.5.
+make_data <- function() {
+  set.seed(1)
+  n <- 400L
+  marker <- rnorm(n)
+  event_time <- rexp(n, rate = 0.1 * exp(0.8 * marker))
+  cens_time <- rexp(n, rate = 0.05)
+  time <- pmin(event_time, cens_time)
+  status <- as.integer(event_time <= cens_time)
+  list(time = time, status = status, marker = marker)
+}
+
+run_test("timeROC returns the expected object", function() {
+  d <- make_data()
+  t_eval <- as.numeric(quantile(d$time[d$status == 1L], probs = c(0.4, 0.6)))
+  tr <- timeROC(T = d$time, delta = d$status, marker = d$marker,
+                cause = 1, times = t_eval, iid = FALSE)
+  stopifnot(inherits(tr, "ipcwsurvivalROC"))
+})
+
+run_test("AUC has one entry per requested time", function() {
+  d <- make_data()
+  t_eval <- as.numeric(quantile(d$time[d$status == 1L], probs = c(0.4, 0.6)))
+  tr <- timeROC(T = d$time, delta = d$status, marker = d$marker,
+                cause = 1, times = t_eval, iid = FALSE)
+  stopifnot(length(tr$AUC) == length(t_eval))
+})
+
+run_test("AUC values are valid probabilities", function() {
+  d <- make_data()
+  t_eval <- as.numeric(quantile(d$time[d$status == 1L], probs = c(0.4, 0.6)))
+  tr <- timeROC(T = d$time, delta = d$status, marker = d$marker,
+                cause = 1, times = t_eval, iid = FALSE)
+  auc <- tr$AUC[is.finite(tr$AUC)]
+  # at least one time point yields a usable AUC, all within [0, 1]
+  stopifnot(length(auc) >= 1L)
+  stopifnot(all(auc >= 0), all(auc <= 1))
+})
+
+run_test("prognostic marker discriminates above chance", function() {
+  d <- make_data()
+  t_eval <- as.numeric(quantile(d$time[d$status == 1L], probs = c(0.4, 0.6)))
+  tr <- timeROC(T = d$time, delta = d$status, marker = d$marker,
+                cause = 1, times = t_eval, iid = FALSE)
+  auc <- tr$AUC[is.finite(tr$AUC)]
+  # a truly prognostic marker beats a coin flip -- generous margin above 0.5
+  stopifnot(all(auc > 0.55))
+})
+
+run_test("single time point is handled", function() {
+  d <- make_data()
+  med <- as.numeric(median(d$time[d$status == 1L]))
+  tr <- timeROC(T = d$time, delta = d$status, marker = d$marker,
+                cause = 1, times = med, iid = FALSE)
+  stopifnot(inherits(tr, "ipcwsurvivalROC"))
+  # the evaluation time is echoed back on the fitted object
+  stopifnot(any(is.finite(tr$times)))
+  stopifnot(length(tr$AUC) == length(tr$times))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all timeROC smoke tests passed\n")

--- a/cli/scripts/lib-validator/umap-learn.py
+++ b/cli/scripts/lib-validator/umap-learn.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `umap-learn` package (import name: umap).
+
+Fully self-contained: no input files, no network, no packages beyond umap-learn
+(and its implied deps — numpy, scikit-learn, numba). Exercises the core API
+surface and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 umap-learn.py
+
+Install: pip install umap-learn   (import name: umap)
+
+FLAG — numba dependency + slow. umap-learn JIT-compiles with numba on first use,
+so even this tiny fit is comparatively slow (seconds, not milliseconds). The fit
+is seeded (`random_state=0`) for determinism.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import umap
+except ImportError:
+    print("FAIL: package 'umap-learn' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"umap-learn version: {_version(umap, 'umap-learn')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_blobs():
+    """Three seeded Gaussian blobs in 10-D — 150 points, well separated."""
+    rng = np.random.default_rng(0)
+    centers = np.array([[0.0] * 10, [8.0] * 10, [-8.0] * 10])
+    X = np.vstack([c + rng.normal(scale=0.5, size=(50, 10)) for c in centers])
+    return X
+
+
+def test_umap_embedding_shape():
+    # FLAG: numba-compiled + slow. Seeded for a deterministic embedding.
+    X = _make_blobs()
+    reducer = umap.UMAP(n_neighbors=10, n_components=2, random_state=0)
+    emb = reducer.fit_transform(X)
+    assert emb.shape == (150, 2)
+    assert np.isfinite(emb).all()
+
+
+run_test("UMAP fit_transform 2D embedding (numba, slow)", test_umap_embedding_shape)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all umap-learn smoke tests passed")

--- a/cli/scripts/lib-validator/upsetplot.py
+++ b/cli/scripts/lib-validator/upsetplot.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `upsetplot` package.
+
+Fully self-contained: no input files, no network, no packages beyond upsetplot
+(and its implied deps — pandas, matplotlib). Forces the headless Agg backend
+before any pyplot import, so it never opens a window; figures are built in
+memory and discarded. Exercises the membership-reshaping helpers and the UpSet
+plotter and exits 0 only if every check passes, so it can be used as a
+pass/fail library validator:
+
+    python3 upsetplot.py
+
+Install: pip install upsetplot   (import name: upsetplot)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+# Force the non-interactive Agg backend BEFORE importing pyplot: UpSet.plot()
+# creates a figure, and this test runs headless and must never pop a window.
+import matplotlib
+
+matplotlib.use("Agg")
+
+try:
+    import upsetplot
+except ImportError:
+    print("FAIL: package 'upsetplot' is not installed")
+    sys.exit(1)
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from matplotlib.axes import Axes
+from upsetplot import UpSet, from_contents, from_memberships
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"upsetplot version: {_version(upsetplot, 'upsetplot')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _membership_series():
+    """A Series indexed by a boolean (cat1, cat2) MultiIndex, counts as values."""
+    return from_memberships(
+        [[], ["cat1"], ["cat2"], ["cat1", "cat2"]],
+        data=[10, 20, 30, 40],
+    )
+
+
+def test_from_memberships_multiindex_and_counts():
+    data = _membership_series()
+    assert isinstance(data, pd.Series)
+    assert isinstance(data.index, pd.MultiIndex)
+    assert set(data.index.names) == {"cat1", "cat2"}
+    assert int(data.sum()) == 100
+    # The (cat1=True, cat2=True) combination carries the value we supplied.
+    assert int(data.loc[(True, True)]) == 40
+    # The empty membership (neither category) carries its value too.
+    assert int(data.loc[(False, False)]) == 10
+
+
+def test_from_contents_dataframe():
+    df = from_contents({"A": ["x", "y", "z"], "B": ["y", "z", "w"]})
+    assert isinstance(df, pd.DataFrame)
+    assert isinstance(df.index, pd.MultiIndex)
+    assert set(df.index.names) == {"A", "B"}
+    # Four distinct elements across the two contents: x, y, z, w.
+    assert len(df) == 4
+    assert "id" in df.columns
+
+
+def test_upset_constructs():
+    us = UpSet(_membership_series())
+    assert us is not None
+
+
+def test_plot_returns_axes_dict():
+    fig = plt.figure()
+    try:
+        axes = UpSet(_membership_series()).plot(fig=fig)
+        assert isinstance(axes, dict)
+        # The matrix subplot is always part of an UpSet rendering.
+        assert "matrix" in axes
+        assert all(isinstance(ax, Axes) for ax in axes.values())
+    finally:
+        plt.close("all")
+
+
+run_test("from_memberships MultiIndex and counts", test_from_memberships_multiindex_and_counts)
+run_test("from_contents DataFrame", test_from_contents_dataframe)
+run_test("UpSet constructs", test_upset_constructs)
+run_test("plot returns Axes dict", test_plot_returns_axes_dict)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all upsetplot smoke tests passed")

--- a/cli/scripts/lib-validator/variancePartition.R
+++ b/cli/scripts/lib-validator/variancePartition.R
@@ -1,0 +1,105 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `variancePartition` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# variancePartition itself (and the dependencies it implies, e.g. lme4 /
+# BiocParallel). All data is simulated with a fixed seed; variance-fraction
+# checks are structural / tolerance-based, never exact floating-point
+# equality. Exercises the core API surface and exits 0 only if every check
+# passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript variancePartition.R
+
+if (!requireNamespace("variancePartition", quietly = TRUE)) {
+  cat("FAIL: package 'variancePartition' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(variancePartition))
+cat(sprintf(
+  "variancePartition version: %s\n",
+  as.character(packageVersion("variancePartition"))
+))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Simulate 50 genes across 40 samples drawn from 10 individuals (4 repeats
+# each) plus a continuous `age` covariate. A strong per-individual random
+# intercept (sd 2) dominates variance; the first 25 genes also carry an age
+# effect. Noise is N(0, 1). This gives the mixed model a clear, recoverable
+# variance decomposition over the terms (1|individual) and age.
+set.seed(1)
+n_ind <- 10L
+n_rep <- 4L
+n_samples <- n_ind * n_rep
+n_genes <- 50L
+individual <- factor(rep(sprintf("ind%02d", seq_len(n_ind)), each = n_rep))
+age <- rnorm(n_samples, mean = 50, sd = 10)
+metadata <- data.frame(individual = individual, age = age)
+
+ind_effect <- matrix(rnorm(n_genes * n_ind, sd = 2), nrow = n_genes, ncol = n_ind)
+expr <- matrix(rnorm(n_genes * n_samples, sd = 1), nrow = n_genes, ncol = n_samples)
+expr <- expr + ind_effect[, as.integer(individual)]
+age_z <- scale(age)[, 1]
+expr[1:25, ] <- expr[1:25, ] +
+  matrix(1.5 * age_z, nrow = 25L, ncol = n_samples, byrow = TRUE)
+rownames(expr) <- sprintf("gene%03d", seq_len(n_genes))
+colnames(expr) <- sprintf("s%02d", seq_len(n_samples))
+
+# Random effect for the categorical individual, fixed effect for age.
+# TODO(robustness): fitExtractVarPartModel() signature + the BPPARAM arg are
+# written against the current variancePartition API from memory -- re-check
+# the formula/BPPARAM contract once the package is installed.
+form <- ~ (1 | individual) + age
+
+# suppressMessages/suppressWarnings silence per-gene fitting chatter and
+# benign lme4 convergence notes; SerialParam keeps the run single-threaded
+# and deterministic. Genuine errors still propagate to run_test.
+fit_vp <- function() {
+  suppressMessages(suppressWarnings(
+    fitExtractVarPartModel(expr, form, metadata, BPPARAM = BiocParallel::SerialParam())
+  ))
+}
+
+run_test("fitExtractVarPartModel: object shape and term columns", function() {
+  vp <- fit_vp()
+  df <- as.data.frame(vp)
+  stopifnot(nrow(df) == n_genes)
+  # One column per model term plus a Residuals column.
+  stopifnot(all(c("individual", "age", "Residuals") %in% colnames(df)))
+})
+
+run_test("variance fractions are valid proportions summing to ~1", function() {
+  vp <- fit_vp()
+  df <- as.data.frame(vp)
+  m <- as.matrix(df[, c("individual", "age", "Residuals")])
+  stopifnot(all(m >= -1e-6 & m <= 1 + 1e-6))
+  row_sums <- rowSums(m)
+  stopifnot(all(abs(row_sums - 1) < 1e-6))
+})
+
+run_test("planted individual effect dominates variance", function() {
+  vp <- fit_vp()
+  df <- as.data.frame(vp)
+  # The strong per-individual random intercept should explain a large median
+  # share of the variance (aggregate/tolerance, not per-gene exact).
+  stopifnot(median(df[["individual"]]) > 0.4)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all variancePartition smoke tests passed\n")

--- a/cli/scripts/lib-validator/vegan.R
+++ b/cli/scripts/lib-validator/vegan.R
@@ -1,0 +1,93 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `vegan` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# vegan and its implied deps (permute, lattice). Community data is a small
+# sites x species count matrix, either fixed-seed random or a hand-built
+# matrix with known structure. Exercises the core community-ecology API and
+# exits 0 only if every check passes, so it can be used as a pass/fail library
+# validator:
+#
+#   Rscript vegan.R
+#
+# Diversity/distance outputs are floating-point (checked with tolerance and
+# range assertions); species counts are integers (checked exactly).
+
+if (!requireNamespace("vegan", quietly = TRUE)) {
+  cat("FAIL: package 'vegan' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(vegan))
+cat(sprintf("vegan version: %s\n", as.character(packageVersion("vegan"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+# Shared fixture: 6 sites x 5 species of Poisson counts. lambda 5 keeps every
+# cell overwhelmingly likely to be > 0, so every row has positive total.
+set.seed(42)
+n_sites <- 6L
+n_species <- 5L
+comm <- matrix(rpois(n_sites * n_species, lambda = 5),
+               nrow = n_sites, ncol = n_species)
+
+run_test("shannon diversity is non-negative, one value per site", function() {
+  h <- vegan::diversity(comm, index = "shannon")
+  stopifnot(length(h) == n_sites)
+  stopifnot(all(is.finite(h)), all(h >= 0))
+})
+
+run_test("simpson diversity stays within [0, 1]", function() {
+  d <- vegan::diversity(comm, index = "simpson")
+  stopifnot(length(d) == n_sites)
+  stopifnot(all(d >= 0), all(d <= 1))
+})
+
+run_test("bray-curtis vegdist is a valid dissimilarity matrix", function() {
+  bc <- vegan::vegdist(comm, method = "bray")
+  stopifnot(inherits(bc, "dist"))
+  # a dist over n objects holds choose(n, 2) pairwise values
+  stopifnot(length(bc) == choose(n_sites, 2))
+  stopifnot(attr(bc, "Size") == n_sites)
+  v <- as.numeric(bc)
+  stopifnot(all(is.finite(v)), all(v >= 0), all(v <= 1))
+})
+
+run_test("specnumber counts nonzero species exactly", function() {
+  # hand-built matrix with a known number of nonzero species per row
+  m <- matrix(c(1, 0, 2,
+                0, 0, 3,
+                4, 5, 6),
+              nrow = 3, ncol = 3, byrow = TRUE)
+  sn <- vegan::specnumber(m)
+  stopifnot(length(sn) == 3L)
+  stopifnot(identical(unname(as.numeric(sn)), c(2, 1, 3)))
+})
+
+run_test("rarefy expected richness never exceeds observed", function() {
+  # rarefy to the smallest site total so every site can be subsampled
+  sample_size <- min(rowSums(comm))
+  er <- vegan::rarefy(comm, sample = sample_size)
+  stopifnot(length(er) == n_sites)
+  stopifnot(all(is.finite(er)), all(er >= 0))
+  # expected rarefied richness <= observed richness (small tolerance)
+  stopifnot(all(er <= vegan::specnumber(comm) + 1e-9))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all vegan smoke tests passed\n")

--- a/cli/scripts/lib-validator/weasyprint.py
+++ b/cli/scripts/lib-validator/weasyprint.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `weasyprint` package.
+
+Fully self-contained: no input files, no network, no packages beyond weasyprint
+(and its implied deps). Exercises the core API surface and exits 0 only if every
+check passes, so it can be used as a pass/fail library validator:
+
+    python3 weasyprint.py
+
+Install: pip install weasyprint   (import name: weasyprint)
+
+NOTE — native library dependency: weasyprint renders through Pango, Cairo and
+gdk-pixbuf, which are SYSTEM libraries (not pip-installable). Even with the
+Python package present, `import weasyprint` raises OSError at import time if the
+shared libs are missing (`brew install pango`, or the distro's libpango/cairo/
+gdk-pixbuf packages). A green run here therefore also attests the native stack.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import weasyprint
+except ImportError:
+    print("FAIL: package 'weasyprint' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"weasyprint version: {_version(weasyprint, 'weasyprint')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_html_string_renders_pdf_bytes():
+    pdf = weasyprint.HTML(string="<h1>Hi</h1>").write_pdf()
+    assert isinstance(pdf, (bytes, bytearray))
+    # Every PDF file begins with the "%PDF" magic header.
+    assert bytes(pdf[:4]) == b"%PDF"
+    assert len(pdf) > 0
+
+
+def test_richer_document_still_produces_pdf():
+    html = "<html><body><h1>Title</h1><p>A paragraph.</p><ul><li>a</li><li>b</li></ul></body></html>"
+    pdf = weasyprint.HTML(string=html).write_pdf()
+    assert bytes(pdf[:4]) == b"%PDF"
+    # A real PDF ends with the end-of-file marker.
+    assert b"%%EOF" in bytes(pdf[-1024:])
+
+
+run_test("HTML string -> PDF bytes", test_html_string_renders_pdf_bytes)
+run_test("richer document -> PDF", test_richer_document_still_produces_pdf)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all weasyprint smoke tests passed")

--- a/cli/scripts/lib-validator/xCell2.R
+++ b/cli/scripts/lib-validator/xCell2.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `xCell2` package (cell-type enrichment / deconvolution;
+# the successor to xCell).
+#
+# Install: remotes::install_github("AlmogAngel/xCell2")
+#
+# Fully self-contained: no input files, no network, no packages beyond xCell2
+# itself. This test is DELIBERATELY MODEST. xCell2's core analysis entry point,
+# xCell2Analysis(mix, xcell2object = ...), requires a TRAINED reference object
+# produced by xCell2Train() over a real reference expression matrix with
+# realistic gene symbols and a matching cell-type label table -- none of which
+# can be constructed cheaply offline. So this script only verifies that the
+# package LOADS and that its core API surface is exported and callable
+# (is.function on the analysis + train entry points, plus a non-empty formals
+# sanity check). It never runs an actual enrichment. Exits 0 only if every
+# check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript xCell2.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# HEAVILY UNVERIFIABLE WITHOUT AN INSTALL -- confirm all of the following once
+# xCell2 is available. This test intentionally does NOT exercise them:
+#   - THE ANALYSIS PATH IS NOT TESTED. xCell2Analysis() needs a trained
+#     `xcell2object` (built by xCell2Train) AND a mixture expression matrix whose
+#     rownames are realistic human gene SYMBOLS overlapping the reference's
+#     signature genes. Random/synthetic symbols will not enrich, and training a
+#     reference offline requires a bundled reference dataset. Both are out of
+#     scope here -- re-run a real xCell2Train() -> xCell2Analysis() end-to-end
+#     once installed.
+#   - FUNCTION NAMES / EXPORTS. Assumes the exported API is `xCell2Analysis`
+#     (the analysis entry point) and `xCell2Train` (the reference builder). If
+#     the package renames or splits these, the is.function guards below fail --
+#     re-confirm the exported symbol names against the installed NAMESPACE.
+#   - ARG NAMES (NOT ASSERTED HERE). The documented arg spelling is
+#     xCell2Analysis(mix, xcell2object = ...) and xCell2Train(ref, labels, ...);
+#     this script only checks that formals() is non-empty, NOT the exact names,
+#     because they are version-dependent. Re-verify the argument names.
+#   - ADDITIONAL EXPORTS. xCell2 may export further helpers (e.g. a lineage
+#     resolver such as xCell2GetLineage); these are NOT asserted here to avoid
+#     false failures, but are worth exercising once installed.
+# ============================================================================
+
+if (!requireNamespace("xCell2", quietly = TRUE)) {
+  cat("FAIL: package 'xCell2' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(xCell2))
+cat(sprintf("xCell2 version: %s\n", as.character(packageVersion("xCell2"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("xCell2Analysis is an exported function", function() {
+  stopifnot(exists("xCell2Analysis"))
+  stopifnot(is.function(xCell2Analysis))
+})
+
+run_test("xCell2Train (reference builder) is an exported function", function() {
+  stopifnot(exists("xCell2Train"))
+  stopifnot(is.function(xCell2Train))
+})
+
+run_test("core functions accept arguments (non-empty formals)", function() {
+  # Only a shape check -- the exact arg NAMES are version-dependent and are
+  # deliberately not asserted here (see the ASSUMPTIONS block above). Any real
+  # analysis/train function takes at least one argument.
+  stopifnot(length(formals(args(xCell2Analysis))) >= 1L)
+  stopifnot(length(formals(args(xCell2Train))) >= 1L)
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all xCell2 smoke tests passed\n")

--- a/cli/scripts/lib-validator/xarray.py
+++ b/cli/scripts/lib-validator/xarray.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `xarray` package.
+
+Fully self-contained: no input files, no network, no packages beyond xarray
+(and its implied deps, notably numpy). Exercises the core labelled-array API
+and exits 0 only if every check passes, so it can be used as a pass/fail
+library validator:
+
+    python3 xarray.py
+
+Install: pip install xarray   (import name: xarray)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import xarray
+except ImportError:
+    print("FAIL: package 'xarray' is not installed")
+    sys.exit(1)
+
+# numpy is a hard dependency of xarray, so it is importable whenever xarray is.
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"xarray version: {_version(xarray, 'xarray')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_dataarray_construct_dims_shape():
+    da = xarray.DataArray(
+        np.arange(12).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": [10, 20, 30], "y": [0, 1, 2, 3]},
+    )
+    assert da.dims == ("x", "y")
+    assert da.shape == (3, 4)
+    assert da.sizes["x"] == 3
+    assert da.sizes["y"] == 4
+    assert list(da.coords["x"].values) == [10, 20, 30]
+
+
+def test_label_and_positional_selection():
+    da = xarray.DataArray(
+        np.arange(12).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": [10, 20, 30], "y": [0, 1, 2, 3]},
+    )
+    # .sel is label-based: x == 20 is the middle row; .isel is positional and
+    # should land on the same row.
+    by_label = da.sel(x=20)
+    by_index = da.isel(x=1)
+    assert np.array_equal(by_label.values, np.array([4, 5, 6, 7]))
+    assert np.array_equal(by_index.values, np.array([4, 5, 6, 7]))
+    assert int(da.sel(x=30, y=3)) == 11
+
+
+def test_reduction_mean_over_dim():
+    da = xarray.DataArray(
+        np.arange(12).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": [10, 20, 30], "y": [0, 1, 2, 3]},
+    )
+    m = da.mean(dim="x")
+    assert m.dims == ("y",)
+    # Column means of [[0..3],[4..7],[8..11]] are [4, 5, 6, 7].
+    assert np.allclose(m.values, np.array([4.0, 5.0, 6.0, 7.0]))
+
+
+def test_dataset_variable_access():
+    da = xarray.DataArray(
+        np.arange(12).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": [10, 20, 30], "y": [0, 1, 2, 3]},
+    )
+    ds = xarray.Dataset({"a": da})
+    assert "a" in ds.data_vars
+    assert ds["a"].shape == (3, 4)
+    assert np.array_equal(ds["a"].values, da.values)
+
+
+def test_to_dict_roundtrip():
+    da = xarray.DataArray(
+        np.arange(12).reshape(3, 4),
+        dims=("x", "y"),
+        coords={"x": [10, 20, 30], "y": [0, 1, 2, 3]},
+    )
+    d = da.to_dict()
+    back = xarray.DataArray.from_dict(d)
+    assert back.dims == da.dims
+    assert np.array_equal(back.values, da.values)
+    assert list(back.coords["x"].values) == list(da.coords["x"].values)
+
+
+run_test("DataArray construct: dims/shape/coords", test_dataarray_construct_dims_shape)
+run_test("label (.sel) and positional (.isel) selection", test_label_and_positional_selection)
+run_test("mean reduction over a dim", test_reduction_mean_over_dim)
+run_test("Dataset variable access", test_dataset_variable_access)
+run_test("to_dict/from_dict roundtrip", test_to_dict_roundtrip)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all xarray smoke tests passed")

--- a/cli/scripts/lib-validator/xcms.R
+++ b/cli/scripts/lib-validator/xcms.R
@@ -1,0 +1,76 @@
+#!/usr/bin/env Rscript
+# Smoke test for the Bioconductor `xcms` package.
+#
+# Fully self-contained: no input files, NO network, no packages beyond xcms
+# itself. xcms's real work -- LC-MS chromatographic peak detection -- needs raw
+# mzML/CDF data (shipped via the faahKO / msdata companion packages, which are
+# NOT assumed installed here), so this validator is deliberately MODEST: it
+# confirms the package loads, its core detection functions and result classes
+# exist, and the fully offline-constructible CentWaveParam builds and reports
+# its parameters. Exits 0 only if every check passes:
+#
+#   Rscript xcms.R
+#
+# ============================ ASSUMPTIONS TO RE-CHECK ========================
+# xcms is NOT installed in this environment, so the bodies below are written
+# correct-by-review and could NOT be executed. Re-confirm once a build exists:
+#   - FLAG: the end-to-end LC-MS workflow (findChromPeaks on a real file, peak
+#     grouping, retention-time alignment) is OUT OF SCOPE offline -- it requires
+#     raw spectra. Only function/class existence + parameter-object shape here.
+#   - CentWaveParam(ppm=, peakwidth=) constructs offline and its ppm()/peakwidth()
+#     accessors report the supplied values (this is a genuine offline check).
+#   - Result container: newer xcms uses XcmsExperiment, legacy uses XCMSnExp;
+#     we accept EITHER being defined. xcmsSet is the legacy S4 entry point.
+# ============================================================================
+
+if (!requireNamespace("xcms", quietly = TRUE)) {
+  cat("FAIL: package 'xcms' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(xcms))
+cat(sprintf("xcms version: %s\n", as.character(packageVersion("xcms"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("core peak-detection functions exist", function() {
+  stopifnot(is.function(findChromPeaks))
+  # Legacy S4 entry point, still exported for backwards compatibility.
+  stopifnot(is.function(xcmsSet))
+})
+
+run_test("a result container class is defined", function() {
+  # Newer xcms uses XcmsExperiment; XCMSnExp is the legacy on-disk container.
+  # Depending on the installed version, at least one must be defined.
+  defined <- vapply(
+    c("XCMSnExp", "XcmsExperiment"),
+    function(cl) !is.null(methods::getClassDef(cl)),
+    logical(1)
+  )
+  stopifnot(any(defined))
+})
+
+run_test("CentWaveParam constructs offline and reports its parameters", function() {
+  p <- CentWaveParam(ppm = 25, peakwidth = c(20, 50))
+  stopifnot(inherits(p, "CentWaveParam"))
+  stopifnot(ppm(p) == 25)
+  stopifnot(identical(peakwidth(p), c(20, 50)))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all xcms smoke tests passed\n")

--- a/cli/scripts/lib-validator/xgboost.py
+++ b/cli/scripts/lib-validator/xgboost.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `xgboost` package.
+
+Fully self-contained: no input files, no network, no packages beyond xgboost
+and its implied deps (numpy, scipy). Data is simulated in-memory. The native
+`xgb.train` / Booster API is used rather than the `XGBClassifier` scikit-learn
+wrapper, so this validator does not pull in scikit-learn.
+
+RUNTIME NOTE: the xgboost wheel links against OpenMP; on macOS `import xgboost`
+fails at load time unless libomp is present (`brew install libomp`). That shows
+up here as the not-installed guard firing (ImportError) even when the wheel is
+present — a missing libomp is reported the same as a missing package.
+
+    python3 xgboost.py
+
+Install: pip install xgboost   (import name: xgboost; macOS also needs libomp)
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import xgboost as xgb
+except ImportError:
+    print("FAIL: package 'xgboost' is not installed")
+    sys.exit(1)
+
+import numpy as np
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"xgboost version: {_version(xgb, 'xgboost')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def _make_binary(rng, n=400, d=6):
+    """Two offset Gaussian clusters → an easily-separable binary problem."""
+    half = n // 2
+    X0 = rng.normal(-1.0, 1.0, size=(half, d))
+    X1 = rng.normal(1.0, 1.0, size=(half, d))
+    X = np.vstack([X0, X1])
+    y = np.concatenate([np.zeros(half, dtype=int), np.ones(half, dtype=int)])
+    return X, y
+
+
+def test_dmatrix_shapes():
+    rng = np.random.default_rng(0)
+    X, y = _make_binary(rng)
+    d = xgb.DMatrix(X, label=y)
+    assert d.num_row() == X.shape[0]
+    assert d.num_col() == X.shape[1]
+
+
+def test_train_predict_accuracy():
+    rng = np.random.default_rng(1)
+    X, y = _make_binary(rng)
+    dtrain = xgb.DMatrix(X, label=y)
+    params = {
+        "objective": "binary:logistic",
+        "max_depth": 3,
+        "eta": 0.3,
+        "seed": 0,
+        "verbosity": 0,
+    }
+    booster = xgb.train(params, dtrain, num_boost_round=20)
+    proba = booster.predict(dtrain)
+    assert proba.shape == (X.shape[0],)
+    assert np.all((proba >= 0.0) & (proba <= 1.0))
+    preds = (proba > 0.5).astype(int)
+    # A planted, separable signal must be fit well above chance on train data.
+    assert float((preds == y).mean()) > 0.8
+
+
+def test_feature_importances():
+    rng = np.random.default_rng(2)
+    X, y = _make_binary(rng)
+    dtrain = xgb.DMatrix(X, label=y)
+    booster = xgb.train(
+        {"objective": "binary:logistic", "max_depth": 3, "seed": 0, "verbosity": 0},
+        dtrain,
+        num_boost_round=20,
+    )
+    # get_score reports importance only for features used in a split.
+    scores = booster.get_score(importance_type="weight")
+    assert isinstance(scores, dict)
+    assert 0 < len(scores) <= X.shape[1]
+    assert all(v > 0.0 for v in scores.values())
+
+
+run_test("DMatrix shapes", test_dmatrix_shapes)
+run_test("train + predict accuracy", test_train_predict_accuracy)
+run_test("feature importances", test_feature_importances)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all xgboost smoke tests passed")

--- a/cli/scripts/lib-validator/yaml.R
+++ b/cli/scripts/lib-validator/yaml.R
@@ -1,0 +1,80 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `yaml` package.
+#
+# Fully self-contained: no input files, no network, no packages beyond
+# yaml itself. Exercises the core API surface and exits 0 only if
+# every check passes, so it can be used as a pass/fail library validator:
+#
+#   Rscript yaml.R
+
+if (!requireNamespace("yaml", quietly = TRUE)) {
+  cat("FAIL: package 'yaml' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(yaml))
+cat(sprintf("yaml version: %s\n", as.character(packageVersion("yaml"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("as.yaml/yaml.load roundtrip of a named list", function() {
+  x <- list(
+    name = "smoke",
+    count = 3L,
+    ratio = 1.5,
+    enabled = TRUE,
+    tags = c("a", "b")
+  )
+  back <- yaml.load(as.yaml(x))
+  stopifnot(identical(back, x))
+})
+
+run_test("yaml.load literal multi-line document", function() {
+  doc <- "server:\n  host: localhost\n  port: 8080\n  debug: true\nfeatures:\n  - alpha\n  - beta\n"
+  x <- yaml.load(doc)
+  stopifnot(identical(names(x), c("server", "features")))
+  stopifnot(identical(x$server, list(host = "localhost", port = 8080L, debug = TRUE)))
+  stopifnot(identical(x$features, c("alpha", "beta")))
+})
+
+run_test("sequences: uniform -> vector, mixed -> list", function() {
+  stopifnot(identical(yaml.load("[1, 2, 3]"), c(1L, 2L, 3L)))
+  stopifnot(identical(yaml.load("[a, b]"), c("a", "b")))
+  stopifnot(identical(yaml.load("[1, two, true]"), list(1L, "two", TRUE)))
+})
+
+run_test("scalar types parse to correct R types", function() {
+  stopifnot(identical(yaml.load("42"), 42L))
+  stopifnot(identical(yaml.load("3.5"), 3.5))
+  stopifnot(identical(yaml.load("true"), TRUE))
+  stopifnot(identical(yaml.load("no"), FALSE))
+  stopifnot(identical(yaml.load("hello"), "hello"))
+  stopifnot(is.null(yaml.load("~")))
+})
+
+run_test("custom type handlers", function() {
+  # handlers receive the RAW scalar string, not a parsed value: convert explicitly
+  x <- yaml.load("count: 5", handlers = list(int = function(v) as.integer(v) + 1L))
+  stopifnot(identical(x, list(count = 6L)))
+  # the str handler is applied to map KEYS too, not just values
+  y <- yaml.load("word: hi", handlers = list(str = function(v) toupper(v)))
+  stopifnot(identical(y, list(WORD = "HI")))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all yaml smoke tests passed\n")

--- a/cli/scripts/lib-validator/zarr.py
+++ b/cli/scripts/lib-validator/zarr.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke test for the Python `zarr` package.
+
+Fully self-contained: no input files, no network, no packages beyond zarr
+(and its implied deps: numpy). Exercises the core API surface and exits 0 only
+if every check passes, so it can be used as a pass/fail library validator:
+
+    python3 zarr.py
+
+Install: pip install zarr   (import name: zarr)
+
+Targets the installed zarr v3 API (zarr.zeros/zarr.array return in-memory
+arrays by default; slicing reads/writes chunks). zarr v2 differs — e.g. store
+plumbing and some kwargs — so this asserts against the v3 surface that ships
+here.
+
+This is the Python counterpart of data.table.R — same contract: a hard
+not-installed guard (exit 1), a per-test harness that isolates failures, and a
+PASS/exit-0 vs FAIL/exit-1 summary.
+"""
+import os
+import sys
+
+# This file is named after the package it tests, so it sits next to (and would
+# shadow) the real top-level module. Drop this script's own directory from the
+# import path before importing the package under test.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path = [p for p in sys.path if p not in ("", ".") and os.path.abspath(p) != _here]
+
+try:
+    import zarr
+except ImportError:
+    print("FAIL: package 'zarr' is not installed")
+    sys.exit(1)
+
+
+def _version(mod, dist):
+    """Best-effort version string: module.__version__, else installed metadata."""
+    v = getattr(mod, "__version__", None)
+    if v:
+        return v
+    try:
+        import importlib.metadata as m
+
+        return m.version(dist)
+    except Exception:
+        return "unknown"
+
+
+print(f"zarr version: {_version(zarr, 'zarr')}")
+
+failures = 0
+
+
+def run_test(name, fn):
+    """Run one check; a raised exception is a failure, not a crash."""
+    global failures
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - any failure is a test failure
+        failures += 1
+        print(f"  FAIL {name}: {e}")
+    else:
+        print(f"  ok   {name}")
+
+
+def test_zeros_shape_chunks_and_slice_write():
+    import numpy as np
+
+    z = zarr.zeros(shape=(10, 10), chunks=(5, 5), dtype="int32")
+    assert z.shape == (10, 10)
+    assert z.chunks == (5, 5)
+    assert int(z[0, 0]) == 0
+    z[0:5, 0:5] = 7
+    assert int(z[0, 0]) == 7
+    assert int(z[4, 4]) == 7
+    assert int(z[5, 5]) == 0
+    # 25 cells set to 7, the rest still zero.
+    assert int(np.asarray(z[:]).sum()) == 7 * 25
+
+
+def test_array_from_numpy_roundtrip():
+    import numpy as np
+
+    source = np.arange(12, dtype="int64").reshape(3, 4)
+    z = zarr.array(source, chunks=(3, 2))
+    assert z.shape == (3, 4)
+    assert z.chunks == (3, 2)
+    assert int(z[2, 3]) == 11
+    assert np.array_equal(np.asarray(z[:]), source)
+
+
+def test_slice_read_back():
+    import numpy as np
+
+    z = zarr.zeros(shape=(6,), chunks=(3,), dtype="float64")
+    z[1:4] = np.array([1.5, 2.5, 3.5])
+    assert np.allclose(np.asarray(z[1:4]), [1.5, 2.5, 3.5])
+    assert float(z[0]) == 0.0
+    assert float(z[5]) == 0.0
+
+
+run_test("zeros shape/chunks + slice write", test_zeros_shape_chunks_and_slice_write)
+run_test("array from numpy roundtrip", test_array_from_numpy_roundtrip)
+run_test("slice read-back", test_slice_read_back)
+
+if failures > 0:
+    print(f"FAIL: {failures} test(s) failed")
+    sys.exit(1)
+print("PASS: all zarr smoke tests passed")

--- a/cli/scripts/lib-validator/zellkonverter.R
+++ b/cli/scripts/lib-validator/zellkonverter.R
@@ -1,0 +1,64 @@
+#!/usr/bin/env Rscript
+# Smoke test for the R `zellkonverter` package.
+#
+# Fully self-contained: no input files, no network. Exercises ONLY the package's
+# exported surface -- that the four conversion entry points load as functions --
+# and exits 0 only if every check passes, so it can be used as a pass/fail
+# library validator:
+#
+#   Rscript zellkonverter.R
+#
+# ============================ DELIBERATELY MODEST -- READ ====================
+# zellkonverter bridges SingleCellExperiment <-> AnnData (.h5ad) through a
+# PYTHON backend managed by basilisk (a conda/anndata environment). A REAL
+# round-trip (SCE2AnnData -> writeH5AD -> readH5AD -> AnnData2SCE) would
+# provision and launch that Python env on first use -- heavy, and it may hit the
+# network to build the conda environment. An offline validator MUST NOT trigger
+# that, so this test asserts only that the functions EXIST and are callable
+# symbols; it never CALLS them.
+#
+# FLAG (verify separately, on a host with the basilisk env available):
+#   - writeH5AD()/readH5AD() disk round-trip of an .h5ad file.
+#   - SCE2AnnData()/AnnData2SCE() in-memory conversion fidelity.
+# These are NOT exercised here by design (they need the Python/basilisk backend).
+# ============================================================================
+
+if (!requireNamespace("zellkonverter", quietly = TRUE)) {
+  cat("FAIL: package 'zellkonverter' is not installed\n")
+  quit(save = "no", status = 1)
+}
+
+suppressPackageStartupMessages(library(zellkonverter))
+cat(sprintf("zellkonverter version: %s\n", as.character(packageVersion("zellkonverter"))))
+
+failures <- 0L
+run_test <- function(name, fn) {
+  result <- tryCatch({
+    fn()
+    "ok"
+  }, error = function(e) conditionMessage(e))
+  if (identical(result, "ok")) {
+    cat(sprintf("  ok   %s\n", name))
+  } else {
+    failures <<- failures + 1L
+    cat(sprintf("  FAIL %s: %s\n", name, result))
+  }
+}
+
+run_test("in-memory converters SCE2AnnData / AnnData2SCE are exported functions", function() {
+  # Referencing the symbols does NOT start the basilisk Python env; only calling
+  # them would. We assert existence + callability, nothing more.
+  stopifnot(is.function(SCE2AnnData))
+  stopifnot(is.function(AnnData2SCE))
+})
+
+run_test("disk converters writeH5AD / readH5AD are exported functions", function() {
+  stopifnot(is.function(writeH5AD))
+  stopifnot(is.function(readH5AD))
+})
+
+if (failures > 0L) {
+  cat(sprintf("FAIL: %d test(s) failed\n", failures))
+  quit(save = "no", status = 1)
+}
+cat("PASS: all zellkonverter smoke tests passed\n")


### PR DESCRIPTION
Self-contained per-package smoke tests under cli/scripts/lib-validator/, one <package>.R or <package>.py per library, following a common contract: a not-installed guard (prints "FAIL: package '<pkg>' is not installed" and exits 1), an isolated per-test harness, and a PASS/exit-0 vs FAIL/exit-1 summary. Covers CRAN, Bioconductor, and GitHub R packages plus the Python data-science / single-cell / omics stack. Missing packages exercise only the guard; installed ones run real API checks (synthetic data, tolerances).

run_all.py discovers every sibling validator, runs them concurrently with the right interpreter (python3 / Rscript), classifies each outcome (PASS / not-installed / FAIL / ERROR), and prints a grouped report. It exits non-zero only when an installed library is actually broken; absent libraries are skipped.

Also ignore Python __pycache__/ bytecode.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (default no network egress, working-directory-only mounts, resource limits); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
