### PR TITLE
feat(refs): URL-only reference-data catalog + 16 new datasets (harness, 0.4.1)

### DIFF
--- a/harness/openspec/specs/reference-data-catalog/spec.md
+++ b/harness/openspec/specs/reference-data-catalog/spec.md
@@ -9,14 +9,14 @@ plans, and shared receipt metadata consumed by every harness embedder.
 
 ### Requirement: The harness publishes the canonical reference-data catalog
 
-The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have the `https` URL of the third party that publishes it, a safe dataset-relative destination path, and an integrity class.
+The harness SHALL ship a checked-in, versioned catalog of reference datasets through its public package surface. Each dataset SHALL have a stable id, version, title, description, source URL, license URL or license identifier, recommendation/group metadata, and at least one artifact. Each artifact SHALL have exactly the `https` URL of the third party that publishes it and a safe dataset-relative destination path — no size, digest, or integrity class.
 
-Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, non-SHA-256 digests, and non-positive artifact sizes.
+Catalog validation SHALL reject duplicate dataset ids, duplicate artifact destinations within a dataset, absolute or traversal-bearing destinations, non-`https` artifact URLs, and any stray size or digest field offered on an artifact.
 
 #### Scenario: An embedder lists supported references
 
 - **WHEN** an embedder reads the exported catalog
-- **THEN** it receives the same validated dataset ids, versions, upstream URLs, source and licensing links, and integrity classes as every other embedder using that harness version
+- **THEN** it receives the same validated dataset ids, versions, upstream URLs, and source and licensing links as every other embedder using that harness version
 
 #### Scenario: An unsafe catalog path is rejected
 
@@ -37,28 +37,28 @@ Each artifact SHALL name the official third-party URL it is fetched from, and th
 - **WHEN** the CLI and managed embedder resolve the same catalog ids from the same harness version
 - **THEN** both receive content-identical plans naming the same upstream URLs
 
-### Requirement: An artifact's integrity class states what its upstream can actually guarantee
+### Requirement: Reference integrity is uniform trust-on-first-use
 
-Every artifact SHALL declare an integrity class, and that class SHALL reflect a property of the upstream rather than a preference of ours. A `pinned` artifact — one whose upstream publishes immutable, versioned bytes — SHALL carry a byte size and SHA-256 digest. An `unpinned` artifact — one whose upstream regenerates the same URL in place, so that no checked-in digest could survive — SHALL carry neither, because a digest that is guaranteed to go stale is worse than an absent one: it promises verification and delivers a broken download.
+The catalog SHALL carry no per-artifact size or digest, and there SHALL be no integrity class. Every artifact is authenticated over TLS at download time, and the bytes actually received are recorded in the install receipt so later verification can prove the local copy has not changed since install. A checked-in digest is deliberately not maintained: it would apply unevenly — only upstreams that publish immutable bytes could ever carry one — and would put on this project the burden of computing and re-syncing a value that a `current` upstream immediately makes stale. TLS authenticates the publisher, and the receipt catches post-install drift; the marginal supply-chain benefit of a reviewed digest does not justify that inconsistency and burden for public, re-downloadable reference data.
 
-#### Scenario: Immutable upstream is pinned
+#### Scenario: The catalog names a source, not a checksum
 
-- **WHEN** an upstream publishes a dated or release-versioned file that never changes
-- **THEN** its artifact is `pinned` with a size and SHA-256, and an install that receives different bytes fails without activating anything
+- **WHEN** a dataset is added to the catalog
+- **THEN** its artifact carries only an `https` URL and destination path — no size, digest, or integrity class — and adding a source requires no downloaded-and-hashed value
 
-#### Scenario: Mutable upstream is not pretended to be pinned
+#### Scenario: Integrity is recovered from the receipt, not the catalog
 
-- **WHEN** an upstream rebuilds a file in place at a stable URL (NCBI regenerating `gene_info`, Reactome overwriting `current`)
-- **THEN** its artifact is `unpinned`, the catalog states no digest, and the weaker guarantee is surfaced to the user rather than hidden
+- **WHEN** an installed file is later altered on disk
+- **THEN** verification against the size and digest the receipt recorded at install reports it modified, even though the catalog never carried a digest
 
 ### Requirement: Catalog artifacts describe final immutable files
 
-Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher, and its digest attests only to the machine that produced it.
+Every artifact in the initial catalog format SHALL describe one final file to stage beneath its dataset installation root. The catalog SHALL NOT contain executable installer scripts, arbitrary shell commands, or untyped transformation recipes, and SHALL NOT describe a derived file that no upstream serves — a locally-converted artifact cannot be fetched from its publisher and carries no third-party provenance.
 
 #### Scenario: A multi-file reference is fully described
 
 - **WHEN** a dataset requires two companion files
-- **THEN** its install plan contains two artifact entries, each with its own upstream URL, destination, and integrity class
+- **THEN** its install plan contains two artifact entries, each with its own upstream URL and destination
 
 #### Scenario: A stable identity survives a moved URL
 
@@ -67,18 +67,18 @@ Every artifact in the initial catalog format SHALL describe one final file to st
 
 ### Requirement: Reference installation receipts record what was actually received
 
-The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path, integrity class, and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable.
+The harness SHALL define a versioned receipt contract containing the dataset id and version, activation timestamp, and for each installed artifact its relative path and the byte size and SHA-256 digest **observed at install time**. A receipt SHALL be optional metadata: its absence or invalidity SHALL NOT mean the corresponding files are unavailable. A receipt written by an older build MAY carry a now-removed integrity field; parsing SHALL ignore it rather than reject the receipt.
 
-Observed digests SHALL NOT be copied from the catalog. For a `pinned` artifact the observed digest necessarily equals the catalog's, since activation fails otherwise; for an `unpinned` artifact the receipt is the only record of what the mutable upstream served, and is therefore what later verification compares against.
+Observed digests SHALL NOT be copied from the catalog, which carries none: the receipt is the sole record of what the upstream served at install time, and is therefore what later verification compares the files against.
 
 #### Scenario: Different embedders describe the same installation
 
 - **WHEN** local and managed installers activate the same install plan
 - **THEN** each can emit a receipt that validates against the same harness-owned contract
 
