### PR TITLE
ci: harden repo for OpenSSF Scorecard (token perms, pinning, signing, vuln)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,8 @@ on:
   issues:
     types: [opened, assigned]
 
+permissions: {}
+
 jobs:
   claude:
     # Run only when someone mentions @claude AND that someone is one of us:
@@ -41,13 +43,13 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history so Claude can diff the PR's whole commit range.
           fetch-depth: 0
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # NOTE: do NOT set `prompt:` here. Providing `prompt` forces the

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -17,7 +17,7 @@ jobs:
   dco:
     runs-on: ubuntu-latest
     steps:
-      - uses: KineticCafe/actions-dco@v3.1.0
+      - uses: KineticCafe/actions-dco@1da04282bbf757dab7d92a5c8535dbfb8113da5c # v3.1.0
         with:
           config: |
             [bot]

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -30,7 +30,7 @@ jobs:
   update-formula:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve and validate the version
         id: version
@@ -62,7 +62,7 @@ jobs:
 
       - name: Mint a tap-scoped token
         id: tap-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.TAP_APP_ID }}
           private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install latest, then a pinned version
         run: |
           INFLEXA_INSTALL_DIR="$RUNNER_TEMP/bin" bash install.sh
@@ -40,7 +40,7 @@ jobs:
   powershell:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Windows PowerShell 5.1 is what a stock machine's `irm | iex` runs in;
       # it exercises the HttpWebResponse redirect branch and TLS pinning.
       - name: Windows PowerShell 5.1 - latest

--- a/.github/workflows/lib-store-acceptance.yml
+++ b/.github/workflows/lib-store-acceptance.yml
@@ -26,11 +26,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# Least privilege by default: the workflow-wide token is read-only; the
+# acceptance job escalates to id-token:write (AWS OIDC) explicitly.
 permissions:
   contents: read
-  id-token: write
-  actions: read
-  packages: read
 
 jobs:
   acceptance:
@@ -49,19 +48,27 @@ jobs:
           - arch: arm64
             runner: '"ubuntu-24.04-arm"'
     runs-on: ${{ fromJSON(matrix.runner) }}
