### PR TITLE
fix(harness,sandbox): drop out-of-tree provenance reads instead of failing the step

### DIFF
--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+A customer's enrichment step died with `lineage_attestation`, taking the run
+with it. The `Logger` seam shipped in 0.3.0 named the cause on the first
+occurrence:
+
+```
+[reconcile-manifest] input read resolves outside the analysis tree
+  path:      /019f6a20-1a3b-7000-a942-ae871e5de040/..
+  hostPath:  /Users/radu/.../.inflexa/analyses
+  throwSite: workspace-root-bound
+```
+
+A capture layer reported a read of `/{resourceId}/..`. The analysis tree mounts
+at `/{resourceId}`, so inside the container that path is `/` — the container
+root. Opening it is benign and says nothing about the analysis. But
+`fillInputHashesFromDisk` maps container paths onto the host by string
+arithmetic, and `path.join(resourceRoot, "..")` lands above the workspace root.
+The bound check catches that correctly — and then throws, killing the step.
+
+The throw is the defect. An out-of-tree read is **not drift**: nothing about the
+analysis has changed, and no lineage edge is at risk. It is a read of something
+the analysis does not track — the same category as a directory read
+(`ls` of a mount), which this same function already drops rather than failing.
+The spec's own invariant is "never register a hashless lineage edge"; dropping
+the ref satisfies it exactly as well as throwing does, without destroying a
+legitimate analysis.
+
+The asymmetry is visible in one file. `reconcileManifestWithDisk` skips an
+out-of-bounds *output* with a warn (`reconcile-manifest.ts:77`), citing
+`../../etc/passwd`. `fillInputHashesFromDisk` throws on an out-of-bounds *input*
+(`:165`), citing the same example. Same guard, same threat, opposite responses.
+
+Reads outside the analysis tree are supposed to be filtered at the sandbox —
+the capture hooks match on `PROVENANCE_DATA_PREFIXES`, so `/usr/lib/...` and
+`/mnt/refs/...` never reach the host, and the lineage graph already describes
+only in-tree inputs. Dropping a leaked out-of-tree read therefore *restores* the
+intended graph rather than degrading it. The sandbox-side leak is fixed
+separately (`recordOp` now canonicalizes before matching watch dirs); this change
+makes the harness resilient to it regardless of which sandbox image a host runs,
+which matters because the image is `workflow_dispatch`-only and `:latest`-tagged
+— a host on an older image would otherwise keep failing.
+
+## What Changes
+
+- `fillInputHashesFromDisk` SHALL **drop** a tracked input whose path resolves
+  outside the analysis tree — at either bound (container-prefix or
+  workspace-root) — via `collector.dropInput(ref)`, and continue. It no longer
+  throws for this condition.
+- The drop is logged at **warn**, not debug: unlike a directory read (an
+  ordinary `ls`, logged at debug), an out-of-tree read means a capture layer
+  reported something it should have filtered. It is not worth a dead analysis,
+  but it is worth noticing. The record carries the ref, the resolved `hostPath`,
+  and a `boundSite` discriminator.
+- Fail-fast is **unchanged for genuine drift**: an in-tree input that is missing
+  at reconcile (`ENOENT`) still throws, as does an unexpected `stat` failure.
+
+Not in scope: the `IN_OPEN`-as-read classification in the inotify layer, which
+remains a separate change.
+
+## Capabilities
+
+### New Capabilities
+
+None. This narrows an existing requirement in `artifact-manifest`.

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/artifact-manifest/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: The manifest is reconciled against disk before registration
+
+`reconcileManifestWithDisk(input)` SHALL run after the sandbox is destroyed and
+before any artifact is registered or synced. For each manifest entry it SHALL
+stat the file at `{workspaceRoot}/runs/{runId}/{stepId}/{entry.path}`, bounded
+to the step root, and:
+
+- If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`, `step_id`), and emit a debug log line.
+- If the path is not a regular file (a directory) → drop it the same way.
+- Otherwise → recompute SHA-256 from disk via `computeSha256File` and replace the entry's `hash` and `size` with the on-disk values.
+
+Every surviving entry SHALL be re-hashed from disk — there is no matched-size
+fast path that skips hashing. The reconcile step SHALL also content-attest the
+collector's tracked inputs via `fillInputHashesFromDisk`: for each tracked input
+that is not an `artifacts`-source read and lacks a valid content hash, it maps
+the container path onto the host workspace tree, bounds it to
+`{workspaceRoot}`, and hashes the file from disk.
+
+An input that is not a content-attestable file **of this analysis** SHALL be
+dropped via `collector.dropInput` and SHALL NOT fail the step:
+
+- An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref, the resolved host path, and a `boundSite` discriminator.
+
+An out-of-tree read is out of scope rather than drift: the analysis tree mounts
+at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container
+root and describes nothing about the analysis. The capture hooks are meant to
+filter such reads by data prefix, so the lineage graph already describes only
+in-tree inputs — dropping a leaked one restores that graph. Dropping upholds
+"never register a hashless lineage edge" exactly as a throw would, without
+destroying a legitimate analysis over an untracked read, and it mirrors the
+out-of-bounds *output* skip in the same function. Warn rather than debug is
+deliberate: a directory read is ordinary, whereas an out-of-tree read means a
+capture layer reported something it should have filtered — not worth a dead
+analysis, but worth noticing.
+
+Fail-fast SHALL remain for genuine drift: an input **file** that is missing at
+reconcile (`ENOENT`) SHALL throw, as SHALL an unexpected `stat` failure, never
+registering a hashless lineage edge.
+
+#### Scenario: Phantom file is dropped silently
+
+- **GIVEN** the agent wrote `output/temp.csv` and later deleted it, but the walk had already recorded it (or the collector still holds a record)
+- **WHEN** `reconcileManifestWithDisk` runs and stat fails with `ENOENT`
+- **THEN** the entry for `output/temp.csv` is removed from the returned manifest, `collector.removeRecord("output/temp.csv")` is called, a debug line is logged, and `cortex.artifact.reconcile.dropped` is incremented once
+- **AND** `output/temp.csv` reaches neither registration nor the vector index
+
+#### Scenario: Every surviving output is re-hashed from disk
+
+- **GIVEN** a manifest entry for `output/clean.csv` whose on-disk size equals the entry's size
+- **WHEN** `reconcileManifestWithDisk` runs
+- **THEN** `computeSha256File` IS invoked for `output/clean.csv` and the entry's hash and size are set from the on-disk bytes
+
+#### Scenario: A missing input file fails the step
+
+- **GIVEN** the collector tracked a non-`artifacts` input read whose file is absent at reconcile time
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** it throws, the step fails loudly, and no hashless lineage edge is registered
+
+#### Scenario: A directory read is dropped from lineage, not failed
+
+- **GIVEN** a tracked input that resolves to a directory (e.g. `ls` of a mount)
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref and the step does NOT fail
+
+#### Scenario: A read resolving outside the analysis tree is dropped, not failed
+
+- **GIVEN** a tracked input read of `/{resourceId}/..` — the container root, which maps to a host path above the workspace root
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `boundSite` is emitted, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/artifact-manifest/spec.md
@@ -22,7 +22,11 @@ An input that is not a content-attestable file **of this analysis** SHALL be
 dropped via `collector.dropInput` and SHALL NOT fail the step:
 
 - An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
-- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref, the resolved host path, and a `boundSite` discriminator.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref and a `boundSite` discriminator; the workspace-root record also carries the resolved host path (the container-prefix bound rejects the path before a host mapping exists).
+
+Every input drop SHALL increment the `cortex.artifact.reconcile.input_dropped`
+counter, tagged `agent_id`, `step_id`, and `reason` (`directory`,
+`container-prefix`, or `workspace-root`).
 
 An out-of-tree read is out of scope rather than drift: the analysis tree mounts
 at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/exec-provenance-lineage/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Each exec frame is threaded into the step-scoped collector
+
+The sandbox-step body SHALL construct one `ProvenanceCollector` per step, seeded
+with the step's `stepId`, `runId`, and `dependsOn`. After each `execute_command`
+resolves its `ExecResult`, the workspace `execute_command` tool SHALL feed that
+result's `provenance` frame into the collector via `feedExecFrame`
+(`src/provenance/exec-frame.ts`). `feedExecFrame` SHALL strip the
+`/{resourceId}/` mount prefix from each frame path — collapsing separators
+doubled at the boundary so an in-mount name lands on its canonical relative
+form — classify every read via
+`classifyReadPath(relativePath, stepId, runId, dependsOn)`, call
+`trackInputAccess` per read, and call `recordCommandExecution` once per exec with
+that exec's own reads scoped to its outputs. A frame path that does not lie
+under the mount SHALL ride onto its `InputRef` verbatim, never with the mount
+root prepended: forging an in-tree name for a foreign path would surface at
+reconcile as phantom drift (a missing file, which fails the step) instead of
+the out-of-tree read it is (which reconcile drops from lineage). Read hashes
+SHALL be left unset at track time and filled from disk by
+`reconcileManifestWithDisk` before registration. When the frame is absent or
+`disabled`, `feedExecFrame` SHALL record the command with no inputs and no
+writes rather than throw.
+
+#### Scenario: Command reading an input and writing an output produces a lineage edge
+
+- **GIVEN** an `execute_command` whose argv is `["python3", "scripts/tmm.py"]` and whose `ExecResult.provenance` reads `/{rid}/data/inputs/Lab/counts.csv` and writes `/{rid}/runs/{run}/{step}/output/tmm.csv`
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** `getRecords()` contains a record for `output/tmm.csv` with `producer.type: "command"`, an inferred `scriptPath: "scripts/tmm.py"`, and an input with `source: "data"` for `data/inputs/Lab/counts.csv`
+
+#### Scenario: Upstream read is classified by step metadata
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and an exec whose frame reads `/{rid}/runs/run-002/qc/output/qc.csv`
+- **WHEN** the read is classified and tracked
+- **THEN** the resulting `InputRef` has `source: "upstream"`, `stepId: "qc"`, `runId: "run-002"`
+
+#### Scenario: A read outside the mount keeps its own name
+
+- **GIVEN** an exec whose frame reports a read of `/etc/passwd` — naming nothing under the mount, a path the hooks should have filtered
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound rather than failing the step
+
+#### Scenario: Missing or disabled frame degrades to no inputs
+
+- **GIVEN** an `ExecResult` whose `provenance` is absent or has `disabled: true`
+- **WHEN** the tool feeds it via `feedExecFrame`
+- **THEN** the command is recorded with an empty `inputs` array and no error is thrown

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/specs/sandbox-provenance-tracking/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: The sandbox-server activates the in-container layers per command
+
+For each `POST /exec` command, the sandbox-server SHALL inject the provenance
+layers into the child process environment when their files are present:
+`PYTHONPATH` prepended with `/opt/provenance` (Layer 1 Python), `R_PROFILE`
+pointing at `/opt/provenance/Rprofile.site` (Layer 1 R), `LD_PRELOAD` pointing at
+`/opt/provenance/provtrack.so` (Layer 2), `PROVENANCE_SOCKET` set to the
+per-command socket path, and `PROVENANCE_DATA_PREFIXES` set from the server's
+configured watch dirs. After the child exits, the server SHALL drain the socket,
+combine the socket reports with the inotify verification channel, and surface the
+result as the exec `provenance` frame.
+
+The server SHALL canonicalize every reported path — collapsing `.` and `..`
+segments — and SHALL record it only if the canonical path lies **within** a
+configured watch dir, at the single point where all layers converge. A watch dir
+itself SHALL NOT be recorded: a read of the mount root is a directory, never an
+attestable file.
+
+Each in-container layer filters by string prefix on whatever path its caller
+passed, and an absolute path need not be canonical: `/{resourceId}/..` literally
+begins with the watch dir `/{resourceId}/` yet names its parent, so it survives
+every layer's own filter. The host maps such a path to a location above the
+workspace root, where it cannot attest it. The layer filters are therefore an
+optimization — they keep a datagram off the socket — and this re-check is the
+boundary that decides what a frame may contain. Canonicalization is
+**lexical**: resolving symlinks would make the reported path disagree with the
+name the workload used, and the layers report names, not inodes.
+
+#### Scenario: Layers are injected for a Python command
+
+- **GIVEN** a sandbox-server with the provenance files installed at `/opt/provenance`
+- **WHEN** a command is executed via `POST /exec`
+- **THEN** the child process environment carries `PYTHONPATH` including `/opt/provenance`, `R_PROFILE`, `LD_PRELOAD`, `PROVENANCE_SOCKET`, and `PROVENANCE_DATA_PREFIXES`
+
+#### Scenario: Socket reports fold into the exec frame
+
+- **WHEN** a script reads `/{resourceId}/data/inputs/test.csv` via `pandas.read_csv` and the command completes
+- **THEN** the exec `provenance` frame's `reads` contains that path
+- **AND** does not contain stdlib paths like `/usr/lib/python3/...`
+
+#### Scenario: A read of the mount's parent is not reported
+
+- **GIVEN** a watch dir of `/{resourceId}/` and a layer reporting a read of `/{resourceId}/..` (the container root, which the workload may legitimately open)
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A traversal out of the tree is not reported
+
+- **GIVEN** a layer reporting a read of `/{resourceId}/../../../etc/passwd`
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/etc/passwd`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A non-canonical in-tree path folds onto its canonical name
+
+- **GIVEN** R's `normalizePath(mustWork = FALSE)` reporting a write to `/{resourceId}/runs/r1/T3S1/scripts/../output/enrich.csv` (it leaves `..` intact whenever a component does not exist yet — the common case for a new output file), and the inotify layer reporting `/{resourceId}/runs/r1/T3S1/output/enrich.csv`
+- **WHEN** the server records both reports
+- **THEN** the frame carries ONE entry, under the canonical path, attributed to both layers

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/tasks.md
@@ -20,3 +20,10 @@
 - [x] 3.2 Delta on `sandbox-provenance-tracking`: the server canonicalizes and re-checks the watch dirs where the layers converge, so a layer's prefix filter is an optimization and the server is the boundary.
 - [x] 3.3 Hand-rewrite both **Purpose** sections, which deltas do not carry: `artifact-manifest` claimed an input "resolving outside the analysis tree" was terminal (only *missing* is), and `sandbox-provenance-tracking` described the fold without naming the server as the boundary.
 - [x] 3.4 Archived (`openspec archive`); both main specs updated and all 57 validate strict.
