### PR TITLE
fix: audit fixes — skill truthfulness and load-bearing ref recommendations

### DIFF
--- a/cli/src/modules/refs/commands.test.ts
+++ b/cli/src/modules/refs/commands.test.ts
@@ -163,6 +163,16 @@ describe("reference command policy", () => {
         expect(await Bun.file(`${env.refsDir}/managed`).exists()).toBe(false);
     });
 
+    test("headless setup without ids defaults to the recommended set but still gates the transfer on consent", async () => {
+        assertTestSandbox(env.refsDir);
+        // The fixture's only dataset is recommended, so the omitted-`--refs` headless path selects it as
+        // the default — but without `--yes` the consent gate must still stop before any transfer, exactly
+        // as an explicit selection does. This pins the invariant that the default never downloads silently.
+        const result = await runReferenceSetup({ interactive: false, source: singleFileSource });
+        expect(result.isOk()).toBe(true);
+        expect(await Bun.file(`${env.refsDir}/managed`).exists()).toBe(false);
+    });
+
     test("headless setup with ids but no consent prints guidance and continues without transfer", async () => {
         const result = await runReferenceSetup({ interactive: false, ids: ["demo"] });
         expect(result.isOk()).toBe(true);

--- a/cli/src/modules/refs/commands.ts
+++ b/cli/src/modules/refs/commands.ts
@@ -36,12 +36,14 @@ export type ReferenceDownloadOptions = {
 
 /** Setup-specific reference selection. */
 export type ReferenceSetupOptions = {
-    /** Explicit ids from `setup --refs`; absent means offer interactively. */
+    /** Explicit ids from `setup --refs`; absent means offer interactively (or default to recommended when headless). */
     readonly ids?: readonly string[];
     /** Explicit consent for a scripted transfer. */
     readonly yes?: boolean;
     /** Whether setup is attached to an interactive terminal. */
     readonly interactive: boolean;
+    /** Matching catalog/plan seam for offline tests, mirroring the download path. */
+    readonly source?: ReferenceCatalogSource;
 };
 
 /** A selection was cancelled before transfer. */
@@ -106,11 +108,17 @@ async function chooseIds(catalog: ReferenceDataCatalog): Promise<readonly string
             ...(dataset.recommendation.recommended ? { hint: "recommended" } : {}),
         });
     }
+    // Preselect the recommended datasets so an accept-all (untouched picker → Enter) installs a
+    // working set — the packs the enrichment/network/single-cell skills are built on — rather than
+    // nothing. `recommended` is the only signal the catalog carries about what a real install looks
+    // like; without seeding it here the flag is a cosmetic hint and the default selection is empty.
+    const recommended = catalog.datasets.filter((dataset) => dataset.recommendation.recommended).map((dataset) => dataset.id);
     const selected = await groupMultiselect({
         message: "Reference datasets to download",
         required: false,
         selectableGroups: true,
         options: grouped,
+        ...(recommended.length > 0 ? { initialValues: recommended } : {}),
     });
     return isCancel(selected) ? undefined : selected;
 }
@@ -327,27 +335,59 @@ export async function runReferenceSetup(options: ReferenceSetupOptions): Promise
             log.info(`Reference selection was not downloaded without explicit consent.\n  Re-run setup with --refs ${options.ids.join(",")} --yes.`);
             return ok(undefined);
         }
-        const downloaded = await downloadReferences({ ids: options.ids, yes: options.yes, interactive: options.interactive });
+        const downloaded = await downloadReferences({
+            ids: options.ids,
+            yes: options.yes,
+            interactive: options.interactive,
+            ...(options.source === undefined ? {} : { source: options.source }),
+        });
         return downloaded.map(() => undefined);
     }
-    if (!options.interactive) {
-        log.info(`Reference store: ${env.refsDir}\n  Install catalog data later with \`inflexa refs download <id...> --yes\`.`);
-        return ok(undefined);
-    }
-    const inspection = await inspectReferenceStore(env.refsDir);
+    const activeCatalog = options.source?.catalog ?? REFERENCE_DATA_CATALOG;
+    const inspection = await inspectReferenceStore(env.refsDir, options.source?.catalog);
     if (inspection.isErr()) return err(inspection.error);
