### PR TITLE
feat(cli): label the sandbox variant picker Python / Python + R

### DIFF
--- a/cli/src/modules/libs/images.ts
+++ b/cli/src/modules/libs/images.ts
@@ -20,7 +20,13 @@ export const SANDBOX_VARIANTS = ["python", "python-r"] as const;
 /** A published sandbox image variant. */
 export type SandboxVariant = (typeof SANDBOX_VARIANTS)[number];
 
-/** One-line descriptions for the interactive variant chooser. */
+/** Human-readable labels for the interactive variant chooser (the option title). */
+export const VARIANT_LABELS: Record<SandboxVariant, string> = {
+    python: "Python",
+    "python-r": "Python + R",
+};
+
+/** One-line descriptions for the interactive variant chooser (the option hint). */
 export const VARIANT_DESCRIPTIONS: Record<SandboxVariant, string> = {
     python: "Python libraries + bioconda CLI tools + Node packages",
     "python-r": "everything in python, plus the R libraries",

--- a/cli/src/modules/libs/pull.ts
+++ b/cli/src/modules/libs/pull.ts
@@ -20,7 +20,7 @@ import { err, ok, type Result } from "neverthrow";
 import { confirm } from "../../lib/cli.ts";
 import { activeRuntime, readConfig, writeConfig } from "../../lib/config.ts";
 import { capture, ensureReady, inherit } from "../../lib/container.ts";
-import { DEFAULT_SANDBOX_IMAGE, SANDBOX_VARIANTS, VARIANT_DESCRIPTIONS, variantImage, variantOfImage, type SandboxVariant } from "./images.ts";
+import { DEFAULT_SANDBOX_IMAGE, SANDBOX_VARIANTS, VARIANT_DESCRIPTIONS, VARIANT_LABELS, variantImage, variantOfImage, type SandboxVariant } from "./images.ts";
 
 /** Flags accepted by `inflexa sandbox pull` (and reused by setup). */
 export type PullOptions = {
@@ -112,7 +112,7 @@ export async function sandboxPull(opts: PullOptions = {}): Promise<Result<PullOu
         }
         const chosen = await clackSelect({
             message: "Which sandbox image?",
-            options: SANDBOX_VARIANTS.map((v) => ({ value: v, label: v, hint: VARIANT_DESCRIPTIONS[v] })),
+            options: SANDBOX_VARIANTS.map((v) => ({ value: v, label: VARIANT_LABELS[v], hint: VARIANT_DESCRIPTIONS[v] })),
         });
         if (isCancel(chosen)) return ok({ type: "declined" });
         variant = chosen;


### PR DESCRIPTION
## What

The `inflexa setup` / `inflexa sandbox pull` variant chooser rendered the bare variant slugs (`python`, `python-r`) as its option titles. This adds a `VARIANT_LABELS` map so the picker reads **"Python"** / **"Python + R"**, making the two install options self-explanatory at the prompt.

The slug remains the option `value` and the package contents remain the hint line, so behavior is unchanged — only the displayed title is clearer.

## Why

The two-option install choice already existed (both `setup` and `sandbox pull` funnel through `sandboxPull()`'s picker), but "python-r" as a title is opaque about what it installs. "Python + R" states it plainly.

## Changes

- `cli/src/modules/libs/images.ts` — add `VARIANT_LABELS`.
- `cli/src/modules/libs/pull.ts` — use it for the `clackSelect` option `label`.

## Verification

- `bun run typecheck` — clean
- `bun run format:file` — no changes (already formatted)

> Note: this PR is the code half of a broader sandbox-image cleanup. The registry-side work (republishing the images to the public bare `ghcr.io/inflexa-ai/sandbox-*` path, multi-arch, and pruning the stale repo-scoped / junk packages) was done out-of-band and needs no code change.