### PR TITLE
feat(cli): deterministic, accessibility-validated default model election

### DIFF
--- a/cli/CONTEXT.md
+++ b/cli/CONTEXT.md
@@ -11,7 +11,7 @@ The local-first host for the Inflexa product, and the **embedder** of `@inflexa-
 Code is grouped by feature, not by layer — a module owns its logic, its text command actions, and its logic-local types.
 
 - **`auth/`** — Auth0 device flow + `login` / `logout` / `whoami`. Config seeded from `.env` (`INFLEXA_AUTH0_*`).
-- **`proxy/`** — the CLIProxyAPI model helpers (`models.ts`: client key discovery + default-model ranking); the container lifecycle/provisioning lives in `infra/`.
+- **`proxy/`** — the CLIProxyAPI model helpers (`models.ts`: client key discovery + default-model election — deterministic recency rank walked against the unbilled `count_tokens` accessibility check); the container lifecycle/provisioning lives in `infra/`.
 - **`analysis/`** — analysis lifecycle + the `sessions` command (live launch-identity rows; message history is frozen legacy data).
 - **`anchor/`** — invisible folder-identity markers (`.inflexa/id`) and lazy path reconciliation.
 - **`harness/`** — the harness embedder: boots the harness runtime (DBOS, sandbox, providers) and drives the chat turn, the model-free `run --plan` replay engine, data profiling, and the provenance bridge.

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/design.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/design.md
@@ -1,0 +1,84 @@
+# Design: Default Model Election
+
+## Context
+
+Three verified facts (issue #144 + live verification against the running proxy, v7.2.77) drive this design:
+
+1. `/v1/models` serving order is unstable, and `pickDefaultModel` (`proxy/models.ts`) takes the first family match in that order — the resolved default changes across launches.
+2. The advertised list reflects the proxy's GitHub-sourced registry, not the credential: some ids answer `404 not_found_error` on use. The #142 launch probe observes that 404 and discards it — the poisoned pick stays in `cachedModelId`, which chat boot consumes via the shared cache (`runtime.ts` `resolveDefaultModel` → `seams.resolveModel` → the same memoized `resolveModelId`).
+3. `POST /v1/messages/count_tokens` is routed by the proxy upstream with the real credential: inaccessible models 404 identically to completions, accessible ones return 200, and Anthropic does not bill it. `/v1/models` passes the registry's `created` unix timestamps through. Both verified live.
+
+Fact 3 makes validation free and fast, which is what lets one mechanism serve the probe, setup, and the picker.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The same model list always elects the same default (deterministic rank).
+- A model the credential cannot serve is never silently elected, pinned, or persisted.
+- Zero added cost on the happy path; extra requests only when a candidate fails.
+- One election primitive consumed by three surfaces: launch probe, setup step, TUI picker.
+
+**Non-Goals:**
+
+- No tier steering (e.g. "prefer sonnet"): a tier keyword list is a hardcoded id-shape list that ages like the registry does (`fable` matches no classic tier). Pure recency is the only rank with zero baked-in model knowledge; the "newest release is premium-tier" wrinkle is accepted — setup/picker pins are the escape hatch.
+- No persistence of the elected winner: an auto-written pin recreates the staleness problem with none of the user's intent behind it. Auto stays adaptive.
+- No picker-list badging/filtering by accessibility in this change: commit-time validation alone closes the "persist a 404ing pin" hole; live badge updates add TUI async complexity for UX sugar. Revisit separately.
+- No change to the per-agent resolution precedence (`models.agents.<agent>` → `harness.model` → mode default), to direct-mode's explicit-model requirement, or to the third-party proxy.
+
+## Decisions
+
+### D1. Election lives inside `resolveModelId` — the probe consumes it, never pokes the cache
+
+`proxy/models.ts` owns the election end-to-end: widen the zod schema to `{ id, created? }`, rank, walk candidates with `count_tokens`, cache the survivor. `probeOnce` keeps its shape (`resolveModelId` → `askProxy` completion POST) and inherits election for free through the existing call.
+
+*Alternative rejected*: election in the probe with a models.ts cache-override seam — keeps `resolveModelId` dumb but requires cross-module cache mutation, and leaves probe-less chat paths (a process where the launch gate never ran) electing unvalidated. With `count_tokens` sub-second and unbilled, in-resolver validation is affordable on every path.
+
+### D2. Rank = family preference, then `created` descending, then id ascending
+
+`MODEL_PREFERENCE` family order (claude > gpt > gemini > qwen) is unchanged; within the matched family, sort by `created` desc; a missing `created` sorts as 0 (oldest); ties break by id asc so the rank is a total order. The no-family-match fallback also becomes recency-sorted (today: raw `ids[0]`). Never sort ids lexicographically as the primary key — ascending byte order puts dated legacy ids (`claude-3-5-…`) first, which would deterministically elect a confirmed-broken model on the reporting account.
+
+### D3. Only a definite `not_found_error` advances the walk
+
+The validation verdict is three-valued: 200 → elect; 404 → advance to the next candidate; anything else (timeout, 5xx, 429, network throw) → **inconclusive, elect anyway**. Walking on inconclusive would let a flaky network elect an arbitrary older model; this mirrors the probe's existing "only a definite rejection gates" policy. If every candidate 404s, elect rank[0] unvalidated — the probe's completion POST then surfaces the failure exactly as today (`unobservable` warn), preserving "the probe must never add a new way for launch to block".
+
+Each validation round-trip is bounded by the caller's existing signal/timeout discipline (the probe already passes `AbortSignal.timeout`); the walk as a whole is bounded by list length.
+
+### D4. `count_tokens` where the family is claude; skip validation otherwise
+
+`count_tokens` is Anthropic-protocol and only verified through the proxy for claude-family ids. Non-claude families elect by rank alone (still deterministic — strictly better than today), and the probe's completion POST remains the universal credential verdict. The picker applies the same rule per connection protocol: `anthropic` protocol validates on commit; `openai-compatible` accepts as today (no cheap check exists).
+
+### D5. Setup step: validated list, preselected Auto row, accept-writes-nothing
+
+After login + probe, interactive setup presents a select prompt: first row **Auto — recommended: `<elected id>`** (preselected), then the connection-family models from `/v1/models`, accessibility-checked via a bounded-concurrency `count_tokens` sweep (models whose check is inconclusive are shown, not hidden — only a definite 404 excludes). Semantics:
+
+- **Enter on Auto → write nothing.** The default stays `model: null` adaptive resolution — the user delegated the choice, and it keeps tracking releases.
+- **Explicit pick → `writeAgentModel` for BOTH agents.** One question at setup; per-agent divergence stays a picker power feature. A pick is validated on commit (it came from the swept list, so normally pre-validated; free-text/inconclusive entries get the commit check).
+- **Non-TTY setup → skip the step** (Auto). No hardcoded model ids anywhere in the flow.
+
+*Alternative rejected*: silently persisting the elected id at setup — recreates pin-staleness without user intent (the option C analysis from the issue discussion).
+
+### D6. Picker commit-time validation with in-dialog error
+
+The TUI agent-model picker validates the chosen id on Enter (busy state while checking, per the existing dialog busy pattern): a definite 404 keeps the dialog open with an inline error naming the model and the account-accessibility cause; 200 or inconclusive commits as today. Applies to both the listed picks and the free-text fallback path.
+
+### D7. Stale-pin warning at launch
+
+The probe today validates only the auto default — an explicit pin is trusted (`runtime.ts` guard comment) even though chat will actually run on the pin. Extend the launch gate: for each distinct explicitly-pinned model (`models.agents.*`, `harness.model`) on an anthropic-family connection, run the free `count_tokens` check; a definite 404 **warns** with the pinned model, the failing agent(s), and the repick remedy — never blocks, never rewrites config. Auto-elected sessions are unaffected (election already validated).
+
+## Risks / Trade-offs
+
+- [`count_tokens` routing is fork-specific (verified on v7.2.77 only)] → D3's inconclusive-accepts policy means a proxy that stops routing it degrades to today's behavior (rank-only, deterministic), never to something worse; the completion POST remains the final verdict.
+- [The proxy's failure mode for an inaccessible model is not stable] → observed live: after repeated 404s the proxy stops forwarding and answers `503 api_error` "auth_unavailable … cooldown" locally, which the verdict mapping reads as inconclusive. Accepted: a 503 must never advance the walk — the same shape appears transiently on perfectly served models (proxy boot, token refresh), and discriminating on the fork's internal message text is brittle. The residual exposure is a narrow, self-healing window (proxy in the learned/cooldown state AND the newest-ranked model inaccessible) where a broken candidate is elected; the probe's completion POST backstop still reports it, identical to the pre-change failure surface.
+- [Recency elects a just-released premium/experimental model] → accepted per Non-Goals; visible in setup's Auto label; pin is one picker action away.
+- [Setup's validation sweep hits upstream N times] → bounded concurrency, unbilled requests, inconclusive-include on failures; the sweep only runs in interactive setup.
+- [Proxy injects a ~1400-token system prompt into `count_tokens`] → harmless (unbilled, no completion), noted so the reported token count is never treated as the user prompt's size.
+- [Two callers race `resolveModelId` before the cache fills] → same as today: the runtime memoizes the promise (`cliproxyAutoDefault`), and a duplicate concurrent walk is idempotent — worst case a few extra free requests.
+
+## Migration Plan
+
+No config-schema or data migration: `models.agents` already exists, Auto writes nothing, and the change is launch-time behavior only. Rollback is a plain revert. The `models.ts` schema widening (`created` optional) is backward-compatible with proxies that omit the field — they degrade to id-ascending determinism within the family.
+
+## Open Questions
+
+None blocking. Deferred (tracked in Non-Goals): picker-list accessibility badging; re-evaluating `count_tokens` support for non-claude families through the proxy.

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/proposal.md
@@ -1,0 +1,34 @@
+# Add Default Model Election
+
+## Why
+
+Issue #144: in cliproxy mode the default chat model is picked non-deterministically — `pickDefaultModel` takes the first `/v1/models` id containing the preferred family substring, and the proxy's serving order shuffles between calls. Worse, the proxy's list is sourced from a GitHub registry, not from what the OAuth credential can actually serve, so the pick can land on a model that answers 404 — producing a chat session where every turn fails (~1 launch in 6–12 on an affected account) and a launch probe that cannot verify a perfectly healthy credential. The #142 probe already observes the 404 at launch and discards the verdict; the fix is to stop discarding it.
+
+## What Changes
+
+- **Deterministic recency ranking**: the proxy `/models` response's `created` timestamps (verified live: passed through from the registry) replace serving order — candidates within the preferred family rank newest-first. Same list ⇒ same rank, always.
+- **Model election primitive**: one shared mechanism — rank candidates by recency, validate accessibility with the free, unbilled `count_tokens` request (verified live: the proxy routes it upstream with the real credential; inaccessible models 404 identically to completions), walk to the first survivor. The survivor becomes the cached auto default that chat boot consumes.
+- **The launch probe elects instead of reporting**: a 404 on the top candidate advances the walk rather than warning "not verifiable". The probe's final credential verdict remains the existing bounded completion POST. The probe additionally validates an explicit model pin and **warns (never blocks)** when a pin has gone stale upstream.
+- **Setup gains a default-model step**: after login/probe, a select prompt listing accessibility-validated models with a preselected **Auto** row (labeled with the currently elected model). Accepting Auto writes nothing — the default stays adaptive. Explicitly choosing a model writes `models.agents.*` for both agents (a deliberate pin). No hardcoded model ids anywhere.
+- **Picker accessibility validation**: the TUI agent-model picker validates a selection on commit (count_tokens) and surfaces an inaccessible model as an in-dialog error instead of persisting a 404ing pin; the listed models are badged/filtered by accessibility where the listing supports it.
+
+## Capabilities
+
+### New Capabilities
+
+- `default-model-election`: the deterministic, validated election of a default model from a live model list — recency ranking, count_tokens accessibility validation with completion-POST fallback, the candidate walk, and the process-cache semantics of the elected winner.
+
+### Modified Capabilities
+
+- `model-connection`: the cliproxy auto-default requirement changes from "the proxy `/models` default ranking" (order-dependent first match) to the deterministic elected candidate; the setup flow gains the default-model selection step with Auto-vs-pin semantics.
+- `agent-model-selection`: the connection's mode default becomes the elected model; the picker gains commit-time accessibility validation and the Auto/pin distinction (explicit setup pick writes both agent keys).
+- `cliproxy-credential-health`: the launch probe's model input changes from "the resolved default model" to the election walk (a 404 advances candidates instead of terminating as `unobservable`); adds the stale-pin warning.
+
+## Impact
+
+- `cli/src/modules/proxy/models.ts` — schema widens to `{ id, created }`; `pickDefaultModel` becomes the ranked-candidates primitive; election + validation live here (cliproxy-owned concerns).
+- `cli/src/modules/infra/setup.ts` — `probeOnce`/`ensureLiveCredential` consume the election walk; the setup flow gains the model-selection prompt.
+- `cli/src/modules/harness/model_listing.ts` / the TUI picker commands — accessibility validation on commit; badge/filter support.
+- `cli/src/modules/harness/runtime.ts` — no resolution-order change; `resolveDefaultModel` consumes the elected id through the existing seam and cache.
+- No config-schema change: `models.agents` already carries pins; Auto writes nothing.
+- No new dependencies. Network cost: zero on the happy path (count_tokens is unbilled; the walk adds requests only when a candidate 404s).

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/agent-model-selection/spec.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/agent-model-selection/spec.md
@@ -1,12 +1,7 @@
-# agent-model-selection Specification
+# agent-model-selection Specification (delta)
 
-## Purpose
-Per-agent model selection over the one shared model connection: the `models.agents` config map
-for the two user-facing agents (conversation, sandbox), per-agent resolution and provider
-construction, the Provider-category palette commands with dynamic model listing, and the
-live/scheduled application semantics gated on agent-work idleness. Created by archiving change
-select-seat-models.
-## Requirements
+## MODIFIED Requirements
+
 ### Requirement: Per-agent model configuration over the shared connection
 
 The `models` config block SHALL carry an `agents` map with the two user-facing agents —
@@ -92,74 +87,3 @@ immediately, independent of when the runtime applies it.
 
 - **WHEN** the user commits a model and the `count_tokens` check times out
 - **THEN** the selection persists (inconclusive-accept) exactly as an unvalidated commit would
-
-### Requirement: A switch applies live only when no agent work is in flight
-
-The runtime SHALL track in-flight agent work — analysis runs, data profiling, chat turns, and
-ephemeral workflows. A persisted agent-model selection SHALL apply to the live runtime
-immediately when no agent work is in flight; otherwise it SHALL be recorded as pending and
-applied at the moment the last in-flight work settles. Application SHALL reconstruct the affected
-agent's provider instance and — for the sandbox agent — its provenance emitters (reconstructed
-WITH the new `{provider}/{model}` name, preserving their construction-time-stamping contract).
-
-Every swappable object SHALL reach its consumers as a stable delegating handle injected once at
-composition: the consumer (harness deps bundles, agent assembly, registered workflows) holds ONE
-identity for the runtime's life, and a swap replaces only the cli-owned inner target behind it.
-The application path SHALL NOT mutate any field of an object a consumer holds — correctness MUST
-NOT depend on when or how often the consumer reads its deps fields. This is the contract the chat
-provider's swappable handle already satisfies; the provenance emitters (`artifactRegistry`,
-`emitProvenance`) SHALL satisfy the same one.
-
-In-flight work SHALL complete on — and
-record provenance under — the model that started it; no request observes a mid-flight model
-change, and an in-progress streamed response is NEVER interrupted, truncated, or aborted by a
-switch (whether requested from the palette or applied at settlement). An indeterminate busy state
-SHALL defer, never apply.
-
-#### Scenario: Idle switch applies immediately
-
-- **WHEN** the user switches the chat model with no run, profile, or chat turn in flight
-- **THEN** the next chat turn runs on the new model and its provenance/metadata carry the new
-  `{provider}/{model}` name
-
-#### Scenario: Busy switch is scheduled, then lands at settlement
-
-- **WHEN** the user switches the sandbox model while an analysis run is executing
-- **THEN** the running work continues and records the old model to completion; the selection is
-  persisted and marked pending; when the run (and any other in-flight work) settles, the new
-  provider is constructed and subsequent steps record the new name
-
-#### Scenario: A chat turn defers the swap to the turn boundary, without disturbing the stream
-
-- **WHEN** the user switches the chat model while a chat turn is streaming a response
-- **THEN** the in-flight turn streams to completion on the old model — uninterrupted and
-  untruncated — and the swap lands before the next turn begins
-
-#### Scenario: A consumer that snapshots its deps still observes the swap
-
-- **WHEN** a consumer captures the injected `emitProvenance` (or `artifactRegistry`) reference
-  once at registration, the sandbox model is then switched at idle, and the consumer emits
-  through its captured reference
-- **THEN** the emitted event carries the NEW `{provider}/{model}` name — the swap is effective
-  regardless of the consumer's read discipline, because the captured reference is the stable
-  delegating handle
-
-### Requirement: The TUI surfaces the connection and the active and pending agent models
-
-The TUI SHALL render, from the runtime's boot/status state: the shared connection's identity —
-the configured provider slug and mode (`cliproxy` or `direct`) — and the active model of each
-user-facing agent, and SHALL surface a pending switch as such (selection made, applies when
-agent work settles) until it lands. The boot/status state SHALL carry per-agent resolved models,
-pending selections, and the connection identity.
-
-#### Scenario: Status shows the connection and what each agent runs on
-
-- **WHEN** the runtime is ready on a cliproxy/anthropic connection with distinct agent models
-- **THEN** the user can see the provider (`anthropic`), the mode, and both active models in the
-  TUI status surface without opening config
-
-#### Scenario: Pending switch is visible, not silent
-
-- **WHEN** a switch is scheduled behind a running analysis
-- **THEN** the TUI shows the pending selection and clears the pending state once applied
-

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/cliproxy-credential-health/spec.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/cliproxy-credential-health/spec.md
@@ -1,26 +1,6 @@
-# cliproxy-credential-health Specification
+# cliproxy-credential-health Specification (delta)
 
-## Purpose
-Detecting a dead provider OAuth credential behind the managed CLIProxyAPI container before it fails work mid-flight: the structural presence check (what counts as a credential on disk), the launch-time live probe that is the sole authority on validity (a dead refresh token leaves no trace in the credential file), and setup's truthful reporting of what it can actually know statically.
-## Requirements
-### Requirement: Credential presence is decided structurally, never by expiry
-
-The cliproxy authenticated-state check SHALL consider only `*.json` entries in the credential dir (`env.cliproxyAuthDir`), SHALL treat a credential whose JSON carries `disabled: true` as not authenticated, and SHALL treat an unreadable or unparseable `*.json` entry as present (the live probe, not the static check, is the authority on validity). The check SHALL NOT gate on the credential's `expired` timestamp: the access token expires every 8 hours by design and the running proxy refreshes it, so a stale `expired` is normal.
-
-#### Scenario: A logs-only auth dir is unauthenticated
-
-- **WHEN** the credential dir contains only a `logs/` subdirectory (the credential JSON was deleted)
-- **THEN** the check reports not authenticated and the interactive login path is offered
-
-#### Scenario: An operator-disabled credential is unauthenticated
-
-- **WHEN** the only credential JSON carries `disabled: true`
-- **THEN** the check reports not authenticated
-
-#### Scenario: A past expired timestamp does not fail the static check
-
-- **WHEN** a credential JSON has `disabled: false` and an `expired` timestamp in the past
-- **THEN** the static check still reports authenticated (the proxy refreshes access tokens; only the live probe may judge validity)
+## MODIFIED Requirements
 
 ### Requirement: The launch gate probes the live credential in cliproxy mode
 
@@ -81,36 +61,7 @@ Because starting a container does not make its server reachable — the engine r
 - **WHEN** nothing answers for the whole retry budget
 - **THEN** launch logs a warning carrying the observed failure and proceeds
 
-### Requirement: A fresh login is made observable to an already-running proxy
-
-The proxy loads credentials only at container start — host-side writes to the mounted auth dir do not reach the running binary's file watcher, and compose-up leaves a running container untouched. Therefore any interactive provider login that completes while a proxy container is already running — setup's authentication step, or the launch gate's missing-credential login — SHALL restart the proxy service so it serves the credential the user just created. When no proxy container is running, no restart SHALL be attempted: the next container start reads the auth dir at boot. A restart failure after a successful login SHALL surface as an actionable error naming the remedy, never proceed silently with a proxy that cannot serve the new credential. (The launch probe's own re-login path already restarts before its re-probe; this requirement extends the same guarantee to logins that run before any probe.)
-
-#### Scenario: Forced re-login reaches the running proxy
-
-- **GIVEN** the compose stack is up and the proxy is serving a dead credential
-- **WHEN** `inflexa setup --provider <name>` completes a sign-in
-- **THEN** the proxy service is restarted before setup exits, and the next chat uses the fresh credential without a relaunch
-
-#### Scenario: Launch-gate login does not demand a second login
-
-- **GIVEN** a proxy container left running with no usable credential (the login was previously skipped)
-- **WHEN** the TUI launches and the missing-credential login completes
-- **THEN** the proxy is restarted before the credential probe runs, the probe reads the fresh credential, and no second login is driven
-
-#### Scenario: No running proxy, no restart
-
-- **WHEN** a login completes while no proxy container is running
-- **THEN** no restart is attempted and the container reads the credential when it next starts
-
-### Requirement: Setup reports credential state truthfully
-
-`inflexa setup`'s already-authenticated branch SHALL state only what it can know statically — that a credential exists — and SHALL name the forced re-login path (`--provider <name>`) as the remedy when provider calls fail authentication. It SHALL NOT assert that the credential is valid.
-
-#### Scenario: Setup after a refresh death does not claim health
-
-- **GIVEN** a present credential whose refresh token has been revoked (statically indistinguishable from a healthy one)
-- **WHEN** `inflexa setup` runs without `--provider`
-- **THEN** the message says a credential exists and names `--provider <name>` re-login as the fix for failing authentication, without claiming the credential works
+## ADDED Requirements
 
 ### Requirement: Launch warns when an explicit model pin has gone stale
 
@@ -139,4 +90,3 @@ sessions are outside this requirement — election already validated the default
 
 - **WHEN** a pinned model's accessibility check times out
 - **THEN** no warning is shown and launch proceeds
-

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/default-model-election/spec.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/default-model-election/spec.md
@@ -1,0 +1,69 @@
+# default-model-election Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Model candidates rank deterministically by family preference, then recency
+
+The default-model rank over a model list SHALL be a total order: candidates matching the
+preferred family (the existing `MODEL_PREFERENCE` order: claude > gpt > gemini > qwen,
+case-insensitive substring) rank first, ordered within the family by the listing's `created`
+timestamp descending, with a missing `created` sorting as oldest and ties broken by id
+ascending. When no family matches, the same recency order SHALL apply to the whole list. The
+rank SHALL NOT depend on the serving order of the model list, and SHALL NOT use lexicographic
+id order as the primary sort (ascending byte order ranks dated legacy ids first). The `/models`
+response parsing SHALL carry `created` through as an optional field; a listing without it
+degrades to the id-ascending tiebreak, still deterministic.
+
+#### Scenario: Same list, same rank, any serving order
+
+- **WHEN** the proxy serves the same model set in two different orders across two calls
+- **THEN** both calls produce the identical ranked candidate sequence
+
+#### Scenario: Recency outranks serving position
+
+- **WHEN** the list serves an older claude id first and a newer claude id (greater `created`) later
+- **THEN** the newer id ranks first
+
+### Requirement: Election walks the rank and only a definite not-found advances it
+
+Electing a default model SHALL walk the ranked candidates, validating each via the unbilled
+`count_tokens` request when the candidate is claude-family on an anthropic-protocol connection,
+with every round-trip bounded by the caller's timeout discipline. The validation verdict is
+three-valued: a 200 elects the candidate; a definite `not_found_error` 404 advances to the next
+candidate; any other outcome (timeout, non-404 status, network failure) is inconclusive and
+SHALL elect the candidate anyway — a flaky network must not walk past the best candidate.
+Non-claude-family candidates SHALL be elected by rank alone (no validation request exists for
+them). If every candidate 404s, the election SHALL yield the top-ranked candidate unvalidated so
+the existing probe failure reporting surfaces the state; the election itself SHALL never fail a
+launch.
+
+#### Scenario: Inaccessible top candidate is walked past
+
+- **WHEN** the top-ranked claude id answers `count_tokens` with a `not_found_error` and the next answers 200
+- **THEN** the next candidate is elected and no warning is emitted for the walk itself
+
+#### Scenario: A transient validation failure does not distort the election
+
+- **WHEN** the top-ranked candidate's `count_tokens` times out or answers a 5xx
+- **THEN** that candidate is elected (inconclusive-accept), not walked past
+
+#### Scenario: An all-404 list elects the top candidate for downstream reporting
+
+- **WHEN** every ranked candidate answers `not_found_error`
+- **THEN** the top-ranked candidate is returned and the launch probe's existing warn-and-proceed
+  path reports the failure; launch is not blocked by the election
+
+### Requirement: The elected winner is the process-cached auto default
+
+`resolveModelId` SHALL perform the election (rank, then validation walk) and cache the elected
+winner per process, so every consumer of the auto default in the same process — the launch
+probe, harness boot's per-agent fallback — observes the same elected id without re-walking. The
+cache SHALL retain its existing lifecycle (never invalidated at runtime; reset only by the
+test hook).
+
+#### Scenario: Probe and chat share one election
+
+- **WHEN** the launch probe resolves the default and harness boot later resolves the per-agent
+  fallback in the same process
+- **THEN** boot receives the probe's elected id from the cache with no additional `/models` or
+  validation requests

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/model-connection/spec.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/specs/model-connection/spec.md
@@ -1,0 +1,97 @@
+# model-connection Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Boot resolves the connection to a chat provider via the harness front door
+
+Boot SHALL resolve `models.connection` into the harness's provider configuration and construct
+the chat provider through the harness's exported factory (one construction path for both modes):
+`cliproxy` resolves to the Anthropic kind at the proxy endpoint with the proxy client key;
+`direct` resolves to the configured protocol kind at the configured `baseURL` with the env key.
+Model resolution per mode: in `cliproxy` mode the existing behavior holds (config override, else
+the elected default from the proxy's `/models` list — the deterministic, accessibility-validated
+election defined by `default-model-election`, replacing the serving-order first match), guarded
+by provider-family agreement — an auto-resolved id whose family does not match the configured
+provider SHALL fail boot with a remediation message (this generalizes and replaces the
+`model_not_claude` guard; with the default provider it is behavior-identical to it). In `direct`
+mode an explicit model id is REQUIRED and no auto-resolve occurs; a missing model SHALL fail
+boot actionably. The composition SHALL carry the connection's `provider` slug (the configured
+fact) wherever the model's vendor identity is consumed.
+
+#### Scenario: Cliproxy default boot is unchanged
+
+- **WHEN** boot runs with the default connection and an authenticated Claude account
+- **THEN** the provider targets the proxy endpoint over the Anthropic protocol with the elected
+  Claude model — indistinguishable from the pre-change boot apart from the deterministic,
+  validated pick
+
+#### Scenario: Provider-family mismatch replaces model_not_claude
+
+- **WHEN** the connection is cliproxy with provider `anthropic` and the proxy's `/models`
+  election yields a non-Claude id
+- **THEN** boot fails with a mismatch error naming the configured provider, the resolved id, and
+  the remedies (authenticate the matching account via setup, or set the model/provider in config)
+
+#### Scenario: Direct mode requires an explicit model
+
+- **WHEN** the connection is `direct` and no model id is configured
+- **THEN** boot fails with an actionable error pointing at the model config — no auto-resolve is
+  attempted against the direct endpoint
+
+### Requirement: Setup offers the connection choice and records the provider fact
+
+`inflexa setup` SHALL let the user choose the connection mode. The CLIProxy path keeps the
+current provisioning flow (container, config generation, provider OAuth login) and SHALL record
+the connection provider slug in config from the authenticated account kind at login time (the
+account-kind→slug mapping lives only in setup, where the kind is a known fact); re-authentication
+SHALL rewrite it. The direct path SHALL collect the endpoint (and provider, and optional
+protocol), write the `models.connection` block, instruct the user to export
+`INFLEXA_MODEL_API_KEY`, and SHALL NOT provision the proxy container. Postgres provisioning is
+mode-independent and unchanged.
+
+After the CLIProxy login, once the provisioned proxy is answering (setup runs no credential
+probe — that is the launch gate's; the step skips gracefully, writing nothing, when the proxy
+or its listing is not available), interactive setup SHALL present a default-model
+selection: a preselected **Auto** row labeled with the currently elected model
+(`default-model-election`), followed by the connection-family models from the proxy's `/models`
+list, accessibility-checked via bounded-concurrency `count_tokens` requests — only a definite
+`not_found_error` excludes a model from the list; an inconclusive check keeps it listed.
+Accepting Auto SHALL write nothing (the default stays adaptive `model: null` resolution).
+Explicitly choosing a model SHALL persist it to `models.agents.<agent>` for BOTH user-facing
+agents (a deliberate pin). The flow SHALL contain no hardcoded model ids. On a non-TTY, setup
+SHALL skip the selection (Auto semantics).
+
+#### Scenario: CLIProxy setup records the provider from the login
+
+- **WHEN** the user runs setup and authenticates the `claude` account kind
+- **THEN** config records connection mode cliproxy with provider `anthropic`, written by setup —
+  not derived from any model id
+
+#### Scenario: Direct setup skips the proxy entirely
+
+- **WHEN** the user chooses the direct path with an endpoint and provider
+- **THEN** the `models.connection` block is written, no proxy container is provisioned or
+  required for chat, and setup still provisions Postgres
+
+#### Scenario: Accepting Auto keeps the default adaptive
+
+- **WHEN** the user accepts the preselected Auto row (labeled with the elected model)
+- **THEN** no model key is written to config and later launches keep electing the default from
+  the live list
+
+#### Scenario: An explicit setup pick pins both agents
+
+- **WHEN** the user selects a specific model instead of Auto
+- **THEN** `models.agents.conversation` and `models.agents.sandbox` are both written to that id
+
+#### Scenario: The selection list hides only definitely inaccessible models
+
+- **WHEN** one listed model answers the accessibility check with `not_found_error` and another's
+  check times out
+- **THEN** the 404ing model is excluded from the list and the timed-out one remains listed
+
+#### Scenario: Non-interactive setup skips the model step
+
+- **WHEN** setup runs without a TTY
+- **THEN** no model prompt is shown, nothing is written to `models.agents`, and the default
+  remains adaptive

--- a/cli/openspec/changes/archive/2026-07-18-add-default-model-election/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-18-add-default-model-election/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Default Model Election
+
+## 1. Election primitive (proxy/models.ts)
+
+- [x] 1.1 Widen `modelsSchema` to carry optional `created` per model and thread `{ id, created }` through `resolveModelId`
+- [x] 1.2 Replace `pickDefaultModel`'s first-match with the deterministic rank: family preference → `created` desc (missing = oldest) → id asc, recency-sorted fallback when no family matches; export the ranked-candidates form for the walk and setup's list
+- [x] 1.3 Add the bounded `count_tokens` accessibility check (claude-family on anthropic protocol only) with the three-valued verdict: 200 elect / definite `not_found_error` advance / anything else inconclusive-elect
+- [x] 1.4 Wire the election walk into `resolveModelId` — walk ranked candidates, cache the survivor, all-404 yields rank[0] unvalidated; preserve the existing signal/timeout discipline and `proxy_unreachable` bridging
+- [x] 1.5 Unit tests: rank determinism under shuffled serving order, recency-over-position, missing-`created` tiebreak, walk-past-404, inconclusive-accept on timeout/5xx, all-404 top-candidate fallback, cache shares one election across callers (use `__resetModelCacheForTest`; inject fetch via seams per the existing test pattern)
+
+## 2. Launch probe (infra/setup.ts)
+
+- [x] 2.1 Confirm `probeOnce` inherits the election through `resolveModelId` unchanged; adjust `classifyModelResolution` only if the election introduces a new `ChatSetupError` shape (design intends none)
+- [x] 2.2 Add the stale-pin check to the launch gate: for each distinct pinned model (`models.agents.*`, `harness.model`) on an anthropic-family cliproxy connection, run the bounded `count_tokens` check; definite 404 → warn naming model, agent(s), and repick remedy; inconclusive → silent; never block, never rewrite config
+- [x] 2.3 Unit tests: probe passes with an inaccessible top candidate (elected past it), stale-pin warn on 404, silence on 200 and on timeout, non-anthropic and auto-resolved sessions skip the pin check
+
+## 3. Setup model-selection step (infra/setup.ts)
+
+- [x] 3.1 Build the accessibility-swept model list for the select prompt: connection-family ids from `/models`, bounded-concurrency `count_tokens` sweep, exclude only definite 404s, keep inconclusive entries
+- [x] 3.2 Add the interactive select after login+probe: preselected `Auto — recommended: <elected>` row plus the swept list; Auto → write nothing; explicit pick → `writeAgentModel` for both agents; non-TTY skips the step; no hardcoded model ids
+- [x] 3.3 Unit tests: Auto writes nothing, explicit pick writes both agent keys, 404-swept model absent from the list, timed-out model present, non-TTY skip
+
+## 4. Picker commit-time validation (TUI)
+
+- [x] 4.1 Expose a single commit-validation helper for the picker (anthropic protocol → bounded `count_tokens`; `openai-compatible` → commit as today), shared with the setup sweep rather than reimplemented
+- [x] 4.2 Wire validation into the model-switch commit path (listed and free-text): busy state while checking, definite 404 keeps the dialog open with an inline error naming the model and the account-accessibility cause, 200/inconclusive persists via `writeAgentModel` as today
+- [x] 4.3 Tests: 404 rejects in-dialog without a config write, timeout commits, openai-compatible skips validation (follow the existing picker/dialog test patterns)
+
+## 5. Verification and docs
+
+- [x] 5.1 `bun run typecheck && bun run lint && bun test`, plus `bun run format:file` on every touched `src/` file
+- [x] 5.2 Live verification against the local proxy: repeated launches elect the same model, no `Provider login not verifiable (HTTP 404)` on a healthy credential, setup shows the swept list with Auto preselected, picker rejects a known-inaccessible id in-dialog
+- [x] 5.3 Update `CONTEXT.md`/module docs where they describe the default-model pick, and note the election in the `proxy/models.ts` header comment

--- a/cli/openspec/specs/default-model-election/spec.md
+++ b/cli/openspec/specs/default-model-election/spec.md
@@ -1,0 +1,71 @@
+# default-model-election Specification
+
+## Purpose
+TBD - created by archiving change add-default-model-election. Update Purpose after archive.
+## Requirements
+### Requirement: Model candidates rank deterministically by family preference, then recency
+
+The default-model rank over a model list SHALL be a total order: candidates matching the
+preferred family (the existing `MODEL_PREFERENCE` order: claude > gpt > gemini > qwen,
+case-insensitive substring) rank first, ordered within the family by the listing's `created`
+timestamp descending, with a missing `created` sorting as oldest and ties broken by id
+ascending. When no family matches, the same recency order SHALL apply to the whole list. The
+rank SHALL NOT depend on the serving order of the model list, and SHALL NOT use lexicographic
+id order as the primary sort (ascending byte order ranks dated legacy ids first). The `/models`
+response parsing SHALL carry `created` through as an optional field; a listing without it
+degrades to the id-ascending tiebreak, still deterministic.
+
+#### Scenario: Same list, same rank, any serving order
+
+- **WHEN** the proxy serves the same model set in two different orders across two calls
+- **THEN** both calls produce the identical ranked candidate sequence
+
+#### Scenario: Recency outranks serving position
+
+- **WHEN** the list serves an older claude id first and a newer claude id (greater `created`) later
+- **THEN** the newer id ranks first
+
+### Requirement: Election walks the rank and only a definite not-found advances it
+
+Electing a default model SHALL walk the ranked candidates, validating each via the unbilled
+`count_tokens` request when the candidate is claude-family on an anthropic-protocol connection,
+with every round-trip bounded by the caller's timeout discipline. The validation verdict is
+three-valued: a 200 elects the candidate; a definite `not_found_error` 404 advances to the next
+candidate; any other outcome (timeout, non-404 status, network failure) is inconclusive and
+SHALL elect the candidate anyway — a flaky network must not walk past the best candidate.
+Non-claude-family candidates SHALL be elected by rank alone (no validation request exists for
+them). If every candidate 404s, the election SHALL yield the top-ranked candidate unvalidated so
+the existing probe failure reporting surfaces the state; the election itself SHALL never fail a
+launch.
+
+#### Scenario: Inaccessible top candidate is walked past
+
+- **WHEN** the top-ranked claude id answers `count_tokens` with a `not_found_error` and the next answers 200
+- **THEN** the next candidate is elected and no warning is emitted for the walk itself
+
+#### Scenario: A transient validation failure does not distort the election
+
+- **WHEN** the top-ranked candidate's `count_tokens` times out or answers a 5xx
+- **THEN** that candidate is elected (inconclusive-accept), not walked past
+
+#### Scenario: An all-404 list elects the top candidate for downstream reporting
+
+- **WHEN** every ranked candidate answers `not_found_error`
+- **THEN** the top-ranked candidate is returned and the launch probe's existing warn-and-proceed
+  path reports the failure; launch is not blocked by the election
+
+### Requirement: The elected winner is the process-cached auto default
+
+`resolveModelId` SHALL perform the election (rank, then validation walk) and cache the elected
+winner per process, so every consumer of the auto default in the same process — the launch
+probe, harness boot's per-agent fallback — observes the same elected id without re-walking. The
+cache SHALL retain its existing lifecycle (never invalidated at runtime; reset only by the
+test hook).
+
+#### Scenario: Probe and chat share one election
+
+- **WHEN** the launch probe resolves the default and harness boot later resolves the per-agent
+  fallback in the same process
+- **THEN** boot receives the probe's elected id from the cache with no additional `/models` or
+  validation requests
+

--- a/cli/openspec/specs/model-connection/spec.md
+++ b/cli/openspec/specs/model-connection/spec.md
@@ -105,23 +105,26 @@ the chat provider through the harness's exported factory (one construction path 
 `cliproxy` resolves to the Anthropic kind at the proxy endpoint with the proxy client key;
 `direct` resolves to the configured protocol kind at the configured `baseURL` with the env key.
 Model resolution per mode: in `cliproxy` mode the existing behavior holds (config override, else
-the proxy `/models` default ranking), guarded by provider-family agreement — an auto-resolved id
-whose family does not match the configured provider SHALL fail boot with a remediation message
-(this generalizes and replaces the `model_not_claude` guard; with the default provider it is
-behavior-identical to it). In `direct` mode an explicit model id is REQUIRED and no auto-resolve
-occurs; a missing model SHALL fail boot actionably. The composition SHALL carry the connection's
-`provider` slug (the configured fact) wherever the model's vendor identity is consumed.
+the elected default from the proxy's `/models` list — the deterministic, accessibility-validated
+election defined by `default-model-election`, replacing the serving-order first match), guarded
+by provider-family agreement — an auto-resolved id whose family does not match the configured
+provider SHALL fail boot with a remediation message (this generalizes and replaces the
+`model_not_claude` guard; with the default provider it is behavior-identical to it). In `direct`
+mode an explicit model id is REQUIRED and no auto-resolve occurs; a missing model SHALL fail
+boot actionably. The composition SHALL carry the connection's `provider` slug (the configured
+fact) wherever the model's vendor identity is consumed.
 
 #### Scenario: Cliproxy default boot is unchanged
 
 - **WHEN** boot runs with the default connection and an authenticated Claude account
-- **THEN** the provider targets the proxy endpoint over the Anthropic protocol with the
-  auto-resolved Claude model — indistinguishable from the pre-change boot
+- **THEN** the provider targets the proxy endpoint over the Anthropic protocol with the elected
+  Claude model — indistinguishable from the pre-change boot apart from the deterministic,
+  validated pick
 
 #### Scenario: Provider-family mismatch replaces model_not_claude
 
 - **WHEN** the connection is cliproxy with provider `anthropic` and the proxy's `/models`
-  auto-resolve yields a non-Claude id
+  election yields a non-Claude id
 - **THEN** boot fails with a mismatch error naming the configured provider, the resolved id, and
   the remedies (authenticate the matching account via setup, or set the model/provider in config)
 
@@ -142,6 +145,18 @@ protocol), write the `models.connection` block, instruct the user to export
 `INFLEXA_MODEL_API_KEY`, and SHALL NOT provision the proxy container. Postgres provisioning is
 mode-independent and unchanged.
 
+After the CLIProxy login, once the provisioned proxy is answering (setup runs no credential
+probe — that is the launch gate's; the step skips gracefully, writing nothing, when the proxy
+or its listing is not available), interactive setup SHALL present a default-model
+selection: a preselected **Auto** row labeled with the currently elected model
+(`default-model-election`), followed by the connection-family models from the proxy's `/models`
+list, accessibility-checked via bounded-concurrency `count_tokens` requests — only a definite
+`not_found_error` excludes a model from the list; an inconclusive check keeps it listed.
+Accepting Auto SHALL write nothing (the default stays adaptive `model: null` resolution).
+Explicitly choosing a model SHALL persist it to `models.agents.<agent>` for BOTH user-facing
+agents (a deliberate pin). The flow SHALL contain no hardcoded model ids. On a non-TTY, setup
+SHALL skip the selection (Auto semantics).
+
 #### Scenario: CLIProxy setup records the provider from the login
 
 - **WHEN** the user runs setup and authenticates the `claude` account kind
@@ -153,6 +168,29 @@ mode-independent and unchanged.
 - **WHEN** the user chooses the direct path with an endpoint and provider
 - **THEN** the `models.connection` block is written, no proxy container is provisioned or
   required for chat, and setup still provisions Postgres
+
+#### Scenario: Accepting Auto keeps the default adaptive
+
+- **WHEN** the user accepts the preselected Auto row (labeled with the elected model)
+- **THEN** no model key is written to config and later launches keep electing the default from
+  the live list
+
+#### Scenario: An explicit setup pick pins both agents
+
+- **WHEN** the user selects a specific model instead of Auto
+- **THEN** `models.agents.conversation` and `models.agents.sandbox` are both written to that id
+
+#### Scenario: The selection list hides only definitely inaccessible models
+
+- **WHEN** one listed model answers the accessibility check with `not_found_error` and another's
+  check times out
+- **THEN** the 404ing model is excluded from the list and the timed-out one remains listed
+
+#### Scenario: Non-interactive setup skips the model step
+
+- **WHEN** setup runs without a TTY
+- **THEN** no model prompt is shown, nothing is written to `models.agents`, and the default
+  remains adaptive
 
 ### Requirement: No provider identity is ever derived from a model id
 

--- a/cli/src/modules/harness/model_listing.test.ts
+++ b/cli/src/modules/harness/model_listing.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { err, ok, type Result } from "neverthrow";
 
 import "../../extensions/index.ts"; // installs Response.prototype.jsonWith, which listConnectionModels uses
-import type { ChatSetupError } from "../proxy/models.ts";
+import type { ChatSetupError, ModelAccess } from "../proxy/models.ts";
 import type { ResolvedModelConnection } from "./config.ts";
-import { listConnectionModels, type ListModelsSeams } from "./model_listing.ts";
+import { listConnectionModels, validateModelSelection, type ListModelsSeams, type ValidateSelectionSeams } from "./model_listing.ts";
 
 // Drives `listConnectionModels` through injected seams so the per-mode request shaping (cliproxy vs.
 // direct OpenAI-compatible vs. direct Anthropic) and the Result-channel degradations are exercised with
@@ -162,5 +162,174 @@ describe("listConnectionModels — expected failures degrade on the Result chann
         ).toEqual({
             type: "no_models",
         });
+    });
+});
+
+// Drives `validateModelSelection` (the picker's commit-time accessibility check) through injected seams:
+// the cliproxy verdict is DELEGATED to checkModelAccess (asserted, never reimplemented here), the
+// direct-anthropic `count_tokens` request is shaped + mapped in-file, and every can't-decide branch
+// resolves to `inconclusive` so a switch is never blocked by validation. No network, no proxy config.
+
+/** Build validate seams; every effect that a given test does NOT expect throws, so an unwanted call fails loudly. */
+function validateSeamsFor(opts: {
+    connection: ResolvedModelConnection;
+    readProxyKey?: () => Promise<Result<string, ChatSetupError>>;
+    modelApiKey?: string | undefined;
+    checkModelAccess?: (apiKey: string, modelId: string, signal?: AbortSignal) => Promise<ModelAccess>;
+    fetch?: (url: string, init: RequestInit) => Promise<Response>;
+}): ValidateSelectionSeams {
+    return {
+        resolveConnection: () => opts.connection,
+        readProxyKey: opts.readProxyKey ?? (async () => ok("sk-proxy")),
+        readModelApiKey: () => opts.modelApiKey,
+        checkModelAccess:
+            opts.checkModelAccess ??
+            (() => {
+                throw new Error("checkModelAccess must not be called");
+            }),
+        fetch:
+            opts.fetch ??
+            (() => {
+                throw new Error("fetch must not be called");
+            }),
+    };
+}
+
+const DIRECT_ANTHROPIC: ResolvedModelConnection = {
+    mode: "direct",
+    provider: "anthropic",
+    baseURL: "https://api.anthropic.com/v1",
+    protocol: "anthropic",
+    agents: {},
+};
+
+describe("validateModelSelection — per-mode commit validation", () => {
+    test("cliproxy delegates to checkModelAccess with the proxy key and returns its verdict", async () => {
+        const seen: { apiKey: string; modelId: string }[] = [];
+        const result = await validateModelSelection(
+            "claude-opus-4-8",
+            validateSeamsFor({
+                connection: { mode: "cliproxy", provider: "anthropic", agents: {} },
+                checkModelAccess: async (apiKey, modelId) => {
+                    seen.push({ apiKey, modelId });
+                    return "served";
+                },
+            }),
+        );
+        expect(result).toBe("served");
+        expect(seen).toEqual([{ apiKey: "sk-proxy", modelId: "claude-opus-4-8" }]);
+    });
+
+    test("cliproxy with no proxy key is inconclusive and never delegates", async () => {
+        let delegated = 0;
+        const result = await validateModelSelection(
+            "claude-opus-4-8",
+            validateSeamsFor({
+                connection: { mode: "cliproxy", provider: "anthropic", agents: {} },
+                readProxyKey: async () => err({ type: "proxy_key_missing" }),
+                checkModelAccess: async () => {
+                    delegated++;
+                    return "served";
+                },
+            }),
+        );
+        expect(result).toBe("inconclusive");
+        expect(delegated).toBe(0);
+    });
+
+    test("direct-anthropic 200 is served, POSTing count_tokens with the x-api-key + version headers", async () => {
+        const calls: { url: string; init: RequestInit }[] = [];
+        const result = await validateModelSelection(
+            "claude-sonnet-4-5",
+            validateSeamsFor({
+                connection: DIRECT_ANTHROPIC,
+                modelApiKey: "sk-ant",
+                fetch: async (url, init) => {
+                    calls.push({ url, init });
+                    return new Response("{}", { status: 200 });
+                },
+            }),
+        );
+        expect(result).toBe("served");
+        expect(calls[0]?.url).toBe("https://api.anthropic.com/v1/messages/count_tokens");
+        expect(calls[0]?.init.method).toBe("POST");
+        expect(calls[0]?.init.headers).toMatchObject({ "x-api-key": "sk-ant", "anthropic-version": "2023-06-01" });
+    });
+
+    test("direct-anthropic 404 with a not_found_error body is not_found", async () => {
+        const result = await validateModelSelection(
+            "claude-nope",
+            validateSeamsFor({
+                connection: DIRECT_ANTHROPIC,
+                modelApiKey: "sk-ant",
+                fetch: async () => new Response(JSON.stringify({ error: { type: "not_found_error" } }), { status: 404 }),
+            }),
+        );
+        expect(result).toBe("not_found");
+    });
+
+    test("direct-anthropic 404 WITHOUT a not_found_error body is inconclusive (matches checkModelAccess)", async () => {
+        const result = await validateModelSelection(
+            "claude-sonnet-4-5",
+            validateSeamsFor({
+                connection: DIRECT_ANTHROPIC,
+                modelApiKey: "sk-ant",
+                // A proxy/gateway that does not route count_tokens 404s everything — a bare 404 must NOT read
+                // as inaccessible, only `not_found_error` does.
+                fetch: async () => new Response("Not Found", { status: 404 }),
+            }),
+        );
+        expect(result).toBe("inconclusive");
+    });
+
+    test("direct-anthropic whose request throws (timeout/abort) is inconclusive", async () => {
+        const result = await validateModelSelection(
+            "claude-sonnet-4-5",
+            validateSeamsFor({
+                connection: DIRECT_ANTHROPIC,
+                modelApiKey: "sk-ant",
+                fetch: async () => {
+                    throw new Error("The operation timed out");
+                },
+            }),
+        );
+        expect(result).toBe("inconclusive");
+    });
+
+    test("direct openai-compatible is inconclusive without issuing any request", async () => {
+        let fetchCount = 0;
+        const result = await validateModelSelection(
+            "gpt-4o",
+            validateSeamsFor({
+                connection: { mode: "direct", provider: "openai", baseURL: "https://api.example.com/v1", protocol: "openai-compatible", agents: {} },
+                modelApiKey: "sk-direct",
+                fetch: async () => {
+                    fetchCount++;
+                    return new Response("{}");
+                },
+            }),
+        );
+        expect(result).toBe("inconclusive");
+        expect(fetchCount).toBe(0);
+    });
+
+    test("an invalid connection config is inconclusive without touching any validation effect", async () => {
+        let touched = 0;
+        const result = await validateModelSelection(
+            "claude-opus-4-8",
+            validateSeamsFor({
+                connection: { mode: "cliproxy", provider: "anthropic", agents: {}, configError: { issues: "models.agents.sandbox: expected string" } },
+                checkModelAccess: async () => {
+                    touched++;
+                    return "served";
+                },
+                fetch: async () => {
+                    touched++;
+                    return new Response("{}");
+                },
+            }),
+        );
+        expect(result).toBe("inconclusive");
+        expect(touched).toBe(0);
     });
 });

--- a/cli/src/modules/harness/model_listing.ts
+++ b/cli/src/modules/harness/model_listing.ts
@@ -2,7 +2,7 @@ import { type Result, ok, err } from "neverthrow";
 import { z } from "zod";
 
 import { env, resolveModelApiKey } from "../../lib/env.ts";
-import { readApiKey, type ChatSetupError } from "../proxy/models.ts";
+import { readApiKey, checkModelAccess, type ChatSetupError, type ModelAccess } from "../proxy/models.ts";
 import { resolveModelConnection, type ResolvedModelConnection } from "./config.ts";
 
 // Live model listing for the agent-model picker. Deliberately DISTINCT from
@@ -122,4 +122,112 @@ export async function listConnectionModels(seams: ListModelsSeams = realSeams): 
     const models = await res.jsonWith(modelsSchema);
     if (!models || models.data.length === 0) return err({ type: "no_models" });
     return ok(models.data.map((m) => m.id));
+}
+
+// Commit-time accessibility validation for the agent-model picker (design D6). Distinct from listing:
+// listing shapes a GET the picker turns into rows; this shapes the connection's cheapest "can the
+// credential serve THIS id?" check and returns the three-valued verdict the commit decision consumes.
+// The cliproxy verdict is delegated verbatim to proxy/models.ts (`checkModelAccess`) — never
+// reimplemented here — while the direct-anthropic `count_tokens` request is direct-mode-specific shaping
+// that belongs beside `requestFor` (same `x-api-key` + `anthropic-version` headers), with a verdict
+// mapping that MUST match `checkModelAccess`'s exactly.
+
+/**
+ * Upper bound on a single commit-time accessibility check. The `count_tokens` route is sub-second and
+ * unbilled (design D3), so this is the "endpoint accepted the connection then never answered" ceiling —
+ * not the expected latency. Matched to the launch probe's timeout discipline (setup.ts `PROBE_TIMEOUT_MS`)
+ * so a hung endpoint can never wedge the picker's busy state open indefinitely; a trip past it aborts the
+ * request, which the mapping below reads as `inconclusive` (the switch commits, never blocks).
+ */
+const VALIDATE_TIMEOUT_MS = 10_000;
+
+/**
+ * The 404 body an Anthropic `count_tokens` endpoint returns for a model the credential cannot serve —
+ * `error.type` is the discriminator. Mirrors the shape `checkModelAccess` (proxy/models.ts) reads on the
+ * proxy's 404 so this direct-mode verdict maps identically: only `not_found_error` means "inaccessible",
+ * a bare/malformed 404 falls through to inconclusive. `jsonWith` yields null on a shape mismatch, so a
+ * malformed body never throws.
+ */
+const countTokensErrorSchema = z.object({ error: z.object({ type: z.string() }) });
+
+/**
+ * The effectful seams for {@link validateModelSelection}, injectable so the per-mode commit validation is
+ * unit-testable offline — mirrors {@link ListModelsSeams}. Production callers omit the argument. The
+ * cliproxy path delegates verbatim to {@link checkModelAccess} (its own request + verdict mapping), so
+ * that is a seam of its own; `fetch` shapes ONLY the direct-anthropic `count_tokens` POST (a full
+ * `RequestInit`, not the listing seam's headers-only GET).
+ */
+export type ValidateSelectionSeams = {
+    /** The resolved model connection. Real: {@link resolveModelConnection}. */
+    readonly resolveConnection: () => ResolvedModelConnection;
+    /** Discover the cliproxy client key from the proxy config. Real: {@link readApiKey}. */
+    readonly readProxyKey: () => Promise<Result<string, ChatSetupError>>;
+    /** The direct-mode secret for the connection's provider. Real: {@link resolveModelApiKey}. */
+    readonly readModelApiKey: (provider: string) => string | undefined;
+    /** The cliproxy accessibility verdict — request + mapping owned by proxy/models.ts. Real: {@link checkModelAccess}. */
+    readonly checkModelAccess: (apiKey: string, modelId: string, signal?: AbortSignal) => Promise<ModelAccess>;
+    /** Issue the direct-anthropic `count_tokens` POST. Real: `fetch`. */
+    readonly fetch: (url: string, init: RequestInit) => Promise<Response>;
+};
+
+const realValidateSeams: ValidateSelectionSeams = {
+    resolveConnection: resolveModelConnection,
+    readProxyKey: readApiKey,
+    readModelApiKey: resolveModelApiKey,
+    checkModelAccess,
+    fetch: (url, init) => fetch(url, init),
+};
+
+/**
+ * Accessibility-validate a committed model id before the picker persists it, per connection protocol
+ * (design D6). Returns the three-valued {@link ModelAccess} the commit decision consumes: `served` and
+ * `inconclusive` commit, only a definite `not_found` is rejected in-dialog. Every branch that cannot
+ * decide resolves to `inconclusive` — the picker must NEVER lose its switch capability to validation:
+ *
+ * - **cliproxy** → delegate to {@link checkModelAccess} over the proxy client key (never reimplement the
+ *   proxy request or its verdict mapping). A missing proxy key is not a user-facing failure — validation
+ *   is simply unavailable → `inconclusive`.
+ * - **direct `anthropic`** → POST `{baseURL}/messages/count_tokens` with the same `x-api-key` +
+ *   `anthropic-version` headers {@link requestFor} shapes for listing; map EXACTLY as `checkModelAccess`
+ *   documents: 200 → `served`, 404 with `error.type === "not_found_error"` → `not_found`, anything else
+ *   (throw, abort/timeout, other status, malformed body) → `inconclusive`.
+ * - **direct `openai-compatible`** → `inconclusive` with no request: no cheap validation route exists, so
+ *   the spec commits the selection as before.
+ * - **invalid connection config** → `inconclusive` (boot reports the malformed block; validation never
+ *   blocks the switch over it).
+ */
+export async function validateModelSelection(modelId: string, seams: ValidateSelectionSeams = realValidateSeams): Promise<ModelAccess> {
+    const connection = seams.resolveConnection();
+    if (connection.configError) return "inconclusive";
+
+    if (connection.mode === "cliproxy") {
+        const keyResult = await seams.readProxyKey();
+        if (keyResult.isErr()) return "inconclusive";
+        return seams.checkModelAccess(keyResult.value, modelId, AbortSignal.timeout(VALIDATE_TIMEOUT_MS));
+    }
+    // Direct mode: only the Anthropic protocol has the unbilled count_tokens route (design D4); an
+    // openai-compatible endpoint has no cheap check, so its selection commits as before.
+    if (connection.protocol !== "anthropic") return "inconclusive";
+    const key = seams.readModelApiKey(connection.provider);
+    if (!key) return "inconclusive";
+
+    let res: Response;
+    // fetch throws on a dead endpoint or an aborted/timed-out signal; any throw is inconclusive, so a flaky
+    // network commits the switch rather than blocking it (the same inconclusive-accept `checkModelAccess` uses).
+    try {
+        res = await seams.fetch(`${connection.baseURL}/messages/count_tokens`, {
+            method: "POST",
+            headers: { "x-api-key": key, "anthropic-version": ANTHROPIC_VERSION, "content-type": "application/json" },
+            body: JSON.stringify({ model: modelId, messages: [{ role: "user", content: "ping" }] }),
+            signal: AbortSignal.timeout(VALIDATE_TIMEOUT_MS),
+        });
+    } catch {
+        return "inconclusive";
+    }
+    if (res.ok) return "served";
+    if (res.status === 404) {
+        const body = await res.jsonWith(countTokensErrorSchema);
+        if (body?.error.type === "not_found_error") return "not_found";
+    }
+    return "inconclusive";
 }

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -15,15 +15,20 @@ import {
     normalizeAdoptedBaseURL,
     parseConnectionMode,
     probeCredentialSource,
+    probeOnce,
     providerKindForSlug,
     recordCliproxyProvider,
     retryWhileUnreachable,
+    selectDefaultModel,
     setup,
+    warnStalePins,
     writeDirectConnection,
     type ProbeAttempt,
 } from "./setup.ts";
 import * as embeddingSetup from "../embedding/setup.ts";
 import * as refsCommands from "../refs/commands.ts";
+import { writeAgentModel, type ResolvedModelConnection } from "../harness/config.ts";
+import { __resetModelCacheForTest, type ModelAccess } from "../proxy/models.ts";
 import { readConfig } from "../../lib/config.ts";
 import * as container from "../../lib/container.ts";
 import { env, type ProviderEnvSnapshot } from "../../lib/env.ts";
@@ -603,5 +608,240 @@ describe("setup() — preselected embeddings run ahead of the runtime gate", () 
         // Called exactly once — the preselected step ahead of the gate; the in-flow site is guarded and skipped.
         expect(embedSpy).toHaveBeenCalledTimes(1);
         expect(embedSpy.mock.calls[0]).toEqual([process.stdin.isTTY, "local"]);
+    });
+});
+
+/** Write a setup-shaped proxy config carrying `key`, so `readApiKey` (which reads a REAL file) resolves. */
+function writeProxyKey(key: string): void {
+    assertTestSandbox(env.cliproxyConfigPath);
+    mkdirSync(dirname(env.cliproxyConfigPath), { recursive: true });
+    writeFileSync(env.cliproxyConfigPath, ["api-keys:", `  - "${key}"`, "port: 8317", ""].join("\n"));
+}
+
+// The election lives INSIDE resolveModelId, so the launch probe inherits it with no adaptation: a
+// top-ranked candidate the credential cannot serve is walked past BEFORE the completion probe runs, so
+// the probe verifies a model the credential can actually use. Global-fetch pattern (from models.test.ts)
+// because the real /models → count_tokens → /messages path is under test.
+describe("probeOnce — the election feeds the probe a servable model", () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        __resetModelCacheForTest();
+        writeProxyKey("sk-probe");
+    });
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+        __resetModelCacheForTest();
+        assertTestSandbox(env.cliproxyConfigPath);
+        rmSync(env.cliproxyConfigPath, { force: true });
+    });
+
+    test("an inaccessible top candidate is walked past, so the completion probe reads ok — not 'not verifiable'", async () => {
+        // /models advertises two claude ids (newest ranks first by recency); the newest 404s the
+        // count_tokens check, so the election walks to the older served one and the /messages completion 200s.
+        globalThis.fetch = (async (url: string, init?: RequestInit) => {
+            const target = String(url);
+            if (target.endsWith("/messages/count_tokens")) {
+                const model = JSON.parse(String(init?.body)).model;
+                return model === "claude-new"
+                    ? new Response(JSON.stringify({ error: { type: "not_found_error" } }), { status: 404 })
+                    : new Response("{}", { status: 200 });
+            }
+            if (target.endsWith("/messages")) return new Response("{}", { status: 200 });
+            return new Response(
+                JSON.stringify({
+                    data: [
+                        { id: "claude-new", created: 200 },
+                        { id: "claude-old", created: 100 },
+                    ],
+                }),
+            );
+        }) as unknown as typeof fetch;
+
+        expect(await probeOnce()).toEqual({ kind: "ok" });
+    });
+});
+
+// The launch gate's stale-pin warning: warn — NEVER block — when an explicitly-pinned model no longer
+// serves. Driven through injected seams (no proxy, container, or real config). `warnStalePins` returns
+// void, so it structurally cannot gate the launch it runs after; the assertions below only pin which
+// pins are checked and which warn.
+describe("warnStalePins", () => {
+    function cliproxy(agents: ResolvedModelConnection["agents"] = {}, provider = "anthropic"): ResolvedModelConnection {
+        return { mode: "cliproxy", provider, agents };
+    }
+
+    function run(connection: ResolvedModelConnection, modelPin: string | null, verdict: (id: string) => ModelAccess) {
+        const checked: string[] = [];
+        const warnings: string[] = [];
+        const done = warnStalePins({
+            connection,
+            modelPin,
+            check: async (id) => {
+                checked.push(id);
+                return verdict(id);
+            },
+            warn: (m) => warnings.push(m),
+        });
+        return { checked, warnings, done };
+    }
+
+    test("a not_found pin warns, naming the model and the agent that resolves to it", async () => {
+        const r = run(cliproxy({ conversation: "claude-stale" }), null, () => "not_found");
+        await r.done;
+        expect(r.checked).toEqual(["claude-stale"]);
+        expect(r.warnings).toHaveLength(1);
+        expect(r.warnings[0]).toContain("claude-stale");
+        expect(r.warnings[0]).toContain("conversation");
+    });
+
+    test("a served pin is silent", async () => {
+        const r = run(cliproxy({ conversation: "claude-ok" }), null, () => "served");
+        await r.done;
+        expect(r.checked).toEqual(["claude-ok"]);
+        expect(r.warnings).toEqual([]);
+    });
+
+    test("an inconclusive check is silent — only a definite verdict interrupts launch output", async () => {
+        const r = run(cliproxy({ conversation: "claude-maybe" }), null, () => "inconclusive");
+        await r.done;
+        expect(r.checked).toEqual(["claude-maybe"]);
+        expect(r.warnings).toEqual([]);
+    });
+
+    test("no pins → nothing is checked (auto-resolved sessions are untouched — election already validated)", async () => {
+        const r = run(cliproxy({}), null, () => "not_found");
+        await r.done;
+        expect(r.checked).toEqual([]);
+        expect(r.warnings).toEqual([]);
+    });
+
+    test("a non-anthropic connection is never checked (count_tokens is anthropic-protocol only)", async () => {
+        const r = run(cliproxy({ conversation: "gpt-4o" }, "openai"), null, () => "not_found");
+        await r.done;
+        expect(r.checked).toEqual([]);
+    });
+
+    test("direct mode is never checked (a user's own endpoint is not ours to spend on validation)", async () => {
+        const conn: ResolvedModelConnection = {
+            mode: "direct",
+            provider: "anthropic",
+            baseURL: "http://localhost:1",
+            protocol: "anthropic",
+            agents: { conversation: "claude-x" },
+        };
+        const r = run(conn, null, () => "not_found");
+        await r.done;
+        expect(r.checked).toEqual([]);
+    });
+
+    test("a harness.model pin covers BOTH agents in one check and one warning", async () => {
+        const r = run(cliproxy({}), "claude-both", () => "not_found");
+        await r.done;
+        expect(r.checked).toEqual(["claude-both"]); // one distinct id, checked once
+        expect(r.warnings).toHaveLength(1);
+        expect(r.warnings[0]).toContain("both agents");
+    });
+
+    test("an agent override redirects one agent, splitting harness.model into two distinct pins", async () => {
+        // conversation → its override (claude-conv); sandbox → the harness.model fallback (claude-both).
+        const r = run(cliproxy({ conversation: "claude-conv" }), "claude-both", () => "not_found");
+        await r.done;
+        expect(new Set(r.checked)).toEqual(new Set(["claude-conv", "claude-both"]));
+        expect(r.warnings).toHaveLength(2);
+    });
+});
+
+// The interactive setup default-model step, driven through injected seams (no clack, proxy, or TTY).
+// Writes land in the sandboxed config; each test starts and ends from a clean config.
+describe("selectDefaultModel", () => {
+    beforeEach(() => {
+        assertTestSandbox(env.configPath);
+        rmSync(env.configPath, { force: true });
+    });
+    afterEach(() => {
+        assertTestSandbox(env.configPath);
+        rmSync(env.configPath, { force: true });
+    });
+
+    const writeBoth = (id: string) => writeAgentModel("conversation", id).andThen(() => writeAgentModel("sandbox", id));
+
+    function deps(over: Partial<Parameters<typeof selectDefaultModel>[0]>): Parameters<typeof selectDefaultModel>[0] {
+        return {
+            isInteractive: () => true,
+            elect: async () => "claude-elected",
+            candidates: async () => ["claude-a"],
+            check: async () => "served",
+            prompt: async () => ({ auto: true }),
+            writeBoth,
+            warn: () => {},
+            ...over,
+        };
+    }
+
+    /** Read back the persisted per-agent overrides; `models` is `unknown` in lib/config.ts (validated elsewhere). */
+    function persistedAgents(): Record<string, string> | undefined {
+        return (readConfig().models as { agents?: Record<string, string> } | undefined)?.agents;
+    }
+
+    test("accepting Auto writes nothing — the default stays adaptive", async () => {
+        await selectDefaultModel(deps({ prompt: async () => ({ auto: true }) }));
+        expect(readConfig().models).toBeUndefined();
+    });
+
+    test("an explicit pick pins BOTH user-facing agents to the chosen id", async () => {
+        await selectDefaultModel(deps({ candidates: async () => ["claude-pick"], prompt: async () => ({ auto: false, modelId: "claude-pick" }) }));
+        expect(persistedAgents()).toEqual({ conversation: "claude-pick", sandbox: "claude-pick" });
+    });
+
+    test("the offered list hides a not_found model but keeps an inconclusive one", async () => {
+        let offered: string[] = [];
+        await selectDefaultModel(
+            deps({
+                candidates: async () => ["claude-404", "claude-maybe"],
+                check: async (id) => (id === "claude-404" ? "not_found" : "inconclusive"),
+                prompt: async (_elected, models) => {
+                    offered = models;
+                    return { auto: true };
+                },
+            }),
+        );
+        expect(offered).toEqual(["claude-maybe"]);
+    });
+
+    test("a non-TTY skips the step entirely — no election, no prompt, no write", async () => {
+        let elected = false;
+        let prompted = false;
+        await selectDefaultModel(
+            deps({
+                isInteractive: () => false,
+                elect: async () => {
+                    elected = true;
+                    return "claude-x";
+                },
+                prompt: async () => {
+                    prompted = true;
+                    return { auto: true };
+                },
+            }),
+        );
+        expect(elected).toBe(false);
+        expect(prompted).toBe(false);
+        expect(readConfig().models).toBeUndefined();
+    });
+
+    test("a failed election (proxy down) skips gracefully — no prompt, no write", async () => {
+        let prompted = false;
+        await selectDefaultModel(
+            deps({
+                elect: async () => null,
+                prompt: async () => {
+                    prompted = true;
+                    return { auto: true };
+                },
+            }),
+        );
+        expect(prompted).toBe(false);
+        expect(readConfig().models).toBeUndefined();
     });
 });

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -740,7 +740,9 @@ describe("warnStalePins", () => {
         await r.done;
         expect(r.checked).toEqual(["claude-both"]); // one distinct id, checked once
         expect(r.warnings).toHaveLength(1);
-        expect(r.warnings[0]).toContain("both agents");
+        // The warning names every agent that resolves to the shared pin (not a hardcoded count word).
+        expect(r.warnings[0]).toContain("conversation");
+        expect(r.warnings[0]).toContain("sandbox");
     });
 
     test("an agent override redirects one agent, splitting harness.model into two distinct pins", async () => {
@@ -769,7 +771,6 @@ describe("selectDefaultModel", () => {
     function deps(over: Partial<Parameters<typeof selectDefaultModel>[0]>): Parameters<typeof selectDefaultModel>[0] {
         return {
             isInteractive: () => true,
-            elect: async () => "claude-elected",
             candidates: async () => ["claude-a"],
             check: async () => "served",
             prompt: async () => ({ auto: true }),
@@ -809,15 +810,46 @@ describe("selectDefaultModel", () => {
         expect(offered).toEqual(["claude-maybe"]);
     });
 
-    test("a non-TTY skips the step entirely — no election, no prompt, no write", async () => {
-        let elected = false;
+    test("the Auto recommendation is the first accessible candidate in rank order, past a not_found", async () => {
+        let recommended = "";
+        await selectDefaultModel(
+            deps({
+                candidates: async () => ["claude-404", "claude-newest", "claude-older"],
+                check: async (id) => (id === "claude-404" ? "not_found" : "served"),
+                prompt: async (electedId) => {
+                    recommended = electedId;
+                    return { auto: true };
+                },
+            }),
+        );
+        expect(recommended).toBe("claude-newest");
+    });
+
+    test("every candidate not_found → skip: nothing to recommend, no prompt, no write", async () => {
+        let prompted = false;
+        await selectDefaultModel(
+            deps({
+                candidates: async () => ["claude-404a", "claude-404b"],
+                check: async () => "not_found",
+                prompt: async () => {
+                    prompted = true;
+                    return { auto: true };
+                },
+            }),
+        );
+        expect(prompted).toBe(false);
+        expect(readConfig().models).toBeUndefined();
+    });
+
+    test("a non-TTY skips the step entirely — no listing, no prompt, no write", async () => {
+        let listed = false;
         let prompted = false;
         await selectDefaultModel(
             deps({
                 isInteractive: () => false,
-                elect: async () => {
-                    elected = true;
-                    return "claude-x";
+                candidates: async () => {
+                    listed = true;
+                    return ["claude-x"];
                 },
                 prompt: async () => {
                     prompted = true;
@@ -825,16 +857,16 @@ describe("selectDefaultModel", () => {
                 },
             }),
         );
-        expect(elected).toBe(false);
+        expect(listed).toBe(false);
         expect(prompted).toBe(false);
         expect(readConfig().models).toBeUndefined();
     });
 
-    test("a failed election (proxy down) skips gracefully — no prompt, no write", async () => {
+    test("a down/unreachable proxy (no candidates) skips gracefully — no prompt, no write", async () => {
         let prompted = false;
         await selectDefaultModel(
             deps({
-                elect: async () => null,
+                candidates: async () => [],
                 prompt: async () => {
                     prompted = true;
                     return { auto: true };

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -513,9 +513,7 @@ type DefaultModelChoice = { auto: true } | { auto: false; modelId: string };
  */
 type DefaultModelDeps = {
     isInteractive: () => boolean;
-    /** The cached election's id, for the Auto label; `null` when election failed (proxy down) → skip. */
-    elect: () => Promise<string | null>;
-    /** The ranked, connection-family candidate ids to sweep; empty (no listing) → skip. */
+    /** The ranked, connection-family candidate ids to sweep; empty (no listing / down proxy) → skip. */
     candidates: () => Promise<string[]>;
     /** One model's accessibility check, bounded like every probe round-trip. */
     check: (modelId: string) => Promise<ModelAccess>;
@@ -527,19 +525,26 @@ type DefaultModelDeps = {
 };
 
 /**
- * The interactive default-model step. A non-TTY skips entirely (writes nothing — Auto semantics). A
- * failed election or an empty candidate list (a down/unreachable proxy) skips gracefully rather than
- * turning an optional step into a failure. Accepting Auto writes nothing (the default stays adaptive
- * `model: null` resolution). An explicit pick persists to BOTH agents; a write failure only warns —
- * setup's real work is already done.
+ * The interactive default-model step. A non-TTY skips entirely (writes nothing — Auto semantics). An
+ * empty candidate list (a down/unreachable proxy) or a sweep that rules out EVERY candidate skips
+ * gracefully rather than turning an optional step into a failure or recommending a model the account
+ * cannot serve. The Auto label is the first accessible candidate in rank order — the SAME id the launch
+ * election resolves (both walk the ranked list past `not_found` to the first servable) — read straight
+ * from the sweep, so the recommendation and the offered list can never disagree, and so setup makes ONE
+ * `/models` pass rather than a separate election round-trip whose per-process cache this setup process
+ * (which exits before any chat launch) would only discard. Accepting Auto writes nothing (the default
+ * stays adaptive `model: null` resolution). An explicit pick persists to BOTH agents; a write failure
+ * only warns — setup's real work is already done.
  */
 export async function selectDefaultModel(deps: DefaultModelDeps): Promise<void> {
     if (!deps.isInteractive()) return;
-    const electedId = await deps.elect();
-    if (electedId === null) return;
     const ranked = await deps.candidates();
     if (ranked.length === 0) return;
     const models = await sweepAccessibleModels(deps.check, ranked);
+    // Every candidate answered `not_found` — no servable model to recommend, so skip rather than preselect
+    // a known-inaccessible id. This guard also makes `models[0]` provably present for the Auto label.
+    if (models.length === 0) return;
+    const electedId = models[0]!;
     const choice = await deps.prompt(electedId, models);
     if (choice.auto) return;
     deps.writeBoth(choice.modelId).match(
@@ -553,12 +558,13 @@ const AUTO_MODEL_SENTINEL = "__auto__";
 
 /**
  * Production assembly of {@link selectDefaultModel} for the cliproxy setup path. Every model id is
- * discovered live: the Auto label from the cached election ({@link resolveModelId}), the offered pool
- * from the raw `/models` list ({@link listModelCandidates}) ranked and filtered to the connection family
- * (in practice the rank already yields the winning family's pool). A missing proxy key or an unreachable
- * proxy resolves to a skip (the seams return `null`/`[]`), so a down proxy never fails setup. Cliproxy
- * only — a direct connection has no owned proxy to elect against. The select matches the surrounding
- * setup prompts (`select` from lib/cli.ts), so a cancel aborts the command exactly as they do.
+ * discovered live from the raw `/models` list ({@link listModelCandidates}), ranked and filtered to the
+ * connection family (in practice the rank already yields the winning family's pool); the sweep then both
+ * offers and recommends from it. A missing proxy key or an unreachable/hung proxy resolves to a skip (the
+ * key read short-circuits, and the bounded `candidates` fetch throws → `[]`), so a down proxy never fails
+ * OR wedges setup. Cliproxy only — a direct connection has no owned proxy to elect against. The select
+ * matches the surrounding setup prompts (`select` from lib/cli.ts), so a cancel aborts the command
+ * exactly as they do.
  */
 async function runDefaultModelSetup(mode: ConnectionMode): Promise<void> {
     if (mode !== "cliproxy") return;
@@ -568,13 +574,11 @@ async function runDefaultModelSetup(mode: ConnectionMode): Promise<void> {
     const provider = resolveModelConnection().provider;
     await selectDefaultModel({
         isInteractive: () => Boolean(process.stdin.isTTY),
-        elect: async () =>
-            (await resolveModelId(apiKey)).match(
-                (id) => id,
-                () => null,
-            ),
+        // Bounded like every probe round-trip: this runs right after compose-up WITHOUT waiting on the
+        // proxy's port bind, so a proxy that accepts the connection then never answers must not hang
+        // setup — the timeout throws, which the Result maps to `[]` (skip), the same as a refused proxy.
         candidates: async () =>
-            (await listModelCandidates(apiKey)).match(
+            (await listModelCandidates(apiKey, AbortSignal.timeout(PROBE_TIMEOUT_MS))).match(
                 (list) => rankModelCandidates(list).filter((id) => modelMatchesProvider(provider, id)),
                 () => [],
             ),
@@ -1738,11 +1742,13 @@ export async function warnStalePins(deps: StalePinDeps): Promise<void> {
 }
 
 /**
- * The launch warning for one stale pin: the pinned id, which agent(s) resolve to it (both when a shared
- * `harness.model` pin covers the whole set, else the specific agent), and the two repick remedies.
+ * The launch warning for one stale pin: the pinned id, which agent(s) resolve to it, and the two repick
+ * remedies. The agents are named explicitly and pluralized from the list's own length, so the phrasing
+ * stays correct whether one agent is pinned or several share a `harness.model` fallback — with no coupling
+ * to how many user-facing agents exist.
  */
 function stalePinWarning(modelId: string, agents: AgentName[]): string {
-    const who = agents.length === AGENT_NAMES.length ? "both agents" : `the ${agents.join(" and ")} agent`;
+    const who = `the ${agents.join(" and ")} agent${agents.length > 1 ? "s" : ""}`;
     return (
         `The pinned model "${modelId}" (${who}) is no longer served by your account.\n` +
         "  Repick it with the model-switch commands in the command palette, or re-run `inflexa setup`."

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -11,8 +11,25 @@ import { firstReadyRuntime, runtimeIds, runtimes, ContainerRuntimeError, type Co
 import { anthropicAuthTokenSet, detectProviderEnv, env, providerApiKeyVar, resolveModelApiKey, type ProviderEnvSnapshot } from "../../lib/env.ts";
 import { createCredentialSource, credentialErrorMessage, type CredentialScheme } from "../../lib/credential.ts";
 import { select, promptText } from "../../lib/cli.ts";
-import { detectedMachine, resolveHarnessConfig, resolveModelConnection } from "../harness/config.ts";
-import { readApiKey, resolveModelId, type ChatSetupError } from "../proxy/models.ts";
+import {
+    AGENT_NAMES,
+    detectedMachine,
+    resolveHarnessConfig,
+    resolveModelConnection,
+    writeAgentModel,
+    type AgentName,
+    type ResolvedModelConnection,
+} from "../harness/config.ts";
+import {
+    checkModelAccess,
+    listModelCandidates,
+    modelMatchesProvider,
+    rankModelCandidates,
+    readApiKey,
+    resolveModelId,
+    type ChatSetupError,
+    type ModelAccess,
+} from "../proxy/models.ts";
 import { type PostgresConnection } from "./postgres_types.ts";
 import {
     writeComposeFile,
@@ -349,6 +366,14 @@ export async function setup(options: SetupOptions): Promise<void> {
             pgConn = resolvePostgresConfig();
         }
 
+        // --- default chat model ---
+        // Cliproxy only, and only after the compose step above started the proxy, so the live `/models`
+        // list and the accessibility sweep can answer. Nothing here WAITS on the proxy's port bind (the
+        // readiness wait above is Postgres's own) — a proxy still binding just makes the step skip
+        // gracefully, which is fine because it is optional and must never fail setup. Offers a
+        // preselected Auto default plus the account's accessible models.
+        await runDefaultModelSetup(mode);
+
         // --- analysis resource allowance ---
         // Collects the machine budget for the harness's resource policy — the
         // total share of this host analyses may use; per-step ceilings are
@@ -441,6 +466,129 @@ async function runSandboxImageSetup(): Promise<void> {
                 ? log.info(error.message)
                 : log.warn(`Sandbox image install failed: ${error.message}\n  You can retry later with \`inflexa sandbox pull\`.`),
     );
