### PR TITLE
sandbox image build: self-hosted arm64 + daemon-cache builder; `sandbox pull` refreshes :latest

### DIFF
--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -12,11 +12,14 @@ name: Build Sandbox Images
 #     friendly), unchanged from before — only the tarball SOURCE moved (an image
 #     subtree, not a throwaway builder).
 #
-# amd64 needs a large self-hosted runner (label `inflexa-builder`) — the full R +
-# Bioconductor compile does not fit a GitHub-hosted runner. arm64 builds on the
-# hosted arm64 runner. Both arches attempt every image best-effort;
-# sandbox-python-r is continue-on-error (arm64 R source compiles are patchy), so
-# an arch that cannot build R still publishes base + python and the non-R tracks.
+# Both arches build on large self-hosted Graviton/x86 builders — the full R +
+# Bioconductor compile does not fit a GitHub-hosted runner. amd64 → label
+# `inflexa-builder` (m6i.4xlarge), arm64 → label `inflexa-builder-arm64`
+# (m7g.4xlarge); the boxes live in platform-infra (modules/internal/builder-ec2*.tf)
+# and are started via `just build-start [arch]`. Both arches attempt every image
+# best-effort; sandbox-python-r stays continue-on-error (a native-arm64 R build
+# still occasionally trips) so an arch that cannot build R still publishes base +
+# python and the non-R tracks.
 #
 # The build-time LOAD CHECK runs inside each image build (best-effort + non-empty
 # floor). The COVERAGE REPORT runs after extraction (want-vs-got + regression diff
@@ -43,7 +46,6 @@ permissions:
   contents: read
 
 env:
-  BUILDER_NAME: sandbox-image-builder
   MANIFEST: images/lib-store-manifest.yaml
   IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/sandbox-base
   IMAGE_PYTHON: ghcr.io/${{ github.repository_owner }}/sandbox-python
@@ -95,7 +97,7 @@ jobs:
             runner: '["self-hosted", "inflexa-builder"]'
           - arch: arm64
             platform: linux/arm64
-            runner: '"ubuntu-24.04-arm"'
+            runner: '["self-hosted", "inflexa-builder-arm64"]'
     runs-on: ${{ fromJSON(matrix.runner) }}
     env:
       PLATFORM: ${{ matrix.platform }}
@@ -107,41 +109,18 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
+        # Use the docker daemon's built-in builder (not a docker-container builder):
+        # its BuildKit cache lives in /var/lib/docker — the persistent EBS volume —
+        # so warm layers survive the box's stop/start with no long-lived builder to
+        # leave stale state, and no runner-writable cache dir to provision.
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
-          driver: docker-container
-          name: ${{ env.BUILDER_NAME }}
-          cleanup: false
-
-      - name: Free disk space (hosted arm64 runner)
-        if: matrix.arch == 'arm64'
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/hostedtoolcache/CodeQL 2>/dev/null || true
-          df -h /
-
-      - name: Recover stale builder state
-        if: matrix.arch == 'amd64'
-        # cleanup:false reuses the BuildKit container across runs on the
-        # persistent self-hosted builder. A cancelled prior run can leave orphaned
-        # sub-container network state behind — every subsequent build then sees
-        # "Connection refused" against public mirrors. Probe egress; recreate the
-        # builder only if broken.
-        run: |
-          set -eu
-          PROBE=$(mktemp -d) && trap 'rm -rf "$PROBE"' EXIT
-          cat > "$PROBE/Dockerfile" <<'EOF'
-          FROM alpine:3
-          RUN wget -q --spider --timeout=15 http://archive.ubuntu.com/ubuntu/dists/noble/InRelease
-          EOF
-          if ! docker buildx build --builder "$BUILDER_NAME" --platform "$PLATFORM" --no-cache "$PROBE" >/tmp/probe.log 2>&1; then
-            echo "::warning::Builder $BUILDER_NAME failed egress probe; recreating to clear stale state"
-            sed 's/^/probe: /' /tmp/probe.log || true
-            docker buildx rm --force "$BUILDER_NAME" || true
-            docker buildx create --driver docker-container --name "$BUILDER_NAME" --bootstrap >/dev/null
-          fi
+          driver: docker
 
       - name: Ensure zstd
-        run: command -v zstd >/dev/null || sudo apt-get install -y -qq zstd
+        # AL2023 ships zstd; fail loudly rather than install (the runner user has no
+        # sudo on the self-hosted builders).
+        run: command -v zstd >/dev/null || { echo "::error::zstd not found on the builder"; exit 1; }
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -161,7 +140,6 @@ jobs:
             -f images/sandbox-base/Dockerfile \
             --platform "$PLATFORM" \
             --build-arg "BASE_IMAGE=$BASE_IMAGE" \
