### PR TITLE
feat(cli): generate and publish the CLI reference docs package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Same category as ESLint: a source-validity gate. Generation fails on a
+      # visible command/argument/option registered without a description, or a
+      # registry that stops being importable standalone — catching it here keeps
+      # the release workflow's docs packaging a pure re-run of what CI verified.
+      - name: Docs generation check
+        run: bun run docs:gen
+
   harness:
     name: lint (harness)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,15 @@ jobs:
         working-directory: cli
         run: |
           bun run docs:gen
-          tar -czf dist/cli-docs.tar.gz -C dist-docs .
+          # Reproducible archive: pin entry order, mtime (the release commit's date), and
+          # ownership, and strip gzip's mtime/name header (-n), so the tarball is byte-identical
+          # when regenerated at this commit — not just its file contents (docs:gen already makes
+          # those deterministic). Keeps the door open to checksumming/re-verifying the asset later
+          # without the tar+gzip layer perturbing the bytes. The default Actions shell runs with
+          # `-o pipefail`, so a tar failure still fails the step through the pipe.
+          mtime="@$(git log -1 --format=%ct "$GITHUB_SHA")"
+          tar --sort=name --mtime="$mtime" --owner=0 --group=0 --numeric-owner \
+            -cf - -C dist-docs . | gzip -n > dist/cli-docs.tar.gz
 
       - name: Install cosign
         if: steps.gate.outputs.release == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,18 @@ jobs:
         working-directory: cli/dist
         run: sha256sum inflexa-* > SHA256SUMS
 
+      # The SSG-neutral CLI reference package the website consumes (manifest.json +
+      # CommonMark pages — see the cli-reference-docs spec). The lint job already ran
+      # this same generator on this commit and generation is byte-deterministic, so
+      # this re-materializes exactly the content CI verified; it is documentation,
+      # not an executable, so it stays out of SHA256SUMS and the attestation.
+      - name: Package the CLI reference docs
+        if: steps.gate.outputs.release == 'true'
+        working-directory: cli
+        run: |
+          bun run docs:gen
+          tar -czf dist/cli-docs.tar.gz -C dist-docs .
+
       - name: Install cosign
         if: steps.gate.outputs.release == 'true'
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
@@ -172,7 +184,7 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "v$VERSION" \
             --generate-notes \
-            dist/inflexa-* dist/SHA256SUMS dist/SHA256SUMS.sig dist/SHA256SUMS.pem dist/THIRD-PARTY-NOTICES.txt
+            dist/inflexa-* dist/SHA256SUMS dist/SHA256SUMS.sig dist/SHA256SUMS.pem dist/THIRD-PARTY-NOTICES.txt dist/cli-docs.tar.gz
 
       # Downstream distribution runs as separate dispatched workflows
       # (homebrew.yml explains why a `release:` trigger cannot work) so a

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 .env
 node_modules
 dist
+dist-docs
 dist-ssr
 *.local
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -22,6 +22,7 @@ bun run dev          # Run the CLI (launches the TUI by default)
 bun run typecheck    # tsc --noEmit
 bun run lint         # Run ESLint
 bun run format       # Format all of src/
