### PR TITLE
feat(cli): embed bge-small model into the binary for offline local-embeddings setup

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,3 +1,3 @@
-# Pinned llama-server release archives cached by scripts/build.ts for the local-embeddings sidecar
-# runtime. Downloaded on demand (hash-verified against the vendored pin), never committed.
+# Build-time embedded artifacts cached by scripts/build.ts: the pinned llama-server release archives and
+# the bge-small embedding-model GGUF. Downloaded on demand (hash-verified against the vendored pins), never committed.
 .llama-cache/

--- a/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/design.md
+++ b/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/design.md
@@ -1,0 +1,58 @@
+## Context
+
+Local-embeddings setup has two artifacts to acquire: the `llama-server` sidecar runtime and the bge-small GGUF model. The runtime is already source-aware (`llama_runtime.ts`): compiled binaries materialize it from a build-time embedded asset with no network; source checkouts download the pinned release. The model is not — `downloadModel()` in `setup.ts` always fetches from huggingface.co, which fails for users behind egress-restricted corporate proxies even when they run the official binary. `scripts/build.ts` already owns the whole embed pipeline: an out-of-git `.llama-cache/`, vendored-SHA-256 verification with loud build failure, a stale-artifact sweep, and define-gated `import(..., { with: { type: "file" } })` embedding.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `inflexa setup --embeddings local` in a compiled binary completes with zero network access.
+- One integrity story: the same vendored `MODEL_SHA256` verifies the build-time fetch, the embedded copy, and the from-source download; nothing lands at `env.embeddingModelPath` unverified.
+- Maximal reuse of the existing llama-runtime embed pattern — no new mechanism, cache, or define where an existing one serves.
+
+**Non-Goals:**
+
+- Committing the model to git (LFS) — rejected in the proposal (owner-billed bandwidth quota, contributor friction, second distribution mechanism).
+- Per-target model variants — the GGUF is platform-independent; every target embeds the same asset.
+- Self-healing a missing model at the launch gate (`ensureEmbedderReady`) — the model is the object of the user's explicit setup consent, unlike the runtime (an internal detail the gate heals silently). The gate keeps directing to `inflexa setup --embeddings local`, whose remediation now works offline in compiled binaries.
+- Changing the from-source flow, the sidecar verification probe, or any config surface.
+
+## Decisions
+
+**D1 — Reuse `.llama-cache/` as the single build artifact cache.** The model GGUF is cached beside the runtime archives. An alternative `.model-cache/` would mean a second gitignore entry, a second sweep, and a second "delete this dir to force re-fetch" story for zero isolation benefit. The `.gitignore` comment widens to "build-time embedded artifacts".
+
+**D2 — Gate the embed import on `__INFLEXA_COMPILED__`, not a new define.** The runtime needs `__INFLEXA_LLAMA_TARGET__` because each target embeds a *different* archive and the other four imports must be DCE'd. The model is one asset for all targets, so the existing every-target `__INFLEXA_COMPILED__` define is exactly the right key: under a `typeof` guard the bundler folds the branch to the file-import when compiling and to `null` in dev/source/test runs (where the identifier is undeclared), so the import specifier into `.llama-cache/` is never resolved outside a release build. `setup.ts` declares the ambient const locally under the same `typeof` discipline — precedent: `llama_runtime.ts` declaring `__INFLEXA_LLAMA_TARGET__`, `install_context.ts` declaring `__INFLEXA_COMPILED__`.
+
+**D3 — Route acquisition with `isCompiledBinary()`, resolve bytes with the folded import.** Mirrors `materialize()` in `llama_runtime.ts` exactly: the routing decision goes through the accessor (which honors `__setCompiledBinaryForTest`), while the embedded-path resolution lives in a private `embeddedModelPath(): Promise<string | null>` whose branches fold at build time. Embedded bytes are read with `Bun.file(path).bytes()` and written with `Bun.write` — the bunfs-safe pair (fd-based APIs ENOENT on `/$bunfs`), same as `writeEmbeddedArchive`.
+
+**D4 — `downloadModel()` becomes `acquireModel()`, keeping its contract.** Skip-if-present, `.part` staging with atomic rename, SHA-256 verification, and clack spinner narration all stay; only the byte source branches. The embedded branch verifies the copied bytes against `MODEL_SHA256` too — the build already verified them, but re-verifying keeps the single invariant "nothing lands at the final path unverified" unconditional rather than source-dependent (identical to `materialize()` hashing the embedded archive). No external callers exist (`runLocalSetup` is the only call site; tests exercise the flow above it), so the rename is contained.
+
+**D5 — Home the pin in a leaf `model_pin.ts` module; both `setup.ts` and the build import it.** The three constants — `MODEL_URL`, `MODEL_SHA256`, and `MODEL_ARTIFACT` (the cache/embed filename, `bge-small-en-v1.5-q8_0.gguf`) — live in a new leaf module `src/modules/embedding/model_pin.ts` with NO imports of its own. They are deliberately NOT homed in `setup.ts`: `setup.ts` transitively imports the `@inflexa-ai/harness` package (via `local-provider.ts`), so `scripts/build.ts` importing the pin from `setup.ts` would evaluate the entire interactive-setup graph (@clack, the harness runtime) inside the build script, for the sake of three constants. A leaf module keeps the build's dependency footprint to the constants alone. `setup.ts` imports the pin from `model_pin.ts` (no re-export — the repo forbids re-exports); `scripts/build.ts` imports all three for its `ensureModelCached()`. Either way it is one hash source shared by build-time and runtime verification, the same sharing `LLAMA_PINS` already does. The string-literal import specifier in `embeddedModelPath()` must be edited in lockstep on a pin bump (Bun embeds only statically-known paths); the pin module's JSDoc carries that lockstep note, mirroring `LLAMA_RUNTIME_TAG`'s.
+
+**D6 — The sweep's keep-set is "current llama artifacts + current model artifact".** `sweepLlamaCache()` currently deletes anything not in `LLAMA_PINS` — which would delete the model on every build. Widening the keep-set preserves the sweep's purpose for the model too: after a model pin bump, the superseded GGUF is removed before compiling, so a stale import literal fails the build loudly instead of silently embedding the old model.
+
+**D7 — Fetch the model once per build, before the target loop.** Unlike the per-target runtime archives, the model is target-independent; `ensureModelCached()` runs once beside `sweepLlamaCache()`, not inside the loop.
+
+**D8 — Install-context-aware user copy.** The mode-picker label ("downloads a ~36 MB model + runtime") and the acquisition spinner text say "download … from HuggingFace" — wrong and alarming for the proxy-restricted compiled-binary user this change exists for. Both pick their wording via `isCompiledBinary()` (compiled: "installs the bundled ~36 MB model"; source: today's copy).
+
+**D9 — Preselected embeddings run before the container-runtime gate; the interactive flow is untouched.** `inflexa setup` gates on a ready container runtime early — `firstReadyRuntime` runs before `intro` (`src/modules/infra/setup.ts`) — and the embedding step lives deep inside that gated flow (the lazy `runEmbeddingSetup(...)` call). The audience this whole change exists for — egress-restricted / air-gapped users, now that the model is a build-time embedded asset — may have no container runtime at all, so `setup --embeddings local` is unreachable for exactly them. Decision: when `options.embeddings` is an explicit preselection (`--embeddings local|api-key|off`), `setup()` runs the embedding step BEFORE the runtime probe, then continues into the rest of setup unchanged — a missing runtime still errors and exits 1 afterward (the remainder genuinely needs one), but the user's embeddings are already durably configured to disk by then. The step must not run twice: the preselected pre-gate run is remembered so the later in-flow embedding step is skipped in the same invocation. The interactive no-preselection flow is untouched — the embedding question stays after provider auth, because the local-embeddings spec ("Embedding setup is wired into the interactive setup flow") requires "an embedding-mode question after provider auth".
+
+Rejected — hoisting the embedding step unconditionally: it would move the interactive question ahead of provider auth, breaking the spec'd interactive question order. Rejected — a standalone `inflexa embeddings` command: a whole new CLI surface for one flag's worth of behavior, and `setup --embeddings` is already the remediation string the launch gate and the docs point users to; a second command would fork that guidance.
+
+Rationale: (1) the air-gapped audience is the reason this change exists, so the one remediation string we advertise must work for them without a runtime; (2) the interactive order is spec-bound and cannot be reordered; (3) exit-code honesty — the remainder of setup genuinely needs a runtime, so still exiting 1 on a missing one is correct, while the embedding outcome is separately durable and separately narrated. This scopes the reorder to the local-embeddings capability only: the container-runtime "Setup falls back to any ready runtime" requirement is honored unchanged (setup still fails when no runtime is ready; the runtime is still pinned before any container work — a non-container step moving ahead of the probe is not something that requirement constrains), so no container-runtime spec delta is warranted.
+
+## Risks / Trade-offs
+
+- [Release binaries grow ~36 MB per target] → Accepted in the proposal; the smoke test already catches a binary that compiles but cannot start with its embedded assets.
+- [HuggingFace outage or throttling breaks release builds] → Same exposure class as the existing GitHub-releases fetch for the runtime; the URL pins an immutable revision (not `main`), `.llama-cache/` makes it once-per-machine, and the failure is loud, never a silently different artifact.
+- [Model pin bump forgets one of the lockstep sites (pin constants vs import literal)] → The sweep removes the superseded file, turning the mismatch into an import-resolution build failure — the same protection the runtime relies on (D6).
+- [Embedded copy doubles peak memory briefly (~36 MB bytes in RAM)] → One-shot at setup time, immediately released; the runtime's archive copy already does the same.
+- [Preselected embeddings succeed but setup still exits 1 on a missing runtime → user confusion (D9)] → The runtime error already carries its own remediation, and the embedding step narrates its own success (acquisition spinner + `embedding.mode = "local"` written) BEFORE the probe runs, so the user sees "embeddings configured" and then the distinct runtime error — two separately legible outcomes, not one ambiguous failure.
+
+## Migration Plan
+
+No data or config migration. The next release's binaries simply carry the model; existing binaries keep downloading as before. From-source checkouts are unaffected. Rollback is reverting the build-script/setup changes — the download path remains intact underneath.
+
+## Open Questions
+
+None.

--- a/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+A client running behind a corporate proxy cannot reach huggingface.co, so `inflexa setup --embeddings local` fails at the model download — even though the compiled binary already carries the llama-server *runtime* as an embedded asset and needs no network for it. The bge-small GGUF (~36 MB) is the last network dependency of local-embeddings setup in the compiled binary; embedding it closes the gap and makes local-embeddings setup fully offline for release binaries.
+
+## What Changes
+
+- `scripts/build.ts` downloads the pinned `bge-small-en-v1.5-q8_0.gguf` into the existing `.llama-cache/` at build time, verifies it against the vendored `MODEL_SHA256` pin (the same integrity authority setup uses at runtime), and embeds it into **every** target binary via the same define-gated `import(..., { with: { type: "file" } })` mechanism the llama runtime uses. The model is platform-independent, so unlike the per-target runtime archives there is one asset and no per-target DCE selection.
+- The build's stale-cache sweep keeps the model artifact in its keep-set so it is not removed as "matching no current pin".
+- Model acquisition in `src/modules/embedding/setup.ts` becomes source-aware, mirroring `llama_runtime.ts`: a compiled binary copies the embedded asset to `env.embeddingModelPath` (bunfs-safe byte read, no network); a source checkout downloads from HuggingFace as today. Both paths verify the SHA-256 before the file lands at the final path.
+- Net effect: `inflexa setup --embeddings local` in a compiled binary completes with zero network access. From-source behavior is unchanged.
+- When `inflexa setup` is invoked with an explicit `--embeddings local|api-key|off` preselection, the embedding step runs BEFORE the container-runtime probe (`firstReadyRuntime`), so egress-restricted/air-gapped users with no ready Docker/Podman can still configure embeddings non-interactively — the exact audience this change serves now that the model is a build-time embedded asset. A missing runtime still fails the rest of setup afterward (exit 1); the interactive no-preselection flow keeps the embedding question in its spec'd position (after provider auth); the step runs at most once per invocation.
+- Release binaries grow by ~36 MB per target. No config, CLI-surface, or hot-path changes.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this hardens an existing capability._
+
+### Modified Capabilities
+
+- `local-embeddings`: the "Embedding setup downloads and verifies the model on opt-in" requirement becomes source-aware — the compiled binary acquires the model from a build-time embedded asset with no network, a source checkout downloads the pinned file; a new requirement covers build-time model embedding (pinned, hash-verified at build, embedded for every target, protected from the stale-cache sweep); and the "Embedding setup is wired into the interactive setup flow" requirement gains a preselected-before-gate path — an explicit `--embeddings` selection runs the embedding step before the container-runtime probe (so a runtime-less host can still configure embeddings non-interactively), while the interactive question keeps its position after provider auth and the step never runs twice in one invocation.
+
+_(The container-runtime "Setup falls back to any ready runtime" requirement is unchanged: setup still fails when no supported runtime is ready, and the runtime is still pinned before any container work. The reorder only moves a non-container step ahead of the probe, which that requirement does not constrain.)_
+
+## Impact
+
+- `cli/scripts/build.ts` — model cache/verify/embed step beside `ensureLlamaArchiveCached`; sweep keep-set.
+- `cli/src/modules/embedding/setup.ts` — `downloadModel()` grows an embedded-asset branch routed by `isCompiledBinary()`; user-facing copy that says "downloads … from HuggingFace" adjusted where it would now be wrong in the compiled context.
+- Release workflow: unchanged (build already fetches pinned artifacts from the network on `ubuntu-latest`); one extra ~36 MB fetch per release build, cached in `.llama-cache/`.
+- Not chosen: committing the model via Git LFS — `actions/checkout` would skip the blob by default, but LFS bandwidth is billed to the repo owner (~28 downloads/month on the free tier at this size), contributors would need `git-lfs`, and it would add a second artifact-distribution mechanism beside the established build-time one.

--- a/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/specs/local-embeddings/spec.md
+++ b/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/specs/local-embeddings/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Embedding model is a build-time embedded asset
+
+The release build SHALL download the pinned `bge-small-en-v1.5-q8_0.gguf` into the build artifact cache before compiling, verify it against the vendored SHA-256 (the sole integrity authority, shared with runtime verification — a cache hit SHALL be re-verified rather than trusted), and embed it into EVERY target binary. The model is platform-independent: one asset serves all targets with no per-target selection. A download or hash failure SHALL fail the build loudly; a binary SHALL never embed unverified or mismatched model bytes. The build's stale-artifact sweep SHALL keep the current model artifact while removing model files that match no current pin, so after a pin bump a stale embed reference fails the build rather than silently embedding the superseded model.
+
+#### Scenario: Cold cache fetches, verifies, and embeds
+
+- **WHEN** a release build runs with no cached model artifact
+- **THEN** the pinned model is downloaded, verified against the vendored SHA-256, cached, and embedded into every target binary
+
+#### Scenario: Cache hit is re-verified
+
+- **WHEN** a release build runs with the model artifact already cached
+- **THEN** the cached bytes are re-hashed against the vendored SHA-256 before being embedded
+- **AND** a mismatch fails the build with direction to delete the cache
+
+#### Scenario: Hash mismatch fails the build
+
+- **WHEN** the downloaded model's SHA-256 does not match the vendored pin
+- **THEN** the build fails loudly and no binary is produced with the mismatched bytes
+
+#### Scenario: Superseded model artifact cannot be embedded
+
+- **WHEN** the model pin changes and a build runs while the cache still holds the superseded model file
+- **THEN** the stale file is removed before compilation, and an embed reference that still names it fails the build
+
+## MODIFIED Requirements
+
+### Requirement: Embedding setup downloads and verifies the model on opt-in
+
+`inflexa setup` SHALL ask the user whether to use local embeddings. If yes, it SHALL ensure the sidecar runtime is materialized (per the acquisition requirement) and acquire `bge-small-en-v1.5-q8_0.gguf` (~36 MB) to `env.embeddingModelPath` source-aware, mirroring runtime acquisition: the compiled binary SHALL copy the model from its build-time embedded asset with no network access; a source checkout SHALL download the pinned revision from `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace. Both sources SHALL be verified against the vendored SHA-256 before any bytes land at `env.embeddingModelPath` — staged beside the final path and atomically renamed, so a partial or failed acquisition leaves nothing there — then verified end-to-end through the sidecar: spawn it against the acquired model, embed a probe text, and assert the vector dimension is 384. On success, it SHALL write `embedding.mode = "local"` and `embedding.modelPath` to config. No acquisition SHALL occur if the user declines. Verification through the sidecar SHALL be the same in the compiled binary and from source. User-facing setup copy SHALL match the install context — the compiled binary SHALL NOT claim it downloads the model.
+
+#### Scenario: User opts into local embeddings in the compiled binary
+
+- **WHEN** the user opts into local embeddings in the compiled binary
+- **THEN** the model SHALL be copied from the embedded asset to `env.embeddingModelPath` with no network access
+- **AND** verified against the vendored SHA-256 before landing at the final path
+- **AND** the sidecar SHALL serve a probe embedding whose dimension is verified as 384
+- **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
+
+#### Scenario: User opts into local embeddings in a source checkout
+
+- **WHEN** the user opts into local embeddings in a source checkout
+- **THEN** the pinned model revision SHALL be downloaded from HuggingFace, verified against the vendored SHA-256, and landed at `env.embeddingModelPath`
+- **AND** the sidecar SHALL serve a probe embedding whose dimension is verified as 384
+- **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
+
+#### Scenario: User declines local embeddings
+
+- **WHEN** the user is prompted "Use local embeddings?" and selects no
+- **THEN** no model SHALL be acquired and no runtime SHALL be materialized
+- **AND** config SHALL remain `embedding.mode = "off"` (or prompt for api-key)
+
+#### Scenario: Model already present is not re-downloaded
+
+- **WHEN** the user opts into local embeddings and `env.embeddingModelPath` already exists
+- **THEN** acquisition SHALL be skipped (no download, no embedded-asset copy)
+- **AND** verification (sidecar probe) SHALL still run
+
+#### Scenario: Checksum mismatch leaves nothing at the final path
+
+- **WHEN** the acquired bytes (from either source) fail SHA-256 verification
+- **THEN** setup SHALL report an actionable error and nothing SHALL be left at `env.embeddingModelPath`
+
+#### Scenario: Verification fails
+
+- **WHEN** the sidecar cannot serve a valid 384-dim probe embedding for the acquired model
+- **THEN** setup SHALL report the error and leave `embedding.mode` unchanged (not "local")
+
+### Requirement: Embedding setup is wired into the interactive setup flow
+
+The interactive `inflexa setup` questionnaire SHALL include an embedding-mode question after provider auth, offering the same three modes (`local`, `api-key`, `off`) in every install context — local mode works identically in the compiled binary and from source, so no context gates the offering. The question SHALL be skippable (defaulting to `off`). Non-interactive shells (no TTY) SHALL skip the embedding question without hanging, leaving `mode` unchanged.
+
+When `inflexa setup` is invoked with an explicit `--embeddings local|api-key|off` preselection, the embedding step SHALL run before the container-runtime probe, so an environment without a ready Docker/Podman can still configure embeddings non-interactively. This reorder applies ONLY to an explicit preselection: the interactive question's position is unchanged (still after provider auth). The remainder of setup still requires a ready runtime and SHALL still fail afterward when none is available — the preselected embeddings are already durably configured by then. The embedding step SHALL NOT run twice in one setup invocation: when the preselected pre-gate step has already run, the in-flow embedding step SHALL be skipped.
+
+#### Scenario: Interactive setup asks about embeddings
+
+- **WHEN** `inflexa setup` runs in a TTY (compiled binary or source checkout)
+- **THEN** the user SHALL be prompted to choose an embedding mode after provider auth, with `local` selectable
+
+#### Scenario: Non-interactive setup skips embeddings
+
+- **WHEN** `inflexa setup` runs without a TTY
+- **THEN** the embedding question SHALL be skipped
+
+#### Scenario: Preselected embeddings configure without a container runtime
+
+- **WHEN** `inflexa setup --embeddings local` runs with no ready Docker or Podman
+- **THEN** the embedding step SHALL run before the container-runtime probe — the model is acquired, verified, and configured (`embedding.mode = "local"`)
+- **AND** the missing-runtime error SHALL still be reported for the remainder of setup
+
+#### Scenario: Preselected embeddings run once
+
+- **WHEN** a preselected mode is given and a container runtime IS ready
+- **THEN** the embedding step SHALL run exactly once — the pre-gate preselected step runs and the in-flow embedding step is skipped

--- a/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/tasks.md
@@ -1,0 +1,30 @@
+## 1. Model pin surface (setup.ts)
+
+- [x] 1.1 Create the leaf module `src/modules/embedding/model_pin.ts` (no imports) exporting `MODEL_URL`, `MODEL_SHA256`, and `MODEL_ARTIFACT` (the filename `bge-small-en-v1.5-q8_0.gguf`), with the pin JSDoc + lockstep-bump note (pin constants + the embed-import literal must change together, mirroring `LLAMA_RUNTIME_TAG`'s note); `src/modules/embedding/setup.ts` imports the pin from it (no re-export). Homed in a leaf module so `scripts/build.ts` can import the pin without evaluating setup.ts's transitive `@inflexa-ai/harness` graph (D5).
+
+## 2. Source-aware model acquisition (setup.ts)
+
+- [x] 2.1 Add the define-gated embedded-asset accessor: `declare const __INFLEXA_COMPILED__` locally, plus a private `embeddedModelPath(): Promise<string | null>` whose `typeof`-guarded branch does `import("../../../.llama-cache/bge-small-en-v1.5-q8_0.gguf", { with: { type: "file" } })` (folds away outside a release build; D2/D3).
+- [x] 2.2 Rename `downloadModel()` → `acquireModel()` and branch by `isCompiledBinary()`: compiled → copy embedded bytes bunfs-safely (`Bun.file(path).bytes()` + write to the `.part` stage), source → today's HuggingFace streaming download. Keep skip-if-present, `.part` → atomic rename, and SHA-256 verification of BOTH sources before the rename (D4); update the sole call site in `runLocalSetup`.
+- [x] 2.3 Make user-facing copy install-context-aware (D8): the acquisition spinner ("Installing the bundled model" vs "Downloading … from HuggingFace") and the mode-picker `local` label in `promptEmbeddingMode`; sweep remaining setup.ts prose (module header, `runtime_unavailable` comment) for now-wrong "download the GGUF" claims about the compiled context.
+
+## 3. Build-time embed (scripts/build.ts)
+
+- [x] 3.1 Add `ensureModelCached()` beside `ensureLlamaArchiveCached()`: import the pin from `model_pin.ts`, download to `.llama-cache/<MODEL_ARTIFACT>` when absent, hash-verify (cache hit re-verifies; mismatch → loud `process.exit(1)` with delete-the-cache direction); run it ONCE before the target loop (D7).
+- [x] 3.2 Widen `sweepLlamaCache()`'s keep-set to current llama artifacts + `MODEL_ARTIFACT` so the model survives the sweep while a superseded model file is removed before compiling (D6); rename/re-comment the sweep if its name no longer fits, and update the `.gitignore` comment for `.llama-cache/` to cover build-time embedded artifacts generally.
+
+## 4. Tests
+
+- [x] 4.1 Unit-test `acquireModel` source routing with `__setCompiledBinaryForTest`: compiled context copies the (test-fixture) embedded bytes with no fetch, source context downloads; checksum mismatch leaves nothing at the final path. Add a test seam for the embedded-byte source only if the folded import cannot be exercised under `bun test` (follow `__setLlamaAcquireForTest`'s pattern).
+- [x] 4.2 Extend `setup.test.ts` flow coverage where behavior changed (already-present model skips acquisition in both contexts; declined setup acquires nothing).
+
+## 5. Verify
+
+- [x] 5.1 `bun run typecheck`, `bun run lint`, `bun test src/modules/embedding/`, and `bun run format:file` on touched src files.
+- [x] 5.2 Host-target `bun run build`, then run the produced binary's `setup --embeddings local` with network egress to huggingface.co blocked (e.g. a bogus `HTTPS_PROXY`) to prove the offline path end-to-end; confirm the binary grew ~36 MB and the smoke test still passes.
+
+## 6. Embeddings-preselection bypasses the runtime gate
+
+- [x] 6.1 Reorder `setup()` in `src/modules/infra/setup.ts` so an explicit `--embeddings local|api-key|off` preselection runs the embedding step BEFORE the `firstReadyRuntime` probe, then continues into the rest of setup unchanged; guard against a double-run so the in-flow embedding step is skipped when the preselected step already ran. Leave the interactive no-preselection flow's embedding question in its current position (after provider auth). WHY comments: the air-gapped audience has no runtime, embeddings are now offline-capable in the compiled binary, and the interactive question order is spec-bound (D9).
+- [x] 6.2 Test coverage for the reorder: a preselected mode configures embeddings when no runtime is ready (gate-independent), and the embedding step runs exactly once when a runtime IS ready — exercised through the module's existing test seams. If the setup module exposes no feasible unit seam for the ordering, record the rationale in the test file/PR instead.
+- [x] 6.3 Re-run the 5.1 verification gate (`bun run typecheck`, `bun run lint`, `bun test src/modules/embedding/`, `bun run format:file` on touched src files) after the reorder.

--- a/cli/openspec/specs/local-embeddings/spec.md
+++ b/cli/openspec/specs/local-embeddings/spec.md
@@ -68,30 +68,43 @@ Every vector returned by `createLocalEmbeddingProvider.embed()` SHALL have exact
 
 ### Requirement: Embedding setup downloads and verifies the model on opt-in
 
-`inflexa setup` SHALL ask the user whether to use local embeddings. If yes, it SHALL ensure the sidecar runtime is materialized (per the acquisition requirement) and download `bge-small-en-v1.5-q8_0.gguf` (~36 MB) from `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace to `env.embeddingModelPath`, then verify end-to-end through the sidecar: spawn it against the downloaded model, embed a probe text, and assert the vector dimension is 384. On success, it SHALL write `embedding.mode = "local"` and `embedding.modelPath` to config. Neither download SHALL occur if the user declines. Verification through the sidecar SHALL be the same in the compiled binary and from source.
+`inflexa setup` SHALL ask the user whether to use local embeddings. If yes, it SHALL ensure the sidecar runtime is materialized (per the acquisition requirement) and acquire `bge-small-en-v1.5-q8_0.gguf` (~36 MB) to `env.embeddingModelPath` source-aware, mirroring runtime acquisition: the compiled binary SHALL copy the model from its build-time embedded asset with no network access; a source checkout SHALL download the pinned revision from `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace. Both sources SHALL be verified against the vendored SHA-256 before any bytes land at `env.embeddingModelPath` — staged beside the final path and atomically renamed, so a partial or failed acquisition leaves nothing there — then verified end-to-end through the sidecar: spawn it against the acquired model, embed a probe text, and assert the vector dimension is 384. On success, it SHALL write `embedding.mode = "local"` and `embedding.modelPath` to config. No acquisition SHALL occur if the user declines. Verification through the sidecar SHALL be the same in the compiled binary and from source. User-facing setup copy SHALL match the install context — the compiled binary SHALL NOT claim it downloads the model.
 
-#### Scenario: User opts into local embeddings
+#### Scenario: User opts into local embeddings in the compiled binary
 
-- **WHEN** the user is prompted "Use local embeddings?" and selects yes
-- **THEN** the sidecar runtime SHALL be materialized and the GGUF model SHALL be downloaded to `env.embeddingModelPath`
+- **WHEN** the user opts into local embeddings in the compiled binary
+- **THEN** the model SHALL be copied from the embedded asset to `env.embeddingModelPath` with no network access
+- **AND** verified against the vendored SHA-256 before landing at the final path
+- **AND** the sidecar SHALL serve a probe embedding whose dimension is verified as 384
+- **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
+
+#### Scenario: User opts into local embeddings in a source checkout
+
+- **WHEN** the user opts into local embeddings in a source checkout
+- **THEN** the pinned model revision SHALL be downloaded from HuggingFace, verified against the vendored SHA-256, and landed at `env.embeddingModelPath`
 - **AND** the sidecar SHALL serve a probe embedding whose dimension is verified as 384
 - **AND** config SHALL be updated with `embedding.mode = "local"` and `embedding.modelPath`
 
 #### Scenario: User declines local embeddings
 
 - **WHEN** the user is prompted "Use local embeddings?" and selects no
-- **THEN** no model SHALL be downloaded and no runtime SHALL be materialized
+- **THEN** no model SHALL be acquired and no runtime SHALL be materialized
 - **AND** config SHALL remain `embedding.mode = "off"` (or prompt for api-key)
 
 #### Scenario: Model already present is not re-downloaded
 
 - **WHEN** the user opts into local embeddings and `env.embeddingModelPath` already exists
-- **THEN** the download SHALL be skipped
+- **THEN** acquisition SHALL be skipped (no download, no embedded-asset copy)
 - **AND** verification (sidecar probe) SHALL still run
+
+#### Scenario: Checksum mismatch leaves nothing at the final path
+
+- **WHEN** the acquired bytes (from either source) fail SHA-256 verification
+- **THEN** setup SHALL report an actionable error and nothing SHALL be left at `env.embeddingModelPath`
 
 #### Scenario: Verification fails
 
-- **WHEN** the sidecar cannot serve a valid 384-dim probe embedding for the downloaded model
+- **WHEN** the sidecar cannot serve a valid 384-dim probe embedding for the acquired model
 - **THEN** setup SHALL report the error and leave `embedding.mode` unchanged (not "local")
 
 ### Requirement: Embedding model path is env-managed
@@ -132,6 +145,8 @@ Every vector returned by `createLocalEmbeddingProvider.embed()` SHALL have exact
 
 The interactive `inflexa setup` questionnaire SHALL include an embedding-mode question after provider auth, offering the same three modes (`local`, `api-key`, `off`) in every install context — local mode works identically in the compiled binary and from source, so no context gates the offering. The question SHALL be skippable (defaulting to `off`). Non-interactive shells (no TTY) SHALL skip the embedding question without hanging, leaving `mode` unchanged.
 
+When `inflexa setup` is invoked with an explicit `--embeddings local|api-key|off` preselection, the embedding step SHALL run before the container-runtime probe, so an environment without a ready Docker/Podman can still configure embeddings non-interactively. This reorder applies ONLY to an explicit preselection: the interactive question's position is unchanged (still after provider auth). The remainder of setup still requires a ready runtime and SHALL still fail afterward when none is available — the preselected embeddings are already durably configured by then. The embedding step SHALL NOT run twice in one setup invocation: when the preselected pre-gate step has already run, the in-flow embedding step SHALL be skipped.
+
 #### Scenario: Interactive setup asks about embeddings
 
 - **WHEN** `inflexa setup` runs in a TTY (compiled binary or source checkout)
@@ -141,6 +156,42 @@ The interactive `inflexa setup` questionnaire SHALL include an embedding-mode qu
 
 - **WHEN** `inflexa setup` runs without a TTY
 - **THEN** the embedding question SHALL be skipped
+
+#### Scenario: Preselected embeddings configure without a container runtime
+
+- **WHEN** `inflexa setup --embeddings local` runs with no ready Docker or Podman
+- **THEN** the embedding step SHALL run before the container-runtime probe — the model is acquired, verified, and configured (`embedding.mode = "local"`)
+- **AND** the missing-runtime error SHALL still be reported for the remainder of setup
+
+#### Scenario: Preselected embeddings run once
+
+- **WHEN** a preselected mode is given and a container runtime IS ready
+- **THEN** the embedding step SHALL run exactly once — the pre-gate preselected step runs and the in-flow embedding step is skipped
+
+### Requirement: Embedding model is a build-time embedded asset
+
+The release build SHALL download the pinned `bge-small-en-v1.5-q8_0.gguf` into the build artifact cache before compiling, verify it against the vendored SHA-256 (the sole integrity authority, shared with runtime verification — a cache hit SHALL be re-verified rather than trusted), and embed it into EVERY target binary. The model is platform-independent: one asset serves all targets with no per-target selection. A download or hash failure SHALL fail the build loudly; a binary SHALL never embed unverified or mismatched model bytes. The build's stale-artifact sweep SHALL keep the current model artifact while removing model files that match no current pin, so after a pin bump a stale embed reference fails the build rather than silently embedding the superseded model.
+
+#### Scenario: Cold cache fetches, verifies, and embeds
+
+- **WHEN** a release build runs with no cached model artifact
+- **THEN** the pinned model is downloaded, verified against the vendored SHA-256, cached, and embedded into every target binary
+
+#### Scenario: Cache hit is re-verified
+
+- **WHEN** a release build runs with the model artifact already cached
+- **THEN** the cached bytes are re-hashed against the vendored SHA-256 before being embedded
+- **AND** a mismatch fails the build with direction to delete the cache
+
+#### Scenario: Hash mismatch fails the build
+
+- **WHEN** the downloaded model's SHA-256 does not match the vendored pin
+- **THEN** the build fails loudly and no binary is produced with the mismatched bytes
+
+#### Scenario: Superseded model artifact cannot be embedded
+
+- **WHEN** the model pin changes and a build runs while the cache still holds the superseded model file
+- **THEN** the stale file is removed before compilation, and an embed reference that still names it fails the build
 
 ### Requirement: Sidecar runtime acquisition is pinned, verified, and atomic
 

--- a/cli/scripts/build.ts
+++ b/cli/scripts/build.ts
@@ -299,12 +299,14 @@ async function ensureModelCached(): Promise<void> {
 
 // Remove every cache file that matches no current pin BEFORE compiling — covering both artifact kinds: the
 // per-target llama-server archives (LLAMA_PINS) and the platform-independent embedding-model GGUF
-// (MODEL_ARTIFACT). A pin bump renames the artifacts (new tag/revision → new filenames) but leaves the
-// superseded files on disk; if the embed-import literals in llama_runtime.ts / setup.ts were not all
-// updated in lockstep, a stale literal could still resolve against one of those leftover files and embed
-// the WRONG artifact silently. Deleting them turns that mistake into a loud import-resolution build failure
-// instead — the same failure a clean CI checkout would produce. Only flat files live here, so directories
-// (none expected) are left untouched.
+// (MODEL_ARTIFACT). The llama archives are tag-named, so a pin bump renames them (new tag → new filenames)
+// and leaves the superseded archives on disk; if the embed-import literals in llama_runtime.ts / setup.ts
+// were not all updated in lockstep, a stale literal could still resolve against one of those leftovers and
+// embed the WRONG runtime silently. Deleting them turns that mistake into a loud import-resolution build
+// failure instead — the same failure a clean CI checkout would produce. (The model GGUF's filename usually
+// does NOT change across a revision bump — MODEL_ARTIFACT carries no revision — so the sweep keeps it and
+// ensureModelCached's cache re-hash, not this sweep, is what catches a stale model.) Only flat files live
+// here, so directories (none expected) are left untouched.
 function sweepLlamaCache(): void {
     if (!existsSync(LLAMA_CACHE_DIR)) return;
     // Widen to Set<string>: LLAMA_PINS is `as const` (and MODEL_ARTIFACT is a literal too), so the artifact

--- a/cli/scripts/build.ts
+++ b/cli/scripts/build.ts
@@ -13,6 +13,7 @@ import { createSolidTransformPlugin, resetSolidTransformPluginState } from "@ope
 
 import { audienceInvalidReason } from "../src/modules/auth/auth.ts";
 import { LLAMA_PINS, LLAMA_RUNTIME_TAG, llamaArtifactUrl, type LlamaPin, type LlamaTargetKey } from "../src/modules/embedding/llama_runtime.ts";
+import { MODEL_ARTIFACT, MODEL_SHA256, MODEL_URL } from "../src/modules/embedding/model_pin.ts";
 import { contentHashOf, packContent, type PackEntry } from "../src/modules/harness/content-pack.ts";
 
 // This process autoloads the repo bunfig.toml, whose preload installs
@@ -217,12 +218,14 @@ const buildRoot = process.cwd();
 const workerEntry = Bun.resolveSync("@opentui/core/parser.worker", buildRoot);
 const workerRelToRoot = relative(buildRoot, workerEntry);
 
-// On-disk cache for the pinned llama-server release archives (local-embeddings sidecar runtime),
-// kept OUTSIDE git (see .gitignore) so a rebuild need not re-download ~10 MB per target. Each target's
-// archive MUST be present here before Bun.build so the define-gated `import(... with { type: "file" })`
-// in src/modules/embedding/llama_runtime.ts can embed it. A host-only `bun run build` caches only the
-// host target's archive: the other three targets' imports are DCE'd away (their `__INFLEXA_LLAMA_TARGET__`
-// comparisons fold to false) and never resolved, so their archives are neither needed nor fetched.
+// On-disk cache for the build-time embedded artifacts — the per-target llama-server release archives
+// (local-embeddings sidecar runtime) AND the platform-independent embedding-model GGUF — kept OUTSIDE git
+// (see .gitignore) so a rebuild need not re-download them. Each artifact MUST be present here before
+// Bun.build so the define-gated `import(... with { type: "file" })` (in src/modules/embedding/llama_runtime.ts
+// for the archives, src/modules/embedding/setup.ts for the model) can embed it. A host-only `bun run build`
+// caches only the host target's archive plus the one model: the other three targets' archive imports are
+// DCE'd away (their `__INFLEXA_LLAMA_TARGET__` comparisons fold to false) and never resolved, so those
+// archives are neither needed nor fetched.
 const LLAMA_CACHE_DIR = join(process.cwd(), ".llama-cache");
 
 // Ensure `targetKey`'s pinned archive sits in the cache, hash-verified against the vendored SHA-256
@@ -262,25 +265,63 @@ async function ensureLlamaArchiveCached(targetKey: string): Promise<LlamaTargetK
     return pin.target;
 }
 
-// Remove every cache file that matches no current LLAMA_PINS artifact BEFORE compiling. A pin bump renames
-// the artifacts (new tag → new filenames) but leaves the superseded archives on disk; if the embed-import
-// literals in llama_runtime.ts were not all updated in lockstep, a stale literal could still resolve
-// against one of those leftover files and embed the WRONG runtime silently. Deleting them turns that
-// mistake into a loud import-resolution build failure instead — the same failure a clean CI checkout would
-// produce. Only flat archive files live here, so directories (none expected) are left untouched.
+// Ensure the pinned embedding-model GGUF sits in the cache, hash-verified against MODEL_SHA256. The model
+// is platform-independent, so unlike the per-target llama-server archives it is cached ONCE per build and
+// embedded into EVERY target binary via the `__INFLEXA_COMPILED__`-gated import in
+// src/modules/embedding/setup.ts (one asset, no per-target DCE selection). MODEL_SHA256 is the SAME
+// integrity authority runtime acquisition re-applies (one hash source, two gates), so the build-time and
+// first-run verifications can never disagree. A cache hit re-verifies rather than trusting the bytes on
+// disk. Any fetch/hash failure fails the build LOUDLY (process.exit(1)) — a binary that silently embedded
+// a wrong or corrupt model is worse than no binary.
+async function ensureModelCached(): Promise<void> {
+    const cachedPath = join(LLAMA_CACHE_DIR, MODEL_ARTIFACT);
+    if (existsSync(cachedPath)) {
+        const cachedDigest = new Bun.CryptoHasher("sha256").update(await Bun.file(cachedPath).bytes()).digest("hex");
+        if (cachedDigest === MODEL_SHA256) return;
+        console.error(`error: cached ${MODEL_ARTIFACT} sha256 ${cachedDigest} does not match the vendored pin ${MODEL_SHA256} — delete ${LLAMA_CACHE_DIR} and rebuild`);
+        process.exit(1);
+    }
+    console.log(`fetching embedding model ${MODEL_ARTIFACT} …`);
+    const response = await fetch(MODEL_URL);
+    if (!response.ok) {
+        console.error(`error: could not download ${MODEL_URL} — HTTP ${response.status} ${response.statusText}`);
+        process.exit(1);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+    if (digest !== MODEL_SHA256) {
+        console.error(`error: downloaded ${MODEL_ARTIFACT} sha256 ${digest} does not match the vendored pin ${MODEL_SHA256} — upstream may have re-cut the file; refusing to embed it`);
+        process.exit(1);
+    }
+    await Bun.write(cachedPath, bytes); // Bun.write creates LLAMA_CACHE_DIR if absent
+    console.log(`cached ${MODEL_ARTIFACT} (${(bytes.length / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+// Remove every cache file that matches no current pin BEFORE compiling — covering both artifact kinds: the
+// per-target llama-server archives (LLAMA_PINS) and the platform-independent embedding-model GGUF
+// (MODEL_ARTIFACT). A pin bump renames the artifacts (new tag/revision → new filenames) but leaves the
+// superseded files on disk; if the embed-import literals in llama_runtime.ts / setup.ts were not all
+// updated in lockstep, a stale literal could still resolve against one of those leftover files and embed
+// the WRONG artifact silently. Deleting them turns that mistake into a loud import-resolution build failure
+// instead — the same failure a clean CI checkout would produce. Only flat files live here, so directories
+// (none expected) are left untouched.
 function sweepLlamaCache(): void {
     if (!existsSync(LLAMA_CACHE_DIR)) return;
-    // Widen to Set<string>: LLAMA_PINS is `as const`, so the mapped artifact names infer a literal union
-    // that would reject a plain-string `.has(entry.name)` membership test.
-    const currentArtifacts = new Set<string>(Object.values(LLAMA_PINS).map((pin) => pin.artifact));
+    // Widen to Set<string>: LLAMA_PINS is `as const` (and MODEL_ARTIFACT is a literal too), so the artifact
+    // names infer a literal union that would reject a plain-string `.has(entry.name)` membership test.
+    const currentArtifacts = new Set<string>([...Object.values(LLAMA_PINS).map((pin) => pin.artifact), MODEL_ARTIFACT]);
     for (const entry of readdirSync(LLAMA_CACHE_DIR, { withFileTypes: true })) {
         if (!entry.isFile() || currentArtifacts.has(entry.name)) continue;
         rmSync(join(LLAMA_CACHE_DIR, entry.name), { force: true });
-        console.log(`swept stale llama-cache archive ${entry.name} (matches no current LLAMA_PINS artifact)`);
+        console.log(`swept stale llama-cache file ${entry.name} (matches no current pin)`);
     }
 }
 
 sweepLlamaCache();
+
+// Fetch + verify the platform-independent embedding model ONCE, outside the target loop: every target
+// embeds the same asset (D7), so a per-target fetch would be wasted work.
+await ensureModelCached();
 
 const plugin = createSolidTransformPlugin();
 for (const target of targets) {

--- a/cli/src/modules/embedding/llama_assets.d.ts
+++ b/cli/src/modules/embedding/llama_assets.d.ts
@@ -1,10 +1,11 @@
-// Ambient declarations for the `with { type: "file" }` archive imports in llama_runtime.ts. Bun's
-// file loader resolves such an import to a path STRING (a real disk path under `bun run dev` / at
-// build time, a `/$bunfs/root/...` path in the compiled binary); TypeScript has no built-in type for
-// these specifiers, so without these declarations `tsc --noEmit` fails with "Cannot find module" —
-// and, crucially, the archives live under an out-of-git `.llama-cache/` that is ABSENT in a fresh
+// Ambient declarations for the `with { type: "file" }` asset imports in llama_runtime.ts (the
+// release archives) and setup.ts (the embedding-model GGUF). Bun's file loader resolves such an
+// import to a path STRING (a real disk path under `bun run dev` / at build time, a
+// `/$bunfs/root/...` path in the compiled binary); TypeScript has no built-in type for these
+// specifiers, so without these declarations `tsc --noEmit` fails with "Cannot find module" —
+// and, crucially, the assets live under an out-of-git `.llama-cache/` that is ABSENT in a fresh
 // checkout, so the wildcard-module resolution is what lets the source typecheck without them on disk.
-// Mirrors src/tui/grammars/assets.d.ts, scoped to the release-archive extensions we embed.
+// Mirrors src/tui/grammars/assets.d.ts, scoped to the embedded-asset extensions.
 
 declare module "*.tar.gz" {
     const path: string;
@@ -12,6 +13,11 @@ declare module "*.tar.gz" {
 }
 
 declare module "*.zip" {
+    const path: string;
+    export default path;
+}
+
+declare module "*.gguf" {
     const path: string;
     export default path;
 }

--- a/cli/src/modules/embedding/model_pin.ts
+++ b/cli/src/modules/embedding/model_pin.ts
@@ -1,0 +1,35 @@
+/**
+ * The pinned bge-small embedding model: one URL + SHA-256 + artifact filename,
+ * shared by every byte path that handles the model. Kept as a LEAF module (no
+ * imports) because scripts/build.ts imports the pin at build time to fetch and
+ * embed the model — homing it in setup.ts would evaluate the interactive setup
+ * module's whole graph (@clack, the harness package via local-provider) inside
+ * the build script, for the sake of three constants.
+ *
+ * Pinned to the repo revision current as of 2026-07 (last modified 2024-02-17),
+ * not `main`: an unpinned ref would let a repo update (or a MITM on the ref)
+ * silently swap the model, with only the dimension probe standing between a
+ * different model and the vector store. {@link MODEL_SHA256} is the file's LFS
+ * object id at this revision and the SOLE integrity authority for every byte
+ * source: the build verifies its fetch against it before embedding, and runtime
+ * acquisition re-verifies both the embedded copy and the from-source download
+ * before any bytes land at the final path.
+ *
+ * TO BUMP THE PIN (a deliberate, reviewed act): update {@link MODEL_URL} +
+ * {@link MODEL_SHA256} here AND — in lockstep — the string-literal import
+ * specifier in setup.ts's `embeddedModelPath` (Bun can only embed
+ * statically-known paths, so that literal cannot be derived from these
+ * constants), plus {@link MODEL_ARTIFACT} if the filename changed. The build's
+ * stale-cache sweep removes superseded model files, so a missed literal fails
+ * the release build loudly instead of embedding the old model — the same
+ * protection LLAMA_RUNTIME_TAG's bump procedure relies on (llama_runtime.ts).
+ */
+
+/** Download URL for the pinned model revision on HuggingFace. */
+export const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/d32f8c040ea3b516330eeb75b72bcc2d3a780ab7/bge-small-en-v1.5-q8_0.gguf";
+
+/** SHA-256 of the pinned model file — the sole integrity authority for build-time and runtime verification. */
+export const MODEL_SHA256 = "ec38e8da142596baa913124ae50550de284b6916bf59577ef2f0cb9660c2f514";
+
+/** The model's artifact filename: its name in the build cache, and the embed specifier's basename. */
+export const MODEL_ARTIFACT = "bge-small-en-v1.5-q8_0.gguf";

--- a/cli/src/modules/embedding/model_pin.ts
+++ b/cli/src/modules/embedding/model_pin.ts
@@ -19,14 +19,21 @@
  * {@link MODEL_SHA256} here AND — in lockstep — the string-literal import
  * specifier in setup.ts's `embeddedModelPath` (Bun can only embed
  * statically-known paths, so that literal cannot be derived from these
- * constants), plus {@link MODEL_ARTIFACT} if the filename changed. The build's
- * stale-cache sweep removes superseded model files, so a missed literal fails
- * the release build loudly instead of embedding the old model — the same
- * protection LLAMA_RUNTIME_TAG's bump procedure relies on (llama_runtime.ts).
+ * constants), plus {@link MODEL_ARTIFACT} if the filename changed. Two
+ * build-time guards keep a half-done bump from silently embedding the old
+ * model: if the filename changed, the stale-cache sweep deletes the superseded
+ * file so a missed import literal fails to resolve (the loud-failure protection
+ * LLAMA_RUNTIME_TAG's tag-named archives rely on); if only the revision/hash
+ * changed and the filename did NOT — the common bge case, since
+ * {@link MODEL_ARTIFACT} carries no revision — the sweep keeps the same-named
+ * file and scripts/build.ts's `ensureModelCached` catches it instead, re-hashing
+ * the cached bytes against the new SHA-256 and failing the build ("delete the
+ * cache") on a mismatch.
  */
 
 /** Download URL for the pinned model revision on HuggingFace. */
-export const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/d32f8c040ea3b516330eeb75b72bcc2d3a780ab7/bge-small-en-v1.5-q8_0.gguf";
+export const MODEL_URL =
+    "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/d32f8c040ea3b516330eeb75b72bcc2d3a780ab7/bge-small-en-v1.5-q8_0.gguf";
 
 /** SHA-256 of the pinned model file — the sole integrity authority for build-time and runtime verification. */
 export const MODEL_SHA256 = "ec38e8da142596baa913124ae50550de284b6916bf59577ef2f0cb9660c2f514";

--- a/cli/src/modules/embedding/setup.test.ts
+++ b/cli/src/modules/embedding/setup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -8,9 +8,10 @@ import { err, ok } from "neverthrow";
 
 import { readConfig, writeConfig, type Config } from "../../lib/config.ts";
 import { env } from "../../lib/env.ts";
+import { __setCompiledBinaryForTest } from "../../lib/install_context.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
 import { __resetLlamaRuntimeForTest, __setLlamaAcquireForTest, __setLlamaPinForTest, materializedLlamaServer, type ResolvedPin } from "./llama_runtime.ts";
-import { ensureEmbedderReady, runEmbeddingSetup } from "./setup.ts";
+import { __setEmbeddedModelForTest, __setModelPinForTest, acquireModel, ensureEmbedderReady, runEmbeddingSetup } from "./setup.ts";
 
 // The test preload sandboxes XDG_DATA_HOME/XDG_CONFIG_HOME, so env.configPath
 // and env.embeddingModelPath point into a temp dir — safe to create/delete here.
@@ -177,5 +178,135 @@ describe("runEmbeddingSetup", () => {
         const result = await runEmbeddingSetup(true, "off");
         expect(result.isOk()).toBe(true);
         expect(readConfig().embedding.mode).toBe("off");
+        // Declined setup acquires nothing: the model path stays empty (no embedded copy, no download).
+        expect(existsSync(env.embeddingModelPath)).toBe(false);
+    });
+});
+
+// --- acquireModel source routing ---------------------------------------------
+// acquireModel is source-aware: a compiled binary copies its build-time embedded asset (no network), a
+// source checkout streams the pinned file from HuggingFace, and BOTH byte sources are SHA-256-verified
+// before anything lands at the final path. These tests force the install context
+// (__setCompiledBinaryForTest), the embedded-asset path (__setEmbeddedModelForTest), and the pin
+// (__setModelPinForTest), and stub globalThis.fetch so no test ever touches the real network — a
+// recorded fetch call proves a wrongly-taken download branch instead of it being silently exercised.
+describe("acquireModel", () => {
+    // A small non-gguf payload standing in for the model; its true SHA-256 lets a forced pin pass (or,
+    // with a deliberately different hash, fail) verification against either byte source.
+    const modelBytes = new TextEncoder().encode("bge-small fixture model bytes — not a real gguf");
+    const modelSha256 = new Bun.CryptoHasher("sha256").update(modelBytes).digest("hex");
+    const partPath = `${env.embeddingModelPath}.part`;
+    const PIN_URL = "https://fixture.invalid/bge-small-en-v1.5-q8_0.gguf";
+
+    // The real fetch, captured ONCE so the per-test stub is always restored regardless of which test set it.
+    const realFetch = globalThis.fetch;
+    // Temp dirs holding embedded-asset fixtures, reaped in afterEach so no fixture leaks between tests.
+    const fixtureDirs: string[] = [];
+
+    /** Write `bytes` to a fresh temp file and return its path, standing in for the compiled binary's embedded asset. */
+    function writeEmbeddedFixture(bytes: Uint8Array): string {
+        const dir = mkdtempSync(join(tmpdir(), "inflexa-embed-asset-"));
+        fixtureDirs.push(dir);
+        const path = join(dir, "bge-small-en-v1.5-q8_0.gguf");
+        writeFileSync(path, bytes);
+        return path;
+    }
+
+    /** Stub globalThis.fetch to record each call's URL and serve `bytes`, standing in for the HuggingFace download. */
+    function stubFetch(bytes: Uint8Array): { calls: string[] } {
+        const spy = { calls: [] as string[] };
+        // Test-only replacement of the global fetch: it records call URLs (so a wrongly-taken download
+        // branch is caught, not silently exercised) and serves fixture bytes for the source path. The
+        // cast is required because a bare recorder is narrower than fetch's overloaded signature; it is
+        // sound because this is a test-only substitution restored to realFetch in this describe's afterEach.
+        globalThis.fetch = ((input: string | URL | Request): Promise<Response> => {
+            spy.calls.push(String(input));
+            return Promise.resolve(new Response(bytes));
+        }) as unknown as typeof globalThis.fetch;
+        return spy;
+    }
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+        __setCompiledBinaryForTest(null);
+        __setEmbeddedModelForTest(null);
+        __setModelPinForTest(null);
+        // The .part sidecar and any embedded-asset fixture are the two artifacts these tests create
+        // outside the paths the top-level afterEach already reaps.
+        assertTestSandbox(partPath);
+        rmSync(partPath, { force: true });
+        for (const dir of fixtureDirs) rmSync(dir, { recursive: true, force: true });
+        fixtureDirs.length = 0;
+    });
+
+    test("compiled context copies the embedded asset with no fetch", async () => {
+        __setCompiledBinaryForTest(true);
+        __setEmbeddedModelForTest(writeEmbeddedFixture(modelBytes));
+        __setModelPinForTest({ url: PIN_URL, sha256: modelSha256 });
+        const spy = stubFetch(modelBytes);
+
+        const result = await acquireModel();
+
+        expect(result.isOk()).toBe(true);
+        expect(await Bun.file(env.embeddingModelPath).text()).toBe(new TextDecoder().decode(modelBytes));
+        expect(spy.calls).toEqual([]);
+    });
+
+    test("source context downloads from the pinned URL", async () => {
+        __setCompiledBinaryForTest(false);
+        __setModelPinForTest({ url: PIN_URL, sha256: modelSha256 });
+        const spy = stubFetch(modelBytes);
+
+        const result = await acquireModel();
+
+        expect(result.isOk()).toBe(true);
+        expect(existsSync(env.embeddingModelPath)).toBe(true);
+        expect(spy.calls).toEqual([PIN_URL]);
+    });
+
+    test("checksum mismatch leaves nothing at the final path or a .part sidecar", async () => {
+        __setCompiledBinaryForTest(false);
+        // A pin hash the fixture bytes cannot produce, so verification must reject the download.
+        __setModelPinForTest({ url: PIN_URL, sha256: "0".repeat(64) });
+        stubFetch(modelBytes);
+
+        const result = await acquireModel();
+
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().type).toBe("download_failed");
+        expect(existsSync(env.embeddingModelPath)).toBe(false);
+        expect(existsSync(partPath)).toBe(false);
+    });
+
+    test("compiled context with no embedded asset is an actionable error, never a fetch", async () => {
+        __setCompiledBinaryForTest(true);
+        // Embedded override left null: in a test process the __INFLEXA_COMPILED__ define is absent, so
+        // embeddedModelPath() resolves to null — the "this binary did not embed the model" case.
+        const spy = stubFetch(modelBytes);
+
+        const result = await acquireModel();
+
+        expect(result.isErr()).toBe(true);
+        const e = result._unsafeUnwrapErr();
+        expect(e.type).toBe("download_failed");
+        expect(e.message).toContain("Reinstall the official binary");
+        expect(spy.calls).toEqual([]);
+    });
+
+    test("already-present model skips acquisition in both install contexts", async () => {
+        placeFakeModel();
+        const spy = stubFetch(modelBytes);
+
+        for (const compiled of [true, false]) {
+            __setCompiledBinaryForTest(compiled);
+            __setModelPinForTest({ url: PIN_URL, sha256: modelSha256 });
+
+            const result = await acquireModel();
+
+            expect(result.isOk()).toBe(true);
+            // The pre-existing fake marker is untouched — neither an embedded copy nor a download ran.
+            expect(await Bun.file(env.embeddingModelPath).text()).toBe("fake-gguf");
+        }
+        expect(spy.calls).toEqual([]);
     });
 });

--- a/cli/src/modules/embedding/setup.test.ts
+++ b/cli/src/modules/embedding/setup.test.ts
@@ -273,7 +273,7 @@ describe("acquireModel", () => {
         const result = await acquireModel();
 
         expect(result.isErr()).toBe(true);
-        expect(result._unsafeUnwrapErr().type).toBe("download_failed");
+        expect(result._unsafeUnwrapErr().type).toBe("acquire_failed");
         expect(existsSync(env.embeddingModelPath)).toBe(false);
         expect(existsSync(partPath)).toBe(false);
     });
@@ -288,7 +288,7 @@ describe("acquireModel", () => {
 
         expect(result.isErr()).toBe(true);
         const e = result._unsafeUnwrapErr();
-        expect(e.type).toBe("download_failed");
+        expect(e.type).toBe("acquire_failed");
         expect(e.message).toContain("Reinstall the official binary");
         expect(spy.calls).toEqual([]);
     });

--- a/cli/src/modules/embedding/setup.ts
+++ b/cli/src/modules/embedding/setup.ts
@@ -1,17 +1,20 @@
 /**
- * Local embedding model lifecycle: download, verify, configure, and the hot-path
- * readiness gate. Mirrors `modules/infra/setup.ts` — "download a thing on opt-in,
+ * Local embedding model lifecycle: acquire, verify, configure, and the hot-path
+ * readiness gate. Mirrors `modules/infra/setup.ts` — "acquire a thing on opt-in,
  * verify it, record the choice in config, and gate the hot path on it being
  * present" — and uses the same `@clack/prompts` UI (`select`/`spinner`/`log`) so
  * the two setup flows feel consistent.
  *
- * The model is `bge-small-en-v1.5` (GGUF, q8_0, 384-dim, ~36 MB) from
- * `CompendiumLabs/bge-small-en-v1.5-gguf` on HuggingFace. Download is skipped if
- * the file already exists; verification (spawn the sidecar + embed probe + dim
- * check) always runs so a truncated/corrupt file is caught now, not on the first
- * hot-path `embed()` call. Verification goes through the SAME `llama-server`
- * sidecar the hot path uses, so it is identical in the compiled binary and from
- * source — no separate load path to diverge.
+ * The model is `bge-small-en-v1.5` (GGUF, q8_0, 384-dim, ~36 MB), pinned in
+ * `model_pin.ts`. Acquisition is source-aware, mirroring the llama runtime: the
+ * compiled binary copies its build-time embedded asset (no network — the whole
+ * point for egress-restricted environments); a source checkout downloads the
+ * pinned revision from HuggingFace. Acquisition is skipped if the file already
+ * exists; verification (spawn the sidecar + embed probe + dim check) always runs
+ * so a truncated/corrupt file is caught now, not on the first hot-path `embed()`
+ * call. Verification goes through the SAME `llama-server` sidecar the hot path
+ * uses, so it is identical in the compiled binary and from source — no separate
+ * load path to diverge.
  */
 
 import { mkdir, rename, stat, unlink } from "node:fs/promises";
@@ -25,8 +28,10 @@ import type { AgentSession } from "@inflexa-ai/harness";
 import { readConfig, writeConfig } from "../../lib/config.ts";
 import { select } from "../../lib/cli.ts";
 import { env } from "../../lib/env.ts";
+import { isCompiledBinary } from "../../lib/install_context.ts";
 import { ensureLlamaServer, materializedLlamaServer } from "./llama_runtime.ts";
 import { createLocalEmbeddingProvider, LOCAL_EMBEDDING_DIMENSIONS, stopLocalSidecar } from "./local-provider.ts";
+import { MODEL_SHA256, MODEL_URL } from "./model_pin.ts";
 
 export type EmbeddingSetupError =
     | { readonly type: "download_failed"; readonly message: string; readonly cause?: unknown }
@@ -39,30 +44,61 @@ export type EmbeddingSetupError =
     // since a compiled binary materializes from its embedded asset without touching the network.
     | { readonly type: "runtime_unavailable"; readonly message: string; readonly cause?: unknown };
 
-/**
- * Pinned to the repo revision current as of 2026-07 (last modified 2024-02-17),
- * not `main`: an unpinned ref would let a repo update (or a MITM on the ref)
- * silently swap the model, with only the dimension probe standing between a
- * different model and the vector store. The sha256 below is the file's LFS
- * object id at this revision, verified against the download stream.
- */
-const MODEL_URL = "https://huggingface.co/CompendiumLabs/bge-small-en-v1.5-gguf/resolve/d32f8c040ea3b516330eeb75b72bcc2d3a780ab7/bge-small-en-v1.5-q8_0.gguf";
-const MODEL_SHA256 = "ec38e8da142596baa913124ae50550de284b6916bf59577ef2f0cb9660c2f514";
+// Baked to the literal `true` by scripts/build.ts for every release target, exactly as
+// install_context.ts's `__INFLEXA_COMPILED__` — that module owns the canonical declaration and its
+// `isCompiledBinary()` accessor. It is RE-declared here because the constant-fold in
+// `embeddedModelPath` below needs the BARE identifier under a `typeof` guard: a read through
+// `isCompiledBinary()` is opaque to the bundler and would not fold, whereas the folded-away branch
+// is precisely what keeps the `.llama-cache/` import specifier from being resolved outside a release
+// build (the asset is absent from a from-source tree). Safe because the only read is `typeof`-guarded,
+// so an undeclared identifier in dev/test evaluates to `undefined`, never a ReferenceError.
+declare const __INFLEXA_COMPILED__: boolean | undefined;
+
+// Module-level test seams (mirroring llama_runtime's __set…ForTest): a forced embedded path lets a
+// unit test exercise the embedded-copy branch without a real compiled binary; a forced pin drives the
+// whole acquire pipeline against a fixture url/hash. Both `null` in production.
+let embeddedModelOverride: string | null = null;
+let modelPinOverride: { readonly url: string; readonly sha256: string } | null = null;
+
+/** The active model pin (url + sha256), honoring a test override; otherwise the vendored constants. */
+function modelPin(): { readonly url: string; readonly sha256: string } {
+    return modelPinOverride ?? { url: MODEL_URL, sha256: MODEL_SHA256 };
+}
 
 /**
- * Download the GGUF model to {@link env.embeddingModelPath}, skipping if it is
- * already present. Streams the response to disk under a clack spinner so the
- * ~36 MB download is visible. A network/HTTP failure surfaces as
- * `download_failed` — never thrown.
- *
- * The stream lands in a `.part` sidecar that is renamed into place only after a
- * complete flush: the "already present" check above trusts bare existence, so a
- * mid-stream failure must never leave bytes at the final path — a truncated
- * file there would be skipped as "already present" on retry and only caught by
- * `verifyModel`, with no hint that deleting it fixes things.
+ * The compiled binary's embedded model asset path, or `null` from source / dev / test. Unlike the
+ * per-target llama archives, ONE platform-independent asset serves every target — so this gates on the
+ * every-target `__INFLEXA_COMPILED__` define rather than a per-target key. The `typeof` guard folds to
+ * a compile-time boolean: the bundler keeps the `import(... with { type: "file" })` only when
+ * compiling and drops it otherwise, so the specifier into the out-of-git `.llama-cache/` (which
+ * scripts/build.ts populates before compiling) is never resolved outside a release build. That literal
+ * must be edited in lockstep with the pin — Bun embeds only statically-known paths (see model_pin.ts).
  */
-export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>> {
+async function embeddedModelPath(): Promise<string | null> {
+    if (embeddedModelOverride !== null) return embeddedModelOverride;
+    if (typeof __INFLEXA_COMPILED__ !== "undefined" && __INFLEXA_COMPILED__ === true) {
+        return (await import("../../../.llama-cache/bge-small-en-v1.5-q8_0.gguf", { with: { type: "file" } })).default;
+    }
+    return null;
+}
+
+/**
+ * Acquire the GGUF model to {@link env.embeddingModelPath}, skipping if it is already present.
+ * Source-aware, mirroring the llama runtime: a compiled binary copies its build-time embedded asset
+ * (no network — the point of this path for egress-restricted environments); a source checkout streams
+ * the pinned file from HuggingFace. Both sources are verified against the pinned SHA-256 before any
+ * bytes land at the final path, so the "nothing lands unverified" invariant holds unconditionally
+ * rather than per-source. Every failure surfaces as `download_failed` — never thrown.
+ *
+ * The bytes stage in a `.part` sidecar renamed into place only after a complete, verified flush: the
+ * "already present" check above trusts bare existence, so a mid-acquisition failure must never leave
+ * bytes at the final path — a truncated file there would be skipped as "already present" on retry and
+ * only caught by `verifyModel`, with no hint that deleting it fixes things.
+ */
+export async function acquireModel(): Promise<Result<void, EmbeddingSetupError>> {
     const partPath = `${env.embeddingModelPath}.part`;
+    const pin = modelPin();
+    const embedded = isCompiledBinary();
     try {
         if (await Bun.file(env.embeddingModelPath).exists()) {
             log.info(`Embedding model already present at ${env.embeddingModelPath}`);
@@ -72,42 +108,63 @@ export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>
         await mkdir(dirname(env.embeddingModelPath), { recursive: true });
 
         const s = clackSpinner();
-        s.start("Downloading bge-small-en-v1.5 (q8_0, ~36 MB) from HuggingFace");
+        s.start(embedded ? "Installing the bundled bge-small-en-v1.5 model (q8_0, ~36 MB)" : "Downloading bge-small-en-v1.5 (q8_0, ~36 MB) from HuggingFace");
 
-        const response = await fetch(MODEL_URL);
-        if (!response.ok || response.body === null) {
-            s.error("Download failed");
-            return err({
-                type: "download_failed",
-                message: `Download failed: HTTP ${response.status} ${response.statusText}`,
-            });
-        }
-
-        const file = Bun.file(partPath);
-        const writer = file.writer();
-        const reader = response.body.getReader();
+        // One hasher spans both byte sources so the digest check below is source-agnostic.
         const hasher = new Bun.CryptoHasher("sha256");
-        for (;;) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            hasher.update(value);
-            await writer.write(value);
+        if (embedded) {
+            const assetPath = await embeddedModelPath();
+            if (assetPath === null) {
+                s.error("Bundled model missing");
+                return err({
+                    type: "download_failed",
+                    message:
+                        "This inflexa binary did not embed the bge-small embedding model. Reinstall the official binary for your platform, or run inflexa from source.",
+                });
+            }
+            // Bun.file().bytes() mmaps the embedded segment and Bun.write() lands it on a real disk
+            // path — the bunfs-safe pair (fd-based APIs ENOENT on /$bunfs), the same constraint
+            // documented at llama_runtime's writeEmbeddedArchive.
+            const bytes = await Bun.file(assetPath).bytes();
+            hasher.update(bytes);
+            await Bun.write(partPath, bytes);
+        } else {
+            const response = await fetch(pin.url);
+            if (!response.ok || response.body === null) {
+                s.error("Download failed");
+                return err({
+                    type: "download_failed",
+                    message: `Download failed: HTTP ${response.status} ${response.statusText}`,
+                });
+            }
+
+            const file = Bun.file(partPath);
+            const writer = file.writer();
+            const reader = response.body.getReader();
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                hasher.update(value);
+                await writer.write(value);
+            }
+            await writer.flush();
         }
-        await writer.flush();
 
         const digest = hasher.digest("hex");
-        if (digest !== MODEL_SHA256) {
+        if (digest !== pin.sha256) {
             s.error("Checksum mismatch");
             await unlink(partPath).catch(() => {});
             return err({
                 type: "download_failed",
-                message: `Downloaded file's sha256 (${digest}) does not match the pinned model checksum. Retry, or check your network path to huggingface.co.`,
+                message: embedded
+                    ? `The bundled model's sha256 (${digest}) does not match the pinned checksum — the embedded asset is corrupt. Reinstall the official binary for your platform.`
+                    : `Downloaded file's sha256 (${digest}) does not match the pinned model checksum. Retry, or check your network path to huggingface.co.`,
             });
         }
         await rename(partPath, env.embeddingModelPath);
 
         const written = (await stat(env.embeddingModelPath)).size;
-        s.stop(`Downloaded ${(written / 1024 / 1024).toFixed(1)} MB`);
+        s.stop(embedded ? `Installed ${(written / 1024 / 1024).toFixed(1)} MB (bundled model)` : `Downloaded ${(written / 1024 / 1024).toFixed(1)} MB`);
         return ok(undefined);
     } catch (cause) {
         // Best-effort cleanup; a `.part` leftover is harmless (never mistaken
@@ -115,7 +172,7 @@ export async function downloadModel(): Promise<Result<void, EmbeddingSetupError>
         await unlink(partPath).catch(() => {});
         return err({
             type: "download_failed",
-            message: `Download failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            message: `Model acquisition failed: ${cause instanceof Error ? cause.message : String(cause)}`,
             cause,
         });
     }
@@ -171,9 +228,9 @@ export async function verifyModel(modelPath: string): Promise<Result<void, Embed
 /**
  * Interactive embedding setup, run as part of `inflexa setup`. Prompts the user
  * to pick an embedding mode via a clack `select` picker (local / api-key / off),
- * then for `local`: materializes the sidecar runtime + downloads the GGUF,
- * verifies it through the sidecar, and records `embedding.mode = "local"` +
- * `embedding.modelPath` in config.
+ * then for `local`: materializes the sidecar runtime + acquires the GGUF (embedded
+ * asset in the compiled binary, download from source), verifies it through the
+ * sidecar, and records `embedding.mode = "local"` + `embedding.modelPath` in config.
  *
  * Non-interactive shells (no TTY, or `interactive === false`) skip the prompt
  * entirely without hanging — `mode` stays whatever it was. A preselected `mode`
@@ -244,7 +301,7 @@ function warnOnModeSwitch(current: "local" | "api-key" | "off", next: "local" | 
     );
 }
 
-/** The local-embeddings opt-in branch: materialize runtime, download model, verify through the sidecar, write config. */
+/** The local-embeddings opt-in branch: materialize runtime, acquire model, verify through the sidecar, write config. */
 async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Result<void, EmbeddingSetupError>> {
     warnOnModeSwitch(config.embedding.mode, "local");
     log.message("Setting up local embeddings (bge-small-en-v1.5 via the pinned llama-server runtime, no API key needed)");
@@ -266,8 +323,8 @@ async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Res
     }
     runtimeSpinner.stop("Local embedding runtime ready");
 
-    const downloadResult = await downloadModel();
-    if (downloadResult.isErr()) return downloadResult;
+    const acquireResult = await acquireModel();
+    if (acquireResult.isErr()) return acquireResult;
 
     const verifyResult = await verifyModel(env.embeddingModelPath);
     if (verifyResult.isErr()) return verifyResult;
@@ -289,11 +346,16 @@ async function runLocalSetup(config: ReturnType<typeof readConfig>): Promise<Res
  * chosen mode string; clack handles cancel (Ctrl-C / Esc) by aborting.
  */
 async function promptEmbeddingMode(): Promise<"local" | "api-key" | "off"> {
-    // Local mode works identically in the compiled binary and from source (the runtime
-    // is a downloaded/embedded sidecar, not a native addon), so all three modes are
-    // offered in every install context — no context gates the offering.
+    // Local mode works identically in the compiled binary and from source (both the runtime AND the
+    // model are downloaded/embedded assets, not native addons), so all three modes are offered in
+    // every install context — no context gates the offering.
     const chosen = await select("Embedding mode", [
-        { value: "local", label: "Local (downloads a ~36 MB model + runtime, no API key)" },
+        {
+            value: "local",
+            label: isCompiledBinary()
+                ? "Local (installs the bundled ~36 MB model + runtime, no API key or network)"
+                : "Local (downloads a ~36 MB model + runtime, no API key)",
+        },
         { value: "api-key", label: "API key (direct to an OpenAI-compatible endpoint)" },
         { value: "off", label: "Off / skip" },
     ]);
@@ -306,7 +368,8 @@ async function promptEmbeddingMode(): Promise<"local" | "api-key" | "off"> {
  *
  * 1. The GGUF must exist — a missing model means setup never ran (or was undone),
  *    so the remediation is `inflexa setup --embeddings local`, which succeeds in
- *    every install context.
+ *    every install context — and in a compiled binary succeeds offline, since both
+ *    the model and the runtime are build-time embedded assets.
  * 2. The pinned runtime must be materialized. When it already is, this is a cheap
  *    directory-existence check and no acquisition work happens. When it is NOT,
  *    the gate materializes it right here rather than returning ok: deferring to
@@ -327,7 +390,7 @@ export async function ensureEmbedderReady(): Promise<Result<void, EmbeddingSetup
     if (!(await Bun.file(env.embeddingModelPath).exists())) {
         return err({
             type: "not_configured",
-            message: `Local embedding model not found at ${env.embeddingModelPath}. Run \`inflexa setup --embeddings local\` to download it.`,
+            message: `Local embedding model not found at ${env.embeddingModelPath}. Run \`inflexa setup --embeddings local\` to install it.`,
         });
     }
 
@@ -342,4 +405,22 @@ export async function ensureEmbedderReady(): Promise<Result<void, EmbeddingSetup
         });
     }
     return ok(undefined);
+}
+
+/**
+ * TEST ONLY. Force the embedded-model asset path so a unit test can exercise the embedded-copy
+ * acquisition branch without a real compiled binary, or `null` to restore the real
+ * `__INFLEXA_COMPILED__`-gated resolution. Production code never calls it.
+ */
+export function __setEmbeddedModelForTest(path: string | null): void {
+    embeddedModelOverride = path;
+}
+
+/**
+ * TEST ONLY. Force the model pin (url + sha256) so a unit test can drive {@link acquireModel} against
+ * a fixture source and checksum, or `null` to restore the vendored constants. Production code never
+ * calls it.
+ */
+export function __setModelPinForTest(pin: { readonly url: string; readonly sha256: string } | null): void {
+    modelPinOverride = pin;
 }

