### PR TITLE
feat(refs): expand catalog, grouped picker, URL-only integrity model

### DIFF
--- a/cli/src/cli/cli.test.ts
+++ b/cli/src/cli/cli.test.ts
@@ -32,15 +32,16 @@ describe("inflexa help & usage (e2e)", () => {
         expect(result.stderr).toContain("Unknown reference dataset");
     });
 
-    test("refs list explains custom content, integrity, and catalog contributions", () => {
+    test("refs list explains custom content, trust-on-first-use integrity, and catalog contributions", () => {
         const result = runCli(["refs", "list"]);
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("Add arbitrary references under");
         expect(result.stdout).toContain("Open a PR");
-        // Nothing is re-hosted: each dataset states the integrity guarantee its own upstream can offer.
-        expect(result.stdout).toContain("Integrity: pinned — verified against the checksums in the catalog");
-        expect(result.stdout).toContain("Integrity: unpinned — upstream is rebuilt in place; verified against what you downloaded");
-        expect(result.stdout).toContain("nothing is mirrored or re-hosted here");
+        // Nothing is mirrored, re-hosted, or checksum-pinned: integrity is trust-on-first-use, checked
+        // against the copy you downloaded rather than a catalog digest.
+        expect(result.stdout).toContain("nothing is mirrored, re-hosted, or checksum-pinned here");
+        expect(result.stdout).toContain("Integrity is trust-on-first-use: `inflexa refs verify` checks each installed file against the copy you downloaded.");
+        expect(result.stdout).toContain("Re-run with `--urls` to print the exact upstream URL of every file.");
     });
 
     test("refs download offers --force to repair damage and refresh mutable upstreams", () => {

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -373,9 +373,10 @@ const refs = cli.command("refs").description("Manage reference data mounted read
 
 refs.command("list")
     .description("List catalog options, links, sizes, and local state")
-    .action(async () => {
+    .option("--urls", "Also print the exact upstream download URL of every file")
+    .action(async (options: { urls?: boolean }) => {
         const { runRefsList } = await import("../modules/refs/commands.ts");
-        await runRefsList();
+        await runRefsList({ urls: options.urls ?? false });
     });
 
 refs.command("download")

--- a/cli/src/modules/refs/commands.test.ts
+++ b/cli/src/modules/refs/commands.test.ts
@@ -37,8 +37,8 @@ function catalog(artifacts: ReferenceDataCatalog["datasets"][number]["artifacts"
     };
 }
 
-const PINNED_ARTIFACT = { integrity: "pinned", path: "file", url: "https://upstream.test/file", bytes: 5, sha256: sha("alpha") } as const;
-const UNPINNED_ARTIFACT = { integrity: "unpinned", path: "mutable", url: "https://upstream.test/mutable" } as const;
+const FILE_ARTIFACT = { path: "file", url: "https://upstream.test/file" } as const;
+const MUTABLE_ARTIFACT = { path: "mutable", url: "https://upstream.test/mutable" } as const;
 
 function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     return {
@@ -52,7 +52,7 @@ function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     };
 }
 
-const pinnedSource = source(catalog([PINNED_ARTIFACT]));
+const singleFileSource = source(catalog([FILE_ARTIFACT]));
 
 /** Activate the pinned fixture on disk exactly as a completed install would leave it. */
 function seedIntactInstall(): void {
@@ -68,7 +68,7 @@ function seedIntactInstall(): void {
             datasetId: "demo",
             datasetVersion: "1",
             activatedAt: "2026-07-14T12:00:00.000Z",
-            artifacts: [{ path: "file", bytes: 5, sha256: sha("alpha"), integrity: "pinned" }],
+            artifacts: [{ path: "file", bytes: 5, sha256: sha("alpha") }],
         }),
     );
 }
@@ -86,28 +86,28 @@ describe("reference command policy", () => {
 
     test("headless downloads require ids and explicit consent before mutation", async () => {
         assertTestSandbox(env.refsDir);
-        const noIds = await downloadReferences({ ids: [], interactive: false, source: pinnedSource });
+        const noIds = await downloadReferences({ ids: [], interactive: false, source: singleFileSource });
         expect(noIds.isErr()).toBe(true);
-        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
-        expect(noConsent._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
+        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: singleFileSource });
+        expect(noConsent._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 
-    test("an unpinned artifact is quoted as upstream-determined rather than given an invented size", async () => {
-        const unsized = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([UNPINNED_ARTIFACT])) });
-        expect(unsized._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+    test("every artifact is quoted as upstream-determined rather than given an invented size", async () => {
+        const oneFile = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([MUTABLE_ARTIFACT])) });
+        expect(oneFile._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
 
-        const mixed = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([PINNED_ARTIFACT, UNPINNED_ARTIFACT])) });
-        expect(mixed._unsafeUnwrapErr().message).toBe("Downloading 5 B + 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+        const twoFiles = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([FILE_ARTIFACT, MUTABLE_ARTIFACT])) });
+        expect(twoFiles._unsafeUnwrapErr().message).toBe("Downloading 2 files of upstream-determined size requires explicit consent; re-run with --yes.");
     });
 
-    test("--force turns an intact install back into bytes to fetch; without it there is nothing to do", async () => {
+    test("--force turns an intact install back into a file to fetch; without it there is nothing to do", async () => {
         seedIntactInstall();
-        const intact = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
-        expect(intact._unsafeUnwrapErr().message).toBe("Downloading 0 B requires explicit consent; re-run with --yes.");
+        const intact = await downloadReferences({ ids: ["demo"], interactive: false, source: singleFileSource });
+        expect(intact._unsafeUnwrapErr().message).toBe("Downloading 0 files of upstream-determined size requires explicit consent; re-run with --yes.");
 
-        const forced = await downloadReferences({ ids: ["demo"], interactive: false, force: true, source: pinnedSource });
-        expect(forced._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
+        const forced = await downloadReferences({ ids: ["demo"], interactive: false, force: true, source: singleFileSource });
+        expect(forced._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
     });
 
     test("a declined interactive download activates nothing", async () => {
@@ -115,14 +115,14 @@ describe("reference command policy", () => {
         const result = await downloadReferences({
             ids: ["demo"],
             interactive: true,
-            source: pinnedSource,
+            source: singleFileSource,
             confirmDownload: async (question) => {
                 questions.push(question);
                 return false;
             },
         });
         expect(result._unsafeUnwrap()).toMatchObject({ declined: true, installed: [] });
-        expect(questions).toEqual([`Download 5 B of reference data into ${env.refsDir}?`]);
+        expect(questions).toEqual([`Download 1 file of upstream-determined size of reference data into ${env.refsDir}?`]);
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -1,4 +1,4 @@
-import { isCancel, log, multiselect } from "@clack/prompts";
+import { groupMultiselect, isCancel, log } from "@clack/prompts";
 import { REFERENCE_DATA_CATALOG, type ReferenceDataCatalog } from "@inflexa-ai/harness";
 import { err, ok, type Result } from "neverthrow";
 
@@ -8,7 +8,7 @@ import {
     ensureReferenceStore,
     inspectReferenceStore,
     installReferenceDatasets,
-    referenceDownloadBytes,
+    referenceDownloadEstimate,
     verifyReferenceDatasets,
     type ReferenceDownloadEstimate,
     type ReferenceInstallOutcome,
@@ -71,46 +71,14 @@ export function formatReferenceBytes(bytes: number): string {
     return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
 }
 
-type ReferenceDatasetSize = {
-    /** Bytes across artifacts the catalog can size. */
-    readonly bytes: number;
-    /** Artifacts whose size only the mutable upstream knows. */
-    readonly unsized: number;
-};
-
-function datasetSize(dataset: ReferenceDataCatalog["datasets"][number]): ReferenceDatasetSize {
-    let bytes = 0;
-    let unsized = 0;
-    for (const artifact of dataset.artifacts) {
-        if (artifact.integrity === "pinned") bytes += artifact.bytes;
-        else unsized += 1;
-    }
-    return { bytes, unsized };
+/** A file count phrased for the terminal — the catalog pins no sizes, so the upstream determines
+ * the bytes at download time and the honest thing to state ahead of time is the number of files. */
+function formatFileCount(count: number): string {
+    return `${count} file${count === 1 ? "" : "s"} of upstream-determined size`;
 }
 
-/** Render a size the catalog may only partly know, without ever inventing a number. */
-function formatReferenceSize(size: ReferenceDatasetSize): string {
-    if (size.unsized === 0) return formatReferenceBytes(size.bytes);
-    const unsized = `${size.unsized} file${size.unsized === 1 ? "" : "s"} of upstream-determined size`;
-    return size.bytes === 0 ? unsized : `${formatReferenceBytes(size.bytes)} + ${unsized}`;
-}
-
-/** The strongest integrity guarantee that holds for every artifact in the dataset. */
-function datasetIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): "pinned" | "unpinned" | "mixed" {
-    const pinned = dataset.artifacts.some((artifact) => artifact.integrity === "pinned");
-    const unpinned = dataset.artifacts.some((artifact) => artifact.integrity === "unpinned");
-    return pinned && unpinned ? "mixed" : unpinned ? "unpinned" : "pinned";
-}
-
-function renderIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): string {
-    switch (datasetIntegrity(dataset)) {
-        case "pinned":
-            return "pinned — verified against the checksums in the catalog";
-        case "unpinned":
-            return "unpinned — upstream is rebuilt in place; verified against what you downloaded";
-        case "mixed":
-            return "mixed — some files are checksum-pinned, others are verified against what you downloaded";
-    }
+function formatDatasetSize(dataset: ReferenceDataCatalog["datasets"][number]): string {
+    return formatFileCount(dataset.artifacts.length);
 }
 
 function renderError(error: ReferenceProvisionError): string {
@@ -118,19 +86,29 @@ function renderError(error: ReferenceProvisionError): string {
 }
 
 function renderEstimate(estimate: ReferenceDownloadEstimate): string {
-    return formatReferenceSize({ bytes: estimate.bytes, unsized: estimate.unsizedArtifacts });
+    return formatFileCount(estimate.artifactsToFetch);
 }
 
 async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string[] | undefined> {
     if (catalog.datasets.length === 0) return [];
-    const selected = await multiselect({
+    // Present the picker as labelled categories rather than one flat wall: the catalog already
+    // carries `recommendation.group` per dataset, so grouping is purely presentational. Group
+    // insertion order follows first appearance in the catalog (which is ordered by group), and
+    // toggling a group header selects every dataset under it — clack returns only the leaf ids,
+    // never the group label, so the strict resolver downstream never sees a phantom id.
+    const grouped: Record<string, { value: string; label: string; hint?: string }[]> = {};
+    for (const dataset of catalog.datasets) {
+        (grouped[dataset.recommendation.group] ??= []).push({
+            value: dataset.id,
+            label: `${dataset.title} (${formatDatasetSize(dataset)})`,
+            ...(dataset.recommendation.recommended ? { hint: "recommended" } : {}),
+        });
+    }
+    const selected = await groupMultiselect({
         message: "Reference datasets to download",
         required: false,
-        options: catalog.datasets.map((dataset) => ({
-            value: dataset.id,
-            label: `${dataset.title} (${formatReferenceSize(datasetSize(dataset))})`,
-            hint: `${dataset.recommendation.group}${dataset.recommendation.recommended ? ", recommended" : ""}`,
-        })),
+        selectableGroups: true,
+        options: grouped,
     });
     return isCancel(selected) ? undefined : selected;
 }
@@ -165,7 +143,7 @@ export async function downloadReferences(
     }
 
     const install = { force: options.force ?? false };
-    const estimate = await referenceDownloadBytes(ids, env.refsDir, options.source ?? undefined, install);
+    const estimate = await referenceDownloadEstimate(ids, env.refsDir, options.source ?? undefined, install);
     if (estimate.isErr()) return err(estimate.error);
     const size = renderEstimate(estimate.value);
     console.log(`Reference download plan: ${size} to fetch from the upstream publishers.`);
@@ -201,26 +179,37 @@ export function runRefsPath(): void {
     console.log(env.refsDir);
 }
 
-/** `inflexa refs list` — render canonical options and recoverable local state. */
-export async function runRefsList(): Promise<void> {
+/** `inflexa refs list` — render canonical options and recoverable local state. Pass `urls` to also
+ * print the exact upstream download URL of every artifact, so the source is inspectable before consent. */
+export async function runRefsList(options: { readonly urls?: boolean } = {}): Promise<void> {
     const result = await inspectReferenceStore(env.refsDir);
     result.match(
         (inspection) => {
             if (inspection.datasets.length === 0) console.log("No catalog reference datasets are published by this harness version yet.");
+            // Datasets arrive in catalog order, which clusters by group, so a header printed on each
+            // group change renders the listing as labelled categories instead of one flat wall.
+            let lastGroup: string | undefined;
             for (const item of inspection.datasets) {
                 const dataset = item.dataset;
-                console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}`);
+                if (dataset.recommendation.group !== lastGroup) {
+                    lastGroup = dataset.recommendation.group;
+                    console.log(`\n== ${lastGroup} ==`);
+                }
+                console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}${dataset.recommendation.recommended ? "" : "  (optional)"}`);
                 console.log(`  ${dataset.title} — ${dataset.description}`);
-                console.log(`  Size: ${formatReferenceSize(datasetSize(dataset))}`);
-                console.log(`  Integrity: ${renderIntegrity(dataset)}`);
-                console.log(`  Group: ${dataset.recommendation.group}${dataset.recommendation.recommended ? " (recommended)" : ""}`);
+                console.log(`  Size: ${formatDatasetSize(dataset)}`);
                 console.log(`  Source: ${dataset.sourceUrl}`);
                 console.log(`  License: ${dataset.license.identifier}${dataset.license.url ? ` — ${dataset.license.url}` : ""}`);
+                if (options.urls) for (const artifact of dataset.artifacts) console.log(`  URL: ${artifact.url}`);
             }
             if (inspection.userContent.length > 0) {
                 console.log(`\nUser/unmanaged top-level content: ${inspection.userContent.join(", ")} (left untouched)`);
             }
-            console.log("\nEvery dataset is downloaded straight from the third party that publishes it; nothing is mirrored or re-hosted here.");
+            console.log(
+                "\nEvery dataset is fetched straight over HTTPS from the third party that publishes it; nothing is mirrored, re-hosted, or checksum-pinned here.",
+            );
+            console.log("Integrity is trust-on-first-use: `inflexa refs verify` checks each installed file against the copy you downloaded.");
+            if (!options.urls) console.log("Re-run with `--urls` to print the exact upstream URL of every file.");
             console.log(`Add arbitrary references under ${env.refsDir}/user; sandboxes discover them dynamically.`);
             console.log("Missing a reusable option? Open a PR adding its upstream URL, provenance, and licensing to the harness reference-data catalog.");
         },
@@ -272,8 +261,7 @@ export async function runRefsVerify(ids: readonly string[]): Promise<void> {
             for (const dataset of verified) {
                 console.log(`${dataset.datasetId}${dataset.version ? `@${dataset.version}` : ""}: ${dataset.state}`);
                 for (const file of dataset.files) {
-                    const against = file.integrity === "pinned" ? "catalog checksum" : "checksum recorded at install";
-                    console.log(`  ${file.state.padEnd(8)} ${file.path}  (vs ${against})`);
+                    console.log(`  ${file.state.padEnd(8)} ${file.path}  (vs the checksum recorded at install)`);
                 }
             }
             const damaged = verified.filter((dataset) => dataset.state !== "valid");

--- a/cli/src/modules/refs/store.test.ts
+++ b/cli/src/modules/refs/store.test.ts
@@ -5,13 +5,13 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
-import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog, type ReferenceIntegrity } from "@inflexa-ai/harness";
+import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
 import { err, ok } from "neverthrow";
 
 import {
     inspectReferenceStore,
     installReferenceDatasets,
-    referenceDownloadBytes,
+    referenceDownloadEstimate,
     referenceStorePaths,
     verifyReferenceDatasets,
     type ReferenceCatalogSource,
@@ -35,8 +35,6 @@ type Fixture = {
     readonly path: string;
     /** Bytes the stub upstream returns. */
     readonly body: string;
-    /** Which integrity class the catalog publishes it under. */
-    readonly integrity: ReferenceIntegrity;
 };
 
 /** Every fixture artifact is fetched straight from its own third-party upstream — there is no distribution base. */
@@ -44,9 +42,9 @@ function url(path: string): string {
     return `https://upstream.test/${path}`;
 }
 
-const PINNED: readonly Fixture[] = [{ path: "a.txt", body: "alpha", integrity: "pinned" }];
+const ARTIFACTS: readonly Fixture[] = [{ path: "a.txt", body: "alpha" }];
 
-function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
+function catalog(files: readonly Fixture[] = ARTIFACTS): ReferenceDataCatalog {
     return {
         version: REFERENCE_DATA_CATALOG_VERSION,
         datasets: [
@@ -58,17 +56,8 @@ function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
                 sourceUrl: "https://example.test/source",
                 license: { identifier: "CC0-1.0", url: "https://example.test/license" },
                 recommendation: { group: "testing", recommended: true },
-                artifacts: files.map((file) =>
-                    file.integrity === "pinned"
-                        ? {
-                              integrity: "pinned" as const,
-                              path: file.path,
-                              url: url(file.path),
-                              bytes: Buffer.byteLength(file.body),
-                              sha256: sha(file.body),
-                          }
-                        : { integrity: "unpinned" as const, path: file.path, url: url(file.path) },
-                ),
+                // The catalog pins nothing but the https URL: no size, no digest, no integrity class.
+                artifacts: files.map((file) => ({ path: file.path, url: url(file.path) })),
             },
         ],
     };
@@ -104,21 +93,19 @@ function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     };
 }
 
-/** What the installer asked the upstream for; `range` is the resume request, absent on a fresh transfer. */
+/** What the installer asked the upstream for; the installer never resumes, so `range` is always null. */
 type Asked = { readonly url: string; readonly range: string | null };
 
-/** Offline upstream. Serves each fixture's bytes and honors a Range request the way a real server would. */
+/** Offline upstream. Serves each fixture's bytes fresh; records the (never-present) Range header so a
+ * test can prove the installer refetches whole rather than resuming from a partial. */
 function serve(files: readonly Fixture[], asked: Asked[] = []): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
     const bodies = new Map(files.map((file) => [url(file.path), file.body]));
     return async (input, init) => {
         const target = String(input);
-        const range = new Headers(init?.headers).get("range");
-        asked.push({ url: target, range });
+        asked.push({ url: target, range: new Headers(init?.headers).get("range") });
         const body = bodies.get(target);
         if (body === undefined) return new Response("missing", { status: 404, statusText: "Not Found" });
-        if (range === null) return new Response(body);
-        // Bodies are ASCII in every fixture, so a character offset is a byte offset.
-        return new Response(body.slice(Number(range.slice("bytes=".length, -1))), { status: 206 });
+        return new Response(body);
     };
 }
 
@@ -156,7 +143,7 @@ describe("reference store inspection", () => {
                 datasetId: "demo",
                 datasetVersion: "2025.01",
                 activatedAt: "2026-07-14T12:00:00.000Z",
-                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
+                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
             }),
         );
         mkdirSync(join(paths.managed, "demo", "2025.01"), { recursive: true });
@@ -175,12 +162,12 @@ describe("reference store inspection", () => {
     });
 });
 
-describe("pinned installation", () => {
-    test("verifies size and digest, activates atomically, and records the observed bytes in the receipt", async () => {
+describe("installation", () => {
+    test("activates atomically and records the observed bytes and digest in the receipt", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "nested/a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.txt", body: "beta", integrity: "pinned" },
+            { path: "nested/a.txt", body: "alpha" },
+            { path: "b.txt", body: "beta" },
         ];
         const fixture = catalog(files);
         mkdirSync(join(path, "user"), { recursive: true });
@@ -204,8 +191,8 @@ describe("pinned installation", () => {
             datasetVersion: "2026.07",
             activatedAt: "2026-07-14T12:00:00.000Z",
             artifacts: [
-                { path: "nested/a.txt", bytes: 5, sha256: sha("alpha"), integrity: "pinned" },
-                { path: "b.txt", bytes: 4, sha256: sha("beta"), integrity: "pinned" },
+                { path: "nested/a.txt", bytes: 5, sha256: sha("alpha") },
+                { path: "b.txt", bytes: 4, sha256: sha("beta") },
             ],
         });
         expect(readFileSync(join(path, "user", "mine.fa"), "utf8")).toBe("mine");
@@ -214,69 +201,31 @@ describe("pinned installation", () => {
         expect(readdirSync(paths.staging)).toEqual([]);
         expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 0 });
 
-        // An intact install is skipped: the hostile upstream below would fail the digest check if it
-        // were ever contacted, so a clean `ok` with zero bytes is the proof that it was not.
+        // An intact install is skipped: the upstream below serves entirely different bytes, so a clean
+        // `ok` with zero bytes downloaded and the file left unchanged is the proof it was never contacted.
         const repeated = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
             fetch: serve([
-                { path: "nested/a.txt", body: "ALPHA", integrity: "pinned" },
-                { path: "b.txt", body: "BETA", integrity: "pinned" },
+                { path: "nested/a.txt", body: "ALPHA" },
+                { path: "b.txt", body: "BETA" },
             ]),
         });
         expect(repeated._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(0);
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "nested", "a.txt"), "utf8")).toBe("alpha");
     });
 
-    test("resumes a partial transfer with Range, because the catalog knows the final size and digest", async () => {
+    // Removed: the model no longer pins a catalog size/digest, so there is nothing to resume against
+    // or to fail a download on — a size_mismatch/digest_mismatch install failure is unrepresentable.
+    // The installer always refetches whole (covered below) and trusts-on-first-use whatever https
+    // serves, recording the observed bytes in the receipt (covered above).
+
+    test("an interrupted stream never activates partial data", async () => {
         const path = root();
         const fixture = catalog();
         const paths = referenceStorePaths(path);
-        mkdirSync(paths.downloads, { recursive: true });
-        writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
-
-        const asked: Asked[] = [];
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED, asked) });
-        expect(installed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(3);
-        expect(asked).toEqual([{ url: url("a.txt"), range: "bytes=2-" }]);
-        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
-    });
-
-    test("a digest mismatch activates nothing and leaves an existing activation intact", async () => {
-        const path = root();
-        const fixture = catalog();
-        const paths = referenceStorePaths(path);
-        const corrupt: readonly Fixture[] = [{ path: "a.txt", body: "ALPHA", integrity: "pinned" }];
-
-        const damaged = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) });
-        expect(damaged._unsafeUnwrapErr()).toMatchObject({ type: "digest_mismatch", path: "a.txt", expected: sha("alpha"), actual: sha("ALPHA") });
-        expect(existsSync(join(paths.managed, "demo", "2026.07"))).toBe(false);
-        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
-
-        const good = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
-        expect(good.isOk()).toBe(true);
-        const receipt = readFileSync(join(paths.receipts, "demo.json"), "utf8");
-
-        const forced = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) }, { force: true });
-        expect(forced._unsafeUnwrapErr().type).toBe("digest_mismatch");
-        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
-        expect(readFileSync(join(paths.receipts, "demo.json"), "utf8")).toBe(receipt);
-    });
-
-    test("size mismatch and interrupted streams never activate partial data", async () => {
-        const path = root();
-        const fixture = catalog();
-        const paths = referenceStorePaths(path);
-
-        const short = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(fixture),
-            fetch: serve([{ path: "a.txt", body: "a", integrity: "pinned" }]),
-        });
-        expect(short._unsafeUnwrapErr()).toMatchObject({ type: "size_mismatch", path: "a.txt", expected: 5, actual: 1 });
-        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
 
         const interrupted = await installReferenceDatasets(["demo"], {
             root: path,
@@ -285,6 +234,7 @@ describe("pinned installation", () => {
         });
         expect(interrupted._unsafeUnwrapErr().type).toBe("download_failed");
         expect(existsSync(join(paths.managed, "demo", "2026.07", "a.txt"))).toBe(false);
+        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
     });
 
     test("a failed update preserves the prior active version and its receipt", async () => {
@@ -299,28 +249,30 @@ describe("pinned installation", () => {
             datasetId: "demo",
             datasetVersion: "2025.01",
             activatedAt: "2025-01-01T00:00:00.000Z",
-            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
+            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
         });
         writeFileSync(receiptPath, prior);
 
+        // The update fetch fails outright (a 404 from the upstream); activation is atomic, so the prior
+        // active version and its receipt must survive untouched.
         const failed = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(catalog()),
-            fetch: serve([{ path: "a.txt", body: "ALPHA", integrity: "pinned" }]),
+            fetch: serve([]),
         });
-        expect(failed._unsafeUnwrapErr().type).toBe("digest_mismatch");
+        expect(failed._unsafeUnwrapErr().type).toBe("download_failed");
         expect(readFileSync(receiptPath, "utf8")).toBe(prior);
         expect(readFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "utf8")).toBe("old");
     });
 });
 