-#### Scenario: An unpinned install is still verifiable afterwards
+#### Scenario: An install is still verifiable afterwards
 
-- **WHEN** an `unpinned` artifact is installed and its bytes are later altered on disk
+- **WHEN** an installed artifact's bytes are later altered on disk
 - **THEN** verification against the receipt reports the file as modified, even though the catalog never carried a digest for it
 
 #### Scenario: Invalid receipt does not hide files

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -328,7 +328,6 @@ export type {
     ReferenceDataset,
     ReferenceInstallPlan,
     ReferenceInstallPlanDataset,
-    ReferenceIntegrity,
 } from "./reference-data/catalog.js";
 export { REFERENCE_INSTALL_RECEIPT_VERSION, ReferenceInstallReceiptSchema, parseReferenceInstallReceipt } from "./reference-data/receipt.js";
 export type { ReferenceInstallReceipt, ReferenceReceiptArtifact } from "./reference-data/receipt.js";

--- a/harness/src/reference-data/catalog.test.ts
+++ b/harness/src/reference-data/catalog.test.ts
@@ -15,21 +15,11 @@ import { REFERENCE_INSTALL_RECEIPT_VERSION, parseReferenceInstallReceipt } from 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 
-function pinned(path: string, index = 0): Record<string, unknown> {
-    return {
-        integrity: "pinned",
-        path,
-        url: `https://example.org/immutable/artifact-${index}`,
-        bytes: index + 1,
-        sha256: index === 0 ? HASH_A : HASH_B,
-    };
+function artifact(path: string, index = 0): Record<string, unknown> {
+    return { path, url: `https://example.org/artifact-${index}` };
 }
 
-function unpinned(path: string, index = 0): Record<string, unknown> {
-    return { integrity: "unpinned", path, url: `https://example.org/current/artifact-${index}` };
-}
-
-function dataset(id: string, artifacts: Record<string, unknown>[] = [pinned("reference.parquet")]): Record<string, unknown> {
+function dataset(id: string, artifacts: Record<string, unknown>[] = [artifact("reference.parquet")]): Record<string, unknown> {
     return {
         id,
         version: "2026.07",
@@ -57,31 +47,52 @@ describe("reference-data catalog", () => {
             "ncbi-gene-human",
             "ncbi-gene-mouse",
             "ncbi-gene-rat",
+            "ncbi-gene2ensembl",
+            "ncbi-gene2refseq",
+            "uniprot-idmapping-human",
+            "uniprot-idmapping-mouse",
+            "uniprot-idmapping-rat",
             "reactome-pathways",
             "reactome-mappings",
             "wikipathways-human",
+            "wikipathways-mouse",
+            "wikipathways-rat",
+            "msigdb-hallmark-human",
+            "msigdb-hallmark-mouse",
             "collectri-human",
             "gtex-v8",
+            "hpa-proteinatlas",
             "celltypist-immune",
+            "celltypist-pan-fetal",
+            "celltypist-covid19",
+            "panglaodb-markers",
+            "azimuth-pbmc",
+            "azimuth-tonsil",
+            "pharmcat-grch38-fasta",
         ]);
     });
 
-    // The ~700 MB of uncompressed Reactome mapping TSV is opt-in, so a default `setup` never
-    // silently pulls two orders of magnitude more than the gene sets it actually asked for.
-    it("recommends every dataset except the very large opt-in mapping tables", () => {
+    // Large or domain-specific downloads are opt-in, so a default `setup` never silently pulls
+    // hundreds of MB (or GB) the user did not ask for: the all-species NCBI mapping tables, the
+    // Reactome mapping TSVs, the 443 MB tonsil reference, and the 842 MB PharmCAT genome bundle.
+    it("recommends every dataset except the very large or domain-specific opt-in downloads", () => {
         const notRecommended = REFERENCE_DATA_CATALOG.datasets.filter((dataset) => !dataset.recommendation.recommended).map(({ id }) => id);
 
-        expect(notRecommended).toEqual(["reactome-mappings"]);
+        expect(notRecommended).toEqual(["ncbi-gene2ensembl", "ncbi-gene2refseq", "reactome-mappings", "azimuth-tonsil", "pharmcat-grch38-fasta"]);
     });
 
     it("fetches every artifact from an official upstream over https", () => {
         const officialHosts = new Set([
             "ftp.ncbi.nlm.nih.gov",
+            "ftp.uniprot.org",
             "reactome.org",
             "data.wikipathways.org",
+            "data.broadinstitute.org",
             "zenodo.org",
             "gtexportal.org",
             "storage.googleapis.com",
+            "www.proteinatlas.org",
+            "panglaodb.se",
             "celltypist.cog.sanger.ac.uk",
             "www.celltypist.org",
         ]);
@@ -96,32 +107,15 @@ describe("reference-data catalog", () => {
         }
     });
 
-    it("pins size and digest exactly for the immutable upstreams and for no other", () => {
-        const byIntegrity = { pinned: [] as string[], unpinned: [] as string[] };
-
+    // The uniform trust-on-first-use model: the catalog is URL + provenance only, so no artifact
+    // may carry a size or digest to compute, review, or let go stale. Integrity lives entirely in
+    // the install receipt, off the bytes the user actually downloaded.
+    it("carries only a path and url for every artifact — no checked-in size or digest", () => {
         for (const dataset of REFERENCE_DATA_CATALOG.datasets) {
             for (const artifact of dataset.artifacts) {
-                byIntegrity[artifact.integrity].push(dataset.id);
-                if (artifact.integrity === "pinned") {
-                    expect(artifact.bytes).toBeGreaterThan(0);
-                    expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
-                } else {
-                    // A mutable upstream admits no checked-in digest: the receipt is the record.
-                    expect(artifact).not.toHaveProperty("bytes");
-                    expect(artifact).not.toHaveProperty("sha256");
-                    expect(dataset.version).toBe("current");
-                }
+                expect(Object.keys(artifact).sort()).toEqual(["path", "url"]);
             }
         }
-
-        expect([...new Set(byIntegrity.pinned)]).toEqual(["wikipathways-human", "collectri-human", "gtex-v8", "celltypist-immune"]);
-        expect([...new Set(byIntegrity.unpinned)]).toEqual([
-            "ncbi-gene-human",
-            "ncbi-gene-mouse",
-            "ncbi-gene-rat",
-            "reactome-pathways",
-            "reactome-mappings",
-        ]);
     });
 
     it("keys every catalog artifact by its stable, URL-independent identity", () => {
@@ -134,61 +128,36 @@ describe("reference-data catalog", () => {
         }
     });
 
-    it("accepts both integrity classes and rejects an unknown discriminant", () => {
-        expect(ReferenceArtifactSchema.safeParse(pinned("one.parquet")).success).toBe(true);
-        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
-        expect(ReferenceArtifactSchema.safeParse({ path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse({ integrity: "trusted", path: "one.parquet", url: "https://example.org/one" }).success).toBe(false);
-    });
-
-    // A digest on an unpinned artifact is a category error: the upstream rewrites that URL, so the
-    // digest is guaranteed to go stale. Silently stripping it would let the mistake reach review
-    // looking like a pinned entry, so the schema rejects it outright.
-    it("rejects a size and digest offered for an unpinned artifact", () => {
-        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), bytes: 5, sha256: HASH_A }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse({ ...unpinned("current.gz"), sha256: HASH_A }).success).toBe(false);
-        expect(ReferenceArtifactSchema.safeParse(unpinned("current.gz")).success).toBe(true);
+    it("accepts a path+url artifact and rejects missing fields or a stray size/digest", () => {
+        expect(ReferenceArtifactSchema.safeParse(artifact("one.parquet")).success).toBe(true);
+        expect(ReferenceArtifactSchema.safeParse({ path: "one.parquet" }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ url: "https://example.org/one" }).success).toBe(false);
+        // strictObject: a stray size or digest is a mistake (the catalog pins nothing), so it is rejected
+        // outright rather than silently accepted and never verified.
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), bytes: 5 }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), sha256: HASH_A }).success).toBe(false);
+        expect(ReferenceArtifactSchema.safeParse({ ...artifact("one.parquet"), integrity: "pinned" }).success).toBe(false);
     });
 
     it.each(["http://example.org/one", "ftp://ftp.example.org/one", "file:///etc/passwd", "example.org/one", ""])(
         "rejects non-https artifact url %s",
         (url) => {
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-url", [{ ...pinned("one.parquet"), url }])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-url", [{ ...artifact("one.parquet"), url }])])).success).toBe(false);
         },
     );
 
