### PR TITLE
fix(harness,cli): token-exact embed truncation and per-item vector-index isolation

### DIFF
--- a/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/design.md
+++ b/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The local provider wraps the harness's OpenAI-shaped client pointed at a loopback `llama-server` sidecar (`baseURL = ${origin}/v1`). Every input is guarded by `guardInputLength` — a pure 1600-character cap applied in `embed()` *before* the sidecar is even launched. The cap is probabilistic: it assumes a chars-per-token density, and real content (dense scientific prose ≈ 2.69 chars/token, CJK ≈ 2.76) crosses the model's hard 512-position ceiling well under 1600 chars, drawing an HTTP 500 per over-length input. `bge-small` cannot accept more than 512 positions regardless of server flags, so client-side bounding is mandatory; the only question is how the bound is computed.
+
+The pinned server build (`b9310`) serves `POST /tokenize` — the exact tokenizer of the loaded model, in the same process that will serve the embed. Measured ground truth: a 1589-char guarded input tokenizes to 590 content tokens, and the server rejects it as 592 — the `[CLS]`/`[SEP]` pair costs 2, so the real content budget is 510.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An input the guard passes can **never** be rejected as over-length — exact, not probabilistic.
+- Keep as much of each document as the ceiling allows: these are retrieval documents; a worst-case-density char cap would discard most of a typical document that token-exact truncation keeps.
+- Zero cost for the common case (short file descriptions) and bounded, small cost for over-length documents.
+- Measurement failure degrades the input bound, never the embed.
+
+**Non-Goals:**
+
+- Guarding the api-key path. Its endpoint/model set is open (user-configured), no tokenize endpoint exists in the OpenAI-compatible contract, and its ~8k ceiling makes precision nearly worthless (any generous char cap keeps real documents whole). Its rejections are contained per-item by the harness change `isolate-vector-index-failures`. A generic optional `maxInputChars` on the harness client is a possible follow-up, not this change.
+- Chunk-then-mean-pool. Truncation (keep the head) is retained: the salient topic of these documents sits up front, and mean-pooled chunk vectors would be qualitatively unlike the api-key path's single-vector embeds.
+- Caching token counts across calls. Inputs are embedded once on their write path; a cache buys nothing.
+
+## Decisions
+
+**Token-exact via `/tokenize`, not a lower char cap, not a bundled tokenizer.** The only *provable* char cap is 510 chars (worst-case one token per char) — it discards ~⅔ of a typical document; any higher cap is the same probabilistic bet that caused the bug. Bundling a tokenizer (WordPiece vocab or tiktoken-style) adds a dependency and a drift risk against the model actually loaded; `/tokenize` is the loaded model's own tokenizer, free, and pinned with the server build.
+
+**Budget 510 content tokens.** 512 minus the `[CLS]`/`[SEP]` wrap, matching the measured 590→592 discrepancy. `/tokenize` is called without special tokens, measuring content only; the budget already reserves the pair.
+
+**Fast path on UTF-16 length.** `text.length <= 510` returns unchanged with no round-trip. Sound because a WordPiece token consumes at least one codepoint and a codepoint is at least one UTF-16 code unit, so token count ≤ `length`. This covers the dominant input class (one-sentence descriptions).
+
+**Measure once, cut proportionally to the *measured* density, re-measure; bounded rounds.** For a text measuring `n > 510` tokens, cut at `510 × (length/n) × 0.95` with the existing word-boundary backoff, then re-measure the candidate. Density is near-uniform within a document, so the first proportional cut typically lands; one more overshoot-scaled shrink round follows, then the fallback. Re-measuring every candidate (rather than trusting the 0.95 margin) is the point — density varies within a document (prose lede, then a dense table), and the guarantee must be exact. Alternatives rejected:
+- *Binary search on cut position*: log₂(n) round-trips for the same answer proportional cutting reaches in 1–2.
+- *Reconstruct the prefix from `with_pieces`*: pieces are the tokenizer's normalized surface (lowercased, `##` continuations), so a joined prefix embeds mutated text and couples the code to WordPiece internals. Measure-and-cut keeps the tokenizer a black box that only ever answers "how many".
+
+**Deterministic fallback: hard cut at 510 code units.** The landing zone both for exhausted rounds and for any `/tokenize` failure (error, timeout, non-JSON body). Provably fits with no tokenizer, so the embed proceeds on every path — degraded input bound, never a failed embed. All tokenize interaction returns `Result` per the CLI's neverthrow discipline; a tokenize `err` selects the fallback rather than propagating.
+
+**Guard moves after `ensureReady`; the ready handle carries the origin.** Today the guard is pure and runs before launch; token measurement needs the live sidecar, so `embed()` becomes `ensureReady → fit each text → provider.embed`. `/tokenize` lives at the server root while the handle exposes only `${origin}/v1`, so the launch site (which has the origin in scope) puts it on the handle rather than any caller string-parsing it back out. The tokenize request sends the minted key — whether the pinned build gates `/tokenize` behind the key is verified at implementation, but sending it is correct in both cases. Each tokenize request carries its own bounded timeout so a wedged server degrades to the fallback instead of hanging the embed path.
+
+## Risks / Trade-offs
+
+- [Over-length documents now cost 1–3 loopback round-trips before embedding] → each is a few ms against a local server, only over-length inputs pay it, and the alternative (worst-case char cap) pays in permanently lost document tail instead.
+- [`/tokenize` response shape drifts on a future server upgrade] → the runtime is hash-pinned (`llama_runtime.ts`); an upgrade is a deliberate act that re-verifies the endpoint, and any response-shape surprise lands in the fallback path, not a failure.
+- [The 0.95 margin under-uses the budget slightly when the first cut fits] → a few tokens of headroom traded for converging in one round on nearly all documents.
+- [Word-boundary backoff can shorten a fallback cut below 510 units] → acceptable; the backoff only trims a dangling partial word, and correctness (≤510 tokens) is unaffected.
+
+## Migration Plan
+
+None: no signature, schema, or dimension change. Previously truncated-at-1600 documents re-embed with more (or all) of their content the next time their write path runs; existing index entries are untouched until then.
+
+## Open Questions
+
+- Whether the pinned build gates `/tokenize` behind the API key — resolved by a one-off check at implementation time; the request sends the key either way.