-    const offered = inspection.value.datasets.filter((item) => item.state !== "installed").map((item) => item.dataset.id);
+    const offered = inspection.value.datasets.filter((item) => item.state !== "installed");
     if (offered.length === 0) {
         log.info("Reference store ready; no missing catalog datasets to offer.");
         return ok(undefined);
     }
+    // `--refs` omitted on a headless terminal used to install nothing, so an unattended setup left the
+    // enrichment/network/single-cell skills with no data to stand on. Default to the catalog's
+    // recommended set instead — the only signal for what a working install looks like — while still
+    // gating the transfer on the same explicit `--yes` consent every other download path requires.
+    if (!options.interactive) {
+        const recommendedOffered = offered.filter((item) => item.dataset.recommendation.recommended).map((item) => item.dataset.id);
+        if (recommendedOffered.length === 0) {
+            log.info(`Reference store: ${env.refsDir}\n  Install catalog data later with \`inflexa refs download <id...> --yes\`.`);
+            return ok(undefined);
+        }
+        if (!options.yes) {
+            log.info(
+                `Reference store: ${env.refsDir}\n  ${recommendedOffered.length} recommended dataset(s) are the default install but need explicit consent.\n  Re-run setup with --yes, or \`inflexa refs download ${recommendedOffered.join(" ")} --yes\`.`,
+            );
+            return ok(undefined);
+        }
+        const downloaded = await downloadReferences({
+            ids: recommendedOffered,
+            yes: true,
+            interactive: false,
+            ...(options.source === undefined ? {} : { source: options.source }),
+        });
+        return downloaded.map(() => undefined);
+    }
     let chosen: readonly string[] | undefined;
     try {
-        chosen = await chooseIds({ ...REFERENCE_DATA_CATALOG, datasets: REFERENCE_DATA_CATALOG.datasets.filter((dataset) => offered.includes(dataset.id)) });
+        const offeredIds = new Set(offered.map((item) => item.dataset.id));
+        chosen = await chooseIds({ ...activeCatalog, datasets: activeCatalog.datasets.filter((dataset) => offeredIds.has(dataset.id)) });
     } catch (cause) {
         return err({ type: "download_failed", message: "Reference selection prompt failed.", cause });
     }
     if (chosen === undefined || chosen.length === 0) return ok(undefined);
-    const downloaded = await downloadReferences({ ids: chosen, yes: options.yes, interactive: true });
+    const downloaded = await downloadReferences({
+        ids: chosen,
+        yes: options.yes,
+        interactive: true,
+        ...(options.source === undefined ? {} : { source: options.source }),
+    });
     return downloaded.map(() => undefined);
 }

--- a/skills/bulk-transcriptomics/SKILL.md
+++ b/skills/bulk-transcriptomics/SKILL.md
@@ -81,9 +81,15 @@ Input data?
 
 - **xCell2** (AlmogAngel/xCell2): Cell type deconvolution from bulk expression data. Estimates 64+ cell type scores from bulk RNA-seq. Use when sample-level cell type composition is needed without single-cell data.
 
-### CLI tools (run as shell commands in the sandbox)
+### CLI tools (upstream FASTQ processing)
 
-- **STAR**: Splice-aware RNA-seq aligner. Use for alignment from FASTQ to BAM.
+These bulk RNA-seq workflows normally begin from a **count matrix** the user
+provides; the sandbox does not guarantee any of the upstream aligners/quantifiers
+below. Before planning a from-FASTQ pipeline around one, confirm it is on `PATH`
+(`which <tool>`) — if it is absent, report that and work from the counts you have
+rather than substituting a different step. Tools that may be available for this:
+
+- **STAR**: Splice-aware RNA-seq aligner. FASTQ → BAM.
 - **subread** (featureCounts): Read counting from BAM to gene-level counts.
 - **kallisto**: Pseudoalignment-based RNA-seq quantification (fast, index-based).
 - **salmon**: Pseudoalignment-based RNA-seq quantification (with bias correction).

