### PR TITLE
Let the agent see what the environment holds, and describe the CLI from the registry

### DIFF
--- a/cli/src/modules/harness/inflexa_tool.test.ts
+++ b/cli/src/modules/harness/inflexa_tool.test.ts
@@ -4,6 +4,7 @@ import { AskRejectedError, UnavailableAsk, type AgentSession, type AskApproval, 
 import { describe, expect, test } from "bun:test";
 
 import type { AgentPolicy } from "../../cli/agent_policy.ts";
+import { reportAgentPolicies } from "../../test_support/agent_policy_report.ts";
 import { createRunInflexaTool, decideAction, resolveInvocation, spawnInflexa, type RunSubprocess, type SubprocessResult } from "./inflexa_tool.ts";
 
 // A canned subprocess outcome; overridden per-test for the timeout/cancel/truncation cases.
@@ -300,6 +301,38 @@ describe("run_inflexa — execute", () => {
 // they are exercised at `decideAction`, the pure seam `execute` runs. These pin the two invariants the
 // black-box tests above cannot: an unknown flag escalates auto→ask (never runs free), and a policy-less
 // action fails closed to blocked (never silently approvable).
+// The description is what the agent knows about this tool, and it is DERIVED from the
+// registry so it cannot drift out of sync with what the tool will actually let it run.
+// The invariant worth holding is coverage: a command the agent may invoke, or is barred
+// from invoking, has to appear — a registered command missing from its own tool's
+// description is a capability the agent will never discover, or one it wastes a turn on.
+describe("run_inflexa — the described surface tracks the registry", () => {
+    test("every policy-stamped command appears, grouped by what it costs the user", () => {
+        const { description } = createRunInflexaTool();
+        for (const row of reportAgentPolicies()) {
+            // `reportAgentPolicies` walks from the root, whose own grantKey is the bare
+            // program name and carries no policy of its own to describe.
+            if (row.grantKey === "inflexa") continue;
+            const path = row.grantKey.replace(/^inflexa /, "");
+            expect(description).toContain(`\`${path}\``);
+        }
+    });
+
+    test("a read-only command and an approval-gated one land in different groups", () => {
+        const { description } = createRunInflexaTool();
+        const free = description.indexOf("Read-only, and normally run without interrupting the user");
+        const gated = description.indexOf("Always stop for the user's approval first");
+        const blocked = description.indexOf("Not available through this tool at all");
+        expect(free).toBeGreaterThan(-1);
+        expect(gated).toBeGreaterThan(free);
+        expect(blocked).toBeGreaterThan(gated);
+        // `refs list` only reads the store; `refs download` fetches and writes. The agent
+        // reporting reference data as unobtainable is exactly the failure this prevents.
+        expect(description.slice(free, gated)).toContain("`refs list`");
+        expect(description.slice(gated, blocked)).toContain("`refs download`");
+    });
+});
+
 describe("decideAction — policy cascade", () => {
     test("no policy fails closed to blocked with a developer-facing message", () => {
         const decision = decideAction(undefined, "inflexa mystery", []);

--- a/cli/src/modules/harness/inflexa_tool.ts
+++ b/cli/src/modules/harness/inflexa_tool.ts
@@ -23,10 +23,12 @@
 import { join } from "node:path";
 
 import { defineTool, type AskRequest, type ToolError } from "@inflexa-ai/harness";
+import type { Command } from "commander";
 import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
-import { type AgentPolicy } from "../../cli/agent_policy.ts";
+import { type AgentPolicy, getAgentPolicy } from "../../cli/agent_policy.ts";
+import { buildProgram } from "../../cli/index.ts";
 import { env } from "../../lib/env.ts";
 import { classifyInflexaArgv } from "./inflexa_classify.ts";
 
@@ -271,6 +273,42 @@ export async function spawnInflexa(cmd: readonly string[], signal: AbortSignal, 
     return { exitCode, stdout: stdout.text(), stderr: stderr.text(), endedBy };
 }
 
+/**
+ * Render the agent-runnable command surface FROM the registry, for the tool's own description.
+ *
+ * The alternative is prose naming what the CLI covers — a second, hand-kept copy
+ * of the registry that nothing typechecks, so it drifts the first time a command
+ * is added or reclassified and stays wrong until an agent believes it. A stamped
+ * policy is the exact membership test: `registerAction` is the only way to attach
+ * an action handler and it requires a policy, so "carries a policy" IS "an agent
+ * could run this" — which also keeps this on the public `getAgentPolicy` read
+ * rather than the private slot the audit tests must reach for.
+ *
+ * Arguments and options are deliberately left out: they are the bulk of the
+ * surface and the fastest-moving part of it, and `--help` already serves them
+ * accurately on demand. Blocked commands need only their name.
+ */
+function describeCommandSurface(): string {
+    const groups: Record<AgentPolicy["kind"], string[]> = { auto: [], approval: [], blocked: [] };
+    const walk = (command: Command, path: readonly string[]): void => {
+        const policy = getAgentPolicy(command);
+        const name = `\`${path.join(" ")}\``;
+        if (policy !== undefined) groups[policy.kind].push(policy.kind === "blocked" ? name : `${name} (${command.description()})`);
+        for (const child of command.commands) walk(child, [...path, child.name()]);
+    };
+    // A fresh throwaway root, reflecting THIS process's baked build channel exactly as
+    // the classifier's does. Nothing is parsed, so there is no help/error output to silence.
+    for (const child of buildProgram().commands) walk(child, [child.name()]);
+
+    return [
+        groups.auto.length > 0 ? `Read-only, and normally run without interrupting the user: ${groups.auto.join("; ")}.` : "",
+        groups.approval.length > 0 ? `Always stop for the user's approval first: ${groups.approval.join("; ")}.` : "",
+        groups.blocked.length > 0 ? `Not available through this tool at all: ${groups.blocked.join(", ")}.` : "",
+    ]
+        .filter(Boolean)
+        .join(" ");
+}
+
 /** Construction deps for {@link createRunInflexaTool}; every field defaults to the real host value, overridable in tests. */
 export interface RunInflexaToolDeps {
     readonly runSubprocess?: RunSubprocess;
@@ -296,14 +334,16 @@ export function createRunInflexaTool(deps: RunInflexaToolDeps = {}) {
     return defineTool({
         id: "run_inflexa",
         description:
-            "Run the local `inflexa` command-line tool. Pass `argv` as the list of words you would type " +
-            'after `inflexa` on a shell (e.g. ["--help"], or ["--version"]). Drive it like any unfamiliar ' +
-            'command: start from ["--help"] to see the top-level commands, then drill in with ' +
-            '["<subcommand>", "--help"] to learn a subcommand\'s arguments and options before you invoke it. ' +
-            "Help and version lookups run right away, and so do some commands classified as read-only; any other " +
-            "command that would actually do something pauses for the user's approval first, and the captured stdout, " +
-            "stderr, and exit code come back to you. The interactive " +
-            "UI launchers and the infrastructure lifecycle commands (up, down, setup) are not available through this tool.",
+            "Run the local `inflexa` command-line tool — the host's control surface for the environment an analysis runs in. " +
+            'Pass `argv` as the list of words you would type after `inflexa` on a shell (e.g. ["--help"], or ["--version"]). ' +
+            "When the environment is missing something the work needs, look here before telling the user it cannot be had: " +
+            "provisioning you can drive through this tool is a real option, not something out of reach. " +
+            "The commands below are the entire surface available to you, listed without their arguments and options — " +
+            'run ["<subcommand>", "--help"] to learn those before invoking, which is always free and never prompts. ' +
+            "A read-only command can still escalate to an approval when an option outside its known-safe set rides along, " +
+            "so being asked is normal and never a sign the command was the wrong one. " +
+            describeCommandSurface() +
+            " Captured stdout, stderr, and exit code come back to you; a non-zero exit is a real answer about what happened, not a tool failure.",
         inputSchema: z.object({
             argv: z
                 .array(z.string())

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -951,6 +951,9 @@ async function bootHarnessRuntimeOnce(
             // Gives the planner reference discovery over the same store the sandbox
             // mounts, so a plan can name what this install actually holds.
             refStorePath: env.refsDir,
+            // Same manifest the sandbox agents read. Without it, answering "is this package
+            // installed?" costs an ephemeral sandbox run — a container spun up to import one name.
+            ...(packagesFile ? { packagesFile } : {}),
             chrome: {},
             // Host-supplied conversation tool: lets the agent drive the local `inflexa` CLI as a subprocess.
             hostTools: [createRunInflexaTool()],

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -50,7 +50,6 @@ describe("createConversationAgent", () => {
         expect(agent.id).toBe(CONVERSATION_AGENT_ID);
         expect(agent.model).toBe("anthropic/claude-opus-4-7");
         expect(agent.maxIterations).toBe(50);
-        expect(agent.tools.length).toBe(36);
     });
 
     // Provisioning is decided in conversation: an embedder may give this agent a way to
@@ -60,6 +59,13 @@ describe("createConversationAgent", () => {
     // that something is absent.
     test("carries reference discovery, so provisioning is never decided blind", () => {
         expect(buildAgent().tools.map((tool) => tool.id)).toContain("list_available_refs");
+    });
+
+    // "Is Seurat installed?" is a manifest lookup, but without this tool the only way to
+    // answer it is `run_ephemeral` — a whole container spun up to run one import. The
+    // sandbox agents already read this manifest; the agent the user actually asks did not.
+    test("carries package discovery, so an environment question costs no sandbox", () => {
+        expect(buildAgent().tools.map((tool) => tool.id)).toContain("list_available_packages");
     });
 
     test("the system prompt is static SOUL composition", () => {

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -82,6 +82,8 @@ import {
 } from "../tools/workspace/index.js";
 import { showUserTool } from "../tools/display/index.js";
 import { createUpdateWorkingMemoryTool } from "../tools/memory/index.js";
+import type { EnvironmentStorePaths } from "../config/environment-stores.js";
+import { createListAvailablePackagesTool } from "../tools/sandbox/list-available-packages.js";
 import { createListAvailableRefsTool } from "../tools/sandbox/list-available-refs.js";
 import { createExecutePlanTool } from "../tools/execute-plan.js";
 import { createRunEphemeralTool } from "../tools/run-ephemeral.js";
@@ -97,8 +99,13 @@ export const CONVERSATION_AGENT_ID = "conversation-agent" as const;
 /** Runaway guard — heavy tool-driving turns need generous headroom. */
 const CONVERSATION_MAX_ITERATIONS = 50;
 
-/** The shared dependencies the composition root explodes apart. */
-export interface ConversationAgentDeps {
+/**
+ * The shared dependencies the composition root explodes apart. The environment
+ * store paths give this agent and its planner the same view of what is staged and
+ * what is importable that a sandbox agent has — read host-side, so answering
+ * "does this environment have X?" costs a lookup rather than a container.
+ */
+export interface ConversationAgentDeps extends EnvironmentStorePaths {
     /** Operational logging seam; omitted falls back to no-op. */
     readonly logger?: Logger;
     /** The LLM seam every loop-driving tool runs its sub-agent on. */
@@ -164,13 +171,6 @@ export interface ConversationAgentDeps {
      * built-in tool.
      */
     readonly hostTools?: readonly Tool[];
-    /**
-     * Host path of the reference store — the same bytes sandboxes mount at
-     * `/mnt/refs`. Gives `generate_plan` reference discovery, so a plan can be
-     * grounded in what this environment actually holds. Omit when no store is
-     * provisioned.
-     */
-    readonly refStorePath?: string;
 }
 
 /** Build the conversation `AgentDefinition` with every tool fully dep-bound. */
@@ -194,6 +194,7 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         resourcePolicy,
         hostTools,
         refStorePath,
+        packagesFile,
     } = deps;
     const workingMemory = createWorkingMemory(pool);
     const ncbi = createNcbiTools(bioKeys);
@@ -231,11 +232,15 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         // blind is how a user gets asked to download something already installed, or
         // told nothing is missing when it is; this is the only tool that can tell.
         createListAvailableRefsTool({ ...(refStorePath ? { refStorePath } : {}) }),
+        // What is importable inside a sandbox. Reads the same manifest a sandbox agent
+        // reads, host-side — so "is scanpy available?" is a manifest lookup here rather
+        // than a whole ephemeral container spun up to run one import.
+        createListAvailablePackagesTool({ ...(packagesFile ? { packagesFile } : {}) }),
         // Execution.
         createInspectRunTool(pool),
         // The dataset's own record. No file backs it — the DB row is the only copy.
         createInspectDataProfileTool(pool),
-        createGeneratePlanTool({ provider, pool, model, resourcePolicy, ...(refStorePath ? { refStorePath } : {}) }),
+        createGeneratePlanTool({ provider, pool, model, resourcePolicy, ...(refStorePath ? { refStorePath } : {}), ...(packagesFile ? { packagesFile } : {}) }),
         createExecutePlanTool({
             pool,
             executeAnalysisWorkflow,

--- a/harness/src/agents/sandbox/shared.ts
+++ b/harness/src/agents/sandbox/shared.ts
@@ -78,6 +78,7 @@ import { setActiveExecId } from "../../state/index.js";
 
 import type { AgentMeta, SandboxToolName } from "./types.js";
 import { SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS } from "./types.js";
+import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 import type { Logger } from "../../lib/logger.js";
 
 /**
@@ -106,7 +107,7 @@ export interface SandboxStepCoords {
 }
 
 /** The shared dependency graph every sandbox agent draws from. */
-export interface SandboxAgentDeps {
+export interface SandboxAgentDeps extends EnvironmentStorePaths {
     /** Operational logging seam; omitted falls back to no-op. */
     readonly logger?: Logger;
     readonly provider: ChatProvider;
@@ -125,18 +126,6 @@ export interface SandboxAgentDeps {
     readonly model: string;
     /** Absolute path to the skills tree. Omit to skip the skill tools. */
     readonly skillsDir?: string;
-    /**
-     * Host path of the reference store — the same bytes the sandbox mounts at
-     * `/mnt/refs`. Omit when no store is provisioned; reference discovery then
-     * reports the store as unavailable rather than failing.
-     */
-    readonly refStorePath?: string;
-    /**
-     * Host path of the library store's `packages.txt`. Omit when the host mounts
-     * the store at the sandbox's own path; a host whose store is baked into the
-     * image must inject its extracted copy, or the inventory reads as unknown.
-     */
-    readonly packagesFile?: string;
     /** Per-step coordinates resolved at the workflow body. */
     readonly step: SandboxStepCoords;
     /** API keys for the external bio/chem data sources. */

--- a/harness/src/config/environment-stores.ts
+++ b/harness/src/config/environment-stores.ts
@@ -1,0 +1,43 @@
+/**
+ * The two host paths that describe what an analysis environment can actually do:
+ * the reference data staged for it, and the packages installed in its sandbox.
+ *
+ * They are declared once, here, because every agent-facing deps bag that carries
+ * them means the same thing by them — and when each bag documented them itself,
+ * the prose drifted per site (the same field explained in terms of "the executor",
+ * "the profiler", "the planner") while the contract stayed identical. Extending
+ * this interface keeps one description of a field that has one meaning.
+ */
+
+/**
+ * Host paths of the environment's two read-only stores.
+ *
+ * Both are HOST paths, deliberately: reading them host-side is what lets the
+ * conversation agent and the planner answer "what does this environment hold?"
+ * before any sandbox exists, and they are the same bytes a sandbox agent sees
+ * through its mounts — so every agent gets one answer rather than a per-vantage
+ * one. Neither store is ever written through these paths.
+ *
+ * Both are optional, and absence is a NORMAL state rather than an error: an
+ * omitted path makes its tool report the store as unavailable or unknown, which
+ * is a truthful answer an agent can act on. Absence must never be reported as a
+ * failure, and never papered over with a guessed path.
+ */
+export interface EnvironmentStorePaths {
+    /**
+     * Host path of the reference store — the same bytes sandboxes mount at
+     * `/mnt/refs`. Omit when no store is provisioned; reference discovery then
+     * reports the store as unavailable. Note that an installed store reads as
+     * absent if this is omitted, which is indistinguishable to an agent from
+     * having no data — so omit it only when there is genuinely nothing staged.
+     */
+    readonly refStorePath?: string;
+    /**
+     * Host path of the library store's `packages.txt` — the inventory of what is
+     * importable inside a sandbox. Omit when the host mounts the store at the
+     * sandbox's own path, which makes the container path correct as-is; a host
+     * whose store is baked into the image and never bind-mounted must inject the
+     * path to its own extracted copy, or the inventory reads as unknown.
+     */
+    readonly packagesFile?: string;
+}

--- a/harness/src/execution/ephemeral-runner.ts
+++ b/harness/src/execution/ephemeral-runner.ts
@@ -29,6 +29,7 @@ import type { RunSession } from "../auth/types.js";
 import { forSubAgent } from "../auth/types.js";
 import { finalText, runAgent } from "../loop/run-agent.js";
 import { durableStep } from "../loop/run-step.js";
+import type { EnvironmentStorePaths } from "../config/environment-stores.js";
 import type { ResourcePolicy, ResourceSpec } from "../config/resource-limits.js";
 import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
 import type { SandboxClient } from "../sandbox/client.js";
@@ -64,7 +65,7 @@ const DEFAULT_DEADLINE_MS = 120_000;
 const EPHEMERAL_SANDBOX_RESOURCES: ResourceSpec = { cpu: 4, memoryGb: 8 };
 
 /** The body's construction-time deps — closed over at registration. */
-export interface EphemeralDeps {
+export interface EphemeralDeps extends EnvironmentStorePaths {
     /** Operational logging seam; omitted falls back to no-op. */
     readonly logger?: Logger;
     readonly provider: ChatProvider;
@@ -81,18 +82,6 @@ export interface EphemeralDeps {
     readonly bioKeys: BioToolKeys;
     /** Host resource policy — its `ephemeral` spec overrides the default sandbox size. */
     readonly resourcePolicy?: ResourcePolicy;
-    /**
-     * Host path of the library store's `packages.txt`. Omit when the host mounts the
-     * store at the sandbox's own path; a host whose store is baked into the image must
-     * inject its extracted copy, or the executor reads the inventory as unknown.
-     */
-    readonly packagesFile?: string;
-    /**
-     * Host path of the reference store. Omit only when none is provisioned: the
-     * executor carries reference discovery, and without this it reports an installed
-     * store as absent.
-     */
-    readonly refStorePath?: string;
 }
 
 /**

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -342,6 +342,11 @@ Instead:
   call spins up a sandbox pod (~30-60s of overhead). Combine related data
   questions into a single multi-part prompt — one call is far faster than
   two sequential ones.
+- **Report an environment gap as permanent without checking.** "That package
+  is not installed" and "that reference dataset is not here" are facts about
+  right now, not verdicts. Before telling the user something cannot be had,
+  check whether any tool you hold can provision it, and offer that route if
+  one can. Call it impossible only after you have looked and found no path.
 
 ## Guidelines
 

--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -113,6 +113,19 @@ before relying on it.
   annotation rather than the run. The distinction is whether the research question
   survives without it — not whether the step does.
 
+### Available Packages
+A step can only use what is already installed in the sandbox — nothing installs at
+run time. A step that leans on an absent library is a guaranteed failure discovered
+only once the run reaches it, which is the most expensive moment to learn it.
+
+- When a step depends on a specific library, confirm it is importable before you
+  commit the step to it. Checking a handful of names is one cheap call.
+- Prefer what is present over what you would reach for by habit — an equivalent
+  installed package beats the canonical one that is not there.
+- When nothing installed can do the step's work, treat it exactly as you would an
+  absent reference: \`request_clarification\`, rather than plan a step that can
+  only report failure.
+
 ### Resource Estimation
 ${resourceEstimationSection(resourcePolicy)}
 

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -23,6 +23,7 @@ import { ok } from "neverthrow";
 import type { Pool } from "pg";
 
 import { forSubAgent, type AuthContext, type RunSession } from "../auth/types.js";
+import type { EnvironmentStorePaths } from "../config/environment-stores.js";
 import type { RunAuthorization, RunAuthorizer } from "../execution/run-authorizer.js";
 import type { StagedInput } from "../execution/staged-input.js";
 import { createDataProfilerAgent } from "../agents/sandbox/data-profiler.js";
@@ -67,7 +68,7 @@ const DATA_PROFILE_AGENT_ID = "data-profiler" as const;
 const DEFAULT_DEADLINE_MS = 300_000;
 
 /** The body's construction-time deps — closed over at registration. */
-export interface DataProfileDeps {
+export interface DataProfileDeps extends EnvironmentStorePaths {
     /** Operational logging seam; omitted falls back to no-op. */
     readonly logger?: Logger;
     readonly provider: ChatProvider;
@@ -90,18 +91,6 @@ export interface DataProfileDeps {
     readonly embedding: EmbeddingProvider;
     /** Absolute path to the skills tree (one subdirectory per skill). */
     readonly skillsDir: string;
-    /**
-     * Host path of the library store's `packages.txt`. Omit when the host mounts the
-     * store at the sandbox's own path; a host whose store is baked into the image must
-     * inject its extracted copy, or the profiler reads the inventory as unknown.
-     */
-    readonly packagesFile?: string;
-    /**
-     * Host path of the reference store. Omit only when none is provisioned: the
-     * profiler carries reference discovery, and without this it reports an installed
-     * store as absent.
-     */
-    readonly refStorePath?: string;
 }
 
 /**

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -214,16 +214,14 @@ describe("generatePlan loop-driving tool", () => {
         expect(result.event).toBe("error");
         expect(result.error).toBe("Data is incompatible with every available agent.");
 
-        // The planner ran on a derived child Session with its 4 terminal tools.
+        // The planner ran on a derived child Session, offered every terminal tool. Only the
+        // terminal set is asserted: those are what can record an outcome, so a missing one
+        // is a planner that can run to completion with nothing to show for it. The rest of
+        // the roster is deliberately not pinned here — an exact list turns every tool added
+        // to the planner into an unrelated failure in a test about blocker outcomes.
         expect(provider.sessions[0]!.provenance.agentId).toBe("planner");
         expect(provider.sessions[0]!.provenance.callPath).toEqual(["conversation-agent", "planner"]);
-        expect(Object.keys(provider.calls[0]!.tools)).toEqual([
-            "validate_plan",
-            "list_available_refs",
-            "submit_plan",
-            "request_clarification",
-            "report_blocker",
-        ]);
+        expect(Object.keys(provider.calls[0]!.tools)).toEqual(expect.arrayContaining(["submit_plan", "request_clarification", "report_blocker"]));
     });
 
     // The planner has no sandbox, so reference discovery is only attachable because it

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -37,6 +37,8 @@ import type { AgentDefinition } from "../../loop/types.js";
 import { forSubAgent, scopeResource } from "../../auth/types.js";
 import { type ChatProvider } from "../../providers/types.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
+import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
+import { createListAvailablePackagesTool } from "../sandbox/list-available-packages.js";
 import { createListAvailableRefsTool } from "../sandbox/list-available-refs.js";
 import { createReportBlockerToolFor } from "../sandbox/report-blocker.js";
 
@@ -356,7 +358,15 @@ interface InnerTools {
  * shared `holder` so the outer `execute` reads the terminal outcome after the
  * loop finishes.
  */
-function buildInnerTools(holder: OutcomeHolder, persistCtx: PersistContext, pool: Pool, resourcePolicy?: ResourcePolicy, refStorePath?: string): InnerTools {
+function buildInnerTools(
+    holder: OutcomeHolder,
+    persistCtx: PersistContext,
+    pool: Pool,
+    resourcePolicy: ResourcePolicy | undefined,
+    // The two environment stores travel together as one bag rather than as a pair
+    // of adjacent optional strings, which would be silently swappable at the call site.
+    stores: EnvironmentStorePaths,
+): InnerTools {
     const validatePlanTool = defineTool({
         id: "validate_plan",
         description:
@@ -470,13 +480,16 @@ function buildInnerTools(holder: OutcomeHolder, persistCtx: PersistContext, pool
             "could fix and submit.",
     });
 
-    // Reference discovery is non-terminal and read-only: it lets the planner check what
-    // reference data this environment actually holds before committing a step to needing
-    // it. It reads the store host-side, so no sandbox exists or is needed at plan time.
-    const listAvailableRefs = createListAvailableRefsTool(refStorePath === undefined ? {} : { refStorePath });
+    // Environment discovery is non-terminal and read-only: it lets the planner check what
+    // reference data this environment holds, and what a step will actually be able to
+    // import, before committing a step to needing either. Both read host-side, so no
+    // sandbox exists or is needed at plan time — which is the whole point, since a plan
+    // that assumes an absent package fails only once the run reaches that step.
+    const listAvailableRefs = createListAvailableRefsTool(stores.refStorePath === undefined ? {} : { refStorePath: stores.refStorePath });
+    const listAvailablePackages = createListAvailablePackagesTool(stores.packagesFile === undefined ? {} : { packagesFile: stores.packagesFile });
 
     const terminal = [submitPlanTool, requestClarificationTool, reportBlockerTool];
-    return { all: [validatePlanTool, listAvailableRefs, ...terminal], terminal };
+    return { all: [validatePlanTool, listAvailableRefs, listAvailablePackages, ...terminal], terminal };
 }
 
 // ── Outcome shaping ─────────────────────────────────────────────────
@@ -535,7 +548,7 @@ function shapeOutcome(args: ShapeOutcomeArgs): PlanningAgentOutput {
 
 // ── Outer tool ──────────────────────────────────────────────────────
 
-export interface GeneratePlanDeps {
+export interface GeneratePlanDeps extends EnvironmentStorePaths {
     /** The LLM seam the planner loop runs on. */
     readonly provider: ChatProvider;
     /** Database pool — plan persistence and prior-plan loading. */
@@ -548,13 +561,6 @@ export interface GeneratePlanDeps {
      * default guidance and validation skips the ceiling check.
      */
     readonly resourcePolicy?: ResourcePolicy;
-    /**
-     * Host path of the reference store, giving the planner reference discovery.
-     * Absent, the tool reports the store as unavailable and the planner keeps
-     * planning as though nothing is guaranteed present — which is what the prompt
-     * already tells it to do.
-     */
-    readonly refStorePath?: string;
 }
 
 /** Build the `generate_plan` tool bound to its provider and pool. */
@@ -653,7 +659,7 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 analysisId,
                 parentPlanId: input.parentPlanId ?? null,
             };
-            const innerTools = buildInnerTools(holder, persistCtx, deps.pool, deps.resourcePolicy, deps.refStorePath);
+            const innerTools = buildInnerTools(holder, persistCtx, deps.pool, deps.resourcePolicy, deps);
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),

--- a/harness/src/tools/sandbox/list-available-packages.ts
+++ b/harness/src/tools/sandbox/list-available-packages.ts
@@ -29,6 +29,7 @@ import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
 import { defineTool, type ToolError } from "../define-tool.js";
+import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 
 /**
  * Where the list lives when the host mounts the library store at the same path
@@ -197,16 +198,7 @@ export function queryPackages(sections: readonly Section[], { names, query, lang
     return { available: true, total, returned, hasMore: returned < total, content };
 }
 
-export interface ListAvailablePackagesDeps {
-    /**
-     * Path to the store's `packages.txt` AS THE HOST SEES IT. Defaults to the
-     * container path, which is correct only when the host mounts the same store.
-     * A host that does not — one whose store is baked into the sandbox image and
-     * never bind-mounted — must inject the path to its own extracted copy, or the
-     * read fails and every caller is told the inventory is unknown.
-     */
-    readonly packagesFile?: string;
-}
+export type ListAvailablePackagesDeps = Pick<EnvironmentStorePaths, "packagesFile">;
 
 /** Create the package inventory over a host-readable `packages.txt`. */
 export function createListAvailablePackagesTool(deps: ListAvailablePackagesDeps = {}) {

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -4,7 +4,10 @@
  * installs and user-added files alike). Narrow with `path`/`category`, filter
  * with `query`, cap with `limit`; every response carries `returned`/`total`/
  * `hasMore` and the `categories` present, so a listing is never an unbounded
- * dump. Symlinks are never followed; nothing can be downloaded at runtime.
+ * dump. Symlinks are never followed. This tool only ever READS the store: the
+ * analysis environment cannot fetch reference data, and staging more is the
+ * host's job — so an absent dataset is a fact about this moment, not a verdict
+ * that it is unobtainable.
  *
  * The store is read from the host filesystem at the embedder-supplied
  * `refStorePath` and reported at `/mnt/refs`, the container path sandboxes mount
@@ -27,6 +30,7 @@ import { join as hostJoin, posix as posixPath } from "node:path";
 import { ok } from "neverthrow";
 import { z } from "zod";
 
+import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 import { REFERENCE_DATA_CATALOG } from "../../reference-data/catalog.js";
 import { parseReferenceInstallReceipt } from "../../reference-data/receipt.js";
 import { defineTool } from "../define-tool.js";
@@ -74,14 +78,7 @@ const ListAvailableRefsInputSchema = z.object({
         ),
 });
 
-export interface ListAvailableRefsDeps {
-    /**
-     * Host path of the reference store — the same bytes sandboxes see at
-     * `/mnt/refs`. Omitted (or absent on disk) means no store is provisioned,
-     * which is a normal state reported as `unavailable`, not an error.
-     */
-    readonly refStorePath?: string;
-}
+export type ListAvailableRefsDeps = Pick<EnvironmentStorePaths, "refStorePath">;
 
 export interface ReferenceInventoryMetadata {
     readonly datasetId?: string;
@@ -538,7 +535,10 @@ function collectCategories(entries: readonly ReferenceInventoryEntry[]): string[
 
 function renderContent(path: string, scan: RawScan, entries: readonly ReferenceInventoryEntry[]): string {
     if (scan.state === "unavailable")
-        return "No reference store is provisioned. Reference data cannot be downloaded at runtime; provision it through the host setup flow.";
+        return (
+            "No reference store is provisioned. Nothing in the analysis environment can fetch reference data — the host stages it, " +
+            "so a store provisioned through the host's own path will show up on a later call."
+        );
     if (scan.state === "not_found") return `Reference path does not exist: ${path}`;
     if (scan.state === "not_a_directory") return `Reference path is not a directory: ${path}`;
     if (scan.state === "symlink") return `Reference path crosses a symlink and was not scanned: ${path}`;
@@ -573,7 +573,8 @@ export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
     return defineTool({
         id: "list_available_refs",
         description:
-            "Resolve reference data you need into a real path. Reports the reference data actually provisioned for this environment — the ONLY reference data that exists here; nothing can be downloaded at runtime. " +
+            "Resolve reference data you need into a real path. Reports the reference data provisioned for this environment right now — the only reference data an analysis script can open. " +
+            "Nothing inside the analysis environment reaches the network, so never write a download into a script. " +
             "Search by what the data IS, not by where you expect it: the store's directory layout is an installer detail and is not a stable interface. " +
             "Catalogued files come back with the organism, the format, and the file's internal shape (key columns, identifier space), so you can pick the right reader and the right species without opening the file first. " +
             "User-added files are returned too, with whatever labels exist — often none. Symlinks are never followed. " +
@@ -583,7 +584,9 @@ export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
             "`path` inspects one directory beneath /mnt/refs (a returned path, or store-relative) — drill in with it when a listing is truncated; " +
             '`category` is shorthand for a top-level group (e.g. "pathways", "regulatory-networks"), and the groups present come back in `categories`; ' +
             "`limit` caps the entries returned. The response carries `returned`, `total`, and `hasMore`, so truncation is never silent. " +
-            "An empty result means the data is genuinely absent — say so and proceed with what you have; do not guess a path. Provision additional files through the host setup flow.",
+            "An empty result means the dataset is absent right now — not that it is unobtainable. Say so; never guess a path, and never silently substitute a different dataset. " +
+            "The store is provisioned by the host and is NOT frozen: datasets can be added through the host's own provisioning path, and whatever is added shows up on a later call. " +
+            "So before you report a gap as permanent, check whether any tool you hold reaches that provisioning path — offer that route if one exists, and call the gap permanent only when none does.",
         inputSchema: ListAvailableRefsInputSchema,
         execute: async ({ path, category, query, limit }) => {
             // `category` is shorthand for a top-level path; an explicit `path` wins.


### PR DESCRIPTION
Two agent-visible facts were wrong, and both were wrong in the same
direction: the agent under-reported what it could do.

Asked what libraries were available, the conversation agent spun up an
ephemeral sandbox and ran an import. Asked whether it could fetch more
reference data, it said no. Neither answer was true.

## The package inventory was already there

`list_available_packages` exists and every sandbox agent already carries
it through `BASE_SANDBOX_TOOLS`. It was never attached to the agent the
user actually talks to, nor to the planner — so a manifest lookup cost a
container. This wires it to both, threading `packagesFile` the way
`refStorePath` already travels.

The planner also gains a prompt section mirroring the reference-data one
it already had, so a step depending on an absent library is caught at plan
time rather than at the step that needs it.

## Reference data was described as unobtainable

`list_available_refs` asserted "nothing can be downloaded at runtime" and
closed with "provision through the host setup flow", which reads as a
human doing it out of band. The first half is true only of the analysis
environment — the store itself is host-provisioned and can grow, and
`refs list` / `refs download` are right there.

The sandbox truth stays (never write a download into a script); the
absolute goes. The tool now tells the agent to check whether any tool it
holds reaches the provisioning path before calling a gap permanent —
deliberately without naming a host tool, since the harness must not know
what an embedder attached.

## `run_inflexa` now describes itself from the registry

The bridge belongs on the host side, so `run_inflexa` carries it. Rather
than hand-written prose naming what the CLI covers — a second copy of the
registry that nothing typechecks, already carrying a hand-maintained list
of blocked commands — it walks `buildProgram()` at construction.

A stamped policy is the exact membership test: `registerAction` is the
only way to attach an action handler and it requires a policy. The tree is
already built per call by the classifier, so this costs nothing new, and
it yields each command's policy, which `--help` does not show. Commands
are grouped by what they cost the user; arguments and options are left to
`--help`, which is free and never prompts.

While verifying the grouping I confirmed that `setOptions` climbs to the
root, so the global `--analysis` / `--project` escalate any `auto` command
to an approval. Left as-is by design — `refs list --analysis` is
meaningless, since the reference store is global rather than per-analysis,
so the prompt catches a nonsensical invocation. The description now says
an approval can happen anyway, so it reads as normal rather than a wrong
turn.

## Incidental cleanup

- `refStorePath` / `packagesFile` were redeclared across eight interfaces,
  each documenting them itself — `ephemeral-runner` and `data-profile` had
  identical paragraphs differing only in "the executor" vs "the profiler".
  Declared once as `EnvironmentStorePaths`.
- Dropped an exact tool-count assertion (restates the code; its failure
  teaches nothing) and narrowed the planner's exact inner-tool list, whose
  comment claimed "its 4 terminal tools" while listing six. New tests pin
  invariants instead: every policy-stamped command must appear in the
  description, and `refs list` / `refs download` must land in different
  groups.

## Verification

harness 542 pass, cli 1481 pass, both typecheck and lint clean.

The cli change consumes the harness change, so it was verified through
`bun run harness:local` rather than the pinned `0.7.0`.

One unrelated cli failure is present on this base and not caused here:
`createLocalEmbeddingProvider (sidecar lifecycle) > with the loopback
bypass suppressed…` fails in isolation on a branch that touches no
embedding files.
