### PR TITLE
feat(cli): UI polish — absolute record times, sticky run progress, tidier chat & sidebar

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -274,6 +274,10 @@ All colors come from `theme` in `src/tui/theme.ts` — the Tokyo Night palette m
 
 Every non-ASCII glyph the TUI prints comes from `GLYPHS` in `src/lib/design_system.ts`, just as colors go through `theme`. **Never inline a glyph literal in `src/tui/`.** Keys are named by shape (one glyph serves many roles). No emoji or Nerd-Font glyphs — they break the fixed-width gutter. Exempt: ASCII `>`/`<` markers and prose em dashes.
 
+### Time rendering
+
+Match the readout to the record's permanence. Durable, referenced records (detail dialogs for profiles/runs, record listings, the completed-profile rail line) render absolute local timestamps via `toLocaleString()`. Live / ephemeral fixed-width readouts (sidebar session/run ages, elapsed indicators) render compact relative ages via `Date.relativeAge`. Durations render via `Date.formatDuration` — one vocabulary, never a hand-rolled `ms`/`s`/`m` formatter at the call site.
+
 ### Text emphasis
 
 The "Type & emphasis" scale (one typeface, one size; hierarchy by weight, dim, color) is exposed as composable inline **JSX components** in `src/tui/components/emphasis.tsx`. **In `src/tui/`, reach for those components — `<Bold>`, `<Italic>`, `<Underline>`, `<Dim>`, `<Reverse>`, `<Fg role={…}>` — never hand-compose opentui's `t`/`bold`/`dim`/`italic`/`underline`/`reverse`/`fg`/`bg` primitives at the call site.** Each emits an inline span, so they nest inside a `<text>` and sit beside each other freely. `emphasis.tsx` is the ONE place the low-level opentui styling (and the `style={{…}}` span escape hatch it requires) is allowed to live.

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/design.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Eight UI polish items across the chat TUI, all grounded in the current code:
+
+1. The data-profile details dialog renders `started 5m` / `completed 4m` via `relAge` → `Date.relativeAge` (`src/tui/hooks/sidebar_live.ts:88-90`, `src/extensions/date.ext.ts:14-22`). The "never a raw date" choice is documented at `sidebar_live.ts:56-59` for fixed-width surfaces — this change consciously reverses it for detail dialogs only. Both `data_profile_started_at` and `data_profile_completed_at` are ISO strings in the harness ledger; `completedAt` is stamped on failure paths too, so duration is derivable for completed *and* failed profiles.
+2. The runs dialog's progress bar is already the reusable `RunBlock` (`src/tui/components/run_block.tsx`, primitive props). Run rows arrive by the sidebar refresh loop (lifecycle edges + bounded 5s poll while work is active); steps are fetched exactly once at dialog open (`runs_dialog.tsx:104-116`). The chat's `run-card` part deliberately carries no live status.
+3. `ToolBlock` stacks name and status as two sibling `<text>` rows in a column box (`tool_block.tsx:45-74`); an optional bordered result panel renders between them (fixture/gallery-only for live events).
+4. The path under the sidebar's ANALYSIS name is the anchor's `cachedPath` (the cwd where the analysis was created, self-healing on move) with a ✓/⚠ `markerWritten` badge. The canonical working dir is `ws.workingDir` on the workspace store (`src/tui/contexts/workspace.ts`, from `add-workspace-context`).
+5. Text selection is an opentui renderer feature the app already drives (`renderer.getSelection()?.getSelectedText()` / `renderer.clearSelection()` — copy-on-select at `app.tsx:264-270`). ESC does nothing to selection natively. The keymap engine (`add-keymap-engine`, implemented) provides mode-less layers, `priority`, and per-keystroke `enabled` thunks.
+6. User and assistant turns differ only by header marker/color (`message_block.tsx:44-53`); bodies render identically.
+7. All list cursor logic lives in `ListCore` (`list_core.tsx:171-179`); `up`/`down`/`moveBy` clamp. `FixedList` and `DynamicList` are its only callers. The config screen's section nav duplicates the clamp pattern (`app_config.tsx:279-280`).
+8. Sidebar sections stack `LABEL` above content (`sidebar.tsx:135-146`); the rail is a fixed `size.railWidth` = 40 columns. opentui 0.4.2 supports `justifyContent: "space-between"`, `gap`, and word-wrap (`wrapMode` defaults to `"word"` once a box has resolved width); the `<box flexGrow={1}/>` spacer idiom is used in StatusBar and ChatBar.
+
+Prerequisites `add-keymap-engine` and `add-workspace-context` are implemented but unarchived; this change builds on them and does not modify them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Absolute local timestamps + duration on durable-record surfaces (profile details, runs details), with the rule codified in `cli/CLAUDE.md`.
+- A sticky run-progress row in the chat column while a run is active, fed by the existing refresh loop.
+- Inline tool status, prop-controlled; user-turn left rule; ESC-clears-selection; FixedList wrap-around; responsive path placement; responsive sidebar label rows.
+- One shared duration formatter replacing the three inline ones.
+
+**Non-Goals:**
+
+- No live run-event stream transport — polling stays the v1 transport; the sticky row rides the existing loop.
+- No user-config time-format key — `toLocaleString()` (system locale) *is* the user's preferred format; a config key was rejected as scope creep.
+- No per-tool-name rendering switches — placement is a `ToolBlock` prop, not a tool registry.
+- No `DynamicList` wrap, no page-movement wrap, no radio-stepping wrap.
+- No sidebar width responsiveness (rail stays fixed 40) and no mouse resize.
+- The empty-chat Welcome block's anchor-path line is unchanged.
+
+## Decisions
+
+### D1 — Absolute time = `toLocaleString()`; duration via one shared formatter
+
+Durable, referenced records get `new Date(iso).toLocaleString()` — the established absolute-time precedent (session-switch dialog, whoami, `analysis ls`). Rejected: a new `config.json` time-format key (nothing else in the app has one; the OS locale already encodes the preference).
+
+Site-by-site (the piece-by-piece enumeration the rule demands):
+
+| Site | Today | After |
+|---|---|---|
+| Profile details dialog `started`/`completed` lines (`profileDetailLines`) | `relAge` | absolute + a `duration` line (`completedAt − startedAt`; running shows live elapsed from `startedAt`) |
+| Runs details view `RECENT RUNS` rows | `relAge(startedAt)` | absolute started time |
+| Sidebar rail (session age, profile age, run age) | `relAge`/`relativeAge` | unchanged (live fixed-width surface) |
+| Boot/thinking elapsed indicators | `relativeAge` | unchanged (live elapsed) |
+| `commands.tsx` / text commands | `toLocaleString()` | unchanged (already absolute) |
+
+Duration formatter: `Date.formatDuration(ms)` beside `Date.relativeAge` in `src/extensions/date.ext.ts` (the established home for cross-cutting date helpers; 4+ callers justify it). Format: `<1s → NNNms`, `<60s → N.Ns` (the dominant existing `tool_block` style), `≥60s → NmSSs` — profile runs can take minutes and `312.5s` is unreadable. `tool_block`, `thinking_block`, `message_block`, and the new profile duration line all adopt it; `thinking`/`message` blocks change from whole seconds to this format (accepted — one vocabulary beats three).
+
+### D2 — Sticky run progress: data from the refresh loop, layout from the BootIndicator recipe
+
+**Data.** `refreshSidebarData` additionally fetches `queryStepsByRun` for the newest **non-terminal** run and exposes an `activeRunProgress` snapshot (name, tag, done, total, step views) beside the existing signals. Cost: one extra bounded query per refresh, only while work is active — an idle sidebar still issues zero queries. `stepStateOf` (status → done/running/failed/queued) lifts from `runs_dialog.tsx` into `sidebar_live.ts` next to `runMark`/`shortRunName`; the dialog imports it from there. Rejected: a separate poller (duplicates the generation-token/skip machinery) and bus events (the bus carries only prov events by design).
+
+**Layout.** A new shell part `src/tui/layout/run_progress_row.tsx` composes `RunBlock`, mounted in `app.tsx` between `<Chat>` and the boot-indicator slot. It MUST follow the documented scrollbox-bleed recipe (`app.tsx:410-415`): full-width, painted with the app background, `flexShrink={0}` — the chat stream (flexGrow + minHeight 0) yields the squeeze. Visible iff `activeRunProgress` is non-null (newest run non-terminal); it auto-hides on terminal status. No dismiss key in v1.
+
+**Density.** `RunBlock` gains an optional `maxSteps?: number` prop: when `steps.length > maxSteps`, render a window of `maxSteps` steps centered on the first non-done step (the bar and `done/total` always show the full run). The sticky row passes a small cap (6); the dialog passes nothing (full list). This keeps the chat usable for long runs without a second progress widget. New gallery exhibit for the sticky row state.
+
+### D3 — Tool status placement is a `ToolBlock` prop
+
+`ToolBlock` gains `inlineStatus?: boolean`, defaulting to `props.result === undefined`: live harness events (which never carry `result`) render `▸ name target  ✓ ok · 14ms` on one line with a `space.md` gap; a block with a result panel keeps the completion line below the panel (the spec'd "completion line" survives for that case, and the gallery pins both states via the explicit prop). Rejected: right-aligning the status via a row + `flexGrow` spacer — a wrapped right-aligned segment lands at column 0 and breaks the fixed 2-cell gutter; a plain gap soft-wraps more gracefully. Verified with `testRender`/`captureCharFrame` sweeps including width 40 (sidebar-open chat column).
+
+### D4 — Responsive path placement via a breakpoint token
+
+New token `size.breakpointWide` (columns; calibration value **120**, tunable) in `design_system.ts`. `app.tsx` reads `useTerminalDimensions()` and:
+
+- **width ≥ breakpoint**: `StatusBar` renders the workspace path as a new segment immediately after the state segment (` | ~/repos/…`), sourced from `ws.workingDir`, home-contracted to `~`. It is NOT part of the right-aligned hints region.
+- **width < breakpoint**: the path renders where it does today — the sidebar ANALYSIS section line with the ✓/⚠ badge.
+
+The ✓/⚠ `markerWritten` badge never moves to the header (it is anchor-marker health, not cwd identity): when the path line is header-borne, the badge joins the ANALYSIS meta line (`✓ 2 inputs · proj: x`). Note the two values can diverge in the unresolved-anchor edge (`workingDir` falls back to `process.cwd()`; `cachedPath` keeps the stale hint) — the header shows `workingDir` because it is what the chat actually roots at.
+
+### D5 — ESC clears selection as a mode-less, high-priority layer
+
+In `app.tsx`: `useBindings(() => ({ priority: 50, enabled: () => !!renderer.getSelection()?.getSelectedText(), bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection(), … }] }))`. Mode-less so it works under dialogs; priority above the dialog host's default-0 layer, below the abort layer (100). The `getSelectedText()` predicate (not bare `hasSelection`) is the app's established "real selection" idiom — a plain click on selectable text creates an empty Selection. Clear only, no copy (copy-on-select already covers copying). Accepted interaction: the engine's pending-leader-chord abort runs before all layers, so ESC mid-chord aborts the chord and leaves the selection; the next ESC clears it.
+
+### D6 — User-turn left rule, gutter alignment preserved
+
+The user turn's parts container gets `border={["left"]} borderColor={theme().user}` — the established quoted-content idiom (thinking/plan/run blocks). Alignment invariant: the border glyph consumes one cell, so the user body's `paddingLeft` drops from `space.md` (2) to `space.sm` (1), keeping body text at the same column as assistant turns (border 1 + padding 1 = gutter 2). The header line (marker `>` at column 0) stays outside the bordered box so the gutter marker column is untouched. Pinned by a frame assertion; gallery's "plain chat turn" exhibit updated. Rejected: full background fill (`bgRaised`) — heavier, interacts with border-on-background painting and the theme-contrast tests.
+
+### D7 — Wrap-around is a `ListCore` option that only `FixedList` enables
+
+`ListCore` gains `wrapNavigation?: boolean` (default false). When true, single-step moves wrap modularly (`(i+1) % n`, `(i−1+n) % n`) — covering ↑/↓, ctrl+p/ctrl+n, j/k. `FixedList` passes `wrapNavigation` on; `DynamicList` does not (user decision: wrap only the fixed list — a filtering/refreshing dynamic source makes a surprise jump to the far end more disorienting). `moveBy(±10)` (page keys) keeps clamping everywhere; `gg`/`G` and the filter-shrink clamp are untouched. The config screen's section nav (`app_config.tsx`) adopts the same modular wrap in its own handlers (it does not use ListCore); its radio stepping stays clamped. Test fallout is known and owned: `list_primitives.render.test.tsx:148-151` (ctrl+p-clamps-at-0 assertion flips to wrap) and `dialog_host.render.test.tsx:424-465` (config "down past the end clamps" becomes exact-count navigation); new cases pin wrap at both ends and the single-row no-op.
+
+### D8 — Sidebar label rows: measured merge with stacked fallback
+
+The `Section` wrapper gains an optional `value?: string` prop. When provided and `label.length + gap + value.length` fits the usable rail width (railWidth − horizontal padding − border = 37 cells; 1 char = 1 cell in the terminal), the section header renders as one row — `LABEL <flexGrow spacer> value` (the StatusBar/ChatBar spacer idiom). When it does not fit, the section renders exactly today's stacked layout (value on its own full-width line, free to word-wrap). Adopters: SESSION (short id), ANALYSIS (name), DATA PROFILE (status word). RUNS and MODELS keep stacked layouts — their content is a row list, not a single value. Rejected: unconditional row + intra-cell word-wrap — a name wrapping *inside* the right cell (`SESSION  drug-repurposing-` / 9 spaces + `screen-v2`) reads worse than the stacked fallback the user sketched. Every relayout is verified with `testRender`/`captureCharFrame` sweeps across widths/heights per the CLAUDE.md layout rule (measure, don't reason by CSS analogy).
+
+## Risks / Trade-offs
+
+- [Scrollbox bleed corrupts the sticky row] → follow the documented recipe exactly (full-width painted `flexShrink={0}` box); frame-assert at several heights, as the bugs are size-dependent.
+- [Sticky row + boot indicator + error banner stack up and squeeze short terminals] → the chat stream is the designated squeeze absorber (flexGrow + minHeight 0); sweep heights in tests; the step window (`maxSteps`) bounds the row's height.
+- [Merged tool line soft-wraps on narrow terminals, wrapped status lands at column 0] → accepted for v1 (wrap beats clip for information); the gap layout degrades more gracefully than right-alignment; pinned in a width-40 frame test.
+- [StatusBar has no truncation; a long path + long analysis name can collide with the hints] → home-contraction plus the breakpoint gate make it rare; accepted residual risk, consistent with the bar's existing no-truncation behavior. If it bites, middle-truncate the path segment in a follow-up.
+- [`toLocaleString()` output length varies by locale] → detail dialogs are `md`-preset panels (64 cols) with scrolling; not a fixed-width rail. The rail keeps relative ages precisely to avoid this.
+- [Wrap-around surprises muscle memory in pickers] → single-step only; page keys and `gg`/`G` still hard-stop, so "slam to the end" gestures keep working.
+- [Poll-fed sticky progress lags up to one poll interval] → inherent to the v1 transport; the refresh-on-turn-completion edge covers the common "agent launched a run" case. The documented swap point (`refreshSidebarData`) is unchanged for the future stream transport.
+- [`add-keymap-engine` also carries an unsynced `key-bindings` delta] → this change only ADDS a requirement to that capability; the deltas are disjoint and archive in either order.
+
+## Migration Plan
+
+UI-only; no data, schema, or config migration. Single branch, lands as one change. Rollback = revert.
+
+## Open Questions
+
+None — all decision points were resolved with the user (format source, step fetching, prop-based tool placement, breakpoint-gated path placement, wrap scope limited to FixedList + config sections).

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Eight small UX papercuts accumulated across the chat TUI: times render as bare relative ages where the user actually needs a readable date, run progress is locked inside a dialog, tool blocks waste horizontal space, the sidebar's anchor path is unexplained and its label rows waste vertical space, ESC ignores an active text selection, user turns are visually indistinguishable from assistant turns beyond the gutter marker, and fixed lists dead-stop at their ends. Each is small; together they define one polish pass with a shared theme — make the shell read better and navigate tighter without new subsystems.
+
+## What Changes
+
+- **Absolute time for durable records.** The data-profile details dialog shows absolute local timestamps (`toLocaleString()`) plus the profile duration; the runs details view shows absolute started times. Live fixed-width surfaces (sidebar rail, elapsed indicators) keep compact relative ages. The rule of thumb is codified in `cli/CLAUDE.md`: **durable, referenced records get absolute local timestamps; live/ephemeral readouts keep relative ages.** A shared duration formatter replaces the three near-identical inline formatters.
+- **Sticky run progress in the chat.** While a run is non-terminal, the chat column shows a sticky progress row (the `RunBlock` progress vocabulary: segmented bar, done/total, steps) pinned above the input, fed by the sidebar refresh loop — which now also fetches the newest active run's steps.
+- **Inline tool status.** `ToolBlock` gains a prop controlling status placement; live tool events (no result panel) render name and status on one line with a gap; a block with a result panel keeps the completion line below the panel.
+- **Workspace path, responsively placed.** A terminal-width breakpoint token enters the design system. At or above it, the StatusBar shows the workspace path immediately after the status segment; below it, the path stays in the sidebar ANALYSIS section (with its anchor-health badge, which never leaves the sidebar).
+- **ESC clears the active text selection** before any other esc behavior, via a mode-less high-priority keymap layer; with no selection, esc falls through unchanged.
+- **User turns get a left border rule** in the user theme color (the established quoted-content idiom), keeping gutter alignment intact.
+- **Fixed lists wrap around**: single-step cursor navigation (↑/↓, ctrl+p/n, j/k) wraps 0 ↔ N−1 in `FixedList`; `DynamicList` keeps clamping; page movement and gg/G are unchanged. The config screen's section navigation wraps the same way.
+- **Sidebar label rows go horizontal**: each section renders `LABEL <flex gap> value` on one row when the pair fits the rail width, falling back to today's stacked layout when it does not.
+
+## Capabilities
+
+### New Capabilities
+
+None — every item lands in an existing capability.
+
+### Modified Capabilities
+
+- `sidebar-live`: the profile details dialog renders absolute timestamps + duration (was: relative ages); the runs details view renders absolute started times; the refresh loop additionally fetches the newest active run's steps (was: steps fetched only at dialog open) to feed the chat's sticky progress row.
+- `tui-layout`: StatusBar gains the responsive workspace-path segment; the sidebar's ANALYSIS path becomes narrow-terminal-only; sidebar sections adopt the responsive label-row layout; `MessageBlock` differentiates user turns with a left rule; the chat-shell composition gains the sticky run-progress row between stream and input.
+- `tui-stream-blocks`: the tool block's completion line becomes placement-controlled (inline beside the name for live events; below the result panel when one renders).
+- `list-primitives`: cursor navigation end behavior splits by component — `FixedList` wraps on single-step movement, `DynamicList` clamps; paging and gg/G clamp everywhere.
+- `key-bindings`: new requirement — esc clears the renderer's active text selection before any other esc behavior.
+- `tui-design-tokens`: new terminal-width breakpoint token for the responsive path placement.
+
+## Impact
+
+- `src/tui/hooks/sidebar_live.ts` — absolute time lines, duration, step fetching in the refresh loop, step-view mapping lifted out of the dialog.
+- `src/tui/components/dialog/runs_dialog.tsx`, `src/tui/components/run_block.tsx` — absolute started times; shared step-state mapper import.
+- `src/tui/components/tool_block.tsx` — inline-status prop; `src/tui/layout/message_block.tsx` — user-turn rule + prop pass-through.
+- `src/tui/app.tsx` — sticky progress row, esc-selection layer; `src/tui/layout/status_bar.tsx` + `src/tui/layout/sidebar.tsx` — responsive path + label rows.
+- `src/tui/components/list_core.tsx`, `fixed_list.tsx`, `dynamic_list.tsx`, `src/tui/app_config.tsx` — wrap-around navigation.
+- `src/lib/design_system.ts` — breakpoint token; shared duration formatter home.
+- `src/tui/layout/design_gallery.tsx` (+ fixtures) — new/updated exhibits for the sticky progress row, inline tool status, user-turn rule, and sidebar label rows.
+- Tests: `list_primitives.render.test.tsx` (clamp assertion flips), `dialog_host.render.test.tsx` (config section clamp test), `sidebar_live.test.ts` (`profileDetailLines`), `sidebar.render.test.tsx`, new frame assertions for ToolBlock layout and the sticky row; `testRender`/`captureCharFrame` size sweeps for every relayout.
+- `cli/CLAUDE.md` — the absolute-vs-relative time rule.
+- Prerequisites (implemented, unarchived, untouched): `add-keymap-engine`, `add-workspace-context`.

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/key-bindings/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/key-bindings/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Escape clears the active text selection first
+
+The chat app SHALL register a mode-less keymap layer that binds `esc` to clear the renderer's
+active mouse text selection (`renderer.clearSelection()`), enabled only while a selection with
+non-empty selected text exists (`renderer.getSelection()?.getSelectedText()` — the app's
+established "real selection" predicate, since a plain click on selectable text creates an empty
+`Selection`). The layer's priority SHALL sit above the dialog host's esc layer and below the abort
+layer, so with a selection active `esc` deselects and does nothing else — the dialog stays open,
+the textarea keeps focus — and with no selection the layer is disabled and `esc` falls through to
+its existing behaviors unchanged (close dialog, INSERT→NORMAL, chord abort). The binding SHALL
+only clear; it MUST NOT copy (copy-on-select already writes the clipboard on mouse-up). The keymap
+engine's pending-leader-sequence abort runs before all layers by design; `esc` pressed mid-chord
+aborts the chord and leaves the selection for the next press — an accepted interaction.
+
+#### Scenario: Esc deselects instead of closing a dialog
+
+- **WHEN** text is selected inside an open dialog and the user presses `esc`
+- **THEN** the selection clears and the dialog remains open; a second `esc` closes it
+
+#### Scenario: Esc deselects without leaving INSERT
+
+- **WHEN** text is selected while the chat textarea is focused and the user presses `esc`
+- **THEN** the selection clears and the textarea keeps focus; a second `esc` switches to NORMAL as before
+
+#### Scenario: No selection means no behavior change
+
+- **WHEN** no text selection exists and the user presses `esc` anywhere in the TUI
+- **THEN** `esc` behaves exactly as it did before this requirement (the layer is disabled)
+
+#### Scenario: An empty click-selection does not arm the layer
+
+- **WHEN** the user clicks (without dragging) on selectable text, creating an empty selection, and presses `esc`
+- **THEN** `esc` falls through to its existing behavior — the layer arms only on non-empty selected text

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/list-primitives/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/list-primitives/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Cursor navigation and scroll-into-view
+
+Both lists SHALL own cursor state and register their keys via `useDialogBindings` (auto-suspended under a stacked dialog; gated by `!dialogIsOpen()` outside one), in two layers split by the bare-printable-key rule:
+
+- **Always-on** (safe beside a focused editor): ↑/↓, ctrl+p/ctrl+n, page-up/page-down (±10 rows), enter.
+- **Bare-printable** (gated by a `bareKeysEnabled` passthrough, which hosts with a focusable filter input MUST wire to `!inputFocused`): the vim cursor keys j/k (down/up), gg (first row), G (last row) — and space-toggle in multi mode.
+
+End-of-list behavior splits by component through a `wrapNavigation` option on the shared core:
+
+- **`FixedList`** SHALL enable it: single-step movement (↑/↓, ctrl+p/ctrl+n, j/k) wraps between the first and last item rows — stepping down from the last row lands on the first, stepping up from the first lands on the last (modular, so a single-row list is a no-op).
+- **`DynamicList`** SHALL NOT enable it: single-step movement clamps at the ends, because a source that refilters or refreshes underfoot makes a surprise jump to the far end disorienting.
+- Page movement (±10 rows) SHALL clamp at the ends in BOTH lists — the deliberate "slam toward the end" gesture must land on the end, not overshoot past it — and `gg`/`G` remain absolute jumps.
+
+The list SHALL compose `ScrollPane` with `focusOnMount={false}` (the pane is never focused) and keep the cursor row visible via `scrollChildIntoView` — a wrap jump scrolls the destination row into view exactly as `gg`/`G` do — pulling a group header into view when the cursor sits on a group's first item. The cursor SHALL clamp when filtering shrinks the set. The whole layer set SHALL also accept an `enabled` passthrough so hosts can suspend the list entirely.
+
+#### Scenario: Navigation keys move the cursor
+
+- **WHEN** the user presses ↓ or ctrl+n
+- **THEN** the cursor moves to the next item row and scrolls into view
+
+#### Scenario: Vim keys move the cursor when no editor is focused
+
+- **WHEN** `bareKeysEnabled` is true (no filter input holds focus) and the user presses j, k, gg, or G
+- **THEN** the cursor moves down / up / to the first row / to the last row — and when an input is focused, those keys type into it instead
+
+#### Scenario: FixedList wraps at the bottom
+
+- **WHEN** the cursor sits on a `FixedList`'s last item row and the user presses ↓, ctrl+n, or j
+- **THEN** the cursor lands on the first item row and it scrolls into view
+
+#### Scenario: FixedList wraps at the top
+
+- **WHEN** the cursor sits on a `FixedList`'s first item row and the user presses ↑, ctrl+p, or k
+- **THEN** the cursor lands on the last item row and it scrolls into view
+
+#### Scenario: DynamicList clamps at the ends
+
+- **WHEN** the cursor sits on a `DynamicList`'s last item row and the user presses ↓
+- **THEN** the cursor stays on the last row — no wrap
+
+#### Scenario: Page movement clamps everywhere
+
+- **WHEN** the cursor is within ten rows of an end and the user presses page-down (or page-up toward the start)
+- **THEN** the cursor lands on the end row in both list components, never wrapping past it
+
+#### Scenario: Host gates the layer
+
+- **WHEN** a host passes `enabled: () => false`
+- **THEN** none of the list's bindings fire
+
+#### Scenario: Cursor clamps on shrink
+
+- **WHEN** the cursor is on the last row and a query removes rows below the new end
+- **THEN** the cursor moves to the new last row

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/sidebar-live/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/sidebar-live/spec.md
@@ -1,9 +1,4 @@
-# sidebar-live Specification
-
-## Purpose
-The sidebar's live-data contract: the DATA PROFILE and RUNS sections source the harness ledger through the booted runtime (never mocks), degrade gracefully pre-ready, refresh on lifecycle edges plus a bounded active-work poll, publish the newest active run's step progress for the chat's sticky progress row, and open details views (profile summary dialog — carrying the keybound re-profile action; runs-with-steps dialog) by section click and leader keybindings. Lives in `src/tui/hooks/sidebar_live.ts`, `src/tui/layout/sidebar.tsx`, and `src/tui/components/dialog/runs_dialog.tsx`.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: The sidebar renders live ledger data with graceful degradation
 

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-design-tokens/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-design-tokens/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Named layout, spacing, and stroke tokens
+
+The system SHALL provide three `as const` objects with derived literal-union types — `space`, `size`, `stroke` — in the dependency-light, solid-js-free design-system module `src/lib/design_system.ts`, the single source of truth for non-color layout primitives:
+
+- `space` — spacing counted in terminal cells: `none: 0` (tight pairs, marker│text), `sm: 1` (rows within a block), `md: 2` (between blocks and panels), `lg: 4` (rare major breaks).
+- `size` — fixed structural dimensions in cells/rows: `gutter: 2` (the marker column), `statusBar: 1` (row height), `railWidth: 40` (sidebar/rail columns), `composerMin: 1` (grows with input), `paletteRows: 12` (visible before scroll), `breakpointWide: 120` (terminal columns at/above which wide-terminal layouts engage — a calibration value, tunable).
+- `stroke` — border roles mapped to opentui `borderStyle`: `panel: "single"`, `overlay: "rounded"`, `focus: "heavy"`, `danger: "double"`.
+
+Each object SHALL be `as const`, and the module SHALL export the union types `Space = keyof typeof space` and `Stroke = keyof typeof stroke`. `railWidth` SHALL be `40` (the existing tuned value), not the design doc's example `30`. `breakpointWide` is the single wide-terminal threshold: any component that places content responsively by terminal width (e.g. the status bar's workspace-path segment vs the sidebar's path line) SHALL compare against this token, never an inline column count, so every responsive surface flips at the same width.
+
+#### Scenario: Tokens are literal-typed constants
+
+- **WHEN** a component imports `space`, `size`, or `stroke`
+- **THEN** each value is a literal type (e.g. `space.md` is `2`, not `number`) and the `Space`/`Stroke` union types name the available keys
+
+#### Scenario: A single source for layout primitives
+
+- **WHEN** a developer needs the rail width, gutter width, status-bar height, or a border style
+- **THEN** it is read from `size`/`stroke` in `design_system.ts`, defined once
+
+#### Scenario: Responsive placement reads the breakpoint token
+
+- **WHEN** a component decides between a wide-terminal and a narrow-terminal placement
+- **THEN** it compares the terminal width against `size.breakpointWide`, not an inline number, and all such surfaces flip at the same threshold

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-layout/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-layout/spec.md
@@ -1,21 +1,4 @@
-# tui-layout Specification
-
-## Purpose
-TBD - created by archiving change standardize-tui-layout. Update Purpose after archive.
-## Requirements
-### Requirement: Layout composition kit directory
-
-The system SHALL house the chat TUI's app-shell composition kit under `src/tui/layout/`, one component per file with no barrel/index re-exports — today `status_bar.tsx`, `message_block.tsx`, `chat_bar.tsx` (renamed from `input_bar.tsx`), `sidebar.tsx`, and `design_gallery.tsx`. (The gutter marker set is NOT a shell-composition part; it is design-system vocabulary and lives in `src/lib/design_system.ts` so the `components/` block widgets may import it — see the "Shared gutter marker set" requirement.) A `layout/` part MAY be single-caller and MAY import domain types/queries (`src/types/`, `src/db/`, `src/modules/`), because it is structural app-shell composition rather than a reusable domain-agnostic widget. This is a deliberate, scoped exception to the "don't extract single-caller sub-components" rule, and `CLAUDE.md`'s Project-structure section SHALL document `src/tui/layout/` and this exception. `layout/` components MUST NOT be imported by `src/modules/` (presentation depends on logic, never the reverse).
-
-#### Scenario: Kit part lives in layout/
-
-- **WHEN** a part composes the chat shell (status bar, message block, chat bar, or sidebar)
-- **THEN** it resides in `src/tui/layout/` as its own file, imported directly by its caller
-
-#### Scenario: Single-caller, domain-coupled part is allowed
-
-- **WHEN** a `layout/` part is composed by only `app.tsx` and imports domain types or db queries
-- **THEN** it still belongs in `layout/` (the single-caller and components/-membership rules do not apply to the shell kit)
+## MODIFIED Requirements
 
 ### Requirement: Direction-B chat shell composition
 