-    it("requires a size and digest on a pinned artifact", () => {
-        const { sha256: _sha256, ...noDigest } = pinned("one.parquet");
-        const { bytes: _bytes, ...noSize } = pinned("one.parquet");
-
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-digest", [noDigest])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("no-size", [noSize])])).success).toBe(false);
-    });
-
     it("rejects duplicate dataset ids and artifact destinations", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one"), dataset("one")])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("a.parquet", 1)])])).success).toBe(false);
-        // A path collides across integrity classes too — the destination is what must be unique.
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet"), unpinned("a.parquet")])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [pinned("a.parquet", 0), pinned("b.parquet", 1)])])).success).toBe(true);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [artifact("a.parquet", 0), artifact("a.parquet", 1)])])).success).toBe(false);
+        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("one", [artifact("a.parquet", 0), artifact("b.parquet", 1)])])).success).toBe(true);
     });
 
     it.each(["/absolute/file", "../escape", "nested/../../escape", "nested//file", "nested/./file", "nested\\file", ""])(
         "rejects unsafe artifact path %s",
         (path) => {
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [pinned(path)])])).success).toBe(false);
-            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [unpinned(path)])])).success).toBe(false);
+            expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("unsafe", [artifact(path)])])).success).toBe(false);
         },
     );
-
-    it("rejects malformed digests and non-positive sizes", () => {
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-digest", [{ ...pinned("a.parquet"), sha256: "abc" }])])).success).toBe(false);
-        expect(
-            ReferenceDataCatalogSchema.safeParse(catalog([dataset("upper-digest", [{ ...pinned("a.parquet"), sha256: HASH_A.toUpperCase() }])])).success,
-        ).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("bad-size", [{ ...pinned("a.parquet"), bytes: 0 }])])).success).toBe(false);
-        expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("float-size", [{ ...pinned("a.parquet"), bytes: 1.5 }])])).success).toBe(false);
-    });
 
     it("requires at least one artifact per dataset", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([dataset("empty", [])])).success).toBe(false);
@@ -198,8 +167,8 @@ describe("reference-data catalog", () => {
         expect(ReferenceDataCatalogSchema.safeParse(catalog([{ ...dataset("unsafe-version"), version }])).success).toBe(false);
     });
 