--- a/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The local embedding provider guards the bge-small 512-token per-input ceiling with a 1600-character cap whose own arithmetic exceeds the ceiling (1600 ÷ its assumed 3.1 chars/token = 516 tokens), and real content tokenizes denser still (measured 2.69 chars/token for gene-name/statistics-heavy prose → ~594 tokens). Guarded inputs draw HTTP 500s from `llama-server`, violating the `local-embeddings` spec requirement that an over-length input never surface as a raw server error — and silently degrading `workspace_search`, since the harness swallows indexing failures (issue #140, observed on a customer machine).
+
+## What Changes
+
+- `guardInputLength`'s probabilistic character cap is replaced by token-exact truncation: token counts are measured with the sidecar's own `/tokenize` endpoint — the same process and tokenizer that serves the embed, available on the pinned server build with no new dependency.
+- The budget is 510 content tokens (512 minus the `[CLS]`/`[SEP]` pair the tokenizer wraps around content), and the guarantee is exact: an input the guard passes can never be rejected as over-length.
+- Inputs of ≤510 UTF-16 code units skip measurement entirely (a WordPiece token consumes at least one code unit, so token count cannot exceed length) — the typical one-sentence file description costs no round-trip.
+- Long inputs that actually fit are embedded whole: documents in the ~1600–2000-character range that the current cap blindly cuts are recovered when they measure ≤510 tokens.
+- Over-length inputs are cut proportionally to their measured chars-per-token density (word-boundary backoff retained, head kept) and re-measured until they fit, within a bounded number of rounds; exhaustion or any `/tokenize` failure degrades to a provably-fitting 510-code-unit hard cut — measurement can never fail an embed.
+- The guard moves from before sidecar launch to after readiness (it needs the live sidecar), and the ready handle carries the server origin (`/tokenize` lives at the root, not under `/v1`).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `local-embeddings`: the input-length guard requirement changes from "truncate or chunk client-side" (mechanism unspecified, currently realized as a character cap that does not actually guarantee the ceiling) to token-exact truncation with a hard guarantee, a measurement-free fast path, and a provable fallback. The guard concern moves out of the sidecar-lifecycle requirement into its own requirement.
+
+## Impact
+
+- `cli/src/modules/embedding/local-provider.ts` — `guardInputLength` replaced, guard relocated after `ensureReady`, ready-handle type gains the origin, tokenize client added (single caller, stays in-file). The `TODO(robustness)` naming token-aware truncation as the real fix is discharged.
+- `openspec/specs/local-embeddings/spec.md` — delta as above.
+- Tests on the existing stub-sidecar rig (fast path, fitting-long-input, truncation convergence, fallback on tokenize failure).
+- No new dependencies. Vector width (384) and existing indexes untouched — truncation changes input length, not output dimensions.
+- The api-key path deliberately keeps no guard here: its endpoint/model set is open (user-configured `baseURL`/`model`), no tokenizer is available in its contract, and its practical ceiling is ~16× higher; rejections there are contained per-item by the harness change `isolate-vector-index-failures`.

--- a/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/specs/local-embeddings/spec.md
+++ b/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/specs/local-embeddings/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Sidecar lifecycle is lazy, loopback-only, and reaped
+
+The provider SHALL spawn `llama-server` lazily on first `embed()` (a process that never embeds never spawns it), bind it to `127.0.0.1` on an ephemerally allocated free port, and protect it with a per-spawn minted API key delivered through the child process's environment — never through argv, where it would be readable in the host's process listing. Readiness SHALL require two gates: the server's public health endpoint reporting the model loaded, then one authenticated request to a key-gated endpoint succeeding with the minted key — the health endpoint is unauthenticated upstream, so only the second gate proves the server on this port holds our key (and proves key delivery end-to-end at launch: an auth rejection of our own key fails the launch with an actionable error rather than surfacing at first embed). Every readiness request SHALL carry its own bounded timeout in addition to the shared deadline, so a half-open server that accepts connections but never answers cannot hold the launch past the advertised bound. Launch SHALL observe the child's exit: a child that exits before becoming healthy fails that launch attempt immediately (the health timeout is a bound, not a sentence), and a sidecar that exits after becoming ready SHALL invalidate the cached readiness so the next `embed()` spawns a fresh one — a mid-session crash costs one failed batch, never the rest of the process lifetime. The child's stderr SHALL be continuously drained into a bounded tail (an undrained pipe would eventually block the server); when a launch fails because the child exited, the drain's completion SHALL be awaited (the exit closes the pipe, so completion is prompt) before the tail is read, so the failure always includes the server's final diagnostics rather than racing them. Before any sidecar traffic flows, the proxy bypass SHALL compute the union of existing entries across both `NO_PROXY` spellings, add the loopback hosts, and write the same union to both spellings — a user's proxy-bypass entry present in only one spelling SHALL never be shadowed. Input-length guarding against the model's token ceiling is its own requirement (token-exact truncation) and runs against the ready sidecar.
+
+#### Scenario: Lazy spawn and reuse
+
+- **WHEN** `embed()` is called for the first time
+- **THEN** the sidecar is spawned, health-checked, and used — and subsequent `embed()` calls in the same process reuse it without a new spawn
+
+#### Scenario: No embed, no sidecar
+
+- **WHEN** a CLI process never calls `embed()`
+- **THEN** no sidecar process is ever spawned
+
+#### Scenario: Key is not visible in the process listing
+
+- **WHEN** the sidecar is running
+- **THEN** the minted API key appears in the child's environment, not in its command line
+
+#### Scenario: Readiness requires the key to be honored
+
+- **WHEN** a server on the sidecar's port answers the public health probe but rejects the minted key on the authenticated gate
+- **THEN** the launch fails with an error naming the authentication mismatch — it is never declared ready
+
+#### Scenario: Half-open server cannot hang the launch
+
+- **WHEN** a process on the sidecar's port accepts connections but never answers the readiness requests
+- **THEN** each request times out individually and the launch fails at the shared deadline, not later
+
+#### Scenario: Early exit fails fast with complete diagnostics
+
+- **WHEN** the spawned server exits before answering the health probe (port already bound, unloadable model)
+- **THEN** that launch attempt fails as soon as the exit is observed — not after the full readiness timeout — and the failure includes the server's complete final stderr tail, never a partially drained one
+
+#### Scenario: Crash after readiness triggers respawn
+
+- **WHEN** the sidecar exits after having served embeddings and `embed()` is called again
+- **THEN** the cached readiness is invalidated and a fresh sidecar is spawned for the new request
+
+#### Scenario: Single-spelling proxy bypass is preserved
+
+- **WHEN** the user has proxy-bypass entries in only one of `NO_PROXY`/`no_proxy` and the sidecar launches
+- **THEN** both spellings end up carrying the union of the user's entries plus loopback, and no previously honored entry is dropped from either
+
+## ADDED Requirements
+
+### Requirement: Input truncation is token-exact and guaranteed under the model's ceiling
+
+The provider SHALL bound every input under the model's 512-token per-input ceiling before it reaches the embeddings endpoint, budgeting 510 content tokens — the tokenizer wraps content in a `[CLS]`/`[SEP]` pair that consumes the remaining two positions. The bound SHALL be exact, not probabilistic: an input the guard passes SHALL never be rejected by the server as over-length. Token counts SHALL be measured with the ready sidecar's own `/tokenize` endpoint — the same process and tokenizer that serves the embed — at the server root (not under `/v1`), sending the minted API key, with a bounded per-request timeout, counting content tokens only (no special tokens; the budget already reserves the pair).
+
+An input of at most 510 UTF-16 code units SHALL pass unchanged with no measurement round-trip — a WordPiece token consumes at least one code unit, so its token count cannot exceed its length. A longer input SHALL first be measured whole and pass unchanged when it fits the budget. An input measuring over budget SHALL be truncated keeping the head, cut proportionally to its measured chars-per-token density with the cut backed off to a word boundary when one sits near it, and every candidate SHALL be re-measured before use, within a bounded number of measurement rounds. When the rounds are exhausted, or when any `/tokenize` interaction fails (error, timeout, malformed body), the provider SHALL fall back to a hard cut at 510 code units — which provably fits without a tokenizer — so measurement can never fail an embed. Tokenize interaction SHALL flow as `Result` values per the CLI's error discipline; a measurement failure selects the fallback rather than propagating into the embed's error channel.
+
+#### Scenario: Short input skips measurement
+
+- **WHEN** an input of at most 510 UTF-16 code units is embedded
+- **THEN** it is embedded unchanged and no `/tokenize` request is made
+
+#### Scenario: Long input that fits is embedded whole
+
+- **WHEN** an input longer than 510 code units measures at or under 510 content tokens
+- **THEN** it is embedded unchanged — no character cap discards content that fits the token budget
+
+#### Scenario: Over-length input is truncated to a verified fit
+
+- **WHEN** an input measures over 510 content tokens
+- **THEN** a head-keeping, word-boundary-backed prefix whose re-measured token count is at or under 510 is embedded, and the server never rejects it as over-length
+
+#### Scenario: Measurement failure degrades to the provable bound
+
+- **WHEN** a `/tokenize` request fails or the bounded truncation rounds are exhausted
+- **THEN** the provider embeds the input hard-cut at 510 code units and returns a valid embedding — the embed does not fail because measuring failed

--- a/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-17-token-exact-embedding-truncation/tasks.md
@@ -1,0 +1,22 @@
+## 1. Plumbing: expose what the guard needs
+
+- [x] 1.1 Carry the server `origin` on the ready sidecar handle (the launch site building `${origin}/v1` has it in scope); update the test launcher stubs that construct handles
+- [x] 1.2 Add the in-file tokenize client: `POST {origin}/tokenize` with the minted key and a bounded per-request timeout, returning `Result<number, _>` (content token count, no special tokens); bridge fetch/JSON throws into `Result` at the boundary
+
+## 2. Token-exact guard
+
+- [x] 2.1 Replace `guardInputLength` with the budgeted fit: 510-code-unit fast path (no round-trip) → measure whole, pass when ≤510 → proportional cut at `510 × measured density × 0.95` with the existing word-boundary backoff → re-measure, one overshoot-scaled retry → hard cut at 510 code units on exhaustion or any tokenize failure
+- [x] 2.2 Move the guard in `embed()` from before `ensureReady` to after it (fit each text against the ready sidecar, then call the wrapped provider); discharge the `TODO(robustness)` comment and rewrite the `MAX_INPUT_CHARS` block comment to document the token-exact rationale and the 510 budget
+- [x] 2.3 Verify against the pinned `b9310` server whether `/tokenize` is key-gated (send the key regardless); note the answer in the tokenize client's comment
+
+## 3. Tests (stub-sidecar rig)
+
+- [x] 3.1 Fast path: a ≤510-code-unit input embeds with zero `/tokenize` requests recorded by the stub
+- [x] 3.2 Recovery: a >510-char input the stub tokenizer measures ≤510 tokens embeds unchanged
+- [x] 3.3 Convergence: an over-budget input (stub tokenizer with non-uniform density) embeds as a word-boundary prefix whose measured count is ≤510, and the embeddings endpoint never sees an over-length input
+- [x] 3.4 Fallback: `/tokenize` failing (error and timeout) embeds the 510-code-unit hard cut and the embed still succeeds
+
+## 4. Verify
+
+- [x] 4.1 `bun run typecheck`, `bun run lint`, `bun test`; `bun run format:file` on touched `src/` files
+- [x] 4.2 `openspec validate token-exact-embedding-truncation`

--- a/cli/openspec/specs/local-embeddings/spec.md
+++ b/cli/openspec/specs/local-embeddings/spec.md
@@ -173,7 +173,7 @@ The local embedding runtime SHALL be an official prebuilt `llama.cpp` release ar
 
 ### Requirement: Sidecar lifecycle is lazy, loopback-only, and reaped
 
-The provider SHALL spawn `llama-server` lazily on first `embed()` (a process that never embeds never spawns it), bind it to `127.0.0.1` on an ephemerally allocated free port, and protect it with a per-spawn minted API key delivered through the child process's environment — never through argv, where it would be readable in the host's process listing. Readiness SHALL require two gates: the server's public health endpoint reporting the model loaded, then one authenticated request to a key-gated endpoint succeeding with the minted key — the health endpoint is unauthenticated upstream, so only the second gate proves the server on this port holds our key (and proves key delivery end-to-end at launch: an auth rejection of our own key fails the launch with an actionable error rather than surfacing at first embed). Every readiness request SHALL carry its own bounded timeout in addition to the shared deadline, so a half-open server that accepts connections but never answers cannot hold the launch past the advertised bound. Launch SHALL observe the child's exit: a child that exits before becoming healthy fails that launch attempt immediately (the health timeout is a bound, not a sentence), and a sidecar that exits after becoming ready SHALL invalidate the cached readiness so the next `embed()` spawns a fresh one — a mid-session crash costs one failed batch, never the rest of the process lifetime. The child's stderr SHALL be continuously drained into a bounded tail (an undrained pipe would eventually block the server); when a launch fails because the child exited, the drain's completion SHALL be awaited (the exit closes the pipe, so completion is prompt) before the tail is read, so the failure always includes the server's final diagnostics rather than racing them. Before any sidecar traffic flows, the proxy bypass SHALL compute the union of existing entries across both `NO_PROXY` spellings, add the loopback hosts, and write the same union to both spellings — a user's proxy-bypass entry present in only one spelling SHALL never be shadowed. Embedding requests SHALL guard the model's 512-token per-input ceiling client-side (truncate or chunk before sending) — an over-length input must never surface as a raw server error.
+The provider SHALL spawn `llama-server` lazily on first `embed()` (a process that never embeds never spawns it), bind it to `127.0.0.1` on an ephemerally allocated free port, and protect it with a per-spawn minted API key delivered through the child process's environment — never through argv, where it would be readable in the host's process listing. Readiness SHALL require two gates: the server's public health endpoint reporting the model loaded, then one authenticated request to a key-gated endpoint succeeding with the minted key — the health endpoint is unauthenticated upstream, so only the second gate proves the server on this port holds our key (and proves key delivery end-to-end at launch: an auth rejection of our own key fails the launch with an actionable error rather than surfacing at first embed). Every readiness request SHALL carry its own bounded timeout in addition to the shared deadline, so a half-open server that accepts connections but never answers cannot hold the launch past the advertised bound. Launch SHALL observe the child's exit: a child that exits before becoming healthy fails that launch attempt immediately (the health timeout is a bound, not a sentence), and a sidecar that exits after becoming ready SHALL invalidate the cached readiness so the next `embed()` spawns a fresh one — a mid-session crash costs one failed batch, never the rest of the process lifetime. The child's stderr SHALL be continuously drained into a bounded tail (an undrained pipe would eventually block the server); when a launch fails because the child exited, the drain's completion SHALL be awaited (the exit closes the pipe, so completion is prompt) before the tail is read, so the failure always includes the server's final diagnostics rather than racing them. Before any sidecar traffic flows, the proxy bypass SHALL compute the union of existing entries across both `NO_PROXY` spellings, add the loopback hosts, and write the same union to both spellings — a user's proxy-bypass entry present in only one spelling SHALL never be shadowed. Input-length guarding against the model's token ceiling is its own requirement (token-exact truncation) and runs against the ready sidecar.
 
 #### Scenario: Lazy spawn and reuse
 
@@ -215,10 +215,31 @@ The provider SHALL spawn `llama-server` lazily on first `embed()` (a process tha
 - **WHEN** the user has proxy-bypass entries in only one of `NO_PROXY`/`no_proxy` and the sidecar launches
 - **THEN** both spellings end up carrying the union of the user's entries plus loopback, and no previously honored entry is dropped from either
 
-#### Scenario: Over-length input is guarded
+### Requirement: Input truncation is token-exact and guaranteed under the model's ceiling
 
-- **WHEN** an input longer than the model's 512-token ceiling is embedded
-- **THEN** the provider truncates or chunks it client-side and returns a valid embedding, never a raw server error
+The provider SHALL bound every input under the model's 512-token per-input ceiling before it reaches the embeddings endpoint, budgeting 510 content tokens — the tokenizer wraps content in a `[CLS]`/`[SEP]` pair that consumes the remaining two positions. The bound SHALL be exact, not probabilistic: an input the guard passes SHALL never be rejected by the server as over-length. Token counts SHALL be measured with the ready sidecar's own `/tokenize` endpoint — the same process and tokenizer that serves the embed — at the server root (not under `/v1`), sending the minted API key, with a bounded per-request timeout, counting content tokens only (no special tokens; the budget already reserves the pair).
+
+An input of at most 510 UTF-16 code units SHALL pass unchanged with no measurement round-trip — a WordPiece token consumes at least one code unit, so its token count cannot exceed its length. A longer input SHALL first be measured whole and pass unchanged when it fits the budget. An input measuring over budget SHALL be truncated keeping the head, cut proportionally to its measured chars-per-token density with the cut backed off to a word boundary when one sits near it, and every candidate SHALL be re-measured before use, within a bounded number of measurement rounds. When the rounds are exhausted, or when any `/tokenize` interaction fails (error, timeout, malformed body), the provider SHALL fall back to a hard cut at 510 code units — which provably fits without a tokenizer — so measurement can never fail an embed. Tokenize interaction SHALL flow as `Result` values per the CLI's error discipline; a measurement failure selects the fallback rather than propagating into the embed's error channel.
+
+#### Scenario: Short input skips measurement
+
+- **WHEN** an input of at most 510 UTF-16 code units is embedded
+- **THEN** it is embedded unchanged and no `/tokenize` request is made
+
+#### Scenario: Long input that fits is embedded whole
+
+- **WHEN** an input longer than 510 code units measures at or under 510 content tokens
+- **THEN** it is embedded unchanged — no character cap discards content that fits the token budget
+
+#### Scenario: Over-length input is truncated to a verified fit
+
+- **WHEN** an input measures over 510 content tokens
+- **THEN** a head-keeping, word-boundary-backed prefix whose re-measured token count is at or under 510 is embedded, and the server never rejects it as over-length
+
+#### Scenario: Measurement failure degrades to the provable bound
+
+- **WHEN** a `/tokenize` request fails or the bounded truncation rounds are exhausted
+- **THEN** the provider embeds the input hard-cut at 510 code units and returns a valid embedding — the embed does not fail because measuring failed
 
 ### Requirement: Sidecar termination is escalated and signal-covered
 

--- a/cli/src/modules/embedding/local-provider.test.ts
+++ b/cli/src/modules/embedding/local-provider.test.ts
@@ -15,6 +15,7 @@ import {
     __setProxyBypassEnabledForTest,
     __setSidecarLauncherForTest,
     __setSpawnForTest,
+    __setTokenizeTimeoutForTest,
     createLocalEmbeddingProvider,
     launchWithBinary,
     pollLlamaHealth,
@@ -30,10 +31,12 @@ import { materializedLlamaServer } from "./llama_runtime.ts";
 const fakeSession = { scope: { kind: "analysis", analysisId: "test" } } as never;
 
 // The launcher handle type is intentionally not exported; a structural literal
-// (`baseURL` / `key` / `stop`, plus the optional `exited` for the crash-recovery
-// tests) satisfies the injected-launcher parameter.
+// (`baseURL` / `origin` / `key` / `stop`, plus the optional `exited` for the
+// crash-recovery tests) satisfies the injected-launcher parameter. `origin` is the
+// server root the token-exact fit hits `/tokenize` on.
 type StubHandle = {
     readonly baseURL: string;
+    readonly origin: string;
     readonly key: string;
     stop: () => Promise<void>;
     readonly exited?: Promise<number>;
@@ -46,15 +49,47 @@ function fixedVector(): number[] {
     return new Array(384).fill(c);
 }
 
+/** Uniform stub tokenizer: ~4 code units per token. */
+function uniformTokens(content: string): number {
+    return Math.ceil(content.length / 4);
+}
+
+/**
+ * Non-uniform stub tokenizer: the first {@link DENSE_PREFIX_CHARS} code units cost
+ * ~2 chars/token (dense), the rest ~4 chars/token. Because the fit only ever keeps head
+ * prefixes, every candidate shares char 0, so this density is consistent across
+ * re-measured prefixes — and a cut scaled to the whole-input average density overshoots,
+ * exercising the re-measure loop rather than landing in one round.
+ */
+const DENSE_PREFIX_CHARS = 400;
+function nonUniformTokens(content: string): number {
+    const dense = Math.min(content.length, DENSE_PREFIX_CHARS);
+    const sparse = Math.max(0, content.length - DENSE_PREFIX_CHARS);
+    return Math.ceil(dense / 2) + Math.ceil(sparse / 4);
+}
+
 /**
  * Build a fetch handler modeling the real (b9310, verified live) llama-server auth
  * shape: `/health` is PUBLIC (no auth honored; `healthStatus` simulates the 503 it
- * answers during model load), `/props` and `/v1/embeddings` are auth-gated (401 to
- * a wrong or missing key). `/v1/embeddings` returns fixed 384-dim vectors and
- * records the last inputs so the over-length guard can be asserted from the
- * server's point of view.
+ * answers during model load), `/props`, `/tokenize`, and `/v1/embeddings` are auth-gated
+ * (401 to a wrong or missing key). `/v1/embeddings` returns fixed 384-dim vectors and
+ * records the last inputs so the token-exact fit can be asserted from the server's point
+ * of view. `/tokenize` returns `{ tokens: number[] }` whose length is the count from the
+ * injected `tokenize` model (default {@link uniformTokens}); `tokenizeStatus` forces an
+ * error status and `tokenizeHang` holds the request open forever, so the fallback paths
+ * are drivable.
  */
-function llamaShapedFetch(serverKey: string, opts?: { readonly healthStatus?: number; readonly onEmbedInputs?: (inputs: string[]) => void }) {
+function llamaShapedFetch(
+    serverKey: string,
+    opts?: {
+        readonly healthStatus?: number;
+        readonly onEmbedInputs?: (inputs: string[]) => void;
+        readonly tokenize?: (content: string) => number;
+        readonly tokenizeStatus?: number;
+        readonly tokenizeHang?: boolean;
+        readonly onTokenize?: (content: string) => void;
+    },
+) {
     return async function fetchHandler(req: Request): Promise<Response> {
         const url = new URL(req.url);
         const authed = req.headers.get("authorization") === `Bearer ${serverKey}`;
@@ -64,6 +99,16 @@ function llamaShapedFetch(serverKey: string, opts?: { readonly healthStatus?: nu
         }
         if (url.pathname === "/props") {
             return authed ? Response.json({ model_path: "/model.gguf" }) : new Response("unauthorized", { status: 401 });
+        }
+        if (url.pathname === "/tokenize" && req.method === "POST") {
+            if (!authed) return new Response("unauthorized", { status: 401 });
+            const body = (await req.json()) as { content: string };
+            opts?.onTokenize?.(body.content);
+            // Never resolve — models a wedged server so the fit's per-request timeout fires.
+            if (opts?.tokenizeHang) return new Promise<Response>(() => {});
+            if (opts?.tokenizeStatus !== undefined && opts.tokenizeStatus !== 200) return new Response("tokenize error", { status: opts.tokenizeStatus });
+            const count = (opts?.tokenize ?? uniformTokens)(body.content);
+            return Response.json({ tokens: new Array(count).fill(0) });
         }
         if (url.pathname === "/v1/embeddings" && req.method === "POST") {
             if (!authed) return Response.json({ error: { message: "invalid api key" } }, { status: 401 });
@@ -77,13 +122,32 @@ function llamaShapedFetch(serverKey: string, opts?: { readonly healthStatus?: nu
 }
 
 /** A {@link llamaShapedFetch} stub on an ephemeral port, for the launcher-level tests. */
-function startStub(expectedKey: string, opts?: { readonly healthStatus?: number }) {
+function startStub(
+    expectedKey: string,
+    opts?: {
+        readonly healthStatus?: number;
+        readonly tokenize?: (content: string) => number;
+        readonly tokenizeStatus?: number;
+        readonly tokenizeHang?: boolean;
+    },
+) {
     let lastInputs: string[] = [];
+    const tokenizeInputs: string[] = [];
     const server = Bun.serve({
         port: 0,
-        fetch: llamaShapedFetch(expectedKey, { ...opts, onEmbedInputs: (inputs) => (lastInputs = inputs) }),
+        fetch: llamaShapedFetch(expectedKey, {
+            ...opts,
+            onEmbedInputs: (inputs) => (lastInputs = inputs),
+            onTokenize: (content) => void tokenizeInputs.push(content),
+        }),
     });
-    return { origin: `http://127.0.0.1:${server.port}`, getLastInputs: (): string[] => lastInputs, stop: (): void => void server.stop(true) };
+    return {
+        origin: `http://127.0.0.1:${server.port}`,
+        getLastInputs: (): string[] => lastInputs,
+        getTokenizeInputs: (): string[] => tokenizeInputs,
+        getTokenizeCount: (): number => tokenizeInputs.length,
+        stop: (): void => void server.stop(true),
+    };
 }
 
 afterEach(() => {
@@ -94,6 +158,7 @@ afterEach(() => {
     __setSpawnForTest(null);
     __setProcessScanForTest(null);
     __setProxyBypassEnabledForTest(true);
+    __setTokenizeTimeoutForTest(null);
 });
 
 describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
@@ -101,7 +166,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         let launches = 0;
         __setSidecarLauncherForTest(() => {
             launches++;
-            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: "http://127.0.0.1:1/v1", key: "k", stop: () => Promise.resolve() }));
+            return Promise.resolve(
+                ok<StubHandle, ProviderError>({ baseURL: "http://127.0.0.1:1/v1", origin: "http://127.0.0.1:1", key: "k", stop: () => Promise.resolve() }),
+            );
         });
         const provider = createLocalEmbeddingProvider({ modelPath: "/nonexistent/path.gguf" });
         const outcome = await provider.embed([], fakeSession).match(
@@ -118,7 +185,7 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         let launches = 0;
         __setSidecarLauncherForTest(() => {
             launches++;
-            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() }));
+            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() }));
         });
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
@@ -152,7 +219,7 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         let launches = 0;
         __setSidecarLauncherForTest(() => {
             launches++;
-            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() }));
+            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() }));
         });
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
@@ -181,7 +248,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
     test("embed returns 384-dim vectors from the sidecar endpoint", async () => {
         const key = "test-key-vectors";
         const stub = startStub(key);
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() })));
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
             const vectors = await provider.embed(["a", "b"], fakeSession).match(
@@ -197,22 +266,131 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         }
     });
 