@@ -52,37 +35,6 @@ The sticky run-progress row is a shell part (`src/tui/layout/run_progress_row.ts
 
 - **WHEN** the terminal is short enough that the chat column must shrink
 - **THEN** the progress row keeps its rows (painted, `flexShrink={0}`) and the stream yields, with no scrollbox content bleeding through the row
-
-### Requirement: Chat focus is always on a widget
-
-The chat's INSERT/NORMAL modality SHALL be modeled purely by focus — there SHALL be no state in which no widget is focused. In INSERT mode the `ChatBar` textarea is focused; `esc` SHALL move focus to the stream's `ScrollPane` (NORMAL mode — the pane's scroll keys become live via its focus-target gating). In NORMAL mode, `i` and enter SHALL refocus the textarea (a chat-side layer gated by `target:` the scroll pane); `esc` while the pane is focused SHALL be a no-op (it MUST NOT blur into a nothing-focused state). The `ChatBar` footer's mode word continues to derive from the textarea's own focused/blurred events and needs no extra wiring.
-
-Because focus is always on some widget, the dialog host's focus save/restore SHALL be uniform: capture the focused renderable when the first dialog opens, restore it (verifying it is still in the tree) when the last closes. The `fallbackFocus` prop and its null-restore branch SHALL NOT exist — there is no nothing-focused case to fall back from.
-
-#### Scenario: Esc enters NORMAL by focusing the pane
-
-- **WHEN** the textarea is focused and the user presses `esc`
-- **THEN** the scroll pane receives focus, the ChatBar footer shows `NORMAL`, and vim scroll keys drive the stream
-
-#### Scenario: i and enter return to INSERT
-
-- **WHEN** the scroll pane is focused and the user presses `i` (or enter)
-- **THEN** the textarea regains focus, the footer shows `INSERT`, and typed letters insert text again
-
-#### Scenario: Esc in NORMAL is a no-op
-
-- **WHEN** the scroll pane is focused and the user presses `esc`
-- **THEN** focus stays on the pane; no widget is blurred into a nothing-focused state
-
-#### Scenario: Dialog restore returns focus to the NORMAL-mode pane
-
-- **WHEN** a dialog opens while the scroll pane is focused and is later closed
-- **THEN** the dialog host restores focus to the scroll pane (no fallback branch involved), and scroll keys are live again
-
-#### Scenario: No fallbackFocus machinery
-
-- **WHEN** `dialog_host.tsx` is read
-- **THEN** it exposes no `fallbackFocus` prop and contains no null-saved-focus fallback path
 
 ### Requirement: Persistent status bar
 
@@ -161,10 +113,9 @@ string (SESSION's short id, ANALYSIS's name) SHALL render `LABEL <flex gap> valu
 the label, a separating gap, and the value fit the rail's usable width — and SHALL fall back to
 today's stacked layout (label above a full-width value line) when they do not, so a long analysis
 name is never truncated or wrapped inside a right-hand cell. Sections whose first line is a
-composite (DATA PROFILE's glyph-bearing `N files · time` line) and row-list sections (RUNS) keep
-the stacked layout — the merge models a single plain value, not a styled composite. The fit
-decision is measured in cells (one character per cell) against the rail width minus its padding
-and border.
+composite (DATA PROFILE's glyph-bearing `N files · age` line) and row-list sections (RUNS) keep the
+stacked layout — the merge models a single plain value, not a styled composite. The fit decision is
+measured in cells (one character per cell) against the rail width minus its padding and border.
 
 #### Scenario: Sidebar renders live sections for an open analysis
 
@@ -205,70 +156,3 @@ and border.
 
 - **WHEN** the terminal is at or above `size.breakpointWide` columns
 - **THEN** the ANALYSIS section shows no path line, the ✓/⚠ badge joins the meta line, and the status bar carries the path
-
-### Requirement: Sidebar toggle keybinding
-
-The chat TUI SHALL toggle the sidebar on the central keymap's sidebar-toggle chord (`ctrl+b`), with the sidebar open by default. The chord SHALL be a Ctrl chord, NOT an Alt chord, because terminals deliver Alt/Option unreliably (on macOS the Option key composes a special character instead of sending a modifier). The handler SHALL call `preventDefault()` so the focused textarea does not also consume the key, and SHALL be gated while a dialog is open — when a modal owns the keyboard, the chord SHALL NOT toggle the sidebar.
-
-#### Scenario: Toggle from the chat
-
-- **WHEN** `ctrl+b` is pressed in the chat with no dialog open
-- **THEN** the sidebar hides or re-shows, and the focused textarea does not receive the keystroke
-
-#### Scenario: Gated while a dialog is open
-
-- **WHEN** a dialog is open and the toggle chord is pressed
-- **THEN** the sidebar does not toggle (the dialog owns the keyboard)
-
-### Requirement: Chat status lives in a shared reactive store
-
-The chat's live status (`idle`/`busy`/`error`) SHALL be held in a shared reactive store module `src/tui/hooks/status.ts` (a Solid signal accessor plus a setter, mirroring `theme.ts`), NOT as private state inside `app.tsx`. `app.tsx` SHALL only READ the store to render the status bar; every mutation SHALL go through the store's exported setter (which the chat's bus handler and the in-place session swap call). The store decouples the holder of the state from its renderer, so the state can be changed indirectly from anywhere without reaching into the chat component.
-
-#### Scenario: App renders, store holds
-
-- **WHEN** a session-status bus event arrives
-- **THEN** the handler calls the store's setter and the status bar repaints from the store accessor, with no status signal owned by `app.tsx`
-
-#### Scenario: Status shows a glyph
-
-- **WHEN** the chat is ready / busy / error
-- **THEN** the status bar's middle region shows a leading glyph before the state text (e.g. `● ready`)
-
-### Requirement: Input bar footer shows session/mode info, not keybinds
-
-`ChatBar` (renamed from `InputBar`, in `layout/chat_bar.tsx`) SHALL compose the shared `TextArea` component with `chrome="full"` and the `Type a message…` placeholder (via `GLYPHS.ellipsis`), and render a single external footer row below the bordered textarea. The footer row SHALL show the mode word on the left (`INSERT` when the textarea is focused, `NORMAL` when blurred — with `NORMAL` rendered in bold with the accent color and the row given a `bgActive` background) and the newline chord hint on the right (`ctrl+j newline`). Global keybind hints SHALL NOT be duplicated in this footer: the command-palette, sidebar-toggle, and abort key hints live ONLY in the status bar, so the header and the input footer never repeat the same keys.
-
-#### Scenario: ChatBar composes TextArea
-
-- **WHEN** the chat renders the input area
-- **THEN** `ChatBar` renders a `TextArea` with `chrome="full"` for the bordered textarea, plus its own external footer row
-
-#### Scenario: Footer is session/mode info
-
-- **WHEN** the chat renders
-- **THEN** the input footer shows the mode word (left) and newline hint (right), and does NOT show the palette/sidebar/abort key hints
-
-#### Scenario: Global keys live in the header only
-
-- **WHEN** the user looks for the command-palette / sidebar / abort shortcuts
-- **THEN** they appear in the status bar, not duplicated in the input footer
-
-#### Scenario: NORMAL mode has distinct visual treatment
-
-- **WHEN** the textarea is blurred (NORMAL mode)
-- **THEN** the footer row shows `NORMAL` in bold accent color with `bgActive` background, signaling that vim scroll keys are live
-
-### Requirement: Shared gutter marker set
-
-The system SHALL define the gutter marker set as a shared constant (`MARKERS`) in `src/lib/design_system.ts` (the merged design-system module — solid-js-free, importable by both the shell and the `components/` block widgets without a components→layout dependency) — one entry per kind: `you >`, `assistant <`, `thinking ◆`, `tool ▸`, `run ●`, `fileEdit ✎`, `ok ✓`, `error ✗` — each mapping to its glyph and an existing `ThemeColors` role (the `thinking` and `tool` kinds use the dedicated `thinking`/`tool` roles; `run` uses `warning`). The set is the single source for every block's marker: `MessageBlock` (shell) reads `you`/`assistant`, and the `components/` block widgets read the rest.
-
-#### Scenario: Message block reads the marker set
-
-- **WHEN** a user or assistant turn renders
-- **THEN** its gutter marker glyph and color come from the shared marker set in `src/lib/design_system.ts`, not an inline literal
-
-#### Scenario: Block widgets read the marker set
-
-- **WHEN** a thinking / tool / run / file-edit / error block widget renders
-- **THEN** its marker glyph and role come from the shared set, imported from the tui root (no components→layout import)
-

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-stream-blocks/spec.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/specs/tui-stream-blocks/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Eight canonical stream-block states
+
+The chat stream SHALL render the eight canonical block states of the design system, each as a gutter-marked block sharing the fixed 2-cell gutter (`size.gutter`) so only the marker glyph and its role color change between blocks:
+
+1. **welcome / startup** — shown at the top of an empty stream; a wordmark plus the active context (greeting, anchor path with ✓/⚠ badge, resume hint, command hint).
+2. **plain chat turn** — the existing user/assistant `MessageBlock` (markdown body under a `>`/`<` marker).
+3. **thinking / reasoning** — a `◆ thinking` marker, an optional duration, and a collapsed-by-default italic reasoning body that can expand.
+4. **tool call & result** — a `▸` marker with the tool/verb name and target, and the call's status (ok / running / error, with duration); for a call without a rendered result the status sits inline on the name line (see "Tool status placement"), and for a call with a result the result renders in a `<code>` block with the status as a completion line beneath it.
+5. **long-running run / task** — a `●` marker with the run name, a progress bar, and an indented step list (done / running / queued).
+6. **diff / file edit** — a `✎` marker with the file name and +/− counts, the hunk rendered via the `<diff>` renderable, and accept/reject/edit affordances.
+7. **error / abort** — a `✗` marker, the abort/error summary, and a bordered callout (using `stroke.danger` chrome and `onAccent` foreground on any filled region); the degraded-anchor case (`markerWritten = false`) renders its callout from existing anchor state.
+8. **command palette** — the existing `^K` palette overlay.
+
+Each block SHALL map to a single built-in opentui renderable (no custom drawing), read all colors via `theme().<role>`, all non-ASCII glyphs via `GLYPHS`, and all spacing/dimension/stroke via the design tokens. Markers SHALL come from the shared marker set (`MARKERS`) in `src/lib/design_system.ts`.
+
+#### Scenario: Blocks share the fixed gutter
+
+- **WHEN** any two block types render consecutively in the stream
+- **THEN** their content aligns in the same gutter column (`size.gutter`) and only the marker glyph and its color differ
+
+#### Scenario: Each block uses a built-in renderable
+
+- **WHEN** a block renders code, a diff, a wordmark, or text
+- **THEN** it uses `<code>`, `<diff>`, `<ascii_font>`, or `<text>`/`<box>` respectively — no custom cell drawing
+
+#### Scenario: No inlined hex or glyph literals
+
+- **WHEN** a block paints a color or prints a non-ASCII glyph
+- **THEN** the color comes from `theme()` and the glyph from `GLYPHS`, never an inline literal
+
+## ADDED Requirements
+
+### Requirement: Tool status placement is prop-controlled
+
+`ToolBlock` SHALL take an `inlineStatus?: boolean` prop controlling where the call's status (glyph + label + optional duration) renders: inline on the name line — after the name and target, separated by a `space.md` gap — or as a standalone completion line below the block's content. The default SHALL derive from the result: a block without a `result` renders inline (live harness tool events never carry a result, so every live call uses the single-line form), and a block with a `result` keeps the completion line below the `<code>` panel, where an inline status would strand the outcome above the output it describes. An explicit prop value SHALL override the derivation (the design gallery pins both forms). The inline form SHALL NOT right-align the status (a wrapped right-aligned segment lands at column 0 and breaks the gutter); it flows after the name so narrow terminals soft-wrap it instead. Both placements SHALL be pinned by frame-assertion render tests, including a sidebar-open-width (40-column) sweep.
+
+#### Scenario: Live tool call renders on one line
+
+- **WHEN** a tool call without a result renders (running or finished)
+- **THEN** the name, target, and status share one line — `▸ name target  ✓ ok · 14ms` — with a `space.md` gap before the status
+
+#### Scenario: A result keeps the completion line
+
+- **WHEN** a tool block renders with a `result`
+- **THEN** the result renders in the `<code>` panel and the status renders as a completion line beneath it, as before
+
+#### Scenario: The gallery pins both placements
+
+- **WHEN** the design gallery renders the tool-block exhibits
+- **THEN** it shows the inline form and the completion-line form via explicit `inlineStatus` values

--- a/cli/openspec/changes/archive/2026-07-13-ui-polish-1/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-13-ui-polish-1/tasks.md
@@ -1,0 +1,66 @@
+## 1. Shared foundations
+
+- [x] 1.1 Add `Date.formatDuration(ms)` to `src/extensions/date.ext.ts` beside `relativeAge` (`<1s → NNNms`, `<60s → N.Ns`, `≥60s → NmSSs` per design D1), with unit tests covering all three ranges and the boundaries
+- [x] 1.2 Add `size.breakpointWide: 120` to `size` in `src/lib/design_system.ts` (with a calibration-value doc comment)
+- [x] 1.3 Replace the three inline duration formatters (`tool_block.tsx`, `thinking_block.tsx`, `message_block.tsx`) with `Date.formatDuration`; update any render assertions that pinned the old whole-second strings
+- [x] 1.4 Add the time-rendering rule to `cli/CLAUDE.md`: durable referenced records get absolute local timestamps (`toLocaleString()`); live/ephemeral fixed-width readouts keep compact relative ages
+
+## 2. Absolute time + duration on detail views
+
+- [x] 2.1 `profileDetailLines` (`src/tui/hooks/sidebar_live.ts`): `started`/`completed` lines become absolute (`toLocaleString()`); add a `duration` line via `Date.formatDuration` for completed AND failed profiles; a running profile shows live elapsed since `startedAt` instead; update `sidebar_live.test.ts` line assertions
+- [x] 2.2 Runs dialog RECENT RUNS rows (`runs_dialog.tsx`): replace `relAge(run.startedAt)` with the absolute started time; update `runs_dialog` render tests
+- [x] 2.3 Verify the sidebar rail still renders relative ages everywhere (session age, profile age, run age) — pin with the existing `sidebar.render.test.tsx` assertions
+
+## 3. FixedList wrap-around navigation
+
+- [x] 3.1 Add `wrapNavigation?: boolean` (default false) to `ListCore` (`list_core.tsx`): `up`/`down` wrap modularly when enabled; `moveBy`, `gg`/`G`, and the filter-shrink clamp unchanged; `FixedList` passes it on, `DynamicList` does not
+- [x] 3.2 Wrap the config screen's section navigation (`app_config.tsx` up/down handlers) with the same modular arithmetic; radio left/right stepping stays clamped
+- [x] 3.3 Update tests: flip the ctrl+p-clamps assertion in `list_primitives.render.test.tsx:128-155` to expect wrap; add wrap-at-bottom, wrap-at-top, and single-row no-op cases; rewrite the exact-count config navigation in `dialog_host.render.test.tsx:424-465`; add a DynamicList still-clamps case in `file_picker` or list-primitives tests
+
+## 4. ESC clears the active text selection
+
+- [x] 4.1 Register the mode-less layer in `app.tsx`: `enabled: () => !!renderer.getSelection()?.getSelectedText()`, priority above the dialog host's esc and below the abort layer, `run: () => renderer.clearSelection()` (clear only, no copy)
+- [x] 4.2 Add render tests: esc with a selection clears it and leaves an open dialog open; esc with a selection keeps textarea focus (no INSERT→NORMAL flip); esc without a selection behaves exactly as before
+
+## 5. Inline tool status
+
+- [x] 5.1 Add `inlineStatus?: boolean` to `ToolBlock` (default `props.result === undefined`): inline form renders name + target + `space.md` gap + status on one line; result form keeps the completion line under the `<code>` panel
+- [x] 5.2 Update the design gallery tool exhibits to pin both forms via explicit `inlineStatus` values
+- [x] 5.3 Add frame-assertion tests for both placements, including a 40-column width sweep for the inline form's soft-wrap behavior
+
+## 6. User-turn left rule
+
+- [x] 6.1 In `MessageBlock`, wrap the user turn's parts container in `border={["left"]} borderColor={theme().user}` with left padding reduced by one cell so body text stays column-aligned with assistant bodies; the header line (gutter `>` marker) stays outside the bordered box
+- [x] 6.2 Add a frame test pinning the alignment invariant (user and assistant body text in the same column); update the gallery's plain-chat-turn exhibit; run the `theme_contrast` render tests across themes
+
+## 7. Sticky run progress in the chat
+
+- [x] 7.1 Lift `stepStateOf` from `runs_dialog.tsx` into `sidebar_live.ts` beside `runMark`/`shortRunName`; update the dialog's import
+- [x] 7.2 Extend `refreshSidebarData` to fetch `queryStepsByRun` for the newest non-terminal run (inside the generation-token guard) and publish an `activeRunProgress` snapshot signal (name, tag, done/total, step views), null when no run is active; test: idle refresh issues zero step queries, active run publishes, terminal run clears
+- [x] 7.3 Add `maxSteps?: number` to `RunBlock`: when steps exceed it, render a window centered on the first non-done step (bar and done/total always reflect the full run); gallery-pin the windowed state
+- [x] 7.4 Create `src/tui/layout/run_progress_row.tsx` composing `RunBlock` (small `maxSteps`, `hint={false}`) from `activeRunProgress`; mount it in `app.tsx` between `<Chat>` and the boot-indicator slot following the scrollbox-bleed recipe (full-width, app-background-painted, `flexShrink={0}`)
+- [x] 7.5 Frame tests: row appears iff the snapshot is non-null, disappears on terminal status, and survives short-terminal squeezes without bleed (sweep several heights)
+
+## 8. Responsive workspace path
+
+- [x] 8.1 Add the optional path-segment prop to `StatusBar` (`status_bar.tsx`), rendered muted immediately after the state segment, before the right-aligned hints
+- [x] 8.2 In `app.tsx`, gate the prop on `useTerminalDimensions().width >= size.breakpointWide`, sourcing `ws.workingDir` with the home directory contracted to `~`
+- [x] 8.3 In `sidebar.tsx`, render the ANALYSIS path line (badge + path) only below the breakpoint; at/above it, move the ✓/⚠ badge onto the ANALYSIS meta line (inputs · project)
+- [x] 8.4 Render tests at widths straddling the breakpoint: exactly one surface carries the path at any width, and the badge is always visible somewhere in ANALYSIS
+
+## 9. Sidebar responsive label rows
+
+- [x] 9.1 Add an optional `value?: string` to the sidebar `Section` wrapper: when `label + gap + value` fits the usable rail width (railWidth − padding − border, measured in cells), render one row with a `flexGrow` spacer; otherwise render today's stacked layout; adopt for SESSION (short id) and ANALYSIS (name); DATA PROFILE stays stacked (its first line is a glyph-bearing composite, not a single value — delta spec amended to match); RUNS keeps stacked
+- [x] 9.2 `testRender`/`captureCharFrame` sweeps: short values merge onto the label row, a long analysis name falls back to stacked (never wrapped inside a right-hand cell); update `sidebar.render.test.tsx`
+
+## 10.5 Smoke-pass feedback fixes
+
+- [x] 10.5.1 Sidebar DATA PROFILE completed line shows the absolute completed time (`absTime`, like the details dialog) instead of `relAge`; RUNS rows and SESSION age stay relative (absolute start times would overflow the 37-cell rail); flip the rail-pinning assertion in `sidebar.render.test.tsx`; adjust the CLAUDE.md time-rendering example so the rail-profile line reads as a durable-record readout
+- [x] 10.5.2 SelectDialog breathing room: a small gap between the filter input and the list, padding above the cursor-row description INSIDE its painted full-width box (a transparent gap would expose the scrollbox bleed), and top/bottom panel padding for the picker content; verify with frame sweeps that no bleed appears through the new spacing; update any pinned render tests
+- [x] 10.5.3 `Date.relativeAge` renders two units when the age is a minute or more (`31s`, `5m31s`, `8h54m`, `2d04h` — largest unit + the next one down, seconds-only below a minute); update its unit tests and every render assertion pinning single-unit ages
+
+## 10. Verification
+
+- [x] 10.1 `cd cli && bun run typecheck && bun run lint && bun test` all green
+- [x] 10.2 `bun run format:file` on every touched file under `src/`
+- [x] 10.3 Manual `bun run dev` smoke pass over all eight behaviors (profile dialog times, sticky progress during a run, inline tool status, header/sidebar path at two terminal widths, esc-deselect, user-turn rule, picker wrap-around, sidebar label rows) — performed by the user; the resulting feedback fixes are group 10.5

--- a/cli/openspec/specs/key-bindings/spec.md
+++ b/cli/openspec/specs/key-bindings/spec.md
@@ -69,3 +69,37 @@ A layer that can be active while a text input or textarea is focused MUST NOT bi
 - **WHEN** a dialog containing no text input (e.g. `ResultsDialog`) binds `q` to close
 - **THEN** the binding is compliant because no focused editor can coexist with it
 
+### Requirement: Escape clears the active text selection first
+
+The chat app SHALL register a mode-less keymap layer that binds `esc` to clear the renderer's
+active mouse text selection (`renderer.clearSelection()`), enabled only while a selection with
+non-empty selected text exists (`renderer.getSelection()?.getSelectedText()` — the app's
+established "real selection" predicate, since a plain click on selectable text creates an empty
+`Selection`). The layer's priority SHALL sit above the dialog host's esc layer and below the abort
+layer, so with a selection active `esc` deselects and does nothing else — the dialog stays open,
+the textarea keeps focus — and with no selection the layer is disabled and `esc` falls through to
+its existing behaviors unchanged (close dialog, INSERT→NORMAL, chord abort). The binding SHALL
+only clear; it MUST NOT copy (copy-on-select already writes the clipboard on mouse-up). The keymap
+engine's pending-leader-sequence abort runs before all layers by design; `esc` pressed mid-chord
+aborts the chord and leaves the selection for the next press — an accepted interaction.
+
+#### Scenario: Esc deselects instead of closing a dialog
+
+- **WHEN** text is selected inside an open dialog and the user presses `esc`
+- **THEN** the selection clears and the dialog remains open; a second `esc` closes it
+
+#### Scenario: Esc deselects without leaving INSERT
+
+- **WHEN** text is selected while the chat textarea is focused and the user presses `esc`
+- **THEN** the selection clears and the textarea keeps focus; a second `esc` switches to NORMAL as before
+
+#### Scenario: No selection means no behavior change
+
+- **WHEN** no text selection exists and the user presses `esc` anywhere in the TUI
+- **THEN** `esc` behaves exactly as it did before this requirement (the layer is disabled)
+
+#### Scenario: An empty click-selection does not arm the layer
+
+- **WHEN** the user clicks (without dragging) on selectable text, creating an empty selection, and presses `esc`
+- **THEN** `esc` falls through to its existing behavior — the layer arms only on non-empty selected text
+

--- a/cli/openspec/specs/list-primitives/spec.md
+++ b/cli/openspec/specs/list-primitives/spec.md
@@ -92,7 +92,13 @@ Both lists SHALL own cursor state and register their keys via `useDialogBindings
 - **Always-on** (safe beside a focused editor): ↑/↓, ctrl+p/ctrl+n, page-up/page-down (±10 rows), enter.
 - **Bare-printable** (gated by a `bareKeysEnabled` passthrough, which hosts with a focusable filter input MUST wire to `!inputFocused`): the vim cursor keys j/k (down/up), gg (first row), G (last row) — and space-toggle in multi mode.
 
-The list SHALL compose `ScrollPane` with `focusOnMount={false}` (the pane is never focused) and keep the cursor row visible via `scrollChildIntoView`, pulling a group header into view when the cursor sits on a group's first item. The cursor SHALL clamp when filtering shrinks the set. The whole layer set SHALL also accept an `enabled` passthrough so hosts can suspend the list entirely.
+End-of-list behavior splits by component through a `wrapNavigation` option on the shared core:
+
+- **`FixedList`** SHALL enable it: single-step movement (↑/↓, ctrl+p/ctrl+n, j/k) wraps between the first and last item rows — stepping down from the last row lands on the first, stepping up from the first lands on the last (modular, so a single-row list is a no-op).
+- **`DynamicList`** SHALL NOT enable it: single-step movement clamps at the ends, because a source that refilters or refreshes underfoot makes a surprise jump to the far end disorienting.
+- Page movement (±10 rows) SHALL clamp at the ends in BOTH lists — the deliberate "slam toward the end" gesture must land on the end, not overshoot past it — and `gg`/`G` remain absolute jumps.
+
+The list SHALL compose `ScrollPane` with `focusOnMount={false}` (the pane is never focused) and keep the cursor row visible via `scrollChildIntoView` — a wrap jump scrolls the destination row into view exactly as `gg`/`G` do — pulling a group header into view when the cursor sits on a group's first item. The cursor SHALL clamp when filtering shrinks the set. The whole layer set SHALL also accept an `enabled` passthrough so hosts can suspend the list entirely.
 
 #### Scenario: Navigation keys move the cursor
 
@@ -103,6 +109,26 @@ The list SHALL compose `ScrollPane` with `focusOnMount={false}` (the pane is nev
 
 - **WHEN** `bareKeysEnabled` is true (no filter input holds focus) and the user presses j, k, gg, or G
 - **THEN** the cursor moves down / up / to the first row / to the last row — and when an input is focused, those keys type into it instead
+
+#### Scenario: FixedList wraps at the bottom
+
+- **WHEN** the cursor sits on a `FixedList`'s last item row and the user presses ↓, ctrl+n, or j
+- **THEN** the cursor lands on the first item row and it scrolls into view
+
+#### Scenario: FixedList wraps at the top
+
+- **WHEN** the cursor sits on a `FixedList`'s first item row and the user presses ↑, ctrl+p, or k
+- **THEN** the cursor lands on the last item row and it scrolls into view
+
+#### Scenario: DynamicList clamps at the ends
+
+- **WHEN** the cursor sits on a `DynamicList`'s last item row and the user presses ↓
+- **THEN** the cursor stays on the last row — no wrap
+
+#### Scenario: Page movement clamps everywhere
+
+- **WHEN** the cursor is within ten rows of an end and the user presses page-down (or page-up toward the start)
+- **THEN** the cursor lands on the end row in both list components, never wrapping past it
 
 #### Scenario: Host gates the layer
 

--- a/cli/openspec/specs/tui-design-tokens/spec.md
+++ b/cli/openspec/specs/tui-design-tokens/spec.md
@@ -8,10 +8,10 @@ TBD - created by archiving change inflexa-design-system. Update Purpose after ar
 The system SHALL provide three `as const` objects with derived literal-union types — `space`, `size`, `stroke` — in the dependency-light, solid-js-free design-system module `src/lib/design_system.ts`, the single source of truth for non-color layout primitives:
 
 - `space` — spacing counted in terminal cells: `none: 0` (tight pairs, marker│text), `sm: 1` (rows within a block), `md: 2` (between blocks and panels), `lg: 4` (rare major breaks).
-- `size` — fixed structural dimensions in cells/rows: `gutter: 2` (the marker column), `statusBar: 1` (row height), `railWidth: 40` (sidebar/rail columns), `composerMin: 1` (grows with input), `paletteRows: 12` (visible before scroll).
+- `size` — fixed structural dimensions in cells/rows: `gutter: 2` (the marker column), `statusBar: 1` (row height), `railWidth: 40` (sidebar/rail columns), `composerMin: 1` (grows with input), `paletteRows: 12` (visible before scroll), `breakpointWide: 120` (terminal columns at/above which wide-terminal layouts engage — a calibration value, tunable).
 - `stroke` — border roles mapped to opentui `borderStyle`: `panel: "single"`, `overlay: "rounded"`, `focus: "heavy"`, `danger: "double"`.
 
-Each object SHALL be `as const`, and the module SHALL export the union types `Space = keyof typeof space` and `Stroke = keyof typeof stroke`. `railWidth` SHALL be `40` (the existing tuned value), not the design doc's example `30`.
+Each object SHALL be `as const`, and the module SHALL export the union types `Space = keyof typeof space` and `Stroke = keyof typeof stroke`. `railWidth` SHALL be `40` (the existing tuned value), not the design doc's example `30`. `breakpointWide` is the single wide-terminal threshold: any component that places content responsively by terminal width (e.g. the status bar's workspace-path segment vs the sidebar's path line) SHALL compare against this token, never an inline column count, so every responsive surface flips at the same width.
 
 #### Scenario: Tokens are literal-typed constants
 
@@ -22,6 +22,11 @@ Each object SHALL be `as const`, and the module SHALL export the union types `Sp
 
 - **WHEN** a developer needs the rail width, gutter width, status-bar height, or a border style
 - **THEN** it is read from `size`/`stroke` in `design_system.ts`, defined once
+
+#### Scenario: Responsive placement reads the breakpoint token
+
+- **WHEN** a component decides between a wide-terminal and a narrow-terminal placement
+- **THEN** it compares the terminal width against `size.breakpointWide`, not an inline number, and all such surfaces flip at the same threshold
 
 ### Requirement: Layout props use tokens, not raw integers
 

--- a/cli/openspec/specs/tui-stream-blocks/spec.md
+++ b/cli/openspec/specs/tui-stream-blocks/spec.md
@@ -10,7 +10,7 @@ The chat stream SHALL render the eight canonical block states of the design syst
 1. **welcome / startup** — shown at the top of an empty stream; a wordmark plus the active context (greeting, anchor path with ✓/⚠ badge, resume hint, command hint).
 2. **plain chat turn** — the existing user/assistant `MessageBlock` (markdown body under a `>`/`<` marker).
 3. **thinking / reasoning** — a `◆ thinking` marker, an optional duration, and a collapsed-by-default italic reasoning body that can expand.
-4. **tool call & result** — a `▸` marker with the tool/verb name and target, the result rendered in a `<code>` block, and a completion line.
+4. **tool call & result** — a `▸` marker with the tool/verb name and target, and the call's status (ok / running / error, with duration); for a call without a rendered result the status sits inline on the name line (see "Tool status placement is prop-controlled"), and for a call with a result the result renders in a `<code>` block with the status as a completion line beneath it.
 5. **long-running run / task** — a `●` marker with the run name, a progress bar, and an indented step list (done / running / queued).
 6. **diff / file edit** — a `✎` marker with the file name and +/− counts, the hunk rendered via the `<diff>` renderable, and accept/reject/edit affordances.
 7. **error / abort** — a `✗` marker, the abort/error summary, and a bordered callout (using `stroke.danger` chrome and `onAccent` foreground on any filled region); the degraded-anchor case (`markerWritten = false`) renders its callout from existing anchor state.
@@ -32,6 +32,25 @@ Each block SHALL map to a single built-in opentui renderable (no custom drawing)
 
 - **WHEN** a block paints a color or prints a non-ASCII glyph
 - **THEN** the color comes from `theme()` and the glyph from `GLYPHS`, never an inline literal
+
+### Requirement: Tool status placement is prop-controlled
+
+`ToolBlock` SHALL take an `inlineStatus?: boolean` prop controlling where the call's status (glyph + label + optional duration) renders: inline on the name line — after the name and target, separated by a `space.md` gap — or as a standalone completion line below the block's content. The default SHALL derive from the result: a block without a `result` renders inline (live harness tool events never carry a result, so every live call uses the single-line form), and a block with a `result` keeps the completion line below the `<code>` panel, where an inline status would strand the outcome above the output it describes. An explicit prop value SHALL override the derivation (the design gallery pins both forms). The inline form SHALL NOT right-align the status (a wrapped right-aligned segment lands at column 0 and breaks the gutter); it flows after the name so narrow terminals soft-wrap it instead. Both placements SHALL be pinned by frame-assertion render tests, including a sidebar-open-width (40-column) sweep.
+
+#### Scenario: Live tool call renders on one line
+
+- **WHEN** a tool call without a result renders (running or finished)
+- **THEN** the name, target, and status share one line — `▸ name target  ✓ ok · 14ms` — with a `space.md` gap before the status
+
+#### Scenario: A result keeps the completion line
+
+- **WHEN** a tool block renders with a `result`
+- **THEN** the result renders in the `<code>` panel and the status renders as a completion line beneath it, as before
+
+#### Scenario: The gallery pins both placements
+
+- **WHEN** the design gallery renders the tool-block exhibits
+- **THEN** it shows the inline form and the completion-line form via explicit `inlineStatus` values
 
 ### Requirement: Message block renders all part kinds exhaustively
 

--- a/cli/src/extensions/date.ext.ts
+++ b/cli/src/extensions/date.ext.ts
@@ -9,7 +9,8 @@ declare global {
          * next unit down keeps the readout honest without spending a full timestamp. A static on Date
          * (mirroring `Date.now`) so any "age" readout reads from one place instead of each panel
          * redeclaring the same bucketing. Clamps negatives (a future timestamp / clock skew) to `0s`
-         * rather than printing a negative age.
+         * rather than printing a negative age; a non-finite `since` (NaN/Infinity) is unknowable and
+         * likewise renders `0s` rather than a `NaNdNaNh` string.
          */
         relativeAge(since: number): string;
         /**
@@ -21,13 +22,15 @@ declare global {
          * a minute or more switches to minutes + zero-padded seconds with no spaces (`1m00s`,
          * `2m05s`, `72m10s`) — large values stay in minutes rather than gaining an hours unit,
          * since durations here are agent-turn-scale, not wall-clock ages. Clamps negatives
-         * (clock skew) to `0ms`.
+         * (clock skew) to `0ms`; a non-finite `ms` (NaN/Infinity) renders `0ms` rather than a
+         * `NaNmNaNs` string.
          */
         formatDuration(ms: number): string;
     }
 }
 
 Date.relativeAge = function (since: number): string {
+    if (!Number.isFinite(since)) return "0s";
     const secs = Math.max(0, Math.floor((Date.now() - since) / 1000));
     if (secs < 60) return `${secs}s`;
     const mins = Math.floor(secs / 60);
@@ -38,8 +41,14 @@ Date.relativeAge = function (since: number): string {
 };
 
 Date.formatDuration = function (ms: number): string {
+    if (!Number.isFinite(ms)) return "0ms";
     const clamped = Math.max(0, ms);
-    if (clamped < 1000) return `${Math.round(clamped)}ms`;
+    // Decide the sub-second branch on the ROUNDED millisecond value, not the raw span: rounding only
+    // after the `< 1000` check let 999.6ms slip in and then print a nonsensical "1000ms". Rounding
+    // first keeps the threshold and the rendered number in agreement — 999.6ms crosses into the
+    // seconds branch and reads "1.0s".
+    const roundedMs = Math.round(clamped);
+    if (roundedMs < 1000) return `${roundedMs}ms`;
     if (clamped < 60_000) return `${(clamped / 1000).toFixed(1)}s`;
     const totalSecs = Math.floor(clamped / 1000);
     const mins = Math.floor(totalSecs / 60);

--- a/cli/src/extensions/date.ext.ts
+++ b/cli/src/extensions/date.ext.ts
@@ -1,13 +1,29 @@
 declare global {
     interface DateConstructor {
         /**
-         * Formats the elapsed time since a past millisecond timestamp as a compact,
-         * single-unit relative age — the largest whole unit that fits (`6m`, `3h`, `2d`).
-         * A static on Date (mirroring `Date.now`) so any "age" readout reads from one
-         * place instead of each panel redeclaring the same bucketing. Clamps negatives
-         * (a future timestamp / clock skew) to `0s` rather than printing a negative age.
+         * Formats the elapsed time since a past millisecond timestamp as a compact relative age.
+         * Below a minute it is a single seconds unit (`31s`); from a minute up it is the largest
+         * whole unit PLUS the next one down, the second zero-padded to two digits so the width is
+         * stable (`5m31s`, `8h54m`, `2d04h` — matching {@link formatDuration}'s `2m05s` shape). The
+         * second unit is the point: a lone coarse unit like `8h` hides up to an hour of drift, so the
+         * next unit down keeps the readout honest without spending a full timestamp. A static on Date
+         * (mirroring `Date.now`) so any "age" readout reads from one place instead of each panel
+         * redeclaring the same bucketing. Clamps negatives (a future timestamp / clock skew) to `0s`
+         * rather than printing a negative age.
          */
         relativeAge(since: number): string;
+        /**
+         * Formats a duration (a span in milliseconds, not a timestamp) as one compact human
+         * string, so every "how long did this take" readout — tool calls, reasoning, turns —
+         * speaks a single vocabulary instead of each block picking its own thresholds. Three
+         * ranges by magnitude: sub-second stays in whole milliseconds (`14ms`); under a minute
+         * shows one decimal second (`1.4s`, `59.9s`) so short spans keep useful precision;
+         * a minute or more switches to minutes + zero-padded seconds with no spaces (`1m00s`,
+         * `2m05s`, `72m10s`) — large values stay in minutes rather than gaining an hours unit,
+         * since durations here are agent-turn-scale, not wall-clock ages. Clamps negatives
+         * (clock skew) to `0ms`.
+         */
+        formatDuration(ms: number): string;
     }
 }
 
@@ -15,10 +31,20 @@ Date.relativeAge = function (since: number): string {
     const secs = Math.max(0, Math.floor((Date.now() - since) / 1000));
     if (secs < 60) return `${secs}s`;
     const mins = Math.floor(secs / 60);
-    if (mins < 60) return `${mins}m`;
+    if (mins < 60) return `${mins}m${(secs % 60).toString().padStart(2, "0")}s`;
     const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}h`;
-    return `${Math.floor(hours / 24)}d`;
+    if (hours < 24) return `${hours}h${(mins % 60).toString().padStart(2, "0")}m`;
+    return `${Math.floor(hours / 24)}d${(hours % 24).toString().padStart(2, "0")}h`;
+};
+
+Date.formatDuration = function (ms: number): string {
+    const clamped = Math.max(0, ms);
+    if (clamped < 1000) return `${Math.round(clamped)}ms`;
+    if (clamped < 60_000) return `${(clamped / 1000).toFixed(1)}s`;
+    const totalSecs = Math.floor(clamped / 1000);
+    const mins = Math.floor(totalSecs / 60);
+    const secs = totalSecs % 60;
+    return `${mins}m${secs.toString().padStart(2, "0")}s`;
 };
 
 export {};

--- a/cli/src/extensions/extensions.test.ts
+++ b/cli/src/extensions/extensions.test.ts
@@ -77,6 +77,12 @@ describe("Date.relativeAge", () => {
             now.mockRestore();
         }
     });
+
+    test("a non-finite `since` renders 0s rather than a NaN string", () => {
+        expect(Date.relativeAge(NaN)).toBe("0s");
+        expect(Date.relativeAge(Infinity)).toBe("0s");
+        expect(Date.relativeAge(-Infinity)).toBe("0s");
+    });
 });
 
 describe("Date.formatDuration", () => {
@@ -93,6 +99,13 @@ describe("Date.formatDuration", () => {
         expect(Date.formatDuration(59_999)).toBe("60.0s"); // still the seconds branch (rounds up to 60.0)
     });
 
+    test("a sub-second span that rounds up to 1000ms reads 1.0s, never 1000ms", () => {
+        // The branch is decided on the rounded value, so 999.6ms crosses into the seconds range instead
+        // of printing an out-of-range "1000ms".
+        expect(Date.formatDuration(999.6)).toBe("1.0s");
+        expect(Date.formatDuration(999.4)).toBe("999ms"); // rounds down → stays in the ms range
+    });
+
     test("a minute or more renders minutes + zero-padded seconds, no spaces", () => {
         expect(Date.formatDuration(60_000)).toBe("1m00s"); // the seconds→minutes boundary
         expect(Date.formatDuration(125_000)).toBe("2m05s");
@@ -101,6 +114,12 @@ describe("Date.formatDuration", () => {
 
     test("clamps a negative duration to 0ms", () => {
         expect(Date.formatDuration(-5)).toBe("0ms");
+    });
+
+    test("a non-finite duration renders 0ms rather than a NaN string", () => {
+        expect(Date.formatDuration(NaN)).toBe("0ms");
+        expect(Date.formatDuration(Infinity)).toBe("0ms");
+        expect(Date.formatDuration(-Infinity)).toBe("0ms");
     });
 });
 

--- a/cli/src/extensions/extensions.test.ts
+++ b/cli/src/extensions/extensions.test.ts
@@ -41,15 +41,29 @@ describe("Date.relativeAge", () => {
     // Pin the clock so bucket boundaries are exact rather than racing real time.
     const NOW = 1_700_000_000_000;
 
-    test("formats the largest whole unit that fits", () => {
+    test("below a minute renders a single seconds unit", () => {
         const now = spyOn(Date, "now").mockReturnValue(NOW);
         try {
             expect(Date.relativeAge(NOW)).toBe("0s");
             expect(Date.relativeAge(NOW - 5_000)).toBe("5s");
-            expect(Date.relativeAge(NOW - 59_000)).toBe("59s");
-            expect(Date.relativeAge(NOW - 60_000)).toBe("1m");
-            expect(Date.relativeAge(NOW - 90 * 60_000)).toBe("1h");
-            expect(Date.relativeAge(NOW - 25 * 3_600_000)).toBe("1d");
+            expect(Date.relativeAge(NOW - 59_000)).toBe("59s"); // upper edge of the seconds range
+        } finally {
+            now.mockRestore();
+        }
+    });
+
+    test("from a minute up renders the largest unit plus the next one down, zero-padded", () => {
+        const now = spyOn(Date, "now").mockReturnValue(NOW);
+        try {
+            expect(Date.relativeAge(NOW - 60_000)).toBe("1m00s"); // the seconds→minutes boundary
+            expect(Date.relativeAge(NOW - 305_000)).toBe("5m05s"); // second unit zero-pads to two digits
+            expect(Date.relativeAge(NOW - 331_000)).toBe("5m31s");
+            expect(Date.relativeAge(NOW - 3_599_000)).toBe("59m59s"); // upper edge of the minutes range
+            expect(Date.relativeAge(NOW - 3_600_000)).toBe("1h00m"); // the minutes→hours boundary
+            expect(Date.relativeAge(NOW - 32_040_000)).toBe("8h54m");
+            expect(Date.relativeAge(NOW - 86_340_000)).toBe("23h59m"); // upper edge of the hours range
+            expect(Date.relativeAge(NOW - 86_400_000)).toBe("1d00h"); // the hours→days boundary
+            expect(Date.relativeAge(NOW - 187_200_000)).toBe("2d04h");
         } finally {
             now.mockRestore();
         }
@@ -62,6 +76,31 @@ describe("Date.relativeAge", () => {
         } finally {
             now.mockRestore();
         }
+    });
+});
+
+describe("Date.formatDuration", () => {
+    test("sub-second spans render whole milliseconds", () => {
+        expect(Date.formatDuration(14)).toBe("14ms");
+        expect(Date.formatDuration(0)).toBe("0ms");
+        expect(Date.formatDuration(999)).toBe("999ms"); // upper edge of the ms range
+    });
+
+    test("under-a-minute spans render one decimal second", () => {
+        expect(Date.formatDuration(1000)).toBe("1.0s"); // first value past the ms range
+        expect(Date.formatDuration(1400)).toBe("1.4s");
+        expect(Date.formatDuration(59_900)).toBe("59.9s");
+        expect(Date.formatDuration(59_999)).toBe("60.0s"); // still the seconds branch (rounds up to 60.0)
+    });
+
+    test("a minute or more renders minutes + zero-padded seconds, no spaces", () => {
+        expect(Date.formatDuration(60_000)).toBe("1m00s"); // the seconds→minutes boundary
+        expect(Date.formatDuration(125_000)).toBe("2m05s");
+        expect(Date.formatDuration(4_330_000)).toBe("72m10s"); // large spans stay in minutes
+    });
+
+    test("clamps a negative duration to 0ms", () => {
+        expect(Date.formatDuration(-5)).toBe("0ms");
     });
 });
 

--- a/cli/src/lib/design_system.ts
+++ b/cli/src/lib/design_system.ts
@@ -701,6 +701,12 @@ export const size = {
     statusBar: 1,
     /** Sidebar / rail width, in columns. */
     railWidth: 40,
+    /**
+     * Terminal-column threshold at/above which wide-terminal placements engage. A calibration
+     * value: the 40-column {@link size.railWidth} plus a comfortable ~80-column chat both fit at
+     * 120, so that is where the extra-wide layout earns its space. Tunable.
+     */
+    breakpointWide: 120,
     /** Composer minimum height; grows with input. */
     composerMin: 1,
     /** Palette rows visible before it scrolls. */

--- a/cli/src/tui/app.tsx
+++ b/cli/src/tui/app.tsx
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
+import { sep } from "node:path";
 import { createSignal, Show } from "solid-js";
-import type { Renderable, TextareaRenderable, ScrollBoxRenderable } from "@opentui/core";
+import type { CliRenderer, Renderable, TextareaRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/solid";
 import { errAsync } from "neverthrow";
 import { queryStepsByRun, type StepExecutionRow, type DbError } from "@inflexa-ai/harness";
@@ -20,7 +21,7 @@ import { CommandPalette, runCommand } from "./components/command_palette.tsx";
 import { ResultsDialog } from "./components/dialog/results_dialog.tsx";
 import { RunsDialog } from "./components/dialog/runs_dialog.tsx";
 import { dialogPush, dialogClose, dialogIsOpen, DialogOverlay } from "./components/dialog/dialog_host.tsx";
-import { useKeymapRoot, useBindings, MODE_BASE, resolveKeybind, keybindLabel, leaderSeq, KEYS } from "./keymap.ts";
+import { useKeymapRoot, useBindings, MODE_BASE, resolveKeybind, keybindLabel, leaderSeq, KEYS, type LayerConfig } from "./keymap.ts";
 import { StatusBar } from "./layout/status_bar.tsx";
 import { Chat } from "./components/chat.tsx";
 import { BootIndicator } from "./components/boot_indicator.tsx";
@@ -40,6 +41,7 @@ type AppProps = {
 };
 
 /**
+ * TODO(slop): Please extract this to somewhere in `lib`
  * Contract the user's home-directory prefix to `~` for a compact display path. A single-caller
  * affordance for the wide-terminal status bar, kept beside its use per the no-extract-helper rule.
  * Only a true path-boundary prefix contracts (exact home, or home followed by a separator), so a
@@ -48,7 +50,36 @@ type AppProps = {
 function contractHome(path: string): string {
     const home = homedir();
     if (path === home) return "~";
-    return path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+    // A path-boundary prefix is home followed by the platform separator (`/` on POSIX, `\` on Windows).
+    // Both `homedir()` and `canonicalPath` (which backs these paths via realpathSync/resolve) yield
+    // platform-native separators — they are NOT normalized to `/` — so hard-coding `/` would fail to
+    // contract any path on Windows. Using `sep` keeps a sibling like `/home/alice-backup` untouched
+    // (no separator boundary) rather than mangling it into `~-backup`.
+    return path.startsWith(`${home}${sep}`) ? `~${path.slice(home.length)}` : path;
+}
+
+/**
+ * The real "esc clears a live text selection" key layer, built as a pure factory over the renderer so
+ * the render test drives the SAME config `App` installs — not a hand-copied replica that could silently
+ * drift out of sync. `App` registers it with `useBindings(() => selectionClearLayer(renderer))`, which
+ * re-invokes it on every keystroke so `enabled` re-reads the live selection.
+ *
+ * It is mode-less and priority 50 on purpose: above the dialog host's structural esc (priority 0), so a
+ * span selected inside a dialog deselects WITHOUT closing the dialog, and below the abort chord
+ * (priority 100), which owns its own selection-aware copy path. Mode-less (not MODE_BASE) because a
+ * selection can be live while a dialog is stacked and MODE_BASE layers suspend under a modal — this must
+ * still fire there. `enabled` reads the SELECTED TEXT, not `hasSelection`: a plain click on selectable
+ * text leaves a non-null but EMPTY Selection, so `hasSelection` would arm on every click and swallow
+ * esc's real jobs (dialog cancel, INSERT→NORMAL). Clear only — copy-on-select already wrote the
+ * clipboard on mouse-up, so esc must not re-copy. With no selected text the layer is disabled and esc
+ * falls through unchanged to every existing binding.
+ */
+export function selectionClearLayer(renderer: CliRenderer): LayerConfig {
+    return {
+        priority: 50,
+        enabled: !!renderer.getSelection()?.getSelectedText(),
+        bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection(), desc: "Clear selection", group: "App" }],
+    };
 }
 
 export function App(props: AppProps) {
@@ -248,21 +279,11 @@ export function App(props: AppProps) {
         ],
     }));
 
-    // esc clears a live text selection — and nothing else. A mode-less layer slotted at priority 50:
-    // above the dialog host's structural esc (priority 0) so a span selected inside a dialog
-    // deselects WITHOUT closing the dialog, and below the abort chord (priority 100), which owns its
-    // own selection-aware copy path. Mode-less (not MODE_BASE) on purpose: a selection can be live
-    // while a dialog is stacked, and MODE_BASE layers are suspended under a modal — this must still
-    // fire there. The arm predicate reads the SELECTED TEXT, not `hasSelection`: a plain click on
-    // selectable text leaves a non-null but EMPTY Selection, so `hasSelection` would arm on every
-    // click and swallow esc's real jobs (dialog cancel, INSERT→NORMAL). Clear only — copy-on-select
-    // already wrote the clipboard on mouse-up, so esc must not re-copy. With no selected text the
-    // layer is disabled and esc falls through unchanged to every existing binding.
-    useBindings(() => ({
-        priority: 50,
-        enabled: !!renderer.getSelection()?.getSelectedText(),
-        bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection(), desc: "Clear selection", group: "App" }],
-    }));
+    // esc clears a live text selection — and nothing else. The layer config is the exported
+    // `selectionClearLayer` factory (its full rationale lives on that export); registering it via a
+    // thunk re-invokes it each keystroke so `enabled` re-reads the live selection. The render test
+    // installs the SAME factory, so the two can never drift.
+    useBindings(() => selectionClearLayer(renderer));
 
     function runCommandById(id: string): void {
         const cmd = commands.find((c) => c.id === id);

--- a/cli/src/tui/app.tsx
+++ b/cli/src/tui/app.tsx
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { createSignal, Show } from "solid-js";
 import type { Renderable, TextareaRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/solid";
@@ -5,7 +6,7 @@ import { errAsync } from "neverthrow";
 import { queryStepsByRun, type StepExecutionRow, type DbError } from "@inflexa-ai/harness";
 
 import { causeDetailLines } from "../lib/cause.ts";
-import { GLYPHS, zIndex } from "../lib/design_system.ts";
+import { GLYPHS, size, zIndex } from "../lib/design_system.ts";
 import { shutdown } from "../lib/shutdown.ts";
 import { writeClipboard } from "../lib/clipboard.ts";
 import { theme, themeVariant, noticeColor, type Notice } from "./theme.ts";
@@ -24,6 +25,7 @@ import { StatusBar } from "./layout/status_bar.tsx";
 import { Chat } from "./components/chat.tsx";
 import { BootIndicator } from "./components/boot_indicator.tsx";
 import { ChatBar } from "./layout/chat_bar.tsx";
+import { RunProgressRow } from "./layout/run_progress_row.tsx";
 import { Sidebar } from "./layout/sidebar.tsx";
 import { WhichKey } from "./layout/which_key.tsx";
 import { WorkspaceContext, createWorkspace } from "./contexts/workspace.ts";
@@ -36,6 +38,18 @@ type AppProps = {
     workingDir: string;
     analysis: Analysis;
 };
+
+/**
+ * Contract the user's home-directory prefix to `~` for a compact display path. A single-caller
+ * affordance for the wide-terminal status bar, kept beside its use per the no-extract-helper rule.
+ * Only a true path-boundary prefix contracts (exact home, or home followed by a separator), so a
+ * sibling like `/home/alice-backup` is left untouched rather than mangled into `~-backup`.
+ */
+function contractHome(path: string): string {
+    const home = homedir();
+    if (path === home) return "~";
+    return path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+}
 
 export function App(props: AppProps) {
     const dims = useTerminalDimensions();
@@ -234,6 +248,22 @@ export function App(props: AppProps) {
         ],
     }));
 
+    // esc clears a live text selection — and nothing else. A mode-less layer slotted at priority 50:
+    // above the dialog host's structural esc (priority 0) so a span selected inside a dialog
+    // deselects WITHOUT closing the dialog, and below the abort chord (priority 100), which owns its
+    // own selection-aware copy path. Mode-less (not MODE_BASE) on purpose: a selection can be live
+    // while a dialog is stacked, and MODE_BASE layers are suspended under a modal — this must still
+    // fire there. The arm predicate reads the SELECTED TEXT, not `hasSelection`: a plain click on
+    // selectable text leaves a non-null but EMPTY Selection, so `hasSelection` would arm on every
+    // click and swallow esc's real jobs (dialog cancel, INSERT→NORMAL). Clear only — copy-on-select
+    // already wrote the clipboard on mouse-up, so esc must not re-copy. With no selected text the
+    // layer is disabled and esc falls through unchanged to every existing binding.
+    useBindings(() => ({
+        priority: 50,
+        enabled: !!renderer.getSelection()?.getSelectedText(),
+        bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection(), desc: "Clear selection", group: "App" }],
+    }));
+
     function runCommandById(id: string): void {
         const cmd = commands.find((c) => c.id === id);
         if (cmd) void runCommand(cmd, workspace);
@@ -397,6 +427,10 @@ export function App(props: AppProps) {
                     title="inflexa"
                     subtitle={workspace.analysis?.name}
                     state={statusState()}
+                    // The working directory is a wide-terminal-only affordance: at/above the breakpoint the
+                    // rail and a comfortable chat both fit, so the path earns its space; below it the sidebar
+                    // carries the path instead, so gating here keeps it on exactly one surface at any width.
+                    path={dims().width >= size.breakpointWide ? contractHome(workspace.workingDir) : undefined}
                     hints={[keybindLabel("app.command-palette"), keybindLabel("app.toggle-sidebar"), keybindLabel("app.abort")]}
                 />
 
@@ -406,6 +440,11 @@ export function App(props: AppProps) {
                     <box flexDirection="column" flexGrow={1} minHeight={0}>
                         {/* The live conversation: stream + error banner, all state in hooks/conversation.ts */}
                         <Chat onScrollPaneRef={(r: ScrollBoxRenderable) => (scrollPaneRef = r)} />
+
+                        {/* Sticky run-progress row: pinned below the stream while the newest run is
+                        non-terminal (renders null otherwise). Its own opaque, full-width flexShrink={0}
+                        box reclaims the scrollbox's 1-cell bleed — same recipe as the boot indicator. */}
+                        <RunProgressRow />
 
                         {/* Boot animation / failed-boot message, shown until the runtime is ready. A
                         full-width box painted with the app background and flexShrink={0}: it sits

--- a/cli/src/tui/app_config.tsx
+++ b/cli/src/tui/app_config.tsx
@@ -276,8 +276,12 @@ export function ConfigApp(props: { onClose?: () => void }) {
                     else toggleFocused();
                 },
             },
-            { chord: KEYS.up, run: () => setSection(Math.max(0, section() - 1)) },
-            { chord: KEYS.down, run: () => setSection(Math.min(sections.length - 1, section() + 1)) },
+            // Section nav wraps end-to-end so a long form is fully reachable without a direction
+            // change: stepping down off the last section lands on the first, up off the first on
+            // the last. (The radios' left/right value stepping stays clamped — wrapping a setting's
+            // value past its ends would be a surprise, not a convenience.)
+            { chord: KEYS.up, run: () => setSection((section() - 1 + sections.length) % sections.length) },
+            { chord: KEYS.down, run: () => setSection((section() + 1) % sections.length) },
             { chord: KEYS.left, run: () => step(-1) },
             { chord: KEYS.right, run: () => step(1) },
         ],

--- a/cli/src/tui/components/dialog/dialog_host.render.test.tsx
+++ b/cli/src/tui/components/dialog/dialog_host.render.test.tsx
@@ -257,6 +257,46 @@ describe("dialog host state machine (rendered, real keyboard bus)", () => {
         }
     });
 
+    test("SelectDialog: a cursor round-trip leaves the frame identical and keeps the one input↔list gap row", async () => {
+        // The list's scroll surface carries NO top padding: padding inside a scrollbox is scrollable
+        // content, so any top pad scrolls away on the first scroll and never returns — the input↔list
+        // spacing would silently lose a row after one round-trip. Separation is a static gap box OUTSIDE
+        // the scrollbox, so walking the cursor to the bottom and back must reproduce the opening frame.
+        const items = Array.from({ length: 20 }, (_, i) => ({
+            value: `v${i}`,
+            title: `item ${String(i).padStart(2, "0")}`,
+            description: `detail for item ${i}`,
+            category: "All",
+        }));
+        const setup = await testRender(() => <Harness />, { width: 80, height: 20 });
+        const settle = makeSettle(setup);
+        const frame = () => setup.captureCharFrame();
+        try {
+            await settle();
+            dialogPush(() => <SelectDialog title="Pick" items={items} emptyText="none" onSelect={() => {}} onCancel={() => {}} />);
+            await settle();
+            const opening = frame();
+
+            // Exactly one static gap row sits between the filter input and the first group header — no
+            // more (a scroll-away pad row), no less (flush against the input).
+            const lines = opening.split("\n");
+            const inputIdx = lines.findIndex((l) => l.includes("Type to filter"));
+            const headerIdx = lines.findIndex((l) => l.includes("All"));
+            expect(inputIdx).toBeGreaterThanOrEqual(0);
+            expect(headerIdx - inputIdx).toBe(2); // input row, one gap row, then the header
+            expect(lines[inputIdx + 1]).not.toContain("item"); // the row between is the empty gap
+
+            // Walk the cursor to the bottom and all the way back: the frame must match the opening one.
+            for (let i = 0; i < 12; i++) setup.mockInput.pressArrow("down");
+            await settle();
+            for (let i = 0; i < 12; i++) setup.mockInput.pressArrow("up");
+            await settle();
+            expect(frame()).toBe(opening);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
     test("close-then-open keeps the next dialog's initial focus and the app restore chain", async () => {
         // The palette pattern: onSelect closes the palette, then the command pushes its own
         // dialog in the same tick. The overlay's deferred app-focus restore (scheduled at N→0)

--- a/cli/src/tui/components/dialog/dialog_host.render.test.tsx
+++ b/cli/src/tui/components/dialog/dialog_host.render.test.tsx
@@ -436,12 +436,15 @@ describe("config screen over the dialog host (the swallowed-keystroke regression
         try {
             await settle();
 
-            // Walk to the last section (a postgres field — down past the end clamps) and open it.
-            for (let i = 0; i < 40; i++) setup.mockInput.pressArrow("down");
+            // Walk to the last section — the postgres password field — and open its edit prompt.
+            // Section nav wraps end-to-end, so the count must be exact: overshooting loops back to
+            // the top. Sections are the telemetry toggle, the theme + runtime radios, then the five
+            // postgres fields (host/port/database/user/password), so the last sits 7 steps down.
+            for (let i = 0; i < 7; i++) setup.mockInput.pressArrow("down");
             await settle();
             setup.mockInput.pressEnter();
             await settle();
-            expect(frame()).toContain("postgres.");
+            expect(frame()).toContain("postgres.password");
 
             // `q` must type into the field, not exit the screen; `s` must not fire save;
             // space must not toggle anything. Any form action here is the old mode-gating bug.

--- a/cli/src/tui/components/dialog/file_picker.tsx
+++ b/cli/src/tui/components/dialog/file_picker.tsx
@@ -340,6 +340,10 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
                     onFocusChange={setInputFocused}
                     onInput={setQuery}
                 />
+                {/* Breathing room between the filter and the list. Safe as a transparent gap because it
+                    sits ABOVE the list's flexGrow scrollbox — the one-cell scrollbox bleed only spills
+                    onto the sibling BELOW it (there the list's own painted detail box reclaims the row). */}
+                <box height={space.sm} flexShrink={0} />
                 <DynamicList
                     items={items()}
                     query={query()}

--- a/cli/src/tui/components/dialog/runs_dialog.render.test.tsx
+++ b/cli/src/tui/components/dialog/runs_dialog.render.test.tsx
@@ -115,7 +115,7 @@ describe("RunsDialog snapshot ladder", () => {
         expect(frame).not.toContain("RECENT RUNS");
     });
 
-    test("loaded → the run list, keyed by the id tail and the status", async () => {
+    test("loaded → the run list, keyed by the id tail, the status, and the absolute started time", async () => {
         const rows = [run(), run({ runId: "aaaaaaaa-bbbb-cccc-dddd-eeeeffff0000", status: "failed" })];
         const frame = await frameOf({ kind: "loaded", runs: rows }, parkedLoad);
         expect(frame).toContain("RECENT RUNS");
@@ -123,6 +123,9 @@ describe("RunsDialog snapshot ladder", () => {
         expect(frame).toContain("ff0000");
         expect(frame).toContain("completed");
         expect(frame).toContain("failed");
+        // Detail dialogs render the durable, absolute started time (not the rail's relative age) —
+        // assert via the same toLocaleString the row runs on the fixture timestamp, not a locale string.
+        expect(frame).toContain(new Date("2026-01-01T00:00:00.000Z").toLocaleString());
     });
 });
 

--- a/cli/src/tui/components/dialog/runs_dialog.test.ts
+++ b/cli/src/tui/components/dialog/runs_dialog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { StepExecutionRow } from "@inflexa-ai/harness";
 
-import { stepStateOf } from "./runs_dialog.tsx";
+import { stepStateOf } from "../../hooks/sidebar_live.ts";
 import type { RunStepView } from "../run_block.tsx";
 
 // A total map keyed by every harness step status: the `Record` type is a compile-time exhaustiveness

--- a/cli/src/tui/components/dialog/runs_dialog.tsx
+++ b/cli/src/tui/components/dialog/runs_dialog.tsx
@@ -12,46 +12,7 @@ import { useDialogBindings, useDialogCancel, useDialogEntry } from "./dialog_hos
 import { DialogPanel } from "./dialog_panel.tsx";
 import { ScrollPane, SCROLL_HINT } from "../scroll_pane.tsx";
 import { RunBlock, type RunStepView } from "../run_block.tsx";
-import { relAge, runMark, shortRunName, type RunsSnapshot } from "../../hooks/sidebar_live.ts";
-
-/**
- * Map a harness step-execution status onto the design-system run-step state. Pure and
- * exhaustive over {@link StepExecutionRow.status} — a `never`-typed default breaks the build if the
- * harness enum grows, so a new status is classified honestly rather than silently mis-bucketed.
- *
- * The four buckets are `done | running | failed | queued`; the honest mapping of the seven harness
- * statuses:
- *  - `pending` / `skipped` → `queued` — neither ran: pending awaits its turn, skipped never will.
- *    The muted hollow glyph reads as "inactive", which is truthful for both (skipped is not a
- *    success and not an error).
- *  - `running` → `running`, `completed` → `done`, `failed` → `failed` — direct.
- *  - `canceled` → `failed` — a fail-fast sibling stopped mid-flight; a non-success terminal, shown
- *    error-toned to match the sidebar's run-level `canceled`.
- *  - `blocked` → `failed` — an agent-declared blocker; `executeAnalysis` treats it as a failure
- *    (`step_blocked`), so the error tone is the honest signal.
- */
-export function stepStateOf(status: StepExecutionRow["status"]): RunStepView["state"] {
-    switch (status) {
-        case "pending":
-        case "skipped":
-            return "queued";
-        case "running":
-            return "running";
-        case "completed":
-            return "done";
-        case "failed":
-        case "canceled":
-        case "blocked":
-            return "failed";
-        default: {
-            const _exhaustive: never = status;
-            // Unreachable: the `never` assignment above proves every status is handled. The cast only
-            // satisfies the return type on this dead branch — if it ever runs, the harness added a
-            // status the switch does not cover, and we surface its raw string rather than crash.
-            return String(_exhaustive) as RunStepView["state"];
-        }
-    }
-}
+import { absTime, idTail, runMark, shortRunName, stepStateOf, type RunsSnapshot } from "../../hooks/sidebar_live.ts";
 
 /** The latest run's step-fetch state — fetched once on open, not by the sidebar poll. */
 type StepsState = { kind: "loading" } | { kind: "loaded"; views: RunStepView[] } | { kind: "unavailable" };
@@ -74,11 +35,6 @@ export type RunsDialogProps = {
     /** Wired to every non-commit close (esc, click-outside, ctrl+c) and the q/enter close keys. */
     onClose: () => void;
 };
-
-/** A short, human-scannable tail of a uuid (dashes stripped). */
-function idTail(id: string): string {
-    return id.replace(/-/g, "").slice(-6);
-}
 
 /**
  * The runs details view: a read-only, scrollable list of the analysis's recent runs plus the latest
@@ -144,7 +100,7 @@ export function RunsDialog(props: RunsDialogProps): JSX.Element {
                                             <text>
                                                 <Fg role={m.role}>{`${m.glyph} `}</Fg>
                                                 <Fg role="fg">{idTail(run.runId)}</Fg>
-                                                <Fg role="fgMuted">{` ${GLYPHS.middot} ${run.status} ${GLYPHS.middot} ${relAge(run.startedAt)}`}</Fg>
+                                                <Fg role="fgMuted">{` ${GLYPHS.middot} ${run.status} ${GLYPHS.middot} ${absTime(run.startedAt)}`}</Fg>
                                             </text>
                                         );
                                     }}

--- a/cli/src/tui/components/dialog/select_dialog.tsx
+++ b/cli/src/tui/components/dialog/select_dialog.tsx
@@ -2,7 +2,7 @@ import { createSignal } from "solid-js";
 import type { JSX } from "solid-js";
 import type { InputRenderable } from "@opentui/core";
 
-import { GLYPHS } from "../../../lib/design_system.ts";
+import { GLYPHS, space } from "../../../lib/design_system.ts";
 import { KEYS, chordLabel, type Chord } from "../../keymap.ts";
 import { useDialogBindings, useDialogCancel, useDialogCloseGuard, useDialogEntry } from "./dialog_host.tsx";
 import { DialogPanel } from "./dialog_panel.tsx";
@@ -90,7 +90,7 @@ export function SelectDialog<T>(props: SelectDialogProps<T>): JSX.Element {
     }
 
     return (
-        <DialogPanel title={props.title} size="lg" footer={footer()}>
+        <DialogPanel title={props.title} size="lg" padY footer={footer()}>
             <TextInput
                 chrome="bare"
                 /* Showcased exhibits must not grab focus at mount — see DialogEntryHandle.inert. */
@@ -103,6 +103,10 @@ export function SelectDialog<T>(props: SelectDialogProps<T>): JSX.Element {
                 onFocusChange={setInputFocused}
                 onInput={setQuery}
             />
+            {/* Breathing room between the filter and the list. Safe as a transparent gap because it
+                sits ABOVE the list's flexGrow scrollbox — the one-cell scrollbox bleed only spills
+                onto the sibling BELOW it (there the list's own painted detail box reclaims the row). */}
+            <box height={space.sm} flexShrink={0} />
             <FixedList
                 items={props.items}
                 query={query()}

--- a/cli/src/tui/components/fixed_list.tsx
+++ b/cli/src/tui/components/fixed_list.tsx
@@ -21,5 +21,6 @@ export type FixedListProps<T> = ListProps<T> & {
 export function FixedList<T>(props: FixedListProps<T>): JSX.Element {
     // eslint-disable-next-line solid/reactivity -- seed-once: the read-once mount semantic IS FixedList's contract (documented on `items`)
     const items = props.items;
-    return <ListCore {...props} items={items} strategy="for" />;
+    // Wrap-around cursor nav is safe here: a fixed row set has stable ends (see `wrapNavigation`).
+    return <ListCore {...props} items={items} strategy="for" wrapNavigation />;
 }

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "solid-js";
 import type { ScrollBoxRenderable } from "@opentui/core";
 
 import { rankBy } from "../../lib/fuzzy.ts";
-import { GLYPHS } from "../../lib/design_system.ts";
+import { GLYPHS, space } from "../../lib/design_system.ts";
 import { theme } from "../theme.ts";
 import { KEYS } from "../keymap.ts";
 import { useDialogBindings } from "./dialog/dialog_host.tsx";
@@ -88,6 +88,15 @@ type ListCoreProps<T> = ListProps<T> & {
      * `for_scrollbox.render.test.tsx`.
      */
     strategy: "for" | "index";
+    /**
+     * When set, single-step cursor movement (arrows, ctrl+p/n, j/k) wraps between the first and
+     * last rows instead of stopping at them: stepping down off the bottom lands on the top, up
+     * off the top on the bottom. Enabled only for a fixed row set, whose ends are stable, so
+     * wrapping is a predictable convenience. A reactive source stays clamping — its rows can
+     * refilter out from under the cursor, and a wrap there would fling it to a disorienting far
+     * end. Page jumps (`moveBy`) and `gg`/`G` clamp regardless.
+     */
+    wrapNavigation?: boolean;
 };
 
 /** Flat position + the header this row must render above itself (it starts a category group). */
@@ -169,10 +178,18 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
     createEffect(() => props.onCursorChange?.(flat()[cursor()]?.value));
 
     function up(): void {
-        setCursor((i) => Math.max(0, i - 1));
+        setCursor((i) => {
+            const n = flat().length;
+            if (n === 0) return 0;
+            return props.wrapNavigation ? (i - 1 + n) % n : Math.max(0, i - 1);
+        });
     }
     function down(): void {
-        setCursor((i) => Math.min(flat().length - 1, i + 1));
+        setCursor((i) => {
+            const n = flat().length;
+            if (n === 0) return 0;
+            return props.wrapNavigation ? (i + 1) % n : Math.min(n - 1, i + 1);
+        });
     }
     function moveBy(delta: number): void {
         setCursor((i) => Math.max(0, Math.min(flat().length - 1, i + delta)));
@@ -303,9 +320,12 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                 </Show>
             </ScrollPane>
             {/* Full-width painted box, not a bare <text>: a fixed row directly below a flexGrow
-                scrollbox must opaquely reclaim its row (the yoga one-cell overlap quirk). */}
+                scrollbox must opaquely reclaim its row (the yoga one-cell overlap quirk). The
+                breathing-room paddingTop lives INSIDE this painted box on purpose — a transparent gap
+                row above it would let the scrollbox bleed show through; the painted pad row reclaims
+                the bled cell instead. */}
             <Show when={flat()[cursor()]?.description}>
-                <box width="100%" flexShrink={0} backgroundColor={theme().bgRaised}>
+                <box width="100%" flexShrink={0} paddingTop={space.sm} backgroundColor={theme().bgRaised}>
                     <text fg={theme().fgMuted}>{flat()[cursor()]?.description ?? ""}</text>
                 </box>
             </Show>

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -287,6 +287,10 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
 
     return (
         <>
+            {/* No paddingTop: padding inside a scrollbox is scrollable content, so any top pad
+                scrolls away on the first scroll and never returns (scrollChildIntoView back to row 0
+                stops at the content top, not the pad). Separation above the list is static chrome the
+                host paints OUTSIDE this surface, never scrollbox padding. */}
             <ScrollPane
                 focusOnMount={false}
                 onRef={(r: ScrollBoxRenderable) => {
@@ -295,7 +299,6 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                 flexGrow={1}
                 width="100%"
                 minHeight={0}
-                paddingTop={1}
             >
                 <Show
                     when={flat().length > 0}

--- a/cli/src/tui/components/list_primitives.render.test.tsx
+++ b/cli/src/tui/components/list_primitives.render.test.tsx
@@ -125,7 +125,7 @@ describe("cursor and navigation", () => {
         }
     });
 
-    test("ctrl+p/ctrl+n move; a new query resets the cursor to the best match", async () => {
+    test("ctrl+p/ctrl+n move; a new query resets the cursor; ctrl+p on the first row wraps to the last", async () => {
         const [query, setQuery] = createSignal("");
         const setup = await testRender(
             () => (
@@ -147,8 +147,8 @@ describe("cursor and navigation", () => {
             setQuery("");
             setup.mockInput.pressKey("p", { ctrl: true });
             frame = await settle(setup);
-            // Query reset put the cursor at 0; ctrl+p clamps there.
-            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+            // Query reset put the cursor at row 0; ctrl+p wraps up to the last row (daikon).
+            expect(frame).toContain(`${GLYPHS.chevronRight} daikon`);
         } finally {
             setup.renderer.destroy();
         }
@@ -174,6 +174,135 @@ describe("cursor and navigation", () => {
             for (let i = 0; i < 29; i++) setup.mockInput.pressArrow("down");
             frame = await settle(setup);
             expect(frame).toContain(`${GLYPHS.chevronRight} row-29`);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("FixedList wraps: down off the last row returns to the first", async () => {
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={FRUIT} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 14 },
+        );
+        try {
+            let frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+
+            setup.mockInput.pressKey("g", { shift: true }); // G → daikon (last row)
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} daikon`);
+
+            setup.mockInput.pressArrow("down"); // one past the end wraps to the top
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("FixedList wraps: up off the first row lands on the last and scrolls it into view", async () => {
+        const many: SelectItem<number>[] = Array.from({ length: 30 }, (_, i) => ({ value: i, title: `row-${String(i).padStart(2, "0")}` }));
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <box width="100%" height={8}>
+                        <FixedList items={many} emptyText="none" />
+                    </box>
+                </Harness>
+            ),
+            { width: 40, height: 8 },
+        );
+        try {
+            let frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} row-00`);
+            expect(frame).not.toContain("row-29");
+
+            setup.mockInput.pressArrow("up"); // wraps from the top to the last row, off-screen until now
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} row-29`);
+            expect(frame).not.toContain("row-00");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("FixedList: a single-row list keeps the cursor put on up/down (wrap is a no-op)", async () => {
+        const one: SelectItem<string>[] = [{ value: "solo", title: "solo" }];
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={one} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 8 },
+        );
+        try {
+            let frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} solo`);
+
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("up");
+            setup.mockInput.pressKey("j");
+            setup.mockInput.pressKey("k");
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} solo`);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("DynamicList clamps at the ends (no wrap): up on the first stays put, down on the last stays put", async () => {
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <DynamicList items={FRUIT} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 14 },
+        );
+        try {
+            let frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+
+            setup.mockInput.pressArrow("up"); // first row: clamps, does not wrap to the bottom
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+
+            setup.mockInput.pressKey("g", { shift: true }); // G → daikon (last row)
+            setup.mockInput.pressArrow("down"); // last row: clamps, does not wrap to the top
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} daikon`);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("FixedList: page keys clamp at the ends and never wrap", async () => {
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={FRUIT} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 14 },
+        );
+        try {
+            let frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
+
+            // A page jump larger than the list clamps to the last row instead of wrapping...
+            await setup.mockInput.pressKeys(["\x1b[6~"]); // pageDown
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} daikon`);
+
+            // ...and paging back up clamps to the first row, never past it.
+            await setup.mockInput.pressKeys(["\x1b[5~"]); // pageUp
+            frame = await settle(setup);
+            expect(frame).toContain(`${GLYPHS.chevronRight} apple`);
         } finally {
             setup.renderer.destroy();
         }