-            --builder "$BUILDER_NAME" \
             -t "${IMAGE_BASE}:${VERSION}-${ARCH}" \
             .
           docker push "${IMAGE_BASE}:${VERSION}-${ARCH}"
@@ -173,7 +151,6 @@ jobs:
             --platform "$PLATFORM" \
             --build-arg "SANDBOX_BASE_IMAGE=${IMAGE_BASE}:${VERSION}-${ARCH}" \
             --build-arg "BASE_IMAGE=$BASE_IMAGE" \
-            --builder "$BUILDER_NAME" \
             -t "${IMAGE_PYTHON}:${VERSION}-${ARCH}" \
             .
           docker push "${IMAGE_PYTHON}:${VERSION}-${ARCH}"
@@ -190,7 +167,6 @@ jobs:
             --build-arg "SANDBOX_PYTHON_IMAGE=${IMAGE_PYTHON}:${VERSION}-${ARCH}" \
             --build-arg "BASE_IMAGE=$BASE_IMAGE" \
             --secret id=github_token,env=GITHUB_TOKEN \
-            --builder "$BUILDER_NAME" \
             -t "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}" \
             .
           docker push "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/cli/src/modules/libs/pull.test.ts
+++ b/cli/src/modules/libs/pull.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-import { sandboxStatus } from "./pull.ts";
+import { isMovingTag, sandboxStatus } from "./pull.ts";
 import { readConfig } from "../../lib/config.ts";
 import { env } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
@@ -41,5 +41,24 @@ describe("sandboxStatus — read-only, never pins", () => {
         }
 
         expect(readConfig().runtime).toBeUndefined();
+    });
+});
+
+describe("isMovingTag — decides when a present image must still be re-pulled", () => {
+    test("`:latest` and untagged refs are moving (re-pull to refresh the digest)", () => {
+        expect(isMovingTag("ghcr.io/inflexa-ai/sandbox-python-r:latest")).toBe(true);
+        // No tag → the runtime defaults to :latest, so it is moving too.
+        expect(isMovingTag("ghcr.io/inflexa-ai/sandbox-python-r")).toBe(true);
+    });
+
+    test("pinned version tags and digest refs are immutable (present is authoritative)", () => {
+        expect(isMovingTag("ghcr.io/inflexa-ai/sandbox-python-r:20260706-034b897")).toBe(false);
+        expect(isMovingTag("ghcr.io/inflexa-ai/sandbox-python-r@sha256:" + "a".repeat(64))).toBe(false);
+    });
+
+    test("a registry host:port prefix is not mistaken for the tag", () => {
+        // The ':5000' is the registry port, and there is no image tag → moving.
+        expect(isMovingTag("localhost:5000/sandbox-python")).toBe(true);
+        expect(isMovingTag("localhost:5000/sandbox-python:v1")).toBe(false);
     });
 });

--- a/cli/src/modules/libs/pull.ts
+++ b/cli/src/modules/libs/pull.ts
@@ -81,17 +81,35 @@ function configureSandboxImage(image: string): Result<void, PullError> {
     }));
 }
 
-/** Whether `rt` already has `image` locally (a present image is never re-pulled). */
+/** Whether `rt` already has `image` locally. */
 async function imagePresent(rt: ContainerRuntime, image: string): Promise<boolean> {
     return (await capture(rt, ["image", "inspect", image])).code === 0;
 }
 
 /**
+ * Whether `image` is a MOVING reference — a `:latest` tag or no tag at all (which
+ * the runtime treats as `:latest`). A moving ref must be re-pulled even when it is
+ * present locally, because a newer remote digest can hide behind the same tag; an
+ * immutable ref (a pinned `:<version>` tag or an `@sha256:` digest) that is present
+ * is already authoritative and needs no pull. The last path segment carries the
+ * tag, so a registry `host:port/` prefix never confuses the check.
+ */
+export function isMovingTag(image: string): boolean {
+    if (image.includes("@")) return false; // digest pin — immutable
+    const lastSegment = image.slice(image.lastIndexOf("/") + 1);
+    const colon = lastSegment.indexOf(":");
+    const tag = colon === -1 ? "latest" : lastSegment.slice(colon + 1);
+    return tag === "latest";
+}
+
+/**
  * Provision the sandbox image. Resolves a variant (prompting interactively when
- * none is given), and — unless the image is already present locally (idempotent
- * no-op) — confirms the download, `docker pull`s the multi-arch image from GHCR,
- * and records it as `harness.sandboxImage`. Re-pulling a present image reports
- * `up_to_date` with nothing on the wire.
+ * none is given), `docker pull`s the multi-arch image from GHCR, and records it as
+ * `harness.sandboxImage`. Because the variant resolves to a moving `:latest` ref,
+ * a pull always refreshes to the current remote digest — even when the image is
+ * present locally — so `sandbox pull` doubles as the image-upgrade path (a present
+ * image transfers only changed layers, so no size prompt). An immutable pinned ref
+ * that is already present short-circuits to `up_to_date` with nothing on the wire.
  */
 export async function sandboxPull(opts: PullOptions = {}): Promise<Result<PullOutcome, PullError>> {
     const interactive = !opts.quiet && process.stdin.isTTY;
@@ -118,21 +136,27 @@ export async function sandboxPull(opts: PullOptions = {}): Promise<Result<PullOu
         variant = chosen;
     }
     const image = variantImage(variant);
