### PR TITLE
feat(cli): consume harness 0.7.0 and release cli 0.4.0

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -6,7 +6,7 @@
       "name": "inflexa",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.6.0",
+        "@inflexa-ai/harness": "0.7.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
@@ -151,7 +151,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.6.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-2N5l1DlF9Nudm/sH6Y85XNIgno3xk0a1ZH7KHQthUyINR/yfWnoaIT4TAZCjsrV3uZwXe87eDwZn8L7S6T5lGg=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.7.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-hFBdFrrWPlEG2hnWEgknOk+Hn2Pse/TSbOrQd90Xand+NHT3umQyzzm/gnyCkrqoSwUpBfkzv5mMwc6DF0wrcg=="],
 
     "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.3.6",
+    "version": "0.4.0",
     "private": true,
     "type": "module",
     "scripts": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.6.0",
+        "@inflexa-ai/harness": "0.7.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",


### PR DESCRIPTION
Completes the two-step promotion started in #166. `@inflexa-ai/harness@0.7.0` is published, so the cli can resolve the API its own source already calls.

## What changes

Two lines, plus their lockfile entries:

- `@inflexa-ai/harness` pin `0.6.0` → `0.7.0`
- cli version `0.3.6` → `0.4.0`

**No cli source changes.** None were needed — the cli was never wrong. It referenced `refStorePath` on `SandboxAgentDeps` / `EphemeralDeps` / `DataProfileDeps` / `ConversationAssemblyDeps`, and required `format` / `contents` on `ReferenceArtifact`, all of which existed only in harness source until 0.7.0 shipped. That gap was the 10 typecheck errors that kept `lint (cli)` red on #166; it is 0 against 0.7.0.

## Why minor

The release carries user-visible behavior, not just a dependency move:

- The conversation agent and the planner can now see what reference data is staged. A plan is grounded in the store's actual contents, and the planner stops to ask when data the analysis cannot proceed without is absent — rather than planning a step that can only report failure.
- Package inventory now comes from the sandbox image's OCI label, so the cli reports what is actually installed instead of answering "unknown" on every call.

This bump is a release trigger: it mints a tag, a GitHub release, and production binaries.

## Verification

| Gate | Result |
|-|-|
| `bun run typecheck` | 0 errors (was 10) |
| `bun run lint` | clean |
| `bun run docs:gen` | clean, 38 files, picks up 0.4.0 |
| `bun test` | 1447 pass, 1 skip, 1 fail |

The single failure is `local-provider.test.ts` "loopback bypass is load-bearing" — it asserts a poisoned proxy blocks a loopback request, which WSL's networking lets through. Environmental to the dev machine, unrelated to harness, and `test (cli)` passed in CI on #166 with this same code.

Lockfile churn is the pin alone — no transitive drift, and no `@opentui` core/solid skew.

## Not included

The lib-store OCI label path is inert until someone dispatches `lib-store.yml` (it is `workflow_dispatch`-only, so no merge builds an image). Until then `cachePackageInventory` returns `label_missing` and discovery degrades to "unknown" — which is what the cli already did, so this is no regression. No pin needs moving when that build runs: the image is `:latest` and the cache keys on image ID.

Spec drift noted in #166 for `ref-store`, `lib-store`, `lib-store-build`, `lib-store-provisioning`, and `harness/CLAUDE.md:198` is still outstanding and out of scope here.