### PR TITLE
fix(images): declare HOME so scanpy imports in Docker poll mode

### DIFF
--- a/images/sandbox-base/Dockerfile
+++ b/images/sandbox-base/Dockerfile
@@ -166,6 +166,18 @@ RUN echo "/mnt/libs/current/python/site-packages" > /usr/lib/python3/dist-packag
 RUN useradd -m -u 1000 -s /bin/bash sandbox \
     && mkdir -p /workspace && chown -R sandbox:sandbox /workspace
 
+# Declared explicitly rather than left to the runtime's passwd lookup, which
+# resolves against the *create-time* user: poll mode creates the container as
+# root (for CAP_NET_ADMIN) and reaches uid 1000 only via the entrypoint's
+# `setpriv`, which changes credentials but not environment; K8s creates it with a
+# numeric `runAsUser` and no lookup at all. Neither yields a home for the uid the
+# workload actually runs as.
+#
+# This path must also stay writable: numba resolves a cache locator per
+# @njit(cache=True) function and raises when none is writable, and with the lib
+# store read-only `$HOME/.cache/numba` is the last candidate.
+ENV HOME=/home/sandbox
+
 # sandbox-server binary — copied last so Go code changes don't invalidate
 # the expensive apt/font layers above.
 COPY --from=server-builder /sandbox-server /usr/local/bin/sandbox-server


### PR DESCRIPTION
## Problem

`import scanpy` and `import cell2location` fail in **every Docker poll-mode sandbox** — the OSS/CLI default transport:

```
RuntimeError: cannot cache function 'agg_sum_csr-parallel':
no locator available for .../scanpy/get/_kernels.py
```

Numba resolves a cache locator per `@njit(cache=True)` function and **raises** rather than degrading to no-caching when no writable candidate exists. Confirmed with `NUMBA_DEBUG_CACHE`:

```
InTreeCacheLocator       -> None (rejected)     # lib store is read-only
UserProvidedCacheLocator -> None (rejected)     # NUMBA_CACHE_DIR unset
UserWideCacheLocator     -> $HOME/.cache/numba  # the only candidate
```

With `HOME=/root` at mode 0700 that last candidate is gone too, so the import fails.

## Why HOME differed by transport

The image never declared `HOME`. Docker derives it from the **create-time user**, and poll mode creates the container as root to install the egress firewall (`docker-client.ts:345`) before `setpriv` drops to uid 1000. `setpriv` changes credentials, not environment, so the workload inherited root's home. Callback mode starts as uid 1000 and was unaffected — which is why only one transport broke.

Both transports end at uid 1000 with no effective capabilities; the divergence was one leaked environment variable, not two user models.

## Change

One `ENV HOME=/home/sandbox` in `sandbox-base`. Verified that an image-level `ENV` wins over Docker's derivation even under `--user 0` and survives the `setpriv` drop. It also covers K8s, where the numeric `runAsUser: 1000` gives no passwd lookup and `HOME` was likewise never set.

## Validation

Measured on `sandbox-python-r:20260716-68b1e9c`, poll shape (`--user 0` + `setpriv`) vs callback shape (`--user 1000:1000`):

| shape | HOME | scanpy | cell2location |
|-|-|-|-|
| poll, before | `/root` | **FAILED** | **FAILED** |
| poll, after | `/home/sandbox` | OK 1.8s | OK 15.3s |
| callback, after | `/home/sandbox` | OK 2.1s | OK 13.9s |

Poll and callback become byte-identical.

## Deliberately not in this PR

Investigation alongside this turned up several adjacent issues. All are real but none are needed to fix the breakage, and each carries more risk than a single `ENV` line:

- **Cache warming does not work.** The build warms a matplotlib font cache and numba caches *into the lib store*, which is read-only at runtime — matplotlib refuses a read-only `MPLCONFIGDIR` outright (`is not a writable directory`) and numba rejects the in-tree locator, so no published image has ever used them. Separately, the warm-up only *imports* packages while numba compiles lazily at call time, so it warms very little regardless: one small `sc.pp.neighbors` call produced 58 cache saves against the 25 entries the whole warm-up baked. Fixing this means both relocating the cache and exercising representative code paths.
- **Managed deployments need a different mechanism.** Managed runs `sandbox-base` with the store mounted, so anything baked into the extended images never reaches it. A store-carried seed plus hydration would cover both.
- **Transport unification.** Collapsing the `pollMode ?` branch so both transports take one path. Once `HOME` is declared this is hygiene and policy, not correctness.
- **Egress policy and verification.** Callback mode on Docker has unrestricted egress; the only current check is `euid != 0`, which proves the entrypoint ran, not that egress is blocked. K8s cannot create a NetworkPolicy today — `k8s-client.ts` imports only `BatchV1Api`/`CoreV1Api`.
- **A CI gap.** The lib-store load tests run inside a builder stage as root with the store still writable, so they structurally cannot observe this class of failure. A check that boots the built image through the poll privilege path would close it.