-    it("resolves a deterministic, deduplicated multi-file plan across both integrity classes", () => {
-        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", [pinned("one.parquet", 0), unpinned("two.json", 1)])]));
+    it("resolves a deterministic, deduplicated multi-file plan", () => {
+        const parsed = ReferenceDataCatalogSchema.parse(catalog([dataset("zeta"), dataset("alpha", [artifact("one.parquet", 0), artifact("two.json", 1)])]));
         const plan = resolveReferenceInstallPlanFromCatalogForTesting(["zeta", "alpha", "zeta"], parsed)._unsafeUnwrap();
 
         expect(plan.catalogVersion).toBe(REFERENCE_DATA_CATALOG_VERSION);
@@ -207,11 +176,7 @@ describe("reference-data catalog", () => {
         expect(plan.datasets[0]!.installPath).toBe("alpha/2026.07");
         expect(plan.datasets[1]!.installPath).toBe("zeta/2026.07");
         expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.path)).toEqual(["one.parquet", "two.json"]);
-        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.integrity)).toEqual(["pinned", "unpinned"]);
-        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.url)).toEqual([
-            "https://example.org/immutable/artifact-0",
-            "https://example.org/current/artifact-1",
-        ]);
+        expect(plan.datasets[0]!.artifacts.map((artifact) => artifact.url)).toEqual(["https://example.org/artifact-0", "https://example.org/artifact-1"]);
         expect(referenceArtifactKey(plan.datasets[0]!, plan.datasets[0]!.artifacts[0]!)).toBe("alpha/2026.07/one.parquet");
     });
 
