### PR TITLE
feat(harness): isolate step failures to their dependents in executeAnalysis

### DIFF
--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/design.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`executeAnalysis` schedules steps through a pure dependency scheduler (`execute-analysis-scheduler.ts`): `scheduleReady` returns a step when every `depends_on` id is in the completed set. A failed step never enters that set, so its transitive dependents are structurally unreachable — no extra logic makes that true. On top of this sits a separate fail-fast cascade in `runSchedulerLoop` (`execute-analysis.ts`): a run-wide `failFast` flag set on the first failed/blocked/thrown child, a `cancelInFlight` sweep over every in-flight sibling, and an early-return guard at the top of `dispatchReady`.
+
+The terminal machinery is already partial-aware: `deriveFinalStatus` lands `partial` when some steps completed and some failed, synthesis runs over whatever completed, `sweepPendingStepExecutions` flips never-started rows to `skipped`, and per-step errors persist on `cortex_step_executions.error`. Fail-fast therefore does not protect an invariant — it chooses to minimize the completed set. The plan DAG is the product's language for conditionality (a QC gate that must stop downstream work is expressed as `depends_on`), so a failure dooming steps the planner did not wire as dependents is the scheduler second-guessing the plan.
+
+The flag currently serves three cascades. Only one is being removed:
+
+- failure/blocker cascade (graceful `failed`/`blocked` result, or a thrown child for a non-budget cause) — **removed by this change**
+- budget cascade (`budget_exceeded`, graceful or thrown; `neverFits` plan validation) — **unchanged**
+- external cancel — never used the flag at all (the parent unwinds via DBOS cancellation exceptions; the `"external_cancel"` cause in `cancelInFlight`'s union has no caller)
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A step failure or blocker makes only its transitive dependents unreachable; every independent ready step continues to dispatch and every in-flight sibling runs to its own conclusion.
+- One uniform settlement rule: graceful `failed`, graceful `blocked`, and a thrown child (non-budget cause) all get identical treatment.
+- Doomed dependents are visible in the live DAG view as `skipped` from the moment the failure settles, and land `skipped` on the ledger at run end.
+- Budget-exceeded, `neverFits`, and external-cancel semantics are byte-for-byte preserved (the in-flight `resume-analysis-after-budget-pause` work depends on them).
+
+**Non-Goals:**
+
+- Retry/resume of a failed step or its doomed subtree.
+- Any change to the budget-pause machinery or its resumability.
+- Downgrading the `neverFits` halt to a per-step failure (possible follow-up, out of scope).
+- CLI rendering of the `skipped` DAG tier (separate cli-subsystem change; harness publishes first).
+- Any change to the pure scheduler — `scheduleReady` already expresses the desired reachability.
+
+## Decisions
+
+### D1: Reachability is the mechanism; no "poisoned set" is introduced
+
+Doomed dependents are not tracked in scheduler state. `scheduleReady` already never returns a step whose dependency is unfinished, and the loop's `while (inFlight.size > 0)` terminates naturally once settled steps stop producing new ready ones. The only new computation is a UI-facing graph walk (D4). Alternative considered: an explicit skipped/poisoned set threaded through scheduling — rejected as redundant state that could drift from the reachability the completed-set already encodes.
+
+Discovered constraint: the caller must filter settled-but-not-completed steps (failed/canceled) out of the candidate list it hands `scheduleReady`. A failed step is neither in `completed` nor in flight, so the pure scheduler would offer it again — under fail-fast that was masked (dispatch never ran after a failure); under continue-semantics it is an infinite re-dispatch loop. The filter also keeps a settled step's declared resources from weighing against the budget. The pure scheduler itself stays unchanged.
+
+### D2: Uniform continue rule for all non-budget settlement failures
+
+Graceful `failed`, graceful `blocked`, and a thrown child (when `isBudgetExceeded(err)` is false and the child is not in `canceledByParent`) all: add the step to `failed`, record the per-step error, mark dependents `skipped` (D4), emit the DAG snapshot, and dispatch. No sibling cancellation, no halt. Alternative considered: continue on graceful work-failures but keep the halt for thrown children (machinery failure predicts sibling failures) — rejected in favor of the simpler uniform rule; a genuinely sick backend will fail the remaining steps on their own merits, and the uniform rule keeps the settlement loop free of a second policy fork.
+
+### D3: The halt flag survives for budget paths only
+
+`failFast` is renamed (e.g. `halted`) and is set only by the budget cascade (`budget_exceeded` graceful/thrown, `neverFits`). The `dispatchReady` early-return guard and `cancelInFlight` remain in place for those paths. Rationale: the budget pause is acknowledged half-baked and slated for future work — this change must neither depend on nor perturb it.
+
+### D4: Doom-marking is an eager UI walk, keyed off the failure settlement
+
+When a non-budget failure settles, the loop walks the static plan DAG (reverse-adjacency from the failed step) and sets every transitive dependent not already terminal to `skipped` in `stepRuntime`, then emits the snapshot. The walk is over workflow-input data and checkpointed settlement state, so it replays deterministically. The `DagStepState.status` vocabulary gains `"skipped"` (contract + Zod schema in `src/contracts/`), mirroring how `"queued"` was added by resource-budgeted-scheduling. The `StepExecutionRow` DB enum is untouched — rows stay `pending` until the terminal sweep flips them to `skipped`, exactly as today. Alternatives considered: leaving doomed steps `pending` in the stream (dishonest for long runs — indistinguishable from "will still run"); reusing `"failed"` with an upstream-dependency error (stream would contradict the ledger's `skipped`).
+
+### D5: Dispatch after every settlement
+
+`dispatchReady()` runs after failed settlements too, not only completions. Required under budget admission: a failed step leaves the in-flight set and frees its declared capacity, which a held-for-capacity step may now claim. Without a budget the extra call is a no-op (a failure never makes a new step dependency-ready).
+
+### D6: Run-level `failureReason` records the first failure
+
+Settlement order is checkpointed (`DBOS.waitFirst`), so first-failure-wins is deterministic. Per-step detail already lives on `cortex_step_executions.error` and in the DAG snapshot; the run-level column is a headline, not the record. Alternative considered: an aggregate ("3 of 8 steps failed") — more honest for multi-failure runs but computable by any reader from the step ledger; not worth a bespoke format.
+
+## Risks / Trade-offs
+
+- [A failure that predicts sibling failures (shared dataset flaw the planner didn't encode as a dependency) burns compute discovering it N times] → The DAG is the declared truth about conditionality; planner prompts already push QC gates upstream. External cancel remains available to a user watching the run. If this bites in practice, a cheap follow-up is a failure-count circuit breaker.
+- [Runs with a failure now run longer, extending the open `RunCharge` bracket] → Inherent to the feature — the extended time is spent producing artifacts the user keeps. Budget admission still bounds concurrent spend.
+- [The CLI renders an unknown `skipped` status until it adopts the new tier] → Harness publishes before the CLI consumes (established two-step promotion); the CLI change is a small rendering addition. Verify the CLI's current handling of unknown statuses degrades gracefully rather than crashing before publishing.
+- [A run in flight across the deploy replays its checkpointed prefix under old recorded decisions, then continues under new semantics] → Benign divergence: already-fail-fasted runs are terminal; a mid-flight run simply stops cancelling siblings from the live frontier onward. Note it in the release notes.
+- [Tests that encode fail-fast flip meaning] → The budget-cascade and workflow-replay DBOS tests must pass **unchanged** — treat any needed edit there as a red flag that budget semantics drifted.
+
+## Migration Plan
+
+1. Land the contract addition (`skipped` in `DagStepState.status`) and the scheduler-loop change together in the harness; build `dist/`, run `bun test`.
+2. Publish `@inflexa-ai/harness` (two-step promotion), then a follow-up cli-subsystem change adopts the `skipped` tier in DAG rendering.
+3. Rollback is a revert of the scheduler-loop commit; the contract addition is additive and can stay.
+
+## Open Questions
+
+- None blocking. The `neverFits` per-step downgrade and a failure-count circuit breaker are noted as possible follow-ups, deliberately out of scope.

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`executeAnalysis` fail-fasts on the first step failure: it cancels every in-flight sibling and stops scheduling, even for steps on completely independent DAG branches. The dependency tree is already the plan's language for "this work is conditional on that work" (a QC gate that should stop downstream work is expressed as `depends_on`), and the run machinery already treats partial outcomes as first-class (`partial` terminal status, synthesis over completed steps, pending→`skipped` sweep). Fail-fast therefore protects no invariant — it just minimizes the completed set, discarding independent work the user paid sandbox and LLM cost to start and must re-buy in a full new run.
+
+## What Changes
+
+- **Continue on step failure.** When a child settles as `failed`, `blocked`, or by throwing (for any non-budget cause), the parent no longer cancels in-flight siblings or halts scheduling. Only the failed step's transitive dependents become unreachable — they are never dispatched (a failed step never enters the completed set, so `scheduleReady` never returns them) and are swept to `skipped` at run end. One uniform rule for all three settlement shapes.
+- **Budget semantics untouched.** The `budget_exceeded` cascade (graceful or thrown), the `neverFits` plan-validation halt, and external cancel keep today's stop-everything behavior. The run-halt flag survives for those paths only.
+- **Dispatch after every settlement.** Failed settlements now also trigger a dispatch round — under budget admission, a failure frees declared capacity that a held-for-capacity step may claim.
+- **`skipped` tier in the DAG stream part.** `data-dag-state` gains a `skipped` step status; the moment a failure settles, the failed step's transitive dependents are marked `skipped` in the snapshot instead of sitting `pending` for the rest of the run. (CLI rendering of the new tier is a follow-up in the cli subsystem; harness publishes first.)
+- **Run-level `failureReason` becomes a summary.** Per-step errors already live on `cortex_step_executions.error` and the DAG snapshot; the single run-level column records the first failure (deterministic settlement order).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `harness-durable-runtime`: the core scheduling requirement changes from "first step failure or declared blocker cancels in-flight siblings and stops scheduling" to "a step failure or blocker makes only its transitive dependents unreachable; independent ready steps continue to dispatch; budget-exceeded and external cancel retain the halt cascade".
+- `harness-sandbox-agents`: the blocker scenario no longer mandates cancelling in-flight siblings — a blocker dooms its dependents exactly like a failure.
+- `workflow-failure-lifecycle`: the finalisation hook's path enumeration loses its fail-fast path (runs with step failures drain the loop and finalise, typically `partial`); the pending→`skipped` sweep now covers dependents that were unreachable because an upstream step failed.
+- `resource-budgeted-scheduling`: capacity-freeing broadens — a held-for-capacity step is admitted when an in-flight sibling settles (completes **or fails**), not only when it completes; the `neverFits` guard states its halt semantics explicitly instead of referencing the removed "standard fail-fast".
+
+The `data-dag-state` `skipped` status lands as an ADDED requirement in `harness-durable-runtime` (mirroring how `"queued"` was added by resource-budgeted-scheduling). `step-execution-tracking` needs no delta: the ledger's enum, sweep helper, and row behavior are unchanged — only purpose-prose framing of when `skipped` arises shifts, which archiving the durable-runtime delta captures.
+
+## Impact
+
+- **Code**: `src/workflows/execute-analysis.ts` (`runSchedulerLoop` settlement branches, doom-marking walk, `dispatchReady` call sites, halt-flag rename to reflect budget-only purpose); `src/contracts/chat-parts.ts` + `src/contracts/schemas/` (dag-state `skipped` status). The pure scheduler (`execute-analysis-scheduler.ts`) is unchanged — dependency gating already produces the desired reachability.
+- **Tests**: `execute-analysis.test.ts` fail-fast/blocked/provenance tests flip to continue-semantics; new tests for independent-branch-continues, dependent-never-dispatched-and-skipped, multi-failure `partial`, capacity-freed-by-failure. `__tests__/dbos/budget-cascade.test.ts` and `workflow-replay.test.ts` must stay green unchanged (budget semantics are frozen).
+- **Consumers**: the CLI's DAG rendering should learn the `skipped` tier (separate cli-subsystem change; harness must publish before the CLI consumes — two-step promotion).
+- **Upgrade edge**: a run in flight across the deploy replays its checkpointed prefix under recorded decisions and continues under the new semantics from the live frontier — benign; fail-fasted runs are already terminal.
+- **Out of scope**: budget-pause resume work (`resume-analysis-after-budget-pause`), retry-from-failed-step, `neverFits` per-step downgrade, CLI rendering.

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/harness-durable-runtime/spec.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/harness-durable-runtime/spec.md
@@ -1,0 +1,104 @@
+# harness-durable-runtime — delta
+
+> Replaces the fail-fast cascade with failure isolation: a step failure or
+> blocker makes only its transitive dependents unreachable, while independent
+> branches keep running. The halt cascade survives solely for the budget paths
+> (`budget_exceeded`, `neverFits`) and external cancel. Doomed dependents become
+> visible as a new `skipped` tier in the `data-dag-state` part.
+
+## REMOVED Requirements
+
+### Requirement: Step scheduling is dependency-gated and fails fast
+
+**Reason**: The fail-fast cascade cancelled in-flight siblings and stopped scheduling on the first step failure, discarding independent work the plan DAG never declared dependent on the failed step. The dependency tree is the plan's language for conditionality; the scheduler no longer second-guesses it.
+**Migration**: Replaced by "Step scheduling is dependency-gated and failure-isolated" below. Budget-driven halts are unchanged and remain specified by the resource-budgeted-scheduling capability.
+
+## ADDED Requirements
+
+### Requirement: Step scheduling is dependency-gated and failure-isolated
+
+`executeAnalysis` SHALL start each step's child workflow when all of its
+`depends_on` steps have completed AND the machine resource budget admits it
+(see the resource-budgeted-scheduling capability), with no wave barrier. When
+the workflow input carries no budget, dependency satisfaction alone SHALL start
+the step. A computed topological level MAY be persisted and emitted for UI
+layout but SHALL NOT gate execution.
+
+A step settling as `failed`, as `blocked`, or by throwing for any non-budget
+cause SHALL NOT cancel in-flight siblings and SHALL NOT stop scheduling: the
+parent SHALL record the step as failed, continue awaiting in-flight children,
+and keep dispatching every step that becomes dependency-satisfied. Only the
+failed step's transitive dependents are affected — they can never become
+dependency-satisfied (a failed step never enters the completed set) and SHALL
+never be dispatched. The parent SHALL run a dispatch round after every child
+settlement, not only after completions. The run-level `failureReason` SHALL
+record the first failure in checkpointed settlement order; per-step errors ride
+on the step ledger and the DAG snapshot.
+
+The halt cascade (cancel in-flight children via explicit `DBOS.cancelWorkflow`
+and stop scheduling) SHALL be reserved for the budget paths — a
+`budget_exceeded` settlement (graceful or thrown) and the `neverFits`
+plan-validation guard — whose semantics are owned by the
+resource-budgeted-scheduling capability, and for external cancel.
+
+#### Scenario: A ready step starts without waiting for an unrelated sibling
+
+- **GIVEN** a step whose single dependency has just completed and a budget with sufficient remaining capacity
+- **WHEN** the scheduler recomputes the ready set
+- **THEN** that step starts immediately even if an unrelated step is still running
+
+#### Scenario: A ready step is held while the budget is exhausted
+
+- **GIVEN** a step whose dependencies have all completed and in-flight siblings whose declared resources consume the full budget
+- **WHEN** the scheduler recomputes the ready set
+- **THEN** the step is not started until an in-flight sibling settles and frees capacity
+
+#### Scenario: A failure dooms only its transitive dependents
+
+- **GIVEN** a plan `A → B → D` and `A → C → E` where B and C run concurrently after A completes
+- **WHEN** B settles as `failed` while C is still running
+- **THEN** C keeps running, E is dispatched when C completes, and D is never dispatched
+- **AND** the run finalises `partial` with per-step errors on the ledger and `failureReason` recording B's failure
+
+#### Scenario: A thrown child is treated exactly like a failed step
+
+- **GIVEN** two independent in-flight steps
+- **WHEN** one child workflow throws for a non-budget cause
+- **THEN** its step is recorded failed with the thrown error, the sibling is not cancelled, and scheduling continues
+
+#### Scenario: A blocker is treated exactly like a failed step
+
+- **GIVEN** a plan with a blocked step and an independent ready sibling
+- **WHEN** the step settles `blocked`
+- **THEN** only the blocked step's transitive dependents are never dispatched and the independent sibling still runs
+
+#### Scenario: Budget-exceeded still halts the run
+
+- **GIVEN** several in-flight children
+- **WHEN** a child settles with `budget_exceeded`
+- **THEN** the parent cancels the remaining in-flight children via `DBOS.cancelWorkflow` and schedules no further steps
+
+### Requirement: Unreachable dependents are visible as skipped in the DAG stream
+
+The `DagStepState.status` vocabulary in the `data-dag-state` part SHALL gain a
+`"skipped"` value. When a non-budget failure or blocker settles, the parent
+SHALL walk the plan DAG and mark every transitive dependent of the failed step
+that is not already terminal as `"skipped"` in the emitted snapshot, so doomed
+steps are distinguishable from steps that will still run. The walk consumes
+only workflow-input plan data and checkpointed settlement state, so it replays
+deterministically. The `StepExecutionRow.status` database enum SHALL NOT
+change: ledger rows stay `pending` until the terminal sweep flips them to
+`skipped` (see the workflow-failure-lifecycle capability) — skipped visibility
+during the run is a stream concern only.
+
+#### Scenario: Dependents of a failed step show as skipped immediately
+
+- **GIVEN** a plan `A → B → D` with D pending and B running
+- **WHEN** B settles as `failed`
+- **THEN** the next `data-dag-state` emission shows D as `"skipped"` while independent steps keep their own statuses
+
+#### Scenario: The ledger is not written at doom-marking time
+
+- **GIVEN** a step marked `"skipped"` in the stream after its upstream dependency failed
+- **WHEN** its `cortex_step_executions` row is read while the run is still in flight
+- **THEN** the row still reads `pending`; it reaches `skipped` only via the terminal sweep

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/harness-sandbox-agents/spec.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/harness-sandbox-agents/spec.md
@@ -1,0 +1,36 @@
+# harness-sandbox-agents — delta
+
+> A blocker no longer fail-fasts the run. It is treated exactly like a step
+> failure by the parent scheduler: only the blocked step's transitive dependents
+> become unreachable; in-flight siblings and independent ready steps continue.
+
+## MODIFIED Requirements
+
+### Requirement: Step agents declare inability via report_blocker, not output inference
+
+A step agent SHALL get a terminal `report_blocker({ reason })` tool whenever a
+blocker cell is supplied; there SHALL be no `submit`/`done` tool, because a
+step's deliverable is its persisted files. Calling `report_blocker` SHALL record
+`{ kind: "blocker", reason }` into the per-run holder the workflow body reads
+after `runAgent`. `blocked` SHALL be a distinct terminal step status — separate
+from `failed` and `completed` — carrying the reason to the
+`cortex_step_executions.blocked_reason` column, a `data-step-blocked` run-event
+part, and the step return. The parent scheduler SHALL treat a blocker exactly
+like a step failure: only the blocked step's transitive dependents become
+unreachable, while in-flight siblings and independent ready steps continue
+(see the harness-durable-runtime capability). The harness SHALL NOT infer
+failure from output/artifact counts: a legitimately-empty step (no files, no
+blocker, clean finish) SHALL stay `completed`.
+
+#### Scenario: Blocker yields a distinct blocked status
+
+- **GIVEN** a step agent that calls `report_blocker({ reason })` and stops
+- **WHEN** the workflow body reads the blocker holder after the loop
+- **THEN** the step SHALL terminate with status `blocked`, persisting the reason to `blocked_reason` and emitting a `data-step-blocked` part
+- **AND** in-flight siblings SHALL NOT be cancelled; only the blocked step's transitive dependents are never dispatched
+
+#### Scenario: Empty step is not auto-failed
+
+- **GIVEN** a step that writes no artifacts, calls no blocker, and ends cleanly
+- **WHEN** the step terminates
+- **THEN** its status SHALL be `completed` (with `artifactCount: 0`), not failed or blocked

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/resource-budgeted-scheduling/spec.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/resource-budgeted-scheduling/spec.md
@@ -1,0 +1,46 @@
+# resource-budgeted-scheduling — delta
+
+> Two adjustments now that step failures no longer halt the run: capacity is
+> freed by any settlement (completion, failure, or blocker), and the `neverFits`
+> guard states its halt semantics explicitly instead of pointing at the removed
+> "standard fail-fast".
+
+## MODIFIED Requirements
+
+### Requirement: Ready steps are admitted against the budget by declared weight
+
+`scheduleReady` SHALL remain a pure function, extended to take the budget and the in-flight steps' declared resources. A dependency-satisfied step SHALL be admitted only when `sum(inFlight.cpu) + step.cpu <= budget.cpu` AND `sum(inFlight.memoryGb) + step.memoryGb <= budget.memoryGb`, using each step's plan-declared `resources`. Each scheduling round SHALL consider candidates in stable plan order, greedily admitting every candidate that fits; a candidate that does not fit SHALL NOT block a later, smaller candidate (skip-over). Capacity SHALL be freed by any settlement of an in-flight step — completion, failure, or blocker — and the scheduler SHALL run an admission round after every settlement, not only after completions. When the workflow input carries no budget, every dependency-satisfied step SHALL be admitted (legacy fan-out).
+
+#### Scenario: A ready step waits for capacity
+
+- **GIVEN** a budget of `{ cpu: 4, memoryGb: 8 }` and two in-flight steps declaring `{ cpu: 2, memoryGb: 4 }` each
+- **WHEN** a third step declaring `{ cpu: 2, memoryGb: 4 }` becomes dependency-satisfied
+- **THEN** it is not started until an in-flight step settles and frees capacity
+
+#### Scenario: A failure frees capacity for a held step
+
+- **GIVEN** a full budget and a dependency-satisfied step held for capacity
+- **WHEN** an in-flight step settles as `failed`
+- **THEN** the next admission round admits the held step against the freed capacity
+
+#### Scenario: A smaller later candidate skips over a blocked larger one
+
+- **GIVEN** remaining capacity `{ cpu: 2, memoryGb: 4 }` and ready candidates in plan order: `stepA { cpu: 4, memoryGb: 8 }`, `stepB { cpu: 1, memoryGb: 2 }`
+- **WHEN** the scheduler runs an admission round
+- **THEN** `stepB` starts and `stepA` remains held
+
+#### Scenario: No budget in workflow input preserves legacy behavior
+
+- **GIVEN** a workflow input without a budget
+- **WHEN** three independent steps become dependency-satisfied
+- **THEN** all three child workflows start immediately
+
+### Requirement: A step that can never fit the budget fails immediately
+
+If a dependency-satisfied step's declared resources exceed the budget outright (it could not be admitted even against an empty budget), the scheduler SHALL mark it `failed` with an error naming the resource shortfall rather than holding it indefinitely, and SHALL halt the run: in-flight children are cancelled via `DBOS.cancelWorkflow` and no further steps are scheduled. The halt is deliberate — the stored plan is invalid against this machine, so continuing other branches is not attempted (unlike an ordinary step failure, which dooms only its dependents; see the harness-durable-runtime capability). Plan-time validation makes this unreachable for newly generated plans; the guard covers stored plans and defensive depth.
+
+#### Scenario: An over-budget step fails with a clear reason
+
+- **GIVEN** a budget of `{ cpu: 4, memoryGb: 8 }` and a stored plan step declaring `{ cpu: 8, memoryGb: 16 }`
+- **WHEN** the step becomes dependency-satisfied
+- **THEN** the step is marked `failed` with an error naming the declared resources and the budget, in-flight children are cancelled, and no further steps are scheduled

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/workflow-failure-lifecycle/spec.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/specs/workflow-failure-lifecycle/spec.md
@@ -1,0 +1,57 @@
+# workflow-failure-lifecycle — delta
+
+> The finalisation hook's path enumeration loses its "fail-fast" path: runs with
+> step failures now drain the scheduler loop and finalise like any other
+> genuinely-terminal run (typically `partial`). The pending→`skipped` sweep is
+> unchanged in mechanism but now covers steps that were unreachable because an
+> upstream dependency failed.
+
+## MODIFIED Requirements
+
+### Requirement: collectAndComplete is the single finalisation hook
+
+`collectAndComplete` SHALL be the only block that finalises run-level state, and
+it SHALL run on every terminal path: success, runs with step failures (which
+drain the scheduler loop and typically finalise `partial`), the budget halt,
+external cancel, synthesis failure, and the 402 pause. Within it the status
+write, charge close, and run-authorization revoke SHALL each be their own named
+`DBOS.runStep`, and a failure of any one SHALL be logged without rolling back
+the side effects that did succeed. There SHALL be NO separate `onError`-style
+hook racing it; child step bodies SHALL NOT call `updateRunStatus` or any
+run-fail helper directly.
+
+On its genuinely-terminal paths (success, runs with step failures, external
+cancel, synthesis failure) `collectAndComplete` SHALL additionally sweep the
+run's still-`pending` step rows to `skipped` (stamping `completed_at`) in its
+own named `DBOS.runStep`, so a finished run never advertises steps that read as
+still waiting to start — including dependents that were never dispatched
+because an upstream step failed or blocked. The sweep SHALL NOT run on the
+resumable 402 budget-pause branch — the branch is selected structurally (the
+pause path itself), never inferred from the written run status (the pause also
+writes `"canceled"`) — because the resumed workflow still needs those `pending`
+rows. A sweep-step failure SHALL be logged without rolling back the other
+finalisation side effects, matching the hook's non-rolling-back rule.
+
+#### Scenario: Step bodies do not write run status
+
+- **WHEN** a child workflow body encounters an error
+- **THEN** the body lets the error propagate (it does not write `cortex_runs.status`)
+- **AND** the parent's `collectAndComplete` owns the run-status transition
+
+#### Scenario: A partial finalisation failure is non-rolling-back
+
+- **WHEN** the charge close succeeds but the run-authorization revoke step throws
+- **THEN** the revoke failure is logged with the `runId` and reason
+- **AND** the already-closed charge and already-written status are not rolled back
+
+#### Scenario: Unreachable dependents are swept to skipped
+
+- **GIVEN** a plan `A → B → D` and `A → C → E` where B failed, D was therefore never dispatched, and C and E completed
+- **WHEN** `collectAndComplete` runs after the scheduler loop drains
+- **THEN** D's seeded `pending` row reaches `status="skipped"` with `completed_at` stamped and the run finalises `partial`
+
+#### Scenario: The budget pause preserves pending rows
+
+- **GIVEN** a run paused on the 402 budget path with unstarted steps seeded `pending`
+- **WHEN** `collectAndComplete` runs on the pause branch
+- **THEN** the `pending` rows are left untouched for the resumed workflow to execute

--- a/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-21-continue-on-step-failure/tasks.md
@@ -1,0 +1,33 @@
+## 1. Contract: `skipped` DAG tier
+
+- [x] 1.1 Add `"skipped"` to the `DagStepState.status` vocabulary in `src/contracts/chat-parts.ts` and its Zod wire schema in `src/contracts/schemas/chat-parts.ts`
+- [x] 1.2 Extend the dag-state conformance test so a snapshot carrying a `skipped` step validates against the wire schema
+
+## 2. Scheduler loop: failure isolation
+
+- [x] 2.1 Rename `failFast` to `halted` in `runSchedulerLoop` and confine it to the budget paths: `neverFits` guard, graceful `budget_exceeded` cancel, and thrown `budget_exceeded` — verify no failure/blocked branch sets it afterward
+- [x] 2.2 In the graceful `failed`/`blocked` settlement branch: stop setting the halt flag and stop calling `cancelInFlight`; record the step failed with its per-step error as today
+- [x] 2.3 In the thrown-child settlement branch (non-budget cause, not `canceledByParent`): same treatment — record failed, no sibling cancellation, no halt
+- [x] 2.4 Keep `failureReason` first-failure-wins across both branches (checkpointed settlement order makes it deterministic)
+- [x] 2.5 Add a doom-marking walk: on each non-budget failure/blocker settlement, walk the plan DAG's reverse adjacency from the failed step and set every non-terminal transitive dependent to `skipped` in `stepRuntime`, then emit the DAG snapshot
+- [x] 2.6 Call `dispatchReady()` after failed/blocked/thrown settlements as well as completions, so freed budget capacity admits held steps
+- [x] 2.7 Confirm `deriveFinalStatus`, the terminal sweep, synthesis-over-completed, and `collectAndComplete` need no changes (they are already partial-aware) — adjust only if a test proves otherwise
+
+## 3. Tests
+
+- [x] 3.1 Flip `execute-analysis.test.ts` "10.7 fail-fast: B errors → A and C cancelled" to continue-semantics: B errors → A and C run to completion, run finalises `partial`, B's error on the ledger
+- [x] 3.2 Flip "blocked fail-fast: B blocked → A and C cancelled" the same way: siblings complete, only B's dependents are never dispatched
+- [x] 3.3 Add a diamond-DAG test (`A → B → D`, `A → C → E`): B fails while C runs → C and E complete, D never dispatched and swept to `skipped`, status `partial`
+- [x] 3.4 Add a stream-vs-ledger test: after B fails, the emitted `data-dag-state` shows D `skipped` while D's `cortex_step_executions` row still reads `pending` until the terminal sweep
+- [x] 3.5 Add a budget test: a held-for-capacity step is admitted after an in-flight sibling fails and frees capacity
+- [x] 3.6 Add a multi-failure test: two independent steps fail → run finalises `partial` (some completed) with `failureReason` = first failure in settlement order, both per-step errors on the ledger
+- [x] 3.7 Update the failed-path provenance test: `step_completed(failed)` for the failed step, `step_completed(completed)` for surviving siblings, never-dispatched dependents emit nothing
+- [x] 3.8 Rename/reframe the sweep test ("fail-fast sweeps still-pending rows to skipped") to unreachable-dependent sweeping; keep the 402-pause-preserves-pending test unchanged
+- [x] 3.9 Verify `__tests__/dbos/budget-cascade.test.ts` and `workflow-replay.test.ts` pass **unchanged** — any needed edit there is a red flag that budget semantics drifted
+
+## 4. Verify and close out
+
+- [x] 4.1 Run `tsc -p tsconfig.json` and `bun test`; run `bun run format:file` on every touched `src/` file
+- [x] 4.2 Run the harness:verify skill flow (build dist, link into a scratch consumer) since the CLI does not yet consume the new contract value
+- [x] 4.3 Confirm the CLI's current DAG rendering degrades gracefully on an unknown `skipped` status (read-only check in `cli/`; the rendering follow-up is a separate cli-subsystem change)
+- [x] 4.4 `openspec validate continue-on-step-failure --strict` passes; note the deploy edge (mid-flight runs adopt continue-semantics at the live frontier) in the PR description

--- a/harness/openspec/specs/harness-durable-runtime/spec.md
+++ b/harness/openspec/specs/harness-durable-runtime/spec.md
@@ -36,9 +36,7 @@ complete, with fail-fast sibling cancellation — and it is written to replay
 deterministically under DBOS recovery. Recovery itself rides a host-supplied
 stable executor identity, with no standing recovery component or HTTP route in
 core.
-
 ## Requirements
-
 ### Requirement: Chat runs in-process; durable operations run as DBOS workflows
 
 Chat turns SHALL run in-process, single-replica per turn, with no workflow or
@@ -141,36 +139,6 @@ is bound.
 - **GIVEN** a runtime assembled with `createNoopArtifactRegistry`
 - **WHEN** a step registers its artifacts through the seam
 - **THEN** `register` returns `{ registered: [], failed: [], failedCount: 0 }` and `sync` resolves without effect, so the post-step fail-fast gate never trips on the local default
-
-### Requirement: Step scheduling is dependency-gated and fails fast
-
-`executeAnalysis` SHALL start each step's child workflow when all of its
-`depends_on` steps have completed AND the machine resource budget admits it
-(see the resource-budgeted-scheduling capability), with no wave barrier. When
-the workflow input carries no budget, dependency satisfaction alone SHALL start
-the step. A computed topological level MAY be persisted and emitted for UI
-layout but SHALL NOT gate execution. Execution SHALL be fail-fast: the first
-step failure or declared blocker SHALL cancel in-flight sibling children with
-explicit `DBOS.cancelWorkflow` and stop scheduling new steps; budget-held steps
-SHALL simply never be started.
-
-#### Scenario: A ready step starts without waiting for an unrelated sibling
-
-- **GIVEN** a step whose single dependency has just completed and a budget with sufficient remaining capacity
-- **WHEN** the scheduler recomputes the ready set
-- **THEN** that step starts immediately even if an unrelated step is still running
-
-#### Scenario: A ready step is held while the budget is exhausted
-
-- **GIVEN** a step whose dependencies have all completed and in-flight siblings whose declared resources consume the full budget
-- **WHEN** the scheduler recomputes the ready set
-- **THEN** the step is not started until an in-flight sibling completes and frees capacity
-
-#### Scenario: First failure cancels in-flight siblings
-
-- **GIVEN** several sibling child workflows in flight and a budget-held ready step
-- **WHEN** one in-flight sibling fails or reports a blocker
-- **THEN** the parent cancels the remaining in-flight children via `DBOS.cancelWorkflow` and schedules no further steps, including the budget-held one
 
 ### Requirement: The scheduler replays deterministically
 
@@ -279,3 +247,92 @@ connection footprint fits inside Postgres `max_connections`.
 - **GIVEN** Postgres exposes a known `max_connections`
 - **WHEN** the application pool `max` is configured
 - **THEN** the guard checks one process's footprint and reports available headroom
+
+### Requirement: Step scheduling is dependency-gated and failure-isolated
+
+`executeAnalysis` SHALL start each step's child workflow when all of its
+`depends_on` steps have completed AND the machine resource budget admits it
+(see the resource-budgeted-scheduling capability), with no wave barrier. When
+the workflow input carries no budget, dependency satisfaction alone SHALL start
+the step. A computed topological level MAY be persisted and emitted for UI
+layout but SHALL NOT gate execution.
+
+A step settling as `failed`, as `blocked`, or by throwing for any non-budget
+cause SHALL NOT cancel in-flight siblings and SHALL NOT stop scheduling: the
+parent SHALL record the step as failed, continue awaiting in-flight children,
+and keep dispatching every step that becomes dependency-satisfied. Only the
+failed step's transitive dependents are affected — they can never become
+dependency-satisfied (a failed step never enters the completed set) and SHALL
+never be dispatched. The parent SHALL run a dispatch round after every child
+settlement, not only after completions. The run-level `failureReason` SHALL
+record the first failure in checkpointed settlement order; per-step errors ride
+on the step ledger and the DAG snapshot.
+
+The halt cascade (cancel in-flight children via explicit `DBOS.cancelWorkflow`
+and stop scheduling) SHALL be reserved for the budget paths — a
+`budget_exceeded` settlement (graceful or thrown) and the `neverFits`
+plan-validation guard — whose semantics are owned by the
+resource-budgeted-scheduling capability, and for external cancel.
+
+#### Scenario: A ready step starts without waiting for an unrelated sibling
+
+- **GIVEN** a step whose single dependency has just completed and a budget with sufficient remaining capacity
+- **WHEN** the scheduler recomputes the ready set
+- **THEN** that step starts immediately even if an unrelated step is still running
+
+#### Scenario: A ready step is held while the budget is exhausted
+
+- **GIVEN** a step whose dependencies have all completed and in-flight siblings whose declared resources consume the full budget
+- **WHEN** the scheduler recomputes the ready set
+- **THEN** the step is not started until an in-flight sibling settles and frees capacity
+
+#### Scenario: A failure dooms only its transitive dependents
+
+- **GIVEN** a plan `A → B → D` and `A → C → E` where B and C run concurrently after A completes
+- **WHEN** B settles as `failed` while C is still running
+- **THEN** C keeps running, E is dispatched when C completes, and D is never dispatched
+- **AND** the run finalises `partial` with per-step errors on the ledger and `failureReason` recording B's failure
+
+#### Scenario: A thrown child is treated exactly like a failed step
+
+- **GIVEN** two independent in-flight steps
+- **WHEN** one child workflow throws for a non-budget cause
+- **THEN** its step is recorded failed with the thrown error, the sibling is not cancelled, and scheduling continues
+
+#### Scenario: A blocker is treated exactly like a failed step
+
+- **GIVEN** a plan with a blocked step and an independent ready sibling
+- **WHEN** the step settles `blocked`
+- **THEN** only the blocked step's transitive dependents are never dispatched and the independent sibling still runs
+
+#### Scenario: Budget-exceeded still halts the run
+
+- **GIVEN** several in-flight children
+- **WHEN** a child settles with `budget_exceeded`
+- **THEN** the parent cancels the remaining in-flight children via `DBOS.cancelWorkflow` and schedules no further steps
+
+### Requirement: Unreachable dependents are visible as skipped in the DAG stream
+
+The `DagStepState.status` vocabulary in the `data-dag-state` part SHALL gain a
+`"skipped"` value. When a non-budget failure or blocker settles, the parent
+SHALL walk the plan DAG and mark every transitive dependent of the failed step
+that is not already terminal as `"skipped"` in the emitted snapshot, so doomed
+steps are distinguishable from steps that will still run. The walk consumes
+only workflow-input plan data and checkpointed settlement state, so it replays
+deterministically. The `StepExecutionRow.status` database enum SHALL NOT
+change: ledger rows stay `pending` until the terminal sweep flips them to
+`skipped` (see the workflow-failure-lifecycle capability) — skipped visibility
+during the run is a stream concern only.
+
+#### Scenario: Dependents of a failed step show as skipped immediately
+
+- **GIVEN** a plan `A → B → D` with D pending and B running
+- **WHEN** B settles as `failed`
+- **THEN** the next `data-dag-state` emission shows D as `"skipped"` while independent steps keep their own statuses
+
+#### Scenario: The ledger is not written at doom-marking time
+
+- **GIVEN** a step marked `"skipped"` in the stream after its upstream dependency failed
+- **WHEN** its `cortex_step_executions` row is read while the run is still in flight
+- **THEN** the row still reads `pending`; it reaches `skipped` only via the terminal sweep
+

--- a/harness/openspec/specs/harness-sandbox-agents/spec.md
+++ b/harness/openspec/specs/harness-sandbox-agents/spec.md
@@ -23,9 +23,7 @@ genuine errors but runs no output-count "wrongness" heuristic. Because the
 deliverables contract plus the blocker make inline-narrate-and-stop the wrong
 move, the post-step summarizers keep drawing on the agent's transcript and also
 gain a scoped `read_file` to ground every claim in the actual persisted outputs.
-
 ## Requirements
-
 ### Requirement: Code-defined sandbox agents in a directory structure
 
 The harness SHALL define every sandbox agent under `harness/src/agents/sandbox/`.
@@ -180,17 +178,19 @@ step's deliverable is its persisted files. Calling `report_blocker` SHALL record
 after `runAgent`. `blocked` SHALL be a distinct terminal step status — separate
 from `failed` and `completed` — carrying the reason to the
 `cortex_step_executions.blocked_reason` column, a `data-step-blocked` run-event
-part, and the step return. A step blocker SHALL fail-fast, cancelling in-flight
-siblings exactly like a failure. The harness SHALL NOT infer failure from
-output/artifact counts: a legitimately-empty step (no files, no blocker, clean
-finish) SHALL stay `completed`.
+part, and the step return. The parent scheduler SHALL treat a blocker exactly
+like a step failure: only the blocked step's transitive dependents become
+unreachable, while in-flight siblings and independent ready steps continue
+(see the harness-durable-runtime capability). The harness SHALL NOT infer
+failure from output/artifact counts: a legitimately-empty step (no files, no
+blocker, clean finish) SHALL stay `completed`.
 
 #### Scenario: Blocker yields a distinct blocked status
 
 - **GIVEN** a step agent that calls `report_blocker({ reason })` and stops
 - **WHEN** the workflow body reads the blocker holder after the loop
 - **THEN** the step SHALL terminate with status `blocked`, persisting the reason to `blocked_reason` and emitting a `data-step-blocked` part
-- **AND** the step SHALL fail-fast, cancelling in-flight siblings
+- **AND** in-flight siblings SHALL NOT be cancelled; only the blocked step's transitive dependents are never dispatched
 
 #### Scenario: Empty step is not auto-failed
 
@@ -229,3 +229,4 @@ on empty output or a loop throw — a summary failure SHALL NOT fail the step.
 - **WHEN** the summary loop returns empty final text or throws
 - **THEN** `generateStepSummary` SHALL return `undefined`
 - **AND** the workflow body SHALL proceed without marking the step failed
+

--- a/harness/openspec/specs/resource-budgeted-scheduling/spec.md
+++ b/harness/openspec/specs/resource-budgeted-scheduling/spec.md
@@ -11,9 +11,7 @@ policy-overridable. Without a policy, scheduling behaves as pure dependency-
 gated fan-out. Planner awareness of the same limits lives in the
 planning-enhancements capability; OOM-kill surfacing lives in
 harness-sandbox-exec.
-
 ## Requirements
-
 ### Requirement: Resource policy shape and load-time invariants
 
 The harness SHALL define `ResourcePolicy` in `config/resource-limits.ts`:
@@ -56,13 +54,19 @@ The policy is embedder-supplied at the composition root and optional — an embe
 
 ### Requirement: Ready steps are admitted against the budget by declared weight
 
-`scheduleReady` SHALL remain a pure function, extended to take the budget and the in-flight steps' declared resources. A dependency-satisfied step SHALL be admitted only when `sum(inFlight.cpu) + step.cpu <= budget.cpu` AND `sum(inFlight.memoryGb) + step.memoryGb <= budget.memoryGb`, using each step's plan-declared `resources`. Each scheduling round SHALL consider candidates in stable plan order, greedily admitting every candidate that fits; a candidate that does not fit SHALL NOT block a later, smaller candidate (skip-over). When the workflow input carries no budget, every dependency-satisfied step SHALL be admitted (legacy fan-out).
+`scheduleReady` SHALL remain a pure function, extended to take the budget and the in-flight steps' declared resources. A dependency-satisfied step SHALL be admitted only when `sum(inFlight.cpu) + step.cpu <= budget.cpu` AND `sum(inFlight.memoryGb) + step.memoryGb <= budget.memoryGb`, using each step's plan-declared `resources`. Each scheduling round SHALL consider candidates in stable plan order, greedily admitting every candidate that fits; a candidate that does not fit SHALL NOT block a later, smaller candidate (skip-over). Capacity SHALL be freed by any settlement of an in-flight step — completion, failure, or blocker — and the scheduler SHALL run an admission round after every settlement, not only after completions. When the workflow input carries no budget, every dependency-satisfied step SHALL be admitted (legacy fan-out).
 
 #### Scenario: A ready step waits for capacity
 
 - **GIVEN** a budget of `{ cpu: 4, memoryGb: 8 }` and two in-flight steps declaring `{ cpu: 2, memoryGb: 4 }` each
 - **WHEN** a third step declaring `{ cpu: 2, memoryGb: 4 }` becomes dependency-satisfied
-- **THEN** it is not started until an in-flight step completes and frees capacity
+- **THEN** it is not started until an in-flight step settles and frees capacity
+
+#### Scenario: A failure frees capacity for a held step
+
+- **GIVEN** a full budget and a dependency-satisfied step held for capacity
+- **WHEN** an in-flight step settles as `failed`
+- **THEN** the next admission round admits the held step against the freed capacity
 
 #### Scenario: A smaller later candidate skips over a blocked larger one
 
@@ -78,13 +82,13 @@ The policy is embedder-supplied at the composition root and optional — an embe
 
 ### Requirement: A step that can never fit the budget fails immediately
 
-If a dependency-satisfied step's declared resources exceed the budget outright (it could not be admitted even against an empty budget), the scheduler SHALL mark it `failed` with an error naming the resource shortfall rather than holding it indefinitely. Plan-time validation makes this unreachable for newly generated plans; the guard covers stored plans and defensive depth. Standard fail-fast semantics apply.
+If a dependency-satisfied step's declared resources exceed the budget outright (it could not be admitted even against an empty budget), the scheduler SHALL mark it `failed` with an error naming the resource shortfall rather than holding it indefinitely, and SHALL halt the run: in-flight children are cancelled via `DBOS.cancelWorkflow` and no further steps are scheduled. The halt is deliberate — the stored plan is invalid against this machine, so continuing other branches is not attempted (unlike an ordinary step failure, which dooms only its dependents; see the harness-durable-runtime capability). Plan-time validation makes this unreachable for newly generated plans; the guard covers stored plans and defensive depth.
 
 #### Scenario: An over-budget step fails with a clear reason
 
 - **GIVEN** a budget of `{ cpu: 4, memoryGb: 8 }` and a stored plan step declaring `{ cpu: 8, memoryGb: 16 }`
 - **WHEN** the step becomes dependency-satisfied
-- **THEN** the step is marked `failed` with an error naming the declared resources and the budget, and fail-fast proceeds as for any step failure
+- **THEN** the step is marked `failed` with an error naming the declared resources and the budget, in-flight children are cancelled, and no further steps are scheduled
 
 ### Requirement: Budget-held steps are visibly distinguishable from dependency-held steps
 
@@ -117,3 +121,4 @@ The `DagStepState.status` vocabulary in the `data-dag-state` part SHALL gain a `
 - **GIVEN** no resource policy supplied at the composition root
 - **WHEN** a `run_ephemeral` sandbox is created
 - **THEN** the sandbox is requested with `{ cpu: 4, memoryGb: 8 }`
+

--- a/harness/openspec/specs/workflow-failure-lifecycle/spec.md
+++ b/harness/openspec/specs/workflow-failure-lifecycle/spec.md
@@ -21,9 +21,7 @@ outputs before a failure is preserved as `partial` rather than thrown away as
 `failed`. The durable-runtime contract (scheduler, fail-fast cascade, child
 cancellation) is owned by the harness-durable-runtime spec; this spec covers the
 terminal transition those mechanisms feed into.
-
 ## Requirements
-
 ### Requirement: The run row exists before the workflow body runs
 
 The `cortex_runs` row SHALL be inserted by `executePlan` at the async edge —
@@ -162,23 +160,26 @@ columns SHALL be left NULL (unknown).
 ### Requirement: collectAndComplete is the single finalisation hook
 
 `collectAndComplete` SHALL be the only block that finalises run-level state, and
-it SHALL run on every terminal path: success, fail-fast, external cancel,
-synthesis failure, and the 402 pause. Within it the status write, charge close,
-and run-authorization revoke SHALL each be their own named `DBOS.runStep`, and a
-failure of any one SHALL be logged without rolling back the side effects that did
-succeed. There SHALL be NO separate `onError`-style hook racing it; child step
-bodies SHALL NOT call `updateRunStatus` or any run-fail helper directly.
+it SHALL run on every terminal path: success, runs with step failures (which
+drain the scheduler loop and typically finalise `partial`), the budget halt,
+external cancel, synthesis failure, and the 402 pause. Within it the status
+write, charge close, and run-authorization revoke SHALL each be their own named
+`DBOS.runStep`, and a failure of any one SHALL be logged without rolling back
+the side effects that did succeed. There SHALL be NO separate `onError`-style
+hook racing it; child step bodies SHALL NOT call `updateRunStatus` or any
+run-fail helper directly.
 
-On its genuinely-terminal paths (success, fail-fast, external cancel, synthesis
-failure) `collectAndComplete` SHALL additionally sweep the run's still-`pending`
-step rows to `skipped` (stamping `completed_at`) in its own named `DBOS.runStep`,
-so a finished run never advertises steps that read as still waiting to start. The
-sweep SHALL NOT run on the resumable 402 budget-pause branch — the branch is
-selected structurally (the pause path itself), never inferred from the written
-run status (the pause also writes `"canceled"`) — because the resumed workflow
-still needs those `pending` rows. A sweep-step failure SHALL be logged without
-rolling back the other finalisation side effects, matching the hook's
-non-rolling-back rule.
+On its genuinely-terminal paths (success, runs with step failures, external
+cancel, synthesis failure) `collectAndComplete` SHALL additionally sweep the
+run's still-`pending` step rows to `skipped` (stamping `completed_at`) in its
+own named `DBOS.runStep`, so a finished run never advertises steps that read as
+still waiting to start — including dependents that were never dispatched
+because an upstream step failed or blocked. The sweep SHALL NOT run on the
+resumable 402 budget-pause branch — the branch is selected structurally (the
+pause path itself), never inferred from the written run status (the pause also
+writes `"canceled"`) — because the resumed workflow still needs those `pending`
+rows. A sweep-step failure SHALL be logged without rolling back the other
+finalisation side effects, matching the hook's non-rolling-back rule.
 
 #### Scenario: Step bodies do not write run status
 
@@ -192,14 +193,15 @@ non-rolling-back rule.
 - **THEN** the revoke failure is logged with the `runId` and reason
 - **AND** the already-closed charge and already-written status are not rolled back
 
-#### Scenario: Fail-fast sweeps never-started steps to skipped
+#### Scenario: Unreachable dependents are swept to skipped
 
-- **GIVEN** a 3-step run whose first step failed before steps 2 and 3 ever started
-- **WHEN** `collectAndComplete` runs on the fail-fast path
-- **THEN** the two seeded `pending` rows reach `status="skipped"` with `completed_at` stamped
+- **GIVEN** a plan `A → B → D` and `A → C → E` where B failed, D was therefore never dispatched, and C and E completed
+- **WHEN** `collectAndComplete` runs after the scheduler loop drains
+- **THEN** D's seeded `pending` row reaches `status="skipped"` with `completed_at` stamped and the run finalises `partial`
 
 #### Scenario: The budget pause preserves pending rows
 
 - **GIVEN** a run paused on the 402 budget path with unstarted steps seeded `pending`
 - **WHEN** `collectAndComplete` runs on the pause branch
 - **THEN** the `pending` rows are left untouched for the resumed workflow to execute
+

--- a/harness/src/contracts/chat-parts.ts
+++ b/harness/src/contracts/chat-parts.ts
@@ -111,8 +111,10 @@ export interface RunStartedPart {
 // ── DAG State (reconciliating) ──────────────────────────────────────
 
 /** `"pending"` = waiting on dependencies; `"queued"` = dependencies satisfied,
- *  held until in-flight steps free machine-budget capacity. */
-export type StepStatus = "pending" | "queued" | "running" | "completed" | "failed";
+ *  held until in-flight steps free machine-budget capacity; `"skipped"` =
+ *  unreachable — an upstream dependency failed or blocked, so the step can
+ *  never be dispatched. */
+export type StepStatus = "pending" | "queued" | "running" | "completed" | "failed" | "skipped";
 
 export interface DagStepState {
     id: string;

--- a/harness/src/contracts/schemas/chat-parts.ts
+++ b/harness/src/contracts/schemas/chat-parts.ts
@@ -115,7 +115,7 @@ export const RunStartedPartSchema = z.object({
 
 // ── DAG State ───────────────────────────────────────────────────────
 
-export const StepStatusSchema = z.enum(["pending", "running", "completed", "failed"]);
+export const StepStatusSchema = z.enum(["pending", "queued", "running", "completed", "failed", "skipped"]);
 
 export const DagStepStateSchema = z
     .object({

--- a/harness/src/workflows/execute-analysis.test.ts
+++ b/harness/src/workflows/execute-analysis.test.ts
@@ -6,14 +6,16 @@
  * design contract that don't require a real DBOS engine or a Postgres
  * testcontainer:
  *
- *   10.7  Fail-fast cascade — B raises ERROR; A/C cancelled; charge=error,
- *         mandate=workflow-failed.
+ *   10.7  Failure isolation — B fails; A/C continue and complete; nothing
+ *         is cancelled; the run lands partial (charge=ok). Only B's
+ *         transitive dependents are doomed (marked skipped, never
+ *         dispatched).
  *   10.8  External cancel — operator cancels child mid-flight; cascade
  *         reaps siblings; charge=canceled, mandate=workflow-canceled.
  *   10.10 Stream emission — every UI part flows through `emitStreamPart`;
  *         `cortex_runs.parts` is never touched (the fake pool would surface
  *         a write).
- *   10.11 Terminal billing close — charge closed on success, fail-fast,
+ *   10.11 Terminal billing close — charge closed on success, failure,
  *         external-cancel, and 402 pause paths (one assertion per).
  *   10.14 collectAndComplete writes nothing to a conversation thread (no
  *         dep calls thread-writing helpers — the test asserts on the
@@ -334,65 +336,44 @@ function input(steps: Array<{ id: string; depends_on?: readonly string[] }>, bud
     };
 }
 
-// ── 10.7 Fail-fast cascade ───────────────────────────────────────────
+// ── 10.7 Failure isolation ───────────────────────────────────────────
 
 describe("executeAnalysis body", () => {
-    it("10.7 fail-fast: B errors → A and C cancelled; charge=error, mandate=failed", async () => {
+    it("10.7 failure isolation: B fails → A and C run to completion; status partial, charge=ok", async () => {
         const pool = makeFakePool();
-        // Real-world dispatch: A/B/C race; B fails fast; parent cancels A & C
-        // in-flight. Their `getResult` then returns the canceled result. Model
-        // that by configuring A/C as canceled (sibling cancel = no
-        // budget_exceeded marker).
+        // A/B/C dispatch together; B fails on its own merits. Nothing depends
+        // on B, so A and C keep running and complete — the parent cancels
+        // nothing.
         const { deps, record } = makeDeps({
             pool,
             childResults: new Map<string, SandboxStepResult | Error>([
-                [
-                    "A",
-                    {
-                        status: "canceled",
-                        durationMs: 1,
-                        finishReason: null,
-                        error: null,
-                    },
-                ],
-                [
-                    "B",
-                    {
-                        status: "failed",
-                        durationMs: 1,
-                        finishReason: null,
-                        error: "boom",
-                    },
-                ],
-                [
-                    "C",
-                    {
-                        status: "canceled",
-                        durationMs: 1,
-                        finishReason: null,
-                        error: null,
-                    },
-                ],
+                ["A", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+                ["B", { status: "failed", durationMs: 1, finishReason: null, error: "boom" }],
+                ["C", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
             ]),
         });
 
         const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B" }, { id: "C" }]), deps);
 
-        // Fail-fast → status "failed" (no siblings completed).
-        expect(result.status).toBe("failed");
-        expect(record.chargeCloseCalls).toEqual([{ reason: "error" }]);
-        expect(record.mandateRevokeCalls).toEqual([{ reason: "workflow-failed" }]);
+        expect(result.status).toBe("partial");
+        expect([...result.completedSteps].sort()).toEqual(["A", "C"]);
+        expect(result.failedSteps).toEqual(["B"]);
+        // No sibling was cancelled.
+        expect(dbosState.cancelled.size).toBe(0);
+        expect(record.chargeCloseCalls).toEqual([{ reason: "ok" }]);
+        expect(record.mandateRevokeCalls).toEqual([{ reason: "workflow-completed" }]);
         expect(suspendWrites(pool)).toEqual([]);
         const terminal = record.emittedParts.find((p) => p.type === "data-run-failed" || p.type === "data-run-completed");
-        expect(terminal?.type).toBe("data-run-failed");
+        expect(terminal?.type).toBe("data-run-completed");
+        expect((terminal as { status?: string } | undefined)?.status).toBe("partial");
     });
 
-    it("blocked fail-fast: B blocked → A and C cancelled; status failed", async () => {
+    it("blocked isolation: B blocked → A and C still complete; only B's dependents are doomed", async () => {
         const pool = makeFakePool();
         const { deps, record } = makeDeps({
             pool,
             childResults: new Map<string, SandboxStepResult | Error>([
-                ["A", { status: "canceled", durationMs: 1, finishReason: null, error: null }],
+                ["A", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
                 [
                     "B",
                     {
@@ -402,17 +383,109 @@ describe("executeAnalysis body", () => {
                         error: "required input file missing",
                     },
                 ],
-                ["C", { status: "canceled", durationMs: 1, finishReason: null, error: null }],
+                ["C", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+                // D intentionally has no configured result: if it were ever
+                // dispatched the startWorkflow mock would throw and fail the test.
+            ]),
+        });
+
+        const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B" }, { id: "C" }, { id: "D", depends_on: ["B"] }]), deps);
+
+        expect(result.status).toBe("partial");
+        expect(result.failedSteps).toContain("B");
+        expect([...result.completedSteps].sort()).toEqual(["A", "C"]);
+        expect(dbosState.cancelled.size).toBe(0);
+        expect(dbosState.childInputs.map((i) => i.stepId)).not.toContain("D");
+        expect(record.chargeCloseCalls).toEqual([{ reason: "ok" }]);
+    });
+
+    it("failure isolation: a diamond plan continues its independent branch; doomed dependents show skipped", async () => {
+        const pool = makeFakePool();
+        const events: RunProvenanceEvent[] = [];
+        // A → B → D and A → C → E. B fails while C is in flight: D is doomed
+        // (never dispatched — no configured result, so the startWorkflow mock
+        // would throw), C completes, then E dispatches and completes.
+        const { deps, record } = makeDeps({
+            pool,
+            emitProvenance: (e) => events.push(e),
+            childResults: new Map<string, SandboxStepResult | Error>([
+                ["A", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+                ["B", { status: "failed", durationMs: 1, finishReason: null, error: "boom" }],
+                ["C", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+                ["E", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+            ]),
+        });
+
+        const result = await runExecuteAnalysisBody(
+            input([
+                { id: "A" },
+                { id: "B", depends_on: ["A"] },
+                { id: "C", depends_on: ["A"] },
+                { id: "D", depends_on: ["B"] },
+                { id: "E", depends_on: ["C"] },
+            ]),
+            deps,
+        );
+
+        expect(result.status).toBe("partial");
+        expect([...result.completedSteps].sort()).toEqual(["A", "C", "E"]);
+        expect(result.failedSteps).toEqual(["B"]);
+        expect(dbosState.cancelled.size).toBe(0);
+        expect(dbosState.childInputs.map((i) => i.stepId)).not.toContain("D");
+
+        // The failure settlement marks D skipped in the very same dag emission
+        // that shows B failed, while C (independent, still in flight) runs on.
+        const dagParts = record.emittedParts.filter((p) => p.type === "data-dag-state") as Array<{
+            steps: Array<{ id: string; status: string }>;
+        }>;
+        const afterFailure = dagParts.find((p) => p.steps.some((s) => s.id === "B" && s.status === "failed"))!;
+        expect(afterFailure.steps.find((s) => s.id === "D")!.status).toBe("skipped");
+        expect(afterFailure.steps.find((s) => s.id === "C")!.status).toBe("running");
+        const last = dagParts[dagParts.length - 1]!;
+        expect(last.steps.find((s) => s.id === "D")!.status).toBe("skipped");
+
+        // Stream-only doom-marking: D's ledger row is touched by the pending
+        // seed and the terminal sweep, never mid-run.
+        const sweeps = pool.queries.filter((q) => q.text.includes("SET status = 'skipped'"));
+        expect(sweeps.length).toBe(1);
+
+        // Surviving siblings settle with their own provenance; D emits nothing.
+        const stepStatusById = new Map(events.flatMap((e) => (e.type === "step_completed" ? [[e.stepId, e.status] as const] : [])));
+        expect(stepStatusById.get("C")).toBe("completed");
+        expect(stepStatusById.get("E")).toBe("completed");
+        expect(stepStatusById.has("D")).toBe(false);
+
+        // Every emitted part — including dag-states carrying "skipped" — passes
+        // the published wire schema the react-client parser runs.
+        for (const part of record.emittedParts) {
+            const parsed = CortexChatPartSchema.safeParse(part);
+            expect(
+                parsed.success,
+                `emitted part ${JSON.stringify(part)} does not conform to CortexChatPartSchema: ` + (parsed.success ? "" : JSON.stringify(parsed.error.issues)),
+            ).toBe(true);
+        }
+    });
+
+    it("multiple independent failures: run lands partial with the FIRST failure as the run-level reason", async () => {
+        const pool = makeFakePool();
+        const { deps } = makeDeps({
+            pool,
+            childResults: new Map<string, SandboxStepResult | Error>([
+                ["A", { status: "failed", durationMs: 1, finishReason: null, error: "first boom" }],
+                ["B", { status: "failed", durationMs: 1, finishReason: null, error: "second boom" }],
+                ["C", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
             ]),
         });
 
         const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B" }, { id: "C" }]), deps);
 
-        expect(result.status).toBe("failed");
-        expect(result.failedSteps).toContain("B");
-        expect(record.chargeCloseCalls).toEqual([{ reason: "error" }]);
-        const terminal = record.emittedParts.find((p) => p.type === "data-run-failed" || p.type === "data-run-completed");
-        expect(terminal?.type).toBe("data-run-failed");
+        expect(result.status).toBe("partial");
+        expect([...result.failedSteps].sort()).toEqual(["A", "B"]);
+        expect(result.completedSteps).toEqual(["C"]);
+        // Run-level failureReason is the first failure in settlement order; the
+        // per-step detail lives on the step ledger and the dag snapshot.
+        const statusWrite = pool.queries.find((q) => /UPDATE cortex_runs\s+SET status/.test(q.text) && q.values?.[0] === "partial");
+        expect(statusWrite?.values?.[2]).toBe("first boom");
     });
 
     // ── waitFirst: multi-child completion ──────────────────────────────
@@ -490,6 +563,29 @@ describe("executeAnalysis body", () => {
         const last = dagParts[dagParts.length - 1]!;
         expect(last.steps[0]!.status).toBe("failed");
         expect(last.steps[0]!.error).toContain("machine budget");
+    });
+
+    it("budget admission: a failed step frees capacity for a held step", async () => {
+        const pool = makeFakePool();
+        const { deps, record } = makeDeps({
+            pool,
+            childResults: new Map<string, SandboxStepResult | Error>([
+                ["A", { status: "failed", durationMs: 1, finishReason: null, error: "boom" }],
+                ["B", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+            ]),
+        });
+
+        // The budget fits one step at a time: A runs, B queues. A's failure must
+        // free the declared capacity and admit B in the same settlement round.
+        const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B" }], { cpu: 2, memoryGb: 4 }), deps);
+
+        expect(result.status).toBe("partial");
+        expect(result.completedSteps).toEqual(["B"]);
+        expect(result.failedSteps).toEqual(["A"]);
+        const dagParts = record.emittedParts.filter((p) => p.type === "data-dag-state") as Array<{ steps: Array<{ id: string; status: string }> }>;
+        const statusesOf = (id: string) => dagParts.map((p) => p.steps.find((s) => s.id === id)!.status);
+        expect(statusesOf("B")).toContain("queued");
+        expect(statusesOf("B")).toContain("running");
     });
 
     it("no budget in the workflow input keeps the legacy full fan-out", async () => {
@@ -826,18 +922,21 @@ describe("executeAnalysis body", () => {
         expect(seeds[0]!.text).toContain("ON CONFLICT (run_id, step_id) DO NOTHING");
     });
 
-    it("fail-fast sweeps still-pending rows to skipped", async () => {
+    it("unreachable dependents are swept to skipped; an all-failed run closes charge=error", async () => {
         const pool = makeFakePool({
             "SELECT run_id, analysis_id, thread_id, workflow_name, workflow_id": [{ attempt_count: 0 }],
         });
-        const { deps } = makeDeps({
+        const { deps, record } = makeDeps({
             pool,
             childResults: new Map<string, SandboxStepResult | Error>([["A", { status: "failed", durationMs: 1, finishReason: null, error: "boom" }]]),
         });
 
-        // B depends on A and is never dispatched — exactly the row the sweep must reap.
+        // B depends on the failed A and is never dispatched — exactly the row
+        // the terminal sweep must reap. Nothing completed, so the run is failed.
         const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B", depends_on: ["A"] }]), deps);
         expect(result.status).toBe("failed");
+        expect(record.chargeCloseCalls).toEqual([{ reason: "error" }]);
+        expect(record.mandateRevokeCalls).toEqual([{ reason: "workflow-failed" }]);
 
         const sweeps = pool.queries.filter((q) => q.text.includes("SET status = 'skipped'"));
         expect(sweeps.length).toBe(1);
@@ -977,7 +1076,8 @@ describe("executeAnalysis body", () => {
         const pool = makeFakePool();
         const events: RunProvenanceEvent[] = [];
         // A/B/C dispatch together at level 0; D depends on the failing B. A
-        // completes, B fails (fail-fast cancels the in-flight C), and C settles
+        // completes, B fails (siblings are NOT cancelled — C's canceled result
+        // models an operator cancel landing on C mid-flight), and C settles
         // canceled. D is never dispatched because its dependency failed.
         const { deps } = makeDeps({
             pool,

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -30,11 +30,16 @@
  *       completion
  *     - await child results via `getResult` (these are themselves cached
  *       in DBOS, so parent recovery does NOT re-run completed children)
- *  3. Fail-fast cascade
- *     - on the first non-resumable child failure (or on external parent
- *       cancel): stop scheduling, then
- *       `Promise.allSettled(handles.map(h => DBOS.cancelWorkflow(h.workflowID)))`
- *     - each cancelled child tears down its sandbox in its own terminal path
+ *  3. Failure isolation
+ *     - a child settling `failed`/`blocked` (or throwing for a non-budget
+ *       cause) dooms only its transitive dependents: they can never become
+ *       dependency-satisfied, are marked `skipped` on the dag-state part, and
+ *       are never dispatched. In-flight siblings and independent ready steps
+ *       continue; the loop drains and the run finalises (typically `partial`).
+ *     - the halt cascade (cancel in-flight via
+ *       `Promise.allSettled(handles.map(h => DBOS.cancelWorkflow(h.workflowID)))`,
+ *       stop scheduling) survives only for the budget paths: a
+ *       `budget_exceeded` settlement and the `neverFits` plan-validation guard.
  *  4. Pause cascade (402)
  *     - on a child cancelling itself with `budget_exceeded`: cancel siblings
  *       then self-cancel the parent to `CANCELLED` (NOT `ERROR` — ERROR
@@ -584,7 +589,7 @@ export async function runExecuteAnalysisBody(input: ExecuteAnalysisInput, deps: 
         atMs: startedAtMs,
     });
 
-    // (2-4) Scheduler loop + fail-fast + pause cascade.
+    // (2-4) Scheduler loop + failure isolation + pause cascade.
     const final = await runSchedulerLoop({
         input,
         runId,
@@ -750,19 +755,55 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
 
     const budgetExceededChildIds = new Set<string>();
 
-    // Child workflow ids the parent itself cancelled (fail-fast / budget cascade). Their `getResult`
+    // Child workflow ids the parent itself cancelled (budget / neverFits halt cascade). Their `getResult`
     // rejects with a DBOS cancellation error and lands in the settlement error branch — but the step was
     // CANCELED by us, not failed on its own merits. Keyed here (deterministic: `cancelInFlight` runs the
     // same way on a replay) so that branch records it as canceled everywhere, matching how a child that
     // returns a graceful `{status:"canceled"}` is already handled.
     const canceledByParent = new Set<string>();
 
-    const stepRuntime = new Map<string, { status: "pending" | "queued" | "running" | "completed" | "failed"; durationMs?: number; error?: string }>();
+    const stepRuntime = new Map<
+        string,
+        { status: "pending" | "queued" | "running" | "completed" | "failed" | "skipped"; durationMs?: number; error?: string }
+    >();
     for (const step of input.steps) {
         stepRuntime.set(step.id, { status: "pending" });
     }
 
-    let failFast = false;
+    // Reverse adjacency over the static plan — who depends on whom.
+    const dependentsByStepId = new Map<string, string[]>();
+    for (const step of input.steps) {
+        for (const dep of step.depends_on) {
+            const list = dependentsByStepId.get(dep);
+            if (list) list.push(step.id);
+            else dependentsByStepId.set(dep, [step.id]);
+        }
+    }
+
+    /**
+     * Mark every transitive dependent of a failed/blocked step `skipped` in the
+     * dag snapshot: a failed step never enters `completed`, so its dependents
+     * can never become dependency-satisfied and will never be dispatched.
+     * Stream-only — ledger rows stay `pending` until the terminal sweep flips
+     * them to `skipped`. Dependents of an unfinished step are necessarily
+     * `pending` (never queued/running); an already-`skipped` one is not
+     * re-walked.
+     */
+    const markDependentsSkipped = (failedStepId: string): void => {
+        const stack = [...(dependentsByStepId.get(failedStepId) ?? [])];
+        while (stack.length > 0) {
+            const id = stack.pop()!;
+            if (stepRuntime.get(id)!.status === "pending") {
+                stepRuntime.set(id, { status: "skipped" });
+                stack.push(...(dependentsByStepId.get(id) ?? []));
+            }
+        }
+    };
+
+    // Halts scheduling entirely — reserved for the budget paths (a
+    // `budget_exceeded` settlement, the `neverFits` guard). An ordinary step
+    // failure does NOT set it: it dooms only that step's transitive dependents.
+    let halted = false;
     let budgetExceeded = false;
     let failureReason: string | null = null;
 
@@ -792,19 +833,27 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
 
     const dbosParentId = DBOS.workflowID ?? workflowId;
     const dispatchReady = async (): Promise<void> => {
-        if (failFast) return;
+        if (halted) return;
         const inFlightStepIds = new Set([...inFlight.values()].map((h) => h.stepId));
+        // A settled-but-not-completed step (failed / blocked / canceled) is not
+        // in `completed` and not in flight, so `scheduleReady` would offer it
+        // again — filter it out of the candidate list. This also stops its
+        // declared resources from weighing against the budget: settled steps
+        // hold no capacity.
+        const candidates = input.steps.filter((s) => !failed.has(s.id) && !canceled.has(s.id));
         let admit: readonly string[];
         let queuedChanged = false;
         if (input.budget) {
-            const scheduled = scheduleReady(input.steps, completed, inFlightStepIds, {
+            const scheduled = scheduleReady(candidates, completed, inFlightStepIds, {
                 budget: input.budget,
                 resourcesByStepId: input.resourcesByStepId,
             });
             if (scheduled.neverFits.length > 0) {
                 // An over-budget step can never be admitted — plan-time validation
                 // makes this unreachable for new plans; stored plans fail loudly
-                // instead of waiting forever. Standard fail-fast follows.
+                // instead of waiting forever. The stored plan is invalid against
+                // this machine, so the run halts outright — unlike an ordinary
+                // step failure, which dooms only its dependents.
                 for (const stepId of scheduled.neverFits) {
                     const r = input.resourcesByStepId[stepId];
                     const declared = r ? `${r.cpu} CPU / ${r.memoryGb} GB` : "undeclared";
@@ -814,7 +863,7 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
                         error: `step resources (${declared}) exceed the machine budget (${input.budget.cpu} CPU / ${input.budget.memoryGb} GB)`,
                     });
                 }
-                failFast = true;
+                halted = true;
                 failureReason = `step "${scheduled.neverFits[0]}" exceeds the machine resource budget`;
                 await cancelInFlight(inFlight, "fail_fast", canceledByParent);
                 await emitDagSnapshot();
@@ -828,7 +877,7 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
             }
             admit = scheduled.admit;
         } else {
-            admit = scheduleReady(input.steps, completed, inFlightStepIds);
+            admit = scheduleReady(candidates, completed, inFlightStepIds);
         }
         if (admit.length === 0) {
             if (queuedChanged) await emitDagSnapshot();
@@ -912,7 +961,7 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
                 const isBudgetCancel = childWasBudgetExceeded || r.error === "budget_exceeded";
                 if (isBudgetCancel && !budgetExceeded) {
                     budgetExceeded = true;
-                    failFast = true;
+                    halted = true;
                     failureReason = "budget_exceeded";
                     await cancelInFlight(inFlight, "budget_exceeded", canceledByParent);
                 }
@@ -925,30 +974,30 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
                 stepDurationMs = r.durationMs ?? undefined;
                 await emitDagSnapshot();
             } else {
-                // failed or blocked — a blocker (see the harness-sandbox-agents spec) fails fast exactly like a
-                // failure: the step declared it cannot deliver, so its dependents can
-                // never run. Same cancel-siblings + stop-scheduling path.
+                // failed or blocked — a blocker (see the harness-sandbox-agents spec)
+                // is treated exactly like a failure: the step declared it cannot
+                // deliver, so only its transitive dependents can never run. In-flight
+                // siblings and independent ready steps continue; the dispatch round
+                // below also lets a budget-held step claim the freed capacity.
                 failed.add(settled.stepId);
-                if (!failFast) {
-                    failFast = true;
-                    failureReason = r.error ?? (r.status === "blocked" ? "step_blocked" : "step_failed");
-                    await cancelInFlight(inFlight, "fail_fast", canceledByParent);
-                }
+                failureReason ??= r.error ?? (r.status === "blocked" ? "step_blocked" : "step_failed");
                 stepRuntime.set(settled.stepId, {
                     status: "failed",
                     durationMs: r.durationMs ?? undefined,
                     error: r.error ?? (r.status === "blocked" ? "step_blocked" : "step_failed"),
                 });
+                markDependentsSkipped(settled.stepId);
                 stepStatus = "failed";
                 stepDurationMs = r.durationMs ?? undefined;
                 await emitDagSnapshot();
+                await dispatchReady();
             }
         } else if (canceledByParent.has(settled.childId)) {
-            // The child threw because the PARENT cancelled it (fail-fast / budget cascade), not because
-            // it failed on its own — its `getResult` rejects with a DBOS cancellation error. Record it as
-            // canceled, mirroring the graceful `{status:"canceled"}` branch above so the `canceled` set,
-            // the terminal result, and the `step_completed` provenance all agree. No failFast / cancel
-            // cascade here: the run is already failing fast (that is why this child was cancelled).
+            // The child threw because the PARENT cancelled it (budget / neverFits halt cascade), not
+            // because it failed on its own — its `getResult` rejects with a DBOS cancellation error.
+            // Record it as canceled, mirroring the graceful `{status:"canceled"}` branch above so the
+            // `canceled` set, the terminal result, and the `step_completed` provenance all agree. No
+            // halt / cancel cascade here: the run is already halted (that is why this child was cancelled).
             canceled.add(settled.stepId);
             stepRuntime.set(settled.stepId, {
                 // `stepRuntime` (the DAG snapshot) has no canceled tier; the graceful-cancel branch above
@@ -960,17 +1009,23 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
             stepDurationMs = undefined;
             await emitDagSnapshot();
         } else {
+            // The child threw on its own (not a parent-driven cancel). A
+            // budget_exceeded throw still halts the run — the pause cascade is a
+            // money decision, not a DAG one. Any other throw is treated exactly
+            // like a step failure: dependents doomed, siblings continue.
             failed.add(settled.stepId);
-            const cause: "budget_exceeded" | "fail_fast" = childWasBudgetExceeded || isBudgetExceeded(settled.err) ? "budget_exceeded" : "fail_fast";
-            if (cause === "budget_exceeded" && !budgetExceeded) {
-                budgetExceeded = true;
-                failFast = true;
-                failureReason = "budget_exceeded";
-            } else if (!failFast) {
-                failFast = true;
-                failureReason = settled.err instanceof Error ? settled.err.message : String(settled.err);
+            const isBudgetThrow = childWasBudgetExceeded || isBudgetExceeded(settled.err);
+            if (isBudgetThrow) {
+                if (!budgetExceeded) {
+                    budgetExceeded = true;
+                    halted = true;
+                    failureReason = "budget_exceeded";
+                }
+                await cancelInFlight(inFlight, "budget_exceeded", canceledByParent);
+            } else {
+                failureReason ??= settled.err instanceof Error ? settled.err.message : String(settled.err);
+                markDependentsSkipped(settled.stepId);
             }
-            await cancelInFlight(inFlight, cause, canceledByParent);
             stepRuntime.set(settled.stepId, {
                 status: "failed",
                 error: settled.err instanceof Error ? settled.err.message : String(settled.err),
@@ -979,6 +1034,7 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
             // A child that settled by throwing carries no durable duration.
             stepDurationMs = undefined;
             await emitDagSnapshot();
+            if (!isBudgetThrow) await dispatchReady();
         }
 
         // One `step_completed` provenance emission per settled child — this


### PR DESCRIPTION
## Summary

Removes the fail-fast cascade from `executeAnalysis`: a step settling `failed`/`blocked` (or throwing for a non-budget cause) no longer cancels in-flight siblings or stops scheduling. Only the failed step's transitive dependents become unreachable — they are marked with the new `skipped` tier on the `data-dag-state` part the moment the failure settles, are never dispatched, and are swept to `skipped` on the ledger at finalisation. Independent branches run to completion and the run lands `partial`, with synthesis over whatever completed.

The rationale (from the archived OpenSpec change `2026-07-21-continue-on-step-failure`): the plan DAG is already the language for conditionality — a QC gate that must stop downstream work is expressed as `depends_on` — and the terminal machinery (`partial` status, pending→skipped sweep, synthesis-over-completed) was already partial-aware. Fail-fast protected no invariant; it just minimized the completed set.

## What changed

- **Scheduler loop** (`src/workflows/execute-analysis.ts`): `failFast` → `halted`, set only by the budget paths (`budget_exceeded` settlements, the `neverFits` plan-validation guard). Failure/blocker settlements record the step failed, doom-mark dependents in the DAG snapshot, and keep dispatching. `failureReason` is first-failure-wins (deterministic via checkpointed settlement order).
- **Re-dispatch guard**: settled-but-not-completed steps are filtered out of the `scheduleReady` candidate list. Without fail-fast masking it, a failed step (neither completed nor in-flight) would be offered for dispatch again — an infinite loop. The filter also frees a settled step's declared resources for budget-held steps.
- **Wire contract** (`src/contracts/`): `StepStatus` gains `skipped`, plus the previously drifted `queued` (the TS type had it; the Zod wire schema did not).
- **Specs**: `harness-durable-runtime` (fail-fast requirement replaced by failure isolation + the `skipped` stream requirement), `harness-sandbox-agents` (blockers no longer cancel siblings), `workflow-failure-lifecycle` (sweep covers unreachable dependents), `resource-budgeted-scheduling` (capacity freed by any settlement; explicit `neverFits` halt semantics).

## Unchanged by design

- The resumable 402 budget pause and its cancel cascade (byte-compatible; `__tests__/dbos/budget-cascade.test.ts` and `workflow-replay.test.ts` pass unmodified).
- External cancel.
- The pure scheduler (`execute-analysis-scheduler.ts`).
- The `cortex_step_executions` DB enum — `skipped` visibility during a run is stream-only; ledger rows stay `pending` until the terminal sweep.

## Testing

- `execute-analysis.test.ts`: 33 pass — flipped fail-fast tests, diamond-DAG isolation (independent branch completes; doomed dependent shows `skipped` in-stream while its ledger row stays `pending`), multi-failure first-reason, capacity-freed-by-failure, wire-schema conformance incl. `skipped`.
- Full harness suite: 1351 pass / 0 fail; `tsc` clean.
- Package-boundary verify: built `dist/` linked into a scratch consumer; compiled schema accepts `skipped`/`queued`, rejects unknown statuses.
- CLI check: the CLI reads step statuses from the ledger (not `data-dag-state`) and its `stepStateOf` already handles `skipped` — nothing breaks; rendering `skipped` distinctly is a small follow-up in `cli/`.

## Deploy note

A run in flight across this deploy replays its checkpointed prefix under the recorded decisions and adopts continue-semantics from the live frontier onward. Already-fail-fasted runs are terminal and unaffected.