+bun run docs:gen     # Generate the CLI reference package (dist-docs/, untracked)
 ```
 
 ## Dependencies
@@ -297,6 +298,14 @@ The "Type & emphasis" scale (one typeface, one size; hierarchy by weight, dim, c
 **Composing:** nest to combine — `<Fg role="fgMuted"><Italic>{text}</Italic></Fg>`. For a single whole-line color, `<text fg={theme().role}>…</text>` is still fine (don't wrap one line in `<Fg>`); reach for the components when a line **mixes** colors/styles.
 
 **Never** nest a block `<text>` inside a `<text>` (rejected as a text-node child at runtime). The emphasis components avoid this by emitting spans — if you need new raw inline styling, add it to `emphasis.tsx` (with the `style={{…}}` channel documented there), never at the call site.
+
+## CLI reference docs
+
+`bun run docs:gen` (`scripts/gen_docs.ts`) walks the commander registry and emits the publishable CLI reference package to `dist-docs/` (untracked): SSG-neutral CommonMark pages + `manifest.json`. The contract lives in the `cli-reference-docs` spec; the release workflow regenerates the package at the tagged commit and attaches it to the GitHub release as `cli-docs.tar.gz` (consumed by the website). Invariants:
+
+- **Never run the generator under `bun test`** — the registry imports `lib/env.ts`, whose data-loss guard throws in a test process without the sandbox marker. Run it as a plain `bun scripts/gen_docs.ts`; CI invokes it as a subprocess.
+- **Dev-channel commands are excluded by design**: the generator bakes a production build channel before importing the registry, so the docs describe exactly the release binary's surface.
+- **Every visible command, argument, and option needs a description** — generation (and the lint CI job that runs it) fails otherwise. Declare positionals via `.argument(name, description)`, never inline in the command string.
 
 ## References
 

--- a/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/design.md
+++ b/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/design.md
@@ -1,0 +1,134 @@
+# Design: CLI Reference Docs Generation and Publishing
+
+## Context
+
+The commander registry (`src/cli/index.ts`) exports the configured `cli` Command without calling `.parse()`; `src/index.ts` is the only parse site. Every command action is lazy-imported, so importing the registry evaluates only commander, `package.json`, and `src/lib/env.ts` — verified: `bun -e 'import("./src/cli/index.ts")'` loads cleanly and reports the full tree. Commander v15's public introspection surface (`.commands`, `.options`, `.registeredArguments`, `.name()`, `.description()`) exposes everything the docs need; there is no built-in JSON/Markdown export.
+
+The Paths/Environment appendix on root `--help` is not free text — it renders from the structured `envDoc` table in `src/lib/env.ts`, which the generator can consume directly.
+
+The consumer is the atrium website (separate repo, Vite + React, no markdown pipeline of its own). It will run a docs SSG (VitePress 1.x recommended) over content fetched from this repo's GitHub releases. The contract must not assume any particular SSG.
+
+The repo-level `release.yml` already cuts an attested GitHub Release on every `cli/package.json` version bump; the repo is public, so release assets have stable unauthenticated URLs (`releases/latest/download/<file>`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One generator, one source of truth: the commander registry + `envDoc`. No hand-maintained command docs anywhere.
+- A single output: the publishable SSG-neutral package (markdown + `manifest.json`) in an untracked build directory. Nothing generated is committed to git.
+- Docs describe exactly the release binary: dev-channel commands never appear.
+- Zero new dependencies in `cli/`.
+- A registry change that breaks generation fails CI on the PR, not first at release time.
+
+**Non-Goals:**
+
+- Website-side rendering (VitePress config, sync script, styling) — lives in the atrium repo.
+- Man pages, `--help`-text capture, or prose guides/tutorials — this is reference generation only.
+- A JSON export of the command tree for programmatic consumers other than the nav manifest.
+- Documenting hidden options or the dev channel.
+
+## Decisions
+
+### D1: DIY introspection script over existing packages
+
+The only dedicated commander→markdown packages (`commander-to-markdown`, `@mitsuru793/commander-document-generator`) are unmaintained (9 and 6 years), predate the modern API, and don't handle nested subcommands. Commander's public properties make the walk trivial. A `scripts/gen_docs.ts` beside `build.ts`/`wipe.ts` follows the existing scripts convention and adds no dependency (the `cli/` CLAUDE.md forbids new deps without approval).
+
+### D2: Import the registry, not the entry point; never under `bun test`
+
+The generator imports `{ cli }` from `src/cli/index.ts` — not `src/index.ts`, which wires telemetry/logging/provenance and parses argv. It never invokes actions, so lazy imports keep the TUI/DB/harness out of the process.
+
+**Load-bearing caveat**: `src/lib/env.ts` (imported by the registry) has a module-evaluation data-loss guard that throws when `NODE_ENV=test` without `INFLEXA_TEST_SANDBOX`, to keep test processes away from real user data. The generator therefore runs only as a plain `bun scripts/gen_docs.ts` process. No test may import `scripts/gen_docs.ts`; the CI generation check runs the script as a subprocess, not as a test.
+
+### D3: Dev channel excluded at generation time
+
+`profile`/`run`/`chat` register only when `devCommandsEnabled()` (`src/cli/index.ts:137`), which is `isDevelopmentBuild(INFLEXA_BUILD_CHANNEL) || INFLEXA_DEV === "1"` — true for ANY non-production channel, including the unset channel of a plain source run. Deleting `INFLEXA_DEV` alone is therefore not enough: the generator bakes `process.env.INFLEXA_BUILD_CHANNEL = "production"` AND deletes `INFLEXA_DEV` before dynamically importing the registry (dynamic, because static imports would hoist past the mutations). Exclusion then happens through the exact gate that shapes a shipped binary — no filtering logic, no second list to maintain. Faking the channel is sound in this import-only process: the registry import path reads the channel solely through that gate (`bakedEnv.gitCommit` would throw under a production channel, but it is a lazy getter nothing in generation reads).
+
+### D4: Portable CommonMark + manifest, not SSG-native output
+
+Alternatives considered:
+
+- **Atrium-native output** (JS data module / JSX / pre-rendered HTML): rejected — couples this repo to the website's framework and design; the website owner explicitly declined.
+- **SSG-specific markdown** (MkDocs nav YAML, VitePress sidebar file, Starlight frontmatter): rejected — picks the website's tooling for it.
+- **Chosen**: CommonMark-only pages with frontmatter limited to `title` + `description` (the subset every candidate SSG reads), plus `manifest.json` carrying the ordered nav tree. Nav is the one thing SSGs disagree on; shipping it as data means the consumer writes ~15 lines of glue mapping manifest → its sidebar format, and switching SSGs later never changes this contract.
+
+Portability rules enforced by the generator (not by convention):
+
+- Every machine-emitted token that can contain angle brackets — flags (`--analysis <id|name>`), usage lines, argument names — is wrapped in code spans or fenced blocks. Raw `<...>` is parsed as an HTML tag by VitePress (markdown compiles through Vue templates) and by Python-Markdown.
+- No admonitions, no `{{ }}`, no MDX/JSX, no HTML blocks.
+- Descriptions come from the registry verbatim; they are authored prose and must stay CommonMark-safe (the generator escapes stray `<`/`{{` in them defensively rather than trusting authors).
+
+### D5: Package layout mirrors the command tree; manifest is the structure channel
+
+```
+cli-docs.tar.gz
+├── manifest.json
+├── index.md                 # root command: usage, global options, subcommand index
+├── new.md, ls.md, resume.md, open.md, status.md, repair.md, relocate.md, prune.md, up.md, down.md, setup.md
+├── analysis/index.md, analysis/set-project.md
+├── project/index.md, project/new.md, project/ls.md
+├── prov/index.md, prov/export.md, prov/lineage.md, prov/verify.md, prov/verify-file.md
+├── auth/index.md, auth/login.md, auth/logout.md, auth/whoami.md
+├── refs/index.md, refs/list.md, refs/download.md, refs/verify.md, refs/path.md
+├── sandbox/index.md, sandbox/pull.md, sandbox/status.md
+├── config.md, sessions.md
+└── environment.md            # Paths + Environment tables from envDoc
+```
+
+`manifest.json` schema (v1):
+
+```json
+{
+  "schemaVersion": 1,
+  "cliVersion": "<package.json version>",
+  "name": "inflexa",
+  "nav": [
+    { "title": "inflexa", "path": "index.md" },
+    { "title": "new", "path": "new.md" },
+    { "title": "prov", "path": "prov/index.md", "items": [
+      { "title": "prov export", "path": "prov/export.md" }
+    ] },
+    { "title": "Environment", "path": "environment.md" }
+  ]
+}
+```
+
+`schemaVersion` is the compatibility handle: consumers hard-fail on a major they don't know. Nav order is registration order (the registry's declaration order is the curated order; no alphabetical resorting). No timestamps in the package — output must be byte-identical for the same registry, so the release-time regeneration provably reproduces what CI verified (D9).
+
+### D6: Single output — the publishable package; nothing generated is committed
+
+The generator writes only the package, to the untracked `dist-docs/`. A committed developer reference (`docs/reference/`) was considered and dropped (owner decision): in-repo readers already have `--help` from source, committing generated files invites merge noise, and it would require a diff-based drift check to keep honest. With a single untracked output, there is exactly one layout, one materialization path, and no committed artifact that can go stale.
+
+Consequence: CI cannot diff anything — instead it verifies generation *succeeds* (D8), which is also what enforces the non-empty-description invariant (D7) on every PR.
+
+### D7: Argument descriptions move to `.argument()` declarations
+
+`registeredArguments` currently carry empty descriptions because positionals are declared inline in the command string (`cli.command("new [name] [paths...]")`). Each registration converts to `.command("new")` + `.argument("[name]", "…")` + `.argument("[paths...]", "…")`. Commander treats both forms identically for parsing — the user-visible syntax and the spec-pinned registration strings (`inflexa new [name] [paths...]`) are unchanged — while `--help` and the generated docs gain per-argument descriptions. The generator fails (non-zero) on any visible argument or option with an empty description, making completeness a build-enforced invariant rather than a review nicety.
+
+### D8: CI runs the generator as a validity gate
+
+The existing repo CI (lint job for `cli`) runs `bun run docs:gen` as a subprocess on every PR. There is nothing to diff (D6); the gate is that generation exits 0 — which fails loudly on an argument/option registered without a description (D7), a registry that stops being importable standalone, or emitted output that violates the generator's own portability assertions. It lives beside ESLint because it is the same category: a source-validity check.
+
+### D9: Release asset step is additive to release.yml
+
+After the existing release-creation step, the workflow runs the generator at the release's source revision (the only materialization — the package is untracked), tars `dist-docs/` as `cli-docs.tar.gz`, and `gh release upload`s it. Because generation is deterministic (D4) and CI ran the same generator on the same commit (D8), the asset matches what CI verified. Consumers use `releases/latest/download/cli-docs.tar.gz` (or a pinned `v<version>` URL); `manifest.json`'s `cliVersion` lets them display what they're rendering.
+
+### D10: Deterministic environment-page paths via placeholder base vars
+
+`renderEnvHelp` prints `env[key]` — absolute paths resolved from the generating machine's home directory, which would break byte-determinism. Instead of dropping the location column, the generator seeds the base vars with their own names as literal placeholders (`XDG_DATA_HOME="$XDG_DATA_HOME"`, `XDG_CONFIG_HOME="$XDG_CONFIG_HOME"`) before importing `env.ts`; `dataDir()`/`configDir()` return an env override verbatim, so `env.dbPath` comes out as `$XDG_DATA_HOME/inflexa/agent.db` — machine-independent and self-documenting. A static prose line documents the unset-var defaults (`~/.local/share`, `~/.config`). Because `dataVar`/`configVar` are themselves platform-dependent (`LOCALAPPDATA` on Windows) and joins use the platform separator, the generator refuses to run on win32 — determinism is a contract property, not a nicety.
+
+## Risks / Trade-offs
+
+- [Registry import gains side effects later] → The generator's process is import-only by design; if a future registry import wires runtime state, generation breaks loudly (it runs in CI on every PR via the generation check), not silently.
+- [`env.ts` guard trips in an unexpected environment] → The generator asserts early that it is not running under `bun test` (checks `NODE_ENV !== "test"`) and documents the plain-`bun` invocation in the script header; the CI generation check invokes it as a subprocess.
+- [Descriptions contain markdown-hostile text] → Generator escapes `<` and `{{` in prose fields defensively (D4); flags/usage are always code-spanned, so the main vector is closed structurally.
+- [Nav manifest and files disagree] → Both are emitted from the same in-memory walk in one pass; there is no second traversal to diverge.
+- [Consumer breaks on schema evolution] → `schemaVersion` bumps on breaking manifest changes; additive fields don't bump. The contract is documented in the spec, which is the reference for the atrium-side glue.
+- [Release asset differs from what CI saw] → Generation is deterministic (no timestamps, no environment-dependent strings), so regenerating at the tagged commit reproduces byte-identical content to CI's run on that commit; a commander upgrade that changes introspected values changes the content at the PR where the upgrade lands, where CI's generation run exercises it.
+
+## Migration Plan
+
+Purely additive: new script, one new CI step, one new release step. No rollback concerns — removing the asset step or the generation check reverts cleanly. The atrium-side consumption starts only after the first release that carries the asset.
+
+## Open Questions
+
+- None blocking. (Whether atrium commits the synced markdown or fetches at build time is an atrium-repo decision and does not affect this contract.)

--- a/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/proposal.md
@@ -1,0 +1,37 @@
+# Add CLI Reference Docs Generation and Publishing
+
+## Why
+
+The CLI has a rich, nested command surface (six command groups, options with defaults, negated `--no-*` flags, variadic positionals, an env/paths help appendix) but its only documentation is the runtime `--help`. The public website (atrium, a separate repo) needs a CLI reference it can render. Commander v15 exposes the full command tree programmatically (`.commands`/`.options`/`.registeredArguments`) and the registry is already importable without side effects — the docs can be generated from the single source of truth instead of hand-written and drifting.
+
+## What Changes
+
+- New Bun script `scripts/gen_docs.ts` (zero new dependencies) that imports the configured `cli` Command from `src/cli/index.ts` and `envDoc` from `src/lib/env.ts`, walks the command tree, and emits the **publishable docs package** into an untracked build directory: portable CommonMark pages (one per command/group, frontmatter limited to `title` + `description`) plus `manifest.json` (`cliVersion`, `schemaVersion`, ordered nav tree) — the SSG-neutral contract the website consumes. Nothing generated is committed to git.
+- Portability rules for all emitted markdown: CommonMark-only (no admonitions/Vue/MDX syntax); every machine-emitted flag/usage/argument token wrapped in code spans, because raw angle brackets (`--analysis <id|name>`) are parsed as HTML by VitePress and Python-Markdown.
+- Dev-channel commands (`profile`/`run`/`chat`) are excluded: generation runs with the dev channel off, so the docs describe exactly the release binary's surface.
+- All positional arguments in the registry gain descriptions: inline declarations (`cli.command("new [name] [paths...]")`) convert to `.argument("<name>", "description")` calls. User-visible command syntax is unchanged; `--help` and generated docs gain argument tables.
+- `package.json` gains a `docs:gen` script; CI runs the generator on every PR so a registry change that breaks generation (missing description, import failure) fails in CI, not first at release time.
+- The repo-level release workflow (`.github/workflows/release.yml`) gains a step that tars the docs package as `cli-docs.tar.gz` and attaches it to the GitHub release it already creates. The repo is public, so consumers fetch `releases/latest/download/cli-docs.tar.gz` unauthenticated.
+- **Recorded caveat**: `src/lib/env.ts` has a data-loss guard that throws when `NODE_ENV=test` without `INFLEXA_TEST_SANDBOX`. The generator imports it transitively, so it MUST run as a plain `bun scripts/gen_docs.ts` — never under `bun test`.
+
+Out of scope: the website-side consumption (VitePress glue lives in the atrium repo; VitePress 1.x is the recommended consumer, but the published contract is SSG-neutral).
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-reference-docs`: Generating the CLI reference from commander introspection — the generator's inputs (command tree, `envDoc`), its output (publishable package with manifest), the markdown portability contract, the manifest schema, dev-channel exclusion, the argument-description requirement on the registry, the CI generation check, and the release-asset packaging.
+
+### Modified Capabilities
+
+<!-- None: converting inline positionals to .argument() calls preserves the exact
+     user-visible syntax that cli-core/projects/prov-*/auth-commands pin ("SHALL
+     register `inflexa new [name] [paths...]`"), and dev-commands' registration
+     gating is consumed as-is, not changed. -->
+
+## Impact
+
+- **Affected code**: `cli/scripts/gen_docs.ts` (new), `cli/src/cli/index.ts` (argument declarations converted to `.argument()`; no behavior change), `cli/package.json` (`docs:gen` script), `.github/workflows/release.yml` (asset step) and the CI lint workflow (generation check).
+- **Dependencies**: none added — the generator uses commander's public introspection API and Bun's stdlib.
+- **Consumers**: the atrium website fetches the release asset; `manifest.json`'s `schemaVersion` is the compatibility handle for that contract.
+- **Release pipeline**: one additive upload step; the attested release flow is otherwise untouched.

--- a/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/specs/cli-reference-docs/spec.md
+++ b/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/specs/cli-reference-docs/spec.md
@@ -1,0 +1,105 @@
+# cli-reference-docs Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Reference docs are generated from commander introspection
+
+The system SHALL provide a generator script at `scripts/gen_docs.ts`, run as a plain `bun scripts/gen_docs.ts` process (exposed as the `docs:gen` package script), that imports the configured `cli` Command from `src/cli/index.ts` (never `src/index.ts`) and `envDoc` from `src/lib/env.ts`, recursively walks `.commands`/`.options`/`.registeredArguments`, and emits every documentation output from that single walk without invoking any command action. The generator SHALL add no dependency to `package.json`.
+
+#### Scenario: Generation walks the full visible tree
+
+- **WHEN** `bun run docs:gen` runs
+- **THEN** every visible command and command group in the registry produces a markdown page containing its usage line, description, argument table, and option table (flags, description, default value where declared)
+- **AND** no command action module (TUI, db, harness) is imported by the generator process
+
+#### Scenario: Environment page renders from envDoc
+
+- **WHEN** generation runs
+- **THEN** an `environment.md` page is emitted with the Paths and Environment tables rendered from `envDoc` entries, not scraped from `--help` text
+
+### Requirement: Generator never runs under bun test
+
+Because `src/lib/env.ts` throws at module evaluation when `NODE_ENV=test` without `INFLEXA_TEST_SANDBOX` (data-loss guard), the generator SHALL refuse to run inside a test process: it exits non-zero with an explanatory message when `NODE_ENV` is `test`, and no test file may import `scripts/gen_docs.ts`. CI checks that need generation SHALL invoke the script as a subprocess.
+
+#### Scenario: Test-process invocation is refused
+
+- **WHEN** the generator is executed in a process where `NODE_ENV` is `test`
+- **THEN** it exits non-zero before importing the registry, naming the plain `bun scripts/gen_docs.ts` invocation as the supported path
+
+### Requirement: Docs describe exactly the release command surface
+
+Generation SHALL run with the dev channel off: the generator bakes the production build channel into its process environment (`INFLEXA_BUILD_CHANNEL=production`) and removes `INFLEXA_DEV` before importing the registry — dev commands register for any non-production channel, including the unset channel of a plain source run — so dev-channel commands (`profile`, `run`, `chat`) are absent from every output by the same registration gate that shapes a release binary. No output may contain a dev-channel command page or nav entry.
+
+#### Scenario: Dev-channel commands are absent
+
+- **WHEN** generation runs in a shell that has `INFLEXA_DEV=1` exported
+- **THEN** the emitted pages and `manifest.json` nav contain no `profile`, `run`, or `chat` entries
+
+### Requirement: Emitted markdown is SSG-neutral CommonMark
+
+All emitted pages SHALL be CommonMark-only with frontmatter limited to `title` and `description`. The generator SHALL wrap every machine-emitted flag, usage line, and argument token in code spans or fenced blocks (raw angle brackets such as `--analysis <id|name>` are parsed as HTML by VitePress and Python-Markdown), SHALL emit no admonitions, MDX/JSX, template interpolation syntax, or raw HTML blocks, and SHALL escape `<` and `{{` occurring in description prose. Output SHALL be byte-deterministic: no timestamps or environment-dependent content.
+
+#### Scenario: Angle-bracket tokens are code-spanned
+
+- **WHEN** a command declares an option `--analysis <id|name>`
+- **THEN** every occurrence of that flag in the emitted markdown appears inside a code span or fenced block
+
+#### Scenario: Regeneration without registry changes is byte-identical
+
+- **WHEN** generation runs twice against an unchanged registry
+- **THEN** all emitted files are byte-identical across the two runs
+
+### Requirement: Generation emits the publishable package only
+
+Generation SHALL emit exactly one output: the publishable package in an untracked build directory (`dist-docs/`), containing the markdown pages plus `manifest.json`. The package SHALL mirror the command tree as directories (one directory per command group with an `index.md`, e.g. `prov/export.md`). No generated documentation SHALL be committed to git; the build directory SHALL be git-ignored.
+
+#### Scenario: Output is untracked
+
+- **WHEN** generation completes
+- **THEN** all emitted files live under the git-ignored build directory and `git status` reports no new tracked-path changes from generation
+
+### Requirement: Manifest carries version and nav structure
+
+The package's `manifest.json` SHALL carry `schemaVersion` (integer, bumped only on breaking manifest changes), `cliVersion` (the `package.json` version the docs were generated from), `name` (the CLI name), and `nav` — an ordered tree of `{ title, path, items? }` entries covering every emitted page exactly once, in registry declaration order (no alphabetical resorting). Consumers resolve `path` relative to the package root.
+
+#### Scenario: Nav covers all pages in declaration order
+
+- **WHEN** the package is generated
+- **THEN** every emitted `.md` file appears exactly once in `nav`, nested to match the command tree, ordered as the registry declares the commands
+
+#### Scenario: Version fields identify the artifact
+
+- **WHEN** a consumer reads `manifest.json`
+- **THEN** `cliVersion` equals the generating `package.json` version and `schemaVersion` identifies the manifest contract revision
+
+### Requirement: All visible arguments and options carry descriptions
+
+Every visible positional argument in the registry SHALL be declared via `.argument(name, description)` with a non-empty description (inline positional syntax in the command string is not used), and every visible option SHALL have a non-empty description. The generator SHALL exit non-zero naming the offending command when a visible argument or option has an empty description. User-visible command syntax is unchanged by the declaration style.
+
+#### Scenario: Missing description fails generation
+
+- **WHEN** a visible command argument is registered without a description
+- **THEN** `bun run docs:gen` exits non-zero and names the command and argument
+
+#### Scenario: Argument descriptions surface in help and docs
+
+- **WHEN** `inflexa new --help` is shown or docs are generated
+- **THEN** the `[name]` and `[paths...]` positionals appear with their descriptions
+
+### Requirement: CI verifies generation succeeds
+
+Repository CI SHALL run the generator (as a subprocess, per the bun-test constraint) on every pull request and fail when it exits non-zero — covering an argument or option registered without a description, a registry that stops being importable standalone, and any violation of the generator's own output assertions.
+
+#### Scenario: Registry change that breaks generation fails CI
+
+- **WHEN** a pull request registers a visible argument without a description
+- **THEN** the CI generation check fails, naming the offending command and argument
+
+### Requirement: Docs package ships as a release asset
+
+The repo-level release workflow SHALL generate the publishable package at the release's source revision, tar it as `cli-docs.tar.gz` (manifest and pages at the archive root), and attach it to the GitHub release it creates for the version, so consumers can fetch `releases/latest/download/cli-docs.tar.gz` or the version-pinned URL unauthenticated.
+
+#### Scenario: Release carries the docs asset
+
+- **WHEN** a release for version `X` is published
+- **THEN** the release has a `cli-docs.tar.gz` asset whose `manifest.json` reports `cliVersion` = `X`

--- a/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-15-add-cli-reference-docs/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: add-cli-reference-docs
+
+## 1. Registry argument descriptions
+
+- [x] 1.1 Convert every inline positional declaration in `src/cli/index.ts` to `.command("<name>")` + `.argument(name, description)` calls with non-empty descriptions (`new`, `resume`, `open`, `analysis set-project`, `project new`, `prov export`, `prov lineage`, `prov verify`, `prov verify-file`, `repair`, `relocate`, `prune` args, `refs download`, `refs verify`, `sandbox pull`, dev-channel `run`/`chat`), preserving the exact user-visible syntax (`[x]`, `<x>`, variadic `...`)
+- [x] 1.2 Verify no behavior change: `bun run typecheck`, `bun test` (registry tests `src/cli/cli.test.ts`, `src/cli/read_commands.test.ts`), and spot-check `bun run dev -- new --help` shows argument descriptions
+
+## 2. Generator script
+
+- [x] 2.1 Write `scripts/gen_docs.ts`: refuse to run when `NODE_ENV=test` (before importing the registry), delete `INFLEXA_DEV` from the environment, then dynamically import `{ cli }` from `src/cli/index.ts` and `{ envDoc }` from `src/lib/env.ts`
+- [x] 2.2 Implement the tree walk: per visible command emit title/description frontmatter, usage line, argument table, option table (flags, description, declared default), subcommand index with relative links; skip hidden options and the implicit `help` command; fail non-zero naming the command when a visible argument/option has an empty description
+- [x] 2.3 Implement the portability layer: code-span every flag/usage/argument token, escape `<` and `{{` in description prose, no admonitions/MDX/HTML blocks, no timestamps (byte-deterministic output)
+- [x] 2.4 Emit the environment page (`environment.md`) from `envDoc`: Paths table and Environment table, including the base-var override rows
+- [x] 2.5 Emit the publishable package to `dist-docs/` (directory-per-group layout with `index.md` per group, relative links) plus `manifest.json` (`schemaVersion: 1`, `cliVersion` from `package.json`, `name`, `nav` tree in registry declaration order covering every page exactly once)
+- [x] 2.6 Add `docs:gen` to `package.json` scripts and add `dist-docs/` to the ignore file; run `bun run format:file scripts/gen_docs.ts` per the formatting convention
+
+## 3. Generated output
+
+- [x] 3.1 Run `bun run docs:gen`, review `dist-docs/` for rendering correctness (tables, code spans, links, manifest nav coverage)
+- [x] 3.2 Verify determinism: run generation twice, assert byte-identical outputs; verify dev-channel exclusion by running with `INFLEXA_DEV=1` exported and confirming no `profile`/`run`/`chat` pages or nav entries
+- [x] 3.3 Validate portability: run the emitted package markdown through a scratch VitePress 1.x build (outside the repo, throwaway) to confirm no page fails Vue-template compilation
+
+## 4. CI generation check
+
+- [x] 4.1 Add a step to the cli lint job in the repo CI workflow that runs `bun run docs:gen` and fails the job on non-zero exit
+- [x] 4.2 Confirm the check catches breakage (locally simulate: blank an argument description, run the generator, see it fail naming the command; revert)
+
+## 5. Release asset
+
+- [x] 5.1 Add a step to `.github/workflows/release.yml` after release creation: `bun install` + `bun run docs:gen` in `cli/`, tar `dist-docs/` contents as `cli-docs.tar.gz` (manifest at archive root), `gh release upload` to the version's release
+- [x] 5.2 Verify the workflow change: actionlint (or careful review against the existing steps' conventions — pinned actions, permissions, idempotent re-run via `--clobber`)
+
+## 6. Documentation
+
+- [x] 6.1 Document the generator in `cli/CLAUDE.md`'s or `docs/` conventions where appropriate: `docs:gen` emits the publishable package to `dist-docs/` (untracked), never run the generator under `bun test` (env.ts data-loss guard), dev channel excluded by design
+- [x] 6.2 Record the consumer contract pointer: the manifest schema lives in the `cli-reference-docs` spec; atrium fetches `releases/latest/download/cli-docs.tar.gz`

--- a/cli/openspec/specs/cli-reference-docs/spec.md
+++ b/cli/openspec/specs/cli-reference-docs/spec.md
@@ -1,0 +1,106 @@
+# cli-reference-docs Specification
+
+## Purpose
+The generated CLI reference: a Bun introspection script (`scripts/gen_docs.ts`) that walks the commander registry and `envDoc`, and emits the SSG-neutral publishable docs package — CommonMark pages plus `manifest.json` — shipped as a `cli-docs.tar.gz` release asset for the website to consume.
+## Requirements
+### Requirement: Reference docs are generated from commander introspection
+
+The system SHALL provide a generator script at `scripts/gen_docs.ts`, run as a plain `bun scripts/gen_docs.ts` process (exposed as the `docs:gen` package script), that imports the configured `cli` Command from `src/cli/index.ts` (never `src/index.ts`) and `envDoc` from `src/lib/env.ts`, recursively walks `.commands`/`.options`/`.registeredArguments`, and emits every documentation output from that single walk without invoking any command action. The generator SHALL add no dependency to `package.json`.
+
+#### Scenario: Generation walks the full visible tree
+
+- **WHEN** `bun run docs:gen` runs
+- **THEN** every visible command and command group in the registry produces a markdown page containing its usage line, description, argument table, and option table (flags, description, default value where declared)
+- **AND** no command action module (TUI, db, harness) is imported by the generator process
+
+#### Scenario: Environment page renders from envDoc
+
+- **WHEN** generation runs
+- **THEN** an `environment.md` page is emitted with the Paths and Environment tables rendered from `envDoc` entries, not scraped from `--help` text
+
+### Requirement: Generator never runs under bun test
+
+Because `src/lib/env.ts` throws at module evaluation when `NODE_ENV=test` without `INFLEXA_TEST_SANDBOX` (data-loss guard), the generator SHALL refuse to run inside a test process: it exits non-zero with an explanatory message when `NODE_ENV` is `test`, and no test file may import `scripts/gen_docs.ts`. CI checks that need generation SHALL invoke the script as a subprocess.
+
+#### Scenario: Test-process invocation is refused
+
+- **WHEN** the generator is executed in a process where `NODE_ENV` is `test`
+- **THEN** it exits non-zero before importing the registry, naming the plain `bun scripts/gen_docs.ts` invocation as the supported path
+
+### Requirement: Docs describe exactly the release command surface
+
+Generation SHALL run with the dev channel off: the generator bakes the production build channel into its process environment (`INFLEXA_BUILD_CHANNEL=production`) and removes `INFLEXA_DEV` before importing the registry — dev commands register for any non-production channel, including the unset channel of a plain source run — so dev-channel commands (`profile`, `run`, `chat`) are absent from every output by the same registration gate that shapes a release binary. No output may contain a dev-channel command page or nav entry.
+
+#### Scenario: Dev-channel commands are absent
+
+- **WHEN** generation runs in a shell that has `INFLEXA_DEV=1` exported
+- **THEN** the emitted pages and `manifest.json` nav contain no `profile`, `run`, or `chat` entries
+
+### Requirement: Emitted markdown is SSG-neutral CommonMark
+
+All emitted pages SHALL be CommonMark-only with frontmatter limited to `title` and `description`. The generator SHALL wrap every machine-emitted flag, usage line, and argument token in code spans or fenced blocks (raw angle brackets such as `--analysis <id|name>` are parsed as HTML by VitePress and Python-Markdown), SHALL emit no admonitions, MDX/JSX, template interpolation syntax, or raw HTML blocks, and SHALL escape `<` and `{{` occurring in description prose. Output SHALL be byte-deterministic: no timestamps or environment-dependent content.
+
+#### Scenario: Angle-bracket tokens are code-spanned
+
+- **WHEN** a command declares an option `--analysis <id|name>`
+- **THEN** every occurrence of that flag in the emitted markdown appears inside a code span or fenced block
+
+#### Scenario: Regeneration without registry changes is byte-identical
+
+- **WHEN** generation runs twice against an unchanged registry
+- **THEN** all emitted files are byte-identical across the two runs
+
+### Requirement: Generation emits the publishable package only
+
+Generation SHALL emit exactly one output: the publishable package in an untracked build directory (`dist-docs/`), containing the markdown pages plus `manifest.json`. The package SHALL mirror the command tree as directories (one directory per command group with an `index.md`, e.g. `prov/export.md`). No generated documentation SHALL be committed to git; the build directory SHALL be git-ignored.
+
+#### Scenario: Output is untracked
+
+- **WHEN** generation completes
+- **THEN** all emitted files live under the git-ignored build directory and `git status` reports no new tracked-path changes from generation
+
+### Requirement: Manifest carries version and nav structure
+
+The package's `manifest.json` SHALL carry `schemaVersion` (integer, bumped only on breaking manifest changes), `cliVersion` (the `package.json` version the docs were generated from), `name` (the CLI name), and `nav` — an ordered tree of `{ title, path, items? }` entries covering every emitted page exactly once, in registry declaration order (no alphabetical resorting). Consumers resolve `path` relative to the package root.
+
+#### Scenario: Nav covers all pages in declaration order
+
+- **WHEN** the package is generated
+- **THEN** every emitted `.md` file appears exactly once in `nav`, nested to match the command tree, ordered as the registry declares the commands
+
+#### Scenario: Version fields identify the artifact
+
+- **WHEN** a consumer reads `manifest.json`
+- **THEN** `cliVersion` equals the generating `package.json` version and `schemaVersion` identifies the manifest contract revision
+
+### Requirement: All visible arguments and options carry descriptions
+
+Every visible positional argument in the registry SHALL be declared via `.argument(name, description)` with a non-empty description (inline positional syntax in the command string is not used), and every visible option SHALL have a non-empty description. The generator SHALL exit non-zero naming the offending command when a visible argument or option has an empty description. User-visible command syntax is unchanged by the declaration style.
+
+#### Scenario: Missing description fails generation
+
+- **WHEN** a visible command argument is registered without a description
+- **THEN** `bun run docs:gen` exits non-zero and names the command and argument
+
+#### Scenario: Argument descriptions surface in help and docs
+
+- **WHEN** `inflexa new --help` is shown or docs are generated
+- **THEN** the `[name]` and `[paths...]` positionals appear with their descriptions
+
+### Requirement: CI verifies generation succeeds
+
+Repository CI SHALL run the generator (as a subprocess, per the bun-test constraint) on every pull request and fail when it exits non-zero — covering an argument or option registered without a description, a registry that stops being importable standalone, and any violation of the generator's own output assertions.
+
+#### Scenario: Registry change that breaks generation fails CI
+
+- **WHEN** a pull request registers a visible argument without a description
+- **THEN** the CI generation check fails, naming the offending command and argument
+
+### Requirement: Docs package ships as a release asset
+
+The repo-level release workflow SHALL generate the publishable package at the release's source revision, tar it as `cli-docs.tar.gz` (manifest and pages at the archive root), and attach it to the GitHub release it creates for the version, so consumers can fetch `releases/latest/download/cli-docs.tar.gz` or the version-pinned URL unauthenticated.
+
+#### Scenario: Release carries the docs asset
+
+- **WHEN** a release for version `X` is published
+- **THEN** the release has a `cli-docs.tar.gz` asset whose `manifest.json` reports `cliVersion` = `X`

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,6 +8,7 @@
         "build:all": "bun scripts/build.ts --all",
         "dev": "bun run src/index.ts",
         "dev:install": "bun scripts/dev_install.ts",
+        "docs:gen": "bun scripts/gen_docs.ts",
         "format": "prettier --write src/",
         "format:file": "prettier --write",
         "harness:local": "cd ../harness && bun run build && bun link && cd ../cli && bun link @inflexa-ai/harness",

--- a/cli/scripts/gen_docs.ts
+++ b/cli/scripts/gen_docs.ts
@@ -1,0 +1,259 @@
+// CLI reference generator: walks the commander registry and emits the publishable
+// docs package (SSG-neutral CommonMark + manifest.json) into dist-docs/.
+// Run via `bun run docs:gen` (or `bun scripts/gen_docs.ts`) — NEVER under `bun test`:
+// src/lib/env.ts (imported by the registry) hard-fails a test process without the
+// sandbox marker, because resolving env paths there risks pointing at real user data.
+//
+// The output is the docs contract consumed by the website (see the cli-reference-docs
+// spec): portable CommonMark only — no admonitions/MDX/Vue syntax, every flag/usage
+// token code-spanned (raw `<...>` parses as HTML in VitePress and Python-Markdown),
+// and byte-deterministic (no timestamps, no machine-specific paths) so regenerating
+// at a tagged commit reproduces exactly what CI verified.
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Argument, Command, Option } from "commander";
+import pkg from "../package.json";
+
+// eslint-disable-next-line no-restricted-syntax -- the sanctioned "is this a `bun test` process?" question (same as env.ts's guard): the build channel is unset in both a source run and a test run, so only NODE_ENV can answer it.
+if (process.env.NODE_ENV === "test") {
+    console.error("gen_docs.ts must not run inside `bun test` (env.ts refuses test processes without the sandbox). Run `bun scripts/gen_docs.ts` directly.");
+    process.exit(1);
+}
+
+// `dataVar`/`configVar` in env.ts are platform-dependent (LOCALAPPDATA vs XDG_DATA_HOME)
+// and path joins use the platform separator — a Windows run would emit different bytes.
+// Determinism is a contract property (the release regenerates what CI verified), so
+// refuse rather than silently produce a divergent package.
+if (process.platform === "win32") {
+    console.error("gen_docs.ts output is only deterministic on POSIX platforms (env.ts base-var names differ on Windows).");
+    process.exit(1);
+}
+
+// Document the RELEASE surface: dev-channel commands (`profile`/`run`/`chat`) register
+// only when devCommandsEnabled(), which is true for any non-production build channel —
+// including the unset channel of a plain source run like this one. Baking the production
+// channel (and dropping the INFLEXA_DEV escape hatch) makes the registry import shape
+// itself through the exact gate a shipped binary uses, so there is no command list to
+// maintain here. Safe in this process: the only channel-sensitive value the import path
+// touches is that gate (bakedEnv.gitCommit would throw under a production channel, but
+// it is a lazy getter nothing here reads).
+delete process.env.INFLEXA_DEV;
+process.env.INFLEXA_BUILD_CHANNEL = "production";
+
+// env.ts resolves every path from these base vars verbatim when set. Seeding them with
+// their own names as literal placeholders makes `env.dbPath` come out as
+// "$XDG_DATA_HOME/inflexa/agent.db" — machine-independent AND self-documenting, exactly
+// what the environment page should print instead of the generating user's home dir.
+process.env.XDG_DATA_HOME = "$XDG_DATA_HOME";
+process.env.XDG_CONFIG_HOME = "$XDG_CONFIG_HOME";
+
+// Dynamic imports so the env mutations above precede env.ts's import-time reads
+// (static imports would hoist past them).
+const { cli } = await import("../src/cli/index.ts");
+const { env, envDoc } = await import("../src/lib/env.ts");
+type EnvDocEntry = import("../src/lib/env.ts").EnvDocEntry;
+
+const OUT_DIR = join(import.meta.dir, "..", "dist-docs");
+
+// --- markdown building blocks -------------------------------------------------------
+
+/** Escape the two tokens that survive CommonMark as live syntax downstream: `<` opens an HTML tag (VitePress, Python-Markdown), `{{` opens Vue interpolation. HTML entities stay literal text through both. */
+function escapeProse(text: string): string {
+    return text.replaceAll("<", "&lt;").replaceAll("{{", "&#123;&#123;");
+}
+
+/** Inline code span; backtick-containing content gets the double-backtick form. */
+function codeSpan(text: string): string {
+    return text.includes("`") ? `\`\` ${text} \`\`` : `\`${text}\``;
+}
+
+/** A GFM table from rows of pre-rendered cells. `|` must be escaped per cell — even inside code spans — or it splits the row. */
+function table(header: string[], rows: string[][]): string {
+    const esc = (cell: string): string => cell.replaceAll("|", "\\|");
+    const line = (cells: string[]): string => `| ${cells.map(esc).join(" | ")} |`;
+    return [line(header), `|${header.map(() => " --- ").join("|")}|`, ...rows.map(line)].join("\n");
+}
+
+/** Frontmatter limited to title + description — the subset every SSG reads. JSON.stringify is a valid YAML double-quoted scalar, so arbitrary prose is safe. */
+function frontmatter(title: string, description: string): string {
+    return `---\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(description)}\n---`;
+}
+
+// --- registry introspection ---------------------------------------------------------
+
+/** Reconstruct the argument's usage token (`<name>`, `[paths...]`) — commander's own formatter is private. */
+function argToken(arg: Argument): string {
+    const name = `${arg.name()}${arg.variadic ? "..." : ""}`;
+    return arg.required ? `<${name}>` : `[${name}]`;
+}
+
+/** Space-joined command path from the root, e.g. "inflexa prov export". */
+function commandPath(pathNames: readonly string[], cmd: Command): string {
+    return [...pathNames, cmd.name()].join(" ");
+}
+
+const helper = cli.createHelp();
+
+/** Visible subcommands in declaration order, without the implicit `help` command the Help class appends. */
+function visibleSubcommands(cmd: Command): Command[] {
+    return helper.visibleCommands(cmd).filter((c) => c.name() !== "help");
+}
+
+/** Visible options in declaration order, without the implicit `-h, --help` the Help class appends. */
+function visibleOptions(cmd: Command): Option[] {
+    return helper.visibleOptions(cmd).filter((o) => o.name() !== "help");
+}
+
+// Completeness is build-enforced: a visible command/argument/option with an empty
+// description would emit a blank docs cell, so collect every offender and refuse.
+const offenders: string[] = [];
+
+function checkDescriptions(cmd: Command, pathNames: readonly string[]): void {
+    const path = commandPath(pathNames, cmd);
+    if (!cmd.description()) offenders.push(`${path}: command has no description`);
+    for (const arg of cmd.registeredArguments) {
+        if (!arg.description) offenders.push(`${path}: argument ${argToken(arg)} has no description`);
+    }
+    for (const opt of visibleOptions(cmd)) {
+        if (!opt.description) offenders.push(`${path}: option ${opt.flags} has no description`);
+    }
+    for (const sub of visibleSubcommands(cmd)) checkDescriptions(sub, [...pathNames, cmd.name()]);
+}
+
+// --- page rendering -------------------------------------------------------------------
+
+type NavEntry = { title: string; path: string; items?: NavEntry[] };
+
+const files = new Map<string, string>();
+
+function renderCommandPage(cmd: Command, pathNames: readonly string[], filePath: string): void {
+    const path = commandPath(pathNames, cmd);
+    const subs = visibleSubcommands(cmd);
+    const opts = visibleOptions(cmd);
+    const args = cmd.registeredArguments;
+
+    const sections: string[] = [
+        frontmatter(path, cmd.description()),
+        `# ${codeSpan(path)}`,
+        escapeProse(cmd.description()),
+        `## Usage\n\n\`\`\`\n${path} ${cmd.usage()}\n\`\`\``,
+    ];
+
+    if (args.length > 0) {
+        sections.push(
+            `## Arguments\n\n` +
+                table(
+                    ["Argument", "Required", "Description"],
+                    args.map((a) => [codeSpan(argToken(a)), a.required ? "required" : "optional", escapeProse(a.description)]),
+                ),
+        );
+    }
+
+    if (opts.length > 0) {
+        sections.push(
+            `## Options\n\n` +
+                table(
+                    ["Option", "Description", "Default"],
+                    opts.map((o) => [codeSpan(o.flags), escapeProse(o.description), o.defaultValue === undefined ? "" : codeSpan(String(o.defaultValue))]),
+                ),
+        );
+    }
+
+    if (subs.length > 0) {
+        // Links are relative to THIS page's directory: a group index links into its own
+        // dir-less children ("export.md"); the root index links into group dirs ("prov/index.md").
+        const linkTo = (sub: Command): string => (visibleSubcommands(sub).length > 0 ? `${sub.name()}/index.md` : `${sub.name()}.md`);
+        sections.push(
+            `## Commands\n\n` +
+                table(
+                    ["Command", "Description"],
+                    subs.map((sub) => [`[${codeSpan(commandPath([...pathNames, cmd.name()], sub))}](${linkTo(sub)})`, escapeProse(sub.description())]),
+                ),
+        );
+    }
+
+    // The env/paths appendix the root --help renders inline lives on its own page here.
+    if (pathNames.length === 0) sections.push(`## See also\n\n- [Environment](environment.md) — paths and environment variables the CLI reads`);
+
+    files.set(filePath, sections.join("\n\n") + "\n");
+}
+
+/** Render `cmd`'s page and recurse into subcommands, returning the nav entry for this subtree. */
+function renderTree(cmd: Command, pathNames: readonly string[], dir: string): NavEntry {
+    const subs = visibleSubcommands(cmd);
+    const isRoot = pathNames.length === 0;
+    const isGroup = subs.length > 0;
+    // Root and groups are the index of their directory; leaves are plain files beside it.
+    const filePath = isRoot ? "index.md" : isGroup ? join(dir, cmd.name(), "index.md") : join(dir, `${cmd.name()}.md`);
+    renderCommandPage(cmd, pathNames, filePath);
+
+    const entry: NavEntry = { title: isRoot ? cmd.name() : commandPath(pathNames, cmd), path: filePath };
+    if (isGroup) {
+        const childDir = isRoot ? dir : join(dir, cmd.name());
+        entry.items = subs.map((sub) => renderTree(sub, [...pathNames, cmd.name()], childDir));
+    }
+    return entry;
+}
+
+function renderEnvironmentPage(): string {
+    const pathRows: string[][] = [];
+    const varRows: string[][] = [];
+    // Mirror of renderEnvHelp's base-var aggregation (src/cli/index.ts): each override
+    // var is documented once, naming every path it moves.
+    const baseVarLabels = new Map<string, string[]>();
+
+    for (const [key, doc] of Object.entries(envDoc) as [keyof typeof envDoc, EnvDocEntry][]) {
+        if (doc.kind === "path") {
+            // env paths resolve from the placeholder base vars seeded above, so this is
+            // "$XDG_DATA_HOME/inflexa/…" — deterministic, not the generating machine's home.
+            pathRows.push([doc.label, codeSpan(env[key] ?? ""), escapeProse(doc.description)]);
+            baseVarLabels.set(doc.baseVar, [...(baseVarLabels.get(doc.baseVar) ?? []), doc.label]);
+        } else {
+            varRows.push([codeSpan(doc.name), escapeProse(doc.description)]);
+        }
+    }
+    for (const [name, labels] of baseVarLabels) {
+        varRows.push([codeSpan(name), `overrides the base directory for: ${labels.join(", ")}`]);
+    }
+
+    const description = "Paths and environment variables the inflexa CLI reads";
+    return [
+        frontmatter("Environment", description),
+        `# Environment`,
+        escapeProse(description),
+        `## Paths\n\nWhen ${codeSpan("$XDG_DATA_HOME")} / ${codeSpan("$XDG_CONFIG_HOME")} are unset, the bases default to ${codeSpan("~/.local/share")} and ${codeSpan("~/.config")}.\n\n` +
+            table(["Path", "Location", "Purpose"], pathRows),
+        `## Variables\n\n` + table(["Variable", "Description"], varRows),
+    ].join("\n\n") + "\n";
+}
+
+// --- main -----------------------------------------------------------------------------
+
+checkDescriptions(cli, []);
+if (offenders.length > 0) {
+    console.error("docs generation refused — every visible command, argument, and option needs a description:");
+    for (const offender of offenders) console.error(`  ${offender}`);
+    process.exit(1);
+}
+
+const rootNav = renderTree(cli, [], "");
+files.set("environment.md", renderEnvironmentPage());
+
+const manifest = {
+    schemaVersion: 1,
+    cliVersion: pkg.version,
+    name: cli.name(),
+    // Registration order IS the curated order — never resort. Root page first, the
+    // command tree as declared, the environment appendix last (mirroring --help).
+    nav: [{ title: rootNav.title, path: rootNav.path }, ...(rootNav.items ?? []), { title: "Environment", path: "environment.md" }],
+};
+files.set("manifest.json", JSON.stringify(manifest, null, 2) + "\n");
+
+// Clean rebuild: stale pages from renamed/removed commands must not survive in the package.
+rmSync(OUT_DIR, { recursive: true, force: true });
+for (const [relPath, content] of files) {
+    const absPath = join(OUT_DIR, relPath);
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, content);
+}
+console.log(`Wrote ${files.size} files to dist-docs/ (cli ${pkg.version}, ${manifest.nav.length} top-level nav entries).`);

--- a/cli/scripts/gen_docs.ts
+++ b/cli/scripts/gen_docs.ts
@@ -74,9 +74,15 @@ function table(header: string[], rows: string[][]): string {
     return [line(header), `|${header.map(() => " --- ").join("|")}|`, ...rows.map(line)].join("\n");
 }
 
-/** Frontmatter limited to title + description — the subset every SSG reads. JSON.stringify is a valid YAML double-quoted scalar, so arbitrary prose is safe. */
+/**
+ * Frontmatter limited to title + description — the subset every SSG reads. Two layers: `escapeProse`
+ * neutralizes `<`/`{{` (the same treatment the body gets) so a consumer that inlines either field into
+ * HTML/markdown can't have it reinterpreted as a tag or Vue interpolation; `JSON.stringify` then wraps
+ * the result as a YAML double-quoted scalar, keeping arbitrary prose syntactically valid. The entities
+ * decode back to the literal text in the canonical `<meta>`-description usage.
+ */
 function frontmatter(title: string, description: string): string {
-    return `---\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(description)}\n---`;
+    return `---\ntitle: ${JSON.stringify(escapeProse(title))}\ndescription: ${JSON.stringify(escapeProse(description))}\n---`;
 }
 
 // --- registry introspection ---------------------------------------------------------

--- a/cli/src/cli/gen_docs.test.ts
+++ b/cli/src/cli/gen_docs.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import pkg from "../../package.json";
+
+// The docs generator refuses to run in-process under `bun test` (src/lib/env.ts's data-loss guard,
+// and the script's own NODE_ENV check) — the ONLY supported invocation is a plain `bun` process. So
+// this suite spawns `bun scripts/gen_docs.ts` as a subprocess (never imports it, per the spec) with
+// NODE_ENV cleared, and asserts on the dist-docs/ package it emits. This guards the portability layer
+// (angle-bracket code-spanning, prose escaping) and dev-channel exclusion, which the "generation
+// exits 0" CI gate cannot catch on its own.
+const CLI_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(CLI_ROOT, "scripts", "gen_docs.ts");
+const OUT_DIR = join(CLI_ROOT, "dist-docs");
+
+type Manifest = { schemaVersion: number; cliVersion: string; name: string; nav: NavEntry[] };
+type NavEntry = { title: string; path: string; items?: NavEntry[] };
+
+function generate(): { exitCode: number; stderr: string } {
+    // Bun.spawnSync's env REPLACES (not merges) the child environment, so copy the live env (Bun.env,
+    // not process.env — sidesteps the no-restricted-properties lint) and drop NODE_ENV: under `bun test`
+    // it is "test", which the generator refuses. The generator seeds its own XDG_* placeholders, so no
+    // real user path is ever resolved regardless of the sandbox marker.
+    const env = { ...Bun.env };
+    delete env.NODE_ENV;
+    const proc = Bun.spawnSync(["bun", SCRIPT], { cwd: CLI_ROOT, env });
+    return { exitCode: proc.exitCode, stderr: proc.stderr.toString() };
+}
+
+/** Package-relative paths of every emitted markdown page (e.g. "prov/export.md"). */
+function markdownFiles(): string[] {
+    const found: string[] = [];
+    const walk = (dir: string): void => {
+        for (const name of readdirSync(dir)) {
+            const abs = join(dir, name);
+            if (statSync(abs).isDirectory()) walk(abs);
+            else if (name.endsWith(".md")) found.push(relative(OUT_DIR, abs));
+        }
+    };
+    walk(OUT_DIR);
+    return found;
+}
+
+/** Every `path` in the nav tree, flattened depth-first. */
+function navPaths(nav: NavEntry[]): string[] {
+    return nav.flatMap((entry) => [entry.path, ...(entry.items ? navPaths(entry.items) : [])]);
+}
+
+function read(rel: string): string {
+    return readFileSync(join(OUT_DIR, rel), "utf8");
+}
+
+function readManifest(): Manifest {
+    return JSON.parse(read("manifest.json")) as Manifest;
+}
+
+let gen: { exitCode: number; stderr: string };
+beforeAll(() => {
+    gen = generate();
+});
+
+describe("gen_docs (subprocess)", () => {
+    test("generation succeeds and writes a versioned manifest", () => {
+        expect(gen.exitCode, gen.stderr).toBe(0);
+        const manifest = readManifest();
+        expect(manifest.schemaVersion).toBe(1);
+        expect(manifest.cliVersion).toBe(pkg.version);
+        expect(manifest.name).toBe("inflexa");
+    });
+
+    test("dev-channel commands are excluded from pages and nav", () => {
+        const files = markdownFiles();
+        for (const dev of ["profile.md", "run.md", "chat.md"]) expect(files).not.toContain(dev);
+        const paths = navPaths(readManifest().nav);
+        for (const dev of ["profile.md", "run.md", "chat.md"]) expect(paths).not.toContain(dev);
+    });
+
+    test("nav covers every emitted page exactly once", () => {
+        const paths = navPaths(readManifest().nav);
+        expect(new Set(paths).size).toBe(paths.length); // no duplicates
+        expect([...paths].sort()).toEqual(markdownFiles().sort()); // bijection with the .md files on disk
+    });
+
+    test("machine-emitted angle-bracket flags are always code-spanned", () => {
+        // The root's `--analysis <id|name>` option is the canonical case: a raw `<...>` token parses as
+        // an HTML tag downstream, so every occurrence of the flag must open a code span (backtick before).
+        const index = read("index.md");
+        let at = index.indexOf("--analysis");
+        expect(at).toBeGreaterThan(-1);
+        while (at !== -1) {
+            expect(index[at - 1]).toBe("`");
+            at = index.indexOf("--analysis", at + 1);
+        }
+    });
+
+    test("angle brackets in description prose are escaped in frontmatter and body", () => {
+        // `prov lineage`'s description embeds a literal `<ref>`; it must be escaped everywhere it appears
+        // as prose (both the YAML frontmatter description and the rendered body), never left as raw HTML.
+        const lineage = read("prov/lineage.md");
+        const frontmatterDesc = lineage.split("\n").find((line) => line.startsWith("description:"));
+        expect(frontmatterDesc).toContain("&lt;ref>");
+        expect(frontmatterDesc).not.toContain("<ref>");
+        expect(lineage).toContain("&lt;ref>"); // body prose too
+    });
+
+    test("regeneration is byte-identical", () => {
+        const before = new Map(markdownFiles().map((f) => [f, readFileSync(join(OUT_DIR, f))]));
+        before.set("manifest.json", readFileSync(join(OUT_DIR, "manifest.json")));
+        expect(generate().exitCode).toBe(0);
+        const after = new Map([...before.keys()].map((f) => [f, readFileSync(join(OUT_DIR, f))]));
+        expect([...after.keys()].sort()).toEqual([...before.keys()].sort());
+        for (const [file, bytes] of before) expect(after.get(file)!.equals(bytes)).toBe(true);
+    });
+});

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -89,8 +89,10 @@ cli.command("config")
 
 // Analysis lifecycle: the primary entity. `new`/`resume` open a chat (TUI layer); `ls`/
 // `status`/`open` are read-only text commands (module layer).
-cli.command("new [name] [paths...]")
+cli.command("new")
     .description("Create an analysis anchored at the current directory and open its chat")
+    .argument("[name]", "Analysis name (prompted when omitted)")
+    .argument("[paths...]", "Input files or folders to attach to the analysis")
     .option("--project <name>", "Group the analysis under a project")
     .action(async (name: string | undefined, paths: string[] | undefined, options: { project?: string }) => {
         const { launchNew } = await import("../tui/app.launch.tsx");
@@ -105,15 +107,17 @@ cli.command("ls")
         runLs({ project: options.project });
     });
 
-cli.command("resume <idOrName>")
+cli.command("resume")
     .description("Reopen an analysis's chat by id or name")
+    .argument("<idOrName>", "Analysis to reopen, by id or name")
     .action(async (idOrName: string) => {
         const { launchResume } = await import("../tui/app.launch.tsx");
         await launchResume(idOrName);
     });
 
-cli.command("open <idOrName>")
+cli.command("open")
     .description("Open an analysis's workspace (inputs, run artifacts, reports, provenance) in the file browser")
+    .argument("<idOrName>", "Analysis whose workspace to open, by id or name")
     .action(async (idOrName: string) => {
         const { runOpen } = await import("../modules/analysis/open.ts");
         runOpen(idOrName);
@@ -150,8 +154,9 @@ if (devCommandsEnabled()) {
 
     // The other deliberate harness entry point: launches a full `executeAnalysis` run
     // from a validated plan file (boots the embedded runtime — no passive flow may).
-    cli.command("run [analysis]")
+    cli.command("run")
         .description("Launch an analysis run from a validated plan file in the harness sandbox")
+        .argument("[analysis]", "Analysis to operate on, by id or name (default: resolved from the current directory)")
         .option("--plan <file>", "Path to the JSON analysis plan to execute")
         .option("--status", "Show this analysis's run history instead of launching a run")
         .action(async (analysis: string | undefined, options: { plan?: string; status?: boolean }) => {
@@ -164,8 +169,9 @@ if (devCommandsEnabled()) {
     // The conversational harness entry point: boots the embedded runtime and drives
     // the conversation agent in a stdout REPL (a dev-channel surface — see chat.ts's
     // TODO(extend); no passive flow may boot the runtime).
-    cli.command("chat [analysis]")
+    cli.command("chat")
         .description("Chat with the analysis agent (plan, execute, and inspect runs conversationally)")
+        .argument("[analysis]", "Analysis to operate on, by id or name (default: resolved from the current directory)")
         .option("--thread <id>", "Resume an existing conversation thread")
         .action(async (analysis: string | undefined, options: { thread?: string }) => {
             const { runChat } = await import("../modules/harness/chat.ts");
@@ -176,8 +182,10 @@ if (devCommandsEnabled()) {
 const analysisCmd = cli.command("analysis").description("Manage analyses (grouping)");
 
 analysisCmd
-    .command("set-project <analysis> [project]")
+    .command("set-project")
     .description("Attach, move, or clear an analysis's project grouping (omit project to clear)")
+    .argument("<analysis>", "Analysis to move, by id or name")
+    .argument("[project]", "Target project, by id or name (omit to clear the grouping)")
     .action(async (analysisRef: string, projectRef: string | undefined) => {
         const { runSetProject } = await import("../modules/analysis/set_project.ts");
         runSetProject(analysisRef, projectRef ?? null);
@@ -189,8 +197,9 @@ analysisCmd
 const project = cli.command("project").description("Manage projects (optional grouping of analyses)");
 
 project
-    .command("new <name>")
+    .command("new")
     .description("Create a project")
+    .argument("<name>", "Name for the project")
     .option("--description <text>", "A short description")
     .option("--tags <tags>", "Comma-separated tags")
     .action(async (name: string, options: { description?: string; tags?: string }) => {
@@ -208,8 +217,9 @@ project
 
 const prov = cli.command("prov").description("Provenance — the recorded history of an analysis's inputs and actions");
 
-prov.command("export <analysis>")
+prov.command("export")
     .description("Export an analysis's provenance document as PROV (writes into its workspace folder by default)")
+    .argument("<analysis>", "Analysis whose provenance to export, by id or name")
     .option("--format <format>", "json (PROV-JSON) or provn (PROV-N)", "json")
     .option("--output <file>", "Write to this file instead of the analysis output folder")
     .action(async (analysisRef: string, options: { format?: string; output?: string }) => {
@@ -217,10 +227,12 @@ prov.command("export <analysis>")
         await runExportProvenance(analysisRef, { format: options.format, output: options.output });
     });
 
-prov.command("lineage <analysis> <ref>")
+prov.command("lineage")
     .description(
         "Trace lineage through the recorded provenance graph — <ref> is a file path, content hash, hash prefix, search string over paths/commands/tools, or record QName",
     )
+    .argument("<analysis>", "Analysis whose provenance graph to walk, by id or name")
+    .argument("<ref>", "What to trace: a file path, content hash, hash prefix, search string, or record QName")
     .option("--forward", "Walk forward: what was derived from this file")
     .option("--depth <n>", "Bound the walk to n generation hops (default: unbounded)")
     .option("--format <format>", "tree (human), json (flat graph), dot (Graphviz), or mermaid (flowchart source)", "tree")
@@ -229,15 +241,17 @@ prov.command("lineage <analysis> <ref>")
         runProvLineage(analysisRef, ref, options);
     });
 
-prov.command("verify <analysis>")
+prov.command("verify")
     .description("Verify the integrity of an analysis's provenance chain and signature")
+    .argument("<analysis>", "Analysis whose provenance chain to verify, by id or name")
     .action(async (analysisRef: string) => {
         const { runVerifyProvenance } = await import("../modules/prov/verify.ts");
         await runVerifyProvenance(analysisRef);
     });
 
-prov.command("verify-file <path>")
+prov.command("verify-file")
     .description("Verify an exported provenance file against its .sig.json sidecar (no database needed)")
+    .argument("<path>", "Exported provenance file to check against its .sig.json sidecar")
     .action(async (path: string) => {
         const { runVerifyFile } = await import("../modules/prov/verify.ts");
         await runVerifyFile(path);
@@ -245,15 +259,18 @@ prov.command("verify-file <path>")
 
 // Anchor move-backstop: the manual fallback for folder moves that the automatic
 // reconciliation in `resolveAnchor` cannot settle on its own. All addressed by path.
-cli.command("repair [path]")
+cli.command("repair")
     .description("Reconcile the anchor marker at <path> (default: current directory)")
+    .argument("[path]", "Folder whose anchor marker to reconcile (default: current directory)")
     .action(async (path: string | undefined) => {
         const { runRepair } = await import("../modules/anchor/backstop.ts");
         runRepair(path);
     });
 
-cli.command("relocate [fromPath] [toPath]")
+cli.command("relocate")
     .description("Re-point a moved anchor — one path pair, or all anchors under a prefix with --from/--to")
+    .argument("[fromPath]", "Path the anchor is currently tracked at")
+    .argument("[toPath]", "Path the folder lives at now")
     .option("--from <prefix>", "Path prefix to rewrite from (bulk mode)")
     .option("--to <prefix>", "Path prefix to rewrite to (bulk mode)")
     .action(async (fromPath: string | undefined, toPath: string | undefined, options: { from?: string; to?: string }) => {
@@ -361,8 +378,9 @@ refs.command("list")
         await runRefsList();
     });
 
-refs.command("download [ids...]")
+refs.command("download")
     .description("Download selected catalog datasets from their upstream publishers and verify them")
+    .argument("[ids...]", "Catalog dataset ids (interactive selection when omitted)")
     .option("--yes", "Skip the download confirmation")
     .option("--force", "Re-fetch even when already installed — repairs damage and refreshes mutable upstreams")
     .action(async (ids: string[], options: { yes?: boolean; force?: boolean }) => {
@@ -370,8 +388,9 @@ refs.command("download [ids...]")
         await runRefsDownload(ids, options);
     });
 
-refs.command("verify [ids...]")
+refs.command("verify")
     .description("Verify active managed datasets without changing them")
+    .argument("[ids...]", "Catalog dataset ids (all installed datasets when omitted)")
     .action(async (ids: string[]) => {
         const { runRefsVerify } = await import("../modules/refs/commands.ts");
         await runRefsVerify(ids);
@@ -391,8 +410,9 @@ refs.command("path")
 const sandbox = cli.command("sandbox").description("Manage the sandbox image (R/Python/conda/node packages baked in)");
 
 sandbox
-    .command("pull [variant]")
+    .command("pull")
     .description("Pull a sandbox image (python | python-r) from GitHub Packages and configure sandboxes to use it")
+    .argument("[variant]", "Image variant: python or python-r (prompted when omitted)")
     .option("--yes", "Skip the download confirmation")
     .action(async (variant: string | undefined, options: { yes?: boolean }) => {
         const { sandboxPull } = await import("../modules/libs/pull.ts");


### PR DESCRIPTION
Add scripts/gen_docs.ts — a zero-dependency introspection generator that walks the commander registry and envDoc, and emits the SSG-neutral docs package (CommonMark pages + manifest.json) to the untracked dist-docs/. The package documents exactly the release surface (production channel baked before the registry import) and is byte-deterministic.

Registry positionals move from inline command strings to .argument() declarations with descriptions; the generator fails on any visible command, argument, or option without one, and the lint workflow runs it as a validity gate. release.yml packages dist-docs as cli-docs.tar.gz on each release for the website to consume.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
