### PR TITLE
feat(refs): grouped download picker + --urls; consume harness 0.4.1 (cli)

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -6,7 +6,7 @@
       "name": "inflexa",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.4.0",
+        "@inflexa-ai/harness": "0.4.1",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
@@ -151,7 +151,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.4.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-k0CixLpb0/1o4sOdGO2w/mr+cAB3Q2D3mpM69Qw4a/IkJTfECNshTUtIuuKV0K+VqI8cbxoiCf6+RkXFN2xG2Q=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.4.1", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-Q0p84R8dhwvbHbEAfWN5Xr/b3z1XK96nc5AyaCiKBDbWo2Oy+xULpUbf2U/IjxsCR0DoTkXcRsU7QHQ8Xlv6XA=="],
 
     "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "private": true,
     "type": "module",
     "scripts": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.4.0",
+        "@inflexa-ai/harness": "0.4.1",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",

--- a/cli/src/cli/cli.test.ts
+++ b/cli/src/cli/cli.test.ts
@@ -32,15 +32,16 @@ describe("inflexa help & usage (e2e)", () => {
         expect(result.stderr).toContain("Unknown reference dataset");
     });
 
-    test("refs list explains custom content, integrity, and catalog contributions", () => {
+    test("refs list explains custom content, trust-on-first-use integrity, and catalog contributions", () => {
         const result = runCli(["refs", "list"]);
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("Add arbitrary references under");
         expect(result.stdout).toContain("Open a PR");
-        // Nothing is re-hosted: each dataset states the integrity guarantee its own upstream can offer.
-        expect(result.stdout).toContain("Integrity: pinned — verified against the checksums in the catalog");
-        expect(result.stdout).toContain("Integrity: unpinned — upstream is rebuilt in place; verified against what you downloaded");
-        expect(result.stdout).toContain("nothing is mirrored or re-hosted here");
+        // Nothing is mirrored, re-hosted, or checksum-pinned: integrity is trust-on-first-use, checked
+        // against the copy you downloaded rather than a catalog digest.
+        expect(result.stdout).toContain("nothing is mirrored, re-hosted, or checksum-pinned here");
+        expect(result.stdout).toContain("Integrity is trust-on-first-use: `inflexa refs verify` checks each installed file against the copy you downloaded.");
+        expect(result.stdout).toContain("Re-run with `--urls` to print the exact upstream URL of every file.");
     });
 
     test("refs download offers --force to repair damage and refresh mutable upstreams", () => {

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -373,9 +373,10 @@ const refs = cli.command("refs").description("Manage reference data mounted read
 
 refs.command("list")
     .description("List catalog options, links, sizes, and local state")
-    .action(async () => {
+    .option("--urls", "Also print the exact upstream download URL of every file")
+    .action(async (options: { urls?: boolean }) => {
         const { runRefsList } = await import("../modules/refs/commands.ts");
-        await runRefsList();
+        await runRefsList({ urls: options.urls ?? false });
     });
 
 refs.command("download")

--- a/cli/src/modules/refs/commands.test.ts
+++ b/cli/src/modules/refs/commands.test.ts
@@ -37,8 +37,8 @@ function catalog(artifacts: ReferenceDataCatalog["datasets"][number]["artifacts"
     };
 }
 
-const PINNED_ARTIFACT = { integrity: "pinned", path: "file", url: "https://upstream.test/file", bytes: 5, sha256: sha("alpha") } as const;
-const UNPINNED_ARTIFACT = { integrity: "unpinned", path: "mutable", url: "https://upstream.test/mutable" } as const;
+const FILE_ARTIFACT = { path: "file", url: "https://upstream.test/file" } as const;
+const MUTABLE_ARTIFACT = { path: "mutable", url: "https://upstream.test/mutable" } as const;
 
 function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     return {
@@ -52,7 +52,7 @@ function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     };
 }
 
-const pinnedSource = source(catalog([PINNED_ARTIFACT]));
+const singleFileSource = source(catalog([FILE_ARTIFACT]));
 
 /** Activate the pinned fixture on disk exactly as a completed install would leave it. */
 function seedIntactInstall(): void {
@@ -68,7 +68,7 @@ function seedIntactInstall(): void {
             datasetId: "demo",
             datasetVersion: "1",
             activatedAt: "2026-07-14T12:00:00.000Z",
-            artifacts: [{ path: "file", bytes: 5, sha256: sha("alpha"), integrity: "pinned" }],
+            artifacts: [{ path: "file", bytes: 5, sha256: sha("alpha") }],
         }),
     );
 }
@@ -86,28 +86,28 @@ describe("reference command policy", () => {
 
     test("headless downloads require ids and explicit consent before mutation", async () => {
         assertTestSandbox(env.refsDir);
-        const noIds = await downloadReferences({ ids: [], interactive: false, source: pinnedSource });
+        const noIds = await downloadReferences({ ids: [], interactive: false, source: singleFileSource });
         expect(noIds.isErr()).toBe(true);
-        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
-        expect(noConsent._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
+        const noConsent = await downloadReferences({ ids: ["demo"], interactive: false, source: singleFileSource });
+        expect(noConsent._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 
-    test("an unpinned artifact is quoted as upstream-determined rather than given an invented size", async () => {
-        const unsized = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([UNPINNED_ARTIFACT])) });
-        expect(unsized._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+    test("every artifact is quoted as upstream-determined rather than given an invented size", async () => {
+        const oneFile = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([MUTABLE_ARTIFACT])) });
+        expect(oneFile._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
 
-        const mixed = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([PINNED_ARTIFACT, UNPINNED_ARTIFACT])) });
-        expect(mixed._unsafeUnwrapErr().message).toBe("Downloading 5 B + 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
+        const twoFiles = await downloadReferences({ ids: ["demo"], interactive: false, source: source(catalog([FILE_ARTIFACT, MUTABLE_ARTIFACT])) });
+        expect(twoFiles._unsafeUnwrapErr().message).toBe("Downloading 2 files of upstream-determined size requires explicit consent; re-run with --yes.");
     });
 
-    test("--force turns an intact install back into bytes to fetch; without it there is nothing to do", async () => {
+    test("--force turns an intact install back into a file to fetch; without it there is nothing to do", async () => {
         seedIntactInstall();
-        const intact = await downloadReferences({ ids: ["demo"], interactive: false, source: pinnedSource });
-        expect(intact._unsafeUnwrapErr().message).toBe("Downloading 0 B requires explicit consent; re-run with --yes.");
+        const intact = await downloadReferences({ ids: ["demo"], interactive: false, source: singleFileSource });
+        expect(intact._unsafeUnwrapErr().message).toBe("Downloading 0 files of upstream-determined size requires explicit consent; re-run with --yes.");
 
-        const forced = await downloadReferences({ ids: ["demo"], interactive: false, force: true, source: pinnedSource });
-        expect(forced._unsafeUnwrapErr().message).toBe("Downloading 5 B requires explicit consent; re-run with --yes.");
+        const forced = await downloadReferences({ ids: ["demo"], interactive: false, force: true, source: singleFileSource });
+        expect(forced._unsafeUnwrapErr().message).toBe("Downloading 1 file of upstream-determined size requires explicit consent; re-run with --yes.");
     });
 
     test("a declined interactive download activates nothing", async () => {
@@ -115,14 +115,14 @@ describe("reference command policy", () => {
         const result = await downloadReferences({
             ids: ["demo"],
             interactive: true,
-            source: pinnedSource,
+            source: singleFileSource,
             confirmDownload: async (question) => {
                 questions.push(question);
                 return false;
             },
         });
         expect(result._unsafeUnwrap()).toMatchObject({ declined: true, installed: [] });
-        expect(questions).toEqual([`Download 5 B of reference data into ${env.refsDir}?`]);
+        expect(questions).toEqual([`Download 1 file of upstream-determined size of reference data into ${env.refsDir}?`]);
         expect(await Bun.file(env.refsDir).exists()).toBe(false);
     });
 

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -1,4 +1,4 @@
-import { isCancel, log, multiselect } from "@clack/prompts";
+import { groupMultiselect, isCancel, log } from "@clack/prompts";
 import { REFERENCE_DATA_CATALOG, type ReferenceDataCatalog } from "@inflexa-ai/harness";
 import { err, ok, type Result } from "neverthrow";
 
@@ -8,7 +8,7 @@ import {
     ensureReferenceStore,
     inspectReferenceStore,
     installReferenceDatasets,
-    referenceDownloadBytes,
+    referenceDownloadEstimate,
     verifyReferenceDatasets,
     type ReferenceDownloadEstimate,
     type ReferenceInstallOutcome,
@@ -71,46 +71,14 @@ export function formatReferenceBytes(bytes: number): string {
     return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
 }
 
-type ReferenceDatasetSize = {
-    /** Bytes across artifacts the catalog can size. */
-    readonly bytes: number;
-    /** Artifacts whose size only the mutable upstream knows. */
-    readonly unsized: number;
-};
-
-function datasetSize(dataset: ReferenceDataCatalog["datasets"][number]): ReferenceDatasetSize {
-    let bytes = 0;
-    let unsized = 0;
-    for (const artifact of dataset.artifacts) {
-        if (artifact.integrity === "pinned") bytes += artifact.bytes;
-        else unsized += 1;
-    }
-    return { bytes, unsized };
+/** A file count phrased for the terminal — the catalog pins no sizes, so the upstream determines
+ * the bytes at download time and the honest thing to state ahead of time is the number of files. */
+function formatFileCount(count: number): string {
+    return `${count} file${count === 1 ? "" : "s"} of upstream-determined size`;
 }
 
-/** Render a size the catalog may only partly know, without ever inventing a number. */
-function formatReferenceSize(size: ReferenceDatasetSize): string {
-    if (size.unsized === 0) return formatReferenceBytes(size.bytes);
-    const unsized = `${size.unsized} file${size.unsized === 1 ? "" : "s"} of upstream-determined size`;
-    return size.bytes === 0 ? unsized : `${formatReferenceBytes(size.bytes)} + ${unsized}`;
-}
-
-/** The strongest integrity guarantee that holds for every artifact in the dataset. */
-function datasetIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): "pinned" | "unpinned" | "mixed" {
-    const pinned = dataset.artifacts.some((artifact) => artifact.integrity === "pinned");
-    const unpinned = dataset.artifacts.some((artifact) => artifact.integrity === "unpinned");
-    return pinned && unpinned ? "mixed" : unpinned ? "unpinned" : "pinned";
-}
-
-function renderIntegrity(dataset: ReferenceDataCatalog["datasets"][number]): string {
-    switch (datasetIntegrity(dataset)) {
-        case "pinned":
-            return "pinned — verified against the checksums in the catalog";
-        case "unpinned":
-            return "unpinned — upstream is rebuilt in place; verified against what you downloaded";
-        case "mixed":
-            return "mixed — some files are checksum-pinned, others are verified against what you downloaded";
-    }
+function formatDatasetSize(dataset: ReferenceDataCatalog["datasets"][number]): string {
+    return formatFileCount(dataset.artifacts.length);
 }
 
 function renderError(error: ReferenceProvisionError): string {
@@ -118,19 +86,29 @@ function renderError(error: ReferenceProvisionError): string {
 }
 
 function renderEstimate(estimate: ReferenceDownloadEstimate): string {
-    return formatReferenceSize({ bytes: estimate.bytes, unsized: estimate.unsizedArtifacts });
+    return formatFileCount(estimate.artifactsToFetch);
 }
 
 async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string[] | undefined> {
     if (catalog.datasets.length === 0) return [];
-    const selected = await multiselect({
+    // Present the picker as labelled categories rather than one flat wall: the catalog already
+    // carries `recommendation.group` per dataset, so grouping is purely presentational. Group
+    // insertion order follows first appearance in the catalog (which is ordered by group), and
+    // toggling a group header selects every dataset under it — clack returns only the leaf ids,
+    // never the group label, so the strict resolver downstream never sees a phantom id.
+    const grouped: Record<string, { value: string; label: string; hint?: string }[]> = {};
+    for (const dataset of catalog.datasets) {
+        (grouped[dataset.recommendation.group] ??= []).push({
+            value: dataset.id,
+            label: `${dataset.title} (${formatDatasetSize(dataset)})`,
+            ...(dataset.recommendation.recommended ? { hint: "recommended" } : {}),
+        });
+    }
+    const selected = await groupMultiselect({
         message: "Reference datasets to download",
         required: false,
-        options: catalog.datasets.map((dataset) => ({
-            value: dataset.id,
-            label: `${dataset.title} (${formatReferenceSize(datasetSize(dataset))})`,
-            hint: `${dataset.recommendation.group}${dataset.recommendation.recommended ? ", recommended" : ""}`,
-        })),
+        selectableGroups: true,
+        options: grouped,
     });
     return isCancel(selected) ? undefined : selected;
 }
@@ -165,7 +143,7 @@ export async function downloadReferences(
     }
 
     const install = { force: options.force ?? false };
-    const estimate = await referenceDownloadBytes(ids, env.refsDir, options.source ?? undefined, install);
+    const estimate = await referenceDownloadEstimate(ids, env.refsDir, options.source ?? undefined, install);
     if (estimate.isErr()) return err(estimate.error);
     const size = renderEstimate(estimate.value);
     console.log(`Reference download plan: ${size} to fetch from the upstream publishers.`);
@@ -201,26 +179,37 @@ export function runRefsPath(): void {
     console.log(env.refsDir);
 }
 
-/** `inflexa refs list` — render canonical options and recoverable local state. */
-export async function runRefsList(): Promise<void> {
+/** `inflexa refs list` — render canonical options and recoverable local state. Pass `urls` to also
+ * print the exact upstream download URL of every artifact, so the source is inspectable before consent. */
+export async function runRefsList(options: { readonly urls?: boolean } = {}): Promise<void> {
     const result = await inspectReferenceStore(env.refsDir);
     result.match(
         (inspection) => {
             if (inspection.datasets.length === 0) console.log("No catalog reference datasets are published by this harness version yet.");
+            // Datasets arrive in catalog order, which clusters by group, so a header printed on each
+            // group change renders the listing as labelled categories instead of one flat wall.
+            let lastGroup: string | undefined;
             for (const item of inspection.datasets) {
                 const dataset = item.dataset;
-                console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}`);
+                if (dataset.recommendation.group !== lastGroup) {
+                    lastGroup = dataset.recommendation.group;
+                    console.log(`\n== ${lastGroup} ==`);
+                }
+                console.log(`\n${dataset.id}  ${dataset.version}  ${item.state}${dataset.recommendation.recommended ? "" : "  (optional)"}`);
                 console.log(`  ${dataset.title} — ${dataset.description}`);
-                console.log(`  Size: ${formatReferenceSize(datasetSize(dataset))}`);
-                console.log(`  Integrity: ${renderIntegrity(dataset)}`);
-                console.log(`  Group: ${dataset.recommendation.group}${dataset.recommendation.recommended ? " (recommended)" : ""}`);
+                console.log(`  Size: ${formatDatasetSize(dataset)}`);
                 console.log(`  Source: ${dataset.sourceUrl}`);
                 console.log(`  License: ${dataset.license.identifier}${dataset.license.url ? ` — ${dataset.license.url}` : ""}`);
+                if (options.urls) for (const artifact of dataset.artifacts) console.log(`  URL: ${artifact.url}`);
             }
             if (inspection.userContent.length > 0) {
                 console.log(`\nUser/unmanaged top-level content: ${inspection.userContent.join(", ")} (left untouched)`);
             }
-            console.log("\nEvery dataset is downloaded straight from the third party that publishes it; nothing is mirrored or re-hosted here.");
+            console.log(
+                "\nEvery dataset is fetched straight over HTTPS from the third party that publishes it; nothing is mirrored, re-hosted, or checksum-pinned here.",
+            );
+            console.log("Integrity is trust-on-first-use: `inflexa refs verify` checks each installed file against the copy you downloaded.");
+            if (!options.urls) console.log("Re-run with `--urls` to print the exact upstream URL of every file.");
             console.log(`Add arbitrary references under ${env.refsDir}/user; sandboxes discover them dynamically.`);
             console.log("Missing a reusable option? Open a PR adding its upstream URL, provenance, and licensing to the harness reference-data catalog.");
         },
@@ -272,8 +261,7 @@ export async function runRefsVerify(ids: readonly string[]): Promise<void> {
             for (const dataset of verified) {
                 console.log(`${dataset.datasetId}${dataset.version ? `@${dataset.version}` : ""}: ${dataset.state}`);
                 for (const file of dataset.files) {
-                    const against = file.integrity === "pinned" ? "catalog checksum" : "checksum recorded at install";
-                    console.log(`  ${file.state.padEnd(8)} ${file.path}  (vs ${against})`);
+                    console.log(`  ${file.state.padEnd(8)} ${file.path}  (vs the checksum recorded at install)`);
                 }
             }
             const damaged = verified.filter((dataset) => dataset.state !== "valid");

--- a/cli/src/modules/refs/store.test.ts
+++ b/cli/src/modules/refs/store.test.ts
@@ -5,13 +5,13 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUIDv7 } from "bun";
 
-import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog, type ReferenceIntegrity } from "@inflexa-ai/harness";
+import { REFERENCE_DATA_CATALOG_VERSION, UnknownReferenceDatasetError, type ReferenceDataCatalog } from "@inflexa-ai/harness";
 import { err, ok } from "neverthrow";
 
 import {
     inspectReferenceStore,
     installReferenceDatasets,
-    referenceDownloadBytes,
+    referenceDownloadEstimate,
     referenceStorePaths,
     verifyReferenceDatasets,
     type ReferenceCatalogSource,
@@ -35,8 +35,6 @@ type Fixture = {
     readonly path: string;
     /** Bytes the stub upstream returns. */
     readonly body: string;
-    /** Which integrity class the catalog publishes it under. */
-    readonly integrity: ReferenceIntegrity;
 };
 
 /** Every fixture artifact is fetched straight from its own third-party upstream — there is no distribution base. */
@@ -44,9 +42,9 @@ function url(path: string): string {
     return `https://upstream.test/${path}`;
 }
 
-const PINNED: readonly Fixture[] = [{ path: "a.txt", body: "alpha", integrity: "pinned" }];
+const ARTIFACTS: readonly Fixture[] = [{ path: "a.txt", body: "alpha" }];
 
-function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
+function catalog(files: readonly Fixture[] = ARTIFACTS): ReferenceDataCatalog {
     return {
         version: REFERENCE_DATA_CATALOG_VERSION,
         datasets: [
@@ -58,17 +56,8 @@ function catalog(files: readonly Fixture[] = PINNED): ReferenceDataCatalog {
                 sourceUrl: "https://example.test/source",
                 license: { identifier: "CC0-1.0", url: "https://example.test/license" },
                 recommendation: { group: "testing", recommended: true },
-                artifacts: files.map((file) =>
-                    file.integrity === "pinned"
-                        ? {
-                              integrity: "pinned" as const,
-                              path: file.path,
-                              url: url(file.path),
-                              bytes: Buffer.byteLength(file.body),
-                              sha256: sha(file.body),
-                          }
-                        : { integrity: "unpinned" as const, path: file.path, url: url(file.path) },
-                ),
+                // The catalog pins nothing but the https URL: no size, no digest, no integrity class.
+                artifacts: files.map((file) => ({ path: file.path, url: url(file.path) })),
             },
         ],
     };
@@ -104,21 +93,19 @@ function source(value: ReferenceDataCatalog): ReferenceCatalogSource {
     };
 }
 
-/** What the installer asked the upstream for; `range` is the resume request, absent on a fresh transfer. */
+/** What the installer asked the upstream for; the installer never resumes, so `range` is always null. */
 type Asked = { readonly url: string; readonly range: string | null };
 
-/** Offline upstream. Serves each fixture's bytes and honors a Range request the way a real server would. */
+/** Offline upstream. Serves each fixture's bytes fresh; records the (never-present) Range header so a
+ * test can prove the installer refetches whole rather than resuming from a partial. */
 function serve(files: readonly Fixture[], asked: Asked[] = []): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
     const bodies = new Map(files.map((file) => [url(file.path), file.body]));
     return async (input, init) => {
         const target = String(input);
-        const range = new Headers(init?.headers).get("range");
-        asked.push({ url: target, range });
+        asked.push({ url: target, range: new Headers(init?.headers).get("range") });
         const body = bodies.get(target);
         if (body === undefined) return new Response("missing", { status: 404, statusText: "Not Found" });
-        if (range === null) return new Response(body);
-        // Bodies are ASCII in every fixture, so a character offset is a byte offset.
-        return new Response(body.slice(Number(range.slice("bytes=".length, -1))), { status: 206 });
+        return new Response(body);
     };
 }
 
@@ -156,7 +143,7 @@ describe("reference store inspection", () => {
                 datasetId: "demo",
                 datasetVersion: "2025.01",
                 activatedAt: "2026-07-14T12:00:00.000Z",
-                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
+                artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
             }),
         );
         mkdirSync(join(paths.managed, "demo", "2025.01"), { recursive: true });
@@ -175,12 +162,12 @@ describe("reference store inspection", () => {
     });
 });
 
-describe("pinned installation", () => {
-    test("verifies size and digest, activates atomically, and records the observed bytes in the receipt", async () => {
+describe("installation", () => {
+    test("activates atomically and records the observed bytes and digest in the receipt", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "nested/a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.txt", body: "beta", integrity: "pinned" },
+            { path: "nested/a.txt", body: "alpha" },
+            { path: "b.txt", body: "beta" },
         ];
         const fixture = catalog(files);
         mkdirSync(join(path, "user"), { recursive: true });
@@ -204,8 +191,8 @@ describe("pinned installation", () => {
             datasetVersion: "2026.07",
             activatedAt: "2026-07-14T12:00:00.000Z",
             artifacts: [
-                { path: "nested/a.txt", bytes: 5, sha256: sha("alpha"), integrity: "pinned" },
-                { path: "b.txt", bytes: 4, sha256: sha("beta"), integrity: "pinned" },
+                { path: "nested/a.txt", bytes: 5, sha256: sha("alpha") },
+                { path: "b.txt", bytes: 4, sha256: sha("beta") },
             ],
         });
         expect(readFileSync(join(path, "user", "mine.fa"), "utf8")).toBe("mine");
@@ -214,69 +201,31 @@ describe("pinned installation", () => {
         expect(readdirSync(paths.staging)).toEqual([]);
         expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 0 });
 
-        // An intact install is skipped: the hostile upstream below would fail the digest check if it
-        // were ever contacted, so a clean `ok` with zero bytes is the proof that it was not.
+        // An intact install is skipped: the upstream below serves entirely different bytes, so a clean
+        // `ok` with zero bytes downloaded and the file left unchanged is the proof it was never contacted.
         const repeated = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(fixture),
             fetch: serve([
-                { path: "nested/a.txt", body: "ALPHA", integrity: "pinned" },
-                { path: "b.txt", body: "BETA", integrity: "pinned" },
+                { path: "nested/a.txt", body: "ALPHA" },
+                { path: "b.txt", body: "BETA" },
             ]),
         });
         expect(repeated._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(0);
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "nested", "a.txt"), "utf8")).toBe("alpha");
     });
 
-    test("resumes a partial transfer with Range, because the catalog knows the final size and digest", async () => {
+    // Removed: the model no longer pins a catalog size/digest, so there is nothing to resume against
+    // or to fail a download on — a size_mismatch/digest_mismatch install failure is unrepresentable.
+    // The installer always refetches whole (covered below) and trusts-on-first-use whatever https
+    // serves, recording the observed bytes in the receipt (covered above).
+
+    test("an interrupted stream never activates partial data", async () => {
         const path = root();
         const fixture = catalog();
         const paths = referenceStorePaths(path);
-        mkdirSync(paths.downloads, { recursive: true });
-        writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
-
-        const asked: Asked[] = [];
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED, asked) });
-        expect(installed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(3);
-        expect(asked).toEqual([{ url: url("a.txt"), range: "bytes=2-" }]);
-        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
-    });
-
-    test("a digest mismatch activates nothing and leaves an existing activation intact", async () => {
-        const path = root();
-        const fixture = catalog();
-        const paths = referenceStorePaths(path);
-        const corrupt: readonly Fixture[] = [{ path: "a.txt", body: "ALPHA", integrity: "pinned" }];
-
-        const damaged = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) });
-        expect(damaged._unsafeUnwrapErr()).toMatchObject({ type: "digest_mismatch", path: "a.txt", expected: sha("alpha"), actual: sha("ALPHA") });
-        expect(existsSync(join(paths.managed, "demo", "2026.07"))).toBe(false);
-        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
-
-        const good = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
-        expect(good.isOk()).toBe(true);
-        const receipt = readFileSync(join(paths.receipts, "demo.json"), "utf8");
-
-        const forced = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(corrupt) }, { force: true });
-        expect(forced._unsafeUnwrapErr().type).toBe("digest_mismatch");
-        expect(readFileSync(join(paths.managed, "demo", "2026.07", "a.txt"), "utf8")).toBe("alpha");
-        expect(readFileSync(join(paths.receipts, "demo.json"), "utf8")).toBe(receipt);
-    });
-
-    test("size mismatch and interrupted streams never activate partial data", async () => {
-        const path = root();
-        const fixture = catalog();
-        const paths = referenceStorePaths(path);
-
-        const short = await installReferenceDatasets(["demo"], {
-            root: path,
-            source: source(fixture),
-            fetch: serve([{ path: "a.txt", body: "a", integrity: "pinned" }]),
-        });
-        expect(short._unsafeUnwrapErr()).toMatchObject({ type: "size_mismatch", path: "a.txt", expected: 5, actual: 1 });
-        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
 
         const interrupted = await installReferenceDatasets(["demo"], {
             root: path,
@@ -285,6 +234,7 @@ describe("pinned installation", () => {
         });
         expect(interrupted._unsafeUnwrapErr().type).toBe("download_failed");
         expect(existsSync(join(paths.managed, "demo", "2026.07", "a.txt"))).toBe(false);
+        expect(existsSync(join(paths.receipts, "demo.json"))).toBe(false);
     });
 
     test("a failed update preserves the prior active version and its receipt", async () => {
@@ -299,28 +249,30 @@ describe("pinned installation", () => {
             datasetId: "demo",
             datasetVersion: "2025.01",
             activatedAt: "2025-01-01T00:00:00.000Z",
-            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old"), integrity: "pinned" }],
+            artifacts: [{ path: "old.txt", bytes: 3, sha256: sha("old") }],
         });
         writeFileSync(receiptPath, prior);
 
+        // The update fetch fails outright (a 404 from the upstream); activation is atomic, so the prior
+        // active version and its receipt must survive untouched.
         const failed = await installReferenceDatasets(["demo"], {
             root: path,
             source: source(catalog()),
-            fetch: serve([{ path: "a.txt", body: "ALPHA", integrity: "pinned" }]),
+            fetch: serve([]),
         });
-        expect(failed._unsafeUnwrapErr().type).toBe("digest_mismatch");
+        expect(failed._unsafeUnwrapErr().type).toBe("download_failed");
         expect(readFileSync(receiptPath, "utf8")).toBe(prior);
         expect(readFileSync(join(paths.managed, "demo", "2025.01", "old.txt"), "utf8")).toBe("old");
     });
 });
 
-describe("unpinned installation", () => {
+describe("mutable upstream installation", () => {
     test("installs without a catalog digest and records what the mutable upstream actually served", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "mutable-bytes", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "mutable-bytes" }];
         const fixture = catalog(files);
-        // The catalog carries no size or digest for an upstream that rebuilds the file in place.
-        expect(fixture.datasets[0]?.artifacts[0]).toEqual({ integrity: "unpinned", path: "gene_info.gz", url: url("gene_info.gz") });
+        // The catalog carries only the https URL — no size or digest — for an upstream that rebuilds in place.
+        expect(fixture.datasets[0]?.artifacts[0]).toEqual({ path: "gene_info.gz", url: url("gene_info.gz") });
 
         const installed = await installReferenceDatasets(["demo"], {
             root: path,
@@ -333,17 +285,17 @@ describe("unpinned installation", () => {
         const paths = referenceStorePaths(path);
         expect(readFileSync(join(paths.managed, "demo", "2026.07", "gene_info.gz"), "utf8")).toBe("mutable-bytes");
         expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
-            { path: "gene_info.gz", bytes: 13, sha256: sha("mutable-bytes"), integrity: "unpinned" },
+            { path: "gene_info.gz", bytes: 13, sha256: sha("mutable-bytes") },
         ]);
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]).toMatchObject({
             state: "valid",
-            files: [{ path: "gene_info.gz", state: "valid", integrity: "unpinned" }],
+            files: [{ path: "gene_info.gz", state: "valid" }],
         });
     });
 
     test("never resumes a stale partial — a rebuilt upstream would splice two files together", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "fresh-upstream", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "fresh-upstream" }];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
         mkdirSync(paths.downloads, { recursive: true });
@@ -358,11 +310,11 @@ describe("unpinned installation", () => {
 
     test("--force is the only way to pull a refreshed copy of a mutable upstream", async () => {
         const path = root();
-        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-a", integrity: "unpinned" }];
+        const files: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-a" }];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
         const active = join(paths.managed, "demo", "2026.07", "gene_info.gz");
-        const refreshed: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-b-longer", integrity: "unpinned" }];
+        const refreshed: readonly Fixture[] = [{ path: "gene_info.gz", body: "release-b-longer" }];
 
         const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
         expect(first.isOk()).toBe(true);
@@ -377,7 +329,7 @@ describe("unpinned installation", () => {
         expect(forced._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(16);
         expect(readFileSync(active, "utf8")).toBe("release-b-longer");
         expect(JSON.parse(readFileSync(join(paths.receipts, "demo.json"), "utf8")).artifacts).toEqual([
-            { path: "gene_info.gz", bytes: 16, sha256: sha("release-b-longer"), integrity: "unpinned" },
+            { path: "gene_info.gz", bytes: 16, sha256: sha("release-b-longer") },
         ]);
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
     });
@@ -390,17 +342,17 @@ describe("self-healing installs", () => {
         const paths = referenceStorePaths(path);
         const active = join(paths.managed, "demo", "2026.07", "a.txt");
 
-        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const first = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(first._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
 
         writeFileSync(active, "ALPHA");
         // `refs list` state is deliberately cheap (size-only), so it still reads as installed — but the
         // install gate hashes, so the damage must be seen and healed rather than skipped.
         expect((await inspectReferenceStore(path, fixture))._unsafeUnwrap().datasets[0]?.state).toBe("installed");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 1 });
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("modified");
 
-        const healed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const healed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(healed._unsafeUnwrap().installed[0]?.bytesDownloaded).toBe(5);
         expect(readFileSync(active, "utf8")).toBe("alpha");
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.state).toBe("valid");
@@ -408,11 +360,11 @@ describe("self-healing installs", () => {
 });
 
 describe("verification", () => {
-    test("reports each file against the integrity it was checked with, and detects same-size damage", async () => {
+    test("reports each file against the digest recorded at install, and detects same-size damage", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.txt", body: "bravo", integrity: "unpinned" },
+            { path: "a.txt", body: "alpha" },
+            { path: "b.txt", body: "bravo" },
         ];
         const fixture = catalog(files);
         const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
@@ -423,8 +375,8 @@ describe("verification", () => {
             version: "2026.07",
             state: "valid",
             files: [
-                { path: "a.txt", state: "valid", integrity: "pinned" },
-                { path: "b.txt", state: "valid", integrity: "unpinned" },
+                { path: "a.txt", state: "valid" },
+                { path: "b.txt", state: "valid" },
             ],
         });
 
@@ -434,15 +386,15 @@ describe("verification", () => {
         const damaged = (await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0];
         expect(damaged?.state).toBe("modified");
         expect(damaged?.files).toEqual([
-            { path: "a.txt", state: "modified", integrity: "pinned" },
-            { path: "b.txt", state: "missing", integrity: "unpinned" },
+            { path: "a.txt", state: "modified" },
+            { path: "b.txt", state: "missing" },
         ]);
     });
 
     test("a symlinked managed file is never followed", async () => {
         const path = root();
         const fixture = catalog();
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(installed.isOk()).toBe(true);
 
         const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
@@ -454,33 +406,34 @@ describe("verification", () => {
         expect((await verifyReferenceDatasets(path, ["demo"], source(fixture)))._unsafeUnwrap()[0]?.files[0]).toEqual({
             path: "a.txt",
             state: "missing",
-            integrity: "pinned",
         });
     });
 });
 
 describe("download estimate", () => {
-    test("sums pinned bytes, counts unsized artifacts, and subtracts resumable partials", async () => {
+    test("counts every artifact not already intact, ignoring leftover partials, and never hits the network", async () => {
         const path = root();
         const files: readonly Fixture[] = [
-            { path: "a.txt", body: "alpha", integrity: "pinned" },
-            { path: "b.bin", body: "mutable", integrity: "unpinned" },
+            { path: "a.txt", body: "alpha" },
+            { path: "b.bin", body: "mutable" },
         ];
         const fixture = catalog(files);
         const paths = referenceStorePaths(path);
 
-        // Only the mutable upstream can report its own size, and the estimate never goes to the network.
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
+        // The catalog knows no sizes and there is no resume to net out, so the estimate is a count of
+        // the artifacts a fresh install would fetch — never going to the network to size them.
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
 
+        // A leftover partial nets out nothing now: the installer always refetches the whole artifact.
         mkdirSync(paths.downloads, { recursive: true });
         writeFileSync(join(paths.downloads, `${sha("demo/2026.07/a.txt")}.part`), "al");
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 3, unsizedArtifacts: 1 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
 
         const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(files) });
         expect(installed.isOk()).toBe(true);
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ bytes: 0, unsizedArtifacts: 0 });
-        expect((await referenceDownloadBytes(["demo"], path, source(fixture), { force: true }))._unsafeUnwrap()).toEqual({ bytes: 5, unsizedArtifacts: 1 });
-        expect((await referenceDownloadBytes(["unknown"], path, source(fixture)))._unsafeUnwrapErr().type).toBe("unknown_dataset");
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture)))._unsafeUnwrap()).toEqual({ artifactsToFetch: 0 });
+        expect((await referenceDownloadEstimate(["demo"], path, source(fixture), { force: true }))._unsafeUnwrap()).toEqual({ artifactsToFetch: 2 });
+        expect((await referenceDownloadEstimate(["unknown"], path, source(fixture)))._unsafeUnwrapErr().type).toBe("unknown_dataset");
     });
 });
 
@@ -495,7 +448,7 @@ describe("installer-owned path safety", () => {
         mkdirSync(path, { recursive: true });
         mkdirSync(outside, { recursive: true });
         symlinkSync(outside, join(path, ".inflexa"));
-        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(ARTIFACTS) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(Array.from(new Bun.Glob("**/*").scanSync(outside))).toEqual([]);
     });
@@ -504,28 +457,26 @@ describe("installer-owned path safety", () => {
         const path = root();
         const active = join(referenceStorePaths(path).managed, "demo", "2026.07");
         mkdirSync(join(active, "surprise"), { recursive: true });
-        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(PINNED) });
+        const conflict = await installReferenceDatasets(["demo"], { root: path, source: source(catalog()), fetch: serve(ARTIFACTS) });
         expect(conflict._unsafeUnwrapErr().type).toBe("managed_path_conflict");
         expect(statSync(join(active, "surprise")).isDirectory()).toBe(true);
     });
 
-    // The catalog can only promise https for the URL we ask for. An unpinned artifact has no digest
-    // to catch a hostile substitution, so a downgraded redirect would be trusted on first use.
+    // The catalog can only promise https for the URL we ask for, and nothing downstream re-checks the
+    // bytes against a reviewed digest (trust-on-first-use), so a downgraded redirect must be refused.
     test("refuses bytes served from a non-https location after a redirect", async () => {
-        for (const integrity of ["pinned", "unpinned"] as const) {
-            const path = root();
-            const fixture = catalog([{ path: "a.txt", body: "alpha", integrity }]);
-            const redirected = await installReferenceDatasets(["demo"], {
-                root: path,
-                source: source(fixture),
-                fetch: serveRedirectedTo("http://downgraded.test/a.txt", [{ path: "a.txt", body: "alpha", integrity }]),
-            });
+        const path = root();
+        const fixture = catalog([{ path: "a.txt", body: "alpha" }]);
+        const redirected = await installReferenceDatasets(["demo"], {
+            root: path,
+            source: source(fixture),
+            fetch: serveRedirectedTo("http://downgraded.test/a.txt", [{ path: "a.txt", body: "alpha" }]),
+        });
 
-            expect(redirected._unsafeUnwrapErr().type).toBe("download_failed");
-            expect(redirected._unsafeUnwrapErr().message).toContain("non-https");
-            expect(existsSync(join(referenceStorePaths(path).managed, "demo"))).toBe(false);
-            expect(existsSync(join(referenceStorePaths(path).receipts, "demo.json"))).toBe(false);
-        }
+        expect(redirected._unsafeUnwrapErr().type).toBe("download_failed");
+        expect(redirected._unsafeUnwrapErr().message).toContain("non-https");
+        expect(existsSync(join(referenceStorePaths(path).managed, "demo"))).toBe(false);
+        expect(existsSync(join(referenceStorePaths(path).receipts, "demo.json"))).toBe(false);
     });
 
     // A receipt is a plain file on disk that anyone can edit, so it is untrusted input. A traversal
@@ -534,7 +485,7 @@ describe("installer-owned path safety", () => {
         const path = root();
         const paths = referenceStorePaths(path);
         const fixture = catalog();
-        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(PINNED) });
+        const installed = await installReferenceDatasets(["demo"], { root: path, source: source(fixture), fetch: serve(ARTIFACTS) });
         expect(installed.isOk()).toBe(true);
 
         const secret = join(paths.user, "private.txt");
@@ -548,7 +499,7 @@ describe("installer-owned path safety", () => {
                 datasetId: "demo",
                 datasetVersion: "2026.07",
                 activatedAt: "2026-07-14T10:30:00.000Z",
-                artifacts: [{ path: "../../../user/private.txt", bytes: 42, sha256: sha("alpha"), integrity: "pinned" }],
+                artifacts: [{ path: "../../../user/private.txt", bytes: 42, sha256: sha("alpha") }],
             }),
         );
 

--- a/cli/src/modules/refs/store.ts
+++ b/cli/src/modules/refs/store.ts
@@ -18,7 +18,6 @@ import {
     type ReferenceInstallPlan,
     type ReferenceInstallPlanDataset,
     type ReferenceInstallReceipt,
-    type ReferenceIntegrity,
     type ReferenceReceiptArtifact,
     type UnknownReferenceDatasetError,
 } from "@inflexa-ai/harness";
@@ -71,10 +70,8 @@ export type ReferenceStoreInspection = {
 export type ReferenceFileVerification = {
     /** Dataset-relative final path. */
     readonly path: string;
-    /** Verification outcome. */
+    /** Verification outcome, checked against the size and digest recorded in the receipt at install. */
     readonly state: "valid" | "missing" | "modified";
-    /** Which guarantee this file's digest was checked against. */
-    readonly integrity: ReferenceIntegrity;
 };
 
 /** Explicit verification result for an active catalog dataset. */
@@ -109,19 +106,6 @@ type ProvisionOperationError = {
     readonly cause?: unknown;
 };
 
-type ContentMismatchError = {
-    /** Integrity mismatch kind. */
-    readonly type: "size_mismatch" | "digest_mismatch";
-    /** User-facing explanation. */
-    readonly message: string;
-    /** Dataset-relative artifact path. */
-    readonly path: string;
-    /** Expected size or digest. */
-    readonly expected: number | string;
-    /** Observed size or digest. */
-    readonly actual: number | string;
-};
-
 type ManagedPathConflictError = {
     /** Stable discriminator. */
     readonly type: "managed_path_conflict";
@@ -132,7 +116,7 @@ type ManagedPathConflictError = {
 };
 
 /** Typed failures from local inspection, verification, transfer, or activation. */
-export type ReferenceProvisionError = UnknownDatasetError | ProvisionOperationError | ContentMismatchError | ManagedPathConflictError;
+export type ReferenceProvisionError = UnknownDatasetError | ProvisionOperationError | ManagedPathConflictError;
 
 /** Network dependencies supplied by the CLI composition edge. */
 export type ReferenceInstallDeps = {
@@ -151,10 +135,10 @@ export type ReferenceInstallDeps = {
 /** Caller-chosen installation behavior. */
 export type ReferenceInstallOptions = {
     /**
-     * Re-fetch and re-activate even when the active install is intact. This is the
-     * only way to pull a fresh copy of an `unpinned` dataset whose mutable upstream
-     * has moved on — an intact install of the bytes we previously received is
-     * indistinguishable from an up-to-date one without going to the network.
+     * Re-fetch and re-activate even when the active install is intact. Because the catalog pins no
+     * digest, this is the only way to pull a fresh copy of a dataset whose upstream has moved on —
+     * an intact install of the bytes we previously received is indistinguishable from an up-to-date
+     * one without going to the network.
      */
     readonly force?: boolean;
 };
@@ -188,12 +172,10 @@ export type ReferenceInstallOutcome = {
     readonly installed: readonly InstalledReferenceDataset[];
 };
 
-/** Bytes still to transfer, plus what cannot be known before contacting the upstream. */
+/** What a download would fetch. The catalog carries no sizes, so only a count is knowable locally. */
 export type ReferenceDownloadEstimate = {
-    /** Bytes missing across `pinned` artifacts, whose sizes the catalog knows. */
-    readonly bytes: number;
-    /** Count of `unpinned` artifacts whose size only the mutable upstream can report. */
-    readonly unsizedArtifacts: number;
+    /** Artifacts that still need fetching, whose sizes only the upstream can report. */
+    readonly artifactsToFetch: number;
 };
 
 /** Resolve all owned paths without creating anything. */
@@ -303,20 +285,17 @@ async function receiptFilesIntact(paths: ReferenceStorePaths, root: string, rece
 }
 
 /**
- * Whether the receipt still describes what the catalog now says. A `pinned` artifact
- * must match the catalog's size and digest; an `unpinned` one has no catalog digest to
- * match, so only its presence and class are compared.
+ * Whether the receipt still describes the same dataset the catalog now names: same version and the
+ * same set of artifact destinations. The catalog carries no size or digest to compare against —
+ * those live only in the receipt (observed at install) and are checked against the files themselves
+ * by `verify`, not against the catalog.
  */
 function receiptMatchesCurrentCatalog(dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): boolean {
     if (receipt.datasetVersion !== dataset.version || receipt.artifacts.length !== dataset.artifacts.length) return false;
-    const expected = new Map(dataset.artifacts.map((artifact) => [artifact.path, artifact]));
+    const expected = new Set(dataset.artifacts.map((artifact) => artifact.path));
     const actualPaths = new Set(receipt.artifacts.map((artifact) => artifact.path));
     if (actualPaths.size !== receipt.artifacts.length) return false;
-    return receipt.artifacts.every((recorded) => {
-        const artifact = expected.get(recorded.path);
-        if (artifact === undefined || artifact.integrity !== recorded.integrity) return false;
-        return artifact.integrity === "pinned" ? artifact.bytes === recorded.bytes && artifact.sha256 === recorded.sha256 : true;
-    });
+    return receipt.artifacts.every((recorded) => expected.has(recorded.path));
 }
 
 function activeManagedRoot(paths: ReferenceStorePaths, dataset: ReferenceDataset, receipt: ReferenceInstallReceipt): string | undefined {
@@ -388,10 +367,9 @@ export async function inspectReferenceStore(
 }
 
 /**
- * Hash active managed files against the receipt without mutating disk. The receipt is
- * the reference in both integrity classes: for `pinned` artifacts it equals the catalog
- * digest (activation would have failed otherwise), and for `unpinned` ones it is the
- * only honest record — what the mutable upstream actually served at install time.
+ * Hash active managed files against the receipt without mutating disk. The receipt is the sole
+ * reference: the catalog pins no digest, so this compares each file to the size and digest observed
+ * when it was installed — the honest record of what the upstream actually served at that time.
  */
 export async function verifyReferenceDatasets(
     root: string,
@@ -433,18 +411,17 @@ export async function verifyReferenceDatasets(
                 const infoResult = owned.isOk() ? await pathLstat(path) : ok(undefined);
                 const info = infoResult.isOk() ? infoResult.value : undefined;
                 if (info === undefined || info.isSymbolicLink() || !info.isFile()) {
-                    files.push({ path: artifact.path, state: "missing", integrity: artifact.integrity });
+                    files.push({ path: artifact.path, state: "missing" });
                     continue;
                 }
                 if (info.size !== artifact.bytes) {
-                    files.push({ path: artifact.path, state: "modified", integrity: artifact.integrity });
+                    files.push({ path: artifact.path, state: "modified" });
                     continue;
                 }
                 const digestResult = await sha256File(path);
                 files.push({
                     path: artifact.path,
                     state: digestResult.isOk() && digestResult.value === artifact.sha256 ? "valid" : "modified",
-                    integrity: artifact.integrity,
                 });
             }
             const state = files.every((file) => file.state === "valid") ? "valid" : files.some((file) => file.state === "modified") ? "modified" : "missing";
@@ -512,77 +489,37 @@ async function downloadArtifact(
         if (owned.isErr()) return err(owned.error);
         await mkdir(paths.downloads, { recursive: true });
 
-        // Resume is only sound when the catalog knows the final size and digest: without
-        // them a partial file cannot be told apart from a complete one, and appending to
-        // bytes an upstream has since changed would splice two different files together.
-        let resumeAt = 0;
-        if (artifact.integrity === "pinned") {
-            const priorResult = await pathStat(partPath);
-            if (priorResult.isErr()) return err(priorResult.error);
-            const prior = priorResult.value;
-            const offset = prior?.isFile() ? prior.size : 0;
-            if (offset > artifact.bytes) await rm(partPath, { force: true });
-            resumeAt = offset <= artifact.bytes ? offset : 0;
-            if (resumeAt === artifact.bytes) {
-                const existingDigest = await sha256File(partPath);
-                if (existingDigest.isOk() && existingDigest.value === artifact.sha256) {
-                    return ok({
-                        partPath,
-                        bytesDownloaded: 0,
-                        observed: { path: artifact.path, bytes: artifact.bytes, sha256: artifact.sha256, integrity: "pinned" },
-                    });
-                }
-                await rm(partPath, { force: true });
-                resumeAt = 0;
-            }
-        } else {
-            await rm(partPath, { force: true });
-        }
+        // The catalog carries no size or digest, so a partial file cannot be told apart from a
+        // complete one, and appending to bytes the upstream may have changed would splice two
+        // versions together — always fetch the whole artifact fresh.
+        // TODO(robustness): a conditional If-Range resume could restore resumable large downloads
+        // without that risk, keying the precondition off an ETag captured on the first attempt.
+        await rm(partPath, { force: true });
 
-        const response = await (deps.fetch ?? fetch)(artifact.url, { headers: resumeAt > 0 ? { Range: `bytes=${resumeAt}-` } : undefined });
+        const response = await (deps.fetch ?? fetch)(artifact.url, {});
         if (!response.ok || response.body === null) {
             return err({
                 type: "download_failed",
                 message: `Download failed for ${artifact.path}: HTTP ${response.status} ${response.statusText} (${artifact.url})`,
             });
         }
-        // The catalog guarantees an https URL, but fetch follows redirects, so the guarantee has to
-        // hold for whatever actually served the bytes. A `pinned` artifact would still be caught by
-        // its digest; an `unpinned` one has none, and would trust a downgraded hop on first use.
+        // https is now the whole integrity story: nothing downstream re-checks the bytes against a
+        // reviewed digest, so a downgraded redirect hop would be trusted on first use. The catalog
+        // guarantees an https URL, but fetch follows redirects, so enforce it on whatever served us.
         if (response.url !== "" && !response.url.startsWith("https://")) {
             return err({
                 type: "download_failed",
                 message: `Refusing ${artifact.path}: ${artifact.url} redirected to a non-https location (${response.url}).`,
             });
         }
-        const appending = resumeAt > 0 && response.status === 206;
-        await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: appending ? "a" : "w" }));
+        await pipeline(Readable.fromWeb(response.body), createWriteStream(partPath, { flags: "w" }));
         const written = (await stat(partPath)).size;
-
-        if (artifact.integrity === "pinned" && written !== artifact.bytes) {
-            return err({
-                type: "size_mismatch",
-                path: artifact.path,
-                expected: artifact.bytes,
-                actual: written,
-                message: `Size mismatch for ${artifact.path}.`,
-            });
-        }
         const digest = await sha256File(partPath);
         if (digest.isErr()) return err({ type: "io_failed", message: `Could not hash ${artifact.path}.`, cause: digest.error.cause });
-        if (artifact.integrity === "pinned" && digest.value !== artifact.sha256) {
-            return err({
-                type: "digest_mismatch",
-                path: artifact.path,
-                expected: artifact.sha256,
-                actual: digest.value,
-                message: `SHA-256 mismatch for ${artifact.path}. The upstream bytes are not the reviewed bytes; nothing was activated.`,
-            });
-        }
         return ok({
             partPath,
-            bytesDownloaded: appending ? written - resumeAt : written,
-            observed: { path: artifact.path, bytes: written, sha256: digest.value, integrity: artifact.integrity },
+            bytesDownloaded: written,
+            observed: { path: artifact.path, bytes: written, sha256: digest.value },
         });
     } catch (cause) {
         return err({ type: "download_failed", message: `Download failed for ${artifact.path} (${artifact.url}).`, cause });
@@ -763,7 +700,7 @@ export async function installReferenceDatasets(
 }
 
 /** Estimate the transfer without creating state or contacting any upstream. */
-export async function referenceDownloadBytes(
+export async function referenceDownloadEstimate(
     datasetIds: readonly string[],
     root: string,
     source: ReferenceCatalogSource = CANONICAL_REFERENCE_SOURCE,
@@ -775,8 +712,7 @@ export async function referenceDownloadBytes(
     }
     const paths = referenceStorePaths(root);
     try {
-        let bytes = 0;
-        let unsizedArtifacts = 0;
+        let artifactsToFetch = 0;
         for (const dataset of plan.value.datasets) {
             const receiptRead = await readReceipt(join(paths.receipts, `${dataset.id}.json`), paths.root);
             const activeReceipt = receiptRead.receipt;
@@ -790,31 +726,12 @@ export async function referenceDownloadBytes(
                     continue;
                 }
             }
-            for (const artifact of dataset.artifacts) {
-                // Only a mutable upstream can say how big its current file is, and asking
-                // would mean a network round-trip inside what is a purely local estimate.
-                if (artifact.integrity === "unpinned") {
-                    unsizedArtifacts += 1;
-                    continue;
-                }
-                const partPath = join(paths.downloads, `${downloadName(referenceArtifactKey(dataset, artifact))}.part`);
-                const owned = await assertOwnedPath(paths.root, partPath);
-                if (owned.isErr()) return err(owned.error);
-                const partialResult = await pathLstat(partPath);
-                if (partialResult.isErr()) return err(partialResult.error);
-                const partial = partialResult.value;
-                if (partial?.isSymbolicLink())
-                    return err({ type: "managed_path_conflict", path: partPath, message: `Refusing resumable symlink path: ${partPath}` });
-                if (partial?.isFile() && partial.size === artifact.bytes) {
-                    const digest = await sha256File(partPath);
-                    bytes += digest.isOk() && digest.value === artifact.sha256 ? 0 : artifact.bytes;
-                } else {
-                    bytes += Math.max(0, artifact.bytes - (partial?.isFile() ? Math.min(partial.size, artifact.bytes) : 0));
-                }
-            }
+            // The catalog knows no sizes, and there is no resume to net out, so the estimate is a
+            // count: every artifact of a dataset that is not already intact is fetched fresh.
+            artifactsToFetch += dataset.artifacts.length;
         }
-        return ok({ bytes, unsizedArtifacts });
+        return ok({ artifactsToFetch });
     } catch (cause) {
-        return err({ type: "io_failed", message: `Could not inspect resumable downloads at ${root}.`, cause });
+        return err({ type: "io_failed", message: `Could not inspect the reference store at ${root}.`, cause });
     }
 }


### PR DESCRIPTION
**CLI half of a two-PR change.** The harness half (#133, `@inflexa-ai/harness@0.4.1`) is **merged and published**, and this PR installs it. Rebased onto latest `main`.

## What

Consume the URL-only reference-data model (#133) and make the download surface navigable as the catalog grows to 25 datasets.

## Grouped download UX

- The interactive picker uses clack `groupMultiselect`, grouped by category; toggling a group header selects everything under it (clack returns only leaf ids, so the strict resolver never sees a group label).
- `refs list` prints category headers instead of one flat wall, and **`refs list --urls`** reveals the exact upstream URL of every artifact — the transparency that replaces a checked-in digest.

## Consuming URL-only integrity

A catalog artifact is now `{ path, url }` (no size/digest), so the installer:
- always fetches each artifact fresh and records the observed bytes+sha256 into the receipt (`referenceDownloadBytes` → `referenceDownloadEstimate`, now a file count);
- refuses non-2xx responses and non-https redirects (TLS is the whole integrity story at download);
- `refs verify` compares installed files against the receipt to catch post-install corruption/tampering.

Sizes render as "N files of upstream-determined size"; the list footer explains the trust-on-first-use model.

## Version

Pins `@inflexa-ai/harness` 0.4.0 → **0.4.1** (published) and updates the lockfile; bumps cli **0.3.2 → 0.3.3** (patch) so merging ships the refs UX as a cli release. (Say the word if you'd rather not cut a cli release here — I'll drop the cli version bump and keep only the dependency pin.)

## Validation (against the published harness 0.4.1)

`typecheck` clean; `refs` + `cli.test.ts` 40 pass; `lint` clean; `refs list` / `--urls` render all 6 groups.
