### PR TITLE
feat(cli): rehome show_user presentations into the workspace, import chart data at render time

### DIFF
--- a/cli/openspec/specs/artifact-open/spec.md
+++ b/cli/openspec/specs/artifact-open/spec.md
@@ -35,7 +35,8 @@ echart spec and `dataPath`, the deterministic `pres-` id) and SHALL NOT store
 a resolved location. Resolution to an openable location happens when the user
 opens: `data-file-reference` paths and `data-report-preview` previews resolve
 against `resolveWorkspaceRoot(analysisId)`; `echart`/`svg` presentations
-resolve to their materialized cache file. A reference that fails to resolve
+resolve to their materialized file under the workspace's `presentations/`
+directory. A reference that fails to resolve
 (missing file, workspace desync) SHALL render that entry in a degraded state
 with its path visible, and open attempts on it SHALL produce a notice — never
 an error.
@@ -51,35 +52,41 @@ an error.
 - **WHEN** a `data-file-reference` entry's resolved path does not exist
 - **THEN** the card renders that entry as missing with its path shown, and opening it produces a notice instead of an error
 
-### Requirement: Presentations materialize into an id-keyed cache
+### Requirement: Presentations materialize into the workspace presentations directory
 
-`echart` and `svg` presentations SHALL materialize on demand into a CLI-owned
-cache directory (app data, outside any analysis workspace), keyed by the
-card's deterministic `pres-` id so re-emission and re-open are idempotent.
-`svg` content materializes as an `.svg` file. `echart` content materializes as
-a self-contained HTML shell embedding the spec and loading ECharts from a
-pinned-major CDN URL, with a visible fallback notice when the script cannot
-load (offline). For an artifact-sourced chart (`dataPath`), materialization
-SHALL read the workspace CSV per the harness display-cards contract (RFC-4180,
-header row, numeric column inference) and inject the rows as
-`dataset.source`; a missing or unparseable CSV degrades the card, never
-crashes. The cache is disposable: content is regenerable from the transcript.
+`echart` and `svg` presentations SHALL materialize on demand into the analysis
+workspace's reserved `presentations/` directory
+(`{workspaceRoot}/presentations/`, a root-level sibling of `data/`, `runs/`,
+`reports/`, and `previews/`), keyed by the card's deterministic `pres-` id so
+re-emission and re-open are idempotent. `svg` content materializes as an
+`.svg` file. `echart` content materializes as a self-contained HTML shell
+embedding the spec and loading ECharts from a pinned-major CDN URL, with a
+visible fallback notice when the script cannot load (offline). For an
+artifact-sourced chart (`dataPath`), the shell SHALL NOT embed the data: it
+references the artifact by a URL relative to where the shell sits
+(`../{dataPath}`) and fetches it at render time, parsing it in-page with a
+pinned-major CDN CSV parser (PapaParse: delimiter auto-detection, numeric
+cell typing, header row first) into `dataset.source`, so an open always
+reflects the current artifact bytes. A failed fetch or parse degrades to a
+visible in-page note, never a crash; an invalid `dataPath` shape is refused
+before a URL is derived and pre-degrades the shell. Materialized files are
+disposable: content is regenerable from the transcript.
 
 #### Scenario: Chart opens interactively
 
 - **WHEN** the user opens an `echart` presentation card
-- **THEN** the CLI writes (or reuses) `<cache>/<pres-id>.html` and opens it in the browser, where the chart renders interactively
+- **THEN** the CLI writes (or reuses) `{workspaceRoot}/presentations/<pres-id>.html` and opens it in the browser, where the chart renders interactively
 
-#### Scenario: Artifact-sourced chart carries its data
+#### Scenario: Artifact-sourced chart imports its data
 
 - **GIVEN** an echart card with `dataPath: "runs/run-abc/step-2/output/de-summary.csv"`
 - **WHEN** the user opens it
-- **THEN** the materialized HTML contains the CSV rows as `dataset.source` with the header row as dimension names
+- **THEN** the materialized HTML references `../runs/run-abc/step-2/output/de-summary.csv` and loads it as `dataset.source` at render time — the CSV rows are never written into the shell
 
 #### Scenario: Same card, same file
 
 - **WHEN** the agent re-emits an identical presentation and the user opens it again
-- **THEN** the same cache file is reused (no duplicate materializations)
+- **THEN** the same presentations file is reused (no duplicate materializations)
 
 ### Requirement: Open UX — click, latest, and picker
 

--- a/cli/openspec/specs/tui-stream-blocks/spec.md
+++ b/cli/openspec/specs/tui-stream-blocks/spec.md
@@ -117,7 +117,7 @@ fails compilation. New block visuals SHALL enter the design gallery.
 #### Scenario: A chart renders as an openable card
 
 - **WHEN** the agent calls `show_user(kind: "echart")`