+}
+
+// --- default-model selection (setup) ---------------------------------------
+//
+// After the CLIProxy login, interactive setup offers a default chat model: a preselected Auto row
+// (labeled with the currently elected id) followed by the account's accessible models. Auto writes
+// nothing — the default stays adaptive `model: null` resolution, which keeps electing the newest served
+// model across launches. An explicit pick pins BOTH user-facing agents (per-agent divergence stays a
+// picker power feature). Every id is discovered live from the proxy — none is ever hardcoded — so a
+// proxy that is down or not yet answering simply skips the step: an optional convenience must not add a
+// new way for setup to fail.
+
+/**
+ * How many accessibility checks the setup sweep runs at once. Small and fixed: it overlaps the
+ * round-trips without firing the whole list at the upstream simultaneously (the design's bounded-sweep
+ * requirement). No dependency — a hand-rolled worker pool over the ranked list.
+ */
+const SETUP_SWEEP_CONCURRENCY = 4;
+
+/**
+ * Filter a ranked id list to the ones the account can serve. ONLY a definite `not_found` hides a model;
+ * an `inconclusive` check keeps it listed (the check failed, not the model) — the spec's "hide only
+ * definitely inaccessible models". The fixed-size worker pool writes each verdict at its id's index, so
+ * the surviving ids are read back in the original rank order.
+ */
+async function sweepAccessibleModels(check: (modelId: string) => Promise<ModelAccess>, ranked: string[]): Promise<string[]> {
+    const verdicts = new Array<ModelAccess>(ranked.length);
+    let next = 0;
+    async function worker(): Promise<void> {
+        for (let i = next++; i < ranked.length; i = next++) {
+            verdicts[i] = await check(ranked[i]!);
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(SETUP_SWEEP_CONCURRENCY, ranked.length) }, worker));
+    return ranked.filter((_, i) => verdicts[i] !== "not_found");
+}
+
+/** The setup select's outcome: accept the adaptive Auto default, or pin a specific id. */
+type DefaultModelChoice = { auto: true } | { auto: false; modelId: string };
+
+/**
+ * The seams {@link selectDefaultModel} drives, injectable so the TTY gate, the accessibility sweep, and
+ * the Auto-vs-pin write policy are unit-testable without clack, a proxy, or a TTY. Production assembly:
+ * {@link runDefaultModelSetup}.
+ */
+type DefaultModelDeps = {
+    isInteractive: () => boolean;
+    /** The cached election's id, for the Auto label; `null` when election failed (proxy down) → skip. */
+    elect: () => Promise<string | null>;
+    /** The ranked, connection-family candidate ids to sweep; empty (no listing) → skip. */
+    candidates: () => Promise<string[]>;
+    /** One model's accessibility check, bounded like every probe round-trip. */
+    check: (modelId: string) => Promise<ModelAccess>;
+    /** Present Auto (preselected, labeled with `electedId`) atop `models`; returns the user's choice. */
+    prompt: (electedId: string, models: string[]) => Promise<DefaultModelChoice>;
+    /** Persist the chosen id to BOTH user-facing agents. */
+    writeBoth: (modelId: string) => Result<void, ConfigError>;
+    warn: (message: string) => void;
+};
+
+/**
+ * The interactive default-model step. A non-TTY skips entirely (writes nothing — Auto semantics). A
+ * failed election or an empty candidate list (a down/unreachable proxy) skips gracefully rather than
+ * turning an optional step into a failure. Accepting Auto writes nothing (the default stays adaptive
+ * `model: null` resolution). An explicit pick persists to BOTH agents; a write failure only warns —
+ * setup's real work is already done.
+ */
+export async function selectDefaultModel(deps: DefaultModelDeps): Promise<void> {
+    if (!deps.isInteractive()) return;
+    const electedId = await deps.elect();
+    if (electedId === null) return;
+    const ranked = await deps.candidates();
+    if (ranked.length === 0) return;
+    const models = await sweepAccessibleModels(deps.check, ranked);
+    const choice = await deps.prompt(electedId, models);
+    if (choice.auto) return;
+    deps.writeBoth(choice.modelId).match(
+        () => {},
+        (e) => deps.warn(`Could not save the model selection: ${e.type}`),
+    );
+}
+
+/** The Auto row's sentinel value — a non-id token so it can never collide with a real model id. */
+const AUTO_MODEL_SENTINEL = "__auto__";
+
+/**
+ * Production assembly of {@link selectDefaultModel} for the cliproxy setup path. Every model id is
+ * discovered live: the Auto label from the cached election ({@link resolveModelId}), the offered pool
+ * from the raw `/models` list ({@link listModelCandidates}) ranked and filtered to the connection family
+ * (in practice the rank already yields the winning family's pool). A missing proxy key or an unreachable
+ * proxy resolves to a skip (the seams return `null`/`[]`), so a down proxy never fails setup. Cliproxy
+ * only — a direct connection has no owned proxy to elect against. The select matches the surrounding
+ * setup prompts (`select` from lib/cli.ts), so a cancel aborts the command exactly as they do.
+ */
+async function runDefaultModelSetup(mode: ConnectionMode): Promise<void> {
+    if (mode !== "cliproxy") return;
+    const key = await readApiKey();
+    if (key.isErr()) return;
+    const apiKey = key.value;
+    const provider = resolveModelConnection().provider;
+    await selectDefaultModel({
+        isInteractive: () => Boolean(process.stdin.isTTY),
+        elect: async () =>
+            (await resolveModelId(apiKey)).match(
+                (id) => id,
+                () => null,
+            ),
+        candidates: async () =>
+            (await listModelCandidates(apiKey)).match(
+                (list) => rankModelCandidates(list).filter((id) => modelMatchesProvider(provider, id)),
+                () => [],
+            ),
+        check: (modelId) => checkModelAccess(apiKey, modelId, AbortSignal.timeout(PROBE_TIMEOUT_MS)),
+        prompt: async (electedId, models) => {
+            const chosen = await select("Default chat model", [
+                { value: AUTO_MODEL_SENTINEL, label: `Auto — recommended: ${electedId}` },
+                ...models.map((id) => ({ value: id, label: id })),
+            ]);
+            return chosen === AUTO_MODEL_SENTINEL ? { auto: true } : { auto: false, modelId: chosen };
+        },
+        writeBoth: (modelId) => writeAgentModel("conversation", modelId).andThen(() => writeAgentModel("sandbox", modelId)),
+        warn: (message) => log.warn(message),
+    });
 }
 
 /**
@@ -1497,9 +1645,12 @@ export async function ensureLiveCredential(deps: LiveCredentialDeps): Promise<Re
 /**
  * One full probe attempt: resolve the inputs from the provisioned config and the proxy's own model
  * list, then ask. Both round-trips are bounded, so {@link retryWhileUnreachable}'s budget bounds the
- * whole loop — an unbounded one would hand a wedged proxy the launch indefinitely.
+ * whole loop — an unbounded one would hand a wedged proxy the launch indefinitely. The election lives
+ * inside {@link resolveModelId}, so this inherits it with no adaptation: a top-ranked candidate the
+ * credential cannot serve is walked past there, and this probes a model already known to be servable.
+ * Exported for its integration test.
  */
