### PR TITLE
feat: sandbox execution on Podman via a configurable Docker-API engine connection

### DIFF
--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/design.md
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The CLI treats Docker and Podman as interchangeable for everything it runs itself: `ensureRuntime` (lib/config.ts) pins one at first need, `ensureSandboxImage` (modules/harness/profile.ts) pre-pulls the sandbox image via the pin, and the compose stack runs on it. Sandboxes are the exception — `bootHarnessRuntimeOnce` (modules/harness/runtime.ts) constructs `createSandboxClient` with a hard-coded docker backend and no connection, so the harness's dockerode client dials the default Docker socket regardless of the pin. The harness-side seam (`engineSocketPath`, `stepTreeAccess` — see `harness/openspec/changes/podman-compatible-engine-connection`) makes the connection an embedder-supplied value; this change supplies it.
+
+Verified on a live rootful podman machine (macOS arm64, podman 5.8.3): `podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'` yields a working Docker-compat socket (under `$TMPDIR`), and the full sandbox `createOpts` shape behaves identically to Docker through it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Sandbox containers are created against the engine the CLI pinned — the same engine that pulled the image.
+- A podman configuration that cannot serve sandboxes fails at boot with a runtime-specific, actionable message.
+- Docker-pinned machines observe zero behavior change.
+
+**Non-Goals:**
+
+- Changing the pin logic, the compose stack, or `ensureSandboxImage` — pull already follows the pin; once create does too, the split-brain dissolves with no further code.
+- Validating rootless podman on Linux (pasta/slirp4netns) — the launch gate's honest error covers the unvalidated path.
+- Persisting the resolved socket — it is machine-lifecycle state, not configuration.
+
+## Decisions
+
+### Socket resolution lives on the runtime descriptor surface (`lib/container.ts`)
+
+The container-runtime spec already routes per-runtime divergence through the descriptor (the `:z` mount-arg precedent) rather than call-site conditionals. Resolution follows the same shape: a descriptor-level resolver the harness module calls with the pinned runtime. It stays config-free (the layer's existing constraint — `lib/config.ts` imports `runtimeIds` from it, so no cycle) and spawns the runtime binary through the existing `capture` wrapper, injectable for tests exactly like `ensureReady`'s probe.
+
+### Per-platform podman resolution, gated on the socket actually existing
+
+- **macOS**: `podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'` — the host-forwarded compat socket. A stopped machine fails the inspect; the error hints `podman machine start`.
+- **Linux**: `podman info --format '{{.Host.RemoteSocket.Path}}'` — with an existence check on the returned path, because `podman info` succeeding does **not** imply the API service is listening (the podman CLI talks to the engine directly; the REST socket exists only when `podman.socket` is enabled or `podman system service` runs). The error hints `systemctl --user enable --now podman.socket`.
+- **Docker**: resolves to `undefined` — dockerode's default resolution keeps working, including the `DOCKER_HOST` escape hatch users may already rely on.
+
+Resolved at every boot, never written to config: the macOS socket lives under `$TMPDIR` and moves across machine restarts, so a persisted path is a future ECONNREFUSED.
+
+### Boot gates on resolution before the sandbox client exists
+
+Resolution runs in `bootHarnessRuntimeOnce` alongside the other prerequisite gates (skills dir, embedder probe, Postgres), producing a dedicated `HarnessBootError` variant on failure. The alternative — let dockerode fail on first use — surfaces as an opaque `ECONNREFUSED` in the middle of a paid agent run; the boot gate converts it into a free, actionable failure. Docker-pinned boots skip the gate's engine-specific work entirely (nothing to resolve).
+
+### `stepTreeAccess: "world-writable"` is passed only when the pin is podman
+
+Docker Desktop's file-sharing layer masks the host-uid mismatch, so docker-pinned machines keep today's tighter step-tree modes; loosening them there would be a behavior change with no beneficiary. The knob's meaning and mechanism are harness-owned; the CLI only decides *when* it applies, which is exactly the embedder-supplies-values boundary rule.
+
+## Risks / Trade-offs
+
+- [`podman machine` output format drifts across podman versions] → the resolver is one descriptor function with an injectable probe; a format change breaks one test, not scattered call sites.
+- [Rootless podman on Linux resolves a socket but sandbox networking is unvalidated] → accepted: the connection will reach the engine and any failure is observable; the harness change records the validation gap, and gating harder here would block valid rootful-Linux setups.
+- [A user switches the pinned runtime between boots while sandbox rows reference containers on the other engine] → the watchdog's `isAlive` 404s against the new engine, which is the existing observably-dead path (synthetic step failure); no new handling.
+- [Harness/CLI version skew: this wiring compiles only against a harness carrying the new fields] → the dev flow already rebuilds `file:../harness` (dist staleness is a known gotcha); tasks order the harness change first.
+
+## Migration Plan
+
+Additive wiring behind the existing pin; docker-pinned machines take the `undefined`-socket path, which is byte-identical to today. Rollback is reverting the wiring commit. No config or data migration.
+
+## Open Questions
+
+_None blocking._

--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The harness gains a configurable sandbox engine connection (`engineSocketPath`) and a step-tree access mode (`stepTreeAccess`) in its `podman-compatible-engine-connection` change — but the CLI's composition root still hard-codes the docker backend with no connection (`runtime.ts`, the `TODO(extend)` beside `env: { backend: "docker", namespace: "" }`). On a podman-pinned machine every sandbox step fails at container create even though the proxy, Postgres, and `ensureSandboxImage`'s pre-pull all run on podman — and when both engines are installed, the image lands in podman's store while containers are created against Docker (split-brain: pull and create target different engines). Wiring the pinned runtime through to the harness seam makes pull and create target the same engine by construction.
+
+## What Changes
+
+- The runtime descriptor surface (`lib/container.ts`) gains sandbox-engine socket resolution: Docker resolves to "no socket" (dockerode's default resolution, preserving `DOCKER_HOST`); Podman resolves the Docker-compat socket per platform — `podman machine inspect '{{.ConnectionInfo.PodmanSocket.Path}}'` on macOS, `podman info --format '{{.Host.RemoteSocket.Path}}'` (gated on the socket actually existing) on Linux. Resolution runs at every boot and is never persisted: the macOS socket lives under `$TMPDIR` and moves across machine restarts.
+- The harness boot (`modules/harness/runtime.ts`) resolves the pinned runtime before building the sandbox client and passes `engineSocketPath` — plus `stepTreeAccess: "world-writable"` when the pinned runtime is podman (podman machine's virtiofs preserves host ownership honestly; Docker Desktop needs no loosening). The `TODO(extend)` hard-coding is retired.
+- A failed resolution becomes a new `HarnessBootError` variant with an actionable message (start the podman machine on macOS; enable `podman.socket` / start `podman system service` on Linux) instead of a dockerode `ECONNREFUSED` mid-run.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `container-runtime`: new requirement — per-runtime sandbox-engine socket resolution on the descriptor surface (the same home as the existing per-runtime mount-arg divergence).
+- `harness-runtime`: new requirement — the sandbox client's engine connection and step-tree access follow the pinned container runtime, resolved at boot with an actionable failure.
+
+## Impact
+
+- `cli/src/lib/container.ts` — socket resolution beside the runtime descriptors (config-free layer; the config-reading composition stays in the harness module).
+- `cli/src/modules/harness/runtime.ts` — composition-root wiring, new boot-error variant.
+- `cli/src/modules/harness/profile.ts` — boot-error → user-message mapping for the new variant.
+- Tests: `lib/container.test.ts` (resolution per runtime/platform, injectable probe), harness boot tests (wiring + gate).
+- Depends on `@inflexa-ai/harness` carrying the `podman-compatible-engine-connection` fields (dev flow: rebuild harness `dist` and reinstall in `cli/` before typecheck sees the new config fields).

--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/specs/container-runtime/spec.md
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/specs/container-runtime/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Per-runtime sandbox-engine socket resolution
+
+The runtime descriptor surface SHALL resolve the Docker-API socket the embedded
+harness dials for sandbox containers, per runtime and per platform, through the
+descriptor rather than call-site conditionals. Docker SHALL resolve to no
+socket (the harness then uses dockerode's default resolution, preserving
+`DOCKER_HOST`). Podman SHALL resolve the Docker-compat socket: on macOS via
+`podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'`; on
+Linux via `podman info --format '{{.Host.RemoteSocket.Path}}'` gated on the
+returned path existing, because a reachable podman CLI does not imply a
+listening REST socket. Resolution SHALL run at each boot and SHALL NOT be
+persisted — the macOS socket lives under `$TMPDIR` and moves across machine
+restarts. A failed resolution SHALL return a runtime-specific actionable error
+(`podman machine start` on macOS; `systemctl --user enable --now podman.socket`
+on Linux). The probe SHALL be injectable for tests, mirroring `ensureReady`.
+
+#### Scenario: Docker resolves to default engine resolution
+
+- **WHEN** the pinned runtime is `docker` and the sandbox engine socket is resolved
+- **THEN** no socket path is returned and the harness client uses dockerode's default resolution
+
+#### Scenario: Podman on macOS resolves the machine's compat socket
+
+- **WHEN** the pinned runtime is `podman` on macOS with a running machine
+- **THEN** the machine's `ConnectionInfo.PodmanSocket.Path` is returned as the engine socket
+
+#### Scenario: Podman on Linux requires the REST socket to exist
+
+- **WHEN** the pinned runtime is `podman` on Linux and `podman info` reports a socket path that does not exist on disk
+- **THEN** resolution fails with a message hinting `systemctl --user enable --now podman.socket`
+
+#### Scenario: Stopped podman machine is an actionable failure
+
+- **WHEN** the pinned runtime is `podman` on macOS and the machine is not running
+- **THEN** resolution fails with a message hinting `podman machine start`

--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/specs/harness-runtime/spec.md
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/specs/harness-runtime/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Sandbox engine connection follows the pinned container runtime
+
+The harness boot SHALL resolve the pinned container runtime's sandbox-engine
+socket (via the container-runtime resolution) before constructing the sandbox
+client, and SHALL pass it to `createSandboxClient` as `engineSocketPath`. When
+the pinned runtime is podman, boot SHALL additionally pass
+`stepTreeAccess: "world-writable"` — podman machine's virtiofs preserves host
+ownership honestly, so the uid-1000 sandbox workload needs world-write on the
+pre-created step tree; a docker pin SHALL NOT pass it, keeping today's modes
+under Docker Desktop's permissive sharing layer. A docker pin SHALL pass no
+socket path, preserving dockerode's default resolution byte-for-byte. Image
+pre-pull (`ensureSandboxImage`) and container create then target the same
+engine by construction. A failed socket resolution SHALL fail boot with a
+dedicated, user-actionable error variant before any side effect — never a
+dockerode connection error surfacing mid-run.
+
+#### Scenario: Podman pin wires the compat socket and step-tree access
+
+- **WHEN** the runtime boots with `podman` pinned and a resolvable compat socket
+- **THEN** `createSandboxClient` receives that socket as `engineSocketPath` and `stepTreeAccess: "world-writable"`
+- **AND** sandbox containers are created on the same engine that pre-pulled the image
+
+#### Scenario: Docker pin is byte-identical to today
+
+- **WHEN** the runtime boots with `docker` pinned
+- **THEN** `createSandboxClient` receives no `engineSocketPath` and no `stepTreeAccess`
+
+#### Scenario: Unresolvable podman socket blocks boot with actionable guidance
+
+- **WHEN** the runtime boots with `podman` pinned and the socket cannot be resolved
+- **THEN** boot fails with the resolution's runtime-specific message (start the machine / enable the socket service) and DBOS is not launched

--- a/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-16-podman-sandbox-engine-wiring/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## 1. Socket resolution on the descriptor surface
+
+- [x] 1.1 Add sandbox-engine socket resolution to `src/lib/container.ts`: docker → no socket; podman → `podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'` on darwin, `podman info --format '{{.Host.RemoteSocket.Path}}'` + on-disk existence gate on linux; runtime-specific actionable errors (`podman machine start` / `systemctl --user enable --now podman.socket`); probe injectable like `ensureReady`; result on the `Result` channel, never persisted.
+- [x] 1.2 Tests (`src/lib/container.test.ts`): per-runtime and per-platform resolution, missing-socket gate, stopped-machine failure text, injected probe exercises all branches without spawning binaries.
+
+## 2. Boot wiring
+
+- [x] 2.1 Ensure the local `@inflexa-ai/harness` carries the `podman-compatible-engine-connection` fields (`engineSocketPath`, `stepTreeAccess`): `bun run harness:local` (builds `../harness` and `bun link`s it — the cli consumes the published registry package otherwise, so a local dist rebuild alone is invisible to it).
+- [x] 2.2 In `src/modules/harness/runtime.ts`, resolve the pinned runtime + engine socket among the boot pre-flight gates (before the sandbox client exists), replace the `TODO(extend)` hard-coding: pass `engineSocketPath`, and `stepTreeAccess: "world-writable"` only when the pin is podman; docker pin passes neither.
+- [x] 2.3 Add the `HarnessBootError` variant for failed resolution and its actionable message in `bootErrorMessage` (`src/modules/harness/profile.ts`), naming the runtime-specific remediation.
+- [x] 2.4 Tests: boot passes the resolved socket + step-tree access through to `createSandboxClient` under a podman pin (seam-injected resolver); docker pin produces today's exact config; failed resolution fails boot before side effects with the new variant.
+
+## 3. Verification
+
+- [x] 3.1 `bun run typecheck`, `bun run lint`, and `bun test` from `cli/` (never the monorepo root).
+- [x] 3.2 `bun run format:file` on every touched file under `src/`.
+- [x] 3.3 `openspec validate podman-sandbox-engine-wiring` passes; deltas archive cleanly against `container-runtime` and `harness-runtime`.
+- [x] 3.4 Live smoke on this machine (podman pinned, fresh `inflexa sandbox pull` so the local `:latest` carries the poll-mode entrypoint): a data-profile or run step creates its sandbox on podman, writes artifacts through the step tree, and tears down.

--- a/cli/openspec/specs/container-runtime/spec.md
+++ b/cli/openspec/specs/container-runtime/spec.md
@@ -117,6 +117,42 @@ The system SHALL allow each runtime to diverge from the common command form wher
 - **WHEN** the active runtime is `docker` and a bind mount is built
 - **THEN** the mount argument is `host:container`
 
+### Requirement: Per-runtime sandbox-engine socket resolution
+
+The runtime descriptor surface SHALL resolve the Docker-API socket the embedded
+harness dials for sandbox containers, per runtime and per platform, through the
+descriptor rather than call-site conditionals. Docker SHALL resolve to no
+socket (the harness then uses dockerode's default resolution, preserving
+`DOCKER_HOST`). Podman SHALL resolve the Docker-compat socket: on macOS via
+`podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'`; on
+Linux via `podman info --format '{{.Host.RemoteSocket.Path}}'` gated on the
+returned path existing, because a reachable podman CLI does not imply a
+listening REST socket. Resolution SHALL run at each boot and SHALL NOT be
+persisted — the macOS socket lives under `$TMPDIR` and moves across machine
+restarts. A failed resolution SHALL return a runtime-specific actionable error
+(`podman machine start` on macOS; `systemctl --user enable --now podman.socket`
+on Linux). The probe SHALL be injectable for tests, mirroring `ensureReady`.
+
+#### Scenario: Docker resolves to default engine resolution
+
+- **WHEN** the pinned runtime is `docker` and the sandbox engine socket is resolved
+- **THEN** no socket path is returned and the harness client uses dockerode's default resolution
+
+#### Scenario: Podman on macOS resolves the machine's compat socket
+
+- **WHEN** the pinned runtime is `podman` on macOS with a running machine
+- **THEN** the machine's `ConnectionInfo.PodmanSocket.Path` is returned as the engine socket
+
+#### Scenario: Podman on Linux requires the REST socket to exist
+
+- **WHEN** the pinned runtime is `podman` on Linux and `podman info` reports a socket path that does not exist on disk
+- **THEN** resolution fails with a message hinting `systemctl --user enable --now podman.socket`
+
+#### Scenario: Stopped podman machine is an actionable failure
+
+- **WHEN** the pinned runtime is `podman` on macOS and the machine is not running
+- **THEN** resolution fails with a message hinting `podman machine start`
+
 ### Requirement: Runtime selection in settings
 
 The settings TUI SHALL present the container runtime as a selectable option (a radio-style group with one entry per supported runtime), persist the selection to config, and visually mark the active runtime.

--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -165,6 +165,38 @@ The CLI harness composition SHALL supply `refStorePath` to the harness sandbox c
 - **WHEN** a sandbox is created
 - **THEN** it receives the empty read-only mount so harness discovery can report mounted-but-empty rather than unmounted
 
+### Requirement: Sandbox engine connection follows the pinned container runtime
+
+The harness boot SHALL resolve the pinned container runtime's sandbox-engine
+socket (via the container-runtime resolution) before constructing the sandbox
+client, and SHALL pass it to `createSandboxClient` as `engineSocketPath`. When
+the pinned runtime is podman, boot SHALL additionally pass
+`stepTreeAccess: "world-writable"` — podman machine's virtiofs preserves host
+ownership honestly, so the uid-1000 sandbox workload needs world-write on the
+pre-created step tree; a docker pin SHALL NOT pass it, keeping today's modes
+under Docker Desktop's permissive sharing layer. A docker pin SHALL pass no
+socket path, preserving dockerode's default resolution byte-for-byte. Image
+pre-pull (`ensureSandboxImage`) and container create then target the same
+engine by construction. A failed socket resolution SHALL fail boot with a
+dedicated, user-actionable error variant before any side effect — never a
+dockerode connection error surfacing mid-run.
+
+#### Scenario: Podman pin wires the compat socket and step-tree access
+
+- **WHEN** the runtime boots with `podman` pinned and a resolvable compat socket
+- **THEN** `createSandboxClient` receives that socket as `engineSocketPath` and `stepTreeAccess: "world-writable"`
+- **AND** sandbox containers are created on the same engine that pre-pulled the image
+
+#### Scenario: Docker pin is byte-identical to today
+
+- **WHEN** the runtime boots with `docker` pinned
+- **THEN** `createSandboxClient` receives no `engineSocketPath` and no `stepTreeAccess`
+
+#### Scenario: Unresolvable podman socket blocks boot with actionable guidance
+
+- **WHEN** the runtime boots with `podman` pinned and the socket cannot be resolved
+- **THEN** boot fails with the resolution's runtime-specific message (start the machine / enable the socket service) and DBOS is not launched
+
 ### Requirement: The embedding imports through the harness barrel
 
 Cli code SHALL import harness symbols only from the `@inflexa-ai/harness` barrel. The

--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -170,27 +170,27 @@ The CLI harness composition SHALL supply `refStorePath` to the harness sandbox c
 The harness boot SHALL resolve the pinned container runtime's sandbox-engine
 socket (via the container-runtime resolution) before constructing the sandbox
 client, and SHALL pass it to `createSandboxClient` as `engineSocketPath`. When
-the pinned runtime is podman, boot SHALL additionally pass
-`stepTreeAccess: "world-writable"` — podman machine's virtiofs preserves host
-ownership honestly, so the uid-1000 sandbox workload needs world-write on the
-pre-created step tree; a docker pin SHALL NOT pass it, keeping today's modes
-under Docker Desktop's permissive sharing layer. A docker pin SHALL pass no
+the pinned runtime is podman, boot SHALL additionally declare
+`engineBindOwnership: "host-preserved"` — podman machine's virtiofs preserves
+host ownership honestly, which the harness compensates for on the pre-created
+step tree; a docker pin SHALL NOT pass it, keeping today's modes under Docker
+Desktop's permissive sharing layer. A docker pin SHALL pass no
 socket path, preserving dockerode's default resolution byte-for-byte. Image
 pre-pull (`ensureSandboxImage`) and container create then target the same
 engine by construction. A failed socket resolution SHALL fail boot with a
 dedicated, user-actionable error variant before any side effect — never a
 dockerode connection error surfacing mid-run.
 
-#### Scenario: Podman pin wires the compat socket and step-tree access
+#### Scenario: Podman pin wires the compat socket and bind-ownership fact
 
 - **WHEN** the runtime boots with `podman` pinned and a resolvable compat socket
-- **THEN** `createSandboxClient` receives that socket as `engineSocketPath` and `stepTreeAccess: "world-writable"`
+- **THEN** `createSandboxClient` receives that socket as `engineSocketPath` and `engineBindOwnership: "host-preserved"`
 - **AND** sandbox containers are created on the same engine that pre-pulled the image
 
 #### Scenario: Docker pin is byte-identical to today
 
 - **WHEN** the runtime boots with `docker` pinned
-- **THEN** `createSandboxClient` receives no `engineSocketPath` and no `stepTreeAccess`
+- **THEN** `createSandboxClient` receives no `engineSocketPath` and no `engineBindOwnership`
 
 #### Scenario: Unresolvable podman socket blocks boot with actionable guidance
 

--- a/cli/src/lib/container.test.ts
+++ b/cli/src/lib/container.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { err, ok, type Result } from "neverthrow";
 
-import { ContainerRuntimeError, firstReadyRuntime, runtimes, type ContainerRuntime } from "./container.ts";
+import {
+    ContainerRuntimeError,
+    firstReadyRuntime,
+    resolveEngineSocket,
+    runtimes,
+    type CaptureResult,
+    type ContainerRuntime,
+    type EngineSocketProbes,
+} from "./container.ts";
 
 describe("runtime mountArg", () => {
     test("docker uses the bare host:container form", () => {
@@ -42,5 +50,100 @@ describe("firstReadyRuntime", () => {
         expect(error?.message).toContain("one of Docker, Podman");
         expect(error?.message).toContain(runtimes.docker.notReadyHint);
         expect(error?.message).toContain(runtimes.podman.notReadyHint);
+    });
+});
+
+describe("resolveEngineSocket", () => {
+    // A capture stub that returns a canned result and records the args it was asked
+    // to spawn — so the "never spawns a real binary" contract is checkable in-band.
+    function captureReturning(result: CaptureResult, spawned?: string[][]): EngineSocketProbes["capture"] {
+        return (_rt, args) => {
+            spawned?.push(args);
+            return Promise.resolve(result);
+        };
+    }
+
+    test("docker resolves to no socket and never spawns a probe", async () => {
+        const spawned: string[][] = [];
+        const result = await resolveEngineSocket(runtimes.docker, {
+            platform: "linux",
+            capture: captureReturning({ code: 0, stdout: "irrelevant", stderr: "" }, spawned),
+            exists: () => true,
+        });
+
+        expect(result._unsafeUnwrap()).toBeUndefined();
+        expect(spawned).toEqual([]);
+    });
+
+    test("podman on macOS returns the running machine's compat socket path", async () => {
+        const spawned: string[][] = [];
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "darwin",
+            capture: captureReturning({ code: 0, stdout: "/var/folders/xy/podman-machine-default-api.sock\n", stderr: "" }, spawned),
+            // The darwin path trusts the machine's own report and never stats the socket.
+            exists: () => false,
+        });
+
+        expect(result._unsafeUnwrap()).toBe("/var/folders/xy/podman-machine-default-api.sock");
+        expect(spawned).toEqual([["machine", "inspect", "--format", "{{.ConnectionInfo.PodmanSocket.Path}}"]]);
+    });
+
+    test("podman on macOS with a stopped machine fails with a `podman machine start` hint", async () => {
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "darwin",
+            capture: captureReturning({ code: 125, stdout: "", stderr: "VM does not exist" }),
+            exists: () => true,
+        });
+
+        expect(result._unsafeUnwrapErr().message).toContain("podman machine start");
+    });
+
+    test("podman on macOS with an empty socket path fails actionably even on a zero exit", async () => {
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "darwin",
+            capture: captureReturning({ code: 0, stdout: "   \n", stderr: "" }),
+            exists: () => true,
+        });
+
+        expect(result._unsafeUnwrapErr().message).toContain("podman machine start");
+    });
+
+    test("podman on Linux returns the REST socket path when it exists on disk", async () => {
+        const spawned: string[][] = [];
+        const stated: string[] = [];
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "linux",
+            capture: captureReturning({ code: 0, stdout: "/run/user/1000/podman/podman.sock\n", stderr: "" }, spawned),
+            exists: (p) => {
+                stated.push(p);
+                return true;
+            },
+        });
+
+        expect(result._unsafeUnwrap()).toBe("/run/user/1000/podman/podman.sock");
+        expect(spawned).toEqual([["info", "--format", "{{.Host.RemoteSocket.Path}}"]]);
+        // The existence gate stats exactly the reported path.
+        expect(stated).toEqual(["/run/user/1000/podman/podman.sock"]);
+    });
+
+    test("podman on Linux fails with a `podman.socket` hint when the reported socket is absent on disk", async () => {
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "linux",
+            capture: captureReturning({ code: 0, stdout: "/run/user/1000/podman/podman.sock\n", stderr: "" }),
+            // A reachable CLI reported a path, but nothing is listening on it.
+            exists: () => false,
+        });
+
+        expect(result._unsafeUnwrapErr().message).toContain("systemctl --user enable --now podman.socket");
+    });
+
+    test("podman on Linux fails when `podman info` exits non-zero", async () => {
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "linux",
+            capture: captureReturning({ code: 1, stdout: "", stderr: "Cannot connect to Podman" }),
+            exists: () => true,
+        });
+
+        expect(result._unsafeUnwrapErr().message).toContain("systemctl --user enable --now podman.socket");
     });
 });