@@ -226,15 +191,31 @@ describe("reference-data catalog", () => {
         expect(resolveReferenceInstallPlan(["fixture-only"])._unsafeUnwrapErr()).toMatchObject({
             unknownId: "fixture-only",
             availableIds: [
+                "azimuth-pbmc",
+                "azimuth-tonsil",
+                "celltypist-covid19",
                 "celltypist-immune",
+                "celltypist-pan-fetal",
                 "collectri-human",
                 "gtex-v8",
+                "hpa-proteinatlas",
+                "msigdb-hallmark-human",
+                "msigdb-hallmark-mouse",
                 "ncbi-gene-human",
                 "ncbi-gene-mouse",
                 "ncbi-gene-rat",
+                "ncbi-gene2ensembl",
+                "ncbi-gene2refseq",
+                "panglaodb-markers",
+                "pharmcat-grch38-fasta",
                 "reactome-mappings",
                 "reactome-pathways",
+                "uniprot-idmapping-human",
+                "uniprot-idmapping-mouse",
+                "uniprot-idmapping-rat",
                 "wikipathways-human",
+                "wikipathways-mouse",
+                "wikipathways-rat",
             ],
         });
 
@@ -250,13 +231,20 @@ describe("reference installation receipt", () => {
         datasetVersion: "2026.07",
         activatedAt: "2026-07-14T10:30:00.000Z",
         artifacts: [
-            { path: "one.parquet", bytes: 42, sha256: HASH_A, integrity: "pinned" as const },
-            { path: "nested/current.gz", bytes: 0, sha256: HASH_B, integrity: "unpinned" as const },
+            { path: "one.parquet", bytes: 42, sha256: HASH_A },
+            { path: "nested/current.gz", bytes: 0, sha256: HASH_B },
         ],
     };
 
-    it("records observed bytes and digest for both integrity classes", () => {
+    it("records the observed size and digest for every artifact", () => {
         expect(parseReferenceInstallReceipt(valid)).toEqual(valid);
+    });
+
+    // A receipt written by an older build carries a now-removed `integrity` field. It must still
+    // parse (the install stays valid across the upgrade); the unknown key is simply dropped.
+    it("accepts a legacy receipt carrying an integrity field, ignoring it", () => {
+        const legacy = { ...valid, artifacts: [{ ...valid.artifacts[0], integrity: "pinned" }] };
+        expect(parseReferenceInstallReceipt(legacy)).toEqual({ ...valid, artifacts: [valid.artifacts[0]] });
     });
 
     it("degrades invalid receipt metadata to undefined", () => {
@@ -271,14 +259,7 @@ describe("reference installation receipt", () => {
         expect(parseReferenceInstallReceipt({ ...valid, artifacts: [valid.artifacts[0], valid.artifacts[0]] })).toBeUndefined();
     });
 
-    it("requires an observed integrity class on every receipt artifact", () => {
-        const { integrity: _integrity, ...noIntegrity } = valid.artifacts[0]!;
-
-        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [noIntegrity] })).toBeUndefined();
-        expect(parseReferenceInstallReceipt({ ...valid, artifacts: [{ ...valid.artifacts[0], integrity: "trusted" }] })).toBeUndefined();
-    });
-
-    it("requires an observed digest even where the catalog could not pin one", () => {
+    it("requires an observed size and digest on every receipt artifact", () => {
         const { sha256: _sha256, ...noDigest } = valid.artifacts[1]!;
         const { bytes: _bytes, ...noSize } = valid.artifacts[1]!;
 

--- a/harness/src/reference-data/catalog.ts
+++ b/harness/src/reference-data/catalog.ts
@@ -29,39 +29,19 @@ export const ReferenceSha256Schema = z.string().regex(SHA256, "Expected a lowerc
 const ReferenceArtifactUrlSchema = z.url().refine((value) => value.startsWith("https://"), "Reference artifacts must be fetched over https");
 
 /**
- * An artifact whose upstream publishes immutable, versioned bytes. The catalog
- * carries the size and digest, so a download is verified against *this file*
- * before it is ever activated: a mismatch means the bytes are not what we
- * reviewed, and the install fails.
+ * One final file distributed for a reference dataset: a stable install-relative
+ * path and the third-party https URL it is fetched from. The catalog carries no
+ * size or digest — every upstream is authenticated over TLS at download time,
+ * and the installer records the bytes it actually received in the receipt so
+ * `verify` can later prove the local copy has not changed since install. This is
+ * one uniform trust-on-first-use model; there is deliberately no per-artifact
+ * integrity class, so adding a source is only ever a URL, and no checked-in
+ * digest is ours to maintain or lets go stale when a `current` upstream rebuilds.
  */
-const PinnedReferenceArtifactSchema = z.strictObject({
-    integrity: z.literal("pinned"),
-    path: ReferenceArtifactPathSchema,
-    url: ReferenceArtifactUrlSchema,
-    bytes: z.number().int().positive(),
-    sha256: ReferenceSha256Schema,
-});
-
-/**
- * An artifact whose upstream regenerates the same URL in place — NCBI rebuilds
- * `gene_info` continuously and Reactome's `current` release is overwritten and
- * its predecessors deleted. No checked-in digest can survive that, and pinning
- * one would only guarantee a broken download. Integrity is therefore
- * trust-on-first-use: the installer records the bytes it actually received in
- * the receipt, and `verify` proves the files have not changed *since install*.
- * This is a weaker guarantee than `pinned` and is surfaced as such to the user.
- */
-const UnpinnedReferenceArtifactSchema = z.strictObject({
-    integrity: z.literal("unpinned"),
+export const ReferenceArtifactSchema = z.strictObject({
     path: ReferenceArtifactPathSchema,
     url: ReferenceArtifactUrlSchema,
 });
-
-/** One immutable final file distributed for a reference dataset. */
-export const ReferenceArtifactSchema = z.discriminatedUnion("integrity", [PinnedReferenceArtifactSchema, UnpinnedReferenceArtifactSchema]);
-
-/** Which integrity guarantee an artifact can actually offer. */
-export type ReferenceIntegrity = z.infer<typeof ReferenceArtifactSchema>["integrity"];
 
 /** Provenance and licensing information for one supported reference dataset. */
 export const ReferenceDatasetSchema = z.object({
@@ -141,14 +121,14 @@ function deepFreeze<T>(value: T): DeepReadonly<T> {
 /**
  * Canonical release catalog. Every artifact is fetched directly from the third
  * party that publishes it; this project hosts, mirrors, and redistributes
- * nothing. Entries are added only with real upstream URLs, provenance, and
- * licensing data — plus a size and digest whenever the upstream publishes
- * immutable bytes we can pin to.
+ * nothing. Entries are added with a real upstream https URL, provenance, and
+ * licensing data — and nothing else per file: no size, no digest to compute or
+ * keep in sync.
  *
  * `version` is the dataset's upstream release identifier. Datasets built on an
  * upstream that has no immutable release — NCBI regenerates `gene_info` daily,
  * Reactome overwrites `current` and deletes prior releases — are versioned
- * `current` and carry `unpinned` artifacts.
+ * `current`; those with an immutable release carry it verbatim.
  */
 export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
     ReferenceDataCatalogSchema.parse({
@@ -168,7 +148,6 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Homo_sapiens.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz",
                     },
@@ -188,7 +167,6 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Mus_musculus.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz",
                     },
@@ -208,9 +186,87 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "gene-identifiers", recommended: true },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "Rattus_norvegicus.gene_info.gz",
                         url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Rattus_norvegicus.gene_info.gz",
+                    },
+                ],
+            },
+            {
+                // All-species monolithic table (~274 MB), not the per-organism split the gene_info entries use:
+                // NCBI publishes Entrez↔Ensembl only in this one combined file. Opt-in for that reason.
+                id: "ncbi-gene2ensembl",
+                version: "current",
+                title: "NCBI Entrez-to-Ensembl gene mapping (all species)",
+                description:
+                    "NCBI Gene's Entrez Gene ID ↔ Ensembl gene/transcript/protein identifier cross-reference for every species (gene2ensembl), tab-separated and gzipped — roughly 274 MB. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: false },
+                artifacts: [{ path: "gene2ensembl.gz", url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz" }],
+            },
+            {
+                // ~2.2 GB all-species monolithic table — the largest catalog entry. Opt-in like reactome-mappings.
+                id: "ncbi-gene2refseq",
+                version: "current",
+                title: "NCBI Entrez-to-RefSeq accession mapping (all species, large)",
+                description:
+                    "NCBI Gene's Entrez Gene ID ↔ RefSeq RNA/protein/genomic accession cross-reference for every species (gene2refseq), tab-separated and gzipped — roughly 2.2 GB. NCBI rebuilds this file in place, so it is verified against what you downloaded rather than a checked-in digest. Only needed to join RefSeq accessions onto genes.",
+                sourceUrl: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/",
+                license: {
+                    identifier: "NCBI-Molecular-Data-Usage-Policy",
+                    url: "https://www.ncbi.nlm.nih.gov/home/about/policies/",
+                },
+                recommendation: { group: "gene-identifiers", recommended: false },
+                artifacts: [{ path: "gene2refseq.gz", url: "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2refseq.gz" }],
+            },
+            {
+                id: "uniprot-idmapping-human",
+                version: "current",
+                title: "UniProt human ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Homo sapiens (idmapping_selected, ~61 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "HUMAN_9606_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping_selected.tab.gz",
+                    },
+                ],
+            },
+            {
+                id: "uniprot-idmapping-mouse",
+                version: "current",
+                title: "UniProt mouse ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Mus musculus (idmapping_selected, ~18 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "MOUSE_10090_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/MOUSE_10090_idmapping_selected.tab.gz",
+                    },
+                ],
+            },
+            {
+                id: "uniprot-idmapping-rat",
+                version: "current",
+                title: "UniProt rat ID mapping",
+                description:
+                    "UniProtKB accession ↔ Entrez, Ensembl, RefSeq and other identifiers for Rattus norvegicus (idmapping_selected, ~6 MB gzipped). UniProt overwrites `current_release` each cycle, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/",
+                license: { identifier: "CC-BY-4.0", url: "https://www.uniprot.org/help/license" },
+                recommendation: { group: "gene-identifiers", recommended: true },
+                artifacts: [
+                    {
+                        path: "RAT_10116_idmapping_selected.tab.gz",
+                        url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/RAT_10116_idmapping_selected.tab.gz",
                     },
                 ],
             },
@@ -224,8 +280,8 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 license: { identifier: "CC0-1.0", url: "https://reactome.org/license" },
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
-                    { integrity: "unpinned", path: "ReactomePathways.gmt", url: "https://reactome.org/download/current/ReactomePathways.gmt" },
-                    { integrity: "unpinned", path: "ReactomePathways.txt", url: "https://reactome.org/download/current/ReactomePathways.txt" },
+                    { path: "ReactomePathways.gmt", url: "https://reactome.org/download/current/ReactomePathways.gmt" },
+                    { path: "ReactomePathways.txt", url: "https://reactome.org/download/current/ReactomePathways.txt" },
                 ],
             },
             {
@@ -243,17 +299,14 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "pathways", recommended: false },
                 artifacts: [
                     {
-                        integrity: "unpinned",
                         path: "NCBI2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/NCBI2Reactome_All_Levels.txt",
                     },
                     {
-                        integrity: "unpinned",
                         path: "Ensembl2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/Ensembl2Reactome_All_Levels.txt",
                     },
                     {
-                        integrity: "unpinned",
                         path: "UniProt2Reactome_All_Levels.txt",
                         url: "https://reactome.org/download/current/UniProt2Reactome_All_Levels.txt",
                     },
@@ -269,11 +322,70 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "pathways", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "wikipathways_Homo_sapiens.gmt",
                         url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Homo_sapiens.gmt",
-                        bytes: 341_474,
-                        sha256: "79615a079246bb0b07cc3505265b1f75ea6cffec88001ce27f644dd86a39c97d",
+                    },
+                ],
+            },
+            {
+                id: "wikipathways-mouse",
+                version: "2026.07.10",
+                title: "WikiPathways mouse pathways",
+                description: "Community-curated Mus musculus pathway gene sets (GMT) from the immutable 2026-07-10 WikiPathways snapshot.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/",
+                license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "wikipathways_Mus_musculus.gmt",
+                        url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Mus_musculus.gmt",
+                    },
+                ],
+            },
+            {
+                id: "wikipathways-rat",
+                version: "2026.07.10",
+                title: "WikiPathways rat pathways",
+                description: "Community-curated Rattus norvegicus pathway gene sets (GMT) from the immutable 2026-07-10 WikiPathways snapshot.",
+                sourceUrl: "https://data.wikipathways.org/20260710/gmt/",
+                license: { identifier: "CC0-1.0", url: "https://www.wikipathways.org/about/terms.html" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "wikipathways_Rattus_norvegicus.gmt",
+                        url: "https://data.wikipathways.org/20260710/gmt/wikipathways-20260710-gmt-Rattus_norvegicus.gmt",
+                    },
+                ],
+            },
+            {
+                id: "msigdb-hallmark-human",
+                version: "2026.1",
+                title: "MSigDB human hallmark gene sets",
+                description:
+                    "The 50 MSigDB hallmark gene sets for Homo sapiens (symbols GMT) — coherent, well-defined biological states and processes for enrichment. From the immutable MSigDB 2026.1 human release.",
+                sourceUrl: "https://data.broadinstitute.org/gsea-msigdb/msigdb/",
+                license: { identifier: "MSigDB-License", url: "https://www.gsea-msigdb.org/gsea/msigdb/license.jsp" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "h.all.v2026.1.Hs.symbols.gmt",
+                        url: "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2026.1.Hs/h.all.v2026.1.Hs.symbols.gmt",
+                    },
+                ],
+            },
+            {
+                id: "msigdb-hallmark-mouse",
+                version: "2026.1",
+                title: "MSigDB mouse hallmark gene sets",
+                description:
+                    "The MSigDB mouse hallmark gene sets for Mus musculus (symbols GMT) — the murine ortholog-mapped hallmark collection for enrichment. From the immutable MSigDB 2026.1 mouse release.",
+                sourceUrl: "https://data.broadinstitute.org/gsea-msigdb/msigdb/",
+                license: { identifier: "MSigDB-License", url: "https://www.gsea-msigdb.org/gsea/msigdb/license.jsp" },
+                recommendation: { group: "pathways", recommended: true },
+                artifacts: [
+                    {
+                        path: "mh.all.v2026.1.Mm.symbols.gmt",
+                        url: "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2026.1.Mm/mh.all.v2026.1.Mm.symbols.gmt",
                     },
                 ],
             },
