### PR TITLE
fix(lib-store): make snapatac2 amd64-only so arm64 builds don't compile from sdist

### DIFF
--- a/images/lib-store-manifest.yaml
+++ b/images/lib-store-manifest.yaml
@@ -321,7 +321,6 @@ python:
       - cell2location
       - rpds-py
       - scglue
-      - "snapatac2>=2.7"
 
       # Spatial
       - spatialdata
@@ -398,8 +397,14 @@ python:
     # liana is arch-split: amd64 installs liana[extras] (the extras pull
     # pyscipopt/SCIP, which has no arm64 build); arm64 installs core liana.
     # The builder installs common + the target arch and strips nothing itself.
+    #
+    # snapatac2 is amd64-only: PyPI ships manylinux x86_64 wheels but no
+    # linux-aarch64 wheel for any version (only macOS arm64), so on the arm64
+    # build uv falls back to compiling its Rust extension from sdist, which
+    # fails under maturin. Same treatment as the arm64-unavailable bioconda tools.
     amd64:
       - "liana[extras]"
+      - "snapatac2>=2.7"
     arm64:
       - "liana"
 


### PR DESCRIPTION
## Problem

The arm64 lib-store build failed in the `python-builder` stage of `images/sandbox-python/Dockerfile`:

```
maturin pep517 build-wheel ... returned non-zero exit status 1
  cargo rustc ... snapatac2/2.9.0/.../src/Cargo.toml --lib
```

## Root cause

`snapatac2>=2.7` sat in `python.pip.common`, so the builder installed it on **both** arches. But snapatac2 publishes **no Linux aarch64 wheel** for any version — only `manylinux_2_28_x86_64` (Linux amd64) and macOS wheels (incl. `macosx_11_0_arm64`, which don't apply to Linux arm64). On the arm64 build, uv found no matching wheel and fell back to compiling the Rust/pyo3 extension from the `snapatac2-2.9.0.tar.gz` sdist via maturin, which failed.

Verified against the PyPI JSON API: 0 `linux/manylinux ... aarch64` wheels across all releases.

## Fix

Move `snapatac2>=2.7` from `python.pip.common` to `python.pip.amd64`. The builder installs `common + <arch>`, so amd64 keeps snapatac2 and arm64 skips it. This matches the manifest's established arm64-unavailable pattern already used for `liana[extras]` (pyscipopt has no arm64 build) and the amd64-only bioconda tools.

## Tradeoff

The arm64 sandbox will not ship snapatac2 (single-cell ATAC-seq), consistent with how `liana`/`pyscipopt` are already handled on that arch. snapatac2 is a leaf package (`scglue`/`pertpy`/`muon` treat it as optional), so nothing should pull it in transitively on arm64.

## Validation

- YAML parses.
- Builder resolution simulation: snapatac2 present on amd64, absent on arm64.