-async function probeOnce(): Promise<ProbeAttempt> {
+export async function probeOnce(): Promise<ProbeAttempt> {
     const key = await readApiKey();
     if (key.isErr()) return { kind: "unobservable", detail: key.error.type };
     const model = await resolveModelId(key.value, AbortSignal.timeout(PROBE_TIMEOUT_MS));
@@ -1528,6 +1679,88 @@ async function verifyCredentialAtLaunch(rt: ContainerRuntime): Promise<Result<vo
         // Printed, not logged: this lands in the normal-stdio launch phase right before the login
         // takes the terminal, beside ensureProxyReady's own fresh-login notice.
         announce: (message) => console.log(`\n  ${message}`),
+        warn: (message) => log.warn(message),
+    });
+}
+
+// --- stale explicit-pin warning --------------------------------------------
+//
+// The credential probe above validates only the AUTO default (election walks it against the live
+// credential). An EXPLICIT pin — `models.agents.*`, or the both-agents `harness.model` fallback — is
+// what chat actually runs on, yet the probe never touches it: it resolves the auto default, not the
+// per-agent id. So a pin that has gone stale (the account no longer serves it) sails past launch and
+// only fails mid-chat. This gate closes that gap: it names the stale pin at launch, where stdio is
+// still normal, without ever blocking the launch or rewriting the user's config.
+
+/**
+ * The seams {@link warnStalePins} drives, injectable so the pin→agent grouping and the verdict→warning
+ * policy are unit-testable without a proxy, a container, or a real config. Production assembly:
+ * {@link warnStalePinsAtLaunch}.
+ */
+type StalePinDeps = {
+    /** The resolved connection — its `mode`/`provider` gate the check and its `agents` carry the per-agent pins. */
+    connection: ResolvedModelConnection;
+    /** The both-agents fallback pin (`harness.model`, i.e. `cfg.model`); `null` when unset. */
+    modelPin: string | null;
+    /** One model's accessibility check, bounded like every probe round-trip. */
+    check: (modelId: string) => Promise<ModelAccess>;
+    warn: (message: string) => void;
+};
+
+/**
+ * Warn — never block — when an explicitly-pinned model has gone stale. Applies ONLY in cliproxy mode on
+ * an anthropic-family connection (the `count_tokens` route is Anthropic-protocol, and a direct or
+ * non-anthropic endpoint is not ours to spend on validation — the same gate the launch probe uses) and
+ * ONLY when at least one explicit pin exists; an auto-resolved session (no pins) is untouched, because
+ * the election already validated its default. Each DISTINCT pinned id is checked exactly once, and only a
+ * definite `not_found` warns — `served`/`inconclusive` stay silent (a flaky check must not interrupt the
+ * launch output). Returns nothing on every path: this can only add a line, never a failure.
+ */
+export async function warnStalePins(deps: StalePinDeps): Promise<void> {
+    if (deps.connection.mode !== "cliproxy" || deps.connection.provider !== "anthropic") return;
+
+    // Each agent's EFFECTIVE explicit pin is its own `models.agents` override, else the both-agents
+    // `harness.model` fallback; an agent with neither is auto-resolved and skipped. Grouping by the
+    // resolved id means a `harness.model` pin shared by both agents is one round-trip and one warning
+    // naming both, while an agent override that redirects one of them splits into its own distinct pin.
+    const byId = new Map<string, AgentName[]>();
+    for (const agent of AGENT_NAMES) {
+        const pin = deps.connection.agents[agent] ?? deps.modelPin ?? undefined;
+        if (pin === undefined) continue;
+        byId.set(pin, [...(byId.get(pin) ?? []), agent]);
+    }
+    if (byId.size === 0) return;
+
+    for (const [modelId, agents] of byId) {
+        if ((await deps.check(modelId)) !== "not_found") continue;
+        deps.warn(stalePinWarning(modelId, agents));
+    }
+}
+
+/**
+ * The launch warning for one stale pin: the pinned id, which agent(s) resolve to it (both when a shared
+ * `harness.model` pin covers the whole set, else the specific agent), and the two repick remedies.
+ */
+function stalePinWarning(modelId: string, agents: AgentName[]): string {
+    const who = agents.length === AGENT_NAMES.length ? "both agents" : `the ${agents.join(" and ")} agent`;
+    return (
+        `The pinned model "${modelId}" (${who}) is no longer served by your account.\n` +
+        "  Repick it with the model-switch commands in the command palette, or re-run `inflexa setup`."
+    );
+}
+
+/**
+ * Production assembly of {@link warnStalePins}: read the proxy client key, then bound each accessibility
+ * check with the same per-round-trip timeout the probe uses. A missing key needs no warning — the probe
+ * above already surfaced it as `unobservable`, and there is nothing to check against.
+ */
+async function warnStalePinsAtLaunch(): Promise<void> {
+    const key = await readApiKey();
+    if (key.isErr()) return;
+    await warnStalePins({
+        connection: resolveModelConnection(),
+        modelPin: resolveHarnessConfig().model,
+        check: (modelId) => checkModelAccess(key.value, modelId, AbortSignal.timeout(PROBE_TIMEOUT_MS)),
         warn: (message) => log.warn(message),
     });
 }
