### PR TITLE
feat(cli): masked api-key embedding setup, config healing, managed apiKeyHelper support

### DIFF
--- a/cli/src/lib/cli.ts
+++ b/cli/src/lib/cli.ts
@@ -1,4 +1,4 @@
-import { confirm as clackConfirm, isCancel, select as clackSelect, text as clackText } from "@clack/prompts";
+import { confirm as clackConfirm, isCancel, password as clackPassword, select as clackSelect, text as clackText } from "@clack/prompts";
 
 import { shutdown } from "./shutdown.ts";
 
@@ -105,6 +105,24 @@ export async function promptText(
         message,
         placeholder: opts?.placeholder,
         defaultValue: opts?.defaultValue,
+        validate: validate ? (v) => validate(v ?? "") : undefined,
+    });
+    if (isCancel(answer)) fail("Cancelled.");
+    return answer;
+}
+
+/**
+ * Interactive SECRET prompt for the text commands (API keys, tokens): behaves like
+ * {@link promptText} but every typed or pasted character renders masked, so a key never
+ * lands in the terminal scrollback. The submitted value is returned in the clear — masking
+ * is display-only. TTY-only (see {@link promptText}); cancelling aborts. Text-command layer
+ * ONLY — never from the opentui TUI.
+ */
+export async function promptSecret(message: string, opts?: { validate?: (value: string) => string | undefined }): Promise<string> {
+    if (!process.stdin.isTTY) fail(`${message}: a value is required, but stdin is not interactive — pass it via configuration instead.`);
+    const validate = opts?.validate;
+    const answer = await clackPassword({
+        message,
         validate: validate ? (v) => validate(v ?? "") : undefined,
     });
     if (isCancel(answer)) fail("Cancelled.");

--- a/cli/src/lib/config.test.ts
+++ b/cli/src/lib/config.test.ts
@@ -93,6 +93,45 @@ describe("writeConfig / readConfig round-trip", () => {
     });
 });
 
