### PR TITLE
docs: add DOI, Scorecard and Test badges; publish Scorecard results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,81 @@
+name: Scorecard
+
+# Runs OpenSSF Scorecard, which grades the repo's security posture (branch protection,
+# pinned dependencies, token permissions, SAST, signed releases, …) and publishes the
+# result to the public OpenSSF API that backs the README badge.
+#
+# Why publish at all: the score is the point. `publish_results: true` is what makes the
+# badge and the scorecard.dev viewer resolve — without it this workflow is a private
+# SARIF generator and the badge stays "unknown". Publishing exposes nothing that is not
+# already public: the repo is public, and the API stores the score, not the source.
+#
+# Actions here are pinned by commit SHA while the other workflows still track tags. That
+# is deliberate, not an inconsistency: this is the only job in the repo granted
+# `id-token: write` (OIDC) and `security-events: write`, so a hijacked mutable tag would
+# be the highest-impact supply-chain vector we have. The version comment on each `uses:`
+# is the human-readable half of the pin — keep them in sync when bumping.
+on:
+  # Scorecard can only publish from the default branch: fork PRs get no OIDC token, so a
+  # `pull_request` trigger would produce runs that cannot update the badge. Scoring is
+  # therefore a property of `main`, not of a proposed change.
+  push:
+    branches: [main]
+  # Re-score when branch protection changes — it is one of the heaviest-weighted checks,
+  # and it is exactly the setting that drifts without anyone noticing.
+  branch_protection_rule:
+  # Weekly, because most checks (Maintained, Vulnerabilities, Dependency-Update-Tool)
+  # measure things that decay over time rather than things a commit changes.
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF so findings land in the Security tab as code-scanning alerts
+      # (free for public repos) rather than living only inside the run log.
+      security-events: write
+      # OIDC token — the credential Scorecard exchanges to publish to the OpenSSF API.
+      # This is the permission that makes the badge work.
+      id-token: write
+      contents: read
+      # Scorecard reads the repo's own workflow definitions to grade Token-Permissions
+      # and Dangerous-Workflow.
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Leave no usable git credential in the workspace for the analysis steps that
+          # follow; Scorecard needs the tree, never the ability to push.
+          persist-credentials: false
+
+      # `repo_token` is intentionally not supplied. A PAT would let the Branch-Protection
+      # check read the full ruleset (the GITHUB_TOKEN sees only part of it, so that
+      # sub-score reads lower than reality), but that means a long-lived, broadly-scoped
+      # secret sitting in the repo forever to improve one number — a worse security
+      # posture than the one it would be reporting. Accepted trade-off.
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Retained briefly so a surprising score can be diffed against the raw findings
+      # even if the code-scanning upload is what failed.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          sarif_file: results.sarif

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,13 +46,14 @@ keywords:
     - AI agent
     - command-line tool
 
-# --- Add AFTER your first Zenodo release mints a DOI (use the CONCEPT DOI, which
-#     always resolves to the latest version). Uncomment and fill in. ---
-# doi: "10.5281/zenodo.XXXXXXX"
-# identifiers:
-#   - type: doi
-#     value: "10.5281/zenodo.XXXXXXX"
-#     description: "Concept DOI — always resolves to the latest Inflexa release."
+doi: "10.5281/zenodo.21361439"
+identifiers:
+    - type: doi
+      value: "10.5281/zenodo.21361439"
+      description: "Concept DOI — always resolves to the latest Inflexa release."
+    - type: doi
+      value: "10.5281/zenodo.21361440"
+      description: "Version DOI — Inflexa v0.1.0 specifically."
 
 # --- Add LATER, once a preprint or JOSS paper exists, so citations point to the
 #     paper instead of (or in addition to) the software. Uncomment and fill in. ---

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/inflexa-ai/inflexa/actions/workflows/test.yml"><img alt="Test" src="https://github.com/inflexa-ai/inflexa/actions/workflows/test.yml/badge.svg?branch=main" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/inflexa-ai/inflexa"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/inflexa-ai/inflexa/badge" /></a>
   <a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" /></a>
+  <a href="https://doi.org/10.5281/zenodo.21361439"><img alt="DOI" src="https://zenodo.org/badge/1266094931.svg" /></a>
   <a href="https://app.inflexa.ai"><img src="https://img.shields.io/badge/Try-Web%20UI-orange" alt="Web UI" /></a>
   <a href="https://www.linkedin.com/company/inflexa-ai"><img src="https://img.shields.io/badge/Follow-LinkedIn-0077B5" alt="Follow on LinkedIn" /></a>
 </p>


### PR DESCRIPTION
Adds the three requested badges to the README, records the Zenodo DOI in `CITATION.cff`, and adds the workflow the Scorecard badge depends on.

## Badges

| Badge | Notes |
|-|-|
| Test | `test.yml` on `main` |
| OpenSSF Scorecard | needs the new workflow below to resolve |
| DOI | concept DOI — always resolves to the newest release |

Written as centered HTML `<a><img>` to match the existing badge block; Markdown image syntax would not center inside `<p align="center">`. All badge URLs point at `inflexa-ai/inflexa` (the git remote still says `inf-cli`, but GitHub serves the repo under the new name and redirects the old one).

## Why this includes a workflow

The Scorecard badge is served from `api.scorecard.dev`, which had **no entry for this repo** — the API returned 404 and the badge rendered `invalid repo path`. A badge on its own would have shipped broken. `.github/workflows/scorecard.yml` runs `ossf/scorecard-action` with `publish_results: true` on pushes to `main`, weekly, and on branch-protection changes, which is what populates the API. SARIF is also uploaded to code scanning so individual checks land in the Security tab as alerts rather than only as a number.

The badge will keep reading `invalid repo path` until this merges and the first run on `main` publishes.

### Actions are SHA-pinned here, tag-tracked elsewhere

Deliberate, not an inconsistency. This is the only job in the repo granted `id-token: write` (OIDC) and `security-events: write`, so a hijacked mutable tag would be the highest-impact supply-chain vector we have — and unpinned actions would dock the very score the workflow exists to publish. Every pin was verified against the GitHub API to resolve to the tag its comment claims (annotated tags dereferenced):

- `actions/checkout` v7.0.0 — matches the checkout major used elsewhere in this repo
- `ossf/scorecard-action` v2.4.3
- `actions/upload-artifact` v4.6.2
- `github/codeql-action/upload-sarif` v3.37.0

`repo_token` is intentionally not supplied — see the comment in the workflow for the trade-off.

## CITATION.cff

`doi:` is the **concept** DOI (`10.5281/zenodo.21361439`), verified against the Zenodo API as the concept record rather than the version record; the v0.1.0 version DOI (`…440`) is listed alongside it under `identifiers`. This is what the placeholder comment in the file asked for. The file still parses and retains all required CFF keys.

## Expectations

The first score will likely be middling, largely because the other workflows pin actions by tag rather than SHA. Left alone rather than changed as a side effect of a badge PR.