@@ -1627,6 +1860,11 @@ export async function ensureProxyReady(mode: "cliproxy" | "direct"): Promise<Res
         }
         const live = await verifyCredentialAtLaunch(rt);
         if (live.isErr()) return err(live.error);
+
+        // The probe validated only the AUTO default; the pins chat actually runs on are checked here,
+        // after the credential is confirmed live and the proxy is answering (so count_tokens reads a real
+        // verdict, not a cold-boot silence). Warn-only — it never gates the launch it just cleared.
+        await warnStalePinsAtLaunch();
     }
 
     // Embedding readiness gate: if the user previously opted into local mode,

--- a/cli/src/modules/proxy/models.test.ts
+++ b/cli/src/modules/proxy/models.test.ts
@@ -2,10 +2,18 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-import "../../extensions/index.ts"; // installs Response.prototype.jsonWith, which resolveModelId uses
+import "../../extensions/index.ts"; // installs Response.prototype.jsonWith, which resolveModelId + checkModelAccess use
 import { env } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
-import { __resetModelCacheForTest, modelMatchesProvider, pickDefaultModel, readApiKey, resolveModelId } from "./models.ts";
+import {
+    __resetModelCacheForTest,
+    checkModelAccess,
+    modelMatchesProvider,
+    rankModelCandidates,
+    readApiKey,
+    resolveModelId,
+    type ModelCandidate,
+} from "./models.ts";
 
 describe("modelMatchesProvider", () => {
     test("a resolved id whose family matches the configured provider agrees (provider→family, case-insensitive)", () => {
@@ -27,22 +35,130 @@ describe("modelMatchesProvider", () => {
     });
 });
 
-describe("pickDefaultModel", () => {
-    test("prefers claude over other families regardless of list order", () => {
-        expect(pickDefaultModel(["gpt-4o", "claude-sonnet", "gemini-pro"])).toBe("claude-sonnet");
+describe("rankModelCandidates", () => {
+    test("family preference holds regardless of serving order: claude > gpt > gemini > qwen", () => {
+        expect(rankModelCandidates([{ id: "gpt-4o" }, { id: "claude-sonnet" }, { id: "gemini-pro" }])[0]).toBe("claude-sonnet");
+        expect(rankModelCandidates([{ id: "gemini-pro" }, { id: "gpt-4o" }])[0]).toBe("gpt-4o");
+        expect(rankModelCandidates([{ id: "qwen-72b" }, { id: "gemini-pro" }])[0]).toBe("gemini-pro");
     });
 
-    test("falls through the preference order: gpt before gemini before qwen", () => {
-        expect(pickDefaultModel(["gemini-pro", "gpt-4o"])).toBe("gpt-4o");
-        expect(pickDefaultModel(["qwen-72b", "gemini-pro"])).toBe("gemini-pro");
+    test("family match is case-insensitive and by substring", () => {
+        expect(rankModelCandidates([{ id: "My-Claude-3.5" }])[0]).toBe("My-Claude-3.5");
     });
 
-    test("matches case-insensitively and by substring", () => {
-        expect(pickDefaultModel(["My-Claude-3.5"])).toBe("My-Claude-3.5");
+    test("recency outranks serving position within the matched family", () => {
+        expect(
+            rankModelCandidates([
+                { id: "claude-old", created: 100 },
+                { id: "claude-new", created: 200 },
+            ]),
+        ).toEqual(["claude-new", "claude-old"]);
     });
 
-    test("falls back to the first id when no preferred family is present", () => {
-        expect(pickDefaultModel(["llama-3", "mistral-7b"])).toBe("llama-3");
+    test("the same set in any serving order yields the identical ranked sequence (total order)", () => {
+        const set: ModelCandidate[] = [
+            { id: "claude-a", created: 300 },
+            { id: "claude-b", created: 200 },
+            { id: "claude-c", created: 100 },
+        ];
+        const forward = rankModelCandidates(set);
+        const shuffled = rankModelCandidates([set[2]!, set[0]!, set[1]!]);
+        expect(forward).toEqual(["claude-a", "claude-b", "claude-c"]);
+        expect(shuffled).toEqual(forward);
+    });
+
+    test("a missing `created` sorts oldest — after every dated sibling", () => {
+        expect(rankModelCandidates([{ id: "claude-dated", created: 100 }, { id: "claude-undated" }])).toEqual(["claude-dated", "claude-undated"]);
+    });
+
+    test("ties on `created` (or both missing) break by id ascending, never as the primary sort", () => {
+        expect(
+            rankModelCandidates([
+                { id: "claude-b", created: 100 },
+                { id: "claude-a", created: 100 },
+            ]),
+        ).toEqual(["claude-a", "claude-b"]);
+        expect(rankModelCandidates([{ id: "claude-z" }, { id: "claude-a" }])).toEqual(["claude-a", "claude-z"]);
+    });
+
+    test("no family match → the whole list, recency-sorted (not raw serving order, not byte order)", () => {
+        expect(
+            rankModelCandidates([
+                { id: "llama-3", created: 100 },
+                { id: "mistral-7b", created: 200 },
+            ]),
+        ).toEqual(["mistral-7b", "llama-3"]);
+    });
+
+    test("does not mutate the caller's array", () => {
+        const input: ModelCandidate[] = [
+            { id: "llama-b", created: 100 },
+            { id: "llama-a", created: 200 },
+        ];
+        rankModelCandidates(input);
+        expect(input.map((m) => m.id)).toEqual(["llama-b", "llama-a"]);
+    });
+});
+
+// `checkModelAccess` bounds the credential check to the proxy's unbilled count_tokens route; its three
+// verdicts are all EXPECTED outcomes, so the tests assert the returned union member, never a throw.
+describe("checkModelAccess", () => {
+    const realFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    function stubOnce(impl: (url: string, init?: RequestInit) => Promise<Response> | Response): void {
+        globalThis.fetch = (async (url: string, init?: RequestInit) => impl(url, init)) as unknown as typeof fetch;
+    }
+
+    function notFoundBody(modelId: string): Response {
+        return new Response(JSON.stringify({ type: "error", error: { type: "not_found_error", message: `model: ${modelId}` } }), { status: 404 });
+    }
+
+    test("a 200 → served", async () => {
+        stubOnce(() => new Response("{}", { status: 200 }));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("served");
+    });
+
+    test("a 404 carrying not_found_error → not_found (the credential definitively cannot serve it)", async () => {
+        stubOnce((_url, init) => notFoundBody(JSON.parse(String(init?.body)).model));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("not_found");
+    });
+
+    test("a 404 whose body is not the not_found_error shape → inconclusive (a fork that never routes count_tokens 404s everything)", async () => {
+        stubOnce(() => new Response("Not Found", { status: 404 }));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("inconclusive");
+
+        stubOnce(() => new Response(JSON.stringify({ error: { type: "overloaded_error" } }), { status: 404 }));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("inconclusive");
+    });
+
+    test("a 5xx → inconclusive (never a verdict on the model)", async () => {
+        stubOnce(() => new Response("boom", { status: 503 }));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("inconclusive");
+    });
+
+    test("a fetch throw (timeout/network/abort) → inconclusive", async () => {
+        stubOnce(() => Promise.reject(new Error("The operation was aborted")));
+        expect(await checkModelAccess("sk-test", "claude-x")).toBe("inconclusive");
+    });
+
+    test("issues the count_tokens POST carrying the model in the body and a bearer token", async () => {
+        // Collect into an array (not narrowable closure-assigned locals) so the property reads keep their
+        // `string | null` type at the assertion sites rather than narrowing to the seed value.
+        const seen: Array<{ url: string; auth: string | null; model: string }> = [];
+        globalThis.fetch = (async (url: string, init?: RequestInit) => {
+            seen.push({ url: String(url), auth: new Headers(init?.headers).get("Authorization"), model: JSON.parse(String(init?.body)).model });
+            return new Response("{}", { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await checkModelAccess("sk-test", "claude-x");
+        expect(seen).toHaveLength(1);
+        expect(seen[0]!.url.endsWith("/messages/count_tokens")).toBe(true);
+        expect(seen[0]!.auth).toBe("Bearer sk-test");
+        expect(seen[0]!.model).toBe("claude-x");
     });
 });
 
@@ -91,10 +207,11 @@ describe("readApiKey", () => {
     });
 });
 
-// `resolveModelId`'s three failure modes are all reachable only through `fetch`, and its cache is
+// `resolveModelId`'s failure modes are reachable only through the `/models` `fetch`, and its cache is
 // process-wide by design. Swap the global rather than inject a seam: the function deliberately has no
 // fetch parameter (the endpoint is env-owned, not user-overridable), and adding one for the test would
-// widen a surface the design keeps closed.
+// widen a surface the design keeps closed. The election's second request shape — the `count_tokens` POST
+// — is discriminated by URL in the same global stub.
 describe("resolveModelId", () => {
     const realFetch = globalThis.fetch;
 
@@ -109,7 +226,7 @@ describe("resolveModelId", () => {
 
     /**
      * Replace `fetch` and record how many times it was called. The double cast is unavoidable: the
-     * stub answers only the one call shape `resolveModelId` makes, while `typeof fetch` also carries
+     * stub answers only the one call shape the error paths make, while `typeof fetch` also carries
      * the unrelated `preconnect` static.
      */
     function stubFetch(impl: () => Promise<Response>): () => number {
@@ -123,6 +240,37 @@ describe("resolveModelId", () => {
 
     function modelsResponse(ids: string[], init?: ResponseInit): Response {
         return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), init);
+    }
+
+    function served(): Response {
+        return new Response("{}", { status: 200 });
+    }
+
+    function notFound(modelId: string): Response {
+        return new Response(JSON.stringify({ type: "error", error: { type: "not_found_error", message: `model: ${modelId}` } }), { status: 404 });
+    }
+
+    /**
+     * Stub fetch discriminating the election's two request shapes by URL: the `/models` GET (answered
+     * from `candidates`) and each `/messages/count_tokens` POST (answered by `access`, keyed by the model
+     * id read from the POST body). Records both the total call count and the count_tokens subset so a test
+     * can prove the walk did — or did not — validate.
+     */
+    function stubElection(
+        candidates: ModelCandidate[],
+        access: (modelId: string) => Promise<Response> | Response,
+    ): { calls: () => number; validations: () => number } {
+        let calls = 0;
+        let validations = 0;
+        globalThis.fetch = (async (url: string, init?: RequestInit) => {
+            calls += 1;
+            if (String(url).endsWith("/messages/count_tokens")) {
+                validations += 1;
+                return access(JSON.parse(String(init?.body)).model);
+            }
+            return new Response(JSON.stringify({ data: candidates }));
+        }) as unknown as typeof fetch;
+        return { calls: () => calls, validations: () => validations };
     }
 
     test("a dead endpoint (fetch throws) → proxy_unreachable carrying the throw's message", async () => {
@@ -151,22 +299,83 @@ describe("resolveModelId", () => {
         expect((await resolveModelId("sk-test"))._unsafeUnwrapErr()).toEqual({ type: "no_models" });
     });
 
-    test("the ok path ranks the list and sends the key as a bearer token", async () => {
+    test("the ok path elects the ranked claude id and sends the key as a bearer token on both requests", async () => {
         const seenAuth: Array<string | null> = [];
-        globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        globalThis.fetch = (async (url: string, init?: RequestInit) => {
             seenAuth.push(new Headers(init?.headers).get("Authorization"));
-            return modelsResponse(["gpt-4o", "claude-sonnet"]);
+            return String(url).endsWith("/messages/count_tokens") ? served() : modelsResponse(["gpt-4o", "claude-sonnet"]);
         }) as unknown as typeof fetch;
 
         expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-sonnet");
-        expect(seenAuth).toEqual(["Bearer sk-test"]);
+        expect(seenAuth).toEqual(["Bearer sk-test", "Bearer sk-test"]); // /models GET, then the count_tokens POST
     });
 
-    test("caches the ok path — a second call issues no request", async () => {
-        const calls = stubFetch(() => Promise.resolve(modelsResponse(["claude-sonnet"])));
+    test("the election walks past a not_found top candidate to the next served one", async () => {
+        const stub = stubElection(
+            [
+                { id: "claude-old", created: 100 },
+                { id: "claude-new", created: 200 },
+            ],
+            (id) => (id === "claude-new" ? notFound(id) : served()),
+        );
+        // Ranked newest-first: claude-new 404s, so the walk elects claude-old.
+        expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-old");
+        expect(stub.validations()).toBe(2);
+    });
+
+    test("a 5xx on the top candidate is inconclusive — it is elected, not walked past", async () => {
+        const stub = stubElection(
+            [
+                { id: "claude-new", created: 200 },
+                { id: "claude-old", created: 100 },
+            ],
+            (id) => (id === "claude-new" ? new Response("boom", { status: 503 }) : served()),
+        );
+        expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-new");
+        expect(stub.validations()).toBe(1); // stopped at the top candidate
+    });
+
+    test("a count_tokens timeout/network throw is inconclusive — the top candidate is elected", async () => {
+        stubElection(
+            [
+                { id: "claude-new", created: 200 },
+                { id: "claude-old", created: 100 },
+            ],
+            () => Promise.reject(new Error("timed out")),
+        );
+        expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-new");
+    });
+
+    test("an all-404 list elects the top-ranked candidate unvalidated for downstream reporting", async () => {
+        const stub = stubElection(
+            [
+                { id: "claude-old", created: 100 },
+                { id: "claude-new", created: 200 },
+            ],
+            (id) => notFound(id),
+        );
+        expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-new"); // rank[0] = newest
+        expect(stub.validations()).toBe(2); // both candidates walked
+    });
+
+    test("a non-claude list elects by rank alone — no count_tokens validation exists for it", async () => {
+        const stub = stubElection(
+            [
+                { id: "gpt-4o", created: 100 },
+                { id: "gpt-4o-mini", created: 200 },
+            ],
+            () => served(),
+        );
+        expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("gpt-4o-mini"); // recency wins
+        expect(stub.validations()).toBe(0);
+    });
+
+    test("the elected winner is cached — a second resolve issues zero requests (probe and boot share one election)", async () => {
+        const stub = stubElection([{ id: "claude-sonnet", created: 100 }], () => served());
         expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-sonnet");
+        const afterFirst = stub.calls();
         expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-sonnet");
-        expect(calls()).toBe(1);
+        expect(stub.calls()).toBe(afterFirst); // the cached path went out over the wire zero times
     });
 
     test("does NOT cache a failure — a transient outage must not poison the process", async () => {
@@ -174,8 +383,9 @@ describe("resolveModelId", () => {
         expect((await resolveModelId("sk-test")).isErr()).toBe(true);
         expect(failing()).toBe(1);
 
-        const ok = stubFetch(() => Promise.resolve(modelsResponse(["claude-sonnet"])));
+        // The error path left no cached value, so the retry really re-fetches /models and elects.
+        const recovered = stubElection([{ id: "claude-sonnet", created: 100 }], () => served());
         expect((await resolveModelId("sk-test"))._unsafeUnwrap()).toBe("claude-sonnet");
-        expect(ok()).toBe(1); // the retry really went out; the error path left no cached value
+        expect(recovered.calls()).toBeGreaterThan(0);
     });
 });

--- a/cli/src/modules/proxy/models.ts
+++ b/cli/src/modules/proxy/models.ts
@@ -4,21 +4,34 @@ import { z } from "zod";
 import { env } from "../../lib/env.ts";
 
 // CLIProxyAPI (provisioned by `inflexa setup`) exposes an OpenAI-compatible endpoint that routes to
-// whichever provider was authenticated. These helpers cover the two proxy-endpoint concerns a model
-// caller must settle before it can stream: discovering the client API key we baked into the proxy
-// config at setup, and resolving/ranking a default model from the proxy's live `/models` list. The
-// endpoint and config path are the single source of truth in env.ts (`cliproxyApiUrl`,
-// `cliproxyConfigPath`) — not user-overridable, since we own the container.
+// whichever provider was authenticated. These helpers cover the proxy-endpoint concerns a model caller
+// must settle before it can stream: discovering the client API key we baked into the proxy config at
+// setup, and electing a default model from the proxy's live `/models` list. Election is a deterministic
+// rank (family preference, then recency) walked against the proxy's unbilled `count_tokens` route: the
+// advertised list is the proxy's GitHub-sourced registry, not the credential, so some ids answer 404 on
+// use — the walk skips those a definite not-found rules out so a model the credential cannot serve is
+// never elected while a serviceable one remains. The endpoint and config path are the single source of
+// truth in env.ts (`cliproxyApiUrl`, `cliproxyConfigPath`) — not user-overridable, since we own the
+// container.
 
-const modelsSchema = z.object({ data: z.array(z.object({ id: z.string() })) });
+const modelsSchema = z.object({ data: z.array(z.object({ id: z.string(), created: z.number().optional() })) });
+
+/**
+ * One entry of the proxy's `/models` list as the ranking consumes it: the id plus the registry's
+ * `created` unix timestamp (verified live: the proxy passes it through from its GitHub-sourced
+ * registry). `created` is optional so a proxy build that omits it degrades to the id tiebreak —
+ * still deterministic — rather than failing the schema.
+ */
+export type ModelCandidate = { id: string; created?: number };
 
 /**
  * The model families CLIProxyAPI can serve (one per authenticatable account kind), in default-pick
  * preference order, each paired with the vendor slug that names its provider. The `provider` column
- * is read in ONE direction only — provider→family, by {@link modelMatchesProvider} — as a cliproxy
- * auto-resolve sanity check. It MUST NEVER be read id→provider to derive a provider identity: the
- * connection's configured `provider` is the sole identity source, and deriving one from a model id
- * here would fabricate provenance. {@link pickDefaultModel} reads only the family column.
+ * is read in ONE direction only — provider→family, by {@link modelMatchesProvider} — both as a cliproxy
+ * auto-resolve sanity check and to recognize the claude family the election validates. It MUST NEVER be
+ * read id→provider to derive a provider identity: the connection's configured `provider` is the sole
+ * identity source, and deriving one from a model id here would fabricate provenance. The `family` column
+ * feeds {@link rankModelCandidates}.
  */
 const MODEL_FAMILIES = [
     { family: "claude", provider: "anthropic" },
@@ -28,10 +41,11 @@ const MODEL_FAMILIES = [
 ] as const;
 
 /**
- * Resolved once per process from the proxy's model list (which reflects the
- * authenticated provider). The user primarily uses Anthropic, so prefer a
- * Claude model when present, then other known families, then whatever is first
- * — this keeps the default adapting to whatever `inflexa setup` signed into.
+ * Family preference for the default-model rank (claude > gpt > gemini > qwen), the `family` column of
+ * {@link MODEL_FAMILIES}. The user primarily uses Anthropic, so a Claude model is preferred when the
+ * authenticated account serves one, then the other known families, then — when none match — the whole
+ * list by recency. This keeps the default adapting to whatever `inflexa setup` signed into with no
+ * baked-in per-model knowledge. {@link rankModelCandidates} consumes it.
  */
 const MODEL_PREFERENCE = MODEL_FAMILIES.map((f) => f.family);
 let cachedModelId: string | null = null;
@@ -50,15 +64,41 @@ export async function readApiKey(): Promise<Result<string, ChatSetupError>> {
 }
 
 /**
- * Resolve the default chat model from the proxy's `/models`, cached per process.
+ * Resolve the default chat model from the proxy's `/models`, cached per process. Ranks the listing
+ * deterministically ({@link rankModelCandidates}), then walks the candidates to elect one the credential
+ * can actually serve: a claude-family candidate is validated via {@link checkModelAccess} and elected on
+ * `served` or `inconclusive` — only a definite `not_found` advances to the next; a non-claude-family
+ * candidate is elected by rank alone (no cheap validation route exists for it). If every candidate is
+ * `not_found`, the top-ranked one is elected unvalidated so the launch probe's completion request — not
+ * the election — surfaces the failure: the election never invents a new way for launch to block. The
+ * elected winner is cached so every consumer of the auto default in this process (launch probe, harness
+ * boot's per-agent fallback) observes the same id without re-walking.
  *
- * `signal` bounds the round-trip for callers that cannot afford to wait on a proxy that accepts the
- * connection and then never answers — the launch-time credential probe, which would otherwise hold
- * the terminal indefinitely. It is optional because the chat path resolves lazily behind a UI that
- * can already be cancelled, and imposing a deadline on it would only invent a new failure mode.
+ * `signal` bounds the round-trips for callers that cannot afford to wait on a proxy that accepts the
+ * connection and then never answers — the launch-time credential probe, which would otherwise hold the
+ * terminal indefinitely. The one signal bounds the `/models` fetch and every validation request in the
+ * walk (a shared deadline over the whole election). It is optional because the chat path resolves lazily
+ * behind a UI that can already be cancelled, and imposing a deadline on it would only invent a new
+ * failure mode.
  */
 export async function resolveModelId(apiKey: string, signal?: AbortSignal): Promise<Result<string, ChatSetupError>> {
     if (cachedModelId) return ok(cachedModelId);
+    const candidates = await listModelCandidates(apiKey, signal);
+    if (candidates.isErr()) return err(candidates.error);
+    cachedModelId = await electModel(rankModelCandidates(candidates.value), apiKey, signal);
+    return ok(cachedModelId);
+}
+
+/**
+ * Fetch and parse the proxy's `/models` list into its raw candidate pool — the single fetch both the
+ * election ({@link resolveModelId}) and the setup accessibility sweep consume, so the GET + schema parse
+ * lives in one place. The error semantics are exactly the ones the election carried inline before, so its
+ * callers are unaffected: a fetch throw (dead endpoint or aborted `signal`) or a non-200 bridges into
+ * `proxy_unreachable`, and an empty or schema-mismatched body (`jsonWith` yields null, never a throw) into
+ * `no_models`. `signal` bounds the round-trip for callers that cannot wait on a proxy that accepts the
+ * connection and then never answers (the launch probe); it is optional for the lazy chat path.
+ */
+export async function listModelCandidates(apiKey: string, signal?: AbortSignal): Promise<Result<ModelCandidate[], ChatSetupError>> {
     let res: Response;
     // fetch throws on a dead endpoint (or an aborted signal); bridge that throw into the Result channel.
     try {
@@ -69,8 +109,26 @@ export async function resolveModelId(apiKey: string, signal?: AbortSignal): Prom
     if (!res.ok) return err({ type: "proxy_unreachable", detail: `HTTP ${res.status}` });
     const models = await res.jsonWith(modelsSchema);
     if (!models || models.data.length === 0) return err({ type: "no_models" });
-    cachedModelId = pickDefaultModel(models.data.map((m) => m.id));
-    return ok(cachedModelId);
+    return ok(models.data);
+}
+
+/**
+ * Walk the ranked candidates to the first the credential can serve. Claude-family ids are validated with
+ * {@link checkModelAccess} — only a definite `not_found` is walked past, while `served`/`inconclusive`
+ * elect (a flaky check must not walk past the best candidate). Non-claude-family ids elect by rank alone:
+ * `count_tokens` is Anthropic-protocol and only verified through the proxy for claude ids. When every
+ * candidate is `not_found`, the top-ranked id is returned unvalidated so downstream probe reporting — not
+ * the election — surfaces the failure. Claude-family membership comes from {@link modelMatchesProvider}
+ * (provider→family via {@link MODEL_FAMILIES}'s anthropic row), never an id→provider derivation.
+ */
+async function electModel(ranked: string[], apiKey: string, signal?: AbortSignal): Promise<string> {
+    for (const id of ranked) {
+        if (!modelMatchesProvider("anthropic", id)) return id;
+        if ((await checkModelAccess(apiKey, id, signal)) !== "not_found") return id;
+    }
+    // `ranked` is non-empty: resolveModelId returns `no_models` before calling this on an empty list, and
+    // rankModelCandidates preserves every id, so the top-ranked candidate always exists here.
+    return ranked[0]!;
 }
 
 /**
@@ -83,29 +141,94 @@ export function __resetModelCacheForTest(): void {
 }
 
 /**
- * Pick the default model id by {@link MODEL_PREFERENCE} (claude > gpt > gemini > qwen, matched
- * case-insensitively by substring), falling back to the first id when no family matches.
+ * Rank a `/models` listing into the deterministic default-model order, as a TOTAL order: the same set in
+ * any serving order yields the identical sequence. Candidates of the FIRST {@link MODEL_PREFERENCE}
+ * family with any match (case-insensitive substring) rank first, ordered by `created` descending — a
+ * missing `created` ranks oldest, ties break by id ascending. When no family matches, that same recency
+ * order applies to the whole list. Recency (never lexicographic id order) is the primary sort: ascending
+ * byte order would rank dated legacy ids (`claude-3-5-…`) first and deterministically elect a stale
+ * model. The election walk and setup's model list both consume the ranked ids.
  */
-export function pickDefaultModel(ids: string[]): string {
-    for (const family of MODEL_PREFERENCE) {
-        const match = ids.find((id) => id.toLowerCase().includes(family));
-        if (match) return match;
+export function rankModelCandidates(models: ModelCandidate[]): string[] {
+    const family = MODEL_PREFERENCE.find((fam) => models.some((m) => m.id.toLowerCase().includes(fam)));
+    const pool = family ? models.filter((m) => m.id.toLowerCase().includes(family)) : models;
+    // Copy before sorting: the no-family branch aliases the caller's array, and rank must never mutate it.
+    return [...pool].sort(byRecencyThenId).map((m) => m.id);
+}
+
+/**
+ * Total-order comparator for the default-model rank: `created` descending (a missing timestamp ranks
+ * oldest — 0 precedes every real unix stamp), ties broken by id ascending so the sort is stable across
+ * serving orders. Id order is ONLY ever the tiebreak, never the primary key.
+ */
+function byRecencyThenId(a: ModelCandidate, b: ModelCandidate): number {
+    const byCreated = (b.created ?? 0) - (a.created ?? 0);
+    if (byCreated !== 0) return byCreated;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** The 404 body the proxy forwards for a model the credential cannot serve; `error.type` is the discriminator. */
+const countTokensErrorSchema = z.object({ error: z.object({ type: z.string() }) });
+
+/**
+ * The accessibility verdict for one model, three-valued by design — all three are EXPECTED outcomes, not
+ * errors, which is why {@link checkModelAccess} returns this plain union rather than a `Result`: no branch
+ * is a fault to propagate. `served` — the credential can use the model; `not_found` — the credential
+ * definitively cannot (the only verdict that advances the election walk); `inconclusive` — the check
+ * itself could not decide, so the election accepts the candidate rather than walking past the best one on
+ * a flaky signal.
+ */
+export type ModelAccess = "served" | "not_found" | "inconclusive";
+
+/**
+ * Ask the proxy whether the authenticated credential can serve `modelId`, via the unbilled `count_tokens`
+ * route (verified live against the fork: the proxy forwards it upstream with the real credential — an
+ * inaccessible model answers 404 `not_found_error`, an accessible one 200 — and Anthropic does not bill
+ * it). Returns a three-valued {@link ModelAccess}, never a Result, because every outcome is a normal
+ * verdict rather than a failure.
+ *
+ * The body discrimination is load-bearing: a proxy fork that does not route `count_tokens` at all would
+ * 404 EVERY request, so a bare 404 must read as `inconclusive` (degrade to rank-only election) — only a
+ * 404 carrying `error.type === "not_found_error"` means "this model is inaccessible". Any throw (fetch
+ * failure, or an aborted/timed-out `signal`) is likewise inconclusive. `jsonWith` yields null on a body
+ * shape mismatch, so a malformed 404 body never throws — it falls through to inconclusive.
+ *
+ * Headers are deliberately the `/models` route's (`Authorization: Bearer` with the proxy client key,
+ * no `anthropic-version`) rather than the `x-api-key` style the chat POST uses: verified live — the
+ * proxy authenticates the client key and injects the provider-side headers upstream itself. If a
+ * future fork build demanded more here, every verdict would become inconclusive, which by design
+ * degrades election to rank-only and silences stale-pin warnings rather than misreporting anything.
+ */
+export async function checkModelAccess(apiKey: string, modelId: string, signal?: AbortSignal): Promise<ModelAccess> {
+    let res: Response;
+    try {
+        res = await fetch(`${env.cliproxyApiUrl}/messages/count_tokens`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+            body: JSON.stringify({ model: modelId, messages: [{ role: "user", content: "ping" }] }),
+            signal,
+        });
+    } catch {
+        return "inconclusive";
     }
-    // Callers pass a non-empty list (resolveModelId returns `no_models` first on an empty `data`),
-    // so index 0 is always present in practice.
-    return ids[0]!;
+    if (res.ok) return "served";
+    if (res.status === 404) {
+        const body = await res.jsonWith(countTokensErrorSchema);
+        if (body?.error.type === "not_found_error") return "not_found";
+    }
+    return "inconclusive";
 }
 
 /**
  * True when `modelId`'s family matches the configured provider slug — the cliproxy auto-resolve
- * agreement guard. Reads {@link MODEL_FAMILIES} in the provider→family direction ONLY:
- * the configured provider names one or more families, and the auto-resolved id must contain one of
- * them (case-insensitive substring, same mechanics as {@link pickDefaultModel}). This is NOT
- * id→provider derivation — it never produces a provider identity, only answers "is this the family I
- * expected for the configured provider?". A configured provider absent from the table (e.g.
- * `deepseek` in cliproxy mode) matches nothing, so it is treated as a mismatch — boot then surfaces
- * an actionable error rather than serving a model the route was not built for. With the default
- * provider `anthropic`, only Claude-family ids pass — the sole family that table maps to `anthropic`.
+ * agreement guard, and the claude-family test the election uses. Reads {@link MODEL_FAMILIES} in the
+ * provider→family direction ONLY: the configured provider names one or more families, and the id must
+ * contain one of them (case-insensitive substring, same mechanics as {@link rankModelCandidates}). This
+ * is NOT id→provider derivation — it never produces a provider identity, only answers "is this the family
+ * I expected for the configured provider?". A configured provider absent from the table (e.g. `deepseek`
+ * in cliproxy mode) matches nothing, so it is treated as a mismatch — boot then surfaces an actionable
+ * error rather than serving a model the route was not built for. With the default provider `anthropic`,
+ * only Claude-family ids pass — the sole family that table maps to `anthropic`.
  */
 export function modelMatchesProvider(provider: string, modelId: string): boolean {
     const lower = modelId.toLowerCase();

--- a/cli/src/modules/proxy/models.ts
+++ b/cli/src/modules/proxy/models.ts
@@ -148,6 +148,16 @@ export function __resetModelCacheForTest(): void {
  * order applies to the whole list. Recency (never lexicographic id order) is the primary sort: ascending
  * byte order would rank dated legacy ids (`claude-3-5-…`) first and deterministically elect a stale
  * model. The election walk and setup's model list both consume the ranked ids.
+ *
+ * Load-bearing on WHY the blind first-family scan is correct: the cliproxy `/models` this consumes is
+ * already scoped by the proxy to the AUTHENTICATED account's provider — verified live, an Anthropic proxy
+ * lists only claude ids, never the gpt/gemini/qwen/… families its GitHub registry also carries. So the
+ * FIRST matching family IS the account's family; `MODEL_PREFERENCE` is not a cross-provider filter (it
+ * only breaks the rare tie of several credentials loaded into one proxy at once — and a wrong-family
+ * election there is caught loudly by boot's provider-family guard, {@link modelMatchesProvider} in
+ * `harness/runtime.ts`, as `model_provider_mismatch`, never served as a silent 404). This is why setup's
+ * `modelMatchesProvider` post-filter is a belt-and-braces no-op in practice, not the thing that selects
+ * the family.
  */
 export function rankModelCandidates(models: ModelCandidate[]): string[] {
     const family = MODEL_PREFERENCE.find((fam) => models.some((m) => m.id.toLowerCase().includes(fam)));

--- a/cli/src/tui/commands.tsx
+++ b/cli/src/tui/commands.tsx
@@ -1,4 +1,4 @@
-import { Show, type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 // Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
@@ -40,7 +40,8 @@ import {
     matchAnalysis,
 } from "../modules/analysis/analysis.ts";
 import { writeAgentModel, type AgentName } from "../modules/harness/config.ts";
-import { listConnectionModels } from "../modules/harness/model_listing.ts";
+import { listConnectionModels, validateModelSelection } from "../modules/harness/model_listing.ts";
+import type { ModelAccess } from "../modules/proxy/models.ts";
 import { currentAgentModels, requestAgentModelChange } from "../modules/harness/agent_switch.ts";
 import { resolveInputPath } from "../modules/analysis/input.ts";
 import { resolveContext, describeContext } from "../modules/analysis/context.ts";
@@ -207,11 +208,43 @@ function applyAgentSelection(agent: AgentName, model: string): void {
 }
 
 /**
- * The agent-parameterized model picker: a {@link SelectDialog} over the
- * connection's live models with the agent's CURRENT model marked, degrading to a {@link PromptDialog}
- * free-text entry when listing failed (`models === null`). Purely presentational — the command
- * resolves the listing and wires `onSubmit` (persist + apply) and `onCancel` (close) — so it renders as an
- * inert design-gallery/test exhibit unchanged.
+ * The commit decision for a validated model pick — PURE, so the "reject in-dialog vs persist" rule is
+ * unit-testable without a live dialog. A definite `not_found` keeps the picker open with an inline error
+ * naming the model and the account-accessibility cause (design D6); `served` and `inconclusive` both
+ * persist (inconclusive-accept: an absent/flaky validation route never blocks a switch — spec).
+ */
+export function modelCommitDecision(model: string, access: ModelAccess): { persist: true } | { persist: false; error: string } {
+    if (access === "not_found") return { persist: false, error: `This account cannot serve ${model}. Pick another model, or check your credential.` };
+    return { persist: true };
+}
+
+/**
+ * Orchestrate one commit attempt: validate `model`, then either persist it or surface the inline error,
+ * per {@link modelCommitDecision}. Extracted from {@link ModelPickerDialog} so the full validate→decide
+ * flow is testable headlessly with injected effects; the dialog supplies only the effects and owns the
+ * busy/error rendering around this call.
+ */
+export async function runModelCommit(
+    model: string,
+    effects: { validate: (model: string) => Promise<ModelAccess>; persist: (model: string) => void; reportError: (message: string) => void },
+): Promise<void> {
+    const decision = modelCommitDecision(model, await effects.validate(model));
+    if (decision.persist) effects.persist(model);
+    else effects.reportError(decision.error);
+}
+
+/**
+ * The agent-parameterized model picker: a {@link SelectDialog} over the connection's live models with the
+ * agent's CURRENT model marked, degrading to a {@link PromptDialog} free-text entry when listing failed
+ * (`models === null`). A committed pick (listed OR free-text) is accessibility-validated (design D6)
+ * before it persists — while checking, the picker shows a busy {@link PromptDialog}; a definite
+ * `not_found` keeps it open with an inline error naming the model; `served`/`inconclusive` persist + close.
+ *
+ * The busy and inline-error affordances are PromptDialog's ONLY — {@link SelectDialog} has neither — so
+ * the validation phase renders as a PromptDialog regardless of which surface the pick came from. A listed
+ * pick therefore CONVERGES onto that same prompt (id pre-filled) rather than growing a bespoke list busy/
+ * error state, which the design-gallery rule forbids inventing. The picking-phase surfaces are unchanged,
+ * so the inert design-gallery/test exhibits render exactly as before (`validate` is never reached at rest).
  */
 export function ModelPickerDialog(props: {
     agent: AgentName;
@@ -219,39 +252,91 @@ export function ModelPickerDialog(props: {
     models: readonly string[] | null;
     /** The agent's currently-running model, marked `current` in the list and pre-filled in the free-text field. */
     current: string;
-    /** Persist + apply the chosen/typed model. */
-    onSubmit: (model: string) => void;
+    /** Accessibility-validate a committed id before persisting (design D6); the picker renders the busy/error phases around it. */
+    validate: (model: string) => Promise<ModelAccess>;
+    /** Persist + apply an accepted model, then close. */
+    onCommit: (model: string) => void;
     /** Close without changing anything (esc, click-outside, ctrl+c). */
     onCancel: () => void;
 }): JSX.Element {
     // A thunk so the fixed-per-mount `props.agent` read lands inside JSX (a tracked scope), satisfying
     // solid/reactivity without destructuring or a disable.
     const title = (): string => (props.agent === "conversation" ? "Switch chat model" : "Switch sandbox model");
+
+    // The picker's own sub-phase. `picking` shows the list/free-text surface; a commit moves it to
+    // `checking` (busy prompt) and then either persists+closes or lands on `error` (stays open, names the
+    // model). `pending`/`errorText` seed EMPTY (not from props) — they are only ever READ in the
+    // checking/error PromptDialog, which renders only after `commit()` has set them, so no props leak in.
+    const [phase, setPhase] = createSignal<"picking" | "checking" | "error">("picking");
+    const [pending, setPending] = createSignal("");
+    const [errorText, setErrorText] = createSignal("");
+
+    function commit(raw: string): void {
+        const id = raw.trim();
+        if (!id) {
+            notify({ kind: "warn", text: "A model id is required." });
+            return;
+        }
+        setPending(id);
+        setErrorText("");
+        setPhase("checking");
+        void runModelCommit(id, {
+            validate: props.validate,
+            persist: (accepted) => {
+                // Drop out of `checking` BEFORE onCommit closes: the busy close-guard vetoes even a
+                // programmatic commit close (dialog_host `dialogClose`), and PromptDialog's guard reads
+                // `busy` (= phase === "checking") LIVE — so clearing the phase first lets the close through.
+                setPhase("picking");
+                props.onCommit(accepted);
+            },
+            reportError: (message) => {
+                setErrorText(message);
+                setPhase("error");
+            },
+        });
+    }
+
     return (
         <Show
-            when={props.models}
-            keyed
+            when={phase() === "picking"}
             fallback={
                 <PromptDialog
                     title={title()}
-                    value={props.current}
+                    value={pending()}
                     placeholder="Enter a model id"
-                    description={() => <text fg={theme().fgMuted}>Could not list the connection's models — enter a model id manually.</text>}
+                    busy={phase() === "checking"}
+                    busyText={`Checking ${pending()}${GLYPHS.ellipsis}`}
+                    description={phase() === "error" ? () => <text fg={theme().error}>{errorText()}</text> : undefined}
                     onCancel={props.onCancel}
-                    onSubmit={props.onSubmit}
+                    onSubmit={commit}
                 />
             }
         >
-            {(models: readonly string[]) => (
-                <SelectDialog
-                    title={title()}
-                    placeholder={`Search models${GLYPHS.ellipsis}`}
-                    items={models.map((id) => ({ value: id, title: id, hint: id === props.current ? "current" : undefined }))}
-                    emptyText="No models listed by the connection"
-                    onCancel={props.onCancel}
-                    onSelect={props.onSubmit}
-                />
-            )}
+            <Show
+                when={props.models}
+                keyed
+                fallback={
+                    <PromptDialog
+                        title={title()}
+                        value={props.current}
+                        placeholder="Enter a model id"
+                        description={() => <text fg={theme().fgMuted}>Could not list the connection's models — enter a model id manually.</text>}
+                        onCancel={props.onCancel}
+                        onSubmit={commit}
+                    />
+                }
+            >
+                {(models: readonly string[]) => (
+                    <SelectDialog
+                        title={title()}
+                        placeholder={`Search models${GLYPHS.ellipsis}`}
+                        items={models.map((id) => ({ value: id, title: id, hint: id === props.current ? "current" : undefined }))}
+                        emptyText="No models listed by the connection"
+                        onCancel={props.onCancel}
+                        onSelect={commit}
+                    />
+                )}
+            </Show>
         </Show>
     );
 }
@@ -277,14 +362,10 @@ async function openModelPicker(ctx: Workspace, agent: AgentName): Promise<void> 
             agent={agent}
             models={models}
             current={current}
-            onSubmit={(model) => {
+            validate={(model) => validateModelSelection(model)}
+            onCommit={(model) => {
                 ctx.closeDialog();
-                const id = model.trim();
-                if (!id) {
-                    notify({ kind: "warn", text: "A model id is required." });
-                    return;
-                }
-                applyAgentSelection(agent, id);
+                applyAgentSelection(agent, model);
             }}
             onCancel={() => ctx.closeDialog()}
         />

--- a/cli/src/tui/model_picker.render.test.tsx
+++ b/cli/src/tui/model_picker.render.test.tsx
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { ok } from "neverthrow";
 
+import "../extensions/index.ts"; // installs Response.prototype.jsonWith, which validateModelSelection uses
 import { renderFrame } from "../test_support/tui.ts";
 import { DialogShowcase } from "./components/dialog/dialog_host.tsx";
-import { commands, ModelPickerDialog } from "./commands.tsx";
+import { commands, ModelPickerDialog, modelCommitDecision, runModelCommit } from "./commands.tsx";
+import { validateModelSelection, type ValidateSelectionSeams } from "../modules/harness/model_listing.ts";
+import type { ModelAccess } from "../modules/proxy/models.ts";
 
 // The picker's whole job is to present the RIGHT surface for the listing outcome: a SelectDialog over the
 // live models with the agent's current one marked, OR — when listing failed (`models === null`) — a
@@ -11,11 +15,13 @@ import { commands, ModelPickerDialog } from "./commands.tsx";
 // Rendered inert (DialogShowcase gives the null entry handle) so exhibits grab no focus, per the gallery.
 
 const noop = (): void => {};
+// The picking-phase exhibits never commit, so validate is unreachable at rest — a stub keeps the surface inert.
+const validateNoop = async (): Promise<ModelAccess> => "inconclusive";
 
 function pickerNode(models: readonly string[] | null, current: string) {
     return () => (
         <DialogShowcase>
-            <ModelPickerDialog agent="sandbox" models={models} current={current} onSubmit={noop} onCancel={noop} />
+            <ModelPickerDialog agent="sandbox" models={models} current={current} validate={validateNoop} onCommit={noop} onCancel={noop} />
         </DialogShowcase>
     );
 }
@@ -45,12 +51,101 @@ describe("ModelPickerDialog", () => {
         const frame = await renderFrame(
             () => (
                 <DialogShowcase>
-                    <ModelPickerDialog agent="conversation" models={["claude-opus-4-8"]} current="" onSubmit={noop} onCancel={noop} />
+                    <ModelPickerDialog agent="conversation" models={["claude-opus-4-8"]} current="" validate={validateNoop} onCommit={noop} onCancel={noop} />
                 </DialogShowcase>
             ),
             { width: 80, height: 24 },
         );
         expect(frame).toContain("Switch chat model");
+    });
+});
+
+// The commit path is validate → decide → (persist | inline-error), extracted from the dialog so the
+// decision is testable headlessly (the TUI busy/error rendering is PromptDialog's, covered by the dialog
+// gallery). `persist` is the writeAgentModel-bearing effect in production, so "persist not called" is
+// "nothing written". Both the listed-pick and free-text paths funnel through the same `runModelCommit`.
+describe("model commit decision", () => {
+    test("a not_found verdict rejects in-dialog: no persist, an error naming the model", () => {
+        const decision = modelCommitDecision("claude-nope", "not_found");
+        expect(decision.persist).toBe(false);
+        // Narrow to the error arm to read its message (persist:false carries the inline error text).
+        if (decision.persist) throw new Error("expected a rejection");
+        expect(decision.error).toContain("claude-nope");
+        expect(decision.error.toLowerCase()).toContain("account");
+    });
+
+    test("served and inconclusive both persist (inconclusive-accept)", () => {
+        expect(modelCommitDecision("claude-opus-4-8", "served")).toEqual({ persist: true });
+        expect(modelCommitDecision("claude-opus-4-8", "inconclusive")).toEqual({ persist: true });
+    });
+});
+
+describe("runModelCommit — validate then persist-or-report", () => {
+    function recordingEffects(access: ModelAccess) {
+        const persisted: string[] = [];
+        const errors: string[] = [];
+        return {
+            persisted,
+            errors,
+            effects: {
+                validate: async (): Promise<ModelAccess> => access,
+                persist: (m: string): void => void persisted.push(m),
+                reportError: (message: string): void => void errors.push(message),
+            },
+        };
+    }
+
+    test("not_found reports the error and never persists", async () => {
+        const rec = recordingEffects("not_found");
+        await runModelCommit("claude-nope", rec.effects);
+        expect(rec.persisted).toEqual([]);
+        expect(rec.errors[0]).toContain("claude-nope");
+    });
+
+    test("served persists and never reports", async () => {
+        const rec = recordingEffects("served");
+        await runModelCommit("claude-opus-4-8", rec.effects);
+        expect(rec.persisted).toEqual(["claude-opus-4-8"]);
+        expect(rec.errors).toEqual([]);
+    });
+
+    test("inconclusive persists (a flaky/absent validation route never blocks a switch)", async () => {
+        const rec = recordingEffects("inconclusive");
+        await runModelCommit("claude-opus-4-8", rec.effects);
+        expect(rec.persisted).toEqual(["claude-opus-4-8"]);
+        expect(rec.errors).toEqual([]);
+    });
+
+    // End-to-end for the openai-compatible protocol: the real validator short-circuits to inconclusive
+    // with NO request, and the commit persists — proving the spec's "commits as before, no validation
+    // request exists" on that protocol through the actual commit path (not a stubbed verdict).
+    test("openai-compatible commits without issuing any validation request", async () => {
+        let fetchCount = 0;
+        let checked = 0;
+        const seams: ValidateSelectionSeams = {
+            resolveConnection: () => ({ mode: "direct", provider: "openai", baseURL: "https://api.example.com/v1", protocol: "openai-compatible", agents: {} }),
+            readProxyKey: async () => ok("sk-proxy"),
+            readModelApiKey: () => "sk-direct",
+            checkModelAccess: async () => {
+                checked++;
+                return "served";
+            },
+            fetch: async () => {
+                fetchCount++;
+                return new Response("{}");
+            },
+        };
+        const persisted: string[] = [];
+        await runModelCommit("gpt-4o", {
+            validate: (m) => validateModelSelection(m, seams),
+            persist: (m) => void persisted.push(m),
+            reportError: () => {
+                throw new Error("openai-compatible must not report an error");
+            },
+        });
+        expect(persisted).toEqual(["gpt-4o"]);
+        expect(fetchCount).toBe(0);
+        expect(checked).toBe(0);
     });
 });
 


### PR DESCRIPTION
## What & why

In cliproxy mode the default chat model was the first `/v1/models` id containing the preferred family substring, in whatever order the proxy served the list — unstable across launches. Worse, the proxy advertises its GitHub-sourced registry rather than what the OAuth credential can actually serve, so roughly 1 launch in 6–12 drew a model that answers 404: every chat turn failed, and the launch probe reported `Provider login not verifiable (HTTP 404)` against a perfectly healthy credential (#144).

The default is now **elected** instead of picked:

- **Deterministic rank** — candidates order by family preference, then the registry's `created` timestamp descending (id ascending as tiebreak). Same list ⇒ same rank, regardless of serving order. Verified live: the proxy passes `created` through `/v1/models`.
- **Accessibility-validated walk** — claude-family candidates are checked through the proxy's `count_tokens` route (unbilled, sub-second; verified live that it forwards upstream with the real credential). Only a definite `not_found_error` advances the walk; anything inconclusive (timeout, 5xx, bare 404) elects the candidate rather than walking past the best model on a flaky signal. All-404 degrades to the top-ranked candidate so the existing probe warn-and-proceed path reports it — election never adds a way for launch to block.
- **Stale-pin warning** — the launch gate now also checks explicit `models.agents.*` / `harness.model` pins and warns (never blocks, never rewrites config) when a pinned model is no longer served for the account.
- **Setup step** — interactive `inflexa setup` offers a default-model select: a preselected **Auto** row labeled with the elected model (accepting it writes nothing, keeping the default adaptive) plus the accessibility-swept list; an explicit pick pins both agents. Non-TTY setups skip it. No hardcoded model ids anywhere.
- **Picker validation** — the TUI model-switch commit validates the selection (listed or free-text) and rejects an inaccessible id in-dialog instead of persisting a broken pin; `openai-compatible` connections commit as before (no cheap validation route exists).

Election lives inside `resolveModelId`, so the launch probe and harness boot share one election through the existing per-process cache — no new plumbing between them.

Verified live against the local proxy: three fresh processes elected the same (newest served) model; the pre-change non-determinism and the spurious not-verifiable warning are gone. One wire fact discovered and recorded in the design's risk register: after repeated 404s the proxy stops forwarding an inaccessible model and answers `503 auth_unavailable` locally — deliberately treated as inconclusive, since the same shape appears transiently on healthy models during proxy boot.

OpenSpec artifacts (proposal, design with decision rationale, spec deltas, tasks) are included under `cli/openspec/` — one new capability (`default-model-election`) and deltas to `model-connection`, `agent-model-selection`, and `cliproxy-credential-health`.

Closes #144

## Type of change

- [x] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