@@ -287,11 +399,8 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "regulatory-networks", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "CollecTRI_regulons.csv",
                         url: "https://zenodo.org/records/8192729/files/CollecTRI_regulons.csv",
-                        bytes: 4_345_649,
-                        sha256: "4473c9189dd53dacc80297709ad1452dda1086a1cc2185f9a56146c261668701",
                     },
                 ],
             },
@@ -306,20 +415,25 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "normal-expression", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
                         url: "https://storage.googleapis.com/adult-gtex/bulk-gex/v8/rna-seq/GTEx_Analysis_2017-06-05_v8_RNASeQCv1.1.9_gene_median_tpm.gct.gz",
-                        bytes: 6_952_331,
-                        sha256: "ee7201ff2f280b0de5657d4b08e9a240362d9757efed7f7bd5dba35a5f8617b8",
                     },
                     {
-                        integrity: "pinned",
                         path: "GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
                         url: "https://storage.googleapis.com/adult-gtex/annotations/v8/metadata-files/GTEx_Analysis_v8_Annotations_SampleAttributesDS.txt",
-                        bytes: 11_512_258,
-                        sha256: "74f6ab4c34ed2648d708a0ae6e6dff324f6c86ea723ae7d1c37d76f5221148f0",
                     },
                 ],
+            },
+            {
+                id: "hpa-proteinatlas",
+                version: "current",
+                title: "Human Protein Atlas",
+                description:
+                    "The full Human Protein Atlas table (proteinatlas.tsv.zip, ~7 MB): per-gene RNA/protein tissue expression, tissue specificity, subcellular location, secretome and blood-concentration annotations for Homo sapiens. HPA republishes this file per release, so it is verified against what you downloaded rather than a checked-in digest.",
+                sourceUrl: "https://www.proteinatlas.org/about/download",
+                license: { identifier: "CC-BY-SA-3.0", url: "https://www.proteinatlas.org/about/licence" },
+                recommendation: { group: "normal-expression", recommended: true },
+                artifacts: [{ path: "proteinatlas.tsv.zip", url: "https://www.proteinatlas.org/download/proteinatlas.tsv.zip" }],
             },
             {
                 id: "celltypist-immune",
@@ -332,18 +446,118 @@ export const REFERENCE_DATA_CATALOG: ReferenceDataCatalog = deepFreeze(
                 recommendation: { group: "cell-typing", recommended: true },
                 artifacts: [
                     {
-                        integrity: "pinned",
                         path: "Immune_All_Low.pkl",
                         url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_Low.pkl",
-                        bytes: 2_824_990,
-                        sha256: "290874d35dac039d4c9218c343fde4aac1077709b72a331ce7266f6828c36502",
                     },
                     {
-                        integrity: "pinned",
                         path: "Immune_All_High.pkl",
                         url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Immune_CellTypist/v2/Immune_All_High.pkl",
-                        bytes: 1_070_426,
-                        sha256: "a715fec36c2c421f7c4e31cf4cb4bea883eedab7fd7b20a4b76f091c22660448",
+                    },
+                ],
+            },
+            {
+                id: "celltypist-pan-fetal",
+                version: "2",
+                title: "CellTypist pan-fetal human model",
+                description:
+                    "CellTypist Pan_Fetal_Human model — cell-type annotation across human fetal tissues. Load by absolute path; CellTypist's by-name lookup expects its own cache layout, which the reference store deliberately does not impersonate.",
+                sourceUrl: "https://www.celltypist.org/models",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "Pan_Fetal_Human.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/Pan_Fetal_Suo/v2/Pan_Fetal_Human.pkl",
+                    },
+                ],
+            },
+            {
+                id: "celltypist-covid19",
+                version: "1",
+                title: "CellTypist COVID-19 immune model",
+                description:
+                    "CellTypist COVID19_Immune_Landscape model — immune cell-type annotation trained on the cross-study COVID-19 immune atlas. Load by absolute path; CellTypist's by-name lookup expects its own cache layout, which the reference store deliberately does not impersonate.",
+                sourceUrl: "https://www.celltypist.org/models",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "COVID19_Immune_Landscape.pkl",
+                        url: "https://celltypist.cog.sanger.ac.uk/models/COVID19_Immune_Ren/v1/COVID19_Immune_Landscape.pkl",
+                    },
+                ],
+            },
+            {
+                id: "panglaodb-markers",
+                version: "2020.03.27",
+                title: "PanglaoDB cell-type markers",
+                description:
+                    "PanglaoDB cell-type marker panel (tab-separated, gzipped): curated marker genes per cell type across human and mouse, for marker-based annotation. From the immutable 27 March 2020 PanglaoDB marker release.",
+                sourceUrl: "https://panglaodb.se/markers.html",
+                license: { identifier: "NOASSERTION" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "PanglaoDB_markers_27_Mar_2020.tsv.gz",
+                        url: "https://panglaodb.se/markers/PanglaoDB_markers_27_Mar_2020.tsv.gz",
+                    },
+                ],
+            },
+            {
+                id: "azimuth-pbmc",
+                version: "1.0.0",
+                title: "Azimuth human PBMC reference",
+                description:
+                    "Azimuth annotated reference for human peripheral blood mononuclear cells: the Seurat reference object plus its Annoy nearest-neighbour index, for supervised mapping and cell-type label transfer. Immutable Zenodo release 4546839.",
+                sourceUrl: "https://zenodo.org/records/4546839",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/4546839" },
+                recommendation: { group: "cell-typing", recommended: true },
+                artifacts: [
+                    {
+                        path: "ref.Rds",
+                        url: "https://zenodo.org/records/4546839/files/ref.Rds",
+                    },
+                    {
+                        path: "idx.annoy",
+                        url: "https://zenodo.org/records/4546839/files/idx.annoy",
+                    },
+                ],
+            },
+            {
+                // ~443 MB (ref + index), so it is opt-in rather than part of a default setup.
+                id: "azimuth-tonsil",
+                version: "1.0.0",
+                title: "Azimuth human tonsil reference",
+                description:
+                    "Azimuth annotated reference for human tonsil: the Seurat reference object plus its Annoy nearest-neighbour index, for supervised mapping and cell-type label transfer. Immutable Zenodo release 7032928, roughly 443 MB.",
+                sourceUrl: "https://zenodo.org/records/7032928",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/7032928" },
+                recommendation: { group: "cell-typing", recommended: false },
+                artifacts: [
+                    {
+                        path: "ref.Rds",
+                        url: "https://zenodo.org/records/7032928/files/ref.Rds",
+                    },
+                    {
+                        path: "idx.annoy",
+                        url: "https://zenodo.org/records/7032928/files/idx.annoy",
+                    },
+                ],
+            },
+            {
+                // ~842 MB reference genome bundle, PGx-specific, so it is opt-in rather than a default download.
+                id: "pharmcat-grch38-fasta",
+                version: "GRCh38.p13",
+                title: "PharmCAT GRCh38 reference FASTA",
+                description:
+                    "The GRCh38.p13 reference genome FASTA that PharmCAT's VCF preprocessor expects (bgzip'd with a .fai/.gzi faidx), bundled as a tar — roughly 842 MB. Immutable Zenodo release 7288118. Needed only for pharmacogenomics (PharmCAT) workflows.",
+                sourceUrl: "https://zenodo.org/records/7288118",
+                license: { identifier: "CC-BY-4.0", url: "https://zenodo.org/records/7288118" },
+                recommendation: { group: "pharmacogenomics", recommended: false },
+                artifacts: [
+                    {
+                        path: "PharmCAT_GRCh38_reference_fasta.tar",
+                        url: "https://zenodo.org/records/7288118/files/GRCh38_reference_fasta.tar?download=1",
                     },
                 ],
             },