-describe("unpinned installation", () => {
+describe("mutable upstream installation", () => {
     test("installs without a catalog digest and records what the mutable upstream actually served", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "mutable-bytes", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "mutable-bytes" }];
         const fixture = catalog(files);
-        // The catalog carries no size or digest for an upstream that rebuilds the file in place.
-        expect(fixture.datasets[0]?.artifacts[0]).toEqual({ integrity: "unpinned", path: "gene_info.gz", url: url("gene_info.gz") });
+        // The catalog carries only the https URL — no size or digest — for an upstream that rebuilds in place.
+        expect(fixture.datasets[0]?.artifacts[0]).toEqual({ path: "gene_info.gz", url: url("gene_info.gz") });
 
         const installed = await installReferenceDatasets(["demo"], {
             root: path,
@@ -333,17 +285,17 @@ describe("unpinned installation", () => {
         const paths = referenceStorePaths(path);
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "gene_info.gz"), "utf8")).toBe("mutable-bytes");
         expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
-            { path: "gene_info.gz", bytes: 13, sha256: sha("mutable-bytes"), integrity: "unpinned" },
+            { path: "gene_info.gz", bytes: 13, sha256: sha("mutable-bytes") },
         ]);
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]).toMatchObject({
             state: "valid",
-            files: [{ path: "gene_info.gz", state: "valid", integrity: "unpinned" }],
+            files: [{ path: "gene_info.gz", state: "valid" }],
         });
     });
 
     test("never resumes a stale partial — a rebuilt upstream would splice two files together", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "fresh-upstream", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "fresh-upstream" }];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
         mkdirSync(paths.downloads, { recursive: true });