--- a/cli/src/tui/components/run_block.tsx
+++ b/cli/src/tui/components/run_block.tsx
@@ -31,6 +31,16 @@ export type RunBlockProps = {
      * would advertise an affordance that does not exist.
      */
     hint?: boolean;
+    /**
+     * Cap on how many step rows to render at once. When the run has MORE steps than this, the list
+     * shows a WINDOW of `maxSteps` rows centered on the frontier of work (the first step that is not
+     * yet done), clamped to the list ends. The progress bar and `done/total` always reflect the FULL
+     * run — only the step list is windowed. Absent → the whole list renders (the runs dialog keeps its
+     * complete view). Exists because the chat's sticky progress row sits in a fixed slice of the chat
+     * column: a long run must not grow the row without bound, and the window keeps it anchored to where
+     * work actually is.
+     */
+    maxSteps?: number;
 };
 
 /** The themed glyph + color role for a step's state. */
@@ -49,6 +59,18 @@ function stepMark(state: RunStepView["state"]): { glyph: string; role: "success"
 export function RunBlock(props: RunBlockProps) {
     const filled = (): string => GLYPHS.bar.repeat(props.done);
     const empty = (): string => GLYPHS.bar.repeat(Math.max(0, props.total - props.done));
+    // The visible slice of the step list. Full list unless `maxSteps` caps it; then a window of that
+    // many rows centered on the frontier — the first not-yet-done step — clamped so it never runs past
+    // either end. When every step is done the frontier is the tail, so the window shows the run's end.
+    const windowedSteps = (): RunStepView[] => {
+        const all = props.steps;
+        const max = props.maxSteps;
+        if (max === undefined || all.length <= max) return all;
+        const frontier = all.findIndex((s) => s.state !== "done");
+        const pivot = frontier === -1 ? all.length - 1 : frontier;
+        const start = Math.max(0, Math.min(pivot - Math.floor(max / 2), all.length - max));
+        return all.slice(start, start + max);
+    };
     return (
         <box flexDirection="column" paddingBottom={space.sm}>
             <text>
@@ -60,7 +82,7 @@ export function RunBlock(props: RunBlockProps) {
                 <Fg role="fgSubtle">{empty()}</Fg> <Fg role="fgMuted">{`${props.done}/${props.total}`}</Fg>
             </text>
             <box paddingLeft={space.md} flexDirection="column" border={["left"]} borderColor={theme().border}>
-                <For each={props.steps}>
+                <For each={windowedSteps()}>
                     {(step) => {
                         const m = stepMark(step.state);
                         return (

--- a/cli/src/tui/components/run_block.tsx
+++ b/cli/src/tui/components/run_block.tsx
@@ -43,6 +43,14 @@ export type RunBlockProps = {
     maxSteps?: number;
 };
 
+/**
+ * Cell budget for the progress meter in the narrow (windowed) mount. The default meter is one cell per
+ * step, which soft-wraps the ~40-column sticky slice once a run passes ~30 steps; when `maxSteps`
+ * signals that narrow mount the meter is scaled to at most this many cells instead. ~20 keeps it
+ * comfortably inside the rail while still reading as a proportional bar.
+ */
+const BAR_BUDGET = 20;
+
 /** The themed glyph + color role for a step's state. */
 function stepMark(state: RunStepView["state"]): { glyph: string; role: "success" | "warning" | "error" | "fgSubtle" } {
     if (state === "done") return { glyph: GLYPHS.check, role: "success" };
@@ -57,8 +65,24 @@ function stepMark(state: RunStepView["state"]): { glyph: string; role: "success"
  * and the detach/abort affordance.
  */
 export function RunBlock(props: RunBlockProps) {
-    const filled = (): string => GLYPHS.bar.repeat(props.done);
-    const empty = (): string => GLYPHS.bar.repeat(Math.max(0, props.total - props.done));
+    // The meter's cell counts. Without `maxSteps` it stays one cell per step — the dialog + gallery full
+    // view, where the block owns its whole width. With `maxSteps` (the narrow sticky mount, where a
+    // 30+-step per-step bar soft-wraps the ~40-column slice) it scales to at most BAR_BUDGET cells,
+    // `filled` proportional to done/total. A partially-done run is clamped to [1, cells−1] so mid-flight
+    // work never paints as fully filled or fully empty — an honest signal beats a rounding artifact.
+    const barCells = (): { filled: number; total: number } => {
+        if (props.maxSteps === undefined) return { filled: props.done, total: props.total };
+        const cells = Math.min(props.total, BAR_BUDGET);
+        if (props.total <= 0) return { filled: 0, total: cells };
+        const proportional = Math.round((props.done / props.total) * cells);
+        const partial = props.done > 0 && props.done < props.total;
+        return { filled: partial ? Math.min(cells - 1, Math.max(1, proportional)) : proportional, total: cells };
+    };
+    const filled = (): string => GLYPHS.bar.repeat(barCells().filled);
+    const empty = (): string => {
+        const c = barCells();
+        return GLYPHS.bar.repeat(Math.max(0, c.total - c.filled));
+    };
     // The visible slice of the step list. Full list unless `maxSteps` caps it; then a window of that
     // many rows centered on the frontier — the first not-yet-done step — clamped so it never runs past
     // either end. When every step is done the frontier is the tail, so the window shows the run's end.

--- a/cli/src/tui/components/thinking_block.tsx
+++ b/cli/src/tui/components/thinking_block.tsx
@@ -24,7 +24,7 @@ export type ThinkingBlockProps = {
  * affordance. The body sits under a left rule so it reads as quoted reasoning.
  */
 export function ThinkingBlock(props: ThinkingBlockProps) {
-    const duration = (): string => (props.durationMs ? ` ${GLYPHS.middot} ${Math.round(props.durationMs / 1000)}s` : "");
+    const duration = (): string => (props.durationMs ? ` ${GLYPHS.middot} ${Date.formatDuration(props.durationMs)}` : "");
     return (
         <box flexDirection="column" paddingBottom={space.sm}>
             <text>

--- a/cli/src/tui/components/tool_block.render.test.tsx
+++ b/cli/src/tui/components/tool_block.render.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/solid";
+
+import { ToolBlock } from "./tool_block.tsx";
+
+// Frame coverage for the inline-vs-completion-line status placement. captureCharFrame gives characters
+// only, which is all these assertions need: the invariant is WHICH ROW the status sits on, and (for the
+// narrow case) that a soft-wrap keeps it on screen rather than dropping it.
+
+/** Render `node` at `{width,height}`, driving frames until `needle` appears (the <code> panel parses async). */
+async function frameWith(node: Parameters<typeof testRender>[0], width: number, height: number, needle: string, timeoutMs = 2500): Promise<string> {
+    const setup = await testRender(node, { width, height });
+    try {
+        const start = Date.now();
+        for (;;) {
+            await setup.renderOnce();
+            const f = setup.captureCharFrame();
+            if (f.includes(needle) || Date.now() - start > timeoutMs) return f;
+            await new Promise((r) => setTimeout(r, 10));
+        }
+    } finally {
+        setup.renderer.destroy();
+    }
+}
+
+/** Index of the first frame row containing `needle`, or -1. */
+function rowOf(frame: string, needle: string): number {
+    return frame.split("\n").findIndex((line) => line.includes(needle));
+}
+
+describe("ToolBlock status placement", () => {
+    test("inline form (no result): name and status share one row", async () => {
+        const frame = await frameWith(() => <ToolBlock name="grep" target="src/x.ts" status="ok" durationMs={14} />, 60, 6, "grep");
+        const nameRow = frame.split("\n")[rowOf(frame, "grep")];
+        // The whole outcome (label + duration) folds onto the name line — nothing drops below it.
+        expect(nameRow).toContain("grep");
+        expect(nameRow).toContain("ok");
+        expect(nameRow).toContain("14ms");
+    });
+
+    test("result form (result present): status sits on its own row below the panel", async () => {
+        const frame = await frameWith(
+            () => <ToolBlock name="read_file" target="src/db.ts" result="RESULTBODY" filetype="text" status="ok" durationMs={14} />,
+            60,
+            12,
+            "RESULTBODY",
+        );
+        const nameRow = rowOf(frame, "read_file");
+        const bodyRow = rowOf(frame, "RESULTBODY");
+        const statusRow = rowOf(frame, "ok");
+        // The name row must NOT carry the outcome, and the completion line must fall BELOW the result panel.
+        expect(frame.split("\n")[nameRow]).not.toContain("ok");
+        expect(bodyRow).toBeGreaterThan(nameRow);
+        expect(statusRow).toBeGreaterThan(bodyRow);
+    });
+
+    // The sidebar-open chat column is ~40 cols. An inline line longer than that must SOFT-WRAP (the reason
+    // the status flows after the name instead of right-aligning), so the outcome survives on the next row
+    // rather than being pushed off the edge. Sweep a couple of heights — the wrap is width-, not height-driven,
+    // but a doubled/clipped row would only show at some heights.
+    for (const height of [6, 8]) {
+        test(`inline form at width 40, height ${height}: the status survives the soft-wrap`, async () => {
+            const frame = await frameWith(
+                () => <ToolBlock name="read_file" target="src/some/really/long/path/that/should/wrap.ts" status="error" durationMs={320} />,
+                40,
+                height,
+                "read_file",
+            );
+            expect(frame).toContain("read_file");
+            // Both the label and its duration made it onto the wrapped row — the line reflowed, it did not vanish.
+            expect(frame).toContain("error");
+            expect(frame).toContain("320ms");
+        });
+    }
+});

--- a/cli/src/tui/components/tool_block.tsx
+++ b/cli/src/tui/components/tool_block.tsx
@@ -18,6 +18,14 @@ export type ToolBlockProps = {
     status: "running" | "ok" | "error";
     /** Wall-clock duration in ms, shown beside a finished outcome; absent while running. */
     durationMs?: number;
+    /**
+     * Whether the outcome is folded onto the name line (`▸ name target  ✓ ok · 14ms`) instead of a
+     * standalone completion line below the result panel. Defaults to `props.result === undefined`: a
+     * live event carries no output, so its status reads best inline, whereas a result-carrying block
+     * keeps the outcome under its `<code>` panel — inlining it there would strand the status above the
+     * output it summarizes. An explicit value overrides the derivation.
+     */
+    inlineStatus?: boolean;
 };
 
 /** The glyph, color role, and label for a tool call's lifecycle state. */
@@ -30,17 +38,21 @@ function statusView(status: ToolBlockProps["status"]): { glyph: string; role: "s
 /**
  * The tool-call block: the `▸` marker with the tool/verb name (in the `tool`
  * role) and its optional target, the optional result in a bordered `<code>`
- * panel with syntax highlighting, and a status line carrying the outcome and its
+ * panel with syntax highlighting, and a status carrying the outcome and its
  * duration. Live harness tool events carry only the name/outcome/duration, so the
  * target/result panel appears only for the fixture-rich mock. The verb name is the
  * only thing painted in the `tool` role — everything else stays in text/meta roles.
+ * The status folds onto the name line for a result-less live event and drops to its
+ * own completion line below the result panel otherwise (see {@link ToolBlockProps.inlineStatus}).
  */
 export function ToolBlock(props: ToolBlockProps) {
-    // Compact human duration for the completed line; whole ms under a second, else one decimal second.
+    const inline = (): boolean => props.inlineStatus ?? props.result === undefined;
+    // The leading ` · ` glues the duration onto the outcome label; the value is delegated to
+    // Date.formatDuration so this line shares one ms/s/m vocabulary with every other readout.
     const duration = (): string => {
         const ms = props.durationMs;
         if (ms === undefined) return "";
-        return ms < 1000 ? ` ${GLYPHS.middot} ${ms}ms` : ` ${GLYPHS.middot} ${(ms / 1000).toFixed(1)}s`;
+        return ` ${GLYPHS.middot} ${Date.formatDuration(ms)}`;
     };
     return (
         <box flexDirection="column" paddingBottom={space.sm}>
@@ -49,6 +61,15 @@ export function ToolBlock(props: ToolBlockProps) {
                 <Fg role="tool">{props.name}</Fg>
                 <Show when={props.target}>
                     <Fg role="fgMuted">{` ${props.target}`}</Fg>
+                </Show>
+                <Show when={inline()}>
+                    {/* Flow the status AFTER the name/target rather than right-aligning it. A right-aligned
+                        segment (a row with a flexGrow spacer) that soft-wraps lands its glyphs at column 0,
+                        colliding with the 2-cell marker gutter; flowing it inline lets a narrow terminal wrap
+                        the whole line while the gutter stays intact. The two-space (space.md) lead sets it off
+                        from the preceding target (or the name, when there is no target). */}
+                    <Fg role={statusView(props.status).role}>{`${" ".repeat(space.md)}${statusView(props.status).glyph} ${statusView(props.status).label}`}</Fg>
+                    <Fg role="fgMuted">{duration()}</Fg>
                 </Show>
             </text>
             <Show when={props.result}>
@@ -67,10 +88,12 @@ export function ToolBlock(props: ToolBlockProps) {
                     <code content={props.result ?? ""} filetype={props.filetype ?? "text"} fg={theme().fg} syntaxStyle={syntaxStyle()} />
                 </box>
             </Show>
-            <text>
-                <Fg role={statusView(props.status).role}>{`${statusView(props.status).glyph} ${statusView(props.status).label}`}</Fg>
-                <Fg role="fgMuted">{duration()}</Fg>
-            </text>
+            <Show when={!inline()}>
+                <text>
+                    <Fg role={statusView(props.status).role}>{`${statusView(props.status).glyph} ${statusView(props.status).label}`}</Fg>
+                    <Fg role="fgMuted">{duration()}</Fg>
+                </text>
+            </Show>
         </box>
     );
 }

--- a/cli/src/tui/hooks/profile_parity.test.ts
+++ b/cli/src/tui/hooks/profile_parity.test.ts
@@ -281,7 +281,7 @@ function profileStatus(over: Partial<DataProfileStatus>): DataProfileStatus {
 }
 
 function refreshSeams(profile: DataProfileStatus | null): RefreshSeams {
-    return { runtime: () => fakeRuntime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync([]) };
+    return { runtime: () => fakeRuntime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync([]), loadSteps: () => okAsync([]) };
 }
 
 describe("watchProfileParity — live input-mutation edge", () => {

--- a/cli/src/tui/hooks/sidebar_live.test.ts
+++ b/cli/src/tui/hooks/sidebar_live.test.ts
@@ -16,6 +16,7 @@ import {
     __resetSidebarLiveForTest,
     activeRunProgress,
     hasActiveWork,
+    idTail,
     profileDetailLines,
     profileSnapshot,
     refreshSidebarData,
@@ -333,6 +334,28 @@ describe("refreshSidebarData — sticky run-progress row", () => {
         };
         await refreshSidebarData("A", s);
         expect(activeRunProgress()).toBe(first); // same reference — the blip did not clear it
+    });
+
+    test("a step-read DbError for a DIFFERENT newest run clears the row rather than showing the old run's progress", async () => {
+        // Prime with run A pinned.
+        await refreshSidebarData(
+            "A",
+            seams(null, [runRow({ runId: "run-a", status: "running" })], () => fakeRuntime, [stepRow("s", "running")]),
+        );
+        const first = activeRunProgress();
+        expect(first).not.toBeNull();
+        if (first) expect(first.tag).toBe(idTail("run-a"));
+
+        // The newest run is now B (A went terminal, B took its place) and B's step read blips. The kept
+        // row belongs to A, so holding it would misattribute A's progress to B — the row must clear.
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([runRow({ runId: "run-b", status: "running" }), runRow({ runId: "run-a", status: "completed" })]),
+            loadSteps: () => errAsync(dbErr),
+        };
+        await refreshSidebarData("A", s);
+        expect(activeRunProgress()).toBeNull();
     });
 
     test("the runtime-not-ready no-op clears the row", async () => {

--- a/cli/src/tui/hooks/sidebar_live.test.ts
+++ b/cli/src/tui/hooks/sidebar_live.test.ts
@@ -6,7 +6,7 @@ import { createStore } from "solid-js/store";
 // Side-effect import: installs `Date.relativeAge` (the loaded-profile timestamp lines call it) via the
 // same central loader the app boots with.
 import "../../extensions/index.ts";
-import type { CortexRunRow, DataProfileStatus, DbError } from "@inflexa-ai/harness";
+import type { CortexRunRow, DataProfileStatus, DbError, StepExecutionRow } from "@inflexa-ai/harness";
 import type { ResolvedHarnessConfig } from "../../modules/harness/config.ts";
 import type { HarnessRuntime } from "../../modules/harness/runtime.ts";
 import type { Workspace } from "../contexts/workspace.ts";
@@ -14,6 +14,7 @@ import { __resetBootForTest, startHarnessBoot, type BootDriver } from "./boot.ts
 import { setChatStatus } from "./status.ts";
 import {
     __resetSidebarLiveForTest,
+    activeRunProgress,
     hasActiveWork,
     profileDetailLines,
     profileSnapshot,
@@ -68,9 +69,38 @@ function runRow(over: Partial<CortexRunRow> = {}): CortexRunRow {
     };
 }
 
-/** Build refresh seams whose reads resolve immediately with the given data. */
-function seams(profile: DataProfileStatus | null, runs: CortexRunRow[], runtime: () => HarnessRuntime | null = () => fakeRuntime): RefreshSeams {
-    return { runtime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync(runs) };
+/** Build refresh seams whose reads resolve immediately with the given data. Steps default to empty. */
+function seams(
+    profile: DataProfileStatus | null,
+    runs: CortexRunRow[],
+    runtime: () => HarnessRuntime | null = () => fakeRuntime,
+    steps: StepExecutionRow[] = [],
+): RefreshSeams {
+    return { runtime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync(runs), loadSteps: () => okAsync(steps) };
+}
+
+/** A minimal step-execution row keyed by id + status — the refresh maps rows → step views via `stepStateOf`. */
+function stepRow(stepId: string, status: StepExecutionRow["status"]): StepExecutionRow {
+    return {
+        runId: "run-1",
+        stepId,
+        analysisId: "a1",
+        wave: 0,
+        agentId: "agent",
+        status,
+        startedAt: null,
+        completedAt: null,
+        durationMs: null,
+        error: null,
+        attempts: 1,
+        lastErrorClass: null,
+        finishReason: null,
+        hitMaxSteps: false,
+        blockedReason: null,
+        execId: null,
+        childWorkflowId: null,
+        sandboxRef: null,
+    };
 }
 
 /** Mount `watchSidebarData` in a disposable reactive root; returns the dispose so the test tears it down. */
@@ -118,6 +148,7 @@ describe("refreshSidebarData — snapshot ladder", () => {
     test("no-ops to not_ready when the runtime is not booted, issuing no query", async () => {
         let profileReads = 0;
         let runReads = 0;
+        let stepReads = 0;
         // Prime to a loaded state so the reset back to not_ready is observable.
         await refreshSidebarData("A", seams(profileStatus(), [runRow()]));
         expect(profileSnapshot().kind).toBe("loaded");
@@ -132,6 +163,10 @@ describe("refreshSidebarData — snapshot ladder", () => {
                 runReads += 1;
                 return okAsync([]);
             },
+            loadSteps: () => {
+                stepReads += 1;
+                return okAsync([]);
+            },
         };
         await refreshSidebarData("A", guarded);
 
@@ -139,10 +174,16 @@ describe("refreshSidebarData — snapshot ladder", () => {
         expect(runsSnapshot().kind).toBe("not_ready");
         expect(profileReads).toBe(0);
         expect(runReads).toBe(0);
+        expect(stepReads).toBe(0);
     });
 
     test("a DbError degrades to unavailable, never a crash", async () => {
-        const failing: RefreshSeams = { runtime: () => fakeRuntime, loadProfile: () => errAsync(dbErr), loadRuns: () => errAsync(dbErr) };
+        const failing: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => errAsync(dbErr),
+            loadRuns: () => errAsync(dbErr),
+            loadSteps: () => errAsync(dbErr),
+        };
         await refreshSidebarData("A", failing);
         expect(profileSnapshot().kind).toBe("unavailable");
         expect(runsSnapshot().kind).toBe("unavailable");
@@ -175,7 +216,12 @@ describe("refreshSidebarData — staleness guard", () => {
                 releaseA = res;
             }),
         );
-        const seamsA: RefreshSeams = { runtime: () => fakeRuntime, loadProfile: () => gatedA, loadRuns: () => okAsync([runRow({ status: "running" })]) };
+        const seamsA: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => gatedA,
+            loadRuns: () => okAsync([runRow({ status: "running" })]),
+            loadSteps: () => okAsync([]),
+        };
         const seamsB = seams(profileStatus({ status: "completed" }), [runRow({ status: "completed" })]);
 
         const pA = refreshSidebarData("A", seamsA); // parks on the gated profile read
@@ -192,6 +238,152 @@ describe("refreshSidebarData — staleness guard", () => {
         expect(settled.kind).toBe("loaded");
         // B's completed profile survives; the superseded A drops rather than overwriting it.
         if (settled.kind === "loaded") expect(settled.profile.status).toBe("completed");
+    });
+});
+
+describe("refreshSidebarData — sticky run-progress row", () => {
+    test("a non-terminal newest run publishes its progress (name, tag, done/total, mapped steps)", async () => {
+        const steps = [stepRow("qc", "completed"), stepRow("align", "running"), stepRow("call", "pending")];
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([runRow({ runId: "11112222-3333-4444-5555-6666aabbccdd", status: "running", workflowName: "executeAnalysis" })]),
+            loadSteps: () => okAsync(steps),
+        };
+        await refreshSidebarData("A", s);
+        const p = activeRunProgress();
+        expect(p).not.toBeNull();
+        if (p) {
+            expect(p.name).toBe("executeAnalysis"); // shortRunName → the workflow name
+            expect(p.tag).toBe("bbccdd"); // idTail of the runId (dashes stripped, last six)
+            expect(p.total).toBe(3);
+            expect(p.done).toBe(1); // only the completed step counts as done
+            expect(p.steps.map((v) => v.state)).toEqual(["done", "running", "queued"]); // pending → queued
+        }
+    });
+
+    test("only the NEWEST run drives the row, and the step read fires exactly once", async () => {
+        const asked: string[] = [];
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([runRow({ runId: "newest", status: "running" }), runRow({ runId: "older", status: "running" })]),
+            loadSteps: (_pool, runId) => {
+                asked.push(runId);
+                return okAsync([stepRow("s", "running")]);
+            },
+        };
+        await refreshSidebarData("A", s);
+        expect(asked).toEqual(["newest"]);
+    });
+
+    test("all-terminal runs clear the row and fire NO step read (idle costs no step query)", async () => {
+        // Prime with an active run so the clear-to-null is observable.
+        await refreshSidebarData(
+            "A",
+            seams(null, [runRow({ status: "running" })], () => fakeRuntime, [stepRow("s", "running")]),
+        );
+        expect(activeRunProgress()).not.toBeNull();
+
+        let stepReads = 0;
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([runRow({ status: "completed" }), runRow({ status: "failed" })]),
+            loadSteps: () => {
+                stepReads += 1;
+                return okAsync([]);
+            },
+        };
+        await refreshSidebarData("A", s);
+        expect(activeRunProgress()).toBeNull();
+        expect(stepReads).toBe(0);
+    });
+
+    test("no runs at all → the row stays null, and no step read is issued", async () => {
+        let stepReads = 0;
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([]),
+            loadSteps: () => {
+                stepReads += 1;
+                return okAsync([]);
+            },
+        };
+        await refreshSidebarData("A", s);
+        expect(activeRunProgress()).toBeNull();
+        expect(stepReads).toBe(0);
+    });
+
+    test("a step-read DbError keeps the previous row rather than blinking it away", async () => {
+        await refreshSidebarData(
+            "A",
+            seams(null, [runRow({ runId: "run-x", status: "running" })], () => fakeRuntime, [stepRow("s", "running")]),
+        );
+        const first = activeRunProgress();
+        expect(first).not.toBeNull();
+
+        // The run is still active but the step read blips → keep the previous snapshot, self-heal next poll.
+        const s: RefreshSeams = {
+            runtime: () => fakeRuntime,
+            loadProfile: () => okAsync(null),
+            loadRuns: () => okAsync([runRow({ runId: "run-x", status: "running" })]),
+            loadSteps: () => errAsync(dbErr),
+        };
+        await refreshSidebarData("A", s);
+        expect(activeRunProgress()).toBe(first); // same reference — the blip did not clear it
+    });
+
+    test("the runtime-not-ready no-op clears the row", async () => {
+        await refreshSidebarData(
+            "A",
+            seams(null, [runRow({ status: "running" })], () => fakeRuntime, [stepRow("s", "running")]),
+        );
+        expect(activeRunProgress()).not.toBeNull();
+
+        await refreshSidebarData(
+            "A",
+            seams(null, [], () => null),
+        );
+        expect(activeRunProgress()).toBeNull();
+    });
+
+    test("an analysis swap clears the row synchronously, before the new analysis loads", async () => {
+        // A reactive workspace so Trigger 1's effect re-runs on the swap (mirrors the snapshot-swap test).
+        const [store, setStore] = createStore<{ analysis: { id: string } | null }>({ analysis: { id: "A" } });
+        const ws = store as unknown as Workspace;
+
+        // B's profile read is gated so the reset window (row null) is deterministically observable.
+        let releaseB!: (v: DataProfileStatus | null) => void;
+        const gatedB: ResultAsync<DataProfileStatus | null, DbError> = ResultAsync.fromSafePromise(
+            new Promise<DataProfileStatus | null>((res) => {
+                releaseB = res;
+            }),
+        );
+        const refresh = async (id: string): Promise<void> => {
+            const s: RefreshSeams =
+                id === "A"
+                    ? seams(null, [runRow({ status: "running" })], () => fakeRuntime, [stepRow("s", "running")])
+                    : { runtime: () => fakeRuntime, loadProfile: () => gatedB, loadRuns: () => okAsync([]), loadSteps: () => okAsync([]) };
+            await refreshSidebarData(id, s);
+        };
+
+        const dispose = mountWatch(ws, { refresh, arm: () => () => {} });
+        try {
+            const readyDriver: BootDriver = async () => ok({ conversation: { model: "m" }, pool: {} } as unknown as HarnessRuntime);
+            await startHarnessBoot({} as ResolvedHarnessConfig, readyDriver); // Trigger 1 fires refresh(A)
+            await new Promise<void>((r) => setTimeout(r, 0)); // let A's reads settle
+            expect(activeRunProgress()).not.toBeNull(); // A's active run is pinned
+
+            setStore("analysis", { id: "B" }); // swap → Trigger 1 resets synchronously, refresh(B) parks on the gate
+            expect(activeRunProgress()).toBeNull(); // no stale A row during the swap window
+
+            releaseB(profileStatus({ status: "completed" })); // let B settle so no read leaks past the test
+            await new Promise<void>((r) => setTimeout(r, 0));
+        } finally {
+            dispose();
+        }
     });
 });
 
@@ -327,7 +519,7 @@ describe("watchSidebarData — swap resets the snapshots before the new analysis
             const s: RefreshSeams =
                 id === "A"
                     ? seams(profileStatus({ status: "completed" }), [runRow()])
-                    : { runtime: () => fakeRuntime, loadProfile: () => gatedB, loadRuns: () => okAsync([]) };
+                    : { runtime: () => fakeRuntime, loadProfile: () => gatedB, loadRuns: () => okAsync([]), loadSteps: () => okAsync([]) };
             await refreshSidebarData(id, s);
         };
 
@@ -366,11 +558,16 @@ describe("profileDetailLines — one line set per snapshot kind", () => {
         expect(profileDetailLines({ kind: "unavailable" })).toEqual(["profile status unavailable"]);
     });
 
-    test("loaded completed → status, times, summary, per-file, seed count", () => {
+    test("loaded completed → status, absolute times, duration, summary, per-file, seed count", () => {
         const lines = profileDetailLines(loaded());
         expect(lines[0]).toBe("status: completed");
-        expect(lines.some((l) => l.startsWith("started "))).toBe(true);
-        expect(lines.some((l) => l.startsWith("completed "))).toBe(true);
+        // Detail dialogs pin absolute local times — assert via the same toLocaleString the code path
+        // runs on the fixture timestamps, never a hardcoded locale string.
+        expect(lines).toContain(`started ${new Date("2026-07-08T00:00:00.000Z").toLocaleString()}`);
+        expect(lines).toContain(`completed ${new Date("2026-07-08T00:00:05.000Z").toLocaleString()}`);
+        // Both timestamps parse → a duration line (the fixture's start/complete are 5s apart); asserted
+        // through the shared formatter, not its literal output.
+        expect(lines).toContain(`duration ${Date.formatDuration(5_000)}`);
         expect(lines).toContain("line one");
         expect(lines).toContain("line two");
         expect(lines).toContain("files (2):");
@@ -380,22 +577,29 @@ describe("profileDetailLines — one line set per snapshot kind", () => {
         expect(lines[lines.length - 1]).toBe("3 seed inputs");
     });
 
-    test("loaded failed → surfaces the multi-line error", () => {
+    test("loaded failed → surfaces the multi-line error and a duration", () => {
         const lines = profileDetailLines(loaded({ status: "failed", error: "boom\ndetails here", result: null, seedInputFileIds: null }));
         expect(lines[0]).toBe("status: failed");
+        // The ledger stamps completedAt on the failure path too, so a failed profile still reports how
+        // long it ran — a duration, not an elapsed age.
+        expect(lines).toContain(`duration ${Date.formatDuration(5_000)}`);
+        expect(lines.some((l) => l.startsWith("elapsed "))).toBe(false);
         expect(lines).toContain("boom");
         expect(lines).toContain("details here");
         // No result + no seed set → zero, pluralized.
         expect(lines[lines.length - 1]).toBe("0 seed inputs");
     });
 
-    test("loaded pending without a result → status + seed count, no files section", () => {
+    test("loaded pending without a result → status, elapsed (not duration), seed count, no files section", () => {
         const lines = profileDetailLines(
             loaded({ status: "pending", startedAt: "2026-07-08T00:00:00.000Z", completedAt: null, result: null, seedInputFileIds: ["only-one"] }),
         );
         expect(lines[0]).toBe("status: pending");
-        expect(lines.some((l) => l.startsWith("started "))).toBe(true);
+        expect(lines).toContain(`started ${new Date("2026-07-08T00:00:00.000Z").toLocaleString()}`);
         expect(lines.some((l) => l.startsWith("completed "))).toBe(false);
+        // Still running (no completedAt) → an elapsed-at-open age, never a duration.
+        expect(lines.some((l) => l.startsWith("elapsed "))).toBe(true);
+        expect(lines.some((l) => l.startsWith("duration "))).toBe(false);
         expect(lines.some((l) => l.startsWith("files ("))).toBe(false);
         // Singular when exactly one seed input.
         expect(lines[lines.length - 1]).toBe("1 seed input");

--- a/cli/src/tui/hooks/sidebar_live.ts
+++ b/cli/src/tui/hooks/sidebar_live.ts
@@ -3,17 +3,20 @@ import { ResultAsync } from "neverthrow";
 import {
     loadDataProfileStatus,
     queryRunsByAnalysis,
+    queryStepsByRun,
     type CortexRunRow,
     type DataProfileStatus,
     type DbError,
     type Pool,
     type RunStatus,
+    type StepExecutionRow,
 } from "@inflexa-ai/harness";
 
 import { GLYPHS } from "../../lib/design_system.ts";
 import type { ThemeColors } from "../../lib/design_system.ts";
 import type { HarnessRuntime } from "../../modules/harness/runtime.ts";
 import type { Workspace } from "../contexts/workspace.ts";
+import type { RunStepView } from "../components/run_block.tsx";
 import { bootState, harnessRuntime } from "./boot.ts";
 import { chatStatus, type ChatStatus } from "./status.ts";
 
@@ -44,23 +47,49 @@ export type ProfileSnapshot = { kind: "not_ready" } | { kind: "unavailable" } | 
  */
 export type RunsSnapshot = { kind: "not_ready" } | { kind: "unavailable" } | { kind: "loaded"; runs: CortexRunRow[] };
 
+/**
+ * Live progress of the analysis's NEWEST run, published ONLY while that run is non-terminal — the
+ * feed for the chat column's sticky progress row (the run-block vocabulary: the segmented bar,
+ * `done/total`, and the ordered steps). `null` means nothing is pinned: the analysis has no runs, its
+ * newest run already reached a terminal state, or the runtime is not booted. Refreshed on the same
+ * cadence as the sidebar sections (the same non-terminal newest run also arms {@link hasActiveWork}),
+ * so the row and the poll rise and fall together.
+ */
+export type ActiveRunProgress = {
+    /** The run's short label (see {@link shortRunName}). */
+    name: string;
+    /** The run's short id tail (see {@link idTail}). */
+    tag: string;
+    /** Completed step count (bar numerator). */
+    done: number;
+    /** Total step count (bar denominator). */
+    total: number;
+    /** The run's ordered step views. */
+    steps: RunStepView[];
+};
+
 const [profile, setProfile] = createSignal<ProfileSnapshot>({ kind: "not_ready" });
 const [runs, setRuns] = createSignal<RunsSnapshot>({ kind: "not_ready" });
+const [activeRun, setActiveRun] = createSignal<ActiveRunProgress | null>(null);
 
 /** The data-profile snapshot — read in a tracking scope to repaint on refresh. */
 export const profileSnapshot = profile;
 /** The runs snapshot — read in a tracking scope to repaint on refresh. */
 export const runsSnapshot = runs;
+/** The newest non-terminal run's progress, or `null` when nothing is active — read in a tracking scope. */
+export const activeRunProgress = activeRun;
 
 /**
- * Relative age of an ISO timestamp, or an em dash when absent/unparseable — never a raw date. The
- * em-dash fallback (not the raw ISO string) is the shared choice across every caller: the sidebar
- * rail, the runs dialog, and the data-profile detail lines all render into fixed-width surfaces where
- * a raw timestamp would overflow, so an absent/bad time collapses to the em dash uniformly.
+ * Compact relative age of an ISO timestamp (`5m31s`, `8h54m`), or an em dash when absent/unparseable.
+ * This is the live-rail vocabulary: the sidebar's fixed-width readouts (the session age, the run rows)
+ * answer "how long ago" at a glance, where a full timestamp would overflow the rail and a slightly-stale
+ * age still reads right. Durable-record readouts render the opposite — an absolute local time (see
+ * {@link absTime}) — because a referenced record (a detail dialog, the rail's completed-profile line)
+ * is read long after "5m ago" meant anything.
  *
- * Homed in this hooks module (not `layout/sidebar.tsx`) because {@link profileDetailLines} below also
- * needs it AND `sidebar.tsx` imports this module — a `relAge` living in `sidebar.tsx` would force this
- * module to import back into the layout, an import cycle. This is the lowest layer all callers share.
+ * Homed in this hooks module (not `layout/sidebar.tsx`) beside {@link runMark} / {@link shortRunName},
+ * the pure sidebar helpers the rail and the runs dialog share, so callers reach them without importing
+ * the JSX layout and nothing forces this module to import back into it.
  */
 export function relAge(iso: string | null): string {
     if (iso === null) return GLYPHS.emDash;
@@ -69,11 +98,25 @@ export function relAge(iso: string | null): string {
 }
 
 /**
+ * Absolute local timestamp of an ISO string (`toLocaleString`), or an em dash when absent/unparseable.
+ * The detail-dialog counterpart to {@link relAge}: the data-profile and runs dialogs render durable,
+ * referenced records read long after the fact — when a compact "5m" has lost its anchor — so they pin
+ * the full local time. Same em-dash guard shape as {@link relAge}, so an absent/bad time collapses
+ * identically across the rail and the dialogs.
+ */
+export function absTime(iso: string | null): string {
+    if (iso === null) return GLYPHS.emDash;
+    const t = Date.parse(iso);
+    return Number.isNaN(t) ? GLYPHS.emDash : new Date(t).toLocaleString();
+}
+
+/**
  * Compose the DATA PROFILE details view's lines from a {@link ProfileSnapshot}. Pure
  * (snapshot → string[]) so every kind is unit-testable: the degraded kinds each yield one placeholder
- * line, and `loaded` yields the ledger truth — a status line, the started/completed relative times,
- * the error (on failure), the summary split into lines, the per-file `path — description`, and the
- * seed-input count. Rendered verbatim by `ResultsDialog` (the design gallery drives it over a mock).
+ * line, and `loaded` yields the ledger truth — a status line, the started/completed absolute local
+ * times plus the run duration (or the elapsed-at-open age while a profile is still running), the error
+ * (on failure), the summary split into lines, the per-file `path — description`, and the seed-input
+ * count. Rendered verbatim by `ResultsDialog` (the design gallery drives it over a mock).
  */
 export function profileDetailLines(snap: ProfileSnapshot): string[] {
     switch (snap.kind) {
@@ -86,8 +129,18 @@ export function profileDetailLines(snap: ProfileSnapshot): string[] {
         case "loaded": {
             const p = snap.profile;
             const lines: string[] = [`status: ${p.status}`];
-            if (p.startedAt) lines.push(`started ${relAge(p.startedAt)}`);
-            if (p.completedAt) lines.push(`completed ${relAge(p.completedAt)}`);
+            if (p.startedAt) lines.push(`started ${absTime(p.startedAt)}`);
+            if (p.completedAt) lines.push(`completed ${absTime(p.completedAt)}`);
+            // A finished profile (completed OR failed — the ledger stamps `completedAt` on both) shows
+            // how long it took; a still-running profile has no end yet, so the dialog — a point-in-time
+            // snapshot — shows the age elapsed at the moment it was opened instead of a duration.
+            const startedMs = p.startedAt ? Date.parse(p.startedAt) : NaN;
+            const completedMs = p.completedAt ? Date.parse(p.completedAt) : NaN;
+            if (!Number.isNaN(startedMs) && !Number.isNaN(completedMs)) {
+                lines.push(`duration ${Date.formatDuration(completedMs - startedMs)}`);
+            } else if (!Number.isNaN(startedMs)) {
+                lines.push(`elapsed ${Date.relativeAge(startedMs)}`);
+            }
             if (p.status === "failed" && p.error) {
                 lines.push("");
                 for (const line of p.error.split("\n")) lines.push(line);
@@ -157,6 +210,54 @@ export function shortRunName(run: CortexRunRow): string {
     return id.replace(/-/g, "").slice(-6);
 }
 
+/** A short, human-scannable tail of a uuid (dashes stripped) — the run tag the runs dialog + sticky row show. */
+export function idTail(id: string): string {
+    return id.replace(/-/g, "").slice(-6);
+}
+
+/**
+ * Map a harness step-execution status onto the design-system run-step state. Pure and
+ * exhaustive over {@link StepExecutionRow.status} — a `never`-typed default breaks the build if the
+ * harness enum grows, so a new status is classified honestly rather than silently mis-bucketed.
+ *
+ * The four buckets are `done | running | failed | queued`; the honest mapping of the seven harness
+ * statuses:
+ *  - `pending` / `skipped` → `queued` — neither ran: pending awaits its turn, skipped never will.
+ *    The muted hollow glyph reads as "inactive", which is truthful for both (skipped is not a
+ *    success and not an error).
+ *  - `running` → `running`, `completed` → `done`, `failed` → `failed` — direct.
+ *  - `canceled` → `failed` — a fail-fast sibling stopped mid-flight; a non-success terminal, shown
+ *    error-toned to match the sidebar's run-level `canceled`.
+ *  - `blocked` → `failed` — an agent-declared blocker; `executeAnalysis` treats it as a failure
+ *    (`step_blocked`), so the error tone is the honest signal.
+ *
+ * Homed here beside {@link runMark} / {@link shortRunName} (the pure, non-JSX run helpers) so both the
+ * runs dialog and the sidebar-live refresh loop share the identical status→state mapping without one
+ * reaching into the other.
+ */
+export function stepStateOf(status: StepExecutionRow["status"]): RunStepView["state"] {
+    switch (status) {
+        case "pending":
+        case "skipped":
+            return "queued";
+        case "running":
+            return "running";
+        case "completed":
+            return "done";
+        case "failed":
+        case "canceled":
+        case "blocked":
+            return "failed";
+        default: {
+            const _exhaustive: never = status;
+            // Unreachable: the `never` assignment above proves every status is handled. The cast only
+            // satisfies the return type on this dead branch — if it ever runs, the harness added a
+            // status the switch does not cover, and we surface its raw string rather than crash.
+            return String(_exhaustive) as RunStepView["state"];
+        }
+    }
+}
+
 /** How many run rows a refresh pulls. The sidebar renders the newest few; the store holds the head. */
 const RUNS_LIMIT = 10;
 
@@ -216,12 +317,15 @@ export type RefreshSeams = {
     readonly loadProfile: (pool: Pool, analysisId: string) => ResultAsync<DataProfileStatus | null, DbError>;
     /** Read the analysis's newest runs (newest-first, capped). Real: `queryRunsByAnalysis` @ {@link RUNS_LIMIT}. */
     readonly loadRuns: (pool: Pool, analysisId: string) => ResultAsync<CortexRunRow[], DbError>;
+    /** Read a run's step ledger — fired only for a non-terminal newest run. Real: `queryStepsByRun`. */
+    readonly loadSteps: (pool: Pool, runId: string) => ResultAsync<StepExecutionRow[], DbError>;
 };
 
 const realRefreshSeams: RefreshSeams = {
     runtime: harnessRuntime,
     loadProfile: loadDataProfileStatus,
     loadRuns: (pool, analysisId) => queryRunsByAnalysis(pool, analysisId, { limit: RUNS_LIMIT }),
+    loadSteps: queryStepsByRun,
 };
 
 // Monotonic token identifying the newest refresh. Two rapid analysis swaps interleave their async
@@ -232,25 +336,34 @@ const realRefreshSeams: RefreshSeams = {
 let refreshGeneration = 0;
 
 /**
- * Reset BOTH snapshots to `not_ready` together (the torn-pair guarantee) and invalidate any in-flight
- * refresh. Used at an analysis swap so the previous analysis's DATA PROFILE / RUNS never render (nor get
- * dialog-snapshotted) during the swap's one-ledger-round-trip refresh window, and by the test reset hook.
+ * Reset BOTH snapshots to `not_ready` together (the torn-pair guarantee), clear the sticky run-progress
+ * row, and invalidate any in-flight refresh. Used at an analysis swap so the previous analysis's DATA
+ * PROFILE / RUNS / progress row never render (nor get dialog-snapshotted) during the swap's
+ * one-ledger-round-trip refresh window, and by the test reset hook.
  */
 function resetSnapshots(): void {
     refreshGeneration += 1;
     setProfile({ kind: "not_ready" });
     setRuns({ kind: "not_ready" });
+    setActiveRun(null);
 }
 
 /**
- * Repopulate both snapshots for `analysisId` from the booted runtime's pool. No-ops to `not_ready`
- * (both snapshots) when the runtime is not booted — the sidebar renders a muted placeholder and no
- * query runs (the no-op guard). Otherwise the two ledger reads are awaited in turn and each
- * `.match`es INDEPENDENTLY into its snapshot: a `DbError` becomes `unavailable` (never a crash), a
- * null profile row becomes `absent`, and every write is a fresh object so Solid always reconciles.
+ * Repopulate both snapshots (and the sticky run-progress row) for `analysisId` from the booted
+ * runtime's pool. No-ops to `not_ready` (both snapshots) and clears the progress row when the runtime
+ * is not booted — the sidebar renders a muted placeholder and no query runs (the no-op guard).
+ * Otherwise the two ledger reads are awaited in turn and each `.match`es INDEPENDENTLY into its
+ * snapshot: a `DbError` becomes `unavailable` (never a crash), a null profile row becomes `absent`,
+ * and every write is a fresh object so Solid always reconciles.
+ *
+ * The sticky row is derived from the runs read: when the NEWEST run is non-terminal a third read
+ * fetches its steps and publishes {@link activeRunProgress}; a terminal (or absent) newest run clears
+ * it and fires NO step query — so an idle analysis stays at zero step reads. A failed step read keeps
+ * the previous row rather than blinking away a genuinely running run.
  *
  * Staleness: the refresh claims a {@link refreshGeneration} token at entry and re-checks it after
- * each read; a refresh superseded by a newer swap silently drops rather than writing stale rows.
+ * each read (including the step read); a refresh superseded by a newer swap silently drops rather than
+ * writing stale rows.
  */
 export async function refreshSidebarData(analysisId: string, seams: RefreshSeams = realRefreshSeams): Promise<void> {
     // Bump BEFORE the runtime guard so even the not_ready path invalidates any in-flight older refresh
@@ -260,6 +373,7 @@ export async function refreshSidebarData(analysisId: string, seams: RefreshSeams
     if (!runtime) {
         setProfile({ kind: "not_ready" });
         setRuns({ kind: "not_ready" });
+        setActiveRun(null);
         return;
     }
 
@@ -277,9 +391,35 @@ export async function refreshSidebarData(analysisId: string, seams: RefreshSeams
         (row) => setProfile(row === null ? { kind: "absent" } : { kind: "loaded", profile: row }),
         () => setProfile({ kind: "unavailable" }),
     );
-    runsRes.match(
-        (rows) => setRuns({ kind: "loaded", runs: rows }),
-        () => setRuns({ kind: "unavailable" }),
+
+    // The sticky chat progress row pins the NEWEST run while it is non-terminal, fed by this same
+    // refresh. A terminal newest run (or no runs) clears it; only a non-terminal newest run fires the
+    // extra step read, so an idle analysis issues zero step queries.
+    await runsRes.match(
+        async (rows) => {
+            setRuns({ kind: "loaded", runs: rows });
+            const newest = rows[0];
+            if (!newest || RUN_STATUS_TERMINAL[newest.status]) {
+                setActiveRun(null);
+                return;
+            }
+            const stepsRes = await seams.loadSteps(runtime.pool, newest.runId);
+            if (myRefresh !== refreshGeneration) return;
+            stepsRes.match(
+                (stepRows) => {
+                    const steps: RunStepView[] = stepRows.map((r) => ({ label: r.stepId, state: stepStateOf(r.status) }));
+                    const done = steps.filter((s) => s.state === "done").length;
+                    setActiveRun({ name: shortRunName(newest), tag: idTail(newest.runId), done, total: steps.length, steps });
+                },
+                // The run is active but its steps could not be read (a transient DB blip). Keep the
+                // previous row rather than clearing — the bounded poll self-heals on the next tick, and
+                // clearing would blink away a genuinely running run.
+                () => {},
+            );
+        },
+        // A runs `DbError` is a transient degrade that itself re-arms the poll (`hasActiveWork`). Keep
+        // any existing progress row so a blip does not flash the sticky row away and back on recovery.
+        async () => setRuns({ kind: "unavailable" }),
     );
 }
 
@@ -389,8 +529,8 @@ export function watchSidebarData(workspace: Workspace, seams: WatchSeams = realW
 }
 
 /**
- * Test hook: reset both snapshots to `not_ready` and invalidate any in-flight refresh. Test-only —
- * mirrors `__resetBootForTest`.
+ * Test hook: reset both snapshots to `not_ready`, clear the sticky run-progress row, and invalidate any
+ * in-flight refresh. Test-only — mirrors `__resetBootForTest`.
  */
 export function __resetSidebarLiveForTest(): void {
     resetSnapshots();

--- a/cli/src/tui/hooks/sidebar_live.ts
+++ b/cli/src/tui/hooks/sidebar_live.ts
@@ -359,7 +359,8 @@ function resetSnapshots(): void {
  * The sticky row is derived from the runs read: when the NEWEST run is non-terminal a third read
  * fetches its steps and publishes {@link activeRunProgress}; a terminal (or absent) newest run clears
  * it and fires NO step query — so an idle analysis stays at zero step reads. A failed step read keeps
- * the previous row rather than blinking away a genuinely running run.
+ * the previous row only when it is THIS run's (avoiding a blink of a genuinely running run); if the
+ * newest run changed on the same tick it clears instead, so one run's progress is never shown for another.
  *
  * Staleness: the refresh claims a {@link refreshGeneration} token at entry and re-checks it after
  * each read (including the step read); a refresh superseded by a newer swap silently drops rather than
@@ -412,9 +413,13 @@ export async function refreshSidebarData(analysisId: string, seams: RefreshSeams
                     setActiveRun({ name: shortRunName(newest), tag: idTail(newest.runId), done, total: steps.length, steps });
                 },
                 // The run is active but its steps could not be read (a transient DB blip). Keep the
-                // previous row rather than clearing — the bounded poll self-heals on the next tick, and
-                // clearing would blink away a genuinely running run.
-                () => {},
+                // previous row ONLY when it belongs to THIS run (its tag is the run's id tail) — the
+                // bounded poll then self-heals on the next tick without blinking a genuinely running run
+                // away. But when the newest run CHANGED on this same tick (the prior newest went terminal
+                // and a different run took its place), the previous row is a DIFFERENT run's progress;
+                // holding it would misattribute one run's steps to another, so drop to null — a briefly
+                // missing row is better than a confidently wrong one.
+                () => setActiveRun((prev) => (prev && prev.tag === idTail(newest.runId) ? prev : null)),
             );
         },
         // A runs `DbError` is a transient degrade that itself re-arms the poll (`hasActiveWork`). Keep

--- a/cli/src/tui/keymap_selection.render.test.tsx
+++ b/cli/src/tui/keymap_selection.render.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { For } from "solid-js";
+import { testRender, useRenderer } from "@opentui/solid";
+import type { ScrollBoxRenderable, TextRenderable, TextareaRenderable } from "@opentui/core";
+
+import { useKeymapRoot, useBindings, MODE_BASE, KEYS, __resetKeybindCache } from "./keymap.ts";
+import { ScrollPane } from "./components/scroll_pane.tsx";
+import { DialogOverlay, dialogPush, dialogClear, dialogIsOpen } from "./components/dialog/dialog_host.tsx";
+
+// End-to-end verification of app.tsx's "esc clears the active text selection" layer through the
+// REAL engine: a headless selection over selectable text arms the layer, then mockInput drives
+// opentui's keyboard bus → useKeymapRoot → dispatchKey → the winning layer. The App itself needs
+// the whole workspace/DB/conversation stack to mount (out of scope here — tsc covers App's wiring),
+// so — exactly as keymap_scroll.render.test does — the esc wiring under test is REPLICATED here:
+// the priority-50 mode-less clear-selection layer, the textarea-targeted esc→pane (INSERT→NORMAL)
+// fall-through, and the dialog host's structural esc (via DialogOverlay). The layer copies is
+// character-for-character the one in app.tsx; keeping the two in sync is the maintenance cost of
+// not mounting the full App (the same trade keymap_scroll accepts).
+
+const LINES = Array.from({ length: 20 }, (_, i) => `line ${i}`);
+
+afterEach(() => {
+    __resetKeybindCache();
+    dialogClear();
+});
+
+type Refs = { text: TextRenderable; ta: TextareaRenderable; sb: ScrollBoxRenderable };
+
+function Harness(props: { onRefs: (refs: Refs) => void }) {
+    useKeymapRoot();
+    const renderer = useRenderer();
+
+    let text: TextRenderable | null = null;
+    let ta: TextareaRenderable | null = null;
+    let sb: ScrollBoxRenderable | null = null;
+    const publish = (): void => {
+        if (text && ta && sb) props.onRefs({ text, ta, sb });
+    };
+
+    // The layer under test, mirroring app.tsx exactly: mode-less, priority 50, armed ONLY on real
+    // selected text (empty Selection from a bare click must not arm), clears and nothing else.
+    useBindings(() => ({
+        priority: 50,
+        enabled: !!renderer.getSelection()?.getSelectedText(),
+        bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection() }],
+    }));
+
+    // app.tsx's INSERT→NORMAL fall-through: esc while the textarea is focused FOCUSES the pane; i
+    // returns. Present so the "no selection → esc flips to NORMAL" case has a real destination.
+    useBindings(() => ({
+        mode: MODE_BASE,
+        target: ta,
+        bindings: [{ chord: KEYS.escape, run: () => sb?.focus() }],
+    }));
+    useBindings(() => ({
+        mode: MODE_BASE,
+        target: sb,
+        bindings: [{ chord: { key: "i" }, run: () => ta?.focus() }],
+    }));
+
+    return (
+        <box flexDirection="column" width="100%" height="100%">
+            <text
+                ref={(r: TextRenderable) => {
+                    text = r;
+                    publish();
+                }}
+            >
+                {"SELECTABLE-CHAT-TEXT-0123456789"}
+            </text>
+            <ScrollPane focusOnMount={false} flexGrow={1} onRef={(r: ScrollBoxRenderable) => ((sb = r), publish())}>
+                <For each={LINES}>{(l) => <text>{l}</text>}</For>
+            </ScrollPane>
+            <textarea
+                ref={(r: TextareaRenderable) => {
+                    ta = r;
+                    queueMicrotask(() => r.focus());
+                    publish();
+                }}
+            />
+            <DialogOverlay />
+        </box>
+    );
+}
+
+// A lone ESC byte is an ambiguous escape-sequence prefix: opentui's StdinParser holds it for
+// timeoutMs (20ms) before flushing it as a standalone "escape" key — so yield real time, not just
+// renderOnce spins, for esc to reach the dispatcher. (Same helper as the other keymap render tests.)
+function makeSettle(setup: { renderOnce: () => Promise<void> }): () => Promise<void> {
+    return async () => {
+        await new Promise((r) => setTimeout(r, 35));
+        await setup.renderOnce();
+        await setup.renderOnce();
+    };
+}
+
+type Setup = Awaited<ReturnType<typeof testRender>>;
+
+// Create a persistent, non-empty selection across the selectable text via the renderer's own
+// selection API (the same calls a mouse drag makes), captured at the text's computed screen box so
+// the coordinates always cover it. Direct API rather than a mock drag: it fires no mouseUp, so it
+// leaves a selection standing to the esc press without any copy-on-select interaction.
+function selectText(setup: Setup, text: TextRenderable): Promise<void> {
+    setup.renderer.startSelection(text, text.x, text.y);
+    setup.renderer.updateSelection(text, text.x + text.width, text.y, { finishDragging: true });
+    return setup.renderOnce();
+}
+
+const selectedText = (setup: Setup): string => setup.renderer.getSelection()?.getSelectedText() ?? "";
+
+describe("esc clears the active text selection (rendered, real keyboard bus)", () => {
+    test("selection + open dialog: esc clears the selection and leaves the dialog open; a second esc closes it", async () => {
+        let refs!: Refs;
+        const setup = await testRender(() => <Harness onRefs={(r) => (refs = r)} />, { width: 80, height: 24 });
+        const settle = makeSettle(setup);
+        try {
+            await settle();
+
+            dialogPush(() => (
+                <box>
+                    <text>dialog body</text>
+                </box>
+            ));
+            await settle();
+            expect(dialogIsOpen()).toBe(true);
+
+            await selectText(setup, refs.text);
+            expect(selectedText(setup)).toContain("SELECTABLE-CHAT-TEXT");
+
+            // First esc: the priority-50 clear-selection layer wins over the dialog host's esc.
+            setup.mockInput.pressEscape();
+            await settle();
+            expect(selectedText(setup)).toBe("");
+            expect(dialogIsOpen()).toBe(true);
+
+            // Second esc: no selection now, so the clear layer is inert and esc falls to the dialog.
+            setup.mockInput.pressEscape();
+            await settle();
+            expect(dialogIsOpen()).toBe(false);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("selection + focused textarea: esc clears the selection and the textarea keeps focus (stays INSERT)", async () => {
+        let refs!: Refs;
+        const setup = await testRender(() => <Harness onRefs={(r) => (refs = r)} />, { width: 80, height: 24 });
+        const settle = makeSettle(setup);
+        try {
+            await settle();
+            // Textarea holds focus on mount = INSERT; the pane is not focused.
+            expect(refs.ta.focused).toBe(true);
+            expect(refs.sb.focused).toBe(false);
+
+            await selectText(setup, refs.text);
+            expect(selectedText(setup)).toContain("SELECTABLE-CHAT-TEXT");
+
+            setup.mockInput.pressEscape();
+            await settle();
+            // Selection gone; focus did NOT move to the pane — the clear layer swallowed esc, so the
+            // textarea-targeted esc→NORMAL never ran. Textarea focus IS the INSERT indicator's source.
+            expect(selectedText(setup)).toBe("");
+            expect(refs.ta.focused).toBe(true);
+            expect(refs.sb.focused).toBe(false);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("no selection, focused textarea: esc falls through and flips INSERT→NORMAL (focuses the pane)", async () => {
+        let refs!: Refs;
+        const setup = await testRender(() => <Harness onRefs={(r) => (refs = r)} />, { width: 80, height: 24 });
+        const settle = makeSettle(setup);
+        try {
+            await settle();
+            expect(selectedText(setup)).toBe("");
+            expect(refs.ta.focused).toBe(true);
+
+            setup.mockInput.pressEscape();
+            await settle();
+            // With nothing selected the clear layer is disabled: esc reaches the textarea-targeted
+            // layer and moves focus to the pane (NORMAL), proving the fall-through is intact.
+            expect(refs.ta.focused).toBe(false);
+            expect(refs.sb.focused).toBe(true);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("no selection, open dialog: esc falls through and cancels the dialog", async () => {
+        let refs!: Refs;
+        const setup = await testRender(() => <Harness onRefs={(r) => (refs = r)} />, { width: 80, height: 24 });
+        const settle = makeSettle(setup);
+        try {
+            await settle();
+            expect(refs).toBeDefined();
+
+            dialogPush(() => (
+                <box>
+                    <text>dialog body</text>
+                </box>
+            ));
+            await settle();
+            expect(dialogIsOpen()).toBe(true);
+            expect(selectedText(setup)).toBe("");
+
+            setup.mockInput.pressEscape();
+            await settle();
+            // The disabled clear layer lets the dialog host's structural esc close the dialog.
+            expect(dialogIsOpen()).toBe(false);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/keymap_selection.render.test.tsx
+++ b/cli/src/tui/keymap_selection.render.test.tsx
@@ -4,6 +4,7 @@ import { testRender, useRenderer } from "@opentui/solid";
 import type { ScrollBoxRenderable, TextRenderable, TextareaRenderable } from "@opentui/core";
 
 import { useKeymapRoot, useBindings, MODE_BASE, KEYS, __resetKeybindCache } from "./keymap.ts";
+import { selectionClearLayer } from "./app.tsx";
 import { ScrollPane } from "./components/scroll_pane.tsx";
 import { DialogOverlay, dialogPush, dialogClear, dialogIsOpen } from "./components/dialog/dialog_host.tsx";
 
@@ -11,11 +12,11 @@ import { DialogOverlay, dialogPush, dialogClear, dialogIsOpen } from "./componen
 // REAL engine: a headless selection over selectable text arms the layer, then mockInput drives
 // opentui's keyboard bus → useKeymapRoot → dispatchKey → the winning layer. The App itself needs
 // the whole workspace/DB/conversation stack to mount (out of scope here — tsc covers App's wiring),
-// so — exactly as keymap_scroll.render.test does — the esc wiring under test is REPLICATED here:
-// the priority-50 mode-less clear-selection layer, the textarea-targeted esc→pane (INSERT→NORMAL)
-// fall-through, and the dialog host's structural esc (via DialogOverlay). The layer copies is
-// character-for-character the one in app.tsx; keeping the two in sync is the maintenance cost of
-// not mounting the full App (the same trade keymap_scroll accepts).
+// so the Harness registers the ACTUAL layer under test — app.tsx's exported `selectionClearLayer`
+// factory — instead of a hand-copied replica, so the test can never drift from app.tsx's real config.
+// Only the destinations esc competes with are minimal stand-ins: the textarea-targeted esc→pane
+// (INSERT→NORMAL) fall-through and the dialog host's structural esc (via DialogOverlay), which give
+// esc's other jobs a real place to land.
 
 const LINES = Array.from({ length: 20 }, (_, i) => `line ${i}`);
 
@@ -37,13 +38,10 @@ function Harness(props: { onRefs: (refs: Refs) => void }) {
         if (text && ta && sb) props.onRefs({ text, ta, sb });
     };
 
-    // The layer under test, mirroring app.tsx exactly: mode-less, priority 50, armed ONLY on real
-    // selected text (empty Selection from a bare click must not arm), clears and nothing else.
-    useBindings(() => ({
-        priority: 50,
-        enabled: !!renderer.getSelection()?.getSelectedText(),
-        bindings: [{ chord: KEYS.escape, run: () => renderer.clearSelection() }],
-    }));
+    // The REAL layer under test: app.tsx's exported factory, registered here over the same renderer so
+    // the test exercises app.tsx's actual config (arm-on-selected-text, priority 50, clear-only) rather
+    // than a copy that could drift.
+    useBindings(() => selectionClearLayer(renderer));
 
     // app.tsx's INSERT→NORMAL fall-through: esc while the textarea is focused FOCUSES the pane; i
     // returns. Present so the "no selection → esc flips to NORMAL" case has a real destination.

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -39,6 +39,7 @@ import {
     mockToolCall,
     mockFileEdit,
     mockRun,
+    mockLongRun,
     mockPlanCard,
     mockRunCard,
     mockCortexRuns,
@@ -89,6 +90,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
         bindings: [{ chord: KEYS.q, run: () => props.onClose() }],
     }));
     const runSteps = mockRun.steps.map((s) => ({ label: s.label, state: s.state }));
+    const longRunSteps = mockLongRun.steps.map((s) => ({ label: s.label, state: s.state }));
     return (
         <DialogPanel title="Design system — stream blocks" size="xl" footer={`${chordLabel(KEYS.escape)}/${chordLabel(KEYS.q)} close`}>
             <ScrollPane focusOnMount={false} onRef={(r) => dialog?.setInitialFocus(r)} flexGrow={1} width="100%" paddingTop={space.sm}>
@@ -318,11 +320,14 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                     />
                 </State>
                 <State n="15" label="live tool activity — running / done (with duration) / error">
-                    {/* The harness emit adapter mints these from tool-started/tool-finished: no
-                        result panel (live events carry no output), just name + outcome + timing. */}
-                    <ToolBlock name="grep" target="src/**/*.ts" status="running" />
-                    <ToolBlock name="read_file" target="src/db/types.ts :55-105" status="ok" durationMs={1240} />
-                    <ToolBlock name="write_file" target="out/report.html" status="error" durationMs={320} />
+                    {/* The harness emit adapter mints these from tool-started/tool-finished: no result
+                        panel (live events carry no output), so the outcome folds onto the name line
+                        (`▸ name target  ✓ ok · 14ms`). `inlineStatus` is pinned true to document the form
+                        explicitly; a result-less block would derive it anyway. Contrast State 4, whose
+                        result fixture keeps the outcome on its own line below the panel. */}
+                    <ToolBlock name="grep" target="src/**/*.ts" status="running" inlineStatus={true} />
+                    <ToolBlock name="read_file" target="src/db/types.ts :55-105" status="ok" durationMs={1240} inlineStatus={true} />
+                    <ToolBlock name="write_file" target="out/report.html" status="error" durationMs={320} inlineStatus={true} />
                 </State>
                 <State n="16" label="harness cards — plan card & run card">
                     <MessageBlock index={1} role="assistant" parts={[mockPlanCard]} streamPartId={noStreamId} streamText={noStreamText} />
@@ -350,6 +355,24 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                             onClose={noop}
                         />
                     </DialogShowcase>
+                </State>
+                <State n="18" label="chat sticky run-progress row — bounded step window">
+                    {/* The chat column's sticky row (RunProgressRow) pins the newest non-terminal run
+                        between the stream and the input. A long run shows a WINDOW of steps centered on
+                        the frontier (maxSteps=6, hint=false — the same props the row passes), while the
+                        bar and done/total reflect the full run. Driven from the long-run fixture. */}
+                    <text fg={theme().fgMuted}>
+                        pinned below the chat stream while the newest run is non-terminal; long runs window their steps (maxSteps=6):
+                    </text>
+                    <RunBlock
+                        name={mockLongRun.name}
+                        tag={mockLongRun.tag}
+                        done={mockLongRun.done}
+                        total={mockLongRun.total}
+                        steps={longRunSteps}
+                        maxSteps={6}
+                        hint={false}
+                    />
                 </State>
             </ScrollPane>
         </DialogPanel>

--- a/cli/src/tui/layout/design_gallery_fixtures.ts
+++ b/cli/src/tui/layout/design_gallery_fixtures.ts
@@ -146,6 +146,34 @@ export const mockRun: Run = {
     ],
 };
 
+/**
+ * MOCK sample: a long run whose step count exceeds the chat sticky row's window (`maxSteps=6`), so the
+ * gallery exhibit shows the window engaging — centered on the frontier (the first non-done step),
+ * clamped to the ends — while the bar and `done/total` still reflect the full 12-step run.
+ */
+export const mockLongRun: Run = {
+    id: "mock-long-run",
+    name: "cohort-screen",
+    tag: "T9S2",
+    status: "running",
+    done: 7,
+    total: 12,
+    steps: [
+        { id: "mock-lstep-1", label: "ingest cohort", state: "done" },
+        { id: "mock-lstep-2", label: "harmonize schemas", state: "done" },
+        { id: "mock-lstep-3", label: "qc filter", state: "done" },
+        { id: "mock-lstep-4", label: "normalize", state: "done" },
+        { id: "mock-lstep-5", label: "batch correct", state: "done" },
+        { id: "mock-lstep-6", label: "cluster", state: "done" },
+        { id: "mock-lstep-7", label: "annotate types", state: "done" },
+        { id: "mock-lstep-8", label: "differential test", state: "running" },
+        { id: "mock-lstep-9", label: "pathway enrich", state: "queued" },
+        { id: "mock-lstep-10", label: "score targets", state: "queued" },
+        { id: "mock-lstep-11", label: "rank consensus", state: "queued" },
+        { id: "mock-lstep-12", label: "build report", state: "queued" },
+    ],
+};
+
 /** Sample age helper: an ISO timestamp `ms` in the past, so gallery exhibits show fresh relative ages. */
 function ago(ms: number): string {
     return new Date(Date.now() - ms).toISOString();

--- a/cli/src/tui/layout/message_block.test.tsx
+++ b/cli/src/tui/layout/message_block.test.tsx
@@ -45,3 +45,40 @@ describe("MessageBlock text rendering", () => {
         expect(frame).toContain("live tokens");
     });
 });
+
+// The user turn's body rides a left border rule; the border glyph eats one gutter cell, so the body pads
+// by space.sm (1) inside the box instead of space.md (2) to land in the SAME column as an assistant body.
+// This pins that alignment invariant: break the border-1 + padding-1 === md arithmetic and the two body
+// texts stop starting in the same column. Rendered together so the columns share one coordinate system.
+describe("MessageBlock user-turn left rule alignment", () => {
+    /** Column (0-based) at which `needle` starts on its frame row, or -1 if not found. */
+    function columnOf(frame: string, needle: string): number {
+        for (const line of frame.split("\n")) {
+            const idx = line.indexOf(needle);
+            if (idx !== -1) return idx;
+        }
+        return -1;
+    }
+
+    test("a user body and an assistant body start in the same column, and the user body carries the border glyph", async () => {
+        const frame = await frameWith(
+            () => (
+                <box flexDirection="column" width="100%">
+                    <MessageBlock index={1} role="user" parts={[textPart("USERBODY")]} streamPartId={() => null} streamText={() => ""} />
+                    <MessageBlock index={2} role="assistant" parts={[textPart("ASSTBODY")]} streamPartId={() => null} streamText={() => ""} />
+                </box>
+            ),
+            "ASSTBODY",
+        );
+        const userCol = columnOf(frame, "USERBODY");
+        const asstCol = columnOf(frame, "ASSTBODY");
+        expect(userCol).toBeGreaterThanOrEqual(0);
+        expect(asstCol).toBeGreaterThanOrEqual(0);
+        expect(userCol).toBe(asstCol);
+        // The left rule ("│", U+2502) sits in the gutter of the user body row; the assistant body has none.
+        const userRow = frame.split("\n").find((line) => line.includes("USERBODY")) ?? "";
+        const asstRow = frame.split("\n").find((line) => line.includes("ASSTBODY")) ?? "";
+        expect(userRow).toContain("│");
+        expect(asstRow).not.toContain("│");
+    });
+});

--- a/cli/src/tui/layout/message_block.tsx
+++ b/cli/src/tui/layout/message_block.tsx
@@ -39,71 +39,89 @@ export type MessageBlockProps = {
  * accessors and flips to the stored text once the part completes.
  */
 export function MessageBlock(props: MessageBlockProps) {
-    // `· #N`, plus `· Ns` for a completed assistant turn (whole seconds, matching the thinking
-    // block's readout). User turns and not-yet-finished assistant turns show only the number.
+    // `· #N`, plus `· <dur>` for a completed assistant turn (via the shared Date.formatDuration
+    // vocabulary). User turns and not-yet-finished assistant turns show only the number.
     const meta = (): string => {
-        const dur = props.role === "assistant" && props.durationMs !== undefined ? ` ${GLYPHS.middot} ${Math.round(props.durationMs / 1000)}s` : "";
+        const dur = props.role === "assistant" && props.durationMs !== undefined ? ` ${GLYPHS.middot} ${Date.formatDuration(props.durationMs)}` : "";
         return `  ${GLYPHS.middot} #${props.index}${dur}`;
     };
+    // Body indent, kept gutter-aligned across roles. An assistant body pads by space.md (2). A user
+    // body rides a left border rule (the quoted-content idiom), whose glyph eats one gutter cell — so it
+    // pads by space.sm (1) instead: border(1) + padding(1) === space.md, landing user and assistant
+    // body text in the SAME column. This sum is the invariant: change one term and the other must move
+    // to match, or the two roles misalign under their headers.
+    const bodyPadLeft = (): number => (props.role === "user" ? space.sm : space.md);
+    const parts = (): JSX.Element => (
+        <For each={props.parts}>
+            {(part): JSX.Element => {
+                switch (part.type) {
+                    case "text": {
+                        const isStreaming = (): boolean => props.streamPartId() === part.id;
+                        const content = (): string => (isStreaming() ? props.streamText() : part.text);
+                        return (
+                            <Show when={content()}>
+                                {/* Mirror opencode's markdown config exactly. `streaming` is pinned true, NOT
+                                    isStreaming(): in @opentui/core 0.4.0 `<markdown streaming={false}>` renders
+                                    nothing (verified headlessly), so a finalized/reloaded part would vanish the
+                                    instant the stream ends. `internalBlockMode="top-level"` is the streaming
+                                    block mode — without it, incrementally-grown content left inline syntax
+                                    (`**bold**`) rendered as raw literal `**`. content() switches source (live
+                                    streamText while streaming, stored part.text once flushed). */}
+                                <markdown
+                                    content={content()}
+                                    fg={theme().fg}
+                                    syntaxStyle={syntaxStyle()}
+                                    streaming={true}
+                                    internalBlockMode="top-level"
+                                    paddingLeft={bodyPadLeft()}
+                                />
+                            </Show>
+                        );
+                    }
+                    case "thinking":
+                        return <ThinkingBlock text={part.text} durationMs={part.durationMs} />;
+                    case "tool-call":
+                        return (
+                            <ToolBlock
+                                name={part.name}
+                                target={part.target}
+                                result={part.result}
+                                filetype={part.filetype}
+                                status={part.status}
+                                durationMs={part.durationMs}
+                            />
+                        );
+                    case "file-edit":
+                        return <DiffBlock path={part.path} diff={part.diff} added={part.added} removed={part.removed} />;
+                    case "plan-card":
+                        return <PlanCardBlock planId={part.planId} title={part.title} steps={part.steps} />;
+                    case "run-card":
+                        return <RunCardBlock runId={part.runId} title={part.title} stepCount={part.stepCount} />;
+                    default: {
+                        // Exhaustive: a new Part kind without a case fails the build here.
+                        const _exhaustive: never = part;
+                        return _exhaustive;
+                    }
+                }
+            }}
+        </For>
+    );
     return (
         <box width="100%" flexDirection="column" paddingBottom={space.sm}>
             <text fg={theme()[props.role === "user" ? MARKERS.you.role : MARKERS.assistant.role]}>
                 <Bold>{props.role === "user" ? `${MARKERS.you.glyph} You` : `${MARKERS.assistant.glyph} Inflexa`}</Bold>
                 <Fg role="fgMuted">{meta()}</Fg>
             </text>
-            <For each={props.parts}>
-                {(part): JSX.Element => {
-                    switch (part.type) {
-                        case "text": {
-                            const isStreaming = (): boolean => props.streamPartId() === part.id;
-                            const content = (): string => (isStreaming() ? props.streamText() : part.text);
-                            return (
-                                <Show when={content()}>
-                                    {/* Mirror opencode's markdown config exactly. `streaming` is pinned true, NOT
-                                        isStreaming(): in @opentui/core 0.4.0 `<markdown streaming={false}>` renders
-                                        nothing (verified headlessly), so a finalized/reloaded part would vanish the
-                                        instant the stream ends. `internalBlockMode="top-level"` is the streaming
-                                        block mode — without it, incrementally-grown content left inline syntax
-                                        (`**bold**`) rendered as raw literal `**`. content() switches source (live
-                                        streamText while streaming, stored part.text once flushed). */}
-                                    <markdown
-                                        content={content()}
-                                        fg={theme().fg}
-                                        syntaxStyle={syntaxStyle()}
-                                        streaming={true}
-                                        internalBlockMode="top-level"
-                                        paddingLeft={space.md}
-                                    />
-                                </Show>
-                            );
-                        }
-                        case "thinking":
-                            return <ThinkingBlock text={part.text} durationMs={part.durationMs} />;
-                        case "tool-call":
-                            return (
-                                <ToolBlock
-                                    name={part.name}
-                                    target={part.target}
-                                    result={part.result}
-                                    filetype={part.filetype}
-                                    status={part.status}
-                                    durationMs={part.durationMs}
-                                />
-                            );
-                        case "file-edit":
-                            return <DiffBlock path={part.path} diff={part.diff} added={part.added} removed={part.removed} />;
-                        case "plan-card":
-                            return <PlanCardBlock planId={part.planId} title={part.title} steps={part.steps} />;
-                        case "run-card":
-                            return <RunCardBlock runId={part.runId} title={part.title} stepCount={part.stepCount} />;
-                        default: {
-                            // Exhaustive: a new Part kind without a case fails the build here.
-                            const _exhaustive: never = part;
-                            return _exhaustive;
-                        }
-                    }
-                }}
-            </For>
+            {props.role === "user" ? (
+                // The user turn's body rides a left border rule in the user color (the quoted-content idiom
+                // shared with the thinking / plan-card / run blocks). The header sits OUTSIDE this box so its
+                // gutter marker column never shifts; only the body is indented under the rule.
+                <box flexDirection="column" border={["left"]} borderColor={theme().user}>
+                    {parts()}
+                </box>
+            ) : (
+                parts()
+            )}
         </box>
     );
 }

--- a/cli/src/tui/layout/run_progress_row.render.test.tsx
+++ b/cli/src/tui/layout/run_progress_row.render.test.tsx
@@ -7,6 +7,7 @@ import type { CortexRunRow, StepExecutionRow } from "@inflexa-ai/harness";
 import { RunProgressRow } from "./run_progress_row.tsx";
 import { ScrollPane } from "../components/scroll_pane.tsx";
 import { theme } from "../theme.ts";
+import { GLYPHS } from "../../lib/design_system.ts";
 import type { HarnessRuntime } from "../../modules/harness/runtime.ts";
 import { __resetSidebarLiveForTest, activeRunProgress, refreshSidebarData, type RefreshSeams } from "../hooks/sidebar_live.ts";
 
@@ -117,6 +118,36 @@ describe("RunProgressRow — presence and the bounded step window", () => {
             expect(frame).toContain("step-09");
             expect(frame).not.toContain("step-00"); // before the window
             expect(frame).not.toContain("step-11"); // after the window
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("caps the meter width for a long run while done/total keeps the true counts", async () => {
+        // 30 steps > BAR_BUDGET (20): a one-cell-per-step meter would soft-wrap the narrow sticky mount,
+        // so the meter must scale to at most 20 cells. 25 are done, so the bar is partially filled.
+        const steps: StepExecutionRow[] = Array.from({ length: 30 }, (_unused, i) =>
+            stepRow(`step-${String(i).padStart(2, "0")}`, i < 25 ? "completed" : i === 25 ? "running" : "pending"),
+        );
+        await publish(steps);
+        expect(activeRunProgress()).not.toBeNull();
+
+        const setup = await testRender(
+            () => (
+                <box width="100%" height="100%">
+                    <RunProgressRow />
+                </box>
+            ),
+            { width: 50, height: 16 },
+        );
+        try {
+            await setup.renderOnce();
+            const frame = setup.captureCharFrame();
+            // The meter is the only source of the bar glyph, so its total cell count is the frame's whole
+            // count: capped to 20 (BAR_BUDGET), never the raw 30 steps.
+            expect(occurrences(frame, GLYPHS.bar)).toBe(20);
+            // The done/total text still reports the FULL run, not the scaled cell counts.
+            expect(frame).toContain("25/30");
         } finally {
             setup.renderer.destroy();
         }

--- a/cli/src/tui/layout/run_progress_row.render.test.tsx
+++ b/cli/src/tui/layout/run_progress_row.render.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { For } from "solid-js";
+import { okAsync } from "neverthrow";
+import { testRender } from "@opentui/solid";
+import type { CortexRunRow, StepExecutionRow } from "@inflexa-ai/harness";
+
+import { RunProgressRow } from "./run_progress_row.tsx";
+import { ScrollPane } from "../components/scroll_pane.tsx";
+import { theme } from "../theme.ts";
+import type { HarnessRuntime } from "../../modules/harness/runtime.ts";
+import { __resetSidebarLiveForTest, activeRunProgress, refreshSidebarData, type RefreshSeams } from "../hooks/sidebar_live.ts";
+
+// The row's whole job is size-dependent: it sits directly below the chat stream's flexGrow scrollbox,
+// so it inherits the two documented layout hazards (cli/CLAUDE.md "Layout") — the 1-cell scrollbox
+// bleed painting scroll content onto the row below, and the short-terminal squeeze dropping chrome
+// off-screen. A render at one size hides both; the squeeze suite sweeps heights. The row is fed by the
+// module signal `activeRunProgress`, driven here through the real `refreshSidebarData` over fake seams
+// (no Postgres), exactly as production populates it.
+
+const fakeRuntime = { pool: {} } as unknown as HarnessRuntime;
+
+afterEach(() => {
+    __resetSidebarLiveForTest();
+});
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function occurrences(haystack: string, needle: string): number {
+    let count = 0;
+    let from = 0;
+    for (;;) {
+        const idx = haystack.indexOf(needle, from);
+        if (idx === -1) break;
+        count++;
+        from = idx + needle.length;
+    }
+    return count;
+}
+
+function runRow(over: Partial<CortexRunRow> = {}): CortexRunRow {
+    return {
+        runId: "11112222-3333-4444-5555-6666aabbccdd",
+        analysisId: "a1",
+        threadId: null,
+        workflowName: "executeAnalysis",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        completedAt: null,
+        error: null,
+        parts: null,
+        mandateJti: null,
+        mandateExpiresAt: null,
+        planId: null,
+        attemptCount: 0,
+        ...over,
+    };
+}
+
+function stepRow(stepId: string, status: StepExecutionRow["status"]): StepExecutionRow {
+    return {
+        runId: "11112222-3333-4444-5555-6666aabbccdd",
+        stepId,
+        analysisId: "a1",
+        wave: 0,
+        agentId: "agent",
+        status,
+        startedAt: null,
+        completedAt: null,
+        durationMs: null,
+        error: null,
+        attempts: 1,
+        lastErrorClass: null,
+        finishReason: null,
+        hitMaxSteps: false,
+        blockedReason: null,
+        execId: null,
+        childWorkflowId: null,
+        sandboxRef: null,
+    };
+}
+
+/** Publish an active (non-terminal newest) run + its steps into the module signal, as a refresh would. */
+async function publish(steps: StepExecutionRow[], run: Partial<CortexRunRow> = {}): Promise<void> {
+    const seams: RefreshSeams = {
+        runtime: () => fakeRuntime,
+        loadProfile: () => okAsync(null),
+        loadRuns: () => okAsync([runRow(run)]),
+        loadSteps: () => okAsync(steps),
+    };
+    await refreshSidebarData("A", seams);
+}
+
+describe("RunProgressRow — presence and the bounded step window", () => {
+    test("renders the bar (done/total) and a windowed step slice when a run is active", async () => {
+        // 12 steps > the row's maxSteps=6: the first 7 are done, so the window centers on the frontier
+        // (step 7) and clamps to a slice of the tail — the bar/done-total still reflect the full run.
+        const steps: StepExecutionRow[] = Array.from({ length: 12 }, (_unused, i) =>
+            stepRow(`step-${String(i).padStart(2, "0")}`, i < 7 ? "completed" : i === 7 ? "running" : "pending"),
+        );
+        await publish(steps);
+        expect(activeRunProgress()).not.toBeNull(); // guard: the fixture produced a pinned run
+
+        const setup = await testRender(
+            () => (
+                <box width="100%" height="100%">
+                    <RunProgressRow />
+                </box>
+            ),
+            { width: 50, height: 16 },
+        );
+        try {
+            await setup.renderOnce();
+            const frame = setup.captureCharFrame();
+            expect(frame).toContain("executeAnalysis"); // the run name (shortRunName)
+            expect(frame).toContain("7/12"); // the bar's done/total, reflecting the FULL run
+            // The window is centered on the frontier (index 7), clamped to indices 4..9.
+            expect(frame).toContain("step-04");
+            expect(frame).toContain("step-09");
+            expect(frame).not.toContain("step-00"); // before the window
+            expect(frame).not.toContain("step-11"); // after the window
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("renders nothing when no run is active (the signal is null)", async () => {
+        __resetSidebarLiveForTest(); // the signal is null
+        expect(activeRunProgress()).toBeNull();
+
+        const setup = await testRender(
+            () => (
+                <box width="100%" height="100%">
+                    <RunProgressRow />
+                </box>
+            ),
+            { width: 50, height: 8 },
+        );
+        try {
+            await setup.renderOnce();
+            const frame = setup.captureCharFrame();
+            expect(frame).not.toContain("executeAnalysis");
+            expect(frame.trim()).toBe(""); // an empty column — no row painted at all
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});
+
+// The row alone at one size cannot catch the two failure modes its ACTUAL mount site risks (see
+// app.tsx + cli/CLAUDE.md "Layout"): the flexGrow-scrollbox 1-cell bleed painting scroll content onto
+// the row, and the short-terminal squeeze pushing the row (or the input below it) off-screen. So mirror
+// the real chat column — a flexGrow ScrollPane with overflowing content, the RunProgressRow, and a
+// flexShrink={0} input-like box below — and sweep heights. At every height the row must render exactly
+// once (not doubled/corrupted by bleed, not squeezed out), its top row must carry no bled scroll
+// content, and the input chrome directly below it must keep its rows.
+describe("RunProgressRow at its real mount shape survives bleed + short-terminal squeeze", () => {
+    const HEIGHTS = [8, 11, 16, 24];
+
+    for (const height of HEIGHTS) {
+        test(`height ${height}: the row renders once, stays opaque, and the input below stays intact`, async () => {
+            // A compact run (3 steps ≤ the window) so the block fits even the shortest sweep height; the
+            // bleed/squeeze property under test is independent of the step count.
+            await publish([stepRow("step-a", "completed"), stepRow("step-b", "running"), stepRow("step-c", "pending")]);
+
+            const setup = await testRender(
+                () => (
+                    <box flexDirection="column" width="100%" height="100%">
+                        <box flexDirection="column" flexGrow={1} minHeight={0}>
+                            {/* Content overflows the pane so the documented 1-cell bleed is in play. */}
+                            <ScrollPane focusOnMount={false} flexGrow={1} stickyScroll stickyStart="bottom" paddingLeft={1}>
+                                <For each={Array.from({ length: 60 }, (_unused, i) => i)}>{(i) => <text>scroll-line-{i}</text>}</For>
+                            </ScrollPane>
+                            <RunProgressRow />
+                            {/* The input-like chrome directly below the row (flexShrink={0}, painted). */}
+                            <box width="100%" flexShrink={0} backgroundColor={theme().bg} paddingLeft={1}>
+                                <text>input-bar-row</text>
+                            </box>
+                        </box>
+                    </box>
+                ),
+                { width: 50, height },
+            );
+            try {
+                await setup.renderOnce();
+                const frame = setup.captureCharFrame();
+                // Exactly once: never doubled/overwritten by the scrollbox bleed (the painted wrapper
+                // opaquely reclaims its row), never zero (the flexShrink={0} wrapper held its rows).
+                expect(occurrences(frame, "executeAnalysis")).toBe(1);
+                expect(frame).toContain("step-b"); // the row's step list stayed intact
+                // The row's top row (the name line) must carry NO bled scroll content — the opaque
+                // full-width box reclaimed it. A bare/transparent row would let a `scroll-line` fragment
+                // show through here.
+                const nameLine = frame.split("\n").find((l) => l.includes("executeAnalysis"));
+                expect(nameLine).toBeDefined();
+                expect(nameLine).not.toContain("scroll-line");
+                // The input chrome directly below the row kept its rows too — not squeezed off-screen.
+                expect(frame).toContain("input-bar-row");
+            } finally {
+                setup.renderer.destroy();
+            }
+        });
+    }
+});

--- a/cli/src/tui/layout/run_progress_row.tsx
+++ b/cli/src/tui/layout/run_progress_row.tsx
@@ -1,5 +1,5 @@
 import { Show } from "solid-js";
-import type { JSX } from "solid-js";
+import type { Accessor, JSX } from "solid-js";
 
 import { theme } from "../theme.ts";
 import { RunBlock } from "../components/run_block.tsx";
@@ -22,16 +22,24 @@ import { activeRunProgress, type ActiveRunProgress } from "../hooks/sidebar_live
  * `hint={false}` drops the detach/abort footer — those keys are the chat's to own here, not the row's.
  */
 export function RunProgressRow(): JSX.Element {
+    // NON-keyed Show with the accessor form. Each sidebar refresh mints a FRESH ActiveRunProgress object,
+    // so `keyed` (which re-runs children on reference change) would tear down and rebuild the whole
+    // RunBlock subtree on every ~5s poll tick. Non-keyed mounts once on the null→present edge and
+    // unmounts on present→null; `progress` is Show's non-null-narrowed accessor, so reading through it
+    // (`progress().name`, …) updates each RunBlock prop fine-grained in place — no `!`, no remount.
     return (
-        <Show when={activeRunProgress()} keyed>
-            {(progress: ActiveRunProgress) => (
+        <Show when={activeRunProgress()}>
+            {/* `progress` is Show's non-null-narrowed accessor for the truthy branch (the opentui/solid
+                JSX types don't infer it, so it is annotated); Show only runs this child while the signal
+                is non-null, so `progress()` is always an `ActiveRunProgress`. */}
+            {(progress: Accessor<ActiveRunProgress>) => (
                 <box width="100%" flexShrink={0} backgroundColor={theme().bg} paddingLeft={1} paddingRight={1}>
                     <RunBlock
-                        name={progress.name}
-                        tag={progress.tag}
-                        done={progress.done}
-                        total={progress.total}
-                        steps={progress.steps}
+                        name={progress().name}
+                        tag={progress().tag}
+                        done={progress().done}
+                        total={progress().total}
+                        steps={progress().steps}
                         maxSteps={6}
                         hint={false}
                     />

--- a/cli/src/tui/layout/run_progress_row.tsx
+++ b/cli/src/tui/layout/run_progress_row.tsx
@@ -1,0 +1,42 @@
+import { Show } from "solid-js";
+import type { JSX } from "solid-js";
+
+import { theme } from "../theme.ts";
+import { RunBlock } from "../components/run_block.tsx";
+import { activeRunProgress, type ActiveRunProgress } from "../hooks/sidebar_live.ts";
+
+/**
+ * The chat column's sticky run-progress row, pinned between the message stream and the input bar.
+ * While the open analysis's NEWEST run is non-terminal, {@link activeRunProgress} carries its live
+ * progress (published by the sidebar-live refresh loop) and this row renders the run-block vocabulary
+ * — the segmented bar, `done/total`, and a bounded step window — so the user tracks the run without
+ * opening the runs dialog. When nothing is active the signal is `null` and the row renders nothing
+ * (no extra query fires, no row appears); it disappears the moment the run reaches a terminal status.
+ *
+ * It sits DIRECTLY below the chat stream's `flexGrow` scrollbox, so — exactly like the boot indicator
+ * and the dialog footer (see cli/CLAUDE.md "Layout") — it MUST be a full-width box painted with the
+ * panel background and `flexShrink={0}`: a bare/transparent row lets the scrollbox's documented 1-cell
+ * bleed paint scroll content through it, and the short-terminal squeeze would drop its rows. The
+ * opaque painted box reclaims its whole width and keeps its rows; the stream yields the squeeze
+ * instead. `maxSteps={6}` bounds the step list so a long run cannot grow the row without limit, and
+ * `hint={false}` drops the detach/abort footer — those keys are the chat's to own here, not the row's.
+ */
+export function RunProgressRow(): JSX.Element {
+    return (
+        <Show when={activeRunProgress()} keyed>
+            {(progress: ActiveRunProgress) => (
+                <box width="100%" flexShrink={0} backgroundColor={theme().bg} paddingLeft={1} paddingRight={1}>
+                    <RunBlock
+                        name={progress.name}
+                        tag={progress.tag}
+                        done={progress.done}
+                        total={progress.total}
+                        steps={progress.steps}
+                        maxSteps={6}
+                        hint={false}
+                    />
+                </box>
+            )}
+        </Show>
+    );
+}

--- a/cli/src/tui/layout/sidebar.render.test.tsx
+++ b/cli/src/tui/layout/sidebar.render.test.tsx
@@ -307,12 +307,14 @@ describe("Sidebar responsive ANALYSIS badge + path", () => {
 // A Section merges its value onto the label row when it fits the rail's usable width, else stacks it
 // on the line below — the rail is a fixed width, so this depends on value length, not terminal width.
 describe("Sidebar Section header merge vs stacked fallback", () => {
-    test("short values share their section's label row", async () => {
+    test("a short ASCII value shares its section's label row; a middot-bearing handle merges too", async () => {
         writeFileSync(join(dirA, "one.txt"), "x");
         const a = createAnalysis({ cwd: dirA, name: str256("alpha")._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
         const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 44, height: 24 });
-        expect(lineContaining(frame, "SESSION")).toContain("nosu"); // the short session id merges up
-        expect(lineContaining(frame, "ANALYSIS")).toContain("alpha"); // the short analysis name merges up
+        expect(lineContaining(frame, "ANALYSIS")).toContain("alpha"); // pure-ASCII name is cell-accurate → merges up
+        // The SESSION handle is `S·nosu` — its `·` is GLYPHS.middot, a single-cell registry glyph the fit
+        // check trusts as width 1, so the whole handle (well within the rail) merges onto the label row.
+        expect(lineContaining(frame, "SESSION")).toContain("nosu");
     });
 
     test("a value too long to fit stacks below the label, rendered in full (never truncated)", async () => {
@@ -322,5 +324,17 @@ describe("Sidebar Section header merge vs stacked fallback", () => {
         const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 44, height: 24 });
         expect(lineContaining(frame, "ANALYSIS")).not.toContain(longName); // label row holds only the label
         expect(frame).toContain(longName); // the name renders in full on its own line
+    });
+
+    test("a non-ASCII (CJK) name stacks even when its .length would fit, since cells ≠ UTF-16 units", async () => {
+        writeFileSync(join(dirA, "one.txt"), "x");
+        // `分析proj`: .length is 6, so the old unit-count check would MERGE it onto the label row — but the
+        // two CJK glyphs are two cells each, so that fit is measured wrong. The conservative guard stacks
+        // any non-ASCII value instead. The ASCII `proj` tail is the reliable capture probe (wide-glyph
+        // capture is not); the workspace has no linked project, so `proj` appears only in the name.
+        const a = createAnalysis({ cwd: dirA, name: str256("分析proj")._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
+        const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 44, height: 24 });
+        expect(lineContaining(frame, "ANALYSIS")).not.toContain("proj"); // did not merge onto the label row
+        expect(frame).toContain("proj"); // stacked on its own full line below the label
     });
 });

--- a/cli/src/tui/layout/sidebar.render.test.tsx
+++ b/cli/src/tui/layout/sidebar.render.test.tsx
@@ -8,9 +8,11 @@ import { testRender } from "@opentui/solid";
 import { freshDb } from "../../test_support/db.ts";
 import { renderFrame } from "../../test_support/tui.ts";
 import { str256 } from "../../lib/types.ts";
+import { GLYPHS } from "../../lib/design_system.ts";
 import { createAnalysis, addInputs } from "../../modules/analysis/analysis.ts";
+import { getAnchor } from "../../db/primary_query.ts";
 import { WorkspaceContext, type Workspace } from "../contexts/workspace.ts";
-import { __resetSidebarLiveForTest, refreshSidebarData, type RefreshSeams } from "../hooks/sidebar_live.ts";
+import { __resetSidebarLiveForTest, absTime, refreshSidebarData, relAge, type RefreshSeams } from "../hooks/sidebar_live.ts";
 import { __setAgentModelsForTest, __setBootStateForTest } from "../hooks/boot.ts";
 import { Sidebar } from "./sidebar.tsx";
 import type { Analysis } from "../../types/analysis.ts";
@@ -55,6 +57,22 @@ function wsFor(analysis: Analysis, workingDir: string): Workspace {
         openSession: () => {},
         quit: async () => {},
     };
+}
+
+// A full-height sidebar mounted under a given workspace — the shared shape the responsive cases render.
+function sidebarNode(ws: Workspace) {
+    return () => (
+        <WorkspaceContext.Provider value={ws}>
+            <box width="100%" height="100%">
+                <Sidebar messageCount={() => 0} />
+            </box>
+        </WorkspaceContext.Provider>
+    );
+}
+
+/** The first captured frame line containing `needle` (or ""), so a test can assert what shares a row. */
+function lineContaining(frame: string, needle: string): string {
+    return frame.split("\n").find((l) => l.includes(needle)) ?? "";
 }
 
 describe("Sidebar input count follows the bus", () => {
@@ -105,7 +123,7 @@ describe("Sidebar input count follows the bus", () => {
 const fakeRuntime = { pool: {} } as unknown as HarnessRuntime;
 
 function seams(profile: DataProfileStatus | null, runs: CortexRunRow[]): RefreshSeams {
-    return { runtime: () => fakeRuntime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync(runs) };
+    return { runtime: () => fakeRuntime, loadProfile: () => okAsync(profile), loadRuns: () => okAsync(runs), loadSteps: () => okAsync([]) };
 }
 
 function completedProfile(fileCount: number): DataProfileStatus {
@@ -168,10 +186,14 @@ describe("Sidebar DATA PROFILE / RUNS live sections", () => {
         expect(frame).toContain("runtime not ready");
     });
 
-    test("a completed profile shows the file count; no runs shows 'no runs'", async () => {
+    test("a completed profile shows the file count and the absolute completed time; no runs shows 'no runs'", async () => {
         await refreshSidebarData("A", seams(completedProfile(2), []));
         const frame = await renderFrame(liveNode(), { width: 44, height: 24 });
         expect(frame).toContain("2 files");
+        // The completed-profile rail line is a durable-record readout: it pins the absolute local
+        // completed time (toLocaleString, via absTime) so the rail matches the details dialog — NOT a
+        // compact relative age. Assert the same absolute token the row computes.
+        expect(frame).toContain(absTime("2026-07-08T00:00:05.000Z"));
         expect(frame).toContain("no runs");
     });
 
@@ -181,11 +203,16 @@ describe("Sidebar DATA PROFILE / RUNS live sections", () => {
         expect(frame).toContain("profiling");
     });
 
-    test("runs render newest with the workflow name; an unprofiled analysis reads 'not profiled'", async () => {
+    test("runs render newest with the workflow name and a relative age; an unprofiled analysis reads 'not profiled'", async () => {
         await refreshSidebarData("A", seams(null, [runRow({ status: "running" })]));
         const frame = await renderFrame(liveNode(), { width: 44, height: 24 });
         expect(frame).toContain("executeAnalysis");
         expect(frame).toContain("not profiled");
+        // Only the profile line flipped to absolute — run (and session) ages stay in the compact
+        // relative-age vocabulary. Assert the same relative token the row computes, and that no full
+        // local timestamp leaks onto a run row.
+        expect(frame).toContain(relAge("2026-07-08T00:00:00.000Z"));
+        expect(frame).not.toContain(new Date("2026-07-08T00:00:00.000Z").toLocaleString());
     });
 });
 
@@ -242,5 +269,58 @@ describe("Sidebar MODELS connection line", () => {
         expect(frame).toContain("conn");
         expect(frame).toContain("deepseek"); // the configured provider slug
         expect(frame).toContain("direct"); // the connection mode
+    });
+});
+
+// The ANALYSIS anchor-marker badge is shown in exactly one place, chosen by terminal width: its own
+// path line below the breakpoint, or prefixed to the meta line at/above it (where the path is dropped).
+// 119/121 straddle `size.breakpointWide` (120); the rail itself stays a fixed width, so only this
+// terminal-width flip changes here. A real analysis is created so getAnchor returns a live marker.
+describe("Sidebar responsive ANALYSIS badge + path", () => {
+    test("narrow: the badge + path own their line; the meta line carries no badge", async () => {
+        writeFileSync(join(dirA, "one.txt"), "x");
+        const a = createAnalysis({ cwd: dirA, name: str256("alpha")._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
+        const anchor = getAnchor(a.anchorId)._unsafeUnwrap();
+        // The head of the resolved path is short enough to land on the first wrapped rail line.
+        const pathHead = anchor!.cachedPath.slice(0, 20);
+
+        const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 119, height: 24 });
+        expect(frame).toContain(pathHead); // the path renders below the breakpoint
+        expect(lineContaining(frame, pathHead)).toContain(GLYPHS.check); // badge leads the path line
+        expect(lineContaining(frame, "input")).not.toContain(GLYPHS.check); // meta line has no badge
+    });
+
+    test("wide: the path line disappears and the badge joins the meta line", async () => {
+        writeFileSync(join(dirA, "one.txt"), "x");
+        const a = createAnalysis({ cwd: dirA, name: str256("alpha")._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
+        const anchor = getAnchor(a.anchorId)._unsafeUnwrap();
+        const pathHead = anchor!.cachedPath.slice(0, 20);
+
+        const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 121, height: 24 });
+        expect(frame).not.toContain(pathHead); // no path line at/above the breakpoint
+        const meta = lineContaining(frame, "input");
+        expect(meta).toContain(`${GLYPHS.check} `); // the badge now prefixes the meta line
+        expect(meta).toContain("1 input");
+    });
+});
+
+// A Section merges its value onto the label row when it fits the rail's usable width, else stacks it
+// on the line below — the rail is a fixed width, so this depends on value length, not terminal width.
+describe("Sidebar Section header merge vs stacked fallback", () => {
+    test("short values share their section's label row", async () => {
+        writeFileSync(join(dirA, "one.txt"), "x");
+        const a = createAnalysis({ cwd: dirA, name: str256("alpha")._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
+        const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 44, height: 24 });
+        expect(lineContaining(frame, "SESSION")).toContain("nosu"); // the short session id merges up
+        expect(lineContaining(frame, "ANALYSIS")).toContain("alpha"); // the short analysis name merges up
+    });
+
+    test("a value too long to fit stacks below the label, rendered in full (never truncated)", async () => {
+        writeFileSync(join(dirA, "one.txt"), "x");
+        const longName = "long-analysis-name-that-will-not-fit";
+        const a = createAnalysis({ cwd: dirA, name: str256(longName)._unsafeUnwrap(), inputPaths: [join(dirA, "one.txt")] })._unsafeUnwrap();
+        const frame = await renderFrame(sidebarNode(wsFor(a, dirA)), { width: 44, height: 24 });
+        expect(lineContaining(frame, "ANALYSIS")).not.toContain(longName); // label row holds only the label
+        expect(frame).toContain(longName); // the name renders in full on its own line
     });
 });

--- a/cli/src/tui/layout/sidebar.tsx
+++ b/cli/src/tui/layout/sidebar.tsx
@@ -148,6 +148,20 @@ const RAIL_BORDER_COLS = 1;
 const RAIL_CONTENT_WIDTH = size.railWidth - RAIL_BORDER_COLS - space.sm * 2;
 
 /**
+ * Every character the {@link GLYPHS} registry can print, as single characters. The design system's
+ * own contract is that each registry value occupies exactly ONE terminal cell — it bans emoji and
+ * Nerd-Font glyphs precisely because the fixed-width TUI layout assumes one cell per glyph — so any
+ * character in this set can be trusted as width 1, which a bare `.length` UTF-16 count cannot prove.
+ * Built once here (flattening the multi-frame spinner value to its characters) so the fit check can
+ * measure a value built from ASCII + registry glyphs (e.g. the SESSION handle `S·2f9a`) exactly.
+ */
+const SINGLE_CELL_GLYPHS: ReadonlySet<string> = new Set(
+    Object.values(GLYPHS)
+        .flat()
+        .flatMap((s) => [...s]),
+);
+
+/**
  * A sidebar section: a bold muted LABEL over its content rows. When a `value` is supplied AND it
  * fits beside the label on one rail row — the label, a one-cell gap, and the value all within
  * {@link RAIL_CONTENT_WIDTH} — the header collapses to a single `LABEL … value` row (label keeps its
@@ -161,7 +175,19 @@ function Section(props: { label: string; value?: string; children: JSX.Element; 
     // one-cell gap is space.sm — the minimum separation so label and value never abut on a full row.
     const fitsOnLabelRow = (): boolean => {
         const value = props.value;
-        return value !== undefined && props.label.length + space.sm + value.length <= RAIL_CONTENT_WIDTH;
+        if (value === undefined) return false;
+        // `.length` counts UTF-16 units, which equal terminal cells only for characters we can vouch
+        // are single-cell: printable ASCII, and the design-system GLYPHS (single-cell by the registry's
+        // contract — see SINGLE_CELL_GLYPHS). So the SESSION handle `S·2f9a`, whose `·` is GLYPHS.middot,
+        // measures reliably and may merge. Any OTHER non-ASCII character (a CJK glyph is one unit but two
+        // cells, an emoji several units for one-or-two) has a cell width we cannot cheaply trust — rather
+        // than embed a wcwidth table, take the safe path and stack the whole value on its own full line,
+        // where the width is never guessed wrong. The label is always an ASCII section name.
+        const chars = [...value];
+        for (const ch of chars) {
+            if (!/[\x20-\x7e]/.test(ch) && !SINGLE_CELL_GLYPHS.has(ch)) return false;
+        }
+        return props.label.length + space.sm + chars.length <= RAIL_CONTENT_WIDTH;
     };
     // The arrow reads `props.onActivate` at click time (reactive-safe, and the section activation is
     // inert on the sections that pass none — only DATA PROFILE / RUNS supply a callback).

--- a/cli/src/tui/layout/sidebar.tsx
+++ b/cli/src/tui/layout/sidebar.tsx
@@ -1,19 +1,19 @@
 import { createMemo, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js";
 import type { Accessor, JSX } from "solid-js";
+import { useTerminalDimensions } from "@opentui/solid";
 import type { CortexRunRow } from "@inflexa-ai/harness";
 
 import { theme } from "../theme.ts";
-import { GLYPHS, size } from "../../lib/design_system.ts";
+import { GLYPHS, size, space } from "../../lib/design_system.ts";
 import type { ThemeColors } from "../../lib/design_system.ts";
 import { Bold, Fg } from "../components/emphasis.tsx";
-import { profileSnapshot, runsSnapshot, relAge, runMark, shortRunName } from "../hooks/sidebar_live.ts";
+import { profileSnapshot, runsSnapshot, absTime, relAge, runMark, shortRunName } from "../hooks/sidebar_live.ts";
 import { agentModels, bootState } from "../hooks/boot.ts";
 import type { AgentName, ModelConnectionIdentity } from "../../modules/harness/config.ts";
 import { getSession, getAnchor, listAnalysisInputs } from "../../db/primary_query.ts";
 import { useWorkspace } from "../contexts/workspace.ts";
 import { Bus } from "../../lib/bus.ts";
 import type { StampedEvent } from "../../types/events.ts";
-import type { Analysis } from "../../types/analysis.ts";
 import type { Session } from "../../types/session.ts";
 import type { Anchor } from "../../types/anchor.ts";
 
@@ -63,7 +63,10 @@ function profileLineOf(snap: ReturnType<typeof profileSnapshot>): LiveLine {
                     return { glyph: GLYPHS.warning, role: "warning", text: `profiling${GLYPHS.ellipsis}` };
                 case "completed": {
                     const n = p.result?.files.length ?? 0;
-                    return { glyph: GLYPHS.check, role: "success", text: `${n} file${n === 1 ? "" : "s"} ${GLYPHS.middot} ${relAge(p.completedAt)}` };
+                    // Absolute local completed time (not a compact relative age): a finished profile is a
+                    // durable record read long after "8h ago" lost its anchor, so the rail matches the
+                    // details dialog. It may soft-wrap on long locales — acceptable in the fixed-width rail.
+                    return { glyph: GLYPHS.check, role: "success", text: `${n} file${n === 1 ? "" : "s"} ${GLYPHS.middot} ${absTime(p.completedAt)}` };
                 }
                 case "failed":
                     return { glyph: GLYPHS.cross, role: "error", text: firstLine(p.error) };
@@ -132,14 +135,60 @@ function ConnectionLine(): JSX.Element {
     );
 }
 
-function Section(props: { label: string; children: JSX.Element; onActivate?: () => void }) {
+// A single-line left border occupies exactly one terminal column; the rail draws one on its left edge.
+const RAIL_BORDER_COLS = 1;
+
+/**
+ * A rail content row's usable width in terminal cells: the rail's fixed width less its left border
+ * and its symmetric horizontal padding. opentui lays out on a character grid (one character = one
+ * cell), so a header can merge its value onto the label row only when the label, a gap, and the
+ * value together measure within this budget. Derived from the same tokens the rail box applies, so
+ * the check can never drift from the real geometry.
+ */
+const RAIL_CONTENT_WIDTH = size.railWidth - RAIL_BORDER_COLS - space.sm * 2;
+
+/**
+ * A sidebar section: a bold muted LABEL over its content rows. When a `value` is supplied AND it
+ * fits beside the label on one rail row — the label, a one-cell gap, and the value all within
+ * {@link RAIL_CONTENT_WIDTH} — the header collapses to a single `LABEL … value` row (label keeps its
+ * bold muted style; value right-aligned by a flexGrow spacer in the section's fg color). When it does
+ * not fit, it renders exactly the stacked layout: the label row, then the value as its own full-width
+ * line below — never truncated or squeezed into a right-hand cell. The remaining children follow in
+ * either case, so a section only ever moves its value, never duplicates it.
+ */
+function Section(props: { label: string; value?: string; children: JSX.Element; onActivate?: () => void }) {
+    // Read reactively so a later value change (session swap, analysis rename) re-decides the fit. The
+    // one-cell gap is space.sm — the minimum separation so label and value never abut on a full row.
+    const fitsOnLabelRow = (): boolean => {
+        const value = props.value;
+        return value !== undefined && props.label.length + space.sm + value.length <= RAIL_CONTENT_WIDTH;
+    };
     // The arrow reads `props.onActivate` at click time (reactive-safe, and the section activation is
     // inert on the sections that pass none — only DATA PROFILE / RUNS supply a callback).
     return (
         <box flexDirection="column" paddingTop={1} onMouseUp={() => props.onActivate?.()}>
-            <text fg={theme().fgMuted}>
-                <Bold>{props.label}</Bold>
-            </text>
+            <Show
+                when={fitsOnLabelRow()}
+                fallback={
+                    <>
+                        <text fg={theme().fgMuted}>
+                            <Bold>{props.label}</Bold>
+                        </text>
+                        <Show when={props.value} keyed>
+                            {(value: string) => <text fg={theme().fg}>{value}</text>}
+                        </Show>
+                    </>
+                }
+            >
+                <box flexDirection="row">
+                    <text fg={theme().fgMuted}>
+                        <Bold>{props.label}</Bold>
+                    </text>
+                    {/* Spacer pushes the value to the rail's right edge — the StatusBar/ChatBar idiom. */}
+                    <box flexGrow={1} />
+                    <text fg={theme().fg}>{props.value}</text>
+                </box>
+            </Show>
             {props.children}
         </box>
     );
@@ -158,6 +207,11 @@ function Section(props: { label: string; children: JSX.Element; onActivate?: () 
  */
 export function Sidebar(props: SidebarProps) {
     const ws = useWorkspace();
+    // The wide-layout flip: at/above the breakpoint the ANALYSIS path line yields to the badge moving
+    // onto the meta line. Reads the SAME `size.breakpointWide` token the status bar gates its path on,
+    // so both surfaces flip together and the working-directory path shows on exactly one of them.
+    const dims = useTerminalDimensions();
+    const isWide = (): boolean => dims().width >= size.breakpointWide;
     const session = createMemo(() =>
         getSession(ws.sessionId).match(
             (s) => s,
@@ -175,6 +229,14 @@ export function Sidebar(props: SidebarProps) {
             () => null,
         );
     });
+    // The anchor-marker health badge (marker written vs missing), or "" when no anchor exists. Muted
+    // to match the surrounding meta text — it flags marker health quietly, without a status color.
+    // Below the breakpoint it prefixes the path line; at/above it, the path line is dropped and this
+    // prefixes the meta line instead, so the signal stays visible in exactly one spot at any width.
+    const markerBadge = (): string => {
+        const a = anchor();
+        return a ? (a.markerWritten ? GLYPHS.check : GLYPHS.warning) : "";
+    };
     // The input count is a DB read with no reactive dependency of its own, so input-change bus
     // events tick a version signal the memo reads — the picker (and any future writer) updates
     // the sidebar live without a session swap. Filtered to THIS analysis: provenance events for
@@ -220,14 +282,13 @@ export function Sidebar(props: SidebarProps) {
             width={size.railWidth}
             flexShrink={0}
             flexDirection="column"
-            paddingLeft={1}
-            paddingRight={1}
+            paddingLeft={space.sm}
+            paddingRight={space.sm}
             border={["left"]}
             borderColor={theme().border}
             backgroundColor={theme().bgRaised}
         >
-            <Section label="SESSION">
-                <text fg={theme().fg}>{shortId(ws.sessionId)}</text>
+            <Section label="SESSION" value={shortId(ws.sessionId)}>
                 <Show when={session()} keyed>
                     {(s: Session) => (
                         <text fg={theme().fgMuted}>
@@ -237,18 +298,25 @@ export function Sidebar(props: SidebarProps) {
                 </Show>
             </Section>
 
-            <Section label="ANALYSIS">
-                <Show when={ws.analysis} keyed fallback={<text fg={theme().fgMuted}>no analysis</text>}>
-                    {(a: Analysis) => <text fg={theme().fg}>{a.name}</text>}
+            <Section label="ANALYSIS" value={ws.analysis?.name}>
+                {/* The name rides the label row (or stacks under it, both via Section); only the
+                    no-analysis fallback needs its own line here, since Section renders nothing when
+                    the value is undefined. */}
+                <Show when={!ws.analysis}>
+                    <text fg={theme().fgMuted}>no analysis</text>
                 </Show>
-                <Show when={anchor()} keyed>
+                {/* Below the breakpoint the marker badge sits on its own line beside the resolved path. */}
+                <Show when={!isWide() && anchor()} keyed>
                     {(a: Anchor) => (
                         <text fg={theme().fgMuted}>
                             {a.markerWritten ? GLYPHS.check : GLYPHS.warning} {a.cachedPath}
                         </text>
                     )}
                 </Show>
+                {/* At/above the breakpoint the path line is dropped and the badge joins this meta line
+                    (badge first, then the inputs/project text). */}
                 <text fg={theme().fgMuted}>
+                    {isWide() && markerBadge() ? `${markerBadge()} ` : ""}
                     {inputCount()} input{inputCount() === 1 ? "" : "s"}
                     {ws.project ? ` ${GLYPHS.middot} proj: ${ws.project.name}` : ""}
                 </text>

--- a/cli/src/tui/layout/status_bar.render.test.tsx
+++ b/cli/src/tui/layout/status_bar.render.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { useTerminalDimensions } from "@opentui/solid";
+
+import { renderFrame } from "../../test_support/tui.ts";
+import { size } from "../../lib/design_system.ts";
+import { StatusBar } from "./status_bar.tsx";
+
+// The working-directory path is a wide-terminal-only affordance. StatusBar is dumb — it renders
+// whatever path string it is handed — so the width decision lives in the app. These cases pin both:
+// the dumb render (path shown iff supplied) and the app-side gate mirrored here over the real terminal
+// dimensions, straddling `size.breakpointWide` (120). Booting the whole chat App would drag in a
+// runtime, DB, and providers for what is a one-line composition, so the gate is reproduced directly.
+function gatedStatusBar(path: string) {
+    return () => {
+        const dims = useTerminalDimensions();
+        return <StatusBar title="inflexa" path={dims().width >= size.breakpointWide ? path : undefined} hints={["ctrl+k"]} />;
+    };
+}
+
+describe("StatusBar working-directory path", () => {
+    test("renders the path segment when one is supplied", async () => {
+        const frame = await renderFrame(() => <StatusBar title="inflexa" path="~/work/proj" hints={["ctrl+k"]} />, { width: 130, height: 3 });
+        expect(frame).toContain("~/work/proj");
+    });
+
+    test("omits the path segment when none is supplied", async () => {
+        const frame = await renderFrame(() => <StatusBar title="inflexa" hints={["ctrl+k"]} />, { width: 130, height: 3 });
+        expect(frame).not.toContain("~/work/proj");
+    });
+
+    test("the app gate shows the path only at/above the breakpoint", async () => {
+        const wide = await renderFrame(gatedStatusBar("~/work/proj"), { width: 121, height: 3 });
+        expect(wide).toContain("~/work/proj");
+
+        const narrow = await renderFrame(gatedStatusBar("~/work/proj"), { width: 119, height: 3 });
+        expect(narrow).not.toContain("~/work/proj");
+    });
+});

--- a/cli/src/tui/layout/status_bar.tsx
+++ b/cli/src/tui/layout/status_bar.tsx
@@ -15,6 +15,12 @@ export type StatusBarProps = {
     subtitle?: string;
     /** Optional middle region — the chat's live state or config's unsaved indicator. Omitted when undefined. */
     state?: { text: string; tone: StatusTone };
+    /**
+     * Optional working-directory path, shown muted immediately after the state as part of the
+     * left-flowing segments (NOT a right hint). A wide-terminal-only affordance the caller gates on
+     * the layout breakpoint; StatusBar stays dumb and simply renders whatever string it is handed.
+     */
+    path?: string;
     /** Right-aligned affordance labels (sourced from the keymap by the caller). */
     hints: string[];
 };
@@ -40,6 +46,9 @@ export function StatusBar(props: StatusBarProps) {
             </Show>
             <Show when={props.state} keyed>
                 {(state: { text: string; tone: StatusTone }) => <text fg={toneColor(state.tone)}> | {state.text}</text>}
+            </Show>
+            <Show when={props.path} keyed>
+                {(path: string) => <text fg={theme().fgMuted}> | {path}</text>}
             </Show>
             {/* Spacer pushes the affordance hints to the right edge. */}
             <box flexGrow={1} />


### PR DESCRIPTION
## Summary

One polish pass over the chat TUI (OpenSpec change `ui-polish-1`, synced and archived in this PR): readable timestamps on durable records, live run progress in the chat, tighter use of horizontal/vertical space, and a handful of interaction fixes.

## What changed

### Time rendering
- The data-profile and runs detail dialogs show **absolute local times** (`toLocaleString()`); profile details add a `duration` line (completed − started, for failed profiles too) or a live `elapsed` readout while running.
- The sidebar's completed-profile line is absolute as well; session/run ages stay relative but now carry **two units** (`5m31s`, `8h54m`, `2d04h`).
- One shared `Date.formatDuration` (`14ms` / `1.4s` / `2m05s`) replaces three near-identical inline formatters. The durable-record-vs-live-readout rule is codified in `cli/CLAUDE.md` (*Time rendering*).

### Chat
- A **sticky run-progress row** pins above the input while the newest run is non-terminal: segmented bar, `done/total`, and a 6-step window centered on the frontier of work. It is fed by the sidebar refresh loop, which now also fetches the active run's steps inside the same generation-token guard — an idle sidebar still issues zero queries.
- Live tool calls fold their status onto the name line (`▸ read_file src/db.ts  ✓ ok · 14ms`); result-carrying blocks keep the completion line under the `<code>` panel (`ToolBlock.inlineStatus`, default derived from the result).
- User turns carry a **left border rule** in the user color, gutter-aligned (border + reduced padding ≡ the assistant indent).

### Layout
- New `size.breakpointWide` token (120 cols): at/above it the `~`-contracted working directory renders in the header right after the status segment; below it the sidebar keeps its badge+path line. The ✓/⚠ anchor-health badge always stays in the sidebar.
- Sidebar SESSION/ANALYSIS labels share a row with their value when it fits (`LABEL <flex gap> value`), stacking when a long name would overflow — never truncated or wrapped inside a right-hand cell.
- Select dialogs (command palette, pickers) gain bleed-safe breathing room around the filter input and the description line.

### Interaction
- `esc` clears an active text selection before any other esc behavior (a mode-less keymap layer between the dialog host and abort priorities; arms only on non-empty selected text).
- `FixedList` cursor navigation wraps 0 ↔ N−1 (arrows / `j`/`k` / `ctrl+p`/`ctrl+n`), and the config screen's sections wrap the same way. `DynamicList`, page keys, and `gg`/`G` still clamp.

## Specs

Six capability specs updated via delta sync — `sidebar-live`, `tui-layout`, `tui-stream-blocks`, `list-primitives`, `key-bindings`, `tui-design-tokens` — and the change is archived at `openspec/changes/archive/2026-07-13-ui-polish-1/`.

## Testing

- Full suite: **971 pass / 0 fail** across 87 files; `tsc` and `eslint` clean.
- New render tests: tool-status placements (incl. a 40-column soft-wrap sweep), user/assistant body alignment, the esc-selection layer (real renderer selections), sticky-row squeeze sweeps across heights, breakpoint straddling (119/121 cols), and the sidebar label-row merge/stack split.
- Manual TTY smoke pass over all eight behaviors.