--- a/skills/dna-methylation/SKILL.md
+++ b/skills/dna-methylation/SKILL.md
@@ -22,7 +22,7 @@ What this means in practice:
 | Array DMR calling (`DMRcate::cpg.annotate(datatype = "array")`) | **Cannot run.** Resolves probe coordinates from the anno package. |
 | Deconvolution from an existing beta matrix (`EpiDISH`) | **Runs.** Self-contained references, no annotation dependency. |
 | Epigenetic clocks (`methylclock`) | Runs on a beta matrix, but needs clock coefficients — see `references/methylclock-api.md`. |
-| Bisulfite-seq (Bismark → `dmrseq` / `DSS`) | **Runs.** No array annotation involved. |
+| Bisulfite-seq (Bismark → `dmrseq` / `DSS`) | **Downstream only.** `dmrseq`/`DSS` run on a methylation/coverage matrix you already have. The upstream Bismark toolchain (Trim Galore, alignment, dedup, extraction) is not guaranteed in the sandbox — verify those binaries before planning a from-FASTQ run (see §2). |
 
 **How to proceed**: verify the annotation package actually loads before building a pipeline around it. If it does not, say so plainly — name the missing package and the step it blocks — and then do the analysis the data *does* support. A beta or M-value matrix that arrives already processed (from GEO, a collaborator, or an upstream step) still supports DMP testing, deconvolution, clocks, and EWAS modelling; only the probe-to-genome annotation is missing, and results can be reported by CpG ID. Do not silently substitute a different array's annotation, and do not present an unannotated result as though it were annotated.
 
@@ -58,6 +58,12 @@ IDAT files
 - ALWAYS verify the correct array annotation: 450K (`IlluminaHumanMethylation450kanno`) vs EPIC (`IlluminaHumanMethylationEPICanno`) vs EPICv2. Wrong annotation silently produces incorrect results. **None of these packages are staged here** — confirm the one you need loads before starting, and if it does not, report the blocker rather than falling back to another platform's annotation (see Environment Constraint above).
 
 ### 2. Bisulfite Sequencing (WGBS / RRBS)