@@ -358,11 +310,11 @@ describe("unpinned installation", () => {
 
     test("--force is the only way to pull a refreshed copy of a mutable upstream", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-a", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-a" }];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
         const active = join(paths.managed, "demo", "2026.07", "gene_info.gz");
-        const refreshed: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-b-longer", integrity: "unpinned" }];
+        const refreshed: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-b-longer" }];
 
         const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
         expect(first.isOk()).toBe(true);
@@ -377,7 +329,7 @@ describe("unpinned installation", () => {
         expect(forced._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(16);
         expect(readFileSync(active, "utf8")).toBe("release-b-longer");
         expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
-            { path: "gene_info.gz", bytes: 16, sha256: sha("release-b-longer"), integrity: "unpinned" },
+            { path: "gene_info.gz", bytes: 16, sha256: sha("release-b-longer") },
         ]);
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
     });
@@ -390,17 +342,17 @@ describe("self-healing installs", () => {
         const paths = referenceStorePaths(path);
         const active = join(paths.managed, "demo", "2026.07", "a.txt");
 
-        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(first._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
 
         writeFileSync(active, "ALPHA");
         // `refs list` state is deliberately cheap (size-only), so it still reads as installed — but the
         // install gate hashes, so the damage must be seen and healed rather than skipped.
         expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 1 });
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("modified");
 
-        const healed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const healed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(healed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
         expect(readFileSync(active, "utf8")).toBe("alpha");
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
@@ -408,11 +360,11 @@ describe("self-healing installs", () => {
 });
 
 describe("verification", () => {
-    test("reports each file against the integrity it was checked with, and detects same-size damage", async () => {
+    test("reports each file against the digest recorded at install, and detects same-size damage", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.txt", body: "bravo", integrity: "unpinned" },
+            { path: "a.txt", body: "alpha" },
+            { path: "b.txt", body: "bravo" },
         ];
         const fixture = catalog(files);
         const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
@@ -423,8 +375,8 @@ describe("verification", () => {
             version: "2026.07",
             state: "valid",
             files: [
-                { path: "a.txt", state: "valid", integrity: "pinned" },
-                { path: "b.txt", state: "valid", integrity: "unpinned" },
+                { path: "a.txt", state: "valid" },
+                { path: "b.txt", state: "valid" },
             ],
         });
 
@@ -434,15 +386,15 @@ describe("verification", () => {
         const damaged = (await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0];
         expect(damaged?.state).toBe("modified");
         expect(damaged?.files).toEqual([
-            { path: "a.txt", state: "modified", integrity: "pinned" },
-            { path: "b.txt", state: "missing", integrity: "unpinned" },
+            { path: "a.txt", state: "modified" },
+            { path: "b.txt", state: "missing" },
         ]);
     });
 
     test("a symlinked managed file is never followed", async () => {
         const path = root();
         const fixture = catalog();
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(installed.isOk()).toBe(true);
 
         const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
@@ -454,33 +406,34 @@ describe("verification", () => {
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.files[0]).toEqual({
             path: "a.txt",
             state: "missing",
-            integrity: "pinned",
         });
     });
 });
 
 describe("download estimate", () => {
-    test("sums pinned bytes, counts unsized artifacts, and subtracts resumable partials", async () => {
+    test("counts every artifact not already intact, ignoring leftover partials, and never hits the network", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.bin", body: "mutable", integrity: "unpinned" },
+            { path: "a.txt", body: "alpha" },
+            { path: "b.bin", body: "mutable" },
         ];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
 
-        // Only the mutable upstream can report its own size, and the estimate never goes to the network.
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
+        // The catalog knows no sizes and there is no resume to net out, so the estimate is a count of
+        // the artifacts a fresh install would fetch — never going to the network to size them.
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
 
+        // A leftover partial nets out nothing now: the installer always refetches the whole artifact.
         mkdirSync(paths.downloads, { recursive: true });
         writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 3, unsizedArtifacts: 1 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
 
         const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
         expect(installed.isOk()).toBe(true);
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture), { force: true }))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
-        expect((await referenceDownloadBytes(["unknown"], path, source(fixture)))._unsafeUnwrapErr().type).toBe("unknown_dataset");
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture), { force: true }))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
+        expect((await referenceDownloadEstimate(["unknown"], path, source(fixture)))._unsafeUnwrapErr().type).toBe("unknown_dataset");
     });
 });
 
@@ -495,7 +448,7 @@ describe("installer-owned path safety", () => {
         mkdirSync(path, { recursive: true });
         mkdirSync(outside, { recursive: true });
         symlinkSync(outside, join(path, ".inflexa"));
-        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(ARTIFACTS) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(Array.from(new Bun.Glob("**/*").scanSync(outside))).toEqual([]);
     });
@@ -504,28 +457,26 @@ describe("installer-owned path safety", () => {
         const path = root();
         const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
         mkdirSync(join(active, "surprise"), { recursive: true });
-        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(ARTIFACTS) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(statSync(join(active, "surprise")).isDirectory()).toBe(true);
     });
 
-    // The catalog can only promise https for the URL we ask for. An unpinned artifact has no digest
-    // to catch a hostile substitution, so a downgraded redirect would be trusted on first use.
+    // The catalog can only promise https for the URL we ask for, and nothing downstream re-checks the
+    // bytes against a reviewed digest (trust-on-first-use), so a downgraded redirect must be refused.
     test("refuses bytes served from a non-https location after a redirect", async () => {
-        for (const integrity of ["pinned", "unpinned"] as const) {
-            const path = root();
-            const fixture = catalog([{ path: "a.txt", body: "alpha", integrity }]);
-            const redirected = await installReferenceDatasets(["demo"], {
-                root: path,
-                source: source(fixture),
-                fetch: serveRedirectedTo("http://downgraded.test/a.txt", [{ path: "a.txt", body: "alpha", integrity }]),
-            });
+        const path = root();
+        const fixture = catalog([{ path: "a.txt", body: "alpha" }]);
+        const redirected = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            fetch: serveRedirectedTo("http://downgraded.test/a.txt", [{ path: "a.txt", body: "alpha" }]),
+        });
 
-            expect(redirected._unsafeUnwrapErr().type).toBe("download_failed");
-            expect(redirected._unsafeUnwrapErr().message).toContain("non-https");
-            expect(existsSync(join(referenceStorePaths(path).managed, "demo"))).toBe(false);
-            expect(existsSync(join(referenceStorePaths(path).receipts, "demo.json"))).toBe(false);
-        }
+        expect(redirected._unsafeUnwrapErr().type).toBe("download_failed");
+        expect(redirected._unsafeUnwrapErr().message).toContain("non-https");
+        expect(existsSync(join(referenceStorePaths(path).managed, "demo"))).toBe(false);
+        expect(existsSync(join(referenceStorePaths(path).receipts, "demo.json"))).toBe(false);
     });
 
     // A receipt is a plain file on disk that anyone can edit, so it is untrusted input. A traversal