--- a/harness/src/reference-data/receipt.ts
+++ b/harness/src/reference-data/receipt.ts
@@ -7,16 +7,15 @@ export const REFERENCE_INSTALL_RECEIPT_VERSION = 1 as const;
 
 /**
  * What was actually written to disk for one artifact. The size and digest are
- * *observed at install*, never copied from the catalog — for a `pinned`
- * artifact they equal the catalog's (the install would have failed otherwise),
- * and for an `unpinned` one they are the only record of what the mutable
- * upstream served, which is what `verify` later checks the files against.
+ * *observed at install* — the catalog carries neither, so this receipt is the
+ * sole record of the bytes the upstream served, and what `verify` later checks
+ * the local files against. A receipt written by an older build may still carry
+ * an `integrity` field; it is simply ignored (unknown keys are stripped).
  */
 const ReferenceReceiptArtifactSchema = z.object({
     path: ReferenceArtifactPathSchema,
     bytes: z.number().int().nonnegative(),
     sha256: ReferenceSha256Schema,
-    integrity: z.enum(["pinned", "unpinned"]),
 });
 
 /** Optional metadata describing one activated reference dataset version. */

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -148,14 +148,14 @@ describe("list_available_refs", () => {
                     datasetId: "alpha",
                     datasetVersion: "2026.07",
                     activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH, integrity: "pinned" }],