+describe("readConfig — embedding block", () => {
+    test("an apiKey without a mode infers api-key mode (a hand-edited key just works)", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false, embedding: { apiKey: "sk-test" } }));
+        const { embedding } = readConfig();
+        expect(embedding.mode).toBe("api-key");
+        expect(embedding.apiKey).toBe("sk-test");
+    });
+
+    test("a modelPath without a mode infers local mode", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false, embedding: { modelPath: "/models/x.gguf" } }));
+        expect(readConfig().embedding.mode).toBe("local");
+    });
+
+    test("an explicit off wins over a set apiKey — a deliberate switch-off is honored", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false, embedding: { mode: "off", apiKey: "sk-test" } }));
+        const { embedding } = readConfig();
+        expect(embedding.mode).toBe("off");
+        expect(embedding.apiKey).toBe("sk-test"); // kept, so the resolver can name the contradiction
+    });
+
+    test("one malformed field degrades alone — it must NOT reset the whole block to off", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false, embedding: { mode: "api-key", apiKey: "sk-test", dimensions: "1536" } }));
+        const { embedding } = readConfig();
+        expect(embedding.mode).toBe("api-key"); // block survived the bad sibling
+        expect(embedding.apiKey).toBe("sk-test");
+        expect(embedding.dimensions).toBeUndefined(); // only the malformed field was dropped
+    });
+
+    test("an unrecognized mode with an apiKey heals to the inferred api-key, not off", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false, embedding: { mode: "apikey", apiKey: "sk-test" } }));
+        expect(readConfig().embedding.mode).toBe("api-key");
+    });
+
+    test("an absent embedding block still defaults to off", () => {
+        writeRawConfig(JSON.stringify({ telemetry: false }));
+        expect(readConfig().embedding.mode).toBe("off");
+    });
+});
+
 describe("ensureRuntime", () => {
     function probeReady(readyIds: readonly string[], probed?: string[]) {
         return (rt: ContainerRuntime): Promise<Result<void, ContainerRuntimeError>> => {

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -76,17 +76,33 @@ const configSchema = z.object({
     // embeddings route): `apiKey` is required; `baseURL`/`model`/`dimensions` default
     // to api.openai.com + text-embedding-3-small + 1536. `dimensions` must match what
     // `model` emits — it sizes each per-analysis vector index.
+    //
+    // Resilience is PER-FIELD (`.catch(undefined)` on each optional), never block-level:
+    // a block-level `.catch({mode:"off"})` would let ONE malformed field (say a quoted
+    // `dimensions`) silently reset the whole block, surfacing a hand-written `apiKey` as
+    // a baffling "embeddings are not configured". A malformed field now degrades to
+    // unset alone, keeping its siblings.
+    //
+    // An ABSENT/invalid `mode` is inferred from which backend fields the user filled in
+    // (`apiKey` → `api-key`, `modelPath` → `local`) — a hand-edited config that supplies
+    // a credential plainly intends the matching mode, and demanding a second field to
+    // activate the first is a trap. An EXPLICIT `mode: "off"` still wins: it is a
+    // deliberate switch-off, not an omission.
     embedding: z
         .object({
-            mode: z.enum(["local", "api-key", "off"]).catch("off").default("off"),
-            modelPath: z.string().optional(),
-            apiKey: z.string().optional(),
-            baseURL: z.string().optional(),
-            model: z.string().optional(),
-            dimensions: z.number().int().positive().optional(),
+            mode: z.enum(["local", "api-key", "off"]).optional().catch(undefined),
+            modelPath: z.string().optional().catch(undefined),
+            apiKey: z.string().optional().catch(undefined),
+            baseURL: z.string().optional().catch(undefined),
+            model: z.string().optional().catch(undefined),
+            dimensions: z.number().int().positive().optional().catch(undefined),
         })
-        .catch({ mode: "off" })
-        .default({ mode: "off" }),
+        .catch({})
+        .default({})
+        .transform((e) => ({
+            ...e,
+            mode: e.mode ?? (e.apiKey !== undefined ? ("api-key" as const) : e.modelPath !== undefined ? ("local" as const) : ("off" as const)),
+        })),
 });
 export type Config = z.infer<typeof configSchema>;
 

--- a/cli/src/modules/embedding/resolve.test.ts
+++ b/cli/src/modules/embedding/resolve.test.ts
@@ -21,6 +21,17 @@ describe("resolveEmbedder", () => {
         expect(outcome).toBe("embeddings_not_configured");
     });
 
+    test("an explicit off beside a set apiKey names the contradiction, not a bare 'not configured'", () => {
+        // Reaching `off` with apiKey set means the user WROTE `mode: "off"` (an absent mode would have
+        // been inferred to api-key by the config schema) — the message must point at that override.
+        const message = resolveEmbedder(baseConfig({ mode: "off", apiKey: "sk-test" })).match(
+            () => "",
+            (e) => e.message,
+        );
+        expect(message).toContain("embedding.apiKey");
+        expect(message).toContain('"off"');
+    });
+
     test("local mode with modelPath → ok provider", () => {
         const provider = resolveEmbedder(baseConfig({ mode: "local", modelPath: "/some/model.gguf" })).match(
             (p) => p,

--- a/cli/src/modules/embedding/resolve.ts
+++ b/cli/src/modules/embedding/resolve.ts
@@ -37,6 +37,14 @@ export const DEFAULT_API_BASE_URL = "https://api.openai.com/v1";
  */
 export const DEFAULT_API_EMBEDDING_DIMENSIONS = 1536;
 
+/**
+ * The model `api-key` mode ends up on when `embedding.model` is unset — mirrors the harness provider's
+ * own default. Like {@link DEFAULT_API_EMBEDDING_DIMENSIONS}, it is not consulted by
+ * {@link resolveEmbedder} (the harness applies its default); it exists so the setup prompt can pre-fill
+ * the exact model the config would otherwise resolve to.
+ */
+export const DEFAULT_API_EMBEDDING_MODEL = "text-embedding-3-small";
+
 export type EmbeddingResolveError =
     | { readonly type: "embeddings_not_configured"; readonly message: string }
     | { readonly type: "local_model_missing"; readonly message: string }
@@ -51,9 +59,17 @@ export function resolveEmbedder(config: Config): Result<EmbeddingProvider, Embed
     const { mode } = config.embedding;
 
     if (mode === "off") {
+        // `mode` is inferred from a lone `apiKey`/`modelPath` (see the embedding schema in lib/config.ts),
+        // so reaching `off` WITH a backend field set means the user wrote an EXPLICIT `mode: "off"` beside
+        // it — name that contradiction instead of claiming nothing is configured.
+        const strandedField =
+            config.embedding.apiKey !== undefined ? "embedding.apiKey" : config.embedding.modelPath !== undefined ? "embedding.modelPath" : null;
         return err({
             type: "embeddings_not_configured",
-            message: "Embeddings are not configured. Run `inflexa setup --embeddings local` to enable local embeddings.",
+            message:
+                strandedField !== null
+                    ? `Embeddings are switched off: ${strandedField} is set but embedding.mode is explicitly "off". Remove the mode override (it is inferred from ${strandedField}), or set it to ${strandedField === "embedding.apiKey" ? '"api-key"' : '"local"'}.`
+                    : "Embeddings are not configured. Run `inflexa setup --embeddings local` to enable local embeddings.",
         });
     }
 

--- a/cli/src/modules/embedding/setup.ts
+++ b/cli/src/modules/embedding/setup.ts
@@ -23,15 +23,16 @@ import { dirname } from "node:path";
 import { log, spinner as clackSpinner } from "@clack/prompts";
 import { err, ok, type Result } from "neverthrow";
 
-import type { AgentSession } from "@inflexa-ai/harness";
+import { createEmbeddingProvider, createNoopBillingResolver, type AgentSession } from "@inflexa-ai/harness";
 
 import { readConfig, writeConfig } from "../../lib/config.ts";
-import { promptText, select } from "../../lib/cli.ts";
+import { promptSecret, promptText, select } from "../../lib/cli.ts";
 import { env } from "../../lib/env.ts";
 import { isCompiledBinary } from "../../lib/install_context.ts";
 import { ensureLlamaServer, materializedLlamaServer } from "./llama_runtime.ts";
 import { createLocalEmbeddingProvider, LOCAL_EMBEDDING_DIMENSIONS, stopLocalSidecar } from "./local-provider.ts";
 import { MODEL_SHA256, MODEL_URL } from "./model_pin.ts";
+import { DEFAULT_API_BASE_URL, DEFAULT_API_EMBEDDING_DIMENSIONS, DEFAULT_API_EMBEDDING_MODEL } from "./resolve.ts";
 
 export type EmbeddingSetupError =
     // Model acquisition failed — spans BOTH byte sources: a from-source HuggingFace download fault AND a
@@ -244,6 +245,9 @@ export async function verifyModel(modelPath: string, expectedDim?: number): Prom
  *   + `modelPath = env.embeddingModelPath`.
  * - your own GGUF → prompt for a path, verify it (measuring whatever width it emits), and record
  *   `mode = "local"` + that `modelPath` + the measured `dimensions` (so the index is sized to it).
+ * - API key → prompt for the endpoint/key (the key input is MASKED — paste-friendly, never echoed) +
+ *   model id, probe the endpoint with one real embed (measuring the emitted width), and record
+ *   `mode = "api-key"` + the key + only the fields that differ from the provider defaults.
  *
  * Non-interactive shells (no TTY, or `interactive === false`) skip the prompt entirely without hanging —
  * `mode` stays whatever it was. A preselected `mode` (from `--embeddings`) overrides the prompt and runs
@@ -256,13 +260,9 @@ export async function runEmbeddingSetup(interactive: boolean, preselected?: "loc
     // A preselected mode from `--embeddings` short-circuits the prompt.
     if (preselected !== undefined) {
         if (preselected === "off") return ok(undefined);
-        if (preselected === "api-key") {
-            warnOnModeSwitch(config.embedding.mode, "api-key");
-            // API-key mode setup is deferred; only local setup is implemented
-            // here. Decline cleanly rather than half-doing it.
-            log.warn("API-key embedding mode is selected but not yet configured by setup. Set it via `inflexa config`, or `embedding.apiKey` in config.json.");
-            return ok(undefined);
-        }
+        // `api-key` still prompts for its endpoint/key (a secret cannot ride a flag), so it needs a TTY
+        // even when preselected — promptText/promptSecret fail fast with a clear message otherwise.
+        if (preselected === "api-key") return runApiKeySetup(config);
         // preselected === "local" → the built-in model (custom paths are interactive-only).
         return runBuiltinLocalSetup(config);
     }
@@ -280,11 +280,7 @@ export async function runEmbeddingSetup(interactive: boolean, preselected?: "loc
         log.info("Embeddings skipped (mode left unchanged).");
         return ok(undefined);
     }
-    if (choice === "api-key") {
-        warnOnModeSwitch(config.embedding.mode, "api-key");
-        log.warn("API-key embedding mode is not yet configured by setup. Set it via `inflexa config`, or `embedding.apiKey` in config.json.");
-        return ok(undefined);
-    }
+    if (choice === "api-key") return runApiKeySetup(config);
     if (choice === "custom") return runCustomLocalSetup(config);
     // choice === "builtin"
     return runBuiltinLocalSetup(config);
@@ -403,6 +399,103 @@ async function runCustomLocalSetup(config: ReturnType<typeof readConfig>): Promi
         .mapErr((e): EmbeddingSetupError => ({ type: "verify_failed", message: `Verification passed but config could not be written: ${e.type}` }))
         .map(() => {
             log.success(`Local embeddings configured from your model (${dimensions}-dim). \`embedding.mode\` is now \`local\`.`);
+            return undefined;
+        });
+}
+
+/**
+ * Probe a candidate api-key configuration with ONE real embed against the endpoint — the same wire path
+ * the hot loop uses (the harness provider + noop billing) — and MEASURE the vector width it emits. A
+ * wrong key, endpoint, or model id surfaces here, at setup, instead of late in the profile workflow;
+ * the measured width is returned so the caller records the true index size rather than trusting a
+ * guessed `dimensions`. Failures are `verify_failed` — the message carries the provider's own cause.
+ */
+async function probeApiEmbedding(candidate: { baseURL: string; apiKey: string; model: string }): Promise<Result<number, EmbeddingSetupError>> {
+    const s = clackSpinner();
+    s.start(`Probing ${candidate.baseURL} with one ${candidate.model} embed`);
+
+    const provider = createEmbeddingProvider({
+        baseURL: candidate.baseURL,
+        token: candidate.apiKey,
+        model: candidate.model,
+        resolveBilling: createNoopBillingResolver(),
+    });
+    // Same structural stand-in as verifyModel's probe: the noop billing resolver reads only `scope`,
+    // and nothing downstream touches the omitted RunSession fields — hence the `as unknown as`.
+    const probeSession = { scope: { kind: "analysis", analysisId: "embedding-setup-verify" } } as unknown as AgentSession;
+    const outcome = await provider.embed(["inflexa embedding verification probe"], probeSession).match(
+        (vectors): { readonly ok: true; readonly dim: number } => ({ ok: true, dim: vectors[0]?.length ?? 0 }),
+        (e): { readonly ok: false; readonly message: string } => ({ ok: false, message: e.message }),
+    );
+
+    if (!outcome.ok) {
+        s.error("Endpoint probe failed");
+        return err({ type: "verify_failed", message: `The embeddings endpoint rejected the probe: ${outcome.message}` });
+    }
+    if (outcome.dim <= 0) {
+        s.error("Endpoint probe failed");
+        return err({ type: "verify_failed", message: "The endpoint answered but produced empty vectors — check the model id names an embedding model." });
+    }
+    s.stop(`Verified: ${outcome.dim}-dim vectors`);
+    return ok(outcome.dim);
+}
+
+/**
+ * The api-key branch: collect endpoint + key + model interactively, probe with one real embed, and
+ * record the choice. The key prompt is MASKED (paste-friendly, never echoed into scrollback) — it is
+ * still persisted in the clear to config.json, which the log line says out loud so the trade-off is the
+ * user's. Only fields that differ from the provider defaults are written (minimal-config, mirroring
+ * {@link runCustomLocalSetup}'s dimensions handling): the measured width replaces any guessed
+ * `dimensions`, so a non-default model sizes the per-analysis index to what it actually emits.
+ */
+async function runApiKeySetup(config: ReturnType<typeof readConfig>): Promise<Result<void, EmbeddingSetupError>> {
+    warnOnModeSwitch(config.embedding.mode, "api-key");
+    log.message("Setting up remote embeddings (an OpenAI-compatible /embeddings endpoint). The key is stored in config.json — keep that file private.");
+
+    const urlPrefill = config.embedding.baseURL ?? DEFAULT_API_BASE_URL;
+    const baseURL = (
+        await promptText("Embeddings endpoint URL — the /v1-terminated root", {
+            defaultValue: urlPrefill,
+            placeholder: urlPrefill,
+            validate: (v) => {
+                const s = v.trim();
+                if (s === "") return undefined; // empty submit keeps the pre-filled default
+                return URL.canParse(s) ? undefined : "Must be a valid URL, including the scheme (e.g. https://…).";
+            },
+        })
+    ).trim();
+    const confirmedURL = baseURL === "" ? urlPrefill : baseURL;
+
+    const apiKey = (
+        await promptSecret("API key (input is hidden — paste it)", {
+            validate: (v) => (v.trim() === "" ? "Enter the API key." : undefined),
+        })
+    ).trim();
+
+    const modelPrefill = config.embedding.model ?? DEFAULT_API_EMBEDDING_MODEL;
+    const model =
+        (
+            await promptText("Embedding model id", {
+                defaultValue: modelPrefill,
+                placeholder: modelPrefill,
+            })
+        ).trim() || modelPrefill;
+
+    const probe = await probeApiEmbedding({ baseURL: confirmedURL, apiKey, model });
+    if (probe.isErr()) return err(probe.error);
+    const dimensions = probe.value;
+
+    const embedding = {
+        mode: "api-key" as const,
+        apiKey,
+        ...(confirmedURL === DEFAULT_API_BASE_URL ? {} : { baseURL: confirmedURL }),
+        ...(model === DEFAULT_API_EMBEDDING_MODEL ? {} : { model }),
+        ...(dimensions === DEFAULT_API_EMBEDDING_DIMENSIONS ? {} : { dimensions }),
+    };
+    return writeConfig({ ...config, embedding })
+        .mapErr((e): EmbeddingSetupError => ({ type: "verify_failed", message: `The endpoint probe passed but config could not be written: ${e.type}` }))
+        .map(() => {
+            log.success(`Remote embeddings configured (${model}, ${dimensions}-dim). \`embedding.mode\` is now \`api-key\`.`);
             return undefined;
         });
 }

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -135,30 +135,32 @@ describe("ecosystem env adoption — detection → non-secret connection", () =>
 });
 
 // The credential-helper detection is a pure shape over its raw signals, so the offer logic and the
-// "managed helper is never auto-executed" guarantee are testable without touching the filesystem or env.
+// "managed helper is never executed without explicit confirmation" guarantee are testable without
+// touching the filesystem or env.
 describe("credential-helper detection", () => {
     test("a user-level apiKeyHelper is detected and carried as a pre-fillable command", () => {
-        const d = detectCredentialHelperFrom("/opt/mint-token", false, false);
+        const d = detectCredentialHelperFrom("/opt/mint-token", null, false);
         expect(credentialHelperDetected(d)).toBe(true);
         expect(d.userHelperCommand).toBe("/opt/mint-token");
     });
 
     test("ANTHROPIC_AUTH_TOKEN alone is a detected signal (env-bearer offerable)", () => {
-        const d = detectCredentialHelperFrom(null, false, true);
+        const d = detectCredentialHelperFrom(null, null, true);
         expect(credentialHelperDetected(d)).toBe(true);
         expect(d.authTokenEnvSet).toBe(true);
     });
 
-    test("an org-managed helper alone is detected but carries NO command to pre-fill or auto-execute", () => {
-        const d = detectCredentialHelperFrom(null, true, false);
+    test("an org-managed helper alone is detected, carried as its own explicit choice — never merged into the user path", () => {
+        const d = detectCredentialHelperFrom(null, "company-code token", false);
         expect(credentialHelperDetected(d)).toBe(true);
-        expect(d.managedHelperPresent).toBe(true);
-        // The user must supply/confirm the command — the managed helper is never lifted into a runnable command.
+        expect(d.managedHelperCommand).toBe("company-code token");
+        // Kept apart from the user's own helper: the offer labels it as the organization's, and the
+        // command is only ever run after the user selects it and confirms it in the editable prompt.
         expect(d.userHelperCommand).toBeNull();
     });
 
     test("no signals → nothing detected", () => {
-        expect(credentialHelperDetected(detectCredentialHelperFrom(null, false, false))).toBe(false);
+        expect(credentialHelperDetected(detectCredentialHelperFrom(null, null, false))).toBe(false);
     });
 });
 

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -1049,33 +1049,41 @@ export function writeDirectConnection(input: DirectConnectionInput): Result<void
 
 /**
  * The read-only signals that a credential-helper Anthropic setup exists. A pure shape (no IO) so the
- * offer/precedence is unit-testable. User-level vs org-managed is tracked SEPARATELY because only the
- * user's OWN `apiKeyHelper` may be pre-filled — the managed one is surfaced but never lifted.
+ * offer/precedence is unit-testable. User-level vs org-managed is tracked SEPARATELY because they are
+ * offered differently: the user's OWN `apiKeyHelper` is the recommended default, while the org-managed
+ * one is shown for the user to explicitly pick and confirm — never silently merged into the user path,
+ * and NEVER executed before the user has seen and accepted the exact command (the probe runs it only
+ * after that confirmation).
  */
 export type CredentialHelperDetection = {
     /** An `apiKeyHelper` from the user's OWN `~/.claude/settings.json` — pre-fillable as an editable default. */
     readonly userHelperCommand: string | null;
-    /** An org-managed `apiKeyHelper` is present — surfaced to the user, but NEVER pre-filled or auto-executed. */
-    readonly managedHelperPresent: boolean;
+    /**
+     * The `apiKeyHelper` from the org-managed Claude Code settings (the per-platform
+     * `managed-settings.json`), or `null` when absent/unreadable. Offered as its own EXPLICIT choice —
+     * shown to the user, editable before use, and executed only after they select and confirm it.
+     */
+    readonly managedHelperCommand: string | null;
     /** `ANTHROPIC_AUTH_TOKEN` is set — the env-bearer source is offerable. */
     readonly authTokenEnvSet: boolean;
 };
 
 /** True when ANY credential-helper signal was detected, so setup should offer the credential-source path. */
 export function credentialHelperDetected(d: CredentialHelperDetection): boolean {
-    return d.userHelperCommand !== null || d.managedHelperPresent || d.authTokenEnvSet;
+    return d.userHelperCommand !== null || d.managedHelperCommand !== null || d.authTokenEnvSet;
 }
 
 /**
- * Assemble the detection from its raw signals — pure, so the offer logic (and the "managed helper is not
- * auto-executed" guarantee) is testable without touching the filesystem or environment.
+ * Assemble the detection from its raw signals — pure, so the offer logic (and the "managed helper is
+ * never executed without explicit confirmation" guarantee) is testable without touching the filesystem
+ * or environment.
  */
 export function detectCredentialHelperFrom(
     userHelperCommand: string | null,
-    managedHelperPresent: boolean,
+    managedHelperCommand: string | null,
     authTokenEnvSet: boolean,
 ): CredentialHelperDetection {
-    return { userHelperCommand, managedHelperPresent, authTokenEnvSet };
+    return { userHelperCommand, managedHelperCommand, authTokenEnvSet };
 }
 
 /** The user's OWN Claude Code settings — an `apiKeyHelper` here is theirs, so setup may pre-fill it as an editable default. */
@@ -1084,15 +1092,23 @@ function userClaudeSettingsPath(): string {
 }
 
 /**
- * The org-managed Claude Code settings file (Claude Code's documented per-platform managed-settings path).
- * An `apiKeyHelper` here belongs to the organization: setup surfaces that one exists but NEVER pre-fills or
- * auto-executes it — the governance decision stays with the user, and the file may be unreadable or need
- * special env anyway.
+ * The org-managed Claude Code settings locations, most-specific first (Claude Code's documented
+ * per-platform managed-settings paths — this is the standard place an enterprise MDM/IT deploys the
+ * org's `apiKeyHelper`). macOS additionally probes the per-user `~/Library` twin of the system path:
+ * some IT rollouts install there ("Library/Application Support/…" in per-user install docs), and a
+ * read-only existence probe of one extra path is free. An `apiKeyHelper` found here belongs to the
+ * organization: setup shows it as an explicit choice but never runs it before the user confirms the
+ * exact command — the governance decision stays with the user, and the file may need special env anyway.
  */
-function managedClaudeSettingsPath(): string {
-    if (process.platform === "darwin") return "/Library/Application Support/ClaudeCode/managed-settings.json";
-    if (process.platform === "win32") return "C:\\ProgramData\\ClaudeCode\\managed-settings.json";
-    return "/etc/claude-code/managed-settings.json";
+function managedClaudeSettingsPaths(): string[] {
+    if (process.platform === "darwin") {
+        return [
+            "/Library/Application Support/ClaudeCode/managed-settings.json",
+            join(homedir(), "Library", "Application Support", "ClaudeCode", "managed-settings.json"),
+        ];
+    }
+    if (process.platform === "win32") return ["C:\\ProgramData\\ClaudeCode\\managed-settings.json"];
+    return ["/etc/claude-code/managed-settings.json"];
 }
 
 /**
@@ -1119,11 +1135,9 @@ function readApiKeyHelper(path: string): string | null {
  * settings-file signal already subsumes it — no fragile `claude` subprocess is spawned.
  */
 function detectCredentialHelper(): CredentialHelperDetection {
-    return detectCredentialHelperFrom(
-        readApiKeyHelper(userClaudeSettingsPath()),
-        readApiKeyHelper(managedClaudeSettingsPath()) !== null,
-        anthropicAuthTokenSet(),
-    );
+    // First managed location that yields a helper wins — the paths are ordered most-authoritative first.
+    const managed = managedClaudeSettingsPaths().reduce<string | null>((found, path) => found ?? readApiKeyHelper(path), null);
+    return detectCredentialHelperFrom(readApiKeyHelper(userClaudeSettingsPath()), managed, anthropicAuthTokenSet());
 }
 
 /** The wire protocol a direct connection speaks, resolving the "infer from provider" default the way `resolveModelConnection` does — the probe needs it to add the anthropic version header. */
@@ -1185,25 +1199,25 @@ function truncateCommand(s: string, max = 44): string {
 
 /**
  * Offer the credential-source path for a detected helper setup. Opt-in: the user chooses a credential
- * command (pre-filled from their OWN settings when present, always editable), the
- * `ANTHROPIC_AUTH_TOKEN` env bearer (when set), or declines to the static-key path. An org-managed helper is
- * announced but the user must still supply/confirm the command — it is never auto-executed. The chosen
- * source is VALIDATED (run once + auth probe) before it is returned; a probe failure reports the likely
- * cause and returns `null` (falling back to the static key). Returns the token-free `auth` block, or `null`.
+ * command — pre-filled from their OWN settings, or from the ORG-MANAGED `managed-settings.json` as its
+ * own explicitly-labeled choice, both always editable — the `ANTHROPIC_AUTH_TOKEN` env bearer (when
+ * set), or declines to the static-key path. The managed helper is never run before the user has seen
+ * and confirmed the exact command in the editable prompt. The chosen source is VALIDATED (run once +
+ * auth probe) before it is returned; a probe failure reports the likely cause and returns `null`
+ * (falling back to the static key). Returns the token-free `auth` block, or `null`.
  */
 async function offerCredentialSource(direct: DirectConnectionInput, detection: CredentialHelperDetection): Promise<ModelAuthConfig | null> {
-    // A managed-only helper: announce it, but the user must still supply/confirm a command — never lifted.
-    if (detection.managedHelperPresent && detection.userHelperCommand === null) {
-        log.info(
-            "An organization-managed Claude credential helper was detected. Inflexa will not run it automatically — supply or confirm the command to use it.",
-        );
-    }
-
     const options: { value: string; label: string }[] = [];
     if (detection.userHelperCommand !== null) {
         options.push({
             value: "command_prefill",
             label: `Use the credential command from ~/.claude/settings.json (${truncateCommand(detection.userHelperCommand)})`,
+        });
+    }
+    if (detection.managedHelperCommand !== null) {
+        options.push({
+            value: "command_prefill_managed",
+            label: `Use your organization's managed credential command (${truncateCommand(detection.managedHelperCommand)})`,
         });
     }
     options.push({ value: "command", label: "Run a credential command to mint a short-lived token" });
@@ -1217,19 +1231,28 @@ async function offerCredentialSource(direct: DirectConnectionInput, detection: C
     if (chosen === "env_bearer") {
         auth = { kind: "env", var: ANTHROPIC_AUTH_TOKEN_VAR, scheme: "bearer" };
     } else {
-        const prefill = chosen === "command_prefill" ? (detection.userHelperCommand ?? "") : "";
+        const prefill =
+            chosen === "command_prefill"
+                ? (detection.userHelperCommand ?? "")
+                : chosen === "command_prefill_managed"
+                  ? (detection.managedHelperCommand ?? "")
+                  : "";
         const command = (
             await promptText("Credential command (its stdout is the token — Claude Code apiKeyHelper compatible)", {
                 ...(prefill !== "" && { defaultValue: prefill, placeholder: prefill }),
                 validate: (v) => (v.trim() === "" ? "Enter a command." : undefined),
             })
         ).trim();
-        // Infer a scheme default and let the user override (the probe validates it): an apiKeyHelper mints an
-        // `x-api-key`; a bearer is the OAuth/WIF case.
-        const scheme = (await select("How is the minted token sent on the wire?", [
+        // Infer a scheme default and let the user override (the probe validates it either way): a personal
+        // apiKeyHelper conventionally mints an `x-api-key`, while an ORG-MANAGED helper fronting an
+        // enterprise gateway conventionally mints a short-lived OAuth access token sent as a Bearer — so
+        // the managed choice lists bearer first. Our `select` has no initialValue; ordering IS the default.
+        const schemeOptions = [
             { value: "x-api-key", label: "x-api-key header (a minted API key — apiKeyHelper default)" },
-            { value: "bearer", label: "Authorization: Bearer (an OAuth / WIF access token)" },
-        ])) as CredentialScheme;
+            { value: "bearer", label: "Authorization: Bearer (an OAuth / WIF / enterprise-gateway access token)" },
+        ];
+        if (chosen === "command_prefill_managed") schemeOptions.reverse();
+        const scheme = (await select("How is the minted token sent on the wire?", schemeOptions)) as CredentialScheme;
         auth = { kind: "command", command, scheme };
     }
 


### PR DESCRIPTION
## What

Three related setup/credential improvements driven by user reports:

**1. API-key embedding setup is now real, with a masked key prompt.** The `api-key` backend was a stub ("set `embedding.apiKey` in config.json"). Setup now collects the endpoint (pre-filled `https://api.openai.com/v1`), the key via a masked, paste-friendly clack `password` prompt (new `promptSecret` in `lib/cli.ts`), and the model id — then probes with one real embed through the same harness provider the hot path uses, measuring the emitted vector width and recording it as `dimensions`. `inflexa setup --embeddings api-key` runs the same branch.

**2. "apiKey set but startup says embeddings not set" — fixed at the schema.** Two compounding bugs: `mode` silently defaulted to `off` when only `apiKey` was hand-set, and the block-level `.catch({mode:"off"})` let ONE malformed field (e.g. a quoted `dimensions`) reset the whole embedding block. The schema now heals per-field, and an absent/invalid `mode` is inferred from what was filled in (`apiKey` → `api-key`, `modelPath` → `local`). An explicit `mode: "off"` still wins, and the resolver names that contradiction instead of claiming nothing is configured.

**3. The org-managed `apiKeyHelper` is surfaced, on all OSes.** An enterprise user found their org's token-minting command in Claude Code's `managed-settings.json` — the documented managed-policy locations, which setup already probed on macOS/Linux/Windows but only announced as "present" without showing the command. Detection now carries the command itself (plus the `~/Library` twin probe on macOS), the offer lists it as its own labeled choice pre-filled into the editable prompt after explicit selection (never executed before the user confirms it), and choosing it defaults the wire scheme to `Authorization: Bearer` (enterprise gateways mint OAuth-style tokens).

No changes to the refresher itself — `createCredentialSource` + `buildAuthInjectingFetch` (cached mint, TTL refresh, 401 → forceRefresh → single retry) were verified already implemented and tested.

## Tests

- new: config schema (mode inference, per-field healing, explicit-off precedence), resolver contradiction message, managed-command detection shape
- updated: credential-helper detection tests for the command-carrying shape
- 183 tests green across the touched areas; typecheck + lint clean