@@ -534,7 +485,7 @@ describe("installer-owned path safety", () => {
         const path = root();
         const paths = referenceStorePaths(path);
         const fixture = catalog();
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(installed.isOk()).toBe(true);
 
         const secret = join(paths.user, "private.txt");
@@ -548,7 +499,7 @@ describe("installer-owned path safety", () => {
                 datasetId: "demo",
                 datasetVersion: "2026.07",
                 activatedAt: "2026-07-14T10:30:00.000Z",
-                artifacts: [{ path: "../../../user/private.txt", bytes: 42, sha256: sha("alpha"), integrity: "pinned" }],
+                artifacts: [{ path: "../../../user/private.txt", bytes: 42, sha256: sha("alpha") }],
             }),
         );
 

--- a/cli/src/modules/refs/store.ts
+++ b/cli/src/modules/refs/store.ts
@@ -18,7 +18,6 @@ import {
     type ReferenceInstallPlan,
     type ReferenceInstallPlanDataset,
     type ReferenceInstallReceipt,
-    type ReferenceIntegrity,
     type ReferenceReceiptArtifact,
     type UnknownReferenceDatasetError,
 } from "@inflexa-ai/harness";
@@ -71,10 +70,8 @@ export type ReferenceStoreInspection = {
 export type ReferenceFileVerification = {
     /** Dataset-relative final path. */
     readonly path: string;
-    /** Verification outcome. */
+    /** Verification outcome, checked against the size and digest recorded in the receipt at install. */
     readonly state: "valid" | "missing" | "modified";
-    /** Which guarantee this file's digest was checked against. */
-    readonly integrity: ReferenceIntegrity;
 };
 
 /** Explicit verification result for an active catalog dataset. */
@@ -109,19 +106,6 @@ type ProvisionOperationError = {
     readonly cause?: unknown;
 };
 
-type ContentMismatchError = {
-    /** Integrity mismatch kind. */
-    readonly type: "size_mismatch" | "digest_mismatch";
-    /** User-facing explanation. */
-    readonly message: string;
-    /** Dataset-relative artifact path. */
-    readonly path: string;
-    /** Expected size or digest. */
-    readonly expected: number | string;
-    /** Observed size or digest. */
-    readonly actual: number | string;
-};
-
 type ManagedPathConflictError = {
     /** Stable discriminator. */
     readonly type: "managed_path_conflict";
@@ -132,7 +116,7 @@ type ManagedPathConflictError = {
 };
 
 /** Typed failures from local inspection, verification, transfer, or activation. */
-export type ReferenceProvisionError = UnknownDatasetError | ProvisionOperationError | ContentMismatchError | ManagedPathConflictError;
+export type ReferenceProvisionError = UnknownDatasetError | ProvisionOperationError | ManagedPathConflictError;
 
 /** Network dependencies supplied by the CLI composition edge. */
 export type ReferenceInstallDeps = {
@@ -151,10 +135,10 @@ export type ReferenceInstallDeps = {
 /** Caller-chosen installation behavior. */
 export type ReferenceInstallOptions = {
     /**
-     * Re-fetch and re-activate even when the active install is intact. This is the
-     * only way to pull a fresh copy of an `unpinned` dataset whose mutable upstream
-     * has moved on — an intact install of the bytes we previously received is
-     * indistinguishable from an up-to-date one without going to the network.
+     * Re-fetch and re-activate even when the active install is intact. Because the catalog pins no
+     * digest, this is the only way to pull a fresh copy of a dataset whose upstream has moved on —
+     * an intact install of the bytes we previously received is indistinguishable from an up-to-date
+     * one without going to the network.
      */
     readonly force?: boolean;
 };
@@ -188,12 +172,10 @@ export type ReferenceInstallOutcome = {
     readonly installed: readonly InstalledReferenceDataset[];
 };
 
-/** Bytes still to transfer, plus what cannot be known before contacting the upstream. */
+/** What a download would fetch. The catalog carries no sizes, so only a count is knowable locally. */
 export type ReferenceDownloadEstimate = {
-    /** Bytes missing across `pinned` artifacts, whose sizes the catalog knows. */
-    readonly bytes: number;
-    /** Count of `unpinned` artifacts whose size only the mutable upstream can report. */
-    readonly unsizedArtifacts: number;
+    /** Artifacts that still need fetching, whose sizes only the upstream can report. */
+    readonly artifactsToFetch: number;
 };
 
 /** Resolve all owned paths without creating anything. */
@@ -303,20 +285,17 @@ async function receiptFilesIntact(paths: ReferenceStorePaths, root: string, rece
 }
 
 /**
- * Whether the receipt still describes what the catalog now says. A `pinned` artifact
- * must match the catalog's size and digest; an `unpinned` one has no catalog digest to
- * match, so only its presence and class are compared.
+ * Whether the receipt still describes the same dataset the catalog now names: same version and the
+ * same set of artifact destinations. The catalog carries no size or digest to compare against —
+ * those live only in the receipt (observed at install) and are checked against the files themselves
+ * by `verify`, not against the catalog.
  */
 function receiptMatchesCurrentCatalog(dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): boolean {
     if (receipt.datasetVersion !== dataset.version || receipt.artifacts.length !== dataset.artifacts.length) return false;
-    const expected = new Map(dataset.artifacts.map((artifact) => [artifact.path, artifact]));
+    const expected = new Set(dataset.artifacts.map((artifact) => artifact.path));
     const actualPaths = new Set(receipt.artifacts.map((artifact) => artifact.path));
     if (actualPaths.size !== receipt.artifacts.length) return false;
-    return receipt.artifacts.every((recorded) => {
-        const artifact = expected.get(recorded.path);
-        if (artifact === undefined || artifact.integrity !== recorded.integrity) return false;
-        return artifact.integrity === "pinned" ? artifact.bytes === recorded.bytes && artifact.sha256 === recorded.sha256 : true;
-    });
+    return receipt.artifacts.every((recorded) => expected.has(recorded.path));
 }
 
 function activeManagedRoot(paths: ReferenceStorePaths, dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): string | undefined {
@@ -388,10 +367,9 @@ export async function inspectReferenceStore(
 }
 
 /**
- * Hash active managed files against the receipt without mutating disk. The receipt is
- * the reference in both integrity classes: for `pinned` artifacts it equals the catalog
- * digest (activation would have failed otherwise), and for `unpinned` ones it is the
- * only honest record — what the mutable upstream actually served at install time.
+ * Hash active managed files against the receipt without mutating disk. The receipt is the sole
+ * reference: the catalog pins no digest, so this compares each file to the size and digest observed
+ * when it was installed — the honest record of what the upstream actually served at that time.
  */
 export async function verifyReferenceDatasets(
     root: string,
@@ -433,18 +411,17 @@ export async function verifyReferenceDatasets(
                 const infoResult = owned.isOk() ? await pathLstat(path) : ok(undefined);
                 const info = infoResult.isOk() ? infoResult.value : undefined;
                 if (info === undefined || info.isSymbolicLink() || !info.isFile()) {
-                    files.push({ path: artifact.path, state: "missing", integrity: artifact.integrity });
+                    files.push({ path: artifact.path, state: "missing" });
                     continue;
                 }
                 if (info.size !== artifact.bytes) {
-                    files.push({ path: artifact.path, state: "modified", integrity: artifact.integrity });
+                    files.push({ path: artifact.path, state: "modified" });
                     continue;
                 }
                 const digestResult = await sha256File(path);
                 files.push({
                     path: artifact.path,
                     state: digestResult.isOk() && digestResult.value === artifact.sha256 ? "valid" : "modified",
-                    integrity: artifact.integrity,
                 });
             }
             const state = files.every((file) => file.state === "valid") ? "valid" : files.some((file) => file.state === "modified") ? "modified" : "missing";
@@ -512,77 +489,37 @@ async function downloadArtifact(
         if (owned.isErr()) return err(owned.error);
         await mkdir(paths.downloads, { recursive: true });
 
-        // Resume is only sound when the catalog knows the final size and digest: without
-        // them a partial file cannot be told apart from a complete one, and appending to
-        // bytes an upstream has since changed would splice two different files together.
-        let resumeAt = 0;
-        if (artifact.integrity === "pinned") {
-            const priorResult = await pathStat(partPath);
-            if (priorResult.isErr()) return err(priorResult.error);
-            const prior = priorResult.value;
-            const offset = prior?.isFile() ? prior.size : 0;
-            if (offset > artifact.bytes) await rm(partPath, { force: true });
-            resumeAt = offset <= artifact.bytes ? offset : 0;
-            if (resumeAt === artifact.bytes) {
-                const existingDigest = await sha256File(partPath);
-                if (existingDigest.isOk() && existingDigest.value === artifact.sha256) {
-                    return ok({
-                        partPath,
-                        bytesDownloaded: 0,
-                        observed: { path: artifact.path, bytes: artifact.bytes, sha256: artifact.sha256, integrity: "pinned" },
-                    });
-                }
-                await rm(partPath, { force: true });
-                resumeAt = 0;
-            }
-        } else {
-            await rm(partPath, { force: true });
-        }
+        // The catalog carries no size or digest, so a partial file cannot be told apart from a
+        // complete one, and appending to bytes the upstream may have changed would splice two
+        // versions together — always fetch the whole artifact fresh.
+        // TODO(robustness): a conditional If-Range resume could restore resumable large downloads
+        // without that risk, keying the precondition off an ETag captured on the first attempt.
+        await rm(partPath, { force: true });
 
-        const response = await (deps.fetch ?? fetch)(artifact.url, { headers: resumeAt > 0 ? { Range: `bytes=${resumeAt}-` } : undefined });
+        const response = await (deps.fetch ?? fetch)(artifact.url, {});
         if (!response.ok || response.body === null) {
             return err({
                 type: "download_failed",
                 message: `Download failed for ${artifact.path}: HTTP ${response.status} ${response.statusText} (${artifact.url})`,
             });
         }
-        // The catalog guarantees an https URL, but fetch follows redirects, so the guarantee has to
-        // hold for whatever actually served the bytes. A `pinned` artifact would still be caught by
-        // its digest; an `unpinned` one has none, and would trust a downgraded hop on first use.
+        // https is now the whole integrity story: nothing downstream re-checks the bytes against a
+        // reviewed digest, so a downgraded redirect hop would be trusted on first use. The catalog
+        // guarantees an https URL, but fetch follows redirects, so enforce it on whatever served us.
         if (response.url !== "" && !response.url.startsWith("https://")) {
             return err({
                 type: "download_failed",
                 message: `Refusing ${artifact.path}: ${artifact.url} redirected to a non-https location (${response.url}).`,
             });
         }
-        const appending = resumeAt > 0 && response.status === 206;
-        await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: appending ? "a" : "w" }));
+        await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: "w" }));
         const written = (await stat(partPath)).size;
-
-        if (artifact.integrity === "pinned" && written !== artifact.bytes) {
-            return err({
-                type: "size_mismatch",
-                path: artifact.path,
-                expected: artifact.bytes,
-                actual: written,
-                message: `Size mismatch for ${artifact.path}.`,
-            });
-        }
         const digest = await sha256File(partPath);
         if (digest.isErr()) return err({ type: "io_failed", message: `Could not hash ${artifact.path}.`, cause: digest.error.cause });
-        if (artifact.integrity === "pinned" && digest.value !== artifact.sha256) {
-            return err({
-                type: "digest_mismatch",
-                path: artifact.path,
-                expected: artifact.sha256,
-                actual: digest.value,
-                message: `SHA-256 mismatch for ${artifact.path}. The upstream bytes are not the reviewed bytes; nothing was activated.`,
-            });
-        }
         return ok({
             partPath,
-            bytesDownloaded: appending ? written - resumeAt : written,
-            observed: { path: artifact.path, bytes: written, sha256: digest.value, integrity: artifact.integrity },
+            bytesDownloaded: written,
+            observed: { path: artifact.path, bytes: written, sha256: digest.value },
         });
     } catch (cause) {
         return err({ type: "download_failed", message: `Download failed for ${artifact.path} (${artifact.url}).`, cause });
@@ -763,7 +700,7 @@ export async function installReferenceDatasets(
 }
 
 /** Estimate the transfer without creating state or contacting any upstream. */
-export async function referenceDownloadBytes(
+export async function referenceDownloadEstimate(
     datasetIds: readonly string[],
     root: string,
     source: ReferenceCatalogSource = CANONICAL_REFERENCE_SOURCE,
@@ -775,8 +712,7 @@ export async function referenceDownloadBytes(
     }
     const paths = referenceStorePaths(root);
     try {
-        let bytes = 0;
-        let unsizedArtifacts = 0;
+        let artifactsToFetch = 0;
         for (const dataset of plan.value.datasets) {
             const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
             const activeReceipt = receiptRead.receipt;
@@ -790,31 +726,12 @@ export async function referenceDownloadBytes(
                     continue;
                 }
             }
-            for (const artifact of dataset.artifacts) {
-                // Only a mutable upstream can say how big its current file is, and asking
-                // would mean a network round-trip inside what is a purely local estimate.
-                if (artifact.integrity === "unpinned") {
-                    unsizedArtifacts += 1;
-                    continue;
-                }
-                const partPath = join(paths.downloads, `${downloadName(referenceArtifactKey(dataset, artifact))}.part`);
-                const owned = await assertOwnedPath(paths.root, partPath);
-                if (owned.isErr()) return err(owned.error);
-                const partialResult = await pathLstat(partPath);
-                if (partialResult.isErr()) return err(partialResult.error);
-                const partial = partialResult.value;
-                if (partial?.isSymbolicLink())
-                    return err({ type: "managed_path_conflict", path: partPath, message: `Refusing resumable symlink path: ${partPath}` });
-                if (partial?.isFile() && partial.size === artifact.bytes) {
-                    const digest = await sha256File(partPath);
-                    bytes += digest.isOk() && digest.value === artifact.sha256 ? 0 : artifact.bytes;
-                } else {
-                    bytes += Math.max(0, artifact.bytes - (partial?.isFile() ? Math.min(partial.size, artifact.bytes) : 0));
-                }
-            }
+            // The catalog knows no sizes, and there is no resume to net out, so the estimate is a
+            // count: every artifact of a dataset that is not already intact is fetched fresh.
+            artifactsToFetch += dataset.artifacts.length;
         }
-        return ok({ bytes, unsizedArtifacts });
+        return ok({ artifactsToFetch });
     } catch (cause) {
-        return err({ type: "io_failed", message: `Could not inspect resumable downloads at ${root}.`, cause });
+        return err({ type: "io_failed", message: `Could not inspect the reference store at ${root}.`, cause });
     }
 }

--- a/harness/openspec/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/specs/reference-data-catalog/spec.md
@@ -9,14 +9,14 @@ plans, and shared receipt metadata consumed by every harness embedder.
 
 ### Requirement: The harness publishes the canonical reference-data catalog
 
-The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have the `https` URL of the third party that publishes it, a safe dataset-relative destination path, and an integrity class.
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have exactly the `https` URL of the third party that publishes it and a safe dataset-relative destination path — no size, digest, or integrity class.
 
-Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, non-SHA-256 digests, and non-positive artifact sizes.
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, and any stray size or digest field offered on an artifact.
 
 #### Scenario: An embedder lists supported references
 
 - **WHEN** an embedder reads the exported catalog
-- **THEN** it receives the same validated dataset ids, versions, upstream URLs, source and licensing links, and integrity classes as every other embedder using that harness version
+- **THEN** it receives the same validated dataset ids, versions, upstream URLs, and source and licensing links as every other embedder using that harness version
 
 #### Scenario: An unsafe catalog path is rejected
 
@@ -37,28 +37,28 @@ Each artifact SHALL name the official third-party URL it is fetched from, and th
 - **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
 - **THEN** both receive content-identical plans naming the same upstream URLs
 
-### Requirement: An artifact's integrity class states what its upstream can actually guarantee
+### Requirement: Reference integrity is uniform trust-on-first-use
 
-Every artifact SHALL declare an integrity class, and that class SHALL reflect a property of the upstream rather than a preference of ours. A `pinned` artifact — one whose upstream publishes immutable, versioned bytes — SHALL carry a byte size and SHA-256 digest. An `unpinned` artifact — one whose upstream regenerates the same URL in place, so that no checked-in digest could survive — SHALL carry neither, because a digest that is guaranteed to go stale is worse than an absent one: it promises verification and delivers a broken download.
+The catalog SHALL carry no per-artifact size or digest, and there SHALL be no integrity class. Every artifact is authenticated over TLS at download time, and the bytes actually received are recorded in the install receipt so later verification can prove the local copy has not changed since install. A checked-in digest is deliberately not maintained: it would apply unevenly — only upstreams that publish immutable bytes could ever carry one — and would put on this project the burden of computing and re-syncing a value that a `current` upstream immediately makes stale. TLS authenticates the publisher, and the receipt catches post-install drift; the marginal supply-chain benefit of a reviewed digest does not justify that inconsistency and burden for public, re-downloadable reference data.
 
-#### Scenario: Immutable upstream is pinned
+#### Scenario: The catalog names a source, not a checksum
 
-- **WHEN** an upstream publishes a dated or release-versioned file that never changes
-- **THEN** its artifact is `pinned` with a size and SHA-256, and an install that receives different bytes fails without activating anything
+- **WHEN** a dataset is added to the catalog
+- **THEN** its artifact carries only an `https` URL and destination path — no size, digest, or integrity class — and adding a source requires no downloaded-and-hashed value
 
-#### Scenario: Mutable upstream is not pretended to be pinned
+#### Scenario: Integrity is recovered from the receipt, not the catalog
 
-- **WHEN** an upstream rebuilds a file in place at a stable URL (NCBI regenerating `gene_info`, Reactome overwriting `current`)
-- **THEN** its artifact is `unpinned`, the catalog states no digest, and the weaker guarantee is surfaced to the user rather than hidden
+- **WHEN** an installed file is later altered on disk
+- **THEN** verification against the size and digest the receipt recorded at install reports it modified, even though the catalog never carried a digest
 
 ### Requirement: Catalog artifacts describe final immutable files
 
-Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher, and its digest attests only to the machine that produced it.
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher and carries no third-party provenance.
 
 #### Scenario: A multi-file reference is fully described
 
 - **WHEN** a dataset requires two companion files
-- **THEN** its install plan contains two artifact entries, each with its own upstream URL, destination, and integrity class
+- **THEN** its install plan contains two artifact entries, each with its own upstream URL and destination
 
 #### Scenario: A stable identity survives a moved URL
 
@@ -67,18 +67,18 @@ Every artifact in the initial catalog format SHALL describe one final file to st
 
 ### Requirement: Reference installation receipts record what was actually received
 
-The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path, integrity class, and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable. A receipt written by an older build MAY carry a now-removed integrity field; parsing SHALL ignore it rather than reject the receipt.
 
-Observed digests SHALL NOT be copied from the catalog. For a `pinned` artifact the observed digest necessarily equals the catalog's, since activation fails otherwise; for an `unpinned` artifact the receipt is the only record of what the mutable upstream served, and is therefore what later verification compares against.
+Observed digests SHALL NOT be copied from the catalog, which carries none: the receipt is the sole record of what the upstream served at install time, and is therefore what later verification compares the files against.
 
 #### Scenario: Different embedders describe the same installation
 
 - **WHEN** local and managed installers activate the same install plan
 - **THEN** each can emit a receipt that validates against the same harness-owned contract
 
-#### Scenario: An unpinned install is still verifiable afterwards
+#### Scenario: An install is still verifiable afterwards
 
-- **WHEN** an `unpinned` artifact is installed and its bytes are later altered on disk
+- **WHEN** an installed artifact's bytes are later altered on disk
 - **THEN** verification against the receipt reports the file as modified, even though the catalog never carried a digest for it
 
 #### Scenario: Invalid receipt does not hide files

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -322,14 +322,7 @@ export {
     referenceArtifactKey,
     resolveReferenceInstallPlan,
 } from "./reference-data/catalog.js";
-export type {
-    ReferenceArtifact,
-    ReferenceDataCatalog,
-    ReferenceDataset,
-    ReferenceInstallPlan,
-    ReferenceInstallPlanDataset,
-    ReferenceIntegrity,
-} from "./reference-data/catalog.js";
+export type { ReferenceArtifact, ReferenceDataCatalog, ReferenceDataset, ReferenceInstallPlan, ReferenceInstallPlanDataset } from "./reference-data/catalog.js";
 export { REFERENCE_INSTALL_RECEIPT_VERSION, ReferenceInstallReceiptSchema, parseReferenceInstallReceipt } from "./reference-data/receipt.js";
 export type { ReferenceInstallReceipt, ReferenceReceiptArtifact } from "./reference-data/receipt.js";
 // Backs `WatchdogDeps.queryActiveSandboxes` when the embedder wires the watchdog.

--- a/harness/src/reference-data/catalog.test.ts
+++ b/harness/src/reference-data/catalog.test.ts
@@ -15,21 +15,11 @@ import { REFERENCE_INSTALL_RECEIPT_VERSION, parseReferenceInstallReceipt } from 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 
-function pinned(path: string, index = 0): Record<string, unknown> {
-    return {
-        integrity: "pinned",
-        path,
-        url: `https://example.org/immutable/artifact-${index}`,
-        bytes: index + 1,
-        sha256: index === 0 ? HASH_A : HASH_B,
-    };
+function artifact(path: string, index = 0): Record<string, unknown> {
+    return { path, url: `https://example.org/artifact-${index}` };
 }
 
-function unpinned(path: string, index = 0): Record<string, unknown> {
-    return { integrity: "unpinned", path, url: `https://example.org/current/artifact-${index}` };
-}
-
-function dataset(id: string, artifacts: Record<string, unknown>[] = [pinned("reference.parquet")]): Record<string, unknown> {
+function dataset(id: string, artifacts: Record<string, unknown>[] = [artifact("reference.parquet")]): Record<string, unknown> {
     return {
         id,
         version: "2026.07",
@@ -57,31 +47,52 @@ describe("reference-data catalog", () => {
             "ncbi-gene-human",
             "ncbi-gene-mouse",
             "ncbi-gene-rat",
+            "ncbi-gene2ensembl",
+            "ncbi-gene2refseq",
+            "uniprot-idmapping-human",
+            "uniprot-idmapping-mouse",
+            "uniprot-idmapping-rat",
             "reactome-pathways",
             "reactome-mappings",
             "wikipathways-human",
+            "wikipathways-mouse",
+            "wikipathways-rat",
+            "msigdb-hallmark-human",
+            "msigdb-hallmark-mouse",
             "collectri-human",
             "gtex-v8",
+            "hpa-proteinatlas",
             "celltypist-immune",
+            "celltypist-pan-fetal",
+            "celltypist-covid19",
+            "panglaodb-markers",
+            "azimuth-pbmc",
+            "azimuth-tonsil",
+            "pharmcat-grch38-fasta",
         ]);
     });
 
-    // The ~700 MB of uncompressed Reactome mapping TSV is opt-in, so a default `setup` never
-    // silently pulls two orders of magnitude more than the gene sets it actually asked for.
-    it("recommends every dataset except the very large opt-in mapping tables", () => {
+    // Large or domain-specific downloads are opt-in, so a default `setup` never silently pulls
+    // hundreds of MB (or GB) the user did not ask for: the all-species NCBI mapping tables, the
+    // Reactome mapping TSVs, the 443 MB tonsil reference, and the 842 MB PharmCAT genome bundle.
+    it("recommends every dataset except the very large or domain-specific opt-in downloads", () => {
         const notRecommended = REFERENCE_DATA_CATALOG.datasets.filter((dataset) => !dataset.recommendation.recommended).map(({ id }) => id);
 
-        expect(notRecommended).toEqual(["reactome-mappings"]);
+        expect(notRecommended).toEqual(["ncbi-gene2ensembl", "ncbi-gene2refseq", "reactome-mappings", "azimuth-tonsil", "pharmcat-grch38-fasta"]);
     });
 
     it("fetches every artifact from an official upstream over https", () => {
         const officialHosts = new Set([
             "ftp.ncbi.nlm.nih.gov",
+            "ftp.uniprot.org",
             "reactome.org",
             "data.wikipathways.org",
+            "data.broadinstitute.org",
             "zenodo.org",
             "gtexportal.org",
             "storage.googleapis.com",
+            "www.proteinatlas.org",
+            "panglaodb.se",
             "celltypist.cog.sanger.ac.uk",
             "www.celltypist.org",
         ]);
@@ -96,32 +107,15 @@ describe("reference-data catalog", () => {
         }
     });
 
-    it("pins size and digest exactly for the immutable upstreams and for no other", () => {
-        const byIntegrity = { pinned: [] as string[], unpinned: [] as string[] };
-
+    // The uniform trust-on-first-use model: the catalog is URL + provenance only, so no artifact
+    // may carry a size or digest to compute, review, or let go stale. Integrity lives entirely in
+    // the install receipt, off the bytes the user actually downloaded.
+    it("carries only a path and url for every artifact — no checked-in size or digest", () => {
         for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
             for (const artifact of dataset.artifacts) {
-                byIntegrity[artifact.integrity].push(dataset.id);
-                if (artifact.integrity === "pinned") {
-                    expect(artifact.bytes).toBeGreaterThan(0);
-                    expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
-                } else {
-                    // A mutable upstream admits no checked-in digest: the receipt is the record.
-                    expect(artifact).not.toHaveProperty("bytes");
-                    expect(artifact).not.toHaveProperty("sha256");
-                    expect(dataset.version).toBe("current");
-                }
+                expect(Object.keys(artifact).sort()).toEqual(["path", "url"]);
             }
         }
-
-        expect([...new Set(byIntegrity.pinned)]).toEqual(["wikipathways-human", "collectri-human", "gtex-v8", "celltypist-immune"]);
-        expect([...new Set(byIntegrity.unpinned)]).toEqual([
-            "ncbi-gene-human",
-            "ncbi-gene-mouse",
-            "ncbi-gene-rat",
-            "reactome-pathways",
-            "reactome-mappings",
-        ]);
     });
 
     it("keys every catalog artifact by its stable, URL-independent identity", () => {
@@ -134,61 +128,36 @@ describe("reference-data catalog", () => {
         }
     });
 
-    it("accepts both integrity classes and rejects an unknown discriminant", () => {
-        expect(ReferenceArtifactSchema.safeParse(pinned("one.parquet")).success).toBe(true);
-        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
-        expect(ReferenceArtifactSchema.safeParse({ path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse({ integrity: "trusted", path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
-    });
-
-    // A digest on an unpinned artifact is a category error: the upstream rewrites that URL, so the
-    // digest is guaranteed to go stale. Silently stripping it would let the mistake reach review
-    // looking like a pinned entry, so the schema rejects it outright.
-    it("rejects a size and digest offered for an unpinned artifact", () => {
-        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), bytes: 5, sha256: HASH_A }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), sha256: HASH_A }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
+    it("accepts a path+url artifact and rejects missing fields or a stray size/digest", () => {
+        expect(ReferenceArtifactSchema.safeParse(artifact("one.parquet")).success).toBe(true);
+        expect(ReferenceArtifactSchema.safeParse({ path: "one.parquet" }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ url: "https://example.org/one" }).success).toBe(false);
+        // strictObject: a stray size or digest is a mistake (the catalog pins nothing), so it is rejected
+        // outright rather than silently accepted and never verified.
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), bytes: 5 }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), sha256: HASH_A }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), integrity: "pinned" }).success).toBe(false);
     });
 
     it.each(["http://example.org/one", "ftp://ftp.example.org/one", "file:///etc/passwd", "example.org/one", ""])(
         "rejects non-https artifact url %s",
         (url) => {
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-url", [{ ...pinned("one.parquet"), url }])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-url", [{ ...artifact("one.parquet"), url }])])).success).toBe(false);
         },
     );
 
