### PR TITLE
fix(lib-store): unblock tarball extraction; arm64 CRAN from P3M binaries; stop chmod duplicating the store

### DIFF
--- a/images/sandbox-python-r/Dockerfile
+++ b/images/sandbox-python-r/Dockerfile
@@ -46,8 +46,18 @@ ARG INFLEXA_LIB_ROOT
 # build-dep set + retry config is shared with sandbox-python; python3-yaml (the
 # system-python YAML the manifest parse reads) installs in the same apt
 # transaction as a stage-specific extra.
+#
+# The jags/libuv1t64/libprotobuf32t64/libglpk40 runtime .so set mirrors what
+# sandbox-base ships, and exists here for the load checks below — which run in this
+# builder, NOT in the runtime image. rjags/fs/otelsdk/igraph are binaries that
+# dyn.load these at library() time, so omitting them makes the checks report a DROP
+# (and omit the package from packages.txt) for packages that are in fact fine in the
+# shipped image. Keep in sync with the runtime list in images/sandbox-base/Dockerfile:
+# a lib there but missing here reappears as a phantom arch-specific coverage gap.
+# On amd64 the r2u apt path pulls these in as transitive Depends; the arm64 P3M path
+# resolves no system libs at all, so they must be named explicitly.
 COPY images/install-build-toolchain.sh /tmp/install-build-toolchain.sh
-RUN bash /tmp/install-build-toolchain.sh python3-yaml
+RUN bash /tmp/install-build-toolchain.sh python3-yaml jags libuv1t64 libprotobuf32t64 libglpk40
 
 # r2u — CRAN packages as Ubuntu .deb binaries. Patch the keyserver to hkps:443
 # — the script's default (port 11371) times out regularly from CI runners.