-- **THEN** the stream shows an openable card with the title and resolved cache path, and the design gallery carries an exhibit of the card's states (openable, missing, degraded)
+- **THEN** the stream shows an openable card with the title and resolved presentations-file path, and the design gallery carries an exhibit of the card's states (openable, missing, degraded)
 
 ### Requirement: Reasoning is collapsed by default
 

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -159,16 +159,6 @@ export const env = Object.freeze({
     /** The local embedding GGUF path — `<modelDir>/bge-small-en-v1.5-q8_0.gguf`. */
     embeddingModelPath: join(dataDir(), "inflexa", "models", "bge-small-en-v1.5-q8_0.gguf"),
     /**
-     * CLI-owned render cache for display cards: materialized `echart` HTML shells and `svg` files,
-     * keyed by the deterministic `pres-` id (`<presentationCacheDir>/<pres-id>.{html,svg}`). A
-     * `dataPath` echart, whose content also depends on the analysis and its CSV bytes, is scoped by
-     * analysis (`<pres-id>.<analysis-hash>.html`) and rematerialized on open. Outside any analysis
-     * workspace (the workspace layout is harness-owned; a host render cache does not belong in it) and
-     * DISPOSABLE — every file is regenerable from the transcript, so wiping it loses nothing. See
-     * src/modules/harness/artifact_open.ts.
-     */
-    presentationCacheDir: join(dataDir(), "inflexa", "cache", "presentations"),
-    /**
      * CLIProxyAPI runs in a container (Docker or Podman, see
      * src/modules/infra/setup.ts). The config and the provider-credential dir are
      * state we own, so they live under our data dir and are bind-mounted into the
@@ -255,12 +245,6 @@ export const envDoc: Readonly<
         kind: "path",
         label: "embedding model",
         description: "the bge-small-en-v1.5 GGUF used by the local embedding provider",
-        baseVar: dataVar,
-    },
-    presentationCacheDir: {
-        kind: "path",
-        label: "render cache",
-        description: "materialized chart/SVG files for external viewing (disposable, regenerable)",
         baseVar: dataVar,
     },
     cliproxyConfigPath: { kind: "path", label: "proxy config", description: "CLIProxyAPI config, mounted into the proxy container", baseVar: dataVar },

--- a/cli/src/modules/harness/artifact_open.test.ts
+++ b/cli/src/modules/harness/artifact_open.test.ts
@@ -3,15 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import {
-    echartHtml,
-    materializeTarget,
-    parseCsvToSource,
-    readFileReference,
-    readPresentation,
-    readReportPreview,
-    readReportPreviewFailed,
-} from "./artifact_open.ts";
+import { echartHtml, materializeTarget, readFileReference, readPresentation, readReportPreview, readReportPreviewFailed } from "./artifact_open.ts";
 import { insertAnalysis, insertAnchor } from "../../db/primary_mutation.ts";
 import { asStr256 } from "../../lib/types.ts";
 import { freshDb } from "../../test_support/db.ts";
@@ -93,87 +85,37 @@ describe("readReportPreview / readReportPreviewFailed", () => {
     });
 });
 
-describe("parseCsvToSource (RFC-4180, header row, numeric inference)", () => {
-    test("keeps the header row and converts fully-numeric columns to numbers", () => {
-        const source = parseCsvToSource("gene,log2fc,padj\nTP53,2.4,3e-8\nMYC,-1.8,1e-5");
-        expect(source).not.toBeNull();
-        expect(source![0]).toEqual(["gene", "log2fc", "padj"]);
-        // `gene` stays textual; the numeric columns become numbers.
-        expect(source![1]).toEqual(["TP53", 2.4, 3e-8]);
-        expect(source![2]).toEqual(["MYC", -1.8, 1e-5]);
-    });
-
-    test("handles quoted fields with embedded commas and doubled quotes", () => {
-        const source = parseCsvToSource('name,note\n"a,b","he said ""hi"""');
-        expect(source![1]).toEqual(["a,b", 'he said "hi"']);
-    });
-
-    test("returns null for empty input", () => {
-        expect(parseCsvToSource("")).toBeNull();
-    });
-});
-
 describe("echartHtml", () => {
     test("embeds the spec, a pinned-major CDN script, and a visible offline fallback notice", () => {
-        const html = echartHtml({ series: [{ type: "line" }] }, null);
+        const html = echartHtml({ series: [{ type: "line" }] }, null, null);
         expect(html).toContain("cdn.jsdelivr.net/npm/echarts@5");
         expect(html).toContain('"series"');
         expect(html).toContain("could not load"); // offline fallback notice
+        expect(html).not.toContain("papaparse"); // an inline chart carries no parser
     });
 
     test("escapes `<` in the embedded spec so a string field cannot break out of the script tag", () => {
-        const html = echartHtml({ title: { text: "</script><b>x" } }, null);
+        const html = echartHtml({ title: { text: "</script><b>x" } }, null, null);
         expect(html).not.toContain("</script><b>x");
         expect(html).toContain("\\u003c");
     });
 
-    test("shows a data note when an artifact CSV could not be loaded", () => {
-        const html = echartHtml({}, 'Data file "x.csv" could not be loaded — the chart is shown without its data.');
-        expect(html).toContain("could not be loaded");
+    test("embeds a relative data URL fetched and parsed at render time — never the data itself", () => {
+        const html = echartHtml({}, "../runs/r/out.csv", null);
+        expect(html).toContain('var dataUrl = "../runs/r/out.csv"');
+        expect(html).toContain("fetch(dataUrl)");
+        expect(html).toContain("cdn.jsdelivr.net/npm/papaparse@5"); // pinned-major in-page parser
+        expect(html).toContain('id="datanote" style="display:none"'); // note hidden until a load failure
+    });
+
+    test("shows a visible data note when the shell is pre-degraded (invalid dataPath shape)", () => {
+        const html = echartHtml({}, null, 'Data file "x.csv" could not be loaded — the chart is shown without its data.');
+        expect(html).toContain('<div id="datanote">Data file "x.csv" could not be loaded');
+        expect(html).toContain("var dataUrl = null");
     });
 });
 
-describe("materializeTarget idempotence", () => {
-    test("an identical echart card materializes to the same cache file (no duplicates)", () => {
-        // No `dataPath` → no workspace lookup, so this exercises the cache write against the test sandbox.
-        const target: OpenTarget = { kind: "echart", presId: "pres-idem-echart", spec: { series: [{ type: "bar" }] } };
-        const first = materializeTarget("a1", target)._unsafeUnwrap();
-        const content = readFileSync(first, "utf8");
-        const second = materializeTarget("a1", target)._unsafeUnwrap();
-        expect(second).toBe(first); // same deterministic path
-        expect(readFileSync(second, "utf8")).toBe(content); // reused, not rewritten differently
-        expect(first.endsWith("pres-idem-echart.html")).toBe(true);
-    });
-
-    test("an svg card materializes to a .svg file keyed by its pres id", () => {
-        const target: OpenTarget = { kind: "svg", presId: "pres-idem-svg", markup: "<svg><rect/></svg>" };
-        const path = materializeTarget("a1", target)._unsafeUnwrap();
-        expect(path.endsWith("pres-idem-svg.svg")).toBe(true);
-        expect(readFileSync(path, "utf8")).toBe("<svg><rect/></svg>");
-    });
-
-    test("an inline chart (no dataPath) is reused from cache without rewrite", () => {
-        const target: OpenTarget = { kind: "echart", presId: "pres-inline-norewrite", spec: { series: [{ type: "bar" }] } };
-        const dest = materializeTarget("a1", target)._unsafeUnwrap();
-        // Tamper with the cached file; a re-open that rewrote it would clobber the sentinel. The
-        // existsSync shortcut — valid only because the pres- id is a genuine content hash for an inline
-        // chart — serves the file untouched.
-        writeFileSync(dest, "SENTINEL");
-        const again = materializeTarget("a1", target)._unsafeUnwrap();
-        expect(again).toBe(dest);
-        expect(readFileSync(again, "utf8")).toBe("SENTINEL");
-    });
-
-    test("an untrusted traversal dataPath is refused before any read — the chart degrades to the no-data note", () => {
-        // validatePath rejects the shape before workspaceRootForAnalysisId is ever consulted (no DB
-        // needed), so nothing is read and the chart renders with the degraded-data note.
-        const target: OpenTarget = { kind: "echart", presId: "pres-traversal-guard", spec: { series: [] }, dataPath: "../../etc/passwd" };
-        const html = readFileSync(materializeTarget("ana-nonexistent", target)._unsafeUnwrap(), "utf8");
-        expect(html).toContain("could not be loaded");
-    });
-});
-
-describe("materializeEchart dataPath charts — analysis-scoped, rematerialize-on-open", () => {
+describe("materializeTarget — the workspace presentations directory", () => {
     const created: string[] = [];
 
     function tmp(): string {
@@ -205,38 +147,72 @@ describe("materializeEchart dataPath charts — analysis-scoped, rematerialize-o
         created.length = 0;
     });
 
-    test("a degraded 'could not be loaded' shell heals once the CSV appears (rematerialize-on-open)", () => {
-        const root = seedAnalysis("ana-heal", "heal");
-        const target: OpenTarget = { kind: "echart", presId: "pres-heal", spec: { series: [{ type: "line" }] }, dataPath: "runs/r/out.csv" };
-
-        const first = materializeTarget("ana-heal", target)._unsafeUnwrap();
-        expect(readFileSync(first, "utf8")).toContain("could not be loaded");
-        // The dataPath chart's file is scoped by analysis, not the bare pres- id.
-        expect(first.endsWith("pres-heal.html")).toBe(false);
-
-        mkdirSync(join(root, "runs", "r"), { recursive: true });
-        writeFileSync(join(root, "runs", "r", "out.csv"), "x,y\n1,2\n3,4");
-
-        const second = materializeTarget("ana-heal", target)._unsafeUnwrap();
-        const healed = readFileSync(second, "utf8");
-        expect(second).toBe(first); // same analysis-scoped file, rewritten in place
-        expect(healed).not.toContain("could not be loaded");
-        expect(healed).toContain('"dataset"');
+    test("an identical echart card materializes once into {root}/presentations (idempotent)", () => {
+        const root = seedAnalysis("ana-idem", "idem");
+        const target: OpenTarget = { kind: "echart", presId: "pres-idem-echart", spec: { series: [{ type: "bar" }] } };
+        const first = materializeTarget("ana-idem", target)._unsafeUnwrap();
+        expect(first).toBe(join(root, "presentations", "pres-idem-echart.html"));
+        const content = readFileSync(first, "utf8");
+        const second = materializeTarget("ana-idem", target)._unsafeUnwrap();
+        expect(second).toBe(first); // same deterministic path
+        expect(readFileSync(second, "utf8")).toBe(content); // reused, not rewritten differently
     });
 
-    test("a rewritten CSV yields an updated dataset on the next materialization (never stale)", () => {
-        const root = seedAnalysis("ana-rw", "rw");
+    test("an svg card materializes to presentations/<pres-id>.svg", () => {
+        const root = seedAnalysis("ana-svg", "svg");
+        const target: OpenTarget = { kind: "svg", presId: "pres-idem-svg", markup: "<svg><rect/></svg>" };
+        const path = materializeTarget("ana-svg", target)._unsafeUnwrap();
+        expect(path).toBe(join(root, "presentations", "pres-idem-svg.svg"));
+        expect(readFileSync(path, "utf8")).toBe("<svg><rect/></svg>");
+    });
+
+    test("an existing presentation file is served untouched (no rewrite)", () => {
+        seedAnalysis("ana-reuse", "reuse");
+        const target: OpenTarget = { kind: "echart", presId: "pres-norewrite", spec: { series: [{ type: "bar" }] } };
+        const dest = materializeTarget("ana-reuse", target)._unsafeUnwrap();
+        // Tamper with the materialized file; a re-open that rewrote it would clobber the sentinel. The
+        // existsSync shortcut — valid because the pres- id is a genuine content hash of the whole tool
+        // input and the shell embeds nothing beyond that input — serves the file untouched.
+        writeFileSync(dest, "SENTINEL");
+        const again = materializeTarget("ana-reuse", target)._unsafeUnwrap();
+        expect(again).toBe(dest);
+        expect(readFileSync(again, "utf8")).toBe("SENTINEL");
+    });
+
+    test("a dataPath chart references its CSV by relative URL and never embeds the bytes", () => {
+        const root = seedAnalysis("ana-ref", "ref");
         mkdirSync(join(root, "runs", "r"), { recursive: true });
-        const csv = join(root, "runs", "r", "out.csv");
-        const target: OpenTarget = { kind: "echart", presId: "pres-rw", spec: {}, dataPath: "runs/r/out.csv" };
+        writeFileSync(join(root, "runs", "r", "out.csv"), "label,value\nSENTINEL_CELL_9137,10");
+        const target: OpenTarget = { kind: "echart", presId: "pres-ref", spec: { series: [{ type: "line" }] }, dataPath: "runs/r/out.csv" };
 
-        writeFileSync(csv, "label,value\nA,10");
-        const v1 = readFileSync(materializeTarget("ana-rw", target)._unsafeUnwrap(), "utf8");
-        expect(v1).toContain('["A",10]');
+        const path = materializeTarget("ana-ref", target)._unsafeUnwrap();
+        expect(path).toBe(join(root, "presentations", "pres-ref.html"));
+        const html = readFileSync(path, "utf8");
+        // The shell imports the artifact from where it sits ({root}/presentations → ../runs/…).
+        expect(html).toContain('var dataUrl = "../runs/r/out.csv"');
+        expect(html).not.toContain("SENTINEL_CELL_9137");
 
-        writeFileSync(csv, "label,value\nA,999");
-        const v2 = readFileSync(materializeTarget("ana-rw", target)._unsafeUnwrap(), "utf8");
-        expect(v2).toContain('["A",999]');
-        expect(v2).not.toContain('["A",10]'); // the prior dataset is gone, not a stale cache
+        // A rewritten CSV needs no rematerialization — the shell fetches the current bytes at render time.
+        writeFileSync(join(root, "runs", "r", "out.csv"), "label,value\nB,999");
+        const again = materializeTarget("ana-ref", target)._unsafeUnwrap();
+        expect(again).toBe(path);
+        expect(readFileSync(again, "utf8")).toBe(html);
+    });
+
+    test("an untrusted traversal dataPath is refused before a URL is derived — the shell pre-degrades", () => {
+        // validatePath rejects the shape (it survives a reload from a persisted tool_use, bypassing the
+        // live tool's validation), so no URL is derived and the shell carries the visible no-data note.
+        seedAnalysis("ana-guard", "guard");
+        const target: OpenTarget = { kind: "echart", presId: "pres-traversal-guard", spec: { series: [] }, dataPath: "../../etc/passwd" };
+        const html = readFileSync(materializeTarget("ana-guard", target)._unsafeUnwrap(), "utf8");
+        expect(html).toContain('<div id="datanote">Data file "../../etc/passwd" could not be loaded');
+        expect(html).toContain("var dataUrl = null");
+    });
+
+    test("an unresolvable workspace root is `unresolved` — nothing materializes", () => {
+        const echart: OpenTarget = { kind: "echart", presId: "pres-lost", spec: {} };
+        const svg: OpenTarget = { kind: "svg", presId: "pres-lost", markup: "<svg/>" };
+        expect(materializeTarget("ana-nonexistent", echart)._unsafeUnwrapErr()).toEqual({ type: "unresolved" });
+        expect(materializeTarget("ana-nonexistent", svg)._unsafeUnwrapErr()).toEqual({ type: "unresolved" });
     });
 });

--- a/cli/src/modules/harness/artifact_open.ts
+++ b/cli/src/modules/harness/artifact_open.ts
@@ -1,20 +1,19 @@
-import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { validatePath } from "@inflexa-ai/harness/tools/lib/path-validation";
 import { err, ok, type Result } from "neverthrow";
 
-import { env } from "../../lib/env.ts";
-import { mkdirResult, readFileResult, writeFileResult } from "../../lib/fs.ts";
+import { mkdirResult, writeFileResult } from "../../lib/fs.ts";
 import { openExternal } from "../../lib/open_external.ts";
 import { workspaceRootForAnalysisId } from "../analysis/output.ts";
 import type { OpenableEntry, OpenableIcon, OpenTarget, PresentationBody } from "../../types/session.ts";
 
 // The `artifact-open` capability: the shared readers that turn a harness display-card `data` payload
 // into a normalized card model, plus open-time RESOLUTION (reference → path) and MATERIALIZATION
-// (echart/svg spec → a self-contained cache file). Consumed by BOTH the TUI store adapter
-// (`hooks/conversation.ts` wraps the readouts into `Part`s) and the REPL printer (`chat_printer.ts`
-// renders them as OSC 8 links), so the coercion + resolution logic lives in one place.
+// (echart/svg spec → a self-contained file under the analysis workspace's `presentations/` directory).
+// Consumed by BOTH the TUI store adapter (`hooks/conversation.ts` wraps the readouts into `Part`s) and
+// the REPL printer (`chat_printer.ts` renders them as OSC 8 links), so the coercion + resolution logic
+// lives in one place.
 //
 // COPY-ON-RECEIVE: the readers run inside the in-process emit path, whose `data` shares mutable
 // references with the agent loop. Every reader extracts primitives and DEEP-COPIES the echart spec at
@@ -198,10 +197,26 @@ export type OpenArtifactError =
     | { type: "unavailable"; reason: string };
 
 /**
+ * The workspace-reserved directory `echart`/`svg` presentations materialize into, a sibling of the
+ * harness-owned `data/`/`runs/`/`reports/`/`previews/` roots. Living inside the analysis tree keeps a
+ * presentation next to the artifacts it renders, so a `dataPath` chart can reference its CSV by a
+ * relative URL.
+ */
+const PRESENTATIONS_DIR = "presentations";
+
+/** `{workspaceRoot}/presentations/<filename>`, or `null` when the root is unresolvable (moved/deleted anchor). */
+function presentationFilePath(analysisId: string, filename: string): string | null {
+    return workspaceRootForAnalysisId(analysisId).match(
+        (root): string | null => join(root, PRESENTATIONS_DIR, filename),
+        () => null,
+    );
+}
+
+/**
  * The path an entry WOULD resolve to, for display beside the card — never materializes and never opens.
  * `workspace-file` joins the analysis workspace root (`null` when the root is unresolvable — a moved or
- * deleted anchor); `echart`/`svg` name their deterministic cache file (which may not exist until opened);
- * `unavailable` has no path.
+ * deleted anchor); `echart`/`svg` name their deterministic presentations file (which may not exist until
+ * opened); `unavailable` has no path.
  */
 export function resolveEntryPath(analysisId: string, target: OpenTarget): string | null {
     switch (target.kind) {
@@ -211,9 +226,9 @@ export function resolveEntryPath(analysisId: string, target: OpenTarget): string
                 () => null,
             );
         case "echart":
-            return echartCachePath(analysisId, target);
+            return presentationFilePath(analysisId, `${target.presId}.html`);
         case "svg":
-            return join(env.presentationCacheDir, `${target.presId}.svg`);
+            return presentationFilePath(analysisId, `${target.presId}.svg`);
         case "unavailable":
             return null;
         default: {
@@ -226,7 +241,7 @@ export function resolveEntryPath(analysisId: string, target: OpenTarget): string
 /**
  * True when an entry should render in the degraded state: a `workspace-file` whose resolved path is
  * missing (workspace desync) or `unavailable` (a failed preview). `echart`/`svg` are never degraded —
- * they materialize on demand, so their cache file's absence is expected, not a fault.
+ * they materialize on demand, so their presentations file's absence is expected, not a fault.
  */
 export function entryDegraded(analysisId: string, target: OpenTarget): boolean {
     switch (target.kind) {
@@ -255,8 +270,8 @@ function spawnOpen(path: string): Result<string, OpenArtifactError> {
 
 /**
  * Resolve an entry to a concrete, ready-to-open location WITHOUT opening it: `workspace-file` returns
- * the resolved workspace path (missing → `missing`); `echart`/`svg` materialize their cache file and
- * return it; `unavailable` never resolves. This is the seam the REPL printer links to (an OSC 8
+ * the resolved workspace path (missing → `missing`); `echart`/`svg` materialize their presentations
+ * file and return it; `unavailable` never resolves. This is the seam the REPL printer links to (an OSC 8
  * `file://` path) and the shared step {@link openEntry} builds on. Never throws.
  */
 export function materializeTarget(analysisId: string, target: OpenTarget): Result<string, OpenArtifactError> {
@@ -270,7 +285,7 @@ export function materializeTarget(analysisId: string, target: OpenTarget): Resul
         case "echart":
             return materializeEchart(analysisId, target);
         case "svg":
-            return materializeSvg(target);
+            return materializeSvg(analysisId, target);
         case "unavailable":
             return err({ type: "unavailable", reason: target.reason });
         default: {
@@ -301,141 +316,58 @@ export function openFolder(analysisId: string, folder: string): Result<string, O
     return spawnOpen(dir);
 }
 
-/** Write `content` to the render cache at `dest` (creating the cache dir), mapping fs faults onto the error channel. */
-function writeCache(dest: string, content: string): Result<string, OpenArtifactError> {
-    return mkdirResult(env.presentationCacheDir, "materialize:mkdir")
+/** Write `content` to the presentations file at `dest` (creating its directory), mapping fs faults onto the error channel. */
+function writePresentationFile(dest: string, content: string): Result<string, OpenArtifactError> {
+    return mkdirResult(dirname(dest), "materialize:mkdir")
         .andThen(() => writeFileResult(dest, content, "materialize:write"))
         .map(() => dest)
         .mapErr((e): OpenArtifactError => ({ type: "materialize_failed", cause: e.cause }));
 }
 
-/** Materialize a `svg` presentation as `<pres-id>.svg`, reusing the file when it already exists (idempotent). */
-function materializeSvg(target: Extract<OpenTarget, { kind: "svg" }>): Result<string, OpenArtifactError> {
-    const dest = join(env.presentationCacheDir, `${target.presId}.svg`);
+/** Materialize a `svg` presentation as `presentations/<pres-id>.svg`, reusing the file when it already exists (idempotent). */
+function materializeSvg(analysisId: string, target: Extract<OpenTarget, { kind: "svg" }>): Result<string, OpenArtifactError> {
+    const dest = presentationFilePath(analysisId, `${target.presId}.svg`);
+    if (dest === null) return err({ type: "unresolved" });
     if (existsSync(dest)) return ok(dest);
-    return writeCache(dest, target.markup);
+    return writePresentationFile(dest, target.markup);
 }
 
 /**
- * The render-cache file for an echart target. An INLINE chart's `pres-` id is a genuine content hash of
- * the whole tool input, so its file is byte-identical for an identical card and needs no further scope.
- * A `dataPath` chart's rendered content ALSO depends on which analysis it belongs to (the workspace root)
- * and the CSV bytes on disk — neither captured by the input-hashed id — so its filename is scoped by
- * analysis, keeping two analyses whose identical input hashes to the same `pres-` id from aliasing onto
- * one file.
+ * The relative URL a `dataPath` shell fetches its CSV through at render time, derived from where the
+ * shell sits (`{root}/presentations/`) against the analysis-rooted `dataPath` — so the shell and the
+ * artifact travel together with the analysis tree (copy or move the tree and the chart still finds its
+ * data). Segments are percent-encoded so a space/`#` in an artifact name survives URL parsing.
  */
-function echartCachePath(analysisId: string, target: Extract<OpenTarget, { kind: "echart" }>): string {
-    if (target.dataPath === undefined) return join(env.presentationCacheDir, `${target.presId}.html`);
-    const scope = createHash("sha256").update(analysisId).digest("hex").slice(0, 12);
-    return join(env.presentationCacheDir, `${target.presId}.${scope}.html`);
+function dataUrlFor(dataPath: string): string {
+    const rel = posix.relative(`/${PRESENTATIONS_DIR}`, posix.join("/", dataPath));
+    return rel
+        .split("/")
+        .map((segment) => encodeURIComponent(segment))
+        .join("/");
 }
 
 /**
- * Materialize an `echart` presentation as a self-contained HTML shell. For an INLINE chart the `pres-`
- * id is a genuine content hash of the whole tool input, so the file is reused when it already exists
- * (idempotent). For an artifact-sourced chart (`dataPath`) the rendered content also depends on the
- * workspace root and the CSV bytes — neither captured by the id — so the file is analysis-scoped and
- * ALWAYS rewritten on open: the CSV is reread and injected as `dataset.source`, which heals a
- * previously-degraded shell once the file appears and reflects a rewritten CSV. A missing/unparseable
- * CSV degrades to a chart shown without its data (a visible notice), never a crash, and that degraded
- * variant is never persisted for reuse — a later successful read overwrites it for free.
+ * Materialize an `echart` presentation as `presentations/<pres-id>.html`. The `pres-` id is a genuine
+ * content hash of the whole tool input (spec + `dataPath`), and the shell embeds nothing beyond that
+ * input — an artifact-sourced chart carries only a RELATIVE URL to its CSV, fetched and parsed inside
+ * the shell at render time — so the file is a pure function of the id and is reused when it already
+ * exists (idempotent), for both variants. A rewritten CSV needs no rematerialization: the next open
+ * fetches the current bytes. A `dataPath` whose SHAPE is invalid (untrusted — it survives a reload from
+ * a persisted tool_use, bypassing the live tool's validation) degrades to a shell with a visible
+ * no-data note, never a crash.
  */
 function materializeEchart(analysisId: string, target: Extract<OpenTarget, { kind: "echart" }>): Result<string, OpenArtifactError> {
-    const dest = echartCachePath(analysisId, target);
-    if (target.dataPath === undefined) {
-        if (existsSync(dest)) return ok(dest);
-        return writeCache(dest, echartHtml(target.spec, null));
+    const dest = presentationFilePath(analysisId, `${target.presId}.html`);
+    if (dest === null) return err({ type: "unresolved" });
+    if (existsSync(dest)) return ok(dest);
+    if (target.dataPath === undefined) return writePresentationFile(dest, echartHtml(target.spec, null, null));
+    if (validatePath(target.dataPath) !== null) {
+        return writePresentationFile(
+            dest,
+            echartHtml(target.spec, null, `Data file "${target.dataPath}" could not be loaded — the chart is shown without its data.`),
+        );
     }
-    const source = readCsvSource(analysisId, target.dataPath);
-    const spec = source !== null ? { ...target.spec, dataset: { source } } : target.spec;
-    const dataNote = source !== null ? null : `Data file "${target.dataPath}" could not be loaded — the chart is shown without its data.`;
-    return writeCache(dest, echartHtml(spec, dataNote));
-}
-
-/**
- * Read + parse the workspace CSV at the analysis-rooted `dataPath` into an ECharts `dataset.source`, or
- * `null` on any failure or a path that escapes the workspace root. `dataPath` is UNTRUSTED — it survives
- * a reload from a persisted tool_use, bypassing the live tool's validation.
- */
-function readCsvSource(analysisId: string, dataPath: string): unknown[][] | null {
-    // Two-stage guard: reject a malformed/traversal SHAPE, then confirm the resolved absolute path stays
-    // under the resolved workspace root. `join("/ws/root", "../../etc/passwd")` would otherwise escape the
-    // analysis tree and read an arbitrary file into the chart HTML.
-    if (validatePath(dataPath) !== null) return null;
-    const path = workspaceRootForAnalysisId(analysisId).match(
-        (root): string | null => {
-            const rootAbs = resolve(root);
-            const abs = resolve(rootAbs, dataPath);
-            return abs === rootAbs || abs.startsWith(rootAbs + sep) ? abs : null;
-        },
-        () => null,
-    );
-    if (path === null || !existsSync(path)) return null;
-    const text = readFileResult(path, "readCsvSource").match(
-        (t): string | null => t,
-        () => null,
-    );
-    return text === null ? null : parseCsvToSource(text);
-}
-
-// ── CSV → ECharts dataset.source (RFC-4180, header row, numeric inference) ────────────────────────────
-
-/** Parse RFC-4180 CSV text into rows of string cells (quoted fields, escaped `""`, embedded newlines). */
-function parseCsv(text: string): string[][] {
-    const rows: string[][] = [];
-    let row: string[] = [];
-    let field = "";
-    let inQuotes = false;
-    // Strip a leading UTF-8 BOM so the first header cell is not prefixed with U+FEFF.
-    const src = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
-    for (let i = 0; i < src.length; i++) {
-        const c = src[i];
-        if (inQuotes) {
-            if (c === '"') {
-                if (src[i + 1] === '"') {
-                    field += '"';
-                    i++;
-                } else {
-                    inQuotes = false;
-                }
-            } else {
-                field += c;
-            }
-            continue;
-        }
-        if (c === '"') inQuotes = true;
-        else if (c === ",") {
-            row.push(field);
-            field = "";
-        } else if (c === "\n") {
-            row.push(field);
-            rows.push(row);
-            row = [];
-            field = "";
-        } else if (c !== "\r") field += c;
-    }
-    // Flush a final field/row that a missing trailing newline would otherwise strand.
-    if (field.length > 0 || row.length > 0) {
-        row.push(field);
-        rows.push(row);
-    }
-    return rows;
-}
-
-/**
- * Parse CSV text into an ECharts `dataset.source`: the header row first (dimension names), then data rows
- * whose fully-numeric columns are converted to numbers (per-column inference), so `encode`-by-name against
- * the header works. `null` when the CSV is empty. Exported for unit tests.
- */
-export function parseCsvToSource(text: string): unknown[][] | null {
-    const rows = parseCsv(text).filter((r) => !(r.length === 1 && r[0] === ""));
-    if (rows.length === 0) return null;
-    const header = rows[0]!;
-    const data = rows.slice(1);
-    // A column is numeric only when every data cell parses as a finite number (an empty column stays textual).
-    const numeric = header.map((_, ci) => data.length > 0 && data.every((r) => r[ci] !== undefined && r[ci]!.trim() !== "" && !Number.isNaN(Number(r[ci]))));
-    const body = data.map((r) => header.map((_, ci) => (numeric[ci] ? Number(r[ci] ?? "") : (r[ci] ?? ""))));
-    return [header, ...body];
+    return writePresentationFile(dest, echartHtml(target.spec, dataUrlFor(target.dataPath), null));
 }
 
 // ── the self-contained echart HTML shell ─────────────────────────────────────────────────────────────
@@ -448,13 +380,23 @@ function escapeHtml(s: string): string {
 /**
  * Build the self-contained echart HTML: the spec embedded inline, ECharts loaded from a pinned-major CDN
  * URL (`echarts@5`), and a VISIBLE fallback notice shown when the script cannot load (offline) so a blank
- * tab is never mysterious. `dataNote`, when present, warns that an artifact CSV could not be loaded.
- * Exported for unit tests. The spec's `<` are escaped so a string field can never break out of the script.
+ * tab is never mysterious. `dataUrl`, when present, is the RELATIVE URL of the chart's data artifact,
+ * fetched at render time and parsed into `dataset.source` in-page by PapaParse (pinned-major CDN, same
+ * pattern as ECharts; delimiter auto-detection, `dynamicTyping` for numeric cells, header row first as
+ * dimension names) — the data lives only in the artifact, never in this file — with a visible degradation
+ * note when the fetch or parse fails (a `file://`-opened page may be denied local data access by the
+ * browser). `dataNote`, when present, pre-degrades the shell (an invalid `dataPath` shape refused before
+ * a URL was derived). Exported for unit tests. Embedded JSON has `<` escaped so a string field can never
+ * break out of the script.
  */
-export function echartHtml(spec: Record<string, unknown>, dataNote: string | null): string {
+export function echartHtml(spec: Record<string, unknown>, dataUrl: string | null, dataNote: string | null): string {
     // Escape `<` in the embedded JSON so a spec string containing `</script>` cannot terminate the script tag.
     const specJson = JSON.stringify(spec).replace(/</g, "\\u003c");
-    const note = dataNote ? `<div id="datanote">${escapeHtml(dataNote)}</div>\n` : "";
+    // The URL rides the same escaped-JSON channel as the spec — an untrusted-shaped path cannot break out.
+    const dataUrlJson = JSON.stringify(dataUrl).replace(/</g, "\\u003c");
+    const noteAttr = dataNote ? "" : ' style="display:none"';
+    // The parser script tag is emitted only for data-carrying shells, so an inline chart stays one fetch.
+    const papaScript = dataUrl !== null ? '<script src="https://cdn.jsdelivr.net/npm/papaparse@5"></script>\n' : "";
     return `<!doctype html>
 <html lang="en">
 <head>
@@ -470,22 +412,53 @@ export function echartHtml(spec: Record<string, unknown>, dataNote: string | nul
 </style>
 </head>
 <body>
-${note}<div id="chart"></div>
+<div id="datanote"${noteAttr}>${escapeHtml(dataNote ?? "")}</div>
+<div id="chart"></div>
 <div id="offline">
   <p>The chart library could not load (are you offline?). The chart spec is shown below.</p>
   <pre id="spec"></pre>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5"></script>
-<script>
+${papaScript}<script>
   var spec = ${specJson};
-  if (window.echarts) {
+  var dataUrl = ${dataUrlJson};
+  function showNote(message) {
+    var note = document.getElementById("datanote");
+    note.textContent = message;
+    note.style.display = "block";
+  }
+  function render(option) {
     var chart = echarts.init(document.getElementById("chart"));
-    chart.setOption(spec);
+    chart.setOption(option);
     window.addEventListener("resize", function () { chart.resize(); });
-  } else {
+  }
+  if (!window.echarts) {
     document.getElementById("chart").style.display = "none";
     document.getElementById("offline").style.display = "block";
     document.getElementById("spec").textContent = JSON.stringify(spec, null, 2);
+  } else if (dataUrl === null) {
+    render(spec);
+  } else {
+    fetch(dataUrl)
+      .then(function (res) {
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.text();
+      })
+      .then(function (text) {
+        if (!window.Papa) throw new Error("the data parser library could not load");
+        // Strip a UTF-8 BOM so the first header cell is not prefixed with U+FEFF.
+        var body = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+        // Array-of-arrays with the header as row 0 IS the ECharts dataset.source shape;
+        // dynamicTyping turns numeric cells into numbers so value axes and encode-by-name work.
+        var parsed = Papa.parse(body, { dynamicTyping: true, skipEmptyLines: "greedy" });
+        if (!parsed.data || parsed.data.length === 0) throw new Error("empty data file");
+        spec.dataset = { source: parsed.data };
+        render(spec);
+      })
+      .catch(function (e) {
+        showNote('Data file "' + dataUrl + '" could not be loaded (' + e.message + ') — the chart is shown without its data. If this page was opened from disk (file://), the browser may block local data access; serve the analysis folder over HTTP to load it.');
+        render(spec);
+      });
   }
 </script>
 </body>

--- a/cli/src/modules/harness/chat.ts
+++ b/cli/src/modules/harness/chat.ts
@@ -163,7 +163,7 @@ export async function runChat(flags: ContextFlags, threadRef: string | undefined
 async function runRepl(runtime: HarnessRuntime, analysisId: string, threadId: string): Promise<void> {
     const history = createThreadHistory(runtime.pool);
     const sink: ChatSink = { out: (str) => void process.stdout.write(str), errLine: (str) => console.error(str) };
-    // The analysis scopes openable references so `show_file`/`show_user` cards resolve to workspace/cache
+    // The analysis scopes openable references so `show_file`/`show_user` cards resolve to workspace
     // paths for their OSC 8 `file://` links.
     const printer = createChatPrinter(sink, { analysisId });
 

--- a/cli/src/modules/harness/chat_printer.ts
+++ b/cli/src/modules/harness/chat_printer.ts
@@ -180,11 +180,11 @@ function formatTable(headers: string[], rows: string[][]): string {
 
 /**
  * How the printer resolves an openable entry to the absolute path it links to (materializing `echart`/`svg`
- * into the shared cache). Injectable so the printer's openable rendering is unit-testable without a booted
- * workspace; production omits it and gets the real {@link materializeTarget}.
+ * into the workspace's `presentations/` directory). Injectable so the printer's openable rendering is
+ * unit-testable without a booted workspace; production omits it and gets the real {@link materializeTarget}.
  */
 export type PrinterOptions = {
-    /** The analysis whose workspace root + render cache resolve openable references. */
+    /** The analysis whose workspace root resolves openable references. */
     readonly analysisId?: string;
     /** Resolve an entry's target to an absolute path (materializing when needed), or `null` when unavailable. */
     readonly resolvePath?: (analysisId: string, target: OpenTarget) => string | null;

--- a/cli/src/tui/components/openable_card_block.tsx
+++ b/cli/src/tui/components/openable_card_block.tsx
@@ -1,6 +1,5 @@
 import { For, Show } from "solid-js";
 
-import { theme } from "../theme.ts";
 import { GLYPHS, space } from "../../lib/design_system.ts";
 import { Bold, Fg, Underline } from "./emphasis.tsx";
 import type { OpenableIcon } from "../../types/session.ts";
@@ -68,7 +67,10 @@ export function OpenableCardBlock(props: OpenableCardBlockProps) {
                     <Bold>{props.title}</Bold>
                 </text>
             </Show>
-            <box paddingLeft={space.md} flexDirection="column" border={["left"]} borderColor={theme().border}>
+            {/* Rows pad by space.md, landing in the same column as assistant body text. Deliberately NO
+                left border rule — that's the quoted-content idiom reserved for user-authored turns, and
+                these cards are agent-emitted content. */}
+            <box paddingLeft={space.md} flexDirection="column">
                 <For each={props.rows}>
                     {(row, index) => (
                         <box flexDirection="column" onMouseDown={() => props.onOpen(index())}>

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -419,7 +419,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         onOpen is inert here — the gallery renders the pure block with resolved fixtures. */}
                     <OpenableCardBlock
                         title="Volcano plot"
-                        rows={[{ icon: "chart", name: "Volcano plot", path: "~/.local/share/inflexa/cache/presentations/pres-9f21a3.html", degraded: false }]}
+                        rows={[{ icon: "chart", name: "Volcano plot", path: "~/proj/.inflexa/analyses/rna/presentations/pres-9f21a3.html", degraded: false }]}
                         onOpen={noop}
                     />
                     <OpenableCardBlock

--- a/cli/src/types/session.ts
+++ b/cli/src/types/session.ts
@@ -145,8 +145,9 @@ export type OpenableIcon = "chart" | "image" | "document" | "report";
 /**
  * How an openable card entry resolves to something to open — the SEMANTIC reference, never a resolved
  * location (the artifact-open spec's open-time-resolution rule). Resolution happens when the user opens:
- * `workspace-file` joins the analysis workspace root; `echart`/`svg` materialize a cache file from the
- * embedded spec/markup; `unavailable` is a card with nothing to open (a failed report preview).
+ * `workspace-file` joins the analysis workspace root; `echart`/`svg` materialize a file under the
+ * workspace's `presentations/` directory from the embedded spec/markup; `unavailable` is a card with
+ * nothing to open (a failed report preview).
  */
 export type OpenTarget =
     | { kind: "workspace-file"; path: string }
@@ -175,7 +176,7 @@ export type OpenableEntry = {
 export type OpenableCardPart = {
     id: string;
     type: "openable-card";
-    /** The analysis whose workspace root + render cache resolve this card's entries at open time. */
+    /** The analysis whose workspace root resolves this card's entries at open time. */
     analysisId: string;
     /** Optional card heading. */
     title?: string;


### PR DESCRIPTION
## Summary

Three improvements to how `show_user` content is rendered and materialized in the CLI.

### 1. No left border on agent-emitted cards

`OpenableCardBlock` (behind `show_user` echart/svg cards, `show_file` galleries, and report previews) rendered its body under a left border rule — the quoted-content idiom reserved for user turns. The border is removed; card rows now pad by `space.md` and land in the same column as assistant body text.

### 2. Presentations materialize into the analysis workspace

echart/svg presentations now materialize into a reserved `{workspaceRoot}/presentations/` directory (root-level sibling of `data/`, `runs/`, `reports/`, `previews/`) as `presentations/<pres-id>.{html,svg}`, instead of the app-data render cache. `env.presentationCacheDir` is gone (also from `--help`). Living inside the analysis tree makes the per-analysis filename scope unnecessary, and an unresolvable workspace root degrades to the standard notice.

### 3. `dataPath` charts import their data instead of embedding it

The materialized HTML no longer contains CSV rows. It references the artifact by a URL relative to where the shell sits (`presentations/x.html` → `../runs/.../out.csv`) and fetches + parses it in-page at render time — PapaParse from the same pinned-major CDN pattern as ECharts (delimiter auto-detection, numeric cell typing). Consequences:

- the chart always reflects the current artifact bytes (no stale-cache healing machinery),
- the shell is a pure function of the tool input, so both variants are written once and reused idempotently,
- a failed fetch or parse degrades to a visible in-page note, never a blank tab.

**Known limitation:** opened via `file://` (the current OS-opener path), browsers block `fetch` of sibling files, so a `dataPath` chart shows the degradation note instead of its data (the note explains this and suggests serving the folder over HTTP). This is forward-compatible with the planned local-webserver architecture; a sidecar `.js` data file is a possible interim fallback if data-from-disk matters before then.

Specs updated to stay truthful: `artifact-open` (materialization location + render-time import) and a stale cache mention in `tui-stream-blocks`.

## Testing

- `bun run typecheck`, `bun run lint`, `bun test` (1040 pass), `openspec validate --specs` (67 pass) all green.
- Verified end-to-end in Chrome: served over HTTP, the chart renders with its CSV data (encode-by-name + numeric typing); with the CSV missing, the visible degradation note appears and the chart still renders without data.