-    it("requires a size and digest on a pinned artifact", () => {
-        const { sha256: _sha256, ...noDigest } = pinned("one.parquet");
-        const { bytes: _bytes, ...noSize } = pinned("one.parquet");
-
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-digest", [noDigest])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-size", [noSize])])).success).toBe(false);
-    });
-
     it("rejects duplicate dataset ids and artifact destinations", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one"), dataset("one")])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("a.parquet", 1)])])).success).toBe(false);
-        // A path collides across integrity classes too — the destination is what must be unique.
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet"), unpinned("a.parquet")])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("b.parquet", 1)])])).success).toBe(true);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [artifact("a.parquet", 0), artifact("a.parquet", 1)])])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [artifact("a.parquet", 0), artifact("b.parquet", 1)])])).success).toBe(true);
     });
 
     it.each(["/absolute/file", "../escape", "nested/../../escape", "nested//file", "nested/./file", "nested\\file", ""])(
         "rejects unsafe artifact path %s",
         (path) => {
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [pinned(path)])])).success).toBe(false);
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [unpinned(path)])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [artifact(path)])])).success).toBe(false);
         },
     );
-
-    it("rejects malformed digests and non-positive sizes", () => {
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-digest", [{ ...pinned("a.parquet"), sha256: "abc" }])])).success).toBe(false);
-        expect(
-            ReferenceDataCatalogSchema.safeParse(catalog([dataset("upper-digest", [{ ...pinned("a.parquet"), sha256: HASH_A.toUpperCase() }])])).success,
-        ).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-size", [{ ...pinned("a.parquet"), bytes: 0 }])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("float-size", [{ ...pinned("a.parquet"), bytes: 1.5 }])])).success).toBe(false);
-    });
 
     it("requires at least one artifact per dataset", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("empty", [])])).success).toBe(false);