+    const present = await imagePresent(rt, image);
 
-    // Present locally → idempotent no-op (record the config, pull nothing).
-    if (await imagePresent(rt, image)) {
+    // An IMMUTABLE ref that is already present is authoritative — record the config
+    // and pull nothing. A MOVING `:latest` ref falls through to the pull below even
+    // when present, so `sandbox pull` refreshes to the current remote digest.
+    if (present && !isMovingTag(image)) {
         const configured = configureSandboxImage(image);
         if (configured.isErr()) return err(configured.error);
         return ok({ type: "up_to_date", variant, image });
     }
 
-    if (interactive && !opts.yes) {
+    // The size confirmation is only for the FIRST (absent) pull — a multi-GB
+    // download. Refreshing a present `:latest` transfers only changed layers (often
+    // nothing), so it runs without the prompt.
+    if (!present && interactive && !opts.yes) {
         const proceed = await confirm(`Pull the ${variant} sandbox image (${image})? This may be a multi-GB download.`);
         if (!proceed) return ok({ type: "declined" });
     }
 
     // Stream progress interactively; capture (buffered) when a caller owns the UI.
-    if (!opts.quiet) log.info(`Pulling ${image} …`);
+    if (!opts.quiet) log.info(`${present ? "Refreshing" : "Pulling"} ${image} …`);
     const code = opts.quiet ? (await capture(rt, ["pull", image])).code : await inherit(rt, ["pull", image]);
     if (code !== 0) {
         return err({


### PR DESCRIPTION
## What

Two related changes to the sandbox-image lifecycle (build → distribute → pull).

### CI — `lib-store.yml`
- **arm64 now builds on a self-hosted Graviton runner** (`[self-hosted, inflexa-builder-arm64]`) instead of the GitHub-hosted arm64 runner, which can't fit the full R + Bioconductor compile. `sandbox-python-r` compiles R natively at full size (see the platform-infra PR that provisions the box).
- **Both arches now build with the docker daemon's built-in BuildKit** (`driver: docker`). Its cache lives in `/var/lib/docker` — the builder's persistent EBS volume — so warm layers survive the box's stop/start with **no long-lived builder**. This removes the ad-hoc `Recover stale builder state` egress-probe (which only existed to work around the persistent `docker-container` builder's orphaned network state) and the obsolete hosted-runner disk-free step.
- `Ensure zstd` no longer shells `apt-get` on a dnf-only AL2023 box.

### CLI — `sandbox pull` refreshes `:latest`
- A locally-present image is no longer an unconditional no-op. A **moving** `:latest` (or untagged) ref is re-pulled so `inflexa sandbox pull` doubles as the image-**upgrade** path; a pinned `:version`/`@digest` ref that is present still short-circuits to `up_to_date`. A present-image refresh transfers only changed layers, so it skips the multi-GB size prompt.
- New `isMovingTag` helper + unit tests (host:port / digest / untagged edge cases).
- Patch bump `0.3.0` → `0.3.1`.

## Note
Publishing (incl. `:latest`) still requires the GHCR package **Actions Write** grant for `sandbox-python` / `sandbox-python-r` (org-admin, one-time) — otherwise pushes 401 regardless of the runners being online.

## Test
`bun run typecheck`, `bun run lint`, `bun test src/modules/libs/pull.test.ts` (4 pass). Workflow YAML validated.