### PR TITLE
fix(cli): externalize cpu-features so the release binary builds

### DIFF
--- a/cli/scripts/build.ts
+++ b/cli/scripts/build.ts
@@ -246,7 +246,12 @@ for (const target of targets) {
         //     a local binary. The packages aren't installed (dbos-sdk fails to declare them as
         //     optionalDependencies), so external keeps the never-hit requires out of the bundle. Matches
         //     the harness's documented posture (runtime/otel-smoke.test.ts: OTLP exporter absent, DBOS degrades).
-        external: ["node-llama-cpp", "@node-llama-cpp/*", "winston", "winston-transport", "@opentelemetry/exporter-logs-otlp-proto"],
+        //   • cpu-features — a native addon (`require('../build/Release/cpufeatures.node')`, unbuilt here)
+        //     that ssh2 loads inside a try/catch purely to detect CPU crypto acceleration; ssh2 arrives via
+        //     dockerode → docker-modem and is only exercised over an SSH docker transport, which the local
+        //     backend never uses (unix socket / TCP). external stops the bundler descending into the package
+        //     and resolving its .node file; the runtime require then throws and ssh2's catch swallows it.
+        external: ["node-llama-cpp", "@node-llama-cpp/*", "winston", "winston-transport", "@opentelemetry/exporter-logs-otlp-proto", "cpu-features"],
         compile: {
             target: `bun-${target.os}-${target.arch}`,
             // Bun appends .exe automatically for windows targets.


### PR DESCRIPTION
Fixes the failed **Release** run for cli `0.2.0` ([run 29411713292](https://github.com/inflexa-ai/inflexa/actions/runs/29411713292)):

```
error: Could not resolve: "../build/Release/cpufeatures.node"
error: script "build:all" exited with code 1
```

**Root cause.** Switching the cli to consume `@inflexa-ai/harness` from npm (#120) re-resolved harness's transitive dependency tree into the cli bundle differently than `file:../harness` did, surfacing `cpu-features` — an optional native addon that `ssh2` loads inside a try/catch to detect CPU crypto acceleration. `ssh2` arrives via `dockerode → docker-modem` and is only exercised over an **SSH** docker transport, which the local backend never uses (unix socket / TCP). `file:../harness` had kept it out of the cli bundle graph; the npm resolution exposed it, and the binary compile can't statically resolve the unbuilt `.node` file.

**Fix.** Add `cpu-features` to the `Bun.build` `external` list — same pattern as the existing entries (native/optional deps behind code paths a normal `inflexa` run never reaches). The bundler stops at the package boundary; at runtime the require throws and ssh2's `catch` swallows it.

**Verified locally:** `bun run build:all` cross-compiles all five targets (darwin arm64/x64, linux x64/arm64, windows x64) and the host binary smoke-tests `--version → 0.2.0`.

> Note: `release.yml` triggers on `cli/package.json` changes, so this build-script fix won't auto-trigger it. Since the failed run created no `v0.2.0` tag, the release must be re-run via **workflow_dispatch** (the gate re-checks tag existence and will proceed) once this merges.