@@ -198,8 +167,8 @@ describe("reference-data catalog", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([{ ...dataset("unsafe-version"), version }])).success).toBe(false);
     });
 
-    it("resolves a deterministic, deduplicated multi-file plan across both integrity classes", () => {
-        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", [pinned("one.parquet", 0), unpinned("two.json", 1)])]));
+    it("resolves a deterministic, deduplicated multi-file plan", () => {
+        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", [artifact("one.parquet", 0), artifact("two.json", 1)])]));
         const plan = resolveReferenceInstallPlanFromCatalogForTesting(["zeta", "alpha", "zeta"], parsed)._unsafeUnwrap();
 
         expect(plan.catalogVersion).toBe(REFERENCE_DATA_CATALOG_VERSION);
@@ -207,11 +176,7 @@ describe("reference-data catalog", () => {
         expect(plan.datasets[0]!.installPath).toBe("alpha/2026.07");
         expect(plan.datasets[1]!.installPath).toBe("zeta/2026.07");
         expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.path)).toEqual(["one.parquet", "two.json"]);
-        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.integrity)).toEqual(["pinned", "unpinned"]);
-        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.url)).toEqual([
-            "https://example.org/immutable/artifact-0",
-            "https://example.org/current/artifact-1",
-        ]);
+        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.url)).toEqual(["https://example.org/artifact-0", "https://example.org/artifact-1"]);
         expect(referenceArtifactKey(plan.datasets[0]!, plan.datasets[0]!.artifacts[0]!)).toBe("alpha/2026.07/one.parquet");
     });
 