+
+The alignment stages below rely on the Bismark toolchain (Trim Galore, `bismark`,
+`deduplicate_bismark`, `bismark_methylation_extractor`), which is **not guaranteed
+to be installed** — confirm each binary is on `PATH` before building a from-FASTQ
+pipeline, and if it is absent, report that and start from a coverage/methylation
+matrix instead. The downstream DMR steps (`dmrseq`, `DSS`) run either way.
 
 ```
 FASTQ files

--- a/skills/genomic-variants/SKILL.md
+++ b/skills/genomic-variants/SKILL.md
@@ -159,10 +159,17 @@ Rare variant analysis
 
 ### CLI tools (run as shell commands)
 
+Guaranteed in the sandbox — rely on these freely:
+
 - **samtools**: view, sort, index, flagstat, idxstats, depth, mpileup.
 - **bcftools**: view, filter, query, stats, norm, merge, annotate, consensus.
 - **tabix**: Index and query tabular genomic data (VCF, BED, GFF).
+- **bedtools**: interval arithmetic (intersect, merge, coverage, closest).
 - **vcftools**: VCF filtering/statistics (`--min-alleles`, `--maf`, `--max-missing`, `--weir-fst-pop`).
+
+May not be present — confirm with `which <tool>` before planning around one, and
+if it is absent, report that rather than substituting a different step:
+
 - **mosdepth**: Fast BAM/CRAM depth calculation (per-base, per-window, per-region).
 - **bwa / minimap2**: Read alignment (`bwa mem` for short reads, `minimap2` for long reads).
 - **picard**: MarkDuplicates, CollectInsertSizeMetrics, ValidateSamFile.

--- a/skills/network-regulatory/references/networkx-api.md
+++ b/skills/network-regulatory/references/networkx-api.md
@@ -151,16 +151,12 @@ communities_greedy = list(greedy_modularity_communities(G, weight="weight"))
 from networkx.algorithms.community import label_propagation_communities
 communities_lp = list(label_propagation_communities(G))
 
-# Louvain (requires python-louvain / community package)
-import community as community_louvain
-partition = community_louvain.best_partition(G, weight="weight", resolution=1.0)
-# partition: dict {node: community_id}
-
-# Convert partition to list of sets (consistent with other methods)
-communities_louvain = {}
-for node, comm_id in partition.items():
-    communities_louvain.setdefault(comm_id, set()).add(node)
-communities_louvain = list(communities_louvain.values())
+# Louvain — networkx ships this built-in, so it works without the standalone
+# python-louvain / community package (which may not be installed; verify, or
+# `pip install python-louvain`, if you specifically need community_louvain).
+from networkx.algorithms.community import louvain_communities
+communities_louvain = louvain_communities(G, weight="weight", resolution=1.0, seed=0)
+# communities_louvain: list of sets of nodes (same shape as the other methods)
 
 # Modularity score
 modularity = nx.community.modularity(G, communities_greedy)
@@ -282,7 +278,7 @@ G_loaded = nx.read_graphml("network.graphml")
 
 - `nx.from_pandas_edgelist()` creates an undirected graph by default. Pass `create_using=nx.DiGraph()` for directed networks.
 - `eigenvector_centrality()` may not converge on disconnected graphs. Either use the largest connected component or increase `max_iter`.
-- The `community` package for Louvain (`community_louvain.best_partition()`) is installed as `python-louvain`, not `community`. Import with `import community as community_louvain`.
+- For Louvain, prefer networkx's built-in `louvain_communities()` (from `networkx.algorithms.community`), which is always available. The standalone `community` package (`community_louvain.best_partition()`, distributed on PyPI as `python-louvain`) may not be present — verify it imports, or `pip install python-louvain`, before relying on it.
 - `spring_layout()` is non-deterministic. Set `seed=` for reproducible layouts.
 - `nx.draw_networkx()` renders to the current matplotlib axes. Always call `plt.close(fig)` afterward to avoid memory leaks when generating many plots.
 - `from_pandas_adjacency()` treats all non-zero entries as edges. For weighted networks, ensure the DataFrame contains the actual weights, not just 0/1.

--- a/skills/report-html/SKILL.md
+++ b/skills/report-html/SKILL.md
@@ -159,7 +159,7 @@ Charts use transparent backgrounds, `#f1f5f9` grid lines, `#64748b` axis labels.
 - Do not author your own `<header>` or `<footer>` element. The base owns the hero, footer, CDN tags, theme registration, sortable tables, fade-in observer, and sidebar tracking — populate them via the `header_*` / `footer_left` / `sidebar` blocks.
 - Do not rewrite `report.html.j2` from scratch on iteration. Read the existing file, edit in place. Wholesale rewrites lose context the reader has already seen.
 - Do not fabricate numbers, gene names, p-values, or any datum. Only render values present in the analysis files you read.
-- Do not inline large datasets into HTML. Copy CSV/JSON into the shared assets dir via `copy_to_assets`, fetch client-side from `assets/...`.
+- Do not inline large datasets into HTML. Declare each large CSV/JSON as a report **source** so the report step stages it into the shared assets dir, then fetch it client-side from `assets/...`.
 - Do not put `border-radius` on data cards (stat-card, insight-box, data-table). Square corners + `corner-accents` only. Chart panels are the sole exception.
 - Do not use `font-mono` on headings or body prose. Mono is reserved for labels, tags, badges, data values, gene symbols.
 - Do not load fonts from `fonts.googleapis.com` (CSP blocked). Use `cdn.jsdelivr.net` fontsource, which the base already wires.

