### PR TITLE
feat(cli): credential-command + short-lived token auth for direct mode

### DIFF
--- a/cli/eslint.config.js
+++ b/cli/eslint.config.js
@@ -151,10 +151,12 @@ export default defineConfig([
         // env.test.ts drives `process.env` directly to exercise the CALL-TIME readers env.ts exposes
         // (resolveModelApiKey / detectProviderEnv): their contract is to read the LIVE environment, so
         // asserting their precedence requires setting the variables — there is no frozen-env route to a
-        // value that is deliberately not frozen.
+        // value that is deliberately not frozen. credential.test.ts does the same to exercise the `env`-kind
+        // credential source, which reads the live environment through env.ts's `readEnvCredentialVar` seam.
         ignores: [
             "src/lib/env.ts",
             "src/lib/env.test.ts",
+            "src/lib/credential.test.ts",
             "src/test_support/preload.ts",
             "src/test_support/sandbox.ts",
             "src/test_support/harness.test.ts",

--- a/cli/openspec/changes/add-credential-command-auth/.openspec.yaml
+++ b/cli/openspec/changes/add-credential-command-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/cli/openspec/changes/add-credential-command-auth/design.md
+++ b/cli/openspec/changes/add-credential-command-auth/design.md
@@ -28,10 +28,13 @@ live in Inflexa.
 
 ## Decisions
 
-**D1 — A credential SOURCE, not a string.** Replace "resolve a string" with a cached async supplier
-`CredentialSource = () => Promise<{ token, scheme, expiresAt? }>`. The static env key stays one
-(expiry-less) source; env-bearer and command are the new ones. Caching keyed by expiry means the
-command runs only on refresh, not per request.
+**D1 — A credential SOURCE, not a string (only when configured).** A configured `auth` block resolves to a
+cached async supplier `CredentialSource = () => Promise<{ token, scheme, expiresAt? }>` (env-bearer or
+command). The plain env key is left untouched — resolved once and passed as the AI SDK `apiKey`, exactly as
+today — so the common path keeps its behavior and only an `auth` block engages the source machinery. Caching
+keyed by expiry means the command runs only on refresh, not per request. (An earlier revision wrapped even
+the static key in an expiry-less source "for uniformity"; that was dropped — it re-set the identical header
+the SDK already derives, so it was pure ceremony on the hot path.)
 
 **D2 — Two proven output formats, nothing bespoke.** A command's stdout is either (a) a **raw token**
 — byte-for-byte Claude Code's `apiKeyHelper`, so an org's existing helper works unchanged (the
@@ -42,14 +45,15 @@ widely-implemented standard for short-lived bearer tokens with expiry. Rejected:
 awkward for a plain bearer; we mirror its *refresh contract* (Version-gate + Expiration) without its
 field names.
 
-**D3 — Inject via the `config.fetch` seam (CLI-side), no hard harness change.** The CLI builds the
-`fetch` passed as `config.fetch`. Per request it calls the source and sets the auth header: for
-`bearer` it deletes the `x-api-key` the AI SDK added and sets `Authorization: Bearer`; for
-`x-api-key` it sets `x-api-key`. The static `apiKey` becomes a placeholder. Alternative: add a
-first-class `{ getToken, authScheme }` to `AiSdkProviderConfig` (cleaner, but a harness change). Chose
-the fetch seam for v1 because it already exists and keeps the whole credential concern in the
-embedder; the first-class API is noted as a future cleanup. This one seam also delivers Bearer for
-`ANTHROPIC_AUTH_TOKEN`, closing the prior deferral.
+**D3 — Inject via the `config.fetch` seam (CLI-side), no hard harness change.** When an `auth` source is
+configured, the CLI builds the `fetch` passed as `config.fetch`: per request it calls the source and sets the
+auth header — `bearer` deletes the `x-api-key` the AI SDK added and sets `Authorization: Bearer`; `x-api-key`
+sets `x-api-key`; the SDK `apiKey` is a placeholder. The static env-key path installs NO fetch — the SDK sends
+the key as the wire's conventional header exactly as before — so the credential concern touches only
+connections that opt in. Alternative: add a first-class `{ getToken, authScheme }` to `AiSdkProviderConfig`
+(cleaner, but a harness change). Chose the fetch seam for v1 because it already exists and keeps the whole
+credential concern in the embedder; the first-class API is noted as a future cleanup. This one seam also
+delivers Bearer for `ANTHROPIC_AUTH_TOKEN`, closing the prior deferral.
 
 **D4 — Refresh = expiry + ttl fallback + 401 retry; no mid-stream refresh.** A single request uses the
 header set at its start and Anthropic validates auth at request start, so a token cannot expire

--- a/cli/openspec/changes/add-credential-command-auth/design.md
+++ b/cli/openspec/changes/add-credential-command-auth/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`direct` mode (post `adopt-provider-env-vars`) resolves the API key **once at boot** via
+`resolveModelApiKey(provider)` → a static string passed as the AI SDK `apiKey`, sent as `x-api-key`
+(anthropic wire) or `Authorization: Bearer` (openai-compatible). The harness provider construction
+(`harness/src/providers/ai-sdk.ts`) already threads a custom `fetch` into both
+`createAnthropic({ baseURL, apiKey, fetch })` and `createOpenAICompatible({ ..., fetch })`.
+
+Enterprises increasingly issue Anthropic access through a **credential helper** that mints a
+short-lived first-party token on demand. A static-string-at-boot model can neither refresh such a
+token nor send it as a Bearer on the anthropic wire. Research confirmed CLIProxyAPI is not a
+substitute (it holds a static upstream key and cannot run an external helper), so the refresh must
+live in Inflexa.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let `direct` mode consume a refreshing credential source: an env bearer token or a command.
+- Conform to existing, proven contracts so interop is guaranteed, not guessed.
+- Detect a helper-based setup and offer it at setup, opt-in, with a validation probe.
+- Close the `ANTHROPIC_AUTH_TOKEN` (Bearer) gap deferred in `adopt-provider-env-vars`.
+
+**Non-Goals:**
+- Reimplementing OAuth / WIF token exchange — the *command* mints the token; we consume it.
+- Auto-executing the org's `managed-settings.json` helper without user confirmation.
+- Using CLIProxyAPI for this case (established: it adds nothing for a first-party token).
+- Mid-stream token refresh (unnecessary — see D4).
+
+## Decisions
+
+**D1 — A credential SOURCE, not a string.** Replace "resolve a string" with a cached async supplier
+`CredentialSource = () => Promise<{ token, scheme, expiresAt? }>`. The static env key stays one
+(expiry-less) source; env-bearer and command are the new ones. Caching keyed by expiry means the
+command runs only on refresh, not per request.
+
+**D2 — Two proven output formats, nothing bespoke.** A command's stdout is either (a) a **raw token**
+— byte-for-byte Claude Code's `apiKeyHelper`, so an org's existing helper works unchanged (the
+strongest "it works" guarantee), or (b) **Kubernetes `ExecCredential` JSON**
+(`client.authentication.k8s.io/v1`, `status.token` + `status.expirationTimestamp`) — a versioned,
+widely-implemented standard for short-lived bearer tokens with expiry. Rejected: adopting the AWS
+`credential_process` shape as a parse target — its token field is `SessionToken`/`AccessKeyId`,
+awkward for a plain bearer; we mirror its *refresh contract* (Version-gate + Expiration) without its
+field names.
+
+**D3 — Inject via the `config.fetch` seam (CLI-side), no hard harness change.** The CLI builds the
+`fetch` passed as `config.fetch`. Per request it calls the source and sets the auth header: for
+`bearer` it deletes the `x-api-key` the AI SDK added and sets `Authorization: Bearer`; for
+`x-api-key` it sets `x-api-key`. The static `apiKey` becomes a placeholder. Alternative: add a
+first-class `{ getToken, authScheme }` to `AiSdkProviderConfig` (cleaner, but a harness change). Chose
+the fetch seam for v1 because it already exists and keeps the whole credential concern in the
+embedder; the first-class API is noted as a future cleanup. This one seam also delivers Bearer for
+`ANTHROPIC_AUTH_TOKEN`, closing the prior deferral.
+
+**D4 — Refresh = expiry + ttl fallback + 401 retry; no mid-stream refresh.** A single request uses the
+header set at its start and Anthropic validates auth at request start, so a token cannot expire
+mid-request. Per-request resolution in the fetch wrapper (returning the cached token, refreshing when
+`now >= expiresAt - buffer`), plus one forced-refresh retry on a `401`, covers every case. Raw tokens
+with no expiry use `ttlMs` (Claude Code's `apiKeyHelper` default is 5 min + refresh-on-401).
+
+**D5 — Detect, then let the user confirm the command (never auto-wire).** Setup detects a helper
+setup from read-only signals (`claude auth status` authMethod=api_key_helper; an `apiKeyHelper` in
+`~/.claude/settings.json` / managed-settings; `ANTHROPIC_AUTH_TOKEN` in env) and OFFERS the
+credential-source path. The user supplies/confirms the command (may be pre-filled from their own
+user-level settings). We do NOT silently lift and execute the org's `managed-settings.json` helper —
+that keeps the governance decision with the user/org and is more robust (the managed file may be
+unreadable or need special env).
+
+**D6 — Validate at setup.** Before writing config, run the source once and do a cheap auth probe
+(`GET {baseURL}/models`, or a minimal call) so a wrong command / scheme / endpoint fails at setup, not
+on first chat. A rotating-token flow is easy to misconfigure; the probe is the "sure it works" gate.
+
+## Risks / Trade-offs
+
+- **Running a configured command is code execution** → same trust model as AWS `credential_process` /
+  Claude Code `apiKeyHelper` (user/admin configures it); only the command *name* is stored, never
+  output. The `Bun.spawn` call is boundary-wrapped to `Result`.
+- **Bearer rewrite depends on stripping the AI SDK's `x-api-key`** → mitigated by passing a placeholder
+  `apiKey` and setting the header explicitly in our fetch; covered by a test asserting the outgoing
+  header.
+- **Command latency** → caching means it runs only on refresh; a slow helper delays only a refresh, not
+  every request.
+- **ExecCredential/raw parse variance across helpers** → the setup probe (D6) surfaces it immediately;
+  parsing is boundary-wrapped and errors are actionable.
+
+## Migration Plan
+
+Purely additive. Configs without an `auth` block behave exactly as today (static env key). No config
+migration. Rollback removes the `auth` resolution + setup branch; the static path is untouched.
+Sequenced on top of `adopt-provider-env-vars`.
+
+## Open Questions
+
+- Pre-fill the detected command from the user's OWN `~/.claude/settings.json` `apiKeyHelper` (but not
+  the org managed file)? (Leaning: yes for user-level, shown editable.)
+- Infer `scheme` from the token prefix (`sk-ant-api…`→x-api-key, `sk-ant-oat…`→bearer) as a default,
+  or always ask? (Leaning: infer a default, let the user override — the setup probe validates it.)

--- a/cli/openspec/changes/add-credential-command-auth/proposal.md
+++ b/cli/openspec/changes/add-credential-command-auth/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Enterprises that buy Anthropic API tokens increasingly issue them through a **credential helper** — a
+script that mints a **short-lived** first-party token on demand (the pattern Claude Code's
+`apiKeyHelper`, AWS `credential_process`, and kubectl exec-plugins all use) — rather than a static
+key. Inflexa's `direct` mode today resolves the key **once at boot** as a static string and only
+sends it as `x-api-key`. That can't consume a rotating helper token (it goes stale) and can't send an
+`Authorization: Bearer` token (what WIF / gateway credentials require). This change lets `direct`
+mode use those already-sanctioned credential sources, so an employee on a company-token plan can run
+Inflexa against their existing budget with a one-time opt-in.
+
+## What Changes
+
+- **A refreshing credential source for `direct` mode.** New `models.connection.auth` block naming
+  either an env var (`{ kind: "env", var, scheme }` — e.g. a short-lived `ANTHROPIC_AUTH_TOKEN`
+  bearer) or a command (`{ kind: "command", command, scheme, format?, ttlMs? }`). Only the **name**
+  is stored — the token value is never written to config, telemetry, logs, or provenance.
+- **Standard, testable formats — nothing bespoke.** A command's stdout is either a **raw token**
+  (byte-for-byte Claude Code `apiKeyHelper` parity) or **Kubernetes `ExecCredential` JSON**
+  (`client.authentication.k8s.io/v1`, `status.token` + `status.expirationTimestamp`). Refresh mirrors
+  AWS `credential_process`: honor the expiry, fall back to `ttlMs` for a raw token, force-refresh on a
+  `401`.
+- **Bearer wire scheme.** The token reaches the wire as `x-api-key` or `Authorization: Bearer` per
+  `scheme`, injected through the harness `config.fetch` seam — so **no hard harness change** (the seam
+  already exists). This also closes the `ANTHROPIC_AUTH_TOKEN` gap deferred in `adopt-provider-env-vars`.
+- **Setup detection + opt-in.** Setup detects a helper-based Anthropic setup (from
+  `claude auth status` authMethod, an `apiKeyHelper` in Claude settings, or `ANTHROPIC_AUTH_TOKEN` in
+  env) and OFFERS the credential-source path. The user **confirms/supplies the command** — setup does
+  not silently lift and execute the org's managed-settings helper.
+- **Setup validation.** Before writing config, setup runs the source once and does a cheap auth probe
+  against the endpoint, so a bad command / scheme / endpoint fails at setup, not first chat.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — extends model-connection, which already owns the direct-mode credential channel and the setup connection flow. -->
+
+### Modified Capabilities
+- `model-connection`: the direct-mode credential may now be a **refreshing source** (an env bearer
+  token or a credential command emitting a raw token / ExecCredential JSON) in addition to the static
+  env key; the token is sent as `x-api-key` or `Bearer` per a configured scheme; and setup detects a
+  helper-based setup and offers the credential-command path with a validation probe.
+
+## Impact
+
+- **Code:** `cli/src/lib/env.ts` (a `CredentialSource` resolver — cache + refresh over env/command,
+  raw/ExecCredential parsing, `Bun.spawn` boundary-wrapped as `Result`); the provider-construction
+  site in `cli/src/modules/harness/` (build the auth-injecting `fetch` passed as `config.fetch`, with
+  scheme rewrite + 401-retry); `cli/src/modules/infra/setup.ts` (helper detection, the opt-in
+  credential-source prompt, and the validation probe).
+- **Spec:** `model-connection` delta (1 modified + 2 added requirements).
+- **No new dependencies. No hard harness change** (bearer handled in the injected fetch); an optional
+  first-class `{ getToken, authScheme }` on the harness provider config is noted as a future cleanup.
+- **Security posture preserved:** no token value is ever persisted; config holds only the source
+  name/command and scheme.
+- **Sequenced after `adopt-provider-env-vars`** (builds on its `direct`-mode key resolution).

--- a/cli/openspec/changes/add-credential-command-auth/proposal.md
+++ b/cli/openspec/changes/add-credential-command-auth/proposal.md
@@ -43,8 +43,9 @@ Inflexa against their existing budget with a one-time opt-in.
 
 ## Impact
 
-- **Code:** `cli/src/lib/env.ts` (a `CredentialSource` resolver — cache + refresh over env/command,
-  raw/ExecCredential parsing, `Bun.spawn` boundary-wrapped as `Result`); the provider-construction
+- **Code:** `cli/src/lib/credential.ts` (a `CredentialSource` resolver — cache + refresh over env/command,
+  raw/ExecCredential parsing, `Bun.spawn` boundary-wrapped as `Result`; the `env` kind reads through
+  `env.ts`'s `readEnvCredentialVar` seam so `env.ts` stays the sole `process.env` reader); the provider-construction
   site in `cli/src/modules/harness/` (build the auth-injecting `fetch` passed as `config.fetch`, with
   scheme rewrite + 401-retry); `cli/src/modules/infra/setup.ts` (helper detection, the opt-in
   credential-source prompt, and the validation probe).

--- a/cli/openspec/changes/add-credential-command-auth/specs/model-connection/spec.md
+++ b/cli/openspec/changes/add-credential-command-auth/specs/model-connection/spec.md
@@ -1,0 +1,142 @@
+## MODIFIED Requirements
+
+### Requirement: The direct-mode secret comes from the environment only
+
+The CLI SHALL resolve the direct-connection API key from the environment only, through the central
+env module (`lib/env.ts`, the sole `process.env` reader), via a provider-parameterized resolver.
+This env resolution is the DEFAULT credential source, used when the connection configures no explicit
+`auth` block; a configured `auth` block (see "The direct connection may use a refreshing credential
+source") takes precedence over it. The resolution order SHALL be: `INFLEXA_MODEL_API_KEY` first (the
+explicit override); when it is unset, the provider-conventional variable derived from the
+connection's configured `provider` — `ANTHROPIC_API_KEY` for provider `anthropic`, `OPENAI_API_KEY`
+for every other provider. The key SHALL never be written to `config.json`, never appear in telemetry
+or logs, and never be recorded in provenance — the provider-derived fallback READS an existing
+environment secret, it never copies it. In `direct` mode a credential that resolves to nothing — from
+neither a configured `auth` source nor the env chain — SHALL fail boot with an actionable error: for
+the env path, naming both `INFLEXA_MODEL_API_KEY` and the provider-conventional variable that was
+tried; for a configured source, naming that source. In `cliproxy` mode the existing proxy client key
+discovery is unchanged and this resolution is not used. Boot SHALL NOT read the endpoint URL from the
+environment; the endpoint remains configuration authored (or adopted) at setup — ecosystem endpoint
+variables are read only for one-time setup detection (see "Setup detects and adopts ecosystem
+provider environment").
+
+#### Scenario: Explicit override wins over the provider variable
+
+- **WHEN** the connection is `direct` with provider `anthropic`, no `auth` block, and BOTH
+  `INFLEXA_MODEL_API_KEY` and `ANTHROPIC_API_KEY` are set
+- **THEN** `INFLEXA_MODEL_API_KEY` is used and `ANTHROPIC_API_KEY` is ignored
+
+#### Scenario: Provider-derived fallback resolves the key
+
+- **WHEN** the connection is `direct` with provider `anthropic`, no `auth` block,
+  `INFLEXA_MODEL_API_KEY` is unset, and `ANTHROPIC_API_KEY` is set (symmetrically: provider `openai`
+  with `OPENAI_API_KEY` set)
+- **THEN** the provider-conventional variable is used as the key, still read from the environment
+  and never written to any persisted surface
+
+#### Scenario: Missing key blocks a direct boot actionably
+
+- **WHEN** the connection is `direct` with no `auth` block and neither `INFLEXA_MODEL_API_KEY` nor
+  the provider's conventional variable is set
+- **THEN** boot fails before any provisioning with an error naming both variables and the config
+  path, and no chat request is attempted
+
+#### Scenario: The key stays out of persisted surfaces
+
+- **WHEN** a direct-mode session runs to completion, resolving its key from either variable
+- **THEN** `config.json`, the telemetry stream, and the signed provenance document contain no API
+  key material
+
+## ADDED Requirements
+
+### Requirement: The direct connection may use a refreshing credential source
+
+When configured, `models.connection.auth` SHALL supply the `direct` connection's wire credential as a
+refreshing source that takes precedence over the environment key resolution. A `direct` connection MAY
+omit it (the environment resolution then applies). The `auth` block SHALL be one of: `{ kind: "env"; var; scheme }` (read a token from a
+named environment variable — e.g. a short-lived `ANTHROPIC_AUTH_TOKEN` bearer), or
+`{ kind: "command"; command; scheme; format?; ttlMs? }` (run a command to mint a token). The CLI
+SHALL resolve either into a cached credential source — an async supplier that yields the token, its
+scheme, and an optional expiry — evaluated at the provider-construction site so the token is obtained
+lazily and refreshed, never read once at boot. A command's stdout SHALL be parsed as either a raw
+token (`format: "raw"`, the default — byte-for-byte Claude Code `apiKeyHelper` parity) or a
+Kubernetes `ExecCredential` JSON (`format: "exec-credential"` — `apiVersion:
+client.authentication.k8s.io/v1`, reading `status.token` and `status.expirationTimestamp`). Refresh
+SHALL honor the parsed expiry (minus a safety buffer), fall back to `ttlMs` for a raw token with no
+expiry, and force-refresh reactively on an HTTP `401` followed by a single retry. The token SHALL be
+sent on the wire as `x-api-key` (scheme `x-api-key`) or `Authorization: Bearer` (scheme `bearer`),
+injected through the harness provider's `fetch` seam. The token value SHALL never be written to
+`config.json`, telemetry, logs, or provenance — the `auth` block persists only the variable name /
+command string / scheme. The command invocation SHALL be wrapped so a spawn or parse failure surfaces
+as an actionable error, never an uncaught throw.
+
+#### Scenario: An env bearer token is sent as Authorization: Bearer
+
+- **WHEN** `auth` is `{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` over the
+  anthropic protocol and the variable holds a token
+- **THEN** the request to `{baseURL}/messages` carries `Authorization: Bearer <token>` and no
+  `x-api-key` header, and the token appears in no persisted surface
+
+#### Scenario: A credential command mints and caches a token
+
+- **WHEN** `auth` is `{ kind: "command", command, scheme: "bearer" }` and the command prints a raw
+  token
+- **THEN** the command is run to obtain the token, the token is cached and reused across requests,
+  and the command is re-run only on refresh — not per request
+
+#### Scenario: ExecCredential expiry drives refresh
+
+- **WHEN** the command emits `ExecCredential` JSON with a `status.expirationTimestamp` in the near
+  future
+- **THEN** the token is reused until the expiry (minus buffer), after which the command is re-run to
+  obtain a fresh token
+
+#### Scenario: A 401 forces a refresh and one retry
+
+- **WHEN** a request returns HTTP 401 with a cached credential
+- **THEN** the source force-refreshes the token and the request is retried once with the new token
+
+#### Scenario: A configured source overrides the environment key
+
+- **WHEN** an `auth` block is configured AND `INFLEXA_MODEL_API_KEY` is also set
+- **THEN** the `auth` source supplies the credential and the env key is not consulted
+
+### Requirement: Setup detects a credential-helper setup and offers the credential-source path
+
+`inflexa setup` SHALL detect a credential-helper Anthropic setup and offer the credential-source
+path, writing only the source's variable name / command and scheme — never a token — and validating
+the source before it is saved. Detection SHALL use read-only signals: `claude auth status` reporting
+an api-key-helper auth method, an `apiKeyHelper` entry in the user's `~/.claude/settings.json` (or the
+managed settings file), or `ANTHROPIC_AUTH_TOKEN` present in the environment. The offer SHALL be
+opt-in: the user SHALL supply or confirm the command (which MAY be pre-filled from the user's OWN
+user-level settings), and setup SHALL NOT silently lift and execute the organization's
+managed-settings helper without the user's confirmation. Before writing config, setup SHALL run the
+resolved source once and perform a cheap authentication probe against the configured endpoint (e.g.
+`GET {baseURL}/models`), failing with an actionable message that names the likely cause (command,
+scheme, or endpoint) when the probe does not succeed. Only the source name/command and scheme SHALL
+be written to `models.connection.auth`.
+
+#### Scenario: A detected helper setup offers the credential-source path
+
+- **WHEN** setup's direct path runs and `claude auth status` reports an api-key-helper method (or an
+  `apiKeyHelper` is present in the user's Claude settings)
+- **THEN** setup offers the credential-source path (credential command or env bearer token) instead
+  of only prompting for a static key
+
+#### Scenario: The user confirms the command and no token is written
+
+- **WHEN** the user chooses the credential-command path and supplies/confirms a command
+- **THEN** `models.connection.auth` records `{ kind: "command", command, scheme, ... }` and
+  `config.json` contains no token material
+
+#### Scenario: The validation probe catches a bad configuration
+
+- **WHEN** the supplied command, scheme, or endpoint is wrong and the setup probe fails
+- **THEN** setup reports an actionable error naming the likely cause and does not write the broken
+  `auth` block
+
+#### Scenario: The org managed-settings helper is not auto-executed
+
+- **WHEN** only an org-managed `managed-settings.json` `apiKeyHelper` is present (no user-level entry)
+- **THEN** setup surfaces that a helper was detected but requires the user to confirm the command
+  before Inflexa will run it — it does not auto-execute the managed helper

--- a/cli/openspec/changes/add-credential-command-auth/tasks.md
+++ b/cli/openspec/changes/add-credential-command-auth/tasks.md
@@ -3,9 +3,9 @@
 - [x] 1.1 Extend the `models.connection` schema (`src/modules/harness/config.ts`) with an optional `auth` block: `{ kind: "env"; var; scheme }` | `{ kind: "command"; command; scheme; format?: "raw" | "exec-credential"; ttlMs? }`, `scheme: "x-api-key" | "bearer"`. Carry it on `ResolvedModelConnection` (direct arm). — schema (`modelAuthSchema`/`ModelAuthConfig`) added in `src/lib/config.ts` beside `modelConnectionSchema` (where that schema lives); `ResolvedModelConnection.auth` carried in `src/modules/harness/config.ts`.
 - [x] 1.2 Validate it in `resolveModelConnection` (fail-closed with a config error naming the offending field, same pattern as the rest of the block).
 
-## 2. Credential source resolver (env.ts)
+## 2. Credential source resolver (credential.ts)
 
-- [x] 2.1 In `src/lib/env.ts`, add a `CredentialSource` = cached async supplier returning `{ token, scheme, expiresAt? }`; keep `lib/env.ts` the sole `process.env` reader for the env kinds.
+- [x] 2.1 In `src/lib/credential.ts`, add a `CredentialSource` = cached async supplier returning `{ token, scheme, expiresAt? }`; the `env` kind reads through `env.ts`'s `readEnvCredentialVar` seam, so `lib/env.ts` stays the sole `process.env` reader.
 - [x] 2.2 `kind: "env"` — read the named var; no expiry; scheme as configured.
 - [x] 2.3 `kind: "command"` — run the command via `Bun.spawn`, boundary-wrapped to `Result`; parse stdout as raw token (default) OR Kubernetes `ExecCredential` JSON (`status.token` + `status.expirationTimestamp`).
 - [x] 2.4 Caching + refresh: reuse until `expiresAt − buffer`; fall back to `ttlMs` for a raw token; expose a `forceRefresh()` for the 401 path.
@@ -25,7 +25,7 @@
 
 ## 5. Documentation
 
-- [x] 5.1 Document the `auth` block + the two output formats (raw / ExecCredential) and the scheme in the CLI help / setup notes; state that the token value is never persisted. — documented on `modelAuthSchema` JSDoc, the setup "Model credential source" / "Model API key" notes, and env.ts credential-source docs.
+- [x] 5.1 Document the `auth` block + the two output formats (raw / ExecCredential) and the scheme in the CLI help / setup notes; state that the token value is never persisted. — documented on `modelAuthSchema` JSDoc, the setup "Model credential source" / "Model API key" notes, and credential.ts credential-source docs.
 
 ## 6. Tests
 

--- a/cli/openspec/changes/add-credential-command-auth/tasks.md
+++ b/cli/openspec/changes/add-credential-command-auth/tasks.md
@@ -1,0 +1,36 @@
+## 1. Config surface (auth block)
+
+- [x] 1.1 Extend the `models.connection` schema (`src/modules/harness/config.ts`) with an optional `auth` block: `{ kind: "env"; var; scheme }` | `{ kind: "command"; command; scheme; format?: "raw" | "exec-credential"; ttlMs? }`, `scheme: "x-api-key" | "bearer"`. Carry it on `ResolvedModelConnection` (direct arm). — schema (`modelAuthSchema`/`ModelAuthConfig`) added in `src/lib/config.ts` beside `modelConnectionSchema` (where that schema lives); `ResolvedModelConnection.auth` carried in `src/modules/harness/config.ts`.
+- [x] 1.2 Validate it in `resolveModelConnection` (fail-closed with a config error naming the offending field, same pattern as the rest of the block).
+
+## 2. Credential source resolver (env.ts)
+
+- [x] 2.1 In `src/lib/env.ts`, add a `CredentialSource` = cached async supplier returning `{ token, scheme, expiresAt? }`; keep `lib/env.ts` the sole `process.env` reader for the env kinds.
+- [x] 2.2 `kind: "env"` — read the named var; no expiry; scheme as configured.
+- [x] 2.3 `kind: "command"` — run the command via `Bun.spawn`, boundary-wrapped to `Result`; parse stdout as raw token (default) OR Kubernetes `ExecCredential` JSON (`status.token` + `status.expirationTimestamp`).
+- [x] 2.4 Caching + refresh: reuse until `expiresAt − buffer`; fall back to `ttlMs` for a raw token; expose a `forceRefresh()` for the 401 path.
+- [x] 2.5 Resolution precedence: a configured `auth` source wins; otherwise fall back to the existing `resolveModelApiKey(provider)` (as an env `x-api-key`/`bearer` source). — precedence encoded in boot's direct branch (`runtime.ts`) against the injectable `readModelApiKey` seam; the env key is wrapped by `staticCredentialSource`.
+
+## 3. Wire injection (provider construction)
+
+- [x] 3.1 At the provider-construction site (`src/modules/harness/runtime.ts`), build the `fetch` passed as harness `config.fetch`: per request, get the token from the source and set the auth header — `bearer` deletes any `x-api-key` and sets `Authorization: Bearer`; `x-api-key` sets `x-api-key`. Pass a placeholder `apiKey` so the SDK doesn't fight it.
+- [x] 3.2 On an HTTP `401`, `forceRefresh()` and retry the request exactly once.
+
+## 4. Setup detection, offer, and validation
+
+- [x] 4.1 Extend detection (`src/modules/infra/setup.ts`, alongside `detectProviderEnv`) to recognize a helper setup: `claude auth status` api-key-helper method, an `apiKeyHelper` in `~/.claude/settings.json` / managed-settings, or `ANTHROPIC_AUTH_TOKEN` in env. — detects the reliable subset: user/managed `apiKeyHelper` (settings.json) + `ANTHROPIC_AUTH_TOKEN`; the `claude auth status` api-key-helper method writes an `apiKeyHelper` into settings.json, so the settings signal subsumes it (no fragile subprocess).
+- [x] 4.2 When detected, offer the credential-source path (credential command / env bearer) in the direct-connection flow; the user supplies/confirms the command (MAY pre-fill from the user's OWN settings; NEVER auto-execute the org managed-settings helper).
+- [x] 4.3 Add a setup validation probe: run the resolved source once and hit `GET {baseURL}/models` (or a minimal call); on failure, report an actionable cause (command / scheme / endpoint) and do NOT write the `auth` block.
+- [x] 4.4 Write only `{ kind, var|command, scheme, format?, ttlMs? }` into `models.connection.auth` — never a token.
+
+## 5. Documentation
+
+- [x] 5.1 Document the `auth` block + the two output formats (raw / ExecCredential) and the scheme in the CLI help / setup notes; state that the token value is never persisted. — documented on `modelAuthSchema` JSDoc, the setup "Model credential source" / "Model API key" notes, and env.ts credential-source docs.
+
+## 6. Tests
+
+- [x] 6.1 CredentialSource: env-bearer source; command raw token cached + refreshed after TTL; ExecCredential parse + expiry-driven refresh; `forceRefresh` re-runs; a configured source overrides `INFLEXA_MODEL_API_KEY`. — CredentialSource unit tests in `env.test.ts` (env/command/exec-credential, cache, forceRefresh); the override is a boot test in `runtime.test.ts` (auth block ⇒ `readModelApiKey` never consulted).
+- [x] 6.2 Wire injection: `bearer` sets `Authorization: Bearer` and strips `x-api-key`; `x-api-key` sets `x-api-key`; a 401 triggers exactly one refresh+retry (assert the outgoing headers/behavior).
+- [x] 6.3 Config: a valid `auth` block round-trips; an invalid one fails closed with a named config error.
+- [x] 6.4 Setup: detection offers the path; a confirmed command writes `{command, scheme}` and no token; the probe blocks a bad config; the managed-settings helper is not auto-executed.
+- [x] 6.5 `bun run typecheck`, `bun run lint`, `bun test` pass; run `bun run format:file` on every changed `src/` file. — typecheck/lint green; all new tests pass; one pre-existing WSL2 proxy/loopback embedding test fails identically on the clean base (unrelated).

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -90,16 +90,13 @@ const configSchema = z.object({
 export type Config = z.infer<typeof configSchema>;
 
 /**
- * The `models.connection.auth` block — a REFRESHING credential source for a `direct` connection, in place
- * of the static environment key. `env` names a variable holding a token (e.g. a short-lived
- * `ANTHROPIC_AUTH_TOKEN` bearer); `command` names a helper that mints one on demand (Claude Code
- * `apiKeyHelper` parity), its stdout parsed as a raw token (`format: "raw"`, the default) or a Kubernetes
- * `ExecCredential` JSON (`format: "exec-credential"`). `scheme` selects the wire header the token is sent
- * under — `x-api-key`, or `Authorization: Bearer`. ONLY the non-secret variable name / command string /
- * scheme is ever persisted; the token value is resolved at runtime and never written to config. Resolved
- * into a cached, refreshing source by `createCredentialSource` (lib/env.ts) at the provider-construction
- * site. Declared here beside {@link modelConnectionSchema} — the model connection is a cli-owned config
- * concept — and consumed as {@link ModelAuthConfig}.
+ * The `models.connection.auth` block — a refreshing credential source for a `direct` connection, in place of
+ * the static env key. `env` names a variable holding a token (e.g. a short-lived `ANTHROPIC_AUTH_TOKEN`
+ * bearer); `command` names a helper that mints one on demand (Claude Code `apiKeyHelper` parity), its stdout
+ * a raw token (`format: "raw"`, default) or a Kubernetes `ExecCredential` JSON (`format: "exec-credential"`).
+ * `scheme` is the wire header — `x-api-key` or `Authorization: Bearer`. Only the non-secret name/command/scheme
+ * is persisted; the token is resolved at runtime by `createCredentialSource` (lib/credential.ts), never written
+ * to config. Consumed as {@link ModelAuthConfig}.
  */
 export const modelAuthSchema = z.discriminatedUnion("kind", [
     z.object({
@@ -140,7 +137,7 @@ export const modelConnectionSchema = z.discriminatedUnion("mode", [
         provider: z.string(),
         baseURL: z.string(),
         protocol: z.enum(["anthropic", "openai-compatible"]).optional(),
-        // An optional REFRESHING credential source, in place of the static env key (see {@link modelAuthSchema}).
+        // An optional refreshing credential source, in place of the static env key (see {@link modelAuthSchema}).
         auth: modelAuthSchema.optional(),
     }),
 ]);

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -90,14 +90,45 @@ const configSchema = z.object({
 export type Config = z.infer<typeof configSchema>;
 
 /**
+ * The `models.connection.auth` block — a REFRESHING credential source for a `direct` connection, in place
+ * of the static environment key. `env` names a variable holding a token (e.g. a short-lived
+ * `ANTHROPIC_AUTH_TOKEN` bearer); `command` names a helper that mints one on demand (Claude Code
+ * `apiKeyHelper` parity), its stdout parsed as a raw token (`format: "raw"`, the default) or a Kubernetes
+ * `ExecCredential` JSON (`format: "exec-credential"`). `scheme` selects the wire header the token is sent
+ * under — `x-api-key`, or `Authorization: Bearer`. ONLY the non-secret variable name / command string /
+ * scheme is ever persisted; the token value is resolved at runtime and never written to config. Resolved
+ * into a cached, refreshing source by `createCredentialSource` (lib/env.ts) at the provider-construction
+ * site. Declared here beside {@link modelConnectionSchema} — the model connection is a cli-owned config
+ * concept — and consumed as {@link ModelAuthConfig}.
+ */
+export const modelAuthSchema = z.discriminatedUnion("kind", [
+    z.object({
+        kind: z.literal("env"),
+        var: z.string().min(1),
+        scheme: z.enum(["x-api-key", "bearer"]),
+    }),
+    z.object({
+        kind: z.literal("command"),
+        command: z.string().min(1),
+        scheme: z.enum(["x-api-key", "bearer"]),
+        format: z.enum(["raw", "exec-credential"]).optional(),
+        ttlMs: z.number().int().positive().optional(),
+    }),
+]);
+
+/** The resolved shape of a {@link modelAuthSchema} block — the declarative credential source (a name/command + scheme, never a token). */
+export type ModelAuthConfig = z.infer<typeof modelAuthSchema>;
+
+/**
  * The `models.connection` union — the user-owned chat backend, mirroring the `embedding` block's
  * mode discrimination. `cliproxy` is the managed local proxy (today's default); `direct` is any
  * user-supplied Anthropic or OpenAI-compatible endpoint. `provider` is the vendor slug (an OPEN
  * vocabulary, e.g. `anthropic`/`openai`/`google`) — a configured FACT in both modes, never derived
  * from a model id. `protocol` selects the harness wire kind for direct endpoints; when absent it is
- * implied from the provider (see `resolveModelConnection`). Validated by `resolveModelConnection`
- * (modules/harness/config.ts), not inline, so a malformed block reports a precise error and fails
- * closed without dropping its config siblings.
+ * implied from the provider (see `resolveModelConnection`). A `direct` connection MAY carry an `auth`
+ * block ({@link modelAuthSchema}) — a refreshing credential source that supersedes the static env key.
+ * Validated by `resolveModelConnection` (modules/harness/config.ts), not inline, so a malformed block
+ * reports a precise error and fails closed without dropping its config siblings.
  */
 export const modelConnectionSchema = z.discriminatedUnion("mode", [
     z.object({
@@ -109,6 +140,8 @@ export const modelConnectionSchema = z.discriminatedUnion("mode", [
         provider: z.string(),
         baseURL: z.string(),
         protocol: z.enum(["anthropic", "openai-compatible"]).optional(),
+        // An optional REFRESHING credential source, in place of the static env key (see {@link modelAuthSchema}).
+        auth: modelAuthSchema.optional(),
     }),
 ]);
 

--- a/cli/src/lib/credential.test.ts
+++ b/cli/src/lib/credential.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUIDv7 } from "bun";
+
+import { createCredentialSource } from "./credential.ts";
+
+// The refreshing direct-mode credential source: env + command kinds, cache/refresh, and the two output
+// formats. The command kinds spawn a real `/bin/sh` (deterministic counter / JSON commands) so the
+// spawn+parse boundary is exercised end-to-end. This file drives process.env directly (eslint ignore) to
+// exercise the `env`-kind source, which reads the live environment through env.ts's seam.
+describe("createCredentialSource", () => {
+    const scratch: string[] = [];
+    /** A file-backed counter command whose stdout increments ("1", "2", …) on every invocation — proves cached vs re-run. */
+    function counterCommand(): string {
+        const file = join(tmpdir(), `cred-counter-${randomUUIDv7()}`);
+        scratch.push(file);
+        return `printf x >> '${file}'; wc -c < '${file}' | tr -d ' \\n'`;
+    }
+    /** A counter command that emits ExecCredential JSON with the given expiry, so the token also increments per run. */
+    function execCredCommand(expiry: string): string {
+        const file = join(tmpdir(), `cred-exec-${randomUUIDv7()}`);
+        scratch.push(file);
+        return `printf x >> '${file}'; n=$(wc -c < '${file}' | tr -d ' \\n'); printf '{"apiVersion":"client.authentication.k8s.io/v1","status":{"token":"tok-%s","expirationTimestamp":"%s"}}' "$n" "${expiry}"`;
+    }
+
+    afterEach(() => {
+        for (const f of scratch.splice(0)) rmSync(f, { force: true });
+        delete process.env.CRED_TEST_TOKEN;
+    });
+
+    test("env kind reads the named variable and yields the configured scheme, no expiry", async () => {
+        process.env.CRED_TEST_TOKEN = "env-tok";
+        const cred = (await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get())._unsafeUnwrap();
+        expect(cred).toEqual({ token: "env-tok", scheme: "bearer" });
+    });
+
+    test("env kind errors when the variable is unset", async () => {
+        const result = await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get();
+        expect(result._unsafeUnwrapErr()).toEqual({ type: "env_var_unset", var: "CRED_TEST_TOKEN" });
+    });
+
+    test("env kind caches until forceRefresh re-reads the live variable", async () => {
+        process.env.CRED_TEST_TOKEN = "v1";
+        const source = createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "x-api-key" });
+        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
+        process.env.CRED_TEST_TOKEN = "v2";
+        // No expiry ⇒ get() keeps serving the cached value; only forceRefresh re-reads.
+        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
+        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("v2");
+        expect((await source.get())._unsafeUnwrap().token).toBe("v2");
+    });
+
+    test("command raw token is minted once, cached across get()s, and re-minted on forceRefresh", async () => {
+        // ttlMs 60s > the 30s refresh buffer, so the token stays cached across get()s within the test.
+        const source = createCredentialSource({ kind: "command", command: counterCommand(), scheme: "bearer", ttlMs: 60_000 });
+        const first = (await source.get())._unsafeUnwrap();
+        expect(first.token).toBe("1");
+        expect(first.scheme).toBe("bearer");
+        expect(first.expiresAt).toBeGreaterThan(Date.now());
+        // Cached: the command does not re-run per request.
+        expect((await source.get())._unsafeUnwrap().token).toBe("1");
+        // forceRefresh (the 401 path) re-runs the command.
+        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("2");
+    });
+
+    test("command raw token with empty output errors", async () => {
+        const result = await createCredentialSource({ kind: "command", command: "true", scheme: "x-api-key" }).get();
+        expect(result._unsafeUnwrapErr().type).toBe("command_empty_output");
+    });
+
+    test("a non-zero command exit surfaces as an actionable error, never a throw", async () => {
+        const result = await createCredentialSource({ kind: "command", command: "echo boom >&2; exit 3", scheme: "bearer" }).get();
+        const e = result._unsafeUnwrapErr();
+        expect(e.type).toBe("command_exit_nonzero");
+        if (e.type === "command_exit_nonzero") expect(e.exitCode).toBe(3);
+    });
+
+    test("exec-credential format parses status.token + expirationTimestamp and caches until near expiry", async () => {
+        const future = new Date(Date.now() + 3_600_000).toISOString();
+        const source = createCredentialSource({ kind: "command", command: execCredCommand(future), scheme: "bearer", format: "exec-credential" });
+        const cred = (await source.get())._unsafeUnwrap();
+        expect(cred.token).toBe("tok-1");
+        expect(cred.expiresAt).toBe(Date.parse(future));
+        // Far-future expiry ⇒ cached across get()s.
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
+    });
+
+    test("exec-credential expiry drives refresh: a past expiry re-runs the command on the next get()", async () => {
+        const past = new Date(Date.now() - 60_000).toISOString();
+        const source = createCredentialSource({ kind: "command", command: execCredCommand(past), scheme: "bearer", format: "exec-credential" });
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
+        // Already past expiry (minus buffer) ⇒ the next get() re-mints rather than serving a stale token.
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-2");
+    });
+
+    test("exec-credential format rejects non-ExecCredential JSON with an actionable error", async () => {
+        const result = await createCredentialSource({
+            kind: "command",
+            command: `printf '{"hello":"world"}'`,
+            scheme: "bearer",
+            format: "exec-credential",
+        }).get();
+        expect(result._unsafeUnwrapErr().type).toBe("exec_credential_invalid");
+    });
+});

--- a/cli/src/lib/credential.ts
+++ b/cli/src/lib/credential.ts
@@ -1,0 +1,155 @@
+import { ok, err, type Result } from "neverthrow";
+import { z } from "zod";
+import type { ModelAuthConfig } from "./config.ts";
+import { readEnvCredentialVar } from "./env.ts";
+
+// A `direct` connection's wire credential, generalized from "a static key read once at boot" to a cached,
+// refreshing SOURCE — so direct mode can consume a short-lived token from a credential helper (the pattern
+// Claude Code's `apiKeyHelper` / kubectl exec-plugins use) that a static string can neither refresh nor send
+// as a Bearer. The one `process.env` read (the `env` kind) goes through env.ts's seam so it stays the sole reader.
+
+/** The wire scheme a resolved credential is sent under: the Anthropic `x-api-key` header, or `Authorization: Bearer`. */
+export type CredentialScheme = "x-api-key" | "bearer";
+
+/** A resolved wire credential. `expiresAt` (epoch ms) is absent for a source with no self-described lifetime. */
+export type Credential = {
+    readonly token: string;
+    readonly scheme: CredentialScheme;
+    readonly expiresAt?: number;
+};
+
+/** How a credential resolution failed — one actionable variant per boundary (env read, command spawn/exit, output parse). */
+export type CredentialError =
+    | { readonly type: "env_var_unset"; readonly var: string }
+    | { readonly type: "command_spawn_failed"; readonly command: string; readonly cause: unknown }
+    | { readonly type: "command_exit_nonzero"; readonly command: string; readonly exitCode: number; readonly stderr: string }
+    | { readonly type: "command_empty_output"; readonly command: string }
+    | { readonly type: "exec_credential_invalid"; readonly command: string; readonly detail: string };
+
+/**
+ * A cached async supplier of the wire credential. `get()` serves the cached token, refreshing once it ages
+ * past its expiry (minus a safety buffer); `forceRefresh()` re-runs the source unconditionally — the reactive
+ * path for an HTTP 401. Caching keyed on expiry means a command runs only on a real refresh, never per request.
+ */
+export type CredentialSource = {
+    readonly get: () => Promise<Result<Credential, CredentialError>>;
+    readonly forceRefresh: () => Promise<Result<Credential, CredentialError>>;
+};
+
+/** Render a {@link CredentialError} as an actionable one-line message for the chat error path and setup's probe. */
+export function credentialErrorMessage(e: CredentialError): string {
+    switch (e.type) {
+        case "env_var_unset":
+            return `environment variable ${e.var} is not set`;
+        case "command_spawn_failed":
+            return `credential command could not be run (${e.command}): ${e.cause instanceof Error ? e.cause.message : String(e.cause)}`;
+        case "command_exit_nonzero":
+            return `credential command exited ${e.exitCode} (${e.command})${e.stderr.trim() ? `: ${e.stderr.trim()}` : ""}`;
+        case "command_empty_output":
+            return `credential command produced no token (${e.command})`;
+        case "exec_credential_invalid":
+            return `credential command output is not valid ExecCredential JSON (${e.command}): ${e.detail}`;
+    }
+}
+
+/** Refresh a credential slightly ahead of its stated expiry, never in its final moments. */
+const CREDENTIAL_REFRESH_BUFFER_MS = 30_000;
+/** Lifetime for a raw command token with no self-described expiry — Claude Code's `apiKeyHelper` refresh cadence. */
+const DEFAULT_RAW_TOKEN_TTL_MS = 5 * 60_000;
+
+/**
+ * The subset of a Kubernetes client-go `ExecCredential` this reads. `apiVersion` is required (so a plain blob
+ * that merely carries `status.token` is not mistaken for one) but matched on the `client.authentication.k8s.io/`
+ * prefix, not pinned to `v1`, so a helper emitting the equally-common `v1beta1` still interops.
+ */
+const execCredentialSchema = z.object({
+    apiVersion: z.string().startsWith("client.authentication.k8s.io/"),
+    status: z.object({
+        token: z.string().min(1),
+        expirationTimestamp: z.string().optional(),
+    }),
+});
+
+/**
+ * Run a credential command and capture its stdout, boundary-wrapped to a {@link Result}. Executed through
+ * `sh -c` so a command string with arguments / flags / pipes runs exactly as a Claude Code `apiKeyHelper` would.
+ */
+async function runCredentialCommand(command: string): Promise<Result<string, CredentialError>> {
+    try {
+        // Inferred from the piped options (not annotated) so `proc.stdout`/`.stderr` narrow to `ReadableStream`.
+        const proc = Bun.spawn(["/bin/sh", "-c", command], { stdout: "pipe", stderr: "pipe" });
+        const [stdout, stderr, exitCode] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+        if (exitCode !== 0) return err({ type: "command_exit_nonzero", command, exitCode, stderr });
+        return ok(stdout);
+    } catch (cause) {
+        // A spawn throw (missing shell / bad exec) and a stream-read throw both mean "the command could not be run".
+        return err({ type: "command_spawn_failed", command, cause });
+    }
+}
+
+/** Parse a credential command's stdout into a {@link Credential} per the configured format. */
+function parseCommandCredential(
+    command: string,
+    stdout: string,
+    scheme: CredentialScheme,
+    format: "raw" | "exec-credential",
+    ttlMs: number | undefined,
+): Result<Credential, CredentialError> {
+    if (format === "exec-credential") {
+        let json: unknown; // command output — validated by execCredentialSchema below
+        try {
+            json = JSON.parse(stdout);
+        } catch (cause) {
+            return err({ type: "exec_credential_invalid", command, detail: cause instanceof Error ? cause.message : String(cause) });
+        }
+        const parsed = execCredentialSchema.safeParse(json);
+        if (!parsed.success) {
+            return err({ type: "exec_credential_invalid", command, detail: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ") });
+        }
+        const ts = parsed.data.status.expirationTimestamp;
+        const expiresAt = ts !== undefined ? Date.parse(ts) : NaN;
+        // An unparseable timestamp degrades to "no expiry" rather than an error: the token is valid, and the
+        // 401 forceRefresh path still covers a rotation we didn't foresee.
+        return ok({ token: parsed.data.status.token, scheme, ...(Number.isNaN(expiresAt) ? {} : { expiresAt }) });
+    }
+    const token = stdout.trim(); // raw: the whole stdout IS the token, minus the trailing newline — apiKeyHelper parity
+    if (token === "") return err({ type: "command_empty_output", command });
+    // A raw token describes no lifetime, so it ages off ttlMs (or the apiKeyHelper-default window) and is re-minted on expiry.
+    return ok({ token, scheme, expiresAt: Date.now() + (ttlMs ?? DEFAULT_RAW_TOKEN_TTL_MS) });
+}
+
+/** Resolve one credential from its source config, uncached (the `env` read via env.ts's seam / the `command` run). */
+async function resolveCredentialOnce(config: ModelAuthConfig): Promise<Result<Credential, CredentialError>> {
+    if (config.kind === "env") {
+        // Expiry-less: a rotated var is picked up when the user re-exports it, and a 401 forceRefresh re-reads it live.
+        const token = readEnvCredentialVar(config.var);
+        if (token === undefined) return err({ type: "env_var_unset", var: config.var });
+        return ok({ token, scheme: config.scheme });
+    }
+    const out = await runCredentialCommand(config.command);
+    return out.andThen((stdout) => parseCommandCredential(config.command, stdout, config.scheme, config.format ?? "raw", config.ttlMs));
+}
+
+/** True once a cached credential has aged within the refresh buffer of its expiry; an expiry-less credential never ages out. */
+function credentialExpired(cred: Credential): boolean {
+    return cred.expiresAt !== undefined && Date.now() >= cred.expiresAt - CREDENTIAL_REFRESH_BUFFER_MS;
+}
+
+/**
+ * Build a cached, refreshing {@link CredentialSource} from a declarative {@link ModelAuthConfig}. Nothing runs
+ * until the first {@link CredentialSource.get}; the result is cached until it ages past its expiry (minus
+ * {@link CREDENTIAL_REFRESH_BUFFER_MS}) or {@link CredentialSource.forceRefresh} is called. The token is
+ * obtained lazily and never logged or persisted — only the config's name/command/scheme are written to disk.
+ */
+export function createCredentialSource(config: ModelAuthConfig): CredentialSource {
+    let cached: Credential | null = null;
+    const refresh = async (): Promise<Result<Credential, CredentialError>> => {
+        const resolved = await resolveCredentialOnce(config);
+        if (resolved.isOk()) cached = resolved.value;
+        return resolved;
+    };
+    return {
+        get: () => (cached !== null && !credentialExpired(cached) ? Promise.resolve(ok(cached)) : refresh()),
+        forceRefresh: refresh,
+    };
+}

--- a/cli/src/lib/env.test.ts
+++ b/cli/src/lib/env.test.ts
@@ -1,12 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { randomUUIDv7 } from "bun";
 
 import {
     anthropicAuthTokenSet,
-    createCredentialSource,
     detectProviderEnv,
     devCommandsActive,
     env,
@@ -16,7 +12,6 @@ import {
     modelConnectionEnvDoc,
     providerApiKeyVar,
     resolveModelApiKey,
-    staticCredentialSource,
 } from "./env.ts";
 
 // The truth table behind env.isDevelopment: a build is development unless the baked channel is exactly
@@ -213,113 +208,6 @@ describe("model-connection env documentation", () => {
 
     test("the secret is no longer an env field, so envDoc carries no modelApiKey entry", () => {
         expect(Object.keys(envDoc)).not.toContain("modelApiKey");
-    });
-});
-
-// The refreshing direct-mode credential source: env + command kinds, cache/refresh, and the two output
-// formats. The command kinds spawn a real `/bin/sh` (deterministic counter / JSON commands) so the
-// spawn+parse boundary is exercised end-to-end. env.test.ts may drive process.env directly (eslint ignore).
-describe("createCredentialSource", () => {
-    const scratch: string[] = [];
-    /** A file-backed counter command whose stdout increments ("1", "2", …) on every invocation — proves cached vs re-run. */
-    function counterCommand(): string {
-        const file = join(tmpdir(), `cred-counter-${randomUUIDv7()}`);
-        scratch.push(file);
-        return `printf x >> '${file}'; wc -c < '${file}' | tr -d ' \\n'`;
-    }
-    /** A counter command that emits ExecCredential JSON with the given expiry, so the token also increments per run. */
-    function execCredCommand(expiry: string): string {
-        const file = join(tmpdir(), `cred-exec-${randomUUIDv7()}`);
-        scratch.push(file);
-        return `printf x >> '${file}'; n=$(wc -c < '${file}' | tr -d ' \\n'); printf '{"apiVersion":"client.authentication.k8s.io/v1","status":{"token":"tok-%s","expirationTimestamp":"%s"}}' "$n" "${expiry}"`;
-    }
-
-    afterEach(() => {
-        for (const f of scratch.splice(0)) rmSync(f, { force: true });
-        delete process.env.CRED_TEST_TOKEN;
-    });
-
-    test("env kind reads the named variable and yields the configured scheme, no expiry", async () => {
-        process.env.CRED_TEST_TOKEN = "env-tok";
-        const cred = (await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get())._unsafeUnwrap();
-        expect(cred).toEqual({ token: "env-tok", scheme: "bearer" });
-    });
-
-    test("env kind errors when the variable is unset", async () => {
-        const result = await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get();
-        expect(result._unsafeUnwrapErr()).toEqual({ type: "env_var_unset", var: "CRED_TEST_TOKEN" });
-    });
-
-    test("env kind caches until forceRefresh re-reads the live variable", async () => {
-        process.env.CRED_TEST_TOKEN = "v1";
-        const source = createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "x-api-key" });
-        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
-        process.env.CRED_TEST_TOKEN = "v2";
-        // No expiry ⇒ get() keeps serving the cached value; only forceRefresh re-reads.
-        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
-        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("v2");
-        expect((await source.get())._unsafeUnwrap().token).toBe("v2");
-    });
-
-    test("command raw token is minted once, cached across get()s, and re-minted on forceRefresh", async () => {
-        // ttlMs 60s > the 30s refresh buffer, so the token stays cached across get()s within the test.
-        const source = createCredentialSource({ kind: "command", command: counterCommand(), scheme: "bearer", ttlMs: 60_000 });
-        const first = (await source.get())._unsafeUnwrap();
-        expect(first.token).toBe("1");
-        expect(first.scheme).toBe("bearer");
-        expect(first.expiresAt).toBeGreaterThan(Date.now());
-        // Cached: the command does not re-run per request.
-        expect((await source.get())._unsafeUnwrap().token).toBe("1");
-        // forceRefresh (the 401 path) re-runs the command.
-        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("2");
-    });
-
-    test("command raw token with empty output errors", async () => {
-        const result = await createCredentialSource({ kind: "command", command: "true", scheme: "x-api-key" }).get();
-        expect(result._unsafeUnwrapErr().type).toBe("command_empty_output");
-    });
-
-    test("a non-zero command exit surfaces as an actionable error, never a throw", async () => {
-        const result = await createCredentialSource({ kind: "command", command: "echo boom >&2; exit 3", scheme: "bearer" }).get();
-        const e = result._unsafeUnwrapErr();
-        expect(e.type).toBe("command_exit_nonzero");
-        if (e.type === "command_exit_nonzero") expect(e.exitCode).toBe(3);
-    });
-
-    test("exec-credential format parses status.token + expirationTimestamp and caches until near expiry", async () => {
-        const future = new Date(Date.now() + 3_600_000).toISOString();
-        const source = createCredentialSource({ kind: "command", command: execCredCommand(future), scheme: "bearer", format: "exec-credential" });
-        const cred = (await source.get())._unsafeUnwrap();
-        expect(cred.token).toBe("tok-1");
-        expect(cred.expiresAt).toBe(Date.parse(future));
-        // Far-future expiry ⇒ cached across get()s.
-        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
-    });
-
-    test("exec-credential expiry drives refresh: a past expiry re-runs the command on the next get()", async () => {
-        const past = new Date(Date.now() - 60_000).toISOString();
-        const source = createCredentialSource({ kind: "command", command: execCredCommand(past), scheme: "bearer", format: "exec-credential" });
-        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
-        // Already past expiry (minus buffer) ⇒ the next get() re-mints rather than serving a stale token.
-        expect((await source.get())._unsafeUnwrap().token).toBe("tok-2");
-    });
-
-    test("exec-credential format rejects non-ExecCredential JSON with an actionable error", async () => {
-        const result = await createCredentialSource({
-            kind: "command",
-            command: `printf '{"hello":"world"}'`,
-            scheme: "bearer",
-            format: "exec-credential",
-        }).get();
-        expect(result._unsafeUnwrapErr().type).toBe("exec_credential_invalid");
-    });
-});
-
-describe("staticCredentialSource", () => {
-    test("wraps a known token as an expiry-less source (get and forceRefresh both yield it)", async () => {
-        const source = staticCredentialSource("static-key", "x-api-key");
-        expect((await source.get())._unsafeUnwrap()).toEqual({ token: "static-key", scheme: "x-api-key" });
-        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("static-key");
     });
 });
 

--- a/cli/src/lib/env.test.ts
+++ b/cli/src/lib/env.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { randomUUIDv7 } from "bun";
 
 import {
+    anthropicAuthTokenSet,
+    createCredentialSource,
     detectProviderEnv,
     devCommandsActive,
     env,
@@ -11,6 +16,7 @@ import {
     modelConnectionEnvDoc,
     providerApiKeyVar,
     resolveModelApiKey,
+    staticCredentialSource,
 } from "./env.ts";
 
 // The truth table behind env.isDevelopment: a build is development unless the baked channel is exactly
@@ -207,6 +213,127 @@ describe("model-connection env documentation", () => {
 
     test("the secret is no longer an env field, so envDoc carries no modelApiKey entry", () => {
         expect(Object.keys(envDoc)).not.toContain("modelApiKey");
+    });
+});
+
+// The refreshing direct-mode credential source: env + command kinds, cache/refresh, and the two output
+// formats. The command kinds spawn a real `/bin/sh` (deterministic counter / JSON commands) so the
+// spawn+parse boundary is exercised end-to-end. env.test.ts may drive process.env directly (eslint ignore).
+describe("createCredentialSource", () => {
+    const scratch: string[] = [];
+    /** A file-backed counter command whose stdout increments ("1", "2", …) on every invocation — proves cached vs re-run. */
+    function counterCommand(): string {
+        const file = join(tmpdir(), `cred-counter-${randomUUIDv7()}`);
+        scratch.push(file);
+        return `printf x >> '${file}'; wc -c < '${file}' | tr -d ' \\n'`;
+    }
+    /** A counter command that emits ExecCredential JSON with the given expiry, so the token also increments per run. */
+    function execCredCommand(expiry: string): string {
+        const file = join(tmpdir(), `cred-exec-${randomUUIDv7()}`);
+        scratch.push(file);
+        return `printf x >> '${file}'; n=$(wc -c < '${file}' | tr -d ' \\n'); printf '{"apiVersion":"client.authentication.k8s.io/v1","status":{"token":"tok-%s","expirationTimestamp":"%s"}}' "$n" "${expiry}"`;
+    }
+
+    afterEach(() => {
+        for (const f of scratch.splice(0)) rmSync(f, { force: true });
+        delete process.env.CRED_TEST_TOKEN;
+    });
+
+    test("env kind reads the named variable and yields the configured scheme, no expiry", async () => {
+        process.env.CRED_TEST_TOKEN = "env-tok";
+        const cred = (await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get())._unsafeUnwrap();
+        expect(cred).toEqual({ token: "env-tok", scheme: "bearer" });
+    });
+
+    test("env kind errors when the variable is unset", async () => {
+        const result = await createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "bearer" }).get();
+        expect(result._unsafeUnwrapErr()).toEqual({ type: "env_var_unset", var: "CRED_TEST_TOKEN" });
+    });
+
+    test("env kind caches until forceRefresh re-reads the live variable", async () => {
+        process.env.CRED_TEST_TOKEN = "v1";
+        const source = createCredentialSource({ kind: "env", var: "CRED_TEST_TOKEN", scheme: "x-api-key" });
+        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
+        process.env.CRED_TEST_TOKEN = "v2";
+        // No expiry ⇒ get() keeps serving the cached value; only forceRefresh re-reads.
+        expect((await source.get())._unsafeUnwrap().token).toBe("v1");
+        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("v2");
+        expect((await source.get())._unsafeUnwrap().token).toBe("v2");
+    });
+
+    test("command raw token is minted once, cached across get()s, and re-minted on forceRefresh", async () => {
+        // ttlMs 60s > the 30s refresh buffer, so the token stays cached across get()s within the test.
+        const source = createCredentialSource({ kind: "command", command: counterCommand(), scheme: "bearer", ttlMs: 60_000 });
+        const first = (await source.get())._unsafeUnwrap();
+        expect(first.token).toBe("1");
+        expect(first.scheme).toBe("bearer");
+        expect(first.expiresAt).toBeGreaterThan(Date.now());
+        // Cached: the command does not re-run per request.
+        expect((await source.get())._unsafeUnwrap().token).toBe("1");
+        // forceRefresh (the 401 path) re-runs the command.
+        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("2");
+    });
+
+    test("command raw token with empty output errors", async () => {
+        const result = await createCredentialSource({ kind: "command", command: "true", scheme: "x-api-key" }).get();
+        expect(result._unsafeUnwrapErr().type).toBe("command_empty_output");
+    });
+
+    test("a non-zero command exit surfaces as an actionable error, never a throw", async () => {
+        const result = await createCredentialSource({ kind: "command", command: "echo boom >&2; exit 3", scheme: "bearer" }).get();
+        const e = result._unsafeUnwrapErr();
+        expect(e.type).toBe("command_exit_nonzero");
+        if (e.type === "command_exit_nonzero") expect(e.exitCode).toBe(3);
+    });
+
+    test("exec-credential format parses status.token + expirationTimestamp and caches until near expiry", async () => {
+        const future = new Date(Date.now() + 3_600_000).toISOString();
+        const source = createCredentialSource({ kind: "command", command: execCredCommand(future), scheme: "bearer", format: "exec-credential" });
+        const cred = (await source.get())._unsafeUnwrap();
+        expect(cred.token).toBe("tok-1");
+        expect(cred.expiresAt).toBe(Date.parse(future));
+        // Far-future expiry ⇒ cached across get()s.
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
+    });
+
+    test("exec-credential expiry drives refresh: a past expiry re-runs the command on the next get()", async () => {
+        const past = new Date(Date.now() - 60_000).toISOString();
+        const source = createCredentialSource({ kind: "command", command: execCredCommand(past), scheme: "bearer", format: "exec-credential" });
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-1");
+        // Already past expiry (minus buffer) ⇒ the next get() re-mints rather than serving a stale token.
+        expect((await source.get())._unsafeUnwrap().token).toBe("tok-2");
+    });
+
+    test("exec-credential format rejects non-ExecCredential JSON with an actionable error", async () => {
+        const result = await createCredentialSource({
+            kind: "command",
+            command: `printf '{"hello":"world"}'`,
+            scheme: "bearer",
+            format: "exec-credential",
+        }).get();
+        expect(result._unsafeUnwrapErr().type).toBe("exec_credential_invalid");
+    });
+});
+
+describe("staticCredentialSource", () => {
+    test("wraps a known token as an expiry-less source (get and forceRefresh both yield it)", async () => {
+        const source = staticCredentialSource("static-key", "x-api-key");
+        expect((await source.get())._unsafeUnwrap()).toEqual({ token: "static-key", scheme: "x-api-key" });
+        expect((await source.forceRefresh())._unsafeUnwrap().token).toBe("static-key");
+    });
+});
+
+describe("anthropicAuthTokenSet", () => {
+    const saved = process.env.ANTHROPIC_AUTH_TOKEN;
+    afterEach(() => {
+        if (saved === undefined) delete process.env.ANTHROPIC_AUTH_TOKEN;
+        else process.env.ANTHROPIC_AUTH_TOKEN = saved;
+    });
+    test("reports presence of ANTHROPIC_AUTH_TOKEN without exposing its value", () => {
+        delete process.env.ANTHROPIC_AUTH_TOKEN;
+        expect(anthropicAuthTokenSet()).toBe(false);
+        process.env.ANTHROPIC_AUTH_TOKEN = "sk-ant-oat-secret";
+        expect(anthropicAuthTokenSet()).toBe(true);
     });
 });
 

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -1,11 +1,5 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { ok, err, type Result } from "neverthrow";
-import { z } from "zod";
-// Type-only (erased at compile): the declarative credential-source shape is owned by the config schema
-// beside the model-connection block. lib/config.ts imports this module for `env`, so this back-reference
-// stays type-only to avoid a runtime import cycle.
-import type { ModelAuthConfig } from "./config.ts";
 
 /**
  * True when this process is a `bun test` run whose sandbox preload never executed — the one condition
@@ -262,23 +256,16 @@ export function providerApiKeyVar(provider: string): string {
 }
 
 /**
- * Resolve the `direct`-connection chat API key from the environment ONLY (env.ts is the sole
- * `process.env` reader), parameterized by the connection's configured `provider`. Precedence:
- * `INFLEXA_MODEL_API_KEY` (the explicit override) first; when unset, the provider-conventional variable
- * ({@link providerApiKeyVar}) so a machine already provisioned for Claude Code / the SDKs works without
- * re-exporting the key under a new name. Consumed only at provider construction / model listing; the
- * resolved value is NEVER written to config.json, telemetry, logs, or provenance — the provider-derived
- * fallback READS an existing ecosystem secret, it never copies it. Ignored in `cliproxy` mode, which
- * mints and reads its own client key.
+ * Resolve the `direct`-connection chat API key from the environment ONLY (env.ts is the sole `process.env`
+ * reader), parameterized by the connection's `provider`. Precedence: `INFLEXA_MODEL_API_KEY` (the explicit
+ * override), then the provider-conventional variable ({@link providerApiKeyVar}) so a machine already
+ * provisioned for Claude Code / the SDKs works unchanged. Read at call time (not frozen at import) so it
+ * reflects the live environment. The resolved value is NEVER written to config, telemetry, logs, or
+ * provenance — it READS an existing secret, never copies it. Ignored in `cliproxy` mode (its own client key).
  *
- * Read at call time, not import (unlike the frozen `env` fields), so it reflects the live environment —
- * correct for a value that may be exported after this module loads, and what makes it unit-testable.
- *
- * This is the DEFAULT credential path (static env key, sent as the wire protocol's conventional header). A
- * connection that configures an `auth` block instead supplies a refreshing source that takes precedence —
- * including the Anthropic-wire Bearer case (`ANTHROPIC_AUTH_TOKEN`), now reachable via
- * `{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` (see {@link createCredentialSource}).
- * Still out of scope here: Bedrock/Vertex (no direct-mode HTTP `/v1` signer).
+ * This is the DEFAULT credential path; a configured `auth` block instead supplies a refreshing source that
+ * supersedes it (including the `ANTHROPIC_AUTH_TOKEN` bearer case — see lib/credential.ts). Bedrock/Vertex
+ * stay out of scope (no direct-mode HTTP `/v1` signer).
  */
 export function resolveModelApiKey(provider: string): string | undefined {
     return process.env[modelApiKeyVar] ?? process.env[providerApiKeyVar(provider)];
@@ -293,185 +280,14 @@ export function anthropicAuthTokenSet(): boolean {
     return Boolean(process.env[anthropicAuthTokenVar]);
 }
 
-// --- direct-mode credential source -----------------------------------------
-//
-// A `direct` connection's wire credential, generalized from "a static key read once at boot" to a cached,
-// refreshing SOURCE. This lets `direct` mode consume a short-lived first-party token from a credential
-// helper (the pattern Claude Code's `apiKeyHelper` / kubectl exec-plugins use) that a static string can
-// neither refresh nor send as a Bearer. env.ts owns it because it reads `process.env` (the `env` kind) and
-// runs the configured command (the `command` kind) — both credential-material boundaries the rest of the
-// codebase reaches only through here.
-
-/** The wire scheme a resolved credential is sent under: the Anthropic `x-api-key` header, or `Authorization: Bearer`. */
-export type CredentialScheme = "x-api-key" | "bearer";
-
 /**
- * A resolved wire credential: the token to send, the scheme to send it under, and an OPTIONAL absolute
- * expiry (epoch ms). `expiresAt` is absent for a source with no self-described lifetime (a static env var);
- * {@link createCredentialSource} still ages a raw command token off its `ttlMs`, so an absent `expiresAt`
- * here means "cache until an explicit forceRefresh" — never a per-request re-resolution.
+ * Read a single environment variable for the credential source's `env` kind (lib/credential.ts) — the sole
+ * sanctioned `process.env` read behind it. A live read (not frozen at import) so a re-exported token is
+ * picked up and a 401 can re-read it; an empty value counts as unset.
  */
-export type Credential = {
-    readonly token: string;
-    readonly scheme: CredentialScheme;
-    readonly expiresAt?: number;
-};
-
-/** How a credential resolution failed — one actionable variant per boundary (env read, command spawn/exit, output parse). */
-export type CredentialError =
-    | { readonly type: "env_var_unset"; readonly var: string }
-    | { readonly type: "command_spawn_failed"; readonly command: string; readonly cause: unknown }
-    | { readonly type: "command_exit_nonzero"; readonly command: string; readonly exitCode: number; readonly stderr: string }
-    | { readonly type: "command_empty_output"; readonly command: string }
-    | { readonly type: "exec_credential_invalid"; readonly command: string; readonly detail: string };
-
-/**
- * A cached async supplier of the wire credential. `get()` returns the cached token, transparently
- * refreshing when it has aged past its expiry (minus a safety buffer); `forceRefresh()` re-runs the
- * underlying source unconditionally — the reactive path for an HTTP 401 (a token rotated out from under the
- * cache). Caching keyed on expiry means a credential COMMAND runs only on a real refresh, never per request.
- */
-export type CredentialSource = {
-    readonly get: () => Promise<Result<Credential, CredentialError>>;
-    readonly forceRefresh: () => Promise<Result<Credential, CredentialError>>;
-};
-
-/** Render a {@link CredentialError} as an actionable one-line message — the wire boundary surfaces it to the chat error path, and setup's probe names it as the likely cause. */
-export function credentialErrorMessage(e: CredentialError): string {
-    switch (e.type) {
-        case "env_var_unset":
-            return `environment variable ${e.var} is not set`;
-        case "command_spawn_failed":
-            return `credential command could not be run (${e.command}): ${e.cause instanceof Error ? e.cause.message : String(e.cause)}`;
-        case "command_exit_nonzero":
-            return `credential command exited ${e.exitCode} (${e.command})${e.stderr.trim() ? `: ${e.stderr.trim()}` : ""}`;
-        case "command_empty_output":
-            return `credential command produced no token (${e.command})`;
-        case "exec_credential_invalid":
-            return `credential command output is not valid ExecCredential JSON (${e.command}): ${e.detail}`;
-    }
-}
-
-/** Safety margin subtracted from a credential's expiry so it is refreshed slightly early, never used in its final moments. */
-const CREDENTIAL_REFRESH_BUFFER_MS = 30_000;
-/** Default lifetime for a raw command token with no self-described expiry and no configured `ttlMs` — Claude Code's `apiKeyHelper` refresh cadence. */
-const DEFAULT_RAW_TOKEN_TTL_MS = 5 * 60_000;
-
-/**
- * The subset of a Kubernetes client-go `ExecCredential` this reads: the minted token and its optional
- * expiry. `apiVersion` is required present (so a plain JSON blob that merely happens to carry `status.token`
- * is not mistaken for one) but matched only on the `client.authentication.k8s.io/` prefix rather than pinned
- * to `v1`, so a helper emitting the equally-common `v1beta1` still interops — the interop guarantee is the
- * whole point of adopting the standard shape. See the client-authentication API reference.
- */
-const execCredentialSchema = z.object({
-    apiVersion: z.string().startsWith("client.authentication.k8s.io/"),
-    status: z.object({
-        token: z.string().min(1),
-        expirationTimestamp: z.string().optional(),
-    }),
-});
-
-/**
- * Run a credential command and capture its stdout, boundary-wrapped to a {@link Result} (Bun.spawn and the
- * stream reads throw). Executed through the system shell (`sh -c`) so a configured command string with
- * arguments / flags / pipes runs exactly as a Claude Code `apiKeyHelper` would.
- */
-async function runCredentialCommand(command: string): Promise<Result<string, CredentialError>> {
-    try {
-        // `proc` is inferred from the piped options here (not annotated), so `proc.stdout`/`.stderr` narrow
-        // to `ReadableStream` — an outer type annotation would widen them back to the generic union.
-        const proc = Bun.spawn(["/bin/sh", "-c", command], { stdout: "pipe", stderr: "pipe" });
-        const [stdout, stderr, exitCode] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
-        if (exitCode !== 0) return err({ type: "command_exit_nonzero", command, exitCode, stderr });
-        return ok(stdout);
-    } catch (cause) {
-        // A spawn throw (missing shell / bad exec) and a stream-read throw both mean "the command could not be run".
-        return err({ type: "command_spawn_failed", command, cause });
-    }
-}
-
-/** Parse a credential command's stdout into a {@link Credential} per the configured format. */
-function parseCommandCredential(
-    command: string,
-    stdout: string,
-    scheme: CredentialScheme,
-    format: "raw" | "exec-credential",
-    ttlMs: number | undefined,
-): Result<Credential, CredentialError> {
-    if (format === "exec-credential") {
-        let json: unknown; // command output — validated by execCredentialSchema below
-        try {
-            json = JSON.parse(stdout);
-        } catch (cause) {
-            return err({ type: "exec_credential_invalid", command, detail: cause instanceof Error ? cause.message : String(cause) });
-        }
-        const parsed = execCredentialSchema.safeParse(json);
-        if (!parsed.success) {
-            return err({ type: "exec_credential_invalid", command, detail: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ") });
-        }
-        const ts = parsed.data.status.expirationTimestamp;
-        const expiresAt = ts !== undefined ? Date.parse(ts) : NaN;
-        // A present-but-unparseable timestamp degrades to "no self-described expiry" rather than an error:
-        // the token itself is valid, and the 401 forceRefresh path still covers a rotation we didn't foresee.
-        return ok({ token: parsed.data.status.token, scheme, ...(Number.isNaN(expiresAt) ? {} : { expiresAt }) });
-    }
-    // raw: the whole stdout IS the token, trimmed of the trailing newline a helper prints — apiKeyHelper parity.
-    const token = stdout.trim();
-    if (token === "") return err({ type: "command_empty_output", command });
-    // A raw token describes no lifetime, so it ages off ttlMs (or the apiKeyHelper-default window) and is re-minted on expiry.
-    return ok({ token, scheme, expiresAt: Date.now() + (ttlMs ?? DEFAULT_RAW_TOKEN_TTL_MS) });
-}
-
-/** Resolve one credential from its source config, uncached (the `env` read / the `command` run). */
-async function resolveCredentialOnce(config: ModelAuthConfig): Promise<Result<Credential, CredentialError>> {
-    if (config.kind === "env") {
-        const token = process.env[config.var];
-        if (token === undefined || token === "") return err({ type: "env_var_unset", var: config.var });
-        // An env token is expiry-less: a rotated ANTHROPIC_AUTH_TOKEN is picked up when the user re-exports it,
-        // and a 401 forceRefresh re-reads the live variable.
-        return ok({ token, scheme: config.scheme });
-    }
-    const out = await runCredentialCommand(config.command);
-    return out.andThen((stdout) => parseCommandCredential(config.command, stdout, config.scheme, config.format ?? "raw", config.ttlMs));
-}
-
-/** True once a cached credential has aged to within the refresh buffer of its expiry; an expiry-less credential never ages out (only forceRefresh replaces it). */
-function credentialExpired(cred: Credential): boolean {
-    return cred.expiresAt !== undefined && Date.now() >= cred.expiresAt - CREDENTIAL_REFRESH_BUFFER_MS;
-}
-
-/**
- * Build a cached, refreshing {@link CredentialSource} from a declarative {@link ModelAuthConfig}. Nothing
- * runs until the first {@link CredentialSource.get}; the result is then cached until it ages past its expiry
- * (minus {@link CREDENTIAL_REFRESH_BUFFER_MS}) or {@link CredentialSource.forceRefresh} is called. The `env`
- * kind reads a named variable; the `command` kind runs the command and parses its stdout as a raw token
- * (default) or Kubernetes ExecCredential JSON. The token value is obtained lazily by the returned source and
- * NEVER logged or persisted — only this config's name/command/scheme are ever written to disk.
- */
-export function createCredentialSource(config: ModelAuthConfig): CredentialSource {
-    let cached: Credential | null = null;
-    const refresh = async (): Promise<Result<Credential, CredentialError>> => {
-        const resolved = await resolveCredentialOnce(config);
-        if (resolved.isOk()) cached = resolved.value;
-        return resolved;
-    };
-    return {
-        get: () => (cached !== null && !credentialExpired(cached) ? Promise.resolve(ok(cached)) : refresh()),
-        forceRefresh: refresh,
-    };
-}
-
-/**
- * Wrap an already-resolved static token (the environment key resolved via {@link resolveModelApiKey}) as an
- * expiry-less {@link CredentialSource}, so the wire path is UNIFORM: `direct` mode always injects its
- * credential through the same source seam whether the token comes from a configured `auth` block or the plain
- * env key. `forceRefresh` returns the same token — a static env key has nothing to re-mint.
- */
-export function staticCredentialSource(token: string, scheme: CredentialScheme): CredentialSource {
-    const credential: Credential = { token, scheme };
-    const resolve = (): Promise<Result<Credential, CredentialError>> => Promise.resolve(ok(credential));
-    return { get: resolve, forceRefresh: resolve };
+export function readEnvCredentialVar(name: string): string | undefined {
+    const value = process.env[name];
+    return value === undefined || value === "" ? undefined : value;
 }
 
 /**
@@ -593,9 +409,8 @@ export const envDoc: Readonly<
  * no gain. Rendered alongside `envDoc`'s var rows by src/cli/index.ts.
  *
  * `ANTHROPIC_AUTH_TOKEN` is consumed not as a bare env fallback here but via a configured `direct`-mode
- * `auth` block (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }`) — see
- * {@link createCredentialSource}; setup offers it when detected. Bedrock/Vertex remain out of scope
- * (no direct-mode HTTP signer).
+ * `auth` block (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` — see lib/credential.ts);
+ * setup offers it when detected. Bedrock/Vertex remain out of scope (no direct-mode HTTP signer).
  */
 export const modelConnectionEnvDoc: readonly { readonly name: string; readonly description: string }[] = Object.freeze([
     {

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -1,5 +1,11 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { ok, err, type Result } from "neverthrow";
+import { z } from "zod";
+// Type-only (erased at compile): the declarative credential-source shape is owned by the config schema
+// beside the model-connection block. lib/config.ts imports this module for `env`, so this back-reference
+// stays type-only to avoid a runtime import cycle.
+import type { ModelAuthConfig } from "./config.ts";
 
 /**
  * True when this process is a `bun test` run whose sandbox preload never executed — the one condition
@@ -51,6 +57,11 @@ const anthropicApiKeyVar = "ANTHROPIC_API_KEY";
 const openaiApiKeyVar = "OPENAI_API_KEY";
 const anthropicBaseUrlVar = "ANTHROPIC_BASE_URL";
 const openaiBaseUrlVar = "OPENAI_BASE_URL";
+// The Anthropic-wire BEARER token variable. A short-lived first-party token (WIF / gateway / enterprise
+// credential) rather than a static `x-api-key`; consumed as a `direct`-mode credential source via a
+// configured `{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` auth block, and detected by
+// setup. Read here (the sole `process.env` reader) — see {@link anthropicAuthTokenSet}.
+const anthropicAuthTokenVar = "ANTHROPIC_AUTH_TOKEN";
 
 function dataDir(): string {
     const base = process.env[dataVar];
@@ -263,12 +274,204 @@ export function providerApiKeyVar(provider: string): string {
  * Read at call time, not import (unlike the frozen `env` fields), so it reflects the live environment —
  * correct for a value that may be exported after this module loads, and what makes it unit-testable.
  *
- * Out of scope (deferred): `ANTHROPIC_AUTH_TOKEN` (Anthropic-wire + Bearer needs a harness
- * custom-auth-header capability the CLI cannot supply alone) and Bedrock/Vertex (no direct-mode HTTP
- * `/v1` signer). A gateway that wants a bearer token can be adopted today as `protocol: openai-compatible`.
+ * This is the DEFAULT credential path (static env key, sent as the wire protocol's conventional header). A
+ * connection that configures an `auth` block instead supplies a refreshing source that takes precedence —
+ * including the Anthropic-wire Bearer case (`ANTHROPIC_AUTH_TOKEN`), now reachable via
+ * `{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` (see {@link createCredentialSource}).
+ * Still out of scope here: Bedrock/Vertex (no direct-mode HTTP `/v1` signer).
  */
 export function resolveModelApiKey(provider: string): string | undefined {
     return process.env[modelApiKeyVar] ?? process.env[providerApiKeyVar(provider)];
+}
+
+/**
+ * True when {@link anthropicAuthTokenVar} (`ANTHROPIC_AUTH_TOKEN`) is set — the env signal of a bearer-token
+ * Anthropic setup. Read here because env.ts is the sole `process.env` reader; setup consumes it (never the
+ * value) to OFFER the `{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }` credential source.
+ */
+export function anthropicAuthTokenSet(): boolean {
+    return Boolean(process.env[anthropicAuthTokenVar]);
+}
+
+// --- direct-mode credential source -----------------------------------------
+//
+// A `direct` connection's wire credential, generalized from "a static key read once at boot" to a cached,
+// refreshing SOURCE. This lets `direct` mode consume a short-lived first-party token from a credential
+// helper (the pattern Claude Code's `apiKeyHelper` / kubectl exec-plugins use) that a static string can
+// neither refresh nor send as a Bearer. env.ts owns it because it reads `process.env` (the `env` kind) and
+// runs the configured command (the `command` kind) — both credential-material boundaries the rest of the
+// codebase reaches only through here.
+
+/** The wire scheme a resolved credential is sent under: the Anthropic `x-api-key` header, or `Authorization: Bearer`. */
+export type CredentialScheme = "x-api-key" | "bearer";
+
+/**
+ * A resolved wire credential: the token to send, the scheme to send it under, and an OPTIONAL absolute
+ * expiry (epoch ms). `expiresAt` is absent for a source with no self-described lifetime (a static env var);
+ * {@link createCredentialSource} still ages a raw command token off its `ttlMs`, so an absent `expiresAt`
+ * here means "cache until an explicit forceRefresh" — never a per-request re-resolution.
+ */
+export type Credential = {
+    readonly token: string;
+    readonly scheme: CredentialScheme;
+    readonly expiresAt?: number;
+};
+
+/** How a credential resolution failed — one actionable variant per boundary (env read, command spawn/exit, output parse). */
+export type CredentialError =
+    | { readonly type: "env_var_unset"; readonly var: string }
+    | { readonly type: "command_spawn_failed"; readonly command: string; readonly cause: unknown }
+    | { readonly type: "command_exit_nonzero"; readonly command: string; readonly exitCode: number; readonly stderr: string }
+    | { readonly type: "command_empty_output"; readonly command: string }
+    | { readonly type: "exec_credential_invalid"; readonly command: string; readonly detail: string };
+
+/**
+ * A cached async supplier of the wire credential. `get()` returns the cached token, transparently
+ * refreshing when it has aged past its expiry (minus a safety buffer); `forceRefresh()` re-runs the
+ * underlying source unconditionally — the reactive path for an HTTP 401 (a token rotated out from under the
+ * cache). Caching keyed on expiry means a credential COMMAND runs only on a real refresh, never per request.
+ */
+export type CredentialSource = {
+    readonly get: () => Promise<Result<Credential, CredentialError>>;
+    readonly forceRefresh: () => Promise<Result<Credential, CredentialError>>;
+};
+
+/** Render a {@link CredentialError} as an actionable one-line message — the wire boundary surfaces it to the chat error path, and setup's probe names it as the likely cause. */
+export function credentialErrorMessage(e: CredentialError): string {
+    switch (e.type) {
+        case "env_var_unset":
+            return `environment variable ${e.var} is not set`;
+        case "command_spawn_failed":
+            return `credential command could not be run (${e.command}): ${e.cause instanceof Error ? e.cause.message : String(e.cause)}`;
+        case "command_exit_nonzero":
+            return `credential command exited ${e.exitCode} (${e.command})${e.stderr.trim() ? `: ${e.stderr.trim()}` : ""}`;
+        case "command_empty_output":
+            return `credential command produced no token (${e.command})`;
+        case "exec_credential_invalid":
+            return `credential command output is not valid ExecCredential JSON (${e.command}): ${e.detail}`;
+    }
+}
+
+/** Safety margin subtracted from a credential's expiry so it is refreshed slightly early, never used in its final moments. */
+const CREDENTIAL_REFRESH_BUFFER_MS = 30_000;
+/** Default lifetime for a raw command token with no self-described expiry and no configured `ttlMs` — Claude Code's `apiKeyHelper` refresh cadence. */
+const DEFAULT_RAW_TOKEN_TTL_MS = 5 * 60_000;
+
+/**
+ * The subset of a Kubernetes client-go `ExecCredential` this reads: the minted token and its optional
+ * expiry. `apiVersion` is required present (so a plain JSON blob that merely happens to carry `status.token`
+ * is not mistaken for one) but matched only on the `client.authentication.k8s.io/` prefix rather than pinned
+ * to `v1`, so a helper emitting the equally-common `v1beta1` still interops — the interop guarantee is the
+ * whole point of adopting the standard shape. See the client-authentication API reference.
+ */
+const execCredentialSchema = z.object({
+    apiVersion: z.string().startsWith("client.authentication.k8s.io/"),
+    status: z.object({
+        token: z.string().min(1),
+        expirationTimestamp: z.string().optional(),
+    }),
+});
+
+/**
+ * Run a credential command and capture its stdout, boundary-wrapped to a {@link Result} (Bun.spawn and the
+ * stream reads throw). Executed through the system shell (`sh -c`) so a configured command string with
+ * arguments / flags / pipes runs exactly as a Claude Code `apiKeyHelper` would.
+ */
+async function runCredentialCommand(command: string): Promise<Result<string, CredentialError>> {
+    try {
+        // `proc` is inferred from the piped options here (not annotated), so `proc.stdout`/`.stderr` narrow
+        // to `ReadableStream` — an outer type annotation would widen them back to the generic union.
+        const proc = Bun.spawn(["/bin/sh", "-c", command], { stdout: "pipe", stderr: "pipe" });
+        const [stdout, stderr, exitCode] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+        if (exitCode !== 0) return err({ type: "command_exit_nonzero", command, exitCode, stderr });
+        return ok(stdout);
+    } catch (cause) {
+        // A spawn throw (missing shell / bad exec) and a stream-read throw both mean "the command could not be run".
+        return err({ type: "command_spawn_failed", command, cause });
+    }
+}
+
+/** Parse a credential command's stdout into a {@link Credential} per the configured format. */
+function parseCommandCredential(
+    command: string,
+    stdout: string,
+    scheme: CredentialScheme,
+    format: "raw" | "exec-credential",
+    ttlMs: number | undefined,
+): Result<Credential, CredentialError> {
+    if (format === "exec-credential") {
+        let json: unknown; // command output — validated by execCredentialSchema below
+        try {
+            json = JSON.parse(stdout);
+        } catch (cause) {
+            return err({ type: "exec_credential_invalid", command, detail: cause instanceof Error ? cause.message : String(cause) });
+        }
+        const parsed = execCredentialSchema.safeParse(json);
+        if (!parsed.success) {
+            return err({ type: "exec_credential_invalid", command, detail: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ") });
+        }
+        const ts = parsed.data.status.expirationTimestamp;
+        const expiresAt = ts !== undefined ? Date.parse(ts) : NaN;
+        // A present-but-unparseable timestamp degrades to "no self-described expiry" rather than an error:
+        // the token itself is valid, and the 401 forceRefresh path still covers a rotation we didn't foresee.
+        return ok({ token: parsed.data.status.token, scheme, ...(Number.isNaN(expiresAt) ? {} : { expiresAt }) });
+    }
+    // raw: the whole stdout IS the token, trimmed of the trailing newline a helper prints — apiKeyHelper parity.
+    const token = stdout.trim();
+    if (token === "") return err({ type: "command_empty_output", command });
+    // A raw token describes no lifetime, so it ages off ttlMs (or the apiKeyHelper-default window) and is re-minted on expiry.
+    return ok({ token, scheme, expiresAt: Date.now() + (ttlMs ?? DEFAULT_RAW_TOKEN_TTL_MS) });
+}
+
+/** Resolve one credential from its source config, uncached (the `env` read / the `command` run). */
+async function resolveCredentialOnce(config: ModelAuthConfig): Promise<Result<Credential, CredentialError>> {
+    if (config.kind === "env") {
+        const token = process.env[config.var];
+        if (token === undefined || token === "") return err({ type: "env_var_unset", var: config.var });
+        // An env token is expiry-less: a rotated ANTHROPIC_AUTH_TOKEN is picked up when the user re-exports it,
+        // and a 401 forceRefresh re-reads the live variable.
+        return ok({ token, scheme: config.scheme });
+    }
+    const out = await runCredentialCommand(config.command);
+    return out.andThen((stdout) => parseCommandCredential(config.command, stdout, config.scheme, config.format ?? "raw", config.ttlMs));
+}
+
+/** True once a cached credential has aged to within the refresh buffer of its expiry; an expiry-less credential never ages out (only forceRefresh replaces it). */
+function credentialExpired(cred: Credential): boolean {
+    return cred.expiresAt !== undefined && Date.now() >= cred.expiresAt - CREDENTIAL_REFRESH_BUFFER_MS;
+}
+
+/**
+ * Build a cached, refreshing {@link CredentialSource} from a declarative {@link ModelAuthConfig}. Nothing
+ * runs until the first {@link CredentialSource.get}; the result is then cached until it ages past its expiry
+ * (minus {@link CREDENTIAL_REFRESH_BUFFER_MS}) or {@link CredentialSource.forceRefresh} is called. The `env`
+ * kind reads a named variable; the `command` kind runs the command and parses its stdout as a raw token
+ * (default) or Kubernetes ExecCredential JSON. The token value is obtained lazily by the returned source and
+ * NEVER logged or persisted — only this config's name/command/scheme are ever written to disk.
+ */
+export function createCredentialSource(config: ModelAuthConfig): CredentialSource {
+    let cached: Credential | null = null;
+    const refresh = async (): Promise<Result<Credential, CredentialError>> => {
+        const resolved = await resolveCredentialOnce(config);
+        if (resolved.isOk()) cached = resolved.value;
+        return resolved;
+    };
+    return {
+        get: () => (cached !== null && !credentialExpired(cached) ? Promise.resolve(ok(cached)) : refresh()),
+        forceRefresh: refresh,
+    };
+}
+
+/**
+ * Wrap an already-resolved static token (the environment key resolved via {@link resolveModelApiKey}) as an
+ * expiry-less {@link CredentialSource}, so the wire path is UNIFORM: `direct` mode always injects its
+ * credential through the same source seam whether the token comes from a configured `auth` block or the plain
+ * env key. `forceRefresh` returns the same token — a static env key has nothing to re-mint.
+ */
+export function staticCredentialSource(token: string, scheme: CredentialScheme): CredentialSource {
+    const credential: Credential = { token, scheme };
+    const resolve = (): Promise<Result<Credential, CredentialError>> => Promise.resolve(ok(credential));
+    return { get: resolve, forceRefresh: resolve };
 }
 
 /**
@@ -389,8 +592,10 @@ export const envDoc: Readonly<
  * is key-locked to `env`'s fields: surfacing these as `env` fields would widen the secret's surface for
  * no gain. Rendered alongside `envDoc`'s var rows by src/cli/index.ts.
  *
- * `ANTHROPIC_AUTH_TOKEN` and Bedrock/Vertex are deliberately ABSENT — not adopted in this version
- * (see {@link resolveModelApiKey}); a bearer-only gateway is reachable today as `protocol: openai-compatible`.
+ * `ANTHROPIC_AUTH_TOKEN` is consumed not as a bare env fallback here but via a configured `direct`-mode
+ * `auth` block (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }`) — see
+ * {@link createCredentialSource}; setup offers it when detected. Bedrock/Vertex remain out of scope
+ * (no direct-mode HTTP signer).
  */
 export const modelConnectionEnvDoc: readonly { readonly name: string; readonly description: string }[] = Object.freeze([
     {

--- a/cli/src/modules/harness/config.test.ts
+++ b/cli/src/modules/harness/config.test.ts
@@ -133,6 +133,75 @@ describe("resolveModelConnection — agent overrides ride through", () => {
     });
 });
 
+describe("resolveModelConnection — direct-mode auth (credential source) round-trip", () => {
+    test("a valid env auth block rides through verbatim onto the resolved direct connection", () => {
+        writeConfigWithModels({
+            connection: {
+                mode: "direct",
+                provider: "anthropic",
+                baseURL: "https://api.anthropic.com/v1",
+                auth: { kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" },
+            },
+        });
+        expect(resolveModelConnection()).toEqual({
+            mode: "direct",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com/v1",
+            protocol: "anthropic",
+            auth: { kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" },
+            agents: {},
+        });
+    });
+
+    test("a valid command auth block carries format + ttlMs verbatim", () => {
+        writeConfigWithModels({
+            connection: {
+                mode: "direct",
+                provider: "deepseek",
+                baseURL: "https://api.deepseek.com/v1",
+                auth: { kind: "command", command: "mint-token --json", scheme: "x-api-key", format: "exec-credential", ttlMs: 300000 },
+            },
+        });
+        expect(resolveModelConnection()).toEqual({
+            mode: "direct",
+            provider: "deepseek",
+            baseURL: "https://api.deepseek.com/v1",
+            protocol: "openai-compatible",
+            auth: { kind: "command", command: "mint-token --json", scheme: "x-api-key", format: "exec-credential", ttlMs: 300000 },
+            agents: {},
+        });
+    });
+
+    test("a direct connection with no auth block resolves without an auth field (env-key path)", () => {
+        writeConfigWithModels({ connection: { mode: "direct", provider: "anthropic", baseURL: "https://api.anthropic.com/v1" } });
+        const resolved = resolveModelConnection();
+        expect(resolved).not.toHaveProperty("auth");
+    });
+
+    test("an invalid auth scheme fails the whole models parse closed, naming the offending field", () => {
+        writeConfigWithModels({
+            connection: { mode: "direct", provider: "anthropic", baseURL: "https://api.anthropic.com/v1", auth: { kind: "env", var: "X", scheme: "basic" } },
+        });
+        const resolved = resolveModelConnection();
+        expect(resolved).toMatchObject({ mode: "cliproxy", provider: "anthropic", agents: {} });
+        expect(resolved.configError?.issues).toContain("models.connection");
+    });
+
+    test("an unknown auth kind fails closed with a config error", () => {
+        writeConfigWithModels({
+            connection: { mode: "direct", provider: "anthropic", baseURL: "https://api.anthropic.com/v1", auth: { kind: "aws-sso", scheme: "bearer" } },
+        });
+        expect(resolveModelConnection().configError).toBeDefined();
+    });
+
+    test("a command auth block missing its command fails closed", () => {
+        writeConfigWithModels({
+            connection: { mode: "direct", provider: "openai", baseURL: "https://api.openai.com/v1", auth: { kind: "command", scheme: "bearer" } },
+        });
+        expect(resolveModelConnection().configError).toBeDefined();
+    });
+});
+
 describe("resolveModelConnection — fail closed", () => {
     test("a direct block missing baseURL fails closed to the default connection, carrying a configError", () => {
         writeConfigWithModels({ connection: { mode: "direct", provider: "openai" } });

--- a/cli/src/modules/harness/config.ts
+++ b/cli/src/modules/harness/config.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { MachineBudget, ResourceLimits, ResourcePolicy } from "@inflexa-ai/harness";
 import { type Result } from "neverthrow";
-import { modelsConfigSchema, readConfig, writeConfig, type ConfigError } from "../../lib/config.ts";
+import { modelsConfigSchema, readConfig, writeConfig, type ConfigError, type ModelAuthConfig } from "../../lib/config.ts";
 import { env } from "../../lib/env.ts";
 import { DEFAULT_SANDBOX_IMAGE } from "../libs/images.ts";
 
@@ -266,6 +266,13 @@ export type ResolvedModelConnection =
           /** The configured endpoint (required in direct mode). */
           readonly baseURL: string;
           readonly protocol: ModelWireProtocol;
+          /**
+           * An optional REFRESHING credential source (`models.connection.auth`) — a named env var or a
+           * token-minting command — that supersedes the env-key resolution at provider construction. Absent
+           * ⇒ the static {@link resolveModelApiKey} env chain applies. Carries only the non-secret
+           * name/command/scheme; the token is never resolved here (never at boot), only lazily at the wire.
+           */
+          readonly auth?: ModelAuthConfig;
           readonly agents: AgentModelOverrides;
           readonly configError?: { issues: string };
       };
@@ -320,5 +327,14 @@ export function resolveModelConnection(): ResolvedModelConnection {
         return { mode: "cliproxy", provider: connection.provider ?? "anthropic", agents };
     }
     const protocol: ModelWireProtocol = connection.protocol ?? (connection.provider === "anthropic" ? "anthropic" : "openai-compatible");
-    return { mode: "direct", provider: connection.provider, baseURL: connection.baseURL, protocol, agents };
+    // Carry the optional `auth` credential source verbatim (only present on a well-formed direct block). It
+    // holds no token — just the name/command/scheme boot hands to `createCredentialSource` at the wire seam.
+    return {
+        mode: "direct",
+        provider: connection.provider,
+        baseURL: connection.baseURL,
+        protocol,
+        agents,
+        ...(connection.auth !== undefined && { auth: connection.auth }),
+    };
 }

--- a/cli/src/modules/harness/config.ts
+++ b/cli/src/modules/harness/config.ts
@@ -267,10 +267,9 @@ export type ResolvedModelConnection =
           readonly baseURL: string;
           readonly protocol: ModelWireProtocol;
           /**
-           * An optional REFRESHING credential source (`models.connection.auth`) — a named env var or a
-           * token-minting command — that supersedes the env-key resolution at provider construction. Absent
-           * ⇒ the static {@link resolveModelApiKey} env chain applies. Carries only the non-secret
-           * name/command/scheme; the token is never resolved here (never at boot), only lazily at the wire.
+           * An optional refreshing credential source (`models.connection.auth`) — a named env var or a
+           * token-minting command — that supersedes the env-key resolution. Carries only the non-secret
+           * name/command/scheme; the token is resolved lazily at the wire, never at boot.
            */
           readonly auth?: ModelAuthConfig;
           readonly agents: AgentModelOverrides;
@@ -327,8 +326,7 @@ export function resolveModelConnection(): ResolvedModelConnection {
         return { mode: "cliproxy", provider: connection.provider ?? "anthropic", agents };
     }
     const protocol: ModelWireProtocol = connection.protocol ?? (connection.provider === "anthropic" ? "anthropic" : "openai-compatible");
-    // Carry the optional `auth` credential source verbatim (only present on a well-formed direct block). It
-    // holds no token — just the name/command/scheme boot hands to `createCredentialSource` at the wire seam.
+    // Carry the optional token-free `auth` source verbatim (present only on a well-formed direct block).
     return {
         mode: "direct",
         provider: connection.provider,

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -6,7 +6,8 @@ import { randomUUIDv7 } from "bun";
 import { ok, okAsync, err } from "neverthrow";
 import type { EmbeddingProvider } from "@inflexa-ai/harness";
 
-import { env, staticCredentialSource, type CredentialSource, type Credential, type CredentialError } from "../../lib/env.ts";
+import { env } from "../../lib/env.ts";
+import { type Credential, type CredentialError, type CredentialScheme, type CredentialSource } from "../../lib/credential.ts";
 import { instanceLockPath } from "../../lib/lock.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
 import { bootHarnessRuntime, buildAuthInjectingFetch, __resetHarnessRuntimeForTest, type BootSeams } from "./runtime.ts";
@@ -708,9 +709,15 @@ describe("buildAuthInjectingFetch", () => {
         };
     }
 
+    /** A fixed, expiry-less credential source for the header-rewrite cases (get and forceRefresh yield the same token). */
+    function fixedSource(token: string, scheme: CredentialScheme): CredentialSource {
+        const cred = ok<Credential, CredentialError>({ token, scheme });
+        return { get: () => Promise.resolve(cred), forceRefresh: () => Promise.resolve(cred) };
+    }
+
     test("bearer scheme sets Authorization: Bearer and strips the SDK's x-api-key", async () => {
         const { fetch: underlying, seen } = recordingFetch([200]);
-        const f = buildAuthInjectingFetch(staticCredentialSource("btok", "bearer"), underlying);
+        const f = buildAuthInjectingFetch(fixedSource("btok", "bearer"), underlying);
         // The AI SDK's anthropic provider sets x-api-key from the placeholder apiKey — the bearer path must remove it.
         await f("https://api.anthropic.com/v1/messages", { method: "POST", headers: { "x-api-key": "placeholder" } });
         expect(seen[0]!.get("authorization")).toBe("Bearer btok");
@@ -719,7 +726,7 @@ describe("buildAuthInjectingFetch", () => {
 
     test("x-api-key scheme sets the x-api-key header", async () => {
         const { fetch: underlying, seen } = recordingFetch([200]);
-        const f = buildAuthInjectingFetch(staticCredentialSource("xtok", "x-api-key"), underlying);
+        const f = buildAuthInjectingFetch(fixedSource("xtok", "x-api-key"), underlying);
         await f("https://api.anthropic.com/v1/messages", { method: "POST", headers: { "x-api-key": "placeholder" } });
         expect(seen[0]!.get("x-api-key")).toBe("xtok");
     });

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -6,10 +6,10 @@ import { randomUUIDv7 } from "bun";
 import { ok, okAsync, err } from "neverthrow";
 import type { EmbeddingProvider } from "@inflexa-ai/harness";
 
-import { env } from "../../lib/env.ts";
+import { env, staticCredentialSource, type CredentialSource, type Credential, type CredentialError } from "../../lib/env.ts";
 import { instanceLockPath } from "../../lib/lock.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
-import { bootHarnessRuntime, __resetHarnessRuntimeForTest, type BootSeams } from "./runtime.ts";
+import { bootHarnessRuntime, buildAuthInjectingFetch, __resetHarnessRuntimeForTest, type BootSeams } from "./runtime.ts";
 import { agentProviderInner } from "./agent_switch.ts";
 import type { ResolvedHarnessConfig, ResolvedModelConnection } from "./config.ts";
 import type { ExecIngress } from "./ingress.ts";
@@ -608,6 +608,22 @@ describe("bootHarnessRuntime", () => {
         expect(result._unsafeUnwrapErr()).toEqual({ type: "model_api_key_missing", providerVar: "ANTHROPIC_API_KEY" });
     });
 
+    test("a configured auth source overrides the env key — readModelApiKey is never consulted", async () => {
+        const calls: string[] = [];
+        // recordingSeams' readModelApiKey returns a key and records the call; the auth block must short-circuit
+        // it so the env key is never consulted (spec: a configured source overrides INFLEXA_MODEL_API_KEY).
+        const result = await bootHarnessRuntime({
+            seams: recordingSeams(calls),
+            config: testConfig({ model: "some-model" }),
+            connection: directConnection({ auth: { kind: "env", var: "SOME_BEARER_TOKEN", scheme: "bearer" } }),
+        });
+
+        result._unsafeUnwrap();
+        expect(calls).not.toContain("readModelApiKey");
+        // The command/env is resolved lazily at the wire, not at boot, so boot proceeds without a token in hand.
+        expect(calls).toContain("boot");
+    });
+
     test("missing skills dir fails before any side effect", async () => {
         const calls: string[] = [];
         const cfg = testConfig();
@@ -672,5 +688,86 @@ describe("bootHarnessRuntime", () => {
             holder.kill();
             await holder.exited;
         }
+    });
+});
+
+// The direct-mode auth-injecting fetch (the config.fetch seam): per-request scheme rewrite + one 401
+// refresh/retry. Driven with a recording underlying fetch so the OUTGOING headers and retry count are the
+// assertions — no real network, no provider boot.
+describe("buildAuthInjectingFetch", () => {
+    /** A recording underlying fetch: captures each request's headers and returns the queued statuses in order. */
+    function recordingFetch(statuses: number[]): { fetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>; seen: Headers[] } {
+        const seen: Headers[] = [];
+        let i = 0;
+        return {
+            seen,
+            fetch: (_input, init) => {
+                seen.push(new Headers(init?.headers));
+                return Promise.resolve(new Response(null, { status: statuses[i++] ?? 200 }));
+            },
+        };
+    }
+
+    test("bearer scheme sets Authorization: Bearer and strips the SDK's x-api-key", async () => {
+        const { fetch: underlying, seen } = recordingFetch([200]);
+        const f = buildAuthInjectingFetch(staticCredentialSource("btok", "bearer"), underlying);
+        // The AI SDK's anthropic provider sets x-api-key from the placeholder apiKey — the bearer path must remove it.
+        await f("https://api.anthropic.com/v1/messages", { method: "POST", headers: { "x-api-key": "placeholder" } });
+        expect(seen[0]!.get("authorization")).toBe("Bearer btok");
+        expect(seen[0]!.get("x-api-key")).toBeNull();
+    });
+
+    test("x-api-key scheme sets the x-api-key header", async () => {
+        const { fetch: underlying, seen } = recordingFetch([200]);
+        const f = buildAuthInjectingFetch(staticCredentialSource("xtok", "x-api-key"), underlying);
+        await f("https://api.anthropic.com/v1/messages", { method: "POST", headers: { "x-api-key": "placeholder" } });
+        expect(seen[0]!.get("x-api-key")).toBe("xtok");
+    });
+
+    test("an HTTP 401 forces exactly one refresh + retry with the new token", async () => {
+        const { fetch: underlying, seen } = recordingFetch([401, 200]);
+        let refreshCount = 0;
+        let token = "tok-1";
+        const source: CredentialSource = {
+            get: () => Promise.resolve(ok<Credential, CredentialError>({ token, scheme: "bearer" })),
+            forceRefresh: () => {
+                refreshCount++;
+                token = "tok-2";
+                return Promise.resolve(ok<Credential, CredentialError>({ token, scheme: "bearer" }));
+            },
+        };
+        const response = await buildAuthInjectingFetch(source, underlying)("https://api.anthropic.com/v1/messages", { method: "POST" });
+
+        expect(response.status).toBe(200);
+        expect(refreshCount).toBe(1); // exactly one forced refresh
+        expect(seen).toHaveLength(2); // one retry only
+        expect(seen[0]!.get("authorization")).toBe("Bearer tok-1");
+        expect(seen[1]!.get("authorization")).toBe("Bearer tok-2");
+    });
+
+    test("a persistent 401 retries only once, then surfaces the 401", async () => {
+        const { fetch: underlying, seen } = recordingFetch([401, 401]);
+        let refreshCount = 0;
+        const source: CredentialSource = {
+            get: () => Promise.resolve(ok<Credential, CredentialError>({ token: "t", scheme: "bearer" })),
+            forceRefresh: () => {
+                refreshCount++;
+                return Promise.resolve(ok<Credential, CredentialError>({ token: "t2", scheme: "bearer" }));
+            },
+        };
+        const response = await buildAuthInjectingFetch(source, underlying)("https://api.anthropic.com/v1/messages", {});
+
+        expect(response.status).toBe(401);
+        expect(refreshCount).toBe(1);
+        expect(seen).toHaveLength(2); // original + exactly one retry, never a third attempt
+    });
+
+    test("a credential-resolution failure rejects the fetch (its throwing contract) with an actionable message", async () => {
+        const { fetch: underlying } = recordingFetch([200]);
+        const source: CredentialSource = {
+            get: () => Promise.resolve(err<Credential, CredentialError>({ type: "env_var_unset", var: "MISSING" })),
+            forceRefresh: () => Promise.resolve(err<Credential, CredentialError>({ type: "env_var_unset", var: "MISSING" })),
+        };
+        await expect(buildAuthInjectingFetch(source, underlying)("https://x/messages", {})).rejects.toThrow(/MISSING/);
     });
 });

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -36,7 +36,17 @@ import {
 } from "@inflexa-ai/harness";
 
 import { readConfig } from "../../lib/config.ts";
-import { env, providerApiKeyVar, resolveModelApiKey } from "../../lib/env.ts";
+import {
+    env,
+    providerApiKeyVar,
+    resolveModelApiKey,
+    createCredentialSource,
+    staticCredentialSource,
+    credentialErrorMessage,
+    type Credential,
+    type CredentialScheme,
+    type CredentialSource,
+} from "../../lib/env.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";
 import { getLogger } from "../../lib/log.ts";
 import { onShutdown } from "../../lib/shutdown.ts";
@@ -365,6 +375,66 @@ export function bootHarnessRuntime(
 }
 
 /**
+ * The `fetch` shape the harness provider config accepts (its `FetchLike`). Redeclared here because the
+ * harness does not export the alias; assigning our function to `config.fetch` structurally checks it.
+ */
+type InjectingFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/**
+ * The apiKey passed to the AI SDK in `direct` mode. Never sent — the injecting fetch overwrites the auth
+ * header on every request — but the SDK requires a non-empty string, and the credential (env key or a
+ * lazily-minted command token) is not known here as a static value. See {@link buildAuthInjectingFetch}.
+ */
+const CREDENTIAL_PLACEHOLDER_API_KEY = "inflexa-credential-source-placeholder";
+
+/**
+ * Apply a resolved credential to an outgoing request's headers per its wire scheme. `bearer` DELETES the
+ * `x-api-key` the AI SDK derived from the placeholder apiKey and sets `Authorization: Bearer` — this is
+ * what delivers `ANTHROPIC_AUTH_TOKEN` / a gateway bearer over the anthropic wire; `x-api-key` sets the
+ * header the Anthropic Messages API reads. Header names are case-insensitive, so this overwrites whatever
+ * the SDK set from the placeholder.
+ */
+function applyCredential(headers: Headers, cred: Credential): void {
+    if (cred.scheme === "bearer") {
+        headers.delete("x-api-key");
+        headers.set("authorization", `Bearer ${cred.token}`);
+    } else {
+        headers.set("x-api-key", cred.token);
+    }
+}
+
+/**
+ * Build the `fetch` the CLI passes as the harness provider's `config.fetch` for a `direct` connection.
+ * Per request it resolves the credential from `source` (cached — the underlying command/env is hit only on
+ * a real refresh), rewrites the auth header per scheme, and calls `underlying`. On an HTTP 401 — the signal
+ * that a cached token rotated out from under us — it force-refreshes the source and retries EXACTLY once; a
+ * second 401 (or a refresh failure) surfaces to the SDK unchanged. A credential-resolution failure REJECTS
+ * the fetch (its contract, the same way a network failure does), which the harness maps to a provider error
+ * carrying the actionable message. `underlying` is injectable for tests; production uses global `fetch`.
+ */
+export function buildAuthInjectingFetch(source: CredentialSource, underlying: InjectingFetch = fetch): InjectingFetch {
+    const attempt = (input: string | URL | Request, init: RequestInit | undefined, cred: Credential): Promise<Response> => {
+        // A fresh Headers per attempt, seeded from the ORIGINAL init, so a retry never inherits the prior
+        // attempt's rewrite — each attempt applies the (possibly refreshed) credential from a clean base.
+        const headers = new Headers(init?.headers);
+        applyCredential(headers, cred);
+        return underlying(input, { ...init, headers });
+    };
+    return async (input, init) => {
+        const first = await source.get();
+        // A failed credential resolution can only surface through fetch's throwing contract; the harness's
+        // provider-error mapping wraps it into the chat error path with this actionable message.
+        if (first.isErr()) throw new Error(`model credential unavailable: ${credentialErrorMessage(first.error)}`);
+        const response = await attempt(input, init, first.value);
+        if (response.status !== 401) return response;
+        const refreshed = await source.forceRefresh();
+        // Refresh failed ⇒ return the original 401 so the SDK surfaces the auth rejection, not the refresh error.
+        if (refreshed.isErr()) return response;
+        return attempt(input, init, refreshed.value);
+    };
+}
+
+/**
  * One boot attempt, run under the {@link bootHarnessRuntime} in-flight guard.
  * This root resolves the host-specific inputs — prerequisites → Postgres
  * readiness → callback ingress → providers/models → instance lock → pool — then
@@ -421,19 +491,34 @@ async function bootHarnessRuntimeOnce(
 
     // The chat credential is mode-specific: cliproxy discovers the
     // minted proxy client key (and contacts the proxy for auto-resolve below);
-    // direct reads the env secret and NEVER touches the proxy. Resolved before the
+    // direct uses a CREDENTIAL SOURCE and NEVER touches the proxy. Resolved before the
     // probe so a missing credential fails as cheaply as the proxy-key path always did.
+    //
+    // In direct mode the wire credential always flows through the source seam (injected via the fetch
+    // below), so `providerApiKey` is a placeholder there — the real header is set per request. Precedence
+    // (spec): a configured `auth` block WINS; otherwise the env key ({@link resolveModelApiKey}, via the
+    // injectable seam) modeled as a static source under the wire protocol's conventional scheme. A
+    // configured `auth` block is trusted lazily — setup already probed it — so boot does NOT run the command
+    // here; only the env fallback (auth absent) fails boot up front when nothing resolves.
     let providerApiKey: string;
+    let credentialSource: CredentialSource | undefined;
     if (connection.mode === "cliproxy") {
         const keyResult = await seams.readKey();
         if (keyResult.isErr()) return err({ type: "proxy_key_missing", cause: keyResult.error });
         providerApiKey = keyResult.value;
+    } else if (connection.auth !== undefined) {
+        credentialSource = createCredentialSource(connection.auth);
+        providerApiKey = CREDENTIAL_PLACEHOLDER_API_KEY;
     } else {
         const key = seams.readModelApiKey(connection.provider);
         // Name the provider-conventional variable that was tried alongside the override in the error, so
         // the boot failure tells the user exactly which two env vars can unblock it.
         if (!key) return err({ type: "model_api_key_missing", providerVar: providerApiKeyVar(connection.provider) });
-        providerApiKey = key;
+        // The anthropic wire sends the key as `x-api-key`; every openai-compatible endpoint as `Bearer` —
+        // the same header the AI SDK would have derived from `apiKey`, now set explicitly by the fetch.
+        const defaultScheme: CredentialScheme = connection.protocol === "anthropic" ? "x-api-key" : "bearer";
+        credentialSource = staticCredentialSource(key, defaultScheme);
+        providerApiKey = CREDENTIAL_PLACEHOLDER_API_KEY;
     }
 
     // Probe the resolved embedder before anything expensive: embeddings are
@@ -584,17 +669,29 @@ async function bootHarnessRuntimeOnce(
         // toolCalling: true }`), so the proxy path is indistinguishable from a bare
         // Anthropic connection. direct resolves to the configured protocol kind at the
         // configured endpoint with the env secret.
+        // The direct-mode auth-injecting fetch (undefined for cliproxy, which sends the proxy key as-is).
+        // One instance shared by every per-model provider over this connection — it holds only the cached
+        // credential source, so all agents' requests refresh/rotate through the same token.
+        const authFetch = credentialSource !== undefined ? buildAuthInjectingFetch(credentialSource) : undefined;
         const providerConfigFor = (agentModel: string): AiSdkProviderConfig =>
             connection.mode === "cliproxy"
                 ? { kind: "anthropic", baseURL: env.cliproxyApiUrl, apiKey: providerApiKey, model: agentModel, capabilities: { toolCalling: true } }
                 : connection.protocol === "anthropic"
-                  ? { kind: "anthropic", baseURL: connection.baseURL, apiKey: providerApiKey, model: agentModel, capabilities: { toolCalling: true } }
+                  ? {
+                        kind: "anthropic",
+                        baseURL: connection.baseURL,
+                        apiKey: providerApiKey,
+                        model: agentModel,
+                        fetch: authFetch,
+                        capabilities: { toolCalling: true },
+                    }
                   : {
                         kind: "openai-compatible",
                         name: connection.provider,
                         baseURL: connection.baseURL,
                         apiKey: providerApiKey,
                         model: agentModel,
+                        fetch: authFetch,
                         capabilities: { toolCalling: true },
                     };
         const buildProvider = (agentModel: string): ChatProvider => createConfiguredAiSdkProvider({ resolveBilling, config: providerConfigFor(agentModel) });

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -36,17 +36,8 @@ import {
 } from "@inflexa-ai/harness";
 
 import { readConfig } from "../../lib/config.ts";
-import {
-    env,
-    providerApiKeyVar,
-    resolveModelApiKey,
-    createCredentialSource,
-    staticCredentialSource,
-    credentialErrorMessage,
-    type Credential,
-    type CredentialScheme,
-    type CredentialSource,
-} from "../../lib/env.ts";
+import { env, providerApiKeyVar, resolveModelApiKey } from "../../lib/env.ts";
+import { createCredentialSource, credentialErrorMessage, type Credential, type CredentialSource } from "../../lib/credential.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";
 import { getLogger } from "../../lib/log.ts";
 import { onShutdown } from "../../lib/shutdown.ts";
@@ -381,18 +372,16 @@ export function bootHarnessRuntime(
 type InjectingFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 /**
- * The apiKey passed to the AI SDK in `direct` mode. Never sent — the injecting fetch overwrites the auth
- * header on every request — but the SDK requires a non-empty string, and the credential (env key or a
- * lazily-minted command token) is not known here as a static value. See {@link buildAuthInjectingFetch}.
+ * The apiKey handed to the AI SDK when a credential SOURCE is configured: never sent (the injecting fetch
+ * overwrites the auth header per request), but the SDK requires a non-empty string and the token is minted
+ * lazily, not known here. See {@link buildAuthInjectingFetch}.
  */
 const CREDENTIAL_PLACEHOLDER_API_KEY = "inflexa-credential-source-placeholder";
 
 /**
- * Apply a resolved credential to an outgoing request's headers per its wire scheme. `bearer` DELETES the
- * `x-api-key` the AI SDK derived from the placeholder apiKey and sets `Authorization: Bearer` — this is
- * what delivers `ANTHROPIC_AUTH_TOKEN` / a gateway bearer over the anthropic wire; `x-api-key` sets the
- * header the Anthropic Messages API reads. Header names are case-insensitive, so this overwrites whatever
- * the SDK set from the placeholder.
+ * Apply a resolved credential to an outgoing request's headers per scheme. `bearer` DELETES the `x-api-key`
+ * the AI SDK set from the placeholder and sets `Authorization: Bearer` (this is what delivers a bearer over
+ * the anthropic wire); `x-api-key` sets the header the Anthropic Messages API reads.
  */
 function applyCredential(headers: Headers, cred: Credential): void {
     if (cred.scheme === "bearer") {
@@ -404,13 +393,11 @@ function applyCredential(headers: Headers, cred: Credential): void {
 }
 
 /**
- * Build the `fetch` the CLI passes as the harness provider's `config.fetch` for a `direct` connection.
- * Per request it resolves the credential from `source` (cached — the underlying command/env is hit only on
- * a real refresh), rewrites the auth header per scheme, and calls `underlying`. On an HTTP 401 — the signal
- * that a cached token rotated out from under us — it force-refreshes the source and retries EXACTLY once; a
- * second 401 (or a refresh failure) surfaces to the SDK unchanged. A credential-resolution failure REJECTS
- * the fetch (its contract, the same way a network failure does), which the harness maps to a provider error
- * carrying the actionable message. `underlying` is injectable for tests; production uses global `fetch`.
+ * Build the `fetch` the CLI passes as the harness provider's `config.fetch` when a credential source is
+ * configured. Per request it resolves the (cached) credential, rewrites the auth header per scheme, and
+ * calls `underlying`. On an HTTP 401 it force-refreshes and retries EXACTLY once; a second 401 or a refresh
+ * failure surfaces unchanged. A resolution failure REJECTS the fetch (its throwing contract), which the
+ * harness maps to a provider error with the actionable message. `underlying` is injectable for tests.
  */
 export function buildAuthInjectingFetch(source: CredentialSource, underlying: InjectingFetch = fetch): InjectingFetch {
     const attempt = (input: string | URL | Request, init: RequestInit | undefined, cred: Credential): Promise<Response> => {
@@ -489,17 +476,15 @@ async function bootHarnessRuntimeOnce(
     if (embedderResult.isErr()) return err({ type: "embedding_unresolved", cause: embedderResult.error });
     const embedding = embedderResult.value;
 
-    // The chat credential is mode-specific: cliproxy discovers the
-    // minted proxy client key (and contacts the proxy for auto-resolve below);
-    // direct uses a CREDENTIAL SOURCE and NEVER touches the proxy. Resolved before the
-    // probe so a missing credential fails as cheaply as the proxy-key path always did.
+    // The chat credential is mode-specific: cliproxy discovers the minted proxy client key (and contacts the
+    // proxy for auto-resolve below); direct reads the env key OR a configured credential source, and NEVER
+    // touches the proxy. Resolved before the probe so a missing credential fails as cheaply as before.
     //
-    // In direct mode the wire credential always flows through the source seam (injected via the fetch
-    // below), so `providerApiKey` is a placeholder there — the real header is set per request. Precedence
-    // (spec): a configured `auth` block WINS; otherwise the env key ({@link resolveModelApiKey}, via the
-    // injectable seam) modeled as a static source under the wire protocol's conventional scheme. A
-    // configured `auth` block is trusted lazily — setup already probed it — so boot does NOT run the command
-    // here; only the env fallback (auth absent) fails boot up front when nothing resolves.
+    // Precedence in direct mode (spec): a configured `auth` block WINS — resolved lazily at the wire via the
+    // injecting fetch, so `providerApiKey` is a placeholder and boot does not run the command (setup probed it).
+    // Otherwise the static env key ({@link resolveModelApiKey}, via the injectable seam) is passed as `apiKey`
+    // exactly as before — the AI SDK sends it as the wire's conventional header, no injecting fetch — and its
+    // absence fails boot up front.
     let providerApiKey: string;
     let credentialSource: CredentialSource | undefined;
     if (connection.mode === "cliproxy") {
@@ -511,14 +496,9 @@ async function bootHarnessRuntimeOnce(
         providerApiKey = CREDENTIAL_PLACEHOLDER_API_KEY;
     } else {
         const key = seams.readModelApiKey(connection.provider);
-        // Name the provider-conventional variable that was tried alongside the override in the error, so
-        // the boot failure tells the user exactly which two env vars can unblock it.
+        // Name the provider-conventional variable tried alongside the override, so the failure names both env vars.
         if (!key) return err({ type: "model_api_key_missing", providerVar: providerApiKeyVar(connection.provider) });
-        // The anthropic wire sends the key as `x-api-key`; every openai-compatible endpoint as `Bearer` —
-        // the same header the AI SDK would have derived from `apiKey`, now set explicitly by the fetch.
-        const defaultScheme: CredentialScheme = connection.protocol === "anthropic" ? "x-api-key" : "bearer";
-        credentialSource = staticCredentialSource(key, defaultScheme);
-        providerApiKey = CREDENTIAL_PLACEHOLDER_API_KEY;
+        providerApiKey = key;
     }
 
     // Probe the resolved embedder before anything expensive: embeddings are
@@ -669,9 +649,9 @@ async function bootHarnessRuntimeOnce(
         // toolCalling: true }`), so the proxy path is indistinguishable from a bare
         // Anthropic connection. direct resolves to the configured protocol kind at the
         // configured endpoint with the env secret.
-        // The direct-mode auth-injecting fetch (undefined for cliproxy, which sends the proxy key as-is).
-        // One instance shared by every per-model provider over this connection — it holds only the cached
-        // credential source, so all agents' requests refresh/rotate through the same token.
+        // The auth-injecting fetch, present only when a credential source is configured (undefined for
+        // cliproxy and for the static env key, which the SDK sends as-is). One instance shared by every
+        // per-model provider over this connection, so all agents refresh/rotate through the same cached token.
         const authFetch = credentialSource !== undefined ? buildAuthInjectingFetch(credentialSource) : undefined;
         const providerConfigFor = (agentModel: string): AiSdkProviderConfig =>
             connection.mode === "cliproxy"

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -2,7 +2,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-import { adoptedConnection, detectedAdoptable, normalizeAdoptedBaseURL, parseConnectionMode, recordCliproxyProvider, writeDirectConnection } from "./setup.ts";
+import {
+    adoptedConnection,
+    credentialHelperDetected,
+    detectCredentialHelperFrom,
+    detectedAdoptable,
+    normalizeAdoptedBaseURL,
+    parseConnectionMode,
+    probeCredentialSource,
+    recordCliproxyProvider,
+    writeDirectConnection,
+} from "./setup.ts";
 import { readConfig } from "../../lib/config.ts";
 import { env, type ProviderEnvSnapshot } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
@@ -104,6 +114,87 @@ describe("ecosystem env adoption — detection → non-secret connection", () =>
     });
 });
 
+// The credential-helper detection is a pure shape over its raw signals, so the offer logic and the
+// "managed helper is never auto-executed" guarantee are testable without touching the filesystem or env.
+describe("credential-helper detection", () => {
+    test("a user-level apiKeyHelper is detected and carried as a pre-fillable command", () => {
+        const d = detectCredentialHelperFrom("/opt/mint-token", false, false);
+        expect(credentialHelperDetected(d)).toBe(true);
+        expect(d.userHelperCommand).toBe("/opt/mint-token");
+    });
+
+    test("ANTHROPIC_AUTH_TOKEN alone is a detected signal (env-bearer offerable)", () => {
+        const d = detectCredentialHelperFrom(null, false, true);
+        expect(credentialHelperDetected(d)).toBe(true);
+        expect(d.authTokenEnvSet).toBe(true);
+    });
+
+    test("an org-managed helper alone is detected but carries NO command to pre-fill or auto-execute", () => {
+        const d = detectCredentialHelperFrom(null, true, false);
+        expect(credentialHelperDetected(d)).toBe(true);
+        expect(d.managedHelperPresent).toBe(true);
+        // The user must supply/confirm the command — the managed helper is never lifted into a runnable command.
+        expect(d.userHelperCommand).toBeNull();
+    });
+
+    test("no signals → nothing detected", () => {
+        expect(credentialHelperDetected(detectCredentialHelperFrom(null, false, false))).toBe(false);
+    });
+});
+
+// The setup validation probe (design D6): run the source once, then a cheap authenticated GET {baseURL}/models.
+// A stubbed fetch drives the HTTP outcomes; the credential command is a real deterministic shell command.
+describe("probeCredentialSource", () => {
+    function recordFetch(status: number): { doFetch: (url: string, init: RequestInit) => Promise<Response>; calls: { url: string; headers: Headers }[] } {
+        const calls: { url: string; headers: Headers }[] = [];
+        return {
+            calls,
+            doFetch: (url, init) => {
+                calls.push({ url, headers: new Headers(init.headers) });
+                return Promise.resolve(new Response(null, { status }));
+            },
+        };
+    }
+
+    test("a raw-token command + a 200 endpoint validates, sending the token as x-api-key with the anthropic version header", async () => {
+        const { doFetch, calls } = recordFetch(200);
+        const result = await probeCredentialSource(
+            "https://api.anthropic.com/v1",
+            "anthropic",
+            { kind: "command", command: "printf tok-123", scheme: "x-api-key" },
+            doFetch,
+        );
+        expect(result.isOk()).toBe(true);
+        expect(calls[0]!.url).toBe("https://api.anthropic.com/v1/models");
+        expect(calls[0]!.headers.get("x-api-key")).toBe("tok-123");
+        expect(calls[0]!.headers.get("anthropic-version")).toBe("2023-06-01");
+    });
+
+    test("a 401 fails the probe with a message naming the scheme (the bad-config gate)", async () => {
+        const { doFetch } = recordFetch(401);
+        const result = await probeCredentialSource(
+            "https://gw.corp/v1",
+            "openai-compatible",
+            { kind: "command", command: "printf gw-tok", scheme: "bearer" },
+            doFetch,
+        );
+        expect(result._unsafeUnwrapErr().message).toContain("bearer");
+    });
+
+    test("a credential that produces no token fails BEFORE any fetch (the command/env cause)", async () => {
+        const { doFetch, calls } = recordFetch(200);
+        // `true` exits 0 with empty stdout → command_empty_output, so the endpoint is never contacted.
+        const result = await probeCredentialSource(
+            "https://api.anthropic.com/v1",
+            "anthropic",
+            { kind: "command", command: "true", scheme: "x-api-key" },
+            doFetch,
+        );
+        expect(result.isErr()).toBe(true);
+        expect(calls).toHaveLength(0);
+    });
+});
+
 // The config-writing tests round-trip through the real readConfig()/writeConfig() surface against the
 // sandboxed env.configPath (set by the test preload). Guard first, in the hooks: at the monorepo root
 // that path is the developer's REAL config.json (data-loss guard — test_support/sandbox.ts).
@@ -200,5 +291,37 @@ describe("connection config writes", () => {
         // The written connection carries exactly mode/provider/baseURL — no apiKey/token field. The
         // direct-mode secret lives only in INFLEXA_MODEL_API_KEY, never in config.
         expect(Object.keys(readModels().connection as Record<string, unknown>).sort()).toEqual(["baseURL", "mode", "provider"]);
+    });
+
+    test("writeDirectConnection persists a command credential source ({command, scheme}) and no token", () => {
+        writeDirectConnection({
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com/v1",
+            protocol: "anthropic",
+            auth: { kind: "command", command: "/opt/mint-token", scheme: "x-api-key" },
+        })._unsafeUnwrap();
+        expect(readModels().connection).toEqual({
+            mode: "direct",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com/v1",
+            protocol: "anthropic",
+            auth: { kind: "command", command: "/opt/mint-token", scheme: "x-api-key" },
+        });
+        // The whole config text carries the command + scheme but never a token value.
+        const configText = JSON.stringify(readConfig());
+        expect(configText).toContain("/opt/mint-token");
+        expect(configText.toLowerCase()).not.toContain('token":"sk-');
+    });
+
+    test("writeDirectConnection persists an env-bearer credential source with no token", () => {
+        writeDirectConnection({
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com/v1",
+            auth: { kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" },
+        })._unsafeUnwrap();
+        const connection = readModels().connection as Record<string, unknown>;
+        expect(connection.auth).toEqual({ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" });
+        // Only the variable NAME is stored — never a resolved token value.
+        expect(JSON.stringify(connection)).not.toContain("sk-ant");
     });
 });

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -7,17 +7,8 @@ import { intro, outro, log, note, spinner as clackSpinner } from "@clack/prompts
 import { type Result, ok, err } from "neverthrow";
 import { ensureRuntime, readConfig, resolvePostgresConfig, selectedRuntime, writeConfig, type ConfigError, type ModelAuthConfig } from "../../lib/config.ts";
 import { firstReadyRuntime, runtimeIds, runtimes, ContainerRuntimeError, type ContainerRuntime } from "../../lib/container.ts";
-import {
-    anthropicAuthTokenSet,
-    createCredentialSource,
-    credentialErrorMessage,
-    detectProviderEnv,
-    env,
-    providerApiKeyVar,
-    resolveModelApiKey,
-    type CredentialScheme,
-    type ProviderEnvSnapshot,
-} from "../../lib/env.ts";
+import { anthropicAuthTokenSet, detectProviderEnv, env, providerApiKeyVar, resolveModelApiKey, type ProviderEnvSnapshot } from "../../lib/env.ts";
+import { createCredentialSource, credentialErrorMessage, type CredentialScheme } from "../../lib/credential.ts";
 import { select, promptText } from "../../lib/cli.ts";
 import { detectedMachine, resolveHarnessConfig } from "../harness/config.ts";
 import { type PostgresConnection } from "./postgres_types.ts";
@@ -180,11 +171,10 @@ export async function setup(options: SetupOptions): Promise<void> {
                 return;
             }
 
-            // A detected credential-helper setup can supply a REFRESHING token (a helper command or an env
-            // bearer) in place of a static key. Offer it opt-in, and only interactively: the command/scheme
-            // need the user's confirmation, and an org-managed helper must never be auto-executed. The
-            // source is validated (run once + auth probe) before its `auth` block is attached — a non-TTY
-            // run keeps the static-key path.
+            // A detected credential-helper setup can supply a refreshing token (a helper command or an env
+            // bearer) in place of a static key. Offer it opt-in and only interactively — the command/scheme
+            // need confirmation, and an org-managed helper must never be auto-executed. A non-TTY run keeps
+            // the static-key path.
             if (process.stdin.isTTY) {
                 const detection = detectCredentialHelper();
                 if (credentialHelperDetected(detection)) {
@@ -541,10 +531,8 @@ const MODEL_API_KEY_VAR = "INFLEXA_MODEL_API_KEY";
 
 /**
  * The Anthropic-wire Bearer variable. When set, setup OFFERS it as a `direct`-mode credential source
- * (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }`) — the injecting fetch delivers it as
- * `Authorization: Bearer` over the anthropic wire (see modules/harness/runtime.ts). Named here to construct
- * that offer and the guidance note; the presence check itself is env.ts's {@link anthropicAuthTokenSet}
- * (the sole `process.env` reader). Bedrock/Vertex remain out of scope (no direct-mode HTTP signer).
+ * (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }`); the presence check is env.ts's
+ * {@link anthropicAuthTokenSet}. Bedrock/Vertex remain out of scope (no direct-mode HTTP signer).
  */
 const ANTHROPIC_AUTH_TOKEN_VAR = "ANTHROPIC_AUTH_TOKEN";
 
@@ -769,11 +757,11 @@ export function writeDirectConnection(input: DirectConnectionInput): Result<void
 
 // --- credential-source auth (direct mode) ----------------------------------
 //
-// A `direct` connection may draw its wire token from a REFRESHING credential source instead of a static
-// key: a helper command (Claude Code `apiKeyHelper` parity) or a short-lived env bearer. Setup DETECTS such
-// a setup from read-only signals and OFFERS the path opt-in; the user supplies/confirms the command (never
-// the org-managed helper auto-executed), and the source is VALIDATED against the endpoint before its
-// token-free `auth` block is written. The refresh/injection itself lives at the wire (modules/harness/runtime.ts).
+// A `direct` connection may draw its wire token from a refreshing credential source instead of a static key:
+// a helper command (Claude Code `apiKeyHelper` parity) or a short-lived env bearer. Setup detects one from
+// read-only signals and OFFERS the path opt-in — the user confirms the command (never the org-managed helper
+// auto-executed) — then VALIDATES the source before its token-free `auth` block is written. The refresh /
+// injection lives at the wire (modules/harness/runtime.ts).
 
 /**
  * The read-only signals that a credential-helper Anthropic setup exists. A pure shape (no IO) so the
@@ -863,8 +851,8 @@ function effectiveProtocol(direct: DirectConnectionInput): "anthropic" | "openai
 export type CredentialProbeError = { readonly message: string };
 
 /**
- * Validate a credential source before it is persisted (design D6): run it ONCE — surfacing a command/env
- * failure as its own cause — then make a cheap authenticated `GET {baseURL}/models` under the resolved
+ * Validate a credential source before it is persisted: run it ONCE — surfacing a command/env failure as its
+ * own cause — then make a cheap authenticated `GET {baseURL}/models` under the resolved
  * scheme, so a wrong scheme or endpoint surfaces as an HTTP/auth failure at setup, not on first chat. The
  * anthropic wire's `/models` needs a version header even on GET, added when the protocol is anthropic.
  * `doFetch` is injectable for tests; production uses global `fetch`.
@@ -912,8 +900,8 @@ function truncateCommand(s: string, max = 44): string {
 }
 
 /**
- * Offer the credential-source path for a detected helper setup (design D5). Opt-in: the user chooses a
- * credential command (pre-filled from their OWN settings when present, always editable), the
+ * Offer the credential-source path for a detected helper setup. Opt-in: the user chooses a credential
+ * command (pre-filled from their OWN settings when present, always editable), the
  * `ANTHROPIC_AUTH_TOKEN` env bearer (when set), or declines to the static-key path. An org-managed helper is
  * announced but the user must still supply/confirm the command — it is never auto-executed. The chosen
  * source is VALIDATED (run once + auth probe) before it is returned; a probe failure reports the likely
@@ -952,8 +940,8 @@ async function offerCredentialSource(direct: DirectConnectionInput, detection: C
                 validate: (v) => (v.trim() === "" ? "Enter a command." : undefined),
             })
         ).trim();
-        // Infer the scheme default from the wire (design open question: infer, let the user override — the
-        // probe validates it). An apiKeyHelper mints an `x-api-key`; a bearer is the OAuth/WIF case.
+        // Infer a scheme default and let the user override (the probe validates it): an apiKeyHelper mints an
+        // `x-api-key`; a bearer is the OAuth/WIF case.
         const scheme = (await select("How is the minted token sent on the wire?", [
             { value: "x-api-key", label: "x-api-key header (a minted API key — apiKeyHelper default)" },
             { value: "bearer", label: "Authorization: Bearer (an OAuth / WIF access token)" },

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -1,10 +1,23 @@
 import { readdir } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { intro, outro, log, note, spinner as clackSpinner } from "@clack/prompts";
 import { type Result, ok, err } from "neverthrow";
-import { ensureRuntime, readConfig, resolvePostgresConfig, selectedRuntime, writeConfig, type ConfigError } from "../../lib/config.ts";
+import { ensureRuntime, readConfig, resolvePostgresConfig, selectedRuntime, writeConfig, type ConfigError, type ModelAuthConfig } from "../../lib/config.ts";
 import { firstReadyRuntime, runtimeIds, runtimes, ContainerRuntimeError, type ContainerRuntime } from "../../lib/container.ts";
-import { detectProviderEnv, env, providerApiKeyVar, resolveModelApiKey, type ProviderEnvSnapshot } from "../../lib/env.ts";
+import {
+    anthropicAuthTokenSet,
+    createCredentialSource,
+    credentialErrorMessage,
+    detectProviderEnv,
+    env,
+    providerApiKeyVar,
+    resolveModelApiKey,
+    type CredentialScheme,
+    type ProviderEnvSnapshot,
+} from "../../lib/env.ts";
 import { select, promptText } from "../../lib/cli.ts";
 import { detectedMachine, resolveHarnessConfig } from "../harness/config.ts";
 import { type PostgresConnection } from "./postgres_types.ts";
@@ -167,6 +180,19 @@ export async function setup(options: SetupOptions): Promise<void> {
                 return;
             }
 
+            // A detected credential-helper setup can supply a REFRESHING token (a helper command or an env
+            // bearer) in place of a static key. Offer it opt-in, and only interactively: the command/scheme
+            // need the user's confirmation, and an org-managed helper must never be auto-executed. The
+            // source is validated (run once + auth probe) before its `auth` block is attached — a non-TTY
+            // run keeps the static-key path.
+            if (process.stdin.isTTY) {
+                const detection = detectCredentialHelper();
+                if (credentialHelperDetected(detection)) {
+                    const auth = await offerCredentialSource(direct, detection);
+                    if (auth !== null) direct = { ...direct, auth };
+                }
+            }
+
             const writeErr = writeDirectConnection(direct).match(
                 () => null,
                 (e) => e,
@@ -177,23 +203,36 @@ export async function setup(options: SetupOptions): Promise<void> {
                 return;
             }
             log.success("Saved the direct model connection.");
-            // Tailor the key guidance to what is actually resolvable now: an adopted ecosystem env already
-            // carries the key (ANTHROPIC_API_KEY/OPENAI_API_KEY), so tell the user it is being read rather
-            // than instruct a redundant re-export. `resolveModelApiKey` reads the env only — nothing is copied.
-            const resolvedVar = resolveModelApiKey(direct.provider) ? providerApiKeyVar(direct.provider) : undefined;
-            note(
-                resolvedVar !== undefined && resolvedVar !== MODEL_API_KEY_VAR
-                    ? `Using ${resolvedVar} from your environment for the model key.\n` +
-                          `Override it any time by exporting ${MODEL_API_KEY_VAR}. The key is read from the environment only — never written to config.\n\n` +
-                          `Not adopted: ${ANTHROPIC_AUTH_TOKEN_VAR} (Anthropic-wire Bearer auth needs a harness capability) and Bedrock/Vertex (no direct signer).\n` +
-                          "  A bearer-token gateway can be reached today as protocol: openai-compatible."
-                    : `Export your provider API key before starting a chat:\n\n  export ${MODEL_API_KEY_VAR}=<your-key>\n` +
-                          `  (or the provider-conventional ${providerApiKeyVar(direct.provider)})\n\n` +
-                          "The key is read from the environment only — it is never written to config.\n\n" +
-                          `Not adopted: ${ANTHROPIC_AUTH_TOKEN_VAR} (Anthropic-wire Bearer auth needs a harness capability) and Bedrock/Vertex (no direct signer).\n` +
-                          "  A bearer-token gateway can be reached today as protocol: openai-compatible.",
-                "Model API key",
-            );
+            if (direct.auth !== undefined) {
+                // A configured credential source supersedes the static key entirely: tell the user what is
+                // stored (name/command + scheme, never the token).
+                note(
+                    direct.auth.kind === "command"
+                        ? `Minting the model token with a credential command, sent as ${direct.auth.scheme}.\n` +
+                              "Only the command and scheme are stored — the token value is never written to config."
+                        : `Reading the model token from ${direct.auth.var}, sent as ${direct.auth.scheme}.\n` +
+                              "Only the variable name and scheme are stored — the token value is never written to config.",
+                    "Model credential source",
+                );
+            } else {
+                // Tailor the key guidance to what is actually resolvable now: an adopted ecosystem env already
+                // carries the key (ANTHROPIC_API_KEY/OPENAI_API_KEY), so tell the user it is being read rather
+                // than instruct a redundant re-export. `resolveModelApiKey` reads the env only — nothing is copied.
+                const resolvedVar = resolveModelApiKey(direct.provider) ? providerApiKeyVar(direct.provider) : undefined;
+                note(
+                    resolvedVar !== undefined && resolvedVar !== MODEL_API_KEY_VAR
+                        ? `Using ${resolvedVar} from your environment for the model key.\n` +
+                              `Override it any time by exporting ${MODEL_API_KEY_VAR}. The key is read from the environment only — never written to config.\n\n` +
+                              `For a short-lived token instead (${ANTHROPIC_AUTH_TOKEN_VAR} bearer, or a credential helper), re-run setup to configure a credential source.\n` +
+                              "Bedrock/Vertex are not adopted (no direct signer)."
+                        : `Export your provider API key before starting a chat:\n\n  export ${MODEL_API_KEY_VAR}=<your-key>\n` +
+                              `  (or the provider-conventional ${providerApiKeyVar(direct.provider)})\n\n` +
+                              "The key is read from the environment only — it is never written to config.\n\n" +
+                              `For a short-lived token instead (${ANTHROPIC_AUTH_TOKEN_VAR} bearer, or a credential helper), re-run setup to configure a credential source.\n` +
+                              "Bedrock/Vertex are not adopted (no direct signer).",
+                    "Model API key",
+                );
+            }
         }
 
         // --- postgres config ---
@@ -501,10 +540,11 @@ function printNextSteps(options: SetupOptions, conn: PostgresConnection, mode: C
 const MODEL_API_KEY_VAR = "INFLEXA_MODEL_API_KEY";
 
 /**
- * The deferred Anthropic-wire Bearer variable, named ONLY to tell the user it is not adopted (see the
- * direct-path note): `ANTHROPIC_AUTH_TOKEN` is Anthropic-wire + Bearer, which needs a harness
- * custom-auth-header capability the CLI cannot supply alone; a bearer gateway is reachable today as
- * `protocol: openai-compatible`. Bedrock/Vertex are likewise out of scope (no direct-mode HTTP signer).
+ * The Anthropic-wire Bearer variable. When set, setup OFFERS it as a `direct`-mode credential source
+ * (`{ kind: "env", var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" }`) — the injecting fetch delivers it as
+ * `Authorization: Bearer` over the anthropic wire (see modules/harness/runtime.ts). Named here to construct
+ * that offer and the guidance note; the presence check itself is env.ts's {@link anthropicAuthTokenSet}
+ * (the sole `process.env` reader). Bedrock/Vertex remain out of scope (no direct-mode HTTP signer).
  */
 const ANTHROPIC_AUTH_TOKEN_VAR = "ANTHROPIC_AUTH_TOKEN";
 
@@ -700,12 +740,15 @@ type DirectConnectionInput = {
     provider: string;
     baseURL: string;
     protocol?: "anthropic" | "openai-compatible";
+    /** An optional REFRESHING credential source (name/command + scheme, never a token) — {@link offerCredentialSource}. */
+    auth?: ModelAuthConfig;
 };
 
 /**
  * Persist a direct-mode model connection. Spread-preserving: keeps every other config key and every
- * other key inside the `models` block (e.g. the `agents` overrides), rewriting only `connection`. The API
- * key is NEVER written here — it comes from {@link MODEL_API_KEY_VAR} at provider construction.
+ * other key inside the `models` block (e.g. the `agents` overrides), rewriting only `connection`. No token
+ * is EVER written here — the static key comes from {@link MODEL_API_KEY_VAR} at provider construction, and a
+ * configured `auth` block persists only the non-secret variable name / command string / scheme.
  */
 export function writeDirectConnection(input: DirectConnectionInput): Result<void, ConfigError> {
     const config = readConfig();
@@ -718,8 +761,217 @@ export function writeDirectConnection(input: DirectConnectionInput): Result<void
         baseURL: input.baseURL,
         // Omit `protocol` when absent so the resolver implies it from the provider.
         ...(input.protocol !== undefined && { protocol: input.protocol }),
+        // The credential source is token-free by construction (setup only ever attaches a {kind, var|command, scheme}).
+        ...(input.auth !== undefined && { auth: input.auth }),
     };
     return writeConfig({ ...config, models: { ...models, connection } });
+}
+
+// --- credential-source auth (direct mode) ----------------------------------
+//
+// A `direct` connection may draw its wire token from a REFRESHING credential source instead of a static
+// key: a helper command (Claude Code `apiKeyHelper` parity) or a short-lived env bearer. Setup DETECTS such
+// a setup from read-only signals and OFFERS the path opt-in; the user supplies/confirms the command (never
+// the org-managed helper auto-executed), and the source is VALIDATED against the endpoint before its
+// token-free `auth` block is written. The refresh/injection itself lives at the wire (modules/harness/runtime.ts).
+
+/**
+ * The read-only signals that a credential-helper Anthropic setup exists. A pure shape (no IO) so the
+ * offer/precedence is unit-testable. User-level vs org-managed is tracked SEPARATELY because only the
+ * user's OWN `apiKeyHelper` may be pre-filled — the managed one is surfaced but never lifted.
+ */
+export type CredentialHelperDetection = {
+    /** An `apiKeyHelper` from the user's OWN `~/.claude/settings.json` — pre-fillable as an editable default. */
+    readonly userHelperCommand: string | null;
+    /** An org-managed `apiKeyHelper` is present — surfaced to the user, but NEVER pre-filled or auto-executed. */
+    readonly managedHelperPresent: boolean;
+    /** `ANTHROPIC_AUTH_TOKEN` is set — the env-bearer source is offerable. */
+    readonly authTokenEnvSet: boolean;
+};
+
+/** True when ANY credential-helper signal was detected, so setup should offer the credential-source path. */
+export function credentialHelperDetected(d: CredentialHelperDetection): boolean {
+    return d.userHelperCommand !== null || d.managedHelperPresent || d.authTokenEnvSet;
+}
+
+/**
+ * Assemble the detection from its raw signals — pure, so the offer logic (and the "managed helper is not
+ * auto-executed" guarantee) is testable without touching the filesystem or environment.
+ */
+export function detectCredentialHelperFrom(
+    userHelperCommand: string | null,
+    managedHelperPresent: boolean,
+    authTokenEnvSet: boolean,
+): CredentialHelperDetection {
+    return { userHelperCommand, managedHelperPresent, authTokenEnvSet };
+}
+
+/** The user's OWN Claude Code settings — an `apiKeyHelper` here is theirs, so setup may pre-fill it as an editable default. */
+function userClaudeSettingsPath(): string {
+    return join(homedir(), ".claude", "settings.json");
+}
+
+/**
+ * The org-managed Claude Code settings file (Claude Code's documented per-platform managed-settings path).
+ * An `apiKeyHelper` here belongs to the organization: setup surfaces that one exists but NEVER pre-fills or
+ * auto-executes it — the governance decision stays with the user, and the file may be unreadable or need
+ * special env anyway.
+ */
+function managedClaudeSettingsPath(): string {
+    if (process.platform === "darwin") return "/Library/Application Support/ClaudeCode/managed-settings.json";
+    if (process.platform === "win32") return "C:\\ProgramData\\ClaudeCode\\managed-settings.json";
+    return "/etc/claude-code/managed-settings.json";
+}
+
+/**
+ * Read a Claude Code settings file's `apiKeyHelper` command, or `null` when the file is absent / unreadable
+ * / carries no helper. Boundary-wrapped: a missing file is the common case, not an error — a settings file
+ * usually does not exist, so `readFileSync` throwing ENOENT resolves to `null`.
+ */
+function readApiKeyHelper(path: string): string | null {
+    try {
+        const parsed: unknown = JSON.parse(readFileSync(path, "utf8")); // on-disk settings — shape-narrowed below
+        if (typeof parsed !== "object" || parsed === null) return null;
+        // Narrowed to a non-null object above, so a Record view for the single field read is sound.
+        const helper = (parsed as Record<string, unknown>).apiKeyHelper;
+        return typeof helper === "string" && helper.trim() !== "" ? helper.trim() : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Detect a credential-helper setup from read-only signals: the user's + org-managed Claude settings, and
+ * `ANTHROPIC_AUTH_TOKEN` in the environment (read via env.ts, the sole `process.env` reader). A configured
+ * `claude auth status` api-key-helper method writes an `apiKeyHelper` into settings.json, so the
+ * settings-file signal already subsumes it — no fragile `claude` subprocess is spawned.
+ */
+function detectCredentialHelper(): CredentialHelperDetection {
+    return detectCredentialHelperFrom(
+        readApiKeyHelper(userClaudeSettingsPath()),
+        readApiKeyHelper(managedClaudeSettingsPath()) !== null,
+        anthropicAuthTokenSet(),
+    );
+}
+
+/** The wire protocol a direct connection speaks, resolving the "infer from provider" default the way `resolveModelConnection` does — the probe needs it to add the anthropic version header. */
+function effectiveProtocol(direct: DirectConnectionInput): "anthropic" | "openai-compatible" {
+    return direct.protocol ?? (direct.provider === "anthropic" ? "anthropic" : "openai-compatible");
+}
+
+/** Why the setup credential probe failed — a single actionable message naming the likely cause (command, scheme, or endpoint). */
+export type CredentialProbeError = { readonly message: string };
+
+/**
+ * Validate a credential source before it is persisted (design D6): run it ONCE — surfacing a command/env
+ * failure as its own cause — then make a cheap authenticated `GET {baseURL}/models` under the resolved
+ * scheme, so a wrong scheme or endpoint surfaces as an HTTP/auth failure at setup, not on first chat. The
+ * anthropic wire's `/models` needs a version header even on GET, added when the protocol is anthropic.
+ * `doFetch` is injectable for tests; production uses global `fetch`.
+ */
+export async function probeCredentialSource(
+    baseURL: string,
+    protocol: "anthropic" | "openai-compatible",
+    auth: ModelAuthConfig,
+    doFetch: (url: string, init: RequestInit) => Promise<Response> = fetch,
+): Promise<Result<void, CredentialProbeError>> {
+    const cred = await createCredentialSource(auth).get();
+    if (cred.isErr()) {
+        return err({
+            message: `The credential ${auth.kind === "command" ? "command" : "source"} did not produce a token: ${credentialErrorMessage(cred.error)}.`,
+        });
+    }
+
+    const headers = new Headers();
+    if (cred.value.scheme === "bearer") headers.set("authorization", `Bearer ${cred.value.token}`);
+    else headers.set("x-api-key", cred.value.token);
+    // The Anthropic Messages API requires a version header even on GET /models.
+    if (protocol === "anthropic") headers.set("anthropic-version", "2023-06-01");
+
+    const url = `${baseURL.replace(/\/+$/, "")}/models`;
+    let response: Response;
+    try {
+        response = await doFetch(url, { method: "GET", headers });
+    } catch (cause) {
+        return err({ message: `Could not reach the endpoint ${url}: ${cause instanceof Error ? cause.message : String(cause)}. Check the endpoint URL.` });
+    }
+    if (response.status === 401 || response.status === 403) {
+        return err({
+            message: `The endpoint rejected the credential (HTTP ${response.status}). Check the ${cred.value.scheme} scheme and that the source mints a valid token for ${baseURL}.`,
+        });
+    }
+    if (!response.ok) {
+        return err({ message: `The endpoint ${url} returned HTTP ${response.status}. Check the endpoint URL exposes a /models route.` });
+    }
+    return ok(undefined);
+}
+
+/** Shorten a command for a menu label so a long helper path does not wrap the clack box. */
+function truncateCommand(s: string, max = 44): string {
+    return s.length <= max ? s : `${s.slice(0, max - 1)}...`;
+}
+
+/**
+ * Offer the credential-source path for a detected helper setup (design D5). Opt-in: the user chooses a
+ * credential command (pre-filled from their OWN settings when present, always editable), the
+ * `ANTHROPIC_AUTH_TOKEN` env bearer (when set), or declines to the static-key path. An org-managed helper is
+ * announced but the user must still supply/confirm the command — it is never auto-executed. The chosen
+ * source is VALIDATED (run once + auth probe) before it is returned; a probe failure reports the likely
+ * cause and returns `null` (falling back to the static key). Returns the token-free `auth` block, or `null`.
+ */
+async function offerCredentialSource(direct: DirectConnectionInput, detection: CredentialHelperDetection): Promise<ModelAuthConfig | null> {
+    // A managed-only helper: announce it, but the user must still supply/confirm a command — never lifted.
+    if (detection.managedHelperPresent && detection.userHelperCommand === null) {
+        log.info(
+            "An organization-managed Claude credential helper was detected. Inflexa will not run it automatically — supply or confirm the command to use it.",
+        );
+    }
+
+    const options: { value: string; label: string }[] = [];
+    if (detection.userHelperCommand !== null) {
+        options.push({
+            value: "command_prefill",
+            label: `Use the credential command from ~/.claude/settings.json (${truncateCommand(detection.userHelperCommand)})`,
+        });
+    }
+    options.push({ value: "command", label: "Run a credential command to mint a short-lived token" });
+    if (detection.authTokenEnvSet) options.push({ value: "env_bearer", label: `Use ${ANTHROPIC_AUTH_TOKEN_VAR} from your environment (bearer)` });
+    options.push({ value: "_skip", label: "Skip — use a static API key from the environment" });
+
+    const chosen = await select("A credential-helper setup was detected. How should inflexa obtain the model token?", options);
+    if (chosen === "_skip") return null;
+
+    let auth: ModelAuthConfig;
+    if (chosen === "env_bearer") {
+        auth = { kind: "env", var: ANTHROPIC_AUTH_TOKEN_VAR, scheme: "bearer" };
+    } else {
+        const prefill = chosen === "command_prefill" ? (detection.userHelperCommand ?? "") : "";
+        const command = (
+            await promptText("Credential command (its stdout is the token — Claude Code apiKeyHelper compatible)", {
+                ...(prefill !== "" && { defaultValue: prefill, placeholder: prefill }),
+                validate: (v) => (v.trim() === "" ? "Enter a command." : undefined),
+            })
+        ).trim();
+        // Infer the scheme default from the wire (design open question: infer, let the user override — the
+        // probe validates it). An apiKeyHelper mints an `x-api-key`; a bearer is the OAuth/WIF case.
+        const scheme = (await select("How is the minted token sent on the wire?", [
+            { value: "x-api-key", label: "x-api-key header (a minted API key — apiKeyHelper default)" },
+            { value: "bearer", label: "Authorization: Bearer (an OAuth / WIF access token)" },
+        ])) as CredentialScheme;
+        auth = { kind: "command", command, scheme };
+    }
+
+    const s = clackSpinner();
+    s.start("Validating the credential source");
+    const probe = await probeCredentialSource(direct.baseURL, effectiveProtocol(direct), auth);
+    if (probe.isErr()) {
+        s.error("Credential source validation failed");
+        log.error(probe.error.message);
+        log.warn("Not writing the credential source — falling back to a static API key. Re-run `inflexa setup` to try again.");
+        return null;
+    }
+    s.stop("Credential source validated");
+    return auth;
 }
 
 /**


### PR DESCRIPTION
> **Stacked on #135** (`adopt-provider-env-vars`). Base this branch on that one; review/merge #135 first. The diff here is only this change.

## Why

Enterprises that buy Anthropic API tokens increasingly issue them through a **credential helper** — a script that mints a **short-lived** first-party token on demand (Claude Code's `apiKeyHelper`, AWS `credential_process`, kubectl exec-plugins). `direct` mode resolved the key once at boot as a static string and only sent `x-api-key` — it couldn't consume a rotating helper token or send a Bearer. This lets an employee on a company-token plan point Inflexa at their org's sanctioned credential source with a one-time opt-in.

## What changed

- **`models.connection.auth`** — a refreshing credential source: `{ kind: "env", var, scheme }` (e.g. a short-lived `ANTHROPIC_AUTH_TOKEN` bearer) or `{ kind: "command", command, scheme, format?, ttlMs? }`. Only the name/command + scheme are persisted; **the token value never touches config, telemetry, logs, or provenance.**
- **`CredentialSource`** (`lib/env.ts`) — cached async supplier; command run via `Bun.spawn` (boundary-wrapped to `Result`); stdout parsed as a **raw token** (Claude Code `apiKeyHelper` parity) or **Kubernetes `ExecCredential` JSON** (`client.authentication.k8s.io/*`, `status.token` + `status.expirationTimestamp`); expiry/`ttlMs` caching + `forceRefresh`.
- **Auth-injecting `fetch`** (`harness/runtime.ts`) — sends `x-api-key` or `Authorization: Bearer` per scheme through the harness `config.fetch` seam (**no `harness/src` change**); one `401` → `forceRefresh` + retry. Also closes the `ANTHROPIC_AUTH_TOKEN` bearer gap deferred in #135.
- **Setup** — credential-helper detection (user/managed `apiKeyHelper`, `ANTHROPIC_AUTH_TOKEN`); an **opt-in** offer that pre-fills the user's own helper and **never auto-runs the org managed-settings helper**; a **validation probe** (`GET {baseURL}/models`) that blocks a bad command/scheme/endpoint before the `auth` block is written.

## Design decisions (see `design.md`)

Standard, testable formats — **nothing bespoke** (raw = `apiKeyHelper`; JSON = k8s `ExecCredential`; wire headers = Anthropic's own conventions). Injection via the existing `fetch` seam (CLI-side, no hard harness change). Refresh = expiry + `ttlMs` + `401`, no mid-stream refresh (Anthropic validates auth at request start). Detect → **user confirms** the command (never auto-wire the org helper) — governance stays with the user/org.

## Testing

- `typecheck` + `lint` clean; `bun test` = 1201 pass / 1 fail — the single failure (`embedding/local-provider.test.ts`) is **pre-existing and unrelated** (reproduces on clean base; WSL2 loopback-proxy quirk).
- **Verified end-to-end against a local mock Anthropic endpoint** with a rotating helper (real `Bun.serve` + real shell helpers, real source/fetch/probe functions): confirmed the Bearer/x-api-key headers the server received, **401 → refresh → retry with a genuinely fresh token**, ExecCredential expiry-driven refresh, the probe pass/fail, `auth` overriding `INFLEXA_MODEL_API_KEY`, and the secret **absent** from the written config tree.

## Scope / follow-up

CLI-only; no new dependencies; no `harness/src` change. **Known follow-up:** the credential-command offer is interactive-only (TTY-gated) — a non-interactive/CI path (`--auth-command` / config-first setup) is deferred to a separate change.