@@ -226,15 +191,31 @@ describe("reference-data catalog", () => {
         expect(resolveReferenceInstallPlan(["fixture-only"])._unsafeUnwrapErr()).toMatchObject({
             unknownId: "fixture-only",
             availableIds: [
+                "azimuth-pbmc",
+                "azimuth-tonsil",
+                "celltypist-covid19",
                 "celltypist-immune",
+                "celltypist-pan-fetal",
                 "collectri-human",
                 "gtex-v8",
+                "hpa-proteinatlas",
+                "msigdb-hallmark-human",
+                "msigdb-hallmark-mouse",
                 "ncbi-gene-human",
                 "ncbi-gene-mouse",
                 "ncbi-gene-rat",
+                "ncbi-gene2ensembl",
+                "ncbi-gene2refseq",
+                "panglaodb-markers",
+                "pharmcat-grch38-fasta",
                 "reactome-mappings",
                 "reactome-pathways",
+                "uniprot-idmapping-human",
+                "uniprot-idmapping-mouse",
+                "uniprot-idmapping-rat",
                 "wikipathways-human",
+                "wikipathways-mouse",
+                "wikipathways-rat",
             ],
         });
 
@@ -250,13 +231,20 @@ describe("reference installation receipt", () => {
         datasetVersion: "2026.07",
         activatedAt: "2026-07-14T10:30:00.000Z",
         artifacts: [
-            { path: "one.parquet", bytes: 42, sha256: HASH_A, integrity: "pinned" as const },
-            { path: "nested/current.gz", bytes: 0, sha256: HASH_B, integrity: "unpinned" as const },
+            { path: "one.parquet", bytes: 42, sha256: HASH_A },
+            { path: "nested/current.gz", bytes: 0, sha256: HASH_B },
         ],
     };
 
-    it("records observed bytes and digest for both integrity classes", () => {
+    it("records the observed size and digest for every artifact", () => {
         expect(parseReferenceInstallReceipt(valid)).toEqual(valid);
+    });
+
+    // A receipt written by an older build carries a now-removed `integrity` field. It must still
+    // parse (the install stays valid across the upgrade); the unknown key is simply dropped.
+    it("accepts a legacy receipt carrying an integrity field, ignoring it", () => {
+        const legacy = { ...valid, artifacts: [{ ...valid.artifacts[0], integrity: "pinned" }] };
+        expect(parseReferenceInstallReceipt(legacy)).toEqual({ ...valid, artifacts: [valid.artifacts[0]] });
     });
 
     it("degrades invalid receipt metadata to undefined", () => {
@@ -271,14 +259,7 @@ describe("reference installation receipt", () => {
         expect(parseReferenceInstallReceipt({ ...valid, artifacts: [valid.artifacts[0], valid.artifacts[0]] })).toBeUndefined();
     });
 
-    it("requires an observed integrity class on every receipt artifact", () => {
-        const { integrity: _integrity, ...noIntegrity } = valid.artifacts[0]!;
-
-        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [noIntegrity] })).toBeUndefined();
-        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], integrity: "trusted" }] })).toBeUndefined();
-    });
-
-    it("requires an observed digest even where the catalog could not pin one", () => {
+    it("requires an observed size and digest on every receipt artifact", () => {
         const { sha256: _sha256, ...noDigest } = valid.artifacts[1]!;
         const { bytes: _bytes, ...noSize } = valid.artifacts[1]!;
 

--- a/harness/src/reference-data/catalog.ts
+++ b/harness/src/reference-data/catalog.ts
@@ -29,39 +29,19 @@ export const ReferenceSha256Schema = z.string().regex(SHA256, "Expected a lowerc
 const ReferenceArtifactUrlSchema = z.url().refine((value) => value.startsWith("https://"), "Reference artifacts must be fetched over https");
 
 /**
- * An artifact whose upstream publishes immutable, versioned bytes. The catalog
- * carries the size and digest, so a download is verified against *this file*
- * before it is ever activated: a mismatch means the bytes are not what we
- * reviewed, and the install fails.
+ * One final file distributed for a reference dataset: a stable install-relative
+ * path and the third-party https URL it is fetched from. The catalog carries no
+ * size or digest — every upstream is authenticated over TLS at download time,
+ * and the installer records the bytes it actually received in the receipt so
+ * `verify` can later prove the local copy has not changed since install. This is
+ * one uniform trust-on-first-use model; there is deliberately no per-artifact
+ * integrity class, so adding a source is only ever a URL, and no checked-in
+ * digest is ours to maintain or lets go stale when a `current` upstream rebuilds.
  */
-const PinnedReferenceArtifactSchema = z.strictObject({
-    integrity: z.literal("pinned"),
-    path: ReferenceArtifactPathSchema,
-    url: ReferenceArtifactUrlSchema,
-    bytes: z.number().int().positive(),
-    sha256: ReferenceSha256Schema,
-});
-
-/**
- * An artifact whose upstream regenerates the same URL in place — NCBI rebuilds
- * `gene_info` continuously and Reactome's `current` release is overwritten and
- * its predecessors deleted. No checked-in digest can survive that, and pinning
- * one would only guarantee a broken download. Integrity is therefore
- * trust-on-first-use: the installer records the bytes it actually received in
- * the receipt, and `verify` proves the files have not changed *since install*.
- * This is a weaker guarantee than `pinned` and is surfaced as such to the user.
- */
-const UnpinnedReferenceArtifactSchema = z.strictObject({
-    integrity: z.literal("unpinned"),
+export const ReferenceArtifactSchema = z.strictObject({
     path: ReferenceArtifactPathSchema,
     url: ReferenceArtifactUrlSchema,
 });
-
-/** One immutable final file distributed for a reference dataset. */
-export const ReferenceArtifactSchema = z.discriminatedUnion("integrity", [PinnedReferenceArtifactSchema, UnpinnedReferenceArtifactSchema]);
-
-/** Which integrity guarantee an artifact can actually offer. */
-export type ReferenceIntegrity = z.infer<typeof ReferenceArtifactSchema>["integrity"];
 
 /** Provenance and licensing information for one supported reference dataset. */
 export const ReferenceDatasetSchema = z.object({
@@ -141,14 +121,14 @@ function deepFreeze<T>(value: T): DeepReadonly<T> {
 /**
  * Canonical release catalog. Every artifact is fetched directly from the third
  * party that publishes it; this project hosts, mirrors, and redistributes
- * nothing. Entries are added only with real upstream URLs, provenance, and
- * licensing data — plus a size and digest whenever the upstream publishes
- * immutable bytes we can pin to.
+ * nothing. Entries are added with a real upstream https URL, provenance, and
+ * licensing data — and nothing else per file: no size, no digest to compute or
+ * keep in sync.
  *
  * `version` is the dataset's upstream release identifier. Datasets built on an
  * upstream that has no immutable release — NCBI regenerates `gene_info` daily,
  * Reactome overwrites `current` and deletes prior releases — are versioned
- * `current` and carry `unpinned` artifacts.
+ * `current`; those with an immutable release carry it verbatim.
  */
 export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
     ReferenceDataCatalogSchema.parse({
@@ -168,7 +148,6 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Homo_sapiens.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz",
                     },
@@ -188,7 +167,6 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Mus_musculus.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz",
                     },
@@ -208,9 +186,87 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Rattus_norvegicus.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Rattus_norvegicus.gene_info.gz",
+                    },
+                ],
+            },
+            {
+                // All-species monolithic table (~274 MB), not the per-organism split the gene_info entries use:
+                // NCBI publishes Entrez↔Ensembl only in this one combined file. Opt-in for that reason.
+                id: "ncbi-gene2ensembl",
+                version: "current",
+                title: "NCBI Entrez-to-Ensembl gene mapping (all species)",
+                description:
+                    "NCBI Gene's Entrez Gene ID ↔ Ensembl gene/transcript/protein identifier cross-reference for every species (gene2ensembl), tab-separated and gzipped — roughly 274 MB. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: false },
+                artifacts: [{ path: "gene2ensembl.gz", url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz" }],
+            },
+            {
+                // ~2.2 GB all-species monolithic table — the largest catalog entry. Opt-in like reactome-mappings.
+                id: "ncbi-gene2refseq",
+                version: "current",
+                title: "NCBI Entrez-to-RefSeq accession mapping (all species, large)",
+                description:
+                    "NCBI Gene's Entrez Gene ID ↔ RefSeq RNA/protein/genomic accession cross-reference for every species (gene2refseq), tab-separated and gzipped — roughly 2.2 GB. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest. Only needed to join RefSeq accessions onto genes.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: false },
+                artifacts: [{ path: "gene2refseq.gz", url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2refseq.gz" }],
+            },
+            {
+                id: "uniprot-idmapping-human",
+                version: "current",
+                title: "UniProt human ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Homo sapiens (idmapping_selected, ~61 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "HUMAN_9606_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping_selected.tab.gz",
+                    },
+                ],
+            },
+            {
+                id: "uniprot-idmapping-mouse",
+                version: "current",
+                title: "UniProt mouse ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Mus musculus (idmapping_selected, ~18 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "MOUSE_10090_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/MOUSE_10090_idmapping_selected.tab.gz",
+                    },
+                ],
+            },
+            {
+                id: "uniprot-idmapping-rat",
+                version: "current",
+                title: "UniProt rat ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Rattus norvegicus (idmapping_selected, ~6 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "RAT_10116_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/RAT_10116_idmapping_selected.tab.gz",
                     },
                 ],
             },
@@ -224,8 +280,8 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 license: { identifier: "CC0-1.0", url: "https://reactome.org/license" },
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
-                    { integrity: "unpinned", path: "ReactomePathways.gmt", url: "https://reactome.org/download/current/ReactomePathways.gmt" },
-                    { integrity: "unpinned", path: "ReactomePathways.txt", url: "https://reactome.org/download/current/ReactomePathways.txt" },
+                    { path: "ReactomePathways.gmt", url: "https://reactome.org/download/current/ReactomePathways.gmt" },
+                    { path: "ReactomePathways.txt", url: "https://reactome.org/download/current/ReactomePathways.txt" },
                 ],
             },
             {
@@ -243,17 +299,14 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "pathways", recommended: false },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "NCBI2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/NCBI2Reactome_All_Levels.txt",
                     },
                     {
-                        integrity: "unpinned",
                         path: "Ensembl2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/Ensembl2Reactome_All_Levels.txt",
                     },
                     {
-                        integrity: "unpinned",
                         path: "UniProt2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/UniProt2Reactome_All_Levels.txt",
                     },
@@ -269,11 +322,70 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "wikipathways_Homo_sapiens.gmt",
                         url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Homo_sapiens.gmt",
-                        bytes: 341_474,
-                        sha256: "79615a079246bb0b07cc3505265b1f75ea6cffec88001ce27f644dd86a39c97d",
+                    },
+                ],
+            },
+            {
+                id: "wikipathways-mouse",
+                version: "2026.07.10",
+                title: "WikiPathways mouse pathways",
+                description: "Community-curated Mus musculus pathway gene sets (GMT) from the immutable 2026-07-10 WikiPathways snapshot.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/",
+                license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "wikipathways_Mus_musculus.gmt",
+                        url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Mus_musculus.gmt",
+                    },
+                ],
+            },
+            {
+                id: "wikipathways-rat",
+                version: "2026.07.10",
+                title: "WikiPathways rat pathways",
+                description: "Community-curated Rattus norvegicus pathway gene sets (GMT) from the immutable 2026-07-10 WikiPathways snapshot.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/",
+                license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "wikipathways_Rattus_norvegicus.gmt",
+                        url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Rattus_norvegicus.gmt",
+                    },
+                ],
+            },
+            {
+                id: "msigdb-hallmark-human",
+                version: "2026.1",
+                title: "MSigDB human hallmark gene sets",
+                description:
+                    "The 50 MSigDB hallmark gene sets for Homo sapiens (symbols GMT) — coherent, well-defined biological states and processes for enrichment. From the immutable MSigDB 2026.1 human release.",
+                sourceUrl: "https://data.broadinstitute.org/gsea-msigdb/msigdb/",
+                license: { identifier: "MSigDB-License", url: "https://www.gsea-msigdb.org/gsea/msigdb/license.jsp" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "h.all.v2026.1.Hs.symbols.gmt",
+                        url: "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2026.1.Hs/h.all.v2026.1.Hs.symbols.gmt",
+                    },
+                ],
+            },
+            {
+                id: "msigdb-hallmark-mouse",
+                version: "2026.1",
+                title: "MSigDB mouse hallmark gene sets",
+                description:
+                    "The MSigDB mouse hallmark gene sets for Mus musculus (symbols GMT) — the murine ortholog-mapped hallmark collection for enrichment. From the immutable MSigDB 2026.1 mouse release.",
+                sourceUrl: "https://data.broadinstitute.org/gsea-msigdb/msigdb/",
+                license: { identifier: "MSigDB-License", url: "https://www.gsea-msigdb.org/gsea/msigdb/license.jsp" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "mh.all.v2026.1.Mm.symbols.gmt",
+                        url: "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2026.1.Mm/mh.all.v2026.1.Mm.symbols.gmt",
                     },
                 ],
             },
@@ -287,11 +399,8 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "regulatory-networks", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "CollecTRI_regulons.csv",
                         url: "https://zenodo.org/records/8192729/files/CollecTRI_regulons.csv",
-                        bytes: 4_345_649,
-                        sha256: "4473c9189dd53dacc80297709ad1452dda1086a1cc2185f9a56146c261668701",
                     },
                 ],
             },
@@ -306,20 +415,25 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "normal-expression", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
                         url: "https://storage.googleapis.com/adult-gtex/bulk-gex/v8/rna-seq/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
-                        bytes: 6_952_331,
-                        sha256: "ee7201ff2f280b0de5657d4b08e9a240362d9757efed7f7bd5dba35a5f8617b8",
                     },
                     {
-                        integrity: "pinned",
                         path: "GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
                         url: "https://storage.googleapis.com/adult-gtex/annotations/v8/metadata-files/GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
-                        bytes: 11_512_258,
-                        sha256: "74f6ab4c34ed2648d708a0ae6e6dff324f6c86ea723ae7d1c37d76f5221148f0",
                     },
                 ],