--- a/cli/src/modules/embedding/setup.ts
+++ b/cli/src/modules/embedding/setup.ts
@@ -34,7 +34,10 @@ import { createLocalEmbeddingProvider, LOCAL_EMBEDDING_DIMENSIONS, stopLocalSide
 import { MODEL_SHA256, MODEL_URL } from "./model_pin.ts";
 
 export type EmbeddingSetupError =
-    | { readonly type: "download_failed"; readonly message: string; readonly cause?: unknown }
+    // Model acquisition failed — spans BOTH byte sources: a from-source HuggingFace download fault AND a
+    // compiled-binary embedded-asset fault (this binary embedded no model, or the embedded bytes are
+    // corrupt). Named for `acquireModel`, not "download", because neither embedded case is a download.
+    | { readonly type: "acquire_failed"; readonly message: string; readonly cause?: unknown }
     | { readonly type: "verify_failed"; readonly message: string; readonly cause?: unknown }
     | { readonly type: "dimension_mismatch"; readonly message: string; readonly expected: number; readonly actual: number }
     | { readonly type: "not_configured"; readonly message: string }
@@ -88,7 +91,7 @@ async function embeddedModelPath(): Promise<string | null> {
  * (no network — the point of this path for egress-restricted environments); a source checkout streams
  * the pinned file from HuggingFace. Both sources are verified against the pinned SHA-256 before any
  * bytes land at the final path, so the "nothing lands unverified" invariant holds unconditionally
- * rather than per-source. Every failure surfaces as `download_failed` — never thrown.
+ * rather than per-source. Every failure surfaces as `acquire_failed` — never thrown.
  *
  * The bytes stage in a `.part` sidecar renamed into place only after a complete, verified flush: the
  * "already present" check above trusts bare existence, so a mid-acquisition failure must never leave
@@ -117,7 +120,7 @@ export async function acquireModel(): Promise<Result<void, EmbeddingSetupError>>
             if (assetPath === null) {
                 s.error("Bundled model missing");
                 return err({
-                    type: "download_failed",
+                    type: "acquire_failed",
                     message:
                         "This inflexa binary did not embed the bge-small embedding model. Reinstall the official binary for your platform, or run inflexa from source.",
                 });
@@ -133,7 +136,7 @@ export async function acquireModel(): Promise<Result<void, EmbeddingSetupError>>
             if (!response.ok || response.body === null) {
                 s.error("Download failed");
                 return err({
-                    type: "download_failed",
+                    type: "acquire_failed",
                     message: `Download failed: HTTP ${response.status} ${response.statusText}`,
                 });
             }
@@ -155,7 +158,7 @@ export async function acquireModel(): Promise<Result<void, EmbeddingSetupError>>
             s.error("Checksum mismatch");
             await unlink(partPath).catch(() => {});
             return err({
-                type: "download_failed",
+                type: "acquire_failed",
                 message: embedded
                     ? `The bundled model's sha256 (${digest}) does not match the pinned checksum — the embedded asset is corrupt. Reinstall the official binary for your platform.`
                     : `Downloaded file's sha256 (${digest}) does not match the pinned model checksum. Retry, or check your network path to huggingface.co.`,
@@ -171,7 +174,7 @@ export async function acquireModel(): Promise<Result<void, EmbeddingSetupError>>
         // for the model) but would confuse a du/ls of the model dir.
         await unlink(partPath).catch(() => {});
         return err({
-            type: "download_failed",
+            type: "acquire_failed",
             message: `Model acquisition failed: ${cause instanceof Error ? cause.message : String(cause)}`,
             cause,
         });

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -18,10 +18,14 @@ import {
     providerKindForSlug,
     recordCliproxyProvider,
     retryWhileUnreachable,
+    setup,
     writeDirectConnection,
     type ProbeAttempt,
 } from "./setup.ts";
+import * as embeddingSetup from "../embedding/setup.ts";
+import * as refsCommands from "../refs/commands.ts";
 import { readConfig } from "../../lib/config.ts";
+import * as container from "../../lib/container.ts";
 import { env, type ProviderEnvSnapshot } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
 
@@ -543,5 +547,61 @@ describe("retryWhileUnreachable", () => {
         });
         expect(result).toEqual({ kind: "unauthorized" });
         expect(tries).toBe(1);
+    });
+});
+
+// Drives the `setup()` command through the repo's spyOn seam pattern (mirroring compose.test.ts's
+// "entry-point wiring" block): the runtime gate and the embedding step are stubbed, so no real
+// container runtime is spawned and no real model is acquired. These assert design D9 — a preselected
+// `--embeddings` mode is configured AHEAD of the runtime gate (so an air-gapped host with no ready
+// runtime still configures embeddings), and the in-flow embedding step does not run a second time.
+describe("setup() — preselected embeddings run ahead of the runtime gate", () => {
+    const spies: { mockRestore: () => void }[] = [];
+
+    beforeEach(() => {
+        assertTestSandbox(env.configPath);
+    });
+    afterEach(() => {
+        for (const s of spies.splice(0)) s.mockRestore();
+        // setup() sets process.exitCode as a global side effect; reset so it never leaks to sibling tests.
+        process.exitCode = 0;
+        assertTestSandbox(env.configPath);
+        rmSync(env.configPath, { force: true });
+    });
+
+    test("a preselected --embeddings mode is configured even when NO container runtime is ready", async () => {
+        // mockImplementation (not mockResolvedValue) so the returned Result is consumed, per the neverthrow
+        // must-use-result rule (same reasoning as compose.test.ts's wiring block).
+        const embedSpy = spyOn(embeddingSetup, "runEmbeddingSetup").mockImplementation(async () => ok(undefined));
+        const runtimeSpy = spyOn(container, "firstReadyRuntime").mockImplementation(async () => err(new container.ContainerRuntimeError("no usable runtime")));
+        spies.push(embedSpy, runtimeSpy);
+
+        await setup({ auth: false, start: false, force: false, postgres: true, embeddings: "local" });
+
+        // The embedding step ran (hoisted ahead of the gate) with the preselected mode — configured despite
+        // the dead runtime.
+        expect(embedSpy).toHaveBeenCalledTimes(1);
+        expect(embedSpy.mock.calls[0]).toEqual([process.stdin.isTTY, "local"]);
+        // ...and setup still reports the missing runtime and takes the failure exit (the remainder genuinely
+        // needs a runtime).
+        expect(runtimeSpy).toHaveBeenCalledTimes(1);
+        expect(process.exitCode).toBe(1);
+    });
+
+    test("with a ready runtime and a preselected mode, the embedding step runs exactly once", async () => {
+        const embedSpy = spyOn(embeddingSetup, "runEmbeddingSetup").mockImplementation(async () => ok(undefined));
+        spies.push(embedSpy);
+        spies.push(spyOn(container, "firstReadyRuntime").mockImplementation(async () => ok(container.runtimes.docker)));
+        // Stub the reference-data step so the full non-interactive flow reaches (and skips) the in-flow
+        // embedding site without doing real reference provisioning.
+        spies.push(spyOn(refsCommands, "runReferenceSetup").mockImplementation(async () => ok(undefined)));
+
+        // postgres:false skips the compose/engine block (which would spawn a real runtime); the flow still
+        // runs past the in-flow embedding site so its guard is exercised.
+        await setup({ auth: false, start: false, force: false, postgres: false, embeddings: "local" });
+
+        // Called exactly once — the preselected step ahead of the gate; the in-flow site is guarded and skipped.
+        expect(embedSpy).toHaveBeenCalledTimes(1);
+        expect(embedSpy.mock.calls[0]).toEqual([process.stdin.isTTY, "local"]);
     });
 });

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -80,6 +80,26 @@ export async function setup(options: SetupOptions): Promise<void> {
     );
     if (connectionFlag === null) return;
 
+    // Local embeddings need no container runtime — the llama-server sidecar is a
+    // plain subprocess, not a compose service — and the bge-small model ships as a
+    // build-time embedded asset. So a preselected `--embeddings` mode is configured
+    // ahead of the runtime gate below, so an air-gapped / egress-restricted
+    // `inflexa setup --embeddings local` still durably configures embeddings on a
+    // host with no ready Docker/Podman; the gate that follows governs only the
+    // container stack, which genuinely needs a runtime. The interactive
+    // no-preselection flow keeps its embedding question in its spec-bound position
+    // after provider auth (see the in-flow step below), so this fires ONLY for an
+    // explicit `--embeddings` value.
+    if (options.embeddings !== undefined) {
+        const { runEmbeddingSetup } = await import("../embedding/setup.ts");
+        const embedResult = await runEmbeddingSetup(process.stdin.isTTY, options.embeddings);
+        if (embedResult.isErr()) {
+            log.error(`Embedding setup: ${embedResult.error.message}`);
+            process.exitCode = 1;
+            return;
+        }
+    }
+
     // Setup treats the runtime selection as a preference, not a gate: the selected
     // runtime (when there is one) is probed first, then the other supported
     // runtimes, and the first ready one wins ("Docker configured but stopped,
@@ -338,16 +358,21 @@ export async function setup(options: SetupOptions): Promise<void> {
         await promptResourceConfig();
 
         // --- embeddings ---
-        // Runs after auth + postgres, before "Setup complete". The interactive
-        // prompt (clack select) offers local / api-key / off; a non-TTY shell or
-        // a preselected `--embeddings` mode skips the prompt. See
-        // modules/embedding/setup.ts.
-        const { runEmbeddingSetup } = await import("../embedding/setup.ts");
-        const embedResult = await runEmbeddingSetup(process.stdin.isTTY, options.embeddings);
-        if (embedResult.isErr()) {
-            log.error(`Embedding setup: ${embedResult.error.message}`);
-            process.exitCode = 1;
-            return;
+        // The spec-bound position for the INTERACTIVE embedding question — after auth
+        // + postgres, before "Setup complete". The clack select offers
+        // local / api-key / off; a non-TTY shell skips the prompt. A preselected
+        // `--embeddings` mode is instead configured ahead of the runtime gate (local
+        // embeddings need no container runtime), so only the no-preselection flow
+        // reaches this call — the guard keeps the preselected step from running a
+        // second time here. See modules/embedding/setup.ts.
+        if (options.embeddings === undefined) {
+            const { runEmbeddingSetup } = await import("../embedding/setup.ts");
+            const embedResult = await runEmbeddingSetup(process.stdin.isTTY, options.embeddings);
+            if (embedResult.isErr()) {
+                log.error(`Embedding setup: ${embedResult.error.message}`);
+                process.exitCode = 1;
+                return;
+            }
         }
 
         // --- reference data ---


### PR DESCRIPTION
## What & why

A client running behind a corporate proxy cannot reach huggingface.co, so `inflexa setup --embeddings local` fails at the model download — even though the compiled binary already carries the llama-server *runtime* as an embedded asset. The bge-small GGUF (~36 MB) was the last network dependency of local-embeddings setup in the compiled binary. This PR embeds it, making local-embeddings setup fully offline for release binaries.

- **Build-time embed**: `scripts/build.ts` gains `ensureModelCached()` beside `ensureLlamaArchiveCached()` — the pinned `bge-small-en-v1.5-q8_0.gguf` is fetched once per build into `.llama-cache/`, verified against the vendored `MODEL_SHA256`, and embedded into **every** target via the same define-gated `import(..., { with: { type: "file" } })` mechanism the llama runtime uses (one platform-independent asset; no per-target selection). The stale-cache sweep keeps the model artifact so a pin bump still fails loudly on a stale embed reference.
- **Source-aware acquisition**: `downloadModel()` → `acquireModel()` in `modules/embedding/setup.ts`, mirroring `llama_runtime.ts`: a compiled binary copies its embedded asset (bunfs-safe byte read, zero network); a source checkout downloads from HuggingFace as before. Both byte sources are SHA-256-verified before the atomic `.part` → final rename, so nothing lands at `env.embeddingModelPath` unverified.
- **One integrity authority**: the pin lives in the new leaf `modules/embedding/model_pin.ts`, shared by the build script and runtime acquisition (a leaf module so the build script doesn't evaluate setup's transitive `@inflexa-ai/harness` graph).
- **Install-context-aware copy**: the setup picker and spinners no longer claim the compiled binary "downloads" the model.
- **Runtime-gate reorder**: `inflexa setup --embeddings <mode>` runs the embedding step *before* the container-runtime probe, so an air-gapped host without a ready Docker/Podman can still configure embeddings non-interactively. The interactive flow keeps the embedding question in its spec'd position (after provider auth); the rest of setup still requires a runtime and fails afterward as before. The step runs at most once per invocation.

Considered and rejected: committing the model via Git LFS — `actions/checkout` skips LFS blobs by default so CI would stay cheap, but bandwidth is billed to the repo owner (~28 downloads/month on the free tier at this size), contributors would need `git-lfs`, and it would add a second artifact-distribution mechanism beside the established build-time one.

**Verification**: typecheck + lint clean; 159 pass / 0 fail across the infra + embedding suites (incl. new tests for source-aware acquisition and the gate reorder). A host `bun run build` fetched and hash-verified the model, the smoke test passed, and a byte-level check found a 128-byte needle from the model's middle inside the compiled binary. **Offline end-to-end proof**: the compiled binary ran `setup --embeddings local` under sandboxed XDG dirs behind an unroutable proxy (huggingface.co unreachable) — the embedding step ran ahead of the runtime probe, installed the bundled model (sha256 `ec38e8da…c2f514`, exact match to the pin), verified 384-dim vectors through the loopback sidecar (the provider's NO_PROXY handling held under the proxy), and wrote `embedding.mode = "local"` — zero network. Size impact: ~36 MB per target binary.

Spec deltas are synced into `openspec/specs/local-embeddings/` and the change is archived (`openspec/changes/archive/2026-07-17-embed-embedding-model-in-binary/`), both in this PR.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