-    test("over-length input is truncated client-side so the server never sees >512 tokens", async () => {
-        const key = "test-key-guard";
+    test("fast path: a <=510-code-unit input embeds with zero /tokenize requests", async () => {
+        const key = "test-key-fast";
         const stub = startStub(key);
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() })));
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
-            // Way past the 1600-char budget; the guard must shrink it before the wire.
-            const huge = "word ".repeat(20_000);
-            const outcome = await provider.embed([huge], fakeSession).match(
+            const short = "a short one-sentence file description, well under the token budget";
+            expect(short.length).toBeLessThanOrEqual(510);
+            const vectors = await provider.embed([short], fakeSession).match(
                 (v) => v,
                 () => null,
             );
-            expect(outcome).not.toBeNull();
+            expect(vectors).not.toBeNull();
+            // Embedded unchanged, and no round-trip: ≤510 code units cannot exceed 510 tokens.
+            expect(stub.getLastInputs()).toEqual([short]);
+            expect(stub.getTokenizeCount()).toBe(0);
+        } finally {
+            stub.stop();
+        }
+    });
+
+    test("recovery: a >510-char input the tokenizer measures <=510 tokens embeds unchanged", async () => {
+        const key = "test-key-recovery";
+        // ~4 chars/token uniform: 2000 code units → 500 tokens, under the 510 budget.
+        const stub = startStub(key, { tokenize: uniformTokens });
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
+        try {
+            const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
+            const fits = "abcd ".repeat(400); // 2000 code units — measured (not fast path), yet fits
+            expect(fits.length).toBeGreaterThan(510);
+            expect(uniformTokens(fits)).toBeLessThanOrEqual(510);
+            const vectors = await provider.embed([fits], fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            expect(vectors).not.toBeNull();
+            // A long document that fits the token budget is embedded WHOLE — no char cap cuts it.
+            expect(stub.getLastInputs()).toEqual([fits]);
+            // It passed through measurement (the whole-input measure), not the fast path.
+            expect(stub.getTokenizeCount()).toBe(1);
+        } finally {
+            stub.stop();
+        }
+    });
+
+    test("convergence: an over-budget input with non-uniform density embeds as a verified word-boundary prefix", async () => {
+        const key = "test-key-convergence";
+        const stub = startStub(key, { tokenize: nonUniformTokens });
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
+        try {
+            const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
+            // 3000 code units of space-delimited words; nonUniformTokens measures it well over
+            // budget (200 dense + 650 sparse = 850 tokens), so it must be cut and re-measured.
+            const over = "abcd ".repeat(600);
+            expect(nonUniformTokens(over)).toBeGreaterThan(510);
+            const vectors = await provider.embed([over], fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            expect(vectors).not.toBeNull();
             const seen = stub.getLastInputs();
             expect(seen.length).toBe(1);
-            expect(seen[0]!.length).toBeLessThanOrEqual(1600);
+            const embedded = seen[0]!;
+            // A head-keeping prefix of the original, cut strictly shorter.
+            expect(over.startsWith(embedded)).toBe(true);
+            expect(embedded.length).toBeLessThan(over.length);
+            // Cut at a word boundary: the original character right after the prefix is a space.
+            expect(over[embedded.length]).toBe(" ");
+            // The endpoint never saw an over-length input — the embedded text re-measures within
+            // budget by the SAME tokenizer.
+            expect(nonUniformTokens(embedded)).toBeLessThanOrEqual(510);
+        } finally {
+            stub.stop();
+        }
+    });
+
+    test("fallback: /tokenize answering 500 embeds the 510-code-unit hard cut and still succeeds", async () => {
+        const key = "test-key-fallback-500";
+        const stub = startStub(key, { tokenizeStatus: 500 });
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
+        try {
+            const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
+            const over = "abcd ".repeat(600); // 3000 code units, over budget
+            const vectors = await provider.embed([over], fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            // The embed succeeds even though measurement failed.
+            expect(vectors).not.toBeNull();
+            const embedded = stub.getLastInputs()[0]!;
+            // Hard cut at 510 code units (word-boundary-backed) — a provable fit with no tokenizer.
+            expect(over.startsWith(embedded)).toBe(true);
+            expect(embedded.length).toBeLessThanOrEqual(510);
+        } finally {
+            stub.stop();
+        }
+    });
+
+    test("fallback: /tokenize hanging past the timeout embeds the 510-code-unit hard cut and still succeeds", async () => {
+        const key = "test-key-fallback-hang";
+        const stub = startStub(key, { tokenizeHang: true });
+        // A short per-request bound so the wedged /tokenize degrades to the fallback fast.
+        __setTokenizeTimeoutForTest(100);
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
+        try {
+            const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
+            const over = "abcd ".repeat(600);
+            const vectors = await provider.embed([over], fakeSession).match(
+                (v) => v,
+                () => null,
+            );
+            expect(vectors).not.toBeNull();
+            const embedded = stub.getLastInputs()[0]!;
+            expect(over.startsWith(embedded)).toBe(true);
+            expect(embedded.length).toBeLessThanOrEqual(510);
         } finally {
             stub.stop();
         }
@@ -252,7 +430,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
             // Only the first handle carries the resolvable exit; the replacement's exit
             // never settles, so its watcher stays dormant.
             const exited = launches === 1 ? firstExited : new Promise<number>(() => {});
-            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve(), exited }));
+            return Promise.resolve(
+                ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve(), exited }),
+            );
         });
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
@@ -292,7 +472,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         __setSidecarLauncherForTest(() => {
             launches++;
             const exited = launches === 1 ? firstExited : new Promise<number>(() => {});
-            return Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve(), exited }));
+            return Promise.resolve(
+                ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve(), exited }),
+            );
         });
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
@@ -353,7 +535,7 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
             stopLocalSidecar();
             // Now the launch resolves: the map sees a superseded epoch, reaps its own
             // process, and caches nothing.