+            },
+            {
+                id: "hpa-proteinatlas",
+                version: "current",
+                title: "Human Protein Atlas",
+                description:
+                    "The full Human Protein Atlas table (proteinatlas.tsv.zip, ~7 MB): per-gene RNA/protein tissue expression, tissue specificity, subcellular location, secretome and blood-concentration annotations for Homo sapiens. HPA republishes this file per release, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://www.proteinatlas.org/about/download",
+                license: { identifier: "CC-BY-SA-3.0", url: "https://www.proteinatlas.org/about/licence" },
+                recommendation: { group: "normal-expression", recommended: true },
+                artifacts: [{ path: "proteinatlas.tsv.zip", url: "https://www.proteinatlas.org/download/proteinatlas.tsv.zip" }],
             },
             {
                 id: "celltypist-immune",
@@ -332,18 +446,118 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "cell-typing", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "Immune_All_Low.pkl",
                         url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_Low.pkl",
-                        bytes: 2_824_990,
-                        sha256: "290874d35dac039d4c9218c343fde4aac1077709b72a331ce7266f6828c36502",
                     },
                     {
-                        integrity: "pinned",
                         path: "Immune_All_High.pkl",
                         url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_High.pkl",
-                        bytes: 1_070_426,
-                        sha256: "a715fec36c2c421f7c4e31cf4cb4bea883eedab7fd7b20a4b76f091c22660448",
+                    },
+                ],
+            },
+            {
+                id: "celltypist-pan-fetal",
+                version: "2",
+                title: "CellTypist pan-fetal human model",
+                description:
+                    "CellTypist Pan_Fetal_Human model — cell-type annotation across human fetal tissues. Load by absolute path; CellTypist's by-name lookup expects its own cache layout, which the reference store deliberately does not impersonate.",
+                sourceUrl: "https://www.celltypist.org/models",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "Pan_Fetal_Human.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Fetal_Suo/v2/Pan_Fetal_Human.pkl",
+                    },
+                ],
+            },
+            {
+                id: "celltypist-covid19",
+                version: "1",
+                title: "CellTypist COVID-19 immune model",
+                description:
+                    "CellTypist COVID19_Immune_Landscape model — immune cell-type annotation trained on the cross-study COVID-19 immune atlas. Load by absolute path; CellTypist's by-name lookup expects its own cache layout, which the reference store deliberately does not impersonate.",
+                sourceUrl: "https://www.celltypist.org/models",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "COVID19_Immune_Landscape.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/COVID19_Immune_Ren/v1/COVID19_Immune_Landscape.pkl",
+                    },
+                ],
+            },
+            {
+                id: "panglaodb-markers",
+                version: "2020.03.27",
+                title: "PanglaoDB cell-type markers",
+                description:
+                    "PanglaoDB cell-type marker panel (tab-separated, gzipped): curated marker genes per cell type across human and mouse, for marker-based annotation. From the immutable 27 March 2020 PanglaoDB marker release.",
+                sourceUrl: "https://panglaodb.se/markers.html",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "PanglaoDB_markers_27_Mar_2020.tsv.gz",
+                        url: "https://panglaodb.se/markers/PanglaoDB_markers_27_Mar_2020.tsv.gz",
+                    },
+                ],
+            },
+            {
+                id: "azimuth-pbmc",
+                version: "1.0.0",
+                title: "Azimuth human PBMC reference",
+                description:
+                    "Azimuth annotated reference for human peripheral blood mononuclear cells: the Seurat reference object plus its Annoy nearest-neighbour index, for supervised mapping and cell-type label transfer. Immutable Zenodo release 4546839.",
+                sourceUrl: "https://zenodo.org/records/4546839",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/4546839" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "ref.Rds",
+                        url: "https://zenodo.org/records/4546839/files/ref.Rds",
+                    },
+                    {
+                        path: "idx.annoy",
+                        url: "https://zenodo.org/records/4546839/files/idx.annoy",
+                    },
+                ],
+            },
+            {
+                // ~443 MB (ref + index), so it is opt-in rather than part of a default setup.
+                id: "azimuth-tonsil",
+                version: "1.0.0",
+                title: "Azimuth human tonsil reference",
+                description:
+                    "Azimuth annotated reference for human tonsil: the Seurat reference object plus its Annoy nearest-neighbour index, for supervised mapping and cell-type label transfer. Immutable Zenodo release 7032928, roughly 443 MB.",
+                sourceUrl: "https://zenodo.org/records/7032928",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/7032928" },
+                recommendation: { group: "cell-typing", recommended: false },
+                artifacts: [
+                    {
+                        path: "ref.Rds",
+                        url: "https://zenodo.org/records/7032928/files/ref.Rds",
+                    },
+                    {
+                        path: "idx.annoy",
+                        url: "https://zenodo.org/records/7032928/files/idx.annoy",
+                    },
+                ],
+            },
+            {
+                // ~842 MB reference genome bundle, PGx-specific, so it is opt-in rather than a default download.
+                id: "pharmcat-grch38-fasta",
+                version: "GRCh38.p13",
+                title: "PharmCAT GRCh38 reference FASTA",
+                description:
+                    "The GRCh38.p13 reference genome FASTA that PharmCAT's VCF preprocessor expects (bgzip'd with a .fai/.gzi faidx), bundled as a tar — roughly 842 MB. Immutable Zenodo release 7288118. Needed only for pharmacogenomics (PharmCAT) workflows.",
+                sourceUrl: "https://zenodo.org/records/7288118",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/7288118" },
+                recommendation: { group: "pharmacogenomics", recommended: false },
+                artifacts: [
+                    {
+                        path: "PharmCAT_GRCh38_reference_fasta.tar",
+                        url: "https://zenodo.org/records/7288118/files/GRCh38_reference_fasta.tar?download=1",
                     },
                 ],
             },

--- a/harness/src/reference-data/receipt.ts
+++ b/harness/src/reference-data/receipt.ts
@@ -7,16 +7,15 @@ export const REFERENCE_INSTALL_RECEIPT_VERSION = 1 as const;
 
 /**
  * What was actually written to disk for one artifact. The size and digest are
- * *observed at install*, never copied from the catalog — for a `pinned`
- * artifact they equal the catalog's (the install would have failed otherwise),
- * and for an `unpinned` one they are the only record of what the mutable
- * upstream served, which is what `verify` later checks the files against.
+ * *observed at install* — the catalog carries neither, so this receipt is the
+ * sole record of the bytes the upstream served, and what `verify` later checks
+ * the local files against. A receipt written by an older build may still carry
+ * an `integrity` field; it is simply ignored (unknown keys are stripped).
  */
 const ReferenceReceiptArtifactSchema = z.object({
     path: ReferenceArtifactPathSchema,
     bytes: z.number().int().nonnegative(),
     sha256: ReferenceSha256Schema,
-    integrity: z.enum(["pinned", "unpinned"]),
 });
 
 /** Optional metadata describing one activated reference dataset version. */

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -148,14 +148,14 @@ describe("list_available_refs", () => {
                     datasetId: "alpha",
                     datasetVersion: "2026.07",
                     activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH, integrity: "pinned" }],
+                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
                 },
                 {
                     version: 1,
                     datasetId: "ncbi-gene-human",
                     datasetVersion: "current",
                     activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "Homo_sapiens.gene_info.gz", bytes: 1_024, sha256: HASH, integrity: "unpinned" }],
+                    artifacts: [{ path: "Homo_sapiens.gene_info.gz", bytes: 1_024, sha256: HASH }],
                 },
             ],
             legacyEntries: [{ local_path: "legacy/pathways.gmt", category: "pathways", dataset: "legacy-pathways", rows: 200 }],
@@ -185,28 +185,6 @@ describe("list_available_refs", () => {
             metadata: { datasetId: "legacy-pathways", category: "pathways", rows: 200 },
         });
         expect(result.entries.find((entry) => entry.path.includes("/user/"))?.metadata).toBeUndefined();
-    });
-
-    it("ignores a receipt artifact that records no observed integrity", async () => {
-        const managedPath = "/mnt/refs/managed/alpha/2026.07/reference.parquet";
-        const client = makeClient({
-            state: "populated",
-            entries: [{ path: managedPath, kind: "file", bytes: 12 }],
-            scannedEntries: 1,
-            truncated: false,
-            receipts: [
-                {
-                    version: 1,
-                    datasetId: "alpha",
-                    datasetVersion: "2026.07",
-                    activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
-                },
-            ],
-        });
-
-        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
-        expect(result.entries).toEqual([{ path: managedPath, kind: "file", bytes: 12 }]);
     });
 
     it("ignores invalid and stale metadata without hiding observed files", async () => {
@@ -332,7 +310,7 @@ describe("list_available_refs", () => {
                 datasetId: "wikipathways-human",
                 datasetVersion: "2026.07.10",
                 activatedAt: "2026-07-14T10:30:00.000Z",
-                artifacts: [{ path: "wikipathways_Homo_sapiens.gmt", bytes: 31, sha256: HASH, integrity: "pinned" }],
+                artifacts: [{ path: "wikipathways_Homo_sapiens.gmt", bytes: 31, sha256: HASH }],
             }),
         );
 


### PR DESCRIPTION
## What

Two things, in the reference-data catalog (`harness/`) and the `refs` CLI (`cli/`):

1. **Expand the catalog** from 9 → 25 datasets and make the download surface navigable.
2. **Collapse the integrity model** to a single URL-only, trust-on-first-use scheme.

## Catalog expansion (16 new datasets)

| Group | Added |
|-|-|
| gene-identifiers | `ncbi-gene2ensembl`, `ncbi-gene2refseq`, `uniprot-idmapping-{human,mouse,rat}` |
| pathways | `wikipathways-{mouse,rat}`, `msigdb-hallmark-{human,mouse}` |
| normal-expression | `hpa-proteinatlas` |
| cell-typing | `celltypist-{pan-fetal,covid19}`, `panglaodb-markers`, `azimuth-{pbmc,tonsil}` |
| pharmacogenomics *(new group)* | `pharmcat-grch38-fasta` |

Large or domain-specific downloads (the all-species NCBI mapping tables, the tonsil reference, the PharmCAT genome bundle) are marked opt-in so a default `setup` never silently pulls hundreds of MB.

## Grouped download UX

- The interactive picker uses clack `groupMultiselect`, grouped by category (toggling a group header selects everything under it).
- `refs list` prints category headers instead of one flat wall, and `refs list --urls` reveals the exact upstream URL of every artifact.

## URL-only integrity (trust-on-first-use)

A catalog artifact is now just `{ path, url }` — **no `pinned`/`unpinned` class, no checked-in size or digest.** Rationale:

- The old split (immutable → pinned+digest, mutable → trust-on-first-use) applied scrutiny **unevenly** — half the catalog was already digest-free — and it put on us the burden of downloading+hashing every immutable file and keeping that digest in sync.
- TLS already authenticates the publisher; the **install receipt** (bytes + sha256 observed from the user's *own* download) already lets `refs verify` catch post-install corruption/tampering. The only thing a checked-in digest added was "these match the bytes a maintainer reviewed" — marginal for public, re-downloadable, sandbox-loaded reference data.

Result: **adding a source is now one line — a URL.** Nothing to hash, nothing to keep in sync, no digest that goes stale when a `current` upstream rebuilds. Old receipts carrying the removed `integrity` field still parse (the key is ignored), so existing installs are not invalidated.

Mechanically: the discriminated union / `bytes` / `sha256` / `ReferenceIntegrity` are gone; `store.ts` always fetches fresh and records observed bytes+digest; `verify` compares against the receipt; `referenceDownloadBytes` → `referenceDownloadEstimate`.

## Spec

`harness/openspec/specs/reference-data-catalog/spec.md` rewritten to the uniform model (`openspec validate` passes).

## Validation

- **harness**: `tsc` build clean; reference-data tests 32 pass; spec valid.
- **cli**: `typecheck` clean; `refs` + `cli.test.ts` 40 pass; `lint` clean.
- Smoke: `refs list` / `refs list --urls` render all 6 groups correctly.

## Deferred (follow-ups, now trivial — just URLs)

ProjecTILs (needs a figshare `sourceUrl` host), Ensembl Compara orthologs, Tabula Sapiens v2, the Group-3 query-URL sources (OmniPath/DoRothEA/PROGENy/LINCS). CellMarker2 is blocked (http-only). Curated JSON (safety panel, signatures, markers) is repo-bundled, not a download.