+                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
                 },
                 {
                     version: 1,
                     datasetId: "ncbi-gene-human",
                     datasetVersion: "current",
                     activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "Homo_sapiens.gene_info.gz", bytes: 1_024, sha256: HASH, integrity: "unpinned" }],
+                    artifacts: [{ path: "Homo_sapiens.gene_info.gz", bytes: 1_024, sha256: HASH }],
                 },
             ],
             legacyEntries: [{ local_path: "legacy/pathways.gmt", category: "pathways", dataset: "legacy-pathways", rows: 200 }],
@@ -185,28 +185,6 @@ describe("list_available_refs", () => {
             metadata: { datasetId: "legacy-pathways", category: "pathways", rows: 200 },
         });
         expect(result.entries.find((entry) => entry.path.includes("/user/"))?.metadata).toBeUndefined();
-    });
-
-    it("ignores a receipt artifact that records no observed integrity", async () => {
-        const managedPath = "/mnt/refs/managed/alpha/2026.07/reference.parquet";
-        const client = makeClient({
-            state: "populated",
-            entries: [{ path: managedPath, kind: "file", bytes: 12 }],
-            scannedEntries: 1,
-            truncated: false,
-            receipts: [
-                {
-                    version: 1,
-                    datasetId: "alpha",
-                    datasetVersion: "2026.07",
-                    activatedAt: "2026-07-14T10:30:00.000Z",
-                    artifacts: [{ path: "reference.parquet", bytes: 999, sha256: HASH }],
-                },
-            ],
-        });
-
-        const result = (await createTool(client).execute({}, makeToolContext().ctx))._unsafeUnwrap();
-        expect(result.entries).toEqual([{ path: managedPath, kind: "file", bytes: 12 }]);
     });
 
     it("ignores invalid and stale metadata without hiding observed files", async () => {
@@ -332,7 +310,7 @@ describe("list_available_refs", () => {
                 datasetId: "wikipathways-human",
                 datasetVersion: "2026.07.10",
                 activatedAt: "2026-07-14T10:30:00.000Z",
-                artifacts: [{ path: "wikipathways_Homo_sapiens.gmt", bytes: 31, sha256: HASH, integrity: "pinned" }],
+                artifacts: [{ path: "wikipathways_Homo_sapiens.gmt", bytes: 31, sha256: HASH }],
             }),
         );
 


### PR DESCRIPTION
**Harness half of a two-PR change** (lands first and publishes `@inflexa-ai/harness@0.4.1`; the CLI half #134 pins that version). Rebased onto latest `main`. Supersedes #131.

## What

Two things in the reference-data catalog:

1. **Expand** the catalog from 9 → 25 datasets.
2. **Collapse** the artifact integrity model to a single URL-only, trust-on-first-use scheme.

## Catalog expansion (16 new datasets)

| Group | Added |
|-|-|
| gene-identifiers | `ncbi-gene2ensembl`, `ncbi-gene2refseq`, `uniprot-idmapping-{human,mouse,rat}` |
| pathways | `wikipathways-{mouse,rat}`, `msigdb-hallmark-{human,mouse}` |
| normal-expression | `hpa-proteinatlas` |
| cell-typing | `celltypist-{pan-fetal,covid19}`, `panglaodb-markers`, `azimuth-{pbmc,tonsil}` |
| pharmacogenomics *(new group)* | `pharmcat-grch38-fasta` |

Large or domain-specific downloads are marked opt-in (not recommended) so a default setup never silently pulls hundreds of MB.

## URL-only integrity (trust-on-first-use)

A catalog artifact is now just `{ path, url }` — **no `pinned`/`unpinned` class, no checked-in size or digest.** The old split applied scrutiny unevenly and put on us the burden of downloading+hashing every immutable file and keeping the digest in sync. TLS authenticates the publisher, and the install **receipt** (bytes+sha256 observed from the user's own download) already lets `verify` catch post-install corruption. Result: **adding a source is one line — a URL.** Old receipts carrying the removed `integrity` field still parse, so existing installs are not invalidated.

Mechanically: the discriminated union / `bytes` / `sha256` / `ReferenceIntegrity` export are gone; the receipt drops its `integrity` field. `reference-data-catalog/spec.md` is rewritten to the uniform model (`openspec validate` passes).

## Version

`@inflexa-ai/harness` 0.4.0 → **0.4.1** (patch). The `ReferenceArtifact` shape change and `ReferenceIntegrity` removal are technically breaking, but harness has not published since 0.4.0, so a patch is the release increment. Merging publishes 0.4.1 via `release-harness.yml`.

## Validation

`tsc` build clean; full harness `bun test` green (reference-data 32 pass + the updated `list_available_refs` receipt test); changed files lint clean; `openspec validate` passes.
