### PR TITLE
chore(cli): consume harness 0.4.4

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -6,7 +6,7 @@
       "name": "inflexa",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.4.3",
+        "@inflexa-ai/harness": "0.4.4",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
@@ -151,7 +151,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.4.3", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-qul1qg5lM0rloSeQZu8awWqgVyBZ4xpbSPhMj13yVOaIC5/HJje1Im4qARHU8RjB6ltFsigrIOjh5+GsC2uxBw=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.4.4", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-/gIrJtVYbNqvl7jN0g8QxR3I7l+tcZPMTikgfC6kWZelqafKQZXXyKF1AwU8e+up/eWiWHZp28t4im7NbtLT3A=="],
 
     "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.4.3",
+        "@inflexa-ai/harness": "0.4.4",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",


### PR DESCRIPTION
Promotes the CLI onto `@inflexa-ai/harness@0.4.4` (published from #149), picking up the run-synthesis submit fixes:

- **last-valid-wins overwrite** — a probe submission no longer latches the run synthesis
- **tool-argument repair** — arguments arriving wrapped in function-call markup are repaired at the loop boundary instead of being rejected with a bare `expected object, received string`
- **one-pass validation** — schema and semantic synthesis issues are reported together

## No version bump — and why

`cli/package.json` stays at **0.3.6**, which is already bumped but **never released**:

- `0f28161` ("Release CLI + bump harness version") bumped 0.3.5 → 0.3.6, but its Release run [failed](https://github.com/inflexa-ai/inflexa/actions/runs/29636627631) with `refusing to release — required checks did not pass: "lint (cli)"=failure`. There is no `v0.3.6` tag.
- The lint failure was fixed separately by `be1035f`, and `lint (cli)` is green on main now.
- `release.yml` gates on **tag existence**, not on a version diff — it is idempotent by design.

So merging this PR touches `cli/package.json`, re-triggers the gate, which finds no `v0.3.6` tag and ships **0.3.6 carrying harness 0.4.4**. Bumping to 0.3.7 here would skip 0.3.6 for no reason and still release exactly the same code. Happy to add the bump instead if a clean 0.3.7 is preferred.

## Verification

Against the real published 0.4.4 (not a local link):

- `bun install` resolved `@inflexa-ai/harness@0.4.4` from npm with an integrity hash; **no transitive drift** — the lockfile diff is exactly the two harness lines.
- `tsc --noEmit` clean
- `eslint .` clean
- `bun test` — 1261 pass / 1 fail, and that one failure (`local-provider` proxy-bypass test) reproduces **identically on 0.4.3** in the same environment, so it is pre-existing and environment-dependent, not caused by this bump.

## Heads-up: a flaky test can block the release again

`test (cli)` [failed on main](https://github.com/inflexa-ai/inflexa/actions/runs/29639790521) on the harness-0.4.4 bump commit — a commit that touched only `harness/package.json` and cannot have caused it. The failure is:

```
(fail) sandboxStatus — read-only, never pins > does not write the runtime config key when none is selected
  ^ this test timed out after 5000ms
```

`sandboxStatus()` shells out to probe for a container runtime (`firstReadyRuntime` → `docker`/`podman` → `image inspect`). On a GitHub runner Docker is present and that probe can exceed the 5 s budget under load; locally it fails fast and the test passes in ~600 ms. Since `release.yml` refuses to release unless required checks pass, this flake can block the 0.3.6 release again. Left alone here as out of scope — worth either stubbing the runtime probe or raising that test's timeout in a follow-up.