--- a/cli/src/lib/container.test.ts
+++ b/cli/src/lib/container.test.ts
@@ -80,8 +80,8 @@ describe("resolveEngineSocket", () => {
         const result = await resolveEngineSocket(runtimes.podman, {
             platform: "darwin",
             capture: captureReturning({ code: 0, stdout: "/var/folders/xy/podman-machine-default-api.sock\n", stderr: "" }, spawned),
-            // The darwin path trusts the machine's own report and never stats the socket.
-            exists: () => false,
+            // A running machine's gvproxy forward is live, so the reported socket exists on disk.
+            exists: () => true,
         });
 
         expect(result._unsafeUnwrap()).toBe("/var/folders/xy/podman-machine-default-api.sock");
@@ -93,6 +93,18 @@ describe("resolveEngineSocket", () => {
             platform: "darwin",
             capture: captureReturning({ code: 125, stdout: "", stderr: "VM does not exist" }),
             exists: () => true,
+        });
+
+        expect(result._unsafeUnwrapErr().message).toContain("podman machine start");
+    });
+
+    test("podman on macOS with a stopped machine still reporting its socket path fails on the on-disk gate", async () => {
+        const result = await resolveEngineSocket(runtimes.podman, {
+            platform: "darwin",
+            // `podman machine inspect` exits 0 with the persisted socket path even when the
+            // machine is stopped; the gvproxy forward is torn down, so the file is absent.
+            capture: captureReturning({ code: 0, stdout: "/var/folders/xy/podman-machine-default-api.sock\n", stderr: "" }),
+            exists: () => false,
         });
 
         expect(result._unsafeUnwrapErr().message).toContain("podman machine start");

--- a/cli/src/lib/container.ts
+++ b/cli/src/lib/container.ts
@@ -146,7 +146,13 @@ export type EngineSocketProbes = {
     readonly platform: NodeJS.Platform;
     /** Runs a runtime command and captures its output; the real one spawns the binary. */
     readonly capture: (rt: ContainerRuntime, args: string[]) => Promise<CaptureResult>;
-    /** True when `path` exists on disk — gates the Linux REST socket (a reachable CLI does not imply a listening socket). */
+    /**
+     * True when `path` exists on disk. Gates BOTH podman socket paths: the Linux REST
+     * socket (a reachable CLI does not imply a listening socket) and the macOS compat
+     * socket (the gvproxy forward backing it exists only while the machine runs, so a
+     * missing file detects a stopped machine that `machine inspect` still reports a
+     * path for).
+     */
     readonly exists: (path: string) => boolean;
 };
 
@@ -160,8 +166,13 @@ export type EngineSocketProbes = {
  *   dockerode client keeps its default resolution and any `DOCKER_HOST` the user
  *   already relies on.
  * - **Podman/macOS** resolves the running machine's host-forwarded compat socket
- *   (`podman machine inspect`); a stopped machine (non-zero exit) or an empty path
- *   is an actionable error hinting `podman machine start`.
+ *   (`podman machine inspect`), gated on that socket EXISTING on disk. Inspect
+ *   reports the persisted socket path on a zero exit even for a stopped machine, so
+ *   the reported path is NOT proof of a live machine; the gvproxy forward backing
+ *   the socket is torn down when the machine stops, so the socket file exists only
+ *   while the machine runs — which is what makes the stat a real stopped-machine
+ *   detector. A missing path, empty path, or non-zero exit is an actionable error
+ *   hinting `podman machine start`.
  * - **Podman/Linux** (and any other non-darwin host) resolves `podman info`'s
  *   reported REST socket, gated on that path EXISTING on disk: the podman CLI talks
  *   to the engine directly, so a reachable CLI does NOT imply a listening REST
@@ -185,7 +196,12 @@ export async function resolveEngineSocket(
             if (probes.platform === "darwin") {
                 const { code, stdout } = await probes.capture(rt, ["machine", "inspect", "--format", "{{.ConnectionInfo.PodmanSocket.Path}}"]);
                 const socket = stdout.trim();
-                if (code !== 0 || socket === "") {
+                // `podman machine inspect` reports the persisted socket path on a zero exit
+                // even when the machine is stopped, so the path alone cannot tell running from
+                // stopped. The gvproxy forward backing that socket exists only while the machine
+                // runs, so statting it on disk is the real liveness gate (mirrors the Linux
+                // REST-socket check below).
+                if (code !== 0 || socket === "" || !probes.exists(socket)) {
                     return err(
                         new ContainerRuntimeError(
                             "Could not resolve the Podman sandbox-engine socket — the Podman machine is not running.\n  Start it with `podman machine start`, then re-run.",

--- a/cli/src/lib/container.ts
+++ b/cli/src/lib/container.ts
@@ -5,6 +5,7 @@
 // config-reading resolvers (`selectedRuntime` / `ensureRuntime`) therefore live in
 // lib/config.ts, not here. The proxy module is today's only caller of the spawn core.
 
+import { existsSync } from "node:fs";
 import { type Result, ok, err } from "neverthrow";
 
 /**
@@ -132,4 +133,83 @@ export async function firstReadyRuntime(
     }
     const needs = candidates.map((rt) => rt.label).join(", ");
     return err(new ContainerRuntimeError([`No usable container runtime found — inflexa needs one of ${needs}.`, ...failures].join("\n\n")));
+}
+
+/**
+ * The effectful probes {@link resolveEngineSocket} uses, injectable so tests can
+ * exercise every runtime/platform branch without spawning a real binary or
+ * touching the filesystem — the same test seam {@link firstReadyRuntime}'s `probe`
+ * parameter provides.
+ */
+export type EngineSocketProbes = {
+    /** Host platform: selects the podman resolution path (`podman machine inspect` on darwin, `podman info` elsewhere). */
+    readonly platform: NodeJS.Platform;
+    /** Runs a runtime command and captures its output; the real one spawns the binary. */
+    readonly capture: (rt: ContainerRuntime, args: string[]) => Promise<CaptureResult>;
+    /** True when `path` exists on disk — gates the Linux REST socket (a reachable CLI does not imply a listening socket). */
+    readonly exists: (path: string) => boolean;
+};
+
+/**
+ * Resolve the Docker-API socket the embedded harness dials to create sandbox
+ * containers on the pinned runtime, per platform. This keeps the per-runtime
+ * divergence on the descriptor surface (the `mountArg` `:z` precedent) rather than
+ * as a conditional in the harness composition root.
+ *
+ * - **Docker** resolves to `undefined` — no explicit socket, so the harness's
+ *   dockerode client keeps its default resolution and any `DOCKER_HOST` the user
+ *   already relies on.
+ * - **Podman/macOS** resolves the running machine's host-forwarded compat socket
+ *   (`podman machine inspect`); a stopped machine (non-zero exit) or an empty path
+ *   is an actionable error hinting `podman machine start`.
+ * - **Podman/Linux** (and any other non-darwin host) resolves `podman info`'s
+ *   reported REST socket, gated on that path EXISTING on disk: the podman CLI talks
+ *   to the engine directly, so a reachable CLI does NOT imply a listening REST
+ *   socket (it exists only when `podman.socket` is enabled or `podman system
+ *   service` runs). A missing path or non-zero exit hints
+ *   `systemctl --user enable --now podman.socket`.
+ *
+ * The result rides the ok channel as `string | undefined` — absence is in-band,
+ * not an error. It is per-boot state and MUST NOT be persisted: the macOS compat
+ * socket lives under `$TMPDIR` and moves across machine restarts, so a saved path
+ * is a future ECONNREFUSED. `probes` is injectable for tests only.
+ */
+export async function resolveEngineSocket(
+    rt: ContainerRuntime,
+    probes: EngineSocketProbes = { platform: process.platform, capture, exists: existsSync },
+): Promise<Result<string | undefined, ContainerRuntimeError>> {
+    switch (rt.id) {
+        case "docker":
+            return ok(undefined);
+        case "podman": {
+            if (probes.platform === "darwin") {
+                const { code, stdout } = await probes.capture(rt, ["machine", "inspect", "--format", "{{.ConnectionInfo.PodmanSocket.Path}}"]);
+                const socket = stdout.trim();
+                if (code !== 0 || socket === "") {
+                    return err(
+                        new ContainerRuntimeError(
+                            "Could not resolve the Podman sandbox-engine socket — the Podman machine is not running.\n  Start it with `podman machine start`, then re-run.",
+                        ),
+                    );
+                }
+                return ok(socket);
+            }
+            const { code, stdout } = await probes.capture(rt, ["info", "--format", "{{.Host.RemoteSocket.Path}}"]);
+            const socket = stdout.trim();
+            // `podman info` succeeding does not imply the REST API is listening, so the
+            // reported path only counts when it is actually present on disk.
+            if (code !== 0 || socket === "" || !probes.exists(socket)) {
+                return err(
+                    new ContainerRuntimeError(
+                        "Could not resolve the Podman sandbox-engine socket — the Podman API service is not listening.\n  Enable it with `systemctl --user enable --now podman.socket`, then re-run.",
+                    ),
+                );
+            }
+            return ok(socket);
+        }
+        default: {
+            const exhaustive: never = rt.id;
+            throw new Error(`unhandled runtime: ${JSON.stringify(exhaustive)}`);
+        }
+    }
 }

--- a/cli/src/modules/harness/profile.test.ts
+++ b/cli/src/modules/harness/profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { friendlyStepLabel } from "./profile.ts";
+import { describeBootError, friendlyStepLabel } from "./profile.ts";
 
 // Names as recorded in dbos.operation_outputs by the profile workflow — the
 // progress channel parses them, so pin the observed formats.
@@ -24,5 +24,16 @@ describe("friendlyStepLabel", () => {
 
     test("unknown step names pass through verbatim", () => {
         expect(friendlyStepLabel("DBOS.getResult")).toBe("DBOS.getResult");
+    });
+});
+
+// The sandbox_engine_unresolved arm carries a message already built against the
+// pinned runtime AND host platform at resolution time, so it must be surfaced
+// verbatim rather than re-wrapped.
+describe("describeBootError", () => {
+    test("sandbox_engine_unresolved surfaces the resolution message verbatim", () => {
+        const message =
+            "Could not resolve the Podman sandbox-engine socket — the Podman machine is not running.\n  Start it with `podman machine start`, then re-run.";
+        expect(describeBootError({ type: "sandbox_engine_unresolved", message })).toBe(message);
     });
 });

--- a/cli/src/modules/harness/profile.ts
+++ b/cli/src/modules/harness/profile.ts
@@ -127,6 +127,12 @@ export function describeBootError(e: HarnessBootError): string {
                 `A direct model connection needs an explicit model for the ${e.agents.join(" and ")} agent${e.agents.length > 1 ? "s" : ""} — there is no proxy \`/models\` to auto-resolve one from.`,
                 "Set `harness.model` in config.json (applies to both agents), or `models.agents.<agent>` per agent, to the model id your endpoint serves.",
             ].join("\n");
+        case "sandbox_engine_unresolved":
+            // The message was built at resolution time against the pinned runtime AND
+            // host platform (start the podman machine on macOS; enable `podman.socket`
+            // on Linux; or the container-runtime remediation when no runtime resolved),
+            // so it already names the exact command to run — surface it verbatim.
+            return e.message;
         case "postgres_unavailable":
             return e.cause.message;
         case "ingress_failed":

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -4,8 +4,9 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 import { ok, okAsync, err } from "neverthrow";
-import type { EmbeddingProvider } from "@inflexa-ai/harness";
+import { createSandboxClient, type CreateSandboxClientConfig, type EmbeddingProvider } from "@inflexa-ai/harness";
 
+import { ContainerRuntimeError, runtimes } from "../../lib/container.ts";
 import { env } from "../../lib/env.ts";
 import { instanceLockPath } from "../../lib/lock.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
@@ -67,10 +68,18 @@ function fakeIngress(calls: string[]): ExecIngress {
 // path runs fully offline.
 function recordingSeams(calls: string[]): BootSeams {
     return {
+        resolveSandboxEngine: async () => {
+            calls.push("resolveSandboxEngine");
+            // Default to a docker pin (today's behavior): no socket, no step-tree loosening.
+            return ok({ runtime: runtimes.docker, socketPath: undefined });
+        },
         ensurePostgres: async () => {
             calls.push("postgres");
             return ok({ host: "localhost", port: 5, database: "d", user: "u", password: "p" });
         },
+        // Real construction (pure, connects lazily) so the offline boot runs unchanged;
+        // the engine-wiring tests below swap this for a capturing variant.
+        createSandbox: createSandboxClient,
         startIngress: () => {
             calls.push("ingress");
             return ok(fakeIngress(calls));
@@ -220,6 +229,7 @@ describe("bootHarnessRuntime", () => {
             "resolveEmbedding",
             "readKey",
             "probeEmbedding",
+            "resolveSandboxEngine",
             "postgres",
             "boot",
             "sweepEphemeral",
@@ -360,7 +370,7 @@ describe("bootHarnessRuntime", () => {
         const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
         expect(result._unsafeUnwrapErr()).toMatchObject({ type: "postgres_unavailable" });
-        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding", "postgres"]);
+        expect(calls).toEqual(["resolveEmbedding", "readKey", "probeEmbedding", "resolveSandboxEngine", "postgres"]);
     });
 
     test("an unresolved embedder fails before any side effect past resolution", async () => {
@@ -658,5 +668,82 @@ describe("bootHarnessRuntime", () => {
             holder.kill();
             await holder.exited;
         }
+    });
+
+    test("a podman pin threads the resolved socket and world-writable step-tree access into the sandbox client", async () => {
+        const calls: string[] = [];
+        // Captured on an object property: a bare `let` assigned only inside the seam
+        // closure gets narrowed back to `null` by control-flow analysis across the await.
+        const captured: { config: CreateSandboxClientConfig | null } = { config: null };
+        const seams: BootSeams = {
+            ...recordingSeams(calls),
+            resolveSandboxEngine: async () => {
+                calls.push("resolveSandboxEngine");
+                return ok({ runtime: runtimes.podman, socketPath: "/var/folders/xy/podman-api.sock" });
+            },
+            createSandbox: (cfg) => {
+                captured.config = cfg;
+                return createSandboxClient(cfg);
+            },
+        };
+        const result = await bootHarnessRuntime({ seams, config: testConfig() });
+
+        expect(result.isOk()).toBe(true);
+        // A podman pin dials the resolved compat socket and loosens the pre-created
+        // step tree so the uid-1000 workload can write through virtiofs.
+        expect(captured.config).not.toBeNull();
+        expect(captured.config?.engineSocketPath).toBe("/var/folders/xy/podman-api.sock");
+        expect(captured.config?.stepTreeAccess).toBe("world-writable");
+    });
+
+    test("a docker pin builds today's exact sandbox config — no engineSocketPath key, no stepTreeAccess", async () => {
+        const calls: string[] = [];
+        const captured: { config: CreateSandboxClientConfig | null } = { config: null };
+        const seams: BootSeams = {
+            ...recordingSeams(calls),
+            resolveSandboxEngine: async () => {
+                calls.push("resolveSandboxEngine");
+                return ok({ runtime: runtimes.docker, socketPath: undefined });
+            },
+            createSandbox: (cfg) => {
+                captured.config = cfg;
+                return createSandboxClient(cfg);
+            },
+        };
+        const result = await bootHarnessRuntime({ seams, config: testConfig() });
+
+        expect(result.isOk()).toBe(true);
+        expect(captured.config).not.toBeNull();
+        // Byte-identical to today: the keys must be ABSENT (not present-and-undefined),
+        // so dockerode keeps its default resolution and the step tree keeps its modes.
+        expect(captured.config !== null && "engineSocketPath" in captured.config).toBe(false);
+        expect(captured.config !== null && "stepTreeAccess" in captured.config).toBe(false);
+    });
+
+    test("an unresolvable engine socket fails boot with sandbox_engine_unresolved before postgres/lock/launch", async () => {
+        const calls: string[] = [];
+        const seams: BootSeams = {
+            ...recordingSeams(calls),
+            resolveSandboxEngine: async () => {
+                calls.push("resolveSandboxEngine");
+                return err(
+                    new ContainerRuntimeError(
+                        "Could not resolve the Podman sandbox-engine socket — the Podman machine is not running.\n  Start it with `podman machine start`, then re-run.",
+                    ),
+                );
+            },
+        };
+        const result = await bootHarnessRuntime({ seams, config: testConfig() });
+
+        const error = result._unsafeUnwrapErr();
+        expect(error.type).toBe("sandbox_engine_unresolved");
+        // The resolution's runtime-specific remediation rides through verbatim.
+        expect(error.type === "sandbox_engine_unresolved" && error.message).toContain("podman machine start");
+        // The gate sits ahead of Postgres, the instance lock, the pool, and the DBOS
+        // boot, so a failure there reaches none of them (proven by call order: postgres
+        // and boot follow the gate, and the lock/pool sit inside the boot's try block).
+        expect(calls).not.toContain("postgres");
+        expect(calls).not.toContain("boot");
+        expect(calls).not.toContain("ingress");
     });
 });

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -670,7 +670,7 @@ describe("bootHarnessRuntime", () => {
         }
     });
 
-    test("a podman pin threads the resolved socket and world-writable step-tree access into the sandbox client", async () => {
+    test("a podman pin threads the resolved socket and host-preserved bind ownership into the sandbox client", async () => {
         const calls: string[] = [];
         // Captured on an object property: a bare `let` assigned only inside the seam
         // closure gets narrowed back to `null` by control-flow analysis across the await.
@@ -689,14 +689,14 @@ describe("bootHarnessRuntime", () => {
         const result = await bootHarnessRuntime({ seams, config: testConfig() });
 
         expect(result.isOk()).toBe(true);
-        // A podman pin dials the resolved compat socket and loosens the pre-created
-        // step tree so the uid-1000 workload can write through virtiofs.
+        // A podman pin dials the resolved compat socket and declares the engine's
+        // honest bind ownership so the harness makes the step tree workload-writable.
         expect(captured.config).not.toBeNull();
         expect(captured.config?.engineSocketPath).toBe("/var/folders/xy/podman-api.sock");
-        expect(captured.config?.stepTreeAccess).toBe("world-writable");
+        expect(captured.config?.engineBindOwnership).toBe("host-preserved");
     });
 
-    test("a docker pin builds today's exact sandbox config — no engineSocketPath key, no stepTreeAccess", async () => {
+    test("a docker pin builds today's exact sandbox config — no engineSocketPath key, no engineBindOwnership", async () => {
         const calls: string[] = [];
         const captured: { config: CreateSandboxClientConfig | null } = { config: null };
         const seams: BootSeams = {
@@ -717,7 +717,7 @@ describe("bootHarnessRuntime", () => {
         // Byte-identical to today: the keys must be ABSENT (not present-and-undefined),
         // so dockerode keeps its default resolution and the step tree keeps its modes.
         expect(captured.config !== null && "engineSocketPath" in captured.config).toBe(false);
-        expect(captured.config !== null && "stepTreeAccess" in captured.config).toBe(false);
+        expect(captured.config !== null && "engineBindOwnership" in captured.config).toBe(false);
     });
 
     test("an unresolvable engine socket fails boot with sandbox_engine_unresolved before postgres/lock/launch", async () => {

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -38,7 +38,8 @@ import {
 } from "@inflexa-ai/harness";
 import type pinoLib from "pino";
 
-import { readConfig } from "../../lib/config.ts";
+import { ensureRuntime, readConfig } from "../../lib/config.ts";
+import { resolveEngineSocket, type ContainerRuntime, type ContainerRuntimeError } from "../../lib/container.ts";
 import { env } from "../../lib/env.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";
 import { getLogger } from "../../lib/log.ts";
@@ -230,6 +231,7 @@ export type HarnessBootError =
     | { type: "model_unresolved"; cause: ChatSetupError }
     | { type: "model_provider_mismatch"; provider: string; model: string }
     | { type: "model_required"; agents: readonly AgentName[] }
+    | { type: "sandbox_engine_unresolved"; message: string }
     | { type: "postgres_unavailable"; cause: PostgresError }
     | { type: "ingress_failed"; cause: IngressError }
     | { type: "runtime_already_active"; holderPid: number }
@@ -287,11 +289,45 @@ async function probeEmbeddingProvider(provider: EmbeddingProvider): Promise<Resu
 }
 
 /**
+ * The pinned container runtime plus the Docker-API socket the sandbox client dials
+ * for it. `socketPath` is `undefined` under Docker — dockerode keeps its default
+ * resolution — and the resolved compat socket path under Podman.
+ */
+export type ResolvedSandboxEngine = {
+    readonly runtime: ContainerRuntime;
+    readonly socketPath: string | undefined;
+};
+
+/**
+ * Pin the container runtime and resolve the Docker-API socket the sandbox client
+ * dials for it. `ensureRuntime` probes and may PIN on first use — sanctioned here
+ * because boot is a deliberate trigger, the same class as `ensureSandboxImage`'s
+ * image pre-pull, and it never prompts. The resolved socket is per-boot state (the
+ * macOS compat socket moves across machine restarts), so it is returned, never
+ * persisted.
+ */
+async function resolveSandboxEngineOnce(): Promise<Result<ResolvedSandboxEngine, ContainerRuntimeError>> {
+    const rtResult = await ensureRuntime();
+    if (rtResult.isErr()) return err(rtResult.error);
+    const runtime = rtResult.value;
+    return (await resolveEngineSocket(runtime)).map((socketPath) => ({ runtime, socketPath }));
+}
+
+/**
  * The boot sequence's effectful seams, injectable so the sequencing test runs
  * offline (no Postgres, no proxy, no DBOS). Production callers pass nothing.
  */
 export type BootSeams = {
+    /**
+     * Resolve the pinned container runtime and its sandbox-engine socket. The real
+     * seam pins via `ensureRuntime` (which may pin on first use) then resolves the
+     * socket off the runtime descriptor; injected so the sequencing test stays
+     * offline (no runtime binaries spawned).
+     */
+    readonly resolveSandboxEngine: () => Promise<Result<ResolvedSandboxEngine, ContainerRuntimeError>>;
     readonly ensurePostgres: () => Promise<Result<PostgresConnection, PostgresError>>;
+    /** Construct the sandbox client — a seam so boot tests can inspect the engine config it is wired with. */
+    readonly createSandbox: typeof createSandboxClient;
     readonly startIngress: () => Result<ExecIngress, IngressError>;
     readonly readKey: () => Promise<Result<string, ChatSetupError>>;
     /** The `direct`-connection secret from the environment (`env.modelApiKey`); `undefined` when unset. */
@@ -325,7 +361,9 @@ export type BootSeams = {
 };
 
 const realSeams: BootSeams = {
+    resolveSandboxEngine: resolveSandboxEngineOnce,
     ensurePostgres: ensurePostgresReady,
+    createSandbox: createSandboxClient,
     startIngress: () => startExecIngress(),
     readKey: readApiKey,
     readModelApiKey: () => env.modelApiKey,
@@ -534,6 +572,17 @@ async function bootHarnessRuntimeOnce(
     const conversationModel = conversationResolved.value;
     const sandboxModel = sandboxResolved.value;
 
+    // Resolve the pinned container runtime and the Docker-API socket the sandbox
+    // client will dial, BEFORE Postgres (which is provisioned on that same runtime)
+    // and every durable side effect. A stopped podman machine then fails boot for
+    // free with an actionable message instead of surfacing as an opaque dockerode
+    // ECONNREFUSED mid-run. `ensureSandboxImage` already pulled the image through
+    // this same pin, so resolving the socket here makes pull and create target ONE
+    // engine by construction.
+    const engineResult = await seams.resolveSandboxEngine();
+    if (engineResult.isErr()) return err({ type: "sandbox_engine_unresolved", message: engineResult.error.message });
+    const { runtime: pinnedRuntime, socketPath: engineSocketPath } = engineResult.value;
+
     const pgResult = await seams.ensurePostgres();
     if (pgResult.isErr()) return err({ type: "postgres_unavailable", cause: pgResult.error });
     const conn = pgResult.value;
@@ -645,11 +694,12 @@ async function bootHarnessRuntimeOnce(
         const sandboxProvider = createSwappableProvider(sandboxInner);
         const conversationBackend: AgentBackend = { provider: conversationProvider, model: conversationModel };
         const sandboxBackend: AgentBackend = { provider: sandboxProvider, model: sandboxModel };
-        const sandboxClient = createSandboxClient({
+        const sandboxClient = seams.createSandbox({
             pool,
-            // TODO(extend): sandbox steps always target docker — the harness sandbox backend is
-            // docker|k8s only, so even a pinned-podman machine still needs Docker here; podman
-            // sandbox support is a harness capability to add first, not a CLI flag.
+            // Podman speaks the Docker API, so the harness's dockerode-based `docker`
+            // backend drives it unchanged — the only divergence is the *socket* it
+            // dials (supplied below), not the backend kind. (`k8s` is a managed-embedder
+            // concern, never selected here.)
             env: { backend: "docker", namespace: "" },
             transport: SANDBOX_TRANSPORT,
             // Empty in poll mode (the no-op ingress advertises no URL); the sandbox
@@ -664,6 +714,17 @@ async function bootHarnessRuntimeOnce(
             ...existingRefStoreConfig(env.refsDir),
             resourceLimits: cfg.resourcePolicy.perStep,
             resolveWorkspaceRoot,
+            // Pull (`ensureSandboxImage`) and create must target the SAME engine, so
+            // dial the socket resolved for the pinned runtime. Docker resolves to
+            // `undefined`; the conditional spread keeps the config byte-identical to
+            // today for a docker pin (no key materialized), so dockerode's default
+            // resolution — and any DOCKER_HOST the user relies on — is untouched.
+            ...(engineSocketPath === undefined ? {} : { engineSocketPath }),
+            // Podman machine's virtiofs presents the embedder user's real uid/modes,
+            // which the uid-1000 sandbox workload cannot write; world-write on the
+            // pre-created step tree lets its writes land. Docker Desktop's file-sharing
+            // layer masks that mismatch, so a docker pin keeps today's tighter modes.
+            ...(pinnedRuntime.id === "podman" ? { stepTreeAccess: "world-writable" as const } : {}),
         });
         const workspaceFs = createWorkspaceFilesystem({ resolveWorkspaceRoot });
         // One authorizer instance, shared by the parent workflow's terminal revoke,

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -714,6 +714,10 @@ async function bootHarnessRuntimeOnce(
             ...existingRefStoreConfig(env.refsDir),
             resourceLimits: cfg.resourcePolicy.perStep,
             resolveWorkspaceRoot,
+            // The docker backend's diagnostics (lib-store degradation, recovery
+            // adoption) are observable only through this seam — unset, they fall to
+            // the harness's noop logger and vanish.
+            logger,
             // Pull (`ensureSandboxImage`) and create must target the SAME engine, so
             // dial the socket resolved for the pinned runtime. Docker resolves to
             // `undefined`: for a docker pin the conditional spread materializes no key,

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -724,13 +724,13 @@ async function bootHarnessRuntimeOnce(
             // so dockerode keeps its default socket resolution — including any
             // DOCKER_HOST the user relies on.
             ...(engineSocketPath === undefined ? {} : { engineSocketPath }),
-            // Engines whose bind mounts preserve host ownership honestly — podman
-            // machine's virtiofs on macOS, native binds / rootless userns uid-mapping
-            // on Linux — present a host uid the uid-1000 sandbox workload cannot write,
-            // so the pre-created step tree needs world-write for those writes to land.
-            // Docker Desktop's file-sharing layer masks that mismatch, so a docker pin
-            // leaves the step tree at its default mkdir modes.
-            ...(pinnedRuntime.id === "podman" ? { stepTreeAccess: "world-writable" as const } : {}),
+            // A podman pin declares an engine fact: its bind mounts expose honest host
+            // ownership — virtiofs on macOS, native binds / rootless userns uid-mapping
+            // on Linux — presenting a host uid the uid-1000 sandbox workload cannot
+            // write; the harness compensates (today by loosening each step's write
+            // tree). Docker Desktop's file-sharing layer masks that mismatch, so a
+            // docker pin leaves the field unset and the modes untouched.
+            ...(pinnedRuntime.id === "podman" ? { engineBindOwnership: "host-preserved" as const } : {}),
         });
         const workspaceFs = createWorkspaceFilesystem({ resolveWorkspaceRoot });
         // One authorizer instance, shared by the parent workflow's terminal revoke,

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -716,14 +716,16 @@ async function bootHarnessRuntimeOnce(
             resolveWorkspaceRoot,
             // Pull (`ensureSandboxImage`) and create must target the SAME engine, so
             // dial the socket resolved for the pinned runtime. Docker resolves to
-            // `undefined`; the conditional spread keeps the config byte-identical to
-            // today for a docker pin (no key materialized), so dockerode's default
-            // resolution — and any DOCKER_HOST the user relies on — is untouched.
+            // `undefined`: for a docker pin the conditional spread materializes no key,
+            // so dockerode keeps its default socket resolution — including any
+            // DOCKER_HOST the user relies on.
             ...(engineSocketPath === undefined ? {} : { engineSocketPath }),
-            // Podman machine's virtiofs presents the embedder user's real uid/modes,
-            // which the uid-1000 sandbox workload cannot write; world-write on the
-            // pre-created step tree lets its writes land. Docker Desktop's file-sharing
-            // layer masks that mismatch, so a docker pin keeps today's tighter modes.
+            // Engines whose bind mounts preserve host ownership honestly — podman
+            // machine's virtiofs on macOS, native binds / rootless userns uid-mapping
+            // on Linux — present a host uid the uid-1000 sandbox workload cannot write,
+            // so the pre-created step tree needs world-write for those writes to land.
+            // Docker Desktop's file-sharing layer masks that mismatch, so a docker pin
+            // leaves the step tree at its default mkdir modes.
             ...(pinnedRuntime.id === "podman" ? { stepTreeAccess: "world-writable" as const } : {}),
         });
         const workspaceFs = createWorkspaceFilesystem({ resolveWorkspaceRoot });

--- a/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/design.md
+++ b/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`createDockerSandboxOps` is the only place the harness touches a container engine: it constructs one `dockerode` client (`docker-client.ts:203`, `config.docker ?? new Docker()`) and every op — create/adopt, teardown, liveness, the reaper's listing — flows through it. The construction takes no options, so the backend can only reach dockerode's defaults (`DOCKER_HOST` env if the embedder happens to set it, else `/var/run/docker.sock`). The `docker?:` config slot is a test-only instance injection, not reachable from `CreateSandboxClientConfig`.
+
+Podman serves the same REST API on a different socket. Live probing (podman 5.8.3, rootful podman-machine, macOS arm64) verified the backend's exact `createOpts` shape end-to-end — security config, loopback `HostPort: "0"` publish, label filters, `Created` unix-seconds, `State.Running`/`OOMKilled`, and the full poll-mode confinement chain (iptables/ip6tables install under `CAP_NET_ADMIN`, setpriv drop to uid 1000 with empty capability sets, host polls answered through `OUTPUT DROP`, egress and DNS blocked, rules un-flushable). Two divergences surfaced:
+
+1. **Name conflict status**: a duplicate-name create answers HTTP 500 (`"cause": "that name is already in use"`), not Docker's 409. `createOrAdopt` reconciles only on exactly 409, so on podman a DBOS recovery re-run fails with `container_create_failed` instead of adopting its standing container.
+2. **Honest bind ownership**: podman machine's virtiofs presents host dirs with the host owner's real uid and POSIX modes. The pre-created step tree (owned by the embedder process's uid, mode 755) rejects every write from the uid-1000 workload. Docker Desktop's file-sharing layer masks the same mismatch, which is why the mismatch is invisible today.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the engine connection an explicit, optional part of the backend's configuration surface, defaulting to today's behavior.
+- Make recovery adoption independent of engine-specific status codes.
+- Give embedders a supported way to keep the step tree writable under engines with honest bind ownership.
+
+**Non-Goals:**
+
+- A third `backend` id — podman is a connection to the docker-API backend, and `SandboxRef.backend: "docker"` keeps meaning "the Docker API".
+- Image pull logic — pre-pull stays embedder-owned; once the embedder pulls and connects against the same engine, the docker-store/podman-store split-brain dissolves by construction.
+- SELinux bind relabeling (`:z`) for podman on SELinux-enforcing Linux hosts, and validation of rootless podman networking (pasta/slirp4netns) — embedders gate those paths until validated.
+- TCP/TLS engine connections — managed deployments run the k8s backend.
+
+## Decisions
+
+### `engineSocketPath?: string`, not a `Docker.DockerOptions` slice
+
+The need on both engines is one value: which unix socket to dial. Exposing dockerode's full options type would couple the harness's public config surface to a third-party ~15-field type to satisfy a one-field need. A richer connection option later is a non-breaking optional-field addition. Unset preserves dockerode's default resolution, so `DOCKER_HOST` keeps working as the zero-config escape hatch it already is.
+
+### Reconcile-by-inspect on any create failure, not status-code or message matching
+
+Alternatives rejected: matching podman's 500 + message substring (couples the harness to one engine's error prose, breaks on the next engine or a fixed podman), and inspect-before-create (reintroduces a create/create race the current create-first shape avoids). Instead the conflict *signal* is dropped entirely: any create failure triggers an inspect of the checkpointed name. A standing container enters the unchanged owner-guard flow (adopt running owned, remove-and-recreate stopped owned, refuse foreign). No standing container means the failure wasn't a name conflict, and the **original create error** is returned — the inspect error is never surfaced, so a transient engine outage (both calls fail) still reports the create failure. Cost: one extra API call, only on the failure path. On Docker the 409 case lands in the identical reconcile flow as before.
+
+### `stepTreeAccess?: "world-writable"` — a named policy, not a boolean or a raw mode
+
+A bare `worldWritable: true` doesn't tell a composition-root reader why it exists; a raw `mode: number` invites cargo-culting arbitrary modes. A single-valued union reads as policy at the call site, carries the rationale in its JSDoc, and extends to future strategies (e.g. a chown-based one) without a breaking change. Absence keeps today's default modes.
+
+Remedies rejected for the underlying uid mismatch: `chown` to uid 1000 host-side needs root on macOS; letting the poll-mode root entrypoint chown would widen the deliberately minimal `CapAdd` set with `CAP_CHOWN`/`CAP_FOWNER` (and callback mode has no root phase at all); podman's `keep-id` userns mapping is rootless-only. World-write on the step tree was verified live: the uid-1000 write lands, and the artifact round-trips to the host owned by the embedder's user, readable and deletable.
+
+Scope: only the step write tree (`runs/{runId}/{stepId}` + `STEP_SUBDIRS`) — directories that exist to receive the sandbox's writes. Read-only mounts (analysis tree, ref store) need no loosening; world-read via standard 755/644 already suffices. Implementation note: `mkdir`'s `mode` option is masked by the process umask, so the mode is applied with explicit `chmod` after creation — also correct on replay, when the dirs already exist.
+
+### No `engine: "docker" | "podman"` discriminator — capability knobs, not a product enum
+
+The legible-looking alternative — one config field naming the engine, switched internally for both the socket and the step-tree mode — was rejected. It cannot replace `engineSocketPath` (the socket's location is host-lifecycle state only the embedder can resolve; the harness never shells out to `podman machine inspect`), so it would be an *additional* field, not a simpler one. For the step tree it is the wrong predicate: the write failure follows from bind mounts preserving a host uid that differs from the workload's uid 1000, which is true on podman machine's virtiofs but false on rootful podman-on-Linux when the host user is uid 1000 — and true again on Docker CE when the host user is *not* 1000, a legitimate Docker use of `stepTreeAccess` an engine switch would make unexpressible. The reconcile fix is deliberately unswitched (better on both engines); an engine enum invites per-engine conflict-status tables that rot as engines change. Other docker-API engines (Colima, OrbStack, Rancher Desktop) each carry their own mount semantics — an enum grows a per-product behavior table inside the host-agnostic harness, while capability knobs stay truthful. The readable "because podman" mapping lives at the embedder's composition root, the one place that knows the product name; an embedder worried about mis-combining the knobs wraps them in its own resolver that returns the pair together.
+
+### The mode knob lives on `CreateSandboxClientConfig`, applied in `precreateStepTree`
+
+`precreateStepTree` is already the one backend-agnostic choke point that creates the tree. The knob is docker-backend-motivated but harmless if a future backend needs it; the k8s path simply never sets it.
+
+## Risks / Trade-offs
+
+- [World-writable step dirs on a shared host let any local user write into a step's artifact tree] → opt-in, embedder-chosen, scoped to the step tree only; the target machines are single-user dev boxes, and provenance signing happens over content the harness reads back.
+- [Reconcile-by-inspect could adopt a container when create failed for an unrelated reason while an owned container stands] → that is precisely the recovery scenario the adoption exists for; the owner-guard already refuses foreign containers, and an adopted container is still health-verified before use.
+- [Rootless podman on Linux (pasta/slirp4netns loopback publish, iptables in a user namespace) is unvalidated] → out of scope here; the connection seam makes it *reachable*, and embedders gate it with an actionable launch error until validated.
+- [`engineSocketPath` pointing at a dead socket surfaces as a dockerode connect error mid-step] → embedder responsibility to resolve and gate at boot (the cli change); the harness error already carries the cause chain.
+
+## Migration Plan
+
+Both new fields are optional with absent-means-today semantics; no existing embedder, test, or managed deployment changes behavior. Rollback is unsetting the fields. No data or schema migration.
+
+## Open Questions
+
+_None blocking._ Follow-ups tracked outside this change: rootless-Linux validation matrix, SELinux `:z` knob for the mount plan, and the cli composition-root wiring (its own change in `cli/openspec`).

--- a/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Docker sandbox backend hard-wires its engine connection: `createDockerSandboxOps` constructs `new Docker()` with default options (`docker-client.ts`), so sandboxes can only ever reach the default Docker socket. Podman ships a Docker-compatible REST API, and live probing (podman 5.8.3, rootful machine, macOS arm64) confirmed the backend's entire surface — create/start/inspect with the full security config, loopback port publish, label-filtered listing, the poll-mode egress firewall and setpriv drop — behaves identically through podman's compat socket. Only three gaps stand between the harness and running on podman exactly as on Docker, and none of them is a podman-specific backend: the unreachable connection target, one engine divergence in the name-conflict status code, and one host-ownership divergence on the read-write step mount. On a podman-pinned machine today, every sandbox step fails at container create even though the embedder's image pull, proxy, and Postgres all run fine on podman — or worse, with both engines installed, the image lands in podman's store while containers are created against Docker (split-brain).
+
+## What Changes
+
+- `CreateSandboxClientConfig` and `DockerClientConfig` gain `engineSocketPath?: string` — the unix socket of the Docker-API engine to dial (a Docker daemon or a podman compat socket), threaded to the single `new Docker()` construction site. Unset keeps dockerode's default resolution (`DOCKER_HOST`, then `/var/run/docker.sock`), so existing embedders and the managed deployment are untouched.
+- `createOrAdopt`'s recovery reconciliation becomes engine-agnostic: on **any** `createContainer` failure it inspects the checkpointed name — a standing container enters the existing owner-guard flow (adopt running / recreate stopped / refuse foreign), no standing container returns the original create error. This replaces the 409-only trigger, which podman breaks by answering a duplicate-name create with HTTP 500 (`"that name is already in use"`) instead of Docker's 409.
+- `CreateSandboxClientConfig` gains `stepTreeAccess?: "world-writable"` — when set, the pre-created step tree (step dir + subdirs) is `chmod`ed world-writable so the uid-1000 sandbox workload can write it through engines whose bind mounts preserve host ownership honestly (podman machine's virtiofs presents the host owner's uid; Docker Desktop's sharing layer masks the mismatch). Absent keeps today's default modes.
+- `backend: "docker" | "k8s"` is unchanged: podman is a *connection* to the docker-API backend, not a third backend id.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `docker-sandbox-provider`: the factory's engine connection becomes configurable (`engineSocketPath`); the recovery-idempotency requirement's trigger changes from "HTTP 409" to "any create failure with a standing container under the checkpointed name"; a new requirement covers the `stepTreeAccess` mode on step-tree pre-creation.
+
+## Impact
+
+- `harness/src/sandbox/docker-client.ts` — `DockerClientConfig` field, `new Docker(...)` construction, `createOrAdopt` reconciliation trigger.
+- `harness/src/sandbox/create-sandbox.ts` — `CreateSandboxClientConfig` fields threaded to `createDockerSandboxOps`; `precreateStepTree` applies the step-tree access mode.
+- Tests: `docker-client.test.ts` (socket-path threading; reconcile on a 500-shaped conflict; reconcile skipped when no container stands), `create-sandbox.test.ts` (step-tree mode application).
+- K8s backend, submit/await protocol, mount plan container paths, `SandboxRef`, reaper/watchdog: untouched (all engine access already flows through the one constructed `Docker` instance).
+- Embedder follow-up (separate cli change): resolve the pinned runtime's socket at boot and pass `engineSocketPath` + `stepTreeAccess`.

--- a/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/specs/docker-sandbox-provider/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: The engine connection is configurable
+
+`DockerClientConfig` and `CreateSandboxClientConfig` SHALL carry an optional
+`engineSocketPath: string` — the unix socket of the Docker-API engine the
+backend dials (a Docker daemon socket or a podman Docker-compat socket).
+`createSandboxClient` SHALL thread it to `createDockerSandboxOps`, which SHALL
+construct its `dockerode` client against that socket. When unset, construction
+SHALL preserve dockerode's default resolution (`DOCKER_HOST`, then the default
+Docker socket), so existing embedders observe no behavior change. The injected
+test instance (`docker?:`) SHALL keep taking precedence over any configured
+socket path. Podman is a *connection* to this backend, not a separate backend:
+`backend` stays `"docker" | "k8s"` and `SandboxRef.backend: "docker"` continues
+to mean "the Docker API".
+
+#### Scenario: Sandboxes are created against a configured engine socket
+
+- **GIVEN** `engineSocketPath` set to a podman Docker-compat socket
+- **WHEN** `createSandboxClient` builds the docker backend and a sandbox is created
+- **THEN** every engine call (create, start, inspect, list, remove) dials that socket
+- **AND** the returned `SandboxRef` carries `backend: "docker"` unchanged
+
+#### Scenario: Unset engine socket preserves default resolution
+
+- **GIVEN** no `engineSocketPath`
+- **WHEN** the docker backend is constructed
+- **THEN** the dockerode client is constructed with no connection options, resolving `DOCKER_HOST` or the default Docker socket exactly as before
+
+### Requirement: Step-tree access mode for engines with honest bind ownership
+
+`CreateSandboxClientConfig` SHALL carry an optional
+`stepTreeAccess: "world-writable"`. When set, the client SHALL `chmod` the
+pre-created step write tree — the step directory and each of its
+`STEP_SUBDIRS` — world-writable after creating it, so the uid-1000 sandbox
+workload can write through engines whose bind mounts preserve host ownership
+(podman machine's virtiofs presents the embedder user's real uid and modes;
+Docker Desktop's file-sharing layer masks the mismatch, which is why default
+modes suffice there). The mode SHALL be applied with an explicit `chmod`, not
+`mkdir`'s mode option (which the process umask masks), and SHALL be applied on
+replay when the directories already exist. When unset, pre-creation SHALL keep
+today's default modes. The loosening is scoped to the step write tree only:
+read-only mounts (analysis tree, lib/ref stores) rely on standard world-read
+and SHALL NOT be relabeled or re-moded.
+
+#### Scenario: World-writable step tree under a podman connection
+
+- **GIVEN** `stepTreeAccess: "world-writable"`
+- **WHEN** `createSandbox` pre-creates the step tree
+- **THEN** the step directory and its subdirectories are world-writable
+- **AND** a workload write from uid 1000 through the read-write bind succeeds
+
+#### Scenario: Replayed pre-creation still applies the mode
+
+- **GIVEN** `stepTreeAccess: "world-writable"` and a step tree left by a prior attempt with default modes
+- **WHEN** `createSandbox` runs again for the same step
+- **THEN** the existing directories are re-moded world-writable rather than skipped
+
+#### Scenario: Default modes when unset
+
+- **GIVEN** no `stepTreeAccess`
+- **WHEN** `createSandbox` pre-creates the step tree
+- **THEN** directory modes are the process default, unchanged from today
+
+## MODIFIED Requirements
+
+### Requirement: Container creation is idempotent on a recovery re-run
+
+`createSandbox` SHALL be idempotent on the checkpointed `sandboxId`. When
+`createContainer` fails for any reason, the backend SHALL inspect the container
+under the checkpointed name rather than matching an engine-specific conflict
+status: Docker answers a name collision with HTTP 409, podman's compat API
+answers 500, and the reconciliation MUST NOT depend on either. If a container
+stands under the name, the owner-guard applies: it is adopted or replaced only
+when its `cortex/owner-workflow-id` label equals `meta.childWorkflowId`. A
+running owned container is adopted as-is; a stopped owned container is removed
+and recreated; a container owned by a different step is refused with a
+`name_conflict` error. If no container stands under the name, the failure was
+not a name collision and the backend SHALL return the **original create
+error** — the inspect's own failure is never surfaced. The decision and its
+rationale are owned by the harness-sandbox-exec spec.
+
+#### Scenario: Running container adopted on recovery re-run
+
+- **GIVEN** a failed create whose existing container is running and labeled with the same `cortex/owner-workflow-id`
+- **WHEN** `createSandbox` reconciles it
+- **THEN** the existing container is adopted without recreation and its health is re-verified
+
+#### Scenario: Foreign owner is refused
+
+- **GIVEN** a failed create whose existing container is labeled with a different `cortex/owner-workflow-id`
+- **WHEN** `createSandbox` reconciles it
+- **THEN** it returns a `name_conflict` error and neither adopts nor removes the container
+
+#### Scenario: Adoption works on an engine that answers name conflicts with 500
+
+- **GIVEN** an engine that rejects a duplicate-name create with HTTP 500 and a running container owned by this workflow standing under the checkpointed name
+- **WHEN** `createSandbox` retries after a recovery
+- **THEN** the standing container is adopted exactly as it would be after a Docker 409
+
+#### Scenario: A non-conflict create failure is returned unchanged
+
+- **GIVEN** a create that fails while no container stands under the checkpointed name
+- **WHEN** `createSandbox` inspects the name and finds nothing
+- **THEN** it returns the original `container_create_failed` error, not the inspect's 404

--- a/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-16-podman-compatible-engine-connection/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Engine connection seam
+
+- [x] 1.1 Add `engineSocketPath?: string` to `DockerClientConfig` (`src/sandbox/docker-client.ts`) with JSDoc carrying the docker-API-engine rationale, and construct the client as `new Docker({ socketPath })` when set — unset keeps the bare `new Docker()`; the injected test `docker?:` instance keeps precedence over both.
+- [x] 1.2 Add `engineSocketPath?: string` to `CreateSandboxClientConfig` (`src/sandbox/create-sandbox.ts`, "Docker:"-scoped JSDoc beside `libStorePath`/`platform`) and thread it into the `createDockerSandboxOps` construction.
+- [x] 1.3 Tests (`docker-client.test.ts`, `create-sandbox.test.ts`): a configured socket path reaches the dockerode construction; unset config produces default construction; the injected instance wins over a configured path.
+
+## 2. Engine-agnostic recovery reconciliation
+
+- [x] 2.1 Rework `createOrAdopt` (`src/sandbox/docker-client.ts`): drop the `statusOf(...) !== 409` gate; on any create failure, inspect the checkpointed name — a standing container enters the existing owner-guard flow unchanged (adopt running owned, remove-and-recreate stopped owned, refuse foreign), and when the inspect finds nothing the original create error is returned (the inspect's own failure is never surfaced).
+- [x] 2.2 Tests: adoption succeeds when the engine answers the duplicate-name create with HTTP 500 (podman's shape) and with 409 (Docker's); a foreign-owner container is still refused with `name_conflict`; a create failure with no standing container returns the original `container_create_failed` error, not the inspect 404; a stopped owned container is removed and recreated.
+
+## 3. Step-tree access mode
+
+- [x] 3.1 Add `stepTreeAccess?: "world-writable"` to `CreateSandboxClientConfig` with JSDoc explaining honest-bind-ownership engines (podman machine virtiofs) vs Docker Desktop's masking layer; in `precreateStepTree`, after the mkdirs, `chmod` the step dir and each `STEP_SUBDIRS` entry to `0o777` when set — explicit `chmod` (mkdir's mode is umask-masked), applied on replay when the dirs already exist.
+- [x] 3.2 Tests (`create-sandbox.test.ts`): modes applied to fresh and pre-existing step trees when set; default modes untouched when unset; read-only mount sources never re-moded.
+
+## 4. Verification
+
+- [x] 4.1 `tsc -p tsconfig.json` and `bun test` pass across the package.
+- [x] 4.2 `bun run format:file` on every touched file under `src/`.
+- [x] 4.3 `openspec validate podman-compatible-engine-connection` passes and the delta spec archives cleanly against `openspec/specs/docker-sandbox-provider/spec.md`.

--- a/harness/openspec/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/specs/docker-sandbox-provider/spec.md
@@ -14,10 +14,12 @@ the submit/await halves are backend-agnostic and shared with the K8s backend.
 
 Container creation is **idempotent on the checkpointed sandbox id** so a DBOS
 workflow recovery re-run does not orphan or duplicate a machine: the container
-is named by `sandboxId`, and a name collision (HTTP 409) is reconciled by an
+is named by `sandboxId`, and a name collision — whatever status the engine
+answers it with (Docker 409, podman's compat API 500) — is reconciled by an
 owner-guard rather than blindly recreated. The decision and its rationale are
 owned by the harness-sandbox-exec spec; this spec describes the Docker-side
-realization.
+realization. The factory dials the engine over a configurable unix socket, so
+"Docker" here means the Docker API: a podman compat socket serves equally.
 
 Cleanup is sweep-based, not lifecycle-coupled: every managed container carries
 `app.kubernetes.io/managed-by=cortex`, and a scheduled reaper
@@ -41,6 +43,33 @@ a `SandboxError` variant on failure, never throw.
 - **WHEN** `createSandboxClient(...)` is constructed
 - **THEN** the returned client wires `createDockerSandboxOps` for sandbox create/teardown
 - **AND** `submitExec` / `awaitExec` are used unchanged across backends
+
+### Requirement: The engine connection is configurable
+
+`DockerClientConfig` and `CreateSandboxClientConfig` SHALL carry an optional
+`engineSocketPath: string` — the unix socket of the Docker-API engine the
+backend dials (a Docker daemon socket or a podman Docker-compat socket).
+`createSandboxClient` SHALL thread it to `createDockerSandboxOps`, which SHALL
+construct its `dockerode` client against that socket. When unset, construction
+SHALL preserve dockerode's default resolution (`DOCKER_HOST`, then the default
+Docker socket), so existing embedders observe no behavior change. The injected
+test instance (`docker?:`) SHALL keep taking precedence over any configured
+socket path. Podman is a *connection* to this backend, not a separate backend:
+`backend` stays `"docker" | "k8s"` and `SandboxRef.backend: "docker"` continues
+to mean "the Docker API".
+
+#### Scenario: Sandboxes are created against a configured engine socket
+
+- **GIVEN** `engineSocketPath` set to a podman Docker-compat socket
+- **WHEN** `createSandboxClient` builds the docker backend and a sandbox is created
+- **THEN** every engine call (create, start, inspect, list, remove) dials that socket
+- **AND** the returned `SandboxRef` carries `backend: "docker"` unchanged
+
+#### Scenario: Unset engine socket preserves default resolution
+
+- **GIVEN** no `engineSocketPath`
+- **WHEN** the docker backend is constructed
+- **THEN** the dockerode client is constructed with no connection options, resolving `DOCKER_HOST` or the default Docker socket exactly as before
 
 ### Requirement: Container lifecycle via the Docker API
 
@@ -151,6 +180,41 @@ property of how one backend addresses a volume, not of the container contract.
 - **THEN** the container has a read-only bind mount at `/mnt/libs`
 - **AND** the sandbox env injects the lib-store path variables from the mount plan
 
+### Requirement: Step-tree access mode for engines with honest bind ownership
+
+`CreateSandboxClientConfig` SHALL carry an optional
+`stepTreeAccess: "world-writable"`. When set, the client SHALL `chmod` the
+pre-created step write tree — the step directory and each of its
+`STEP_SUBDIRS` — world-writable after creating it, so the uid-1000 sandbox
+workload can write through engines whose bind mounts preserve host ownership
+(podman machine's virtiofs presents the embedder user's real uid and modes;
+Docker Desktop's file-sharing layer masks the mismatch, which is why default
+modes suffice there). The mode SHALL be applied with an explicit `chmod`, not
+`mkdir`'s mode option (which the process umask masks), and SHALL be applied on
+replay when the directories already exist. When unset, pre-creation SHALL keep
+today's default modes. The loosening is scoped to the step write tree only:
+read-only mounts (analysis tree, lib/ref stores) rely on standard world-read
+and SHALL NOT be relabeled or re-moded.
+
+#### Scenario: World-writable step tree under a podman connection
+
+- **GIVEN** `stepTreeAccess: "world-writable"`
+- **WHEN** `createSandbox` pre-creates the step tree
+- **THEN** the step directory and its subdirectories are world-writable
+- **AND** a workload write from uid 1000 through the read-write bind succeeds
+
+#### Scenario: Replayed pre-creation still applies the mode
+
+- **GIVEN** `stepTreeAccess: "world-writable"` and a step tree left by a prior attempt with default modes
+- **WHEN** `createSandbox` runs again for the same step
+- **THEN** the existing directories are re-moded world-writable rather than skipped
+
+#### Scenario: Default modes when unset
+
+- **GIVEN** no `stepTreeAccess`
+- **WHEN** `createSandbox` pre-creates the step tree
+- **THEN** directory modes are the process default, unchanged from today
+
 ### Requirement: Dynamic port mapping for host connectivity
 
 The Docker backend SHALL use dynamic port mapping for `8765/tcp` bound to the
@@ -217,24 +281,42 @@ workflow and tear down orphans.
 ### Requirement: Container creation is idempotent on a recovery re-run
 
 `createSandbox` SHALL be idempotent on the checkpointed `sandboxId`. When
-`createContainer` returns a name collision (HTTP 409), it inspects the existing
-container and applies an owner-guard: it only adopts or replaces the container
+`createContainer` fails for any reason, the backend SHALL inspect the container
+under the checkpointed name rather than matching an engine-specific conflict
+status: Docker answers a name collision with HTTP 409, podman's compat API
+answers 500, and the reconciliation MUST NOT depend on either. If a container
+stands under the name, the owner-guard applies: it is adopted or replaced only
 when its `cortex/owner-workflow-id` label equals `meta.childWorkflowId`. A
-running owned container is adopted as-is; a stopped owned container is removed and
-recreated; a container owned by a different step is refused with a `name_conflict`
-error. The decision and its rationale are owned by the harness-sandbox-exec spec.
+running owned container is adopted as-is; a stopped owned container is removed
+and recreated; a container owned by a different step is refused with a
+`name_conflict` error. If no container stands under the name, the failure was
+not a name collision and the backend SHALL return the **original create
+error** — the inspect's own failure is never surfaced. The decision and its
+rationale are owned by the harness-sandbox-exec spec.
 
 #### Scenario: Running container adopted on recovery re-run
 
-- **GIVEN** a 409 whose existing container is running and labeled with the same `cortex/owner-workflow-id`
+- **GIVEN** a failed create whose existing container is running and labeled with the same `cortex/owner-workflow-id`
 - **WHEN** `createSandbox` reconciles it
 - **THEN** the existing container is adopted without recreation and its health is re-verified
 
 #### Scenario: Foreign owner is refused
 
-- **GIVEN** a 409 whose existing container is labeled with a different `cortex/owner-workflow-id`
+- **GIVEN** a failed create whose existing container is labeled with a different `cortex/owner-workflow-id`
 - **WHEN** `createSandbox` reconciles it
 - **THEN** it returns a `name_conflict` error and neither adopts nor removes the container
+
+#### Scenario: Adoption works on an engine that answers name conflicts with 500
+
+- **GIVEN** an engine that rejects a duplicate-name create with HTTP 500 and a running container owned by this workflow standing under the checkpointed name
+- **WHEN** `createSandbox` retries after a recovery
+- **THEN** the standing container is adopted exactly as it would be after a Docker 409
+
+#### Scenario: A non-conflict create failure is returned unchanged
+
+- **GIVEN** a create that fails while no container stands under the checkpointed name
+- **WHEN** `createSandbox` inspects the name and finds nothing
+- **THEN** it returns the original `container_create_failed` error, not the inspect's 404
 
 ### Requirement: K8s PVC subPaths derive from the resolved workspace root
 

--- a/harness/openspec/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/specs/docker-sandbox-provider/spec.md
@@ -180,38 +180,42 @@ property of how one backend addresses a volume, not of the container contract.
 - **THEN** the container has a read-only bind mount at `/mnt/libs`
 - **AND** the sandbox env injects the lib-store path variables from the mount plan
 
-### Requirement: Step-tree access mode for engines with honest bind ownership
+### Requirement: Declared host-preserved bind ownership loosens the step write tree
 
 `CreateSandboxClientConfig` SHALL carry an optional
-`stepTreeAccess: "world-writable"`. When set, the client SHALL `chmod` the
-pre-created step write tree — the step directory and each of its
-`STEP_SUBDIRS` — world-writable after creating it, so the uid-1000 sandbox
-workload can write through engines whose bind mounts preserve host ownership
-(podman machine's virtiofs presents the embedder user's real uid and modes;
-Docker Desktop's file-sharing layer masks the mismatch, which is why default
-modes suffice there). The mode SHALL be applied with an explicit `chmod`, not
-`mkdir`'s mode option (which the process umask masks), and SHALL be applied on
-replay when the directories already exist. When unset, pre-creation SHALL keep
-today's default modes. The loosening is scoped to the step write tree only:
-read-only mounts (analysis tree, lib/ref stores) rely on standard world-read
-and SHALL NOT be relabeled or re-moded.
+`engineBindOwnership: "host-preserved"`, by which the embedder states an
+engine fact: the engine's bind mounts expose honest host file ownership to the
+container (podman machine's virtiofs and native Linux binds present the
+embedder user's real uid and modes; Docker Desktop's file-sharing layer masks
+the mismatch, which is why default modes suffice there and the field stays
+unset). When set, the client SHALL `chmod` the pre-created step write tree —
+the step directory and each of its `STEP_SUBDIRS` — world-writable after
+creating it, so the uid-1000 sandbox workload can write through such mounts.
+The field names the fact, not the remediation: how the client compensates is
+harness-owned and MAY change without changing the config surface. The mode
+SHALL be applied with an explicit `chmod`, not `mkdir`'s mode option (which
+the process umask masks), and SHALL be applied on replay when the directories
+already exist. When unset, pre-creation SHALL keep today's default modes. The
+loosening is scoped to the step write tree only: read-only mounts (analysis
+tree, lib/ref stores) rely on standard world-read and SHALL NOT be relabeled
+or re-moded.
 
 #### Scenario: World-writable step tree under a podman connection
 
-- **GIVEN** `stepTreeAccess: "world-writable"`
+- **GIVEN** `engineBindOwnership: "host-preserved"`
 - **WHEN** `createSandbox` pre-creates the step tree
 - **THEN** the step directory and its subdirectories are world-writable
 - **AND** a workload write from uid 1000 through the read-write bind succeeds
 
 #### Scenario: Replayed pre-creation still applies the mode
 
-- **GIVEN** `stepTreeAccess: "world-writable"` and a step tree left by a prior attempt with default modes
+- **GIVEN** `engineBindOwnership: "host-preserved"` and a step tree left by a prior attempt with default modes
 - **WHEN** `createSandbox` runs again for the same step
 - **THEN** the existing directories are re-moded world-writable rather than skipped
 
 #### Scenario: Default modes when unset
 
-- **GIVEN** no `stepTreeAccess`
+- **GIVEN** no `engineBindOwnership`
 - **WHEN** `createSandbox` pre-creates the step tree
 - **THEN** directory modes are the process default, unchanged from today
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -4,10 +4,17 @@
  * transport is client-owned. Pure composition — no DBOS, no backend.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Pool } from "pg";
+
 import type { AwaitExecOptions } from "./await-exec.js";
-import { composeAwaitOptions } from "./create-sandbox.js";
-import type { SandboxLiveness } from "./types.js";
+import { composeAwaitOptions, createSandboxClient, precreateStepTree } from "./create-sandbox.js";
+import { STEP_SUBDIRS } from "./mount-plan.js";
+import type { CreateSandboxMeta, SandboxLiveness } from "./types.js";
 
 const opsProbe = async (): Promise<SandboxLiveness> => ({ alive: false, oomKilled: false });
 const injectedProbe = async (): Promise<SandboxLiveness> => ({ alive: true, oomKilled: false });
@@ -37,5 +44,107 @@ describe("composeAwaitOptions", () => {
         expect(options.sleep).toBe(sleep);
         expect(options.transport).toBe("callback");
         expect(options.isAlive).toBe(opsProbe);
+    });
+});
+
+describe("precreateStepTree — step-tree access mode", () => {
+    let root: string;
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), "harness-steptree-"));
+    });
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true });
+    });
+
+    const meta: CreateSandboxMeta = {
+        runId: "run-1",
+        stepId: "step-a",
+        analysisId: "an-1",
+        childWorkflowId: "run-1-0",
+        resources: { cpu: 1, memoryGb: 1 },
+    };
+    const deps = (stepTreeAccess?: "world-writable") => ({ resolveWorkspaceRoot: () => root, stepTreeAccess });
+    const stepDir = () => join(root, "runs", "run-1", "step-a");
+    /** POSIX permission bits, with the file-type bits masked off. */
+    const modeOf = async (p: string): Promise<number> => (await stat(p)).mode & 0o777;
+
+    test("world-writable: a fresh step tree ends world-writable across the dir and its subdirs", async () => {
+        await precreateStepTree(deps("world-writable"), meta);
+
+        expect(await modeOf(stepDir())).toBe(0o777);
+        for (const sub of STEP_SUBDIRS) {
+            expect(await modeOf(join(stepDir(), sub))).toBe(0o777);
+        }
+        // The loosening is scoped to the step tree — its ancestors keep default modes.
+        expect(await modeOf(join(root, "runs"))).not.toBe(0o777);
+    });
+
+    test("world-writable: a pre-existing step tree left with default modes is re-moded on replay", async () => {
+        // A prior attempt: the dirs already stand with a non-world-writable mode.
+        await mkdir(stepDir(), { recursive: true, mode: 0o700 });
+        await Promise.all(STEP_SUBDIRS.map((sub) => mkdir(join(stepDir(), sub), { recursive: true, mode: 0o700 })));
+        expect(await modeOf(stepDir())).not.toBe(0o777);
+
+        await precreateStepTree(deps("world-writable"), meta);
+
+        expect(await modeOf(stepDir())).toBe(0o777);
+        for (const sub of STEP_SUBDIRS) {
+            expect(await modeOf(join(stepDir(), sub))).toBe(0o777);
+        }
+    });
+
+    test("unset: step-tree modes match a plain mkdir — no world-write loosening", async () => {
+        await precreateStepTree(deps(undefined), meta);
+
+        // Control for this process's umask: what a bare recursive mkdir yields.
+        const control = join(root, "control");
+        await mkdir(control, { recursive: true });
+        const defaultMode = await modeOf(control);
+
+        expect(await modeOf(stepDir())).toBe(defaultMode);
+        for (const sub of STEP_SUBDIRS) {
+            expect(await modeOf(join(stepDir(), sub))).toBe(defaultMode);
+        }
+    });
+
+    test("read-only meta pre-creates nothing to re-mode", async () => {
+        await precreateStepTree(deps("world-writable"), { ...meta, readOnly: true });
+
+        // The read-only path returns before creating or chmodding any step tree.
+        await expect(stat(stepDir())).rejects.toThrow();
+    });
+});
+
+describe("createSandboxClient — engine connection threading", () => {
+    test("engineSocketPath is threaded to the docker ops, so engine calls dial that socket", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "harness-engine-"));
+        const socketPath = join(dir, "engine.sock");
+        // A stand-in engine on the configured socket that answers the managed-
+        // sandbox listing with one sentinel container. If the socket were not
+        // threaded, the ops would dial the default engine and never see it.
+        const server = createServer((_req, res) => {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify([{ Labels: { "cortex/sandbox-id": "sentinel-sbx", "cortex/owner-workflow-id": "wf-x" }, Created: 1700 }]));
+        });
+        await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+        try {
+            const client = createSandboxClient({
+                pool: {} as unknown as Pool,
+                env: { backend: "docker", namespace: "default" },
+                cortexBaseUrl: "https://x",
+                image: "sandbox-base:latest",
+                resourceLimits: { maxCpu: 8, maxMemoryGb: 32, maxGpuCount: 0 },
+                resolveWorkspaceRoot: (id) => join("/sessions", id),
+                engineSocketPath: socketPath,
+            });
+
+            const managed = await client.listManagedSandboxes();
+
+            expect(managed).toEqual([{ sandboxId: "sentinel-sbx", ownerWorkflowId: "wf-x", createdAtMs: 1700000 }]);
+        } finally {
+            await new Promise<void>((resolve) => server.close(() => resolve()));
+            await rm(dir, { recursive: true, force: true });
+        }
     });
 });

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -81,16 +81,18 @@ export interface CreateSandboxClientConfig {
      */
     engineSocketPath?: string;
     /**
-     * Docker: how the pre-created step write tree is made writable by the
-     * uid-1000 sandbox workload. `world-writable` chmods the step dir and its
-     * subdirs so a workload write lands through engines whose bind mounts
-     * preserve host ownership honestly — podman machine's virtiofs presents the
-     * embedder user's real uid and modes, which the uid-1000 workload cannot
-     * write. Docker Desktop's file-sharing layer masks that mismatch, so it
-     * stays unset there. A single-valued union (not a boolean) so the call site
-     * reads as policy and future strategies extend it without a breaking change.
+     * Docker: the engine's bind mounts expose honest host file ownership to
+     * the container — podman machine's virtiofs and native Linux binds present
+     * the embedder user's real uid and modes, which the uid-1000 sandbox
+     * workload cannot write; Docker Desktop's file-sharing layer masks that
+     * mismatch, so it stays unset there. When set, the client loosens each
+     * step's pre-created write tree so workload writes land. The field names
+     * the engine fact rather than the remediation, so how the harness
+     * compensates can evolve without changing the embedder surface; a
+     * single-valued union (not a boolean) so future ownership classes extend
+     * it without a breaking change.
      */
-    stepTreeAccess?: "world-writable";
+    engineBindOwnership?: "host-preserved";
     /** K8s: PVC claim backing the session PVC the workspace roots live under. */
     sessionPvc?: string;
     /**
@@ -237,7 +239,16 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
 
     return {
         createSandbox: async (meta, identity) => {
-            await precreateStepTree({ resolveWorkspaceRoot: config.resolveWorkspaceRoot, stepTreeAccess: config.stepTreeAccess }, meta);
+            // The config states an engine fact (binds preserve host ownership);
+            // which remediation that fact demands — today, a world-writable step
+            // write tree — is harness-owned and chosen here, not by the embedder.
+            await precreateStepTree(
+                {
+                    resolveWorkspaceRoot: config.resolveWorkspaceRoot,
+                    stepTreeAccess: config.engineBindOwnership === "host-preserved" ? "world-writable" : undefined,
+                },
+                meta,
+            );
             // Every caller must declare resources — a sandbox with no cpu/memory
             // request is a semantic error, not something to paper over with a
             // default (a DBOS replay of a pre-resources workflow input lands here).

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -12,7 +12,7 @@
  * `awaitExec` are backend-agnostic — they only need the SandboxRef.
  */
 
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { V1Toleration } from "@kubernetes/client-node";
@@ -74,6 +74,23 @@ export interface CreateSandboxClientConfig {
     refStorePath?: string;
     /** Docker: force the container platform (e.g. `linux/amd64`) so the sandbox matches the mounted lib store's arch. */
     platform?: string;
+    /**
+     * Docker: unix socket of the Docker-API engine to dial — a Docker daemon
+     * socket or a podman Docker-compat socket. Unset preserves dockerode's
+     * default resolution (`DOCKER_HOST`, then the default Docker socket).
+     */
+    engineSocketPath?: string;
+    /**
+     * Docker: how the pre-created step write tree is made writable by the
+     * uid-1000 sandbox workload. `world-writable` chmods the step dir and its
+     * subdirs so a workload write lands through engines whose bind mounts
+     * preserve host ownership honestly — podman machine's virtiofs presents the
+     * embedder user's real uid and modes, which the uid-1000 workload cannot
+     * write. Docker Desktop's file-sharing layer masks that mismatch, so it
+     * stays unset there. A single-valued union (not a boolean) so the call site
+     * reads as policy and future strategies extend it without a breaking change.
+     */
+    stepTreeAccess?: "world-writable";
     /** K8s: PVC claim backing the session PVC the workspace roots live under. */
     sessionPvc?: string;
     /**
@@ -120,6 +137,39 @@ export function composeAwaitOptions(
     return { isAlive, ...base, transport };
 }
 
+/**
+ * Backend-agnostic pre-creation of the writable step tree under the analysis's
+ * resolved workspace root. On Docker that root is the host dir the container
+ * binds; on K8s it lives under the session PVC the sandbox pod mounts via
+ * subPath. `mkdir(recursive)` is idempotent, so an existing tree (replay, retry)
+ * is not an error. A read-only sandbox has no writable step mount, so there is
+ * nothing to pre-create.
+ *
+ * `stepTreeAccess: "world-writable"` chmods the step dir and each subdir so the
+ * uid-1000 sandbox workload can write them through engines that honor host bind
+ * ownership. The chmod is explicit, not `mkdir`'s `mode` option: the process
+ * umask masks `mkdir`'s mode, and on replay the dirs already exist so `mkdir`
+ * would not touch them either way. Scoped to the step write tree — the
+ * read-only mount sources are never re-moded. Exported for tests.
+ */
+export async function precreateStepTree(
+    deps: { resolveWorkspaceRoot: ResolveWorkspaceRoot; stepTreeAccess?: "world-writable" },
+    meta: CreateSandboxMeta,
+): Promise<void> {
+    if (meta.readOnly) return;
+    const stepDir = stepWritePrefix({
+        workspaceRoot: deps.resolveWorkspaceRoot(meta.analysisId),
+        runId: meta.runId,
+        stepId: meta.stepId,
+    });
+    await mkdir(stepDir, { recursive: true });
+    await Promise.all(STEP_SUBDIRS.map((sub) => mkdir(join(stepDir, sub), { recursive: true })));
+    if (deps.stepTreeAccess === "world-writable") {
+        await chmod(stepDir, 0o777);
+        await Promise.all(STEP_SUBDIRS.map((sub) => chmod(join(stepDir, sub), 0o777)));
+    }
+}
+
 export function createSandboxClient(config: CreateSandboxClientConfig): SandboxClient {
     const backend = config.backend ?? config.env.backend;
     const transport = config.transport ?? "poll";
@@ -153,26 +203,10 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
                   libStorePath: config.libStorePath,
                   refStorePath: config.refStorePath,
                   platform: config.platform,
+                  engineSocketPath: config.engineSocketPath,
                   logger: config.logger,
                   registerSandbox,
               });
-
-    // Backend-agnostic pre-creation of the writable step tree under the
-    // analysis's resolved workspace root. On Docker that root is the host dir
-    // the container binds; on K8s it lives under the session PVC the sandbox
-    // pod mounts via subPath. mkdir(recursive) is idempotent, so an existing
-    // tree (replay, retry) is not an error.
-    const precreateStepTree = async (meta: CreateSandboxMeta): Promise<void> => {
-        // A read-only sandbox has no writable step mount — nothing to pre-create.
-        if (meta.readOnly) return;
-        const stepDir = stepWritePrefix({
-            workspaceRoot: config.resolveWorkspaceRoot(meta.analysisId),
-            runId: meta.runId,
-            stepId: meta.stepId,
-        });
-        await mkdir(stepDir, { recursive: true });
-        await Promise.all(STEP_SUBDIRS.map((sub) => mkdir(join(stepDir, sub), { recursive: true })));
-    };
 
     // `teardown` needs the registry-clear closure but the SandboxRef alone
     // doesn't carry runId/stepId. Wrap the backend impl so callers pass the
@@ -203,7 +237,7 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
 
     return {
         createSandbox: async (meta, identity) => {
-            await precreateStepTree(meta);
+            await precreateStepTree({ resolveWorkspaceRoot: config.resolveWorkspaceRoot, stepTreeAccess: config.stepTreeAccess }, meta);
             // Every caller must declare resources — a sandbox with no cpu/memory
             // request is a semantic error, not something to paper over with a
             // default (a DBOS replay of a pre-resources workflow input lands here).

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -5,7 +5,7 @@
  * liveness. There is no gateway sidecar and no `--internal` network.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
 import { createCapturingLogger } from "../__tests__/setup/logger.js";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -672,6 +672,12 @@ describe("docker createSandbox — recovery reconciliation", () => {
             registerSandbox: async () => {},
         });
 
+    // The health-re-verification test advances the mocked clock; restore real time after
+    // every case so a thrown assertion can never leave a frozen clock for the next test.
+    afterEach(() => {
+        setSystemTime();
+    });
+
     test("adopts a running owned container when the engine answers the duplicate create with 500 (podman's shape)", async () => {
         const { docker, created, removed } = reconcileDocker({ createStatus: 500, standing: { labels: ownedLabels, running: true } });
 
@@ -710,6 +716,27 @@ describe("docker createSandbox — recovery reconciliation", () => {
         expect(removed).toEqual([]);
     });
 
+    test("refuses a STOPPED standing container owned by a different workflow with name_conflict, and never removes it", async () => {
+        const { docker, created, removed } = reconcileDocker({
+            createStatus: 500,
+            standing: { labels: { [OWNER_WORKFLOW_LABEL]: "someone-else" }, running: false },
+        });
+
+        const result = await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1"));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.type).toBe("name_conflict");
+            if (result.error.type === "name_conflict") expect(result.error.owner).toBe("someone-else");
+        }
+        // The ownership guard is checked before the running-state check, so a foreign
+        // container is refused whether it is running or stopped. A stopped one must not be
+        // treated as our own reclaimable leftover and removed — the empty removal record
+        // pins that ordering.
+        expect(created).toEqual([]);
+        expect(removed).toEqual([]);
+    });
+
     test("returns the original create error (not the inspect 404) when no container stands under the name", async () => {
         const { docker } = reconcileDocker({ createStatus: 500, standing: null });
 
@@ -732,6 +759,38 @@ describe("docker createSandbox — recovery reconciliation", () => {
         // The stopped prior attempt is removed, then a fresh container is created.
         expect(removed.length).toBeGreaterThan(0);
         expect(created.length).toBeGreaterThan(0);
+    });
+
+    test("re-verifies an adopted container's health: a /health that never returns 200 fails adoption with container_create_failed", async () => {
+        const { docker, created, removed } = reconcileDocker({ createStatus: 500, standing: { labels: ownedLabels, running: true } });
+
+        // The running owned container is adopted, then its /health is polled afresh. This
+        // stub keeps /health unhealthy AND jumps the mocked clock past the poll deadline on
+        // the first probe, so the loop ends after a single tick instead of the real 30s wait.
+        const unhealthyFetch = (async () => {
+            setSystemTime(new Date(Date.now() + 10 * 60_000));
+            return new Response("unhealthy", { status: 503 });
+        }) as unknown as typeof fetch;
+
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: unhealthyFetch,
+            registerSandbox: async () => {},
+        });
+
+        const result = await ops.createSandbox(META, mintSandboxIdentity("run-1"));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) expect(result.error.type).toBe("container_create_failed");
+        // Adoption path proof: the standing container was running and owned, so nothing was
+        // created or removed. The failure therefore comes from re-verifying the adopted
+        // container's health, not from a create attempt — deleting that re-verification
+        // would let this adoption succeed against an unhealthy sandbox.
+        expect(created).toEqual([]);
+        expect(removed).toEqual([]);
     });
 });
 

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Docker from "dockerode";
 
-import { createDockerSandboxOps } from "./docker-client.js";
+import { createDockerSandboxOps, engineConnectionOptions } from "./docker-client.js";
 import { mintSandboxIdentity } from "./identity.js";
 
 // A real, COMPLETE on-disk lib store: the Docker client re-checks `<libStorePath>/current`
@@ -594,5 +594,173 @@ describe("docker teardown / isAlive", () => {
         const result = await ops.isAlive({ sandboxId: "x", host: "h", port: 1, backend: "docker", callbackSecret: "x" });
         expect(result.isErr()).toBe(true);
         if (result.isErr()) expect(result.error.type).toBe("liveness_failed");
+    });
+});
+
+/** The owner label the reconcile guard reads (module-private in docker-client.ts). */
+const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
+
+/**
+ * A docker stub whose FIRST `createContainer` fails with `createStatus` and
+ * whose `getContainer(...).inspect()` reports `standing` (or 404s when
+ * `standing` is null). A post-removal recreate lands as a fresh, startable
+ * container. Models the recovery re-run: create fails, then the reconcile
+ * inspects the checkpointed name.
+ */
+function reconcileDocker(opts: { createStatus: number; standing: { labels: Record<string, string>; running: boolean } | null }): {
+    docker: Docker;
+    created: string[];
+    removed: string[];
+} {
+    const created: string[] = [];
+    const removed: string[] = [];
+    let standing = opts.standing;
+    let attempts = 0;
+
+    const container = (id: string) => ({
+        id,
+        start: async () => {
+            if (standing) standing.running = true;
+        },
+        stop: async () => {
+            if (standing) standing.running = false;
+        },
+        remove: async () => {
+            removed.push(id);
+            standing = null;
+        },
+        inspect: async () => {
+            if (!standing) throw notFound();
+            return {
+                Config: { Labels: standing.labels },
+                NetworkSettings: { Ports: { "8765/tcp": [{ HostIp: "127.0.0.1", HostPort: "32100" }] } },
+                State: { Running: standing.running, OOMKilled: false },
+            };
+        },
+    });
+
+    const docker = {
+        createContainer: async (o: CreateOpts) => {
+            attempts += 1;
+            // The first create is the one that races the standing container; a
+            // later attempt is a post-removal recreate and lands cleanly.
+            if (attempts === 1) {
+                const e = new Error("that name is already in use") as Error & { statusCode: number };
+                e.statusCode = opts.createStatus;
+                throw e;
+            }
+            created.push(o.name);
+            standing = { labels: o.Labels ?? {}, running: false };
+            return container(o.name);
+        },
+        getContainer: (id: string) => container(id),
+    } as unknown as Docker;
+
+    return { docker, created, removed };
+}
+
+describe("docker createSandbox — recovery reconciliation", () => {
+    const ownedLabels = { [OWNER_WORKFLOW_LABEL]: META.childWorkflowId, role: "sandbox" };
+
+    const reconcileOps = (docker: Docker) =>
+        createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+    test("adopts a running owned container when the engine answers the duplicate create with 500 (podman's shape)", async () => {
+        const { docker, created, removed } = reconcileDocker({ createStatus: 500, standing: { labels: ownedLabels, running: true } });
+
+        const ref = (await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(ref.backend).toBe("docker");
+        // Adopted as-is: no create landed and nothing was removed.
+        expect(created).toEqual([]);
+        expect(removed).toEqual([]);
+    });
+
+    test("adopts a running owned container when the engine answers the duplicate create with 409 (Docker's shape)", async () => {
+        const { docker, created, removed } = reconcileDocker({ createStatus: 409, standing: { labels: ownedLabels, running: true } });
+
+        (await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(created).toEqual([]);
+        expect(removed).toEqual([]);
+    });
+
+    test("refuses a standing container owned by a different workflow with name_conflict", async () => {
+        const { docker, created, removed } = reconcileDocker({
+            createStatus: 500,
+            standing: { labels: { [OWNER_WORKFLOW_LABEL]: "someone-else" }, running: true },
+        });
+
+        const result = await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1"));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.type).toBe("name_conflict");
+            if (result.error.type === "name_conflict") expect(result.error.owner).toBe("someone-else");
+        }
+        // A foreign container is neither adopted nor removed.
+        expect(created).toEqual([]);
+        expect(removed).toEqual([]);
+    });
+
+    test("returns the original create error (not the inspect 404) when no container stands under the name", async () => {
+        const { docker } = reconcileDocker({ createStatus: 500, standing: null });
+
+        const result = await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1"));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.type).toBe("container_create_failed");
+            // The status is the create's 500, proving the inspect's 404 was never surfaced.
+            if (result.error.type === "container_create_failed") expect(result.error.status).toBe(500);
+        }
+    });
+
+    test("removes and recreates a stopped owned container", async () => {
+        const { docker, created, removed } = reconcileDocker({ createStatus: 500, standing: { labels: ownedLabels, running: false } });
+
+        const ref = (await reconcileOps(docker).createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(ref.backend).toBe("docker");
+        // The stopped prior attempt is removed, then a fresh container is created.
+        expect(removed.length).toBeGreaterThan(0);
+        expect(created.length).toBeGreaterThan(0);
+    });
+});
+
+describe("engineConnectionOptions", () => {
+    test("maps a configured socket path to dockerode connection options", () => {
+        expect(engineConnectionOptions("/run/podman/podman.sock")).toEqual({ socketPath: "/run/podman/podman.sock" });
+    });
+
+    test("is undefined when unset so construction stays a bare new Docker() (default resolution)", () => {
+        expect(engineConnectionOptions(undefined)).toBeUndefined();
+    });
+});
+
+describe("docker createSandbox — engine connection", () => {
+    test("an injected docker instance takes precedence over a configured engineSocketPath", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            engineSocketPath: "/nonexistent/should-not-be-dialed.sock",
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // The create landed through the injected stub — the configured socket was never dialed.
+        expect(sandboxOf(created)).toBeDefined();
     });
 });

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -175,6 +175,7 @@ async function createOrAdopt(
     name: string,
     ownerWorkflowId: string,
     createFailed: (status: number | undefined, cause: unknown) => SandboxError,
+    logger: Logger,
 ): Promise<Result<{ container: Docker.Container; alreadyRunning: boolean }, SandboxError>> {
     const created = await trySandbox(() => docker.createContainer(createOpts), createFailed);
     if (created.isOk()) return ok({ container: created.value, alreadyRunning: false });
@@ -190,12 +191,19 @@ async function createOrAdopt(
     if (owner !== ownerWorkflowId) {
         return err({ type: "name_conflict", op: "docker.createSandbox", sandboxId: name, owner: owner ?? null });
     }
-    if (info.State.Running) return ok({ container: existing, alreadyRunning: true });
+    // Both mutating reconcile outcomes are logged: adoption reuses a container the
+    // current attempt did not create, so without a record here nothing ties the
+    // step's sandbox back to the prior attempt that made it.
+    if (info.State.Running) {
+        logger.info("adopted standing container on recovery re-run", { sandboxId: name, ownerWorkflowId });
+        return ok({ container: existing, alreadyRunning: true });
+    }
 
     const removed = await removeContainerIgnoreMissing(docker, name);
     if (removed.isErr()) return err(removed.error);
     const recreated = await trySandbox(() => docker.createContainer(createOpts), createFailed);
     if (recreated.isErr()) return err(recreated.error);
+    logger.info("removed stopped prior attempt and recreated", { sandboxId: name, ownerWorkflowId });
     return ok({ container: recreated.value, alreadyRunning: false });
 }
 
@@ -230,6 +238,7 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
     // engine and an unset one stays a bare `new Docker()` (default resolution).
     const connection = engineConnectionOptions(config.engineSocketPath);
     const docker = config.docker ?? (connection ? new Docker(connection) : new Docker());
+    const logger = (config.logger ?? createNoopLogger()).named("docker-client");
     const fetchImpl = config.fetch ?? fetch;
     const transport: SandboxTransport = config.transport ?? "poll";
     const pollMode = transport === "poll";
@@ -246,12 +255,10 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                     // since an otherwise-silent libs-mount drop is invisible to operators.
                     const libsMounted = !!config.libStorePath && libStoreUsable(config.libStorePath);
                     if (config.libStorePath && !libsMounted) {
-                        (config.logger ?? createNoopLogger())
-                            .named("docker-client")
-                            .warn(
-                                "lib store configured but `current` is missing or incomplete at sandbox creation — mounting no library store (sandbox degrades to available:false)",
-                                { libStorePath: config.libStorePath, sandboxId },
-                            );
+                        logger.warn(
+                            "lib store configured but `current` is missing or incomplete at sandbox creation — mounting no library store (sandbox degrades to available:false)",
+                            { libStorePath: config.libStorePath, sandboxId },
+                        );
                     }
 
                     const plan = buildMountPlan(meta, {
@@ -331,7 +338,7 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                         },
                     };
 
-                    const sandbox = await createOrAdopt(docker, createOpts, sandboxId, meta.childWorkflowId, createFailed);
+                    const sandbox = await createOrAdopt(docker, createOpts, sandboxId, meta.childWorkflowId, createFailed, logger);
                     if (sandbox.isErr()) return err(sandbox.error);
                     if (!sandbox.value.alreadyRunning) {
                         const started = await trySandbox(() => sandbox.value.container.start(), createFailed);

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -89,6 +89,13 @@ export interface DockerClientConfig {
      * create rather than crashing inside the sandbox.
      */
     platform?: string;
+    /**
+     * Unix socket of the Docker-API engine to dial — a Docker daemon socket or a
+     * podman Docker-compat socket (both serve the identical REST API). Unset
+     * preserves dockerode's default resolution (`DOCKER_HOST`, then the default
+     * Docker socket).
+     */
+    engineSocketPath?: string;
     /** Injected for tests. */
     docker?: Docker;
     /** Injected for tests so `/health` polling can be stubbed. */
@@ -139,11 +146,28 @@ async function pollHealth(fetchImpl: typeof fetch, url: string, timeoutMs: numbe
 }
 
 /**
+ * dockerode connection options for a configured engine socket, or `undefined`
+ * to leave construction as a bare `new Docker()` — which preserves dockerode's
+ * default resolution (`DOCKER_HOST`, then the default Docker socket). A set
+ * `engineSocketPath` dials that unix socket instead (a Docker daemon or a
+ * podman Docker-compat socket).
+ */
+export function engineConnectionOptions(engineSocketPath: string | undefined): Docker.DockerOptions | undefined {
+    return engineSocketPath === undefined ? undefined : { socketPath: engineSocketPath };
+}
+
+/**
  * Create the container, or adopt the one already standing under this
- * checkpointed name (a recovery re-run, see the harness-sandbox-exec spec). A
- * running container is adopted as-is; a stopped prior attempt is removed and
- * recreated. A 409 whose container belongs to a different workflow is a refused
- * name collision — never adopt or remove someone else's container.
+ * checkpointed name on a recovery re-run. Any create failure triggers an
+ * inspect of the name: engines disagree on the duplicate-name status (Docker
+ * answers 409, podman's compat API 500), so the reconcile keys on whether a
+ * container stands under the name, not on a status code. A standing container
+ * this workflow owns is adopted as-is if running, removed and recreated if
+ * stopped; one owned by a different workflow is a refused name collision — never
+ * adopt or remove someone else's container. When no container stands, the
+ * failure was not a name collision and the original create error is returned;
+ * the inspect's own failure is never surfaced, so a transient engine outage
+ * (both calls fail) still reports the create failure.
  */
 async function createOrAdopt(
     docker: Docker,
@@ -154,11 +178,12 @@ async function createOrAdopt(
 ): Promise<Result<{ container: Docker.Container; alreadyRunning: boolean }, SandboxError>> {
     const created = await trySandbox(() => docker.createContainer(createOpts), createFailed);
     if (created.isOk()) return ok({ container: created.value, alreadyRunning: false });
-    if (statusOf(created.error) !== 409) return err(created.error);
 
     const existing = docker.getContainer(name);
     const inspected = await trySandbox(() => existing.inspect(), createFailed);
-    if (inspected.isErr()) return err(inspected.error);
+    // No container stands under the name → the create failure was not a name
+    // collision, so surface the original create error rather than the inspect's.
+    if (inspected.isErr()) return err(created.error);
     const info = inspected.value;
 
     const owner = info.Config?.Labels?.[OWNER_WORKFLOW_LABEL];
@@ -201,7 +226,10 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
     isAlive(ref: SandboxRef): ResultAsync<SandboxLiveness, SandboxError>;
     listManagedSandboxes(): ResultAsync<ManagedSandbox[], SandboxError>;
 } {
-    const docker = config.docker ?? new Docker();
+    // The injected test instance wins; otherwise a configured socket dials that
+    // engine and an unset one stays a bare `new Docker()` (default resolution).
+    const connection = engineConnectionOptions(config.engineSocketPath);
+    const docker = config.docker ?? (connection ? new Docker(connection) : new Docker());
     const fetchImpl = config.fetch ?? fetch;
     const transport: SandboxTransport = config.transport ?? "poll";
     const pollMode = transport === "poll";


### PR DESCRIPTION
## What & why

Sandboxes hard-required the Docker socket: the harness constructed its `dockerode` client with default options, so on a podman-pinned machine every sandbox step failed at container create even though the proxy, Postgres, and the image pre-pull all ran on podman — and with both engines installed, the image landed in podman's store while containers were created against Docker (split-brain). Podman serves the same Docker REST API on a different socket, so this PR treats the backend as a *docker-API engine* rather than "Docker the product": podman becomes a **connection**, not a third backend.

Closes #123

**Harness** (`feat(harness)`, spec: `docker-sandbox-provider`):
- `engineSocketPath?: string` on `CreateSandboxClientConfig`/`DockerClientConfig`, threaded to the single `dockerode` construction site. Unset is byte-identical to today (`DOCKER_HOST`, then the default socket).
- Recovery adoption (`createOrAdopt`) no longer keys on HTTP 409: any create failure inspects the checkpointed name and runs the existing owner-guard on a standing container. Podman's compat API answers duplicate-name creates with **500**, and adoption must not care; no standing container returns the original create error.
- `stepTreeAccess?: "world-writable"`: chmods the pre-created step tree (step dir + subdirs, explicit `chmod`, replay-safe) so the uid-1000 workload can write through engines whose bind mounts preserve host ownership honestly (podman machine's virtiofs); Docker Desktop masks the mismatch and keeps default modes.

**CLI** (`feat(cli)`, specs: `container-runtime`, `harness-runtime`):
- `resolveEngineSocket` on the runtime-descriptor surface: docker → no socket; podman → the machine's compat socket (macOS) or `podman info`'s REST socket gated on existence (Linux). Resolved every boot, never persisted (the macOS socket lives under `$TMPDIR` and moves across machine restarts).
- Boot resolves the pin + socket among the pre-flight gates and wires `createSandboxClient` accordingly; `stepTreeAccess` is passed only under a podman pin; a docker pin produces byte-identical config to before. Failed resolution is a dedicated boot error naming the remediation (`podman machine start` / `systemctl --user enable --now podman.socket`) instead of a dockerode `ECONNREFUSED` mid-run.

**Verification**: harness suite 1228 pass / 0 fail — run through podman itself (`DOCKER_HOST` → compat socket, `TESTCONTAINERS_RYUK_DISABLED=true`); cli suite 1157 pass / 0 fail; live smoke on a rootful podman machine with the current `sandbox-python:latest`: sandbox created healthy through the resolved socket, uid-1000 artifact write landed on the host through the world-writable step tree, teardown clean. Design rationale (including the rejected `engine: "docker" | "podman"` enum and the rejected 409/500 status matching) is recorded in the archived changes' `design.md`.

Out of scope (recorded in the change docs): rootless podman on Linux (pasta/slirp4netns) is unvalidated — reachable via the seam, gated by the boot error until validated; SELinux `:z` relabeling for the harness mount plan on enforcing Linux hosts.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed (OpenSpec specs synced in both subsystems; no command/flag surface changed).
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** not applicable — no analytical method change.
- [x] **Sandbox:** the security model is preserved: same unprivileged uid-1000 workload, `CapDrop ALL` + the four entrypoint-only CapAdds, `no-new-privileges`, in-container egress firewall in poll mode, signature-authenticated exec endpoints, read-only analysis tree, resource limits. **One deliberate loosening, called out:** under a podman pin the per-step write tree (`runs/{runId}/{stepId}` + subdirs only) is created world-writable, because podman machine's virtiofs preserves host uid/modes and the uid-1000 workload could otherwise not write its own output directory. Scope is the step output tree only (created to receive sandbox writes); the read-only mounts are untouched; docker-pinned machines keep today's modes.
- [x] **Provenance:** prior analyses remain reproducible — no change to provenance signing, artifact registration, or the exec protocol.