+
+## 4. Review follow-ups
+
+- [x] 4.1 Close the ingestion gap: an out-of-mount frame path rides verbatim onto its `InputRef` (never mount-root-prefixed, which forged an in-tree name and turned the read into phantom ENOENT drift), and separators doubled at the mount boundary collapse to the canonical relative form. The container-prefix bound is now reachable end-to-end; its regression test drives `feedExecFrame` with a literal `/etc/passwd` read.
+- [x] 4.2 Count every reconcile input drop on `cortex.artifact.reconcile.input_dropped` (tagged `agent_id`, `step_id`, `reason` ∈ `directory` / `container-prefix` / `workspace-root`).
+- [x] 4.3 sandbox-server: debug-log each report `recordOp` drops — a dropped report never reaches the host, so this is the only trace of a hook-filter leak on a current image.
+- [x] 4.4 Spec sync: delta + main update on `exec-provenance-lineage` (verbatim out-of-mount refs, boundary canonicalization); `artifact-manifest` warn-record wording scoped to the bound that actually resolves a host path, plus the input-drop counter.

--- a/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-17-drop-out-of-tree-lineage-reads/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## 1. Drop out-of-tree reads instead of failing the step
+
+- [x] 1.1 `fillInputHashesFromDisk` — replace both bound throws with `collector.dropInput(ref)` + `continue`, logged at warn with the ref, resolved `hostPath`, and a `boundSite` discriminator (`container-prefix` / `workspace-root`).
+- [x] 1.2 Keep the ENOENT and `stat`-failure throws untouched — genuine drift still fails fast.
+- [x] 1.3 Update the `fillInputHashesFromDisk` doc comment and `ProvenanceCollector.dropInput`'s, which named the directory read as its only caller.
+- [x] 1.4 Regression test driving the customer's `/{RID}/..` through the real `feedExecFrame` path: the step survives, its output still reconciles, the ref leaves both the tracked inputs and every record, exactly one warn names the ref + `boundSite`, and nothing is logged at error. Verified it fails against the old throw.
+- [x] 1.5 Cover the other bound too (`container-prefix`) — the spec drops at both, so both are tested.
+
+## 2. Sandbox-side: stop emitting the path at all
+
+- [x] 2.1 `recordOp` — canonicalize with `filepath.Clean` and re-check the watch dirs at the one point all four capture layers converge, so each hook's prefix filter is a hint and the server is the boundary.
+- [x] 2.2 Go tests: the customer's literal path, a traversal out of tree, the mount root itself, an in-tree read surviving, and two layers folding onto one canonical path. Verified all four guard tests fail without the fix.
+- [ ] 2.3 Dispatch `lib-store.yml` to rebuild + push the sandbox images — the fix only reaches a host that re-pulls (`workflow_dispatch`-only, `:latest`).
+
+## 3. Spec
+
+- [x] 3.1 Delta on `artifact-manifest`: `fillInputHashesFromDisk` drops out-of-tree reads; fail-fast retained for ENOENT/stat drift.
+- [x] 3.2 Delta on `sandbox-provenance-tracking`: the server canonicalizes and re-checks the watch dirs where the layers converge, so a layer's prefix filter is an optimization and the server is the boundary.
+- [x] 3.3 Hand-rewrite both **Purpose** sections, which deltas do not carry: `artifact-manifest` claimed an input "resolving outside the analysis tree" was terminal (only *missing* is), and `sandbox-provenance-tracking` described the fold without naming the server as the boundary.
+- [x] 3.4 Archived (`openspec archive`); both main specs updated and all 57 validate strict.

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -113,7 +113,11 @@ An input that is not a content-attestable file **of this analysis** SHALL be
 dropped via `collector.dropInput` and SHALL NOT fail the step:
 
 - An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
-- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref, the resolved host path, and a `boundSite` discriminator.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref and a `boundSite` discriminator; the workspace-root record also carries the resolved host path (the container-prefix bound rejects the path before a host mapping exists).
+
+Every input drop SHALL increment the `cortex.artifact.reconcile.input_dropped`
+counter, tagged `agent_id`, `step_id`, and `reason` (`directory`,
+`container-prefix`, or `workspace-root`).
 
 An out-of-tree read is out of scope rather than drift: the analysis tree mounts
 at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -27,24 +27,26 @@ input hashes can be read from disk now because inputs are immutable for the
 step's lifetime (the analysis tree is mounted read-only; the only writable mount
 is the step's own directory). This makes the registered hash equal `sha256sum` of
 the bytes the sync target receives at upload time. The reconcile/register/sync
-stages are pulled out of the best-effort net: an input that cannot be hashed
-(missing, or resolving outside the analysis tree) and a registry rejection are
-**terminal** — they fail the step loudly rather than orphaning real outputs
-green. Genuine *file* drift fails fast; a read that resolves to a **directory**
-(e.g. `ls` of a mount) is not a content-attestable artifact and is dropped from
-lineage instead. The enrichment stages — file-metadata, step-summary,
-vector-index — stay best-effort and keep degrading via `safeRun`, because they
-are search/UX quality, not integrity.
+stages are pulled out of the best-effort net: a tracked input **file** that is
+missing at reconcile, and a registry rejection, are **terminal** — they fail the
+step loudly rather than orphaning real outputs green.
+
+Genuine *file* drift fails fast. A read that is not a content-attestable file of
+this analysis is dropped from lineage instead — a **directory** (e.g. `ls` of a
+mount), and a read **resolving outside the analysis tree** (e.g. `/{resourceId}/..`,
+the container root, which the sandbox may legitimately open). Neither is drift:
+nothing about the analysis changed and no edge is at risk, so dropping upholds
+"never register a hashless lineage edge" exactly as a throw would, without
+destroying a legitimate analysis over an untracked read. The enrichment stages —
+file-metadata, step-summary, vector-index — stay best-effort and keep degrading
+via `safeRun`, because they are search/UX quality, not integrity.
 
 The ledger is a thin index: identity (`path`, `hash`, `size`), provenance
 (`source_step`, `source_run`), and optional external registration state
 (`artifact_id`, `file_id`). It stores no file descriptions — the per-analysis
 vector index is the sole source of truth for descriptions and discovery.
-
 ## Requirements
-
 ### Requirement: The step manifest is a disk walk of the writable step directory
-
 
 The per-step artifact manifest SHALL be produced by `walkStepArtifacts`, which
 recursively walks the step's writable directory (`writePrefix`,
@@ -71,7 +73,6 @@ the manifest.
 
 ### Requirement: cortex_artifacts is the local ledger
 