--- a/skills/shared/omics-general/SKILL.md
+++ b/skills/shared/omics-general/SKILL.md
@@ -116,7 +116,7 @@ are installed:
 
 When you need gene ID conversion, annotation, or organism databases:
 - **AnnotationDbi** + **org.Hs.eg.db** / **org.Mm.eg.db** / **org.Rn.eg.db** / **org.Dr.eg.db** / **org.Cf.eg.db** / **org.Bt.eg.db**: Map between gene symbols, Entrez IDs, Ensembl IDs, UniProt IDs. Use `mapIds()` or `select()`.
-- **biomaRt**: Query Ensembl BioMart for gene annotations, GO terms, orthologs across species. Use `useMart()`, `getBM()`.
+- **biomaRt**: installed, but it queries Ensembl BioMart over the network and the sandbox has no outbound access — so `useMart()` / `getBM()` will not connect. Do annotation offline instead: `org.*.eg.db` via AnnotationDbi (above), `babelgene` for orthologs, or the ID-mapping tables in the reference inventory. Reach for biomaRt only in an environment where network access is confirmed.
 - **ensembldb** + **EnsDb.Hsapiens.v86** / **EnsDb.Mmusculus.v79**: Gene models with coordinates, transcripts, exons. Use `genes()`, `transcripts()`.
 - **babelgene**: Cross-species gene name conversion (human ↔ mouse ↔ rat). Use `orthologs()`.
 


### PR DESCRIPTION
Two independent audit fixes, each verified against ground truth in this repo.

## `fix(skills)` — reflect tool/package uncertainty instead of asserting presence

Five skills affirmatively told agents a package or CLI tool was present when it is not guaranteed in the sandbox. A skill that asserts an absent dependency costs a committed plan and a failed step, and none of it is typechecked (`validateAgentSkills` reads only whether each `SKILL.md` is readable, never its prose). Reworded each to reflect uncertainty — verify/probe before relying, report absence and proceed with what exists — checked against `images/lib-store-manifest.yaml` (system_tools = samtools/bcftools/tabix/bedtools/vcftools/mageck + amd64 plink2; `louvain` present but no `python-louvain`; `biomaRt` present but network-only):

- **networkx-api**: use networkx's built-in `louvain_communities()` (present); soften the `python-louvain`/`community` claim to "may not be installed".
- **bulk-transcriptomics, genomic-variants**: relabel upstream FASTQ CLI tools as not-guaranteed (confirm with `which`); split off the real guaranteed baseline in genomic-variants.
- **omics-general**: `biomaRt` is installed but network-only and unusable in the offline sandbox — point to offline annotation alternatives (matches how `enrichment`/`immune-deconvolution` already word it).
- **report-html**: drop the nonexistent `copy_to_assets` tool; state the task (declare each large file as a report source), not a tool name.
- **dna-methylation**: downgrade the Bisulfite-seq "Runs." cell to downstream-only (`dmrseq`/`DSS` on a provided matrix); note the Bismark toolchain is not guaranteed present.

## `fix(refs)` — make `recommended` load-bearing so a default install downloads data

The catalog's `recommendation.recommended` flag (set on 24 of 29 datasets) drove no selection anywhere: `chooseIds` passed no `initialValues`, so an untouched picker returned empty and empty is treated as a decline; headless `setup` with `--refs` omitted installed nothing. A user who ran setup and accepted every default got zero reference datasets — including the ones the enrichment, network, and single-cell skill packs are built on.

- Preselect the recommended ids in the picker via `initialValues`, so accept-all installs a working set instead of nothing.
- Default the headless `setup` path (no `--refs`) to the recommended set, still gated on the same explicit `--yes` consent every download requires: without consent it now names the recommended default and the exact `refs download … --yes` command.
- Thread a `source` seam into `ReferenceSetupOptions` (mirroring the download path) so the headless default is testable offline; add a test pinning that the default never downloads without consent.

## Verification

- `bun run typecheck` clean, `eslint .` clean.
- `refs/commands` 19/19 pass; adjacent `store`/`setup` suites 114/114 pass.
- The consent gate is preserved everywhere — the refs change alters the *default selection*, not the download policy.

Both commits are DCO signed-off.