### PR TITLE
fix(images): pin lib-store builds to the default buildx builder

### DIFF
--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -104,6 +104,14 @@ jobs:
       ARCH: ${{ matrix.arch }}
       VERSION: ${{ needs.prepare.outputs.version }}
       BASE_IMAGE: ${{ needs.prepare.outputs.base_image }}
+      # Self-hosted boxes keep buildx state across jobs: setup-buildx-action boots
+      # the `default` docker-driver builder but never selects it, so a leftover
+      # `docker buildx use <name>` on the box silently reroutes every build — in
+      # this workflow and inside its scripts — to a docker-container builder that
+      # cannot see locally-loaded images (the pre-push label stamp FROMs a tag
+      # that exists only in the daemon at that point). Pin the builder instead of
+      # trusting machine state.
+      BUILDX_BUILDER: default
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## What happened

Build Sandbox Images run [29754049911](https://github.com/inflexa-ai/inflexa/actions/runs/29754049911) failed on the amd64 self-hosted builder in **Build + push: sandbox-python**:

```
FROM ghcr.io/inflexa-ai/sandbox-python:20260720-b83ed2c-amd64
ERROR: ...: not found
```

The failing build is the label-stamping rebuild in `scripts/lib-store-label-packages.sh`, which intentionally runs **before** `docker push` — the tag exists only in the local daemon at that point.

## Root cause

`docker/setup-buildx-action` with `driver: docker` boots the daemon's built-in `default` builder but does **not** select it. The amd64 box had a leftover `docker buildx use sandbox-image-builder` (a docker-container builder; the name appears nowhere in the repo), so every `docker buildx build` in the job ran on that instance. The image builds survived because their `FROM`s were registry-resolvable and `--load` re-imports the tarball, but the stamping rebuild `FROM`s a daemon-only tag, which a docker-container builder cannot see.

The arm64 job in the same run passed the identical step — its selected builder is the intended default — confirming this is amd64 machine state, not the commit under build. This is also the likely cause of the recurring amd64 publish gap (images not landing on the bare GHCR path from this workflow).

## Fix

Set `BUILDX_BUILDER: default` in the build job's env, pinning the workflow **and the scripts it invokes** to the docker-driver builder regardless of what a self-hosted box has selected. As a bonus this restores the intended `/var/lib/docker` layer caching on the amd64 builder (the container-driver detour was also skipping it, and paying a ~5-minute tarball export/import per image).