### PR TITLE
feat: provision reference data from its upstream publishers

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -65,3 +65,16 @@ Analyses run inside a **sandbox image** that bakes the R / Python / conda / Node
 - **No local store** — the packages ship inside the pulled image, so there is no `~/.local/share/inflexa/libs` tree, no `/mnt/libs` bind mount, and no architecture-forcing. `harness.sandboxImage` (in `config.json`) records the pulled image tag; set it to a custom `FROM`-extended image to run your own.
 - **Extend it** — `FROM ghcr.io/inflexa-ai/sandbox-python-r` then `RUN pip install …` / `install.packages(…)` lands in the store automatically (the image exports `PIP_TARGET`/`R_LIBS_USER`/`INFLEXA_LIB_ROOT`); run `inflexa-libs-refresh` afterward so the additions show up in `list_available_packages`. See [`images/README.md`](../images/README.md).
 - **Managed deployments** still mount per-track tarballs read-only (cold-start friendly); those tarballs are extracted from these same images by the build pipeline and are infra-managed, not a CLI concern.
+
+## Reference data
+
+`inflexa refs path` prints the public reference store (normally `~/.local/share/inflexa/refs`). When that directory exists, it is mounted read-only in sandboxes at `/mnt/refs`; sandboxed analyses remain offline and cannot download into it themselves.
+
+| Command | Does |
+|-|-|
+| `inflexa refs list` | List the harness catalog with versions, sizes, source/license links, and local state |
+| `inflexa refs download [ids...]` | Download, checksum, and atomically activate selected catalog datasets |
+| `inflexa refs verify [ids...]` | Hash active managed files and report missing or modified content |
+| `inflexa refs path` | Print the host path without creating it |
+
+The CLI owns `managed/` and `.inflexa/` below the store. Put arbitrary reference files under `user/`; the installer never adopts, verifies, overwrites, or deletes that content, and sandbox discovery sees it dynamically. Catalog artifacts resolve through the configured `INFLEXA_REFERENCE_DATA_BASE_URL`; source and license links stay in the harness-owned catalog. If a useful dataset is missing, custom files work immediately, and a PR adding immutable file sizes/checksums and provenance to the harness catalog makes it an opt-in setup choice for everyone.

--- a/cli/README.md
+++ b/cli/README.md
@@ -72,9 +72,18 @@ Analyses run inside a **sandbox image** that bakes the R / Python / conda / Node
 
 | Command | Does |
 |-|-|
-| `inflexa refs list` | List the harness catalog with versions, sizes, source/license links, and local state |
-| `inflexa refs download [ids...]` | Download, checksum, and atomically activate selected catalog datasets |
+| `inflexa refs list` | List the harness catalog with versions, sizes, integrity class, source/license links, and local state |
+| `inflexa refs download [ids...]` | Download from the upstream publishers, verify, and atomically activate selected datasets |
 | `inflexa refs verify [ids...]` | Hash active managed files and report missing or modified content |
 | `inflexa refs path` | Print the host path without creating it |
 
-The CLI owns `managed/` and `.inflexa/` below the store. Put arbitrary reference files under `user/`; the installer never adopts, verifies, overwrites, or deletes that content, and sandbox discovery sees it dynamically. Catalog artifacts resolve through the configured `INFLEXA_REFERENCE_DATA_BASE_URL`; source and license links stay in the harness-owned catalog. If a useful dataset is missing, custom files work immediately, and a PR adding immutable file sizes/checksums and provenance to the harness catalog makes it an opt-in setup choice for everyone.
+**Every dataset is fetched straight from the third party that publishes it — NCBI, Reactome, WikiPathways, Zenodo, GTEx, CellTypist. This project mirrors, re-hosts, and redistributes nothing**, so there is no endpoint to configure and the licence you accept is the upstream's.
+
+That upstream decides what integrity we can honestly promise, and `refs list` tells you which you get:
+
+- **pinned** — the upstream publishes immutable, versioned bytes, so the catalog carries their size and SHA-256. A download is verified against the catalog *before* it is activated; a mismatch fails the install and changes nothing on disk.
+- **unpinned** — the upstream rebuilds the same URL in place (NCBI regenerates `gene_info` daily; Reactome overwrites `current` and deletes the prior release), so no checked-in digest could survive. Integrity is trust-on-first-use: the installer records the bytes it actually received, and `refs verify` proves they have not changed *since you installed them*. This is a weaker guarantee, and it is labelled as one.
+
+`refs download --force` re-fetches even when a dataset is already installed: it repairs a damaged install and is how you refresh an `unpinned` dataset once its upstream has moved on.
+
+The CLI owns `managed/` and `.inflexa/` below the store. Put arbitrary reference files under `user/`; the installer never adopts, verifies, overwrites, or deletes that content, and sandbox discovery sees it dynamically. Nothing in the sandbox image points a library at the store — agents call `list-available-refs` and pass the returned absolute paths explicitly. If a useful dataset is missing, custom files work immediately, and a PR adding its upstream URL, provenance, and licensing to the harness catalog makes it an opt-in setup choice for everyone.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
@@ -1,0 +1,97 @@
+## Context
+
+The harness Docker backend already accepts `refStorePath` and mounts it read-only at `/mnt/refs`, but the CLI composition root never supplies one. The CLI has no reference-store path, commands, receipts, or setup flow. At the same time, the harness companion change introduces a canonical catalog shared with managed deployment and makes sandbox discovery filesystem-driven.
+
+The CLI owns host-local policy: platform paths, terminal interaction, public artifact resolution, downloads, activation, and what setup offers. It must preserve the repository's no-litter rule, never let Docker create a missing bind source, and never treat user-added reference data as installer-owned state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give users a stable, documented host directory whose content appears read-only at `/mnt/refs`.
+- Install selected catalog datasets safely and reproducibly without a second catalog definition.
+- Make setup and explicit commands share one dogfooded handler.
+- Keep user-added data discoverable and outside installer cleanup/update ownership.
+- Make scripted setup deterministic and prevent silent multi-GB downloads.
+
+**Non-Goals:**
+
+- Provisioning the managed deployment's PVC or object store.
+- Downloading from within a sandbox.
+- Importing arbitrary user files into the managed namespace or validating their scientific meaning.
+- Maintaining reference installation state in SQLite.
+- Supporting executable installer recipes or archive transformations in the first catalog format.
+
+## Decisions
+
+### The public store lives under the platform data home
+
+`env.refsDir` resolves to `<data-home>/inflexa/refs` (`XDG_DATA_HOME`/`~/.local/share` on Unix and the existing platform equivalent on Windows). It is included in the root help Paths table, and `inflexa refs path` prints the exact resolved path. Setup and explicit reference commands are deliberate actions and may create it; passive launch and status-only flows do not.
+
+The layout is:
+
+```text
+refs/
+  managed/<dataset-id>/<version>/...  # immutable activated catalog content
+  user/                                # recommended user-owned namespace
+  .inflexa/
+    receipts/<dataset-id>.json
+    staging/<attempt>/...
+    downloads/<artifact>.part
+```
+
+The `managed` and `.inflexa` namespaces are installer-owned. The CLI never deletes, rewrites, or adopts content under `user/` or unknown top-level paths.
+
+### The CLI consumes install plans and resolves public artifact URLs
+
+The CLI imports the harness catalog interface from the package barrel. Its adapter maps each plan artifact key to the configured public distribution base. Dataset source and licensing links remain catalog facts; the artifact base remains distribution configuration. The CLI does not copy or reinterpret catalog entries.
+
+An alternative was a CLI catalog overlay. That would let supported options drift from managed deployment and undermine checksum identity.
+
+### Installation stages a complete dataset before activation
+
+The downloader computes the missing-byte plan before consent, downloads final-file artifacts to `.part` files, verifies byte size and SHA-256, and places them in a per-attempt staging directory using their validated relative destinations. Only after every artifact verifies does it atomically rename the staged dataset directory to `managed/<id>/<version>` and atomically write the active receipt.
+
+Version directories are immutable. An update activates the new version in its receipt only after success; older managed versions are retained initially rather than being deleted under a running sandbox. `refs verify` hashes the receipt's active files on explicit request. Ordinary `refs list` performs a cheap receipt/path/size check and labels a dataset `missing`, `partial`, `installed`, `update available`, or `invalid receipt`.
+
+The initial catalog contains final files rather than archives, so installation needs no extraction dependency and has no archive traversal surface.
+
+### Commands form the reusable provisioning interface
+
+- `inflexa refs list` renders every catalog option with version, description, download size, source/license links, and local state; it also notes unregistered top-level/user content without claiming ownership.
+- `inflexa refs download [ids...]` accepts explicit ids or uses an interactive multi-select, shows total missing bytes, asks for confirmation unless `--yes`, and installs through the one handler.
+- `inflexa refs verify [ids...]` verifies active managed files against catalog hashes; with no ids it verifies all installed catalog datasets.
+- `inflexa refs path` prints `env.refsDir` without creating it.
+
+The module's headless install operation takes selected ids and resolved policy and returns a typed outcome. Command rendering and setup consume that interface; they do not duplicate transfer logic.
+
+### Setup offers references but never guesses in headless mode
+
+Interactive `inflexa setup` creates the public store and `user/` namespace, inspects catalog state, and offers a size-labelled multi-select of missing or updateable datasets. A decline or empty selection continues. A selected download failure fails setup visibly so scripted/user-requested provisioning is not reported as complete.
+
+Headless setup downloads nothing unless an explicit `--refs <id,...>` selection is supplied; explicit selection implies consent only when paired with the existing/non-interactive confirmation policy (`--yes` or the setup's explicit provisioning flag). Otherwise setup prints `inflexa refs download ...` guidance.
+
+### Runtime wiring is existence-gated
+
+The composition root passes `refStorePath: env.refsDir` only when the directory exists. This prevents Docker from creating a missing bind source as a root-owned empty directory and respects no-litter behavior. An existing empty directory is still mounted so discovery can distinguish empty from unmounted and user additions become visible to future sandboxes without config changes.
+
+## Risks / Trade-offs
+
+- **Reference files can be very large** → Calculate missing bytes before consent, stream to resumable `.part` files, verify before activation, and never auto-download headlessly.
+- **Update leaves old versions on disk** → Accept bounded disk growth initially; add explicit managed-version reclamation later rather than deleting bytes used by a running sandbox.
+- **Public distribution endpoint is unavailable** → Preserve prior active receipts and version directories; a failed staging attempt never changes activation.
+- **User places files in a reserved namespace** → Document ownership clearly and refuse to adopt or overwrite unexpected managed paths.
+- **Receipt and disk disagree after manual edits** → Report normal recoverable states and let `download` repair managed content; never touch user content.
+
+## Migration Plan
+
+1. Add the path and commands without creating anything on passive reads.
+2. Add the installer and setup reuse over the harness catalog.
+3. Wire the existing directory into sandbox creation conditionally.
+4. Existing users have no migration: an absent store remains unmounted until setup, download, or manual directory creation.
+
+Rollback removes the command and mount wiring without deleting the reference directory, receipts, managed versions, or user content.
+
+## Open Questions
+
+- The concrete public artifact base and initial catalog selections are release configuration/data, not architectural blockers for the provisioning interface.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
@@ -1,26 +1,27 @@
 ## Context
 
-The harness Docker backend already accepts `refStorePath` and mounts it read-only at `/mnt/refs`, but the CLI composition root never supplies one. The CLI has no reference-store path, commands, receipts, or setup flow. At the same time, the harness companion change introduces a canonical catalog shared with managed deployment and makes sandbox discovery filesystem-driven.
+The harness Docker backend already accepts `refStorePath` and mounts it read-only at `/mnt/refs`, but the CLI composition root never supplies one. The CLI has no reference-store path, commands, receipts, or setup flow. At the same time, the harness companion change introduces a canonical catalog shared with managed deployment — one whose artifacts name their upstream publisher and declare what integrity that upstream can actually guarantee — and makes sandbox discovery filesystem-driven.
 
-The CLI owns host-local policy: platform paths, terminal interaction, public artifact resolution, downloads, activation, and what setup offers. It must preserve the repository's no-litter rule, never let Docker create a missing bind source, and never treat user-added reference data as installer-owned state.
+The CLI owns host-local policy: platform paths, terminal interaction, transfer, activation, and what setup offers. It must preserve the repository's no-litter rule, never let Docker create a missing bind source, and never treat user-added reference data as installer-owned state.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Give users a stable, documented host directory whose content appears read-only at `/mnt/refs`.
-- Install selected catalog datasets safely and reproducibly without a second catalog definition.
+- Install selected catalog datasets from their publishers, safely and repeatably, without a second catalog definition.
+- Deliver the strongest integrity check each artifact's upstream permits — and say plainly which one was checked.
 - Make setup and explicit commands share one dogfooded handler.
 - Keep user-added data discoverable and outside installer cleanup/update ownership.
 - Make scripted setup deterministic and prevent silent multi-GB downloads.
 
 **Non-Goals:**
 
+- Mirroring, re-hosting, or proxying reference bytes, or offering any way to point the installer elsewhere.
 - Provisioning the managed deployment's PVC or object store.
 - Downloading from within a sandbox.
 - Importing arbitrary user files into the managed namespace or validating their scientific meaning.
 - Maintaining reference installation state in SQLite.
-- Supporting executable installer recipes or archive transformations in the first catalog format.
 
 ## Decisions
 
@@ -32,7 +33,7 @@ The layout is:
 
 ```text
 refs/
-  managed/<dataset-id>/<version>/...  # immutable activated catalog content
+  managed/<dataset-id>/<version>/...  # activated catalog content
   user/                                # recommended user-owned namespace
   .inflexa/
     receipts/<dataset-id>.json
@@ -40,36 +41,44 @@ refs/
     downloads/<artifact>.part
 ```
 
-The `managed` and `.inflexa` namespaces are installer-owned. The CLI never deletes, rewrites, or adopts content under `user/` or unknown top-level paths.
+The `managed` and `.inflexa` namespaces are installer-owned. The CLI never deletes, rewrites, or adopts content under `user/` or unknown top-level paths, and it refuses to follow a symlink or overwrite unexpected content on an installer-owned path.
 
-### The CLI consumes install plans and resolves public artifact URLs
+### The CLI fetches from the catalog's upstream; there is nothing to configure
 
-The CLI imports the harness catalog interface from the package barrel. Its adapter maps each plan artifact key to the configured public distribution base. Dataset source and licensing links remain catalog facts; the artifact base remains distribution configuration. The CLI does not copy or reinterpret catalog entries.
+Each catalog artifact carries the `https` URL of the third party that publishes it, and the installer fetches exactly that. There is no artifact-key adapter, no distribution base, and no `INFLEXA_REFERENCE_DATA_BASE_URL`.
 
-An alternative was a CLI catalog overlay. That would let supported options drift from managed deployment and undermine checksum identity.
+**Rejected: a configurable distribution base** (the earlier design's opaque keys plus a CLI-resolved public endpoint, with managed free to point at an internal mirror). A configurable source is a source that can be *substituted* — and once it can be, the catalog's provenance and licensing statements ("this is NCBI's `gene_info`; you accept NCBI's terms") stop describing the bytes the user actually receives. It would also quietly make us a redistributor of data we reviewed only for use. The only supported way to bring in other reference data is the `user/` namespace, which the installer never touches.
+
+**Rejected, likewise: a CLI catalog overlay.** It would let the local option set drift from managed deployment and undermine content identity.
+
+### Verification is as strong as the upstream allows, and never stronger than it claims
+
+- A **`pinned`** artifact is verified against the catalog's byte size and SHA-256 before anything is activated. A mismatch means the bytes are not the reviewed bytes: the install fails and the prior activation stands.
+- An **`unpinned`** artifact has no catalog digest — its upstream rebuilds the same URL in place — so there is nothing to check the download against. The installer records the size and digest it *observed* in the receipt, and `verify` proves the files are unchanged since install. `refs verify` names, per file, which guarantee it checked, so a weaker guarantee is never silently presented as a checksum match against a reviewed digest.
+
+The receipt is therefore written from observation, never copied from the catalog — for `pinned` artifacts the two necessarily agree, and for `unpinned` ones the observation is the only honest record.
+
+### Resume applies to pinned artifacts only
+
+A partial `.part` is resumed with an HTTP Range request only when the artifact is `pinned`, because only then do we know the final size and digest — the two facts that make "this prefix belongs to that file" checkable. For an `unpinned` artifact the partial is discarded and the file re-fetched whole: the upstream may have replaced the file since the partial was written, and appending to it would splice two different files into one that verifies against nothing and looks complete.
+
+### `--force` is the refresh path, not just a repair path
+
+`refs download --force` re-fetches and re-activates even when the active install is intact. It repairs damage, and — for an `unpinned` dataset — it is the *only* way to pull a fresh copy: an intact local install of the bytes we previously received is indistinguishable from an up-to-date one without going to the network, so the user must be able to ask.
+
+### The skip gate compares digests, not sizes
+
+Deciding "already installed, nothing to transfer" hashes the active files against the receipt (`receiptFilesIntact`). A size-only check cannot see a same-size corruption — a flipped byte, bad sector, hand-edit — and would skip the repair *while printing "Installed"*: a false claim of success on exactly the input a user re-runs `download` to fix. Cheap `refs list` state stays size-only (it is a status glance, and hashing every dataset on every list would be slow), but an install and a download estimate both gate on the digest.
+
+### Sizes are reported honestly, including when they are unknown
+
+Only the upstream knows how big an `unpinned` file currently is, and a local estimate must not make a network round-trip. So the pre-transfer estimate returns both the bytes the catalog knows and the count of artifacts whose size only the upstream can report; the CLI shows both and never invents a total.
 
 ### Installation stages a complete dataset before activation
 
-The downloader computes the missing-byte plan before consent, downloads final-file artifacts to `.part` files, verifies byte size and SHA-256, and places them in a per-attempt staging directory using their validated relative destinations. Only after every artifact verifies does it atomically rename the staged dataset directory to `managed/<id>/<version>` and atomically write the active receipt.
+Artifacts download to installer-owned `.part` files, are placed into a per-attempt staging directory at their validated relative destinations, and the staged version directory is atomically renamed into `managed/<id>/<version>` only when every artifact is accounted for. The receipt is then written atomically. Any failure restores the prior version directory, and the per-attempt staging root is always removed — the activation `rename` moves the staged version out but leaves its parents behind, and every attempt has a fresh id, so without cleanup they would accumulate forever.
 
-Version directories are immutable. An update activates the new version in its receipt only after success; older managed versions are retained initially rather than being deleted under a running sandbox. `refs verify` hashes the receipt's active files on explicit request. Ordinary `refs list` performs a cheap receipt/path/size check and labels a dataset `missing`, `partial`, `installed`, `update available`, or `invalid receipt`.
-
-The initial catalog contains final files rather than archives, so installation needs no extraction dependency and has no archive traversal surface.
-
-### Commands form the reusable provisioning interface
-
-- `inflexa refs list` renders every catalog option with version, description, download size, source/license links, and local state; it also notes unregistered top-level/user content without claiming ownership.
-- `inflexa refs download [ids...]` accepts explicit ids or uses an interactive multi-select, shows total missing bytes, asks for confirmation unless `--yes`, and installs through the one handler.
-- `inflexa refs verify [ids...]` verifies active managed files against catalog hashes; with no ids it verifies all installed catalog datasets.
-- `inflexa refs path` prints `env.refsDir` without creating it.
-
-The module's headless install operation takes selected ids and resolved policy and returns a typed outcome. Command rendering and setup consume that interface; they do not duplicate transfer logic.
-
-### Setup offers references but never guesses in headless mode
-
-Interactive `inflexa setup` creates the public store and `user/` namespace, inspects catalog state, and offers a size-labelled multi-select of missing or updateable datasets. A decline or empty selection continues. A selected download failure fails setup visibly so scripted/user-requested provisioning is not reported as complete.
-
-Headless setup downloads nothing unless an explicit `--refs <id,...>` selection is supplied; explicit selection implies consent only when paired with the existing/non-interactive confirmation policy (`--yes` or the setup's explicit provisioning flag). Otherwise setup prints `inflexa refs download ...` guidance.
+An update activates the new version only after success; older managed versions are retained rather than deleted under a running sandbox.
 
 ### Runtime wiring is existence-gated
 
@@ -77,9 +86,10 @@ The composition root passes `refStorePath: env.refsDir` only when the directory 
 
 ## Risks / Trade-offs
 
-- **Reference files can be very large** → Calculate missing bytes before consent, stream to resumable `.part` files, verify before activation, and never auto-download headlessly.
+- **Reference files can be large** → Estimate the missing bytes before consent, stream to resumable `.part` files, verify before activation, and never auto-download headlessly.
+- **An `unpinned` dataset silently ages** → Accepted and surfaced: the class is shown in `refs list`, `verify` says which guarantee it checked, and `--force` refreshes on demand. The alternative (pinning a digest to a mutable URL) would guarantee a broken download instead.
+- **An upstream can be slow, rate-limited, or down** → Accepted as the price of not redistributing. A failed attempt never changes an existing activation.
 - **Update leaves old versions on disk** → Accept bounded disk growth initially; add explicit managed-version reclamation later rather than deleting bytes used by a running sandbox.
-- **Public distribution endpoint is unavailable** → Preserve prior active receipts and version directories; a failed staging attempt never changes activation.
 - **User places files in a reserved namespace** → Document ownership clearly and refuse to adopt or overwrite unexpected managed paths.
 - **Receipt and disk disagree after manual edits** → Report normal recoverable states and let `download` repair managed content; never touch user content.
 
@@ -91,7 +101,3 @@ The composition root passes `refStorePath: env.refsDir` only when the directory 
 4. Existing users have no migration: an absent store remains unmounted until setup, download, or manual directory creation.
 
 Rollback removes the command and mount wiring without deleting the reference directory, receipts, managed versions, or user content.
-
-## Open Questions
-
-- The concrete public artifact base and initial catalog selections are release configuration/data, not architectural blockers for the provisioning interface.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
@@ -2,11 +2,16 @@
 
 Local sandboxes support a read-only reference-data mount, but the CLI neither exposes a stable host directory nor provisions or wires it. Users need a visible place for their own references and an optional, verified download path for the canonical catalog shared with managed deployments.
 
+Those downloads must come from the party that publishes them. The catalog's provenance and licence links are only true of the upstream it names, so the CLI has no distribution endpoint to configure — it fetches from NCBI, Reactome, WikiPathways, Zenodo, GTEx, and CellTypist directly.
+
 ## What Changes
 
 - Add a documented reference-store directory under the platform data home and mount it read-only at `/mnt/refs` whenever it deliberately exists.
-- Add `inflexa refs list`, `download`, `verify`, and `path` actions backed by the harness-owned catalog and a local artifact-location adapter.
-- Install managed datasets into a reserved namespace using resumable staging, per-file checksum verification, receipts, and atomic activation without modifying user-owned content.
+- Add `inflexa refs list`, `download`, `verify`, and `path` actions backed by the harness-owned catalog, fetching every artifact straight from the upstream URL the catalog names. There is no mirror, no re-hosting, and no `INFLEXA_REFERENCE_DATA_BASE_URL` — a configurable source is a source that can be substituted.
+- Install managed datasets with resumable staging, per-file verification, receipts, and atomic activation without modifying user-owned content: a `pinned` artifact is checked against the catalog's size and SHA-256 before activation; an `unpinned` one has no catalog digest to check, so the receipt records the bytes actually received.
+- Resume (HTTP Range) only `pinned` artifacts; re-fetch an `unpinned` artifact whole, since appending to bytes a mutable upstream has since replaced would splice two files together.
+- Add `refs download --force` to re-fetch an intact install — the repair path for local damage and the only way to refresh a dataset whose mutable upstream has moved on.
+- Gate the "already installed, nothing to do" skip on digests rather than sizes, so a same-size corruption is repaired instead of being silently reported as installed.
 - Reserve and document a `user/` namespace where users may place arbitrary reference data that future sandboxes discover automatically.
 - Extend interactive `inflexa setup` to inspect installed references and offer catalog selections through the same download handler; headless setup never downloads large data without explicit selection and consent.
 - Tell users how to contribute new catalog entries by pull request when an option is missing.
@@ -15,7 +20,7 @@ Local sandboxes support a read-only reference-data mount, but the CLI neither ex
 
 ### New Capabilities
 
-- `reference-data-provisioning`: The local reference-store path, catalog-driven commands, verified installer, receipts, user-owned namespace, and setup integration.
+- `reference-data-provisioning`: The local reference-store path, catalog-driven commands, upstream-sourced verified installer, integrity-class-aware resume/verify, receipts, user-owned namespace, and setup integration.
 
 ### Modified Capabilities
 
@@ -24,5 +29,5 @@ Local sandboxes support a read-only reference-data mount, but the CLI neither ex
 ## Impact
 
 - Adds a `src/modules/refs/` feature slice and command group; updates `src/lib/env.ts`, root help, setup, and harness runtime composition.
-- Consumes the harness's new catalog/install-plan exports and supplies the public artifact resolver and local filesystem adapter.
+- Consumes the harness's catalog/install-plan/receipt exports; supplies only the local filesystem and transfer behavior, never an alternative source.
 - Adds persistent data under the CLI's platform data directory; user content is outside installer ownership and is never pruned or overwritten.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Local sandboxes support a read-only reference-data mount, but the CLI neither exposes a stable host directory nor provisions or wires it. Users need a visible place for their own references and an optional, verified download path for the canonical catalog shared with managed deployments.
+
+## What Changes
+
+- Add a documented reference-store directory under the platform data home and mount it read-only at `/mnt/refs` whenever it deliberately exists.
+- Add `inflexa refs list`, `download`, `verify`, and `path` actions backed by the harness-owned catalog and a local artifact-location adapter.
+- Install managed datasets into a reserved namespace using resumable staging, per-file checksum verification, receipts, and atomic activation without modifying user-owned content.
+- Reserve and document a `user/` namespace where users may place arbitrary reference data that future sandboxes discover automatically.
+- Extend interactive `inflexa setup` to inspect installed references and offer catalog selections through the same download handler; headless setup never downloads large data without explicit selection and consent.
+- Tell users how to contribute new catalog entries by pull request when an option is missing.
+
+## Capabilities
+
+### New Capabilities
+
+- `reference-data-provisioning`: The local reference-store path, catalog-driven commands, verified installer, receipts, user-owned namespace, and setup integration.
+
+### Modified Capabilities
+
+- `harness-runtime`: The local composition root conditionally supplies the existing reference-store directory as `refStorePath` so Docker sandboxes receive the read-only mount without auto-creating a missing host path.
+
+## Impact
+
+- Adds a `src/modules/refs/` feature slice and command group; updates `src/lib/env.ts`, root help, setup, and harness runtime composition.
+- Consumes the harness's new catalog/install-plan exports and supplies the public artifact resolver and local filesystem adapter.
+- Adds persistent data under the CLI's platform data directory; user content is outside installer ownership and is never pruned or overwritten.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/harness-runtime/spec.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/harness-runtime/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Existing local reference store is mounted read-only into sandboxes
+
+The CLI harness composition SHALL supply `refStorePath` to the harness sandbox client exactly when `env.refsDir` already exists. It SHALL NOT create the directory during runtime boot or passive launch. An existing directory, including an empty one, SHALL be mounted read-only by the harness at `/mnt/refs`; an absent directory SHALL leave the mount unconfigured so Docker cannot auto-create a root-owned bind source.
+
+#### Scenario: Deliberately created store is wired
+
+- **GIVEN** setup, reference download, or the user has created `env.refsDir`
+- **WHEN** the embedded harness runtime creates a Docker sandbox
+- **THEN** the sandbox client receives that host path as `refStorePath` and the sandbox sees it read-only at `/mnt/refs`
+
+#### Scenario: Missing store is not auto-created
+
+- **GIVEN** `env.refsDir` does not exist
+- **WHEN** the runtime boots and creates a sandbox
+- **THEN** `refStorePath` is omitted and neither the CLI nor Docker creates the host directory as a side effect of composition
+
+#### Scenario: Empty store remains distinguishable from no mount
+
+- **GIVEN** `env.refsDir` deliberately exists but contains no reference data
+- **WHEN** a sandbox is created
+- **THEN** it receives the empty read-only mount so harness discovery can report mounted-but-empty rather than unmounted

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-provisioning/spec.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-provisioning/spec.md
@@ -25,12 +25,19 @@ The CLI installer SHALL write catalog-managed datasets only beneath `managed/<da
 
 ### Requirement: Reference options come from the harness catalog
 
-The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, total bytes, source and licensing links, recommendation/group metadata, and local state. The CLI's artifact adapter SHALL map plan artifact keys to the public distribution endpoint without changing their content identity or destination paths.
+The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, size, integrity class, source and licensing links, recommendation/group metadata, and local state. The CLI SHALL fetch every artifact from the upstream URL the catalog names and SHALL NOT provide any means — environment variable, flag, or config — of redirecting a fetch to a different origin.
+
+Because an `unpinned` artifact's size is known only to its mutable upstream, a displayed size SHALL distinguish bytes the catalog knows from files whose size the upstream determines, and SHALL NOT invent a total.
 
 #### Scenario: Catalog option is visible with links
 
 - **WHEN** `inflexa refs list` runs
-- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links and local installation state
+- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links, its integrity class, and its local installation state
+
+#### Scenario: The download source cannot be redirected
+
+- **WHEN** a user or operator wishes to install catalog data from somewhere other than its publisher
+- **THEN** the CLI offers no such configuration, and the only supported way to add other reference data is to place files under the store's `user/` namespace
 
 #### Scenario: Unknown id is rejected before download
 
@@ -39,26 +46,35 @@ The CLI SHALL consume the harness-exported reference catalog and install-plan in
 
 ### Requirement: Downloads are verified and dataset activation is atomic
 
-For each selected dataset, the CLI SHALL compute a missing-byte plan, download artifacts to installer-owned `.part` paths, verify each artifact's expected byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts verify. It SHALL then atomically write a harness-compatible active receipt. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content.
+For each selected dataset, the CLI SHALL download artifacts to installer-owned `.part` paths, verify every `pinned` artifact against the catalog's byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts are accounted for. It SHALL then atomically write a harness-compatible active receipt recording the size and digest **observed** for each artifact. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content, and SHALL NOT leave orphaned staging directories behind.
+
+Resuming a partial transfer SHALL be attempted only for a `pinned` artifact. An `unpinned` artifact SHALL be re-fetched whole, because its upstream may have replaced the file since the partial was written and appending to it would splice two different files into one that verifies against nothing.
 
 #### Scenario: Complete dataset activates
 
-- **WHEN** every artifact downloads and matches its catalog size and digest
-- **THEN** the complete immutable version appears under `managed/<id>/<version>` and its receipt records exactly those verified files
+- **WHEN** every artifact downloads, and every `pinned` artifact matches its catalog size and digest
+- **THEN** the complete version appears under `managed/<id>/<version>` and its receipt records the observed size, digest, and integrity class of each file
 
 #### Scenario: Digest mismatch preserves prior version
 
-- **WHEN** any downloaded artifact fails size or SHA-256 verification
+- **WHEN** any `pinned` artifact fails size or SHA-256 verification
 - **THEN** the command fails, the staged version is not activated, and the prior active receipt and version remain unchanged
 
-#### Scenario: Interrupted download is resumable but not visible
+#### Scenario: Interrupted pinned download is resumable but not visible
 
-- **WHEN** a transfer stops after writing part of an artifact
-- **THEN** resumable installer-owned partial state may remain, but no partial dataset appears as active managed reference data
+- **WHEN** a transfer stops after writing part of a `pinned` artifact
+- **THEN** resumable installer-owned partial state may remain and is resumed by range request, but no partial dataset appears as active managed reference data
+
+#### Scenario: A mutable upstream is never resumed into
+
+- **WHEN** a partial `.part` exists for an `unpinned` artifact
+- **THEN** the CLI discards it and fetches the whole file again rather than appending to bytes the upstream may have since replaced
 
 ### Requirement: Reference commands expose install, verification, and path operations
 
-The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show total missing bytes and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against the catalog and receipt and SHALL report missing, modified, and valid states without modifying them.
+The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show the missing size and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against their receipt and SHALL report missing, modified, and valid states without modifying them, naming for each file which guarantee was checked — the catalog's checksum for a `pinned` file, the checksum recorded at install for an `unpinned` one.
+
+`inflexa refs download --force` SHALL re-fetch and re-activate a dataset even when its active install is intact. This is the supported way to refresh an `unpinned` dataset, whose upstream may have moved on in a way no local inspection can detect.
 
 #### Scenario: Interactive selection shows cost before consent
 
@@ -68,7 +84,12 @@ The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `in
 #### Scenario: Verification detects manual damage
 
 - **WHEN** an active managed file has been edited or removed
-- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid and changes no bytes
+- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid, names the repair command, exits non-zero, and changes no bytes
+
+#### Scenario: A mutable upstream is refreshed on request
+
+- **WHEN** an `unpinned` dataset is installed and intact, and the user runs `refs download <id> --force`
+- **THEN** the CLI re-fetches from the upstream and re-activates, replacing the receipt with the newly observed digests
 
 ### Requirement: Setup reuses the reference download handler
 
@@ -95,7 +116,14 @@ Headless setup SHALL download no reference bytes unless dataset ids and non-inte
 
 Cheap status inspection SHALL derive managed state from the catalog, receipts, and filesystem and SHALL report at least missing, installed, update available, partial, and invalid-receipt states. Absence or inconsistency SHALL NOT crash the CLI. Re-running download for a selected dataset SHALL repair installer-owned content through normal staged verification and activation.
 
+Deciding whether an install may be skipped as already-complete SHALL compare digests, not sizes. A size-only check cannot see a same-size corruption — a flipped byte, a bad sector, a hand-edit — and would skip the repair while reporting the dataset as installed, which is a false claim of success. Cheap listing MAY remain size-only, but an install SHALL NOT be skipped on that basis.
+
 #### Scenario: Receipt references a deleted file
 
 - **WHEN** a receipt names a managed file that is absent
 - **THEN** list reports a partial or damaged state and download can repair it without database surgery or changes to user content
+
+#### Scenario: Same-size corruption is repaired, not skipped
+
+- **WHEN** an installed artifact is corrupted in place without changing its byte length, and download is re-run for that dataset
+- **THEN** the CLI detects the digest mismatch, re-downloads and re-activates the dataset, and never reports it as already installed with nothing transferred

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-provisioning/spec.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-provisioning/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: The CLI exposes a stable public reference-store directory
+
+The CLI SHALL resolve a `refsDir` under the platform data home at `<data-home>/inflexa/refs`. Root help SHALL list the directory in its Paths table, and `inflexa refs path` SHALL print the exact resolved path without creating it. Deliberate setup or reference-download actions SHALL create the directory and a documented `user/` namespace for arbitrary user-provided reference data.
+
+#### Scenario: User discovers the host path
+
+- **WHEN** the user runs root help or `inflexa refs path`
+- **THEN** the CLI displays the host directory whose contents sandboxes see at `/mnt/refs`
+
+#### Scenario: Path inspection does not litter
+
+- **WHEN** `inflexa refs path` runs before the store exists
+- **THEN** it prints the path and creates no directory or metadata
+
+### Requirement: Managed and user-owned namespaces have separate ownership
+
+The CLI installer SHALL write catalog-managed datasets only beneath `managed/<dataset-id>/<version>` and its own metadata only beneath `.inflexa/`. It SHALL recommend `user/` for arbitrary additions and SHALL NOT overwrite, adopt, verify as managed, prune, or delete content under `user/` or unknown top-level paths.
+
+#### Scenario: User-added reference survives managed update
+
+- **WHEN** a user places files under `refs/user/custom-atlas/` and updates a catalog dataset
+- **THEN** the installer changes only its managed dataset/version and receipt paths and leaves the custom atlas byte-for-byte untouched
+
+### Requirement: Reference options come from the harness catalog
+
+The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, total bytes, source and licensing links, recommendation/group metadata, and local state. The CLI's artifact adapter SHALL map plan artifact keys to the public distribution endpoint without changing their content identity or destination paths.
+
+#### Scenario: Catalog option is visible with links
+
+- **WHEN** `inflexa refs list` runs
+- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links and local installation state
+
+#### Scenario: Unknown id is rejected before download
+
+- **WHEN** `inflexa refs download unknown-id` runs
+- **THEN** the CLI reports the unknown id and available ids and performs no network or filesystem mutation
+
+### Requirement: Downloads are verified and dataset activation is atomic
+
+For each selected dataset, the CLI SHALL compute a missing-byte plan, download artifacts to installer-owned `.part` paths, verify each artifact's expected byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts verify. It SHALL then atomically write a harness-compatible active receipt. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content.
+
+#### Scenario: Complete dataset activates
+
+- **WHEN** every artifact downloads and matches its catalog size and digest
+- **THEN** the complete immutable version appears under `managed/<id>/<version>` and its receipt records exactly those verified files
+
+#### Scenario: Digest mismatch preserves prior version
+
+- **WHEN** any downloaded artifact fails size or SHA-256 verification
+- **THEN** the command fails, the staged version is not activated, and the prior active receipt and version remain unchanged
+
+#### Scenario: Interrupted download is resumable but not visible
+
+- **WHEN** a transfer stops after writing part of an artifact
+- **THEN** resumable installer-owned partial state may remain, but no partial dataset appears as active managed reference data
+
+### Requirement: Reference commands expose install, verification, and path operations
+
+The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show total missing bytes and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against the catalog and receipt and SHALL report missing, modified, and valid states without modifying them.
+
+#### Scenario: Interactive selection shows cost before consent
+
+- **WHEN** an interactive user selects multiple missing datasets
+- **THEN** the CLI shows the combined missing download size and begins transfer only after confirmation
+
+#### Scenario: Verification detects manual damage
+
+- **WHEN** an active managed file has been edited or removed
+- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid and changes no bytes
+
+### Requirement: Setup reuses the reference download handler
+
+Interactive `inflexa setup` SHALL deliberately create the reference-store and `user/` directories, inspect catalog installation state, and offer missing or updateable datasets with their sizes through the same headless download operation used by `inflexa refs download`. Declining or selecting nothing SHALL continue setup. A selected installation failure SHALL fail setup visibly.
+
+Headless setup SHALL download no reference bytes unless dataset ids and non-interactive consent are explicit. Without them it SHALL print the reference-store path and an actionable `inflexa refs download` command and continue.
+
+#### Scenario: Setup and explicit command share one installer
+
+- **WHEN** setup installs a selected dataset
+- **THEN** it produces the same managed layout, verification, activation, and receipt as `inflexa refs download` for that id
+
+#### Scenario: Headless setup does not silently download
+
+- **WHEN** setup runs without a TTY and without explicit reference ids and consent
+- **THEN** it downloads nothing, prints how to install references later, and continues
+
+#### Scenario: User declines optional references
+
+- **WHEN** an interactive user declines or selects no catalog datasets
+- **THEN** setup leaves the public store available for manual additions and continues successfully
+
+### Requirement: Missing or inconsistent managed state is recoverable
+
+Cheap status inspection SHALL derive managed state from the catalog, receipts, and filesystem and SHALL report at least missing, installed, update available, partial, and invalid-receipt states. Absence or inconsistency SHALL NOT crash the CLI. Re-running download for a selected dataset SHALL repair installer-owned content through normal staged verification and activation.
+
+#### Scenario: Receipt references a deleted file
+
+- **WHEN** a receipt names a managed file that is absent
+- **THEN** list reports a partial or damaged state and download can repair it without database surgery or changes to user content

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
@@ -1,0 +1,37 @@
+## 1. Public Store and Catalog Adapter
+
+- [x] 1.1 Add `env.refsDir`, document it through `envDoc`, and cover platform/XDG resolution and no-litter path inspection in tests.
+- [x] 1.2 Create the `modules/refs` feature slice with a public-artifact-key resolver consuming only the harness catalog/install-plan barrel exports.
+- [x] 1.3 Define the installer-owned `managed/` and `.inflexa/` paths plus the user-owned `user/` path, with helpers that never create state during passive inspection.
+
+## 2. Store Inspection and Verification
+
+- [x] 2.1 Implement receipt reads and cheap catalog/filesystem state classification for missing, installed, update-available, partial, and invalid-receipt datasets.
+- [x] 2.2 Implement explicit verification of active managed files against receipt/catalog size and SHA-256 without mutating disk.
+- [x] 2.3 Add tests for absent stores, empty stores, valid installs, deleted/modified managed files, stale receipts, unknown top-level content, and untouched user data.
+
+## 3. Verified Dataset Installation
+
+- [x] 3.1 Implement missing-byte install planning and resumable streaming downloads to installer-owned `.part` files with typed network and filesystem errors.
+- [x] 3.2 Implement size/SHA-256 verification and safe placement of final-file artifacts into a per-attempt dataset staging directory.
+- [x] 3.3 Implement atomic immutable-version activation and atomic harness-compatible receipt writes that preserve the prior active version on every failure path.
+- [x] 3.4 Add installer tests for successful multi-file activation, resume, digest/size mismatch, interruption, prior-version preservation, and refusal to overwrite unexpected managed or user paths.
+
+## 4. Reference Command Surface
+
+- [x] 4.1 Register `inflexa refs list`, `download [ids...]`, `verify [ids...]`, and `path` with lazy feature imports and typed option parsing.
+- [x] 4.2 Implement catalog/state rendering with versions, sizes, recommendation groups, source/license links, and contribution guidance for missing options.
+- [x] 4.3 Implement interactive multi-select and pre-transfer size confirmation plus explicit-id/`--yes` non-interactive behavior through the same headless install operation.
+- [x] 4.4 Add command tests for unknown ids, declined downloads, headless consent, verification reporting, exact path output, and user-content notices.
+
+## 5. Setup and Runtime Wiring
+
+- [x] 5.1 Extend setup options with explicit reference selection/consent and add the interactive installed-state check and size-labelled selection using the reference download handler.
+- [x] 5.2 Make setup deliberately create the store and `user/` namespace, continue on decline/empty selection, fail visibly on a selected install failure, and emit actionable headless guidance when no explicit selection is supplied.
+- [x] 5.3 Condition the harness composition's `refStorePath` on the pre-existing `env.refsDir`, including an existing empty directory while omitting an absent one.
+- [x] 5.4 Add setup and runtime-composition tests proving handler reuse, no silent headless download, no passive directory creation, read-only mount wiring, and the missing-bind-source guard.
+
+## 6. Verification
+
+- [x] 6.1 Update user-facing help/documentation for the host path, `/mnt/refs` mapping, managed/user ownership, offline sandbox behavior, and catalog contribution workflow.
+- [x] 6.2 Run targeted source formatting, `bun run typecheck`, `bun run lint`, and the relevant CLI test suites.

--- a/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
@@ -1,28 +1,31 @@
-## 1. Public Store and Catalog Adapter
+## 1. Public Store and Catalog Consumption
 
 - [x] 1.1 Add `env.refsDir`, document it through `envDoc`, and cover platform/XDG resolution and no-litter path inspection in tests.
-- [x] 1.2 Create the `modules/refs` feature slice with a public-artifact-key resolver consuming only the harness catalog/install-plan barrel exports.
-- [x] 1.3 Define the installer-owned `managed/` and `.inflexa/` paths plus the user-owned `user/` path, with helpers that never create state during passive inspection.
+- [x] 1.2 Create the `modules/refs` feature slice consuming the harness catalog/install-plan/receipt barrel exports directly — no key-to-URL adapter and no distribution base: artifacts are fetched from the upstream URL the catalog names.
+- [x] 1.3 Define the installer-owned `managed/` and `.inflexa/` paths plus the user-owned `user/` path, with helpers that never create state during passive inspection and refuse symlinked or unexpected installer-owned paths.
 
 ## 2. Store Inspection and Verification
 
 - [x] 2.1 Implement receipt reads and cheap catalog/filesystem state classification for missing, installed, update-available, partial, and invalid-receipt datasets.
-- [x] 2.2 Implement explicit verification of active managed files against receipt/catalog size and SHA-256 without mutating disk.
+- [x] 2.2 Implement explicit verification of active managed files against the **receipt's** observed size and SHA-256, reporting per file which guarantee was checked (catalog digest for `pinned`, install-time digest for `unpinned`) without mutating disk.
 - [x] 2.3 Add tests for absent stores, empty stores, valid installs, deleted/modified managed files, stale receipts, unknown top-level content, and untouched user data.
 
 ## 3. Verified Dataset Installation
 
-- [x] 3.1 Implement missing-byte install planning and resumable streaming downloads to installer-owned `.part` files with typed network and filesystem errors.
-- [x] 3.2 Implement size/SHA-256 verification and safe placement of final-file artifacts into a per-attempt dataset staging directory.
-- [x] 3.3 Implement atomic immutable-version activation and atomic harness-compatible receipt writes that preserve the prior active version on every failure path.
-- [x] 3.4 Add installer tests for successful multi-file activation, resume, digest/size mismatch, interruption, prior-version preservation, and refusal to overwrite unexpected managed or user paths.
+- [x] 3.1 Implement streaming downloads from the catalog's upstream URLs to installer-owned `.part` files with typed network and filesystem errors, keyed off the artifact's catalog identity rather than its URL.
+- [x] 3.2 Restrict HTTP Range resume to `pinned` artifacts and re-fetch `unpinned` ones whole, so a partial is never appended to bytes a mutable upstream may have replaced.
+- [x] 3.3 Verify `pinned` artifacts against the catalog's size and SHA-256 before activation; for `unpinned` artifacts record the observed size and digest instead of checking against a digest the catalog cannot honestly carry.
+- [x] 3.4 Implement atomic version activation, atomic receipts recording the **observed** bytes/digest/integrity per artifact, prior-version restore on every failure path, and removal of the per-attempt staging root so activation leaves no orphaned directories.
+- [x] 3.5 Gate the "already installed" skip on a digest check of the active files, not a size check, so a same-size corruption re-downloads instead of being reported as installed; apply the same gate to the pre-transfer estimate.
+- [x] 3.6 Report the download estimate as known catalog bytes plus a count of `unpinned` artifacts whose size only the upstream knows, without inventing a total.
+- [x] 3.7 Add installer tests for multi-file activation, pinned resume, unpinned whole re-fetch, digest/size mismatch, interruption, prior-version preservation, staging cleanup, forced re-fetch, and refusal to overwrite unexpected managed or user paths.
 
 ## 4. Reference Command Surface
 
-- [x] 4.1 Register `inflexa refs list`, `download [ids...]`, `verify [ids...]`, and `path` with lazy feature imports and typed option parsing.
-- [x] 4.2 Implement catalog/state rendering with versions, sizes, recommendation groups, source/license links, and contribution guidance for missing options.
-- [x] 4.3 Implement interactive multi-select and pre-transfer size confirmation plus explicit-id/`--yes` non-interactive behavior through the same headless install operation.
-- [x] 4.4 Add command tests for unknown ids, declined downloads, headless consent, verification reporting, exact path output, and user-content notices.
+- [x] 4.1 Register `inflexa refs list`, `download [ids...] [--yes] [--force]`, `verify [ids...]`, and `path` with lazy feature imports and typed option parsing.
+- [x] 4.2 Implement catalog/state rendering with versions, integrity class, sizes, recommendation groups, source/license links, and contribution guidance for missing options.
+- [x] 4.3 Implement interactive multi-select and pre-transfer size confirmation plus explicit-id/`--yes` non-interactive behavior through the same headless install operation; `--force` re-fetches an intact install (repair, and the refresh path for a mutable upstream).
+- [x] 4.4 Make `verify` name the repair command and exit non-zero on damage, and add command tests for unknown ids, declined downloads, headless consent, verification reporting, exact path output, and user-content notices.
 
 ## 5. Setup and Runtime Wiring
 
@@ -33,5 +36,5 @@
 
 ## 6. Verification
 
-- [x] 6.1 Update user-facing help/documentation for the host path, `/mnt/refs` mapping, managed/user ownership, offline sandbox behavior, and catalog contribution workflow.
+- [x] 6.1 Remove `INFLEXA_REFERENCE_DATA_BASE_URL` from `env`/`envDoc` and update user-facing help/README for the host path, `/mnt/refs` mapping, upstream-only sourcing, integrity classes, managed/user ownership, offline sandbox behavior, and the catalog contribution workflow.
 - [x] 6.2 Run targeted source formatting, `bun run typecheck`, `bun run lint`, and the relevant CLI test suites.

--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -143,6 +143,28 @@ the exit sequence.
 - **WHEN** the cli exits while a profile workflow is running
 - **THEN** DBOS shutdown marks it recoverable and a later runtime boot resumes it
 
+### Requirement: Existing local reference store is mounted read-only into sandboxes
+
+The CLI harness composition SHALL supply `refStorePath` to the harness sandbox client exactly when `env.refsDir` already exists. It SHALL NOT create the directory during runtime boot or passive launch. An existing directory, including an empty one, SHALL be mounted read-only by the harness at `/mnt/refs`; an absent directory SHALL leave the mount unconfigured so Docker cannot auto-create a root-owned bind source.
+
+#### Scenario: Deliberately created store is wired
+
+- **GIVEN** setup, reference download, or the user has created `env.refsDir`
+- **WHEN** the embedded harness runtime creates a Docker sandbox
+- **THEN** the sandbox client receives that host path as `refStorePath` and the sandbox sees it read-only at `/mnt/refs`
+
+#### Scenario: Missing store is not auto-created
+
+- **GIVEN** `env.refsDir` does not exist
+- **WHEN** the runtime boots and creates a sandbox
+- **THEN** `refStorePath` is omitted and neither the CLI nor Docker creates the host directory as a side effect of composition
+
+#### Scenario: Empty store remains distinguishable from no mount
+
+- **GIVEN** `env.refsDir` deliberately exists but contains no reference data
+- **WHEN** a sandbox is created
+- **THEN** it receives the empty read-only mount so harness discovery can report mounted-but-empty rather than unmounted
+
 ### Requirement: The embedding imports through the harness barrel
 
 Cli code SHALL import harness symbols only from the `@inflexa-ai/harness` barrel. The
@@ -299,4 +321,3 @@ The realization SHALL be memoized through `workspaceRootForAnalysisId` (see path
 - **GIVEN** an analysis was deleted and a new one created with the same name under the same anchor
 - **WHEN** the resolver resolves the new analysis's root
 - **THEN** the root is the same path, and it holds none of the deleted analysis's artifacts
-

--- a/cli/openspec/specs/reference-data-provisioning/spec.md
+++ b/cli/openspec/specs/reference-data-provisioning/spec.md
@@ -32,12 +32,19 @@ The CLI installer SHALL write catalog-managed datasets only beneath `managed/<da
 
 ### Requirement: Reference options come from the harness catalog
 
-The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, total bytes, source and licensing links, recommendation/group metadata, and local state. The CLI's artifact adapter SHALL map plan artifact keys to the public distribution endpoint without changing their content identity or destination paths.
+The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, size, integrity class, source and licensing links, recommendation/group metadata, and local state. The CLI SHALL fetch every artifact from the upstream URL the catalog names and SHALL NOT provide any means — environment variable, flag, or config — of redirecting a fetch to a different origin.
+
+Because an `unpinned` artifact's size is known only to its mutable upstream, a displayed size SHALL distinguish bytes the catalog knows from files whose size the upstream determines, and SHALL NOT invent a total.
 
 #### Scenario: Catalog option is visible with links
 
 - **WHEN** `inflexa refs list` runs
-- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links and local installation state
+- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links, its integrity class, and its local installation state
+
+#### Scenario: The download source cannot be redirected
+
+- **WHEN** a user or operator wishes to install catalog data from somewhere other than its publisher
+- **THEN** the CLI offers no such configuration, and the only supported way to add other reference data is to place files under the store's `user/` namespace
 
 #### Scenario: Unknown id is rejected before download
 
@@ -46,26 +53,35 @@ The CLI SHALL consume the harness-exported reference catalog and install-plan in
 
 ### Requirement: Downloads are verified and dataset activation is atomic
 
-For each selected dataset, the CLI SHALL compute a missing-byte plan, download artifacts to installer-owned `.part` paths, verify each artifact's expected byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts verify. It SHALL then atomically write a harness-compatible active receipt. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content.
+For each selected dataset, the CLI SHALL download artifacts to installer-owned `.part` paths, verify every `pinned` artifact against the catalog's byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts are accounted for. It SHALL then atomically write a harness-compatible active receipt recording the size and digest **observed** for each artifact. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content, and SHALL NOT leave orphaned staging directories behind.
+
+Resuming a partial transfer SHALL be attempted only for a `pinned` artifact. An `unpinned` artifact SHALL be re-fetched whole, because its upstream may have replaced the file since the partial was written and appending to it would splice two different files into one that verifies against nothing.
 
 #### Scenario: Complete dataset activates
 
-- **WHEN** every artifact downloads and matches its catalog size and digest
-- **THEN** the complete immutable version appears under `managed/<id>/<version>` and its receipt records exactly those verified files
+- **WHEN** every artifact downloads, and every `pinned` artifact matches its catalog size and digest
+- **THEN** the complete version appears under `managed/<id>/<version>` and its receipt records the observed size, digest, and integrity class of each file
 
 #### Scenario: Digest mismatch preserves prior version
 
-- **WHEN** any downloaded artifact fails size or SHA-256 verification
+- **WHEN** any `pinned` artifact fails size or SHA-256 verification
 - **THEN** the command fails, the staged version is not activated, and the prior active receipt and version remain unchanged
 
-#### Scenario: Interrupted download is resumable but not visible
+#### Scenario: Interrupted pinned download is resumable but not visible
 
-- **WHEN** a transfer stops after writing part of an artifact
-- **THEN** resumable installer-owned partial state may remain, but no partial dataset appears as active managed reference data
+- **WHEN** a transfer stops after writing part of a `pinned` artifact
+- **THEN** resumable installer-owned partial state may remain and is resumed by range request, but no partial dataset appears as active managed reference data
+
+#### Scenario: A mutable upstream is never resumed into
+
+- **WHEN** a partial `.part` exists for an `unpinned` artifact
+- **THEN** the CLI discards it and fetches the whole file again rather than appending to bytes the upstream may have since replaced
 
 ### Requirement: Reference commands expose install, verification, and path operations
 
-The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show total missing bytes and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against the catalog and receipt and SHALL report missing, modified, and valid states without modifying them.
+The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show the missing size and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against their receipt and SHALL report missing, modified, and valid states without modifying them, naming for each file which guarantee was checked — the catalog's checksum for a `pinned` file, the checksum recorded at install for an `unpinned` one.
+
+`inflexa refs download --force` SHALL re-fetch and re-activate a dataset even when its active install is intact. This is the supported way to refresh an `unpinned` dataset, whose upstream may have moved on in a way no local inspection can detect.
 
 #### Scenario: Interactive selection shows cost before consent
 
@@ -75,7 +91,12 @@ The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `in
 #### Scenario: Verification detects manual damage
 
 - **WHEN** an active managed file has been edited or removed
-- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid and changes no bytes
+- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid, names the repair command, exits non-zero, and changes no bytes
+
+#### Scenario: A mutable upstream is refreshed on request
+
+- **WHEN** an `unpinned` dataset is installed and intact, and the user runs `refs download <id> --force`
+- **THEN** the CLI re-fetches from the upstream and re-activates, replacing the receipt with the newly observed digests
 
 ### Requirement: Setup reuses the reference download handler
 
@@ -102,7 +123,14 @@ Headless setup SHALL download no reference bytes unless dataset ids and non-inte
 
 Cheap status inspection SHALL derive managed state from the catalog, receipts, and filesystem and SHALL report at least missing, installed, update available, partial, and invalid-receipt states. Absence or inconsistency SHALL NOT crash the CLI. Re-running download for a selected dataset SHALL repair installer-owned content through normal staged verification and activation.
 
+Deciding whether an install may be skipped as already-complete SHALL compare digests, not sizes. A size-only check cannot see a same-size corruption — a flipped byte, a bad sector, a hand-edit — and would skip the repair while reporting the dataset as installed, which is a false claim of success. Cheap listing MAY remain size-only, but an install SHALL NOT be skipped on that basis.
+
 #### Scenario: Receipt references a deleted file
 
 - **WHEN** a receipt names a managed file that is absent
 - **THEN** list reports a partial or damaged state and download can repair it without database surgery or changes to user content
+
+#### Scenario: Same-size corruption is repaired, not skipped
+
+- **WHEN** an installed artifact is corrupted in place without changing its byte length, and download is re-run for that dataset
+- **THEN** the CLI detects the digest mismatch, re-downloads and re-activates the dataset, and never reports it as already installed with nothing transferred

--- a/cli/openspec/specs/reference-data-provisioning/spec.md
+++ b/cli/openspec/specs/reference-data-provisioning/spec.md
@@ -1,0 +1,108 @@
+# reference-data-provisioning Specification
+
+## Purpose
+
+Define the CLI's public reference-store location, catalog-driven installation,
+verification, setup integration, and ownership boundary for user-provided data.
+
+## Requirements
+
+### Requirement: The CLI exposes a stable public reference-store directory
+
+The CLI SHALL resolve a `refsDir` under the platform data home at `<data-home>/inflexa/refs`. Root help SHALL list the directory in its Paths table, and `inflexa refs path` SHALL print the exact resolved path without creating it. Deliberate setup or reference-download actions SHALL create the directory and a documented `user/` namespace for arbitrary user-provided reference data.
+
+#### Scenario: User discovers the host path
+
+- **WHEN** the user runs root help or `inflexa refs path`
+- **THEN** the CLI displays the host directory whose contents sandboxes see at `/mnt/refs`
+
+#### Scenario: Path inspection does not litter
+
+- **WHEN** `inflexa refs path` runs before the store exists
+- **THEN** it prints the path and creates no directory or metadata
+
+### Requirement: Managed and user-owned namespaces have separate ownership
+
+The CLI installer SHALL write catalog-managed datasets only beneath `managed/<dataset-id>/<version>` and its own metadata only beneath `.inflexa/`. It SHALL recommend `user/` for arbitrary additions and SHALL NOT overwrite, adopt, verify as managed, prune, or delete content under `user/` or unknown top-level paths.
+
+#### Scenario: User-added reference survives managed update
+
+- **WHEN** a user places files under `refs/user/custom-atlas/` and updates a catalog dataset
+- **THEN** the installer changes only its managed dataset/version and receipt paths and leaves the custom atlas byte-for-byte untouched
+
+### Requirement: Reference options come from the harness catalog
+
+The CLI SHALL consume the harness-exported reference catalog and install-plan interface rather than defining a second list. `inflexa refs list` SHALL show each catalog dataset's id, version, description, total bytes, source and licensing links, recommendation/group metadata, and local state. The CLI's artifact adapter SHALL map plan artifact keys to the public distribution endpoint without changing their content identity or destination paths.
+
+#### Scenario: Catalog option is visible with links
+
+- **WHEN** `inflexa refs list` runs
+- **THEN** every downloadable option from the installed harness version is shown with its upstream source/licensing links and local installation state
+
+#### Scenario: Unknown id is rejected before download
+
+- **WHEN** `inflexa refs download unknown-id` runs
+- **THEN** the CLI reports the unknown id and available ids and performs no network or filesystem mutation
+
+### Requirement: Downloads are verified and dataset activation is atomic
+
+For each selected dataset, the CLI SHALL compute a missing-byte plan, download artifacts to installer-owned `.part` paths, verify each artifact's expected byte size and SHA-256 digest, stage every final file beneath one attempt directory, and activate the complete version directory only after all artifacts verify. It SHALL then atomically write a harness-compatible active receipt. A failed or interrupted attempt SHALL leave any previously active receipt/version unchanged and SHALL never expose a partially staged dataset as active managed content.
+
+#### Scenario: Complete dataset activates
+
+- **WHEN** every artifact downloads and matches its catalog size and digest
+- **THEN** the complete immutable version appears under `managed/<id>/<version>` and its receipt records exactly those verified files
+
+#### Scenario: Digest mismatch preserves prior version
+
+- **WHEN** any downloaded artifact fails size or SHA-256 verification
+- **THEN** the command fails, the staged version is not activated, and the prior active receipt and version remain unchanged
+
+#### Scenario: Interrupted download is resumable but not visible
+
+- **WHEN** a transfer stops after writing part of an artifact
+- **THEN** resumable installer-owned partial state may remain, but no partial dataset appears as active managed reference data
+
+### Requirement: Reference commands expose install, verification, and path operations
+
+The CLI SHALL provide `inflexa refs list`, `inflexa refs download [ids...]`, `inflexa refs verify [ids...]`, and `inflexa refs path`. Interactive download with no ids SHALL offer a multi-select. Before transfer, download SHALL show total missing bytes and require confirmation unless explicit non-interactive consent is present. Verify SHALL hash active managed files against the catalog and receipt and SHALL report missing, modified, and valid states without modifying them.
+
+#### Scenario: Interactive selection shows cost before consent
+
+- **WHEN** an interactive user selects multiple missing datasets
+- **THEN** the CLI shows the combined missing download size and begins transfer only after confirmation
+
+#### Scenario: Verification detects manual damage
+
+- **WHEN** an active managed file has been edited or removed
+- **THEN** `inflexa refs verify` reports the affected dataset and file as invalid and changes no bytes
+
+### Requirement: Setup reuses the reference download handler
+
+Interactive `inflexa setup` SHALL deliberately create the reference-store and `user/` directories, inspect catalog installation state, and offer missing or updateable datasets with their sizes through the same headless download operation used by `inflexa refs download`. Declining or selecting nothing SHALL continue setup. A selected installation failure SHALL fail setup visibly.
+
+Headless setup SHALL download no reference bytes unless dataset ids and non-interactive consent are explicit. Without them it SHALL print the reference-store path and an actionable `inflexa refs download` command and continue.
+
+#### Scenario: Setup and explicit command share one installer
+
+- **WHEN** setup installs a selected dataset
+- **THEN** it produces the same managed layout, verification, activation, and receipt as `inflexa refs download` for that id
+
+#### Scenario: Headless setup does not silently download
+
+- **WHEN** setup runs without a TTY and without explicit reference ids and consent
+- **THEN** it downloads nothing, prints how to install references later, and continues
+
+#### Scenario: User declines optional references
+
+- **WHEN** an interactive user declines or selects no catalog datasets
+- **THEN** setup leaves the public store available for manual additions and continues successfully
+
+### Requirement: Missing or inconsistent managed state is recoverable
+
+Cheap status inspection SHALL derive managed state from the catalog, receipts, and filesystem and SHALL report at least missing, installed, update available, partial, and invalid-receipt states. Absence or inconsistency SHALL NOT crash the CLI. Re-running download for a selected dataset SHALL repair installer-owned content through normal staged verification and activation.
+
+#### Scenario: Receipt references a deleted file
+
+- **WHEN** a receipt names a managed file that is absent
+- **THEN** list reports a partial or damaged state and download can repair it without database surgery or changes to user content

--- a/cli/src/cli/cli.test.ts
+++ b/cli/src/cli/cli.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
+import { env } from "../lib/env.ts";
 import { runCli } from "../test_support/cli.ts";
+import { assertTestSandbox } from "../test_support/sandbox.ts";
 
 // e2e of the commander registry surface — help text and the error/exit-code contract. No DB needed:
 // --help exits before any action, and unknown option/command errors during parse.
@@ -11,6 +15,50 @@ describe("inflexa help & usage (e2e)", () => {
         expect(result.stdout).toContain("Usage: inflexa");
         expect(result.stdout).toContain("project");
         expect(result.stdout).toContain("sessions");
+        expect(result.stdout).toContain("refs");
+        expect(result.stdout).toContain("reference data mounted read-only in sandboxes at /mnt/refs");
+    });
+
+    test("refs path prints the exact public path without creating it", async () => {
+        const result = runCli(["refs", "path"]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toContain("/inflexa/refs");
+        expect(await Bun.file(result.stdout.trim()).exists()).toBe(false);
+    });
+
+    test("unknown reference ids fail before filesystem or network work", () => {
+        const result = runCli(["refs", "download", "unknown", "--yes"]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("Unknown reference dataset");
+    });
+
+    test("refs list explains custom content and catalog contributions", () => {
+        const result = runCli(["refs", "list"]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("Add arbitrary references under");
+        expect(result.stdout).toContain("Open a PR");
+    });
+
+    test("refs list identifies user-owned content without adopting it", () => {
+        assertTestSandbox(env.refsDir);
+        const custom = join(env.refsDir, "user", "custom.fa");
+        mkdirSync(join(env.refsDir, "user"), { recursive: true });
+        writeFileSync(custom, "custom");
+        try {
+            const result = runCli(["refs", "list"]);
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("user/custom.fa");
+            expect(result.stdout).toContain("left untouched");
+        } finally {
+            assertTestSandbox(env.refsDir);
+            rmSync(env.refsDir, { recursive: true, force: true });
+        }
+    });
+
+    test("refs verify with no active catalog receipts reports an empty verification set", () => {
+        const result = runCli(["refs", "verify"]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("No installed catalog reference datasets to verify.");
     });
 
     test("an unknown option exits non-zero", () => {

--- a/cli/src/cli/cli.test.ts
+++ b/cli/src/cli/cli.test.ts
@@ -32,11 +32,23 @@ describe("inflexa help & usage (e2e)", () => {
         expect(result.stderr).toContain("Unknown reference dataset");
     });
 
-    test("refs list explains custom content and catalog contributions", () => {
+    test("refs list explains custom content, integrity, and catalog contributions", () => {
         const result = runCli(["refs", "list"]);
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("Add arbitrary references under");
         expect(result.stdout).toContain("Open a PR");
+        // Nothing is re-hosted: each dataset states the integrity guarantee its own upstream can offer.
+        expect(result.stdout).toContain("Integrity: pinned — verified against the checksums in the catalog");
+        expect(result.stdout).toContain("Integrity: unpinned — upstream is rebuilt in place; verified against what you downloaded");
+        expect(result.stdout).toContain("nothing is mirrored or re-hosted here");
+    });
+
+    test("refs download offers --force to repair damage and refresh mutable upstreams", () => {
+        const result = runCli(["refs", "download", "--help"]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("--yes");
+        expect(result.stdout).toContain("--force");
+        expect(result.stdout).toContain("Re-fetch even when already installed");
     });
 
     test("refs list identifies user-owned content without adopting it", () => {

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -362,9 +362,10 @@ refs.command("list")
     });
 
 refs.command("download [ids...]")
-    .description("Download and verify selected catalog datasets")
+    .description("Download selected catalog datasets from their upstream publishers and verify them")
     .option("--yes", "Skip the download confirmation")
-    .action(async (ids: string[], options: { yes?: boolean }) => {
+    .option("--force", "Re-fetch even when already installed — repairs damage and refreshes mutable upstreams")
+    .action(async (ids: string[], options: { yes?: boolean; force?: boolean }) => {
         const { runRefsDownload } = await import("../modules/refs/commands.ts");
         await runRefsDownload(ids, options);
     });

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -316,9 +316,22 @@ cli.command("setup")
     .option("--no-postgres", "Skip the Postgres provisioning step")
     .option("--force", "Re-pull images even if they are already cached")
     .option("--embeddings <mode>", "Configure embeddings non-interactively: local|api-key|off")
+    .option("--refs <ids>", "Download comma-separated reference dataset ids")
+    .option("--yes", "Confirm explicitly selected reference downloads")
     .action(
-        async (options: { connection?: string; provider?: string; auth: boolean; start: boolean; postgres: boolean; force?: boolean; embeddings?: string }) => {
+        async (options: {
+            connection?: string;
+            provider?: string;
+            auth: boolean;
+            start: boolean;
+            postgres: boolean;
+            force?: boolean;
+            embeddings?: string;
+            refs?: string;
+            yes?: boolean;
+        }) => {
             const { setup } = await import("../modules/infra/setup.ts");
+            const { parseReferenceIds } = await import("../modules/refs/commands.ts");
             const embeddings = parseEmbeddingMode(options.embeddings);
             if (embeddings === null) {
                 console.error("\n  `--embeddings` must be one of: local, api-key, off.\n");
@@ -333,9 +346,42 @@ cli.command("setup")
                 force: options.force ?? false,
                 postgres: options.postgres,
                 embeddings,
+                refs: parseReferenceIds(options.refs),
+                yes: options.yes,
             });
         },
     );
+
+const refs = cli.command("refs").description("Manage reference data mounted read-only in sandboxes at /mnt/refs");
+
+refs.command("list")
+    .description("List catalog options, links, sizes, and local state")
+    .action(async () => {
+        const { runRefsList } = await import("../modules/refs/commands.ts");
+        await runRefsList();
+    });
+
+refs.command("download [ids...]")
+    .description("Download and verify selected catalog datasets")
+    .option("--yes", "Skip the download confirmation")
+    .action(async (ids: string[], options: { yes?: boolean }) => {
+        const { runRefsDownload } = await import("../modules/refs/commands.ts");
+        await runRefsDownload(ids, options);
+    });
+
+refs.command("verify [ids...]")
+    .description("Verify active managed datasets without changing them")
+    .action(async (ids: string[]) => {
+        const { runRefsVerify } = await import("../modules/refs/commands.ts");
+        await runRefsVerify(ids);
+    });
+
+refs.command("path")
+    .description("Print the public host reference-store path")
+    .action(async () => {
+        const { runRefsPath } = await import("../modules/refs/commands.ts");
+        runRefsPath();
+    });
 
 // The sandbox image: pull a variant (python | python-r) and inspect it. The
 // pulled image bakes the R/Python/conda/node packages at `/mnt/libs/current`, so

--- a/cli/src/lib/env.test.ts
+++ b/cli/src/lib/env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 
 import { devCommandsActive, env, envDoc, isDevelopmentBuild, isUnsandboxedTestRun } from "./env.ts";
 
@@ -99,5 +100,15 @@ describe("INFLEXA_MODEL_API_KEY", () => {
         expect(entry.kind).toBe("var");
         if (entry.kind !== "var") throw new Error("expected a var entry");
         expect(entry.name).toBe("INFLEXA_MODEL_API_KEY");
+    });
+});
+
+describe("reference-data paths", () => {
+    test("refsDir resolves below the platform data home and is documented", () => {
+        const dataHome = process.platform === "win32" ? Bun.env.LOCALAPPDATA : Bun.env.XDG_DATA_HOME;
+        if (dataHome === undefined) throw new Error("test preload must provide the platform data home");
+        expect(env.refsDir).toBe(join(dataHome, "inflexa", "refs"));
+        expect(envDoc.refsDir).toMatchObject({ kind: "path", label: "references" });
+        expect(envDoc.referenceDataBaseUrl).toMatchObject({ kind: "var", name: "INFLEXA_REFERENCE_DATA_BASE_URL" });
     });
 });

--- a/cli/src/lib/env.test.ts
+++ b/cli/src/lib/env.test.ts
@@ -109,6 +109,8 @@ describe("reference-data paths", () => {
         if (dataHome === undefined) throw new Error("test preload must provide the platform data home");
         expect(env.refsDir).toBe(join(dataHome, "inflexa", "refs"));
         expect(envDoc.refsDir).toMatchObject({ kind: "path", label: "references" });
-        expect(envDoc.referenceDataBaseUrl).toMatchObject({ kind: "var", name: "INFLEXA_REFERENCE_DATA_BASE_URL" });
+        // Reference artifacts are fetched from the upstream that publishes them, so there is
+        // no distribution endpoint to configure and no env var that could point one elsewhere.
+        expect(Object.keys(envDoc)).not.toContain("referenceDataBaseUrl");
     });
 });

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -43,7 +43,6 @@ const configVar = process.platform === "win32" ? "APPDATA" : "XDG_CONFIG_HOME";
 const logLevelVar = "INFLEXA_LOG_LEVEL";
 const otelEndpointVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
 const modelApiKeyVar = "INFLEXA_MODEL_API_KEY";
-const referenceDataBaseUrlVar = "INFLEXA_REFERENCE_DATA_BASE_URL";
 
 function dataDir(): string {
     const base = process.env[dataVar];
@@ -198,11 +197,6 @@ export const env = Object.freeze({
      */
     modelApiKey: process.env[modelApiKeyVar],
     /**
-     * Optional public distribution root for opaque catalog artifact keys. Release packaging may
-     * configure it without putting deployment URLs in the host-neutral harness catalog.
-     */
-    referenceDataBaseUrl: process.env[referenceDataBaseUrlVar],
-    /**
      * CLIProxyAPI networking — internal constants, deliberately excluded from
      * envDoc/--help (see the Exclude on envDoc below).
      */
@@ -287,11 +281,6 @@ export const envDoc: Readonly<
         kind: "var",
         name: modelApiKeyVar,
         description: 'API key for a direct model connection (config `models.connection.mode: "direct"`); unused with the default managed proxy',
-    },
-    referenceDataBaseUrl: {
-        kind: "var",
-        name: referenceDataBaseUrlVar,
-        description: "public distribution base for catalog reference-data artifacts",
     },
 });
 

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -43,6 +43,7 @@ const configVar = process.platform === "win32" ? "APPDATA" : "XDG_CONFIG_HOME";
 const logLevelVar = "INFLEXA_LOG_LEVEL";
 const otelEndpointVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
 const modelApiKeyVar = "INFLEXA_MODEL_API_KEY";
+const referenceDataBaseUrlVar = "INFLEXA_REFERENCE_DATA_BASE_URL";
 
 function dataDir(): string {
     const base = process.env[dataVar];
@@ -144,6 +145,11 @@ export const env = Object.freeze({
     dbPath: join(dataDir(), "inflexa", "agent.db"),
     logDir: join(dataDir(), "inflexa", "logs"),
     /**
+     * Public reference-data store. Deliberate setup/download actions create this path; passive
+     * runtime composition only checks whether it exists before offering it to the harness.
+     */
+    refsDir: join(dataDir(), "inflexa", "refs"),
+    /**
      * Advisory instance locks: `<dataDir>/inflexa/locks/<key>.lock`, keyed by an analysis id (one
      * inflexa process may have an analysis open at a time) or a fixed sentinel for the embedded harness
      * runtime (one DBOS engine per machine). The lock files coordinate that across instances.
@@ -192,6 +198,11 @@ export const env = Object.freeze({
      */
     modelApiKey: process.env[modelApiKeyVar],
     /**
+     * Optional public distribution root for opaque catalog artifact keys. Release packaging may
+     * configure it without putting deployment URLs in the host-neutral harness catalog.
+     */
+    referenceDataBaseUrl: process.env[referenceDataBaseUrlVar],
+    /**
      * CLIProxyAPI networking — internal constants, deliberately excluded from
      * envDoc/--help (see the Exclude on envDoc below).
      */
@@ -239,6 +250,12 @@ export const envDoc: Readonly<
 > = Object.freeze({
     dbPath: { kind: "path", label: "database", description: "saved sessions (SQLite)", baseVar: dataVar },
     logDir: { kind: "path", label: "logs", description: "log files, rotated daily, 7-day retention", baseVar: dataVar },
+    refsDir: {
+        kind: "path",
+        label: "references",
+        description: "reference data mounted read-only in sandboxes at /mnt/refs",
+        baseVar: dataVar,
+    },
     locksDir: { kind: "path", label: "locks", description: "advisory per-analysis instance locks", baseVar: dataVar },
     modelDir: { kind: "path", label: "models", description: "local embedding GGUF models, downloaded by `inflexa setup --embeddings`", baseVar: dataVar },
     embeddingModelPath: {
@@ -270,6 +287,11 @@ export const envDoc: Readonly<
         kind: "var",
         name: modelApiKeyVar,
         description: 'API key for a direct model connection (config `models.connection.mode: "direct"`); unused with the default managed proxy',
+    },
+    referenceDataBaseUrl: {
+        kind: "var",
+        name: referenceDataBaseUrlVar,
+        description: "public distribution base for catalog reference-data artifacts",
     },
 });
 

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync } from "node:fs";
 import { ok, err, type Result } from "neverthrow";
 import {
     bootHarness,
@@ -65,6 +65,30 @@ import {
     type AgentBackend,
 } from "./run_deps.ts";
 import { clearAgentSwitch, createSwappableProvider, installAgentSwitch } from "./agent_switch.ts";
+
+/**
+ * Return the reference-store bind source only when it already exists. This existence gate is
+ * deliberately pure/injectable so runtime boot never asks Docker to create a missing host path.
+ */
+export function existingRefStorePath(path: string, isDirectory: (candidate: string) => boolean = existingDirectory): string | undefined {
+    return isDirectory(path) ? path : undefined;
+}
+
+/** Build the optional sandbox-client reference mount fragment, omitting a missing source entirely. */
+export function existingRefStoreConfig(path: string, isDirectory: (candidate: string) => boolean = existingDirectory): { readonly refStorePath?: string } {
+    const refStorePath = existingRefStorePath(path, isDirectory);
+    return refStorePath === undefined ? {} : { refStorePath };
+}
+
+function existingDirectory(path: string): boolean {
+    try {
+        // Reject symlinks as bind authorities: the configured path should itself be the deliberately
+        // created public store, not an indirection that may later move outside user expectations.
+        return lstatSync(path).isDirectory();
+    } catch {
+        return false;
+    }
+}
 
 // The embedded-harness composition root. Boots lazily on the first profile
 // trigger (never from a passive flow — no-litter policy) and holds a process
@@ -579,6 +603,7 @@ async function bootHarnessRuntimeOnce(
             // pull time). Managed still mounts the tarballs via its PVC — that
             // lives in infra/harness config, not here.
             image: cfg.sandboxImage,
+            ...existingRefStoreConfig(env.refsDir),
             resourceLimits: cfg.resourcePolicy.perStep,
             resolveWorkspaceRoot,
         });

--- a/cli/src/modules/harness/runtime_refs.test.ts
+++ b/cli/src/modules/harness/runtime_refs.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUIDv7 } from "bun";
+
+import { existingRefStoreConfig, existingRefStorePath } from "./runtime.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("existingRefStorePath", () => {
+    test("accepts exactly an existing real directory without creating a missing path", async () => {
+        const root = join(tmpdir(), `refs-runtime-${randomUUIDv7()}`);
+        const missing = join(root, "missing");
+        const directory = join(root, "directory");
+        const file = join(root, "file");
+        const link = join(root, "link");
+        roots.push(root);
+        mkdirSync(directory, { recursive: true });
+        writeFileSync(file, "not a directory");
+        symlinkSync(directory, link);
+
+        expect(existingRefStorePath(directory)).toBe(directory);
+        expect(existingRefStoreConfig(directory)).toEqual({ refStorePath: directory });
+        expect(existingRefStorePath(file)).toBeUndefined();
+        expect(existingRefStorePath(link)).toBeUndefined();
+        expect(existingRefStorePath(missing)).toBeUndefined();
+        expect(existingRefStoreConfig(missing)).toEqual({});
+        expect(await Bun.file(missing).exists()).toBe(false);
+    });
+});

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -38,6 +38,10 @@ type SetupOptions = {
     postgres: boolean;
     /** Preselected embedding mode from `--embeddings`; overrides the interactive prompt. */
     embeddings?: "local" | "api-key" | "off";
+    /** Explicit comma-separated reference ids parsed at the command boundary. */
+    refs?: readonly string[];
+    /** Explicit consent for selected reference downloads. */
+    yes?: boolean;
 };
 
 export async function setup(options: SetupOptions): Promise<void> {
@@ -211,6 +215,21 @@ export async function setup(options: SetupOptions): Promise<void> {
         const embedResult = await runEmbeddingSetup(process.stdin.isTTY, options.embeddings);
         if (embedResult.isErr()) {
             log.error(`Embedding setup: ${embedResult.error.message}`);
+            process.exitCode = 1;
+            return;
+        }
+
+        // --- reference data ---
+        // The setup offer and `inflexa refs download` share one handler. Creating the public
+        // store/user namespace is deliberate here; no passive runtime path creates it.
+        const { runReferenceSetup } = await import("../refs/commands.ts");
+        const refsResult = await runReferenceSetup({
+            interactive: process.stdin.isTTY,
+            ...(options.refs === undefined ? {} : { ids: options.refs }),
+            ...(options.yes === undefined ? {} : { yes: options.yes }),
+        });
+        if (refsResult.isErr()) {
+            log.error(`Reference-data setup: ${refsResult.error.message}`);
             process.exitCode = 1;
             return;
         }

--- a/cli/src/modules/refs/commands.test.ts
+++ b/cli/src/modules/refs/commands.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync, statSync } from "node:fs";
+
+import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
+import { err, ok } from "neverthrow";
+
+import { env } from "../../lib/env.ts";
+import { assertTestSandbox } from "../../test_support/sandbox.ts";
+import { downloadReferences, formatReferenceBytes, parseReferenceIds, runReferenceSetup } from "./commands.ts";
+import type { ReferenceCatalogSource } from "./store.ts";
+
+const fixture: ReferenceDataCatalog = {
+    version: REFERENCE_DATA_CATALOG_VERSION,
+    datasets: [
+        {
+            id: "demo",
+            version: "1",
+            title: "Demo",
+            description: "Fixture",
+            sourceUrl: "https://example.test/source",
+            license: { identifier: "CC0-1.0" },
+            recommendation: { group: "testing", recommended: true },
+            artifacts: [{ key: "demo/file", path: "file", bytes: 5, sha256: "8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8" }],
+        },
+    ],
+};
+
+const fixtureSource: ReferenceCatalogSource = {
+    catalog: fixture,
+    resolveInstallPlan: (ids) => {
+        const unknown = ids.find((id) => id !== "demo");
+        if (unknown !== undefined) return err(new UnknownReferenceDatasetError(unknown, ["demo"]));
+        const dataset = fixture.datasets[0];
+        return ok({ catalogVersion: fixture.version, datasets: ids.length === 0 || dataset === undefined ? [] : [{ ...dataset, installPath: "demo/1" }] });
+    },
+};
+
+afterEach(() => {
+    assertTestSandbox(env.refsDir);
+    rmSync(env.refsDir, { recursive: true, force: true });
+});
+
+describe("reference command policy", () => {
+    test("parses stable selections and human-readable sizes", () => {
+        expect(parseReferenceIds("demo, other, demo")).toEqual(["demo", "other"]);
+        expect(formatReferenceBytes(1024)).toBe("1.0 KiB");
+    });
+
+    test("headless downloads require ids and explicit consent before mutation", async () => {
+        assertTestSandbox(env.refsDir);
+        const noIds = await downloadReferences({ ids: [], interactive: false, source: fixtureSource });
+        expect(noIds.isErr()).toBe(true);
+        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: fixtureSource });
+        expect(noConsent._unsafeUnwrapErr().message).toContain("--yes");
+        expect(await Bun.file(env.refsDir).exists()).toBe(false);
+    });
+
+    test("a declined interactive download activates nothing", async () => {
+        const result = await downloadReferences({
+            ids: ["demo"],
+            interactive: true,
+            source: fixtureSource,
+            confirmDownload: async () => false,
+        });
+        expect(result._unsafeUnwrap()).toMatchObject({ declined: true, installed: [] });
+        expect(await Bun.file(env.refsDir).exists()).toBe(false);
+    });
+
+    test("headless setup creates the public/user namespace but downloads nothing without selection", async () => {
+        assertTestSandbox(env.refsDir);
+        const result = await runReferenceSetup({ interactive: false });
+        expect(result.isOk()).toBe(true);
+        expect(statSync(`${env.refsDir}/user`).isDirectory()).toBe(true);
+        expect(await Bun.file(`${env.refsDir}/managed`).exists()).toBe(false);
+    });
+
+    test("headless setup with ids but no consent prints guidance and continues without transfer", async () => {
+        const result = await runReferenceSetup({ interactive: false, ids: ["demo"] });
+        expect(result.isOk()).toBe(true);
+        expect(await Bun.file(`${env.refsDir}/managed`).exists()).toBe(false);
+    });
+
+    test("an explicit selected setup failure is returned visibly through the shared handler", async () => {
+        const result = await runReferenceSetup({ interactive: false, ids: ["unknown"], yes: true });
+        expect(result._unsafeUnwrapErr().type).toBe("unknown_dataset");
+        expect(await Bun.file(`${env.refsDir}/managed`).exists()).toBe(false);
+    });
+});

--- a/cli/src/modules/refs/commands.test.ts
+++ b/cli/src/modules/refs/commands.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { rmSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
 import { err, ok } from "neverthrow";
@@ -7,33 +9,69 @@ import { err, ok } from "neverthrow";
 import { env } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
 import { downloadReferences, formatReferenceBytes, parseReferenceIds, runReferenceSetup } from "./commands.ts";
-import type { ReferenceCatalogSource } from "./store.ts";
+import { referenceStorePaths, type ReferenceCatalogSource } from "./store.ts";
 
-const fixture: ReferenceDataCatalog = {
-    version: REFERENCE_DATA_CATALOG_VERSION,
-    datasets: [
-        {
-            id: "demo",
-            version: "1",
-            title: "Demo",
-            description: "Fixture",
-            sourceUrl: "https://example.test/source",
-            license: { identifier: "CC0-1.0" },
-            recommendation: { group: "testing", recommended: true },
-            artifacts: [{ key: "demo/file", path: "file", bytes: 5, sha256: "8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8" }],
+function sha(bytes: string): string {
+    return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Catalog fixtures. Every test here stops before the transfer (no ids, no consent, declined, or an
+ * unknown id), so no `fetch` seam is needed — nothing in this file may ever reach an upstream.
+ */
+function catalog(artifacts: ReferenceDataCatalog["datasets"][number]["artifacts"]): ReferenceDataCatalog {
+    return {
+        version: REFERENCE_DATA_CATALOG_VERSION,
+        datasets: [
+            {
+                id: "demo",
+                version: "1",
+                title: "Demo",
+                description: "Fixture",
+                sourceUrl: "https://example.test/source",
+                license: { identifier: "CC0-1.0" },
+                recommendation: { group: "testing", recommended: true },
+                artifacts,
+            },
+        ],
+    };
+}
+
+const PINNED_ARTIFACT = { integrity: "pinned", path: "file", url: "https://upstream.test/file", bytes: 5, sha256: sha("alpha") } as const;
+const UNPINNED_ARTIFACT = { integrity: "unpinned", path: "mutable", url: "https://upstream.test/mutable" } as const;
+
+function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
+    return {
+        catalog: value,
+        resolveInstallPlan: (ids) => {
+            const unknown = ids.find((id) => id !== "demo");
+            if (unknown !== undefined) return err(new UnknownReferenceDatasetError(unknown, ["demo"]));
+            const dataset = value.datasets[0];
+            return ok({ catalogVersion: value.version, datasets: ids.length === 0 || dataset === undefined ? [] : [{ ...dataset, installPath: "demo/1" }] });
         },
-    ],
-};
+    };
+}
 
-const fixtureSource: ReferenceCatalogSource = {
-    catalog: fixture,
-    resolveInstallPlan: (ids) => {
-        const unknown = ids.find((id) => id !== "demo");
-        if (unknown !== undefined) return err(new UnknownReferenceDatasetError(unknown, ["demo"]));
-        const dataset = fixture.datasets[0];
-        return ok({ catalogVersion: fixture.version, datasets: ids.length === 0 || dataset === undefined ? [] : [{ ...dataset, installPath: "demo/1" }] });
-    },
-};
+const pinnedSource = source(catalog([PINNED_ARTIFACT]));
+
+/** Activate the pinned fixture on disk exactly as a completed install would leave it. */
+function seedIntactInstall(): void {
+    assertTestSandbox(env.refsDir);
+    const paths = referenceStorePaths(env.refsDir);
+    mkdirSync(join(paths.managed, "demo", "1"), { recursive: true });
+    mkdirSync(paths.receipts, { recursive: true });
+    writeFileSync(join(paths.managed, "demo", "1", "file"), "alpha");
+    writeFileSync(
+        join(paths.receipts, "demo.json"),
+        JSON.stringify({
+            version: 1,
+            datasetId: "demo",
+            datasetVersion: "1",
+            activatedAt: "2026-07-14T12:00:00.000Z",
+            artifacts: [{ path: "file", bytes: 5, sha256: sha("alpha"), integrity: "pinned" }],
+        }),
+    );
+}
 
 afterEach(() => {
     assertTestSandbox(env.refsDir);
@@ -48,21 +86,43 @@ describe("reference command policy", () => {
 
     test("headless downloads require ids and explicit consent before mutation", async () => {
         assertTestSandbox(env.refsDir);
-        const noIds = await downloadReferences({ ids: [], interactive: false, source: fixtureSource });
+        const noIds = await downloadReferences({ ids: [], interactive: false, source: pinnedSource });
         expect(noIds.isErr()).toBe(true);
-        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: fixtureSource });
-        expect(noConsent._unsafeUnwrapErr().message).toContain("--yes");
+        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
+        expect(noConsent._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 
+    test("an unpinned artifact is quoted as upstream-determined rather than given an invented size", async () => {
+        const unsized = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([UNPINNED_ARTIFACT])) });
+        expect(unsized._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+
+        const mixed = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([PINNED_ARTIFACT, UNPINNED_ARTIFACT])) });
+        expect(mixed._unsafeUnwrapErr().message).toBe("Downloading 5 B + 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+    });
+
+    test("--force turns an intact install back into bytes to fetch; without it there is nothing to do", async () => {
+        seedIntactInstall();
+        const intact = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
+        expect(intact._unsafeUnwrapErr().message).toBe("Downloading 0 B requires explicit consent; re-run with --yes.");
+
+        const forced = await downloadReferences({ ids: ["demo"], interactive: false, force: true, source: pinnedSource });
+        expect(forced._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
+    });
+
     test("a declined interactive download activates nothing", async () => {
+        const questions: string[] = [];
         const result = await downloadReferences({
             ids: ["demo"],
             interactive: true,
-            source: fixtureSource,
-            confirmDownload: async () => false,
+            source: pinnedSource,
+            confirmDownload: async (question) => {
+                questions.push(question);
+                return false;
+            },
         });
         expect(result._unsafeUnwrap()).toMatchObject({ declined: true, installed: [] });
+        expect(questions).toEqual([`Download 5 B of reference data into ${env.refsDir}?`]);
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -144,11 +144,14 @@ export async function downloadReferences(
     let ids = options.ids;
     if (ids.length === 0) {
         if (!interactive) {
+            // Not `unknown_dataset`: nothing was requested, so there is no unknown id to name. That
+            // variant carries the id that missed, and an empty string there is a lie a caller could
+            // pattern-match on.
             return err({
-                type: "unknown_dataset",
-                unknownId: "",
-                availableIds: catalog.datasets.map((dataset) => dataset.id),
-                message: "No reference ids supplied. Pass catalog ids explicitly on a non-interactive terminal.",
+                type: "download_failed",
+                message: `No reference ids supplied. Pass catalog ids explicitly on a non-interactive terminal. Available ids: ${catalog.datasets
+                    .map((dataset) => dataset.id)
+                    .join(", ")}`,
             });
         }
         let chosen: readonly string[] | undefined;
@@ -275,9 +278,7 @@ export async function runRefsVerify(ids: readonly string[]): Promise<void> {
             }
             const damaged = verified.filter((dataset) => dataset.state !== "valid");
             if (damaged.length > 0) {
-                console.error(
-                    `\nRe-download to repair: inflexa refs download ${damaged.map((dataset) => dataset.datasetId).join(" ")} --force --yes`,
-                );
+                console.error(`\nRe-download to repair: inflexa refs download ${damaged.map((dataset) => dataset.datasetId).join(" ")} --force --yes`);
                 process.exitCode = 1;
             }
         },

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -9,8 +9,8 @@ import {
     inspectReferenceStore,
     installReferenceDatasets,
     referenceDownloadBytes,
-    resolvePublicArtifactUrl,
     verifyReferenceDatasets,
+    type ReferenceDownloadEstimate,
     type ReferenceInstallOutcome,
     type ReferenceCatalogSource,
     type ReferenceProvisionError,
@@ -22,6 +22,8 @@ export type ReferenceDownloadOptions = {
     readonly ids: readonly string[];
     /** Explicit non-interactive consent and interactive confirmation bypass. */
     readonly yes?: boolean;
+    /** Re-fetch even when the active install is intact; the only way to refresh a mutable upstream. */
+    readonly force?: boolean;
     /** Whether terminal prompts may be used. */
     readonly interactive?: boolean;
     /** Matching catalog/plan seam for offline tests. */
@@ -69,12 +71,54 @@ export function formatReferenceBytes(bytes: number): string {
     return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
 }
 
-function totalBytes(dataset: ReferenceDataCatalog["datasets"][number]): number {
-    return dataset.artifacts.reduce((sum, artifact) => sum + artifact.bytes, 0);
+type ReferenceDatasetSize = {
+    /** Bytes across artifacts the catalog can size. */
+    readonly bytes: number;
+    /** Artifacts whose size only the mutable upstream knows. */
+    readonly unsized: number;
+};
+
+function datasetSize(dataset: ReferenceDataCatalog["datasets"][number]): ReferenceDatasetSize {
+    let bytes = 0;
+    let unsized = 0;
+    for (const artifact of dataset.artifacts) {
+        if (artifact.integrity === "pinned") bytes += artifact.bytes;
+        else unsized += 1;
+    }
+    return { bytes, unsized };
+}
+
+/** Render a size the catalog may only partly know, without ever inventing a number. */
+function formatReferenceSize(size: ReferenceDatasetSize): string {
+    if (size.unsized === 0) return formatReferenceBytes(size.bytes);
+    const unsized = `${size.unsized} file${size.unsized === 1 ? "" : "s"} of upstream-determined size`;
+    return size.bytes === 0 ? unsized : `${formatReferenceBytes(size.bytes)} + ${unsized}`;
+}
+
+/** The strongest integrity guarantee that holds for every artifact in the dataset. */
+function datasetIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): "pinned" | "unpinned" | "mixed" {
+    const pinned = dataset.artifacts.some((artifact) => artifact.integrity === "pinned");
+    const unpinned = dataset.artifacts.some((artifact) => artifact.integrity === "unpinned");
+    return pinned && unpinned ? "mixed" : unpinned ? "unpinned" : "pinned";
+}
+
+function renderIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): string {
+    switch (datasetIntegrity(dataset)) {
+        case "pinned":
+            return "pinned — verified against the checksums in the catalog";
+        case "unpinned":
+            return "unpinned — upstream is rebuilt in place; verified against what you downloaded";
+        case "mixed":
+            return "mixed — some files are checksum-pinned, others are verified against what you downloaded";
+    }
 }
 
 function renderError(error: ReferenceProvisionError): string {
     return error.message;
+}
+
+function renderEstimate(estimate: ReferenceDownloadEstimate): string {
+    return formatReferenceSize({ bytes: estimate.bytes, unsized: estimate.unsizedArtifacts });
 }
 
 async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string[] | undefined> {
@@ -84,7 +128,7 @@ async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string
         required: false,
         options: catalog.datasets.map((dataset) => ({
             value: dataset.id,
-            label: `${dataset.title} (${formatReferenceBytes(totalBytes(dataset))})`,
+            label: `${dataset.title} (${formatReferenceSize(datasetSize(dataset))})`,
             hint: `${dataset.recommendation.group}${dataset.recommendation.recommended ? ", recommended" : ""}`,
         })),
     });
@@ -117,20 +161,21 @@ export async function downloadReferences(
         ids = chosen;
     }
 
-    const bytes =
-        options.source === undefined ? await referenceDownloadBytes(ids, env.refsDir) : await referenceDownloadBytes(ids, env.refsDir, options.source);
-    if (bytes.isErr()) return err(bytes.error);
-    console.log(`Reference download plan: ${formatReferenceBytes(bytes.value)} missing.`);
+    const install = { force: options.force ?? false };
+    const estimate = await referenceDownloadBytes(ids, env.refsDir, options.source ?? undefined, install);
+    if (estimate.isErr()) return err(estimate.error);
+    const size = renderEstimate(estimate.value);
+    console.log(`Reference download plan: ${size} to fetch from the upstream publishers.`);
     if (!options.yes) {
         if (!interactive) {
             return err({
                 type: "download_failed",
-                message: `Downloading ${formatReferenceBytes(bytes.value)} requires explicit consent; re-run with --yes.`,
+                message: `Downloading ${size} requires explicit consent; re-run with --yes.`,
             });
         }
         let confirmed: boolean;
         try {
-            confirmed = await (options.confirmDownload ?? confirm)(`Download ${formatReferenceBytes(bytes.value)} of reference data into ${env.refsDir}?`);
+            confirmed = await (options.confirmDownload ?? confirm)(`Download ${size} of reference data into ${env.refsDir}?`);
         } catch (cause) {
             return err({ type: "download_failed", message: "Reference download confirmation failed.", cause });
         }
@@ -138,11 +183,14 @@ export async function downloadReferences(
             return ok({ installed: [], declined: true });
         }
     }
-    return installReferenceDatasets(ids, {
-        root: env.refsDir,
-        ...(options.source === undefined ? {} : { source: options.source }),
-        resolveArtifactUrl: (key) => resolvePublicArtifactUrl(key, env.referenceDataBaseUrl),
-    });
+    return installReferenceDatasets(
+        ids,
+        {
+            root: env.refsDir,
+            ...(options.source === undefined ? {} : { source: options.source }),
+        },
+        install,
+    );
 }
 
 /** `inflexa refs path` — print the public path without creating it. */
@@ -160,7 +208,8 @@ export async function runRefsList(): Promise<void> {
                 const dataset = item.dataset;
                 console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}`);
                 console.log(`  ${dataset.title} — ${dataset.description}`);
-                console.log(`  Size: ${formatReferenceBytes(totalBytes(dataset))}`);
+                console.log(`  Size: ${formatReferenceSize(datasetSize(dataset))}`);
+                console.log(`  Integrity: ${renderIntegrity(dataset)}`);
                 console.log(`  Group: ${dataset.recommendation.group}${dataset.recommendation.recommended ? " (recommended)" : ""}`);
                 console.log(`  Source: ${dataset.sourceUrl}`);
                 console.log(`  License: ${dataset.license.identifier}${dataset.license.url ? ` — ${dataset.license.url}` : ""}`);
@@ -168,8 +217,9 @@ export async function runRefsList(): Promise<void> {
             if (inspection.userContent.length > 0) {
                 console.log(`\nUser/unmanaged top-level content: ${inspection.userContent.join(", ")} (left untouched)`);
             }
-            console.log(`\nAdd arbitrary references under ${env.refsDir}/user; sandboxes discover them dynamically.`);
-            console.log("Missing a reusable option? Open a PR adding immutable metadata to the harness reference-data catalog.");
+            console.log("\nEvery dataset is downloaded straight from the third party that publishes it; nothing is mirrored or re-hosted here.");
+            console.log(`Add arbitrary references under ${env.refsDir}/user; sandboxes discover them dynamically.`);
+            console.log("Missing a reusable option? Open a PR adding its upstream URL, provenance, and licensing to the harness reference-data catalog.");
         },
         (error) => {
             console.error(`Reference-data inspection failed: ${renderError(error)}`);
@@ -179,15 +229,19 @@ export async function runRefsList(): Promise<void> {
 }
 
 /** `inflexa refs download` command action. */
-export async function runRefsDownload(ids: readonly string[], options: { readonly yes?: boolean }): Promise<void> {
-    const result = await downloadReferences({ ids, yes: options.yes });
+export async function runRefsDownload(ids: readonly string[], options: { readonly yes?: boolean; readonly force?: boolean }): Promise<void> {
+    const result = await downloadReferences({ ids, yes: options.yes, force: options.force });
     result.match(
         (outcome) => {
             if ("declined" in outcome) console.log("Cancelled — no reference data activated.");
             else if (outcome.installed.length === 0) console.log("No reference datasets selected.");
             else
                 for (const installed of outcome.installed)
-                    console.log(`Installed ${installed.id}@${installed.version} (${formatReferenceBytes(installed.bytesDownloaded)} downloaded).`);
+                    console.log(
+                        installed.bytesDownloaded === 0
+                            ? `Already installed and intact: ${installed.id}@${installed.version} (nothing downloaded).`
+                            : `Installed ${installed.id}@${installed.version} (${formatReferenceBytes(installed.bytesDownloaded)} downloaded).`,
+                    );
         },
         (error) => {
             console.error(`Reference-data download failed: ${renderError(error)}`);
@@ -214,9 +268,18 @@ export async function runRefsVerify(ids: readonly string[]): Promise<void> {
             if (verified.length === 0) console.log("No installed catalog reference datasets to verify.");
             for (const dataset of verified) {
                 console.log(`${dataset.datasetId}${dataset.version ? `@${dataset.version}` : ""}: ${dataset.state}`);
-                for (const file of dataset.files) console.log(`  ${file.state.padEnd(8)} ${file.path}`);
+                for (const file of dataset.files) {
+                    const against = file.integrity === "pinned" ? "catalog checksum" : "checksum recorded at install";
+                    console.log(`  ${file.state.padEnd(8)} ${file.path}  (vs ${against})`);
+                }
             }
-            if (verified.some((dataset) => dataset.state !== "valid")) process.exitCode = 1;
+            const damaged = verified.filter((dataset) => dataset.state !== "valid");
+            if (damaged.length > 0) {
+                console.error(
+                    `\nRe-download to repair: inflexa refs download ${damaged.map((dataset) => dataset.datasetId).join(" ")} --force --yes`,
+                );
+                process.exitCode = 1;
+            }
         },
         (error) => {
             console.error(`Reference-data verification failed: ${renderError(error)}`);

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -1,0 +1,261 @@
+import { isCancel, log, multiselect } from "@clack/prompts";
+import { REFERENCE_DATA_CATALOG, type ReferenceDataCatalog } from "@inflexa-ai/harness";
+import { err, ok, type Result } from "neverthrow";
+
+import { confirm } from "../../lib/cli.ts";
+import { env } from "../../lib/env.ts";
+import {
+    ensureReferenceStore,
+    inspectReferenceStore,
+    installReferenceDatasets,
+    referenceDownloadBytes,
+    resolvePublicArtifactUrl,
+    verifyReferenceDatasets,
+    type ReferenceInstallOutcome,
+    type ReferenceCatalogSource,
+    type ReferenceProvisionError,
+} from "./store.ts";
+
+/** Options shared by the explicit download command and setup. */
+export type ReferenceDownloadOptions = {
+    /** Selected catalog ids. */
+    readonly ids: readonly string[];
+    /** Explicit non-interactive consent and interactive confirmation bypass. */
+    readonly yes?: boolean;
+    /** Whether terminal prompts may be used. */
+    readonly interactive?: boolean;
+    /** Matching catalog/plan seam for offline tests. */
+    readonly source?: ReferenceCatalogSource;
+    /** Confirmation seam for text-command tests; defaults to the shared terminal prompt. */
+    readonly confirmDownload?: (question: string) => Promise<boolean>;
+};
+
+/** Setup-specific reference selection. */
+export type ReferenceSetupOptions = {
+    /** Explicit ids from `setup --refs`; absent means offer interactively. */
+    readonly ids?: readonly string[];
+    /** Explicit consent for a scripted transfer. */
+    readonly yes?: boolean;
+    /** Whether setup is attached to an interactive terminal. */
+    readonly interactive: boolean;
+};
+
+/** A selection was cancelled before transfer. */
+export type DeclinedReferenceDownload = {
+    /** No dataset was activated. */
+    readonly installed: readonly [];
+    /** Distinguishes cancellation from an empty successful plan. */
+    readonly declined: true;
+};
+
+/** Parse a comma-separated setup selection into stable, non-empty ids. */
+export function parseReferenceIds(value: string | undefined): readonly string[] | undefined {
+    if (value === undefined) return undefined;
+    return [
+        ...new Set(
+            value
+                .split(",")
+                .map((id) => id.trim())
+                .filter(Boolean),
+        ),
+    ];
+}
+
+/** Format a byte count for terminal output. */
+export function formatReferenceBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KiB`;
+    if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+    return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+}
+
+function totalBytes(dataset: ReferenceDataCatalog["datasets"][number]): number {
+    return dataset.artifacts.reduce((sum, artifact) => sum + artifact.bytes, 0);
+}
+
+function renderError(error: ReferenceProvisionError): string {
+    return error.message;
+}
+
+async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string[] | undefined> {
+    if (catalog.datasets.length === 0) return [];
+    const selected = await multiselect({
+        message: "Reference datasets to download",
+        required: false,
+        options: catalog.datasets.map((dataset) => ({
+            value: dataset.id,
+            label: `${dataset.title} (${formatReferenceBytes(totalBytes(dataset))})`,
+            hint: `${dataset.recommendation.group}${dataset.recommendation.recommended ? ", recommended" : ""}`,
+        })),
+    });
+    return isCancel(selected) ? undefined : selected;
+}
+
+/** Headless, reusable download operation after selection and consent policy are resolved. */
+export async function downloadReferences(
+    options: ReferenceDownloadOptions,
+): Promise<Result<ReferenceInstallOutcome | DeclinedReferenceDownload, ReferenceProvisionError>> {
+    const catalog = options.source?.catalog ?? REFERENCE_DATA_CATALOG;
+    const interactive = options.interactive ?? process.stdin.isTTY;
+    let ids = options.ids;
+    if (ids.length === 0) {
+        if (!interactive) {
+            return err({
+                type: "unknown_dataset",
+                unknownId: "",
+                availableIds: catalog.datasets.map((dataset) => dataset.id),
+                message: "No reference ids supplied. Pass catalog ids explicitly on a non-interactive terminal.",
+            });
+        }
+        let chosen: readonly string[] | undefined;
+        try {
+            chosen = await chooseIds(catalog);
+        } catch (cause) {
+            return err({ type: "download_failed", message: "Reference selection prompt failed.", cause });
+        }
+        if (chosen === undefined || chosen.length === 0) return ok({ installed: [], declined: true });
+        ids = chosen;
+    }
+
+    const bytes =
+        options.source === undefined ? await referenceDownloadBytes(ids, env.refsDir) : await referenceDownloadBytes(ids, env.refsDir, options.source);
+    if (bytes.isErr()) return err(bytes.error);
+    console.log(`Reference download plan: ${formatReferenceBytes(bytes.value)} missing.`);
+    if (!options.yes) {
+        if (!interactive) {
+            return err({
+                type: "download_failed",
+                message: `Downloading ${formatReferenceBytes(bytes.value)} requires explicit consent; re-run with --yes.`,
+            });
+        }
+        let confirmed: boolean;
+        try {
+            confirmed = await (options.confirmDownload ?? confirm)(`Download ${formatReferenceBytes(bytes.value)} of reference data into ${env.refsDir}?`);
+        } catch (cause) {
+            return err({ type: "download_failed", message: "Reference download confirmation failed.", cause });
+        }
+        if (!confirmed) {
+            return ok({ installed: [], declined: true });
+        }
+    }
+    return installReferenceDatasets(ids, {
+        root: env.refsDir,
+        ...(options.source === undefined ? {} : { source: options.source }),
+        resolveArtifactUrl: (key) => resolvePublicArtifactUrl(key, env.referenceDataBaseUrl),
+    });
+}
+
+/** `inflexa refs path` — print the public path without creating it. */
+export function runRefsPath(): void {
+    console.log(env.refsDir);
+}
+
+/** `inflexa refs list` — render canonical options and recoverable local state. */
+export async function runRefsList(): Promise<void> {
+    const result = await inspectReferenceStore(env.refsDir);
+    result.match(
+        (inspection) => {
+            if (inspection.datasets.length === 0) console.log("No catalog reference datasets are published by this harness version yet.");
+            for (const item of inspection.datasets) {
+                const dataset = item.dataset;
+                console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}`);
+                console.log(`  ${dataset.title} — ${dataset.description}`);
+                console.log(`  Size: ${formatReferenceBytes(totalBytes(dataset))}`);
+                console.log(`  Group: ${dataset.recommendation.group}${dataset.recommendation.recommended ? " (recommended)" : ""}`);
+                console.log(`  Source: ${dataset.sourceUrl}`);
+                console.log(`  License: ${dataset.license.identifier}${dataset.license.url ? ` — ${dataset.license.url}` : ""}`);
+            }
+            if (inspection.userContent.length > 0) {
+                console.log(`\nUser/unmanaged top-level content: ${inspection.userContent.join(", ")} (left untouched)`);
+            }
+            console.log(`\nAdd arbitrary references under ${env.refsDir}/user; sandboxes discover them dynamically.`);
+            console.log("Missing a reusable option? Open a PR adding immutable metadata to the harness reference-data catalog.");
+        },
+        (error) => {
+            console.error(`Reference-data inspection failed: ${renderError(error)}`);
+            process.exitCode = 1;
+        },
+    );
+}
+
+/** `inflexa refs download` command action. */
+export async function runRefsDownload(ids: readonly string[], options: { readonly yes?: boolean }): Promise<void> {
+    const result = await downloadReferences({ ids, yes: options.yes });
+    result.match(
+        (outcome) => {
+            if ("declined" in outcome) console.log("Cancelled — no reference data activated.");
+            else if (outcome.installed.length === 0) console.log("No reference datasets selected.");
+            else
+                for (const installed of outcome.installed)
+                    console.log(`Installed ${installed.id}@${installed.version} (${formatReferenceBytes(installed.bytesDownloaded)} downloaded).`);
+        },
+        (error) => {
+            console.error(`Reference-data download failed: ${renderError(error)}`);
+            process.exitCode = 1;
+        },
+    );
+}
+
+/** `inflexa refs verify` command action. */
+export async function runRefsVerify(ids: readonly string[]): Promise<void> {
+    let selected = ids;
+    if (selected.length === 0) {
+        const inspection = await inspectReferenceStore(env.refsDir);
+        if (inspection.isErr()) {
+            console.error(`Reference-data verification failed: ${renderError(inspection.error)}`);
+            process.exitCode = 1;
+            return;
+        }
+        selected = inspection.value.datasets.filter((item) => item.receipt !== undefined || item.state === "invalid_receipt").map((item) => item.dataset.id);
+    }
+    const result = await verifyReferenceDatasets(env.refsDir, selected);
+    result.match(
+        (verified) => {
+            if (verified.length === 0) console.log("No installed catalog reference datasets to verify.");
+            for (const dataset of verified) {
+                console.log(`${dataset.datasetId}${dataset.version ? `@${dataset.version}` : ""}: ${dataset.state}`);
+                for (const file of dataset.files) console.log(`  ${file.state.padEnd(8)} ${file.path}`);
+            }
+            if (verified.some((dataset) => dataset.state !== "valid")) process.exitCode = 1;
+        },
+        (error) => {
+            console.error(`Reference-data verification failed: ${renderError(error)}`);
+            process.exitCode = 1;
+        },
+    );
+}
+
+/** Deliberate reference-store setup reused by the main setup wizard. */
+export async function runReferenceSetup(options: ReferenceSetupOptions): Promise<Result<void, ReferenceProvisionError>> {
+    const created = await ensureReferenceStore(env.refsDir);
+    if (created.isErr()) return err(created.error);
+    if (options.ids !== undefined) {
+        if (options.ids.length === 0) return ok(undefined);
+        if (!options.interactive && !options.yes) {
+            log.info(`Reference selection was not downloaded without explicit consent.\n  Re-run setup with --refs ${options.ids.join(",")} --yes.`);
+            return ok(undefined);
+        }
+        const downloaded = await downloadReferences({ ids: options.ids, yes: options.yes, interactive: options.interactive });
+        return downloaded.map(() => undefined);
+    }
+    if (!options.interactive) {
+        log.info(`Reference store: ${env.refsDir}\n  Install catalog data later with \`inflexa refs download <id...> --yes\`.`);
+        return ok(undefined);
+    }
+    const inspection = await inspectReferenceStore(env.refsDir);
+    if (inspection.isErr()) return err(inspection.error);
+    const offered = inspection.value.datasets.filter((item) => item.state !== "installed").map((item) => item.dataset.id);
+    if (offered.length === 0) {
+        log.info("Reference store ready; no missing catalog datasets to offer.");
+        return ok(undefined);
+    }
+    let chosen: readonly string[] | undefined;
+    try {
+        chosen = await chooseIds({ ...REFERENCE_DATA_CATALOG, datasets: REFERENCE_DATA_CATALOG.datasets.filter((dataset) => offered.includes(dataset.id)) });
+    } catch (cause) {
+        return err({ type: "download_failed", message: "Reference selection prompt failed.", cause });
+    }
+    if (chosen === undefined || chosen.length === 0) return ok(undefined);
+    const downloaded = await downloadReferences({ ids: chosen, yes: options.yes, interactive: true });
+    return downloaded.map(() => undefined);
+}

--- a/cli/src/modules/refs/store.test.ts
+++ b/cli/src/modules/refs/store.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
-import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
+import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog, type ReferenceIntegrity } from "@inflexa-ai/harness";
 import { err, ok } from "neverthrow";
 
 import {
@@ -13,7 +13,6 @@ import {
     installReferenceDatasets,
     referenceDownloadBytes,
     referenceStorePaths,
-    resolvePublicArtifactUrl,
     verifyReferenceDatasets,
     type ReferenceCatalogSource,
 } from "./store.ts";
@@ -30,7 +29,24 @@ function sha(bytes: string): string {
     return createHash("sha256").update(bytes).digest("hex");
 }
 
-function catalog(files: readonly { key: string; path: string; body: string }[] = [{ key: "demo/a.txt", path: "a.txt", body: "alpha" }]): ReferenceDataCatalog {
+/** One catalog artifact paired with the bytes its (offline) upstream serves for it. */
+type Fixture = {
+    /** Dataset-relative final path. */
+    readonly path: string;
+    /** Bytes the stub upstream returns. */
+    readonly body: string;
+    /** Which integrity class the catalog publishes it under. */
+    readonly integrity: ReferenceIntegrity;
+};
+
+/** Every fixture artifact is fetched straight from its own third-party upstream — there is no distribution base. */
+function url(path: string): string {
+    return `https://upstream.test/${path}`;
+}
+
+const PINNED: readonly Fixture[] = [{ path: "a.txt", body: "alpha", integrity: "pinned" }];
+
+function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
     return {
         version: REFERENCE_DATA_CATALOG_VERSION,
         datasets: [
@@ -42,7 +58,17 @@ function catalog(files: readonly { key: string; path: string; body: string }[] =
                 sourceUrl: "https://example.test/source",
                 license: { identifier: "CC0-1.0", url: "https://example.test/license" },
                 recommendation: { group: "testing", recommended: true },
-                artifacts: files.map((file) => ({ key: file.key, path: file.path, bytes: Buffer.byteLength(file.body), sha256: sha(file.body) })),
+                artifacts: files.map((file) =>
+                    file.integrity === "pinned"
+                        ? {
+                              integrity: "pinned" as const,
+                              path: file.path,
+                              url: url(file.path),
+                              bytes: Buffer.byteLength(file.body),
+                              sha256: sha(file.body),
+                          }
+                        : { integrity: "unpinned" as const, path: file.path, url: url(file.path) },
+                ),
             },
         ],
     };
@@ -67,8 +93,22 @@ function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     };
 }
 
-function resolver(key: string) {
-    return resolvePublicArtifactUrl(key, "https://refs.example.test/releases/");
+/** What the installer asked the upstream for; `range` is the resume request, absent on a fresh transfer. */
+type Asked = { readonly url: string; readonly range: string | null };
+
+/** Offline upstream. Serves each fixture's bytes and honors a Range request the way a real server would. */
+function serve(files: readonly Fixture[], asked: Asked[] = []): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+    const bodies = new Map(files.map((file) => [url(file.path), file.body]));
+    return async (input, init) => {
+        const target = String(input);
+        const range = new Headers(init?.headers).get("range");
+        asked.push({ url: target, range });
+        const body = bodies.get(target);
+        if (body === undefined) return new Response("missing", { status: 404, statusText: "Not Found" });
+        if (range === null) return new Response(body);
+        // Bodies are ASCII in every fixture, so a character offset is a byte offset.
+        return new Response(body.slice(Number(range.slice("bytes=".length, -1))), { status: 206 });
+    };
 }
 
 afterEach(() => {
@@ -105,7 +145,7 @@ describe("reference store inspection", () => {
                 datasetId: "demo",
                 datasetVersion: "2025.01",
                 activatedAt: "2026-07-14T12:00:00.000Z",
-                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
+                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
             }),
         );
         mkdirSync(join(paths.managed, "demo", "2025.01"), { recursive: true });
@@ -124,134 +164,119 @@ describe("reference store inspection", () => {
     });
 });
 
-describe("reference installation", () => {
-    test("activates multiple verified final files, writes a receipt, cleans partials, and preserves user content", async () => {
+describe("pinned installation", () => {
+    test("verifies size and digest, activates atomically, and records the observed bytes in the receipt", async () => {
         const path = root();
-        const fixture = catalog([
-            { key: "demo/a.txt", path: "nested/a.txt", body: "alpha" },
-            { key: "demo/b.txt", path: "b.txt", body: "beta" },
-        ]);
+        const files: readonly Fixture[] = [
+            { path: "nested/a.txt", body: "alpha", integrity: "pinned" },
+            { path: "b.txt", body: "beta", integrity: "pinned" },
+        ];
+        const fixture = catalog(files);
         mkdirSync(join(path, "user"), { recursive: true });
         writeFileSync(join(path, "user", "mine.fa"), "mine");
-        const bodies = new Map([
-            ["https://refs.example.test/releases/demo/a.txt", "alpha"],
-            ["https://refs.example.test/releases/demo/b.txt", "beta"],
-        ]);
+
         const result = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async (input) => new Response(bodies.get(String(input)) ?? "missing"),
+            fetch: serve(files),
             now: () => new Date("2026-07-14T12:00:00.000Z"),
             attemptId: () => "attempt",
         });
-        expect(result._unsafeUnwrap().installed[0]).toMatchObject({ id: "demo", version: "2026.07", bytesDownloaded: 9 });
+        expect(result._unsafeUnwrap().installed[0]).toEqual({ id: "demo", version: "2026.07", bytesDownloaded: 9 });
+
         const paths = referenceStorePaths(path);
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "nested", "a.txt"), "utf8")).toBe("alpha");
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "b.txt"), "utf8")).toBe("beta");
-        expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8"))).toMatchObject({ datasetId: "demo", datasetVersion: "2026.07" });
+        expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8"))).toEqual({
+            version: 1,
+            datasetId: "demo",
+            datasetVersion: "2026.07",
+            activatedAt: "2026-07-14T12:00:00.000Z",
+            artifacts: [
+                { path: "nested/a.txt", bytes: 5, sha256: sha("alpha"), integrity: "pinned" },
+                { path: "b.txt", bytes: 4, sha256: sha("beta"), integrity: "pinned" },
+            ],
+        });
         expect(readFileSync(join(path, "user", "mine.fa"), "utf8")).toBe("mine");
-        expect((await Array.fromAsync(new Bun.Glob("*.part").scan(paths.downloads))).length).toBe(0);
+        expect(await Array.fromAsync(new Bun.Glob("*.part").scan(paths.downloads))).toEqual([]);
+        // Every attempt gets a fresh staging id, so a leftover attempt dir would accumulate forever.
+        expect(readdirSync(paths.staging)).toEqual([]);
         expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toBe(0);
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
 
-        let fetched = false;
+        // An intact install is skipped: the hostile upstream below would fail the digest check if it
+        // were ever contacted, so a clean `ok` with zero bytes is the proof that it was not.
         const repeated = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async () => {
-                fetched = true;
-                return new Response("unexpected");
-            },
+            fetch: serve([
+                { path: "nested/a.txt", body: "ALPHA", integrity: "pinned" },
+                { path: "b.txt", body: "BETA", integrity: "pinned" },
+            ]),
         });
         expect(repeated._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(0);
-        expect(fetched).toBe(false);
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "nested", "a.txt"), "utf8")).toBe("alpha");
     });
 
-    test("resumes a partial response with Range and refuses digest damage without activation", async () => {
+    test("resumes a partial transfer with Range, because the catalog knows the final size and digest", async () => {
         const path = root();
-        const fixture = catalog([{ key: "demo/a.txt", path: "a.txt", body: "alpha" }]);
+        const fixture = catalog();
         const paths = referenceStorePaths(path);
-        const partName = `${sha("demo/a.txt")}.part`;
         mkdirSync(paths.downloads, { recursive: true });
-        writeFileSync(join(paths.downloads, partName), "al");
-        let range: string | null = null;
-        const installed = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async (_input, init) => {
-                range = new Headers(init?.headers).get("range");
-                return new Response("pha", { status: 206 });
-            },
-            attemptId: () => "resume",
-        });
-        expect(installed.isOk()).toBe(true);
-        expect(String(range)).toBe("bytes=2-");
+        writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
 
-        rmSync(join(paths.managed, "demo", "2026.07"), { recursive: true, force: true });
-        rmSync(join(paths.receipts, "demo.json"), { force: true });
-        mkdirSync(paths.downloads, { recursive: true });
-        writeFileSync(join(paths.downloads, partName), "ALPHA");
-        const damaged = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async () => new Response("ALPHA"),
-            attemptId: () => "damage",
-        });
-        expect(damaged._unsafeUnwrapErr().type).toBe("digest_mismatch");
-        expect(await Bun.file(join(paths.receipts, "demo.json")).exists()).toBe(false);
+        const asked: Asked[] = [];
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED, asked) });
+        expect(installed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(3);
+        expect(asked).toEqual([{ url: url("a.txt"), range: "bytes=2-" }]);
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
     });
 
-    test("unknown ids and reserved symlink conflicts mutate nothing", async () => {
+    test("a digest mismatch activates nothing and leaves an existing activation intact", async () => {
         const path = root();
-        const unknownCatalog = catalog();
-        const unknown = await installReferenceDatasets(["unknown"], { root: path, source: source(unknownCatalog), resolveArtifactUrl: resolver });
-        expect(unknown._unsafeUnwrapErr().type).toBe("unknown_dataset");
-        expect(await Bun.file(path).exists()).toBe(false);
+        const fixture = catalog();
+        const paths = referenceStorePaths(path);
+        const corrupt: readonly Fixture[] = [{ path: "a.txt", body: "ALPHA", integrity: "pinned" }];
 
-        const outside = root();
-        mkdirSync(path, { recursive: true });
-        mkdirSync(outside, { recursive: true });
-        symlinkSync(outside, join(path, ".inflexa"));
-        const conflict = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(catalog()),
-            resolveArtifactUrl: resolver,
-            fetch: async () => new Response("alpha"),
-        });
-        expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
-        expect(Array.from(new Bun.Glob("**/*").scanSync(outside))).toEqual([]);
+        const damaged = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) });
+        expect(damaged._unsafeUnwrapErr()).toMatchObject({ type: "digest_mismatch", path: "a.txt", expected: sha("alpha"), actual: sha("ALPHA") });
+        expect(existsSync(join(paths.managed, "demo", "2026.07"))).toBe(false);
+        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
+
+        const good = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        expect(good.isOk()).toBe(true);
+        const receipt = readFileSync(join(paths.receipts, "demo.json"), "utf8");
+
+        const forced = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) }, { force: true });
+        expect(forced._unsafeUnwrapErr().type).toBe("digest_mismatch");
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
+        expect(readFileSync(join(paths.receipts, "demo.json"), "utf8")).toBe(receipt);
     });
 
     test("size mismatch and interrupted streams never activate partial data", async () => {
         const path = root();
         const fixture = catalog();
+        const paths = referenceStorePaths(path);
+
         const short = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async () => new Response("a"),
-            attemptId: () => "short",
+            fetch: serve([{ path: "a.txt", body: "a", integrity: "pinned" }]),
         });
-        expect(short._unsafeUnwrapErr().type).toBe("size_mismatch");
-        expect(await Bun.file(join(referenceStorePaths(path).receipts, "demo.json")).exists()).toBe(false);
+        expect(short._unsafeUnwrapErr()).toMatchObject({ type: "size_mismatch", path: "a.txt", expected: 5, actual: 1 });
+        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
 
         const interrupted = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
-            resolveArtifactUrl: resolver,
             fetch: async () => Promise.reject(new Error("connection lost")),
-            attemptId: () => "interrupted",
         });
         expect(interrupted._unsafeUnwrapErr().type).toBe("download_failed");
-        expect(await Bun.file(join(referenceStorePaths(path).managed, "demo", "2026.07", "a.txt")).exists()).toBe(false);
+        expect(existsSync(join(paths.managed, "demo", "2026.07", "a.txt"))).toBe(false);
     });
 
-    test("failed updates preserve the prior active version and receipt", async () => {
+    test("a failed update preserves the prior active version and its receipt", async () => {
         const path = root();
         const paths = referenceStorePaths(path);
         const receiptPath = join(paths.receipts, "demo.json");
@@ -263,74 +288,213 @@ describe("reference installation", () => {
             datasetId: "demo",
             datasetVersion: "2025.01",
             activatedAt: "2025-01-01T00:00:00.000Z",
-            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
+            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
         });
         writeFileSync(receiptPath, prior);
 
         const failed = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(catalog()),
-            resolveArtifactUrl: resolver,
-            fetch: async () => new Response("ALPHA"),
-            attemptId: () => "failed-update",
+            fetch: serve([{ path: "a.txt", body: "ALPHA", integrity: "pinned" }]),
         });
         expect(failed._unsafeUnwrapErr().type).toBe("digest_mismatch");
         expect(readFileSync(receiptPath, "utf8")).toBe(prior);
         expect(readFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "utf8")).toBe("old");
     });
+});
 
-    test("verification detects deleted, modified, and symlinked managed files without following links", async () => {
+describe("unpinned installation", () => {
+    test("installs without a catalog digest and records what the mutable upstream actually served", async () => {
         const path = root();
-        const fixture = catalog([
-            { key: "demo/a", path: "a.txt", body: "alpha" },
-            { key: "demo/b", path: "b.txt", body: "beta" },
-        ]);
-        await installReferenceDatasets(["demo"], {
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "mutable-bytes", integrity: "unpinned" }];
+        const fixture = catalog(files);
+        // The catalog carries no size or digest for an upstream that rebuilds the file in place.
+        expect(fixture.datasets[0]?.artifacts[0]).toEqual({ integrity: "unpinned", path: "gene_info.gz", url: url("gene_info.gz") });
+
+        const installed = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
-            resolveArtifactUrl: resolver,
-            fetch: async (input) => new Response(String(input).endsWith("/a") ? "alpha" : "beta"),
+            fetch: serve(files),
+            now: () => new Date("2026-07-14T12:00:00.000Z"),
         });
-        const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
-        rmSync(join(active, "a.txt"));
-        writeFileSync(join(active, "b.txt"), "BETA");
-        const damaged = (await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0];
-        expect(damaged?.files).toEqual([
-            { path: "a.txt", state: "missing" },
-            { path: "b.txt", state: "modified" },
-        ]);
+        expect(installed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(13);
 
+        const paths = referenceStorePaths(path);
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "gene_info.gz"), "utf8")).toBe("mutable-bytes");
+        expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
+            { path: "gene_info.gz", bytes: 13, sha256: sha("mutable-bytes"), integrity: "unpinned" },
+        ]);
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]).toMatchObject({
+            state: "valid",
+            files: [{ path: "gene_info.gz", state: "valid", integrity: "unpinned" }],
+        });
+    });
+
+    test("never resumes a stale partial — a rebuilt upstream would splice two files together", async () => {
+        const path = root();
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "fresh-upstream", integrity: "unpinned" }];
+        const fixture = catalog(files);
+        const paths = referenceStorePaths(path);
+        mkdirSync(paths.downloads, { recursive: true });
+        writeFileSync(join(paths.downloads, `${sha("demo/2026.07/gene_info.gz")}.part`), "stale-prefix");
+
+        const asked: Asked[] = [];
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files, asked) });
+        expect(installed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(14);
+        expect(asked).toEqual([{ url: url("gene_info.gz"), range: null }]);
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "gene_info.gz"), "utf8")).toBe("fresh-upstream");
+    });
+
+    test("--force is the only way to pull a refreshed copy of a mutable upstream", async () => {
+        const path = root();
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-a", integrity: "unpinned" }];
+        const fixture = catalog(files);
+        const paths = referenceStorePaths(path);
+        const active = join(paths.managed, "demo", "2026.07", "gene_info.gz");
+        const refreshed: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-b-longer", integrity: "unpinned" }];
+
+        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
+        expect(first.isOk()).toBe(true);
+
+        // Without --force an intact install is indistinguishable from an up-to-date one, so the newer
+        // upstream release is deliberately not picked up.
+        const skipped = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(refreshed) });
+        expect(skipped._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(0);
+        expect(readFileSync(active, "utf8")).toBe("release-a");
+
+        const forced = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(refreshed) }, { force: true });
+        expect(forced._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(16);
+        expect(readFileSync(active, "utf8")).toBe("release-b-longer");
+        expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
+            { path: "gene_info.gz", bytes: 16, sha256: sha("release-b-longer"), integrity: "unpinned" },
+        ]);
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
+    });
+});
+
+describe("self-healing installs", () => {
+    test("a same-size corruption is re-downloaded without --force instead of being reported installed", async () => {
+        const path = root();
+        const fixture = catalog();
+        const paths = referenceStorePaths(path);
+        const active = join(paths.managed, "demo", "2026.07", "a.txt");
+
+        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        expect(first._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
+
+        writeFileSync(active, "ALPHA");
+        // `refs list` state is deliberately cheap (size-only), so it still reads as installed — but the
+        // install gate hashes, so the damage must be seen and healed rather than skipped.
+        expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 0 });
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("modified");
+
+        const healed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        expect(healed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
+        expect(readFileSync(active, "utf8")).toBe("alpha");
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
+    });
+});
+
+describe("verification", () => {
+    test("reports each file against the integrity it was checked with, and detects same-size damage", async () => {
+        const path = root();
+        const files: readonly Fixture[] = [
+            { path: "a.txt", body: "alpha", integrity: "pinned" },
+            { path: "b.txt", body: "bravo", integrity: "unpinned" },
+        ];
+        const fixture = catalog(files);
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
+        expect(installed.isOk()).toBe(true);
+
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]).toEqual({
+            datasetId: "demo",
+            version: "2026.07",
+            state: "valid",
+            files: [
+                { path: "a.txt", state: "valid", integrity: "pinned" },
+                { path: "b.txt", state: "valid", integrity: "unpinned" },
+            ],
+        });
+
+        const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
+        writeFileSync(join(active, "a.txt"), "ALPHA");
         rmSync(join(active, "b.txt"));
+        const damaged = (await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0];
+        expect(damaged?.state).toBe("modified");
+        expect(damaged?.files).toEqual([
+            { path: "a.txt", state: "modified", integrity: "pinned" },
+            { path: "b.txt", state: "missing", integrity: "unpinned" },
+        ]);
+    });
+
+    test("a symlinked managed file is never followed", async () => {
+        const path = root();
+        const fixture = catalog();
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        expect(installed.isOk()).toBe(true);
+
+        const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
         const outside = root();
         mkdirSync(outside, { recursive: true });
-        writeFileSync(join(outside, "beta"), "beta");
-        symlinkSync(join(outside, "beta"), join(active, "b.txt"));
-        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.files[1]?.state).toBe("missing");
+        writeFileSync(join(outside, "alpha"), "alpha");
+        rmSync(join(active, "a.txt"));
+        symlinkSync(join(outside, "alpha"), join(active, "a.txt"));
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.files[0]).toEqual({
+            path: "a.txt",
+            state: "missing",
+            integrity: "pinned",
+        });
+    });
+});
+
+describe("download estimate", () => {
+    test("sums pinned bytes, counts unsized artifacts, and subtracts resumable partials", async () => {
+        const path = root();
+        const files: readonly Fixture[] = [
+            { path: "a.txt", body: "alpha", integrity: "pinned" },
+            { path: "b.bin", body: "mutable", integrity: "unpinned" },
+        ];
+        const fixture = catalog(files);
+        const paths = referenceStorePaths(path);
+
+        // Only the mutable upstream can report its own size, and the estimate never goes to the network.
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
+
+        mkdirSync(paths.downloads, { recursive: true });
+        writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 3, unsizedArtifacts: 1 });
+
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
+        expect(installed.isOk()).toBe(true);
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture), { force: true }))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
+        expect((await referenceDownloadBytes(["unknown"], path, source(fixture)))._unsafeUnwrapErr().type).toBe("unknown_dataset");
+    });
+});
+
+describe("installer-owned path safety", () => {
+    test("unknown ids and reserved symlink conflicts mutate nothing", async () => {
+        const path = root();
+        const unknown = await installReferenceDatasets(["unknown"], { root: path, source: source(catalog()) });
+        expect(unknown._unsafeUnwrapErr().type).toBe("unknown_dataset");
+        expect(await Bun.file(path).exists()).toBe(false);
+
+        const outside = root();
+        mkdirSync(path, { recursive: true });
+        mkdirSync(outside, { recursive: true });
+        symlinkSync(outside, join(path, ".inflexa"));
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
+        expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
+        expect(Array.from(new Bun.Glob("**/*").scanSync(outside))).toEqual([]);
     });
 
     test("unexpected managed files and directories are never overwritten", async () => {
         const path = root();
         const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
         mkdirSync(join(active, "surprise"), { recursive: true });
-        const conflict = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(catalog()),
-            resolveArtifactUrl: resolver,
-            fetch: async () => new Response("alpha"),
-        });
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(statSync(join(active, "surprise")).isDirectory()).toBe(true);
-    });
-});
-
-describe("public artifact resolver", () => {
-    test("keeps opaque keys under the configured base", () => {
-        expect(resolvePublicArtifactUrl("demo/a file.fa", "https://refs.example/base")._unsafeUnwrap().href).toBe("https://refs.example/base/demo/a%20file.fa");
-    });
-
-    test("rejects missing configuration and escaping keys", () => {
-        expect(resolvePublicArtifactUrl("demo/a", undefined).isErr()).toBe(true);
-        expect(resolvePublicArtifactUrl("../secret", "https://refs.example/base").isErr()).toBe(true);
-        expect(resolvePublicArtifactUrl("https://evil.example/a", "https://refs.example/base").isErr()).toBe(true);
     });
 });

--- a/cli/src/modules/refs/store.test.ts
+++ b/cli/src/modules/refs/store.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUIDv7 } from "bun";
+
+import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
+import { err, ok } from "neverthrow";
+
+import {
+    inspectReferenceStore,
+    installReferenceDatasets,
+    referenceDownloadBytes,
+    referenceStorePaths,
+    resolvePublicArtifactUrl,
+    verifyReferenceDatasets,
+    type ReferenceCatalogSource,
+} from "./store.ts";
+
+const roots: string[] = [];
+
+function root(): string {
+    const path = join(tmpdir(), `inflexa-refs-${randomUUIDv7()}`);
+    roots.push(path);
+    return path;
+}
+
+function sha(bytes: string): string {
+    return createHash("sha256").update(bytes).digest("hex");
+}
+
+function catalog(files: readonly { key: string; path: string; body: string }[] = [{ key: "demo/a.txt", path: "a.txt", body: "alpha" }]): ReferenceDataCatalog {
+    return {
+        version: REFERENCE_DATA_CATALOG_VERSION,
+        datasets: [
+            {
+                id: "demo",
+                version: "2026.07",
+                title: "Demo reference",
+                description: "Offline fixture",
+                sourceUrl: "https://example.test/source",
+                license: { identifier: "CC0-1.0", url: "https://example.test/license" },
+                recommendation: { group: "testing", recommended: true },
+                artifacts: files.map((file) => ({ key: file.key, path: file.path, bytes: Buffer.byteLength(file.body), sha256: sha(file.body) })),
+            },
+        ],
+    };
+}
+
+function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
+    return {
+        catalog: value,
+        resolveInstallPlan: (ids) => {
+            const byId = new Map(value.datasets.map((dataset) => [dataset.id, dataset]));
+            const selected = [...new Set(ids)].sort();
+            const unknown = selected.find((id) => !byId.has(id));
+            if (unknown !== undefined) return err(new UnknownReferenceDatasetError(unknown, [...byId.keys()].sort()));
+            return ok({
+                catalogVersion: value.version,
+                datasets: selected.flatMap((id) => {
+                    const dataset = byId.get(id);
+                    return dataset === undefined ? [] : [{ ...dataset, installPath: `${dataset.id}/${dataset.version}` }];
+                }),
+            });
+        },
+    };
+}
+
+function resolver(key: string) {
+    return resolvePublicArtifactUrl(key, "https://refs.example.test/releases/");
+}
+
+afterEach(() => {
+    for (const path of roots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("reference store inspection", () => {
+    test("an absent store is missing and passive inspection creates nothing", async () => {
+        const path = root();
+        const result = await inspectReferenceStore(path, catalog());
+        expect(result._unsafeUnwrap()).toMatchObject({ exists: false, datasets: [{ state: "missing" }] });
+        expect(await Bun.file(path).exists()).toBe(false);
+    });
+
+    test("setup-created empty user namespace is not reported as user content", async () => {
+        const path = root();
+        mkdirSync(join(path, "user"), { recursive: true });
+        expect((await inspectReferenceStore(path, catalog()))._unsafeUnwrap().userContent).toEqual([]);
+        writeFileSync(join(path, "user", "custom.fa"), "custom");
+        expect((await inspectReferenceStore(path, catalog()))._unsafeUnwrap().userContent).toEqual(["user/custom.fa"]);
+    });
+
+    test("invalid and stale receipts are recoverable states", async () => {
+        const path = root();
+        const paths = referenceStorePaths(path);
+        mkdirSync(paths.receipts, { recursive: true });
+        writeFileSync(join(paths.receipts, "demo.json"), "not-json");
+        expect((await inspectReferenceStore(path, catalog()))._unsafeUnwrap().datasets[0]?.state).toBe("invalid_receipt");
+
+        writeFileSync(
+            join(paths.receipts, "demo.json"),
+            JSON.stringify({
+                version: 1,
+                datasetId: "demo",
+                datasetVersion: "2025.01",
+                activatedAt: "2026-07-14T12:00:00.000Z",
+                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
+            }),
+        );
+        mkdirSync(join(paths.managed, "demo", "2025.01"), { recursive: true });
+        writeFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "old");
+        expect((await inspectReferenceStore(path, catalog()))._unsafeUnwrap().datasets[0]?.state).toBe("update_available");
+    });
+
+    test("receipt metadata symlinks are not followed", async () => {
+        const path = root();
+        const outside = root();
+        mkdirSync(join(path, ".inflexa"), { recursive: true });
+        mkdirSync(outside, { recursive: true });
+        writeFileSync(join(outside, "demo.json"), "{}");
+        symlinkSync(outside, join(path, ".inflexa", "receipts"));
+        expect((await inspectReferenceStore(path, catalog()))._unsafeUnwrap().datasets[0]?.state).toBe("invalid_receipt");
+    });
+});
+
+describe("reference installation", () => {
+    test("activates multiple verified final files, writes a receipt, cleans partials, and preserves user content", async () => {
+        const path = root();
+        const fixture = catalog([
+            { key: "demo/a.txt", path: "nested/a.txt", body: "alpha" },
+            { key: "demo/b.txt", path: "b.txt", body: "beta" },
+        ]);
+        mkdirSync(join(path, "user"), { recursive: true });
+        writeFileSync(join(path, "user", "mine.fa"), "mine");
+        const bodies = new Map([
+            ["https://refs.example.test/releases/demo/a.txt", "alpha"],
+            ["https://refs.example.test/releases/demo/b.txt", "beta"],
+        ]);
+        const result = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async (input) => new Response(bodies.get(String(input)) ?? "missing"),
+            now: () => new Date("2026-07-14T12:00:00.000Z"),
+            attemptId: () => "attempt",
+        });
+        expect(result._unsafeUnwrap().installed[0]).toMatchObject({ id: "demo", version: "2026.07", bytesDownloaded: 9 });
+        const paths = referenceStorePaths(path);
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "nested", "a.txt"), "utf8")).toBe("alpha");
+        expect(readFileSync(join(paths.managed, "demo", "2026.07", "b.txt"), "utf8")).toBe("beta");
+        expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8"))).toMatchObject({ datasetId: "demo", datasetVersion: "2026.07" });
+        expect(readFileSync(join(path, "user", "mine.fa"), "utf8")).toBe("mine");
+        expect((await Array.fromAsync(new Bun.Glob("*.part").scan(paths.downloads))).length).toBe(0);
+        expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
+        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toBe(0);
+
+        let fetched = false;
+        const repeated = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async () => {
+                fetched = true;
+                return new Response("unexpected");
+            },
+        });
+        expect(repeated._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(0);
+        expect(fetched).toBe(false);
+    });
+
+    test("resumes a partial response with Range and refuses digest damage without activation", async () => {
+        const path = root();
+        const fixture = catalog([{ key: "demo/a.txt", path: "a.txt", body: "alpha" }]);
+        const paths = referenceStorePaths(path);
+        const partName = `${sha("demo/a.txt")}.part`;
+        mkdirSync(paths.downloads, { recursive: true });
+        writeFileSync(join(paths.downloads, partName), "al");
+        let range: string | null = null;
+        const installed = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async (_input, init) => {
+                range = new Headers(init?.headers).get("range");
+                return new Response("pha", { status: 206 });
+            },
+            attemptId: () => "resume",
+        });
+        expect(installed.isOk()).toBe(true);
+        expect(String(range)).toBe("bytes=2-");
+
+        rmSync(join(paths.managed, "demo", "2026.07"), { recursive: true, force: true });
+        rmSync(join(paths.receipts, "demo.json"), { force: true });
+        mkdirSync(paths.downloads, { recursive: true });
+        writeFileSync(join(paths.downloads, partName), "ALPHA");
+        const damaged = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async () => new Response("ALPHA"),
+            attemptId: () => "damage",
+        });
+        expect(damaged._unsafeUnwrapErr().type).toBe("digest_mismatch");
+        expect(await Bun.file(join(paths.receipts, "demo.json")).exists()).toBe(false);
+    });
+
+    test("unknown ids and reserved symlink conflicts mutate nothing", async () => {
+        const path = root();
+        const unknownCatalog = catalog();
+        const unknown = await installReferenceDatasets(["unknown"], { root: path, source: source(unknownCatalog), resolveArtifactUrl: resolver });
+        expect(unknown._unsafeUnwrapErr().type).toBe("unknown_dataset");
+        expect(await Bun.file(path).exists()).toBe(false);
+
+        const outside = root();
+        mkdirSync(path, { recursive: true });
+        mkdirSync(outside, { recursive: true });
+        symlinkSync(outside, join(path, ".inflexa"));
+        const conflict = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(catalog()),
+            resolveArtifactUrl: resolver,
+            fetch: async () => new Response("alpha"),
+        });
+        expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
+        expect(Array.from(new Bun.Glob("**/*").scanSync(outside))).toEqual([]);
+    });
+
+    test("size mismatch and interrupted streams never activate partial data", async () => {
+        const path = root();
+        const fixture = catalog();
+        const short = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async () => new Response("a"),
+            attemptId: () => "short",
+        });
+        expect(short._unsafeUnwrapErr().type).toBe("size_mismatch");
+        expect(await Bun.file(join(referenceStorePaths(path).receipts, "demo.json")).exists()).toBe(false);
+
+        const interrupted = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async () => Promise.reject(new Error("connection lost")),
+            attemptId: () => "interrupted",
+        });
+        expect(interrupted._unsafeUnwrapErr().type).toBe("download_failed");
+        expect(await Bun.file(join(referenceStorePaths(path).managed, "demo", "2026.07", "a.txt")).exists()).toBe(false);
+    });
+
+    test("failed updates preserve the prior active version and receipt", async () => {
+        const path = root();
+        const paths = referenceStorePaths(path);
+        const receiptPath = join(paths.receipts, "demo.json");
+        mkdirSync(join(paths.managed, "demo", "2025.01"), { recursive: true });
+        mkdirSync(dirname(receiptPath), { recursive: true });
+        writeFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "old");
+        const prior = JSON.stringify({
+            version: 1,
+            datasetId: "demo",
+            datasetVersion: "2025.01",
+            activatedAt: "2025-01-01T00:00:00.000Z",
+            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
+        });
+        writeFileSync(receiptPath, prior);
+
+        const failed = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(catalog()),
+            resolveArtifactUrl: resolver,
+            fetch: async () => new Response("ALPHA"),
+            attemptId: () => "failed-update",
+        });
+        expect(failed._unsafeUnwrapErr().type).toBe("digest_mismatch");
+        expect(readFileSync(receiptPath, "utf8")).toBe(prior);
+        expect(readFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "utf8")).toBe("old");
+    });
+
+    test("verification detects deleted, modified, and symlinked managed files without following links", async () => {
+        const path = root();
+        const fixture = catalog([
+            { key: "demo/a", path: "a.txt", body: "alpha" },
+            { key: "demo/b", path: "b.txt", body: "beta" },
+        ]);
+        await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            resolveArtifactUrl: resolver,
+            fetch: async (input) => new Response(String(input).endsWith("/a") ? "alpha" : "beta"),
+        });
+        const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
+        rmSync(join(active, "a.txt"));
+        writeFileSync(join(active, "b.txt"), "BETA");
+        const damaged = (await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0];
+        expect(damaged?.files).toEqual([
+            { path: "a.txt", state: "missing" },
+            { path: "b.txt", state: "modified" },
+        ]);
+
+        rmSync(join(active, "b.txt"));
+        const outside = root();
+        mkdirSync(outside, { recursive: true });
+        writeFileSync(join(outside, "beta"), "beta");
+        symlinkSync(join(outside, "beta"), join(active, "b.txt"));
+        expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.files[1]?.state).toBe("missing");
+    });
+
+    test("unexpected managed files and directories are never overwritten", async () => {
+        const path = root();
+        const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
+        mkdirSync(join(active, "surprise"), { recursive: true });
+        const conflict = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(catalog()),
+            resolveArtifactUrl: resolver,
+            fetch: async () => new Response("alpha"),
+        });
+        expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
+        expect(statSync(join(active, "surprise")).isDirectory()).toBe(true);
+    });
+});
+
+describe("public artifact resolver", () => {
+    test("keeps opaque keys under the configured base", () => {
+        expect(resolvePublicArtifactUrl("demo/a file.fa", "https://refs.example/base")._unsafeUnwrap().href).toBe("https://refs.example/base/demo/a%20file.fa");
+    });
+
+    test("rejects missing configuration and escaping keys", () => {
+        expect(resolvePublicArtifactUrl("demo/a", undefined).isErr()).toBe(true);
+        expect(resolvePublicArtifactUrl("../secret", "https://refs.example/base").isErr()).toBe(true);
+        expect(resolvePublicArtifactUrl("https://evil.example/a", "https://refs.example/base").isErr()).toBe(true);
+    });
+});

--- a/cli/src/modules/refs/store.test.ts
+++ b/cli/src/modules/refs/store.test.ts
@@ -74,6 +74,17 @@ function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
     };
 }
 
+/** An upstream that answers from a different, downgraded location — what a redirect hop looks like. */
+function serveRedirectedTo(finalUrl: string, files: readonly Fixture[]): (input: string | URL | Request) => Promise<Response> {
+    const bodies = new Map(files.map((file) => [url(file.path), file.body]));
+    return async (input) => {
+        const response = new Response(bodies.get(String(input)) ?? "");
+        // fetch reports the post-redirect location here; Response leaves it "" unless it redirected.
+        Object.defineProperty(response, "url", { value: finalUrl });
+        return response;
+    };
+}
+
 function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     return {
         catalog: value,
@@ -496,5 +507,56 @@ describe("installer-owned path safety", () => {
         const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(statSync(join(active, "surprise")).isDirectory()).toBe(true);
+    });
+
+    // The catalog can only promise https for the URL we ask for. An unpinned artifact has no digest
+    // to catch a hostile substitution, so a downgraded redirect would be trusted on first use.
+    test("refuses bytes served from a non-https location after a redirect", async () => {
+        for (const integrity of ["pinned", "unpinned"] as const) {
+            const path = root();
+            const fixture = catalog([{ path: "a.txt", body: "alpha", integrity }]);
+            const redirected = await installReferenceDatasets(["demo"], {
+                root: path,
+                source: source(fixture),
+                fetch: serveRedirectedTo("http://downgraded.test/a.txt", [{ path: "a.txt", body: "alpha", integrity }]),
+            });
+
+            expect(redirected._unsafeUnwrapErr().type).toBe("download_failed");
+            expect(redirected._unsafeUnwrapErr().message).toContain("non-https");
+            expect(existsSync(join(referenceStorePaths(path).managed, "demo"))).toBe(false);
+            expect(existsSync(join(referenceStorePaths(path).receipts, "demo.json"))).toBe(false);
+        }
+    });
+
+    // A receipt is a plain file on disk that anyone can edit, so it is untrusted input. A traversal
+    // segment must never let verification reach out of the dataset into `user/` or a sibling.
+    test("a receipt whose artifact path escapes the dataset is rejected, and reads no file outside it", async () => {
+        const path = root();
+        const paths = referenceStorePaths(path);
+        const fixture = catalog();
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        expect(installed.isOk()).toBe(true);
+
+        const secret = join(paths.user, "private.txt");
+        mkdirSync(paths.user, { recursive: true });
+        writeFileSync(secret, "user content the installer must never adopt");
+
+        writeFileSync(
+            join(paths.receipts, "demo.json"),
+            JSON.stringify({
+                version: 1,
+                datasetId: "demo",
+                datasetVersion: "2026.07",
+                activatedAt: "2026-07-14T10:30:00.000Z",
+                artifacts: [{ path: "../../../user/private.txt", bytes: 42, sha256: sha("alpha"), integrity: "pinned" }],
+            }),
+        );
+
+        const verified = await verifyReferenceDatasets(path, ["demo"], source(fixture));
+        expect(verified._unsafeUnwrap()[0]).toMatchObject({ datasetId: "demo", state: "invalid_receipt", files: [] });
+
+        const inspected = await inspectReferenceStore(path, fixture);
+        expect(inspected._unsafeUnwrap().datasets[0]).toMatchObject({ state: "invalid_receipt" });
+        expect(readFileSync(secret, "utf8")).toBe("user content the installer must never adopt");
     });
 });

--- a/cli/src/modules/refs/store.ts
+++ b/cli/src/modules/refs/store.ts
@@ -1,0 +1,734 @@
+import { createHash } from "node:crypto";
+import { createWriteStream, type Stats } from "node:fs";
+import { copyFile, lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { randomUUIDv7 } from "bun";
+
+import {
+    REFERENCE_DATA_CATALOG,
+    REFERENCE_INSTALL_RECEIPT_VERSION,
+    parseReferenceInstallReceipt,
+    resolveReferenceInstallPlan,
+    type ReferenceDataCatalog,
+    type ReferenceDataset,
+    type ReferenceInstallPlan,
+    type ReferenceInstallPlanDataset,
+    type ReferenceInstallReceipt,
+    type UnknownReferenceDatasetError,
+} from "@inflexa-ai/harness";
+import { err, ok, type Result } from "neverthrow";
+
+import { sha256File } from "../../lib/hash.ts";
+
+/** Reserved and user-owned paths below one public reference store. */
+export type ReferenceStorePaths = {
+    /** Public store mounted into sandboxes. */
+    readonly root: string;
+    /** Catalog-managed immutable datasets. */
+    readonly managed: string;
+    /** User-owned arbitrary reference data. */
+    readonly user: string;
+    /** Installer-owned metadata and temporary state. */
+    readonly metadata: string;
+    /** Active installation receipts. */
+    readonly receipts: string;
+    /** Per-attempt complete-dataset staging. */
+    readonly staging: string;
+    /** Resumable artifact partials. */
+    readonly downloads: string;
+};
+
+/** Cheap local state shown by `refs list`. */
+export type ReferenceDatasetState = "missing" | "installed" | "update_available" | "partial" | "invalid_receipt";
+
+/** Catalog dataset paired with its cheap local state. */
+export type ReferenceDatasetInspection = {
+    /** Canonical catalog entry. */
+    readonly dataset: ReferenceDataset;
+    /** Recoverable local state. */
+    readonly state: ReferenceDatasetState;
+    /** Valid active receipt, when present. */
+    readonly receipt?: ReferenceInstallReceipt;
+};
+
+/** Passive store inspection, including content the installer does not own. */
+export type ReferenceStoreInspection = {
+    /** Whether the public root exists. */
+    readonly exists: boolean;
+    /** State for every canonical catalog dataset. */
+    readonly datasets: readonly ReferenceDatasetInspection[];
+    /** Unknown top-level entries, including user content, never adopted by the installer. */
+    readonly userContent: readonly string[];
+};
+
+/** One file-level verification result. */
+export type ReferenceFileVerification = {
+    /** Dataset-relative final path. */
+    readonly path: string;
+    /** Verification outcome. */
+    readonly state: "valid" | "missing" | "modified";
+};
+
+/** Explicit verification result for an active catalog dataset. */
+export type ReferenceVerification = {
+    /** Stable dataset id. */
+    readonly datasetId: string;
+    /** Active receipt version, when valid. */
+    readonly version?: string;
+    /** File results; empty when no valid receipt exists. */
+    readonly files: readonly ReferenceFileVerification[];
+    /** Overall state. */
+    readonly state: "valid" | "missing" | "invalid_receipt" | "modified";
+};
+
+type UnknownDatasetError = {
+    /** Stable discriminator. */
+    readonly type: "unknown_dataset";
+    /** User-facing explanation. */
+    readonly message: string;
+    /** Requested unknown id. */
+    readonly unknownId: string;
+    /** Catalog ids available to select. */
+    readonly availableIds: readonly string[];
+};
+
+type ArtifactUrlError = {
+    /** Stable discriminator. */
+    readonly type: "artifact_url_unconfigured";
+    /** User-facing explanation. */
+    readonly message: string;
+    /** Opaque artifact key that could not be resolved. */
+    readonly key: string;
+    /** Underlying URL parse failure, when present. */
+    readonly cause?: unknown;
+};
+
+type ProvisionOperationError = {
+    /** Failure stage. */
+    readonly type: "io_failed" | "download_failed";
+    /** User-facing explanation. */
+    readonly message: string;
+    /** Underlying filesystem/network failure, when present. */
+    readonly cause?: unknown;
+};
+
+type ContentMismatchError = {
+    /** Integrity mismatch kind. */
+    readonly type: "size_mismatch" | "digest_mismatch";
+    /** User-facing explanation. */
+    readonly message: string;
+    /** Dataset-relative artifact path. */
+    readonly path: string;
+    /** Expected size or digest. */
+    readonly expected: number | string;
+    /** Observed size or digest. */
+    readonly actual: number | string;
+};
+
+type ManagedPathConflictError = {
+    /** Stable discriminator. */
+    readonly type: "managed_path_conflict";
+    /** User-facing explanation. */
+    readonly message: string;
+    /** Conflicting or unsafe path. */
+    readonly path: string;
+};
+
+/** Typed failures from local inspection, verification, transfer, or activation. */
+export type ReferenceProvisionError = UnknownDatasetError | ArtifactUrlError | ProvisionOperationError | ContentMismatchError | ManagedPathConflictError;
+
+/** Network and release-location dependencies supplied by the CLI composition edge. */
+export type ReferenceInstallDeps = {
+    /** Public store root. */
+    readonly root: string;
+    /** Convert an opaque harness artifact key to a concrete public URL. */
+    readonly resolveArtifactUrl: (key: string) => Result<URL, ReferenceProvisionError>;
+    /** Catalog/plan seam used by tests; production always defaults to the immutable harness source. */
+    readonly source?: ReferenceCatalogSource;
+    /** Fetch implementation; defaults to the runtime fetch. */
+    readonly fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+    /** Clock used in receipts. */
+    readonly now?: () => Date;
+    /** Stable attempt id used for staging. */
+    readonly attemptId?: () => string;
+};
+
+/** Read-only catalog plus the matching pure selection operation. */
+export type ReferenceCatalogSource = {
+    /** Catalog metadata used for listing and state comparison. */
+    readonly catalog: ReferenceDataCatalog;
+    /** Resolve ids against exactly that catalog. */
+    readonly resolveInstallPlan: (datasetIds: readonly string[]) => Result<ReferenceInstallPlan, UnknownReferenceDatasetError>;
+};
+
+const CANONICAL_REFERENCE_SOURCE: ReferenceCatalogSource = {
+    catalog: REFERENCE_DATA_CATALOG,
+    resolveInstallPlan: resolveReferenceInstallPlan,
+};
+
+/** One activated dataset. */
+export type InstalledReferenceDataset = {
+    /** Stable catalog id. */
+    readonly id: string;
+    /** Activated catalog version. */
+    readonly version: string;
+    /** Network bytes transferred in this operation. */
+    readonly bytesDownloaded: number;
+};
+
+/** Successful installation details. */
+export type ReferenceInstallOutcome = {
+    /** Activated datasets in deterministic id order. */
+    readonly installed: readonly InstalledReferenceDataset[];
+};
+
+/** Resolve all owned paths without creating anything. */
+export function referenceStorePaths(root: string): ReferenceStorePaths {
+    const metadata = join(root, ".inflexa");
+    return {
+        root,
+        managed: join(root, "managed"),
+        user: join(root, "user"),
+        metadata,
+        receipts: join(metadata, "receipts"),
+        staging: join(metadata, "staging"),
+        downloads: join(metadata, "downloads"),
+    };
+}
+
+/** Deliberately create the public store and recommended user namespace. */
+export async function ensureReferenceStore(root: string): Promise<Result<ReferenceStorePaths, ReferenceProvisionError>> {
+    const paths = referenceStorePaths(root);
+    try {
+        const owned = await assertOwnedPath(root, paths.user);
+        if (owned.isErr()) return err(owned.error);
+        await mkdir(paths.user, { recursive: true });
+        return ok(paths);
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not create reference store at ${root}.`, cause });
+    }
+}
+
+/** Resolve an artifact key below an explicitly configured public distribution base. */
+export function resolvePublicArtifactUrl(key: string, baseUrl: string | undefined): Result<URL, ReferenceProvisionError> {
+    if (baseUrl === undefined || baseUrl.trim() === "") {
+        return err({
+            type: "artifact_url_unconfigured",
+            key,
+            message: `No public reference-data artifact endpoint is configured for ${key}.`,
+        });
+    }
+    try {
+        const base = new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+        const segments = key.split("/");
+        if (key.startsWith("/") || key.includes("\\") || segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+            return err({ type: "artifact_url_unconfigured", key, message: `Unsafe reference-data artifact key: ${key}` });
+        }
+        const url = new URL(segments.map(encodeURIComponent).join("/"), base);
+        if (url.origin !== base.origin || !url.pathname.startsWith(base.pathname)) {
+            return err({ type: "artifact_url_unconfigured", key, message: `Artifact key escapes the configured reference-data endpoint: ${key}` });
+        }
+        return ok(url);
+    } catch (cause) {
+        return err({ type: "artifact_url_unconfigured", key, message: `The configured reference-data endpoint is invalid: ${baseUrl}`, cause });
+    }
+}
+
+async function pathStat(path: string): Promise<Result<Stats | undefined, ReferenceProvisionError>> {
+    try {
+        return ok(await stat(path));
+    } catch (cause) {
+        return isMissing(cause) ? ok(undefined) : err({ type: "io_failed", message: `Could not stat ${path}.`, cause });
+    }
+}
+
+async function pathLstat(path: string): Promise<Result<Stats | undefined, ReferenceProvisionError>> {
+    try {
+        return ok(await lstat(path));
+    } catch (cause) {
+        return isMissing(cause) ? ok(undefined) : err({ type: "io_failed", message: `Could not inspect ${path}.`, cause });
+    }
+}
+
+function isMissing(cause: unknown): boolean {
+    return cause instanceof Error && "code" in cause && cause.code === "ENOENT";
+}
+
+async function readReceipt(path: string, storeRoot: string): Promise<{ readonly exists: boolean; readonly receipt?: ReferenceInstallReceipt }> {
+    try {
+        const owned = await assertOwnedPath(storeRoot, path);
+        if (owned.isErr()) return { exists: true };
+        const infoResult = await pathLstat(path);
+        if (infoResult.isErr()) return { exists: true };
+        const info = infoResult.value;
+        if (info === undefined) return { exists: false };
+        if (info.isSymbolicLink() || !info.isFile()) return { exists: true };
+        const raw: unknown = JSON.parse(await readFile(path, "utf8"));
+        return { exists: true, receipt: parseReferenceInstallReceipt(raw) };
+    } catch (cause) {
+        if (isMissing(cause)) return { exists: false };
+        return { exists: true };
+    }
+}
+
+async function receiptFilesPresent(paths: ReferenceStorePaths, root: string, receipt: ReferenceInstallReceipt): Promise<boolean> {
+    for (const artifact of receipt.artifacts) {
+        const path = join(root, artifact.path);
+        const owned = await assertOwnedPath(paths.root, path);
+        if (owned.isErr()) return false;
+        const fileResult = await pathLstat(path);
+        // Cheap state deliberately treats unreadable content as damaged/partial: it must never claim
+        // an installation is usable when the sandbox cannot read it. Explicit verify retains the
+        // file-level invalid outcome while top-level I/O failures still use the Result channel.
+        if (fileResult.isErr()) return false;
+        const file = fileResult.value;
+        if (file === undefined || file.isSymbolicLink() || !file.isFile() || file.size !== artifact.bytes) return false;
+    }
+    return true;
+}
+
+function receiptMatchesCurrentCatalog(dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): boolean {
+    if (receipt.datasetVersion !== dataset.version || receipt.artifacts.length !== dataset.artifacts.length) return false;
+    const expected = new Map(dataset.artifacts.map((artifact) => [artifact.path, `${artifact.bytes}:${artifact.sha256}`]));
+    const actualPaths = new Set(receipt.artifacts.map((artifact) => artifact.path));
+    return (
+        actualPaths.size === receipt.artifacts.length &&
+        receipt.artifacts.every((artifact) => expected.get(artifact.path) === `${artifact.bytes}:${artifact.sha256}`)
+    );
+}
+
+function activeManagedRoot(paths: ReferenceStorePaths, dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): string | undefined {
+    if (receipt.datasetId !== dataset.id || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(receipt.datasetVersion)) return undefined;
+    const root = join(paths.managed, dataset.id, receipt.datasetVersion);
+    return containedPath(paths.managed, root) ? root : undefined;
+}
+
+/** Inspect catalog state without creating or modifying the store. */
+export async function inspectReferenceStore(
+    root: string,
+    catalog: ReferenceDataCatalog = REFERENCE_DATA_CATALOG,
+): Promise<Result<ReferenceStoreInspection, ReferenceProvisionError>> {
+    const paths = referenceStorePaths(root);
+    try {
+        const rootInfoResult = await pathLstat(root);
+        if (rootInfoResult.isErr()) return err(rootInfoResult.error);
+        const rootInfo = rootInfoResult.value;
+        if (rootInfo === undefined) {
+            return ok({
+                exists: false,
+                datasets: catalog.datasets.map((dataset) => ({ dataset, state: "missing" })),
+                userContent: [],
+            });
+        }
+        if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
+            return err({ type: "io_failed", message: `Reference store is not a real directory: ${root}` });
+        }
+        const top = await readdir(root);
+        let userEntries: string[] = [];
+        try {
+            userEntries = await readdir(paths.user);
+        } catch (cause) {
+            if (!isMissing(cause)) return err({ type: "io_failed", message: `Could not inspect user references at ${paths.user}.`, cause });
+        }
+        const userContent = [
+            ...top.filter((name) => name !== "managed" && name !== ".inflexa" && name !== "user"),
+            ...userEntries.map((name) => `user/${name}`),
+        ].sort();
+        const datasets: ReferenceDatasetInspection[] = [];
+        for (const dataset of catalog.datasets) {
+            const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
+            if (receiptRead.exists && receiptRead.receipt === undefined) {
+                datasets.push({ dataset, state: "invalid_receipt" });
+                continue;
+            }
+            const receipt = receiptRead.receipt;
+            if (receipt === undefined) {
+                const versionResult = await pathStat(join(paths.managed, dataset.id, dataset.version));
+                if (versionResult.isErr()) return err(versionResult.error);
+                const version = versionResult.value;
+                datasets.push({ dataset, state: version === undefined ? "missing" : "partial" });
+                continue;
+            }
+            const activeRoot = activeManagedRoot(paths, dataset, receipt);
+            if (receipt.datasetVersion === dataset.version && !receiptMatchesCurrentCatalog(dataset, receipt)) {
+                datasets.push({ dataset, state: "invalid_receipt" });
+                continue;
+            }
+            const complete = activeRoot !== undefined && (await receiptFilesPresent(paths, activeRoot, receipt));
+            if (!complete) datasets.push({ dataset, receipt, state: "partial" });
+            else if (receipt.datasetVersion !== dataset.version) datasets.push({ dataset, receipt, state: "update_available" });
+            else datasets.push({ dataset, receipt, state: "installed" });
+        }
+        return ok({ exists: true, datasets, userContent });
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not inspect reference store at ${root}.`, cause });
+    }
+}
+
+/** Hash active managed files against the receipt and current catalog without mutating disk. */
+export async function verifyReferenceDatasets(
+    root: string,
+    datasetIds: readonly string[],
+    source: ReferenceCatalogSource = CANONICAL_REFERENCE_SOURCE,
+): Promise<Result<readonly ReferenceVerification[], ReferenceProvisionError>> {
+    const plan = source.resolveInstallPlan(datasetIds);
+    if (plan.isErr()) {
+        return err({
+            type: "unknown_dataset",
+            message: plan.error.message,
+            unknownId: plan.error.unknownId,
+            availableIds: plan.error.availableIds,
+        });
+    }
+    const paths = referenceStorePaths(root);
+    try {
+        const results: ReferenceVerification[] = [];
+        for (const dataset of plan.value.datasets) {
+            const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
+            if (!receiptRead.exists) {
+                results.push({ datasetId: dataset.id, files: [], state: "missing" });
+                continue;
+            }
+            const receipt = receiptRead.receipt;
+            const activeRoot = receipt === undefined ? undefined : activeManagedRoot(paths, dataset, receipt);
+            if (
+                receipt === undefined ||
+                activeRoot === undefined ||
+                (receipt.datasetVersion === dataset.version && !receiptMatchesCurrentCatalog(dataset, receipt))
+            ) {
+                results.push({ datasetId: dataset.id, files: [], state: "invalid_receipt" });
+                continue;
+            }
+            const files: ReferenceFileVerification[] = [];
+            for (const artifact of receipt.artifacts) {
+                const path = join(activeRoot, artifact.path);
+                const owned = await assertOwnedPath(paths.root, path);
+                const infoResult = owned.isOk() ? await pathLstat(path) : ok(undefined);
+                const info = infoResult.isOk() ? infoResult.value : undefined;
+                if (info === undefined || info.isSymbolicLink() || !info.isFile()) {
+                    files.push({ path: artifact.path, state: "missing" });
+                    continue;
+                }
+                if (info.size !== artifact.bytes) {
+                    files.push({ path: artifact.path, state: "modified" });
+                    continue;
+                }
+                const digestResult = await sha256File(path);
+                files.push({ path: artifact.path, state: digestResult.isOk() && digestResult.value === artifact.sha256 ? "valid" : "modified" });
+            }
+            const state = files.every((file) => file.state === "valid") ? "valid" : files.some((file) => file.state === "modified") ? "modified" : "missing";
+            results.push({ datasetId: dataset.id, version: receipt.datasetVersion, files, state });
+        }
+        return ok(results);
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not verify reference store at ${root}.`, cause });
+    }
+}
+
+function downloadName(key: string): string {
+    return createHash("sha256").update(key).digest("hex");
+}
+
+async function assertOwnedPath(root: string, candidate: string): Promise<Result<void, ReferenceProvisionError>> {
+    try {
+        if (!containedPath(root, candidate)) {
+            return err({ type: "managed_path_conflict", path: candidate, message: `Installer-owned path escapes the reference store: ${candidate}` });
+        }
+        const rootInfoResult = await pathLstat(root);
+        if (rootInfoResult.isErr()) return err(rootInfoResult.error);
+        const rootInfo = rootInfoResult.value;
+        if (rootInfo !== undefined && (!rootInfo.isDirectory() || rootInfo.isSymbolicLink())) {
+            return err({ type: "managed_path_conflict", path: root, message: `Reference store root is not a real directory: ${root}` });
+        }
+        const rel = relative(root, candidate);
+        let current = root;
+        for (const segment of rel.split(sep).filter(Boolean)) {
+            current = join(current, segment);
+            const infoResult = await pathLstat(current);
+            if (infoResult.isErr()) return err(infoResult.error);
+            const info = infoResult.value;
+            if (info === undefined) break;
+            if (info.isSymbolicLink()) {
+                return err({ type: "managed_path_conflict", path: current, message: `Refusing installer-owned symlink path: ${current}` });
+            }
+            if (current !== candidate && !info.isDirectory()) {
+                return err({ type: "managed_path_conflict", path: current, message: `Installer-owned path ancestor is not a directory: ${current}` });
+            }
+        }
+        return ok(undefined);
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not inspect installer-owned path ${candidate}.`, cause });
+    }
+}
+
+async function downloadArtifact(
+    artifact: ReferenceInstallPlanDataset["artifacts"][number],
+    paths: ReferenceStorePaths,
+    deps: ReferenceInstallDeps,
+): Promise<Result<{ readonly partPath: string; readonly bytesDownloaded: number }, ReferenceProvisionError>> {
+    const url = deps.resolveArtifactUrl(artifact.key);
+    if (url.isErr()) return err(url.error);
+    const partPath = join(paths.downloads, `${downloadName(artifact.key)}.part`);
+    try {
+        const owned = await assertOwnedPath(paths.root, partPath);
+        if (owned.isErr()) return err(owned.error);
+        await mkdir(paths.downloads, { recursive: true });
+        const priorResult = await pathStat(partPath);
+        if (priorResult.isErr()) return err(priorResult.error);
+        const prior = priorResult.value;
+        const offset = prior?.isFile() ? prior.size : 0;
+        if (offset > artifact.bytes) await rm(partPath, { force: true });
+        let resumeAt = offset <= artifact.bytes ? offset : 0;
+        if (resumeAt === artifact.bytes) {
+            const existingDigest = await sha256File(partPath);
+            if (existingDigest.isOk() && existingDigest.value === artifact.sha256) return ok({ partPath, bytesDownloaded: 0 });
+            await rm(partPath, { force: true });
+            resumeAt = 0;
+        }
+        const response = await (deps.fetch ?? fetch)(url.value, { headers: resumeAt > 0 ? { Range: `bytes=${resumeAt}-` } : undefined });
+        if (!response.ok || response.body === null) {
+            return err({ type: "download_failed", message: `Download failed for ${artifact.key}: HTTP ${response.status} ${response.statusText}` });
+        }
+        const appending = resumeAt > 0 && response.status === 206;
+        await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: appending ? "a" : "w" }));
+        const written = (await stat(partPath)).size;
+        if (written !== artifact.bytes) {
+            return err({
+                type: "size_mismatch",
+                path: artifact.path,
+                expected: artifact.bytes,
+                actual: written,
+                message: `Size mismatch for ${artifact.path}.`,
+            });
+        }
+        const digest = await sha256File(partPath);
+        if (digest.isErr()) return err({ type: "io_failed", message: `Could not hash ${artifact.path}.`, cause: digest.error.cause });
+        if (digest.value !== artifact.sha256) {
+            return err({
+                type: "digest_mismatch",
+                path: artifact.path,
+                expected: artifact.sha256,
+                actual: digest.value,
+                message: `SHA-256 mismatch for ${artifact.path}.`,
+            });
+        }
+        return ok({ partPath, bytesDownloaded: appending ? written - resumeAt : written });
+    } catch (cause) {
+        return err({ type: "download_failed", message: `Download failed for ${artifact.key}.`, cause });
+    }
+}
+
+function containedPath(root: string, child: string): boolean {
+    const rel = relative(resolve(root), resolve(child));
+    return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..");
+}
+
+async function assertReplaceable(finalRoot: string, dataset: ReferenceInstallPlanDataset): Promise<Result<void, ReferenceProvisionError>> {
+    const existingResult = await pathLstat(finalRoot);
+    if (existingResult.isErr()) return err(existingResult.error);
+    const existing = existingResult.value;
+    if (existing === undefined) return ok(undefined);
+    if (existing.isSymbolicLink() || !existing.isDirectory()) {
+        return err({ type: "managed_path_conflict", path: finalRoot, message: `Refusing to replace non-directory managed path: ${finalRoot}` });
+    }
+    const allowed = new Set(dataset.artifacts.map((artifact) => artifact.path));
+    const allowedDirectories = new Set(
+        dataset.artifacts.flatMap((artifact) => {
+            const segments = artifact.path.split("/").slice(0, -1);
+            return segments.map((_, index) => segments.slice(0, index + 1).join("/"));
+        }),
+    );
+    const visit = async (dir: string): Promise<Result<void, ReferenceProvisionError>> => {
+        for (const entry of await readdir(dir, { withFileTypes: true })) {
+            const full = join(dir, entry.name);
+            const rel = relative(finalRoot, full).split(sep).join("/");
+            const link = await lstat(full);
+            if (link.isSymbolicLink())
+                return err({ type: "managed_path_conflict", path: full, message: `Refusing to replace symlink in managed dataset: ${full}` });
+            if (entry.isDirectory()) {
+                if (!allowedDirectories.has(rel)) {
+                    return err({ type: "managed_path_conflict", path: full, message: `Refusing to overwrite unexpected managed directory: ${full}` });
+                }
+                const nested = await visit(full);
+                if (nested.isErr()) return nested;
+            } else if (!entry.isFile() || !allowed.has(rel)) {
+                return err({ type: "managed_path_conflict", path: full, message: `Refusing to overwrite unexpected managed content: ${full}` });
+            }
+        }
+        return ok(undefined);
+    };
+    try {
+        return await visit(finalRoot);
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not inspect existing managed path ${finalRoot}.`, cause });
+    }
+}
+
+async function writeReceiptAtomic(path: string, receipt: ReferenceInstallReceipt): Promise<Result<void, ReferenceProvisionError>> {
+    const temp = `${path}.${randomUUIDv7()}.tmp`;
+    try {
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(temp, `${JSON.stringify(receipt, null, 2)}\n`, { flag: "wx" });
+        await rename(temp, path);
+        return ok(undefined);
+    } catch (cause) {
+        await rm(temp, { force: true }).catch(() => undefined);
+        return err({ type: "io_failed", message: `Could not atomically write reference receipt ${path}.`, cause });
+    }
+}
+
+async function installDataset(
+    dataset: ReferenceInstallPlanDataset,
+    paths: ReferenceStorePaths,
+    deps: ReferenceInstallDeps,
+): Promise<Result<{ readonly id: string; readonly version: string; readonly bytesDownloaded: number }, ReferenceProvisionError>> {
+    const attempt = deps.attemptId?.() ?? `${Date.now()}-${createHash("sha256").update(dataset.id).digest("hex").slice(0, 8)}`;
+    const stageRoot = join(paths.staging, attempt, dataset.installPath);
+    const finalRoot = join(paths.managed, dataset.installPath);
+    if (!containedPath(paths.staging, stageRoot) || !containedPath(paths.managed, finalRoot)) {
+        return err({ type: "managed_path_conflict", path: finalRoot, message: `Unsafe managed destination for ${dataset.id}.` });
+    }
+    const stageOwned = await assertOwnedPath(paths.root, stageRoot);
+    if (stageOwned.isErr()) return err(stageOwned.error);
+    const finalOwned = await assertOwnedPath(paths.root, finalRoot);
+    if (finalOwned.isErr()) return err(finalOwned.error);
+    const replaceable = await assertReplaceable(finalRoot, dataset);
+    if (replaceable.isErr()) return err(replaceable.error);
+    const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
+    const activeReceipt = receiptRead.receipt;
+    if (activeReceipt !== undefined) {
+        const activeRoot = activeManagedRoot(paths, dataset, activeReceipt);
+        if (activeRoot !== undefined && receiptMatchesCurrentCatalog(dataset, activeReceipt) && (await receiptFilesPresent(paths, activeRoot, activeReceipt))) {
+            return ok({ id: dataset.id, version: dataset.version, bytesDownloaded: 0 });
+        }
+    }
+    let bytesDownloaded = 0;
+    try {
+        await rm(join(paths.staging, attempt), { recursive: true, force: true });
+        await mkdir(stageRoot, { recursive: true });
+        for (const artifact of dataset.artifacts) {
+            const downloaded = await downloadArtifact(artifact, paths, deps);
+            if (downloaded.isErr()) return err(downloaded.error);
+            bytesDownloaded += downloaded.value.bytesDownloaded;
+            const destination = join(stageRoot, artifact.path);
+            if (!containedPath(stageRoot, destination)) {
+                return err({ type: "managed_path_conflict", path: destination, message: `Unsafe artifact destination ${artifact.path}.` });
+            }
+            await mkdir(dirname(destination), { recursive: true });
+            await copyFile(downloaded.value.partPath, destination);
+        }
+
+        await mkdir(dirname(finalRoot), { recursive: true });
+        const receiptPath = join(paths.receipts, `${dataset.id}.json`);
+        const receiptOwned = await assertOwnedPath(paths.root, receiptPath);
+        if (receiptOwned.isErr()) return err(receiptOwned.error);
+        const backup = `${finalRoot}.previous-${attempt}`;
+        const finalStatus = await pathStat(finalRoot);
+        if (finalStatus.isErr()) return err(finalStatus.error);
+        const hadFinal = finalStatus.value !== undefined;
+        if (hadFinal) await rename(finalRoot, backup);
+        try {
+            await rename(stageRoot, finalRoot);
+        } catch (cause) {
+            await rm(finalRoot, { recursive: true, force: true }).catch(() => undefined);
+            if (hadFinal) await rename(backup, finalRoot).catch(() => undefined);
+            return err({ type: "io_failed", message: `Could not activate ${dataset.id}@${dataset.version}; prior activation was preserved.`, cause });
+        }
+        const receipt: ReferenceInstallReceipt = {
+            version: REFERENCE_INSTALL_RECEIPT_VERSION,
+            datasetId: dataset.id,
+            datasetVersion: dataset.version,
+            activatedAt: (deps.now?.() ?? new Date()).toISOString(),
+            artifacts: dataset.artifacts.map(({ path, bytes, sha256 }) => ({ path, bytes, sha256 })),
+        };
+        const receiptWrite = await writeReceiptAtomic(receiptPath, receipt);
+        if (receiptWrite.isErr()) {
+            await rm(finalRoot, { recursive: true, force: true }).catch(() => undefined);
+            if (hadFinal) await rename(backup, finalRoot).catch(() => undefined);
+            return err(receiptWrite.error);
+        }
+        if (hadFinal) await rm(backup, { recursive: true, force: true }).catch(() => undefined);
+        for (const artifact of dataset.artifacts) {
+            await rm(join(paths.downloads, `${downloadName(artifact.key)}.part`), { force: true }).catch(() => undefined);
+        }
+        return ok({ id: dataset.id, version: dataset.version, bytesDownloaded });
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not stage ${dataset.id}@${dataset.version}.`, cause });
+    }
+}
+
+/** Resolve, download, verify, and atomically activate selected catalog datasets. */
+export async function installReferenceDatasets(
+    datasetIds: readonly string[],
+    deps: ReferenceInstallDeps,
+): Promise<Result<ReferenceInstallOutcome, ReferenceProvisionError>> {
+    const plan = (deps.source ?? CANONICAL_REFERENCE_SOURCE).resolveInstallPlan(datasetIds);
+    if (plan.isErr()) {
+        return err({
+            type: "unknown_dataset",
+            message: plan.error.message,
+            unknownId: plan.error.unknownId,
+            availableIds: plan.error.availableIds,
+        });
+    }
+    const ensured = await ensureReferenceStore(deps.root);
+    if (ensured.isErr()) return err(ensured.error);
+    const installed: { readonly id: string; readonly version: string; readonly bytesDownloaded: number }[] = [];
+    for (const dataset of plan.value.datasets) {
+        const result = await installDataset(dataset, ensured.value, deps);
+        if (result.isErr()) return err(result.error);
+        installed.push(result.value);
+    }
+    return ok({ installed });
+}
+
+/** Compute bytes still needed from resumable partials without creating state. */
+export async function referenceDownloadBytes(
+    datasetIds: readonly string[],
+    root: string,
+    source: ReferenceCatalogSource = CANONICAL_REFERENCE_SOURCE,
+): Promise<Result<number, ReferenceProvisionError>> {
+    const plan = source.resolveInstallPlan(datasetIds);
+    if (plan.isErr()) {
+        return err({ type: "unknown_dataset", message: plan.error.message, unknownId: plan.error.unknownId, availableIds: plan.error.availableIds });
+    }
+    const paths = referenceStorePaths(root);
+    try {
+        let bytes = 0;
+        for (const dataset of plan.value.datasets) {
+            const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
+            const activeReceipt = receiptRead.receipt;
+            if (activeReceipt !== undefined) {
+                const activeRoot = activeManagedRoot(paths, dataset, activeReceipt);
+                if (
+                    activeRoot !== undefined &&
+                    receiptMatchesCurrentCatalog(dataset, activeReceipt) &&
+                    (await receiptFilesPresent(paths, activeRoot, activeReceipt))
+                ) {
+                    continue;
+                }
+            }
+            for (const artifact of dataset.artifacts) {
+                const partPath = join(paths.downloads, `${downloadName(artifact.key)}.part`);
+                const owned = await assertOwnedPath(paths.root, partPath);
+                if (owned.isErr()) return err(owned.error);
+                const partialResult = await pathLstat(partPath);
+                if (partialResult.isErr()) return err(partialResult.error);
+                const partial = partialResult.value;
+                if (partial?.isSymbolicLink())
+                    return err({ type: "managed_path_conflict", path: partPath, message: `Refusing resumable symlink path: ${partPath}` });
+                if (partial?.isFile() && partial.size === artifact.bytes) {
+                    const digest = await sha256File(partPath);
+                    bytes += digest.isOk() && digest.value === artifact.sha256 ? 0 : artifact.bytes;
+                } else {
+                    bytes += Math.max(0, artifact.bytes - (partial?.isFile() ? Math.min(partial.size, artifact.bytes) : 0));
+                }
+            }
+        }
+        return ok(bytes);
+    } catch (cause) {
+        return err({ type: "io_failed", message: `Could not inspect resumable downloads at ${root}.`, cause });
+    }
+}

--- a/cli/src/modules/refs/store.ts
+++ b/cli/src/modules/refs/store.ts
@@ -263,7 +263,11 @@ async function readReceipt(path: string, storeRoot: string): Promise<{ readonly 
 async function receiptFilesPresent(paths: ReferenceStorePaths, root: string, receipt: ReferenceInstallReceipt): Promise<boolean> {
     for (const artifact of receipt.artifacts) {
         const path = join(root, artifact.path);
-        const owned = await assertOwnedPath(paths.root, path);
+        // Contained against the dataset's own root, not the store's: `managed/` and `user/` are
+        // siblings, so a store-scoped check would let a receipt path reach into user content or a
+        // neighbouring dataset. The receipt schema already refuses traversal segments — this is the
+        // second lock on the same door, because the receipt is a file on disk that anyone can edit.
+        const owned = await assertOwnedPath(root, path);
         if (owned.isErr()) return false;
         const fileResult = await pathLstat(path);
         // Cheap state deliberately treats unreadable content as damaged/partial: it must never claim
@@ -286,7 +290,7 @@ async function receiptFilesPresent(paths: ReferenceStorePaths, root: string, rec
 async function receiptFilesIntact(paths: ReferenceStorePaths, root: string, receipt: ReferenceInstallReceipt): Promise<boolean> {
     for (const artifact of receipt.artifacts) {
         const path = join(root, artifact.path);
-        const owned = await assertOwnedPath(paths.root, path);
+        const owned = await assertOwnedPath(root, path);
         if (owned.isErr()) return false;
         const fileResult = await pathLstat(path);
         if (fileResult.isErr()) return false;
@@ -425,7 +429,7 @@ export async function verifyReferenceDatasets(
             const files: ReferenceFileVerification[] = [];
             for (const artifact of receipt.artifacts) {
                 const path = join(activeRoot, artifact.path);
-                const owned = await assertOwnedPath(paths.root, path);
+                const owned = await assertOwnedPath(activeRoot, path);
                 const infoResult = owned.isOk() ? await pathLstat(path) : ok(undefined);
                 const info = infoResult.isOk() ? infoResult.value : undefined;
                 if (info === undefined || info.isSymbolicLink() || !info.isFile()) {
@@ -540,6 +544,15 @@ async function downloadArtifact(
             return err({
                 type: "download_failed",
                 message: `Download failed for ${artifact.path}: HTTP ${response.status} ${response.statusText} (${artifact.url})`,
+            });
+        }
+        // The catalog guarantees an https URL, but fetch follows redirects, so the guarantee has to
+        // hold for whatever actually served the bytes. A `pinned` artifact would still be caught by
+        // its digest; an `unpinned` one has none, and would trust a downgraded hop on first use.
+        if (response.url !== "" && !response.url.startsWith("https://")) {
+            return err({
+                type: "download_failed",
+                message: `Refusing ${artifact.path}: ${artifact.url} redirected to a non-https location (${response.url}).`,
             });
         }
         const appending = resumeAt > 0 && response.status === 206;

--- a/cli/src/modules/refs/store.ts
+++ b/cli/src/modules/refs/store.ts
@@ -10,12 +10,16 @@ import {
     REFERENCE_DATA_CATALOG,
     REFERENCE_INSTALL_RECEIPT_VERSION,
     parseReferenceInstallReceipt,
+    referenceArtifactKey,
     resolveReferenceInstallPlan,
+    type ReferenceArtifact,
     type ReferenceDataCatalog,
     type ReferenceDataset,
     type ReferenceInstallPlan,
     type ReferenceInstallPlanDataset,
     type ReferenceInstallReceipt,
+    type ReferenceIntegrity,
+    type ReferenceReceiptArtifact,
     type UnknownReferenceDatasetError,
 } from "@inflexa-ai/harness";
 import { err, ok, type Result } from "neverthrow";
@@ -69,6 +73,8 @@ export type ReferenceFileVerification = {
     readonly path: string;
     /** Verification outcome. */
     readonly state: "valid" | "missing" | "modified";
+    /** Which guarantee this file's digest was checked against. */
+    readonly integrity: ReferenceIntegrity;
 };
 
 /** Explicit verification result for an active catalog dataset. */
@@ -92,17 +98,6 @@ type UnknownDatasetError = {
     readonly unknownId: string;
     /** Catalog ids available to select. */
     readonly availableIds: readonly string[];
-};
-
-type ArtifactUrlError = {
-    /** Stable discriminator. */
-    readonly type: "artifact_url_unconfigured";
-    /** User-facing explanation. */
-    readonly message: string;
-    /** Opaque artifact key that could not be resolved. */
-    readonly key: string;
-    /** Underlying URL parse failure, when present. */
-    readonly cause?: unknown;
 };
 
 type ProvisionOperationError = {
@@ -137,14 +132,12 @@ type ManagedPathConflictError = {
 };
 
 /** Typed failures from local inspection, verification, transfer, or activation. */
-export type ReferenceProvisionError = UnknownDatasetError | ArtifactUrlError | ProvisionOperationError | ContentMismatchError | ManagedPathConflictError;
+export type ReferenceProvisionError = UnknownDatasetError | ProvisionOperationError | ContentMismatchError | ManagedPathConflictError;
 
-/** Network and release-location dependencies supplied by the CLI composition edge. */
+/** Network dependencies supplied by the CLI composition edge. */
 export type ReferenceInstallDeps = {
     /** Public store root. */
     readonly root: string;
-    /** Convert an opaque harness artifact key to a concrete public URL. */
-    readonly resolveArtifactUrl: (key: string) => Result<URL, ReferenceProvisionError>;
     /** Catalog/plan seam used by tests; production always defaults to the immutable harness source. */
     readonly source?: ReferenceCatalogSource;
     /** Fetch implementation; defaults to the runtime fetch. */
@@ -153,6 +146,17 @@ export type ReferenceInstallDeps = {
     readonly now?: () => Date;
     /** Stable attempt id used for staging. */
     readonly attemptId?: () => string;
+};
+
+/** Caller-chosen installation behavior. */
+export type ReferenceInstallOptions = {
+    /**
+     * Re-fetch and re-activate even when the active install is intact. This is the
+     * only way to pull a fresh copy of an `unpinned` dataset whose mutable upstream
+     * has moved on — an intact install of the bytes we previously received is
+     * indistinguishable from an up-to-date one without going to the network.
+     */
+    readonly force?: boolean;
 };
 
 /** Read-only catalog plus the matching pure selection operation. */
@@ -184,6 +188,14 @@ export type ReferenceInstallOutcome = {
     readonly installed: readonly InstalledReferenceDataset[];
 };
 
+/** Bytes still to transfer, plus what cannot be known before contacting the upstream. */
+export type ReferenceDownloadEstimate = {
+    /** Bytes missing across `pinned` artifacts, whose sizes the catalog knows. */
+    readonly bytes: number;
+    /** Count of `unpinned` artifacts whose size only the mutable upstream can report. */
+    readonly unsizedArtifacts: number;
+};
+
 /** Resolve all owned paths without creating anything. */
 export function referenceStorePaths(root: string): ReferenceStorePaths {
     const metadata = join(root, ".inflexa");
@@ -208,31 +220,6 @@ export async function ensureReferenceStore(root: string): Promise<Result<Referen
         return ok(paths);
     } catch (cause) {
         return err({ type: "io_failed", message: `Could not create reference store at ${root}.`, cause });
-    }
-}
-
-/** Resolve an artifact key below an explicitly configured public distribution base. */
-export function resolvePublicArtifactUrl(key: string, baseUrl: string | undefined): Result<URL, ReferenceProvisionError> {
-    if (baseUrl === undefined || baseUrl.trim() === "") {
-        return err({
-            type: "artifact_url_unconfigured",
-            key,
-            message: `No public reference-data artifact endpoint is configured for ${key}.`,
-        });
-    }
-    try {
-        const base = new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
-        const segments = key.split("/");
-        if (key.startsWith("/") || key.includes("\\") || segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
-            return err({ type: "artifact_url_unconfigured", key, message: `Unsafe reference-data artifact key: ${key}` });
-        }
-        const url = new URL(segments.map(encodeURIComponent).join("/"), base);
-        if (url.origin !== base.origin || !url.pathname.startsWith(base.pathname)) {
-            return err({ type: "artifact_url_unconfigured", key, message: `Artifact key escapes the configured reference-data endpoint: ${key}` });
-        }
-        return ok(url);
-    } catch (cause) {
-        return err({ type: "artifact_url_unconfigured", key, message: `The configured reference-data endpoint is invalid: ${baseUrl}`, cause });
     }
 }
 
@@ -289,14 +276,43 @@ async function receiptFilesPresent(paths: ReferenceStorePaths, root: string, rec
     return true;
 }
 
+/**
+ * Whether every activated file still hashes to what the receipt recorded. This is the
+ * authoritative completeness check — `receiptFilesPresent` compares sizes only, so a
+ * same-size corruption (bit rot, a hand-edit) reads as "installed" to it. Install and
+ * download-planning both gate on *this*, so a damaged dataset re-downloads and heals
+ * instead of being silently skipped.
+ */
+async function receiptFilesIntact(paths: ReferenceStorePaths, root: string, receipt: ReferenceInstallReceipt): Promise<boolean> {
+    for (const artifact of receipt.artifacts) {
+        const path = join(root, artifact.path);
+        const owned = await assertOwnedPath(paths.root, path);
+        if (owned.isErr()) return false;
+        const fileResult = await pathLstat(path);
+        if (fileResult.isErr()) return false;
+        const file = fileResult.value;
+        if (file === undefined || file.isSymbolicLink() || !file.isFile() || file.size !== artifact.bytes) return false;
+        const digest = await sha256File(path);
+        if (digest.isErr() || digest.value !== artifact.sha256) return false;
+    }
+    return true;
+}
+
+/**
+ * Whether the receipt still describes what the catalog now says. A `pinned` artifact
+ * must match the catalog's size and digest; an `unpinned` one has no catalog digest to
+ * match, so only its presence and class are compared.
+ */
 function receiptMatchesCurrentCatalog(dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): boolean {
     if (receipt.datasetVersion !== dataset.version || receipt.artifacts.length !== dataset.artifacts.length) return false;
-    const expected = new Map(dataset.artifacts.map((artifact) => [artifact.path, `${artifact.bytes}:${artifact.sha256}`]));
+    const expected = new Map(dataset.artifacts.map((artifact) => [artifact.path, artifact]));
     const actualPaths = new Set(receipt.artifacts.map((artifact) => artifact.path));
-    return (
-        actualPaths.size === receipt.artifacts.length &&
-        receipt.artifacts.every((artifact) => expected.get(artifact.path) === `${artifact.bytes}:${artifact.sha256}`)
-    );
+    if (actualPaths.size !== receipt.artifacts.length) return false;
+    return receipt.artifacts.every((recorded) => {
+        const artifact = expected.get(recorded.path);
+        if (artifact === undefined || artifact.integrity !== recorded.integrity) return false;
+        return artifact.integrity === "pinned" ? artifact.bytes === recorded.bytes && artifact.sha256 === recorded.sha256 : true;
+    });
 }
 
 function activeManagedRoot(paths: ReferenceStorePaths, dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): string | undefined {
@@ -367,7 +383,12 @@ export async function inspectReferenceStore(
     }
 }
 
-/** Hash active managed files against the receipt and current catalog without mutating disk. */
+/**
+ * Hash active managed files against the receipt without mutating disk. The receipt is
+ * the reference in both integrity classes: for `pinned` artifacts it equals the catalog
+ * digest (activation would have failed otherwise), and for `unpinned` ones it is the
+ * only honest record — what the mutable upstream actually served at install time.
+ */
 export async function verifyReferenceDatasets(
     root: string,
     datasetIds: readonly string[],
@@ -408,15 +429,19 @@ export async function verifyReferenceDatasets(
                 const infoResult = owned.isOk() ? await pathLstat(path) : ok(undefined);
                 const info = infoResult.isOk() ? infoResult.value : undefined;
                 if (info === undefined || info.isSymbolicLink() || !info.isFile()) {
-                    files.push({ path: artifact.path, state: "missing" });
+                    files.push({ path: artifact.path, state: "missing", integrity: artifact.integrity });
                     continue;
                 }
                 if (info.size !== artifact.bytes) {
-                    files.push({ path: artifact.path, state: "modified" });
+                    files.push({ path: artifact.path, state: "modified", integrity: artifact.integrity });
                     continue;
                 }
                 const digestResult = await sha256File(path);
-                files.push({ path: artifact.path, state: digestResult.isOk() && digestResult.value === artifact.sha256 ? "valid" : "modified" });
+                files.push({
+                    path: artifact.path,
+                    state: digestResult.isOk() && digestResult.value === artifact.sha256 ? "valid" : "modified",
+                    integrity: artifact.integrity,
+                });
             }
             const state = files.every((file) => file.state === "valid") ? "valid" : files.some((file) => file.state === "modified") ? "modified" : "missing";
             results.push({ datasetId: dataset.id, version: receipt.datasetVersion, files, state });
@@ -463,38 +488,65 @@ async function assertOwnedPath(root: string, candidate: string): Promise<Result<
     }
 }
 
+/** What one transfer actually produced, whether or not the catalog could predict it. */
+type DownloadedArtifact = {
+    readonly partPath: string;
+    readonly bytesDownloaded: number;
+    readonly observed: ReferenceReceiptArtifact;
+};
+
 async function downloadArtifact(
-    artifact: ReferenceInstallPlanDataset["artifacts"][number],
+    dataset: ReferenceInstallPlanDataset,
+    artifact: ReferenceArtifact,
     paths: ReferenceStorePaths,
     deps: ReferenceInstallDeps,
-): Promise<Result<{ readonly partPath: string; readonly bytesDownloaded: number }, ReferenceProvisionError>> {
-    const url = deps.resolveArtifactUrl(artifact.key);
-    if (url.isErr()) return err(url.error);
-    const partPath = join(paths.downloads, `${downloadName(artifact.key)}.part`);
+): Promise<Result<DownloadedArtifact, ReferenceProvisionError>> {
+    const key = referenceArtifactKey(dataset, artifact);
+    const partPath = join(paths.downloads, `${downloadName(key)}.part`);
     try {
         const owned = await assertOwnedPath(paths.root, partPath);
         if (owned.isErr()) return err(owned.error);
         await mkdir(paths.downloads, { recursive: true });
-        const priorResult = await pathStat(partPath);
-        if (priorResult.isErr()) return err(priorResult.error);
-        const prior = priorResult.value;
-        const offset = prior?.isFile() ? prior.size : 0;
-        if (offset > artifact.bytes) await rm(partPath, { force: true });
-        let resumeAt = offset <= artifact.bytes ? offset : 0;
-        if (resumeAt === artifact.bytes) {
-            const existingDigest = await sha256File(partPath);
-            if (existingDigest.isOk() && existingDigest.value === artifact.sha256) return ok({ partPath, bytesDownloaded: 0 });
+
+        // Resume is only sound when the catalog knows the final size and digest: without
+        // them a partial file cannot be told apart from a complete one, and appending to
+        // bytes an upstream has since changed would splice two different files together.
+        let resumeAt = 0;
+        if (artifact.integrity === "pinned") {
+            const priorResult = await pathStat(partPath);
+            if (priorResult.isErr()) return err(priorResult.error);
+            const prior = priorResult.value;
+            const offset = prior?.isFile() ? prior.size : 0;
+            if (offset > artifact.bytes) await rm(partPath, { force: true });
+            resumeAt = offset <= artifact.bytes ? offset : 0;
+            if (resumeAt === artifact.bytes) {
+                const existingDigest = await sha256File(partPath);
+                if (existingDigest.isOk() && existingDigest.value === artifact.sha256) {
+                    return ok({
+                        partPath,
+                        bytesDownloaded: 0,
+                        observed: { path: artifact.path, bytes: artifact.bytes, sha256: artifact.sha256, integrity: "pinned" },
+                    });
+                }
+                await rm(partPath, { force: true });
+                resumeAt = 0;
+            }
+        } else {
             await rm(partPath, { force: true });
-            resumeAt = 0;
         }
-        const response = await (deps.fetch ?? fetch)(url.value, { headers: resumeAt > 0 ? { Range: `bytes=${resumeAt}-` } : undefined });
+
+        const response = await (deps.fetch ?? fetch)(artifact.url, { headers: resumeAt > 0 ? { Range: `bytes=${resumeAt}-` } : undefined });
         if (!response.ok || response.body === null) {
-            return err({ type: "download_failed", message: `Download failed for ${artifact.key}: HTTP ${response.status} ${response.statusText}` });
+            return err({
+                type: "download_failed",
+                message: `Download failed for ${artifact.path}: HTTP ${response.status} ${response.statusText} (${artifact.url})`,
+            });
         }
         const appending = resumeAt > 0 && response.status === 206;
         await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: appending ? "a" : "w" }));
         const written = (await stat(partPath)).size;
-        if (written !== artifact.bytes) {
+
+        if (artifact.integrity === "pinned" && written !== artifact.bytes) {
             return err({
                 type: "size_mismatch",
                 path: artifact.path,
@@ -505,18 +557,22 @@ async function downloadArtifact(
         }
         const digest = await sha256File(partPath);
         if (digest.isErr()) return err({ type: "io_failed", message: `Could not hash ${artifact.path}.`, cause: digest.error.cause });
-        if (digest.value !== artifact.sha256) {
+        if (artifact.integrity === "pinned" && digest.value !== artifact.sha256) {
             return err({
                 type: "digest_mismatch",
                 path: artifact.path,
                 expected: artifact.sha256,
                 actual: digest.value,
-                message: `SHA-256 mismatch for ${artifact.path}.`,
+                message: `SHA-256 mismatch for ${artifact.path}. The upstream bytes are not the reviewed bytes; nothing was activated.`,
             });
         }
-        return ok({ partPath, bytesDownloaded: appending ? written - resumeAt : written });
+        return ok({
+            partPath,
+            bytesDownloaded: appending ? written - resumeAt : written,
+            observed: { path: artifact.path, bytes: written, sha256: digest.value, integrity: artifact.integrity },
+        });
     } catch (cause) {
-        return err({ type: "download_failed", message: `Download failed for ${artifact.key}.`, cause });
+        return err({ type: "download_failed", message: `Download failed for ${artifact.path} (${artifact.url}).`, cause });
     }
 }
 
@@ -583,9 +639,11 @@ async function installDataset(
     dataset: ReferenceInstallPlanDataset,
     paths: ReferenceStorePaths,
     deps: ReferenceInstallDeps,
-): Promise<Result<{ readonly id: string; readonly version: string; readonly bytesDownloaded: number }, ReferenceProvisionError>> {
+    options: ReferenceInstallOptions,
+): Promise<Result<InstalledReferenceDataset, ReferenceProvisionError>> {
     const attempt = deps.attemptId?.() ?? `${Date.now()}-${createHash("sha256").update(dataset.id).digest("hex").slice(0, 8)}`;
-    const stageRoot = join(paths.staging, attempt, dataset.installPath);
+    const attemptRoot = join(paths.staging, attempt);
+    const stageRoot = join(attemptRoot, dataset.installPath);
     const finalRoot = join(paths.managed, dataset.installPath);
     if (!containedPath(paths.staging, stageRoot) || !containedPath(paths.managed, finalRoot)) {
         return err({ type: "managed_path_conflict", path: finalRoot, message: `Unsafe managed destination for ${dataset.id}.` });
@@ -598,20 +656,22 @@ async function installDataset(
     if (replaceable.isErr()) return err(replaceable.error);
     const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
     const activeReceipt = receiptRead.receipt;
-    if (activeReceipt !== undefined) {
+    if (!options.force && activeReceipt !== undefined) {
         const activeRoot = activeManagedRoot(paths, dataset, activeReceipt);
-        if (activeRoot !== undefined && receiptMatchesCurrentCatalog(dataset, activeReceipt) && (await receiptFilesPresent(paths, activeRoot, activeReceipt))) {
+        if (activeRoot !== undefined && receiptMatchesCurrentCatalog(dataset, activeReceipt) && (await receiptFilesIntact(paths, activeRoot, activeReceipt))) {
             return ok({ id: dataset.id, version: dataset.version, bytesDownloaded: 0 });
         }
     }
     let bytesDownloaded = 0;
     try {
-        await rm(join(paths.staging, attempt), { recursive: true, force: true });
+        await rm(attemptRoot, { recursive: true, force: true });
         await mkdir(stageRoot, { recursive: true });
+        const observed: ReferenceReceiptArtifact[] = [];
         for (const artifact of dataset.artifacts) {
-            const downloaded = await downloadArtifact(artifact, paths, deps);
+            const downloaded = await downloadArtifact(dataset, artifact, paths, deps);
             if (downloaded.isErr()) return err(downloaded.error);
             bytesDownloaded += downloaded.value.bytesDownloaded;
+            observed.push(downloaded.value.observed);
             const destination = join(stageRoot, artifact.path);
             if (!containedPath(stageRoot, destination)) {
                 return err({ type: "managed_path_conflict", path: destination, message: `Unsafe artifact destination ${artifact.path}.` });
@@ -641,7 +701,7 @@ async function installDataset(
             datasetId: dataset.id,
             datasetVersion: dataset.version,
             activatedAt: (deps.now?.() ?? new Date()).toISOString(),
-            artifacts: dataset.artifacts.map(({ path, bytes, sha256 }) => ({ path, bytes, sha256 })),
+            artifacts: observed,
         };
         const receiptWrite = await writeReceiptAtomic(receiptPath, receipt);
         if (receiptWrite.isErr()) {
@@ -651,11 +711,15 @@ async function installDataset(
         }
         if (hadFinal) await rm(backup, { recursive: true, force: true }).catch(() => undefined);
         for (const artifact of dataset.artifacts) {
-            await rm(join(paths.downloads, `${downloadName(artifact.key)}.part`), { force: true }).catch(() => undefined);
+            await rm(join(paths.downloads, `${downloadName(referenceArtifactKey(dataset, artifact))}.part`), { force: true }).catch(() => undefined);
         }
         return ok({ id: dataset.id, version: dataset.version, bytesDownloaded });
     } catch (cause) {
         return err({ type: "io_failed", message: `Could not stage ${dataset.id}@${dataset.version}.`, cause });
+    } finally {
+        // The activation `rename` moves the staged version dir out, leaving its parents
+        // behind; every attempt gets a fresh id, so without this they accumulate forever.
+        await rm(attemptRoot, { recursive: true, force: true }).catch(() => undefined);
     }
 }
 
@@ -663,6 +727,7 @@ async function installDataset(
 export async function installReferenceDatasets(
     datasetIds: readonly string[],
     deps: ReferenceInstallDeps,
+    options: ReferenceInstallOptions = {},
 ): Promise<Result<ReferenceInstallOutcome, ReferenceProvisionError>> {
     const plan = (deps.source ?? CANONICAL_REFERENCE_SOURCE).resolveInstallPlan(datasetIds);
     if (plan.isErr()) {
@@ -675,21 +740,22 @@ export async function installReferenceDatasets(
     }
     const ensured = await ensureReferenceStore(deps.root);
     if (ensured.isErr()) return err(ensured.error);
-    const installed: { readonly id: string; readonly version: string; readonly bytesDownloaded: number }[] = [];
+    const installed: InstalledReferenceDataset[] = [];
     for (const dataset of plan.value.datasets) {
-        const result = await installDataset(dataset, ensured.value, deps);
+        const result = await installDataset(dataset, ensured.value, deps, options);
         if (result.isErr()) return err(result.error);
         installed.push(result.value);
     }
     return ok({ installed });
 }
 
-/** Compute bytes still needed from resumable partials without creating state. */
+/** Estimate the transfer without creating state or contacting any upstream. */
 export async function referenceDownloadBytes(
     datasetIds: readonly string[],
     root: string,
     source: ReferenceCatalogSource = CANONICAL_REFERENCE_SOURCE,
-): Promise<Result<number, ReferenceProvisionError>> {
+    options: ReferenceInstallOptions = {},
+): Promise<Result<ReferenceDownloadEstimate, ReferenceProvisionError>> {
     const plan = source.resolveInstallPlan(datasetIds);
     if (plan.isErr()) {
         return err({ type: "unknown_dataset", message: plan.error.message, unknownId: plan.error.unknownId, availableIds: plan.error.availableIds });
@@ -697,21 +763,28 @@ export async function referenceDownloadBytes(
     const paths = referenceStorePaths(root);
     try {
         let bytes = 0;
+        let unsizedArtifacts = 0;
         for (const dataset of plan.value.datasets) {
             const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
             const activeReceipt = receiptRead.receipt;
-            if (activeReceipt !== undefined) {
+            if (!options.force && activeReceipt !== undefined) {
                 const activeRoot = activeManagedRoot(paths, dataset, activeReceipt);
                 if (
                     activeRoot !== undefined &&
                     receiptMatchesCurrentCatalog(dataset, activeReceipt) &&
-                    (await receiptFilesPresent(paths, activeRoot, activeReceipt))
+                    (await receiptFilesIntact(paths, activeRoot, activeReceipt))
                 ) {
                     continue;
                 }
             }
             for (const artifact of dataset.artifacts) {
-                const partPath = join(paths.downloads, `${downloadName(artifact.key)}.part`);
+                // Only a mutable upstream can say how big its current file is, and asking
+                // would mean a network round-trip inside what is a purely local estimate.
+                if (artifact.integrity === "unpinned") {
+                    unsizedArtifacts += 1;
+                    continue;
+                }
+                const partPath = join(paths.downloads, `${downloadName(referenceArtifactKey(dataset, artifact))}.part`);
                 const owned = await assertOwnedPath(paths.root, partPath);
                 if (owned.isErr()) return err(owned.error);
                 const partialResult = await pathLstat(partPath);
@@ -727,7 +800,7 @@ export async function referenceDownloadBytes(
                 }
             }
         }
-        return ok(bytes);
+        return ok({ bytes, unsizedArtifacts });
     } catch (cause) {
         return err({ type: "io_failed", message: `Could not inspect resumable downloads at ${root}.`, cause });
     }

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The harness already owns the sandbox reference-store contract: embedders may mount a host directory or PVC read-only at `/mnt/refs`, and sandbox agents receive `list_available_refs`. The current tool is a static singleton that reads `/mnt/refs/registry.json` from the harness process. That works only when the harness process itself sees that path, treats a missing registry as a missing store, and hides user-added files not named by the registry.
+
+The local CLI and managed deployment now both need to provision the same supported datasets. The common facts are dataset identity, version, provenance, licensing, content hashes, sizes, and final sandbox layout. Transfer URLs, credentials, storage roots, prompts, PVC lifecycle, and update policy remain host concerns.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give supported reference data one versioned, reviewable owner shared by all embedders.
+- Keep the harness host-agnostic by returning content-addressed install plans rather than performing downloads.
+- Make runtime discovery reflect the filesystem actually mounted in the sandbox.
+- Discover arbitrary user content without requiring catalog or receipt registration.
+- Bound inventory cost and model-context size while allowing agents to drill into a subtree.
+- Keep existing managed `registry.json` stores useful during migration.
+
+**Non-Goals:**
+
+- Downloading data from a sandbox workload or granting the sandbox network access.
+- Owning local XDG paths, cloud buckets, PVC provisioning, credentials, prompts, or progress rendering.
+- Defining a mutable remote catalog or allowing an embedder to silently replace catalog content.
+- Parsing scientific data formats or inferring biological semantics from file contents.
+
+## Decisions
+
+### The harness owns a checked-in catalog; embedders own artifact resolution and transfer
+
+The catalog lives under `src/reference-data/`, is validated as trusted package data, and is exposed through the curated package barrel. Each dataset entry carries a stable id, version, title, description, source and license links, recommendation/grouping metadata, and one or more final-file artifacts. Each artifact carries an opaque distribution key, byte size, SHA-256 digest, and a safe path relative to the dataset's installation root.
+
+The catalog deliberately carries an artifact key rather than a deployment URL. The CLI maps the key to the public distribution endpoint; managed infrastructure may map the same key to an internal mirror. This keeps content identity and sandbox layout identical without making network topology part of the harness interface.
+
+An alternative was a root-level JSON file. That has no package/build owner and would require the CLI binary, harness package, and managed tooling to invent separate packaging rules. An alternative was a CLI-local catalog; the second real consumer makes that ownership incorrect.
+
+### Catalog artifacts are final files, not installer recipes
+
+The first catalog version describes the final files of a dataset rather than arbitrary scripts or archive extraction instructions. Build/publish automation is responsible for producing those immutable files. A selection resolves to a pure install plan containing dataset roots and file artifacts; the embedder stages, verifies, and activates the plan.
+
+This keeps the harness interface small and avoids embedding host-specific process execution, archive tooling, or untrusted transformation logic. A future archive format requires an explicit catalog-version extension rather than an untyped recipe escape hatch.
+
+### Receipts are a shared optional metadata format
+
+The harness defines a versioned receipt shape recording dataset id/version, installed artifacts, digests, sizes, relative paths, and activation time. Both embedders may write receipts under a reserved metadata directory. Discovery may use valid receipts to label catalog-managed datasets and preferred versions, but invalid or absent receipts never hide files.
+
+The legacy top-level `registry.json` remains an optional enrichment source. It is no longer the availability oracle and can be retired independently after managed stores emit receipts.
+
+### Discovery runs against the live sandbox filesystem
+
+`list_available_refs` becomes a dependency-bearing tool created with the sandbox agent. It uses the same internal sandbox-exec runner as `execute_command`, receives a replay-stable function id and step deadline, and declares `executionMode: "workflow"`. The shared runner remains the one submit/await chokepoint; the reference tool does not introduce a parallel sandbox protocol.
+
+The tool accepts an optional path constrained beneath `/mnt/refs`. The default call returns a bounded summary of the root; a path call drills into one subtree. It does not follow symlinks, excludes the reserved metadata directory from data results, reports truncation explicitly, and distinguishes unmounted, empty, and populated stores. The scan runs where `/mnt/refs` is actually mounted, so Docker host paths and Kubernetes PVC paths need not be visible under that name in the harness process.
+
+An alternative was passing a host `refsRoot` into agent construction. That would report the embedder's intended source rather than the sandbox's observable truth and would couple Docker and Kubernetes path models to the tool.
+
+### Discovery is bounded and metadata is enrichment
+
+A complete recursive manifest can be enormous for sharded references. The default result summarizes top-level entries with counts, aggregate bytes where cheaply available, representative file types, and concrete `/mnt/refs/...` paths. Drill-down remains capped by entry count and output bytes and returns a continuation/truncation hint rather than silently dropping data.
+
+Catalog descriptions, receipts, and legacy registry fields may add names and provenance to matching paths. The filesystem inventory is always merged in, so `user/` and any other unregistered content remains visible.
+
+## Risks / Trade-offs
+
+- **Catalog changes require a harness release** → This is intentional: dataset identity and digests are supply-chain inputs and should pass package review. Artifact bytes can be published independently under already-cataloged immutable keys.
+- **A sandbox scan consumes an exec operation** → Keep it on-demand, bounded, and replay-safe through the existing runner; agents already orient once before analysis.
+- **Large directories can still be expensive to summarize** → Bound traversal work as well as rendered output, avoid content hashing during discovery, and require drill-down for deep trees.
+- **Legacy registry metadata may disagree with disk** → Disk wins; stale metadata is labeled or ignored and never causes a real path to disappear.
+- **User content may contain misleading names or symlinks** → Treat it as untrusted read-only data, never execute it during discovery, never follow symlinks, and keep sandbox confinement unchanged.
+
+## Migration Plan
+
+1. Add and validate the catalog and receipt contracts without changing mounts.
+2. Export the catalog selection interface for embedders.
+3. Convert `list_available_refs` to sandbox-visible bounded discovery with receipt and registry enrichment.
+4. Keep existing managed stores working unchanged; their registry becomes optional metadata.
+5. Let each embedder adopt the catalog and receipt format independently.
+
+Rollback is additive for catalog consumers. Reverting dynamic discovery restores manifest-only behavior but does not alter stored reference bytes.
+
+## Open Questions
+
+- The initial catalog contents and public artifact publication base are release-data work; the contract does not require those deployment values to be decided in this change.

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/design.md
@@ -2,67 +2,96 @@
 
 The harness already owns the sandbox reference-store contract: embedders may mount a host directory or PVC read-only at `/mnt/refs`, and sandbox agents receive `list_available_refs`. The current tool is a static singleton that reads `/mnt/refs/registry.json` from the harness process. That works only when the harness process itself sees that path, treats a missing registry as a missing store, and hides user-added files not named by the registry.
 
-The local CLI and managed deployment now both need to provision the same supported datasets. The common facts are dataset identity, version, provenance, licensing, content hashes, sizes, and final sandbox layout. Transfer URLs, credentials, storage roots, prompts, PVC lifecycle, and update policy remain host concerns.
+The local CLI and managed deployment now both need to provision the same supported datasets. The common facts are dataset identity, version, provenance, licensing, the upstream that publishes each file, what integrity that upstream can actually guarantee, and the final sandbox layout. Credentials, storage roots, prompts, PVC lifecycle, and update policy remain host concerns.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Give supported reference data one versioned, reviewable owner shared by all embedders.
-- Keep the harness host-agnostic by returning content-addressed install plans rather than performing downloads.
+- Keep the catalog's provenance and licensing claims true by construction: the bytes come from the party the catalog names.
+- State honestly, per artifact, what integrity can be guaranteed — rather than uniformly promising a verification we cannot deliver.
+- Keep the harness host-agnostic by returning install plans rather than performing downloads.
 - Make runtime discovery reflect the filesystem actually mounted in the sandbox.
 - Discover arbitrary user content without requiring catalog or receipt registration.
 - Bound inventory cost and model-context size while allowing agents to drill into a subtree.
-- Keep existing managed `registry.json` stores useful during migration.
 
 **Non-Goals:**
 
+- Mirroring, re-hosting, converting, or otherwise redistributing reference bytes.
 - Downloading data from a sandbox workload or granting the sandbox network access.
 - Owning local XDG paths, cloud buckets, PVC provisioning, credentials, prompts, or progress rendering.
-- Defining a mutable remote catalog or allowing an embedder to silently replace catalog content.
 - Parsing scientific data formats or inferring biological semantics from file contents.
 
 ## Decisions
 
-### The harness owns a checked-in catalog; embedders own artifact resolution and transfer
+### The harness owns a checked-in catalog; embedders own transfer only
 
-The catalog lives under `src/reference-data/`, is validated as trusted package data, and is exposed through the curated package barrel. Each dataset entry carries a stable id, version, title, description, source and license links, recommendation/grouping metadata, and one or more final-file artifacts. Each artifact carries an opaque distribution key, byte size, SHA-256 digest, and a safe path relative to the dataset's installation root.
+The catalog lives under `src/reference-data/`, is validated as trusted package data, and is exposed through the curated package barrel. Each dataset entry carries a stable id, version, title, description, source and license links, recommendation/grouping metadata, and one or more final-file artifacts. A selection resolves to a pure install plan; the embedder stages, verifies, and activates it.
 
-The catalog deliberately carries an artifact key rather than a deployment URL. The CLI maps the key to the public distribution endpoint; managed infrastructure may map the same key to an internal mirror. This keeps content identity and sandbox layout identical without making network topology part of the harness interface.
+An alternative was a root-level JSON file: it has no package/build owner and would force the CLI binary, harness package, and managed tooling to invent separate packaging rules. An alternative was a CLI-local catalog; the second real consumer makes that ownership incorrect.
 
-An alternative was a root-level JSON file. That has no package/build owner and would require the CLI binary, harness package, and managed tooling to invent separate packaging rules. An alternative was a CLI-local catalog; the second real consumer makes that ownership incorrect.
+### Artifacts name their upstream publisher — there is no mirror and no configurable base
 
-### Catalog artifacts are final files, not installer recipes
+Each artifact carries the real `https` URL of the third party that publishes it (NCBI, Reactome, WikiPathways, Zenodo, GTEx, CellTypist). The project hosts and redistributes nothing.
 
-The first catalog version describes the final files of a dataset rather than arbitrary scripts or archive extraction instructions. Build/publish automation is responsible for producing those immutable files. A selection resolves to a pure install plan containing dataset roots and file artifacts; the embedder stages, verifies, and activates the plan.
+**Rejected: an opaque distribution key plus an embedder-mapped base URL** (`INFLEXA_REFERENCE_DATA_BASE_URL`, an internal mirror for managed). It looked like a clean host-neutral seam, but it makes the source *substitutable* — and the catalog's most valuable content is precisely its claim about the source. Provenance ("this is NCBI's gene_info") and licensing ("you accept NCBI's terms") are only true of the upstream the catalog names; behind a configurable base they become claims about whatever bytes an operator decided to serve. A mirror also silently converts us into a redistributor of data whose licences we did not review for redistribution. So there is nothing to configure: no env var, no flag, no config key can redirect a fetch.
 
-This keeps the harness interface small and avoids embedding host-specific process execution, archive tooling, or untrusted transformation logic. A future archive format requires an explicit catalog-version extension rather than an untyped recipe escape hatch.
+The cost is accepted deliberately: we depend on upstream availability and on upstream URL stability, and we cannot serve a faster or geographically closer copy. If an upstream URL moves, that is a catalog change and passes package review — which is the same review that any change to a provenance claim deserves.
 
-### Receipts are a shared optional metadata format
+### Integrity is a property of the upstream, not a preference
 
-The harness defines a versioned receipt shape recording dataset id/version, installed artifacts, digests, sizes, relative paths, and activation time. Both embedders may write receipts under a reserved metadata directory. Discovery may use valid receipts to label catalog-managed datasets and preferred versions, but invalid or absent receipts never hide files.
+Each artifact declares an integrity class:
 
-The legacy top-level `registry.json` remains an optional enrichment source. It is no longer the availability oracle and can be retired independently after managed stores emit receipts.
+- **`pinned`** — the upstream publishes immutable, versioned bytes (a dated WikiPathways snapshot, a Zenodo record, GTEx v8, a versioned CellTypist model). The catalog carries `bytes` + `sha256`; a download that does not match them fails and nothing is activated.
+- **`unpinned`** — the upstream regenerates the same URL in place. NCBI rebuilds `gene_info` continuously; Reactome overwrites `current` each quarter and **deletes** the prior release (verified: `/download/95` and `/download/96` are 404, so there is not even a stable archival URL to pin instead). No checked-in digest can survive that.
+
+**Rejected: pin a digest to a mutable upstream anyway.** A digest that is guaranteed to go stale is strictly worse than no digest: it promises verification and delivers a broken download — every user of that dataset gets a hard "SHA-256 mismatch" failure the day the upstream rebuilds, with no local fault and no local fix. It converts a routine refresh into an outage, and it would train users to bypass verification.
+
+For `unpinned` artifacts, integrity is therefore **trust-on-first-use**: the installer records the bytes and digest it actually received in the receipt, and later verification proves the files are unchanged *since install*. That is a real, checkable guarantee against local corruption and tampering — it is simply weaker than `pinned`, and it is surfaced to the user as such rather than being dressed up as content-addressing.
+
+### Only files an upstream actually serves are catalogued
+
+**Rejected: locally-derived artifacts** (the earlier design converted several sources to `.parquet` and catalogued the conversions). No third party serves those files, so they cannot be fetched from a publisher — only from us. Their SHA-256 attests to nothing but the machine that produced them, and shipping them makes us the distributor of a derived work under someone else's licence. Format convenience is a workload concern; the sandbox can convert on read.
+
+The catalog therefore describes only final files as published, and contains no installer scripts, shell commands, or untyped transformation recipes. A future archive format requires an explicit catalog-version extension rather than an untyped recipe escape hatch.
+
+### An artifact's identity is not its URL
+
+Resumable transfer state is keyed off `<dataset-id>/<version>/<path>` (`referenceArtifactKey`), never off the URL. An upstream that moves a file must not orphan an in-flight partial or resurrect a stale one under a new name.
+
+### Receipts record what was received, not what was expected
+
+The receipt shape (`src/reference-data/receipt.ts`) records, per artifact, the relative path, integrity class, and the size + SHA-256 **observed at install**. Digests are never copied from the catalog: for `pinned` they necessarily agree (activation fails otherwise), and for `unpinned` the receipt is the *only* honest record of what the mutable upstream served — and therefore the thing `verify` must compare against. Receipts remain optional metadata; an absent or invalid one never hides readable files.
+
+The legacy top-level `registry.json` remains an optional enrichment source, no longer the availability oracle, and can be retired once managed stores emit receipts.
 
 ### Discovery runs against the live sandbox filesystem
 
-`list_available_refs` becomes a dependency-bearing tool created with the sandbox agent. It uses the same internal sandbox-exec runner as `execute_command`, receives a replay-stable function id and step deadline, and declares `executionMode: "workflow"`. The shared runner remains the one submit/await chokepoint; the reference tool does not introduce a parallel sandbox protocol.
+`list_available_refs` becomes a dependency-bearing tool created with the sandbox agent. It uses the same internal sandbox-exec runner as `execute_command`, receives a replay-stable function id and step deadline, and declares `executionMode: "workflow"`. The shared runner remains the one submit/await chokepoint.
 
 The tool accepts an optional path constrained beneath `/mnt/refs`. The default call returns a bounded summary of the root; a path call drills into one subtree. It does not follow symlinks, excludes the reserved metadata directory from data results, reports truncation explicitly, and distinguishes unmounted, empty, and populated stores. The scan runs where `/mnt/refs` is actually mounted, so Docker host paths and Kubernetes PVC paths need not be visible under that name in the harness process.
 
 An alternative was passing a host `refsRoot` into agent construction. That would report the embedder's intended source rather than the sandbox's observable truth and would couple Docker and Kubernetes path models to the tool.
 
+### No library-specific reference path is baked into the sandbox image
+
+The image previously carried `ENV CELLTYPIST_FOLDER=/mnt/refs/celltypist_models`, so that CellTypist's by-name model lookup would resolve without a network call. That is removed.
+
+**Rejected: keep the baked env var.** It contradicts the ref-store rule that no reference-store environment variables are injected, and it cannot be correct: the store is optional (the path usually points at nothing), and its layout is owned by the catalog and versioned per dataset — so a path compiled into the image either dangles or pins the image to one catalog version. Impersonating a library's private cache layout in the reference store, purely so a by-name lookup succeeds, would freeze that layout as an image-level contract.
+
+Agents instead call `list_available_refs`, receive absolute paths, and pass them explicitly — the contract Azimuth (`Azimuth::LoadReference()`) already required. A library that insists on an env var can have one exported per-command, by the agent that just learned the real path; the shared sandbox standards say so.
+
 ### Discovery is bounded and metadata is enrichment
 
-A complete recursive manifest can be enormous for sharded references. The default result summarizes top-level entries with counts, aggregate bytes where cheaply available, representative file types, and concrete `/mnt/refs/...` paths. Drill-down remains capped by entry count and output bytes and returns a continuation/truncation hint rather than silently dropping data.
-
-Catalog descriptions, receipts, and legacy registry fields may add names and provenance to matching paths. The filesystem inventory is always merged in, so `user/` and any other unregistered content remains visible.
+A complete recursive manifest can be enormous for sharded references. The default result summarizes top-level entries with counts, aggregate bytes where cheaply available, representative file types, and concrete `/mnt/refs/...` paths. Drill-down remains capped by entry count and output bytes and returns a continuation/truncation hint rather than silently dropping data. Catalog descriptions, receipts, and legacy registry fields may add names and provenance to matching paths; the filesystem inventory is always merged in, so `user/` and any other unregistered content remains visible.
 
 ## Risks / Trade-offs
 
-- **Catalog changes require a harness release** → This is intentional: dataset identity and digests are supply-chain inputs and should pass package review. Artifact bytes can be published independently under already-cataloged immutable keys.
+- **We depend on upstream availability and URL stability** → Accepted as the price of not being a redistributor. A moved URL is a catalog change under package review; a down upstream fails the install without touching a prior activation.
+- **`unpinned` datasets can change under us between installs** → State it plainly rather than hide it: the class is visible in `refs list`, verification names which guarantee it checked, and a refresh is an explicit `--force` re-fetch.
+- **Catalog changes require a harness release** → Intentional: dataset identity, source, and digests are supply-chain inputs and should pass package review.
 - **A sandbox scan consumes an exec operation** → Keep it on-demand, bounded, and replay-safe through the existing runner; agents already orient once before analysis.
-- **Large directories can still be expensive to summarize** → Bound traversal work as well as rendered output, avoid content hashing during discovery, and require drill-down for deep trees.
 - **Legacy registry metadata may disagree with disk** → Disk wins; stale metadata is labeled or ignored and never causes a real path to disappear.
 - **User content may contain misleading names or symlinks** → Treat it as untrusted read-only data, never execute it during discovery, never follow symlinks, and keep sandbox confinement unchanged.
 
@@ -71,11 +100,7 @@ Catalog descriptions, receipts, and legacy registry fields may add names and pro
 1. Add and validate the catalog and receipt contracts without changing mounts.
 2. Export the catalog selection interface for embedders.
 3. Convert `list_available_refs` to sandbox-visible bounded discovery with receipt and registry enrichment.
-4. Keep existing managed stores working unchanged; their registry becomes optional metadata.
-5. Let each embedder adopt the catalog and receipt format independently.
+4. Drop the image's baked reference env var and state the explicit-path contract in the shared sandbox standards.
+5. Keep existing managed stores working unchanged; their registry becomes optional metadata.
 
 Rollback is additive for catalog consumers. Reverting dynamic discovery restores manifest-only behavior but does not alter stored reference bytes.
-
-## Open Questions
-
-- The initial catalog contents and public artifact publication base are release-data work; the contract does not require those deployment values to be decided in this change.

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The harness already defines the read-only `/mnt/refs` mount, but its inventory is gated on a managed-only `registry.json` and the downloadable reference set has no host-neutral owner. Both the local CLI and managed deployment now need one versioned, reviewable catalog while sandboxes must still discover user-supplied files that are absent from that catalog.
+
+## What Changes
+
+- Add a harness-owned reference-data catalog describing supported datasets, their versions, provenance and licensing links, content identities, sizes, and sandbox-relative final-file locations.
+- Export a small host-neutral catalog interface that validates entries and resolves a selection into an install plan; embedders remain responsible for artifact URL resolution, transfer, storage, credentials, and user interaction.
+- Replace manifest-exclusive `list_available_refs` behavior with bounded, on-demand discovery of the filesystem actually visible inside the sandbox.
+- Treat catalog or receipt metadata as optional enrichment only: arbitrary user-added reference files remain discoverable without registration.
+- Preserve the existing read-only `/mnt/refs` mount and the prohibition on network downloads from sandbox workloads.
+
+## Capabilities
+
+### New Capabilities
+
+- `reference-data-catalog`: The canonical, host-neutral catalog contract and selection/install-plan interface shared by local and managed embedders.
+
+### Modified Capabilities
+
+- `ref-store`: Reference discovery becomes filesystem-driven and sandbox-visible rather than requiring `/mnt/refs/registry.json`; metadata may enrich but never define the complete inventory.
+
+## Impact
+
+- Affects `harness/src/reference-data/`, the public package barrel, sandbox-agent tool construction, and `list_available_refs` tests and prompts.
+- Changes the producer/consumer contract with both embedders: the harness defines content identity and install layout, while each embedder supplies artifact locations and provisioning behavior.
+- The existing managed `registry.json` remains readable as optional metadata but is no longer required for availability.

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/proposal.md
@@ -2,10 +2,15 @@
 
 The harness already defines the read-only `/mnt/refs` mount, but its inventory is gated on a managed-only `registry.json` and the downloadable reference set has no host-neutral owner. Both the local CLI and managed deployment now need one versioned, reviewable catalog while sandboxes must still discover user-supplied files that are absent from that catalog.
 
+The catalog is also a provenance claim, not just a download list. It only stays true if the bytes come from the party it names — so the catalog carries the real upstream URL rather than an opaque key an embedder resolves against a mirror it controls.
+
 ## What Changes
 
-- Add a harness-owned reference-data catalog describing supported datasets, their versions, provenance and licensing links, content identities, sizes, and sandbox-relative final-file locations.
-- Export a small host-neutral catalog interface that validates entries and resolves a selection into an install plan; embedders remain responsible for artifact URL resolution, transfer, storage, credentials, and user interaction.
+- Add a harness-owned reference-data catalog describing supported datasets, their versions, provenance and licensing links, sandbox-relative final-file locations, and the `https` URL of the third party that publishes each artifact.
+- Fetch every artifact from its publisher: no mirror, no re-hosting, no distribution endpoint, and no embedder-configurable base URL that could substitute the source behind the catalog's own licensing/provenance claims.
+- Give each artifact an integrity class reflecting what its upstream can guarantee: `pinned` (immutable versioned bytes — the catalog carries size + SHA-256) or `unpinned` (upstream regenerates the same URL in place — no checked-in digest can survive, so integrity is trust-on-first-use against the receipt).
+- Export a small host-neutral catalog interface that validates entries and resolves a selection into an install plan; embedders remain responsible for transfer, storage, credentials, and user interaction — but never for choosing a different source.
+- Define receipts that record the size, digest, and integrity class **observed at install**, so an `unpinned` dataset is still verifiable as "unchanged since install".
 - Replace manifest-exclusive `list_available_refs` behavior with bounded, on-demand discovery of the filesystem actually visible inside the sandbox.
 - Treat catalog or receipt metadata as optional enrichment only: arbitrary user-added reference files remain discoverable without registration.
 - Preserve the existing read-only `/mnt/refs` mount and the prohibition on network downloads from sandbox workloads.
@@ -14,7 +19,7 @@ The harness already defines the read-only `/mnt/refs` mount, but its inventory i
 
 ### New Capabilities
 
-- `reference-data-catalog`: The canonical, host-neutral catalog contract and selection/install-plan interface shared by local and managed embedders.
+- `reference-data-catalog`: The canonical, host-neutral catalog contract — upstream-sourced artifacts, integrity classes, install plans, and observed-bytes receipts — shared by local and managed embedders.
 
 ### Modified Capabilities
 
@@ -23,5 +28,6 @@ The harness already defines the read-only `/mnt/refs` mount, but its inventory i
 ## Impact
 
 - Affects `harness/src/reference-data/`, the public package barrel, sandbox-agent tool construction, and `list_available_refs` tests and prompts.
-- Changes the producer/consumer contract with both embedders: the harness defines content identity and install layout, while each embedder supplies artifact locations and provisioning behavior.
+- Changes the producer/consumer contract with both embedders: the harness defines dataset identity, upstream source, integrity guarantee, and install layout; each embedder supplies only provisioning behavior.
+- Removes the sandbox image's baked `CELLTYPIST_FOLDER` reference path, which contradicted the existing ref-store rule that no reference-store environment variables are injected. Agents get absolute paths from `list_available_refs` and pass (or export) them explicitly.
 - The existing managed `registry.json` remains readable as optional metadata but is no longer required for availability.

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/ref-store/spec.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/ref-store/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: References are discoverable via the list_available_refs tool
+
+The harness SHALL expose a dependency-bearing `list_available_refs` tool that inspects the reference filesystem visible inside the active sandbox at `/mnt/refs`. The tool SHALL accept an optional path constrained beneath that root: an omitted path SHALL return a bounded root summary and a supplied path SHALL drill into that subtree. Results SHALL use absolute `/mnt/refs/...` paths, SHALL NOT follow symlinks, SHALL exclude reserved installer metadata from the data inventory, and SHALL report truncation explicitly when traversal or output limits are reached.
+
+The tool SHALL distinguish an unmounted store, a mounted but empty store, and a populated store without throwing for any of those expected states. It SHALL execute through the shared sandbox-exec runner with replay-stable identity and workflow execution mode so discovery observes the same mount as analysis commands.
+
+#### Scenario: Arbitrary mounted files are available without a manifest
+
+- **WHEN** `/mnt/refs/user/cohort/reference.h5ad` exists and no `registry.json` or receipt names it
+- **THEN** `list_available_refs` reports that path through the root summary or a bounded drill-down result
+
+#### Scenario: Store is mounted but empty
+
+- **WHEN** `/mnt/refs` is mounted and contains no reference data
+- **THEN** the tool returns an available-but-empty result rather than a missing-store result
+
+#### Scenario: Store is not mounted
+
+- **WHEN** the active sandbox has no `/mnt/refs` mount
+- **THEN** the tool returns an unavailable data variant with an actionable note, without throwing
+
+#### Scenario: Deep inventory is bounded
+
+- **WHEN** a requested subtree exceeds the traversal or output limit
+- **THEN** the tool returns the bounded entries plus an explicit truncation or drill-down hint
+
+#### Scenario: Traversal outside the store is rejected
+
+- **WHEN** the optional path is absolute outside `/mnt/refs` or contains traversal escaping the root
+- **THEN** the tool returns an out-of-scope data result and performs no scan outside the store
+
+## REMOVED Requirements
+
+### Requirement: The registry.json manifest defines the discoverable inventory
+
+**Reason**: A manifest-exclusive inventory hides user-added files and cannot represent the live sandbox mount as the source of truth.
+
+**Migration**: Existing `/mnt/refs/registry.json` files remain optional enrichment inputs. Managed stores may continue producing them while adopting the shared receipt format; readable files are discovered whether or not either metadata format exists.
+
+## ADDED Requirements
+
+### Requirement: Catalog and store metadata only enrich filesystem discovery
+
+When a valid harness receipt or legacy `registry.json` describes a path that exists on disk, `list_available_refs` SHALL use its dataset name, version, provenance, category, or descriptive fields to enrich the rendered inventory. Metadata SHALL NOT add nonexistent files, hide unregistered files, or override the observed path and size of a filesystem entry.
+
+#### Scenario: Managed and user content are merged
+
+- **WHEN** a store contains a receipted managed dataset and unregistered content under `user/`
+- **THEN** discovery reports both, enriching the managed entry and listing the user content from the filesystem
+
+#### Scenario: Stale metadata is ignored
+
+- **WHEN** metadata names a file that no longer exists
+- **THEN** discovery omits the nonexistent file and continues reporting the remaining filesystem content

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-catalog/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: The harness publishes the canonical reference-data catalog
+
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have an opaque distribution key, byte size, SHA-256 digest, and a safe dataset-relative destination path.
+
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-SHA-256 digests, and non-positive artifact sizes.
+
+#### Scenario: An embedder lists supported references
+
+- **WHEN** an embedder reads the exported catalog
+- **THEN** it receives the same validated dataset ids, versions, source and licensing links, and content identities as every other embedder using that harness version
+
+#### Scenario: An unsafe catalog path is rejected
+
+- **WHEN** a catalog artifact destination is absolute or contains a `..` traversal segment
+- **THEN** catalog validation fails before an embedder can construct an install plan
+
+### Requirement: Reference selection resolves to a host-neutral install plan
+
+The harness SHALL expose a pure selection operation that accepts requested dataset ids and returns either a typed unknown-id error or a deterministic install plan. The plan SHALL contain the selected dataset metadata and final-file artifacts with distribution keys, hashes, sizes, and dataset-relative destinations. It SHALL NOT contain host storage roots, credentials, terminal behavior, PVC configuration, or a required concrete download URL.
+
+#### Scenario: CLI and managed select the same datasets
+
+- **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
+- **THEN** both receive content-identical plans even if they map artifact keys to different distribution endpoints
+
+#### Scenario: Unknown selection is explicit
+
+- **WHEN** a requested id is absent from the catalog
+- **THEN** selection returns a typed error naming the unknown id and available ids, without producing a partial plan
+
+### Requirement: Catalog artifacts describe final immutable files
+
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes. A dataset with multiple files SHALL list each file as a separately hashed artifact.
+
+#### Scenario: A multi-file reference is fully content-addressed
+
+- **WHEN** a dataset requires two companion files
+- **THEN** its install plan contains two artifact entries, each with its own distribution key, destination, size, and SHA-256 digest
+
+### Requirement: Reference installation receipts have a shared versioned shape
+
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and the installed artifacts' relative paths, sizes, and SHA-256 digests. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+
+#### Scenario: Different embedders describe the same installation
+
+- **WHEN** local and managed installers activate the same install plan
+- **THEN** each can emit a receipt that validates against the same harness-owned contract
+
+#### Scenario: Invalid receipt does not hide files
+
+- **WHEN** discovery encounters an invalid or stale receipt beside readable reference files
+- **THEN** it reports the filesystem content without receipt enrichment rather than treating the store as unavailable
+
+### Requirement: The harness does not provision reference bytes
+
+The catalog module SHALL perform no network transfer, credential resolution, host-directory creation, archive extraction, PVC management, or user prompting. Those behaviors SHALL remain the responsibility of embedder adapters.
+
+#### Scenario: Catalog planning is side-effect free
+
+- **WHEN** an install plan is resolved
+- **THEN** no filesystem or network state changes and no deployment-specific configuration is required

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/specs/reference-data-catalog/spec.md
@@ -2,51 +2,77 @@
 
 ### Requirement: The harness publishes the canonical reference-data catalog
 
-The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have an opaque distribution key, byte size, SHA-256 digest, and a safe dataset-relative destination path.
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have the `https` URL of the third party that publishes it, a safe dataset-relative destination path, and an integrity class.
 
-Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-SHA-256 digests, and non-positive artifact sizes.
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, non-SHA-256 digests, and non-positive artifact sizes.
 
 #### Scenario: An embedder lists supported references
 
 - **WHEN** an embedder reads the exported catalog
-- **THEN** it receives the same validated dataset ids, versions, source and licensing links, and content identities as every other embedder using that harness version
+- **THEN** it receives the same validated dataset ids, versions, upstream URLs, source and licensing links, and integrity classes as every other embedder using that harness version
 
 #### Scenario: An unsafe catalog path is rejected
 
 - **WHEN** a catalog artifact destination is absolute or contains a `..` traversal segment
 - **THEN** catalog validation fails before an embedder can construct an install plan
 
-### Requirement: Reference selection resolves to a host-neutral install plan
+### Requirement: Reference artifacts are fetched from the upstream that publishes them
 
-The harness SHALL expose a pure selection operation that accepts requested dataset ids and returns either a typed unknown-id error or a deterministic install plan. The plan SHALL contain the selected dataset metadata and final-file artifacts with distribution keys, hashes, sizes, and dataset-relative destinations. It SHALL NOT contain host storage roots, credentials, terminal behavior, PVC configuration, or a required concrete download URL.
+Each artifact SHALL name the official third-party URL it is fetched from, and the project SHALL NOT mirror, re-host, or redistribute reference bytes. No embedder-configurable distribution endpoint SHALL exist, because a configurable source is a source that can be substituted: the catalog's provenance and licensing claims are only true of the upstream it names.
+
+#### Scenario: There is no endpoint to configure
+
+- **WHEN** an embedder installs a catalog dataset
+- **THEN** it fetches every artifact from the upstream URL in the catalog, and no configuration can redirect that fetch to another origin
 
 #### Scenario: CLI and managed select the same datasets
 
 - **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
-- **THEN** both receive content-identical plans even if they map artifact keys to different distribution endpoints
+- **THEN** both receive content-identical plans naming the same upstream URLs
 
-#### Scenario: Unknown selection is explicit
+### Requirement: An artifact's integrity class states what its upstream can actually guarantee
 
-- **WHEN** a requested id is absent from the catalog
-- **THEN** selection returns a typed error naming the unknown id and available ids, without producing a partial plan
+Every artifact SHALL declare an integrity class, and that class SHALL reflect a property of the upstream rather than a preference of ours. A `pinned` artifact — one whose upstream publishes immutable, versioned bytes — SHALL carry a byte size and SHA-256 digest. An `unpinned` artifact — one whose upstream regenerates the same URL in place, so that no checked-in digest could survive — SHALL carry neither, because a digest that is guaranteed to go stale is worse than an absent one: it promises verification and delivers a broken download.
+
+#### Scenario: Immutable upstream is pinned
+
+- **WHEN** an upstream publishes a dated or release-versioned file that never changes
+- **THEN** its artifact is `pinned` with a size and SHA-256, and an install that receives different bytes fails without activating anything
+
+#### Scenario: Mutable upstream is not pretended to be pinned
+
+- **WHEN** an upstream rebuilds a file in place at a stable URL (NCBI regenerating `gene_info`, Reactome overwriting `current`)
+- **THEN** its artifact is `unpinned`, the catalog states no digest, and the weaker guarantee is surfaced to the user rather than hidden
 
 ### Requirement: Catalog artifacts describe final immutable files
 
-Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes. A dataset with multiple files SHALL list each file as a separately hashed artifact.
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher, and its digest attests only to the machine that produced it.
 
-#### Scenario: A multi-file reference is fully content-addressed
+#### Scenario: A multi-file reference is fully described
 
 - **WHEN** a dataset requires two companion files
-- **THEN** its install plan contains two artifact entries, each with its own distribution key, destination, size, and SHA-256 digest
+- **THEN** its install plan contains two artifact entries, each with its own upstream URL, destination, and integrity class
 
-### Requirement: Reference installation receipts have a shared versioned shape
+#### Scenario: A stable identity survives a moved URL
 
-The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and the installed artifacts' relative paths, sizes, and SHA-256 digests. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+- **WHEN** an embedder keys a resumable partial transfer off an artifact
+- **THEN** it uses the artifact's catalog identity (`<dataset-id>/<version>/<path>`), not its URL, so a changed upstream URL does not orphan in-flight state
+
+### Requirement: Reference installation receipts record what was actually received
+
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path, integrity class, and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+
+Observed digests SHALL NOT be copied from the catalog. For a `pinned` artifact the observed digest necessarily equals the catalog's, since activation fails otherwise; for an `unpinned` artifact the receipt is the only record of what the mutable upstream served, and is therefore what later verification compares against.
 
 #### Scenario: Different embedders describe the same installation
 
 - **WHEN** local and managed installers activate the same install plan
 - **THEN** each can emit a receipt that validates against the same harness-owned contract
+
+#### Scenario: An unpinned install is still verifiable afterwards
+
+- **WHEN** an `unpinned` artifact is installed and its bytes are later altered on disk
+- **THEN** verification against the receipt reports the file as modified, even though the catalog never carried a digest for it
 
 #### Scenario: Invalid receipt does not hide files
 

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
@@ -1,10 +1,14 @@
 ## 1. Catalog and Receipt Contracts
 
-- [x] 1.1 Add the reference-data catalog schema, trusted catalog data, safe relative-path validation, and catalog-version contract under `src/reference-data/`.
-- [x] 1.2 Add pure dataset selection/install-plan resolution with typed unknown-id errors and deterministic ordering.
-- [x] 1.3 Add the versioned reference installation receipt schema and parsing helpers that degrade invalid metadata without hiding files.
-- [x] 1.4 Export the catalog, selection, plan, receipt, and error types/functions through the curated harness barrel.
-- [x] 1.5 Add catalog contract tests for duplicate ids/destinations, traversal and absolute paths, digests, sizes, multi-file plans, deterministic selection, and receipt validation.
+- [x] 1.1 Add the reference-data catalog schema under `src/reference-data/`: safe ids/versions, safe relative destinations, `https`-only upstream artifact URLs, and the catalog-version contract.
+- [x] 1.2 Model the artifact integrity class as a discriminated union — `pinned` (upstream-immutable: carries `bytes` + `sha256`) and `unpinned` (upstream regenerates the URL in place: carries neither) — and document why a digest is deliberately absent rather than stale.
+- [x] 1.3 Populate the canonical catalog with real upstream URLs, provenance, and licences: `pinned` wikipathways-human, collectri-human, gtex-v8, celltypist-immune; `unpinned` (version `current`) ncbi-gene-human, ncbi-gene-mouse, ncbi-gene-rat, reactome-pathways, reactome-mappings. No mirror, no re-hosted bytes, and no locally-derived artifacts that no upstream serves.
+- [x] 1.4 Split Reactome's identifier-mapping tables out of `reactome-pathways` into an opt-in `reactome-mappings` (`recommended: false`): upstream serves them only as uncompressed TSV totalling ~700 MB, so bundling them would make the recommended pathways dataset two orders of magnitude larger than the GMT that workflows actually use.
+- [x] 1.4 Add `referenceArtifactKey` so resumable transfer state is keyed off catalog identity (`<id>/<version>/<path>`) rather than a URL that may move.
+- [x] 1.5 Add pure dataset selection/install-plan resolution with typed unknown-id errors and deterministic ordering.
+- [x] 1.6 Add the versioned receipt schema recording the **observed** size, digest, and integrity class per artifact, plus parsing helpers that degrade invalid metadata without hiding files.
+- [x] 1.7 Export the catalog, integrity type, artifact key, selection, plan, receipt, and error types/functions through the curated harness barrel.
+- [x] 1.8 Add contract tests for duplicate ids/destinations, traversal and absolute paths, non-`https` URLs, digests, sizes, the integrity-class split across the real catalog, multi-file plans, deterministic selection, and receipt validation.
 
 ## 2. Sandbox-Visible Reference Discovery
 
@@ -13,10 +17,14 @@
 - [x] 2.3 Implement confined optional-path resolution, no-follow symlink handling, bounded traversal/output, explicit truncation, and distinct unmounted/empty/populated result variants.
 - [x] 2.4 Add optional harness-receipt and legacy `registry.json` enrichment that merges only existing paths and always retains unregistered filesystem entries.
 - [x] 2.5 Wire the tool factory through sandbox-agent construction with the step's sandbox, function-id, deadline, and event dependencies.
-- [x] 2.6 Update sandbox orientation/tool descriptions to explain dynamic mounted discovery, user-added references, and the continued prohibition on runtime downloads.
+- [x] 2.6 Update sandbox orientation/tool descriptions: the store is optional and may be absent, paths are never assumed or hardcoded, discovered paths are passed explicitly, and a library that resolves by env var (CellTypist) gets that var exported per-command from a path the inventory actually returned.
 
-## 3. Verification
+## 3. Sandbox Image
 
-- [x] 3.1 Add tool tests covering manifest-free user files, managed-plus-user merging, stale/invalid metadata, empty and absent mounts, traversal rejection, symlinks, and bounded deep trees.
-- [x] 3.2 Extend sandbox-agent tool-surface and replay/durability tests for the new dependency-bearing workflow-mode discovery tool.
-- [x] 3.3 Run targeted formatting, `tsc -p tsconfig.json`, and the relevant harness test suites.
+- [x] 3.1 Remove `ENV CELLTYPIST_FOLDER=/mnt/refs/celltypist_models` from the sandbox image and record why no library-specific reference path is compiled in: the store is optional and its layout is catalog-owned and versioned, so a baked path either dangles or pins the image to one catalog version.
+
+## 4. Verification
+
+- [x] 4.1 Add tool tests covering manifest-free user files, managed-plus-user merging, stale/invalid metadata, empty and absent mounts, traversal rejection, symlinks, and bounded deep trees.
+- [x] 4.2 Extend sandbox-agent tool-surface and replay/durability tests for the new dependency-bearing workflow-mode discovery tool.
+- [x] 4.3 Run targeted formatting, `tsc -p tsconfig.json`, and the relevant harness test suites.

--- a/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-14-add-reference-data-provisioning/tasks.md
@@ -1,0 +1,22 @@
+## 1. Catalog and Receipt Contracts
+
+- [x] 1.1 Add the reference-data catalog schema, trusted catalog data, safe relative-path validation, and catalog-version contract under `src/reference-data/`.
+- [x] 1.2 Add pure dataset selection/install-plan resolution with typed unknown-id errors and deterministic ordering.
+- [x] 1.3 Add the versioned reference installation receipt schema and parsing helpers that degrade invalid metadata without hiding files.
+- [x] 1.4 Export the catalog, selection, plan, receipt, and error types/functions through the curated harness barrel.
+- [x] 1.5 Add catalog contract tests for duplicate ids/destinations, traversal and absolute paths, digests, sizes, multi-file plans, deterministic selection, and receipt validation.
+
+## 2. Sandbox-Visible Reference Discovery
+
+- [x] 2.1 Refactor the existing sandbox command path into one internal replay-safe exec runner shared by `execute_command` without changing its observable behavior.
+- [x] 2.2 Convert `list_available_refs` into a dependency-bearing workflow-mode tool that uses the shared runner and inspects `/mnt/refs` inside the active sandbox.
+- [x] 2.3 Implement confined optional-path resolution, no-follow symlink handling, bounded traversal/output, explicit truncation, and distinct unmounted/empty/populated result variants.
+- [x] 2.4 Add optional harness-receipt and legacy `registry.json` enrichment that merges only existing paths and always retains unregistered filesystem entries.
+- [x] 2.5 Wire the tool factory through sandbox-agent construction with the step's sandbox, function-id, deadline, and event dependencies.
+- [x] 2.6 Update sandbox orientation/tool descriptions to explain dynamic mounted discovery, user-added references, and the continued prohibition on runtime downloads.
+
+## 3. Verification
+
+- [x] 3.1 Add tool tests covering manifest-free user files, managed-plus-user merging, stale/invalid metadata, empty and absent mounts, traversal rejection, symlinks, and bounded deep trees.
+- [x] 3.2 Extend sandbox-agent tool-surface and replay/durability tests for the new dependency-bearing workflow-mode discovery tool.
+- [x] 3.3 Run targeted formatting, `tsc -p tsconfig.json`, and the relevant harness test suites.

--- a/harness/openspec/specs/ref-store/spec.md
+++ b/harness/openspec/specs/ref-store/spec.md
@@ -11,19 +11,18 @@ runtime (sandboxes have no network). It lives in a shared **reference store**
 mounted **read-only** into every sandbox container at `/mnt/refs`.
 
 Agents discover what is staged through the `list_available_refs` tool
-(`src/tools/sandbox/list-available-refs.ts`), which reads
-`/mnt/refs/registry.json` — a machine-generated manifest of every reference
-file grouped by category — and renders it into agent-readable paths. Each file's
-absolute path is `/mnt/refs/<local_path>` from its registry entry. No
-environment variables are injected for the ref store; the tool is the sole
-discovery surface.
+(`src/tools/sandbox/list-available-refs.ts`), which inspects the filesystem
+actually mounted at `/mnt/refs`. Catalog receipts and a legacy `registry.json`
+may enrich that inventory, but neither metadata source defines what files are
+available. No environment variables are injected for the ref store; the tool
+is the sole discovery surface.
 
 The store is supplied by the embedder: the Docker backend bind-mounts a host
 directory (`refStorePath`), the Kubernetes backend mounts a read-only PVC
 (`refStorePvc`). How the reference data is *built, versioned, and published* is
 owned by a separate reference-store build pipeline in another repository and is
-out of scope here — this spec describes only the runtime mount contract, the
-`registry.json` shape the tool consumes, and the discovery surface.
+out of scope here — this spec describes only the runtime mount contract,
+filesystem-driven discovery, and optional metadata enrichment.
 
 ## Requirements
 
@@ -55,37 +54,62 @@ no `/mnt/refs` mount.
 
 ### Requirement: References are discoverable via the list_available_refs tool
 
-The harness SHALL expose a `list_available_refs` tool (built with `defineTool`)
-that reads `/mnt/refs/registry.json`, resolves each entry's path to
-`/mnt/refs/<local_path>`, and returns a rendered inventory grouped by category.
-A missing or unmounted store is an expected state: the tool SHALL NOT throw — it
-SHALL return an `available: false` data variant carrying a fallback note.
+The harness SHALL expose a dependency-bearing `list_available_refs` tool that
+inspects the reference filesystem visible inside the active sandbox at
+`/mnt/refs`. The tool SHALL accept an optional path constrained beneath that
+root: an omitted path SHALL return a bounded root summary and a supplied path
+SHALL drill into that subtree. Results SHALL use absolute `/mnt/refs/...` paths,
+SHALL NOT follow symlinks, SHALL exclude reserved installer metadata from the
+data inventory, and SHALL report truncation explicitly when traversal or output
+limits are reached.
 
-#### Scenario: References available
+The tool SHALL distinguish an unmounted store, a mounted but empty store, and a
+populated store without throwing for any of those expected states. It SHALL
+execute through the shared sandbox-exec runner with replay-stable identity and
+workflow execution mode so discovery observes the same mount as analysis
+commands.
 
-- **WHEN** `list_available_refs` is called and `/mnt/refs/registry.json` is readable
-- **THEN** it returns `{ available: true, content }` listing categories with absolute `/mnt/refs/<local_path>` paths
+#### Scenario: Arbitrary mounted files are available without a manifest
 
-#### Scenario: Store not mounted
+- **WHEN** `/mnt/refs/user/cohort/reference.h5ad` exists and no `registry.json` or receipt names it
+- **THEN** `list_available_refs` reports that path through the root summary or a bounded drill-down result
 
-- **WHEN** `list_available_refs` is called and the registry cannot be read
-- **THEN** it returns `{ available: false, content }` advising that the reference store may not be mounted at `/mnt/refs`, without throwing
+#### Scenario: Store is mounted but empty
 
-### Requirement: The registry.json manifest defines the discoverable inventory
+- **WHEN** `/mnt/refs` is mounted and contains no reference data
+- **THEN** the tool returns an available-but-empty result rather than a missing-store result
 
-`/mnt/refs/registry.json` SHALL carry `registry_version`, `build_id`,
-`generated_at`, a `files.by_category` map of category name to an array of file
-entries, and a `summary` with `total_output_files` and `categories`. Each file
-entry SHALL carry at least `local_path` (relative to `/mnt/refs`) and `sha256`,
-plus optional descriptive fields (`bytes`, `rows`, `category`, `subtype`,
-`organism`, `tax_id`, `dataset`, `endpoint`) the tool uses to group and label
-output.
+#### Scenario: Store is not mounted
 
-#### Scenario: Registry groups files by category
+- **WHEN** the active sandbox has no `/mnt/refs` mount
+- **THEN** the tool returns an unavailable data variant with an actionable note, without throwing
 
-- **GIVEN** a `registry.json` with `files.by_category` populated
-- **WHEN** `list_available_refs` renders it
-- **THEN** each category becomes a section listing its files by name and `/mnt/refs/<local_path>` path
+#### Scenario: Deep inventory is bounded
+
+- **WHEN** a requested subtree exceeds the traversal or output limit
+- **THEN** the tool returns the bounded entries plus an explicit truncation or drill-down hint
+
+#### Scenario: Traversal outside the store is rejected
+
+- **WHEN** the optional path is absolute outside `/mnt/refs` or contains traversal escaping the root
+- **THEN** the tool returns an out-of-scope data result and performs no scan outside the store
+
+### Requirement: Catalog and store metadata only enrich filesystem discovery
+
+When a valid harness receipt or legacy `registry.json` describes a path that exists on disk, `list_available_refs` SHALL use its dataset name, version,
+provenance, category, or descriptive fields to enrich the rendered inventory.
+Metadata SHALL NOT add nonexistent files, hide unregistered files, or override
+the observed path and size of a filesystem entry.
+
+#### Scenario: Managed and user content are merged
+
+- **WHEN** a store contains a receipted managed dataset and unregistered content under `user/`
+- **THEN** discovery reports both, enriching the managed entry and listing the user content from the filesystem
+
+#### Scenario: Stale metadata is ignored
+
+- **WHEN** metadata names a file that no longer exists
+- **THEN** discovery omits the nonexistent file and continues reporting the remaining filesystem content
 
 ### Requirement: No environment variables are injected for the reference store
 

--- a/harness/openspec/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/specs/reference-data-catalog/spec.md
@@ -1,0 +1,70 @@
+# reference-data-catalog Specification
+
+## Purpose
+
+Define the canonical host-neutral reference-data catalog, deterministic install
+plans, and shared receipt metadata consumed by every harness embedder.
+
+## Requirements
+
+### Requirement: The harness publishes the canonical reference-data catalog
+
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have an opaque distribution key, byte size, SHA-256 digest, and a safe dataset-relative destination path.
+
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-SHA-256 digests, and non-positive artifact sizes.
+
+#### Scenario: An embedder lists supported references
+
+- **WHEN** an embedder reads the exported catalog
+- **THEN** it receives the same validated dataset ids, versions, source and licensing links, and content identities as every other embedder using that harness version
+
+#### Scenario: An unsafe catalog path is rejected
+
+- **WHEN** a catalog artifact destination is absolute or contains a `..` traversal segment
+- **THEN** catalog validation fails before an embedder can construct an install plan
+
+### Requirement: Reference selection resolves to a host-neutral install plan
+
+The harness SHALL expose a pure selection operation that accepts requested dataset ids and returns either a typed unknown-id error or a deterministic install plan. The plan SHALL contain the selected dataset metadata and final-file artifacts with distribution keys, hashes, sizes, and dataset-relative destinations. It SHALL NOT contain host storage roots, credentials, terminal behavior, PVC configuration, or a required concrete download URL.
+
+#### Scenario: CLI and managed select the same datasets
+
+- **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
+- **THEN** both receive content-identical plans even if they map artifact keys to different distribution endpoints
+
+#### Scenario: Unknown selection is explicit
+
+- **WHEN** a requested id is absent from the catalog
+- **THEN** selection returns a typed error naming the unknown id and available ids, without producing a partial plan
+
+### Requirement: Catalog artifacts describe final immutable files
+
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes. A dataset with multiple files SHALL list each file as a separately hashed artifact.
+
+#### Scenario: A multi-file reference is fully content-addressed
+
+- **WHEN** a dataset requires two companion files
+- **THEN** its install plan contains two artifact entries, each with its own distribution key, destination, size, and SHA-256 digest
+
+### Requirement: Reference installation receipts have a shared versioned shape
+
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and the installed artifacts' relative paths, sizes, and SHA-256 digests. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+
+#### Scenario: Different embedders describe the same installation
+
+- **WHEN** local and managed installers activate the same install plan
+- **THEN** each can emit a receipt that validates against the same harness-owned contract
+
+#### Scenario: Invalid receipt does not hide files
+
+- **WHEN** discovery encounters an invalid or stale receipt beside readable reference files
+- **THEN** it reports the filesystem content without receipt enrichment rather than treating the store as unavailable
+
+### Requirement: The harness does not provision reference bytes
+
+The catalog module SHALL perform no network transfer, credential resolution, host-directory creation, archive extraction, PVC management, or user prompting. Those behaviors SHALL remain the responsibility of embedder adapters.
+
+#### Scenario: Catalog planning is side-effect free
+
+- **WHEN** an install plan is resolved
+- **THEN** no filesystem or network state changes and no deployment-specific configuration is required

--- a/harness/openspec/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/specs/reference-data-catalog/spec.md
@@ -9,51 +9,77 @@ plans, and shared receipt metadata consumed by every harness embedder.
 
 ### Requirement: The harness publishes the canonical reference-data catalog
 
-The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have an opaque distribution key, byte size, SHA-256 digest, and a safe dataset-relative destination path.
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have the `https` URL of the third party that publishes it, a safe dataset-relative destination path, and an integrity class.
 
-Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-SHA-256 digests, and non-positive artifact sizes.
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, non-SHA-256 digests, and non-positive artifact sizes.
 
 #### Scenario: An embedder lists supported references
 
 - **WHEN** an embedder reads the exported catalog
-- **THEN** it receives the same validated dataset ids, versions, source and licensing links, and content identities as every other embedder using that harness version
+- **THEN** it receives the same validated dataset ids, versions, upstream URLs, source and licensing links, and integrity classes as every other embedder using that harness version
 
 #### Scenario: An unsafe catalog path is rejected
 
 - **WHEN** a catalog artifact destination is absolute or contains a `..` traversal segment
 - **THEN** catalog validation fails before an embedder can construct an install plan
 
-### Requirement: Reference selection resolves to a host-neutral install plan
+### Requirement: Reference artifacts are fetched from the upstream that publishes them
 
-The harness SHALL expose a pure selection operation that accepts requested dataset ids and returns either a typed unknown-id error or a deterministic install plan. The plan SHALL contain the selected dataset metadata and final-file artifacts with distribution keys, hashes, sizes, and dataset-relative destinations. It SHALL NOT contain host storage roots, credentials, terminal behavior, PVC configuration, or a required concrete download URL.
+Each artifact SHALL name the official third-party URL it is fetched from, and the project SHALL NOT mirror, re-host, or redistribute reference bytes. No embedder-configurable distribution endpoint SHALL exist, because a configurable source is a source that can be substituted: the catalog's provenance and licensing claims are only true of the upstream it names.
+
+#### Scenario: There is no endpoint to configure
+
+- **WHEN** an embedder installs a catalog dataset
+- **THEN** it fetches every artifact from the upstream URL in the catalog, and no configuration can redirect that fetch to another origin
 
 #### Scenario: CLI and managed select the same datasets
 
 - **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
-- **THEN** both receive content-identical plans even if they map artifact keys to different distribution endpoints
+- **THEN** both receive content-identical plans naming the same upstream URLs
 
-#### Scenario: Unknown selection is explicit
+### Requirement: An artifact's integrity class states what its upstream can actually guarantee
 
-- **WHEN** a requested id is absent from the catalog
-- **THEN** selection returns a typed error naming the unknown id and available ids, without producing a partial plan
+Every artifact SHALL declare an integrity class, and that class SHALL reflect a property of the upstream rather than a preference of ours. A `pinned` artifact — one whose upstream publishes immutable, versioned bytes — SHALL carry a byte size and SHA-256 digest. An `unpinned` artifact — one whose upstream regenerates the same URL in place, so that no checked-in digest could survive — SHALL carry neither, because a digest that is guaranteed to go stale is worse than an absent one: it promises verification and delivers a broken download.
+
+#### Scenario: Immutable upstream is pinned
+
+- **WHEN** an upstream publishes a dated or release-versioned file that never changes
+- **THEN** its artifact is `pinned` with a size and SHA-256, and an install that receives different bytes fails without activating anything
+
+#### Scenario: Mutable upstream is not pretended to be pinned
+
+- **WHEN** an upstream rebuilds a file in place at a stable URL (NCBI regenerating `gene_info`, Reactome overwriting `current`)
+- **THEN** its artifact is `unpinned`, the catalog states no digest, and the weaker guarantee is surfaced to the user rather than hidden
 
 ### Requirement: Catalog artifacts describe final immutable files
 
-Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes. A dataset with multiple files SHALL list each file as a separately hashed artifact.
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher, and its digest attests only to the machine that produced it.
 
-#### Scenario: A multi-file reference is fully content-addressed
+#### Scenario: A multi-file reference is fully described
 
 - **WHEN** a dataset requires two companion files
-- **THEN** its install plan contains two artifact entries, each with its own distribution key, destination, size, and SHA-256 digest
+- **THEN** its install plan contains two artifact entries, each with its own upstream URL, destination, and integrity class
 
-### Requirement: Reference installation receipts have a shared versioned shape
+#### Scenario: A stable identity survives a moved URL
 
-The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and the installed artifacts' relative paths, sizes, and SHA-256 digests. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+- **WHEN** an embedder keys a resumable partial transfer off an artifact
+- **THEN** it uses the artifact's catalog identity (`<dataset-id>/<version>/<path>`), not its URL, so a changed upstream URL does not orphan in-flight state
+
+### Requirement: Reference installation receipts record what was actually received
+
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path, integrity class, and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+
+Observed digests SHALL NOT be copied from the catalog. For a `pinned` artifact the observed digest necessarily equals the catalog's, since activation fails otherwise; for an `unpinned` artifact the receipt is the only record of what the mutable upstream served, and is therefore what later verification compares against.
 
 #### Scenario: Different embedders describe the same installation
 
 - **WHEN** local and managed installers activate the same install plan
 - **THEN** each can emit a receipt that validates against the same harness-owned contract
+
+#### Scenario: An unpinned install is still verifiable afterwards
+
+- **WHEN** an `unpinned` artifact is installed and its bytes are later altered on disk
+- **THEN** verification against the receipt reports the file as modified, even though the catalog never carried a digest for it
 
 #### Scenario: Invalid receipt does not hide files
 

--- a/harness/src/agents/sandbox/shared.test.ts
+++ b/harness/src/agents/sandbox/shared.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
 import { SOULKernelPrompt, SOULConversationalPrompt } from "../../prompts/SOUL.js";
+import type { SandboxClient } from "../../sandbox/client.js";
+import type { SubmitExecBody } from "../../sandbox/types.js";
+import { makeToolContext } from "../../tools/__fixtures__/tool-context.js";
 
-import { makeFakeSandboxAgentDeps } from "./__fixtures__/deps.js";
+import { makeFakeSandboxAgentDeps, makeFakeSandboxClient } from "./__fixtures__/deps.js";
 import { BASE_SANDBOX_TOOLS, createSandboxAgent } from "./shared.js";
 import type { AgentMeta } from "./types.js";
 import { SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS } from "./types.js";
@@ -64,6 +67,37 @@ describe("createSandboxAgent", () => {
         expect(toolIds).not.toContain("search_compounds");
         expect(toolIds).not.toContain("search_faers");
         expect(toolIds).not.toContain("search_toxcast");
+    });
+
+    it("wires list_available_refs as a workflow tool through step-bound replay-safe exec coordinates", async () => {
+        const submits: SubmitExecBody[] = [];
+        const fake = makeFakeSandboxClient();
+        const sandboxClient: SandboxClient = {
+            ...fake,
+            async submitExec(_sandbox, body) {
+                submits.push(body);
+            },
+            async awaitExec(_sandbox, execId) {
+                return {
+                    execId,
+                    exitCode: 0,
+                    stdout: JSON.stringify({ state: "empty", entries: [], scannedEntries: 0, truncated: false }),
+                    stderr: "",
+                    durationMs: 1,
+                    timedOut: false,
+                };
+            },
+        };
+        const base = makeFakeSandboxAgentDeps();
+        const def = createSandboxAgent({ ...base, sandboxClient }, meta, body);
+        const tool = def.tools.find((candidate) => candidate.id === "list_available_refs")!;
+
+        expect(tool.executionMode).toBe("workflow");
+        const result = (await tool.execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result).toMatchObject({ available: true, state: "empty" });
+        expect(submits).toHaveLength(1);
+        expect(submits[0]!.execId).toBe("wf-001:step-001:fn-1");
+        expect(submits[0]!.command.slice(0, 2)).toEqual(["python3", "-c"]);
     });
 
     it("readOnly drops write_file/edit_file but keeps execute_command + read tools", () => {

--- a/harness/src/agents/sandbox/shared.ts
+++ b/harness/src/agents/sandbox/shared.ts
@@ -30,7 +30,7 @@ import { sandboxOrientCorePrompt, sandboxAnalysisStepStandardsPrompt } from "../
 import { composeSystemPrompt } from "../system-prompt.js";
 
 // Sandbox-environment introspection.
-import { listAvailablePackagesTool, listAvailableRefsTool } from "../../tools/sandbox/index.js";
+import { createListAvailableRefsTool, listAvailablePackagesTool } from "../../tools/sandbox/index.js";
 
 // Context7 docs (pure leaves).
 import { queryDocsTool, resolveLibraryIdTool } from "../../tools/research/context7-docs.js";
@@ -162,7 +162,15 @@ function resolveSandboxTools(deps: SandboxAgentDeps, tools: readonly SandboxTool
     const chemDb = createChemDbTools(deps.bioKeys);
     const registry: Record<SandboxToolName, Tool> = {
         listAvailablePackages: listAvailablePackagesTool,
-        listAvailableRefs: listAvailableRefsTool,
+        listAvailableRefs: createListAvailableRefsTool({
+            sandboxClient: deps.sandboxClient,
+            sandbox: deps.step.sandbox,
+            workflowId: deps.step.workflowId,
+            stepId: deps.step.stepId,
+            nextFunctionId: deps.step.nextFunctionId,
+            deadlineMs: deps.step.deadlineMs,
+            markExecActive: createMarkExecActive(deps),
+        }),
         resolveLibraryId: resolveLibraryIdTool,
         queryDocs: queryDocsTool,
         inspectRun: createInspectRunTool(deps.pool),
@@ -215,6 +223,14 @@ function resolveSandboxTools(deps: SandboxAgentDeps, tools: readonly SandboxTool
     return resolved;
 }
 
+function createMarkExecActive(deps: SandboxAgentDeps): (execId: string) => Promise<void> {
+    return (execId: string): Promise<void> =>
+        setActiveExecId(deps.pool, deps.step.runId, deps.step.stepId, execId).match(
+            () => {},
+            () => {},
+        );
+}
+
 /** Build the workspace mutate + read tools every sandbox agent receives. In
  *  `readOnly` mode the write_file/edit_file pair is omitted; execute_command
  *  and the read tools stay. */
@@ -223,11 +239,7 @@ function buildWorkspaceTools(deps: SandboxAgentDeps, readOnly: boolean): Tool[] 
     // Registry tagging is a best-effort watchdog backstop (`run-exec.ts` already
     // swallows a throw here); fold a `DbError` into a no-op so a registry write
     // failure neither fails the exec nor surfaces as an unhandled rejection.
-    const markExecActive = (execId: string): Promise<void> =>
-        setActiveExecId(pool, step.runId, step.stepId, execId).match(
-            () => {},
-            () => {},
-        );
+    const markExecActive = createMarkExecActive(deps);
 
     // The agent's writable working directory: relative paths resolve here, and
     // writes are confined here. `allowedWritePrefix` is its host path; the

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -287,6 +287,21 @@ export type { CortexRunRow, StepExecutionRow, RunStatus } from "./state/schema.j
 // surface a trigger or ledger failure need it by name to map the `cause`;
 // without it they must re-derive it from a function signature.
 export type { DbError } from "./lib/db-result.js";
+
+// Host-neutral reference-data catalog and shared installation receipts.
+// Embedders resolve artifact keys and own all transfer/storage behavior.
+export {
+    REFERENCE_DATA_CATALOG,
+    REFERENCE_DATA_CATALOG_VERSION,
+    ReferenceArtifactSchema,
+    ReferenceDataCatalogSchema,
+    ReferenceDatasetSchema,
+    UnknownReferenceDatasetError,
+    resolveReferenceInstallPlan,
+} from "./reference-data/catalog.js";
+export type { ReferenceArtifact, ReferenceDataCatalog, ReferenceDataset, ReferenceInstallPlan, ReferenceInstallPlanDataset } from "./reference-data/catalog.js";
+export { REFERENCE_INSTALL_RECEIPT_VERSION, ReferenceInstallReceiptSchema, parseReferenceInstallReceipt } from "./reference-data/receipt.js";
+export type { ReferenceInstallReceipt } from "./reference-data/receipt.js";
 // Backs `WatchdogDeps.queryActiveSandboxes` when the embedder wires the watchdog.
 export { queryActiveSandboxes } from "./state/active-sandboxes.js";
 

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -288,20 +288,31 @@ export type { CortexRunRow, StepExecutionRow, RunStatus } from "./state/schema.j
 // without it they must re-derive it from a function signature.
 export type { DbError } from "./lib/db-result.js";
 
-// Host-neutral reference-data catalog and shared installation receipts.
-// Embedders resolve artifact keys and own all transfer/storage behavior.
+// Host-neutral reference-data catalog and shared installation receipts. Each
+// artifact names the third-party upstream it is fetched from; embedders own all
+// transfer/storage behavior but never choose a different source.
 export {
     REFERENCE_DATA_CATALOG,
     REFERENCE_DATA_CATALOG_VERSION,
+    ReferenceArtifactPathSchema,
     ReferenceArtifactSchema,
     ReferenceDataCatalogSchema,
     ReferenceDatasetSchema,
+    ReferenceSha256Schema,
     UnknownReferenceDatasetError,
+    referenceArtifactKey,
     resolveReferenceInstallPlan,
 } from "./reference-data/catalog.js";
-export type { ReferenceArtifact, ReferenceDataCatalog, ReferenceDataset, ReferenceInstallPlan, ReferenceInstallPlanDataset } from "./reference-data/catalog.js";
+export type {
+    ReferenceArtifact,
+    ReferenceDataCatalog,
+    ReferenceDataset,
+    ReferenceInstallPlan,
+    ReferenceInstallPlanDataset,
+    ReferenceIntegrity,
+} from "./reference-data/catalog.js";
 export { REFERENCE_INSTALL_RECEIPT_VERSION, ReferenceInstallReceiptSchema, parseReferenceInstallReceipt } from "./reference-data/receipt.js";
-export type { ReferenceInstallReceipt } from "./reference-data/receipt.js";
+export type { ReferenceInstallReceipt, ReferenceReceiptArtifact } from "./reference-data/receipt.js";
 // Backs `WatchdogDeps.queryActiveSandboxes` when the embedder wires the watchdog.
 export { queryActiveSandboxes } from "./state/active-sandboxes.js";
 

--- a/harness/src/prompts/sandbox-standards.ts
+++ b/harness/src/prompts/sandbox-standards.ts
@@ -44,11 +44,11 @@ Before writing any code:
 
 1. **Check available packages** — call \`list-available-packages\`. No runtime
    installs are possible. Only import packages confirmed here.
-2. **Check reference data** — call \`list-available-refs\` for pre-staged
-   resources (PROGENy, CollecTRI, MSigDB, WikiPathways, Reactome, OmniPath,
-   gene mappings, design-system templates). Use the exact paths returned. Each
-   biological collection is available as **Parquet** (pandas/decoupler) and
-   **GMT** (gseapy/fgsea/GSVA) — use the format your tool expects.
+2. **Check reference data** — call \`list-available-refs\` to inspect the files
+   actually mounted read-only at \`/mnt/refs\`. The inventory includes both
+   managed references and arbitrary user-added files; a manifest is not
+   required. Use the exact paths returned, and pass a returned subtree path to
+   the tool when a large inventory says it was truncated.
    Do NOT call \`dc.op.collectri()\`, \`dc.op.progeny()\`, \`dc.op.msigdb()\`, or
    any \`dc.op.*()\` function — these require network access. Do NOT pass Enrichr
    library names to gseapy — pass the pre-staged GMT file path.

--- a/harness/src/prompts/sandbox-standards.ts
+++ b/harness/src/prompts/sandbox-standards.ts
@@ -49,6 +49,16 @@ Before writing any code:
    managed references and arbitrary user-added files; a manifest is not
    required. Use the exact paths returned, and pass a returned subtree path to
    the tool when a large inventory says it was truncated.
+   The reference store is OPTIONAL and may be absent or hold none of what you
+   want — that is a normal state, not an error. Never assume a reference path
+   exists, and never hardcode one: if a reference you need is not in the
+   inventory, say so plainly and proceed with what you do have (or explain what
+   the user should provision) rather than inventing a path or a substitute.
+   Pass reference paths EXPLICITLY to the library. Nothing in the image points
+   a library at the store for you, so a library that resolves data by name from
+   an env var (CellTypist reads \`$CELLTYPIST_FOLDER\`) will not find it — export
+   that variable yourself, in the same command, using a path the inventory
+   actually returned.
    Do NOT call \`dc.op.collectri()\`, \`dc.op.progeny()\`, \`dc.op.msigdb()\`, or
    any \`dc.op.*()\` function — these require network access. Do NOT pass Enrichr
    library names to gseapy — pass the pre-staged GMT file path.

--- a/harness/src/reference-data/catalog.test.ts
+++ b/harness/src/reference-data/catalog.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+    REFERENCE_DATA_CATALOG,
+    REFERENCE_DATA_CATALOG_VERSION,
+    ReferenceDataCatalogSchema,
+    UnknownReferenceDatasetError,
+    resolveReferenceInstallPlan,
+    resolveReferenceInstallPlanFromCatalogForTesting,
+} from "./catalog.js";
+import { REFERENCE_INSTALL_RECEIPT_VERSION, parseReferenceInstallReceipt } from "./receipt.js";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+function dataset(id: string, paths = ["reference.parquet"]) {
+    return {
+        id,
+        version: "2026.07",
+        title: `Dataset ${id}`,
+        description: "A fixture reference dataset.",
+        sourceUrl: "https://example.org/source",
+        license: { identifier: "CC-BY-4.0", url: "https://creativecommons.org/licenses/by/4.0/" },
+        recommendation: { group: "fixtures", recommended: true },
+        artifacts: paths.map((path, index) => ({
+            key: `fixtures/${id}/${path}`,
+            path,
+            bytes: index + 1,
+            sha256: index === 0 ? HASH_A : HASH_B,
+        })),
+    };
+}
+
+function catalog(datasets: unknown[]) {
+    return { version: REFERENCE_DATA_CATALOG_VERSION, datasets };
+}
+
+describe("reference-data catalog", () => {
+    it("ships validated trusted catalog data", () => {
+        expect(ReferenceDataCatalogSchema.safeParse(REFERENCE_DATA_CATALOG).success).toBe(true);
+        expect(Object.isFrozen(REFERENCE_DATA_CATALOG)).toBe(true);
+        expect(Object.isFrozen(REFERENCE_DATA_CATALOG.datasets)).toBe(true);
+        expect(REFERENCE_DATA_CATALOG.datasets.map(({ id }) => id)).toEqual([
+            "ncbi-gene-human",
+            "ncbi-gene-mouse",
+            "ncbi-gene-rat",
+            "reactome-pathways",
+            "wikipathways-human",
+            "collectri-human",
+            "gtex-v8",
+            "celltypist-immune",
+        ]);
+    });
+
+    it("records only official upstream dataset sources", () => {
+        const officialHosts = new Set(["ftp.ncbi.nlm.nih.gov", "reactome.org", "data.wikipathways.org", "zenodo.org", "gtexportal.org", "www.celltypist.org"]);
+
+        for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
+            expect(officialHosts.has(new URL(dataset.sourceUrl).hostname)).toBe(true);
+            for (const artifact of dataset.artifacts) {
+                expect(artifact.key).toBe(`${dataset.id}/${dataset.version}/${artifact.path}`);
+            }
+        }
+    });
+
+    it("rejects duplicate dataset ids and artifact destinations", () => {
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one"), dataset("one")])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", ["a.parquet", "a.parquet"])]))).toMatchObject({ success: false });
+    });
+
+    it.each(["/absolute/file", "../escape", "nested/../../escape", "nested//file", "nested/./file", "nested\\file"])(
+        "rejects unsafe artifact path %s",
+        (path) => {
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [path])])).success).toBe(false);
+        },
+    );
+
+    it("rejects malformed digests and non-positive sizes", () => {
+        const badDigest = dataset("bad-digest");
+        badDigest.artifacts[0]!.sha256 = "abc";
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([badDigest])).success).toBe(false);
+
+        const badSize = dataset("bad-size");
+        badSize.artifacts[0]!.bytes = 0;
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([badSize])).success).toBe(false);
+    });
+
+    it.each(["../escape", "nested/version", "nested\\version", ".", ".."])("rejects unsafe dataset version %s", (version) => {
+        const unsafe = dataset("unsafe-version");
+        unsafe.version = version;
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([unsafe])).success).toBe(false);
+    });
+
+    it("resolves a deterministic, deduplicated multi-file plan", () => {
+        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", ["one.parquet", "two.json"])]));
+        const plan = resolveReferenceInstallPlanFromCatalogForTesting(["zeta", "alpha", "zeta"], parsed)._unsafeUnwrap();
+
+        expect(plan.datasets.map((item) => item.id)).toEqual(["alpha", "zeta"]);
+        expect(plan.datasets[0]!.installPath).toBe("alpha/2026.07");
+        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.path)).toEqual(["one.parquet", "two.json"]);
+    });
+
+    it("returns a typed error without a partial plan for an unknown id", () => {
+        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha")]));
+        const error = resolveReferenceInstallPlanFromCatalogForTesting(["alpha", "missing"], parsed)._unsafeUnwrapErr();
+        expect(error).toBeInstanceOf(UnknownReferenceDatasetError);
+        expect(error).toMatchObject({ unknownId: "missing", availableIds: ["alpha", "zeta"] });
+    });
+
+    it("resolves public selections only against the canonical catalog", () => {
+        expect(resolveReferenceInstallPlan(["fixture-only"])._unsafeUnwrapErr()).toMatchObject({
+            unknownId: "fixture-only",
+            availableIds: [
+                "celltypist-immune",
+                "collectri-human",
+                "gtex-v8",
+                "ncbi-gene-human",
+                "ncbi-gene-mouse",
+                "ncbi-gene-rat",
+                "reactome-pathways",
+                "wikipathways-human",
+            ],
+        });
+    });
+});
+
+describe("reference installation receipt", () => {
+    const valid = {
+        version: REFERENCE_INSTALL_RECEIPT_VERSION,
+        datasetId: "alpha",
+        datasetVersion: "2026.07",
+        activatedAt: "2026-07-14T10:30:00.000Z",
+        artifacts: [{ path: "one.parquet", bytes: 42, sha256: HASH_A }],
+    };
+
+    it("parses valid versioned receipts", () => {
+        expect(parseReferenceInstallReceipt(valid)).toEqual(valid);
+    });
+
+    it("degrades invalid receipt metadata to undefined", () => {
+        expect(parseReferenceInstallReceipt({ ...valid, version: 99 })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, activatedAt: "yesterday" })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, datasetVersion: "../escape" })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], path: "../escape" }] })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [valid.artifacts[0], valid.artifacts[0]] })).toBeUndefined();
+    });
+});

--- a/harness/src/reference-data/catalog.test.ts
+++ b/harness/src/reference-data/catalog.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "bun:test";
 import {
     REFERENCE_DATA_CATALOG,
     REFERENCE_DATA_CATALOG_VERSION,
+    ReferenceArtifactSchema,
     ReferenceDataCatalogSchema,
     UnknownReferenceDatasetError,
+    referenceArtifactKey,
     resolveReferenceInstallPlan,
     resolveReferenceInstallPlanFromCatalogForTesting,
 } from "./catalog.js";
@@ -13,7 +15,21 @@ import { REFERENCE_INSTALL_RECEIPT_VERSION, parseReferenceInstallReceipt } from 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 
-function dataset(id: string, paths = ["reference.parquet"]) {
+function pinned(path: string, index = 0): Record<string, unknown> {
+    return {
+        integrity: "pinned",
+        path,
+        url: `https://example.org/immutable/artifact-${index}`,
+        bytes: index + 1,
+        sha256: index === 0 ? HASH_A : HASH_B,
+    };
+}
+
+function unpinned(path: string, index = 0): Record<string, unknown> {
+    return { integrity: "unpinned", path, url: `https://example.org/current/artifact-${index}` };
+}
+
+function dataset(id: string, artifacts: Record<string, unknown>[] = [pinned("reference.parquet")]): Record<string, unknown> {
     return {
         id,
         version: "2026.07",
@@ -22,12 +38,7 @@ function dataset(id: string, paths = ["reference.parquet"]) {
         sourceUrl: "https://example.org/source",
         license: { identifier: "CC-BY-4.0", url: "https://creativecommons.org/licenses/by/4.0/" },
         recommendation: { group: "fixtures", recommended: true },
-        artifacts: paths.map((path, index) => ({
-            key: `fixtures/${id}/${path}`,
-            path,
-            bytes: index + 1,
-            sha256: index === 0 ? HASH_A : HASH_B,
-        })),
+        artifacts,
     };
 }
 
@@ -36,6 +47,8 @@ function catalog(datasets: unknown[]) {
 }
 
 describe("reference-data catalog", () => {
+    // The shipped catalog is parsed at module load, so a malformed entry throws on
+    // import and every test in this file fails — re-parsing here only pins the shape.
     it("ships validated trusted catalog data", () => {
         expect(ReferenceDataCatalogSchema.safeParse(REFERENCE_DATA_CATALOG).success).toBe(true);
         expect(Object.isFrozen(REFERENCE_DATA_CATALOG)).toBe(true);
@@ -45,6 +58,7 @@ describe("reference-data catalog", () => {
             "ncbi-gene-mouse",
             "ncbi-gene-rat",
             "reactome-pathways",
+            "reactome-mappings",
             "wikipathways-human",
             "collectri-human",
             "gtex-v8",
@@ -52,59 +66,160 @@ describe("reference-data catalog", () => {
         ]);
     });
 
-    it("records only official upstream dataset sources", () => {
-        const officialHosts = new Set(["ftp.ncbi.nlm.nih.gov", "reactome.org", "data.wikipathways.org", "zenodo.org", "gtexportal.org", "www.celltypist.org"]);
+    // The ~700 MB of uncompressed Reactome mapping TSV is opt-in, so a default `setup` never
+    // silently pulls two orders of magnitude more than the gene sets it actually asked for.
+    it("recommends every dataset except the very large opt-in mapping tables", () => {
+        const notRecommended = REFERENCE_DATA_CATALOG.datasets.filter((dataset) => !dataset.recommendation.recommended).map(({ id }) => id);
+
+        expect(notRecommended).toEqual(["reactome-mappings"]);
+    });
+
+    it("fetches every artifact from an official upstream over https", () => {
+        const officialHosts = new Set([
+            "ftp.ncbi.nlm.nih.gov",
+            "reactome.org",
+            "data.wikipathways.org",
+            "zenodo.org",
+            "gtexportal.org",
+            "storage.googleapis.com",
+            "celltypist.cog.sanger.ac.uk",
+            "www.celltypist.org",
+        ]);
 
         for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
             expect(officialHosts.has(new URL(dataset.sourceUrl).hostname)).toBe(true);
             for (const artifact of dataset.artifacts) {
-                expect(artifact.key).toBe(`${dataset.id}/${dataset.version}/${artifact.path}`);
+                expect(artifact.url.startsWith("https://")).toBe(true);
+                expect(new URL(artifact.url).protocol).toBe("https:");
+                expect(officialHosts.has(new URL(artifact.url).hostname)).toBe(true);
             }
         }
     });
 
-    it("rejects duplicate dataset ids and artifact destinations", () => {
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one"), dataset("one")])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", ["a.parquet", "a.parquet"])]))).toMatchObject({ success: false });
+    it("pins size and digest exactly for the immutable upstreams and for no other", () => {
+        const byIntegrity = { pinned: [] as string[], unpinned: [] as string[] };
+
+        for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
+            for (const artifact of dataset.artifacts) {
+                byIntegrity[artifact.integrity].push(dataset.id);
+                if (artifact.integrity === "pinned") {
+                    expect(artifact.bytes).toBeGreaterThan(0);
+                    expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
+                } else {
+                    // A mutable upstream admits no checked-in digest: the receipt is the record.
+                    expect(artifact).not.toHaveProperty("bytes");
+                    expect(artifact).not.toHaveProperty("sha256");
+                    expect(dataset.version).toBe("current");
+                }
+            }
+        }
+
+        expect([...new Set(byIntegrity.pinned)]).toEqual(["wikipathways-human", "collectri-human", "gtex-v8", "celltypist-immune"]);
+        expect([...new Set(byIntegrity.unpinned)]).toEqual([
+            "ncbi-gene-human",
+            "ncbi-gene-mouse",
+            "ncbi-gene-rat",
+            "reactome-pathways",
+            "reactome-mappings",
+        ]);
     });
 
-    it.each(["/absolute/file", "../escape", "nested/../../escape", "nested//file", "nested/./file", "nested\\file"])(
+    it("keys every catalog artifact by its stable, URL-independent identity", () => {
+        expect(referenceArtifactKey({ id: "alpha", version: "2026.07" }, { path: "nested/one.parquet" })).toBe("alpha/2026.07/nested/one.parquet");
+
+        for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
+            for (const artifact of dataset.artifacts) {
+                expect(referenceArtifactKey(dataset, artifact)).toBe(`${dataset.id}/${dataset.version}/${artifact.path}`);
+            }
+        }
+    });
+
+    it("accepts both integrity classes and rejects an unknown discriminant", () => {
+        expect(ReferenceArtifactSchema.safeParse(pinned("one.parquet")).success).toBe(true);
+        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
+        expect(ReferenceArtifactSchema.safeParse({ path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ integrity: "trusted", path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
+    });
+
+    // A digest on an unpinned artifact is a category error: the upstream rewrites that URL, so the
+    // digest is guaranteed to go stale. Silently stripping it would let the mistake reach review
+    // looking like a pinned entry, so the schema rejects it outright.
+    it("rejects a size and digest offered for an unpinned artifact", () => {
+        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), bytes: 5, sha256: HASH_A }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), sha256: HASH_A }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
+    });
+
+    it.each(["http://example.org/one", "ftp://ftp.example.org/one", "file:///etc/passwd", "example.org/one", ""])(
+        "rejects non-https artifact url %s",
+        (url) => {
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-url", [{ ...pinned("one.parquet"), url }])])).success).toBe(false);
+        },
+    );
+
+    it("requires a size and digest on a pinned artifact", () => {
+        const { sha256: _sha256, ...noDigest } = pinned("one.parquet");
+        const { bytes: _bytes, ...noSize } = pinned("one.parquet");
+
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-digest", [noDigest])])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-size", [noSize])])).success).toBe(false);
+    });
+
+    it("rejects duplicate dataset ids and artifact destinations", () => {
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one"), dataset("one")])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("a.parquet", 1)])])).success).toBe(false);
+        // A path collides across integrity classes too — the destination is what must be unique.
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet"), unpinned("a.parquet")])])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("b.parquet", 1)])])).success).toBe(true);
+    });
+
+    it.each(["/absolute/file", "../escape", "nested/../../escape", "nested//file", "nested/./file", "nested\\file", ""])(
         "rejects unsafe artifact path %s",
         (path) => {
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [path])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [pinned(path)])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [unpinned(path)])])).success).toBe(false);
         },
     );
 
     it("rejects malformed digests and non-positive sizes", () => {
-        const badDigest = dataset("bad-digest");
-        badDigest.artifacts[0]!.sha256 = "abc";
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([badDigest])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-digest", [{ ...pinned("a.parquet"), sha256: "abc" }])])).success).toBe(false);
+        expect(
+            ReferenceDataCatalogSchema.safeParse(catalog([dataset("upper-digest", [{ ...pinned("a.parquet"), sha256: HASH_A.toUpperCase() }])])).success,
+        ).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-size", [{ ...pinned("a.parquet"), bytes: 0 }])])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("float-size", [{ ...pinned("a.parquet"), bytes: 1.5 }])])).success).toBe(false);
+    });
 
-        const badSize = dataset("bad-size");
-        badSize.artifacts[0]!.bytes = 0;
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([badSize])).success).toBe(false);
+    it("requires at least one artifact per dataset", () => {
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("empty", [])])).success).toBe(false);
     });
 
     it.each(["../escape", "nested/version", "nested\\version", ".", ".."])("rejects unsafe dataset version %s", (version) => {
-        const unsafe = dataset("unsafe-version");
-        unsafe.version = version;
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([unsafe])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([{ ...dataset("unsafe-version"), version }])).success).toBe(false);
     });
 
-    it("resolves a deterministic, deduplicated multi-file plan", () => {
-        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", ["one.parquet", "two.json"])]));
+    it("resolves a deterministic, deduplicated multi-file plan across both integrity classes", () => {
+        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", [pinned("one.parquet", 0), unpinned("two.json", 1)])]));
         const plan = resolveReferenceInstallPlanFromCatalogForTesting(["zeta", "alpha", "zeta"], parsed)._unsafeUnwrap();
 
+        expect(plan.catalogVersion).toBe(REFERENCE_DATA_CATALOG_VERSION);
         expect(plan.datasets.map((item) => item.id)).toEqual(["alpha", "zeta"]);
         expect(plan.datasets[0]!.installPath).toBe("alpha/2026.07");
+        expect(plan.datasets[1]!.installPath).toBe("zeta/2026.07");
         expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.path)).toEqual(["one.parquet", "two.json"]);
+        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.integrity)).toEqual(["pinned", "unpinned"]);
+        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.url)).toEqual([
+            "https://example.org/immutable/artifact-0",
+            "https://example.org/current/artifact-1",
+        ]);
+        expect(referenceArtifactKey(plan.datasets[0]!, plan.datasets[0]!.artifacts[0]!)).toBe("alpha/2026.07/one.parquet");
     });
 
     it("returns a typed error without a partial plan for an unknown id", () => {
         const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha")]));
         const error = resolveReferenceInstallPlanFromCatalogForTesting(["alpha", "missing"], parsed)._unsafeUnwrapErr();
         expect(error).toBeInstanceOf(UnknownReferenceDatasetError);
-        expect(error).toMatchObject({ unknownId: "missing", availableIds: ["alpha", "zeta"] });
+        expect(error).toMatchObject({ code: "unknown_reference_dataset", unknownId: "missing", availableIds: ["alpha", "zeta"] });
     });
 
     it("resolves public selections only against the canonical catalog", () => {
@@ -117,10 +232,14 @@ describe("reference-data catalog", () => {
                 "ncbi-gene-human",
                 "ncbi-gene-mouse",
                 "ncbi-gene-rat",
+                "reactome-mappings",
                 "reactome-pathways",
                 "wikipathways-human",
             ],
         });
+
+        const plan = resolveReferenceInstallPlan(["reactome-pathways", "gtex-v8"])._unsafeUnwrap();
+        expect(plan.datasets.map((item) => item.installPath)).toEqual(["gtex-v8/8", "reactome-pathways/current"]);
     });
 });
 
@@ -130,18 +249,40 @@ describe("reference installation receipt", () => {
         datasetId: "alpha",
         datasetVersion: "2026.07",
         activatedAt: "2026-07-14T10:30:00.000Z",
-        artifacts: [{ path: "one.parquet", bytes: 42, sha256: HASH_A }],
+        artifacts: [
+            { path: "one.parquet", bytes: 42, sha256: HASH_A, integrity: "pinned" as const },
+            { path: "nested/current.gz", bytes: 0, sha256: HASH_B, integrity: "unpinned" as const },
+        ],
     };
 
-    it("parses valid versioned receipts", () => {
+    it("records observed bytes and digest for both integrity classes", () => {
         expect(parseReferenceInstallReceipt(valid)).toEqual(valid);
     });
 
     it("degrades invalid receipt metadata to undefined", () => {
+        expect(parseReferenceInstallReceipt(undefined)).toBeUndefined();
+        expect(parseReferenceInstallReceipt("garbage")).toBeUndefined();
         expect(parseReferenceInstallReceipt({ ...valid, version: 99 })).toBeUndefined();
         expect(parseReferenceInstallReceipt({ ...valid, activatedAt: "yesterday" })).toBeUndefined();
         expect(parseReferenceInstallReceipt({ ...valid, datasetVersion: "../escape" })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [] })).toBeUndefined();
         expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], path: "../escape" }] })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], sha256: "abc" }] })).toBeUndefined();
         expect(parseReferenceInstallReceipt({ ...valid, artifacts: [valid.artifacts[0], valid.artifacts[0]] })).toBeUndefined();
+    });
+
+    it("requires an observed integrity class on every receipt artifact", () => {
+        const { integrity: _integrity, ...noIntegrity } = valid.artifacts[0]!;
+
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [noIntegrity] })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], integrity: "trusted" }] })).toBeUndefined();
+    });
+
+    it("requires an observed digest even where the catalog could not pin one", () => {
+        const { sha256: _sha256, ...noDigest } = valid.artifacts[1]!;
+        const { bytes: _bytes, ...noSize } = valid.artifacts[1]!;
+
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [noDigest] })).toBeUndefined();
+        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [noSize] })).toBeUndefined();
     });
 });

--- a/harness/src/reference-data/catalog.ts
+++ b/harness/src/reference-data/catalog.ts
@@ -16,13 +16,52 @@ function isSafeRelativePath(value: string): boolean {
     return segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..") && posixPath.normalize(value) === value;
 }
 
-/** One immutable final file distributed for a reference dataset. */
-export const ReferenceArtifactSchema = z.object({
-    key: z.string().min(1),
+/** Dataset-relative destination of one artifact below its install path. */
+export const ReferenceArtifactPathSchema = z.string().refine(isSafeRelativePath, "Expected a safe dataset-relative path");
+
+/** Lowercase SHA-256 digest of one artifact's bytes. */
+export const ReferenceSha256Schema = z.string().regex(SHA256, "Expected a lowercase SHA-256 digest");
+
+/**
+ * Artifacts are fetched from the upstream that publishes them — this project
+ * redistributes nothing — so the URL must be a real third-party https endpoint.
+ */
+const ReferenceArtifactUrlSchema = z.url().refine((value) => value.startsWith("https://"), "Reference artifacts must be fetched over https");
+
+/**
+ * An artifact whose upstream publishes immutable, versioned bytes. The catalog
+ * carries the size and digest, so a download is verified against *this file*
+ * before it is ever activated: a mismatch means the bytes are not what we
+ * reviewed, and the install fails.
+ */
+const PinnedReferenceArtifactSchema = z.strictObject({
+    integrity: z.literal("pinned"),
+    path: ReferenceArtifactPathSchema,
+    url: ReferenceArtifactUrlSchema,
     bytes: z.number().int().positive(),
-    sha256: z.string().regex(SHA256, "Expected a lowercase SHA-256 digest"),
-    path: z.string().refine(isSafeRelativePath, "Expected a safe dataset-relative path"),
+    sha256: ReferenceSha256Schema,
 });
+
+/**
+ * An artifact whose upstream regenerates the same URL in place — NCBI rebuilds
+ * `gene_info` continuously and Reactome's `current` release is overwritten and
+ * its predecessors deleted. No checked-in digest can survive that, and pinning
+ * one would only guarantee a broken download. Integrity is therefore
+ * trust-on-first-use: the installer records the bytes it actually received in
+ * the receipt, and `verify` proves the files have not changed *since install*.
+ * This is a weaker guarantee than `pinned` and is surfaced as such to the user.
+ */
+const UnpinnedReferenceArtifactSchema = z.strictObject({
+    integrity: z.literal("unpinned"),
+    path: ReferenceArtifactPathSchema,
+    url: ReferenceArtifactUrlSchema,
+});
+
+/** One immutable final file distributed for a reference dataset. */
+export const ReferenceArtifactSchema = z.discriminatedUnion("integrity", [PinnedReferenceArtifactSchema, UnpinnedReferenceArtifactSchema]);
+
+/** Which integrity guarantee an artifact can actually offer. */
+export type ReferenceIntegrity = z.infer<typeof ReferenceArtifactSchema>["integrity"];
 
 /** Provenance and licensing information for one supported reference dataset. */
 export const ReferenceDatasetSchema = z.object({
@@ -82,6 +121,15 @@ export type ReferenceArtifact = DeepReadonly<z.infer<typeof ReferenceArtifactSch
 export type ReferenceDataset = DeepReadonly<z.infer<typeof ReferenceDatasetSchema>>;
 export type ReferenceDataCatalog = DeepReadonly<z.infer<typeof ReferenceDataCatalogSchema>>;
 
+/**
+ * Stable identity of one artifact within the catalog, independent of its URL.
+ * Embedders key resumable partials off this, so a moved upstream URL does not
+ * orphan a half-finished transfer.
+ */
+export function referenceArtifactKey(dataset: { readonly id: string; readonly version: string }, artifact: { readonly path: string }): string {
+    return `${dataset.id}/${dataset.version}/${artifact.path}`;
+}
+
 function deepFreeze<T>(value: T): DeepReadonly<T> {
     if (value && typeof value === "object" && !Object.isFrozen(value)) {
         for (const nested of Object.values(value)) deepFreeze(nested);
@@ -91,9 +139,16 @@ function deepFreeze<T>(value: T): DeepReadonly<T> {
 }
 
 /**
- * Canonical release catalog. Release-data publication is deliberately separate
- * from this contract; entries are added only with real immutable files, sizes,
- * digests, provenance, and licensing data.
+ * Canonical release catalog. Every artifact is fetched directly from the third
+ * party that publishes it; this project hosts, mirrors, and redistributes
+ * nothing. Entries are added only with real upstream URLs, provenance, and
+ * licensing data — plus a size and digest whenever the upstream publishes
+ * immutable bytes we can pin to.
+ *
+ * `version` is the dataset's upstream release identifier. Datasets built on an
+ * upstream that has no immutable release — NCBI regenerates `gene_info` daily,
+ * Reactome overwrites `current` and deletes prior releases — are versioned
+ * `current` and carry `unpinned` artifacts.
  */
 export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
     ReferenceDataCatalogSchema.parse({
@@ -101,10 +156,11 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
         datasets: [
             {
                 id: "ncbi-gene-human",
-                version: "2026.07.13",
+                version: "current",
                 title: "NCBI human gene identifiers",
-                description: "Entrez Gene identifiers and approved symbols for Homo sapiens (NCBI taxonomy 9606).",
-                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                description:
+                    "Entrez Gene records for Homo sapiens (NCBI taxonomy 9606): identifiers, approved symbols, synonyms, and cross-references (Ensembl, HGNC) in the dbXrefs column. Tab-separated, gzipped. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/",
                 license: {
                     identifier: "NCBI-Molecular-Data-Usage-Policy",
                     url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
@@ -112,43 +168,19 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        key: "ncbi-gene-human/2026.07.13/entrez_to_symbol_9606.parquet",
-                        path: "entrez_to_symbol_9606.parquet",
-                        bytes: 2_211_032,
-                        sha256: "98069fffcf0207437541dae8b67d515d460122785731322b817d2b6e2bd4c111",
-                    },
-                    {
-                        key: "ncbi-gene-human/2026.07.13/ensembl_to_symbol_9606.parquet",
-                        path: "ensembl_to_symbol_9606.parquet",
-                        bytes: 888_646,
-                        sha256: "70f713757a2f53c4b487c3f9b9328263f4d3a28b4e7bbce599ac585df0e336fe",
-                    },
-                    {
-                        key: "ncbi-gene-human/2026.07.13/refseq_rna_to_symbol_9606.parquet",
-                        path: "refseq_rna_to_symbol_9606.parquet",
-                        bytes: 4_366_526,
-                        sha256: "5d379282d370ab3e182c634a0aa6c2c4eea5a107a5570e5945f766872ae4b402",
-                    },
-                    {
-                        key: "ncbi-gene-human/2026.07.13/refseq_protein_to_symbol_9606.parquet",
-                        path: "refseq_protein_to_symbol_9606.parquet",
-                        bytes: 3_014_150,
-                        sha256: "c66b67e9791a39dc0e724447d26754115a2ea0497ff33a7e4a9522eab448449b",
-                    },
-                    {
-                        key: "ncbi-gene-human/2026.07.13/refseq_genomic_to_symbol_9606.parquet",
-                        path: "refseq_genomic_to_symbol_9606.parquet",
-                        bytes: 7_682_265,
-                        sha256: "16627f33ec4895192ce72a73ade8c9c6f3f73ffb5a3fff30b8b528ca013e2d49",
+                        integrity: "unpinned",
+                        path: "Homo_sapiens.gene_info.gz",
+                        url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz",
                     },
                 ],
             },
             {
                 id: "ncbi-gene-mouse",
-                version: "2026.07.13",
+                version: "current",
                 title: "NCBI mouse gene identifiers",
-                description: "Entrez Gene identifiers and approved symbols for Mus musculus (NCBI taxonomy 10090).",
-                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                description:
+                    "Entrez Gene records for Mus musculus (NCBI taxonomy 10090): identifiers, approved symbols, synonyms, and cross-references (Ensembl, MGI) in the dbXrefs column. Tab-separated, gzipped. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/",
                 license: {
                     identifier: "NCBI-Molecular-Data-Usage-Policy",
                     url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
@@ -156,43 +188,19 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        key: "ncbi-gene-mouse/2026.07.13/entrez_to_symbol_10090.parquet",
-                        path: "entrez_to_symbol_10090.parquet",
-                        bytes: 1_441_782,
-                        sha256: "ff38eb371626380fc2953d2b605ba14b4c2de32ca1a615add353d3ff2dd53c4b",
-                    },
-                    {
-                        key: "ncbi-gene-mouse/2026.07.13/ensembl_to_symbol_10090.parquet",
-                        path: "ensembl_to_symbol_10090.parquet",
-                        bytes: 795_156,
-                        sha256: "1e4f63138d7deefa81e9158085254b6208ef74822400aead0b10e7f4a8416826",
-                    },
-                    {
-                        key: "ncbi-gene-mouse/2026.07.13/refseq_rna_to_symbol_10090.parquet",
-                        path: "refseq_rna_to_symbol_10090.parquet",
-                        bytes: 2_595_845,
-                        sha256: "d1536e7c76063ab5875d35059d7c1509d6fdf71fcd16d9bcd5b3bef80625755a",
-                    },
-                    {
-                        key: "ncbi-gene-mouse/2026.07.13/refseq_protein_to_symbol_10090.parquet",
-                        path: "refseq_protein_to_symbol_10090.parquet",
-                        bytes: 1_822_348,
-                        sha256: "ec7105e2a56ba459f3de8f3818bfb330deabc0347852b1fe51e870a95f4461ff",
-                    },
-                    {
-                        key: "ncbi-gene-mouse/2026.07.13/refseq_genomic_to_symbol_10090.parquet",
-                        path: "refseq_genomic_to_symbol_10090.parquet",
-                        bytes: 2_414_497,
-                        sha256: "c9285ab759a14cd5c4ac9c08e7b8f63b0ce08c7045f1232a05a3f387c4c91290",
+                        integrity: "unpinned",
+                        path: "Mus_musculus.gene_info.gz",
+                        url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz",
                     },
                 ],
             },
             {
                 id: "ncbi-gene-rat",
-                version: "2026.07.13",
+                version: "current",
                 title: "NCBI rat gene identifiers",
-                description: "Entrez Gene identifiers and approved symbols for Rattus norvegicus (NCBI taxonomy 10116).",
-                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                description:
+                    "Entrez Gene records for Rattus norvegicus (NCBI taxonomy 10116): identifiers, approved symbols, synonyms, and cross-references (Ensembl, RGD) in the dbXrefs column. Tab-separated, gzipped. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/",
                 license: {
                     identifier: "NCBI-Molecular-Data-Usage-Policy",
                     url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
@@ -200,81 +208,54 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        key: "ncbi-gene-rat/2026.07.13/entrez_to_symbol_10116.parquet",
-                        path: "entrez_to_symbol_10116.parquet",
-                        bytes: 690_739,
-                        sha256: "1fd12f59344c270788ce8fc4cf9ec45d7f0d4f4b4d8063c19d5c1bff606b6bb7",
-                    },
-                    {
-                        key: "ncbi-gene-rat/2026.07.13/ensembl_to_symbol_10116.parquet",
-                        path: "ensembl_to_symbol_10116.parquet",
-                        bytes: 569_330,
-                        sha256: "3a42f41e2558470fc5a8b07c34d34f4762dc97626067f6a0cbdcccf9239186b2",
-                    },
-                    {
-                        key: "ncbi-gene-rat/2026.07.13/refseq_rna_to_symbol_10116.parquet",
-                        path: "refseq_rna_to_symbol_10116.parquet",
-                        bytes: 2_315_288,
-                        sha256: "6dafb16d2385e575b7710c320da92f552467a0f7f2bf268b2513e2945323b544",
-                    },
-                    {
-                        key: "ncbi-gene-rat/2026.07.13/refseq_protein_to_symbol_10116.parquet",
-                        path: "refseq_protein_to_symbol_10116.parquet",
-                        bytes: 1_741_627,
-                        sha256: "843fe6a6721189b5ec77bdcfc4deccea0dad6f74df46a43898fcc7a78dbb9392",
-                    },
-                    {
-                        key: "ncbi-gene-rat/2026.07.13/refseq_genomic_to_symbol_10116.parquet",
-                        path: "refseq_genomic_to_symbol_10116.parquet",
-                        bytes: 744_008,
-                        sha256: "755264d887c4dbf0ef6719cae9a210e99e9b173285fee17b4cce301a6934424a",
+                        integrity: "unpinned",
+                        path: "Rattus_norvegicus.gene_info.gz",
+                        url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Rattus_norvegicus.gene_info.gz",
                     },
                 ],
             },
             {
                 id: "reactome-pathways",
-                version: "97",
+                version: "current",
                 title: "Reactome pathways",
-                description: "Reactome pathway gene sets for pathway enrichment and annotation workflows.",
+                description:
+                    "Reactome pathway gene sets (GMT) and the pathway index — the enrichment workhorse, ~2 MB. Reactome overwrites its `current` release each quarter and removes the prior one, so this is verified against what you downloaded rather than a checked-in digest. For identifier-to-pathway mapping tables, add `reactome-mappings`.",
                 sourceUrl: "https://reactome.org/download-data",
                 license: { identifier: "CC0-1.0", url: "https://reactome.org/license" },
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
+                    { integrity: "unpinned", path: "ReactomePathways.gmt", url: "https://reactome.org/download/current/ReactomePathways.gmt" },
+                    { integrity: "unpinned", path: "ReactomePathways.txt", url: "https://reactome.org/download/current/ReactomePathways.txt" },
+                ],
+            },
+            {
+                // Split out of `reactome-pathways` and NOT recommended by default: upstream serves these
+                // as uncompressed TSV and they total roughly 700 MB, two orders of magnitude more than the
+                // GMT most workflows actually want. Anyone who needs Entrez/Ensembl/UniProt -> pathway
+                // joins opts in deliberately, rather than every `setup` paying for them by accident.
+                id: "reactome-mappings",
+                version: "current",
+                title: "Reactome identifier mappings (large)",
+                description:
+                    "Entrez/Ensembl/UniProt-to-Reactome mapping tables at all pathway levels. Large: roughly 700 MB of uncompressed TSV, because Reactome publishes no compressed form. Only needed to join external identifiers onto Reactome pathways; the gene sets themselves live in `reactome-pathways`.",
+                sourceUrl: "https://reactome.org/download-data",
+                license: { identifier: "CC0-1.0", url: "https://reactome.org/license" },
+                recommendation: { group: "pathways", recommended: false },
+                artifacts: [
                     {
-                        key: "reactome-pathways/97/ReactomePathways.gmt",
-                        path: "ReactomePathways.gmt",
-                        bytes: 1_032_186,
-                        sha256: "89983d5c1f0af11c52edfeee7323eb425580ac6281d387a528562ab1787ce56b",
+                        integrity: "unpinned",
+                        path: "NCBI2Reactome_All_Levels.txt",
+                        url: "https://reactome.org/download/current/NCBI2Reactome_All_Levels.txt",
                     },
                     {
-                        key: "reactome-pathways/97/ReactomePathways.parquet",
-                        path: "ReactomePathways.parquet",
-                        bytes: 277_654,
-                        sha256: "776899a3705cc62a990e9679215c0b4e9a2dafeb0e14cdb21d4673e089a2e295",
+                        integrity: "unpinned",
+                        path: "Ensembl2Reactome_All_Levels.txt",
+                        url: "https://reactome.org/download/current/Ensembl2Reactome_All_Levels.txt",
                     },
                     {
-                        key: "reactome-pathways/97/Ensembl2Reactome_All_Levels.parquet",
-                        path: "Ensembl2Reactome_All_Levels.parquet",
-                        bytes: 22_872_142,
-                        sha256: "a41c547c9ade3798383b8e85e6c1e77e7c196e0887977b92295d236c408ca16d",
-                    },
-                    {
-                        key: "reactome-pathways/97/NCBI2Reactome_All_Levels.parquet",
-                        path: "NCBI2Reactome_All_Levels.parquet",
-                        bytes: 7_008_817,
-                        sha256: "e882959816d92e9e762490bfa6e6617f7fe62ddd5a90b879b93c1aac8cc86291",
-                    },
-                    {
-                        key: "reactome-pathways/97/UniProt2Reactome_All_Levels.parquet",
-                        path: "UniProt2Reactome_All_Levels.parquet",
-                        bytes: 8_612_412,
-                        sha256: "0f80922ce23c24af3718cf706149432d9a4ed3c099ebaf4d758941e884384efd",
-                    },
-                    {
-                        key: "reactome-pathways/97/reactome_homo_sapiens_interactions.parquet",
-                        path: "reactome_homo_sapiens_interactions.parquet",
-                        bytes: 2_136_397,
-                        sha256: "a19cdb33cd304fe1e090219850db8f7fe59e12754e930ad4568edfb887110517",
+                        integrity: "unpinned",
+                        path: "UniProt2Reactome_All_Levels.txt",
+                        url: "https://reactome.org/download/current/UniProt2Reactome_All_Levels.txt",
                     },
                 ],
             },
@@ -282,22 +263,17 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 id: "wikipathways-human",
                 version: "2026.07.10",
                 title: "WikiPathways human pathways",
-                description: "Community-curated Homo sapiens pathway gene sets and a tabular membership index.",
-                sourceUrl: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Homo_sapiens.gmt",
+                description: "Community-curated Homo sapiens pathway gene sets (GMT) from the immutable 2026-07-10 WikiPathways snapshot.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/",
                 license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
                     {
-                        key: "wikipathways-human/2026.07.10/wikipathways_Homo_sapiens.gmt",
+                        integrity: "pinned",
                         path: "wikipathways_Homo_sapiens.gmt",
+                        url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Homo_sapiens.gmt",
                         bytes: 341_474,
                         sha256: "79615a079246bb0b07cc3505265b1f75ea6cffec88001ce27f644dd86a39c97d",
-                    },
-                    {
-                        key: "wikipathways-human/2026.07.10/wikipathways_Homo_sapiens.parquet",
-                        path: "wikipathways_Homo_sapiens.parquet",
-                        bytes: 165_089,
-                        sha256: "8fafff05009b10c8bdf6ce4601542e87c772a07950c183a96e658efe6229a8d8",
                     },
                 ],
             },
@@ -305,16 +281,17 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 id: "collectri-human",
                 version: "2.0",
                 title: "CollecTRI human regulatory network",
-                description: "A literature-curated human transcription-factor target interaction network.",
-                sourceUrl: "https://zenodo.org/records/8192729/files/CollecTRI_regulons.csv",
+                description: "A literature-curated human transcription-factor target interaction network (CSV) from the immutable Zenodo record 8192729.",
+                sourceUrl: "https://zenodo.org/records/8192729",
                 license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/8192729" },
                 recommendation: { group: "regulatory-networks", recommended: true },
                 artifacts: [
                     {
-                        key: "collectri-human/2.0/collectri_human.parquet",
-                        path: "collectri_human.parquet",
-                        bytes: 709_038,
-                        sha256: "fefa0f04541982b9240317d8e7a0d6f090bd5510dab589b5436d1f9f52cb0c6d",
+                        integrity: "pinned",
+                        path: "CollecTRI_regulons.csv",
+                        url: "https://zenodo.org/records/8192729/files/CollecTRI_regulons.csv",
+                        bytes: 4_345_649,
+                        sha256: "4473c9189dd53dacc80297709ad1452dda1086a1cc2185f9a56146c261668701",
                     },
                 ],
             },
@@ -322,22 +299,25 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 id: "gtex-v8",
                 version: "8",
                 title: "GTEx v8 normal tissue expression",
-                description: "GTEx v8 median gene expression by tissue with sample metadata for normal-reference workflows.",
+                description:
+                    "GTEx v8 median gene TPM by tissue (GCT) with the sample attributes table, for normal-reference workflows. Immutable v8 release files.",
                 sourceUrl: "https://gtexportal.org/home/downloads/adult-gtex/bulk_tissue_expression",
                 license: { identifier: "GTEx-Portal-Data-License", url: "https://gtexportal.org/home/license" },
                 recommendation: { group: "normal-expression", recommended: true },
                 artifacts: [
                     {
-                        key: "gtex-v8/8/median_tpm.parquet",
-                        path: "median_tpm.parquet",
-                        bytes: 16_950_024,
-                        sha256: "93d387307b70aa2cd3f8081fd32a7ac4a307b24c50ba619725d6b06933685ef4",
+                        integrity: "pinned",
+                        path: "GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
+                        url: "https://storage.googleapis.com/adult-gtex/bulk-gex/v8/rna-seq/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
+                        bytes: 6_952_331,
+                        sha256: "ee7201ff2f280b0de5657d4b08e9a240362d9757efed7f7bd5dba35a5f8617b8",
                     },
                     {
-                        key: "gtex-v8/8/metadata.parquet",
-                        path: "metadata.parquet",
-                        bytes: 5_176_784,
-                        sha256: "cc01f5a5bf16ba486b0d88a931e71d197cebbbd10a47f3f5aad5c6536540d756",
+                        integrity: "pinned",
+                        path: "GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
+                        url: "https://storage.googleapis.com/adult-gtex/annotations/v8/metadata-files/GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
+                        bytes: 11_512_258,
+                        sha256: "74f6ab4c34ed2648d708a0ae6e6dff324f6c86ea723ae7d1c37d76f5221148f0",
                     },
                 ],
             },
@@ -345,20 +325,23 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 id: "celltypist-immune",
                 version: "2",
                 title: "CellTypist immune cell models",
-                description: "CellTypist Immune All low- and high-resolution models for immune cell-type annotation.",
+                description:
+                    "CellTypist Immune All low- and high-resolution models for immune cell-type annotation. Load by absolute path — CellTypist's by-name lookup expects its own cache layout, which the reference store deliberately does not impersonate.",
                 sourceUrl: "https://www.celltypist.org/models",
                 license: { identifier: "NOASSERTION" },
                 recommendation: { group: "cell-typing", recommended: true },
                 artifacts: [
                     {
-                        key: "celltypist-immune/2/Immune_All_Low.pkl",
+                        integrity: "pinned",
                         path: "Immune_All_Low.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_Low.pkl",
                         bytes: 2_824_990,
                         sha256: "290874d35dac039d4c9218c343fde4aac1077709b72a331ce7266f6828c36502",
                     },
                     {
-                        key: "celltypist-immune/2/Immune_All_High.pkl",
+                        integrity: "pinned",
                         path: "Immune_All_High.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_High.pkl",
                         bytes: 1_070_426,
                         sha256: "a715fec36c2c421f7c4e31cf4cb4bea883eedab7fd7b20a4b76f091c22660448",
                     },
@@ -371,7 +354,7 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
 /** One selected dataset and its host-neutral installation location. */
 export type ReferenceInstallPlanDataset = ReferenceDataset & { readonly installPath: string };
 
-/** Deterministic content-addressed plan; embedders resolve artifact keys. */
+/** Deterministic plan; every artifact carries the upstream URL it is fetched from. */
 export interface ReferenceInstallPlan {
     readonly catalogVersion: typeof REFERENCE_DATA_CATALOG_VERSION;
     readonly datasets: readonly ReferenceInstallPlanDataset[];

--- a/harness/src/reference-data/catalog.ts
+++ b/harness/src/reference-data/catalog.ts
@@ -1,0 +1,420 @@
+import { posix as posixPath } from "node:path";
+
+import { err, ok, type Result } from "neverthrow";
+import { z } from "zod";
+
+/** Schema version for the checked-in reference-data catalog. */
+export const REFERENCE_DATA_CATALOG_VERSION = 1 as const;
+
+const SAFE_ID = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+const SAFE_VERSION = /^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+function isSafeRelativePath(value: string): boolean {
+    if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
+    const segments = value.split("/");
+    return segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..") && posixPath.normalize(value) === value;
+}
+
+/** One immutable final file distributed for a reference dataset. */
+export const ReferenceArtifactSchema = z.object({
+    key: z.string().min(1),
+    bytes: z.number().int().positive(),
+    sha256: z.string().regex(SHA256, "Expected a lowercase SHA-256 digest"),
+    path: z.string().refine(isSafeRelativePath, "Expected a safe dataset-relative path"),
+});
+
+/** Provenance and licensing information for one supported reference dataset. */
+export const ReferenceDatasetSchema = z.object({
+    id: z.string().regex(SAFE_ID, "Expected a stable lowercase dataset id"),
+    version: z.string().regex(SAFE_VERSION, "Expected a safe dataset version path segment"),
+    title: z.string().min(1),
+    description: z.string().min(1),
+    sourceUrl: z.url(),
+    license: z.object({
+        identifier: z.string().min(1),
+        url: z.url().optional(),
+    }),
+    recommendation: z.object({
+        group: z.string().min(1),
+        recommended: z.boolean(),
+    }),
+    artifacts: z.array(ReferenceArtifactSchema).min(1),
+});
+
+/** Versioned canonical catalog consumed identically by every harness embedder. */
+export const ReferenceDataCatalogSchema = z
+    .object({
+        version: z.literal(REFERENCE_DATA_CATALOG_VERSION),
+        datasets: z.array(ReferenceDatasetSchema),
+    })
+    .superRefine((catalog, ctx) => {
+        const ids = new Set<string>();
+        for (const [datasetIndex, dataset] of catalog.datasets.entries()) {
+            if (ids.has(dataset.id)) {
+                ctx.addIssue({ code: "custom", message: `Duplicate dataset id: ${dataset.id}`, path: ["datasets", datasetIndex, "id"] });
+            }
+            ids.add(dataset.id);
+
+            const paths = new Set<string>();
+            for (const [artifactIndex, artifact] of dataset.artifacts.entries()) {
+                if (paths.has(artifact.path)) {
+                    ctx.addIssue({
+                        code: "custom",
+                        message: `Duplicate artifact path in ${dataset.id}: ${artifact.path}`,
+                        path: ["datasets", datasetIndex, "artifacts", artifactIndex, "path"],
+                    });
+                }
+                paths.add(artifact.path);
+            }
+        }
+    });
+
+type DeepReadonly<T> = T extends (...args: never[]) => unknown
+    ? T
+    : T extends readonly (infer Item)[]
+      ? readonly DeepReadonly<Item>[]
+      : T extends object
+        ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+        : T;
+
+export type ReferenceArtifact = DeepReadonly<z.infer<typeof ReferenceArtifactSchema>>;
+export type ReferenceDataset = DeepReadonly<z.infer<typeof ReferenceDatasetSchema>>;
+export type ReferenceDataCatalog = DeepReadonly<z.infer<typeof ReferenceDataCatalogSchema>>;
+
+function deepFreeze<T>(value: T): DeepReadonly<T> {
+    if (value && typeof value === "object" && !Object.isFrozen(value)) {
+        for (const nested of Object.values(value)) deepFreeze(nested);
+        Object.freeze(value);
+    }
+    return value as DeepReadonly<T>;
+}
+
+/**
+ * Canonical release catalog. Release-data publication is deliberately separate
+ * from this contract; entries are added only with real immutable files, sizes,
+ * digests, provenance, and licensing data.
+ */
+export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
+    ReferenceDataCatalogSchema.parse({
+        version: REFERENCE_DATA_CATALOG_VERSION,
+        datasets: [
+            {
+                id: "ncbi-gene-human",
+                version: "2026.07.13",
+                title: "NCBI human gene identifiers",
+                description: "Entrez Gene identifiers and approved symbols for Homo sapiens (NCBI taxonomy 9606).",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        key: "ncbi-gene-human/2026.07.13/entrez_to_symbol_9606.parquet",
+                        path: "entrez_to_symbol_9606.parquet",
+                        bytes: 2_211_032,
+                        sha256: "98069fffcf0207437541dae8b67d515d460122785731322b817d2b6e2bd4c111",
+                    },
+                    {
+                        key: "ncbi-gene-human/2026.07.13/ensembl_to_symbol_9606.parquet",
+                        path: "ensembl_to_symbol_9606.parquet",
+                        bytes: 888_646,
+                        sha256: "70f713757a2f53c4b487c3f9b9328263f4d3a28b4e7bbce599ac585df0e336fe",
+                    },
+                    {
+                        key: "ncbi-gene-human/2026.07.13/refseq_rna_to_symbol_9606.parquet",
+                        path: "refseq_rna_to_symbol_9606.parquet",
+                        bytes: 4_366_526,
+                        sha256: "5d379282d370ab3e182c634a0aa6c2c4eea5a107a5570e5945f766872ae4b402",
+                    },
+                    {
+                        key: "ncbi-gene-human/2026.07.13/refseq_protein_to_symbol_9606.parquet",
+                        path: "refseq_protein_to_symbol_9606.parquet",
+                        bytes: 3_014_150,
+                        sha256: "c66b67e9791a39dc0e724447d26754115a2ea0497ff33a7e4a9522eab448449b",
+                    },
+                    {
+                        key: "ncbi-gene-human/2026.07.13/refseq_genomic_to_symbol_9606.parquet",
+                        path: "refseq_genomic_to_symbol_9606.parquet",
+                        bytes: 7_682_265,
+                        sha256: "16627f33ec4895192ce72a73ade8c9c6f3f73ffb5a3fff30b8b528ca013e2d49",
+                    },
+                ],
+            },
+            {
+                id: "ncbi-gene-mouse",
+                version: "2026.07.13",
+                title: "NCBI mouse gene identifiers",
+                description: "Entrez Gene identifiers and approved symbols for Mus musculus (NCBI taxonomy 10090).",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        key: "ncbi-gene-mouse/2026.07.13/entrez_to_symbol_10090.parquet",
+                        path: "entrez_to_symbol_10090.parquet",
+                        bytes: 1_441_782,
+                        sha256: "ff38eb371626380fc2953d2b605ba14b4c2de32ca1a615add353d3ff2dd53c4b",
+                    },
+                    {
+                        key: "ncbi-gene-mouse/2026.07.13/ensembl_to_symbol_10090.parquet",
+                        path: "ensembl_to_symbol_10090.parquet",
+                        bytes: 795_156,
+                        sha256: "1e4f63138d7deefa81e9158085254b6208ef74822400aead0b10e7f4a8416826",
+                    },
+                    {
+                        key: "ncbi-gene-mouse/2026.07.13/refseq_rna_to_symbol_10090.parquet",
+                        path: "refseq_rna_to_symbol_10090.parquet",
+                        bytes: 2_595_845,
+                        sha256: "d1536e7c76063ab5875d35059d7c1509d6fdf71fcd16d9bcd5b3bef80625755a",
+                    },
+                    {
+                        key: "ncbi-gene-mouse/2026.07.13/refseq_protein_to_symbol_10090.parquet",
+                        path: "refseq_protein_to_symbol_10090.parquet",
+                        bytes: 1_822_348,
+                        sha256: "ec7105e2a56ba459f3de8f3818bfb330deabc0347852b1fe51e870a95f4461ff",
+                    },
+                    {
+                        key: "ncbi-gene-mouse/2026.07.13/refseq_genomic_to_symbol_10090.parquet",
+                        path: "refseq_genomic_to_symbol_10090.parquet",
+                        bytes: 2_414_497,
+                        sha256: "c9285ab759a14cd5c4ac9c08e7b8f63b0ce08c7045f1232a05a3f387c4c91290",
+                    },
+                ],
+            },
+            {
+                id: "ncbi-gene-rat",
+                version: "2026.07.13",
+                title: "NCBI rat gene identifiers",
+                description: "Entrez Gene identifiers and approved symbols for Rattus norvegicus (NCBI taxonomy 10116).",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        key: "ncbi-gene-rat/2026.07.13/entrez_to_symbol_10116.parquet",
+                        path: "entrez_to_symbol_10116.parquet",
+                        bytes: 690_739,
+                        sha256: "1fd12f59344c270788ce8fc4cf9ec45d7f0d4f4b4d8063c19d5c1bff606b6bb7",
+                    },
+                    {
+                        key: "ncbi-gene-rat/2026.07.13/ensembl_to_symbol_10116.parquet",
+                        path: "ensembl_to_symbol_10116.parquet",
+                        bytes: 569_330,
+                        sha256: "3a42f41e2558470fc5a8b07c34d34f4762dc97626067f6a0cbdcccf9239186b2",
+                    },
+                    {
+                        key: "ncbi-gene-rat/2026.07.13/refseq_rna_to_symbol_10116.parquet",
+                        path: "refseq_rna_to_symbol_10116.parquet",
+                        bytes: 2_315_288,
+                        sha256: "6dafb16d2385e575b7710c320da92f552467a0f7f2bf268b2513e2945323b544",
+                    },
+                    {
+                        key: "ncbi-gene-rat/2026.07.13/refseq_protein_to_symbol_10116.parquet",
+                        path: "refseq_protein_to_symbol_10116.parquet",
+                        bytes: 1_741_627,
+                        sha256: "843fe6a6721189b5ec77bdcfc4deccea0dad6f74df46a43898fcc7a78dbb9392",
+                    },
+                    {
+                        key: "ncbi-gene-rat/2026.07.13/refseq_genomic_to_symbol_10116.parquet",
+                        path: "refseq_genomic_to_symbol_10116.parquet",
+                        bytes: 744_008,
+                        sha256: "755264d887c4dbf0ef6719cae9a210e99e9b173285fee17b4cce301a6934424a",
+                    },
+                ],
+            },
+            {
+                id: "reactome-pathways",
+                version: "97",
+                title: "Reactome pathways",
+                description: "Reactome pathway gene sets for pathway enrichment and annotation workflows.",
+                sourceUrl: "https://reactome.org/download-data",
+                license: { identifier: "CC0-1.0", url: "https://reactome.org/license" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        key: "reactome-pathways/97/ReactomePathways.gmt",
+                        path: "ReactomePathways.gmt",
+                        bytes: 1_032_186,
+                        sha256: "89983d5c1f0af11c52edfeee7323eb425580ac6281d387a528562ab1787ce56b",
+                    },
+                    {
+                        key: "reactome-pathways/97/ReactomePathways.parquet",
+                        path: "ReactomePathways.parquet",
+                        bytes: 277_654,
+                        sha256: "776899a3705cc62a990e9679215c0b4e9a2dafeb0e14cdb21d4673e089a2e295",
+                    },
+                    {
+                        key: "reactome-pathways/97/Ensembl2Reactome_All_Levels.parquet",
+                        path: "Ensembl2Reactome_All_Levels.parquet",
+                        bytes: 22_872_142,
+                        sha256: "a41c547c9ade3798383b8e85e6c1e77e7c196e0887977b92295d236c408ca16d",
+                    },
+                    {
+                        key: "reactome-pathways/97/NCBI2Reactome_All_Levels.parquet",
+                        path: "NCBI2Reactome_All_Levels.parquet",
+                        bytes: 7_008_817,
+                        sha256: "e882959816d92e9e762490bfa6e6617f7fe62ddd5a90b879b93c1aac8cc86291",
+                    },
+                    {
+                        key: "reactome-pathways/97/UniProt2Reactome_All_Levels.parquet",
+                        path: "UniProt2Reactome_All_Levels.parquet",
+                        bytes: 8_612_412,
+                        sha256: "0f80922ce23c24af3718cf706149432d9a4ed3c099ebaf4d758941e884384efd",
+                    },
+                    {
+                        key: "reactome-pathways/97/reactome_homo_sapiens_interactions.parquet",
+                        path: "reactome_homo_sapiens_interactions.parquet",
+                        bytes: 2_136_397,
+                        sha256: "a19cdb33cd304fe1e090219850db8f7fe59e12754e930ad4568edfb887110517",
+                    },
+                ],
+            },
+            {
+                id: "wikipathways-human",
+                version: "2026.07.10",
+                title: "WikiPathways human pathways",
+                description: "Community-curated Homo sapiens pathway gene sets and a tabular membership index.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Homo_sapiens.gmt",
+                license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        key: "wikipathways-human/2026.07.10/wikipathways_Homo_sapiens.gmt",
+                        path: "wikipathways_Homo_sapiens.gmt",
+                        bytes: 341_474,
+                        sha256: "79615a079246bb0b07cc3505265b1f75ea6cffec88001ce27f644dd86a39c97d",
+                    },
+                    {
+                        key: "wikipathways-human/2026.07.10/wikipathways_Homo_sapiens.parquet",
+                        path: "wikipathways_Homo_sapiens.parquet",
+                        bytes: 165_089,
+                        sha256: "8fafff05009b10c8bdf6ce4601542e87c772a07950c183a96e658efe6229a8d8",
+                    },
+                ],
+            },
+            {
+                id: "collectri-human",
+                version: "2.0",
+                title: "CollecTRI human regulatory network",
+                description: "A literature-curated human transcription-factor target interaction network.",
+                sourceUrl: "https://zenodo.org/records/8192729/files/CollecTRI_regulons.csv",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/8192729" },
+                recommendation: { group: "regulatory-networks", recommended: true },
+                artifacts: [
+                    {
+                        key: "collectri-human/2.0/collectri_human.parquet",
+                        path: "collectri_human.parquet",
+                        bytes: 709_038,
+                        sha256: "fefa0f04541982b9240317d8e7a0d6f090bd5510dab589b5436d1f9f52cb0c6d",
+                    },
+                ],
+            },
+            {
+                id: "gtex-v8",
+                version: "8",
+                title: "GTEx v8 normal tissue expression",
+                description: "GTEx v8 median gene expression by tissue with sample metadata for normal-reference workflows.",
+                sourceUrl: "https://gtexportal.org/home/downloads/adult-gtex/bulk_tissue_expression",
+                license: { identifier: "GTEx-Portal-Data-License", url: "https://gtexportal.org/home/license" },
+                recommendation: { group: "normal-expression", recommended: true },
+                artifacts: [
+                    {
+                        key: "gtex-v8/8/median_tpm.parquet",
+                        path: "median_tpm.parquet",
+                        bytes: 16_950_024,
+                        sha256: "93d387307b70aa2cd3f8081fd32a7ac4a307b24c50ba619725d6b06933685ef4",
+                    },
+                    {
+                        key: "gtex-v8/8/metadata.parquet",
+                        path: "metadata.parquet",
+                        bytes: 5_176_784,
+                        sha256: "cc01f5a5bf16ba486b0d88a931e71d197cebbbd10a47f3f5aad5c6536540d756",
+                    },
+                ],
+            },
+            {
+                id: "celltypist-immune",
+                version: "2",
+                title: "CellTypist immune cell models",
+                description: "CellTypist Immune All low- and high-resolution models for immune cell-type annotation.",
+                sourceUrl: "https://www.celltypist.org/models",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        key: "celltypist-immune/2/Immune_All_Low.pkl",
+                        path: "Immune_All_Low.pkl",
+                        bytes: 2_824_990,
+                        sha256: "290874d35dac039d4c9218c343fde4aac1077709b72a331ce7266f6828c36502",
+                    },
+                    {
+                        key: "celltypist-immune/2/Immune_All_High.pkl",
+                        path: "Immune_All_High.pkl",
+                        bytes: 1_070_426,
+                        sha256: "a715fec36c2c421f7c4e31cf4cb4bea883eedab7fd7b20a4b76f091c22660448",
+                    },
+                ],
+            },
+        ],
+    }),
+);
+
+/** One selected dataset and its host-neutral installation location. */
+export type ReferenceInstallPlanDataset = ReferenceDataset & { readonly installPath: string };
+
+/** Deterministic content-addressed plan; embedders resolve artifact keys. */
+export interface ReferenceInstallPlan {
+    readonly catalogVersion: typeof REFERENCE_DATA_CATALOG_VERSION;
+    readonly datasets: readonly ReferenceInstallPlanDataset[];
+}
+
+/** A requested dataset id was not present in the selected catalog. */
+export class UnknownReferenceDatasetError extends Error {
+    readonly code = "unknown_reference_dataset" as const;
+    readonly unknownId: string;
+    readonly availableIds: readonly string[];
+
+    constructor(unknownId: string, availableIds: readonly string[]) {
+        super(`Unknown reference dataset "${unknownId}". Available ids: ${availableIds.join(", ") || "(none)"}`);
+        this.name = "UnknownReferenceDatasetError";
+        this.unknownId = unknownId;
+        this.availableIds = availableIds;
+    }
+}
+
+/** Resolve dataset ids without I/O, preserving a stable dataset-id ordering. */
+/** @internal Fixture seam for harness contract tests; not exported by the package barrel. */
+export function resolveReferenceInstallPlanFromCatalogForTesting(
+    datasetIds: readonly string[],
+    catalog: ReferenceDataCatalog,
+): Result<ReferenceInstallPlan, UnknownReferenceDatasetError> {
+    const byId = new Map(catalog.datasets.map((dataset) => [dataset.id, dataset]));
+    const availableIds = [...byId.keys()].sort();
+    const selectedIds = [...new Set(datasetIds)].sort();
+
+    for (const id of selectedIds) {
+        if (!byId.has(id)) return err(new UnknownReferenceDatasetError(id, availableIds));
+    }
+
+    return ok({
+        catalogVersion: catalog.version,
+        datasets: selectedIds.map((id) => {
+            const dataset = byId.get(id)!;
+            return { ...dataset, installPath: `${dataset.id}/${dataset.version}` };
+        }),
+    });
+}
+
+/** Resolve ids strictly against the immutable canonical catalog shipped by this package. */
+export function resolveReferenceInstallPlan(datasetIds: readonly string[]): Result<ReferenceInstallPlan, UnknownReferenceDatasetError> {
+    return resolveReferenceInstallPlanFromCatalogForTesting(datasetIds, REFERENCE_DATA_CATALOG);
+}

--- a/harness/src/reference-data/receipt.ts
+++ b/harness/src/reference-data/receipt.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import { ReferenceArtifactSchema, ReferenceDatasetSchema } from "./catalog.js";
+
+/** Schema version for installation receipts shared by all embedders. */
+export const REFERENCE_INSTALL_RECEIPT_VERSION = 1 as const;
+
+/** Optional metadata describing one activated reference dataset version. */
+export const ReferenceInstallReceiptSchema = z
+    .object({
+        version: z.literal(REFERENCE_INSTALL_RECEIPT_VERSION),
+        datasetId: ReferenceDatasetSchema.shape.id,
+        datasetVersion: ReferenceDatasetSchema.shape.version,
+        activatedAt: z.iso.datetime({ offset: true }),
+        artifacts: z.array(ReferenceArtifactSchema.pick({ path: true, bytes: true, sha256: true })).min(1),
+    })
+    .superRefine((receipt, ctx) => {
+        const paths = new Set<string>();
+        for (const [index, artifact] of receipt.artifacts.entries()) {
+            if (paths.has(artifact.path)) {
+                ctx.addIssue({ code: "custom", message: `Duplicate receipt artifact path: ${artifact.path}`, path: ["artifacts", index, "path"] });
+            }
+            paths.add(artifact.path);
+        }
+    });
+
+export type ReferenceInstallReceipt = z.infer<typeof ReferenceInstallReceiptSchema>;
+
+/** Parse optional/untrusted receipt metadata; invalid receipts are ignored. */
+export function parseReferenceInstallReceipt(input: unknown): ReferenceInstallReceipt | undefined {
+    const result = ReferenceInstallReceiptSchema.safeParse(input);
+    return result.success ? result.data : undefined;
+}

--- a/harness/src/reference-data/receipt.ts
+++ b/harness/src/reference-data/receipt.ts
@@ -1,9 +1,23 @@
 import { z } from "zod";
 
-import { ReferenceArtifactSchema, ReferenceDatasetSchema } from "./catalog.js";
+import { ReferenceArtifactPathSchema, ReferenceDatasetSchema, ReferenceSha256Schema } from "./catalog.js";
 
 /** Schema version for installation receipts shared by all embedders. */
 export const REFERENCE_INSTALL_RECEIPT_VERSION = 1 as const;
+
+/**
+ * What was actually written to disk for one artifact. The size and digest are
+ * *observed at install*, never copied from the catalog — for a `pinned`
+ * artifact they equal the catalog's (the install would have failed otherwise),
+ * and for an `unpinned` one they are the only record of what the mutable
+ * upstream served, which is what `verify` later checks the files against.
+ */
+const ReferenceReceiptArtifactSchema = z.object({
+    path: ReferenceArtifactPathSchema,
+    bytes: z.number().int().nonnegative(),
+    sha256: ReferenceSha256Schema,
+    integrity: z.enum(["pinned", "unpinned"]),
+});
 
 /** Optional metadata describing one activated reference dataset version. */
 export const ReferenceInstallReceiptSchema = z
@@ -12,7 +26,7 @@ export const ReferenceInstallReceiptSchema = z
         datasetId: ReferenceDatasetSchema.shape.id,
         datasetVersion: ReferenceDatasetSchema.shape.version,
         activatedAt: z.iso.datetime({ offset: true }),
-        artifacts: z.array(ReferenceArtifactSchema.pick({ path: true, bytes: true, sha256: true })).min(1),
+        artifacts: z.array(ReferenceReceiptArtifactSchema).min(1),
     })
     .superRefine((receipt, ctx) => {
         const paths = new Set<string>();
@@ -25,6 +39,9 @@ export const ReferenceInstallReceiptSchema = z
     });
 
 export type ReferenceInstallReceipt = z.infer<typeof ReferenceInstallReceiptSchema>;
+
+/** One artifact as recorded by a completed installation. */
+export type ReferenceReceiptArtifact = z.infer<typeof ReferenceReceiptArtifactSchema>;
 
 /** Parse optional/untrusted receipt metadata; invalid receipts are ignored. */
 export function parseReferenceInstallReceipt(input: unknown): ReferenceInstallReceipt | undefined {

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "bun:test";
+
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { SandboxClient } from "../../sandbox/client.js";
+import type { CreateSandboxMeta, ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import { makeToolContext } from "../__fixtures__/tool-context.js";
+import { createListAvailableRefsTool } from "./list-available-refs.js";
+
+const HASH = "a".repeat(64);
+const sandbox: SandboxRef = {
+    sandboxId: "sb-refs",
+    host: "127.0.0.1",
+    port: 8765,
+    backend: "docker",
+    callbackSecret: "secret",
+};
+
+interface FakeClient extends SandboxClient {
+    readonly submits: SubmitExecBody[];
+}
+
+interface ExecutingClient extends FakeClient {
+    readonly outputs: string[];
+}
+
+function makeClient(payload: unknown): FakeClient {
+    const submits: SubmitExecBody[] = [];
+    return {
+        submits,
+        async createSandbox(_meta: CreateSandboxMeta) {
+            return sandbox;
+        },
+        async submitExec(_sandbox: SandboxRef, body: SubmitExecBody) {
+            submits.push(body);
+        },
+        async awaitExec(_sandbox: SandboxRef, execId: string, _emit: ExecEmit, _deadline: number): Promise<ExecResult> {
+            return { execId, exitCode: 0, stdout: JSON.stringify(payload), stderr: "", durationMs: 1, timedOut: false };
+        },
+        async isAlive() {
+            return { alive: true, oomKilled: false };
+        },
+        async teardown() {},
+        async teardownById() {},
+        async listManagedSandboxes() {
+            return [];
+        },
+    };
+}
+
+function makeExecutingClient(): ExecutingClient {
+    const submits: SubmitExecBody[] = [];
+    const outputs: string[] = [];
+    return {
+        submits,
+        outputs,
+        async createSandbox(_meta: CreateSandboxMeta) {
+            return sandbox;
+        },
+        async submitExec(_sandbox: SandboxRef, body: SubmitExecBody) {
+            submits.push(body);
+        },
+        async awaitExec(_sandbox: SandboxRef, execId: string, _emit: ExecEmit, _deadline: number): Promise<ExecResult> {
+            const body = submits.at(-1)!;
+            const child = Bun.spawn(body.command, { stdout: "pipe", stderr: "pipe" });
+            const [stdout, stderr, exitCode] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
+            outputs.push(stdout);
+            return { execId, exitCode, stdout, stderr, durationMs: 1, timedOut: false };
+        },
+        async isAlive() {
+            return { alive: true, oomKilled: false };
+        },
+        async teardown() {},
+        async teardownById() {},
+        async listManagedSandboxes() {
+            return [];
+        },
+    };
+}
+
+function createTool(client: FakeClient, nextFunctionId: () => string = () => "fn-1") {
+    return createListAvailableRefsTool({
+        sandboxClient: client,
+        sandbox,
+        workflowId: "wf-1",
+        stepId: "step-1",
+        nextFunctionId,
+        deadlineMs: () => 123_456,
+    });
+}
+
+function createFilesystemTool(client: FakeClient, scanRoot: string) {
+    return createListAvailableRefsTool({
+        sandboxClient: client,
+        sandbox,
+        workflowId: "wf-fs",
+        stepId: "step-fs",
+        nextFunctionId: (() => {
+            let id = 0;
+            return () => `fn-${++id}`;
+        })(),
+        deadlineMs: () => Date.now() + 60_000,
+        scanRoot,
+    });
+}
+
+describe("list_available_refs", () => {
+    it("is a dependency-bearing workflow tool and discovers manifest-free user files", async () => {
+        const client = makeClient({
+            state: "populated",
+            entries: [{ path: "/mnt/refs/user/cohort/reference.h5ad", kind: "file", bytes: 42 }],
+            scannedEntries: 3,
+            truncated: false,
+            receipts: [],
+            legacyEntries: [],
+        });
+        const tool = createTool(client);
+        const result = (await tool.execute({}, makeToolContext().ctx))._unsafeUnwrap();
+
+        expect(tool.executionMode).toBe("workflow");
+        expect(result).toMatchObject({ available: true, state: "populated", truncated: false });
+        expect(result.entries[0]).toEqual({ path: "/mnt/refs/user/cohort/reference.h5ad", kind: "file", bytes: 42 });
+        expect(client.submits[0]!.execId).toBe("wf-1:step-1:fn-1");
+        expect(client.submits[0]!.command.slice(0, 2)).toEqual(["python3", "-c"]);
+        expect(client.submits[0]!.command[3]).toBe("/mnt/refs");
+        expect(client.submits[0]!.command[4]).toBe(".");
+    });
+
+    it("merges valid receipt and legacy enrichment while retaining user files", async () => {
+        const managedPath = "/mnt/refs/managed/alpha/2026.07/reference.parquet";
+        const legacyPath = "/mnt/refs/legacy/pathways.gmt";
+        const client = makeClient({
+            state: "populated",
+            entries: [
+                { path: managedPath, kind: "file", bytes: 12 },
+                { path: legacyPath, kind: "file", bytes: 13 },
+                { path: "/mnt/refs/user/custom.csv", kind: "file", bytes: 14 },
+            ],
+            scannedEntries: 5,
+            truncated: false,
+            receipts: [
+                {
+                    version: 1,
+                    datasetId: "alpha",
+                    datasetVersion: "2026.07",
+                    activatedAt: "2026-07-14T10:30:00.000Z",
+                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
+                },
+            ],
+            legacyEntries: [{ local_path: "legacy/pathways.gmt", category: "pathways", dataset: "legacy-pathways", rows: 200 }],
+        });
+
+        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
+
+        expect(result.entries).toHaveLength(3);
+        expect(result.entries.find((entry) => entry.path === managedPath)).toMatchObject({
+            bytes: 12,
+            metadata: { datasetId: "alpha", version: "2026.07" },
+        });
+        expect(result.entries.find((entry) => entry.path === legacyPath)).toMatchObject({
+            bytes: 13,
+            metadata: { datasetId: "legacy-pathways", category: "pathways", rows: 200 },
+        });
+        expect(result.entries.find((entry) => entry.path.includes("/user/"))?.metadata).toBeUndefined();
+    });
+
+    it("ignores invalid and stale metadata without hiding observed files", async () => {
+        const client = makeClient({
+            state: "populated",
+            entries: [{ path: "/mnt/refs/user/observed.csv", kind: "file", bytes: 7 }],
+            scannedEntries: 1,
+            truncated: false,
+            receipts: [{ version: 99, datasetId: "bad" }],
+            legacyEntries: [{ local_path: "missing.csv", category: "stale" }],
+        });
+
+        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result.entries).toEqual([{ path: "/mnt/refs/user/observed.csv", kind: "file", bytes: 7 }]);
+    });
+
+    it.each([
+        ["unavailable", false, "not mounted"],
+        ["empty", true, "contains no reference files"],
+    ] as const)("returns expected %s state as data", async (state, available, content) => {
+        const client = makeClient({ state, entries: [], scannedEntries: 0, truncated: false });
+        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result).toMatchObject({ state, available, entries: [] });
+        expect(result.content).toContain(content);
+    });
+
+    it.each(["../etc", "/etc/passwd", "/mnt/refs/../etc", "user//cohort", ".inflexa/receipts"])(
+        "rejects out-of-scope path %s without executing",
+        async (path) => {
+            const client = makeClient({});
+            const result = (await createTool(client).execute({ path }, makeToolContext().ctx))._unsafeUnwrap();
+            expect(result).toMatchObject({ state: "out_of_scope", available: false });
+            expect(client.submits).toHaveLength(0);
+        },
+    );
+
+    it("bounds an oversized zero-entry path rejection without executing", async () => {
+        const client = makeClient({});
+        const result = (await createTool(client).execute({ path: "a".repeat(70_000) }, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result).toMatchObject({ state: "out_of_scope", available: false, path: "/mnt/refs", entries: [] });
+        expect(result.content).toContain("4096-byte");
+        expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThanOrEqual(64_000);
+        expect(client.submits).toHaveLength(0);
+    });
+
+    it("reports symlinks without following them", async () => {
+        const client = makeClient({
+            state: "populated",
+            entries: [{ path: "/mnt/refs/user/external", kind: "symlink", bytes: 0 }],
+            scannedEntries: 1,
+            truncated: false,
+        });
+        const result = (await createTool(client).execute({ path: "user" }, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result.entries[0]).toMatchObject({ kind: "symlink", path: "/mnt/refs/user/external" });
+        expect(client.submits[0]!.command[4]).toBe("user");
+    });
+
+    it("surfaces bounded traversal truncation with a drill-down hint", async () => {
+        const client = makeClient({
+            state: "populated",
+            entries: [{ path: "/mnt/refs/shards/0001.parquet", kind: "file", bytes: 5 }],
+            scannedEntries: 2000,
+            truncated: true,
+        });
+        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result.truncated).toBe(true);
+        expect(result.content).toContain("narrower path");
+    });
+
+    it("derives the same exec id across replay", async () => {
+        const payload = { state: "empty", entries: [], scannedEntries: 0, truncated: false };
+        const first = makeClient(payload);
+        const replay = makeClient(payload);
+        await createTool(first, () => "stable").execute({}, makeToolContext().ctx);
+        await createTool(replay, () => "stable").execute({}, makeToolContext().ctx);
+        expect(first.submits[0]!.execId).toBe(replay.submits[0]!.execId);
+    });
+
+    it("runs the real scanner against manifest-free trees and supports directory drill-down", async () => {
+        const root = await mkdtemp(join(tmpdir(), "refs-scan-"));
+        const outside = await mkdtemp(join(tmpdir(), "refs-outside-"));
+        await mkdir(join(root, "user", "cohort"), { recursive: true });
+        await writeFile(join(root, "user", "cohort", "reference.h5ad"), "reference");
+        await writeFile(join(outside, "registry.json"), JSON.stringify({ files: { by_category: { fake: [{ local_path: "user/cohort/reference.h5ad" }] } } }));
+        await symlink(join(outside, "registry.json"), join(root, "registry.json"));
+        await symlink(outside, join(root, ".inflexa"));
+        await symlink(outside, join(root, "user", "external"));
+
+        const client = makeExecutingClient();
+        const tool = createFilesystemTool(client, root);
+        const rootResult = (await tool.execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(rootResult.entries).toEqual([expect.objectContaining({ path: "/mnt/refs/user", kind: "directory", fileCount: 1, bytes: 9 })]);
+        expect(rootResult.entries[0]?.metadata).toBeUndefined();
+
+        const userResult = (await tool.execute({ path: "/mnt/refs/user" }, makeToolContext().ctx))._unsafeUnwrap();
+        expect(userResult.entries).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ path: "/mnt/refs/user/cohort", kind: "directory", fileCount: 1 }),
+                { path: "/mnt/refs/user/external", kind: "symlink", bytes: 0 },
+            ]),
+        );
+
+        const cohortResult = (await tool.execute({ path: "/mnt/refs/user/cohort" }, makeToolContext().ctx))._unsafeUnwrap();
+        expect(cohortResult.entries).toEqual([{ path: "/mnt/refs/user/cohort/reference.h5ad", kind: "file", bytes: 9 }]);
+        expect(client.outputs.every((output) => Buffer.byteLength(output) <= 64_001)).toBe(true);
+    });
+
+    it("bounds the real scanner and final tool envelope for large subtrees and metadata", async () => {
+        const root = await mkdtemp(join(tmpdir(), "refs-large-"));
+        await mkdir(join(root, "shards"), { recursive: true });
+        for (let start = 0; start < 2_100; start += 200) {
+            await Promise.all(
+                Array.from({ length: Math.min(200, 2_100 - start) }, (_, offset) => {
+                    const index = start + offset;
+                    return writeFile(join(root, "shards", `${String(index).padStart(4, "0")}.parquet`), "x");
+                }),
+            );
+        }
+        const huge = "x".repeat(500);
+        await writeFile(
+            join(root, "registry.json"),
+            JSON.stringify({
+                files: {
+                    by_category: {
+                        huge: Array.from({ length: 200 }, (_, index) => ({ local_path: `shards/${String(index).padStart(4, "0")}.parquet`, dataset: huge })),
+                    },
+                },
+            }),
+        );
+
+        const client = makeExecutingClient();
+        const tool = createFilesystemTool(client, root);
+        const summary = (await tool.execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(summary.scannedEntries).toBe(2_000);
+        expect(summary.entries).toEqual([expect.objectContaining({ path: "/mnt/refs/shards", kind: "directory", truncated: true, fileCount: 1_999 })]);
+
+        const result = (await tool.execute({ path: "shards" }, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result.truncated).toBe(true);
+        expect(result.entries.length).toBeLessThanOrEqual(200);
+        expect(result.content).toContain("narrower path");
+        expect(client.outputs.every((output) => Buffer.byteLength(output, "utf8") <= 64_001)).toBe(true);
+        expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThanOrEqual(64_000);
+    });
+
+    it("rejects malformed and oversized scanner stdout", async () => {
+        const malformed = makeClient({ state: "populated", entries: "not-an-array", scannedEntries: 1, truncated: false });
+        await expect(createTool(malformed).execute({}, makeToolContext().ctx)).rejects.toThrow();
+
+        const oversized = makeClient({ state: "populated", entries: [], scannedEntries: 1, truncated: false, padding: "x".repeat(70_000) });
+        await expect(createTool(oversized).execute({}, makeToolContext().ctx)).rejects.toThrow(/exceeded its output bound/);
+    });
+});

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -314,6 +314,39 @@ describe("list_available_refs", () => {
         expect(client.outputs.every((output) => Buffer.byteLength(output) <= 64_001)).toBe(true);
     });
 
+    // A single unparseable receipt used to abort the scan loop, silently dropping every receipt
+    // that sorted after it — so one corrupt file stripped the labels off datasets that were fine.
+    it("keeps enriching from the receipts that parse when one of them is corrupt", async () => {
+        const root = await mkdtemp(join(tmpdir(), "refs-bad-receipt-"));
+        const version = join(root, "managed", "wikipathways-human", "2026.07.10");
+        await mkdir(version, { recursive: true });
+        await mkdir(join(root, ".inflexa", "receipts"), { recursive: true });
+        await writeFile(join(version, "wikipathways_Homo_sapiens.gmt"), "pathway\tdescription\tGENE");
+
+        // "aaa" sorts before "wikipathways", so a loop that dies on the bad file never reaches the good one.
+        await writeFile(join(root, ".inflexa", "receipts", "aaa-corrupt.json"), "{ not json");
+        await writeFile(
+            join(root, ".inflexa", "receipts", "wikipathways-human.json"),
+            JSON.stringify({
+                version: 1,
+                datasetId: "wikipathways-human",
+                datasetVersion: "2026.07.10",
+                activatedAt: "2026-07-14T10:30:00.000Z",
+                artifacts: [{ path: "wikipathways_Homo_sapiens.gmt", bytes: 31, sha256: HASH, integrity: "pinned" }],
+            }),
+        );
+
+        const tool = createFilesystemTool(makeExecutingClient(), root);
+        const result = (await tool.execute({ path: "/mnt/refs/managed/wikipathways-human/2026.07.10" }, makeToolContext().ctx))._unsafeUnwrap();
+
+        expect(result.state).toBe("populated");
+        expect(result.entries[0]).toMatchObject({
+            path: "/mnt/refs/managed/wikipathways-human/2026.07.10/wikipathways_Homo_sapiens.gmt",
+            kind: "file",
+            metadata: { datasetId: "wikipathways-human", title: "WikiPathways human pathways" },
+        });
+    });
+
     it("bounds the real scanner and final tool envelope for large subtrees and metadata", async () => {
         const root = await mkdtemp(join(tmpdir(), "refs-large-"));
         await mkdir(join(root, "shards"), { recursive: true });

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -130,11 +130,13 @@ describe("list_available_refs", () => {
 
     it("merges valid receipt and legacy enrichment while retaining user files", async () => {
         const managedPath = "/mnt/refs/managed/alpha/2026.07/reference.parquet";
+        const catalogPath = "/mnt/refs/managed/ncbi-gene-human/current/Homo_sapiens.gene_info.gz";
         const legacyPath = "/mnt/refs/legacy/pathways.gmt";
         const client = makeClient({
             state: "populated",
             entries: [
                 { path: managedPath, kind: "file", bytes: 12 },
+                { path: catalogPath, kind: "file", bytes: 15 },
                 { path: legacyPath, kind: "file", bytes: 13 },
                 { path: "/mnt/refs/user/custom.csv", kind: "file", bytes: 14 },
             ],
@@ -146,7 +148,14 @@ describe("list_available_refs", () => {
                     datasetId: "alpha",
                     datasetVersion: "2026.07",
                     activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
+                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH, integrity: "pinned" }],
+                },
+                {
+                    version: 1,
+                    datasetId: "ncbi-gene-human",
+                    datasetVersion: "current",
+                    activatedAt: "2026-07-14T10:30:00.000Z",
+                    artifacts: [{ path: "Homo_sapiens.gene_info.gz", bytes: 1_024, sha256: HASH, integrity: "unpinned" }],
                 },
             ],
             legacyEntries: [{ local_path: "legacy/pathways.gmt", category: "pathways", dataset: "legacy-pathways", rows: 200 }],
@@ -154,16 +163,50 @@ describe("list_available_refs", () => {
 
         const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
 
-        expect(result.entries).toHaveLength(3);
+        expect(result.entries).toHaveLength(4);
+        // Receipt for a dataset the catalog does not know: identity only, no provenance labels.
         expect(result.entries.find((entry) => entry.path === managedPath)).toMatchObject({
             bytes: 12,
             metadata: { datasetId: "alpha", version: "2026.07" },
+        });
+        // Receipt for a catalog dataset: provenance is joined in from the catalog entry.
+        expect(result.entries.find((entry) => entry.path === catalogPath)).toMatchObject({
+            bytes: 15,
+            metadata: {
+                datasetId: "ncbi-gene-human",
+                version: "current",
+                title: "NCBI human gene identifiers",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/",
+                license: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+            },
         });
         expect(result.entries.find((entry) => entry.path === legacyPath)).toMatchObject({
             bytes: 13,
             metadata: { datasetId: "legacy-pathways", category: "pathways", rows: 200 },
         });
         expect(result.entries.find((entry) => entry.path.includes("/user/"))?.metadata).toBeUndefined();
+    });
+
+    it("ignores a receipt artifact that records no observed integrity", async () => {
+        const managedPath = "/mnt/refs/managed/alpha/2026.07/reference.parquet";
+        const client = makeClient({
+            state: "populated",
+            entries: [{ path: managedPath, kind: "file", bytes: 12 }],
+            scannedEntries: 1,
+            truncated: false,
+            receipts: [
+                {
+                    version: 1,
+                    datasetId: "alpha",
+                    datasetVersion: "2026.07",
+                    activatedAt: "2026-07-14T10:30:00.000Z",
+                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
+                },
+            ],
+        });
+
+        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(result.entries).toEqual([{ path: managedPath, kind: "file", bytes: 12 }]);
     });
 
     it("ignores invalid and stale metadata without hiding observed files", async () => {

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -160,11 +160,18 @@ try:
         path = os.path.join(receipts_dir, name)
         if kind != "file":
             continue
-        with open(path, "rb") as handle:
-            raw = handle.read(16385)
-        if len(raw) > 16384 or receipt_bytes + len(raw) > 32768:
+        # Per-file, so one unreadable or malformed receipt costs only its own labels.
+        # A shared try would abandon the loop and silently drop every receipt sorting
+        # after the bad one, quietly stripping metadata from datasets that are fine.
+        try:
+            with open(path, "rb") as handle:
+                raw = handle.read(16385)
+            if len(raw) > 16384 or receipt_bytes + len(raw) > 32768:
+                continue
+            parsed = json.loads(raw)
+        except Exception:
             continue
-        receipts.append(json.loads(raw))
+        receipts.append(parsed)
         receipt_bytes += len(raw)
 except Exception:
     pass

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -1,194 +1,503 @@
-/**
- * listAvailableRefs — list reference data available in the sandbox.
- */
+/** Sandbox-visible, bounded discovery for the read-only reference store. */
 
-import { readFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { posix as posixPath } from "node:path";
 
 import { ok } from "neverthrow";
 import { z } from "zod";
 
+import { REFERENCE_DATA_CATALOG } from "../../reference-data/catalog.js";
+import { parseReferenceInstallReceipt } from "../../reference-data/receipt.js";
+import type { SandboxClient } from "../../sandbox/client.js";
+import type { SandboxRef } from "../../sandbox/types.js";
 import { defineTool } from "../define-tool.js";
+import { runSandboxExec } from "../workspace/run-exec.js";
 
 const REFS_ROOT = "/mnt/refs";
-const REGISTRY_FILE = join(REFS_ROOT, "registry.json");
+const MAX_ENTRIES = 200;
+const MAX_SCANNED_ENTRIES = 2_000;
+const MAX_PATH_BYTES = 40_000;
+const MAX_ENVELOPE_BYTES = 64_000;
+const MAX_INPUT_PATH_BYTES = 4_096;
 
-interface RegistryEntry {
-    local_path: string;
-    sha256: string;
-    bytes: number;
-    rows: number | null;
-    category: string | null;
-    subtype: string | null;
-    organism: string | null;
-    tax_id: string | null;
-    dataset: string | null;
-    endpoint: string | null;
+const SCAN_SCRIPT = String.raw`
+import json, os, sys
+
+ROOT = sys.argv[1]
+RELATIVE = sys.argv[2]
+TARGET = ROOT if RELATIVE == "." else os.path.join(ROOT, *RELATIVE.split("/"))
+MAX_ENTRIES = int(sys.argv[3])
+MAX_SCANNED = int(sys.argv[4])
+MAX_PATH_BYTES = int(sys.argv[5])
+MAX_ENVELOPE_BYTES = int(sys.argv[6])
+
+def emit(value):
+    print(json.dumps(value, separators=(",", ":")))
+
+def capped_entries(path, limit):
+    """Inspect and sort at most limit names; probe one extra only to mark truncation."""
+    values = []
+    visited = 0
+    cut = False
+    try:
+        with os.scandir(path) as iterator:
+            for entry in iterator:
+                if visited >= limit:
+                    cut = True
+                    break
+                visited += 1
+                try:
+                    if entry.is_symlink():
+                        kind, size = "symlink", 0
+                    elif entry.is_file(follow_symlinks=False):
+                        kind, size = "file", entry.stat(follow_symlinks=False).st_size
+                    elif entry.is_dir(follow_symlinks=False):
+                        kind, size = "directory", 0
+                    else:
+                        kind, size = "other", 0
+                    values.append((entry.name, kind, size))
+                except OSError:
+                    continue
+    except OSError:
+        return [], False
+    values.sort(key=lambda value: value[0])
+    return values, cut
+
+if not os.path.isdir(ROOT) or os.path.islink(ROOT):
+    emit({"state": "unavailable", "entries": [], "scannedEntries": 0, "truncated": False})
+    raise SystemExit(0)
+
+relative = RELATIVE
+cursor = ROOT
+if relative != ".":
+    for part in relative.split(os.sep):
+        cursor = os.path.join(cursor, part)
+        if os.path.islink(cursor):
+            emit({"state": "symlink", "entries": [], "scannedEntries": 0, "truncated": False})
+            raise SystemExit(0)
+
+if not os.path.exists(TARGET):
+    emit({"state": "not_found", "entries": [], "scannedEntries": 0, "truncated": False})
+    raise SystemExit(0)
+if not os.path.isdir(TARGET):
+    emit({"state": "not_a_directory", "entries": [], "scannedEntries": 0, "truncated": False})
+    raise SystemExit(0)
+
+entries = []
+scanned = 0
+path_bytes = 0
+truncated = False
+
+children, children_cut = capped_entries(TARGET, min(MAX_ENTRIES + 2, MAX_SCANNED))
+truncated = children_cut
+
+for name, kind, size in children:
+    path = os.path.join(TARGET, name)
+    rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+    if rel == ".inflexa" or rel.startswith(".inflexa/") or rel == "registry.json":
+        continue
+    scanned += 1
+    rendered = "/mnt/refs/" + rel
+    item = None
+
+    if kind == "symlink":
+        item = {"path": rendered, "kind": "symlink", "bytes": 0}
+    elif kind == "file":
+        item = {"path": rendered, "kind": "file", "bytes": size}
+    elif kind == "directory":
+        total_bytes = 0
+        file_count = 0
+        file_types = set()
+        directory_truncated = False
+        stack = [path]
+        while stack and scanned < MAX_SCANNED:
+            current = stack.pop()
+            descendants, descendants_cut = capped_entries(current, MAX_SCANNED - scanned)
+            directory_truncated = directory_truncated or descendants_cut
+            child_directories = []
+            for child_name, child_kind, child_size in descendants:
+                scanned += 1
+                if child_kind == "directory":
+                    child_directories.append(os.path.join(current, child_name))
+                elif child_kind == "file":
+                    file_count += 1
+                    total_bytes += child_size
+                    suffix = os.path.splitext(child_name)[1].lower()
+                    if suffix:
+                        file_types.add(suffix)
+                if scanned >= MAX_SCANNED:
+                    directory_truncated = True
+                    break
+            stack.extend(reversed(child_directories))
+        item = {
+            "path": rendered,
+            "kind": "directory",
+            "bytes": total_bytes,
+            "fileCount": file_count,
+            "fileTypes": sorted(file_types)[:10],
+            "truncated": directory_truncated,
+        }
+        truncated = truncated or directory_truncated
+
+    if item is not None:
+        if len(entries) < MAX_ENTRIES and path_bytes + len(rendered.encode()) <= MAX_PATH_BYTES:
+            entries.append(item)
+            path_bytes += len(rendered.encode())
+        else:
+            truncated = True
+    if scanned >= MAX_SCANNED:
+        truncated = True
+        break
+
+receipts = []
+receipt_bytes = 0
+metadata_dir = os.path.join(ROOT, ".inflexa")
+receipts_dir = os.path.join(metadata_dir, "receipts")
+try:
+    if os.path.islink(metadata_dir) or os.path.islink(receipts_dir):
+        raise ValueError("symlinked metadata directory")
+    receipt_entries, _ = capped_entries(receipts_dir, 100)
+    for name, kind, _ in receipt_entries:
+        path = os.path.join(receipts_dir, name)
+        if kind != "file":
+            continue
+        with open(path, "rb") as handle:
+            raw = handle.read(16385)
+        if len(raw) > 16384 or receipt_bytes + len(raw) > 32768:
+            continue
+        receipts.append(json.loads(raw))
+        receipt_bytes += len(raw)
+except Exception:
+    pass
+
+legacy_entries = []
+try:
+    registry_path = os.path.join(ROOT, "registry.json")
+    if os.path.islink(registry_path):
+        raise ValueError("symlinked registry")
+    with open(registry_path, "rb") as handle:
+        registry = json.loads(handle.read(131073))
+    if isinstance(registry, dict):
+        by_category = registry.get("files", {}).get("by_category", {})
+        if isinstance(by_category, dict):
+            for category in sorted(by_category):
+                values = by_category.get(category)
+                if not isinstance(values, list):
+                    continue
+                for item in values:
+                    if len(legacy_entries) >= 200:
+                        break
+                    if isinstance(item, dict) and isinstance(item.get("local_path"), str):
+                        legacy_entries.append({
+                            "local_path": item["local_path"][:1000],
+                            "category": str(category)[:500],
+                            "dataset": str(item.get("dataset"))[:500] if item.get("dataset") is not None else None,
+                            "subtype": str(item.get("subtype"))[:500] if item.get("subtype") is not None else None,
+                            "organism": str(item.get("organism"))[:500] if item.get("organism") is not None else None,
+                            "rows": item.get("rows"),
+                            "endpoint": item.get("endpoint"),
+                        })
+except Exception:
+    pass
+
+payload = {
+    "state": "empty" if len(entries) == 0 else "populated",
+    "entries": entries,
+    "scannedEntries": scanned,
+    "truncated": truncated,
+    "receipts": receipts,
+    "legacyEntries": legacy_entries,
+}
+while len(json.dumps(payload, separators=(",", ":")).encode()) > MAX_ENVELOPE_BYTES:
+    payload["truncated"] = True
+    if payload["legacyEntries"]:
+        payload["legacyEntries"].pop()
+    elif payload["receipts"]:
+        payload["receipts"].pop()
+    elif payload["entries"]:
+        payload["entries"].pop()
+    else:
+        break
+emit(payload)
+`;
+
+const ListAvailableRefsInputSchema = z.object({
+    path: z
+        .string()
+        .max(MAX_INPUT_PATH_BYTES)
+        .optional()
+        .describe("Optional directory beneath /mnt/refs to inspect. Use a returned absolute path or a store-relative path."),
+});
+
+export interface ListAvailableRefsDeps {
+    readonly sandboxClient: SandboxClient;
+    readonly sandbox: SandboxRef;
+    readonly workflowId: string;
+    readonly stepId: string;
+    readonly nextFunctionId: () => string;
+    readonly deadlineMs: () => number;
+    readonly markExecActive?: (execId: string) => Promise<void>;
+    /** Filesystem root used by the scanner; production callers omit this. */
+    readonly scanRoot?: string;
 }
 
-interface Registry {
-    registry_version: string;
-    build_id: string;
-    generated_at: string;
-    files: {
-        by_category: Record<string, RegistryEntry[]>;
-    };
-    summary: {
-        total_output_files: number;
-        categories: string[];
-    };
+export interface ReferenceInventoryMetadata {
+    readonly datasetId?: string;
+    readonly version?: string;
+    readonly title?: string;
+    readonly description?: string;
+    readonly sourceUrl?: string;
+    readonly license?: string;
+    readonly category?: string;
+    readonly subtype?: string;
+    readonly organism?: string;
+    readonly rows?: number;
+    readonly endpoint?: string;
 }
 
-function formatCategory(category: string, entries: RegistryEntry[]): string {
-    const labels: Record<string, string> = {
-        atlas_singlecell:
-            "Single-cell reference atlases for label transfer (Pan-Cancer T cell — " +
-            "Zheng 2021, Pan-Cancer Myeloid — Cheng 2021, Tumor Immune Cell Atlas — " +
-            "Nieto 2021, Tabula Sapiens v2). Available as .h5ad (Python: anndata, " +
-            "scanpy, scvi-tools, symphonypy) and/or .rds (R: Seurat, ProjecTILs). " +
-            "Tabula Sapiens ships full + immune_subset variants. " +
-            "Use these for label transfer BEFORE falling back to marker genes.",
-        atlas_azimuth:
-            "Azimuth references (Seurat-native): PBMC v1.0.0 and Tonsil v1.0.0. " +
-            "Each entry is a (ref.Rds, idx.annoy) pair stored under " +
-            "/mnt/refs/atlas_azimuth/{pbmc,tonsil}/. Load with " +
-            "Azimuth::LoadReference(path) where path is the directory containing " +
-            "ref.Rds + idx.annoy (e.g. '/mnt/refs/atlas_azimuth/pbmc'), then " +
-            "Azimuth::RunAzimuth(query, reference = path).",
-        atlas_projectils:
-            "ProjecTILs reference atlases (Seurat .rds): human + mouse, CD8 + CD4. " +
-            "Use ProjecTILs::ProjecTILs.classifier() to assign every CD8 to one of " +
-            "the canonical TCF7+/GZMK+/TEX/TPEX/MAIT substates without re-deriving " +
-            "the classifier from scratch.",
-        celltypist_models:
-            "Pre-staged CellTypist .pkl classifier models (Immune_All_Low backed by " +
-            "the Cross-Tissue Immune Cell Atlas; Immune_All_High; Pan_Fetal_Human; " +
-            "COVID19_Immune_Landscape). CELLTYPIST_FOLDER env var is preset, so " +
-            "celltypist.annotate_cells(model='Immune_All_Low') resolves with no " +
-            "network call.",
-        marker_panels:
-            "Marker gene panels: PanglaoDB (community, parquet long-format), " +
-            "CellMarker 2.0 (tumor-context, parquet long-format), and the Cortex " +
-            "hand-curated panel for Stage 1 substates (TCF7+ memory CD8, exhausted " +
-            "CD8, effector-memory CD8, proliferating T, cDC1/cDC2/LAMP3+ DC, SPP1+ " +
-            "TAM, C1Q+ TAM, Tregs) — JSON with full provenance.",
-        gene_signatures:
-            "Curated gene signatures from key tumor-immune papers: Sade-Feldman " +
-            "2018 exhausted CD8 (Table S2), Jerby-Arnon 2018 malignant resistance " +
-            "program (Table S1, Stage 3 classifier substrate), Tirosh 2016 AXL/MITF " +
-            "programs, Puram 2017 p-EMT (Table S5, HNSCC), Reactome cGAS-STING " +
-            "pathway (Stage 2.3 type-I IFN). JSON with PMID/DOI per entry.",
-        normal_reference:
-            "Normal-tissue references for safety firing checks: GTEx v8 per-tissue " +
-            "median TPM (parquet) + sample attributes (parquet). Use to quantify " +
-            "off-target activation of any nominated classifier across healthy tissues.",
-        gene_mappings:
-            "Gene ID Conversion Tables: Entrez/Ensembl/RefSeq/UniProt to symbol (NCBI); " +
-            "orthologs (Ensembl Compara) — file: orthologs_{tax_id}.parquet, columns: " +
-            "tax_id, ensembl_gene_id, entrez_id, symbol, relationship, other_tax_id, " +
-            "other_ensembl_gene_id, other_entrez_id, other_symbol; symmetric — to find " +
-            "human orthologs of Macaca fascicularis genes, open orthologs_9541.parquet " +
-            "and filter other_tax_id == '9606'; cross-division (e.g. yeast↔mouse) " +
-            "requires pivoting through human: yeast→human via orthologs_4896.parquet, " +
-            "then human→mouse via orthologs_9606.parquet",
-        omnipath: "OmniPath (interactions, regulons, annotations)",
-        reactome: "Reactome Pathways",
-        progeny: "PROGENy Pathway Weights (decoupler: source/target/weight/padj)",
-        collectri: "CollecTRI TF-Target Regulons (decoupler: source/target/mor)",
-        dorothea: "DoRothEA TF Regulons (decoupler: source/target/weight/confidence)",
-        lincs: "LINCS L1000 Drug Perturbation Consensus Signatures (up/down gene sets)",
-        hpa: "Human Protein Atlas (tissue RNA expression, target safety/secretome, full 107-column atlas)",
-        wikipathways: "WikiPathways Gene Sets",
-        msigdb: "MSigDB Gene Set Collections",
-        safety_targets: "Curated Off-Target Safety Panel (CSV + JSON: chembl_id, gene_symbol, uniprot, organ_system, severity, clinical_consequence)",
-    };
+interface ReferenceInventoryEntryBase {
+    readonly path: string;
+    readonly metadata?: ReferenceInventoryMetadata;
+}
 
-    const lines: string[] = [`\n## ${labels[category] ?? category}`];
+/** A bounded, no-follow observation from the live reference mount. */
+export type ReferenceInventoryEntry =
+    | (ReferenceInventoryEntryBase & { readonly kind: "file"; readonly bytes: number })
+    | (ReferenceInventoryEntryBase & { readonly kind: "symlink"; readonly bytes: 0 })
+    | (ReferenceInventoryEntryBase & {
+          readonly kind: "directory";
+          readonly bytes: number;
+          readonly fileCount: number;
+          readonly fileTypes: readonly string[];
+          readonly truncated: boolean;
+      });
 
-    const grouped = new Map<string, RegistryEntry[]>();
-    for (const e of entries) {
-        const key = e.organism ?? e.tax_id ?? e.subtype ?? "general";
-        if (!grouped.has(key)) grouped.set(key, []);
-        grouped.get(key)!.push(e);
+/** Structured result returned for every expected reference-store state. */
+export interface ReferenceInventoryResult {
+    readonly available: boolean;
+    readonly state: RawScan["state"] | "out_of_scope";
+    readonly path: string;
+    readonly entries: readonly ReferenceInventoryEntry[];
+    readonly scannedEntries: number;
+    readonly truncated: boolean;
+    readonly content: string;
+}
+
+interface RawScan {
+    readonly state: "unavailable" | "empty" | "populated" | "not_found" | "not_a_directory" | "symlink";
+    readonly entries: ReferenceInventoryEntry[];
+    readonly scannedEntries: number;
+    readonly truncated: boolean;
+    readonly receipts?: unknown[];
+    readonly legacyEntries?: unknown[];
+}
+
+const RawScanSchema = z.object({
+    state: z.enum(["unavailable", "empty", "populated", "not_found", "not_a_directory", "symlink"]),
+    entries: z.array(
+        z.discriminatedUnion("kind", [
+            z.object({ path: z.string().startsWith(`${REFS_ROOT}/`), kind: z.literal("file"), bytes: z.number().nonnegative() }),
+            z.object({ path: z.string().startsWith(`${REFS_ROOT}/`), kind: z.literal("symlink"), bytes: z.literal(0) }),
+            z.object({
+                path: z.string().startsWith(`${REFS_ROOT}/`),
+                kind: z.literal("directory"),
+                bytes: z.number().nonnegative(),
+                fileCount: z.number().int().nonnegative(),
+                fileTypes: z.array(z.string()),
+                truncated: z.boolean(),
+            }),
+        ]),
+    ),
+    scannedEntries: z.number().int().nonnegative(),
+    truncated: z.boolean(),
+    receipts: z.array(z.unknown()).optional(),
+    legacyEntries: z.array(z.unknown()).optional(),
+});
+
+function resolveRequestedPath(input: string | undefined): { ok: true; path: string } | { ok: false; reason: string } {
+    if (input === undefined || input === "" || input === REFS_ROOT) return { ok: true, path: REFS_ROOT };
+    if (Buffer.byteLength(input, "utf8") > MAX_INPUT_PATH_BYTES) {
+        return { ok: false, reason: `Path exceeds the ${MAX_INPUT_PATH_BYTES}-byte POSIX path limit.` };
     }
+    if (input.includes("\0") || input.includes("\\")) return { ok: false, reason: "Path must use safe POSIX segments beneath /mnt/refs." };
 
-    for (const [group, items] of grouped) {
-        if (grouped.size > 1) lines.push(`\n### ${group}`);
-        for (const e of items) {
-            const path = join(REFS_ROOT, e.local_path);
-            const name = basename(e.local_path);
-            const info = [e.rows != null ? `${e.rows.toLocaleString()} rows` : null, e.subtype, e.dataset].filter(Boolean).join(", ");
-            lines.push(`  ${name}: ${path}${info ? `  (${info})` : ""}`);
+    const relative = input.startsWith(`${REFS_ROOT}/`) ? input.slice(REFS_ROOT.length + 1) : input.startsWith("/") ? undefined : input;
+    if (relative === undefined || relative.length === 0) return { ok: false, reason: "Path is outside /mnt/refs." };
+    const segments = relative.split("/");
+    if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+        return { ok: false, reason: "Path traversal and empty path segments are not allowed." };
+    }
+    if (segments[0] === ".inflexa" || relative === "registry.json") return { ok: false, reason: "Installer metadata is not reference data." };
+    const normalized = posixPath.join(REFS_ROOT, relative);
+    if (!normalized.startsWith(`${REFS_ROOT}/`)) return { ok: false, reason: "Path is outside /mnt/refs." };
+    return { ok: true, path: normalized };
+}
+
+function stringValue(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function enrichEntries(entries: readonly ReferenceInventoryEntry[], raw: RawScan): ReferenceInventoryEntry[] {
+    const metadata = new Map<string, ReferenceInventoryMetadata>();
+    for (const value of raw.receipts ?? []) {
+        const receipt = parseReferenceInstallReceipt(value);
+        if (!receipt) continue;
+        const dataset = REFERENCE_DATA_CATALOG.datasets.find((candidate) => candidate.id === receipt.datasetId && candidate.version === receipt.datasetVersion);
+        for (const artifact of receipt.artifacts) {
+            metadata.set(`${REFS_ROOT}/managed/${receipt.datasetId}/${receipt.datasetVersion}/${artifact.path}`, {
+                datasetId: receipt.datasetId,
+                version: receipt.datasetVersion,
+                ...(dataset
+                    ? {
+                          title: dataset.title,
+                          description: dataset.description,
+                          sourceUrl: dataset.sourceUrl,
+                          license: dataset.license.url ?? dataset.license.identifier,
+                      }
+                    : {}),
+            });
         }
     }
+
+    for (const value of raw.legacyEntries ?? []) {
+        if (!value || typeof value !== "object") continue;
+        const item = value as Record<string, unknown>;
+        const localPath = stringValue(item.local_path);
+        if (!localPath) continue;
+        const resolved = resolveRequestedPath(localPath);
+        if (!resolved.ok) continue;
+        const legacyMetadata: ReferenceInventoryMetadata = {
+            ...(stringValue(item.dataset) ? { datasetId: stringValue(item.dataset)! } : {}),
+            ...(stringValue(item.category) ? { category: stringValue(item.category)! } : {}),
+            ...(stringValue(item.subtype) ? { subtype: stringValue(item.subtype)! } : {}),
+            ...(stringValue(item.organism) ? { organism: stringValue(item.organism)! } : {}),
+            ...(numberValue(item.rows) !== undefined ? { rows: numberValue(item.rows)! } : {}),
+            ...(stringValue(item.endpoint) ? { endpoint: stringValue(item.endpoint)! } : {}),
+        };
+        metadata.set(resolved.path, { ...legacyMetadata, ...metadata.get(resolved.path) });
+    }
+
+    return entries.map((entry) => {
+        const extra = metadata.get(entry.path);
+        return extra ? { ...entry, metadata: extra } : entry;
+    });
+}
+
+function renderContent(path: string, scan: RawScan, entries: readonly ReferenceInventoryEntry[]): string {
+    if (scan.state === "unavailable")
+        return "Reference store is not mounted at /mnt/refs. Reference data cannot be downloaded from sandbox workloads; provision it through the host setup flow.";
+    if (scan.state === "not_found") return `Reference path does not exist: ${path}`;
+    if (scan.state === "not_a_directory") return `Reference path is not a directory: ${path}`;
+    if (scan.state === "symlink") return `Reference path crosses a symlink and was not scanned: ${path}`;
+    if (scan.state === "empty") return `Reference store path is mounted but contains no reference files: ${path}`;
+
+    const lines = [`Reference files visible beneath ${path}:`];
+    for (const entry of entries) {
+        const labels = entry.metadata
+            ? [entry.metadata.title ?? entry.metadata.datasetId, entry.metadata.version, entry.metadata.category, entry.metadata.organism]
+                  .filter(Boolean)
+                  .join(", ")
+            : "";
+        const details =
+            entry.kind === "directory"
+                ? `directory, ${entry.fileCount} files, ${entry.bytes} bytes${entry.fileTypes.length > 0 ? `, types: ${entry.fileTypes.join(", ")}` : ""}${entry.truncated ? ", summary truncated" : ""}`
+                : entry.kind === "file"
+                  ? `file, ${entry.bytes} bytes`
+                  : "symlink (not followed)";
+        lines.push(`- ${entry.path} (${details}${labels ? `; ${labels}` : ""})`);
+    }
+    if (scan.truncated)
+        lines.push(`Inventory truncated after scanning ${scan.scannedEntries} entries. Call list_available_refs with a narrower path to drill down.`);
     return lines.join("\n");
 }
 
-export const listAvailableRefsTool = defineTool({
-    id: "list_available_refs",
-    description:
-        "List all reference data available in the sandbox: single-cell atlases for " +
-        "label transfer (Pan-Cancer T/Myeloid, TICA, Tabula Sapiens, Azimuth PBMC/Tonsil), " +
-        "ProjecTILs CD8/CD4 atlases, CellTypist models, marker panels (PanglaoDB, " +
-        "CellMarker 2.0, Cortex curated), gene signatures (Sade-Feldman, Jerby-Arnon, " +
-        "Tirosh, Puram, cGAS-STING), normal-tissue references (GTEx v8), gene mappings, " +
-        "UniProt, OmniPath networks, Reactome, PROGENy, CollecTRI, DoRothEA, " +
-        "WikiPathways, MSigDB, LINCS L1000, HPA, and the curated off-target safety " +
-        "panel. Returns file paths for h5ad/rds/pkl/parquet/GMT/CSV/JSON resources. " +
-        "No data can be downloaded at runtime — only what this tool returns is available.",
-    inputSchema: z.object({}),
-    execute: async () => {
-        // A missing reference-store mount is an expected environment state —
-        // model it as an `available: false` data variant with a fallback note.
-        try {
-            const raw = await readFile(REGISTRY_FILE, "utf-8");
-            const registry: Registry = JSON.parse(raw);
+/** Create replay-safe reference discovery bound to the active sandbox. */
+export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
+    return defineTool({
+        id: "list_available_refs",
+        executionMode: "workflow",
+        description:
+            "Inspect the reference files actually mounted read-only at /mnt/refs. " +
+            "Returns managed and user-added files even when no manifest names them; valid receipts and legacy registry data only add labels. " +
+            "Pass a returned directory path to drill down when results are truncated. Symlinks are never followed. " +
+            "Sandbox workloads cannot download reference data; provision additional files through the host and re-run in a sandbox with that store mounted.",
+        inputSchema: ListAvailableRefsInputSchema,
+        execute: async ({ path }, ctx) => {
+            const requested = resolveRequestedPath(path);
+            if (!requested.ok) {
+                const response: ReferenceInventoryResult = {
+                    available: false,
+                    state: "out_of_scope",
+                    path: path !== undefined && Buffer.byteLength(path, "utf8") <= MAX_INPUT_PATH_BYTES ? path : REFS_ROOT,
+                    entries: [],
+                    scannedEntries: 0,
+                    truncated: false,
+                    content: requested.reason,
+                };
+                return ok(response);
+            }
 
-            const header = [
-                `Reference Store (build ${registry.build_id}, ${registry.generated_at})`,
-                `Total files: ${registry.summary.total_output_files}`,
-                `Mount: ${REFS_ROOT}`,
-            ].join("\n");
-
-            const categoryOrder = [
-                "atlas_singlecell",
-                "atlas_azimuth",
-                "atlas_projectils",
-                "celltypist_models",
-                "marker_panels",
-                "gene_signatures",
-                "normal_reference",
-                "safety_targets",
-                "progeny",
-                "collectri",
-                "dorothea",
-                "omnipath",
-                "lincs",
-                "msigdb",
-                "wikipathways",
-                "reactome",
-                "hpa",
-                "gene_mappings",
-            ];
-
-            const known = new Set(categoryOrder);
-            const allCategories = [
-                ...categoryOrder.filter((c) => registry.files.by_category[c]),
-                ...Object.keys(registry.files.by_category).filter((c) => !known.has(c)),
-            ];
-
-            const sections = allCategories.map((c) => formatCategory(c, registry.files.by_category[c]!));
-
-            return ok({ available: true, content: header + "\n" + sections.join("\n") });
-        } catch {
-            return ok({
-                available: false,
-                content:
-                    "Reference store not available. The reference store may not be mounted at /mnt/refs. " +
-                    "Gene mappings, UniProt, OmniPath, Reactome, PROGENy, CollecTRI, DoRothEA, " +
-                    "WikiPathways, MSigDB, LINCS L1000, HPA, and the curated off-target safety panel " +
-                    "cannot be loaded from pre-staged files.",
+            const execId = `${deps.workflowId}:${deps.stepId}:${deps.nextFunctionId()}`;
+            const result = await runSandboxExec({
+                sandboxClient: deps.sandboxClient,
+                sandbox: deps.sandbox,
+                execId,
+                command: [
+                    "python3",
+                    "-c",
+                    SCAN_SCRIPT,
+                    deps.scanRoot ?? REFS_ROOT,
+                    posixPath.relative(REFS_ROOT, requested.path) || ".",
+                    String(MAX_ENTRIES),
+                    String(MAX_SCANNED_ENTRIES),
+                    String(MAX_PATH_BYTES),
+                    String(MAX_ENVELOPE_BYTES),
+                ],
+                timeoutSeconds: 20,
+                deadlineMs: deps.deadlineMs(),
+                emit: ctx.emit,
+                ...(deps.markExecActive ? { markExecActive: deps.markExecActive } : {}),
             });
-        }
-    },
-});
+            if (result.exitCode !== 0) throw new Error(`Reference inventory command failed (${result.exitCode}): ${result.stderr}`);
+
+            if (Buffer.byteLength(result.stdout, "utf8") > MAX_ENVELOPE_BYTES + 1) {
+                throw new Error("Reference inventory response exceeded its output bound");
+            }
+            const raw: RawScan = RawScanSchema.parse(JSON.parse(result.stdout));
+            const entries = enrichEntries(raw.entries, raw);
+            let boundedEntries = entries;
+            const outputTruncated = raw.truncated;
+            let response: ReferenceInventoryResult = {
+                available: raw.state !== "unavailable",
+                state: raw.state,
+                path: requested.path,
+                entries: boundedEntries,
+                scannedEntries: raw.scannedEntries,
+                truncated: outputTruncated,
+                content: renderContent(requested.path, { ...raw, truncated: outputTruncated }, boundedEntries),
+            };
+            while (Buffer.byteLength(JSON.stringify(response), "utf8") > MAX_ENVELOPE_BYTES && boundedEntries.length > 0) {
+                boundedEntries = boundedEntries.slice(0, -1);
+                response = {
+                    ...response,
+                    entries: boundedEntries,
+                    truncated: true,
+                    content: renderContent(requested.path, { ...raw, truncated: true }, boundedEntries),
+                };
+            }
+            if (Buffer.byteLength(JSON.stringify(response), "utf8") > MAX_ENVELOPE_BYTES) {
+                response = {
+                    ...response,
+                    path: REFS_ROOT,
+                    entries: [],
+                    truncated: true,
+                    content: "Reference inventory output exceeded its bound. Call list_available_refs with a shorter, narrower path.",
+                };
+            }
+            return ok(response);
+        },
+    });
+}

--- a/harness/src/tools/workspace/run-exec.ts
+++ b/harness/src/tools/workspace/run-exec.ts
@@ -1,10 +1,10 @@
 /**
- * Internal helper used by the three mutate tools to drive one sandbox exec
+ * Internal helper used by dependency-bearing tools to drive one sandbox exec
  * through the `SandboxClient`. Centralises the submit/await pair, exec-id
  * derivation, and intermediate-event forwarding so all three tools share
- * one chokepoint — the contract `execute_command` makes structural is that
- * `write_file` / `edit_file` are layered on top of it, not parallel side
- * paths into sandbox-server.
+ * one chokepoint. `write_file` / `edit_file` are layered on the workspace
+ * mutator and environment introspection tools such as `list_available_refs`
+ * use this same replay-safe submit/await path rather than a parallel protocol.
  *
  * Not a registered tool — `defineTool` is called by the user-facing tools
  * (`execute-command.ts`, `write-file.ts`, `edit-file.ts`) which wrap this.

--- a/images/sandbox-base/Dockerfile
+++ b/images/sandbox-base/Dockerfile
@@ -154,12 +154,14 @@ RUN ln -s /usr/bin/python3 /usr/local/bin/python
 # PYTHONPATH (which would leak into conda's Python 3.11 and break ABI).
 RUN echo "/mnt/libs/current/python/site-packages" > /usr/lib/python3/dist-packages/inflexa-libs.pth
 
-# CellTypist resolves models at $CELLTYPIST_FOLDER/data/models/<file>.pkl
-# (see Teichlab/celltypist:celltypist/models.py). The ref-store builder
-# mirrors that layout, so by-name model loading works without a network call.
-# Azimuth (satijalab) does not have an analogous env var — agents must pass
-# an explicit path to Azimuth::LoadReference(); see list-available-refs.
-ENV CELLTYPIST_FOLDER=/mnt/refs/celltypist_models
+# No library-specific reference paths are baked in. The reference store is
+# optional, its layout is owned by the catalog (and versioned per dataset), and
+# a path compiled into the image would either point at nothing or pin the image
+# to one catalog version. Agents call `list-available-refs`, get absolute paths
+# back, and pass them explicitly — the same contract Azimuth already required
+# via Azimuth::LoadReference(). A library that insists on an env var (CellTypist
+# reads $CELLTYPIST_FOLDER) can have one exported per-command, by the agent that
+# just learned the real path.
 
 RUN useradd -m -u 1000 -s /bin/bash sandbox \
     && mkdir -p /workspace && chown -R sandbox:sandbox /workspace


### PR DESCRIPTION
## Summary

Reference data is downloaded **directly from the third party that publishes it**. This project hosts, mirrors, and redistributes nothing, so there is no distribution endpoint to configure and the licence you accept is the upstream's.

- define the host-neutral reference-data catalog, install plan, receipt, and dynamic sandbox discovery contracts in the harness
- add CLI `refs path/list/download/verify`, setup integration, and read-only `/mnt/refs` sandbox mounts
- catalog 9 datasets — NCBI gene identifiers (human/mouse/rat), Reactome, WikiPathways, CollecTRI, GTEx v8, CellTypist — each pointing at its publisher's own URL
- keep user-added files discoverable without adopting them, and explain how to contribute supported datasets

## Integrity: two classes, because four upstreams can't promise immutable bytes

The class is a property of the upstream, not a preference of ours, and `refs list` says which one you're getting.

| class | datasets | guarantee |
|-|-|-|
| **pinned** | wikipathways-human, collectri-human, gtex-v8, celltypist-immune | the catalog carries the size and SHA-256; a download that doesn't match fails and activates nothing |
| **unpinned** | ncbi-gene-{human,mouse,rat}, reactome-pathways, reactome-mappings | trust-on-first-use: the installer records the bytes it actually received, and `verify` proves they haven't changed *since install* |

The unpinned class exists because those upstreams rebuild the same URL in place: NCBI regenerates `gene_info` continuously (its `Last-Modified` moved during this PR's own testing), and Reactome overwrites `current` each release and **deletes** its predecessors — `/download/95` and `/download/96` are already `404`, so there isn't even an archival URL to pin instead. A checked-in digest there wouldn't be a guarantee; it would be a scheduled outage. The weaker guarantee is labelled as weaker rather than hidden behind a checksum that happens to be stale.

Every artifact is a file an upstream actually serves. The `.parquet` conversions in the first draft of this PR were derived locally, which meant no third party could serve them and their digests attested only to the machine that produced them.

`reactome-mappings` is split out and **not recommended by default**: upstream serves those identifier-mapping tables as ~700 MB of uncompressed TSV, two orders of magnitude more than the GMT most workflows actually want.

## The sandbox image assumes nothing

`ENV CELLTYPIST_FOLDER=/mnt/refs/celltypist_models` is removed. It pointed at a layout the ref store doesn't produce — its own comment claimed "the ref-store builder mirrors that layout", describing a convention that no longer exists — so CellTypist found nothing there, fell back to downloading the model, and died against the egress firewall instead of reporting that nothing was provisioned.

No library-specific reference path is compiled into the image now: the store is optional and its layout is catalog-owned and versioned, so a baked path either dangles or pins the image to one catalog version. Agents call `list_available_refs`, get absolute paths back, and pass them explicitly — the contract Azimuth already required — exporting a library's env var themselves when one is needed. The sandbox prompt now states that the store may be absent and that a missing reference is a normal state to report, not to route around.

## Fixes

- **Same-size corruption was unrepairable and falsely reported.** The already-installed check compared sizes, so a corrupted file of unchanged length was skipped and reported as `Installed (0 B downloaded)`. It now compares digests and re-downloads to heal. `--force` re-fetches an intact install, which is also how an `unpinned` dataset is refreshed once its upstream moves on.
- **Resume is pinned-only.** Appending to a partial whose mutable upstream has since replaced the file would splice two files into one that verifies against nothing.
- **Redirects can't downgrade.** `fetch` follows redirects, and an `unpinned` artifact has no digest to catch a hostile substitution, so bytes served from a non-https location are refused.
- **Receipt reads are contained to their dataset** (`managed/` and `user/` are siblings; the schema already refuses traversal, this is the second lock).
- **One corrupt receipt no longer hides the others** — a shared `try` abandoned the scan loop, silently dropping every receipt sorting after the bad one.
- Activation no longer strands a staging directory per attempt.

## Validation

Exercised end-to-end against the **real upstreams**, not a stub:

- `refs download` from `data.wikipathways.org`, `ftp.ncbi.nlm.nih.gov`, and `reactome.org`; pinned and unpinned both install and `verify` clean. Reactome's five chunked, `Content-Length`-less files download and verify.
- Catalog digests confirmed byte-exact against the publishers (WikiPathways GMT, both CellTypist models).
- Same-size corruption is detected and healed; `--force` refreshes; resume issues a real `206`.
- In a sandbox container with the real bind mount, `list_available_refs` discovers the datasets with catalog metadata joined from the receipt, writes fail with `Read-only file system`, and the data is usable (47,819 rat gene rows; 987 WikiPathways pathways).
- harness: `lint`, `typecheck`, tests, OpenSpec strict 62/62. cli: `lint`, `typecheck`, tests, OpenSpec strict 71/71.

## Follow-up (not in this PR)

The published sandbox images still carry the old baked `CELLTYPIST_FOLDER`; they must be rebuilt and republished for the Dockerfile change to take effect. CI does not rebuild the image, so it won't catch this.