+    permissions:
+      contents: read # checkout
+      id-token: write # AWS OIDC to read the candidate pointer from S3
+      actions: read # download the candidate artifact from the build run
+      packages: read # pull the published image from GHCR
     env:
       ARCH: ${{ matrix.arch }}
       S3_BUCKET: ${{ vars.LIB_STORE_S3_BUCKET }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Pin to the commit that produced the candidate build: this workflow
-          # runs the validation suite from the checked-out tree, so an unpinned
-          # checkout would validate against a DIFFERENT suite if main advanced.
-          # `head_sha` is empty on workflow_dispatch → checkout falls back to the
-          # dispatched ref.
-          ref: ${{ github.event.workflow_run.head_sha }}
+        # No `ref:` here — the triggering "Build Sandbox Images" workflow only
+        # runs on push to main and manual dispatch (both trusted), so its
+        # head_sha is always a main commit. Checking out event-supplied
+        # `workflow_run.head_sha` in this privileged (id-token/packages)
+        # workflow_run is exactly the "untrusted code checkout" pattern OpenSSF
+        # Scorecard flags as a Dangerous-Workflow, and static analysis cannot
+        # see that the source is trust-restricted. A bare checkout runs the
+        # current-main suite instead; since acceptance is NON-GATING, the small
+        # window where main advanced past the built commit is immaterial to
+        # what is only a post-publish report.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Gate publish configuration
         id: cfg
@@ -78,14 +85,14 @@ jobs:
       # to validate. Acceptance itself promotes nothing.
       - name: Configure AWS credentials
         if: steps.cfg.outputs.enabled == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.LIB_STORE_PUBLISH_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Download candidate metadata (from the build run)
         if: steps.cfg.outputs.enabled == 'true' && github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: lib-store-candidate-${{ matrix.arch }}
           path: candidate
@@ -133,7 +140,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.candidate.outputs.present == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/lib-store-acceptance.yml
+++ b/.github/workflows/lib-store-acceptance.yml
@@ -11,32 +11,23 @@ name: Sandbox Image Acceptance
 # It is NON-GATING: `latest` was already advanced by the build. This run reports a
 # per-arch results table to the step summary and a green/red status for review —
 # it promotes nothing and rolls nothing back.
-#
-# Requires the same opt-in publish config as the build (LIB_STORE_S3_BUCKET,
-# LIB_STORE_PUBLISH_ROLE_ARN) to resolve the candidate pointer; without it the run
-# no-ops.
 
 on:
   workflow_run:
     workflows: ["Build Sandbox Images"]
     types: [completed]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-# Least privilege by default: the workflow-wide token is read-only; the
-# acceptance job escalates to id-token:write (AWS OIDC) explicitly.
 permissions:
   contents: read
 
 jobs:
   acceptance:
     # Only when the build succeeded (a fully-failed build has nothing to check).
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       # Arch list — keep in lock-step with the build workflow matrix and its
@@ -49,49 +40,16 @@ jobs:
             runner: '"ubuntu-24.04-arm"'
     runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
-      contents: read # checkout
-      id-token: write # AWS OIDC to read the candidate pointer from S3
-      actions: read # download the candidate artifact from the build run
-      packages: read # pull the published image from GHCR
+      contents: read
+      actions: read
+      packages: read
     env:
       ARCH: ${{ matrix.arch }}
-      S3_BUCKET: ${{ vars.LIB_STORE_S3_BUCKET }}
     steps:
       - name: Checkout
-        # No `ref:` here — the triggering "Build Sandbox Images" workflow only
-        # runs on push to main and manual dispatch (both trusted), so its
-        # head_sha is always a main commit. Checking out event-supplied
-        # `workflow_run.head_sha` in this privileged (id-token/packages)
-        # workflow_run is exactly the "untrusted code checkout" pattern OpenSSF
-        # Scorecard flags as a Dangerous-Workflow, and static analysis cannot
-        # see that the source is trust-restricted. A bare checkout runs the
-        # current-main suite instead; since acceptance is NON-GATING, the small
-        # window where main advanced past the built commit is immaterial to
-        # what is only a post-publish report.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Gate publish configuration
-        id: cfg
-        run: |
-          if [ -n "$S3_BUCKET" ] && [ -n "${{ vars.LIB_STORE_PUBLISH_ROLE_ARN }}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Acceptance skipped — LIB_STORE_S3_BUCKET / LIB_STORE_PUBLISH_ROLE_ARN unset, so nothing was published to promote."
-          fi
-
-      # AWS credentials are configured BEFORE resolving the candidate: the
-      # workflow_dispatch path reads the candidate pointer from S3 to find the image
-      # to validate. Acceptance itself promotes nothing.
-      - name: Configure AWS credentials
-        if: steps.cfg.outputs.enabled == 'true'
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: ${{ vars.LIB_STORE_PUBLISH_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-
       - name: Download candidate metadata (from the build run)
-        if: steps.cfg.outputs.enabled == 'true' && github.event_name == 'workflow_run'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: lib-store-candidate-${{ matrix.arch }}
@@ -101,35 +59,12 @@ jobs:
 
       - name: Resolve candidate version + image
         id: candidate
-        if: steps.cfg.outputs.enabled == 'true'
         run: |
           set -euo pipefail
-          if [ -f "candidate/linux-${ARCH}.json" ]; then
-            VERSION=$(python3 -c "import json;print(json.load(open('candidate/linux-${ARCH}.json'))['version'])")
-            PUBLISHED=$(python3 -c "import json;print(json.load(open('candidate/linux-${ARCH}.json')).get('publish',''))")
-            IMAGE=$(python3 -c "import json;print(json.load(open('candidate/linux-${ARCH}.json')).get('image',''))")
-          else
-            # workflow_dispatch fallback: read the recorded candidate JSON pointer,
-            # which carries the exact top image ref for this arch (sandbox-python-r,
-            # or sandbox-python where R did not build) — validate that image rather
-            # than reconstructing a tag.
-            PUBLISHED=true
-            IMAGE=""
-            if aws s3 cp "s3://$S3_BUCKET/candidate/linux-${ARCH}.json" candidate.json 2>aws-err.log; then
-              VERSION=$(python3 -c "import json;print(json.load(open('candidate.json'))['version'])")
-              PUBLISHED=$(python3 -c "import json;print(json.load(open('candidate.json')).get('publish',''))")
-              IMAGE=$(python3 -c "import json;print(json.load(open('candidate.json')).get('image',''))")
-            elif grep -Eqi 'Not Found|404|NoSuchKey|does not exist' aws-err.log; then
-              echo "::notice::No candidate pointer object for linux-${ARCH}; nothing to validate."
-              VERSION=""
-            else
-              echo "::error::Failed to read the candidate pointer for linux-${ARCH}:"
-              cat aws-err.log >&2
-              exit 1
-            fi
-          fi
-          if [ -z "$VERSION" ] || [ "$PUBLISHED" != "true" ]; then
-            echo "::notice::No published candidate for linux-${ARCH}; nothing to validate."
+          VERSION=$(python3 -c "import json;print(json.load(open('candidate/linux-${ARCH}.json'))['version'])")
+          IMAGE=$(python3 -c "import json;print(json.load(open('candidate/linux-${ARCH}.json')).get('image',''))")
+          if [ -z "$IMAGE" ]; then
+            echo "::notice::No candidate image for linux-${ARCH}; nothing to validate."
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "present=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -46,10 +46,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+# Least privilege by default: the workflow-wide token is read-only. The build
+# and manifest jobs escalate to packages:write (GHCR push) and id-token:write
+# (AWS OIDC) explicitly, so no job inherits a write scope it does not use.
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 env:
   BUILDER_NAME: sandbox-image-builder
@@ -72,7 +73,7 @@ jobs:
       r_version: ${{ steps.meta.outputs.r_version }}
       python_version: ${{ steps.meta.outputs.python_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Compute version + parse manifest
         id: meta
         run: |
@@ -89,6 +90,10 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read # checkout
+      packages: write # push the per-arch images to GHCR
+      id-token: write # AWS OIDC for the optional S3 tarball publish
     strategy:
       fail-fast: false
       # Arch list — keep in lock-step with the workflow-level ARCHES env (manifest
@@ -109,10 +114,10 @@ jobs:
       BASE_IMAGE: ${{ needs.prepare.outputs.base_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver: docker-container
           name: ${{ env.BUILDER_NAME }}
@@ -149,7 +154,7 @@ jobs:
         run: command -v zstd >/dev/null || sudo apt-get install -y -qq zstd
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -260,7 +265,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.publish.outputs.enabled == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.LIB_STORE_PUBLISH_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -292,7 +297,7 @@ jobs:
           cat "candidate/linux-${ARCH}.json"
 
       - name: Upload candidate artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: lib-store-candidate-${{ matrix.arch }}
           path: candidate/
@@ -313,11 +318,13 @@ jobs:
     needs: [prepare, build]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # push the multi-arch manifest list to GHCR
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -33,22 +33,12 @@ name: Build Sandbox Images
 #   - vars.AWS_REGION                 optional; defaults to us-east-1
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - images/lib-store-manifest.yaml
-      - images/sandbox-base/**
-      - images/sandbox-python/**
-      - images/sandbox-python-r/**
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-# Least privilege by default: the workflow-wide token is read-only. The build
-# and manifest jobs escalate to packages:write (GHCR push) and id-token:write
-# (AWS OIDC) explicitly, so no job inherits a write scope it does not use.
 permissions:
   contents: read
 
@@ -91,9 +81,9 @@ jobs:
   build:
     needs: prepare
     permissions:
-      contents: read # checkout
-      packages: write # push the per-arch images to GHCR
-      id-token: write # AWS OIDC for the optional S3 tarball publish
+      contents: read
+      packages: write
+      id-token: write
     strategy:
       fail-fast: false
       # Arch list — keep in lock-step with the workflow-level ARCHES env (manifest
@@ -319,7 +309,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     permissions:
-      packages: write # push the multi-arch manifest list to GHCR
+      packages: write
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       # cli depends on @inflexa-ai/harness via file:../harness, whose exports
       # resolve to harness/dist/ — not checked in, and bun blocks the package's
@@ -52,9 +52,9 @@ jobs:
       run:
         working-directory: harness
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release-harness.yml
+++ b/.github/workflows/release-harness.yml
@@ -29,10 +29,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Creating the harness-v* tag.
-  contents: write
-  # The OIDC token npm exchanges for its short-lived publish credential.
-  id-token: write
+  contents: read
 
 # Never cancel a run that may sit between the npm publish and the tag; later
 # pushes queue behind it and their gates then no-op.
@@ -46,8 +43,11 @@ jobs:
     # workflow_dispatch hole, which would otherwise publish from any branch.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve package version
         id: pkg
@@ -122,7 +122,7 @@ jobs:
             sleep 30
           done
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: steps.npm-check.outputs.published == 'false'
 
       # Trusted publishing needs npm >= 11.5.1; Node 24 is the LTS line whose
@@ -131,7 +131,7 @@ jobs:
       # and npm hard-fails on an unset env var in .npmrc — trusted publishing
       # is tokenless, npm resolves the registry from publishConfig and
       # authenticates via OIDC on its own.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.npm-check.outputs.published == 'false'
         with:
           node-version: "24"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,8 +24,6 @@ on:
 
 permissions:
   contents: read
-  # The OIDC token npm exchanges for its short-lived publish credential.
-  id-token: write
 
 concurrency:
   group: release-npm
@@ -37,8 +35,11 @@ jobs:
     # ever ship what main's automation assembled.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve and validate the version
         id: version
@@ -64,14 +65,14 @@ jobs:
             --pattern 'inflexa-*' --pattern SHA256SUMS --pattern THIRD-PARTY-NOTICES.txt \
             --dir assets
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       # Trusted publishing needs npm >= 11.5.1; Node 24's bundled npm
       # satisfies that. Deliberately NO registry-url: that writes an .npmrc
       # reading ${NODE_AUTH_TOKEN} and npm hard-fails on the unset var —
       # trusted publishing is tokenless and resolves the registry from each
       # package's publishConfig.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -38,7 +38,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.RELEASE_PREP_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  # attest-build-provenance signs with the workflow's OIDC identity.
-  id-token: write
-  attestations: write
-  # The final step dispatches homebrew.yml via `gh workflow run`.
-  actions: write
+  contents: read
 
 # Never cancel a half-published release; later pushes queue behind it and
 # their gate then sees the new tag and no-ops.
@@ -37,8 +32,13 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      actions: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Gate on an unreleased version
         id: gate
@@ -104,7 +104,7 @@ jobs:
             sleep 30
           done
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: steps.gate.outputs.release == 'true'
 
       # cli depends on @inflexa-ai/harness via file:../harness, whose exports
@@ -143,9 +143,21 @@ jobs:
         working-directory: cli/dist
         run: sha256sum inflexa-* > SHA256SUMS
 
+      - name: Install cosign
+        if: steps.gate.outputs.release == 'true'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      - name: Sign the checksum manifest
+        if: steps.gate.outputs.release == 'true'
+        working-directory: cli/dist
+        run: |
+          cosign sign-blob --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
       # Signed SLSA provenance: lets a user verify a downloaded binary was
       # built by this workflow from this repo (`gh attestation verify`).
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         if: steps.gate.outputs.release == 'true'
         with:
           subject-path: cli/dist/inflexa-*
@@ -163,7 +175,7 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "v$VERSION" \
             --generate-notes \
-            dist/inflexa-* dist/SHA256SUMS dist/THIRD-PARTY-NOTICES.txt
+            dist/inflexa-* dist/SHA256SUMS dist/SHA256SUMS.sig dist/SHA256SUMS.pem dist/THIRD-PARTY-NOTICES.txt
 
       # Downstream distribution runs as separate dispatched workflows
       # (homebrew.yml explains why a `release:` trigger cannot work) so a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       # cli depends on @inflexa-ai/harness via file:../harness, whose exports
       # resolve to harness/dist/ — not checked in, and bun blocks the package's
@@ -51,9 +51,9 @@ jobs:
       run:
         working-directory: harness
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -25,7 +25,7 @@ jobs:
     name: version-guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Block version bumps from non-maintainers
         # Context values are passed through env rather than interpolated into

--- a/images/sandbox-base/server/go.mod
+++ b/images/sandbox-base/server/go.mod
@@ -2,4 +2,4 @@ module github.com/inflexa/sandbox-server
 
 go 1.26
 
-require golang.org/x/sys v0.42.0
+require golang.org/x/sys v0.44.0

--- a/images/sandbox-base/server/go.sum
+++ b/images/sandbox-base/server/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/images/sandbox-python-r/Dockerfile
+++ b/images/sandbox-python-r/Dockerfile
@@ -25,8 +25,10 @@
 # locally-built/loaded tag; the default is the GHCR-published image.
 ARG SANDBOX_PYTHON_IMAGE=ghcr.io/inflexa-ai/sandbox-python:latest
 # R builder base — MUST match sandbox-base's R runtime so the compiled R
-# packages' ABI matches (same R 4.6.0).
-ARG BASE_IMAGE=rocker/r-ver:4.6.0
+# packages' ABI matches (same R 4.6.0). Pinned by digest to match sandbox-base
+# and images/lib-store-manifest.yaml; CI overrides it with the manifest value
+# (also digest-pinned).
+ARG BASE_IMAGE=rocker/r-ver:4.6.0@sha256:6f05a1a8b8c52328f181593923909b01cbfd14c9caea93bf75ddc65e806d8eac
 ARG INFLEXA_LIB_ROOT=/mnt/libs/current
 
 # Cap on parallel R package compiles (install.packages/BiocManager Ncpus). Empty

--- a/images/sandbox-python/Dockerfile
+++ b/images/sandbox-python/Dockerfile
@@ -22,8 +22,10 @@
 # locally-built/loaded tag; the default is the GHCR-published base.
 ARG SANDBOX_BASE_IMAGE=ghcr.io/inflexa-ai/sandbox-base:latest
 # Builder base — MUST match sandbox-base's own base so the compiled Python
-# extensions and their .so ABI match the runtime (system Python 3.12).
-ARG BASE_IMAGE=rocker/r-ver:4.6.0
+# extensions and their .so ABI match the runtime (system Python 3.12). Pinned
+# by digest to match sandbox-base and images/lib-store-manifest.yaml; CI
+# overrides it with the manifest value (also digest-pinned).
+ARG BASE_IMAGE=rocker/r-ver:4.6.0@sha256:6f05a1a8b8c52328f181593923909b01cbfd14c9caea93bf75ddc65e806d8eac
 
 # The store root every layer installs into and every resolver env derives from.
 ARG INFLEXA_LIB_ROOT=/mnt/libs/current


### PR DESCRIPTION
## What & why

Raises the repo's [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/inflexa-ai/inflexa)
(baseline **4.2/10**) by fixing every check that can be fixed from the repo
itself. Findings were taken from the live Scorecard SARIF
(`code-scanning/alerts`), not guessed. No workflow changes its behaviour except
the two deliberate ones called out below.

## In-repo fixes

| Check | Was | Change |
|-|-|-|
| **Token-Permissions** | 0 | Every workflow now has a read-only/empty top-level `permissions:`; write scopes (`contents`/`packages`/`attestations`/`actions`) are granted per-job. |
| **Dangerous-Workflow** | 0 | `lib-store-acceptance.yml` drops the `workflow_run.head_sha` checkout (the "untrusted code checkout" pattern). |
| **Pinned-Dependencies** | 1 | All 36 `uses:` pinned to commit SHA; `rocker/r-ver` base pinned by digest in the two Dockerfile ARG defaults. |
| **Vulnerabilities** | 9 | `golang.org/x/sys` 0.42.0 → 0.44.0 (clears `GO-2026-5024`). `go build`/`go vet` pass. |
| **Signed-Releases** | 0 | `release.yml` signs `SHA256SUMS` with keyless cosign and ships `.sig`/`.pem` assets — effective next release. |

## Deliberate behaviour changes

**1. `lib-store` build is now manual-only; acceptance runs only after a build.**
- `lib-store.yml` drops the `images/**` push trigger — the build starts only on
  `workflow_dispatch`, which requires repo write access, so only maintainers can
  publish images. (Dependabot base-image bumps still land as PRs but no longer
  auto-rebuild; a maintainer dispatches when ready.)
- `lib-store-acceptance.yml` drops `workflow_dispatch` — it runs only on the
  build's `workflow_run` completion, so it always validates a real, just-finished
  build.
- **Permission win:** acceptance validates only the **pullable GHCR image**
  (candidate comes from the build run's artifact via `GITHUB_TOKEN`; the store is
  baked into the image, no S3 mount). So the S3 gate, the AWS-credentials step,
  and `id-token: write` are all gone — acceptance now holds only
  `contents`/`actions`/`packages` **read** scopes and no privileged token.

**2. Acceptance checkout no longer pins the built commit.** It previously checked
out `github.event.workflow_run.head_sha` (Scorecard's critical untrusted-checkout
pattern). Since the build is now maintainer-dispatch-only, a bare checkout of
`main` runs the same suite; acceptance is non-gating, so drift is immaterial.

## Can't be fixed from the repo (maintainer follow-ups)

- **Branch-Protection (8)** & **Code-Review (3)** — ruleset settings: enforce for
  admins, require Code Owner review, route all changes through reviewed PRs. Biggest
  remaining lever.
- **CII-Best-Practices (0)** — register at bestpractices.dev + earn the badge.
- **Maintained (0)** & **SAST (5)** — self-heal (repo <90 days; CodeQL default
  setup already on). Do **not** add a CodeQL workflow — it conflicts with default
  setup.
- **Contributors (6)**, **Fuzzing (0)**, **Binary-Artifacts (7)** — community /
  larger engineering efforts.

## Verification

- All 14 workflows parse; no top-level write scopes remain.
- `go build ./...` and `go vet ./...` pass with the `x/sys` bump.
- Action SHAs resolved from upstream tags; Dependabot's `github-actions` updater
  keeps them current.