@@ -106,9 +116,18 @@ cat(sprintf("Load check OK: %d/%d %s package(s) loaded\n", length(ok), length(pk
 RSCRIPT
 
 # =============================================================================
-# Stage: cran — R CRAN packages.
-#   amd64: fast binary install via r2u .deb packages
-#   arm64: source install via install.packages() (r2u is amd64-only)
+# Stage: cran — R CRAN packages. Binary on both arches, by different routes.
+#   amd64: r2u .deb packages via apt (r2u is amd64-only). apt resolves each
+#          package's system libraries transitively, so they come in for free.
+#   arm64: install.packages() with NO repos= override. rocker/r-ver pins repos to
+#          a P3M snapshot and sets an HTTPUserAgent carrying the platform triple;
+#          that UA is what makes P3M serve prebuilt aarch64 binaries. Naming any
+#          repo here (e.g. cloud.r-project.org) drops that UA and silently falls
+#          back to ~300 source builds, which fail on every package needing a system
+#          -dev header: fs (uv.h), gmp, symengine, rjags, clarabel, otelsdk.
+#          Inheriting the option also keeps the snapshot in lockstep with BASE_IMAGE.
+#          Unlike the r2u path, P3M binaries do NOT pull system libs — anything
+#          with a runtime .so (e.g. rjags → libjags) needs it in the apt list above.
 # =============================================================================
 FROM r-toolchain AS cran
 ARG INFLEXA_LIB_ROOT
@@ -130,11 +149,11 @@ print('\n'.join(m.get('r',{}).get('cran',[])))" 2>/dev/null) \
          && cp -a /usr/lib/R/site-library/* ${INFLEXA_LIB_ROOT}/r/cran/ 2>/dev/null || true \
          && cp -a /usr/local/lib/R/site-library/* ${INFLEXA_LIB_ROOT}/r/cran/ 2>/dev/null || true; \
        else \
-         echo "Installing CRAN packages from source (r2u unavailable on $TARGETARCH)..." \
+         echo "Installing CRAN packages via the base image's P3M snapshot (binary) on $TARGETARCH..." \
          && R -e "\
            pkgs <- trimws(strsplit('$(echo "$CRAN_PKGS" | tr "\n" ",")', ',')[[1]]); \
            pkgs <- pkgs[nchar(pkgs) > 0]; \
-           install.packages(pkgs, lib='${INFLEXA_LIB_ROOT}/r/cran', repos='https://cloud.r-project.org', \
+           install.packages(pkgs, lib='${INFLEXA_LIB_ROOT}/r/cran', \
                             Ncpus=${R_NCPUS:-parallel::detectCores()}, quiet=FALSE)" > /tmp/cran-install.log 2>&1 \
          && grep -E '^\* (installing|DONE)|^Error|^ERROR:|had non-zero|is not available' /tmp/cran-install.log || true; \
        fi \

--- a/images/sandbox-python-r/Dockerfile
+++ b/images/sandbox-python-r/Dockerfile
@@ -306,6 +306,14 @@ RUN GH_PKGS=$(ls ${INFLEXA_LIB_ROOT}/r/github 2>/dev/null | tr '\n' ' ') \
          Rscript /usr/local/bin/lib-store-loadtest.R \
            "R (GitHub)" ${INFLEXA_LIB_ROOT}/github.packages.txt $GH_PKGS
 
+# World-readable for the unprivileged sandbox user, matching the managed
+# read-only mount. This MUST happen here, in the last builder stage to touch the
+# r/ subtree, and never after the COPY in a shipped stage: chmod is a write, so
+# it copies up every file it walks — even ones whose mode does not change — and
+# the shipped layer then carries a second copy of the whole subtree. The COPY
+# below preserves these modes, so the runtime needs no chmod of its own.
+RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
+
 # =============================================================================
 # Stage: runtime — the lean published image. FROM sandbox-python; COPY the built
 # r/ subtree + fragments in and regenerate packages.txt. No R build toolchain
@@ -328,8 +336,10 @@ COPY --from=github ${INFLEXA_LIB_ROOT}/github.packages.txt ${INFLEXA_LIB_ROOT}/g
 
 # Rebuild packages.txt from all six fragments (python/conda/node inherited from
 # sandbox-python plus the three R fragments just copied), load-tested set only.
-RUN INFLEXA_LIB_ROOT=${INFLEXA_LIB_ROOT} inflexa-libs-refresh --from-fragments \
-    && chmod -R a+rX ${INFLEXA_LIB_ROOT}
+# No chmod here: every subtree is already world-readable from the builder stage
+# that produced it, and re-walking the store with chmod would copy up the whole
+# thing into this layer (see the note in the github stage).
+RUN INFLEXA_LIB_ROOT=${INFLEXA_LIB_ROOT} inflexa-libs-refresh --from-fragments
 
 USER sandbox
 WORKDIR /workspace

--- a/images/sandbox-python/Dockerfile
+++ b/images/sandbox-python/Dockerfile
@@ -219,6 +219,17 @@ RUN if [ "$(uname -m)" = aarch64 ]; then export NUMBA_CPU_NAME=generic; fi; \
     FRAGMENT_OUT=${INFLEXA_LIB_ROOT}/python.packages.txt \
     python3 /usr/local/bin/lib-store-py-loadtest.py
 
+# World-readable for the unprivileged sandbox user, matching the managed
+# read-only mount. Each builder stage chmods the subtree it owns, and the runtime
+# COPY preserves those modes. This MUST NOT be deferred to a single chmod after
+# the COPYs in the runtime stage: chmod is a write, so it copies up every file it
+# walks — even ones whose mode does not change — and the shipped layer then
+# carries a second copy of the entire store. Here the cost stays in a builder
+# layer that is never pushed. (Measured: a no-op `chmod -R a+rX` after COPY
+# duplicated the full 200 MB tree in a control build; on the real arm64 image it
+# cost 4.77 GB in sandbox-python and 9.76 GB in sandbox-python-r.)
+RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
+
 # =============================================================================
 # Stage: conda-builder — bioinformatics CLI tools via bioconda into the store's
 # conda prefix. Installed directly at the runtime mount path so conda writes
@@ -272,6 +283,9 @@ print('\n'.join(g['common'] + g.get(os.environ.get('TARGETARCH', 'amd64'), [])))
     if [ -z "$(printf '%s' $ok)" ]; then echo "ERROR: the conda track resolved ZERO tools (non-empty floor) — failing the build."; exit 1; fi; \
     echo "Load check OK: system tools resolved"
 
+# World-readable — see the note above the matching chmod in python-builder.
+RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
+
 # =============================================================================
 # Stage: node-builder — Node.js packages into the store's node subtree.
 # =============================================================================
@@ -304,6 +318,9 @@ require("fs").writeFileSync(process.env.FRAG, "## Node (npm)\n" + ok.join(", ") 
 if (bad.length) console.error("NOTE: " + bad.length + " Node package(s) dropped"); \
 if (!ok.length) { console.error("ERROR: the node track loaded ZERO packages (non-empty floor)"); process.exit(1); } \
 console.log("Load check OK: " + ok.length + "/" + pkgs.length + " Node package(s) loaded");'
+
+# World-readable — see the note above the matching chmod in python-builder.
+RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
 
 # =============================================================================
 # Stage: runtime — the lean published image. FROM sandbox-base; COPY the built
@@ -367,10 +384,6 @@ ENV INFLEXA_LIB_ROOT="${INFLEXA_LIB_ROOT}"
 ENV PIP_TARGET="${INFLEXA_LIB_ROOT}/python/site-packages"
 ENV R_LIBS_USER="${INFLEXA_LIB_ROOT}/r/github"
 ENV NPM_CONFIG_PREFIX="${INFLEXA_LIB_ROOT}/node"
-
-# The store is world-readable so the unprivileged sandbox user can read it, matching
-# the managed read-only mount's permissions.
-RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
 
 USER sandbox
 WORKDIR /workspace

--- a/scripts/lib-store-extract-tarballs.sh
+++ b/scripts/lib-store-extract-tarballs.sh
@@ -25,7 +25,11 @@ PLATFORM_ARGS=()
 
 # The sandbox image runs as a non-root user (uid 1000). Extraction runs as root so
 # it can drop the root-owned dangling symlinks below and read every track file.
-DOCKER_RUN=(docker run --rm --user 0:0 "${PLATFORM_ARGS[@]}")
+# --entrypoint "" is essential: the image ENTRYPOINT is sandbox-entrypoint.sh,
+# which ends in `exec sandbox-server "$@"`, so a bare `docker run <image> test …`
+# would be handed to sandbox-server as args (it aborts on missing startup config)
+# instead of being executed — making every probe below spuriously "not present".
+DOCKER_RUN=(docker run --rm --user 0:0 --entrypoint "" "${PLATFORM_ARGS[@]}")
 
 ROOT="$LIB_STORE_ROOT"
 extracted=""


### PR DESCRIPTION
The `Extract per-track tarballs` step in **Build Sandbox Images** (`.github/workflows/lib-store.yml`) has failed on every run since `a085c41` (#47, 2026-07-09). Latest failure: [run 29443374796](https://github.com/inflexa-ai/inflexa/actions/runs/29443374796) — both amd64 and arm64.

## Root cause

`scripts/lib-store-extract-tarballs.sh` probes each freshly-built image with bare commands via `docker run <image> test -d …` / `tar` / `cat`, assuming CMD-style override. But `sandbox-base` sets `ENTRYPOINT ["/usr/local/bin/sandbox-entrypoint.sh"]`, and since #47 that script ends in `exec sandbox-server "$@"` (not `exec "$@"`). So the probe command is handed to `sandbox-server` as arguments; it aborts at startup (`SANDBOX_CALLBACK_SECRET is required`, exit 1) before ever evaluating the path.

Result: every track probe returns non-zero, the script reads that as "directory not present," all six tracks are skipped, and extraction fails:

```
skip cran/bioconductor/github/python/conda/node: /mnt/libs/current/… not present in …
ERROR: no library-store tracks found in …sandbox-python-r:<ver>-<arch>
```

The images build and publish fine — the `manifest` job (`if: always()`) still produced the multi-arch `:latest` / `:<ver>` tags. Only the managed-mount tarball extraction/publish (S3 tarballs, coverage, candidate manifest) is blocked.

## Fix

Add `--entrypoint ""` to `DOCKER_RUN` so the bare commands run directly.

## Reproduction (public `sandbox-base`, arm64)

```
$ docker run --rm --user 0:0                <img> test -d /tmp   # exit 1 — "SANDBOX_CALLBACK_SECRET is required" (yet /tmp exists)
$ docker run --rm                           <img> echo HELLO     # prints the config error, never prints HELLO
$ docker run --rm --user 0:0 --entrypoint "" <img> test -d /tmp   # exit 0 — test actually runs
```

## Verification

Static/repro only here. End-to-end confirmation requires re-running **Build Sandbox Images** (restarts the two self-hosted builder EC2 boxes).

---

# 2. arm64 CRAN installs from source instead of P3M binaries

Same run, separate bug. The arm64 job reported `Load check OK: 51/62 R (CRAN)` and `78/79 R (Bioconductor)` against a clean 62/62 + 79/79 on amd64, and took 1h55m.

## Root cause

The `cran` stage pinned `repos='https://cloud.r-project.org'` on the arm64 branch — a source-only repo — discarding the binary repo the base image already configures. `rocker/r-ver` pins `repos` to a P3M snapshot **and** sets an `HTTPUserAgent` carrying the platform triple; that UA is what makes P3M serve prebuilt aarch64 binaries:

```
$ docker run --rm --platform linux/arm64 --entrypoint "" rocker/r-ver:4.6.0 \
    R -s -e 'cat(getOption("repos"), "\n", getOption("HTTPUserAgent"))'
https://p3m.dev/cran/__linux__/noble/2026-06-23
R/4.6.0 R (4.6.0 aarch64-unknown-linux-gnu aarch64 linux-gnu)
```

The comment claimed source was necessary because "r2u is amd64-only". r2u is indeed amd64-only, but it is not the only binary source — P3M ships aarch64 binaries for every package that was failing (distinct payloads per UA, confirmed against the live registry):

| package | arm64 binary | source |
|-|-|-|
| `fs` | 245,915 | 1,473,936 |
| `otelsdk` | 1,092,523 | 3,706,391 |
| `symengine` | 2,355,878 | 683,180 |
| `rjags` | 136,643 | 76,947 |
| `clarabel` | 1,749,836 | 5,974,442 |
| `gmp` | 331,712 | 167,626 |

So the arm64 job was doing ~300 source compiles, then failing the six packages that need system `-dev` headers this image has no reason to carry (`fs` needs `uv.h`; plus `gmp`, `symengine`, `rjags`, `clarabel`, `otelsdk`) — cascading to 11 CRAN drops.

Six of those 11 "drops" were not actually missing from the image: the Bioconductor stage later reinstalled them as P3M binaries into `r/bioconductor`, but the CRAN load check runs earlier and only reads `r/cran`.

## Fix

1. **Drop the `repos=` override** so `install.packages()` inherits the pinned P3M snapshot. Also keeps the snapshot date in lockstep with `BASE_IMAGE`.
2. **Name the runtime `.so` set in the builder.** P3M binaries, unlike r2u `.deb`s, resolve no system libraries. These load checks run in the *builder*, not the runtime image — so a lib that `sandbox-base` already ships but the builder lacks surfaces as a phantom arch-specific gap. `igraph`/`Seurat` were being dropped from `packages.txt` over `libglpk40` despite working fine in the shipped image.

## Verification (native arm64, real manifest)

Built the `cran` and `bioconductor` targets:

| track | before | after |
|-|-|-|
| R (CRAN) | 51/62 | **62/62** |
| R (Bioconductor) | 78/79 | **79/79** |
| source compiles | 301 | 3 |
| binary installs | 0 | 331 |

The 3 remaining source builds are `nlme`/`survival`/`mgcv` — R recommended packages P3M does not ship as binaries. They compile cleanly.

Confirmed `bspm` (installed by the r2u setup on every arch) does not intercept the install; the P3M path holds in the real image.

---

# 3. `chmod -R` after the COPY duplicates the whole library store

The arm64 image was **2.3x** the amd64 one (24.96 vs 10.75 GB compressed). Not an arch problem — the arm64 *content* layers are in fact smaller:

| `sandbox-python-r` | amd64 | arm64 |
|-|-|-|
| content (python+conda+r COPY) | 10.03 GB | **9.75 GB** |
| `chmod -R` layers | **0 MB** | **14,525 MB** |
| total | 10.75 GB | 24.96 GB |

## Root cause

Both runtime stages walked the finished store with `chmod -R a+rX` (`sandbox-python:373`, `sandbox-python-r:312`). `chmod` is a write, so it copies up every file it touches — **including ones whose mode does not change** — and BuildKit records the whole subtree, with content, as a second layer.

A control build isolates the mechanism from any mode difference:

| stage | chmod layer |
|-|-|
| `COPY` + `RUN true` | none |
| `COPY` + `chmod -R a+rX`, modes **already correct** | **+210 MB** (full duplicate) |
| `COPY` + `chmod -R a+rX`, modes actually wrong | **+210 MB** |

The R subtree is already world-readable in the `bioconductor` stage, so the chmod was changing nothing and copying everything.

## Fix

Move each chmod into the builder stage that owns the subtree, where the extra layer is never pushed. `COPY --from` preserves modes, so the runtime needs none — the store stays world-readable for the unprivileged sandbox user.

## Verification (native arm64, real manifest)

Built `sandbox-python` for `linux/arm64`:

| | before | after |
|-|-|-|
| shipped chmod layer | 10.5 GB | **none** |
| image (extracted) | 22.9 GB | **12.5 GB** |

Store still readable as uid 1000: 0 files `!o+r`, 0 dirs `!o+x`; `packages.txt` (written after the last chmod) readable; numpy/pandas/scanpy import as the sandbox user.

`sandbox-python-r` follows the same shape but was not built end-to-end locally (its `github` stage needs credentialed network), so CI is the first full check of that image.

## Open question for a reviewer

The identical instruction costs **0 MB on the amd64 runner and 14.5 GB on arm64**. Arch cannot cause that — it points at the two self-hosted runners using different build storage (containerd snapshotter vs overlay2 graphdriver). Worth confirming with `docker info` on both. The duplication is a latent bug on any builder that copies up, so it is fixed at the source regardless.