-            resolveLaunch({ baseURL: `${stub.origin}/v1`, key, stop: stopSpy });
+            resolveLaunch({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: stopSpy });
             const outcome = await embedOutcome;
             expect(outcome.ok).toBe(false);
             expect(stopSpy).toHaveBeenCalledTimes(1);
@@ -382,7 +564,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         process.env.http_proxy = "http://127.0.0.1:9";
         process.env.NO_PROXY = "corp.example.com";
         process.env.no_proxy = "corp.example.com";
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() })));
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
             const vectors = await provider.embed(["through the bypass"], fakeSession).match(
@@ -417,7 +601,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         // The user set the bypass in ONLY the lowercase spelling; uppercase is empty.
         process.env.NO_PROXY = "";
         process.env.no_proxy = "corp.example.com";
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() })));
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
             await provider.embed(["x"], fakeSession).match(
@@ -456,7 +642,9 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         process.env.NO_PROXY = "corp.example.com";
         process.env.no_proxy = "corp.example.com";
         __setProxyBypassEnabledForTest(false);
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop: () => Promise.resolve() })));
+        __setSidecarLauncherForTest(() =>
+            Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop: () => Promise.resolve() })),
+        );
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
             const outcome = await provider.embed(["through the dead proxy"], fakeSession).match(
@@ -479,7 +667,7 @@ describe("createLocalEmbeddingProvider (sidecar lifecycle)", () => {
         const key = "test-key-reap";
         const stub = startStub(key);
         const stop = mock(() => Promise.resolve());
-        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, key, stop })));
+        __setSidecarLauncherForTest(() => Promise.resolve(ok<StubHandle, ProviderError>({ baseURL: `${stub.origin}/v1`, origin: stub.origin, key, stop })));
         try {
             const provider = createLocalEmbeddingProvider({ modelPath: "/model.gguf" });
             await provider.embed(["one"], fakeSession).match(

--- a/cli/src/modules/embedding/local-provider.ts
+++ b/cli/src/modules/embedding/local-provider.ts
@@ -71,27 +71,65 @@ export const LOCAL_EMBEDDING_DIMENSIONS = 384;
 const LOCAL_EMBEDDING_MODEL = "bge-small-en-v1.5";
 
 /**
- * Character budget applied to every input before it reaches the sidecar.
+ * Content-token budget every input is fitted under before it reaches the embeddings
+ * endpoint.
  *
- * bge-small's context ceiling is 512 WordPiece tokens; llama-server answers an
- * over-length input with HTTP 500 ("input is too large to process"), so the
- * guard must live client-side (the harness sends whole documents — step
- * summaries and run syntheses — un-chunked, so over-length inputs do occur). We
- * cannot tokenize without pulling in the model's tokenizer, so we bound by
- * characters: English prose runs ~4 chars/token, and we budget at a deliberately
- * conservative ~3.1 chars/token (512 tokens → 1600 chars, leaving headroom for
- * the 2 special tokens and for token-dense content like citations, markdown, and
- * numbers) so even dense prose stays under 512 and the server never 500s.
+ * bge-small's hard ceiling is 512 WordPiece positions per input, and llama-server
+ * answers an over-length input with HTTP 500 ("input is too large to process"), so the
+ * bound MUST hold client-side (the harness sends whole documents — step summaries, run
+ * syntheses — un-chunked, so over-length inputs do occur). The budget is 510, not 512:
+ * the tokenizer wraps content in a `[CLS]`/`[SEP]` pair that consumes the remaining two
+ * positions (measured live — a 590-content-token input is rejected as 592), and
+ * `/tokenize` is called WITHOUT special tokens so it measures content only, leaving the
+ * pair already reserved here.
  *
- * Truncation (keep the head) is chosen over chunk-then-mean-pool: these inputs
- * are retrieval documents whose salient topic sits up front (a synthesis leads
- * with its overview/conclusions; a summary with its lede), mean-pooling several
- * chunk vectors dilutes that signal and would make local vectors qualitatively
- * unlike the api-key path's, and truncation matches the prior in-process
- * realization (llama.cpp silently truncated to its context) — no retrieval
- * regression, far less code.
+ * The bound is token-EXACT, not a chars-per-token estimate: counts come from the ready
+ * sidecar's own `/tokenize` — the exact tokenizer of the loaded model, in the process
+ * that serves the embed — so an input the fit passes can NEVER be rejected as
+ * over-length. A char cap cannot promise that: the only provable char cap is 510 (worst
+ * case one token per char), which discards ~⅔ of a typical document, and any higher cap
+ * is the same probabilistic bet that let dense prose (~2.69 chars/token) cross 512 and
+ * draw a 500. `/tokenize` is the loaded model's own tokenizer — free, no bundled-vocab
+ * dependency, and no drift against the model actually loaded.
+ *
+ * The same 510 doubles as the fast-path length threshold and the fallback cut, both
+ * sound because a WordPiece token spans at least one UTF-16 code unit: an input of ≤510
+ * code units cannot exceed 510 tokens (skip measurement entirely — the dominant
+ * one-sentence-description case pays no round-trip), and a hard cut at 510 code units
+ * provably fits with no tokenizer (the deterministic landing zone when measurement
+ * fails).
+ *
+ * Truncation keeps the HEAD rather than chunk-then-mean-pool: these are retrieval
+ * documents whose salient topic sits up front (a synthesis leads with its conclusions,
+ * a summary with its lede); mean-pooling chunk vectors dilutes that signal and would
+ * make local vectors qualitatively unlike the api-key path's single-vector embeds.
  */
-const MAX_INPUT_CHARS = 1600;
+const CONTENT_TOKEN_BUDGET = 510;
+
+/**
+ * Safety margin on a proportional cut: aim slightly under budget so the first cut
+ * typically lands in a single round. A few tokens of headroom traded for convergence —
+ * density is near-uniform within a document, so 0.95 almost always fits immediately.
+ */
+const PROPORTIONAL_MARGIN = 0.95;
+
+/**
+ * Measurement rounds after the whole-input measurement before degrading to the fallback:
+ * one proportional cut, then one overshoot-scaled shrink. Density can vary within a
+ * document (prose lede, then a dense table), so each candidate is re-measured rather
+ * than trusting the margin; two rounds converge on essentially every real input, and
+ * exhaustion degrades to the provable 510-code-unit cut.
+ */
+const PROPORTIONAL_ROUNDS = 2;
+
+/**
+ * Per-request timeout on a single `/tokenize` call, distinct from any whole-batch bound.
+ * A healthy loopback `/tokenize` answers in sub-ms, so on every real path this never
+ * fires; it exists solely to bound a half-open server that accepts the connection but
+ * never answers. Measurement must never fail an embed, so a timed-out request becomes
+ * the deterministic hard-cut fallback rather than a hung embed path.
+ */
+const TOKENIZE_REQUEST_TIMEOUT_MS = 2_000;
 
 /**
  * How long to wait for the sidecar's whole readiness sequence (`/health` 200,
@@ -141,6 +179,13 @@ const STOP_GRACE_MS = 2_000;
 type SidecarHandle = {
     /** OpenAI base URL for the harness client — `http://127.0.0.1:<port>/v1`. */
     readonly baseURL: string;
+    /**
+     * Server root origin (`http://127.0.0.1:<port>`), carried beside `baseURL` because
+     * `/tokenize` (the token-exact fit's measurement endpoint) lives at the root, not
+     * under `/v1`. The launch site has the origin in scope and records it here so the
+     * fit never string-parses it back out of `baseURL`.
+     */
+    readonly origin: string;
     /**
      * The per-spawn minted key every request presents; the authenticated `/props`
      * gate verified at launch that the server on this port holds it.
@@ -270,27 +315,132 @@ let launchEpoch = 0;
  */
 let proxyBypassEnabled = true;
 
+/**
+ * Per-request `/tokenize` timeout the fit uses. Its own mutable so a test can drive the
+ * measurement-timeout → fallback path fast ({@link __setTokenizeTimeoutForTest}) without
+ * waiting the production {@link TOKENIZE_REQUEST_TIMEOUT_MS}. Always the production value
+ * in a real run.
+ */
+let tokenizeRequestTimeoutMs = TOKENIZE_REQUEST_TIMEOUT_MS;
+
 /** Build a `provider`-kind {@link ProviderError} for a local-runtime fault. */
 function providerFault(message: string, retryable: boolean): ProviderError {
     return { type: "provider", retryable, message };
 }
 
 /**
- * Truncate to {@link MAX_INPUT_CHARS}, backing off to the last word boundary when
- * one sits near the cut so a dangling partial word is not embedded. A single
- * enormous token (rare for these inputs) falls back to the hard cut rather than
- * collapsing the input.
+ * Measure `text`'s content-token count with the ready sidecar's own tokenizer via
+ * `POST {origin}/tokenize` — the exact tokenizer of the loaded model, in the same
+ * process that serves the embed. The body is `{ content }` and no special tokens are
+ * requested, so the count is content-only (the `[CLS]`/`[SEP]` pair is already reserved
+ * in {@link CONTENT_TOKEN_BUDGET}). The minted key is sent because the pinned b9310 build
+ * key-gates `/tokenize` (verified live against the pinned binary: a missing or wrong key
+ * answers 401, the minted key answers 200) — and sending it stays correct even if a
+ * future build stopped gating it. The response is `{ "tokens": number[] }`; the count is
+ * its length.
+ *
+ * Returns `Result` per the CLI's error discipline: fetch/JSON throws, a non-200 status,
+ * and a malformed body are all bridged into an `err` at the boundary so this never
+ * throws. {@link fitInput} consumes the error locally to select the fallback — it never
+ * reaches the embed's error channel — so `retryable` is a formality here.
  */
-function guardInputLength(text: string): string {
-    // TODO(robustness): the budget is tuned for ~3.1 chars/token English prose. CJK
-    // and emoji tokenize far denser (often <1 char/token), so a sub-MAX_INPUT_CHARS
-    // input of such text can still cross the model's 512-token ceiling and draw an
-    // HTTP 500 for that one request — a bounded per-request failure, not a wedge. The
-    // real fix is token-aware truncation, which needs the model's own tokenizer.
-    if (text.length <= MAX_INPUT_CHARS) return text;
-    const hardCut = text.slice(0, MAX_INPUT_CHARS);
+async function tokenizeCount(origin: string, key: string, text: string, timeoutMs: number): Promise<Result<number, ProviderError>> {
+    try {
+        const res = await fetch(`${origin}/tokenize`, {
+            method: "POST",
+            headers: { "content-type": "application/json", Authorization: `Bearer ${key}` },
+            body: JSON.stringify({ content: text }),
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (res.status !== 200) return err(providerFault(`The local embedding runtime's /tokenize endpoint answered ${res.status}.`, true));
+        // External JSON: the Array.isArray guard below validates the shape before the
+        // count is trusted, so this cast only names the one field we probe.
+        const body = (await res.json()) as { tokens?: unknown };
+        if (!Array.isArray(body.tokens)) {
+            return err(providerFault("The local embedding runtime's /tokenize endpoint returned an unexpected body (no tokens array).", true));
+        }
+        return ok(body.tokens.length);
+    } catch (cause) {
+        return err(providerFault(`Measuring token length via /tokenize failed: ${cause instanceof Error ? cause.message : String(cause)}`, true));
+    }
+}
+
+/**
+ * Back a cut off to the last word boundary when a space sits within the final 20% of the
+ * cut, so a dangling partial word is dropped without discarding a meaningful tail. A cut
+ * whose only near text is a single enormous token (rare for these inputs) is kept as the
+ * hard cut.
+ */
+function truncateAtWordBoundary(text: string, cut: number): string {
+    const hardCut = text.slice(0, cut);
     const lastSpace = hardCut.lastIndexOf(" ");
-    return lastSpace > MAX_INPUT_CHARS * 0.8 ? hardCut.slice(0, lastSpace) : hardCut;
+    return lastSpace > cut * 0.8 ? hardCut.slice(0, lastSpace) : hardCut;
+}
+
+/**
+ * The deterministic fallback: a hard cut at {@link CONTENT_TOKEN_BUDGET} code units,
+ * word-boundary-backed. It provably fits with no tokenizer — a WordPiece token spans at
+ * least one code unit, so ≤510 code units is ≤510 tokens — so measurement failure or
+ * exhausted rounds degrade the input bound, never the embed. Backoff may shorten it
+ * slightly, which only drops a partial word and cannot break the ≤510-token guarantee.
+ */
+function hardCutToBudget(text: string): string {
+    return truncateAtWordBoundary(text, CONTENT_TOKEN_BUDGET);
+}
+
+/**
+ * Cut `text` proportionally to its measured chars-per-token density, aimed at the token
+ * budget with the {@link PROPORTIONAL_MARGIN} margin, then backed off to a word boundary.
+ * `measuredTokens` is always over {@link CONTENT_TOKEN_BUDGET} at the call sites, so the
+ * target is strictly shorter than `text` and the fit makes progress every round.
+ */
+function proportionalCut(text: string, measuredTokens: number): string {
+    const target = Math.floor(CONTENT_TOKEN_BUDGET * (text.length / measuredTokens) * PROPORTIONAL_MARGIN);
+    return truncateAtWordBoundary(text, target);
+}
+
+/**
+ * Fit one input under the token budget against the ready sidecar, keeping the head:
+ *
+ * 1. ≤{@link CONTENT_TOKEN_BUDGET} code units → unchanged, no round-trip (a token spans
+ *    ≥1 code unit, so it cannot be over budget).
+ * 2. Measure the whole input; at or under budget → unchanged (a long document that
+ *    actually fits is embedded whole, not cut by a worst-case char cap).
+ * 3. Over budget → cut proportionally to the measured density and re-measure, up to
+ *    {@link PROPORTIONAL_ROUNDS} rounds (each round re-scales by the latest overshoot).
+ * 4. Rounds exhausted, or ANY `/tokenize` failure → {@link hardCutToBudget}.
+ *
+ * Never rejects: every path yields a fitting string, so measurement can never fail an
+ * embed.
+ */
+async function fitInput(origin: string, key: string, text: string): Promise<string> {
+    if (text.length <= CONTENT_TOKEN_BUDGET) return text;
+
+    const whole = await tokenizeCount(origin, key, text, tokenizeRequestTimeoutMs);
+    if (whole.isErr()) return hardCutToBudget(text);
+    if (whole.value <= CONTENT_TOKEN_BUDGET) return text;
+
+    let candidate = text;
+    let measured = whole.value;
+    for (let round = 0; round < PROPORTIONAL_ROUNDS; round++) {
+        candidate = proportionalCut(candidate, measured);
+        const remeasured = await tokenizeCount(origin, key, candidate, tokenizeRequestTimeoutMs);
+        if (remeasured.isErr()) return hardCutToBudget(text);
+        if (remeasured.value <= CONTENT_TOKEN_BUDGET) return candidate;
+        measured = remeasured.value;
+    }
+    return hardCutToBudget(text);
+}
+
+/**
+ * Fit every input in a batch under the token budget against the ready sidecar. Fitted in
+ * order; the dominant short-input case returns synchronously with no round-trip, and only
+ * over-length inputs pay measurement.
+ */
+async function fitInputs(handle: SidecarHandle, texts: readonly string[]): Promise<string[]> {
+    const fitted: string[] = [];
+    for (const text of texts) fitted.push(await fitInput(handle.origin, handle.key, text));
+    return fitted;
 }
 
 /**
@@ -681,7 +831,7 @@ export async function launchWithBinary(
             }),
         ]);
         if (readyOrExit.isOk()) {
-            return ok({ baseURL: `${origin}/v1`, key, exited: handle.exited, tail: handle.tail, stop: handle.terminate });
+            return ok({ baseURL: `${origin}/v1`, origin, key, exited: handle.exited, tail: handle.tail, stop: handle.terminate });
         }
         // Reap ours (a no-op if already gone). Guard the clear against a concurrent
         // launch having already re-set the slot to its own handle.
@@ -930,13 +1080,14 @@ export function createLocalEmbeddingProvider(deps: LocalEmbeddingProviderDeps): 
         // Matches the harness `createEmbeddingProvider` shortcut.
         if (texts.length === 0) return okAsync([]);
 
-        // Guard the 512-token ceiling before anything hits the wire.
-        const guarded = texts.map(guardInputLength);
-
         return new ResultAsync(
             ensureReady(deps.modelPath).then((rs) =>
                 rs.match(
-                    (sidecar) => sidecar.provider.embed(guarded, session),
+                    // The token-exact fit measures against the sidecar's own tokenizer, so
+                    // it runs AFTER readiness against the ready handle; the fitted texts
+                    // then embed. Fitting always yields a fitting string (never fails), so it
+                    // enters the Result chain through fromSafePromise.
+                    (sidecar) => ResultAsync.fromSafePromise(fitInputs(sidecar.handle, texts)).andThen((fitted) => sidecar.provider.embed(fitted, session)),
                     (e) => errAsync<number[][], ProviderError>(e),
                 ),
             ),
@@ -972,6 +1123,15 @@ export function __setSpawnForTest(fn: typeof spawnFor | null): void {
  */
 export function __setProxyBypassEnabledForTest(enabled: boolean): void {
     proxyBypassEnabled = enabled;
+}
+
+/**
+ * TEST ONLY. Override the per-request `/tokenize` timeout so a test can drive the
+ * measurement-timeout → hard-cut fallback fast against a hanging stub, instead of
+ * waiting the production {@link TOKENIZE_REQUEST_TIMEOUT_MS}. Pass `null` to restore it.
+ */
+export function __setTokenizeTimeoutForTest(ms: number | null): void {
+    tokenizeRequestTimeoutMs = ms ?? TOKENIZE_REQUEST_TIMEOUT_MS;
 }
 
 /**

--- a/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/design.md
+++ b/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`vectorIndexStepOutputs` (`src/execution/post-step-pipeline.ts`) is the vector-index enrichment stage of the post-step pipeline. It embeds and upserts each surviving file description plus the step summary into the per-analysis pgvector index. Today one try/catch spans index setup, the whole per-file loop, and the summary: any single embed/upsert failure warns once and abandons everything after it. The `artifact-manifest` spec makes the stage best-effort (indexing must never fail the step), which the fix preserves — only the granularity of degradation changes.
+
+The dominant real-world failure is a deterministic per-input rejection: a local embedding backend with a hard context ceiling answers one over-length document with an HTTP 500 on that input's own merits. Preventing those rejections is a CLI embedding-provider concern (cli change `token-exact-embedding-truncation`); this change makes the harness robust to whatever rejections still occur, from any `EmbeddingProvider` realization.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One rejected input costs exactly its own index entry — every other file and the summary still land.
+- Partial failure is observable in the logs: which item failed, and how many landed vs were lost.
+- The stage's contract is untouched: indexing failures never fail the step.
+
+**Non-Goals:**
+
+- Input truncation/chunking (provider-side; tracked in the cli tree).
+- Changing `synthesize-run.ts` (single document — its existing isolated try/catch already has per-item granularity) or `data-profile.ts` (indexing there is integrity-coupled by `data-profile-init`; loosening that is a separate spec decision).
+- Retrying failed items: the dominant rejection is deterministic for a given input, so a retry spends latency to reproduce the same failure.
+- Surfacing indexing degradation beyond logs (run events, UI). The logged counts are the minimum observability; a richer surface is future work.
+
+## Decisions
+
+**Index setup stays all-or-nothing.** `ensureSearchIndex` + store construction happen before the loop under their own catch; if the index cannot exist there is no meaningful per-item work, so setup failure degrades the whole stage exactly as today.
+
+**Per-item boundary is a local `indexOne(id, text, metadata) → boolean` helper.** Each call embeds and upserts one item, absorbing its own failure and logging it with the item `id` and `textLength`. `textLength` is logged because over-length input is the known failure driver — it lets a reader separate the oversized-document case from transient faults without logging the content itself (descriptions and summaries describe user data and stay out of logs). Alternative considered: collecting error objects and logging once at the end — rejected because the per-item log line carries per-item context (id, length) that an aggregate cannot, and the aggregate count is still emitted separately.
+
+**Counts, then a single summary warn.** The stage tallies `indexed`/`failed` and, when `failed > 0`, emits one `"indexed with failures"` warn with both counts. A partial index is invisible at the search surface — it returns fewer hits, never an error — so the counts are the only signal degradation happened at all.
+
+**Log level stays `warn`.** The spec defines the stage as best-effort degradation; `error` would misrepresent a tolerated condition. The logger keeps the existing `post-step.vector-index` namespace with `runId`/`stepId` as structured fields (bound once via `.with(...)`).
+
+**Loop stays sequential.** Isolation changes the failure boundary, not the concurrency model; parallelizing embeds is an unrelated performance decision.
+
+## Risks / Trade-offs
+
+- [A systematically failing backend now emits one warn per item instead of one per step] → bounded by the step's file count, and the summary-count warn gives the one-line view; noisy logs under total failure are preferable to a silent empty index.
+- [Per-item catch could mask a wedged backend as N independent failures] → the failure count in the summary warn makes "everything failed" visually distinct from "one item failed"; liveness of the provider is out of this stage's scope.
+
+## Migration Plan
+
+None required: internal function, no signature change, no schema change. Under partial failure, strictly more entries land in the index than before.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`vectorIndexStepOutputs` wraps the entire per-file embed/upsert loop **and** the step summary in a single try/catch that warns and swallows, so the first rejected input (e.g. an over-length document the embedding backend 500s on) abandons every remaining file and the summary for that step. The step still goes green, and the search surface returns fewer hits rather than an error — a customer-observed silent degradation of `workspace_search` (issue #140: 5 occurrences across 3 steps in one run, each single warn hiding an unknown number of lost entries).
+
+## What Changes
+
+- `vectorIndexStepOutputs` isolates each indexed item: every file description and the step summary is embedded and upserted under its own failure boundary, so one rejected input costs exactly its own entry.
+- Index setup (`ensureSearchIndex` + store construction) remains all-or-nothing — without an index there is nothing to index into, so setup failure still skips the whole stage.
+- Partial failure becomes observable: each failed item logs its id and text length, and a final warn reports how many items indexed vs failed. A partial index is invisible at the search surface, so the logged count is the only signal it happened.
+- The stage's contract with the step is unchanged: indexing failures never fail the step.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `artifact-manifest`: the vector-index enrichment stage's degradation granularity changes from per-step (one failure swallows the remaining items) to per-item (one failure costs one entry), and partial failure must be logged with counts.
+
+## Impact
+
+- `harness/src/execution/post-step-pipeline.ts` — `vectorIndexStepOutputs` restructured; no signature change.
+- `openspec/specs/artifact-manifest/spec.md` — the "enrichment stages degrade" requirement gains per-item granularity for vector indexing.
+- Tests for the new isolation behavior (one poisoned item; setup failure; failure counts).
+- Out of scope, deliberately: `synthesize-run.ts` (single document — already isolated), `data-profile.ts` (indexing is integrity-coupled there per `data-profile-init`; changing that is a separate spec decision), and input-length truncation itself (a CLI embedding-provider fix tracked in the cli tree as `token-exact-embedding-truncation`).
+- Not affected: vector dimensions, `vector(384/1536)` columns, HNSW indexes.

--- a/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/specs/artifact-manifest/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Integrity stages fail-fast; enrichment stages degrade
+
+`reconcileAndRegisterStepArtifacts` SHALL reconcile, then register, then
+`ArtifactRegistry.sync` the step's artifacts, and SHALL treat the whole sequence
+as fail-fast: a non-zero `externalFailed` SHALL throw with the
+per-file failure detail, and the sandbox-step body SHALL tear down the sandbox,
+mark the step failed, and re-raise so the parent's fail-fast cascade fires. The
+OSS `createNoopArtifactRegistry` returns `externalFailed: 0` and never trips
+this. The enrichment stages — file-metadata generation, step-summary generation,
+and vector indexing — SHALL run under `safeRun`/`safeRunValue` so any single
+failure degrades without failing the step.
+
+Within the vector-index stage, degradation SHALL be per-item: each surviving
+file description and the step summary SHALL be embedded and upserted under its
+own failure boundary, so one rejected input costs only its own index entry and
+every remaining item is still attempted. Index setup (ensuring the search index
+exists and constructing the store) SHALL remain all-or-nothing — a setup failure
+degrades the whole stage. Each per-item failure SHALL be logged with the item's
+id and input text length, and when at least one item fails the stage SHALL log a
+summary carrying the counts of items indexed and items failed — a partial index
+returns fewer search hits rather than an error, so the logged counts are the
+only signal that degradation occurred.
+
+#### Scenario: Registry rejection fails the step
+
+- **WHEN** `reconcileAndRegisterStepArtifacts` gets `externalFailed > 0` from registration
+- **THEN** it throws with the per-file detail and the step is marked failed
+
+#### Scenario: A degraded enrichment stage does not fail the step
+
+- **WHEN** vector indexing throws while indexing a step's outputs
+- **THEN** the failure is logged and swallowed and the step still completes
+
+#### Scenario: One rejected input costs only its own entry
+
+- **WHEN** embedding one file description fails while the step has other file descriptions and a summary
+- **THEN** every other file description and the summary are still embedded and upserted, and the step completes
+
+#### Scenario: Partial indexing is observable in the logs
+
+- **WHEN** at least one item fails to index while others succeed
+- **THEN** each failed item is logged with its id and text length, and a summary log reports the indexed and failed counts
+
+#### Scenario: Index setup failure degrades the whole stage
+
+- **WHEN** ensuring the search index exists fails before any item is indexed
+- **THEN** the stage logs the failure and indexes nothing, and the step still completes

--- a/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-17-isolate-vector-index-failures/tasks.md
@@ -1,0 +1,17 @@
+## 1. Restructure `vectorIndexStepOutputs`
+
+- [x] 1.1 Split index setup (`ensureSearchIndex` + `createVectorStore` + `searchIndexName`) into its own failure boundary: on failure, warn and return without attempting any item
+- [x] 1.2 Add a per-item boundary (`indexOne(id, text, metadata) → boolean`) that embeds and upserts one item, absorbing its failure and logging it with the item id and text length; bind `runId`/`stepId` once on the stage logger via `.with(...)`
+- [x] 1.3 Drive the surviving file descriptions and the step summary through the per-item boundary, tallying indexed/failed, and emit one summary warn carrying both counts when at least one item failed
+
+## 2. Tests (`post-step-pipeline` vector-index stage)
+
+- [x] 2.1 One poisoned item: embedding fails for a single file description — assert every other description and the summary still land in the vector store and the stage does not throw
+- [x] 2.2 Poisoned summary: the summary embed fails — assert all file descriptions still land
+- [x] 2.3 Setup failure: `ensureSearchIndex` fails — assert nothing is indexed and the stage does not throw
+- [x] 2.4 Observability: with a recording test logger, assert the per-item failure log carries the item id and text length and the summary log carries the indexed/failed counts
+
+## 3. Verify
+
+- [x] 3.1 `tsc -p tsconfig.json` and `bun test` pass; `bun run format:file` on touched `src/` files
+- [x] 3.2 `openspec validate isolate-vector-index-failures`

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -205,6 +205,17 @@ this. The enrichment stages — file-metadata generation, step-summary generatio
 and vector indexing — SHALL run under `safeRun`/`safeRunValue` so any single
 failure degrades without failing the step.
 
+Within the vector-index stage, degradation SHALL be per-item: each surviving
+file description and the step summary SHALL be embedded and upserted under its
+own failure boundary, so one rejected input costs only its own index entry and
+every remaining item is still attempted. Index setup (ensuring the search index
+exists and constructing the store) SHALL remain all-or-nothing — a setup failure
+degrades the whole stage. Each per-item failure SHALL be logged with the item's
+id and input text length, and when at least one item fails the stage SHALL log a
+summary carrying the counts of items indexed and items failed — a partial index
+returns fewer search hits rather than an error, so the logged counts are the
+only signal that degradation occurred.
+
 #### Scenario: Registry rejection fails the step
 
 - **WHEN** `reconcileAndRegisterStepArtifacts` gets `externalFailed > 0` from registration
@@ -214,6 +225,21 @@ failure degrades without failing the step.
 
 - **WHEN** vector indexing throws while indexing a step's outputs
 - **THEN** the failure is logged and swallowed and the step still completes
+
+#### Scenario: One rejected input costs only its own entry
+
+- **WHEN** embedding one file description fails while the step has other file descriptions and a summary
+- **THEN** every other file description and the summary are still embedded and upserted, and the step completes
+
+#### Scenario: Partial indexing is observable in the logs
+
+- **WHEN** at least one item fails to index while others succeed
+- **THEN** each failed item is logged with its id and text length, and a summary log reports the indexed and failed counts
+
+#### Scenario: Index setup failure degrades the whole stage
+
+- **WHEN** ensuring the search index exists fails before any item is indexed
+- **THEN** the stage logs the failure and indexes nothing, and the step still completes
 
 ### Requirement: Artifact upsert semantics
 

--- a/harness/src/execution/post-step-pipeline.test.ts
+++ b/harness/src/execution/post-step-pipeline.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Vector-index stage isolation tests (`vectorIndexStepOutputs`).
+ *
+ * The stage is best-effort and degrades per-item: one rejected embedding costs
+ * only its own index entry while every other file description and the step
+ * summary still land, and the step never fails. A partial index returns fewer
+ * search hits rather than an error, so these tests read what actually landed in
+ * the pgvector store — and, for the observability case where a log line is the
+ * only signal, the captured records.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { errAsync, okAsync } from "neverthrow";
+import type { Pool } from "pg";
+
+import { createCapturingLogger } from "../__tests__/setup/logger.js";
+import { withSchema } from "../__tests__/setup/postgres.js";
+import { makeLocalAuth } from "../auth/local-auth-context.js";
+import type { RunSession } from "../auth/types.js";
+import type { Logger } from "../lib/logger.js";
+import { ProvenanceCollector } from "../provenance/collector.js";
+import type { ProviderError } from "../providers/errors.js";
+import type { AgentChat, EmbeddingProvider } from "../providers/types.js";
+import type { ArtifactManifestEntry } from "../schemas/artifact-manifest.js";
+import type { StepSummary } from "../schemas/step-summary.js";
+import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
+import { searchIndexName } from "../workspace/search-config.js";
+import type { ArtifactRegistry } from "./artifact-registry.js";
+import type { FileMetadataEntry } from "./artifact-metadata.js";
+import { vectorIndexStepOutputs, type PostStepPipelineDeps } from "./post-step-pipeline.js";
+import type { PostStepArtifacts, PostStepContext, SandboxStepInput } from "../workflows/sandbox-step.js";
+
+const RUN_ID = "run-vec";
+const STEP_ID = "T1S1";
+const AGENT_ID = "test-agent";
+
+// `ensureSearchIndex` memoizes ensured index names for the process lifetime, and
+// the name derives from the analysis id — so a per-test id guarantees the stage
+// actually creates the index table inside that test's own schema.
+let analysisCounter = 0;
+function uniqueAnalysisId(): string {
+    return `analysis_vec_${Date.now().toString(36)}_${analysisCounter++}`;
+}
+
+function makeRunSession(analysisId: string): RunSession {
+    return {
+        identity: { user: "user-vec" },
+        scope: { kind: "analysis", analysisId },
+        provenance: { agentId: AGENT_ID, callPath: [AGENT_ID] },
+        runFrame: { runId: RUN_ID },
+        auth: makeLocalAuth(),
+    };
+}
+
+function makePostCtx(analysisId: string): PostStepContext {
+    // The vector-index stage reads only `input.{analysisId,runId,stepId,agentId}`
+    // and `session`; the remaining `SandboxStepInput` fields never reach it.
+    const input = { analysisId, runId: RUN_ID, stepId: STEP_ID, agentId: AGENT_ID } as unknown as SandboxStepInput;
+    return {
+        input,
+        session: makeRunSession(analysisId),
+        transcript: [],
+        writePrefix: "/unused",
+        sandboxId: "sbx-test",
+        lineageCollector: new ProvenanceCollector({ stepId: STEP_ID, runId: RUN_ID }),
+    };
+}
+
+function makeDeps(pool: Pool, embedding: EmbeddingProvider, logger: Logger): PostStepPipelineDeps {
+    // The vector-index stage consumes only pool, logger, and embedding; the other
+    // post-step seams are never touched here.
+    return {
+        pool,
+        logger,
+        embedding,
+        provider: {} as AgentChat,
+        workspaceFs: {} as WorkspaceFilesystem,
+        artifactRegistry: {} as ArtifactRegistry,
+        resolveWorkspaceRoot: (id) => id,
+        model: "test-model",
+    };
+}
+
+/** Embedding provider that rejects exactly the texts matching `poison`. */
+function embeddingRejecting(poison: (text: string) => boolean): EmbeddingProvider {
+    return {
+        dimensions: 3,
+        embed: (texts) => {
+            if (texts.some(poison)) {
+                const providerErr: ProviderError = { type: "provider", retryable: false, message: "embedding backend rejected input" };
+                return errAsync(providerErr);
+            }
+            return okAsync(texts.map(() => [0.1, 0.2, 0.3]));
+        },
+    };
+}
+
+function fileEntry(rel: string, description: string): FileMetadataEntry {
+    return {
+        dbPath: `runs/${RUN_ID}/${STEP_ID}/${rel}`,
+        description,
+        metadata: { path: rel, role: "step_output" },
+    };
+}
+
+function manifestEntry(rel: string): ArtifactManifestEntry {
+    return { stepId: STEP_ID, runId: RUN_ID, path: rel, size: 100, type: "output" };
+}
+
+function summaryOf(markdown: string): StepSummary {
+    return { stepId: STEP_ID, agentId: AGENT_ID, markdown };
+}
+
+function vectorId(analysisId: string, rel: string): string {
+    return `/${analysisId}/runs/${RUN_ID}/${STEP_ID}/${rel}`;
+}
+
+interface IndexedRow {
+    id: string;
+    metadata: Record<string, unknown>;
+}
+
+/** What actually landed in the per-analysis index, or `[]` if the table was never created. */
+async function readIndex(pool: Pool, analysisId: string): Promise<IndexedRow[]> {
+    const name = searchIndexName(analysisId);
+    const present = await pool.query<{ reg: string | null }>(`SELECT to_regclass($1) AS reg`, [name]);
+    if (!present.rows[0]?.reg) return [];
+    const res = await pool.query<{ vector_id: string; metadata: Record<string, unknown> }>(`SELECT vector_id, metadata FROM "${name}" ORDER BY vector_id`);
+    return res.rows.map((r) => ({ id: r.vector_id, metadata: r.metadata }));
+}
+
+describe("vectorIndexStepOutputs — per-item isolation", () => {
+    const cleanups: Array<() => Promise<void>> = [];
+    afterEach(async () => {
+        for (const drop of cleanups.splice(0)) await drop();
+    });
+
+    it("one poisoned file description costs only its own entry; the rest and the summary still land", async () => {
+        const analysisId = uniqueAnalysisId();
+        const { pool, drop } = await withSchema("vec-poisoned-file");
+        cleanups.push(drop);
+
+        const artifacts: PostStepArtifacts = {
+            metadataEntries: [
+                fileEntry("output/a.csv", "alpha description"),
+                fileEntry("output/poison.csv", "poison description"),
+                fileEntry("output/c.csv", "gamma description"),
+            ],
+            reconciledManifest: [manifestEntry("output/a.csv"), manifestEntry("output/poison.csv"), manifestEntry("output/c.csv")],
+            summary: summaryOf("## step summary"),
+        };
+        const deps = makeDeps(
+            pool,
+            embeddingRejecting((t) => t === "poison description"),
+            createCapturingLogger(),
+        );
+
+        // Direct await: a throw here would fail the test — the stage must swallow.
+        await vectorIndexStepOutputs(deps, makePostCtx(analysisId), artifacts);
+
+        const ids = (await readIndex(pool, analysisId)).map((r) => r.id);
+        expect(ids).toContain(vectorId(analysisId, "output/a.csv"));
+        expect(ids).toContain(vectorId(analysisId, "output/c.csv"));
+        expect(ids).toContain(vectorId(analysisId, "output/summary.md"));
+        expect(ids).not.toContain(vectorId(analysisId, "output/poison.csv"));
+        expect(ids).toHaveLength(3);
+    });
+
+    it("a poisoned summary still lands every file description", async () => {
+        const analysisId = uniqueAnalysisId();
+        const { pool, drop } = await withSchema("vec-poisoned-summary");
+        cleanups.push(drop);
+
+        const artifacts: PostStepArtifacts = {
+            metadataEntries: [fileEntry("output/a.csv", "alpha description"), fileEntry("output/b.csv", "beta description")],
+            reconciledManifest: [manifestEntry("output/a.csv"), manifestEntry("output/b.csv")],
+            summary: summaryOf("## poisoned summary"),
+        };
+        const deps = makeDeps(
+            pool,
+            embeddingRejecting((t) => t === "## poisoned summary"),
+            createCapturingLogger(),
+        );
+
+        await vectorIndexStepOutputs(deps, makePostCtx(analysisId), artifacts);
+
+        const ids = (await readIndex(pool, analysisId)).map((r) => r.id);
+        expect(ids).toContain(vectorId(analysisId, "output/a.csv"));
+        expect(ids).toContain(vectorId(analysisId, "output/b.csv"));
+        expect(ids).not.toContain(vectorId(analysisId, "output/summary.md"));
+        expect(ids).toHaveLength(2);
+    });
+
+    it("a setup failure indexes nothing and does not throw", async () => {
+        const analysisId = uniqueAnalysisId();
+        const { pool, drop } = await withSchema("vec-setup-failure");
+        cleanups.push(drop);
+
+        // A pool that rejects every query fails `ensureSearchIndex` before any item
+        // is attempted; the real schema pool below is untouched.
+        const brokenPool = { query: () => Promise.reject(new Error("index setup boom")) } as unknown as Pool;
+        const logger = createCapturingLogger();
+        const deps = makeDeps(
+            brokenPool,
+            embeddingRejecting(() => false),
+            logger,
+        );
+        const artifacts: PostStepArtifacts = {
+            metadataEntries: [fileEntry("output/a.csv", "alpha description")],
+            reconciledManifest: [manifestEntry("output/a.csv")],
+            summary: summaryOf("## step summary"),
+        };
+
+        await vectorIndexStepOutputs(deps, makePostCtx(analysisId), artifacts);
+
+        expect(await readIndex(pool, analysisId)).toHaveLength(0);
+
+        // The only signal is a single setup-failure warn — no per-item id/length and
+        // no indexed/failed summary count, since nothing was attempted.
+        const warns = logger.records.filter((r) => r.level === "warn");
+        expect(warns).toHaveLength(1);
+        expect(warns[0]!.msg).toBe("[post-step.vector-index] indexing failed");
+        expect(warns[0]!.fields).not.toHaveProperty("id");
+        expect(warns[0]!.fields).not.toHaveProperty("indexed");
+    });
+
+    it("logs each per-item failure with its id and text length, and a summary with the counts", async () => {
+        const analysisId = uniqueAnalysisId();
+        const { pool, drop } = await withSchema("vec-observability");
+        cleanups.push(drop);
+
+        const poisonDesc = "poison description body";
+        const logger = createCapturingLogger();
+        const artifacts: PostStepArtifacts = {
+            metadataEntries: [fileEntry("output/ok.csv", "fine description"), fileEntry("output/bad.csv", poisonDesc)],
+            reconciledManifest: [manifestEntry("output/ok.csv"), manifestEntry("output/bad.csv")],
+            summary: summaryOf("## good summary"),
+        };
+        const deps = makeDeps(
+            pool,
+            embeddingRejecting((t) => t === poisonDesc),
+            logger,
+        );
+
+        await vectorIndexStepOutputs(deps, makePostCtx(analysisId), artifacts);
+
+        const warns = logger.records.filter((r) => r.level === "warn");
+
+        const itemWarn = warns.find((r) => r.msg === "[post-step.vector-index] indexing failed");
+        expect(itemWarn).toBeDefined();
+        expect(itemWarn!.fields.id).toBe(vectorId(analysisId, "output/bad.csv"));
+        expect(itemWarn!.fields.textLength).toBe(poisonDesc.length);
+
+        // ok.csv + summary.md landed; bad.csv did not.
+        const summaryWarn = warns.find((r) => r.msg === "[post-step.vector-index] indexed with failures");
+        expect(summaryWarn).toBeDefined();
+        expect(summaryWarn!.fields.indexed).toBe(2);
+        expect(summaryWarn!.fields.failed).toBe(1);
+    });
+});

--- a/harness/src/execution/post-step-pipeline.ts
+++ b/harness/src/execution/post-step-pipeline.ts
@@ -202,66 +202,87 @@ export async function reconcileAndRegisterStepArtifacts(
 }
 
 /**
- * Vector-index the threaded file descriptions + summary into the per-analysis
- * pgvector store. Best-effort (see the artifact-manifest spec): indexing degrades on any failure
- * without failing the step — the internal try/catch logs + swallows.
+ * Vector-index the threaded file descriptions + the step summary into the
+ * per-analysis pgvector store. Best-effort (see the artifact-manifest spec):
+ * indexing degrades without failing the step.
+ *
+ * Degradation is per-item. Index setup (ensuring the index exists and building
+ * the store) is all-or-nothing — a setup failure logs and skips the stage,
+ * because without an index there is nowhere to index into. Past setup, each
+ * file description and the summary is embedded and upserted under its own
+ * failure boundary, so one rejected input (e.g. an over-length document the
+ * embedding backend rejects) costs only its own entry and every other item is
+ * still attempted. A partial index is invisible at the search surface — it
+ * returns fewer hits, never an error — so each per-item failure logs the item
+ * id and input text length, and when any item fails a final record carries the
+ * indexed/failed counts as the only signal that degradation occurred.
  */
 export async function vectorIndexStepOutputs(deps: PostStepPipelineDeps, postCtx: PostStepContext, artifacts: PostStepArtifacts): Promise<void> {
     const { input } = postCtx;
     const { metadataEntries, summary, reconciledManifest } = artifacts;
+    const logger = (deps.logger ?? createNoopLogger()).named("post-step").named("vector-index").with({ runId: input.runId, stepId: input.stepId });
 
+    let vectorStore: ReturnType<typeof createVectorStore>;
+    let indexName: string;
     try {
+        // Setup is all-or-nothing: without an index there is nothing to index into.
         await ensureSearchIndex(deps.pool, input.analysisId, deps.embedding.dimensions);
-        const vectorStore = createVectorStore(deps.pool);
-        const indexName = searchIndexName(input.analysisId);
-
-        const embedOne = async (text: string): Promise<number[]> => {
-            const [vec] = unwrapOrThrow(await deps.embedding.embed([text], postCtx.session));
-            if (!vec) throw new Error("vectorIndexStepOutputs: empty embedding response");
-            return vec;
-        };
-
-        const dbPathPrefix = `runs/${input.runId}/${input.stepId}/`;
-        const survivingPaths = new Set(reconciledManifest.map((a) => a.path));
-        const liveMetadata = metadataEntries.filter((e) => survivingPaths.has(e.dbPath.slice(dbPathPrefix.length)));
-        for (const entry of liveMetadata) {
-            const embedding = await embedOne(entry.description);
-            unwrapOrThrow(
-                await vectorStore.upsert({
-                    indexName,
-                    vectors: [embedding],
-                    metadata: [{ text: entry.description, type: "output", ...entry.metadata }],
-                    ids: [`/${input.analysisId}/${entry.dbPath}`],
-                }),
-            );
-        }
-
-        if (summary && summary.markdown.trim().length > 0) {
-            const relPath = `runs/${input.runId}/${input.stepId}/output/summary.md`;
-            const summaryDbPath = `/${input.analysisId}/${relPath}`;
-            const summaryEmbedding = await embedOne(summary.markdown);
-            unwrapOrThrow(
-                await vectorStore.upsert({
-                    indexName,
-                    vectors: [summaryEmbedding],
-                    metadata: [
-                        {
-                            text: summary.markdown,
-                            type: "summary",
-                            stepId: input.stepId,
-                            runId: input.runId,
-                            agentId: input.agentId,
-                            path: relPath,
-                        },
-                    ],
-                    ids: [summaryDbPath],
-                }),
-            );
-        }
+        vectorStore = createVectorStore(deps.pool);
+        indexName = searchIndexName(input.analysisId);
     } catch (err) {
-        const logger = (deps.logger ?? createNoopLogger()).named("post-step").named("vector-index");
-        logger.warn("indexing failed", { runId: input.runId, stepId: input.stepId, ...logger.errorFields(err) });
+        logger.warn("indexing failed", logger.errorFields(err));
+        return;
     }
+
+    const embedOne = async (text: string): Promise<number[]> => {
+        const [vec] = unwrapOrThrow(await deps.embedding.embed([text], postCtx.session));
+        if (!vec) throw new Error("vectorIndexStepOutputs: empty embedding response");
+        return vec;
+    };
+
+    /** Index one item, absorbing its failure so the rest of the step still lands. */
+    const indexOne = async (id: string, text: string, metadata: Record<string, unknown>): Promise<boolean> => {
+        try {
+            const embedding = await embedOne(text);
+            unwrapOrThrow(await vectorStore.upsert({ indexName, vectors: [embedding], metadata: [metadata], ids: [id] }));
+            return true;
+        } catch (err) {
+            // Text length rides as a field because over-length input is the known
+            // failure driver, and the description/summary itself stays out of logs.
+            logger.warn("indexing failed", { id, textLength: text.length, ...logger.errorFields(err) });
+            return false;
+        }
+    };
+
+    const dbPathPrefix = `runs/${input.runId}/${input.stepId}/`;
+    const survivingPaths = new Set(reconciledManifest.map((a) => a.path));
+    const liveMetadata = metadataEntries.filter((e) => survivingPaths.has(e.dbPath.slice(dbPathPrefix.length)));
+
+    let indexed = 0;
+    let failed = 0;
+    for (const entry of liveMetadata) {
+        const ok = await indexOne(`/${input.analysisId}/${entry.dbPath}`, entry.description, { text: entry.description, type: "output", ...entry.metadata });
+        if (ok) indexed++;
+        else failed++;
+    }
+
+    if (summary && summary.markdown.trim().length > 0) {
+        const relPath = `runs/${input.runId}/${input.stepId}/output/summary.md`;
+        const ok = await indexOne(`/${input.analysisId}/${relPath}`, summary.markdown, {
+            text: summary.markdown,
+            type: "summary",
+            stepId: input.stepId,
+            runId: input.runId,
+            agentId: input.agentId,
+            path: relPath,
+        });
+        if (ok) indexed++;
+        else failed++;
+    }
+
+    // A partial index is invisible at the search surface — it returns fewer hits,
+    // never an error — so the count of what did not land is the only signal.
+    if (failed > 0) logger.warn("indexed with failures", { indexed, failed });
 }
 
 /**


### PR DESCRIPTION
## What & why

Vector indexing silently dropped files: step summaries and file descriptions failed to reach the search index while the step went green, invisibly degrading `workspace_search` (#140, observed on a customer machine). Two independent bugs compounded, and this PR fixes both:

**cli — token-exact embedding truncation** (`src/modules/embedding/local-provider.ts`)

The local provider's guard was a probabilistic 1600-char cap whose own arithmetic exceeds bge-small's hard 512-token ceiling (1600 ÷ its assumed 3.1 chars/token = 516), and real content tokenizes denser still (~2.69 chars/token measured) — so guarded inputs drew HTTP 500s. The guard is now exact:

- Budget **510 content tokens** (512 minus the `[CLS]`/`[SEP]` pair, confirmed against the live server).
- Counts come from the sidecar's own `/tokenize` — the exact tokenizer of the loaded model, no new dependency. Verified live on the pinned `b9310` build: the endpoint is key-gated (401 without the minted key) and returns content-only counts.
- ≤510-code-unit inputs skip measurement entirely (a WordPiece token spans ≥1 code unit, so tokens ≤ length) — the dominant case pays zero round-trips.
- Long inputs that actually fit are embedded **whole** (the old cap blindly cut them); over-budget inputs are cut proportionally to their measured density, word-boundary-backed, and re-measured until they fit (bounded rounds).
- Any measurement failure degrades to a provably-fitting 510-code-unit hard cut — measuring can never fail an embed. All `/tokenize` interaction flows as `Result` per the neverthrow discipline.

**harness — per-item vector-index isolation** (`src/execution/post-step-pipeline.ts`)

One try/catch spanned the whole per-file loop and the summary, so the first rejected input abandoned every remaining item for that step. `vectorIndexStepOutputs` now degrades per-item: index setup stays all-or-nothing, each file description and the summary embeds under its own failure boundary, and the stage logs each failed item (id + text length) plus a final `indexed`/`failed` count — the only observable signal of a partial index, which surfaces as fewer search hits, never an error. The stage still never fails the step. This also contains the api-key embedding path, which has no client-side guard and keeps rejections to one entry instead of a step's whole slice.

Not affected: vector widths (384/1536), existing `vector` columns, and HNSW indexes — truncation changes input length, not output dimensions. Documents previously cut at 1600 chars pick up their recovered tail the next time their write path embeds them.

Both halves went through OpenSpec: the `local-embeddings` and `artifact-manifest` specs are updated (delta specs synced, changes archived in-repo under `openspec/changes/archive/`).

Closes #140

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`) — harness: 1252 pass / 0 fail; cli: 1161 pass / 0 fail.
- [x] Tests added or updated for the change — 4 new harness isolation tests (state-asserted against pgvector), 5 new cli fit tests on the stub-sidecar rig (fast path, recovery, convergence, both fallback modes).
- [x] Documentation updated if user-facing behavior changed — OpenSpec specs updated in both trees; no end-user docs affected.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
