### PR TITLE
feat(ci): derive CITATION.cff's version from cli/package.json

### DIFF
--- a/.github/citation/sync.sh
+++ b/.github/citation/sync.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Keeps CITATION.cff's version in step with cli/package.json's.
+#
+# Usage: sync.sh [--check]
+#   (no args)  rewrite CITATION.cff in place
+#   --check    exit non-zero if it is out of step, changing nothing
+#
+# cli/package.json is the single source of truth for the product version: its
+# version field is what mints the v* tag and the GitHub release
+# (.github/workflows/release.yml), so the citation metadata follows it rather
+# than being maintained by hand.
+#
+# --check compares ONLY the version. date-released is written from the clock at
+# sync time and would otherwise make the check fail every day after a release.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+manifest="$root/cli/package.json"
+citation="$root/CITATION.cff"
+
+check_only=false
+if [ "${1:-}" = "--check" ]; then
+  check_only=true
+elif [ $# -gt 0 ]; then
+  echo "error: unknown argument '$1' (expected --check or nothing)" >&2
+  exit 2
+fi
+
+version=$(jq -r .version "$manifest")
+if [ -z "$version" ] || [ "$version" = "null" ]; then
+  echo "error: $manifest has no version field" >&2
+  exit 1
+fi
+
+# The version is spliced into a sed program below; reject anything that isn't a
+# plain semver before it can corrupt the file.
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: version must be bare semver (got: $version)" >&2
+  exit 1
+fi
+
+# Both keys are top-level, so the ^ anchor is what keeps `version:` from also
+# matching `cff-version:`. A restructured file that no longer has them at column
+# zero must fail loudly here rather than silently sync nothing.
+for key in version date-released; do
+  if ! grep -qE "^$key: " "$citation"; then
+    echo "error: $citation has no top-level '$key:' key — the sync patterns no longer match this file" >&2
+    exit 1
+  fi
+done
+
+current=$(sed -nE 's/^version: (.*)$/\1/p' "$citation")
+
+if [ "$check_only" = true ]; then
+  if [ "$current" != "$version" ]; then
+    echo "::error file=CITATION.cff::CITATION.cff declares version $current but cli/package.json is $version. Run .github/citation/sync.sh and commit the result."
+    exit 1
+  fi
+  echo "CITATION.cff is in step with cli/package.json ($version)"
+  exit 0
+fi
+
+# Stamped in UTC so the value does not depend on the contributor's timezone.
+# This is the bump date, which may precede the release by the PR's review time —
+# accepted, because the alternative (writing it after the release publishes)
+# means committing to main from the release workflow.
+today=$(date -u +%F)
+
+# -i.bak, not a bare -i: BSD sed (macOS, where this is run by hand) requires an
+# argument to -i while GNU sed (the CI runner) treats one as the next script, so
+# the explicit suffix is the only spelling both accept. The backup is discarded.
+sed -E -i.bak \
+  -e "s/^version: .*$/version: $version/" \
+  -e "s/^date-released: .*$/date-released: \"$today\"/" \
+  "$citation"
+rm -f "$citation.bak"
+
+if [ "$current" = "$version" ]; then
+  echo "CITATION.cff already at $version (date-released stamped $today)"
+else
+  echo "CITATION.cff: $current -> $version (date-released $today)"
+fi

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -60,8 +60,13 @@ jobs:
           version=${out#v}
           branch="release/v$version"
 
+          # Same commit as the bump, so the tag release.yml cuts from this
+          # merge already carries matching citation metadata — and so the
+          # version-guard check on this PR passes on its own merits.
+          .github/citation/sync.sh
+
           git checkout -b "$branch"
-          git add cli/package.json
+          git add cli/package.json CITATION.cff
           git commit -s -m "release: v$version"
           git push origin "$branch"
 

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -76,3 +76,14 @@ jobs:
               exit 1
               ;;
           esac
+
+      # CITATION.cff restates cli/package.json's version as citation metadata,
+      # and it is what GitHub's "Cite this repository" button renders — so a
+      # stale value ships as a wrong citation rather than as a broken build,
+      # which no other check would catch. Zenodo archives this file off the tag
+      # too, but derives its own record version from the tag name and ignores
+      # the version key, so this guard serves the GitHub citation box and human
+      # readers, not the DOI. Checked unconditionally, not only on bump PRs,
+      # because the drift can equally arrive from an edit to CITATION.cff.
+      - name: Check CITATION.cff is in step with cli/package.json
+        run: .github/citation/sync.sh --check

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ authors:
       orcid: "https://orcid.org/0009-0005-8000-0055"
     - name: "Inflexa, Inc."
 
-version: 0.1.0
-date-released: "2026-07-07"
+version: 0.4.2
+date-released: "2026-07-20"
 url: "https://inflexa.ai"
 repository-code: "https://github.com/inflexa-ai/inflexa"
 
@@ -46,14 +46,16 @@ keywords:
     - AI agent
     - command-line tool
 
+# Only the concept DOI is listed, deliberately. Zenodo mints a version DOI per
+# release, but it does not exist until after the tag is published and archived —
+# so a version DOI written here could only ever name the PREVIOUS release, and
+# the file is read at the tag it ships in. The concept DOI resolves to the
+# latest version and needs no maintenance.
 doi: "10.5281/zenodo.21361439"
 identifiers:
     - type: doi
       value: "10.5281/zenodo.21361439"
       description: "Concept DOI — always resolves to the latest Inflexa release."
-    - type: doi
-      value: "10.5281/zenodo.21361440"
-      description: "Version DOI — Inflexa v0.1.0 specifically."
 
 # --- Add LATER, once a preprint or JOSS paper exists, so citations point to the
 #     paper instead of (or in addition to) the software. Uncomment and fill in. ---


### PR DESCRIPTION
CITATION.cff restated the product version by hand and had drifted five releases behind (0.1.0 against a cli/package.json at 0.4.2), shipping a wrong citation in every release since. Nothing caught it, because a stale citation is not a build failure.

cli/package.json is already the single source of truth for the product version — its version field is what mints the v* tag and the GitHub release — so the citation metadata now follows it:

- .github/citation/sync.sh rewrites version/date-released, or verifies them with --check. It refuses to run if the top-level keys ever move, so a restructured file fails loudly instead of syncing nothing.
- version-guard.yml checks it on every PR. It already runs as a required check and already reads the version field, so the job name is unchanged and no required-check reconfiguration is needed. Checked unconditionally rather than only on bump PRs, since the drift can equally arrive from an edit to CITATION.cff itself.
- release-prep.yml syncs inside the bump commit. Zenodo reads the file at the tag's ref, so same-commit placement keeps the tagged tree correct.

release.yml is deliberately untouched: it cuts the tag at $GITHUB_SHA, so syncing there would either tag a stale file or require pushing an unreviewed commit to protected main.

Also drops the per-version DOI entry. Zenodo mints a version DOI only after the tag is published, so a value written into a file that ships inside that tag could only ever name the previous release — and Zenodo ignores the identifiers key regardless. The concept DOI resolves to the latest version and needs no maintenance.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
