### PR TITLE
feat(cli): make the run step window admit what it hides, and let the …

### DIFF
--- a/cli/src/lib/design_system.ts
+++ b/cli/src/lib/design_system.ts
@@ -740,6 +740,15 @@ export const size = {
     composerMin: 1,
     /** Palette rows visible before it scrolls. */
     paletteRows: 12,
+    /**
+     * Run-step rows the rail's progress embed shows before it windows the list behind its scrollable
+     * elision markers. ODD by requirement, not by taste: the window centres by placing the running step
+     * at `floor(n / 2)`, which is the exact middle row only for an odd count. Lives here as a token
+     * because the sidebar, the gallery exhibit, and the tests that pin the window's arithmetic must all
+     * name the SAME cap — held by hand in four places it has already drifted, and a stale copy silently
+     * measures a window the product never renders.
+     */
+    railStepRows: 7,
 } as const;
 
 /**

--- a/cli/src/tui/components/run_block.render.test.tsx
+++ b/cli/src/tui/components/run_block.render.test.tsx
@@ -3,10 +3,14 @@ import { createSignal } from "solid-js";
 import { testRender } from "@opentui/solid";
 import { renderFrame } from "../../test_support/tui.ts";
 
+import { size } from "../../lib/design_system.ts";
 import { RunBlock, type RunStepView } from "./run_block.tsx";
 
-/** The rail's window size — the sidebar RUNS embed's `maxSteps`, mirrored so the cases track it. */
-const RAIL_WINDOW = 7;
+/**
+ * The rail's window size, taken from the design-system token the sidebar itself passes rather than
+ * repeated here — the arithmetic these cases assert is only meaningful against the cap that ships.
+ */
+const RAIL_WINDOW = size.railStepRows;
 
 /** A run whose first `done` steps are complete, the next is running, and the rest are queued. */
 function steps(total: number, done: number): RunStepView[] {
@@ -301,6 +305,57 @@ describe("RunBlock parallel steps", () => {
             expect(frame()).toContain("5 earlier steps");
             expect(hasStep(frame(), 9)).toBe(true);
         });
+    });
+});
+
+describe("RunBlock marker click containment", () => {
+    test("a plain marker click is swallowed, but a release carrying a selection still bubbles", async () => {
+        // The wrapper stands in for the ancestors that act on mouse-up: the sidebar RUNS section (opens
+        // the runs picker) and the app root (copy-on-select). A marker click must not reach them; a
+        // selection drag that merely ends on a marker must.
+        let bubbled = 0;
+        const setup = await testRender(
+            () => (
+                <box onMouseUp={() => bubbled++}>
+                    <RunBlock name="cohort-screen" tag="T9S2" done={10} total={20} steps={steps(20, 10)} maxSteps={RAIL_WINDOW} hint={false} heading={false} />
+                </box>
+            ),
+            { width: 40, height: 24 },
+        );
+        try {
+            await setup.renderOnce();
+            const row = (needle: string): { x: number; y: number } => {
+                const lines = setup.captureCharFrame().split("\n");
+                const y = lines.findIndex((l) => l.includes(needle));
+                expect(y).toBeGreaterThanOrEqual(0);
+                return { x: lines[y]!.indexOf(needle), y };
+            };
+
+            const up = row("↑");
+            await setup.mockMouse.click(up.x, up.y);
+            await setup.renderOnce();
+            expect(bubbled).toBe(0);
+
+            // Walk to the top. The final press unmounts the very marker it landed on, so no mouse-up ever
+            // returns to that marker — the gesture that leaves press state remembered on mouse-down
+            // stranded, and with it the next unrelated release wrongly swallowed.
+            while (setup.captureCharFrame().includes("↑")) {
+                const m = row("↑");
+                await setup.mockMouse.click(m.x, m.y);
+                await setup.renderOnce();
+            }
+
+            // A selection drag ending on the surviving marker: the root's copy handler needs this release.
+            const baseline = bubbled;
+            const from = row("S3");
+            const to = row("↓");
+            await setup.mockMouse.drag(from.x, from.y, to.x, to.y);
+            await setup.renderOnce();
+            expect(setup.renderer.getSelection()?.getSelectedText() ?? "").not.toBe("");
+            expect(bubbled).toBe(baseline + 1);
+        } finally {
+            setup.renderer.destroy();
+        }
     });
 });
 