-
 The `cortex_artifacts` table SHALL be the local ledger for file registration and
 provenance tracking. Each row SHALL carry: `analysis_id` (TEXT, NOT NULL),
 `path` (TEXT, NOT NULL — analysis-relative canonical path), `hash` (TEXT, NOT
@@ -92,12 +93,10 @@ index owns those.
 
 ### Requirement: The manifest is reconciled against disk before registration
 
-
-Before registration, the draft manifest SHALL be reconciled against disk by
-`reconcileManifestWithDisk`. For each manifest entry the helper SHALL stat the
-absolute step path (`{workspaceRoot}/runs/{runId}/{stepId}/{path}`, where
-`{workspaceRoot}` is the analysis's resolved workspace root),
-bounded to the step root, and:
+`reconcileManifestWithDisk(input)` SHALL run after the sandbox is destroyed and
+before any artifact is registered or synced. For each manifest entry it SHALL
+stat the file at `{workspaceRoot}/runs/{runId}/{stepId}/{entry.path}`, bounded
+to the step root, and:
 
 - If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`, `step_id`), and emit a debug log line.
 - If the path is not a regular file (a directory) → drop it the same way.
@@ -108,10 +107,29 @@ fast path that skips hashing. The reconcile step SHALL also content-attest the
 collector's tracked inputs via `fillInputHashesFromDisk`: for each tracked input
 that is not an `artifacts`-source read and lacks a valid content hash, it maps
 the container path onto the host workspace tree, bounds it to
-`{workspaceRoot}`, and hashes the file from disk. A directory input is
-dropped via `collector.dropInput`. An input file that is missing or resolves
-outside the analysis tree SHALL throw (fail-fast attestation), never register a
-hashless lineage edge.
+`{workspaceRoot}`, and hashes the file from disk.
+
+An input that is not a content-attestable file **of this analysis** SHALL be
+dropped via `collector.dropInput` and SHALL NOT fail the step:
+
+- An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref, the resolved host path, and a `boundSite` discriminator.
+
+An out-of-tree read is out of scope rather than drift: the analysis tree mounts
+at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container
+root and describes nothing about the analysis. The capture hooks are meant to
+filter such reads by data prefix, so the lineage graph already describes only
+in-tree inputs — dropping a leaked one restores that graph. Dropping upholds
+"never register a hashless lineage edge" exactly as a throw would, without
+destroying a legitimate analysis over an untracked read, and it mirrors the
+out-of-bounds *output* skip in the same function. Warn rather than debug is
+deliberate: a directory read is ordinary, whereas an out-of-tree read means a
+capture layer reported something it should have filtered — not worth a dead
+analysis, but worth noticing.
+
+Fail-fast SHALL remain for genuine drift: an input **file** that is missing at
+reconcile (`ENOENT`) SHALL throw, as SHALL an unexpected `stat` failure, never
+registering a hashless lineage edge.
 
 #### Scenario: Phantom file is dropped silently
 
@@ -126,9 +144,9 @@ hashless lineage edge.
 - **WHEN** `reconcileManifestWithDisk` runs
 - **THEN** `computeSha256File` IS invoked for `output/clean.csv` and the entry's hash and size are set from the on-disk bytes
 
-#### Scenario: An input that cannot be hashed fails the step
+#### Scenario: A missing input file fails the step
 
-- **GIVEN** the collector tracked a non-`artifacts` input read whose file is absent at reconcile time (or resolves outside the analysis tree)
+- **GIVEN** the collector tracked a non-`artifacts` input read whose file is absent at reconcile time
 - **WHEN** `fillInputHashesFromDisk` runs
 - **THEN** it throws, the step fails loudly, and no hashless lineage edge is registered
 
@@ -138,8 +156,14 @@ hashless lineage edge.
 - **WHEN** `fillInputHashesFromDisk` runs
 - **THEN** `collector.dropInput` is called for that ref and the step does NOT fail
 
-### Requirement: Registration through the ArtifactRegistry seam
+#### Scenario: A read resolving outside the analysis tree is dropped, not failed
 
+- **GIVEN** a tracked input read of `/{resourceId}/..` — the container root, which maps to a host path above the workspace root
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `boundSite` is emitted, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register
+
+### Requirement: Registration through the ArtifactRegistry seam
 
 `registerStepArtifacts(db, registry, input, session)` SHALL: (1) build the
 `cortex_artifacts` rows from the reconciled manifest — `role = 'step_output'`,
@@ -167,7 +191,6 @@ return all-zero counts immediately and SHALL NOT call the registry.
 
 ### Requirement: Integrity stages fail-fast; enrichment stages degrade
 
-
 `reconcileAndRegisterStepArtifacts` SHALL reconcile, then register, then
 `ArtifactRegistry.sync` the step's artifacts, and SHALL treat the whole sequence
 as fail-fast: a non-zero `externalFailed` SHALL throw with the
@@ -190,7 +213,6 @@ failure degrades without failing the step.
 
 ### Requirement: Artifact upsert semantics
 
-
 `upsertArtifact` and `upsertArtifacts` SHALL use a Postgres `INSERT ... ON
 CONFLICT (analysis_id, path) DO UPDATE` that updates `hash`, `size`, `role`,
 `source_step`, `source_run`, and `COALESCE`s `file_type` and `file_id`.
@@ -204,7 +226,6 @@ existing row rather than fail on the duplicate key.
 - **THEN** the existing `cortex_artifacts` row is updated with the new `hash`, `size`, and `source_run`, and no duplicate row is created
 
 ### Requirement: Optional external sync tracking
-
 
 `cortex_artifacts` SHALL track external sync state via `artifact_id` (set after
 external registration by `updateArtifactId`) and `file_id` (set when an adapter
@@ -230,7 +251,6 @@ IS NULL`, ordered by `created_at`.
 
 ### Requirement: Manifest is scoped per analysis with cross-run visibility
 
-
 `cortex_artifacts` SHALL hold all runs of an analysis in one table, queryable by
 `source_run`; the flat read-only mount gives filesystem access to all runs.
 Agents discover cross-run files via workspace vector search, not by reading the
@@ -241,3 +261,4 @@ artifact table directly.
 - **WHEN** a step in run-2 runs `workspace_search("normalized expression matrix")`
 - **THEN** results MAY include files from run-1 (e.g. `runs/run-01/qc/output/normalized.csv`)
 - **AND** the file is accessible via the flat read-only mount
+

--- a/harness/openspec/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/specs/exec-provenance-lineage/spec.md
@@ -34,13 +34,20 @@ with the step's `stepId`, `runId`, and `dependsOn`. After each `execute_command`
 resolves its `ExecResult`, the workspace `execute_command` tool SHALL feed that
 result's `provenance` frame into the collector via `feedExecFrame`
 (`src/provenance/exec-frame.ts`). `feedExecFrame` SHALL strip the
-`/{resourceId}/` mount prefix from each frame path, classify every read via
+`/{resourceId}/` mount prefix from each frame path — collapsing separators
+doubled at the boundary so an in-mount name lands on its canonical relative
+form — classify every read via
 `classifyReadPath(relativePath, stepId, runId, dependsOn)`, call
 `trackInputAccess` per read, and call `recordCommandExecution` once per exec with
-that exec's own reads scoped to its outputs. Read hashes SHALL be left unset at
-track time and filled from disk by `reconcileManifestWithDisk` before
-registration. When the frame is absent or `disabled`, `feedExecFrame` SHALL
-record the command with no inputs and no writes rather than throw.
+that exec's own reads scoped to its outputs. A frame path that does not lie
+under the mount SHALL ride onto its `InputRef` verbatim, never with the mount
+root prepended: forging an in-tree name for a foreign path would surface at
+reconcile as phantom drift (a missing file, which fails the step) instead of
+the out-of-tree read it is (which reconcile drops from lineage). Read hashes
+SHALL be left unset at track time and filled from disk by
+`reconcileManifestWithDisk` before registration. When the frame is absent or
+`disabled`, `feedExecFrame` SHALL record the command with no inputs and no
+writes rather than throw.
 
 #### Scenario: Command reading an input and writing an output produces a lineage edge
 
@@ -53,6 +60,12 @@ record the command with no inputs and no writes rather than throw.
 - **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and an exec whose frame reads `/{rid}/runs/run-002/qc/output/qc.csv`
 - **WHEN** the read is classified and tracked
 - **THEN** the resulting `InputRef` has `source: "upstream"`, `stepId: "qc"`, `runId: "run-002"`
+
+#### Scenario: A read outside the mount keeps its own name
+
+- **GIVEN** an exec whose frame reports a read of `/etc/passwd` — naming nothing under the mount, a path the hooks should have filtered
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound rather than failing the step
 
 #### Scenario: Missing or disabled frame degrades to no inputs
 

--- a/harness/openspec/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/specs/sandbox-provenance-tracking/spec.md
@@ -25,6 +25,12 @@ in-container layers per command by injecting `PYTHONPATH`, `R_PROFILE`,
 process environment, then drains the socket after the child exits and folds the
 result into the exec frame.
 
+**The server, not the layers, is the boundary.** Each layer filters by string
+prefix on the path its caller passed, which need not be canonical — so a layer
+can report a path that matches a watch dir textually while naming somewhere
+else. Every report is canonicalized and re-checked against the watch dirs where
+the layers converge; a layer's own filter only keeps a datagram off the socket.
+
 This tracking is **production-wired**, not a prototype: the harness's
 `buildMountPlan` sets `PROVENANCE_WATCH_DIRS` to each step's analysis resource
 mount root (`/{resourceId}`), and the resulting frame is consumed by the
@@ -44,9 +50,7 @@ survives an adversary is artifact *content*, not lineage: hashes are recomputed
 host-side from disk at registration (see the exec-provenance-lineage and
 artifact-manifest specs), so content integrity holds even when the self-reported
 operation frame cannot be trusted.
-
 ## Requirements
-
 ### Requirement: Python audit hook tracks file I/O via sitecustomize.py
 
 A `sitecustomize.py` file SHALL be installed at `/opt/provenance/sitecustomize.py` in the sandbox container image. When `PYTHONPATH` includes `/opt/provenance`, the hook SHALL be loaded automatically before any user script.
@@ -292,6 +296,22 @@ configured watch dirs. After the child exits, the server SHALL drain the socket,
 combine the socket reports with the inotify verification channel, and surface the
 result as the exec `provenance` frame.
 
+The server SHALL canonicalize every reported path — collapsing `.` and `..`
+segments — and SHALL record it only if the canonical path lies **within** a
+configured watch dir, at the single point where all layers converge. A watch dir
+itself SHALL NOT be recorded: a read of the mount root is a directory, never an
+attestable file.
+
+Each in-container layer filters by string prefix on whatever path its caller
+passed, and an absolute path need not be canonical: `/{resourceId}/..` literally
+begins with the watch dir `/{resourceId}/` yet names its parent, so it survives
+every layer's own filter. The host maps such a path to a location above the
+workspace root, where it cannot attest it. The layer filters are therefore an
+optimization — they keep a datagram off the socket — and this re-check is the
+boundary that decides what a frame may contain. Canonicalization is
+**lexical**: resolving symlinks would make the reported path disagree with the
+name the workload used, and the layers report names, not inodes.
+
 #### Scenario: Layers are injected for a Python command
 
 - **GIVEN** a sandbox-server with the provenance files installed at `/opt/provenance`
@@ -303,3 +323,22 @@ result as the exec `provenance` frame.
 - **WHEN** a script reads `/{resourceId}/data/inputs/test.csv` via `pandas.read_csv` and the command completes
 - **THEN** the exec `provenance` frame's `reads` contains that path
 - **AND** does not contain stdlib paths like `/usr/lib/python3/...`
+
+#### Scenario: A read of the mount's parent is not reported
+
+- **GIVEN** a watch dir of `/{resourceId}/` and a layer reporting a read of `/{resourceId}/..` (the container root, which the workload may legitimately open)
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A traversal out of the tree is not reported
+
+- **GIVEN** a layer reporting a read of `/{resourceId}/../../../etc/passwd`
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/etc/passwd`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A non-canonical in-tree path folds onto its canonical name
+
+- **GIVEN** R's `normalizePath(mustWork = FALSE)` reporting a write to `/{resourceId}/runs/r1/T3S1/scripts/../output/enrich.csv` (it leaves `..` intact whenever a component does not exist yet — the common case for a new output file), and the inotify layer reporting `/{resourceId}/runs/r1/T3S1/output/enrich.csv`
+- **WHEN** the server records both reports
+- **THEN** the frame carries ONE entry, under the canonical path, attributed to both layers
+

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -124,6 +124,115 @@ describe("reconcileManifestWithDisk — input content attestation", () => {
         }
     });
 
+    test("drops a read resolving outside the analysis tree instead of failing the step", async () => {
+        // The field failure this behaviour exists for: a capture layer reported a
+        // read of `/{RID}/..` — the container root, since the tree mounts at
+        // `/{RID}` — which maps to a host path ABOVE the workspace root. It is not
+        // attestable and not this analysis's lineage, but it is not drift either:
+        // throwing here killed a whole enrichment run in the field.
+        const sessionPath = await mkdtemp(join(tmpdir(), "cortex-reconcile-"));
+        const root = join(sessionPath, RID);
+        const logger = createCapturingLogger();
+        try {
+            await mkdir(join(root, "runs/run-001/de/output"), { recursive: true });
+            await writeFile(join(root, "runs/run-001/de/output/result.csv"), "result\n1\n");
+
+            const collector = new ProvenanceCollector({ stepId: "de", runId: "run-001" });
+            feedExecFrame({
+                collector,
+                mountRoot: `/${RID}`,
+                command: ["python3", "scripts/enrich.py"],
+                exitCode: 0,
+                durationMs: 100,
+                provenance: {
+                    disabled: false,
+                    reads: [{ path: `/${RID}/..`, layers: ["preload"] }],
+                    writes: [{ path: `/${RID}/runs/run-001/de/output/result.csv`, layers: ["inotify"] }],
+                    deletes: [],
+                },
+            });
+            const manifest: ArtifactManifestEntry[] = [{ stepId: "de", runId: "run-001", path: "output/result.csv", size: 0, type: "output", hash: "" }];
+
+            const result = await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+                logger,
+            });
+
+            // The step survives and its real output still reconciles.
+            expect(result.manifest).toHaveLength(1);
+            // The out-of-tree ref is gone from both the tracked inputs and any record.
+            expect(collector.getTrackedInputs().some((r) => r.path === `/${RID}/..`)).toBe(false);
+            expect(
+                collector
+                    .getRecords()
+                    .flatMap((r) => r.inputs)
+                    .some((i) => i.path === `/${RID}/..`),
+            ).toBe(false);
+
+            // Dropping lineage is never silent — the warn names the ref and the bound.
+            const warns = logger.records.filter((r) => r.level === "warn");
+            expect(warns).toHaveLength(1);
+            expect(warns[0]!.msg).toBe("[reconcile-manifest] dropping out-of-tree input from lineage");
+            expect(warns[0]!.fields).toMatchObject({
+                runId: "run-001",
+                stepId: "de",
+                path: `/${RID}/..`,
+                boundSite: "workspace-root",
+            });
+            // A drop is not a failure: nothing is logged at error.
+            expect(logger.records.filter((r) => r.level === "error")).toHaveLength(0);
+        } finally {
+            await rm(sessionPath, { recursive: true, force: true });
+        }
+    });
+
+    test("drops a read that never names the mount root (container-prefix bound)", async () => {
+        // The other bound: a path that is not under `/{RID}` at all, so it cannot
+        // even be mapped onto the host tree. Same verdict as the workspace-root
+        // bound — out of scope, not drift.
+        const sessionPath = await mkdtemp(join(tmpdir(), "cortex-reconcile-"));
+        const root = join(sessionPath, RID);
+        const logger = createCapturingLogger();
+        try {
+            await mkdir(join(root, "runs/run-001/de/output"), { recursive: true });
+            await writeFile(join(root, "runs/run-001/de/output/result.csv"), "result\n1\n");
+
+            const collector = new ProvenanceCollector({ stepId: "de", runId: "run-001" });
+            // `feedExecFrame` strips the mount prefix, so an absolute path outside the
+            // mount survives verbatim onto the ref — drive the collector directly to
+            // get one, exactly as a leaked stdlib read would arrive.
+            collector.trackInputAccess("/etc", "passwd", null);
+            const manifest: ArtifactManifestEntry[] = [{ stepId: "de", runId: "run-001", path: "output/result.csv", size: 0, type: "output", hash: "" }];
+
+            const result = await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+                logger,
+            });
+
+            expect(result.manifest).toHaveLength(1);
+            expect(collector.getTrackedInputs().some((r) => r.path === "/etc/passwd")).toBe(false);
+
+            const warns = logger.records.filter((r) => r.level === "warn");
+            expect(warns).toHaveLength(1);
+            expect(warns[0]!.fields).toMatchObject({ path: "/etc/passwd", boundSite: "container-prefix" });
+            expect(logger.records.filter((r) => r.level === "error")).toHaveLength(0);
+        } finally {
+            await rm(sessionPath, { recursive: true, force: true });
+        }
+    });
+
     test("throws when an attested input is missing at reconcile (fail-fast)", async () => {
         const { sessionPath, root, collector, manifest } = await setup({ writeUpstream: false });
         try {

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -193,9 +193,11 @@ describe("reconcileManifestWithDisk — input content attestation", () => {
     });
 
     test("drops a read that never names the mount root (container-prefix bound)", async () => {
-        // The other bound: a path that is not under `/{RID}` at all, so it cannot
-        // even be mapped onto the host tree. Same verdict as the workspace-root
-        // bound — out of scope, not drift.
+        // The other bound: a frame report naming somewhere outside the mount
+        // entirely — a hook that failed to filter, e.g. a leaked stdlib read.
+        // `feedExecFrame` keeps such a path verbatim on the ref, so reconcile
+        // sees the real name and reaches the same verdict as the workspace-root
+        // bound: out of scope, not drift.
         const sessionPath = await mkdtemp(join(tmpdir(), "cortex-reconcile-"));
         const root = join(sessionPath, RID);
         const logger = createCapturingLogger();
@@ -204,10 +206,19 @@ describe("reconcileManifestWithDisk — input content attestation", () => {
             await writeFile(join(root, "runs/run-001/de/output/result.csv"), "result\n1\n");
 
             const collector = new ProvenanceCollector({ stepId: "de", runId: "run-001" });
-            // `feedExecFrame` strips the mount prefix, so an absolute path outside the
-            // mount survives verbatim onto the ref — drive the collector directly to
-            // get one, exactly as a leaked stdlib read would arrive.
-            collector.trackInputAccess("/etc", "passwd", null);
+            feedExecFrame({
+                collector,
+                mountRoot: `/${RID}`,
+                command: ["python3", "scripts/enrich.py"],
+                exitCode: 0,
+                durationMs: 100,
+                provenance: {
+                    disabled: false,
+                    reads: [{ path: "/etc/passwd", layers: ["preload"] }],
+                    writes: [{ path: `/${RID}/runs/run-001/de/output/result.csv`, layers: ["inotify"] }],
+                    deletes: [],
+                },
+            });
             const manifest: ArtifactManifestEntry[] = [{ stepId: "de", runId: "run-001", path: "output/result.csv", size: 0, type: "output", hash: "" }];
 
             const result = await reconcileManifestWithDisk({

--- a/harness/src/execution/reconcile-manifest.ts
+++ b/harness/src/execution/reconcile-manifest.ts
@@ -45,9 +45,9 @@ export interface ReconcileManifestInput {
     /** Collector backing the manifest; mutated to reflect drops/rehashes. */
     collector: ProvenanceCollector;
     /**
-     * Operational logging seam; omitted falls back to no-op. Attestation is
-     * fail-fast, so what this records — which entry was dropped, which input
-     * could not be hashed — is the account of why a step died.
+     * Operational logging seam; omitted falls back to no-op. What this records
+     * — which entry or input was dropped, which input could not be hashed — is
+     * the sole account of why lineage changed or a step died.
      */
     logger?: Logger;
 }
@@ -128,8 +128,13 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
  *
  * `artifacts`-source reads are the step's OWN files (mutating, dropped by the
  * registration translator), so they are not attested and not hashed here.
- * Lineage attestation is fail-fast: an input we cannot hash (gone, or resolving
- * outside the analysis tree) throws rather than registering a hashless edge.
+ * Lineage attestation is fail-fast for drift: an input that should be on disk
+ * and is not (ENOENT) throws rather than registering a hashless edge. A read
+ * that resolves OUTSIDE the analysis tree is dropped from lineage instead —
+ * the sandbox can legitimately open paths above its mount (`/{resourceId}/..`
+ * is the container root) and a capture layer may report them; that is out of
+ * scope, not drift, and failing the step over it killed real analyses in the
+ * field. Dropping still registers no hashless edge, which is the invariant.
  */
 async function fillInputHashesFromDisk(
     collector: ProvenanceCollector,
@@ -145,26 +150,31 @@ async function fillInputHashesFromDisk(
         if (ref.source === "artifacts") continue;
         if (hasValidContentHash(ref.hash)) continue;
 
-        // Each throw below is logged before it is raised. The thrown message reaches
-        // `failStep` as one opaque string and everything downstream of that is
-        // scrubbed, so naming the site and the offending ref HERE is what makes a
-        // fail-fast attestation distinguishable from a registry rejection after the
-        // fact — the read's `source` in particular says whether the step declared
+        // Every throw below is logged before it is raised, and every drop is
+        // logged as it happens. The thrown message reaches `failStep` as one
+        // opaque string and everything downstream of that is scrubbed, so naming
+        // the site and the offending ref HERE is the only account of why a step
+        // died — the read's `source` in particular says whether the step declared
         // this input at all.
         const attestation = { path: ref.path, source: ref.source, refRunId: ref.runId, refStepId: ref.stepId };
 
         // `ref.path` is the absolute container path `/{resourceId}/...`; strip the
         // mount segment and map the tail onto the host workspace root. `path.join`
         // normalizes any `..`, and the bound confines the read to the analysis tree.
+        // An out-of-tree resolution is dropped, not thrown: it is not an attestable
+        // lineage edge, but it is also not drift — mirrors the out-of-bounds output
+        // skip in `reconcileManifestWithDisk` and the directory drop below.
         const containerPrefix = `/${resourceId}`;
         if (ref.path !== containerPrefix && !ref.path.startsWith(containerPrefix + "/")) {
-            logger.error("input read resolves outside the analysis tree", { ...attestation, throwSite: "container-prefix-bound" });
-            throw new Error(`[reconcile-manifest] input read resolves outside the analysis tree: path=${ref.path} stepId=${stepId} runId=${runId}`);
+            logger.warn("dropping out-of-tree input from lineage", { ...attestation, boundSite: "container-prefix" });
+            collector.dropInput(ref);
+            continue;
         }
         const hostPath = path.join(resourceRoot, ref.path.slice(containerPrefix.length + 1));
         if (hostPath !== resourceRoot && !hostPath.startsWith(resourceRoot + path.sep)) {
-            logger.error("input read resolves outside the analysis tree", { ...attestation, hostPath, throwSite: "workspace-root-bound" });
-            throw new Error(`[reconcile-manifest] input read resolves outside the analysis tree: path=${ref.path} stepId=${stepId} runId=${runId}`);
+            logger.warn("dropping out-of-tree input from lineage", { ...attestation, hostPath, boundSite: "workspace-root" });
+            collector.dropInput(ref);
+            continue;
         }
 
         let info;

--- a/harness/src/execution/reconcile-manifest.ts
+++ b/harness/src/execution/reconcile-manifest.ts
@@ -27,7 +27,7 @@ import type { ProvenanceCollector } from "../provenance/collector.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { computeSha256File, hasValidContentHash } from "../lib/fs-helpers.js";
-import { artifactReconcileDropped } from "../lib/metrics.js";
+import { artifactReconcileDropped, lineageInputDropped } from "../lib/metrics.js";
 
 export interface ReconcileManifestInput {
     /** Absolute host root of the analysis's workspace tree. */
@@ -113,7 +113,7 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
         reconciled.push({ ...entry, hash, size: info.size });
     }
 
-    await fillInputHashesFromDisk(collector, workspaceRoot, resourceId, runId, stepId, logger);
+    await fillInputHashesFromDisk(collector, workspaceRoot, resourceId, runId, stepId, agentId, logger);
 
     return { manifest: reconciled, droppedCount };
 }
@@ -142,6 +142,7 @@ async function fillInputHashesFromDisk(
     resourceId: string,
     runId: string,
     stepId: string,
+    agentId: string,
     logger: Logger,
 ): Promise<void> {
     const resourceRoot = path.resolve(workspaceRoot);
@@ -167,12 +168,14 @@ async function fillInputHashesFromDisk(
         const containerPrefix = `/${resourceId}`;
         if (ref.path !== containerPrefix && !ref.path.startsWith(containerPrefix + "/")) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, boundSite: "container-prefix" });
+            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "container-prefix" });
             collector.dropInput(ref);
             continue;
         }
         const hostPath = path.join(resourceRoot, ref.path.slice(containerPrefix.length + 1));
         if (hostPath !== resourceRoot && !hostPath.startsWith(resourceRoot + path.sep)) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, hostPath, boundSite: "workspace-root" });
+            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "workspace-root" });
             collector.dropInput(ref);
             continue;
         }
@@ -197,6 +200,7 @@ async function fillInputHashesFromDisk(
             // non-file drop above. A genuinely missing FILE (ENOENT) still fails fast
             // as drift; a directory is not drift.
             logger.debug("dropping non-file input from lineage", attestation);
+            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "directory" });
             collector.dropInput(ref);
             continue;
         }

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -3,6 +3,7 @@
  *
  * Instruments:
  *   - cortex.artifact.reconcile.dropped — counter for missing manifest entries
+ *   - cortex.artifact.reconcile.input_dropped — counter for lineage input drops
  */
 
 import { metrics } from "@opentelemetry/api";
@@ -13,4 +14,11 @@ export const artifactReconcileDropped = meter.createCounter("cortex.artifact.rec
     description:
         "Manifest entries dropped because their on-disk file was missing at " +
         "registration time (writes-then-deletes, renames). Tagged by agent_id, step_id.",
+});
+
+export const lineageInputDropped = meter.createCounter("cortex.artifact.reconcile.input_dropped", {
+    description:
+        "Tracked input reads dropped from lineage at reconcile because they are " +
+        "not content-attestable files of the analysis (directory reads, " +
+        "out-of-tree resolutions). Tagged by agent_id, step_id, reason.",
 });

--- a/harness/src/provenance/collector.ts
+++ b/harness/src/provenance/collector.ts
@@ -181,7 +181,9 @@ export class ProvenanceCollector {
      * Called by sandbox exec provenance frame processing.
      *
      * @param mountPath - The workspace mount path (e.g., "/a1/data" or "/a1" for single-mount)
-     * @param relativePath - Path relative to the mount root
+     * @param relativePath - Path relative to the mount root; or, for a frame
+     *   report naming somewhere outside the mount, the verbatim absolute path
+     *   (see `stripMountPrefix`)
      * @param hash - SHA-256 hash of the file content, or null if file no longer exists
      * @param context - Explicit classification context from the caller. When provided,
      *   the collector uses it directly instead of classifying from the path.
@@ -193,7 +195,12 @@ export class ProvenanceCollector {
 
         // Use explicit context if provided, otherwise fall back to path classification
         const classification = context ?? classifyReadPath(relativePath, this.stepId, this.runId, this.dependsOn);
-        const fullPath = `${mountPath}/${relativePath}`;
+        // A still-absolute `relativePath` is a report the caller could not
+        // relativize — it names somewhere outside the mount. It rides verbatim:
+        // prepending the mount root would forge an in-tree name for a foreign
+        // path, and reconcile would then see phantom drift (a missing file,
+        // which fails the step) instead of an out-of-tree read (which it drops).
+        const fullPath = relativePath.startsWith("/") ? relativePath : `${mountPath}/${relativePath}`;
 
         // Resolve fileId for data-source inputs via materialized file metadata map
         let fileId: string | undefined;

--- a/harness/src/provenance/collector.ts
+++ b/harness/src/provenance/collector.ts
@@ -323,10 +323,11 @@ export class ProvenanceCollector {
      * Drop an input ref from lineage entirely — removes it from the tracked-input
      * map and from every record's `inputs` array (identity match, since the refs
      * are shared objects). `reconcileManifestWithDisk` calls this for a read that
-     * resolves to a directory (e.g. an `ls` / `list.files` of a mount): the
-     * inotify frame tracks the open, but a directory is not a content-attestable
-     * file artifact and must never reach registration. Mirrors the output-side
-     * non-file drop.
+     * is not a content-attestable file of this analysis: one resolving to a
+     * directory (e.g. an `ls` / `list.files` of a mount, which the inotify frame
+     * tracks as an open), or one resolving outside the analysis tree (e.g.
+     * `/{resourceId}/..`, the container root). Neither may reach registration.
+     * Mirrors the output-side non-file and out-of-bounds drops.
      */
     dropInput(ref: InputRef): void {
         for (const [key, val] of this.inputAccesses) {

--- a/harness/src/provenance/exec-frame.test.ts
+++ b/harness/src/provenance/exec-frame.test.ts
@@ -75,6 +75,53 @@ describe("feedExecFrame", () => {
         expect(rec.inputs[0]!.runId).toBe("run-002");
     });
 
+    test("a read outside the mount keeps its own name on the ref", () => {
+        // A path no hook should have let through. Prepending the mount root
+        // would forge the in-tree name `/a1/etc/passwd` and reconcile would
+        // fail the step over a missing file; verbatim, reconcile recognizes
+        // it as out-of-tree and drops it.
+        const collector = new ProvenanceCollector({ stepId: "s", runId: "r" });
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/x.py"],
+            exitCode: 0,
+            durationMs: 5,
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/etc/passwd", layers: ["preload"] }],
+                writes: [],
+                deletes: [],
+            },
+        });
+        const refs = collector.getTrackedInputs();
+        expect(refs).toHaveLength(1);
+        expect(refs[0]!.path).toBe("/etc/passwd");
+    });
+
+    test("separators doubled at the mount boundary collapse to the canonical name", () => {
+        // POSIX-wise `/a1//data/x.csv` names `/a1/data/x.csv`; the ref must land
+        // on the canonical form so it maps into the host tree and dedups.
+        const collector = new ProvenanceCollector({ stepId: "s", runId: "r" });
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/x.py"],
+            exitCode: 0,
+            durationMs: 5,
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/a1//data/inputs/Lab/counts.csv", layers: ["python"] }],
+                writes: [],
+                deletes: [],
+            },
+        });
+        const refs = collector.getTrackedInputs();
+        expect(refs).toHaveLength(1);
+        expect(refs[0]!.path).toBe("/a1/data/inputs/Lab/counts.csv");
+        expect(refs[0]!.source).toBe("data");
+    });
+
     test("missing frame degrades to no inputs without throwing", () => {
         const collector = new ProvenanceCollector({ stepId: "s", runId: "r" });
         expect(() =>

--- a/harness/src/provenance/exec-frame.ts
+++ b/harness/src/provenance/exec-frame.ts
@@ -17,10 +17,16 @@ import type { ProvenanceFrame } from "../sandbox/types.js";
 import { classifyReadPath, type ProvenanceCollector, type ObservedWrite } from "./collector.js";
 import type { InputRef } from "./types.js";
 
-/** Strip the `/{resourceId}/` mount prefix from an absolute frame path. */
+/**
+ * Strip the `/{resourceId}/` mount prefix from an absolute frame path.
+ * Separators doubled at the boundary collapse (`/{rid}//a` → `a`) so an
+ * in-mount name lands on its canonical relative form. A path not under the
+ * mount comes back unchanged — still absolute — and the collector carries it
+ * verbatim (see `trackInputAccess`).
+ */
 export function stripMountPrefix(mountRoot: string, absPath: string): string {
     const prefix = mountRoot.endsWith("/") ? mountRoot : `${mountRoot}/`;
-    return absPath.startsWith(prefix) ? absPath.slice(prefix.length) : absPath;
+    return absPath.startsWith(prefix) ? absPath.slice(prefix.length).replace(/^\/+/, "") : absPath;
 }
 
 export interface FeedExecFrameArgs {

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -248,7 +249,32 @@ func (pt *ProvenanceTracker) parseDatagram(data []byte) {
 	pt.recordOp(op, dg.Path, dg.Layer)
 }
 
+// underWatchDir reports whether a cleaned absolute path lies within one of the
+// watch dirs. Entries carry a trailing slash, so this also excludes a watch dir
+// itself — a read of the mount root is a directory, never an attestable file.
+func underWatchDir(path string, dirs []string) bool {
+	for _, d := range dirs {
+		if strings.HasPrefix(path, d) {
+			return true
+		}
+	}
+	return false
+}
+
 func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
+	// Canonicalize and re-check here, the one point every layer converges on:
+	// each hook filters by string prefix on whatever path its caller passed,
+	// which need not be canonical. "/{id}/.." literally starts with the watch
+	// dir "/{id}/" yet names its parent, so it survives the hook's filter and
+	// reaches the host as a tracked read that resolves above the mount root —
+	// which the host cannot attest, and fails the step over. Filtering on the
+	// cleaned path makes each hook's own check an optimization and this the
+	// boundary.
+	path = filepath.Clean(path)
+	if !underWatchDir(path, pt.watchDirs) {
+		return
+	}
+
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 	opMap := pt.ops[op]

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -76,7 +77,7 @@ func NewProvenanceTracker(id string, watchDirs []string) *ProvenanceTracker {
 		socketPath: socketPath,
 		rlogPath:   socketPath + ".rlog",
 		watchDirs:  watchDirs,
-		stopCh: make(chan struct{}),
+		stopCh:     make(chan struct{}),
 		ops: map[string]map[string]map[string]bool{
 			"read":   {},
 			"write":  {},
@@ -272,6 +273,11 @@ func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 	// boundary.
 	path = filepath.Clean(path)
 	if !underWatchDir(path, pt.watchDirs) {
+		// A dropped report never reaches the host, so nothing over there can
+		// account for it — this line is the only trace of a hook-filter leak.
+		if sandboxLogLevel == logLevelDebug {
+			log.Printf("[provenance] dropping out-of-tree report op=%s layer=%s path=%q", op, layer, path)
+		}
 		return
 	}
 

--- a/images/sandbox-base/server/provenance_recordop_test.go
+++ b/images/sandbox-base/server/provenance_recordop_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+)
+
+// The watch dir as provenanceWatchDirs builds it: absolute, trailing slash.
+const testWatchDir = "/019f6a20-1a3b-7000-a942-ae871e5de040/"
+
+func newTestTracker() *ProvenanceTracker {
+	return &ProvenanceTracker{
+		watchDirs: []string{testWatchDir},
+		ops:       make(map[string]map[string]map[string]bool),
+	}
+}
+
+func recordedPaths(pt *ProvenanceTracker, op string) []string {
+	var out []string
+	for p := range pt.ops[op] {
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestRecordOp_DropsParentOfMountRoot(t *testing.T) {
+	// "/{id}/.." string-prefix-matches the watch dir but names its parent. The
+	// host maps it to a host path above the workspace root, cannot attest it,
+	// and fails the step with lineage_attestation.
+	pt := newTestTracker()
+	pt.recordOp("read", "/019f6a20-1a3b-7000-a942-ae871e5de040/..", "ld_preload")
+
+	if got := recordedPaths(pt, "read"); len(got) != 0 {
+		t.Fatalf("parent of mount root must not be recorded; got %v", got)
+	}
+}
+
+func TestRecordOp_DropsTraversalOutOfTree(t *testing.T) {
+	pt := newTestTracker()
+	pt.recordOp("read", "/019f6a20-1a3b-7000-a942-ae871e5de040/../../../etc/passwd", "ld_preload")
+
+	if got := recordedPaths(pt, "read"); len(got) != 0 {
+		t.Fatalf("traversal outside the tree must not be recorded; got %v", got)
+	}
+}
+
+func TestRecordOp_DropsMountRootItself(t *testing.T) {
+	// A read of the mount root is a directory, never an attestable file.
+	pt := newTestTracker()
+	pt.recordOp("read", "/019f6a20-1a3b-7000-a942-ae871e5de040", "inotify")
+
+	if got := recordedPaths(pt, "read"); len(got) != 0 {
+		t.Fatalf("mount root itself must not be recorded; got %v", got)
+	}
+}
+
+func TestRecordOp_KeepsInTreeRead(t *testing.T) {
+	pt := newTestTracker()
+	want := "/019f6a20-1a3b-7000-a942-ae871e5de040/data/inputs/f1/counts.csv"
+	pt.recordOp("read", want, "python")
+
+	got := recordedPaths(pt, "read")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("in-tree read must survive; want [%s], got %v", want, got)
+	}
+}
+
+func TestRecordOp_CanonicalizesInTreePath(t *testing.T) {
+	// R's normalizePath(mustWork=FALSE) leaves ".." intact whenever a component
+	// does not exist yet — the common case for a write to a new output file.
+	// Such a path still resolves inside the tree and must be recorded, but under
+	// its canonical name so it dedups against the other layers' reports of it.
+	pt := newTestTracker()
+	pt.recordOp("write", "/019f6a20-1a3b-7000-a942-ae871e5de040/runs/r1/T3S1/scripts/../output/enrich.csv", "r")
+	pt.recordOp("write", "/019f6a20-1a3b-7000-a942-ae871e5de040/runs/r1/T3S1/output/enrich.csv", "inotify")
+
+	got := recordedPaths(pt, "write")
+	want := "/019f6a20-1a3b-7000-a942-ae871e5de040/runs/r1/T3S1/output/enrich.csv"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("both layers must fold onto the canonical path; want [%s], got %v", want, got)
+	}
+	if layers := pt.ops["write"][want]; !layers["r"] || !layers["inotify"] {
+		t.Fatalf("both layers must be attributed; got %v", layers)
+	}
+}


### PR DESCRIPTION
## What & why

A customer's enrichment step died with `lineage_attestation`, taking the whole run with it. The `Logger` seam released in 0.3.0 named the cause on its first occurrence — the exact record from their log:

```
[reconcile-manifest] input read resolves outside the analysis tree
  path:      /019f6a20-1a3b-7000-a942-ae871e5de040/..
  hostPath:  /Users/…/.inflexa/analyses
  throwSite: workspace-root-bound
  → errorClass: lineage_attestation   (run 2bd3be95, T3S1, enrichment-agent)
```

A capture layer reported a read of `/{resourceId}/..`. The analysis tree mounts at `/{resourceId}`, so inside the container that path is `/` — the container root. Opening it is benign and says nothing about the analysis. But `fillInputHashesFromDisk` maps container paths onto the host by string arithmetic, and `path.join(resourceRoot, "..")` lands above the workspace root, tripping the bound guard. (Reproduced: the computed `hostPath` matches the logged one byte-for-byte.)

**The guard was right; the throw was the defect.** An out-of-tree read is not drift — nothing about the analysis changed and no lineage edge is at risk. It is a read of something the analysis does not track, the same category as a directory read (`ls` of a mount), which this very function already drops eleven lines further on. Dropping upholds the spec's invariant — *never register a hashless lineage edge* — exactly as a throw does, without destroying a legitimate analysis.

The asymmetry was visible in a single file. `reconcileManifestWithDisk` skipped an out-of-bounds **output** with a warn (`reconcile-manifest.ts:77`); `fillInputHashesFromDisk` threw on an out-of-bounds **input** (`:165`). Same guard, same threat, both comments citing `../../etc/passwd`, opposite verdicts.

### Two independent fixes

**Harness — `fillInputHashesFromDisk`.** Both bounds (container-prefix and workspace-root) now drop the ref via `collector.dropInput` and continue, logged at **warn** with the ref, resolved `hostPath`, and a `boundSite` discriminator. Warn rather than debug because — unlike an ordinary `ls` — an out-of-tree read means a capture layer reported something it should have filtered: not worth a dead analysis, but worth noticing. **Fail-fast is unchanged for genuine drift**: an in-tree input missing at reconcile (`ENOENT`) still throws, as does an unexpected `stat` failure.

**Sandbox — `recordOp`.** The point where all four capture layers converge now canonicalizes with `filepath.Clean` and re-checks the watch dirs, so each hook's prefix filter becomes an optimization and the server is the boundary. A hook filters on the path its caller passed, which need not be canonical: `/{resourceId}/..` string-prefix-matches the watch dir `/{resourceId}/` while naming its parent, so it survives every hook's own filter. This also covers R's `normalizePath(mustWork = FALSE)`, which leaves `..` intact whenever a component does not yet exist — the common case for a write to a new output file, and a second latent emitter the reported path never came from.

The two are deliberately independent. The harness fix ships via npm and holds on **any** sandbox image, which matters because `lib-store.yml` is `workflow_dispatch`-only and `:latest`-tagged — a host on an older image would otherwise keep failing.

### Verification

- Harness suite **1235 pass / 0 fail**; `tsc` clean; changed files lint clean.
- Go suite green, `go vet` clean.
- Each new guard test was confirmed to **fail against the old behavior** rather than pass vacuously — the harness one reproduces the customer's error verbatim (`path=/a1/..`), and all four Go guard tests fail without the fix.
- All 57 specs validate `--strict`.

### Not in scope

The inotify `IN_OPEN`-as-read classification (`provenance_inotify_linux.go:145`) — a separate change. Also unaddressed here: two unrelated bugs the same customer log exposed, filed as #139 (expired provider OAuth token) and #140 (vector indexing silently dropping files).

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`). — tests + typecheck clean; the changed files lint clean. Repo-wide `bun run lint` fails on a **pre-existing** issue in `scripts/smoke.mjs` (a typed-linting parserOptions error) that this PR does not touch.
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed. — two spec deltas, archived; both Purpose sections hand-rewritten.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** n/a — no analytical method changes. Behavior is spec'd in `artifact-manifest` and `sandbox-provenance-tracking` (deltas archived as `2026-07-17-drop-out-of-tree-lineage-reads`).
- [x] **Sandbox:** the security model is preserved, and this **tightens** rather than loosens it. No change to the workload uid, capabilities, `no-new-privileges`, egress posture, exec-endpoint signatures, mount read-only-ness, or resource limits. The one behavioral change is that `recordOp` now *refuses* reports whose canonical path lies outside the watch dirs — paths a hook previously let through. `/{resourceId}/../../../etc/passwd` used to string-prefix-match the watch dir and be reported as an in-tree read; it now canonicalizes to `/etc/passwd` and is dropped. The harness bound guard was the only thing that stopped such a path from being `stat`ed and hashed, and it remains in place — the sandbox simply stops emitting them. Canonicalization is **lexical** (`filepath.Clean`), not `realpath`: the layers report *names*, not inodes, so resolving symlinks would make the reported path disagree with the name the workload used.
- [x] **Provenance:** prior analyses remain reproducible, and the expected variance is documented. No path that *should* have been in a lineage graph leaves it: the hooks already filter on `PROVENANCE_DATA_PREFIXES`, so out-of-tree reads (`/usr/lib/python3/…`, `/mnt/refs/…`) were never tracked by design — the graph already describes only in-tree inputs, and dropping a leaked out-of-tree read **restores** that intent rather than degrading it. The variance is strictly in the safe direction: a step that previously died with no lineage at all now completes and registers its real, fully-attested edges. In-tree lineage is byte-identical, and every surviving input is still content-attested from disk with fail-fast on genuine drift.