--- a/cli/src/tui/components/run_block.render.test.tsx
+++ b/cli/src/tui/components/run_block.render.test.tsx
@@ -1,0 +1,343 @@
+import { describe, expect, test } from "bun:test";
+import { createSignal } from "solid-js";
+import { testRender } from "@opentui/solid";
+import { renderFrame } from "../../test_support/tui.ts";
+
+import { RunBlock, type RunStepView } from "./run_block.tsx";
+
+/** The rail's window size — the sidebar RUNS embed's `maxSteps`, mirrored so the cases track it. */
+const RAIL_WINDOW = 7;
+
+/** A run whose first `done` steps are complete, the next is running, and the rest are queued. */
+function steps(total: number, done: number): RunStepView[] {
+    return Array.from({ length: total }, (_, i) => ({
+        label: `S${i + 1}`,
+        state: i < done ? "done" : i === done ? "running" : "queued",
+    }));
+}
+
+/** The rail mount the sidebar RUNS section uses: windowed, no heading, no detach/abort footer. */
+function railBlock(total: number, done: number) {
+    return () => (
+        <RunBlock name="cohort-screen" tag="T9S2" done={done} total={total} steps={steps(total, done)} maxSteps={RAIL_WINDOW} hint={false} heading={false} />
+    );
+}
+
+/** Whether step `n` has a row on screen. Word-bounded, so `S1` never matches the `S10`/`S12` rows. */
+function hasStep(frame: string, n: number): boolean {
+    return new RegExp(`\\bS${n}\\b`).test(frame);
+}
+
+/** Every step the frame accounts for: the rows it shows plus the counts its elision markers admit to hiding. */
+function accountedFor(frame: string, total: number): number {
+    const shown = Array.from({ length: total }, (_, i) => i + 1).filter((n) => hasStep(frame, n)).length;
+    return shown + [...frame.matchAll(/(\d+) (?:earlier|more) steps?/g)].reduce((sum, m) => sum + Number(m[1]), 0);
+}
+
+/** Right-trim + drop trailing blanks, matching `renderFrame` so frame text and coordinates agree. */
+function tidy(frame: string): string {
+    return frame
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .join("\n")
+        .trimEnd();
+}
+
+/**
+ * Render the rail mount live over a mutable run, and hand the caller a click driver, a frame reader and
+ * a props updater. `update` always mints a FRESH props object even when the values are unchanged, which
+ * is what the sidebar's poll does every few seconds — the distinction between "the ledger was re-read"
+ * and "something actually changed" is exactly what the window's pin-and-release rules turn on, and a
+ * harness that reused the object would let a broken release rule pass.
+ */
+async function withRail(
+    initial: RunStepView[],
+    body: (rail: {
+        click: (arrow: "↑" | "↓") => Promise<void>;
+        frame: () => string;
+        update: (next: { steps?: RunStepView[]; tag?: string }) => Promise<void>;
+    }) => Promise<void>,
+) {
+    const [run, setRun] = createSignal({ steps: initial, tag: "T9S2" });
+    const doneCount = (xs: RunStepView[]): number => xs.filter((s) => s.state === "done").length;
+    const setup = await testRender(
+        () => (
+            <RunBlock
+                name="cohort-screen"
+                tag={run().tag}
+                done={doneCount(run().steps)}
+                total={run().steps.length}
+                steps={run().steps}
+                maxSteps={RAIL_WINDOW}
+                hint={false}
+                heading={false}
+            />
+        ),
+        { width: 40, height: 24 },
+    );
+    try {
+        await setup.renderOnce();
+        const frame = (): string => tidy(setup.captureCharFrame());
+        const click = async (arrow: "↑" | "↓"): Promise<void> => {
+            const lines = setup.captureCharFrame().split("\n");
+            const y = lines.findIndex((line) => line.includes(arrow));
+            if (y < 0) throw new Error(`no ${arrow} marker on screen:\n${frame()}`);
+            await setup.mockMouse.click(lines[y]!.indexOf(arrow), y);
+            await setup.renderOnce();
+        };
+        const update = async (next: { steps?: RunStepView[]; tag?: string }): Promise<void> => {
+            // A fresh object every time, even when nothing changed — the poll's shape.
+            setRun((prev) => ({ steps: next.steps ?? [...prev.steps], tag: next.tag ?? prev.tag }));
+            await setup.renderOnce();
+            await setup.renderOnce();
+        };
+        await body({ click, frame, update });
+    } finally {
+        setup.renderer.destroy();
+    }
+}
+
+describe("RunBlock step window", () => {
+    test("a run one step over the cap renders every step rather than hiding one behind a marker", async () => {
+        // Eliding a single step to spend a row on its marker saves nothing, so the whole list renders.
+        const frame = await renderFrame(railBlock(8, 4), { width: 40, height: 18 });
+        for (let i = 1; i <= 8; i++) expect(hasStep(frame, i)).toBe(true);
+        expect(frame).toContain("4/8");
+        expect(frame).not.toContain("more step");
+        expect(frame).not.toContain("earlier step");
+    });
+
+    test("a long run windows its steps and states both hidden counts", async () => {
+        // 12 steps with the frontier at S8: the window centres on it (S5–S11), leaving 4 elided above
+        // and 1 below — 9 rows for 12 steps, so the markers earn their place.
+        const frame = await renderFrame(railBlock(12, 7), { width: 40, height: 18 });
+        expect(frame).toContain("4 earlier steps");
+        expect(frame).toContain("1 more step");
+        expect(frame).toContain("7/12");
+        expect(hasStep(frame, 8)).toBe(true);
+        expect(hasStep(frame, 1)).toBe(false);
+        expect(hasStep(frame, 12)).toBe(false);
+    });
+
+    test("an odd window puts the frontier on its exact middle row", async () => {
+        // The centring promise: with room on both sides the running step sits at offset floor(7/2)=3,
+        // the 4th of 7 rows, so equal context is visible before and after it.
+        const frame = await renderFrame(railBlock(20, 10), { width: 40, height: 24 });
+        const rows = frame.split("\n").filter((l) => /\bS\d+\b/.test(l));
+        expect(rows).toHaveLength(RAIL_WINDOW);
+        expect(rows[3]).toContain("S11"); // the running step (index 10)
+    });
+
+    test("the visible rows plus both hidden counts always account for every step", async () => {
+        // The invariant the markers exist to uphold: nothing is silently dropped at any run length.
+        for (const total of [7, 8, 9, 10, 12, 20, 31]) {
+            const frame = await renderFrame(railBlock(total, Math.floor(total / 2)), { width: 40, height: 44 });
+            expect({ total, accounted: accountedFor(frame, total) }).toEqual({ total, accounted: total });
+        }
+    });
+
+    test("without maxSteps the whole list renders — the runs dialog's full view", async () => {
+        const frame = await renderFrame(() => <RunBlock name="cohort-screen" tag="T9S2" done={7} total={12} steps={steps(12, 7)} hint={false} />, {
+            width: 80,
+            height: 24,
+        });
+        for (let i = 1; i <= 12; i++) expect(hasStep(frame, i)).toBe(true);
+        expect(frame).not.toContain("more step");
+    });
+});
+
+describe("RunBlock window scrolling", () => {
+    // 20 steps with the frontier at S11: the window centres at start=7, leaving room to scroll both ways.
+    test("clicking the up marker slides the window one step earlier", async () => {
+        await withRail(steps(20, 10), async ({ click, frame }) => {
+            expect(frame()).toContain("7 earlier steps");
+            expect(hasStep(frame(), 7)).toBe(false);
+
+            await click("↑");
+
+            expect(frame()).toContain("6 earlier steps");
+            expect(frame()).toContain("7 more steps");
+            expect(hasStep(frame(), 7)).toBe(true);
+            expect(hasStep(frame(), 14)).toBe(false);
+        });
+    });
+
+    test("clicking the down marker slides the window one step later", async () => {
+        await withRail(steps(20, 10), async ({ click, frame }) => {
+            await click("↓");
+            expect(frame()).toContain("8 earlier steps");
+            expect(frame()).toContain("5 more steps");
+            expect(hasStep(frame(), 15)).toBe(true);
+            expect(hasStep(frame(), 8)).toBe(false);
+        });
+    });
+
+    test("the window stops at the list ends and the exhausted marker disappears", async () => {
+        await withRail(steps(20, 10), async ({ click, frame }) => {
+            for (let i = 0; i < 7; i++) await click("↑");
+            expect(frame()).not.toContain("earlier step");
+            expect(frame()).toContain("13 more steps");
+            expect(hasStep(frame(), 1)).toBe(true);
+            await expect(click("↑")).rejects.toThrow("no ↑ marker");
+
+            for (let i = 0; i < 13; i++) await click("↓");
+            expect(frame()).not.toContain("more step");
+            expect(frame()).toContain("13 earlier steps");
+            expect(hasStep(frame(), 20)).toBe(true);
+            await expect(click("↓")).rejects.toThrow("no ↓ marker");
+        });
+    });
+
+    test("scrolling never loses a step — the accounting invariant holds at every position", async () => {
+        await withRail(steps(20, 10), async ({ click, frame }) => {
+            for (let i = 0; i < 7; i++) await click("↑");
+            for (let position = 0; position <= 13; position++) {
+                expect({ position, accounted: accountedFor(frame(), 20) }).toEqual({ position, accounted: 20 });
+                if (frame().includes("↓")) await click("↓");
+            }
+        });
+    });
+});
+
+describe("RunBlock window pinning", () => {
+    test("a scrolled window survives a ledger poll that changed nothing", async () => {
+        // The rail re-reads every few seconds and re-renders this block with a freshly-minted props
+        // object. Only a real change may move the window; a bare refresh must leave the reader where
+        // they are, or scrolling back through a long run is impossible on a live rail.
+        await withRail(steps(20, 10), async ({ click, frame, update }) => {
+            await click("↑");
+            await click("↑");
+            expect(frame()).toContain("5 earlier steps");
+
+            await update({});
+            await update({});
+
+            expect(frame()).toContain("5 earlier steps");
+        });
+    });
+
+    test("the window snaps back to the work when the active step advances", async () => {
+        await withRail(steps(20, 10), async ({ click, frame, update }) => {
+            for (let i = 0; i < 5; i++) await click("↑");
+            expect(frame()).toContain("2 earlier steps");
+            expect(hasStep(frame(), 11)).toBe(false); // the running step is scrolled out of view
+
+            await update({ steps: steps(20, 11) });
+
+            // Recentred on the new running step (S12, index 11) — start clamps to 11-3 = 8.
+            expect(frame()).toContain("8 earlier steps");
+            expect(hasStep(frame(), 12)).toBe(true);
+            const rows = frame()
+                .split("\n")
+                .filter((l) => /\bS\d+\b/.test(l));
+            expect(rows[3]).toContain("S12");
+        });
+    });
+
+    test("a different run releases the pin instead of inheriting the previous run's position", async () => {
+        // The sidebar's embed is non-keyed, so a run handover reuses this instance.
+        await withRail(steps(20, 10), async ({ click, frame, update }) => {
+            for (let i = 0; i < 4; i++) await click("↑");
+            expect(frame()).toContain("3 earlier steps");
+
+            await update({ tag: "OTHER1" });
+
+            expect(frame()).toContain("7 earlier steps");
+        });
+    });
+});
+
+describe("RunBlock parallel steps", () => {
+    /** Steps from an explicit state list, so a wave with several in flight can be spelled out. */
+    function wave(states: RunStepView["state"][]): RunStepView[] {
+        return states.map((state, i) => ({ label: `S${i + 1}`, state }));
+    }
+
+    /** A 20-step run with `running` at the given indices, everything before them done, the rest queued. */
+    function parallel(running: number[]): RunStepView[] {
+        const last = Math.max(...running);
+        return wave(Array.from({ length: 20 }, (_, i) => (running.includes(i) ? "running" : i < last ? "done" : "queued")));
+    }
+
+    test("the window anchors on the EARLIEST running step, not the first not-done one", async () => {
+        // Steps 8, 9 and 10 are in flight together. Centring on the earliest puts it on the middle row
+        // with its siblings just below, so the whole wave is on screen at once.
+        const frame = await renderFrame(
+            () => <RunBlock name="r" tag="T1" done={8} total={20} steps={parallel([8, 9, 10])} maxSteps={RAIL_WINDOW} hint={false} heading={false} />,
+            { width: 40, height: 24 },
+        );
+        const rows = frame.split("\n").filter((l) => /\bS\d+\b/.test(l));
+        expect(rows[3]).toContain("S9"); // index 8, the earliest running step, dead centre
+        for (const n of [9, 10, 11]) expect(hasStep(frame, n)).toBe(true);
+    });
+
+    test("a later parallel step finishing leaves the still-running earlier one on screen", async () => {
+        // The reported shape: [done, running, running, done] → [done, running, done, done]. The step that
+        // is STILL running must not be scrolled away just because its sibling finished — which is exactly
+        // what anchoring on "first not-done" would have done once the sibling's row went done.
+        await withRail(parallel([8, 9]), async ({ frame, update }) => {
+            expect(hasStep(frame(), 9)).toBe(true);
+
+            await update({ steps: parallel([8]) });
+
+            expect(hasStep(frame(), 9)).toBe(true);
+            const rows = frame()
+                .split("\n")
+                .filter((l) => /\bS\d+\b/.test(l));
+            expect(rows[3]).toContain("S9");
+        });
+    });
+
+    test("a change anywhere in the active set snaps a scrolled window back", async () => {
+        // The anchor itself does not move here — only the sibling finishes — so a snap keyed on the
+        // anchor alone would leave the reader stranded. The whole running set is the trigger.
+        await withRail(parallel([8, 9]), async ({ click, frame, update }) => {
+            for (let i = 0; i < 4; i++) await click("↑");
+            expect(frame()).toContain("1 earlier step");
+            expect(hasStep(frame(), 9)).toBe(false);
+
+            await update({ steps: parallel([8]) });
+
+            expect(frame()).toContain("5 earlier steps");
+            expect(hasStep(frame(), 9)).toBe(true);
+        });
+    });
+});
+
+describe("RunBlock marker selection", () => {
+    /**
+     * Drag across the row holding `needle` and report what the renderer considers selected. The drag
+     * STARTS on the needle's own column, not at x=0: the step list is a bordered, padded box, and a press
+     * on the border or the padding lands on the box rather than the text — no selection begins at all,
+     * which would make every assertion here pass for the wrong reason.
+     */
+    async function dragRow(setup: Awaited<ReturnType<typeof testRender>>, needle: string): Promise<string> {
+        const lines = setup.captureCharFrame().split("\n");
+        const y = lines.findIndex((line) => line.includes(needle));
+        expect(y).toBeGreaterThanOrEqual(0);
+        await setup.mockMouse.drag(lines[y]!.indexOf(needle), y, lines[y]!.trimEnd().length, y);
+        await setup.renderOnce();
+        return setup.renderer.getSelection()?.getSelectedText() ?? "";
+    }
+
+    test("the markers are controls, not prose — dragging over one selects nothing", async () => {
+        const setup = await testRender(railBlock(20, 10), { width: 40, height: 24 });
+        try {
+            await setup.renderOnce();
+            expect(await dragRow(setup, "earlier step")).not.toContain("earlier");
+            expect(await dragRow(setup, "more step")).not.toContain("more");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("step rows stay selectable — the opt-out is scoped to the two controls", async () => {
+        const setup = await testRender(railBlock(20, 10), { width: 40, height: 24 });
+        try {
+            await setup.renderOnce();
+            expect(await dragRow(setup, "S11")).toContain("S11");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/components/run_block.tsx
+++ b/cli/src/tui/components/run_block.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js";
+import { useRenderer } from "@opentui/solid";
 
 import { theme } from "../theme.ts";
 import { GLYPHS, space, MARKERS } from "../../lib/design_system.ts";
@@ -101,6 +102,8 @@ function stepMark(state: RunStepView["state"]): { glyph: string; role: "success"
  * and the detach/abort affordance.
  */
 export function RunBlock(props: RunBlockProps) {
+    // Read for its selection state alone, on the marker release path — the block renders nothing from it.
+    const renderer = useRenderer();
     // The meter's cell counts. Without `maxSteps` it stays one cell per step — the dialog + gallery full
     // view, where the block owns its whole width. With `maxSteps` (the narrow rail mount, where a
     // 30+-step per-step bar soft-wraps the ~40-column slice) it scales to at most BAR_BUDGET cells,
@@ -201,22 +204,26 @@ export function RunBlock(props: RunBlockProps) {
         setPinnedStart(Math.max(0, Math.min(stepWindow().hiddenBefore + delta, props.steps.length - max)));
     }
 
-    // Whether the in-flight mouse gesture began on one of this block's elision markers. The shift fires on
-    // mouse-DOWN (these are controls, not drag targets, and firing on the press means a selection drag that
-    // merely ends here can never trigger one), so the matching mouse-UP has to be swallowed as well: the
-    // sidebar's RUNS section opens the runs picker on mouse-up, and an un-stopped release would both scroll
-    // the window and pop a dialog over it. A release that did NOT start on a marker is the tail of someone
-    // else's gesture — a text-selection drag crossing the rail — and still bubbles to the root's copy
-    // handler. Mirrors the click-containment bookkeeping the dialog host does for its scrim.
-    let pressedMarker = false;
+    // The shift fires on mouse-DOWN: these are controls, not drag targets, and acting on the press means a
+    // selection drag that merely ends here can never trigger one.
     function pressMarker(delta: number, e: { stopPropagation(): void }): void {
-        pressedMarker = true;
         e.stopPropagation();
         shiftWindow(delta);
     }
+
+    // The matching mouse-UP has to be contained too, because the sidebar's RUNS section opens the runs
+    // picker on mouse-up — an un-stopped release would scroll the window AND pop a dialog over it on the
+    // same press. The one release worth letting through is the tail of a text-selection drag that happened
+    // to end on a marker: the root's copy-on-select handler needs to see it, and the section's own
+    // activation already ignores selection-carrying releases, so letting it bubble cannot open anything.
+    //
+    // Decided from the LIVE SELECTION rather than from press state remembered on mouse-down. A flag can
+    // outlive its gesture: pressing a marker that then reaches the list's end unmounts that very marker,
+    // so no mouse-up ever arrives to clear it, and the next unrelated release landing there would be
+    // swallowed — losing a copy. Reading the selection has no lifetime to get wrong, and mirrors the guard
+    // `openProfileFromSidebar`/`openRunsFromSidebar` already apply on the same gesture.
     function releaseMarker(e: { stopPropagation(): void }): void {
-        if (!pressedMarker) return;
-        pressedMarker = false;
+        if (renderer.getSelection()?.getSelectedText()) return;
         e.stopPropagation();
     }
     return (

--- a/cli/src/tui/components/run_block.tsx
+++ b/cli/src/tui/components/run_block.tsx
@@ -1,4 +1,4 @@
-import { For } from "solid-js";
+import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js";
 
 import { theme } from "../theme.ts";
 import { GLYPHS, space, MARKERS } from "../../lib/design_system.ts";
@@ -38,24 +38,54 @@ export type RunBlockProps = {
      */
     heading?: boolean;
     /**
-     * Cap on how many step rows to render at once. When the run has MORE steps than this, the list
-     * shows a WINDOW of `maxSteps` rows centered on the frontier of work (the first step that is not
-     * yet done), clamped to the list ends. The progress bar and `done/total` always reflect the FULL
-     * run — only the step list is windowed. Absent → the whole list renders (the runs dialog keeps its
-     * complete view). Exists because the chat's sticky progress row sits in a fixed slice of the chat
-     * column: a long run must not grow the row without bound, and the window keeps it anchored to where
-     * work actually is.
+     * Cap on how many step rows to render at once. When the run has enough steps that windowing
+     * actually saves rows, the list shows a WINDOW of `maxSteps` rows over the steps, centred on the
+     * earliest step still running and thereafter positioned by the reader — each elision marker names
+     * how many steps are hidden on its side AND slides the window one step that way when clicked. The
+     * window returns to the work whenever the set of running steps changes. The progress bar and
+     * `done/total` always reflect the FULL run — only the step list is windowed.
+     * Absent → the whole list renders and the markers never appear (the runs dialog keeps its complete,
+     * non-interactive view). Exists for the narrow rail mount, where a long run must not grow the embed
+     * without bound.
+     *
+     * Prefer an ODD value: the window centres by placing the frontier at `floor(maxSteps / 2)`, which is
+     * the exact middle row only when the count is odd.
      */
     maxSteps?: number;
 };
 
 /**
+ * The step list's visible slice plus how many steps the window elides on each side. Both counts zero
+ * means the whole list is rendered. The counts are what the elision markers report, so a hidden step is
+ * never merely absent — the reader can always reconcile the rows on screen against `done/total`.
+ */
+type StepWindow = {
+    /** The steps to render, in order. */
+    steps: RunStepView[];
+    /** How many steps precede the slice. */
+    hiddenBefore: number;
+    /** How many steps follow the slice. */
+    hiddenAfter: number;
+};
+
+/**
  * Cell budget for the progress meter in the narrow (windowed) mount. The default meter is one cell per
- * step, which soft-wraps the ~40-column sticky slice once a run passes ~30 steps; when `maxSteps`
- * signals that narrow mount the meter is scaled to at most this many cells instead. ~20 keeps it
- * comfortably inside the rail while still reading as a proportional bar.
+ * step, which soft-wraps the ~40-column rail once a run passes ~30 steps; when `maxSteps` signals that
+ * narrow mount the meter is scaled to at most this many cells instead. ~20 keeps it comfortably inside
+ * the rail while still reading as a proportional bar.
  */
 const BAR_BUDGET = 20;
+
+/**
+ * An elision marker's text — `4 earlier steps` / `1 more step`. Named counts, not a bare `…`: the
+ * marker's job is to let the reader reconcile the visible rows against `done/total` and see where the
+ * window sits, neither of which a shape-only ellipsis can do. Painted in the muted TEXT tier by its
+ * caller (not the `fgSubtle` decoration tier) because it carries information and must clear the 4.5:1
+ * floor; the directional arrow is a separate accent span, so it is not part of this string.
+ */
+function elisionLabel(count: number, word: "earlier" | "more"): string {
+    return `${count} ${word} step${count === 1 ? "" : "s"}`;
+}
 
 /** The themed glyph + color role for a step's state. */
 function stepMark(state: RunStepView["state"]): { glyph: string; role: "success" | "warning" | "error" | "fgSubtle" } {
@@ -72,7 +102,7 @@ function stepMark(state: RunStepView["state"]): { glyph: string; role: "success"
  */
 export function RunBlock(props: RunBlockProps) {
     // The meter's cell counts. Without `maxSteps` it stays one cell per step — the dialog + gallery full
-    // view, where the block owns its whole width. With `maxSteps` (the narrow sticky mount, where a
+    // view, where the block owns its whole width. With `maxSteps` (the narrow rail mount, where a
     // 30+-step per-step bar soft-wraps the ~40-column slice) it scales to at most BAR_BUDGET cells,
     // `filled` proportional to done/total. A partially-done run is clamped to [1, cells−1] so mid-flight
     // work never paints as fully filled or fully empty — an honest signal beats a rounding artifact.
@@ -89,18 +119,106 @@ export function RunBlock(props: RunBlockProps) {
         const c = barCells();
         return GLYPHS.bar.repeat(Math.max(0, c.total - c.filled));
     };
+    // Where the reader has scrolled the window to, or null while it tracks the frontier on its own. The
+    // rail re-reads the ledger every few seconds and hands this block a fresh steps array each tick; a
+    // window that recentred on every tick would drag the list out from under someone reading the earlier
+    // steps, so a click pins the position and only the two releases below let go of it.
+    const [pinnedStart, setPinnedStart] = createSignal<number | null>(null);
+
+    // The anchor the window centres on: the FIRST RUNNING step, because a plan's steps run in parallel
+    // waves and several can be in flight at once. Anchoring on the earliest of them is what keeps a
+    // still-running step on screen when a LATER sibling finishes — with the naive "first step that is not
+    // done" rule, `[done, running, running, done]` collapsing to `[done, running, done, done]` would
+    // leave the anchor on the finished sibling's side and scroll the work that is still live out of view.
+    // Falls back to the first not-yet-done step between waves (nothing running, work still pending), and
+    // to the tail once every step is done.
+    //
+    // A MEMO, not a plain accessor, and that is load-bearing for every reader below. `on(deps, fn)` runs
+    // `fn` whenever a signal `deps` touched changes — it never diffs what `deps` returned — and the rail
+    // hands this block a freshly-minted props object on every poll. Reading `props.steps` through a bare
+    // accessor would therefore fire the release effects several times a minute and silently undo the
+    // reader's scrolling. A memo re-computes just as often but only NOTIFIES on a real change.
+    const anchorIndex = createMemo((): number => {
+        const running = props.steps.findIndex((s) => s.state === "running");
+        if (running !== -1) return running;
+        const pending = props.steps.findIndex((s) => s.state !== "done");
+        return pending === -1 ? props.steps.length - 1 : pending;
+    });
+
+    // What "the run's in-flight work" is, as a comparable value: every running step, plus the anchor so a
+    // wave boundary with nothing running still counts as movement. The whole SET matters, not just the
+    // anchor — when one of several parallel steps finishes, the anchor can stay put while the work
+    // genuinely changed, and that is exactly a moment the reader wants to be looking at the run again.
+    const activityKey = createMemo((): string => {
+        const running: number[] = [];
+        for (const [i, step] of props.steps.entries()) if (step.state === "running") running.push(i);
+        return `${anchorIndex()}|${running.join(",")}`;
+    });
+
+    // Release 1 — the work moved. Snapping back to it is the point of the embed: it is a live progress
+    // readout first and a browser second, so when the steps it exists to report change, the window
+    // returns to them rather than stranding the reader on history they scrolled to minutes ago.
+    createEffect(on(activityKey, () => setPinnedStart(null), { defer: true }));
+
+    // Release 2 — a different run took over. The sidebar's progress embed is NOT keyed, so when one run
+    // succeeds another the same block instance is handed the new run's props rather than being remounted
+    // — without this the previous run's scroll position would carry onto a different run's steps. Memoed
+    // for the same reason as the frontier: the tag string is re-read every poll but rarely changes.
+    const runTag = createMemo((): string => props.tag);
+    createEffect(on(runTag, () => setPinnedStart(null), { defer: true }));
+
     // The visible slice of the step list. Full list unless `maxSteps` caps it; then a window of that
-    // many rows centered on the frontier — the first not-yet-done step — clamped so it never runs past
-    // either end. When every step is done the frontier is the tail, so the window shows the run's end.
-    const windowedSteps = (): RunStepView[] => {
+    // many rows over the steps, clamped so it never runs past either end. Its default position centres
+    // the anchor — with an odd `maxSteps` it lands on the exact middle row, so parallel siblings running
+    // just after it are on screen too — and once the reader clicks an elision marker it sits wherever
+    // they left it until a release above fires.
+    const stepWindow = (): StepWindow => {
         const all = props.steps;
         const max = props.maxSteps;
-        if (max === undefined || all.length <= max) return all;
-        const frontier = all.findIndex((s) => s.state !== "done");
-        const pivot = frontier === -1 ? all.length - 1 : frontier;
-        const start = Math.max(0, Math.min(pivot - Math.floor(max / 2), all.length - max));
-        return all.slice(start, start + max);
+        const whole: StepWindow = { steps: all, hiddenBefore: 0, hiddenAfter: 0 };
+        if (max === undefined || all.length <= max) return whole;
+        const auto = Math.max(0, Math.min(anchorIndex() - Math.floor(max / 2), all.length - max));
+        // Each elided side spends a row on its marker, so a window only earns its place when those
+        // markers occupy fewer rows than the steps they stand in for. Windowing 8 steps into 7 costs a
+        // marker row to hide a single labelled step — the same height, strictly less information — and
+        // that near-miss is the common case: an ordinary plan lands just over the cap. Below the
+        // break-even point the whole list is the better render, so the cap engages only once it pays.
+        // Measured at the AUTO position, never the pinned one, so scrolling can never change whether the
+        // window exists — a click must move the window, not make it collapse into the full list.
+        const markerRows = (auto > 0 ? 1 : 0) + (all.length - (auto + max) > 0 ? 1 : 0);
+        if (max + markerRows >= all.length) return whole;
+        const start = Math.max(0, Math.min(pinnedStart() ?? auto, all.length - max));
+        return { steps: all.slice(start, start + max), hiddenBefore: start, hiddenAfter: all.length - (start + max) };
     };
+
+    // Slide the window by `delta` steps, clamped to the list. `hiddenBefore` IS the current start, so the
+    // shift composes off whatever is on screen whether the window is still auto-positioned or already
+    // pinned. Every rendered marker is actionable by construction — a marker only exists when that side
+    // hides something — so no click can be a no-op and no disabled state is needed.
+    function shiftWindow(delta: number): void {
+        const max = props.maxSteps;
+        if (max === undefined) return;
+        setPinnedStart(Math.max(0, Math.min(stepWindow().hiddenBefore + delta, props.steps.length - max)));
+    }
+
+    // Whether the in-flight mouse gesture began on one of this block's elision markers. The shift fires on
+    // mouse-DOWN (these are controls, not drag targets, and firing on the press means a selection drag that
+    // merely ends here can never trigger one), so the matching mouse-UP has to be swallowed as well: the
+    // sidebar's RUNS section opens the runs picker on mouse-up, and an un-stopped release would both scroll
+    // the window and pop a dialog over it. A release that did NOT start on a marker is the tail of someone
+    // else's gesture — a text-selection drag crossing the rail — and still bubbles to the root's copy
+    // handler. Mirrors the click-containment bookkeeping the dialog host does for its scrim.
+    let pressedMarker = false;
+    function pressMarker(delta: number, e: { stopPropagation(): void }): void {
+        pressedMarker = true;
+        e.stopPropagation();
+        shiftWindow(delta);
+    }
+    function releaseMarker(e: { stopPropagation(): void }): void {
+        if (!pressedMarker) return;
+        pressedMarker = false;
+        e.stopPropagation();
+    }
     return (
         <box flexDirection="column" paddingBottom={space.sm}>
             {(props.heading ?? true) ? (
@@ -114,7 +232,23 @@ export function RunBlock(props: RunBlockProps) {
                 <Fg role="fgSubtle">{empty()}</Fg> <Fg role="fgMuted">{`${props.done}/${props.total}`}</Fg>
             </text>
             <box paddingLeft={space.md} flexDirection="column" border={["left"]} borderColor={theme().border}>
-                <For each={windowedSteps()}>
+                {/* The elision markers bracket the window so a truncated list never reads as a complete
+                one — the rule the runs picker already follows for its 100-run cap: truncation is stated,
+                never silent. They are also the window's scroll control: each click slides it one step
+                toward that side, so the same row that admits what is hidden is the thing that reveals it,
+                and the two counts double as the position indicator. The accent-colored arrow is the
+                codebase's established "this row is clickable" affordance (see `OpenableCardBlock`).
+                `selectable={false}` because these are buttons, not prose: the renderer's text selection
+                would otherwise highlight the label on every press, which reads as the click having done
+                something other than what it did. The STEP rows stay selectable — those are content a
+                reader may legitimately want to copy. */}
+                <Show when={stepWindow().hiddenBefore > 0}>
+                    <text selectable={false} onMouseDown={(e) => pressMarker(-1, e)} onMouseUp={releaseMarker}>
+                        <Fg role="accent">{`${GLYPHS.arrowUp} `}</Fg>
+                        <Fg role="fgMuted">{elisionLabel(stepWindow().hiddenBefore, "earlier")}</Fg>
+                    </text>
+                </Show>
+                <For each={stepWindow().steps}>
                     {(step) => {
                         const m = stepMark(step.state);
                         return (
@@ -125,6 +259,12 @@ export function RunBlock(props: RunBlockProps) {
                         );
                     }}
                 </For>
+                <Show when={stepWindow().hiddenAfter > 0}>
+                    <text selectable={false} onMouseDown={(e) => pressMarker(1, e)} onMouseUp={releaseMarker}>
+                        <Fg role="accent">{`${GLYPHS.arrowDown} `}</Fg>
+                        <Fg role="fgMuted">{elisionLabel(stepWindow().hiddenAfter, "more")}</Fg>
+                    </text>
+                </Show>
             </box>
             {(props.hint ?? true) ? <text fg={theme().fgMuted}>esc detach {GLYPHS.middot} ctrl+c abort</text> : null}
         </box>

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -4,7 +4,7 @@ import { useRenderer } from "@opentui/solid";
 import { okAsync } from "neverthrow";
 import type { DbError, StepExecutionRow } from "@inflexa-ai/harness";
 
-import { GLYPHS, space } from "../../lib/design_system.ts";
+import { GLYPHS, size, space } from "../../lib/design_system.ts";
 import { theme } from "../theme.ts";
 import { KEYS, chordLabel } from "../keymap.ts";
 import { useDialogBindings, useDialogCancel, useDialogEntry, DialogShowcase } from "../components/dialog/dialog_host.tsx";
@@ -426,14 +426,14 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                 <State n="18" label="sidebar RUNS progress embed — bounded step window, no heading">
                     {/* The sidebar RUNS section renders the newest non-terminal run's progress under
                         that run's own row: heading suppressed (the row above names the run), the same
-                        frontier-positioned step window (maxSteps=7, hint=false) the section passes, while
+                        frontier-positioned step window (the rail step cap, hint=false) the section passes, while
                         the bar and done/total reflect the full run. The elision markers above and below
                         the window name the hidden counts, so the rows on screen always reconcile against
                         done/total — and each one is a click target that slides the window a step its way.
                         Driven from the long-run fixture. */}
                     <text fg={theme().fgMuted}>
                         under the newest run row in the sidebar while it is non-terminal; long runs window their steps behind counted elision markers — click
-                        one to slide the window a step (maxSteps=7, heading off):
+                        one to slide the window a step (rail step cap, heading off):
                     </text>
                     <RunBlock
                         name={mockLongRun.name}
@@ -441,7 +441,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         done={mockLongRun.done}
                         total={mockLongRun.total}
                         steps={longRunSteps}
-                        maxSteps={7}
+                        maxSteps={size.railStepRows}
                         hint={false}
                         heading={false}
                     />

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -426,10 +426,14 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                 <State n="18" label="sidebar RUNS progress embed — bounded step window, no heading">
                     {/* The sidebar RUNS section renders the newest non-terminal run's progress under
                         that run's own row: heading suppressed (the row above names the run), the same
-                        frontier-centered step window (maxSteps=6, hint=false) the section passes, while
-                        the bar and done/total reflect the full run. Driven from the long-run fixture. */}
+                        frontier-positioned step window (maxSteps=7, hint=false) the section passes, while
+                        the bar and done/total reflect the full run. The elision markers above and below
+                        the window name the hidden counts, so the rows on screen always reconcile against
+                        done/total — and each one is a click target that slides the window a step its way.
+                        Driven from the long-run fixture. */}
                     <text fg={theme().fgMuted}>
-                        under the newest run row in the sidebar while it is non-terminal; long runs window their steps (maxSteps=6, heading off):
+                        under the newest run row in the sidebar while it is non-terminal; long runs window their steps behind counted elision markers — click
+                        one to slide the window a step (maxSteps=7, heading off):
                     </text>
                     <RunBlock
                         name={mockLongRun.name}
@@ -437,7 +441,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         done={mockLongRun.done}
                         total={mockLongRun.total}
                         steps={longRunSteps}
-                        maxSteps={6}
+                        maxSteps={7}
                         hint={false}
                         heading={false}
                     />

--- a/cli/src/tui/layout/design_gallery_fixtures.ts
+++ b/cli/src/tui/layout/design_gallery_fixtures.ts
@@ -308,9 +308,14 @@ export const mockRun: Run = {
 };
 
 /**
- * MOCK sample: a long run whose step count exceeds the chat sticky row's window (`maxSteps=6`), so the
- * gallery exhibit shows the window engaging — centered on the frontier (the first non-done step),
- * clamped to the ends — while the bar and `done/total` still reflect the full 12-step run.
+ * MOCK sample: a long run whose step count clears the rail window's break-even point (`maxSteps=7`), so
+ * the gallery exhibit shows the window engaging — centred on the frontier (the first non-done step),
+ * clamped to the ends, bracketed by the clickable elision markers naming the hidden counts — while the
+ * bar and `done/total` still reflect the full 12-step run. Twelve steps, not nine: a run only a step or
+ * two over the cap renders whole (the markers would cost more rows than they save), so a shorter fixture
+ * would exhibit the unwindowed state and silently stop covering the window at all. The frontier sits far
+ * enough in that steps are hidden on BOTH sides, which is what lets the exhibit show scrolling either
+ * way — and the single step hidden below also exercises the marker's singular wording.
  */
 export const mockLongRun: Run = {
     id: "mock-long-run",

--- a/cli/src/tui/layout/sidebar.render.test.tsx
+++ b/cli/src/tui/layout/sidebar.render.test.tsx
@@ -423,3 +423,85 @@ describe("Sidebar Section header merge vs stacked fallback", () => {
         expect(frame).toContain("proj"); // stacked on its own full line below the label
     });
 });
+
+// The embed's elision markers are click targets that scroll its step window, and they sit INSIDE the
+// RUNS Section — whose own mouse-up opens the runs picker. opentui propagates mouse events, so without
+// containment every scroll click would also pop a dialog over the rail. These pin both halves: the
+// marker click is swallowed, and an ordinary click elsewhere in the section still opens the picker.
+describe("Sidebar RUNS progress embed — window scroll containment", () => {
+    // Twelve steps with the frontier at s8: past the rail window's break-even point, and hiding steps on
+    // BOTH sides, so each marker renders and can be clicked.
+    function longRunSteps(): StepExecutionRow[] {
+        return [
+            ...["s1", "s2", "s3", "s4", "s5", "s6", "s7"].map((id) => stepRow(id, "completed" as const)),
+            stepRow("s8", "running"),
+            ...["s9", "s10", "s11", "s12"].map((id) => stepRow(id, "pending" as const)),
+        ];
+    }
+
+    function runsNode(onOpenRuns: () => void) {
+        const ws = {
+            analysis: null,
+            sessionId: "no-such-session",
+            workingDir: "/x",
+            project: null,
+            openDialog: () => {},
+            closeDialog: () => {},
+            openSession: () => {},
+            quit: async () => {},
+        } as Workspace;
+        return () => (
+            <WorkspaceContext.Provider value={ws}>
+                <box width="100%" height="100%">
+                    <Sidebar messageCount={() => 0} onOpenRuns={onOpenRuns} />
+                </box>
+            </WorkspaceContext.Provider>
+        );
+    }
+
+    test("clicking an elision marker scrolls the window and does NOT open the runs picker", async () => {
+        let opened = 0;
+        await refreshSidebarData("A", seams(null, [runRow({ status: "running" })], longRunSteps()));
+        const setup = await testRender(
+            runsNode(() => opened++),
+            { width: 44, height: 34 },
+        );
+        try {
+            await setup.renderOnce();
+            expect(setup.captureCharFrame()).toContain("4 earlier steps");
+
+            const lines = setup.captureCharFrame().split("\n");
+            const y = lines.findIndex((l) => l.includes(GLYPHS.arrowUp));
+            expect(y).toBeGreaterThanOrEqual(0);
+            await setup.mockMouse.click(lines[y]!.indexOf(GLYPHS.arrowUp), y);
+            await setup.renderOnce();
+
+            // The window moved one step earlier...
+            expect(setup.captureCharFrame()).toContain("3 earlier steps");
+            // ...and the section's activation never fired, so no picker covered the rail.
+            expect(opened).toBe(0);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("containment is narrow — a click elsewhere in the RUNS section still opens the picker", async () => {
+        let opened = 0;
+        await refreshSidebarData("A", seams(null, [runRow({ status: "running" })], longRunSteps()));
+        const setup = await testRender(
+            runsNode(() => opened++),
+            { width: 44, height: 34 },
+        );
+        try {
+            await setup.renderOnce();
+            const lines = setup.captureCharFrame().split("\n");
+            const y = lines.findIndex((l) => l.includes("RUNS"));
+            expect(y).toBeGreaterThanOrEqual(0);
+            await setup.mockMouse.click(lines[y]!.indexOf("RUNS"), y);
+            await setup.renderOnce();
+            expect(opened).toBe(1);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/layout/sidebar.tsx
+++ b/cli/src/tui/layout/sidebar.tsx
@@ -418,7 +418,7 @@ export function Sidebar(props: SidebarProps) {
                                                             done={progress().done}
                                                             total={progress().total}
                                                             steps={progress().steps}
-                                                            maxSteps={6}
+                                                            maxSteps={7}
                                                             hint={false}
                                                             heading={false}
                                                         />

--- a/cli/src/tui/layout/sidebar.tsx
+++ b/cli/src/tui/layout/sidebar.tsx
@@ -418,7 +418,7 @@ export function Sidebar(props: SidebarProps) {
                                                             done={progress().done}
                                                             total={progress().total}
                                                             steps={progress().steps}
-                                                            maxSteps={7}
+                                                            maxSteps={size.railStepRows}
                                                             hint={false}
                                                             heading={false}
                                                         />

--- a/cli/src/tui/theme_contrast.render.test.tsx
+++ b/cli/src/tui/theme_contrast.render.test.tsx
@@ -3,7 +3,7 @@ import { testRender } from "@opentui/solid";
 import { parseColor, rgbToHex, type RGBA } from "@opentui/core";
 import type { JSX } from "solid-js";
 
-import { DEFAULT_THEME_ID, GLYPHS, themes } from "../lib/design_system.ts";
+import { DEFAULT_THEME_ID, GLYPHS, size, themes } from "../lib/design_system.ts";
 import { contrast } from "../test_support/contrast.ts";
 import { setTheme, syntaxStyle, theme } from "./theme.ts";
 import { AskPrompt } from "./components/ask_prompt.tsx";
@@ -263,7 +263,7 @@ const BLOCKS: BlockCase[] = [
                 done={mockLongRun.done}
                 total={mockLongRun.total}
                 steps={mockLongRun.steps}
-                maxSteps={6}
+                maxSteps={size.railStepRows}
                 hint={false}
                 heading={false}
             />

--- a/cli/src/tui/theme_contrast.render.test.tsx
+++ b/cli/src/tui/theme_contrast.render.test.tsx
@@ -17,7 +17,7 @@ import { RunCardBlock } from "./components/run_card_block.tsx";
 import { ThinkingBlock } from "./components/thinking_block.tsx";
 import { ToolBlock } from "./components/tool_block.tsx";
 import { Welcome } from "./components/welcome.tsx";
-import { mockAskPrompts, mockFileEdit, mockPlanCard, mockRun, mockRunCard, mockThinking, mockToolCall } from "./layout/design_gallery_fixtures.ts";
+import { mockAskPrompts, mockFileEdit, mockLongRun, mockPlanCard, mockRun, mockRunCard, mockThinking, mockToolCall } from "./layout/design_gallery_fixtures.ts";
 
 // End-to-end guard for RENDERED contrast. captureCharFrame() gives characters only, so it cannot see
 // this defect class — the failure is a COLOR, not a missing glyph. The test harness's captureSpans()
@@ -250,6 +250,25 @@ const BLOCKS: BlockCase[] = [
         name: "RunBlock",
         node: () => <RunBlock name={mockRun.name} tag={mockRun.tag} done={mockRun.done} total={mockRun.total} steps={mockRun.steps} />,
         until: mockRun.tag,
+    },
+    {
+        // The windowed rail mount renders spans the full mount never does — the elision markers naming
+        // the hidden step counts. They carry information, so they must clear the 4.5:1 TEXT floor; the
+        // sweep only reaches them when the fixture is long enough for the window to engage.
+        name: "RunBlock (windowed)",
+        node: () => (
+            <RunBlock
+                name={mockLongRun.name}
+                tag={mockLongRun.tag}
+                done={mockLongRun.done}
+                total={mockLongRun.total}
+                steps={mockLongRun.steps}
+                maxSteps={6}
+                hint={false}
+                heading={false}
+            />
+        ),
+        until: "earlier",
     },
     {
         name: "DiffBlock",


### PR DESCRIPTION
…reader scroll it

The sidebar RUNS progress embed capped its step list at a fixed number of rows and dropped the remainder silently, so a seven-step run rendered `1/7` above six rows with nothing to say a seventh existed. The reader could not tell whether the missing step was hidden, unreported, or never planned — the same defect the runs picker already guards against by stating its 100-run cap out loud.

The window now brackets itself with markers naming the hidden count on each side, and those markers are the control that resolves them: a click slides the window one step that way, so the row admitting what is missing is the thing that reveals it, and the two counts double as the position indicator. Windowing is skipped entirely when it would not pay for itself — hiding one step to spend a row on its marker is the same height carrying strictly less information, and a plan landing a step or two over the cap is the common case, not the exception.

The window centres on the earliest RUNNING step rather than the first not-done one. Steps run in parallel waves, so several are in flight at once, and anchoring on the first not-done step would follow a finished sibling forward and scroll work that is still live off screen. It returns there whenever the set of running steps changes — the set, not merely the anchor, because a sibling completing changes the work while leaving the anchor exactly where it was.

Scroll position survives a ledger poll. The rail re-reads every few seconds and re-renders with a freshly minted props object, so the release triggers are memoised to fire on a real change rather than on every read; `on()` alone would fire on each one, since it never diffs what its dependency returned.

The markers opt out of text selection and contain their own clicks. They are buttons rather than prose, and they sit inside the RUNS section, whose mouse-up opens the runs picker — an un-contained release would scroll the window and pop a dialog over it on the same press. Containment is scoped to gestures that begin on a marker, so a selection drag merely crossing the rail still reaches the root's copy handler.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
