### PR TITLE
fix(harness,sandbox): gate lineage edges on producing-step completion

### DIFF
--- a/harness/openspec/changes/gate-lineage-on-step-completion/.openspec.yaml
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/harness/openspec/changes/gate-lineage-on-step-completion/design.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/design.md
@@ -1,0 +1,288 @@
+## Context
+
+Lineage inputs are captured at runtime by the sandbox provenance layers, classified by
+`classifyReadPath`, accumulated in a step-scoped `ProvenanceCollector`, and content-attested at
+reconcile. An input that cannot be hashed at reconcile is treated as drift and fails the step
+(`reconcile-manifest.ts:187-191`), which is the correct behaviour for a genuine input that
+vanished — it prevents registering a hashless lineage edge.
+
+Two premises in the current design make that fail-fast fire on files the step never consumed:
+
+1. `classifyReadPath` branch 4 turns **any** path under `runs/{ownRunId}/` that is not the
+   step's own directory into `{source: "upstream"}`, scraping the step id out of the path. The
+   spec justifies it with "`dependsOn` drives only topo-sort ordering, not read authorization:
+   a read of a same-run step outside `dependsOn` is still a valid upstream input."
+2. Reconcile defers input hashing to teardown "because inputs are immutable for the step — the
+   analysis tree is mounted read-only."
+
+Premise 2 is false whenever a sibling runs concurrently. The read-only mount constrains *this*
+step's writes; every other step has its own directory mounted read-write and mutates it freely,
+including creating and deleting scratch files. Premise 1 then converts that churn into
+mandatory attestation targets.
+
+Concurrency is normal, not exceptional: the CLI's machine budget is a user-chosen percentage of
+the host (`cli/src/modules/infra/setup.ts:729-748`) and the scheduler starts every
+dependency-satisfied step that fits (`execute-analysis-scheduler.ts:206-208`). The capture scope
+makes it unavoidable: `mount-plan.ts:140` sets `PROVENANCE_WATCH_DIRS` to the entire analysis
+tree, so every step observes every sibling's directory.
+
+The constraint that shapes the implementation is that `execute_command` is
+`executionMode: "workflow"` (`execute-command.ts:103`) — its body runs unwrapped in the DBOS
+workflow body, where a raw database read is non-deterministic across replay.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make sibling lineage edges admissible only when the producing step actually finished, so a
+  concurrently running step can never appear in another step's lineage.
+- Stop fabricating edges silently. The `T4S1` case — three `T2S2` files registered as real
+  inputs because they happened to survive — must become impossible, not merely rarer.
+- Preserve fail-fast for genuine drift. An admissible input that vanished is still a hard
+  failure; only inadmissible edges are dropped.
+- Keep classification pure and unit-testable. No database access inside `classifyReadPath`.
+- Keep lineage deterministic under DBOS replay: the same run must produce the same edges.
+
+**Non-Goals:**
+
+- Reconstructing correct lineage for already-registered runs. Detecting fabricated historical
+  edges is a separate audit, tracked in tasks, not attempted inline.
+- Changing the `data`, `artifacts`, or `prior` classification branches' behaviour.
+- Making provenance capture exhaustive. Provenance stays best-effort and must never fail an
+  exec; this change only narrows what it is allowed to *assert*.
+- Replacing the capture layers. Narrowing the watch scope and fixing `IN_OPEN` reduces noise at
+  the source but is not what makes the rule correct.
+
+## Decisions
+
+### Gate on step completion, not on `dependsOn`
+
+`dependsOn` is a scheduling input: it says what must finish before a step may *start*, and the
+current spec explicitly declines to treat it as read authorization. That reasoning is sound — a
+step may legitimately read a sibling it did not declare — so tightening the gate to "must be in
+`dependsOn`" would break real lineage.
+
+Completion is the causally correct predicate instead. If Y has not completed, Y's directory
+contains work in progress, and nothing X observed there is a stable artifact X can be said to
+have consumed. This subsumes the parallel case without a separate rule: a step running
+concurrently with X is by definition not completed, so it cannot contribute an edge.
+
+`completed` is the only admissible status. `failed`, `canceled`, and `skipped` are terminal but
+their outputs were never finalized — that is exactly what a `lineage_attestation` failure means
+— so treating them as admissible would let one step's unfinalized output become another's
+attested input.
+
+`dependsOn` is still threaded into the collector, as `exec-provenance-lineage` already requires
+and the implementation never honoured (`sandbox-step.ts:380-383` passes only `stepId`/`runId`,
+leaving the declared-dependency branch dead code). It no longer gates admissibility; it earns
+its place by letting diagnostics distinguish a declared edge from an observed one.
+
+### Snapshot admissibility before the exec, not at reconcile
+
+Reconcile is the wrong moment. It runs after sandbox teardown, so a sibling that was mid-flight
+*while the file was read* may have completed by then, and the edge would pass — registering
+precisely the fabricated lineage this change exists to prevent. The `T4S1` case would still slip
+through a reconcile-time check.
+
+The snapshot is therefore taken **before the exec is submitted**, and submit time — not start
+time — is the normative predicate. Submission precedes start, so a set observed at submit is a
+subset of what is completed at start; the rule is deliberately stricter than the causal minimum,
+and the strictness is the point. Completion is monotonic, so a step observed `completed` at
+submit time was necessarily completed before any read that exec performs. The converse is deliberately conservative: a sibling that completes *during* the exec
+is treated as inadmissible for that exec, because we cannot tell whether the read landed before
+or after its final write. Dropping a marginal edge is strictly better than registering a racy
+one, and the drop is logged so the choice is visible rather than silent.
+
+The snapshot is per-exec, not per-step, so a long-running step naturally picks up siblings that
+completed since its previous command.
+
+Alternative considered: timestamp comparison, using the frame's per-read times against each
+sibling's `completed_at`. Rejected — it buys precision we cannot trust, since the read timestamps
+come from capture layers whose clocks and ordering are not guaranteed to agree with the
+database's, and it would make the rule depend on the least reliable field in the pipeline.
+
+### Take the snapshot inside `ctx.runStep`
+
+`execute_command` declares `executionMode: "workflow"`, so its body is *not* wrapped in a
+durable step; it runs directly in the DBOS workflow body. A bare `queryStepsByRun` there would
+re-execute on every replay and return whatever the table says at replay time — a strictly larger
+completed-set than the original execution saw. The same run would then produce different lineage
+on recovery, which breaks both determinism and the audit value of the record.
+
+The snapshot must therefore go through `ctx.runStep`, which checkpoints the result so replay
+returns the original answer. The house rule from `lib/result.ts` applies at that boundary: a
+`Result` error crossing a DBOS step must throw (`unwrapOrThrow`), or the step is durably cached
+as a success and replayed as one forever.
+
+### Inadmissible reads are dropped, not fatal
+
+An inadmissible read is noise, not drift — the step observed activity it did not consume. The
+codebase already has the precedent and the mechanism: out-of-tree reads (`reconcile-manifest.ts:169-181`)
+and directory reads (`196-206`) both call `collector.dropInput` and continue. Inadmissible
+sibling reads join them.
+
+The drop happens at classification, before the ref enters the collector, so the inadmissible
+path never becomes an attestation target in the first place. `classifyReadPath` stays pure: it
+receives the completed-step set as an argument and returns an explicit "not an admissible edge"
+outcome, which `feedExecFrame` honours by not calling `trackInputAccess`.
+
+### Observability is part of the contract
+
+Every rejection logs through the injected `Logger` seam with the ref path, the scraped step id,
+and that step's observed status, and increments a new `lineageEdgeRejected` counter
+(`cortex.lineage.edge_rejected`) with a `reason`.
+
+The counter is deliberately separate from reconcile's `lineageInputDropped`, which is registered
+as `cortex.artifact.reconcile.input_dropped` (`src/lib/metrics.ts:19`). Reusing it would mean a
+counter named for a reconcile-time drop firing from classification, which makes both the metric
+and any dashboard built on it lie about where the loss happened.
+
+This is not decoration: the failure that motivated this change was diagnosable only because a previous
+fix routed `lineage_attestation` through the Logger, and the silent half of the bug (`T4S1`) is
+invisible precisely because nothing recorded the fabricated edges. A silent drop would rebuild
+the same blind spot one layer down.
+
+### Watch the immutable set, not the declared set
+
+The criterion for what to inotify-watch is **immutability**, not declaration. A step that has
+completed will never write again, so its directory cannot churn — watching it is free, and any
+read of it is admissible under the completion gate anyway. A *running* sibling's directory is
+the only thing that churns, and that is precisely what caused this defect.
+
+`PROVENANCE_WATCH_DIRS` therefore enumerates `data/`, the step's own tree, and the tree of every
+sibling of the same run that is `completed` at sandbox creation. `dependsOn` is not the
+criterion: the scheduler already guarantees declared dependencies completed before the step
+starts, so they are a strict subset of that set.
+
+Scoping to `dependsOn` instead was considered and rejected — it would exclude completed
+non-declared siblings, which classification admits, so the capture layer and the admissibility
+rule would have contradicted each other and made a whole class of legitimate edge unreachable.
+Using the same immutability criterion in both places keeps one concept with two enforcement
+points.
+
+Known limitation, stated rather than implied: the watcher walks once at container start and
+never re-walks, so a sibling that completes *after* this sandbox was created is not
+inotify-watched. That is under-capture, conservative in the same direction as the gate, and the
+in-process hooks still cover it (below).
+
+### Decouple the hook prefixes from the watch dirs
+
+`PROVENANCE_DATA_PREFIXES` and `PROVENANCE_WATCH_DIRS` are derived from the same value today
+(`provenance.go:198-199`), which forces the hooks to inherit whatever narrowing inotify needs.
+They should be independent, because the two layers have fundamentally different exposure.
+
+The Python audit hook, the R hooks, and the `provtrack.c` LD_PRELOAD interposer observe only
+**their own process's** opens. They cannot see another container's writes at all, so they were
+never a source of sibling contamination. Only inotify watches the shared filesystem, and only
+inotify needs the narrow scope.
+
+So the hook prefixes stay at the analysis mount root while the watch dirs narrow. A legitimate
+cross-step or prior-run read performed by the command *itself* therefore stays capturable even
+when the path is not inotify-watched — which is what keeps the previous decision's
+under-capture from becoming a real lineage gap.
+
+### Snapshot failure fails closed, loudly, and durably
+
+If the completed-step query fails, three things must hold at once. The exec must not die —
+provenance is best-effort and failing an exec over bookkeeping is the exact failure mode this
+change exists to remove. The result must not be silent — a quiet empty set would drop every
+sibling edge with no record, rebuilding the blind spot one layer down. And the outcome must be
+deterministic under replay.
+
+The durable step therefore resolves to an explicit "snapshot unavailable" outcome rather than
+throwing. All same-run sibling reads for that exec become inadmissible, the unavailability is
+logged at error level and counted under its own reason, and the step completes.
+
+The subtle part is that the *degradation itself* must be checkpointed. If only the success path
+were durable, a replay could re-run the query, succeed where the original failed, and produce a
+different lineage graph for the same run — the same determinism hazard as the unwrapped query,
+arriving through the error path instead.
+
+### One predicate for every producing step, whatever run it belongs to
+
+The defect generalizes from steps to runs: nothing stops a second run over the same workspace
+from being in flight, and a `prior` read of its directory reproduces this bug across runs
+instead of within one. The `prior` branch is currently ungated, and reconcile treats `prior`
+reads as attestable, so both the crash and the fabricated-edge case recur there.
+
+Gating `prior` on "the referenced **run** is terminal" was the obvious move and is the wrong
+one. `cortex_runs` counts `partial`, `failed`, and `canceled` as terminal (`runs.ts:121`), so
+that rule would admit a *failed* step inside a finished run — whose outputs were never
+finalized, which is exactly what the sibling rule exists to reject. It also introduces a second
+predicate, and a second table, for what is really the same question.
+
+The predicate is therefore uniform across branches 3, 4, and 5: **the producing step is
+`completed`**. Which run it belongs to is irrelevant — what makes an artifact stable is that the
+step that writes it has finished, not that its run has. A prior run's completed step qualifies;
+a prior run's failed step does not; a concurrent sibling does not.
+
+That collapses two rules into one and two queries into one. The snapshot becomes a set of
+`(runId, stepId)` pairs for the analysis, which `cortex_step_executions` already indexes by
+`analysis_id` (`state/init.ts:102-103`), so the wider scope costs nothing and `cortex_runs` is
+not consulted at all.
+
+### Stop treating a bare `IN_OPEN` as a read
+
+`classifyInotifyMask` (`provenance_inotify_linux.go:145-153`) returns `"read"` for everything
+that is not CREATE/DELETE/MOVE, and the watch mask includes `IN_OPEN`. `IN_OPEN` fires on opens
+for *writing* and on opens by processes unrelated to the command, so it cannot on its own mean
+"this command consumed this file". The mode-aware Python, R, and C hooks already classify by
+open mode and remain the authoritative read signal; inotify's role is verification.
+
+## Risks / Trade-offs
+
+**A legitimate edge is dropped when a sibling completes mid-exec** → The read is dropped and
+logged with the sibling's observed status, so the gap is visible and attributable rather than
+silent. The step's next exec sees the sibling as completed. Accepted deliberately: an
+under-reported edge is a recoverable gap, a fabricated edge is a corrupt record.
+
+**Narrowing the watch scope hides genuinely useful reads** → Declared upstream directories stay
+in scope, so ordinary dependency reads are unaffected. Reads outside that scope were already
+inadmissible under the new rule, so nothing that would have survived classification is lost.
+
+**Harness and sandbox image ship on different cadences** → The change is sequenced so the
+harness-side rule is independently sufficient for the reported failure and requires no image
+rebuild. The Go changes are additive noise reduction and can land in a later image version
+without leaving a window where lineage is wrong.
+
+**A per-exec database read adds latency** → The query is a prefix scan on the
+`(run_id, step_id)` primary key, measured against exec durations of seconds to minutes. The
+`ctx.runStep` wrapper also makes it a cached step on replay rather than a repeated query.
+
+**Historical lineage is already corrupted** → Not fixable in this change and not pretended
+otherwise. Fabricated edges from before this change are indistinguishable from real ones by
+inspection, so an audit pass is called out explicitly in tasks rather than left implicit.
+
+**Seeding `dependsOn` changes a durable workflow input shape** → `SandboxStepInput` has no
+`dependsOn` field today (verified: the identifier appears nowhere in `sandbox-step.ts`), so the
+parent must thread it through DBOS workflow input. Workflows already in flight were persisted
+without the field, so it must be optional at the type level and absence must degrade to the same
+fail-closed posture as an unavailable snapshot — never to "declared nothing, so everything is a
+plain sibling".
+
+**`buildMountPlan` is pure today and now needs to know which siblings completed** → It takes
+coordinates and stores, with no database access. The completed-sibling list must be resolved by
+the caller and passed in, keeping the mount plan a pure function of its inputs rather than
+growing a query. Otherwise sandbox creation acquires a hidden I/O dependency that its tests
+cannot express.
+
+## Migration Plan
+
+1. **Harness-only (fixes the reported failure).** Admissibility rule, `dependsOn` seeding,
+   drop-and-log path, metric reason, and tests. No sandbox image rebuild required, so this can
+   ship on the harness's own cadence.
+2. **Sandbox image.** Narrowed `PROVENANCE_WATCH_DIRS` and the `IN_OPEN` classification fix,
+   with a `sandbox-base` rebuild and version bump.
+3. **Audit.** Survey registered lineage edges for sibling edges that could not have been
+   admissible, using each step's recorded completion time against the reading step's window.
+
+Rollback is per-phase and independent: phase 1 reverts to the previous classification behaviour
+without touching the image, and phase 2 reverts to the previous watch scope without touching the
+rule.
+
+## Open Questions
+
+- **Should an inadmissible read be retained as a non-attested observation** (visible for
+  debugging, excluded from the registered lineage graph) rather than dropped outright? This
+  would preserve evidence of cross-step interference without asserting an edge, at the cost of a
+  second class of ref the registration translator must understand.

--- a/harness/openspec/changes/gate-lineage-on-step-completion/proposal.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/proposal.md
@@ -1,0 +1,131 @@
+## Why
+
+A step currently records a **concurrently running** sibling step's files as mandatory,
+content-attested `upstream` lineage inputs. When that sibling deletes the file — a scratch
+file it never meant to publish — the reading step's reconcile ENOENTs and kills the step with
+`errorClass: lineage_attestation`, after the science has already completed successfully.
+
+This is not hypothetical. In run `19110b58`, step `T2S2` (enrichment) died attesting
+`runs/<runId>/T5S1/output/_ct_for_r_BRAF.csv` — a scratch file belonging to `T5S1`, the
+statistical-modeling step, which was running at the same time. The failure is symmetric:
+`T5S1` was simultaneously failing to attest `T2S2/output/gseapy_hallmark`. Two steps each
+claimed the other's outputs as inputs, which is not a DAG.
+
+The crash is the *lucky* case. In the same run, `T4S1` recorded three `T2S2` files
+(`logs/run_gsea.log`, `output/wikipathways_symbols.gmt`, `scripts/run_gsea.py`) as its inputs
+while `T2S2` was still running. Those files happened to survive to reconcile, hashed cleanly,
+and were **registered as real lineage edges**. A survival-analysis step did not read a GSEA
+log. Silent provenance corruption is the worse half of this defect, and it is invisible today.
+
+The root premise is wrong. `classifyReadPath` branch 4 is justified in the spec by "a read of
+a same-run step outside `dependsOn` is still a valid upstream input", and reconcile defers
+input hashing on the grounds that "inputs are immutable for the step — the analysis tree is
+mounted read-only". Read-only describes *this* step's write capability. A concurrent sibling
+has its own directory mounted read-write and mutates it freely, so the tree is shared mutable
+state for exactly the paths that branch marks as attestable inputs.
+
+## What Changes
+
+- **BREAKING (lineage semantics)**: an input edge from step X to a sibling step Y in the same
+  run is admissible **iff Y's `cortex_step_executions.status` was `completed` at the moment
+  X's exec started**. Y running, queued, failed, canceled, skipped, blocked, or absent means
+  there is no lineage relationship — the read is dropped from lineage, never fatal. Two steps
+  running in parallel therefore have no lineage relationship to each other, which falls out of
+  the same predicate rather than needing its own rule.
+- `completed` is the only admissible status. A failed or canceled step's outputs were never
+  finalized (that is precisely what the `lineage_attestation` failure means), so they must
+  never become another step's attested input.
+- The admissibility snapshot is taken **before the exec is submitted**, not at reconcile.
+  Reconcile runs after teardown, by which time a sibling that was mid-flight *during* the read
+  may have completed and the edge would wrongly pass. Completion is monotonic, so a step
+  `completed` at submit time was necessarily completed before any read that exec performs —
+  conservative in the safe direction.
+- `classifyReadPath` gains an explicit "not an admissible edge" outcome so `feedExecFrame`
+  drops the read rather than tracking it. The function stays pure and unit-testable; the
+  completed-set is passed in, not queried inside.
+- The step-scoped `ProvenanceCollector` is finally seeded with `dependsOn`, which the
+  `exec-provenance-lineage` spec already requires and the implementation never did. Under the
+  new rule `dependsOn` is no longer the admissibility gate; it is retained to distinguish a
+  *declared* edge from an *observed* one in diagnostics.
+- The predicate is uniform across same-run siblings and earlier runs alike: **the producing step
+  is `completed`**. Which run it belongs to is irrelevant — an artifact is stable because the
+  step writing it finished, not because its run did. This closes the same hole in `prior`-run
+  reads, where a second in-flight run over one workspace reproduces the defect across runs.
+  Gating `prior` on the *run* being terminal was rejected: `cortex_runs` treats `partial`,
+  `failed`, and `canceled` as terminal, so it would admit a failed step's unfinalized outputs.
+- If the completed-step snapshot cannot be taken, the exec still succeeds but every same-run
+  sibling read for it becomes inadmissible — fail closed, logged at error level, and counted.
+  The degraded outcome is itself checkpointed so a replay cannot succeed where the original
+  failed and produce different lineage.
+- Provenance capture is narrowed at the source, on an **immutability** criterion rather than a
+  declaration one: `PROVENANCE_WATCH_DIRS` stops being the whole analysis tree and becomes
+  `data/`, the step's own directory, and the directory of every sibling already `completed` at
+  sandbox creation. A completed step never writes again, so watching it cannot produce churn;
+  only a running sibling can, and it is never watched.
+- `PROVENANCE_DATA_PREFIXES` is decoupled from `PROVENANCE_WATCH_DIRS`. The in-container hooks
+  observe only their own process's opens and were never a contamination source, so their prefix
+  filter stays broad while inotify — the one layer that sees the shared filesystem — narrows.
+- The inotify layer stops classifying every non-CREATE/DELETE/MOVE event as a read. `IN_OPEN`
+  fires on opens for writing and on opens by unrelated processes, so it cannot by itself mean
+  "this command consumed this file as input".
+- Every rejected edge is logged through the injected `Logger` seam (ref path, scraped step id,
+  that step's observed status) and counted on a **new** `lineageEdgeRejected` counter with a
+  `reason`. It is deliberately separate from reconcile's `lineageInputDropped`, which is named
+  for a reconcile-time drop and keeps only its three existing reasons. A silent drop would hide
+  exactly the class of bug this change exists to fix.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change corrects the requirements of existing capabilities; it introduces no new
+capability surface.
+
+### Modified Capabilities
+
+- `explicit-input-classification`: branch 4 of `classifyReadPath` becomes completion-gated
+  rather than unconditional, its stated justification is replaced, and the
+  "Same-run sibling outside dependsOn classified as upstream" scenario is inverted. The
+  `feedExecFrame` requirement gains the completed-step set and the drop behaviour.
+- `exec-provenance-lineage`: the false "inputs are immutable for the step" premise is replaced
+  with an accurate statement of what the read-only mount does and does not guarantee, and the
+  completion-gated admissibility rule is added as a requirement.
+- `artifact-manifest`: the reconcile rules gain the distinction between an inadmissible edge
+  (dropped) and genuine drift on an admissible edge (still fatal, unchanged).
+- `sandbox-provenance-tracking`: `PROVENANCE_WATCH_DIRS` is narrowed from the analysis resource
+  mount root to the immutable set (data, own tree, completed siblings); `PROVENANCE_DATA_PREFIXES`
+  is decoupled from it and stays broad; the inotify read classification stops treating a bare
+  `IN_OPEN` as evidence of a read; and exhaustion of the pre-existing 1000-watch budget becomes
+  observable to the harness instead of only an in-container log line.
+
+## Impact
+
+**Harness (TypeScript)**
+- `src/provenance/collector.ts` — `classifyReadPath` branch 4; inadmissible outcome.
+- `src/provenance/exec-frame.ts` — `feedExecFrame` carries the completed-step set and drops
+  inadmissible reads.
+- `src/tools/workspace/execute-command.ts` — snapshots the completed-step set. This tool is
+  `executionMode: "workflow"`, so it runs unwrapped in the DBOS workflow body: the snapshot
+  **must** be taken inside `ctx.runStep` or it re-executes on replay and can return a different
+  answer, producing different lineage for the same run.
+- `src/workflows/sandbox-step.ts` — seed the collector with `dependsOn`.
+- `src/state/step-executions.ts` — a narrow query for the run's completed step ids.
+- `src/sandbox/mount-plan.ts` — narrowed `PROVENANCE_WATCH_DIRS`, computed from a
+  completed-sibling list the caller resolves and passes in so the plan stays a pure function.
+- `src/lib/metrics.ts` — new `lineageEdgeRejected` counter.
+- `SandboxStepInput` (`src/workflows/sandbox-step.ts`) — gains `dependsOn`. This is a **durable
+  DBOS workflow input shape change**: workflows persisted before it must still recover, so the
+  field is optional and its absence degrades fail-closed.
+
+**Sandbox image (Go)**
+- `images/sandbox-base/server/provenance_inotify_linux.go` — read classification.
+
+**Data already written**
+Lineage edges registered before this change may contain fabricated sibling edges of the
+`T4S1` kind. They are indistinguishable from real edges by inspection alone, so an audit pass
+over registered inputs is in scope for follow-up and is called out in tasks rather than
+silently ignored.
+
+**Not affected**
+The `data`, `artifacts`, and `prior` classification branches keep their current behaviour, and
+genuine drift on an admissible input stays fatal.

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/artifact-manifest/spec.md
@@ -1,0 +1,193 @@
+## MODIFIED Requirements
+
+### Requirement: The manifest is reconciled against disk before registration
+
+`reconcileManifestWithDisk(input)` SHALL run after the sandbox is destroyed and
+before any artifact is registered or synced. For each manifest entry it SHALL
+stat the file at `{workspaceRoot}/runs/{runId}/{stepId}/{entry.path}`, bounded
+to the step root, and:
+
+- If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`, `step_id`), and emit a debug log line.
+- If the path is not a regular file (a directory) → drop it the same way.
+- Otherwise → recompute SHA-256 from disk via `computeSha256File` and replace the entry's `hash` and `size` with the on-disk values.
+
+Every surviving entry SHALL be re-hashed from disk — there is no matched-size
+fast path that skips hashing. The reconcile step SHALL also content-attest the
+collector's tracked inputs via `fillInputHashesFromDisk`: for each tracked input
+that is not an `artifacts`-source read and lacks a valid content hash, it maps
+the container path onto the host workspace tree, bounds it to
+`{workspaceRoot}`, and hashes the file from disk.
+
+**Reconcile attests admissible inputs only.** An input is *admissible* when the
+bytes it names are stable across the step's execution: a staged `data` read, a
+`prior`-run read **of a step that had `completed`** (a step still running mutates
+its directory exactly as a concurrent sibling does, whatever state its run is in,
+so an unqualified `prior` read is not admissible), the step's own artifacts
+(`artifacts`-source — not attested here), and a same-run **sibling step that had
+already completed when the reading step's exec started**. A read of a producing
+step that had **not** completed at that moment is **inadmissible**, whether that
+step belongs to this run or an earlier one: in both cases the step observed
+activity it did not consume, which is noise rather than drift, and such a read
+SHALL be dropped from lineage and SHALL NEVER fail the step. One predicate — the
+producing step's own status — settles both; the state of the run containing that
+step SHALL play no part. Inadmissible edges
+SHALL be dropped at **classification**
+time, before the ref enters the collector (see the
+`explicit-input-classification` capability), so `fillInputHashesFromDisk` SHALL
+be entitled to assume every tracked input it sees is already admissible, and by
+the time reconcile runs there SHALL be no inadmissible ref left for it to drop.
+Reconcile SHALL NOT acquire a completion check of its own: it runs after
+teardown, by which time a sibling that was mid-flight *while the file was read*
+may have completed, so a check there would admit exactly the racy edge the
+classification-time gate exists to reject.
+
+An input that is not a content-attestable file **of this analysis** SHALL be
+dropped via `collector.dropInput` and SHALL NOT fail the step:
+
+- An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref and a `boundSite` discriminator; the workspace-root record also carries the resolved host path (the container-prefix bound rejects the path before a host mapping exists).
+
+Every input drop taken **at reconcile** SHALL increment the
+`lineageInputDropped` counter (`cortex.artifact.reconcile.input_dropped`), tagged
+`agent_id`, `step_id`, and `reason`. That counter's `reason` set SHALL remain
+exactly `directory`, `container-prefix`, and `workspace-root`: this change adds
+no reason to it and changes nothing else about it.
+
+An inadmissible edge to a producing step SHALL NOT be counted here. It is
+counted at its own drop site, at classification, on the separate
+`lineageEdgeRejected` counter (`cortex.lineage.edge_rejected`) — tagged
+`agent_id`, `step_id`, and `reason` ∈ `producing-step-not-completed`,
+`snapshot-unavailable` (see the
+`explicit-input-classification` capability) — and SHALL NOT appear among
+reconcile's reasons, because reconcile never sees it. The two counters measure
+different events at different sites and SHALL NOT be merged.
+
+An out-of-tree read is out of scope rather than drift: the analysis tree mounts
+at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container
+root and describes nothing about the analysis. The capture hooks are meant to
+filter such reads by data prefix, so the lineage graph already describes only
+in-tree inputs — dropping a leaked one restores that graph. Dropping upholds
+"never register a hashless lineage edge" exactly as a throw would, without
+destroying a legitimate analysis over an untracked read, and it mirrors the
+out-of-bounds *output* skip in the same function. Warn rather than debug is
+deliberate: a directory read is ordinary, whereas an out-of-tree read means a
+capture layer reported something it should have filtered — not worth a dead
+analysis, but worth noticing.
+
+Fail-fast SHALL remain for genuine drift: an **admissible** input **file** that
+is missing at reconcile (`ENOENT`) SHALL throw, as SHALL an unexpected `stat`
+failure, never registering a hashless lineage edge. The admissibility rule SHALL
+NOT weaken this: dropping applies only to reads excluded *before* reconcile and
+to the not-a-file / out-of-tree cases above, never to a tracked input that
+reaches `fillInputHashesFromDisk` and cannot be hashed.
+
+#### Scenario: Phantom file is dropped silently
+
+- **GIVEN** the agent wrote `output/temp.csv` and later deleted it, but the walk had already recorded it (or the collector still holds a record)
+- **WHEN** `reconcileManifestWithDisk` runs and stat fails with `ENOENT`
+- **THEN** the entry for `output/temp.csv` is removed from the returned manifest, `collector.removeRecord("output/temp.csv")` is called, a debug line is logged, and `cortex.artifact.reconcile.dropped` is incremented once
+- **AND** `output/temp.csv` reaches neither registration nor the vector index
+
+#### Scenario: Every surviving output is re-hashed from disk
+
+- **GIVEN** a manifest entry for `output/clean.csv` whose on-disk size equals the entry's size
+- **WHEN** `reconcileManifestWithDisk` runs
+- **THEN** `computeSha256File` IS invoked for `output/clean.csv` and the entry's hash and size are set from the on-disk bytes
+
+#### Scenario: An admissible input missing at reconcile still fails the step
+
+- **GIVEN** the collector tracked a non-`artifacts` input read that is admissible — a `data` read, a `prior`-run read of a step that had completed, or a read of a sibling step that had completed before this step's exec started — and whose file is absent at reconcile time
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** it throws, the step fails loudly, and no hashless lineage edge is registered
+- **AND** the throw is logged first with the ref, its `source`, the resolved `hostPath`, and the `throwSite` discriminator
+
+#### Scenario: An inadmissible sibling read never reaches reconcile
+
+- **GIVEN** sibling step `T5S1` is running concurrently with this step and its scratch file `runs/{runId}/T5S1/output/_scratch.csv` was reported as a read and then deleted by `T5S1`
+- **WHEN** the exec frame is classified and `reconcileManifestWithDisk` later runs
+- **THEN** the read was dropped as inadmissible at classification and was never tracked by the collector, so `fillInputHashesFromDisk` has no ref for it, does not stat it, and does not throw
+- **AND** the step's real outputs still reconcile and register, and the step completes
+
+#### Scenario: A directory read is dropped from lineage, not failed
+
+- **GIVEN** a tracked input that resolves to a directory (e.g. `ls` of a mount)
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, `lineageInputDropped` (`cortex.artifact.reconcile.input_dropped`) is incremented with `reason = "directory"`, and the step does NOT fail
+- **AND** `lineageEdgeRejected` is NOT incremented — reconcile's drop sites keep exactly the reasons `directory`, `container-prefix`, and `workspace-root`
+
+#### Scenario: A read resolving outside the analysis tree is dropped, not failed
+
+- **GIVEN** a tracked input read of `/{resourceId}/..` — the container root, which maps to a host path above the workspace root
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `boundSite` is emitted, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register
+
+## ADDED Requirements
+
+### Requirement: Deferred input hashing is sound only for admissible, stable inputs
+
+Input hashes SHALL be read from disk at reconcile rather than captured at read
+time, and that deferral SHALL be justified **only** by the stability of
+*admissible* inputs. It SHALL NOT be justified by the analysis tree being mounted
+read-only: the read-only mount constrains the **reading** step's own writes and
+says nothing about a sibling step, which has its own directory mounted
+read-write and mutates it freely, including creating and deleting scratch files
+it never intends to publish.
+
+Deferred hashing is sound for, and only for, inputs whose bytes can no longer
+change before reconcile:
+
+- staged `data`, immutable for the run;
+- outputs of a prior run's step that had **completed** — a step still running writes on, so `prior` is admissible only under the same completion gate, never unconditionally and never on the strength of its run having ended;
+- the step's own directory (`artifacts`-source, excluded from attestation anyway);
+- a same-run sibling that had **completed** before the reading step's exec started — completion is monotonic, so such a sibling performs no further writes.
+
+The list is one rule, not four: the producing step finished writing. A prior
+run's **failed** step is therefore excluded exactly as a running sibling is, even
+though its run has ended, because a step that did not complete never finalized
+its outputs.
+
+Deferred hashing is **not** sound for a concurrently running sibling, nor for a
+step of another run that had not completed: between the
+read and reconcile its bytes may change or vanish, so the hash recorded at
+reconcile would not be the bytes the command consumed, and its absence would be
+indistinguishable from drift. Such an edge SHALL therefore be excluded **before**
+reconcile — at classification, per the `explicit-input-classification` capability
+— rather than tolerated at reconcile. The harness SHALL NOT reconcile that
+unsoundness by relaxing reconcile's fail-fast, because a reconcile that no longer
+throws on an unhashable tracked input can register a hashless lineage edge, which
+is the invariant reconcile exists to hold.
+
+#### Scenario: A completed sibling's output is attested at reconcile
+
+- **GIVEN** a tracked input naming a file under a sibling step whose `cortex_step_executions.status` was `completed` before this step's exec started
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** the ref's hash is computed from disk and equals the bytes the sibling finalized, because a completed step performs no further writes
+- **AND** the edge is registered and the step does NOT fail
+
+#### Scenario: A prior run's completed step is attested at reconcile
+
+- **GIVEN** a tracked `prior` input naming a file under step `qc` of the earlier run `run-001`, whose `cortex_step_executions.status` was `completed` when this step's exec was submitted
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** the ref's hash is computed from disk and the edge is registered — the producing step finished, so its bytes are stable, and no state of `run-001` itself was consulted to reach that conclusion
+
+#### Scenario: A prior run's failed step is never an attestation target
+
+- **GIVEN** step `norm` of the earlier run `run-001` ended `failed`, `run-001` itself has finished, and the capture layer reported a read of `runs/run-001/norm/output/partial.csv`
+- **WHEN** the read is classified
+- **THEN** it is dropped as an inadmissible edge, is never tracked by the collector, and therefore never becomes a deferred-hashing target at reconcile — `norm` never finalized those bytes, and its run having ended does not finalize them for it
+- **AND** whether that file survives to reconcile makes no difference to this step's outcome
+
+#### Scenario: A concurrent sibling's file is never an attestation target
+
+- **GIVEN** a sibling step was still running when this step's exec started, and the capture layer reported a read of one of that sibling's files
+- **WHEN** the read is classified
+- **THEN** it is dropped as an inadmissible edge, is never tracked by the collector, and therefore never becomes a deferred-hashing target at reconcile
+- **AND** whether that file survives to reconcile or is deleted by the sibling makes no difference to this step's outcome
+
+#### Scenario: Reconcile is not relaxed to absorb an unsound edge
+
+- **GIVEN** a tracked input reached the collector and its file cannot be hashed at reconcile (`ENOENT` or an unexpected `stat` failure)
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** it throws and the step fails, regardless of whether the ref names a sibling step's directory
+- **AND** the remedy for an inadmissible read SHALL be dropping it at classification, never softening this throw

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/exec-provenance-lineage/spec.md
@@ -1,0 +1,380 @@
+# exec-provenance-lineage Specification
+
+## MODIFIED Requirements
+
+### Requirement: Each exec frame is threaded into the step-scoped collector
+
+The sandbox-step body SHALL construct one `ProvenanceCollector` per step, seeded
+with the step's `stepId`, `runId`, and `dependsOn`. Seeding is not optional: a
+construction site that passes only `stepId` and `runId` SHALL NOT be conformant,
+because the declared-dependency classification branch is then unreachable and
+every declared upstream read is indistinguishable from an undeclared sibling
+read. `dependsOn` no longer gates admissibility (see "A sibling lineage edge
+requires the producing step to have completed"); it is seeded so diagnostics can
+tell a *declared* edge from a merely *observed* one.
+
+The frame-threading path SHALL additionally supply the set of `(runId, stepId)`
+pairs observed `completed` at the moment the exec was **submitted** — submit is
+the normative instant throughout this capability — and SHALL pass that set into
+classification: `classifyReadPath` SHALL be called with the step's `stepId`,
+`runId`, `dependsOn`, **and** that completed-step set. The set SHALL be scoped to
+the **analysis**, not to the step's own run, so that a read of an earlier run's
+step is decided by the same set and the same predicate as a same-run sibling; it
+SHALL be the only admissibility input, with no second run-level parameter beside
+it. The snapshot SHALL be taken per exec, at submit, and SHALL be checkpointed
+durably, so a DBOS replay classifies against the set the original execution saw
+rather than a larger one read at replay time.
+
+The snapshot SHALL be a SINGLE query over `cortex_step_executions` scoped by
+`analysis_id`, which that table already indexes, so the analysis-wide scope costs
+no additional query and no additional index. `cortex_runs` SHALL NOT be consulted
+by this capability at all: run state answers no question the gate asks.
+
+When the completed-step query fails, the frame-threading path SHALL receive an
+explicit "snapshot unavailable" outcome rather than a thrown error, and that
+degraded outcome SHALL be checkpointed durably exactly as a successful snapshot
+is, so replay reproduces the degradation rather than succeeding where the
+original execution failed (see "A sibling lineage edge requires the producing
+step to have completed").
+
+After each `execute_command` resolves its `ExecResult`, the workspace
+`execute_command` tool SHALL feed that result's `provenance` frame into the
+collector via `feedExecFrame` (`src/provenance/exec-frame.ts`). `feedExecFrame`
+SHALL strip the `/{resourceId}/` mount prefix from each frame path — collapsing
+separators doubled at the boundary so an in-mount name lands on its canonical
+relative form — classify every read via `classifyReadPath`, call
+`trackInputAccess` per admissible read, and call `recordCommandExecution` once
+per exec with that exec's own reads scoped to its outputs. A read that
+classification reports as inadmissible SHALL NOT reach `trackInputAccess`: it is
+dropped at classification, so it never becomes an attestation target. A frame
+path that does not lie under the mount SHALL ride onto its `InputRef` verbatim,
+never with the mount root prepended: forging an in-tree name for a foreign path
+would surface at reconcile as phantom drift (a missing file, which fails the
+step) instead of the out-of-tree read it is (which reconcile drops from
+lineage). Read hashes SHALL be left unset at track time and filled from disk by
+`reconcileManifestWithDisk` before registration. When the frame is absent or
+`disabled`, `feedExecFrame` SHALL record the command with no inputs and no
+writes rather than throw.
+
+#### Scenario: Command reading an input and writing an output produces a lineage edge
+
+- **GIVEN** an `execute_command` whose argv is `["python3", "scripts/tmm.py"]` and whose `ExecResult.provenance` reads `/{rid}/data/inputs/Lab/counts.csv` and writes `/{rid}/runs/{run}/{step}/output/tmm.csv`
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** `getRecords()` contains a record for `output/tmm.csv` with `producer.type: "command"`, an inferred `scriptPath: "scripts/tmm.py"`, and an input with `source: "data"` for `data/inputs/Lab/counts.csv`
+
+#### Scenario: The collector is seeded with the step's declared dependencies
+
+- **WHEN** the sandbox-step body constructs the step's `ProvenanceCollector`
+- **THEN** it passes the step's `dependsOn` alongside `stepId` and `runId`, so the declared-dependency branch of `classifyReadPath` is reachable at runtime and a declared edge is distinguishable from an observed one in the drop diagnostics
+
+#### Scenario: Upstream read is classified by step metadata
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]`, `qc` observed `completed` at exec-submit time, and an exec whose frame reads `/{rid}/runs/run-002/qc/output/qc.csv`
+- **WHEN** the read is classified and tracked
+- **THEN** the resulting `InputRef` has `source: "upstream"`, `stepId: "qc"`, `runId: "run-002"`
+
+#### Scenario: The completed-step snapshot reaches classification
+
+- **GIVEN** an exec in run `run-002` submitted while `qc` is `completed`, `norm` is `running`, and step `qc` of the earlier run `run-001` is `completed`
+- **WHEN** the tool feeds the resulting frame via `feedExecFrame`
+- **THEN** `classifyReadPath` is called for every read with the snapshot taken at submit time — `(run-002, qc)` and `(run-001, qc)` present, `(run-002, norm)` absent — not with an empty set, and not with a set re-read after teardown
+- **AND** the set spans the analysis, so no separate run-level lookup is made for the `run-001` read
+
+#### Scenario: An inadmissible read never enters the collector
+
+- **GIVEN** step `de` in run `run-002` whose frame reports a read of `/{rid}/runs/run-002/norm/output/_scratch.csv` while `norm` is absent from the completed-step snapshot
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** `trackInputAccess` is NOT called for that path, no `InputRef` exists for it, and `reconcileManifestWithDisk` never stats or hashes it
+
+#### Scenario: A read outside the mount keeps its own name
+
+- **GIVEN** an exec whose frame reports a read of `/etc/passwd` — naming nothing under the mount, a path the hooks should have filtered
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound rather than failing the step
+
+#### Scenario: Missing or disabled frame degrades to no inputs
+
+- **GIVEN** an `ExecResult` whose `provenance` is absent or has `disabled: true`
+- **WHEN** the tool feeds it via `feedExecFrame`
+- **THEN** the command is recorded with an empty `inputs` array and no error is thrown
+
+### Requirement: Sandbox provenance capture is scoped to the analysis resource mount
+
+`buildMountPlan` SHALL set the container's `PROVENANCE_WATCH_DIRS` to an
+**enumerated** list of absolute container paths — never to the analysis resource
+mount root (`/{resourceId}`). For a given step the list SHALL contain exactly:
+
+1. the analysis data tree — `/{resourceId}/data`,
+2. the step's own run tree — `/{resourceId}/runs/{runId}/{stepId}`, omitted when the mount plan emits no read-write step mount (a read-only sandbox), since no such tree exists,
+3. `/{resourceId}/runs/{runId}/{siblingStepId}` for every sibling step of the **same run** whose status is `completed` at **sandbox-creation** time — one entry per completed sibling.
+
+The watch set is therefore the **immutable** set. A completed step's directory
+is immutable — it will never be written again — so watching it costs nothing in
+churn AND its reads are admissible under the completion gate; the two scopes
+agree by construction instead of contradicting each other. A **running**
+sibling's tree is never watched, which is exactly the churn that caused the
+defect this change exists to fix.
+
+`dependsOn` SHALL NOT be the criterion. The scheduler already guarantees that
+every declared dependency completed before the step starts, so the declared set
+is a strict subset of (3). This replaces the earlier "declared `dependsOn` only"
+scoping, which wrongly excluded completed non-declared siblings that
+classification admits — a step could then be denied capture of a read the
+admissibility rule would have accepted.
+
+The value SHALL be an enumeration rather than a single root because the
+read-only mount of the analysis tree is **flat**: no directory has exactly this
+set as its contents, so the only covering root is the mount root, and that root
+covers every sibling step's tree as well.
+
+**Known limitation, stated rather than implied away**: the watcher walks its
+configured dirs once at container start and never re-walks, so a sibling that
+completes *after* this sandbox was created is not inotify-watched for the
+remainder of this step. That is under-capture, conservative in the same
+direction as the completion gate, and such a read remains capturable by the
+in-process hooks (below).
+
+`PROVENANCE_DATA_PREFIXES` SHALL be configured **independently** of
+`PROVENANCE_WATCH_DIRS`, and SHALL NOT be derived from it. The in-container
+hooks — the Python audit hook, the R hooks, and the `LD_PRELOAD` `provtrack.c`
+interposer — intercept only **their own process's** opens: they are an
+`LD_PRELOAD` interposer and interpreter-level hooks, so they physically cannot
+observe another container's writes, and they need no narrowing to be safe. Their
+prefix filter MAY therefore remain the analysis resource mount root
+(`/{resourceId}`). Only inotify observes the shared filesystem, so only inotify
+needs the narrow scope.
+
+The consequence is deliberate: a legitimate cross-step or prior-run read
+performed by the command **itself** stays capturable via the hooks even when the
+path is not inotify-watched. Whether such a read becomes a lineage edge is
+decided by classification, not by capture scope (see "A sibling lineage edge
+requires the producing step to have completed"). Narrowing the watch scope is
+noise reduction at the capture layer, not the correctness rule. Reads and writes
+outside the configured prefixes (system libraries, `/mnt/libs`, interpreter
+internals) SHALL NOT appear in the frame.
+
+#### Scenario: Input read under the resource mount is captured
+
+- **GIVEN** an analysis mounted at `/{resourceId}` and a sandbox created for one of its steps, whose watch dirs include `/{resourceId}/data`
+- **WHEN** a script reads `/{resourceId}/data/inputs/Lab/counts.csv`
+- **THEN** the exec frame's `reads` includes that path
+
+#### Scenario: Library read is not captured
+
+- **GIVEN** the same sandbox
+- **WHEN** a script imports a package from `/mnt/libs`
+- **THEN** the exec frame's `reads` does NOT include any `/mnt/libs` path
+
+#### Scenario: A running sibling's directory is not watched
+
+- **GIVEN** step `T4S1` of run `run-002` with `dependsOn: ["qc"]`, a sibling `qc` that is `completed`, and a sibling `T2S2` that is `running` when `T4S1`'s sandbox is created
+- **WHEN** `buildMountPlan` composes the sandbox for `T4S1`
+- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/data`, `/{resourceId}/runs/run-002/T4S1`, and `/{resourceId}/runs/run-002/qc`, and does NOT contain `/{resourceId}/runs/run-002/T2S2` or the mount root `/{resourceId}`
+- **AND** `T2S2` creating and deleting `output/_ct_for_r_BRAF.csv` while `T4S1` runs produces no entry in any `T4S1` exec frame
+
+#### Scenario: A completed non-declared sibling is both watched and admissible
+
+- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, and a sibling `norm` that is NOT in `de`'s `dependsOn` but whose status is `completed` when `de`'s sandbox is created
+- **WHEN** `buildMountPlan` composes the sandbox for `de` and `de` later reads `/{resourceId}/runs/run-002/norm/output/norm.csv`
+- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/runs/run-002/norm`, the read appears in the exec frame, and classification admits it as `source: "upstream"` — capture scope and admissibility agree, where `dependsOn`-based scoping would have watched nothing and silently lost an edge the gate accepts
+
+#### Scenario: A sibling that completes after sandbox creation is not watched but stays capturable
+
+- **GIVEN** step `de` whose sandbox was created while sibling `norm` was `running`, so `/{resourceId}/runs/run-002/norm` is absent from `PROVENANCE_WATCH_DIRS`, and `norm` reaches `completed` before `de` submits a later exec
+- **WHEN** that exec's command itself opens `/{resourceId}/runs/run-002/norm/output/norm.csv`
+- **THEN** inotify does not report the read — the watcher walked once at container start and never re-walks — while the in-process hook that intercepted the command's own open does report it, because `PROVENANCE_DATA_PREFIXES` still covers `/{resourceId}`, and the read is admissible under the submit-time snapshot
+
+## ADDED Requirements
+
+### Requirement: A sibling lineage edge requires the producing step to have completed
+
+An input edge from step X to a producing step Y SHALL be admissible if and only
+if Y's `cortex_step_executions.status` was `completed` at the moment X's exec was
+**submitted** — regardless of which run Y belongs to. Submit time is the normative predicate
+throughout this capability — every statement of the gate SHALL be expressed
+against it, and no other instant (start, first read, teardown, reconcile) SHALL
+be used. Submit necessarily precedes the exec's start, so gating on the
+submit-time set is deliberately **stricter** than gating on the set as of start
+time: a sibling that reaches `completed` in the window between submit and start
+is inadmissible for that exec. That stricter reading is intentional — it costs
+at most one exec before the sibling becomes admissible, and it keeps the rule
+anchored to an instant the harness actually observes rather than one it would
+have to infer.
+
+The snapshot SHALL NOT be taken at reconcile: reconcile runs after sandbox
+teardown, by which time a sibling that was mid-flight *while the file was read*
+has often reached `completed`, and the edge would wrongly pass. Completion is
+monotonic, so a step observed `completed` at submit time was necessarily
+completed before any read that exec performs; the converse is deliberately
+conservative — a sibling that completes *during* the exec SHALL be treated as
+inadmissible for that exec, because nothing distinguishes a read that landed
+before its final write from one that landed after.
+
+`completed` SHALL be the only admissible status. `running`, `pending`/`queued`,
+`failed`, `canceled`, `skipped`, `blocked`, and the absence of any row for Y
+SHALL all be inadmissible: a step that did not complete never finalized its
+outputs, so nothing under its directory is a stable artifact another step can be
+said to have consumed — and a step that failed attestation is precisely a step
+whose outputs are not attestable. Two steps executing concurrently SHALL
+therefore have no lineage relationship to each other in either direction; this
+falls out of the same predicate rather than needing a separate rule.
+
+`dependsOn` SHALL NOT be the admissibility gate. A declared dependency observed
+in a non-`completed` state is inadmissible, and a completed sibling outside
+`dependsOn` is admissible.
+
+A `prior`-run edge SHALL be gated by the SAME predicate, applied to the same
+table, with no run-level notion anywhere in it: a read classified as `prior` —
+naming a run other than the step's own — SHALL be admissible if and only if the
+producing step it names was `completed` at X's submit time. What makes an
+artifact stable is that the step which wrote it finished, not that its run
+finished. A prior run's completed step is therefore admissible; a prior run's
+failed step is NOT, even though its run has ended; and a step of a concurrent
+run is not. The failure mode this closes is the sibling case one level out —
+nothing stops two runs over one workspace from interleaving — but it is closed
+by the same rule rather than a parallel one.
+
+The state of the referenced **run** SHALL NOT enter this decision, and
+`cortex_runs` SHALL NOT be consulted by this gate at all. A run that has ended
+does not finalize the outputs of a step inside it that failed, so a run-level
+predicate would admit precisely the unfinalized bytes the step-level rule exists
+to reject — and would answer one question with two predicates over two tables.
+
+If the completed-step query fails, the durable step SHALL resolve to an explicit
+"snapshot unavailable" outcome rather than throwing. Throwing would fail the
+exec, and provenance SHALL never fail an exec. Under that outcome **every** read
+naming a producing step for that exec — a same-run sibling and another run's step
+alike — SHALL be inadmissible: the gate fails **closed**, because an unknown
+status is not a completed one. The unavailability
+SHALL be logged at error level and counted with its own `reason`. The degraded
+outcome SHALL itself be checkpointed durably, so a DBOS replay classifies
+identically instead of succeeding where the original execution failed —
+otherwise the same run would register on replay exactly the edges the failure
+suppressed.
+
+An inadmissible read SHALL be dropped from lineage — never tracked as an input,
+never content-attested, never registered as an edge — and SHALL NOT fail the
+step. Every rejection SHALL be logged through the injected `Logger` seam with
+the ref path, the step id scraped from the path, and that step's observed
+status, and SHALL increment a **new** counter `lineageEdgeRejected`
+(`cortex.lineage.edge_rejected`), tagged `agent_id`, `step_id`, and `reason`,
+where `reason` is one of exactly two values: `producing-step-not-completed` —
+carried by a same-run sibling and a prior-run step alike, since one rule rejected
+both — or `snapshot-unavailable`. It SHALL NOT increment `lineageInputDropped`
+(`cortex.artifact.reconcile.input_dropped`): that counter belongs to reconcile
+and keeps only its existing reasons, so the two remain separately attributable.
+A silent drop SHALL NOT be acceptable: the fabricated-edge half of this defect
+is invisible exactly because nothing recorded it.
+
+Genuine drift on an **admissible** input remains fatal and unchanged: an
+admissible input file that cannot be hashed at reconcile SHALL still fail the
+step rather than register a hashless lineage edge.
+
+#### Scenario: A completed sibling's file is admitted as upstream
+
+- **GIVEN** step `de` in run `run-002` and step `norm`, whose `cortex_step_executions.status` was `completed` when `de`'s exec was submitted
+- **WHEN** `de`'s frame reports a read of `runs/run-002/norm/output/norm.csv`
+- **THEN** the read is tracked with `source: "upstream"`, `stepId: "norm"`, `runId: "run-002"`, is content-attested at reconcile, and registers as a lineage edge — whether or not `norm` is in `de`'s `dependsOn`
+
+#### Scenario: A running sibling's file is dropped
+
+- **GIVEN** step `T4S1` in run `19110b58` and step `T2S2`, whose status was `running` when `T4S1`'s exec was submitted
+- **WHEN** `T4S1`'s frame reports reads of `runs/19110b58/T2S2/logs/run_gsea.log`, `runs/19110b58/T2S2/output/wikipathways_symbols.gmt`, and `runs/19110b58/T2S2/scripts/run_gsea.py`
+- **THEN** all three reads are dropped from lineage, each logged with path, scraped step id `T2S2`, and observed status `running`, and `lineageEdgeRejected` is incremented once per drop with `reason = "producing-step-not-completed"` — no `T2S2` edge is registered for `T4S1` even though the files survive to reconcile and would hash cleanly
+
+#### Scenario: Two concurrent steps get no edge in either direction
+
+- **GIVEN** steps `T2S2` and `T5S1` executing at the same time in one run, each of whose frames reports reads under the other's step directory, and neither of which is `completed` in the other's snapshot
+- **WHEN** both steps' frames are classified
+- **THEN** neither step tracks an input naming the other, no lineage edge exists between them in either direction, and both rejections are logged and counted on `lineageEdgeRejected`
+
+#### Scenario: A prior run's completed step is admitted as prior
+
+- **GIVEN** step `de` of run `run-002` whose frame reports a read of `runs/run-001/qc/output/qc.csv`, where `run-001` is an earlier run over the same workspace and its step `qc` was `completed` when `de`'s exec was submitted
+- **WHEN** the read is classified
+- **THEN** the read is tracked with `source: "prior"`, `stepId: "qc"`, `runId: "run-001"`, is content-attested at reconcile, and registers as a lineage edge — the producing step finished, which is the whole of what the gate asks
+
+#### Scenario: A prior run's failed step is rejected even though its run has ended
+
+- **GIVEN** step `de` of run `run-002` whose frame reports a read of `runs/run-001/qc/output/partial.csv`, where `run-001` has ended and its step `qc` was `failed` when `de`'s exec was submitted
+- **WHEN** the read is classified
+- **THEN** the `prior` edge is rejected — not tracked, not attested, not registered — logged with the ref path and `qc`'s observed status `failed`, and `lineageEdgeRejected` is incremented with `reason = "producing-step-not-completed"`
+- **AND** the rejection does NOT depend on `run-001`'s own state: `cortex_runs` is never consulted, so a finished run cannot vouch for a step inside it that failed
+
+#### Scenario: A step of a concurrent other run is rejected
+
+- **GIVEN** step `de` of run `run-002` whose frame reports a read of `runs/run-003/norm/output/norm.csv`, where `run-003` is a second run over the same workspace and its step `norm` was `running` when `de`'s exec was submitted
+- **WHEN** the read is classified
+- **THEN** the `prior` edge is rejected and counted with `reason = "producing-step-not-completed"` — a running step mutates its directory whether or not it belongs to the reading step's run
+
+#### Scenario: A failed snapshot degrades instead of failing the exec
+
+- **GIVEN** an exec whose completed-step query fails (the database is unreachable when the snapshot step runs)
+- **WHEN** the snapshot step resolves and the exec's frame is classified
+- **THEN** the step resolves to an explicit "snapshot unavailable" outcome rather than throwing, the exec runs and completes normally, every read naming a producing step for that exec — same-run sibling or prior-run step — is inadmissible, the unavailability is logged at error level, and `lineageEdgeRejected` is incremented with `reason = "snapshot-unavailable"`
+
+#### Scenario: The degraded snapshot is replayed as degraded
+
+- **GIVEN** an exec whose snapshot resolved to "snapshot unavailable", checkpointed durably, and a subsequent DBOS replay of the same workflow in which the database is reachable again
+- **WHEN** the replay re-executes the step body
+- **THEN** the checkpointed "snapshot unavailable" outcome is returned rather than a fresh query, and the replay classifies the same reads inadmissible — the run does not acquire on replay the sibling edges the original execution suppressed
+
+#### Scenario: A failed sibling's file is dropped
+
+- **GIVEN** step `de` in run `run-002` and step `qc`, whose status was `failed` (equivalently `canceled`, `skipped`, or `blocked`) when `de`'s exec was submitted
+- **WHEN** `de`'s frame reports a read of `runs/run-002/qc/output/partial.csv`
+- **THEN** the read is dropped from lineage with the observed status recorded — `qc` never finalized its outputs, so they SHALL NOT become `de`'s attested input
+
+#### Scenario: A dropped read does not fail the step
+
+- **GIVEN** step `T2S2` whose exec read `runs/{runId}/T5S1/output/_ct_for_r_BRAF.csv` — a scratch file of the concurrently running `T5S1`, which deletes it before `T2S2`'s reconcile
+- **WHEN** the read is classified as inadmissible and `reconcileManifestWithDisk` subsequently runs
+- **THEN** the path is absent from the collector, reconcile never stats it, the step does NOT fail with `errorClass: lineage_attestation`, and `T2S2`'s own outputs reconcile and register normally
+
+### Requirement: The read-only mount bounds this step's writes, not the tree's mutability
+
+The read-only mount of the analysis tree at `/{resourceId}` SHALL be understood
+to guarantee exactly one thing: the step running in that container cannot write
+anywhere except its own nested read-write mount at
+`/{resourceId}/runs/{runId}/{stepId}`. It SHALL NOT be read as a guarantee that
+the tree's contents are stable while the step runs. Every other step of the run
+has its **own** directory mounted read-write in its own container and mutates it
+freely — creating, overwriting, and deleting scratch files it never intended to
+publish — so from any one step's point of view the analysis tree is shared
+mutable state, and the churned paths are exactly the ones sibling classification
+would otherwise mark as attestable inputs.
+
+Deferred input hashing — `reconcileManifestWithDisk` / `fillInputHashesFromDisk`
+filling an `InputRef`'s hash from disk after teardown rather than at read time —
+is therefore sound ONLY for admissible inputs:
+
+- the step's own artifacts (`source: "artifacts"`), written by this step alone;
+- `data/` inputs, staged before the run and immutable for its duration;
+- same-run siblings that were already `completed` at exec-submit time and will therefore write no more;
+- reads of a step of a **prior** run that was already `completed` at exec-submit time, for the same reason and under the same predicate — the producing step's own status, never its run's.
+
+For any other path naming another step — in this run or any other — the bytes
+present at reconcile SHALL NOT be assumed to be the bytes that were read, and no
+hash taken then SHALL be attested as that read's content. Documentation, prose,
+and in-code comments in this capability SHALL NOT justify deferred hashing with
+the claim that inputs are immutable because the analysis tree is mounted
+read-only — that claim is false for exactly the paths the completion gate now
+excludes.
+
+#### Scenario: A sibling mutates a tree this step has mounted read-only
+
+- **GIVEN** steps `T2S2` and `T5S1` running concurrently, each seeing the analysis tree read-only with only its own step directory read-write
+- **WHEN** `T5S1` creates `runs/{runId}/T5S1/output/_ct_for_r_BRAF.csv` and deletes it before finishing
+- **THEN** `T2S2`'s read-only mount did not and cannot prevent that mutation, and the file's absence at `T2S2`'s reconcile is ordinary sibling churn — not drift on a `T2S2` input
+
+#### Scenario: Deferred hashing stands only for admissible inputs
+
+- **WHEN** reconcile fills input hashes from disk after teardown
+- **THEN** it does so only for the step's own artifacts, `data/` inputs, and reads of steps admissible under the completion gate — same-run siblings and prior-run steps alike — every read of a step that had not completed having been rejected at classification, so no hash is attested for a path another step was still free to rewrite or delete between the read and the hash
+
+#### Scenario: A prior run's completed step is a sound deferred-hashing target, its failed step is not
+
+- **GIVEN** two reads by step `de` of run `run-002`: one of `runs/run-001/qc/output/qc.csv` where `run-001`'s step `qc` was `completed` at exec-submit time, and one of `runs/run-001/norm/output/partial.csv` where `norm` was `failed`
+- **WHEN** reconcile fills input hashes from disk
+- **THEN** the `qc` read is hashed and attested — a completed step writes no more, so its bytes at reconcile are the bytes that were read — while the `norm` read never reached the collector and is not a hashing target at all
+- **AND** the fact that both files sit under the same finished run changes nothing: soundness follows the producing step's status, not its run's

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/exec-provenance-lineage/spec.md
@@ -100,39 +100,35 @@ writes rather than throw.
 
 ### Requirement: Sandbox provenance capture is scoped to the analysis resource mount
 
-`buildMountPlan` SHALL set the container's `PROVENANCE_WATCH_DIRS` to an
-**enumerated** list of absolute container paths — never to the analysis resource
-mount root (`/{resourceId}`). For a given step the list SHALL contain exactly:
+`buildMountPlan` SHALL set the container's `PROVENANCE_WATCH_DIRS` to the step's
+own run tree alone — `/{resourceId}/runs/{runId}/{stepId}` — and SHALL leave it
+empty when the mount plan emits no read-write step mount (a read-only sandbox),
+which writes nowhere. It SHALL NOT be set to the analysis resource mount root
+(`/{resourceId}`), to the `data/` tree, or to any sibling step's tree.
 
-1. the analysis data tree — `/{resourceId}/data`,
-2. the step's own run tree — `/{resourceId}/runs/{runId}/{stepId}`, omitted when the mount plan emits no read-write step mount (a read-only sandbox), since no such tree exists,
-3. `/{resourceId}/runs/{runId}/{siblingStepId}` for every sibling step of the **same run** whose status is `completed` at **sandbox-creation** time — one entry per completed sibling.
+The criterion is **what this exec mutates**, not what it may read. inotify
+reports only creations, deletions, and moves — a bare `IN_OPEN` may not be
+reported as a read (see the sandbox-provenance-tracking spec) — and the only tree
+this exec writes is its own. `data/` is staged before the run and frozen for its
+duration; a completed sibling is immutable by this capability's own completion
+gate. Neither can emit a create, delete, or move while this step runs, so
+watching them would register watches that structurally cannot fire.
 
-The watch set is therefore the **immutable** set. A completed step's directory
-is immutable — it will never be written again — so watching it costs nothing in
-churn AND its reads are admissible under the completion gate; the two scopes
-agree by construction instead of contradicting each other. A **running**
-sibling's tree is never watched, which is exactly the churn that caused the
-defect this change exists to fix.
+Exclusion from the watch set SHALL NOT be read as inadmissibility. A completed
+sibling's outputs remain a perfectly admissible lineage input; they are simply
+not something inotify has anything to say about. Capture scope and admissibility
+answer different questions, and this requirement answers only the first.
 
-`dependsOn` SHALL NOT be the criterion. The scheduler already guarantees that
-every declared dependency completed before the step starts, so the declared set
-is a strict subset of (3). This replaces the earlier "declared `dependsOn` only"
-scoping, which wrongly excluded completed non-declared siblings that
-classification admits — a step could then be denied capture of a read the
-admissibility rule would have accepted.
+Narrowing SHALL NOT cost a read edge, because reads do not come from inotify at
+all. That is what makes the scope safe to shrink, and it holds only because the
+layer prefixes are configured separately (below).
 
-The value SHALL be an enumeration rather than a single root because the
-read-only mount of the analysis tree is **flat**: no directory has exactly this
-set as its contents, so the only covering root is the mount root, and that root
-covers every sibling step's tree as well.
-
-**Known limitation, stated rather than implied away**: the watcher walks its
-configured dirs once at container start and never re-walks, so a sibling that
-completes *after* this sandbox was created is not inotify-watched for the
-remainder of this step. That is under-capture, conservative in the same
-direction as the completion gate, and such a read remains capturable by the
-in-process hooks (below).
+Excluding `data/` also removes the only **unbounded** term from the walk.
+`data/` is user-staged and its directory count follows the shape of the input
+dataset, as does a sibling's output tree whenever a step writes per-entity
+directories. Neither is bounded by anything the harness controls, and the walk is
+a startup cost paid before the child process spawns. What remains is bounded by
+what this step itself created.
 
 `PROVENANCE_DATA_PREFIXES` SHALL be configured **independently** of
 `PROVENANCE_WATCH_DIRS`, and SHALL NOT be derived from it. The in-container
@@ -155,9 +151,9 @@ internals) SHALL NOT appear in the frame.
 
 #### Scenario: Input read under the resource mount is captured
 
-- **GIVEN** an analysis mounted at `/{resourceId}` and a sandbox created for one of its steps, whose watch dirs include `/{resourceId}/data`
+- **GIVEN** an analysis mounted at `/{resourceId}` and a sandbox whose watch dirs do NOT include `/{resourceId}/data`
 - **WHEN** a script reads `/{resourceId}/data/inputs/Lab/counts.csv`
-- **THEN** the exec frame's `reads` includes that path
+- **THEN** the exec frame's `reads` includes that path, because the hook that intercepted the open filters on the mount-root prefix rather than on the watch dirs
 
 #### Scenario: Library read is not captured
 
@@ -165,24 +161,26 @@ internals) SHALL NOT appear in the frame.
 - **WHEN** a script imports a package from `/mnt/libs`
 - **THEN** the exec frame's `reads` does NOT include any `/mnt/libs` path
 
-#### Scenario: A running sibling's directory is not watched
+#### Scenario: No tree but the step's own is watched
 
 - **GIVEN** step `T4S1` of run `run-002` with `dependsOn: ["qc"]`, a sibling `qc` that is `completed`, and a sibling `T2S2` that is `running` when `T4S1`'s sandbox is created
 - **WHEN** `buildMountPlan` composes the sandbox for `T4S1`
-- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/data`, `/{resourceId}/runs/run-002/T4S1`, and `/{resourceId}/runs/run-002/qc`, and does NOT contain `/{resourceId}/runs/run-002/T2S2` or the mount root `/{resourceId}`
+- **THEN** `PROVENANCE_WATCH_DIRS` is exactly `/{resourceId}/runs/run-002/T4S1`, containing neither `/{resourceId}/data`, nor either sibling's tree, nor the mount root `/{resourceId}`
 - **AND** `T2S2` creating and deleting `output/_ct_for_r_BRAF.csv` while `T4S1` runs produces no entry in any `T4S1` exec frame
 
-#### Scenario: A completed non-declared sibling is both watched and admissible
+#### Scenario: A completed non-declared sibling is unwatched yet admissible
 
-- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, and a sibling `norm` that is NOT in `de`'s `dependsOn` but whose status is `completed` when `de`'s sandbox is created
-- **WHEN** `buildMountPlan` composes the sandbox for `de` and `de` later reads `/{resourceId}/runs/run-002/norm/output/norm.csv`
-- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/runs/run-002/norm`, the read appears in the exec frame, and classification admits it as `source: "upstream"` — capture scope and admissibility agree, where `dependsOn`-based scoping would have watched nothing and silently lost an edge the gate accepts
+- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, and a sibling `norm` that is NOT in `de`'s `dependsOn` but whose status is `completed` when `de`'s exec is submitted
+- **WHEN** `de` reads `/{resourceId}/runs/run-002/norm/output/norm.csv` and a hook intercepts the open
+- **THEN** `PROVENANCE_WATCH_DIRS` does NOT contain `/{resourceId}/runs/run-002/norm`, yet the read still appears in the exec frame and classification admits it as `source: "upstream"`
+- **AND** capture scope did not decide admissibility — being unwatched costs the edge nothing, because inotify was never the source of reads
 
-#### Scenario: A sibling that completes after sandbox creation is not watched but stays capturable
+#### Scenario: Admissibility tracks each exec's submit time, not sandbox creation
 
-- **GIVEN** step `de` whose sandbox was created while sibling `norm` was `running`, so `/{resourceId}/runs/run-002/norm` is absent from `PROVENANCE_WATCH_DIRS`, and `norm` reaches `completed` before `de` submits a later exec
-- **WHEN** that exec's command itself opens `/{resourceId}/runs/run-002/norm/output/norm.csv`
-- **THEN** inotify does not report the read — the watcher walked once at container start and never re-walks — while the in-process hook that intercepted the command's own open does report it, because `PROVENANCE_DATA_PREFIXES` still covers `/{resourceId}`, and the read is admissible under the submit-time snapshot
+- **GIVEN** step `de` whose sandbox was created while sibling `norm` was still `running`, and `norm` reaching `completed` before `de` submits a later exec
+- **WHEN** that later exec's command opens `/{resourceId}/runs/run-002/norm/output/norm.csv`
+- **THEN** the read is admissible, because each exec snapshots the completed set at its own submit time rather than inheriting one fixed at sandbox creation
+- **AND** the same read performed by an earlier exec, submitted while `norm` was still running, is rejected — the sandbox is shared but the snapshot is per-exec
 
 ## ADDED Requirements
 

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/explicit-input-classification/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/explicit-input-classification/spec.md
@@ -1,0 +1,327 @@
+# explicit-input-classification — delta
+
+## MODIFIED Requirements
+
+### Requirement: classifyReadPath resolves five classification branches by prefix
+
+`classifyReadPath(relativePath, ownStepId, ownRunId, dependsOn?, completedSteps?)` SHALL resolve in
+order, where `completedSteps` is the set of `(runId, stepId)` PAIRS — scoped to the
+ANALYSIS, not to a single run — whose `cortex_step_executions.status` was observed
+`completed` at the moment the reading exec was submitted:
+
+1. path under `data/` or `dataprofile/` → `{ source: "data" }`
+2. path under `runs/{ownRunId}/{ownStepId}/` → `{ source: "artifacts", stepId: ownStepId, runId: ownRunId }`
+3. path under `runs/{ownRunId}/{depStepId}/` for a `depStepId` in `dependsOn` → `{ source: "upstream", stepId: depStepId, runId: ownRunId }` when `(ownRunId, depStepId)` is in `completedSteps`, otherwise the inadmissible outcome
+4. any other path under `runs/{ownRunId}/` → a same-run sibling: extract the step id from the path → `{ source: "upstream", stepId, runId: ownRunId }` when `(ownRunId, stepId)` is in `completedSteps`, otherwise the inadmissible outcome
+5. any other path under `runs/` → a prior run: extract the run and step ids from the path → `{ source: "prior", stepId, runId }` when that extracted `(runId, stepId)` pair is in `completedSteps`, otherwise the inadmissible outcome
+
+Anything else SHALL classify as `{ source: "data" }`.
+
+The observation point SHALL be **exec-submit time**, and no wording in this capability
+SHALL substitute "started" for "submitted". Submit precedes start, so a step observed
+`completed` at submit time was necessarily completed before any read that exec performs.
+Reading the snapshot at submit time is therefore deliberately STRICTER than reading it at
+start time — it excludes a sibling that completed in the window between submit and start —
+and that strictness is intentional: an under-reported edge is a recoverable gap, a
+fabricated edge is a corrupt record. It is not an approximation of start-time to be
+loosened later.
+
+Every edge to a producing step SHALL be gated by ONE predicate: the edge is admissible if
+and only if that step's `cortex_step_executions.status` was `completed` when the reading
+exec was submitted — regardless of which run the producing step belongs to. An artifact is
+stable because the step that writes it finished, not because its run finished, so a prior
+run's completed step qualifies, a prior run's failed step does not, and a concurrent
+sibling does not. Branches 3, 4, and 5 therefore differ only in where the `(runId, stepId)`
+pair under test comes from — `dependsOn` paired with `ownRunId` for branch 3, the step id
+scraped from the path paired with `ownRunId` for branch 4, and both ids scraped from the
+path for branch 5 — never in what is asked of it.
+
+`completed` SHALL be the ONLY admissible status: `failed`, `canceled`, `skipped`,
+`blocked`, `running`, `queued`, and absent-from-the-set SHALL all yield the inadmissible
+outcome, because a step that has not completed never finalized its outputs and so has no
+stable artifact that could have been consumed. The gate applies to branch 3 as well as
+branch 4 — a declared `dependsOn` sibling that has somehow not completed is still
+inadmissible; declaration does not exempt it — and to branch 5 alike, which is therefore
+no longer an unconditional classification: it keeps its scraped ids and its `prior` source
+only under the gate. Branches 1 and 2 SHALL keep their current behaviour, and branch 3
+SHALL keep its current classification for a completed dependency.
+
+Branch 5 SHALL NOT consult the state of the referenced RUN, and this capability SHALL NOT
+read `cortex_runs` at all. A run that has finished says nothing about whether every step
+inside it finalized its outputs — a FAILED step's outputs stay unfinalized however its run
+ended — so a run-level predicate would admit, one run away, exactly what this rule rejects
+among the reading step's own siblings. One predicate over one table answers the question
+for every branch.
+
+When the completed-step snapshot is unavailable — the query that would have produced it
+failed, so there is no set rather than an empty one — every read naming a producing step
+for that exec (branches 3, 4, and 5 alike) SHALL be inadmissible. This fails closed, the
+same posture the "trackInputAccess uses caller classification, else path fallback"
+requirement specifies for its no-completed-step-set fallback: absence of an observation
+SHALL NEVER be read as "every producing step completed". An unavailable snapshot SHALL
+remain distinguishable from an obtained-but-empty one, because the resulting rejection is
+counted with reason `snapshot-unavailable` rather than `producing-step-not-completed` (see
+"feedExecFrame classifies each exec read from structured step context").
+
+`dependsOn` remains scheduling-only and is still NOT read authorization: a step may
+legitimately read a same-run sibling it never declared. But a sibling that has not
+completed has no stable artifact to have been consumed, so completion — not declaration —
+is the admissibility predicate.
+
+The inadmissible outcome SHALL be an explicit result distinguishable from every
+`source` classification (it is neither a `data` classification nor a thrown error), and
+it SHALL carry the scraped step id so the caller can attribute the drop. `classifyReadPath`
+SHALL remain pure: it receives `completedSteps` as its one admissibility argument and
+SHALL NOT query any store to determine admissibility — not the step-execution table, and
+not the run table, which this capability does not consult at all.
+
+#### Scenario: Own-artifact read classified as artifacts
+
+- **GIVEN** step `de` in run `run-002`
+- **WHEN** classifying `runs/run-002/de/output/results.csv`
+- **THEN** the result is `{ source: "artifacts", stepId: "de", runId: "run-002" }` and the completed-step set is not consulted
+
+#### Scenario: dependsOn read of a completed step classified as upstream
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and a completed-step set containing the pair `(run-002, qc)`
+- **WHEN** classifying `runs/run-002/qc/output/qc.csv`
+- **THEN** the result is `{ source: "upstream", stepId: "qc", runId: "run-002" }`
+
+#### Scenario: dependsOn sibling that has not completed is inadmissible
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and a completed-step set that does not contain `(run-002, qc)`
+- **WHEN** classifying `runs/run-002/qc/output/qc.csv`
+- **THEN** the result is the inadmissible outcome carrying step id `qc`, and no `upstream` classification is produced
+
+#### Scenario: Same-run sibling that has not completed is inadmissible
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and a completed-step set containing the pair `(run-002, qc)`
+- **WHEN** classifying `runs/run-002/norm/output/norm.csv` where `norm` is not in `dependsOn` and `(run-002, norm)` is not in the completed-step set
+- **THEN** the result is the inadmissible outcome carrying step id `norm`, and the read is dropped rather than classified `upstream`
+
+#### Scenario: Same-run sibling outside dependsOn that has completed is upstream
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and a completed-step set containing the pairs `(run-002, qc)` and `(run-002, norm)`
+- **WHEN** classifying `runs/run-002/norm/output/norm.csv` where `norm` is not in `dependsOn`
+- **THEN** the result is `{ source: "upstream", stepId: "norm", runId: "run-002" }` — completion, not declaration, admits the edge
+
+#### Scenario: Sibling observed running is inadmissible
+
+- **GIVEN** step `de` in run `run-002` and sibling `T5S1` observed with status `running` at exec-submit time, so it is absent from the completed-step set
+- **WHEN** classifying `runs/run-002/T5S1/output/_ct_for_r_BRAF.csv`
+- **THEN** the result is the inadmissible outcome carrying step id `T5S1`, so two steps running in parallel have no lineage relationship
+
+#### Scenario: Sibling observed failed is inadmissible
+
+- **GIVEN** step `de` in run `run-002` and sibling `qc` observed with status `failed`, so it is absent from the completed-step set
+- **WHEN** classifying `runs/run-002/qc/output/qc.csv`
+- **THEN** the result is the inadmissible outcome carrying step id `qc`, because a failed step's outputs were never finalized
+
+#### Scenario: Sibling that completed between submit and start is still inadmissible
+
+- **GIVEN** step `de` in run `run-002` and sibling `norm`, which was `running` when `de`'s exec was submitted and reached `completed` before that exec started
+- **WHEN** classifying `runs/run-002/norm/output/norm.csv` against the submit-time snapshot
+- **THEN** the result is the inadmissible outcome carrying step id `norm` — the submit-time reading is deliberately stricter than a start-time reading, and SHALL NOT be relaxed to admit this edge
+
+#### Scenario: Prior-run read of a completed step classified via path extraction
+
+- **GIVEN** step `de` in run `run-002` and a completed-step set containing the pair `(run-001, de)`
+- **WHEN** classifying `runs/run-001/de/output/prior.csv`
+- **THEN** the pair tested is the one extracted from the path, and the result is `{ source: "prior", stepId: "de", runId: "run-001" }` — a prior run's completed step is admissible on the same predicate as a same-run sibling
+
+#### Scenario: Prior-run read of a failed step is inadmissible
+
+- **GIVEN** step `de` in run `run-002` and a prior run `run-001` whose step `qc` was observed `failed`, so `(run-001, qc)` is absent from the completed-step set even though `run-001` itself has finished
+- **WHEN** classifying `runs/run-001/qc/output/partial.csv`
+- **THEN** the result is the inadmissible outcome carrying step id `qc`, and no `prior` classification is produced — `qc` never finalized its outputs, and its run having finished does not change that
+
+#### Scenario: Prior-run read of a step still running is inadmissible
+
+- **GIVEN** step `de` in run `run-002` and another run `run-003` over the same workspace whose step `norm` is observed `running`, so `(run-003, norm)` is absent from the completed-step set
+- **WHEN** classifying `runs/run-003/norm/output/norm.csv`
+- **THEN** the result is the inadmissible outcome carrying step id `norm`, and no `prior` classification is produced — a running step is still mutating its directory whether or not it belongs to this run
+
+#### Scenario: An unavailable snapshot makes every producing-step read inadmissible
+
+- **GIVEN** step `de` in run `run-002` for which the completed-step snapshot query failed, so no completed-step set exists for this exec
+- **WHEN** classifying `runs/run-002/qc/output/qc.csv`, where `qc` is a declared `dependsOn` sibling, and `runs/run-001/de/output/prior.csv`, a prior run's step
+- **THEN** both results are the inadmissible outcome, carrying step ids `qc` and `de` respectively — classification fails closed and SHALL NOT treat the missing snapshot as "every producing step completed"
+
+### Requirement: feedExecFrame classifies each exec read from structured step context
+
+`feedExecFrame(args: FeedExecFrameArgs)` SHALL translate one sandbox-server exec
+provenance frame into the step's `ProvenanceCollector`: for each read in the frame it
+SHALL strip the `/{resourceId}/` mount prefix, classify the analysis-relative path with
+`classifyReadPath(rel, collector.stepId, collector.runId, collector.dependsOn, completedSteps)`,
+and record it via `collector.trackInputAccess(mountRoot, rel, null, context)`.
+
+`feedExecFrame` SHALL receive the analysis-scoped set of `(runId, stepId)` pairs observed
+`completed` at exec-submit time, and SHALL pass it through to `classifyReadPath`
+unmodified. It SHALL receive no second, run-level admissibility input: one set answers for
+same-run siblings and prior runs alike.
+
+When classification returns the inadmissible outcome, `feedExecFrame` SHALL NOT call
+`trackInputAccess` for that read. The ref never enters the collector, so it never becomes
+an attestation target and can never be registered as a lineage edge.
+
+Each rejection SHALL be observable: `feedExecFrame` SHALL log it through the injected
+`Logger` seam with the ref path, the scraped step id, and that step's observed status as
+structured fields, and SHALL increment the `lineageEdgeRejected` metric
+(`cortex.lineage.edge_rejected`), tagged `agent_id`, `step_id`, and `reason`. `reason`
+SHALL be one of exactly two values:
+
+- `producing-step-not-completed` — a snapshot was obtained and the producing step's `(runId, stepId)` pair was not in it. This covers the same-run sibling and the prior-run step identically, because they are rejected by one rule and separating them would imply two;
+- `snapshot-unavailable` — no observation existed for this exec, so the read failed closed.
+
+`lineageEdgeRejected` SHALL be a counter of its own, distinct from reconcile's
+`lineageInputDropped` (`cortex.artifact.reconcile.input_dropped`). The two count different
+events at different sites, and this change SHALL NOT add a reason to the reconcile
+counter: its `reason` set stays exactly `directory`, `container-prefix`, and
+`workspace-root` (see the `artifact-manifest` capability).
+
+It SHALL remain best-effort: a disabled or absent frame records the command with no
+inputs and no writes, an inadmissible read is dropped rather than fatal, and it SHALL NOT
+throw.
+
+#### Scenario: Frame read of a completed sibling classified from collector context
+
+- **GIVEN** a collector for step `de` in run `run-002` with `dependsOn: ["qc"]` and a completed-step set containing the pair `(run-002, qc)`
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-002/qc/output/qc.csv`
+- **THEN** `trackInputAccess` is called with context `{ source: "upstream", stepId: "qc", runId: "run-002" }`
+
+#### Scenario: Frame read of a running sibling is dropped before the collector
+
+- **GIVEN** a collector for step `T4S1` in run `run-002` and sibling `T2S2` observed `running` at exec-submit time
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-002/T2S2/logs/run_gsea.log`
+- **THEN** `trackInputAccess` is not called for that read, the ref is absent from the collector's inputs, and no attestation target is created for it
+
+#### Scenario: Rejected sibling edge is logged and metered
+
+- **GIVEN** a collector for step `T4S1` in run `run-002` and sibling `T2S2` observed `running` at exec-submit time
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-002/T2S2/output/wikipathways_symbols.gmt`
+- **THEN** a record is emitted through the injected `Logger` carrying the ref path, step id `T2S2`, and status `running`, and `lineageEdgeRejected` is incremented with `reason = "producing-step-not-completed"`
+- **AND** `lineageInputDropped` is NOT incremented for that read
+
+#### Scenario: Rejected prior-run edge is metered under the same reason
+
+- **GIVEN** a collector for step `de` in run `run-002` and a prior run `run-001` whose step `qc` was observed `failed`, so `(run-001, qc)` is absent from the completed-step set
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-001/qc/output/partial.csv`
+- **THEN** `trackInputAccess` is not called for that read and `lineageEdgeRejected` is incremented with `reason = "producing-step-not-completed"` — the same reason a same-run sibling's rejection carries, because it is the same rule
+
+#### Scenario: Prior-run read of a completed step reaches the collector
+
+- **GIVEN** a collector for step `de` in run `run-002` and a completed-step set containing the pair `(run-001, qc)`
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-001/qc/output/qc.csv`
+- **THEN** `trackInputAccess` is called with context `{ source: "prior", stepId: "qc", runId: "run-001" }` and `lineageEdgeRejected` is not incremented
+
+#### Scenario: An unavailable snapshot is metered as its own reason
+
+- **GIVEN** a collector for step `de` in run `run-002` whose completed-step snapshot query failed, so no set was supplied for this exec
+- **WHEN** a frame reports a read of `/{resourceId}/runs/run-002/qc/output/qc.csv`
+- **THEN** the read is dropped before the collector and `lineageEdgeRejected` is incremented with `reason = "snapshot-unavailable"`, distinguishing a failed observation from a producing step observed not-completed
+
+#### Scenario: Inadmissible read does not fail the exec
+
+- **WHEN** every read in a frame classifies as inadmissible
+- **THEN** `feedExecFrame` records the command execution with those reads dropped and does not throw
+
+#### Scenario: Disabled frame records the command with no inputs
+
+- **WHEN** `feedExecFrame` is called with a `provenance` frame marked `disabled`
+- **THEN** it records the command execution with no inputs and no writes, and does not throw
+
+### Requirement: trackInputAccess uses caller classification, else path fallback
+
+`ProvenanceCollector.trackInputAccess(mountPath, relativePath, hash, context?)` SHALL use
+a provided `InputClassificationContext` directly; when none is provided it SHALL fall
+back to `classifyReadPath` over its own `stepId`/`runId`/`dependsOn`. Re-reading the same
+`mountPath:relativePath` SHALL return the already-tracked ref.
+
+The fallback SHALL fail closed. When no completed-step set is available to the collector,
+a path that resolves to a producing step SHALL be treated as INADMISSIBLE: a same-run
+sibling (branch 3 or branch 4) SHALL NOT be tracked as an `upstream` input, and another
+run's step (branch 5) SHALL NOT be tracked as a `prior` input. One missing observation
+disqualifies both, because both are decided by the same predicate. The no-context path
+therefore cannot silently reintroduce an ungated edge of either kind, and absence of an
+observation SHALL never be read as "every producing step completed" — this is the same
+fail-closed posture "classifyReadPath resolves five classification branches by prefix"
+specifies for an unavailable snapshot, stated here for the collector's own fallback rather
+than contradicting it. The `data` and `artifacts` branches of the fallback SHALL keep
+their current behaviour.
+
+#### Scenario: Caller provides upstream classification
+
+- **WHEN** `trackInputAccess(mountPath, relativePath, null, { source: "upstream", stepId: "qc", runId: "run-002" })` is called
+- **THEN** the resulting InputRef has `source: "upstream"`, `stepId: "qc"`, `runId: "run-002"` and no path parsing occurs
+
+#### Scenario: No context falls back to path classification
+
+- **WHEN** `trackInputAccess(mountPath, relativePath, null)` is called without a context for a `data/` path
+- **THEN** the collector classifies the read via `classifyReadPath` using its own `stepId`/`runId`/`dependsOn`, yielding `{ source: "data" }`
+
+#### Scenario: No-context sibling read fails closed
+
+- **GIVEN** a collector for step `de` in run `run-002` with no completed-step set available
+- **WHEN** `trackInputAccess(mountPath, "runs/run-002/norm/output/norm.csv", null)` is called without a context
+- **THEN** the read is treated as inadmissible and no `upstream` InputRef is tracked for it
+
+#### Scenario: No-context prior-run read fails closed
+
+- **GIVEN** a collector for step `de` in run `run-002` with no completed-step set available
+- **WHEN** `trackInputAccess(mountPath, "runs/run-001/de/output/prior.csv", null)` is called without a context
+- **THEN** the read is treated as inadmissible and no `prior` InputRef is tracked for it, even though `run-001` has long since finished
+
+#### Scenario: Re-read returns the already-tracked ref
+
+- **GIVEN** `trackInputAccess` has already tracked `mountPath:relativePath`
+- **WHEN** the same `mountPath:relativePath` is tracked again
+- **THEN** the already-tracked ref is returned and no reclassification occurs
+
+### Requirement: Prior-run classification is the one documented path-extraction fallback
+
+Path-segment extraction SHALL be confined to the classification branches that genuinely
+have no structured alternative — the same-run sibling branch (branch 4), which scrapes the
+step id, and the prior-run branch (branch 5), which scrapes the run and step ids — and
+SHALL NOT appear in any other branch. The prior-run branch is no longer the only such
+site: branch 4 also extracts a step id from the path, so "the one path-extraction
+fallback" SHALL be read as the confinement rule, not as a count.
+
+Each extraction site SHALL carry an in-code comment stating why the fallback exists there:
+a read under `runs/{ownRunId}/{otherStepId}/…` matches neither the step's own ids nor a
+`dependsOn` entry, and a read under `runs/{otherRunId}/…` matches neither the step's own
+run nor a `dependsOn` entry, so in both cases the path segments are the only available
+source for the identity the outcome carries — `{source: "prior", runId, stepId}` for
+branch 5, and the producing step id for branch 4. The comment SHALL describe only code
+that exists — it SHALL NOT reference declarations, types, or plumbing absent from the
+tree.
+
+The extracted identity SHALL also be the key the gate tests, not merely a label on the
+result: branch 5 SHALL look up the `(runId, stepId)` pair it scraped from the path, and
+branch 4 SHALL look up its scraped step id paired with `ownRunId`. Extraction that
+produced the outcome's identity but not the membership test would let a branch classify
+one step while admitting on the strength of another.
+
+Branch 4's and branch 5's scraped ids SHALL survive rejection: when either branch yields
+the inadmissible outcome, the extracted id SHALL ride on that outcome, because it is the
+only thing that makes the drop attributable to a producing step in the drop record's
+structured fields (see "feedExecFrame classifies each exec read from structured step
+context"). An inadmissible outcome that carries no step id SHALL NOT be conformant.
+
+#### Scenario: Comment exists at each extraction site
+
+- **WHEN** a developer reads the same-run sibling branch and the prior-run classification branch
+- **THEN** each carries a comment stating why path extraction is the only source for the identity that branch produces, with no references to nonexistent declarations
+- **AND** no other classification branch parses path segments
+
+#### Scenario: A rejected sibling read still names its producing step
+
+- **GIVEN** step `de` in run `run-002` and a read of `runs/run-002/norm/output/norm.csv` where `(run-002, norm)` is absent from the completed-step set
+- **WHEN** the path is classified
+- **THEN** the inadmissible outcome carries the scraped step id `norm`, so the drop is attributable in logs rather than anonymous
+
+#### Scenario: The pair scraped from a prior-run path is the key the gate tests
+
+- **GIVEN** step `de` in run `run-002`, a read of `runs/run-001/qc/output/qc.csv`, and a completed-step set containing `(run-002, qc)` but not `(run-001, qc)`
+- **WHEN** the path is classified
+- **THEN** the pair looked up is `(run-001, qc)` — the one extracted from the path — so the result is the inadmissible outcome carrying step id `qc`, and the same-run `qc` entry does NOT admit it
+- **AND** a rejected prior-run read carries its scraped step id exactly as a rejected sibling read does

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/sandbox-provenance-tracking/spec.md
@@ -1,0 +1,275 @@
+# sandbox-provenance-tracking — delta
+
+## ADDED Requirements
+
+### Requirement: Provenance capture is scoped to the immutable set — data, the step's own tree, and completed siblings
+
+The container's `PROVENANCE_WATCH_DIRS` SHALL enumerate, for a given step, exactly:
+
+1. the analysis `data/` tree — `/{resourceId}/data`,
+2. the step's own run tree — `/{resourceId}/runs/{runId}/{stepId}`, omitted when the mount plan emits no read-write step mount (a read-only sandbox), since no such tree exists,
+3. `/{resourceId}/runs/{runId}/{siblingStepId}` for every sibling step of the **same run** whose status is `completed` at sandbox-creation time — one entry per completed sibling.
+
+It SHALL NOT be set to the analysis resource mount root (`/{resourceId}`). The read-only
+mount of the analysis tree is **flat** — no single directory has exactly this set as its
+contents — so the value SHALL be an enumeration of absolute container paths rather than one
+root. A configured watch dir that does not exist when the container starts SHALL be skipped
+without failing the exec: provenance is best-effort and never fails a command.
+
+Completion is the criterion because a completed step's directory is **immutable** — it will
+never be written again — so watching it costs nothing in churn, *and* its reads are admissible
+under the completion gate (see the exec-provenance-lineage spec, "A sibling lineage edge
+requires the producing step to have completed"). A **running** sibling's tree SHALL NOT be
+watched, which is exactly the churn that caused the defect this change exists to remove.
+
+`dependsOn` SHALL NOT be the criterion. The scheduler already guarantees that every declared
+dependency completed before the step starts, so the declared set is a strict subset of (3).
+Scoping to declared dependencies alone was wrong because it excluded completed non-declared
+siblings that classification admits.
+
+**Known limitation — the watch set is fixed at container start.** The watcher walks each
+configured dir once when the container starts and never re-walks, so a sibling that completes
+*after* this sandbox was created is not inotify-watched for the remainder of the sandbox's
+life. That is under-capture, conservative in the same direction as the completion gate, and it
+is not a capture hole: a read the command itself performs under such a tree is still observed
+by the in-container hooks, whose prefix filter is configured independently of the watch dirs
+(see "inotify provides verification channel for all file operations").
+
+This narrowing is **noise reduction at the capture layer, not the correctness rule**. What an
+observed read is allowed to assert is decided by the harness when it classifies the read (see
+the explicit-input-classification and exec-provenance-lineage specs); narrowing the watch scope
+only keeps unusable observations out of the frame. It also relieves the watcher's **pre-existing**
+watch budget — the recursive walk is capped at `maxInotifyWatches` (1000), a bound this
+capability already carries and this change neither introduces nor alters — by reducing the
+number of directories the walk has to cover.
+
+#### Scenario: A running sibling's directory is not watched
+
+- **GIVEN** step `T4S1` of run `run-002`, and a sibling step `T2S2` in the same run whose status is `running` when `T4S1`'s sandbox is created
+- **WHEN** the sandbox for `T4S1` is created and its watch dirs are configured
+- **THEN** `PROVENANCE_WATCH_DIRS` does NOT contain `/{resourceId}/runs/run-002/T2S2` or the mount root `/{resourceId}`, and no watch is added anywhere under `T2S2`'s tree
+- **AND** `T2S2` creating and deleting `output/_ct_for_r_BRAF.csv` while `T4S1` runs produces no entry in any `T4S1` exec frame
+
+#### Scenario: A completed sibling is watched whether or not it is declared
+
+- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, and a sibling `norm` that `de` does not declare, both `qc` and `norm` being `completed` when `de`'s sandbox is created
+- **WHEN** the sandbox for `de` is created
+- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/runs/run-002/qc` **and** `/{resourceId}/runs/run-002/norm` — membership follows observed completion, not declaration
+- **AND** a read of `/{resourceId}/runs/run-002/norm/output/norm.csv` is captured and appears in the exec frame's `reads`
+
+#### Scenario: The data tree and the step's own tree are watched
+
+- **GIVEN** step `de` of run `run-002`
+- **WHEN** the sandbox for `de` is created
+- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/data` and `/{resourceId}/runs/run-002/de`
+- **AND** a read of `/{resourceId}/data/inputs/Lab/counts.csv` and a write of `/{resourceId}/runs/run-002/de/output/tmm.csv` both appear in the exec frame
+
+#### Scenario: A sibling that completes after sandbox creation is not watched but stays capturable
+
+- **GIVEN** step `de` whose sandbox was created while sibling `norm` was `running`, and `norm` subsequently reaching `completed`
+- **WHEN** a `de` command later reads `/{resourceId}/runs/run-002/norm/output/norm.csv`
+- **THEN** no inotify watch exists under `norm`'s tree — the walk is not repeated — yet the in-container hook that intercepted the open reports the path, since the layer prefixes are not derived from the watch dirs, and the read reaches the frame
+- **AND** whether that read may assert lineage is decided by classification against the completed-step snapshot, not by whether it was inotify-watched
+
+#### Scenario: A missing watch dir does not fail the command
+
+- **GIVEN** a configured watch dir that does not exist in the container (a completed sibling whose tree was never created, or a read-only sandbox with no step tree)
+- **WHEN** a command executes
+- **THEN** the watcher skips that dir, the remaining watch dirs are watched normally, and the exec completes with a provenance frame
+
+### Requirement: Reaching the inotify watch budget is observable to the harness
+
+Reaching the pre-existing `maxInotifyWatches` cap SHALL be observable to the harness. When the
+watcher's recursive walk stops adding watches at the cap, the sandbox-server SHALL surface that
+fact — as a signal on the exec `provenance` frame (a flag, or the count of directories left
+unwatched) or as a counter the harness increments on receipt — and the harness SHALL record it
+through the injected `Logger` with the run's structured identifiers. An in-container
+`log.Printf` alone SHALL NOT be a conforming
+realization: that line never reaches the harness log, so watch-budget exhaustion silently
+degrades capture — the same class of blind spot as the silently fabricated edges this change
+exists to remove.
+
+The cap itself is unchanged and is not introduced here: it is `maxInotifyWatches` in
+`images/sandbox-base/server/provenance_inotify_linux.go:16`, and the degraded behaviour on
+reaching it (warn, then watch only the top-level directories) is already specified by "inotify
+provides verification channel for all file operations". This requirement adds observability
+only.
+
+Exhaustion SHALL NOT fail the exec: capture is best-effort, so the signal rides alongside a
+normal completion rather than turning a degraded capture into a failed command.
+
+This signal counts **capture degradation**, not a rejected edge. It SHALL NOT be counted on
+`lineageEdgeRejected` (`cortex.lineage.edge_rejected`, tagged `agent_id`, `step_id`, `reason`),
+which counts lineage edges rejected at classification, nor on `lineageInputDropped`
+(`cortex.artifact.reconcile.input_dropped`), which stays reconcile's with its existing reasons
+only.
+
+#### Scenario: Watch-budget exhaustion reaches the harness
+
+- **GIVEN** a step whose configured watch dirs contain more subdirectories than `maxInotifyWatches`
+- **WHEN** the watcher walks them at container start and stops adding watches at the cap
+- **THEN** the completion payload carries a watch-budget signal alongside the provenance frame, and the harness records it through the injected `Logger` with `runId`, `stepId`, and `execId` as structured fields
+- **AND** the in-container log line is not the only record of the degradation
+
+#### Scenario: Exhaustion degrades capture without failing the step
+
+- **GIVEN** the same step, with the watcher having fallen back to watching only the top-level directories
+- **WHEN** the command completes
+- **THEN** the exec completes normally with a provenance frame carrying whatever was captured, and the step does NOT fail
+
+#### Scenario: A run inside the budget carries no signal
+
+- **GIVEN** a step whose configured watch dirs walk to fewer watches than the cap
+- **WHEN** the command completes
+- **THEN** no watch-budget signal is present on the frame and no exhaustion record is logged
+
+## MODIFIED Requirements
+
+### Requirement: inotify provides verification channel for all file operations
+
+The sandbox-server SHALL use inotify to watch the configured watch dirs during command
+execution for `IN_CREATE`, `IN_DELETE`, `IN_MOVED_FROM`, and `IN_MOVED_TO` events. Inotify
+operates as a **verification layer** over the reports the in-container layers send: an
+operation observed only by inotify SHALL be surfaced — folded into the frame as a write or a
+delete, or logged as an untracked alert — rather than silently lost.
+
+A bare `IN_OPEN` SHALL NOT by itself be reported as a read. `IN_OPEN` fires on opens for
+**writing** and on opens performed by processes unrelated to the command, so it cannot on its
+own establish that the command consumed the file as an input. The mode-aware Python and R
+hooks (Layer 1) and the LD_PRELOAD hook (Layer 2) classify by open mode and SHALL remain the
+authoritative read signal. The requirement is the absence of the unsupported read, not one
+mechanism: omitting `IN_OPEN` from the watch mask, and retaining `IN_OPEN` while suppressing
+any `IN_OPEN`-derived read whose path was also observed created or written during the same
+exec, are both conforming realizations. No read SHALL enter the exec provenance frame on the
+strength of an `IN_OPEN` alone.
+
+Since `inotify_add_watch` is per-directory (not recursive), the watcher SHALL walk each
+configured watch dir at startup and add a watch on each subdirectory. If the configured trees
+are too deep or too large (> 1000 watches), the watcher SHALL log a warning and watch only the
+top-level directories — the pre-existing `maxInotifyWatches` bound, which this change neither
+introduces nor alters and whose exhaustion SHALL additionally be surfaced per "Reaching the
+inotify watch budget is observable to the harness".
+
+The inotify watcher SHALL be started before the child process is spawned and stopped after the
+child process exits (with a short drain window for late events). The watcher SHALL use
+`golang.org/x/sys/unix` raw inotify syscalls (no CGO required).
+
+The data directories to watch SHALL be configurable via the `PROVENANCE_WATCH_DIRS`
+environment variable (comma-separated list of absolute paths, default: `/data`).
+`PROVENANCE_WATCH_DIRS` and `PROVENANCE_DATA_PREFIXES` SHALL be configured **independently**,
+and the sandbox-server SHALL NOT derive the in-container layer prefixes from the watch dirs.
+Only inotify observes the shared filesystem, so only inotify needs the narrow scope: the
+in-container hooks (the Python audit hook, the R hooks, and the LD_PRELOAD `provtrack.c`)
+intercept only **their own process's** opens — LD_PRELOAD interposition and interpreter-level
+hooks cannot observe another container's writes — so their prefix filter MAY remain the
+analysis resource mount root `/{resourceId}`, unchanged. In production the harness's
+`buildMountPlan` sets `PROVENANCE_WATCH_DIRS` to the enumerated, step-scoped list required by
+"Provenance capture is scoped to the immutable set — data, the step's own tree, and completed
+siblings" — never to the mount root — while `PROVENANCE_DATA_PREFIXES` stays the mount root.
+
+The consequence is intended: a legitimate cross-step or prior-run read performed by the command
+itself remains capturable through the hooks even when its path is not inotify-watched, and
+reaches the frame where classification decides whether it may assert lineage — a visible,
+counted drop rather than an invisible non-observation. Keeping the prefixes at the mount root
+also preserves the canonicalization and bounds behaviour the prefix layer performs (see "The
+sandbox-server activates the in-container layers per command").
+
+#### Scenario: inotify observes a file creation inside gVisor
+
+- **GIVEN** a sandbox container running under gVisor with the inotify watcher active on the configured watch dirs
+- **WHEN** a script creates `/{resourceId}/runs/{runId}/{stepId}/output/result.csv`
+- **THEN** the inotify watcher receives an `IN_CREATE` event for `result.csv` and records it as a write
+
+#### Scenario: inotify watches nested subdirectories
+
+- **GIVEN** a configured watch dir `/{resourceId}/runs/{runId}/{stepId}` containing `output/sub/`
+- **WHEN** the inotify watcher starts
+- **THEN** watches are added on `/{resourceId}/runs/{runId}/{stepId}/`, its `output/`, and its `output/sub/`
+- **AND** a file created at `/{resourceId}/runs/{runId}/{stepId}/output/sub/file.csv` triggers an event attributed to that directory
+
+#### Scenario: The layer prefixes are not narrowed to the watch dirs
+
+- **GIVEN** a sandbox whose `PROVENANCE_WATCH_DIRS` omits the tree of a sibling that was still running at sandbox creation
+- **WHEN** the command itself reads a file under that sibling's tree and the LD_PRELOAD hook intercepts the open
+- **THEN** the path matches `PROVENANCE_DATA_PREFIXES` (the mount root `/{resourceId}`), the datagram is sent, and the read appears in the frame despite there being no watch on that tree
+- **AND** the harness drops it at classification if the sibling was not `completed` in the exec's snapshot — the capture layer does not make that decision
+
+#### Scenario: A write-open does not produce a read edge
+
+- **GIVEN** a sandbox with the watcher active on the step's own run tree
+- **WHEN** the command opens `/{resourceId}/runs/{runId}/{stepId}/output/result.csv` for writing, and the mode-aware layers report it with `"op": "write"`
+- **THEN** the exec provenance frame records that path as a write
+- **AND** the frame's `reads` does NOT contain it, even though the open raised an `IN_OPEN`
+
+#### Scenario: An open no layer reported does not become a read
+
+- **GIVEN** a command execution where Layer 1 and Layer 2 reported reads for files A and B
+- **WHEN** inotify observes opens of A, B, and C
+- **THEN** the exec provenance frame's `reads` contains A and B and does NOT contain C
+- **AND** any retained inotify evidence for C is confined to an untracked-read diagnostic, never a lineage read
+
+#### Scenario: inotify works under runc
+
+- **GIVEN** a sandbox container running under runc (no gVisor)
+- **WHEN** a script creates a file under a configured watch dir
+- **THEN** the inotify watcher receives an `IN_CREATE` event for it
+
+### Requirement: The sandbox-server activates the in-container layers per command
+
+For each `POST /exec` command, the sandbox-server SHALL inject the provenance
+layers into the child process environment when their files are present:
+`PYTHONPATH` prepended with `/opt/provenance` (Layer 1 Python), `R_PROFILE`
+pointing at `/opt/provenance/Rprofile.site` (Layer 1 R), `LD_PRELOAD` pointing at
+`/opt/provenance/provtrack.so` (Layer 2), `PROVENANCE_SOCKET` set to the
+per-command socket path, and `PROVENANCE_DATA_PREFIXES` set from the server's
+**own** configured prefix list — the analysis resource mount root — never derived
+from `PROVENANCE_WATCH_DIRS`, which is configured independently and narrower.
+After the child exits, the server SHALL drain the socket, combine the socket
+reports with the inotify verification channel, and surface the result as the exec
+`provenance` frame.
+
+The server SHALL canonicalize every reported path — collapsing `.` and `..`
+segments — and SHALL record it only if the canonical path lies **within** a
+configured data prefix, at the single point where all layers converge. A prefix
+root itself SHALL NOT be recorded: a read of the mount root is a directory, never
+an attestable file.
+
+Each in-container layer filters by string prefix on whatever path its caller
+passed, and an absolute path need not be canonical: `/{resourceId}/..` literally
+begins with the prefix `/{resourceId}/` yet names its parent, so it survives
+every layer's own filter. The host maps such a path to a location above the
+analysis tree, where it cannot attest it. The layer filters are therefore an
+optimization — they keep a datagram off the socket — and this re-check is the
+boundary that decides what a frame may contain. Canonicalization is **lexical**:
+resolving symlinks would make the reported path disagree with the name the
+workload used, and the layers report names, not inodes.
+
+#### Scenario: Layers are injected for a Python command
+
+- **GIVEN** a sandbox-server with the provenance files installed at `/opt/provenance`
+- **WHEN** a command is executed via `POST /exec`
+- **THEN** the child process environment carries `PYTHONPATH` including `/opt/provenance`, `R_PROFILE`, `LD_PRELOAD`, `PROVENANCE_SOCKET`, and `PROVENANCE_DATA_PREFIXES` set to the configured prefix list — the mount root — and NOT to the enumerated watch dirs
+
+#### Scenario: Socket reports fold into the exec frame
+
+- **WHEN** a script reads `/{resourceId}/data/inputs/test.csv` via `pandas.read_csv` and the command completes
+- **THEN** the exec `provenance` frame's `reads` contains that path
+- **AND** does not contain stdlib paths like `/usr/lib/python3/...`
+
+#### Scenario: A read of the mount's parent is not reported
+
+- **GIVEN** a configured prefix of `/{resourceId}/` and a layer reporting a read of `/{resourceId}/data/..` (the analysis mount root, which the workload may legitimately open)
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/{resourceId}`, the prefix root itself and therefore a directory rather than an attestable file, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A traversal out of the tree is not reported
+
+- **GIVEN** a layer reporting a read of `/{resourceId}/data/../../../etc/passwd`
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/etc/passwd`, which lies outside every configured prefix, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A non-canonical in-tree path folds onto its canonical name
+
+- **GIVEN** a configured prefix of `/{resourceId}`, R's `normalizePath(mustWork = FALSE)` reporting a write to `/{resourceId}/runs/r1/T3S1/scripts/../output/enrich.csv` (it leaves `..` intact whenever a component does not exist yet — the common case for a new output file), and the inotify layer reporting `/{resourceId}/runs/r1/T3S1/output/enrich.csv`
+- **WHEN** the server records both reports
+- **THEN** the frame carries ONE entry, under the canonical path, attributed to both layers

--- a/harness/openspec/changes/gate-lineage-on-step-completion/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/specs/sandbox-provenance-tracking/spec.md
@@ -2,101 +2,118 @@
 
 ## ADDED Requirements
 
-### Requirement: Provenance capture is scoped to the immutable set — data, the step's own tree, and completed siblings
+### Requirement: Provenance capture is scoped to the step's own run tree
 
-The container's `PROVENANCE_WATCH_DIRS` SHALL enumerate, for a given step, exactly:
-
-1. the analysis `data/` tree — `/{resourceId}/data`,
-2. the step's own run tree — `/{resourceId}/runs/{runId}/{stepId}`, omitted when the mount plan emits no read-write step mount (a read-only sandbox), since no such tree exists,
-3. `/{resourceId}/runs/{runId}/{siblingStepId}` for every sibling step of the **same run** whose status is `completed` at sandbox-creation time — one entry per completed sibling.
-
-It SHALL NOT be set to the analysis resource mount root (`/{resourceId}`). The read-only
-mount of the analysis tree is **flat** — no single directory has exactly this set as its
-contents — so the value SHALL be an enumeration of absolute container paths rather than one
-root. A configured watch dir that does not exist when the container starts SHALL be skipped
+The container's `PROVENANCE_WATCH_DIRS` SHALL name exactly one path — the step's own run tree,
+`/{resourceId}/runs/{runId}/{stepId}` — and SHALL be empty when the mount plan emits no
+read-write step mount (a read-only sandbox), which writes nowhere. It SHALL NOT be set to the
+analysis resource mount root (`/{resourceId}`), to the `data/` tree, or to any sibling step's
+tree. A configured watch dir that does not exist when the container starts SHALL be skipped
 without failing the exec: provenance is best-effort and never fails a command.
 
-Completion is the criterion because a completed step's directory is **immutable** — it will
-never be written again — so watching it costs nothing in churn, *and* its reads are admissible
-under the completion gate (see the exec-provenance-lineage spec, "A sibling lineage edge
-requires the producing step to have completed"). A **running** sibling's tree SHALL NOT be
-watched, which is exactly the churn that caused the defect this change exists to remove.
+The criterion is **what this exec mutates**, not what it may read. inotify reports only
+creations, deletions, and moves — never reads, since a bare `IN_OPEN` may not be reported as one
+(see "inotify provides verification channel for all file operations"). The only tree this exec
+writes is its own. The `data/` tree is staged before the run and frozen for its duration, and a
+completed sibling is immutable by the completion gate's own premise, so neither can emit a
+create, delete, or move while this step runs. Watching them would register watches that
+structurally cannot fire.
 
-`dependsOn` SHALL NOT be the criterion. The scheduler already guarantees that every declared
-dependency completed before the step starts, so the declared set is a strict subset of (3).
-Scoping to declared dependencies alone was wrong because it excluded completed non-declared
-siblings that classification admits.
+Narrowing SHALL NOT cost a read edge, because reads do not come from inotify. A read the command
+itself performs — of `data/`, of a sibling's tree, or of a prior run — is intercepted by the
+in-container hooks, whose prefix filter (`PROVENANCE_DATA_PREFIXES`) is the analysis resource
+mount root and is configured independently of the watch dirs. The hooks are the authoritative
+read signal; inotify verifies mutations.
 
-**Known limitation — the watch set is fixed at container start.** The watcher walks each
-configured dir once when the container starts and never re-walks, so a sibling that completes
-*after* this sandbox was created is not inotify-watched for the remainder of the sandbox's
-life. That is under-capture, conservative in the same direction as the completion gate, and it
-is not a capture hole: a read the command itself performs under such a tree is still observed
-by the in-container hooks, whose prefix filter is configured independently of the watch dirs
-(see "inotify provides verification channel for all file operations").
+Excluding `data/` also removes the only **unbounded** term from the walk. `data/` is user-staged
+and its directory count follows the shape of the input dataset, so a per-sample cohort makes it
+arbitrarily large; a sibling's output tree grows the same way whenever a step writes per-entity
+directories. Neither is bounded by anything the harness controls, and the walk is a startup cost
+paid before the child process spawns. What remains — the step's own tree — holds only the
+directories `precreateStepTree` created, plus, on a retry, whatever the previous attempt left.
 
-This narrowing is **noise reduction at the capture layer, not the correctness rule**. What an
-observed read is allowed to assert is decided by the harness when it classifies the read (see
-the explicit-input-classification and exec-provenance-lineage specs); narrowing the watch scope
-only keeps unusable observations out of the frame. It also relieves the watcher's **pre-existing**
-watch budget — the recursive walk is capped at `maxInotifyWatches` (1000), a bound this
-capability already carries and this change neither introduces nor alters — by reducing the
-number of directories the walk has to cover.
+**Accepted limitation — reads by uninstrumented processes are not captured.** A process the
+hooks cannot instrument (a statically-linked binary, which `LD_PRELOAD` does not apply to, or a
+runtime with no hook) performs reads that no layer observes. This is deliberate rather than an
+oversight: inotify cannot attribute an event to the process that caused it, so restoring
+`IN_OPEN` to recover those reads would also manufacture reads from other containers' opens of
+the same shared tree — including opens of *completed* siblings, which the completion gate
+admits, so the gate does not contain the damage. An under-reported read leaves a lineage graph
+that is incomplete; a fabricated one leaves a graph that is wrong, and only the second is
+unrecoverable by inspection.
 
-#### Scenario: A running sibling's directory is not watched
+This narrowing is **capture-layer scoping, not the correctness rule**. What an observed read is
+allowed to assert is decided by the harness when it classifies the read (see the
+explicit-input-classification and exec-provenance-lineage specs).
 
-- **GIVEN** step `T4S1` of run `run-002`, and a sibling step `T2S2` in the same run whose status is `running` when `T4S1`'s sandbox is created
-- **WHEN** the sandbox for `T4S1` is created and its watch dirs are configured
-- **THEN** `PROVENANCE_WATCH_DIRS` does NOT contain `/{resourceId}/runs/run-002/T2S2` or the mount root `/{resourceId}`, and no watch is added anywhere under `T2S2`'s tree
+#### Scenario: The step's own tree is the only watch dir
+
+- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, a completed sibling `norm`, and a running sibling `T2S2`
+- **WHEN** the sandbox for `de` is created
+- **THEN** `PROVENANCE_WATCH_DIRS` is exactly `/{resourceId}/runs/run-002/de`
+- **AND** it contains neither `/{resourceId}/data`, nor `/{resourceId}/runs/run-002/qc`, nor `/{resourceId}/runs/run-002/norm`, nor `/{resourceId}/runs/run-002/T2S2`, nor the mount root `/{resourceId}`
+
+#### Scenario: A write to the step's own tree is verified by inotify
+
+- **GIVEN** a sandbox for step `de` of run `run-002`
+- **WHEN** the command creates `/{resourceId}/runs/run-002/de/output/tmm.csv`
+- **THEN** the inotify watcher receives an `IN_CREATE` event for it and the exec frame records that path as a write
+
+#### Scenario: The data tree is not watched, and its reads are still captured
+
+- **GIVEN** a sandbox whose `PROVENANCE_WATCH_DIRS` omits `/{resourceId}/data`
+- **WHEN** the command reads `/{resourceId}/data/inputs/Lab/counts.csv` and an in-container hook intercepts the open
+- **THEN** the path matches `PROVENANCE_DATA_PREFIXES` (the mount root), the read reaches the exec frame's `reads`, and it classifies as `source: "data"`
+- **AND** no inotify watch under `data/` was required for that edge
+
+#### Scenario: No sibling's tree is watched, completed or running
+
+- **GIVEN** step `T4S1` of run `run-002`, a completed sibling `qc`, and a sibling `T2S2` still running
+- **WHEN** the sandbox for `T4S1` is created
+- **THEN** no watch is added anywhere under either sibling's tree
 - **AND** `T2S2` creating and deleting `output/_ct_for_r_BRAF.csv` while `T4S1` runs produces no entry in any `T4S1` exec frame
+- **AND** a `T4S1` command that itself reads `/{resourceId}/runs/run-002/qc/output/qc.csv` still has that read captured by the hooks, where classification decides whether it may assert lineage
 
-#### Scenario: A completed sibling is watched whether or not it is declared
+#### Scenario: A read-only sandbox configures no watch dirs
 
-- **GIVEN** step `de` of run `run-002` with `dependsOn: ["qc"]`, and a sibling `norm` that `de` does not declare, both `qc` and `norm` being `completed` when `de`'s sandbox is created
-- **WHEN** the sandbox for `de` is created
-- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/runs/run-002/qc` **and** `/{resourceId}/runs/run-002/norm` — membership follows observed completion, not declaration
-- **AND** a read of `/{resourceId}/runs/run-002/norm/output/norm.csv` is captured and appears in the exec frame's `reads`
-
-#### Scenario: The data tree and the step's own tree are watched
-
-- **GIVEN** step `de` of run `run-002`
-- **WHEN** the sandbox for `de` is created
-- **THEN** `PROVENANCE_WATCH_DIRS` contains `/{resourceId}/data` and `/{resourceId}/runs/run-002/de`
-- **AND** a read of `/{resourceId}/data/inputs/Lab/counts.csv` and a write of `/{resourceId}/runs/run-002/de/output/tmm.csv` both appear in the exec frame
-
-#### Scenario: A sibling that completes after sandbox creation is not watched but stays capturable
-
-- **GIVEN** step `de` whose sandbox was created while sibling `norm` was `running`, and `norm` subsequently reaching `completed`
-- **WHEN** a `de` command later reads `/{resourceId}/runs/run-002/norm/output/norm.csv`
-- **THEN** no inotify watch exists under `norm`'s tree — the walk is not repeated — yet the in-container hook that intercepted the open reports the path, since the layer prefixes are not derived from the watch dirs, and the read reaches the frame
-- **AND** whether that read may assert lineage is decided by classification against the completed-step snapshot, not by whether it was inotify-watched
+- **GIVEN** a mount plan that emits no read-write step mount
+- **WHEN** the sandbox is created
+- **THEN** `PROVENANCE_WATCH_DIRS` is empty, the watcher registers no watches, and the exec completes with a provenance frame carrying whatever the hooks reported
 
 #### Scenario: A missing watch dir does not fail the command
 
-- **GIVEN** a configured watch dir that does not exist in the container (a completed sibling whose tree was never created, or a read-only sandbox with no step tree)
+- **GIVEN** a configured watch dir that does not exist in the container
 - **WHEN** a command executes
-- **THEN** the watcher skips that dir, the remaining watch dirs are watched normally, and the exec completes with a provenance frame
+- **THEN** the watcher skips that dir and the exec completes with a provenance frame
 
-### Requirement: Reaching the inotify watch budget is observable to the harness
+### Requirement: The inotify watch budget is configurable, and every form of exhaustion is observable
 
-Reaching the pre-existing `maxInotifyWatches` cap SHALL be observable to the harness. When the
-watcher's recursive walk stops adding watches at the cap, the sandbox-server SHALL surface that
-fact — as a signal on the exec `provenance` frame (a flag, or the count of directories left
-unwatched) or as a counter the harness increments on receipt — and the harness SHALL record it
-through the injected `Logger` with the run's structured identifiers. An in-container
-`log.Printf` alone SHALL NOT be a conforming
-realization: that line never reaches the harness log, so watch-budget exhaustion silently
-degrades capture — the same class of blind spot as the silently fabricated edges this change
-exists to remove.
+The watcher's cap on registered watches SHALL be configurable through the environment, in
+keeping with every neighbouring knob in this capability (`PROVENANCE_WATCH_DIRS`,
+`PROVENANCE_DATA_PREFIXES`, the tree-diff interval). A bare compile-time constant is not a
+conforming realization: the value bounds a walk over user-shaped trees, so the one deployment
+that outgrows it must be able to raise it without a rebuilt image. The shipped default remains
+the pre-existing `maxInotifyWatches` (1000), which this change neither introduces nor alters.
 
-The cap itself is unchanged and is not introduced here: it is `maxInotifyWatches` in
-`images/sandbox-base/server/provenance_inotify_linux.go:16`, and the degraded behaviour on
-reaching it (warn, then watch only the top-level directories) is already specified by "inotify
-provides verification channel for all file operations". This requirement adds observability
-only.
+Reaching that cap SHALL be observable to the harness. When the walk stops adding watches, the
+sandbox-server SHALL surface the fact — as a signal on the exec `provenance` frame (a flag, or
+the count of directories left unwatched) or as a counter the harness increments on receipt — and
+the harness SHALL record it through the injected `Logger` with the run's structured identifiers.
+An in-container `log.Printf` alone SHALL NOT be a conforming realization: that line never
+reaches the harness log, so exhaustion would silently degrade capture — the same class of blind
+spot as the silently fabricated edges this change exists to remove.
 
-Exhaustion SHALL NOT fail the exec: capture is best-effort, so the signal rides alongside a
-normal completion rather than turning a degraded capture into a failed command.
+**Kernel-side exhaustion SHALL be reported distinctly from the configured cap.** Registering a
+watch can fail because the kernel's own per-uid limit
+(`/proc/sys/fs/inotify/max_user_watches`) is exhausted, which is a different condition with a
+different remedy: the configured cap is the harness declining to watch more, while `ENOSPC` is
+the host refusing. A failed registration SHALL NOT be silently skipped — it SHALL be counted and
+surfaced alongside the cap signal, distinguishable from it. Reporting only the self-imposed cap
+would leave the genuine resource failure exactly as invisible as it is today, which is the blind
+spot one layer down.
+
+Neither form of exhaustion SHALL fail the exec: capture is best-effort, so the signal rides
+alongside a normal completion rather than turning degraded capture into a failed command.
 
 This signal counts **capture degradation**, not a rejected edge. It SHALL NOT be counted on
 `lineageEdgeRejected` (`cortex.lineage.edge_rejected`, tagged `agent_id`, `step_id`, `reason`),
@@ -123,6 +140,19 @@ only.
 - **WHEN** the command completes
 - **THEN** no watch-budget signal is present on the frame and no exhaustion record is logged
 
+#### Scenario: The cap is raised without rebuilding the image
+
+- **GIVEN** a deployment whose step trees walk to more directories than the default cap
+- **WHEN** the operator sets the cap's environment variable to a higher value and a command executes
+- **THEN** the watcher registers watches up to the configured value rather than the shipped default, and no image rebuild was required
+
+#### Scenario: Kernel watch exhaustion is distinguishable from the configured cap
+
+- **GIVEN** a host whose `/proc/sys/fs/inotify/max_user_watches` is already exhausted by other processes, and a step whose walk stays well inside the configured cap
+- **WHEN** the watcher attempts to register a watch and the kernel returns `ENOSPC`
+- **THEN** the failure is counted and surfaced to the harness, distinguishable from a configured-cap refusal, and the exec still completes with whatever the hooks reported
+- **AND** the failure is not silently skipped, so degraded capture is never reported as a clean walk
+
 ## MODIFIED Requirements
 
 ### Requirement: inotify provides verification channel for all file operations
@@ -144,11 +174,11 @@ exec, are both conforming realizations. No read SHALL enter the exec provenance 
 strength of an `IN_OPEN` alone.
 
 Since `inotify_add_watch` is per-directory (not recursive), the watcher SHALL walk each
-configured watch dir at startup and add a watch on each subdirectory. If the configured trees
-are too deep or too large (> 1000 watches), the watcher SHALL log a warning and watch only the
-top-level directories — the pre-existing `maxInotifyWatches` bound, which this change neither
-introduces nor alters and whose exhaustion SHALL additionally be surfaced per "Reaching the
-inotify watch budget is observable to the harness".
+configured watch dir at startup and add a watch on each subdirectory. If the configured tree is
+too deep or too large, the watcher SHALL log a warning and watch only the top-level
+directories — the pre-existing `maxInotifyWatches` bound, which this change neither introduces
+nor alters in value, and whose configurability and exhaustion reporting are required by "The
+inotify watch budget is configurable, and every form of exhaustion is observable".
 
 The inotify watcher SHALL be started before the child process is spawned and stopped after the
 child process exits (with a short drain window for late events). The watcher SHALL use
@@ -163,9 +193,9 @@ in-container hooks (the Python audit hook, the R hooks, and the LD_PRELOAD `prov
 intercept only **their own process's** opens — LD_PRELOAD interposition and interpreter-level
 hooks cannot observe another container's writes — so their prefix filter MAY remain the
 analysis resource mount root `/{resourceId}`, unchanged. In production the harness's
-`buildMountPlan` sets `PROVENANCE_WATCH_DIRS` to the enumerated, step-scoped list required by
-"Provenance capture is scoped to the immutable set — data, the step's own tree, and completed
-siblings" — never to the mount root — while `PROVENANCE_DATA_PREFIXES` stays the mount root.
+`buildMountPlan` sets `PROVENANCE_WATCH_DIRS` to the step's own run tree alone, as required by
+"Provenance capture is scoped to the step's own run tree" — never to the mount root, the `data/`
+tree, or a sibling's tree — while `PROVENANCE_DATA_PREFIXES` stays the mount root.
 
 The consequence is intended: a legitimate cross-step or prior-run read performed by the command
 itself remains capturable through the hooks even when its path is not inotify-watched, and
@@ -189,10 +219,10 @@ sandbox-server activates the in-container layers per command").
 
 #### Scenario: The layer prefixes are not narrowed to the watch dirs
 
-- **GIVEN** a sandbox whose `PROVENANCE_WATCH_DIRS` omits the tree of a sibling that was still running at sandbox creation
-- **WHEN** the command itself reads a file under that sibling's tree and the LD_PRELOAD hook intercepts the open
+- **GIVEN** a sandbox whose `PROVENANCE_WATCH_DIRS` is the step's own run tree alone, omitting `data/` and every sibling's tree
+- **WHEN** the command itself reads a file under a sibling's tree and the LD_PRELOAD hook intercepts the open
 - **THEN** the path matches `PROVENANCE_DATA_PREFIXES` (the mount root `/{resourceId}`), the datagram is sent, and the read appears in the frame despite there being no watch on that tree
-- **AND** the harness drops it at classification if the sibling was not `completed` in the exec's snapshot — the capture layer does not make that decision
+- **AND** the harness rejects it at classification if the sibling was not `completed` in the exec's snapshot — the capture layer does not make that decision
 
 #### Scenario: A write-open does not produce a read edge
 

--- a/harness/openspec/changes/gate-lineage-on-step-completion/tasks.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/tasks.md
@@ -74,3 +74,15 @@
 - [ ] 9.1 Write a read-only audit that flags registered `upstream` edges which could not have been admissible, comparing the producing step's `completed_at` against the reading step's execution window in `cortex_step_executions`.
 - [ ] 9.2 Run it over existing analyses and report the blast radius. Known instance to expect: run `19110b58`, step `T4S1`, three fabricated edges to `T2S2` (`logs/run_gsea.log`, `output/wikipathways_symbols.gmt`, `scripts/run_gsea.py`).
 - [ ] 9.3 Decide with the user whether to purge, annotate, or leave flagged edges. Do not mutate registered provenance without that decision.
+
+## 10. Amendment — scope the watch set to the step's own tree
+
+Dropping `IN_OPEN` (task 6.6) removed inotify's ability to report reads at all, which invalidated the premise of the wider watch set: `data/` and completed siblings are immutable during the step, so they cannot emit the creates, deletes, and moves inotify still collects. They cost budget and yield nothing. Reads of them are captured by the process-local hooks, whose prefixes are configured independently (task 6.3), so narrowing costs no lineage edge.
+
+- [x] 10.1 Set `PROVENANCE_WATCH_DIRS` to the step's own run tree alone in `src/sandbox/mount-plan.ts`, and to empty for a read-only sandbox. It must not contain the mount root, `data/`, or any sibling's tree.
+- [x] 10.2 Remove the completed-sibling resolution that scoping made necessary: `resolveCompletedSiblings` in `src/sandbox/create-sandbox.ts`, `CreateSandboxMeta.completedSiblingStepIds`, `buildMountPlan`'s third parameter, and the docker/k8s client threading. Sandbox creation should no longer query step state at all.
+- [x] 10.3 Keep `queryCompletedStepsByAnalysis` — it is still the classification snapshot's source (task 4.1). Only the mount-plan caller goes away. Verify no other caller regressed.
+- [x] 10.4 Make the inotify watch cap configurable through the environment rather than a bare `const`, defaulting to the existing 1000. A value bounding a walk over user-shaped trees must be raisable without rebuilding the image.
+- [x] 10.5 Count and surface a failed `InotifyAddWatch` distinctly from a configured-cap refusal. A kernel `ENOSPC` is currently swallowed by `if err != nil { return nil }`, so the genuine resource failure stays as invisible as it was before task 6.7 — the same blind spot one layer down.
+- [x] 10.6 Update the mount-plan, docker-client, k8s-client, create-sandbox, and Go watcher tests to the narrowed scope; delete assertions that depended on siblings or `data/` being watched.
+- [x] 10.7 Re-run `tsc`, `bun test`, `go build ./... && go test ./...`, and `openspec validate --strict`.

--- a/harness/openspec/changes/gate-lineage-on-step-completion/tasks.md
+++ b/harness/openspec/changes/gate-lineage-on-step-completion/tasks.md
@@ -1,0 +1,76 @@
+## 1. State layer — observe completion
+
+- [x] 1.1 Add a query to `src/state/step-executions.ts` returning the set of `(runId, stepId)` pairs in an analysis whose `status` is `completed`. Scope it to `WHERE analysis_id = $1 AND status = 'completed'`, which uses the existing `idx_cortex_step_exec_analysis` index (`state/init.ts:102-103`); do not reuse `queryStepsByRun` and filter in memory.
+- [x] 1.2 Scope it to the analysis, not the run — the same predicate serves same-run siblings and `prior`-run reads, so one snapshot answers both and `cortex_runs` is never consulted.
+- [x] 1.3 Return it as a `ResultAsync<..., DbError>` consistent with the rest of the module. `completed` is the only admissible status — do not widen to "terminal", which would admit `failed`/`canceled`/`skipped` at step level and, via `cortex_runs`, `partial`/`failed`/`canceled` at run level.
+- [x] 1.4 Unit-test against the Postgres testcontainer (`withSchema`): rows in each of `running`/`completed`/`failed`/`canceled`/`skipped`/`blocked`, asserting only `completed` pairs return, that pairs from other runs of the SAME analysis are included, and that another analysis's rows are excluded.
+
+## 2. Classification — completion-gated admissibility
+
+- [x] 2.1 Add an explicit inadmissible outcome to the classification result type in `src/provenance/collector.ts`, distinguishable from every `source` value and from a thrown error, carrying the scraped step id so the caller can attribute the rejection.
+- [x] 2.2 Extend `classifyReadPath` with a single `completedSteps` parameter — an analysis-scoped set of `(runId, stepId)` pairs. Gate **both** branch 3 (`dependsOn` sibling) and branch 4 (same-run sibling) on membership of `(ownRunId, stepId)`: a declared dependency that has not completed is still inadmissible.
+- [x] 2.3 Keep branch 4 admitting a **completed** sibling that is not in `dependsOn` — completion, not declaration, is the gate. Over-tightening to "must be declared" would drop legitimate edges.
+- [x] 2.4 Gate branch 5 (`prior`) on membership of the `(runId, stepId)` pair extracted from the path — the same predicate as branches 3 and 4. A prior run's completed step is admissible; a prior run's failed step is not. Do not gate on run-level terminality: `cortex_runs` counts `partial`/`failed`/`canceled` as terminal (`runs.ts:121`), which would admit unfinalized outputs.
+- [x] 2.5 Keep `classifyReadPath` pure — `completedSteps` is a parameter, never queried inside. Leave branches 1 and 2 (`data`, `artifacts`) behaviourally unchanged.
+- [x] 2.6 Replace the in-code comment at the branch-4 site. The current text ("a read outside dependsOn is still a valid upstream input") is the premise being removed; state instead that a sibling which has not completed has no stable artifact to have been consumed. Do not describe the change itself — write the rationale a fresh reader meets tomorrow.
+- [x] 2.7 Make `trackInputAccess`'s no-context fallback fail closed: with no completed-step set available, a same-run sibling path is inadmissible and is not tracked as `upstream`. Absence of the set must never read as "every sibling completed".
+- [x] 2.8 Unit-test every branch per the `explicit-input-classification` delta scenarios, including running-sibling, failed-sibling, uncompleted-`dependsOn`, completed-non-dependency, prior-run-completed-step (admitted), and prior-run-failed-step (rejected) cases.
+
+## 3. Frame threading — reject before the collector
+
+- [x] 3.1 Thread the single `completedSteps` set through `FeedExecFrameArgs` in `src/provenance/exec-frame.ts` and pass it to `classifyReadPath` unmodified.
+- [x] 3.2 On the inadmissible outcome, skip `trackInputAccess` entirely so the ref never enters the collector and never becomes an attestation target. Do not track-then-drop at reconcile.
+- [x] 3.3 Log each rejection through the injected `Logger` seam with the ref path, scraped step id, and that step's observed status as structured fields — identifiers ride as fields, never interpolated into the message.
+- [x] 3.4 Add a **new** `lineageEdgeRejected` counter (`cortex.lineage.edge_rejected`) to `src/lib/metrics.ts`, tagged `agent_id`, `step_id`, `reason`, with reasons `producing-step-not-completed` and `snapshot-unavailable`. Leave reconcile's `lineageInputDropped` and its three existing reasons untouched — a counter named for a reconcile-time drop must not be incremented from classification.
+- [x] 3.5 Keep `feedExecFrame` best-effort and non-throwing; an all-inadmissible frame still records the command execution.
+- [x] 3.6 Unit-test the rejection path, including that the log record and the metric both fire and that the collector's inputs are empty afterwards.
+- [x] 3.7 Bind `src/lib/metrics.ts` instruments lazily, following the memoized pattern already used in `src/loop/metrics.ts` and `src/workflows/metrics.ts`. The module currently calls `metrics.getMeter("cortex")` at import (line 12), and it sits in `index.ts`'s static graph, so it evaluates before the embedder calls `initOtel()` (`cli/src/index.ts:15`, after the import at line 12). The OTel metrics API has no proxy upgrade, so every counter in this file — including the two pre-existing ones — binds to a NoopMeter permanently. Without this, the spec's "SHALL increment `lineageEdgeRejected`" is unsatisfiable in production.
+
+## 4. Snapshot the completed set — replay-safe
+
+- [x] 4.1 In `src/tools/workspace/execute-command.ts`, take the snapshot **before** submitting the exec. Submit time is the normative predicate; monotonicity then guarantees every id in it completed before any read the exec performs.
+- [x] 4.2 Wrap the snapshot in `ctx.runStep`. This tool is `executionMode: "workflow"` and runs unwrapped in the DBOS workflow body — an unwrapped query re-executes on replay and returns a larger completed-set, producing different lineage for the same run. This is the single most important correctness detail in the change.
+- [x] 4.3 On query failure, resolve the durable step to an explicit "snapshot unavailable" outcome rather than throwing — throwing would fail the exec, and provenance must never fail an exec. Do not `unwrapOrThrow` this particular error; return it as a discriminated value from inside the step.
+- [x] 4.4 Ensure the degraded outcome is itself checkpointed, so a replay classifies identically instead of succeeding where the original failed. A durable success path with a non-durable failure path reintroduces the determinism hazard through the error branch.
+- [x] 4.5 On the degraded path, treat every same-run sibling read as inadmissible, log at error level, and count with `reason: "snapshot-unavailable"`.
+- [x] 4.6 Add a workflow-shape test using `setupDbosForTests` asserting that a replayed step classifies against the originally snapshotted set — including a replay of the degraded outcome.
+
+## 5. Thread `dependsOn` to the collector
+
+- [x] 5.1 Add `dependsOn` to `SandboxStepInput` in `src/workflows/sandbox-step.ts`. Verified: the field does not exist and the identifier appears nowhere in that file, so this is a **durable DBOS workflow input shape change**, not a local edit.
+- [x] 5.2 Populate it from the plan step where the parent (`executeAnalysis`) starts each child workflow.
+- [x] 5.3 Make the field optional and degrade fail-closed when absent, so workflows persisted before this change still recover. Absence must not read as "declared nothing, therefore every sibling is a plain undeclared sibling".
+- [x] 5.4 Pass it when constructing `ProvenanceCollector` at `sandbox-step.ts:380-383`. It must not become the admissibility gate — it exists to distinguish a declared edge from an observed one in diagnostics.
+
+## 6. Sandbox image (Go) — narrow capture at the source
+
+- [x] 6.1 Change `buildMountPlan` in `src/sandbox/mount-plan.ts:140` to emit an enumerated `PROVENANCE_WATCH_DIRS`: `/{resourceId}/data`, the step's own `runs/{runId}/{stepId}`, and `runs/{runId}/{siblingStepId}` for every sibling `completed` at sandbox creation. Watch the immutable set, not the declared set — a completed step never writes again, so it cannot churn.
+- [x] 6.2 Resolve the completed-sibling list in the caller and pass it into `buildMountPlan` so the plan stays a pure function of its inputs rather than acquiring a hidden database dependency its tests cannot express.
+- [x] 6.3 Decouple `PROVENANCE_DATA_PREFIXES` from `PROVENANCE_WATCH_DIRS` in `images/sandbox-base/server/provenance.go:198-199`. The hooks observe only their own process's opens and were never a contamination source, so their prefixes stay at the mount root while inotify narrows.
+- [x] 6.4 Update `mount-plan.test.ts`, `docker-client.test.ts`, and `k8s-client.test.ts`, which currently assert `PROVENANCE_WATCH_DIRS === "/an-1"`.
+- [x] 6.5 Skip a configured watch dir that does not exist without failing sandbox creation.
+- [x] 6.6 In `provenance_inotify_linux.go`, stop reporting a bare `IN_OPEN` as a read — either drop `IN_OPEN` from the watch mask (lines 59-60) or suppress an `IN_OPEN`-derived read when a write/create for the same path was seen in the same exec. Preserve inotify's verification role; the mode-aware hooks remain the authoritative read signal.
+- [x] 6.7 Make exhaustion of the **pre-existing** 1000-watch budget (`maxInotifyWatches`) observable to the harness rather than only an in-container `log.Printf` that never reaches the harness log. Silent under-capture is the same blind spot as the silent fabricated edges.
+- [x] 6.8 Update the Go tests covering `classifyInotifyMask`, `recordOp`, and prefix derivation.
+- [ ] 6.9 Rebuild `sandbox-base` and bump the image version. This phase ships on the image's cadence — phases 1-5 must be independently sufficient for the reported failure so there is no window where lineage is wrong.
+
+## 7. Spec prose not reachable by a delta
+
+- [x] 7.1 Correct the false premise in `openspec/specs/exec-provenance-lineage/spec.md` Purpose (~line 16): "inputs are immutable for the step — the analysis tree is mounted read-only". Read-only bounds only this step's writes; siblings mutate their own read-write directories.
+- [x] 7.2 Correct the same claim in `openspec/specs/artifact-manifest/spec.md` Purpose (~lines 26-28).
+- [x] 7.3 Confirm the `exec-provenance-lineage` and `sandbox-provenance-tracking` deltas describe `PROVENANCE_WATCH_DIRS` and `PROVENANCE_DATA_PREFIXES` identically — two specs must not define the same env vars differently.
+
+## 8. Verification
+
+- [ ] 8.1 Run `bun run format:file` on every changed file under `src/` (only `src/`, never markdown or specs).
+- [ ] 8.2 Run `tsc -p tsconfig.json` and `bun test` from `harness/`.
+- [ ] 8.3 Run `openspec validate gate-lineage-on-step-completion --strict`.
+- [ ] 8.4 Exercise the package boundary with the `harness:verify` skill, since the CLI does not yet consume this change.
+- [ ] 8.5 Reproduce the original failure shape: two concurrent steps where one reads a path under the other's directory, and assert no lineage edge is created in either direction and neither step fails.
+- [ ] 8.6 Cover the boundary the design resolves conservatively: a sibling that completes *between* the snapshot and the read is rejected for that exec, and admitted on the step's next exec.
+
+## 9. Follow-up — historical lineage audit (does not gate phases 1-8)
+
+- [ ] 9.1 Write a read-only audit that flags registered `upstream` edges which could not have been admissible, comparing the producing step's `completed_at` against the reading step's execution window in `cortex_step_executions`.
+- [ ] 9.2 Run it over existing analyses and report the blast radius. Known instance to expect: run `19110b58`, step `T4S1`, three fabricated edges to `T2S2` (`logs/run_gsea.log`, `output/wikipathways_symbols.gmt`, `scripts/run_gsea.py`).
+- [ ] 9.3 Decide with the user whether to purge, annotate, or leave flagged edges. Do not mutate registered provenance without that decision.

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -23,9 +23,13 @@ SHA-256 hashes from disk at `reconcileManifestWithDisk` for **every surviving
 output** and **every tracked input**, and registers those. Output hashes must be
 re-read because outputs mutate during the step (a long-running script flushes
 after the frame fires; an atomic-rename swaps content under a stable byte count);
-input hashes can be read from disk now because inputs are immutable for the
-step's lifetime (the analysis tree is mounted read-only; the only writable mount
-is the step's own directory). This makes the registered hash equal `sha256sum` of
+input hashes can be read from disk now because every input reconcile attests is
+stable by then — staged `data`, the step's own directory, and a producing step
+that had already `completed` when the reading exec was submitted. Read-only
+mounting is not what secures this: it bounds what *this* step may write, while
+every sibling has its own directory mounted read-write and churns it freely. An
+edge to a step that had not completed is refused at classification, so it never
+becomes an attestation target. This makes the registered hash equal `sha256sum` of
 the bytes the sync target receives at upload time. The reconcile/register/sync
 stages are pulled out of the best-effort net: a tracked input **file** that is
 missing at reconcile, and a registry rejection, are **terminal** — they fail the

--- a/harness/openspec/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/specs/exec-provenance-lineage/spec.md
@@ -13,9 +13,17 @@ Lineage is content-attested and fail-fast (see the artifact-manifest spec). The
 sandbox provenance frame is path-only: it names the files a
 command read and wrote but never carries their bytes, so input refs arrive with
 empty hashes. `reconcileManifestWithDisk` fills those hashes from disk just
-before registration (inputs are immutable for the step — the analysis tree is
-mounted read-only), and an input that cannot be hashed is terminal rather than
+before registration, and an input that cannot be hashed is terminal rather than
 registered hashless (see the artifact-manifest spec for the reconcile rules).
+
+Deferring the hash to reconcile is sound only because every input it attests is
+stable by then. The read-only mount does not establish that: it bounds what
+*this* step may write, while every other step of the run has its own directory
+mounted read-write and mutates it freely, scratch files included. What makes an
+input stable is that the step producing it has finished — which is why a lineage
+edge is admissible only when the producing step was observed `completed` at the
+moment the reading exec was submitted, and why a concurrently running sibling
+contributes no edge in either direction.
 
 This is the OSS view of the seam. The OSS build exposes the `ArtifactRegistry`
 interface with `createNoopArtifactRegistry` as its local default; the live

--- a/harness/src/agents/sandbox/shared.ts
+++ b/harness/src/agents/sandbox/shared.ts
@@ -215,7 +215,7 @@ function createMarkExecActive(deps: SandboxAgentDeps): (execId: string) => Promi
  *  `readOnly` mode the write_file/edit_file pair is omitted; execute_command
  *  and the read tools stay. */
 function buildWorkspaceTools(deps: SandboxAgentDeps, readOnly: boolean): Tool[] {
-    const { step, sandboxClient, workspaceFs, pool, embedding, lineageCollector } = deps;
+    const { step, sandboxClient, workspaceFs, pool, embedding, lineageCollector, logger } = deps;
     // Registry tagging is a best-effort watchdog backstop (`run-exec.ts` already
     // swallows a throw here); fold a `DbError` into a no-op so a registry write
     // failure neither fails the exec nor surfaces as an unhandled rejection.
@@ -258,7 +258,17 @@ function buildWorkspaceTools(deps: SandboxAgentDeps, readOnly: boolean): Tool[] 
             deadlineMs: step.deadlineMs,
             defaultCwd: sandboxWorkingDir,
             markExecActive,
-            ...(lineageCollector ? { lineageCollector, mountRoot: `/${step.analysisId}` } : {}),
+            // `pool` and `analysisId` ride with the collector because they exist
+            // solely to snapshot which producing steps have completed — the
+            // admissibility gate for a lineage edge. Without them the tool runs
+            // fail-closed: no fabricated sibling edges, but no sibling lineage
+            // at all, so they belong to exactly the construction sites that
+            // asked for a collector.
+            ...(lineageCollector ? { lineageCollector, mountRoot: `/${step.analysisId}`, pool, analysisId: step.analysisId } : {}),
+            // The degraded-snapshot path reports at error level; an unwired
+            // logger would route that to the no-op sink and make a total loss of
+            // sibling lineage indistinguishable from having none to record.
+            ...(logger ? { logger } : {}),
         }),
         ...mutateTools,
         createReadFileTool(workspaceFs, hostWorkingDir),

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createCapturingLogger } from "../__tests__/setup/logger.js";
-import { ProvenanceCollector } from "../provenance/collector.js";
+import { completedStepKey, ProvenanceCollector } from "../provenance/collector.js";
 import { feedExecFrame } from "../provenance/exec-frame.js";
 import { reconcileManifestWithDisk } from "./reconcile-manifest.js";
 import { computeSha256File } from "../lib/fs-helpers.js";
@@ -37,6 +37,11 @@ async function setup(opts: { writeUpstream: boolean }) {
     feedExecFrame({
         collector,
         mountRoot: `/${RID}`,
+        // `qc` completed before this exec was submitted, so its output is an
+        // admissible upstream input — the precondition every reconcile case
+        // below assumes. Without it the read is refused at classification and
+        // never reaches attestation, which is a different test entirely.
+        completedSteps: new Set([completedStepKey("run-001", "qc")]),
         command: ["python3", "scripts/de.py"],
         exitCode: 0,
         durationMs: 100,

--- a/harness/src/execution/reconcile-manifest.ts
+++ b/harness/src/execution/reconcile-manifest.ts
@@ -27,7 +27,7 @@ import type { ProvenanceCollector } from "../provenance/collector.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { computeSha256File, hasValidContentHash } from "../lib/fs-helpers.js";
-import { artifactReconcileDropped, lineageInputDropped } from "../lib/metrics.js";
+import { recordArtifactReconcileDropped, recordLineageInputDropped } from "../lib/metrics.js";
 
 export interface ReconcileManifestInput {
     /** Absolute host root of the analysis's workspace tree. */
@@ -86,7 +86,7 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
                 logger.debug("dropping phantom entry", { path: entry.path });
                 collector.removeRecord(entry.path);
                 droppedCount++;
-                artifactReconcileDropped.add(1, { agent_id: agentId, step_id: stepId });
+                recordArtifactReconcileDropped({ agentId, stepId });
                 continue;
             }
             throw err;
@@ -100,7 +100,7 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
             logger.debug("dropping non-file entry", { path: entry.path });
             collector.removeRecord(entry.path);
             droppedCount++;
-            artifactReconcileDropped.add(1, { agent_id: agentId, step_id: stepId });
+            recordArtifactReconcileDropped({ agentId, stepId });
             continue;
         }
 
@@ -168,14 +168,14 @@ async function fillInputHashesFromDisk(
         const containerPrefix = `/${resourceId}`;
         if (ref.path !== containerPrefix && !ref.path.startsWith(containerPrefix + "/")) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, boundSite: "container-prefix" });
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "container-prefix" });
+            recordLineageInputDropped({ agentId, stepId, reason: "container-prefix" });
             collector.dropInput(ref);
             continue;
         }
         const hostPath = path.join(resourceRoot, ref.path.slice(containerPrefix.length + 1));
         if (hostPath !== resourceRoot && !hostPath.startsWith(resourceRoot + path.sep)) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, hostPath, boundSite: "workspace-root" });
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "workspace-root" });
+            recordLineageInputDropped({ agentId, stepId, reason: "workspace-root" });
             collector.dropInput(ref);
             continue;
         }
@@ -200,7 +200,7 @@ async function fillInputHashesFromDisk(
             // non-file drop above. A genuinely missing FILE (ENOENT) still fails fast
             // as drift; a directory is not drift.
             logger.debug("dropping non-file input from lineage", attestation);
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "directory" });
+            recordLineageInputDropped({ agentId, stepId, reason: "directory" });
             collector.dropInput(ref);
             continue;
         }

--- a/harness/src/lib/metrics.test.ts
+++ b/harness/src/lib/metrics.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The instruments must reach a `MeterProvider` registered AFTER this module was
+ * imported. `metrics.getMeter` resolves the provider when an instrument is created
+ * and the metrics API never upgrades a meter afterwards, so an instrument built at
+ * module load — before any embedder can register a provider — would record into the
+ * noop meter forever and export nothing. Every assertion below registers the
+ * provider first and then records, which is the ordering production runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { metrics } from "@opentelemetry/api";
+import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, type MetricData, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+
+import { __resetLineageMetricsForTest, recordArtifactReconcileDropped, recordLineageEdgeRejected, recordLineageInputDropped } from "./metrics.js";
+
+let exporter: InMemoryMetricExporter;
+let provider: MeterProvider;
+
+beforeEach(() => {
+    exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    // Long interval — every export in this suite is a manual forceFlush.
+    const reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 });
+    provider = new MeterProvider({ readers: [reader] });
+    metrics.setGlobalMeterProvider(provider);
+    __resetLineageMetricsForTest();
+});
+
+afterEach(async () => {
+    await provider.shutdown();
+    metrics.disable();
+    __resetLineageMetricsForTest();
+});
+
+async function collect(name: string): Promise<MetricData | undefined> {
+    await provider.forceFlush();
+    return exporter
+        .getMetrics()
+        .flatMap((rm) => rm.scopeMetrics)
+        .flatMap((sm) => sm.metrics)
+        .find((m) => m.descriptor.name === name);
+}
+
+describe("lineage and artifact-reconcile counters", () => {
+    it("exports a reconcile drop under its metric name and tags", async () => {
+        recordArtifactReconcileDropped({ agentId: "qc-agent", stepId: "qc" });
+
+        const metric = await collect("cortex.artifact.reconcile.dropped");
+        expect(metric).toBeDefined();
+        expect(metric!.dataPoints).toEqual([expect.objectContaining({ value: 1, attributes: { agent_id: "qc-agent", step_id: "qc" } })]);
+    });
+
+    it("exports an input drop tagged with its reconcile-time reason", async () => {
+        recordLineageInputDropped({ agentId: "qc-agent", stepId: "qc", reason: "directory" });
+
+        const metric = await collect("cortex.artifact.reconcile.input_dropped");
+        expect(metric).toBeDefined();
+        expect(metric!.dataPoints).toEqual([expect.objectContaining({ value: 1, attributes: { agent_id: "qc-agent", step_id: "qc", reason: "directory" } })]);
+    });
+
+    it("exports an edge rejection on a counter of its own, tagged with its classification-time reason", async () => {
+        recordLineageEdgeRejected({ agentId: "gsea-agent", stepId: "T4S1", reason: "producing-step-not-completed" });
+
+        const metric = await collect("cortex.lineage.edge_rejected");
+        expect(metric).toBeDefined();
+        expect(metric!.dataPoints).toEqual([
+            expect.objectContaining({ value: 1, attributes: { agent_id: "gsea-agent", step_id: "T4S1", reason: "producing-step-not-completed" } }),
+        ]);
+        // A reconcile-time drop counter must not move for a classification-time refusal.
+        expect(await collect("cortex.artifact.reconcile.input_dropped")).toBeUndefined();
+    });
+
+    it("omits agent_id rather than inventing one when the caller does not know it", async () => {
+        recordLineageEdgeRejected({ stepId: "T4S1", reason: "snapshot-unavailable" });
+
+        const metric = await collect("cortex.lineage.edge_rejected");
+        expect(metric!.dataPoints[0]!.attributes).toEqual({ step_id: "T4S1", reason: "snapshot-unavailable" });
+    });
+});

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -4,21 +4,93 @@
  * Instruments:
  *   - cortex.artifact.reconcile.dropped — counter for missing manifest entries
  *   - cortex.artifact.reconcile.input_dropped — counter for lineage input drops
+ *   - cortex.lineage.edge_rejected — counter for lineage edges refused at classification
+ *
+ * Instruments are created on first record, never at module load. `metrics.getMeter`
+ * resolves the global `MeterProvider` at creation time and the metrics API has no
+ * proxy that upgrades a meter afterwards (the trace API's `ProxyTracer` has no
+ * counterpart here), so an instrument built before a provider is registered stays
+ * bound to the noop meter for the life of the process and reaches no exporter.
+ * This module sits in `index.ts`'s static import graph, which is evaluated before
+ * an embedder's entry point runs a line — so import time is exactly the moment no
+ * provider is registered yet.
  */
 
-import { metrics } from "@opentelemetry/api";
+import { type Counter, metrics } from "@opentelemetry/api";
 
-const meter = metrics.getMeter("cortex");
+/** Why a tracked input ref was removed from lineage at reconcile. */
+export type LineageInputDropReason = "directory" | "container-prefix" | "workspace-root";
 
-export const artifactReconcileDropped = meter.createCounter("cortex.artifact.reconcile.dropped", {
-    description:
-        "Manifest entries dropped because their on-disk file was missing at " +
-        "registration time (writes-then-deletes, renames). Tagged by agent_id, step_id.",
-});
+/** Why an exec read was refused a lineage edge at classification. */
+export type LineageEdgeRejectionReason = "producing-step-not-completed" | "snapshot-unavailable";
 
-export const lineageInputDropped = meter.createCounter("cortex.artifact.reconcile.input_dropped", {
-    description:
-        "Tracked input reads dropped from lineage at reconcile because they are " +
-        "not content-attestable files of the analysis (directory reads, " +
-        "out-of-tree resolutions). Tagged by agent_id, step_id, reason.",
-});
+interface Instruments {
+    readonly artifactReconcileDropped: Counter;
+    readonly lineageInputDropped: Counter;
+    readonly lineageEdgeRejected: Counter;
+}
+
+let instruments: Instruments | undefined;
+
+function getInstruments(): Instruments {
+    if (instruments === undefined) {
+        const meter = metrics.getMeter("cortex");
+        instruments = {
+            artifactReconcileDropped: meter.createCounter("cortex.artifact.reconcile.dropped", {
+                description:
+                    "Manifest entries dropped because their on-disk file was missing at " +
+                    "registration time (writes-then-deletes, renames). Tagged by agent_id, step_id.",
+            }),
+            lineageInputDropped: meter.createCounter("cortex.artifact.reconcile.input_dropped", {
+                description:
+                    "Tracked input reads dropped from lineage at reconcile because they are " +
+                    "not content-attestable files of the analysis (directory reads, " +
+                    "out-of-tree resolutions). Tagged by agent_id, step_id, reason.",
+            }),
+            lineageEdgeRejected: meter.createCounter("cortex.lineage.edge_rejected", {
+                description:
+                    "Exec reads refused at classification because the producing step was not " +
+                    "observed `completed` when the exec was submitted, so no lineage edge was " +
+                    "created for them. Tagged by agent_id, step_id, reason " +
+                    "(producing-step-not-completed | snapshot-unavailable).",
+            }),
+        };
+    }
+    return instruments;
+}
+
+/** Record one manifest entry reconcile dropped for want of a file on disk. */
+export function recordArtifactReconcileDropped(args: { readonly agentId: string; readonly stepId: string }): void {
+    getInstruments().artifactReconcileDropped.add(1, { agent_id: args.agentId, step_id: args.stepId });
+}
+
+/** Record one input ref reconcile removed from a lineage the collector already held. */
+export function recordLineageInputDropped(args: { readonly agentId: string; readonly stepId: string; readonly reason: LineageInputDropReason }): void {
+    getInstruments().lineageInputDropped.add(1, { agent_id: args.agentId, step_id: args.stepId, reason: args.reason });
+}
+
+/**
+ * Record one edge never asserted, where `recordLineageInputDropped` records a ref
+ * removed from a lineage the collector already held. The two fire at different
+ * sites for different causes, so folding them together would make either counter —
+ * and any dashboard over it — misreport where the loss happened.
+ *
+ * `agentId` is left out of the tags rather than filled with a placeholder when the
+ * caller does not know it — an invented dimension value is indistinguishable from a
+ * real agent in an aggregation.
+ */
+export function recordLineageEdgeRejected(args: { readonly agentId?: string; readonly stepId: string; readonly reason: LineageEdgeRejectionReason }): void {
+    getInstruments().lineageEdgeRejected.add(1, {
+        ...(args.agentId === undefined ? {} : { agent_id: args.agentId }),
+        step_id: args.stepId,
+        reason: args.reason,
+    });
+}
+
+/**
+ * Drop the memoized instruments so the next record rebinds to a freshly-registered
+ * `MeterProvider`. Test-only — production registers its provider once at startup.
+ */
+export function __resetLineageMetricsForTest(): void {
+    instruments = undefined;
+}

--- a/harness/src/provenance/collector.test.ts
+++ b/harness/src/provenance/collector.test.ts
@@ -1,16 +1,21 @@
 /**
- * `ProvenanceCollector.recordFileToolWrite` contract tests — the file-tool
- * feed and its shared last-write-wins keyspace with the command feed.
+ * `ProvenanceCollector` contract tests — the write feeds and their shared
+ * last-write-wins keyspace, plus the completion gate on read classification.
  *
- * The two feeds accept paths in different shapes (the mutate seam hands
+ * The two write feeds accept paths in different shapes (the mutate seam hands
  * `recordFileToolWrite` an analysis-root-relative path; exec frames hand
  * `recordCommandExecution` a step-relative one), so these tests pin that both
  * normalize to the same step-relative key and the bidirectional unlink fires.
+ *
+ * The classification tests pin the admissibility rule: an edge to a producing
+ * step exists only when that step was observed `completed`, so a fabricated
+ * edge to a concurrent sibling — the failure this gate exists to prevent — is
+ * unrepresentable rather than merely unlikely.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { ProvenanceCollector } from "./collector.js";
+import { classifyReadPath, completedStepKey, ProvenanceCollector, type CompletedSteps } from "./collector.js";
 import type { ArtifactRecord } from "../execution/artifact-record.js";
 
 const RUN = "run-001";
@@ -65,5 +70,201 @@ describe("ProvenanceCollector.recordFileToolWrite", () => {
         expect(rec.producer).toEqual({ type: "file_tool", tool: "edit_file", timestamp: "2026-07-13T00:00:00.000Z" });
         expect(rec.inputs).toEqual([]);
         expect(rec.outputPath).toBe("output/x.csv");
+    });
+});
+
+// ── Classification ──────────────────────────────────────────────────
+
+/** The reading step's own coordinates for every classification test. */
+const OWN_RUN = "run-002";
+const OWN_STEP = "de";
+/** A run of the same analysis that is not the reading step's run. */
+const OTHER_RUN = "run-001";
+const DEPENDS_ON = ["qc"];
+
+/** Build a completed-step snapshot from `(runId, stepId)` pairs. */
+function completed(...pairs: [string, string][]): CompletedSteps {
+    return new Set(pairs.map(([runId, stepId]) => completedStepKey(runId, stepId)));
+}
+
+describe("classifyReadPath — branches that never consult completion", () => {
+    test("a data read is admissible with no snapshot at all", () => {
+        expect(classifyReadPath("data/inputs/f1/counts.csv", OWN_STEP, OWN_RUN, DEPENDS_ON)).toEqual({
+            admissible: true,
+            context: { source: "data" },
+        });
+        expect(classifyReadPath("dataprofile/summary.json", OWN_STEP, OWN_RUN, DEPENDS_ON)).toEqual({
+            admissible: true,
+            context: { source: "data" },
+        });
+    });
+
+    test("a read of the step's own artifacts is admissible with no snapshot at all", () => {
+        // The step is writing this directory itself; its own completion is not
+        // a question it can be asked about.
+        expect(classifyReadPath(`runs/${OWN_RUN}/${OWN_STEP}/output/results.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON)).toEqual({
+            admissible: true,
+            context: { source: "artifacts", stepId: OWN_STEP, runId: OWN_RUN },
+        });
+        expect(classifyReadPath(`runs/${OWN_RUN}/${OWN_STEP}/output/results.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed())).toEqual({
+            admissible: true,
+            context: { source: "artifacts", stepId: OWN_STEP, runId: OWN_RUN },
+        });
+    });
+
+    test("a path under neither data/ nor runs/ falls through to data", () => {
+        expect(classifyReadPath("reports/rep-1/index.html", OWN_STEP, OWN_RUN, DEPENDS_ON, completed())).toEqual({
+            admissible: true,
+            context: { source: "data" },
+        });
+    });
+});
+
+describe("classifyReadPath — same-run siblings gate on completion", () => {
+    test("a completed dependsOn sibling is upstream", () => {
+        const result = classifyReadPath(`runs/${OWN_RUN}/qc/output/qc.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "qc"]));
+
+        expect(result).toEqual({ admissible: true, context: { source: "upstream", stepId: "qc", runId: OWN_RUN } });
+    });
+
+    test("a dependsOn sibling that has not completed is inadmissible — declaration does not exempt it", () => {
+        const result = classifyReadPath(`runs/${OWN_RUN}/qc/output/qc.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed());
+
+        expect(result).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "qc" });
+    });
+
+    test("a completed sibling outside dependsOn is upstream — completion, not declaration, admits the edge", () => {
+        const result = classifyReadPath(`runs/${OWN_RUN}/norm/output/norm.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "qc"], [OWN_RUN, "norm"]));
+
+        expect(result).toEqual({ admissible: true, context: { source: "upstream", stepId: "norm", runId: OWN_RUN } });
+    });
+
+    test("an undeclared sibling that has not completed is inadmissible and names its step", () => {
+        const result = classifyReadPath(`runs/${OWN_RUN}/norm/output/norm.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "qc"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "norm" });
+    });
+
+    test("a sibling observed running is inadmissible — two parallel steps have no lineage relationship", () => {
+        // `running` is absent from the snapshot, which is the whole of what
+        // classification sees about it.
+        const result = classifyReadPath(`runs/${OWN_RUN}/T5S1/output/_ct_for_r_BRAF.csv`, "T4S1", OWN_RUN, [], completed([OWN_RUN, "T2S2"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "T5S1" });
+    });
+
+    test("a sibling observed failed is inadmissible — its outputs were never finalized", () => {
+        const result = classifyReadPath(`runs/${OWN_RUN}/qc/output/qc.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "norm"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "qc" });
+    });
+
+    test("a sibling that completes after the snapshot stays inadmissible for that snapshot", () => {
+        // Submit-time is deliberately stricter than read-time: the later
+        // snapshot admits the edge, the submit-time one it was classified
+        // against does not.
+        const atSubmit = classifyReadPath(`runs/${OWN_RUN}/norm/output/norm.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed());
+        const laterSnapshot = classifyReadPath(`runs/${OWN_RUN}/norm/output/norm.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "norm"]));
+
+        expect(atSubmit).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "norm" });
+        expect(laterSnapshot.admissible).toBe(true);
+    });
+});
+
+describe("classifyReadPath — other runs gate on the same predicate", () => {
+    test("a completed step of another run is prior", () => {
+        const result = classifyReadPath(`runs/${OTHER_RUN}/de/output/prior.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OTHER_RUN, "de"]));
+
+        expect(result).toEqual({ admissible: true, context: { source: "prior", stepId: "de", runId: OTHER_RUN } });
+    });
+
+    test("a failed step of a finished run is inadmissible — the run's outcome is not the step's", () => {
+        const result = classifyReadPath(`runs/${OTHER_RUN}/qc/output/partial.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OTHER_RUN, "de"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: OTHER_RUN, refStepId: "qc" });
+    });
+
+    test("a running step of a concurrent run over the same workspace is inadmissible", () => {
+        const result = classifyReadPath("runs/run-003/norm/output/norm.csv", OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "qc"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: "run-003", refStepId: "norm" });
+    });
+
+    test("the pair scraped from the path is the key tested — a same-run namesake does not admit it", () => {
+        const result = classifyReadPath(`runs/${OTHER_RUN}/qc/output/qc.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON, completed([OWN_RUN, "qc"]));
+
+        expect(result).toEqual({ admissible: false, refRunId: OTHER_RUN, refStepId: "qc" });
+    });
+});
+
+describe("classifyReadPath — an unavailable snapshot fails closed", () => {
+    test("every producing-step read is inadmissible when no snapshot is supplied", () => {
+        const declared = classifyReadPath(`runs/${OWN_RUN}/qc/output/qc.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON);
+        const sibling = classifyReadPath(`runs/${OWN_RUN}/norm/output/norm.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON);
+        const prior = classifyReadPath(`runs/${OTHER_RUN}/de/output/prior.csv`, OWN_STEP, OWN_RUN, DEPENDS_ON);
+
+        expect(declared).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "qc" });
+        expect(sibling).toEqual({ admissible: false, refRunId: OWN_RUN, refStepId: "norm" });
+        expect(prior).toEqual({ admissible: false, refRunId: OTHER_RUN, refStepId: "de" });
+    });
+
+    test("data and own-artifact reads survive an unavailable snapshot", () => {
+        expect(classifyReadPath("data/inputs/f1/counts.csv", OWN_STEP, OWN_RUN, DEPENDS_ON).admissible).toBe(true);
+        expect(classifyReadPath(`runs/${OWN_RUN}/${OWN_STEP}/logs/run.log`, OWN_STEP, OWN_RUN, DEPENDS_ON).admissible).toBe(true);
+    });
+});
+
+describe("ProvenanceCollector.trackInputAccess", () => {
+    const MOUNT = "/an-1";
+
+    test("a caller-supplied context is used verbatim, with no path parsing", () => {
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: OWN_RUN, dependsOn: DEPENDS_ON });
+
+        // The path names a sibling; the context says data. The context wins,
+        // which is what "no path parsing occurs" means observationally.
+        const ref = collector.trackInputAccess(MOUNT, `runs/${OWN_RUN}/qc/output/qc.csv`, null, { source: "upstream", stepId: "qc", runId: OWN_RUN });
+
+        expect(ref).toMatchObject({ path: `${MOUNT}/runs/${OWN_RUN}/qc/output/qc.csv`, source: "upstream", stepId: "qc", runId: OWN_RUN });
+        expect(collector.getTrackedInputs()).toHaveLength(1);
+    });
+
+    test("no context over a data path falls back to path classification", () => {
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: OWN_RUN, dependsOn: DEPENDS_ON });
+
+        const ref = collector.trackInputAccess(MOUNT, "data/inputs/f1/counts.csv", null);
+
+        expect(ref).toMatchObject({ source: "data", path: `${MOUNT}/data/inputs/f1/counts.csv` });
+        expect(collector.getDataInputs()).toHaveLength(1);
+    });
+
+    test("no context over a same-run sibling fails closed and tracks nothing", () => {
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: OWN_RUN, dependsOn: DEPENDS_ON });
+
+        const sibling = collector.trackInputAccess(MOUNT, `runs/${OWN_RUN}/norm/output/norm.csv`, null);
+        const declared = collector.trackInputAccess(MOUNT, `runs/${OWN_RUN}/qc/output/qc.csv`, null);
+
+        expect(sibling).toBeNull();
+        expect(declared).toBeNull();
+        expect(collector.getTrackedInputs()).toEqual([]);
+    });
+
+    test("no context over another run's step fails closed, however long ago that run finished", () => {
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: OWN_RUN, dependsOn: DEPENDS_ON });
+
+        const ref = collector.trackInputAccess(MOUNT, `runs/${OTHER_RUN}/de/output/prior.csv`, null);
+
+        expect(ref).toBeNull();
+        expect(collector.getTrackedInputs()).toEqual([]);
+    });
+
+    test("re-reading the same mount path returns the already-tracked ref", () => {
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: OWN_RUN, dependsOn: DEPENDS_ON });
+        const context = { source: "upstream", stepId: "qc", runId: OWN_RUN } as const;
+
+        const first = collector.trackInputAccess(MOUNT, `runs/${OWN_RUN}/qc/output/qc.csv`, null, context);
+        const second = collector.trackInputAccess(MOUNT, `runs/${OWN_RUN}/qc/output/qc.csv`, null);
+
+        expect(second).toBe(first);
+        expect(collector.getTrackedInputs()).toHaveLength(1);
     });
 });

--- a/harness/src/provenance/collector.ts
+++ b/harness/src/provenance/collector.ts
@@ -69,65 +69,134 @@ export interface InputClassificationContext {
 }
 
 /**
- * Build classification context for a file read using known step metadata.
+ * Membership key for the completed-step snapshot.
  *
- * Uses prefix matching against structured metadata — no path segment
- * extraction. The caller knows its own stepId/runId and its upstream
- * dependencies (dependsOn).
- *
- * For prior-run reads (paths under runs/ that don't match own run or
- * any dependsOn entry), this falls back to path extraction — see the
- * prior-run branch below for why.
+ * Step ids are directory names in the workspace layout, so neither id can
+ * contain the separator and the flattened key is as precise as the pair.
  */
-export function classifyReadPath(relativePath: string, ownStepId: string, ownRunId: string, dependsOn?: string[]): InputClassificationContext {
+export function completedStepKey(runId: string, stepId: string): string {
+    return `${runId}/${stepId}`;
+}
+
+/**
+ * Analysis-scoped snapshot: producing steps observed `completed` when the
+ * reading exec was submitted, keyed by `completedStepKey`. It spans the whole
+ * analysis rather than one run because a producing step is admissible on its
+ * own completion, whichever run it belongs to.
+ */
+export type CompletedSteps = ReadonlySet<string>;
+
+/**
+ * The outcome of classifying one read: either an input edge the step may
+ * assert, or an explicit refusal that carries the producing step it names.
+ *
+ * The refusal is a value, not a thrown error and not a `data` classification:
+ * an inadmissible read is noise the step observed but did not consume, so it
+ * must be droppable without failing the exec and without being mistaken for a
+ * real input. The scraped ids ride along because they are the only thing that
+ * makes the drop attributable to a producing step in a log record.
+ */
+export type ReadClassification =
+    | { readonly admissible: true; readonly context: InputClassificationContext }
+    | { readonly admissible: false; readonly refRunId?: string; readonly refStepId?: string };
+
+/**
+ * Admit an edge to a producing step only on that step's own completion.
+ *
+ * An undefined `completedSteps` is an absent observation, not an empty one,
+ * and both fail closed: with nothing to test membership against, no producing
+ * step can be shown to have finished, and asserting the edge anyway is how a
+ * fabricated lineage record gets written.
+ */
+function gateProducingStep(source: "upstream" | "prior", runId: string, stepId: string, completedSteps?: CompletedSteps): ReadClassification {
+    if (completedSteps?.has(completedStepKey(runId, stepId))) {
+        return { admissible: true, context: { source, stepId, runId } };
+    }
+    return { admissible: false, refRunId: runId, refStepId: stepId };
+}
+
+/**
+ * Classify a file read against the reading step's own coordinates.
+ *
+ * Branches resolve by prefix, and every branch naming a *producing* step — a
+ * declared `dependsOn` sibling, any other same-run sibling, or a step of
+ * another run — is admitted only when that step is in `completedSteps`. A step
+ * that has not completed is still writing its own directory, so nothing
+ * observed there is a stable artifact this step can be said to have consumed;
+ * an artifact is stable because the step that wrote it finished, not because
+ * its run finished, which is why one predicate decides all three branches and
+ * `cortex_runs` is never consulted.
+ *
+ * `completedSteps` is a parameter rather than a lookup so classification stays
+ * pure: the set is snapshotted once, before the exec is submitted, and the
+ * same snapshot replays to the same lineage.
+ */
+export function classifyReadPath(
+    relativePath: string,
+    ownStepId: string,
+    ownRunId: string,
+    dependsOn?: string[],
+    completedSteps?: CompletedSteps,
+): ReadClassification {
     if (relativePath.startsWith("data/") || relativePath.startsWith("dataprofile/")) {
-        return { source: "data" };
+        return { admissible: true, context: { source: "data" } };
     }
 
     // Own artifacts: runs/{ownRunId}/{ownStepId}/...
     const ownPrefix = `runs/${ownRunId}/${ownStepId}/`;
     if (relativePath.startsWith(ownPrefix)) {
-        return { source: "artifacts", stepId: ownStepId, runId: ownRunId };
+        return { admissible: true, context: { source: "artifacts", stepId: ownStepId, runId: ownRunId } };
     }
 
-    // Upstream dependencies: runs/{ownRunId}/{depStepId}/...
+    // Declared upstream dependency: runs/{ownRunId}/{depStepId}/...
+    // Declaration names the edge but does not license it — the scheduler's
+    // ordering guarantee is what usually makes a dependency complete, and a
+    // dependency that somehow has not completed has the same unfinalized
+    // outputs as any other in-flight sibling.
     if (dependsOn) {
         for (const depStepId of dependsOn) {
             const upstreamPrefix = `runs/${ownRunId}/${depStepId}/`;
             if (relativePath.startsWith(upstreamPrefix)) {
-                return { source: "upstream", stepId: depStepId, runId: ownRunId };
+                return gateProducingStep("upstream", ownRunId, depStepId, completedSteps);
             }
         }
     }
 
-    // Same-run sibling step. dependsOn only drives topo-sort ordering, not
-    // read authorization, so a read outside dependsOn is still a valid
-    // upstream input — just extract the stepId from the path.
+    // Same-run sibling. A sibling this step never declared can still be a
+    // genuine input — `dependsOn` orders the schedule, it does not enumerate
+    // reads — so completion, not declaration, decides: until the sibling
+    // completes, its directory holds work in progress rather than an artifact
+    // that could have been consumed. The step id exists only in the path here:
+    // the read matches neither this step's own ids nor a `dependsOn` entry, so
+    // path segments are the only source for the identity the outcome carries,
+    // and the same scraped id is both the key the gate tests and the name a
+    // rejection is attributed to.
     const ownRunPrefix = `runs/${ownRunId}/`;
     if (relativePath.startsWith(ownRunPrefix)) {
         const afterRun = relativePath.slice(ownRunPrefix.length);
         const slashIdx = afterRun.indexOf("/");
         const stepId = slashIdx > 0 ? afterRun.slice(0, slashIdx) : afterRun;
         if (stepId) {
-            return { source: "upstream", stepId, runId: ownRunId };
+            return gateProducingStep("upstream", ownRunId, stepId, completedSteps);
         }
     }
 
-    // Prior-run fallback: a read under `runs/{otherRunId}/...` that is neither
-    // this step's own run nor a `dependsOn` entry carries no step metadata
-    // linking it, so the path segments are the only source for the
-    // `{source: "prior", runId, stepId}` classification. This is the one place
-    // the provenance system extracts identity from path segments.
+    // Another run's step: a read under `runs/{otherRunId}/...` matches neither
+    // this step's own run nor a `dependsOn` entry, so the path segments are the
+    // only source for the `{source: "prior", runId, stepId}` identity — and the
+    // pair scraped here is the pair the gate looks up, so a same-run step of
+    // the same name cannot admit it. Path extraction is confined to this branch
+    // and the same-run sibling branch above; no other branch reads segments.
     if (relativePath.startsWith("runs/")) {
         const parts = relativePath.split("/");
         const priorRunId = parts[1];
         const priorStepId = parts[2];
         if (priorRunId && priorStepId) {
-            return { source: "prior", stepId: priorStepId, runId: priorRunId };
+            return gateProducingStep("prior", priorRunId, priorStepId, completedSteps);
         }
     }
 
-    return { source: "data" };
+    return { admissible: true, context: { source: "data" } };
 }
 
 // ── Collector ───────────────────────────────────────────────────────
@@ -187,14 +256,27 @@ export class ProvenanceCollector {
      * @param hash - SHA-256 hash of the file content, or null if file no longer exists
      * @param context - Explicit classification context from the caller. When provided,
      *   the collector uses it directly instead of classifying from the path.
+     * @returns the tracked ref, or `null` when the caller supplied no context and the
+     *   path resolves to a producing step — the collector holds no completed-step
+     *   snapshot, so it cannot show that step finished (see the fallback below).
      */
-    trackInputAccess(mountPath: string, relativePath: string, hash: string | null, context?: InputClassificationContext): InputRef {
+    trackInputAccess(mountPath: string, relativePath: string, hash: string | null, context: InputClassificationContext): InputRef;
+    trackInputAccess(mountPath: string, relativePath: string, hash: string | null): InputRef | null;
+    trackInputAccess(mountPath: string, relativePath: string, hash: string | null, context?: InputClassificationContext): InputRef | null {
         const key = `${mountPath}:${relativePath}`;
         const existing = this.inputAccesses.get(key);
         if (existing) return existing;
 
-        // Use explicit context if provided, otherwise fall back to path classification
-        const classification = context ?? classifyReadPath(relativePath, this.stepId, this.runId, this.dependsOn);
+        // Use explicit context if provided, otherwise fall back to path
+        // classification. The collector holds no completed-step snapshot — that
+        // is observed per exec, at submit time, by the caller that classifies —
+        // so the fallback cannot admit an edge to any producing step and refuses
+        // every same-run sibling and prior-run read. Tracking one anyway would
+        // make an unobserved step an attestation target of this one.
+        const fallback = context ? null : classifyReadPath(relativePath, this.stepId, this.runId, this.dependsOn);
+        const classification = context ?? (fallback?.admissible === true ? fallback.context : null);
+        if (classification === null) return null;
+
         // A still-absolute `relativePath` is a report the caller could not
         // relativize — it names somewhere outside the mount. It rides verbatim:
         // prepending the mount root would forge an in-tree name for a foreign

--- a/harness/src/provenance/exec-frame.test.ts
+++ b/harness/src/provenance/exec-frame.test.ts
@@ -4,13 +4,59 @@
  * and the resulting records/data-inputs are asserted.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type Attributes, metrics } from "@opentelemetry/api";
+import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
-import { ProvenanceCollector } from "./collector.js";
+import { createCapturingLogger } from "../__tests__/setup/logger.js";
+import { __resetLineageMetricsForTest } from "../lib/metrics.js";
+import { completedStepKey, ProvenanceCollector } from "./collector.js";
 import { feedExecFrame } from "./exec-frame.js";
 import type { ProvenanceFrame } from "../sandbox/types.js";
 
 const MOUNT = "/a1";
+const EDGE_REJECTED_METRIC = "cortex.lineage.edge_rejected";
+
+/** Analysis-scoped completed-step snapshot from `(runId, stepId)` pairs. */
+function completed(...pairs: readonly (readonly [string, string])[]): ReadonlySet<string> {
+    return new Set(pairs.map(([runId, stepId]) => completedStepKey(runId, stepId)));
+}
+
+let exporter: InMemoryMetricExporter;
+let provider: MeterProvider;
+
+beforeEach(() => {
+    exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    // Long interval — every export in this suite is a manual forceFlush.
+    const reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 });
+    provider = new MeterProvider({ readers: [reader] });
+    metrics.setGlobalMeterProvider(provider);
+    // Instruments memoized against an earlier provider would keep reporting there.
+    __resetLineageMetricsForTest();
+});
+
+afterEach(async () => {
+    await provider.shutdown();
+    metrics.disable();
+    __resetLineageMetricsForTest();
+});
+
+/**
+ * The exported measurements of the rejection counter, one entry per distinct tag
+ * set. Reading them from a provider registered after `lib/metrics.ts` was imported
+ * is what asserts the dimensions *and* that the instrument binds late enough to
+ * reach an exporter at all — the metrics API resolves the provider when an
+ * instrument is created and never upgrades it afterwards.
+ */
+async function rejections(): Promise<{ value: number; attributes: Attributes }[]> {
+    await provider.forceFlush();
+    return exporter
+        .getMetrics()
+        .flatMap((rm) => rm.scopeMetrics)
+        .flatMap((sm) => sm.metrics)
+        .filter((m) => m.descriptor.name === EDGE_REJECTED_METRIC)
+        .flatMap((m) => m.dataPoints.map((dp) => ({ value: dp.value as number, attributes: dp.attributes })));
+}
 
 describe("feedExecFrame", () => {
     test("data read + output write yields a command record with a data input + script", () => {
@@ -48,7 +94,7 @@ describe("feedExecFrame", () => {
         expect(dataInputs[0]!.fileId).toBe("uuid-1");
     });
 
-    test("upstream read is classified by step metadata", () => {
+    test("upstream read is classified by step metadata", async () => {
         const collector = new ProvenanceCollector({
             stepId: "de",
             runId: "run-002",
@@ -61,6 +107,7 @@ describe("feedExecFrame", () => {
             command: ["Rscript", "scripts/de.R"],
             exitCode: 0,
             durationMs: 50,
+            completedSteps: completed(["run-002", "qc"]),
             provenance: {
                 disabled: false,
                 reads: [{ path: "/a1/runs/run-002/qc/output/qc.csv", layers: ["inotify"] }],
@@ -73,6 +120,32 @@ describe("feedExecFrame", () => {
         expect(rec.inputs[0]!.source).toBe("upstream");
         expect(rec.inputs[0]!.stepId).toBe("qc");
         expect(rec.inputs[0]!.runId).toBe("run-002");
+        expect(await rejections()).toEqual([]);
+    });
+
+    test("a prior run's completed step reaches the collector", async () => {
+        const collector = new ProvenanceCollector({ stepId: "de", runId: "run-002" });
+
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["Rscript", "scripts/de.R"],
+            exitCode: 0,
+            durationMs: 50,
+            completedSteps: completed(["run-001", "qc"]),
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/a1/runs/run-001/qc/output/qc.csv", layers: ["inotify"] }],
+                writes: [{ path: "/a1/runs/run-002/de/output/de.csv", layers: ["inotify"] }],
+                deletes: [],
+            },
+        });
+
+        const rec = collector.getRecords()[0]!;
+        expect(rec.inputs[0]!.source).toBe("prior");
+        expect(rec.inputs[0]!.stepId).toBe("qc");
+        expect(rec.inputs[0]!.runId).toBe("run-001");
+        expect(await rejections()).toEqual([]);
     });
 
     test("a read outside the mount keeps its own name on the ref", () => {
@@ -149,5 +222,188 @@ describe("feedExecFrame", () => {
             provenance: { disabled: true, reads: [{ path: "/a1/data/x.csv", layers: [] }], writes: [], deletes: [] },
         });
         expect(collector.getDataInputs()).toHaveLength(0);
+    });
+});
+
+/**
+ * The field failure this gate exists for: `T4S1` and `T2S2` ran concurrently
+ * over one workspace, `T4S1`'s capture layers saw `T2S2`'s directory churn, and
+ * three of `T2S2`'s working files were registered as `T4S1` inputs — then failed
+ * attestation once `T2S2` deleted them.
+ */
+const SIBLING_FRAME: ProvenanceFrame = {
+    disabled: false,
+    reads: [
+        { path: "/a1/runs/run-002/T2S2/logs/run_gsea.log", layers: ["inotify"] },
+        { path: "/a1/runs/run-002/T2S2/output/wikipathways_symbols.gmt", layers: ["inotify"] },
+    ],
+    writes: [{ path: "/a1/runs/run-002/T4S1/output/gsea.csv", layers: ["inotify"] }],
+    deletes: [],
+};
+
+function readingStep(): ProvenanceCollector {
+    return new ProvenanceCollector({ stepId: "T4S1", runId: "run-002" });
+}
+
+describe("feedExecFrame — edges refused before the collector", () => {
+    test("a sibling not observed completed leaves no ref in the collector", () => {
+        const collector = readingStep();
+
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/run_gsea.py"],
+            exitCode: 0,
+            durationMs: 900,
+            // `T2S2` was still running when this exec was submitted, so the
+            // snapshot holds no pair for it.
+            completedSteps: completed(),
+            provenance: SIBLING_FRAME,
+        });
+
+        // Nothing reached the collector, so nothing can become an attestation
+        // target — the refusal is structural, not a later filtering pass.
+        expect(collector.getTrackedInputs()).toEqual([]);
+        const rec = collector.getRecords()[0]!;
+        expect(rec.outputPath).toBe("output/gsea.csv");
+        expect(rec.inputs).toEqual([]);
+    });
+
+    test("each refusal names the ref path and the producing step it names", () => {
+        const logger = createCapturingLogger();
+
+        feedExecFrame({
+            collector: readingStep(),
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/run_gsea.py"],
+            exitCode: 0,
+            durationMs: 900,
+            completedSteps: completed(),
+            provenance: SIBLING_FRAME,
+            logger,
+        });
+
+        const warns = logger.records.filter((r) => r.level === "warn");
+        expect(warns).toHaveLength(2);
+        expect(warns[0]!.msg).toBe("[exec-frame] refusing lineage edge to a step not observed completed");
+        // Identifiers ride as fields, never interpolated into the message.
+        expect(warns[0]!.fields).toEqual({
+            path: "runs/run-002/T2S2/logs/run_gsea.log",
+            refRunId: "run-002",
+            refStepId: "T2S2",
+            reason: "producing-step-not-completed",
+        });
+        expect(warns[1]!.fields).toMatchObject({
+            path: "runs/run-002/T2S2/output/wikipathways_symbols.gmt",
+            refStepId: "T2S2",
+        });
+    });
+
+    test("a refusal against an obtained snapshot counts as producing-step-not-completed", async () => {
+        feedExecFrame({
+            collector: readingStep(),
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/run_gsea.py"],
+            exitCode: 0,
+            durationMs: 900,
+            completedSteps: completed(),
+            provenance: SIBLING_FRAME,
+            agentId: "gsea-agent",
+        });
+
+        // Both reads carry the same tags, so the counter aggregates them onto one
+        // series — the two rejections are the value, not two points.
+        expect(await rejections()).toEqual([{ value: 2, attributes: { agent_id: "gsea-agent", step_id: "T4S1", reason: "producing-step-not-completed" } }]);
+    });
+
+    test("a prior run's step that is absent from the snapshot counts under the same reason", async () => {
+        feedExecFrame({
+            collector: new ProvenanceCollector({ stepId: "de", runId: "run-002" }),
+            mountRoot: MOUNT,
+            command: ["Rscript", "scripts/de.R"],
+            exitCode: 0,
+            durationMs: 40,
+            // `run-001`'s `qc` failed, so its outputs were never finalized —
+            // one rule, so one reason, whichever run the producer belongs to.
+            completedSteps: completed(["run-002", "qc"]),
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/a1/runs/run-001/qc/output/partial.csv", layers: ["inotify"] }],
+                writes: [],
+                deletes: [],
+            },
+            agentId: "de-agent",
+        });
+
+        expect(await rejections()).toEqual([{ value: 1, attributes: { agent_id: "de-agent", step_id: "de", reason: "producing-step-not-completed" } }]);
+    });
+
+    test("a missing snapshot counts under its own reason and refuses a declared dependency too", async () => {
+        const collector = new ProvenanceCollector({ stepId: "de", runId: "run-002", dependsOn: ["qc"] });
+        const logger = createCapturingLogger();
+
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["Rscript", "scripts/de.R"],
+            exitCode: 0,
+            durationMs: 40,
+            // `completedSteps` omitted: the observation failed, which is not an
+            // empty observation and never reads as "everything completed".
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/a1/runs/run-002/qc/output/qc.csv", layers: ["inotify"] }],
+                writes: [],
+                deletes: [],
+            },
+            logger,
+            agentId: "de-agent",
+        });
+
+        expect(collector.getTrackedInputs()).toEqual([]);
+        expect(await rejections()).toEqual([{ value: 1, attributes: { agent_id: "de-agent", step_id: "de", reason: "snapshot-unavailable" } }]);
+        expect(logger.records.filter((r) => r.level === "warn")[0]!.fields).toMatchObject({ reason: "snapshot-unavailable" });
+    });
+
+    test("data reads are untouched by the gate", async () => {
+        const collector = readingStep();
+
+        feedExecFrame({
+            collector,
+            mountRoot: MOUNT,
+            command: ["python3", "scripts/run_gsea.py"],
+            exitCode: 0,
+            durationMs: 10,
+            provenance: {
+                disabled: false,
+                reads: [{ path: "/a1/data/inputs/Lab/counts.csv", layers: ["python"] }],
+                writes: [],
+                deletes: [],
+            },
+        });
+
+        expect(collector.getDataInputs()).toHaveLength(1);
+        expect(await rejections()).toEqual([]);
+    });
+
+    test("an all-refused frame still records its command and does not throw", () => {
+        const collector = readingStep();
+
+        expect(() =>
+            feedExecFrame({
+                collector,
+                mountRoot: MOUNT,
+                command: ["python3", "scripts/run_gsea.py"],
+                exitCode: 0,
+                durationMs: 900,
+                completedSteps: completed(),
+                provenance: SIBLING_FRAME,
+            }),
+        ).not.toThrow();
+
+        const rec = collector.getRecords()[0]!;
+        expect(rec.producer.type).toBe("command");
+        expect(rec.scriptPath).toBe("scripts/run_gsea.py");
+        expect(rec.inputs).toEqual([]);
     });
 });

--- a/harness/src/provenance/exec-frame.ts
+++ b/harness/src/provenance/exec-frame.ts
@@ -8,13 +8,25 @@
  * `runs/{priorRunId}/...`) so `classifyReadPath` and the collector's
  * `stepPrefix` normalization see the shapes they expect.
  *
+ * A read naming a producing step that was not observed `completed` when this
+ * exec was submitted is refused here, before it reaches the collector: a ref
+ * the collector never holds cannot become an attestation target, so the edge is
+ * unrepresentable rather than merely filtered downstream. Every refusal is
+ * logged and counted: an edge asserted over a step that was still writing is
+ * invisible by nature, so a silent drop would rebuild exactly the blind spot
+ * the gate exists to close.
+ *
  * Degrades safely: a disabled or absent frame records the command with no
- * inputs and no writes (its outputs fall back to leaves at registration).
- * It never throws — provenance is best-effort and must not fail an exec.
+ * inputs and no writes (its outputs fall back to leaves at registration), and a
+ * frame whose every read is refused still records its command. It never throws —
+ * provenance is best-effort and must not fail an exec.
  */
 
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { Logger } from "../lib/logger.js";
+import { recordLineageEdgeRejected, type LineageEdgeRejectionReason } from "../lib/metrics.js";
 import type { ProvenanceFrame } from "../sandbox/types.js";
-import { classifyReadPath, type ProvenanceCollector, type ObservedWrite } from "./collector.js";
+import { classifyReadPath, type CompletedSteps, type ProvenanceCollector, type ObservedWrite } from "./collector.js";
 import type { InputRef } from "./types.js";
 
 /**
@@ -39,6 +51,20 @@ export interface FeedExecFrameArgs {
     readonly durationMs: number | null;
     /** The frame surfaced on `ExecResult.provenance` (may be absent). */
     readonly provenance?: ProvenanceFrame;
+    /**
+     * Producing steps observed `completed` at the moment this exec was
+     * submitted, passed to `classifyReadPath` unmodified.
+     *
+     * Absent means the observation itself failed, which is not the same as an
+     * empty one and is not a licence to admit: with no set to test membership
+     * against, no producing step can be shown to have finished, so every read
+     * naming one is refused and counted under its own reason.
+     */
+    readonly completedSteps?: CompletedSteps;
+    /** Diagnostics seam. Left unwired, refusals are still counted but unnarrated. */
+    readonly logger?: Logger;
+    /** The reading step's agent, carried as the `agent_id` metric dimension. */
+    readonly agentId?: string;
 }
 
 /**
@@ -48,7 +74,7 @@ export interface FeedExecFrameArgs {
  * inputs don't collapse onto another's outputs.
  */
 export function feedExecFrame(args: FeedExecFrameArgs): void {
-    const { collector, mountRoot, command, exitCode, durationMs, provenance } = args;
+    const { collector, mountRoot, command, exitCode, durationMs, provenance, completedSteps, agentId } = args;
     const cmd = command[0] ?? "";
     const cmdArgs = command.slice(1);
     const code = exitCode ?? -1;
@@ -59,11 +85,32 @@ export function feedExecFrame(args: FeedExecFrameArgs): void {
         return;
     }
 
+    // Resolved once so the read loop logs unconditionally instead of threading
+    // `?.` through every diagnostic (see the Logger seam's fallback rule).
+    const logger = (args.logger ?? createNoopLogger()).named("exec-frame");
+
+    // Whether the snapshot exists is a property of the exec, not of a read, so
+    // the reason is fixed for the whole frame. The two are counted apart because
+    // "the gate asked and the answer was no" and "the gate never got to ask" call
+    // for different responses: the first is the rule working, the second is an
+    // observation that failed and should be chased.
+    const reason: LineageEdgeRejectionReason = completedSteps === undefined ? "snapshot-unavailable" : "producing-step-not-completed";
+
     const commandReads: InputRef[] = [];
     for (const read of provenance.reads) {
         const rel = stripMountPrefix(mountRoot, read.path);
-        const context = classifyReadPath(rel, collector.stepId, collector.runId, collector.dependsOn);
-        commandReads.push(collector.trackInputAccess(mountRoot, rel, null, context));
+        const classification = classifyReadPath(rel, collector.stepId, collector.runId, collector.dependsOn, completedSteps);
+        if (!classification.admissible) {
+            logger.warn("refusing lineage edge to a step not observed completed", {
+                path: rel,
+                refRunId: classification.refRunId,
+                refStepId: classification.refStepId,
+                reason,
+            });
+            recordLineageEdgeRejected({ agentId, stepId: collector.stepId, reason });
+            continue;
+        }
+        commandReads.push(collector.trackInputAccess(mountRoot, rel, null, classification.context));
     }
 
     const writes: ObservedWrite[] = provenance.writes.map((w) => ({

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -12,8 +12,7 @@ import { join } from "node:path";
 import type { Pool } from "pg";
 
 import type { AwaitExecOptions } from "./await-exec.js";
-import { composeAwaitOptions, createSandboxClient, precreateStepTree, resolveCompletedSiblings } from "./create-sandbox.js";
-import { createNoopLogger } from "../lib/console-logger.js";
+import { composeAwaitOptions, createSandboxClient, precreateStepTree } from "./create-sandbox.js";
 import { STEP_SUBDIRS } from "./mount-plan.js";
 import type { CreateSandboxMeta, SandboxLiveness } from "./types.js";
 
@@ -113,49 +112,6 @@ describe("precreateStepTree — step-tree access mode", () => {
 
         // The read-only path returns before creating or chmodding any step tree.
         await expect(stat(stepDir())).rejects.toThrow();
-    });
-});
-
-describe("resolveCompletedSiblings", () => {
-    const meta: CreateSandboxMeta = {
-        runId: "run-2",
-        stepId: "de",
-        analysisId: "an-1",
-        childWorkflowId: "run-2-0",
-        resources: { cpu: 1, memoryGb: 1 },
-    };
-    /** Stands in for the completed-step rows the query returns. */
-    const poolOf = (rows: Array<{ run_id: string; step_id: string }>) =>
-        ({
-            query: async () => ({ rows }),
-        }) as unknown as Pool;
-
-    test("keeps this run's completed steps and drops other runs' and this step's own", async () => {
-        const siblings = await resolveCompletedSiblings(
-            poolOf([
-                { run_id: "run-2", step_id: "qc" },
-                { run_id: "run-2", step_id: "norm" },
-                // A prior run's completed step: admissible for lineage, but not
-                // a watch dir under this run's tree.
-                { run_id: "run-1", step_id: "qc" },
-                // The step's own prior attempt.
-                { run_id: "run-2", step_id: "de" },
-            ]),
-            meta,
-            createNoopLogger(),
-        );
-
-        expect(siblings).toEqual(["qc", "norm"]);
-    });
-
-    test("a failed lookup narrows the watch set instead of failing sandbox creation", async () => {
-        const pool = {
-            query: async () => {
-                throw new Error("connection terminated");
-            },
-        } as unknown as Pool;
-
-        expect(await resolveCompletedSiblings(pool, meta, createNoopLogger())).toEqual([]);
     });
 });
 

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -12,7 +12,8 @@ import { join } from "node:path";
 import type { Pool } from "pg";
 
 import type { AwaitExecOptions } from "./await-exec.js";
-import { composeAwaitOptions, createSandboxClient, precreateStepTree } from "./create-sandbox.js";
+import { composeAwaitOptions, createSandboxClient, precreateStepTree, resolveCompletedSiblings } from "./create-sandbox.js";
+import { createNoopLogger } from "../lib/console-logger.js";
 import { STEP_SUBDIRS } from "./mount-plan.js";
 import type { CreateSandboxMeta, SandboxLiveness } from "./types.js";
 
@@ -112,6 +113,49 @@ describe("precreateStepTree — step-tree access mode", () => {
 
         // The read-only path returns before creating or chmodding any step tree.
         await expect(stat(stepDir())).rejects.toThrow();
+    });
+});
+
+describe("resolveCompletedSiblings", () => {
+    const meta: CreateSandboxMeta = {
+        runId: "run-2",
+        stepId: "de",
+        analysisId: "an-1",
+        childWorkflowId: "run-2-0",
+        resources: { cpu: 1, memoryGb: 1 },
+    };
+    /** Stands in for the completed-step rows the query returns. */
+    const poolOf = (rows: Array<{ run_id: string; step_id: string }>) =>
+        ({
+            query: async () => ({ rows }),
+        }) as unknown as Pool;
+
+    test("keeps this run's completed steps and drops other runs' and this step's own", async () => {
+        const siblings = await resolveCompletedSiblings(
+            poolOf([
+                { run_id: "run-2", step_id: "qc" },
+                { run_id: "run-2", step_id: "norm" },
+                // A prior run's completed step: admissible for lineage, but not
+                // a watch dir under this run's tree.
+                { run_id: "run-1", step_id: "qc" },
+                // The step's own prior attempt.
+                { run_id: "run-2", step_id: "de" },
+            ]),
+            meta,
+            createNoopLogger(),
+        );
+
+        expect(siblings).toEqual(["qc", "norm"]);
+    });
+
+    test("a failed lookup narrows the watch set instead of failing sandbox creation", async () => {
+        const pool = {
+            query: async () => {
+                throw new Error("connection terminated");
+            },
+        } as unknown as Pool;
+
+        expect(await resolveCompletedSiblings(pool, meta, createNoopLogger())).toEqual([]);
     });
 });
 

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -18,12 +18,13 @@ import { join } from "node:path";
 import type { V1Toleration } from "@kubernetes/client-node";
 import type { Pool } from "pg";
 
+import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { clampResources, type ResourceLimits } from "../config/resource-limits.js";
 import { stepWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { tryMutation } from "../lib/db-result.js";
 import { unwrapOrThrow } from "../lib/result.js";
-import { clearSandboxRef, setSandboxRef } from "../state/index.js";
+import { clearSandboxRef, queryCompletedStepsByAnalysis, setSandboxRef } from "../state/index.js";
 import { awaitExec, type AwaitExecOptions } from "./await-exec.js";
 import type { SandboxClient } from "./client.js";
 import { createDockerSandboxOps } from "./docker-client.js";
@@ -172,6 +173,39 @@ export async function precreateStepTree(
     }
 }
 
+/**
+ * Step ids of this step's own run whose executions are already `completed` —
+ * the trees `buildMountPlan` may hand the container as watch dirs.
+ *
+ * Resolved here rather than inside the mount plan: this is the composition edge
+ * that already owns I/O (it pre-creates the step tree and writes the registry),
+ * so the plan below it stays a pure function of its inputs. Scoped to the
+ * step's own run because a watch dir is a path under `runs/{runId}/`; reads of
+ * another run's step reach the frame through the in-container hooks, whose
+ * prefix filter is the whole mount.
+ *
+ * A failed query narrows the watch set instead of failing sandbox creation:
+ * provenance is best-effort, and the command's own reads under an unwatched
+ * tree are still reported by the hooks.
+ *
+ * Exported for tests.
+ */
+export async function resolveCompletedSiblings(pool: Pool, meta: CreateSandboxMeta, logger: Logger): Promise<string[]> {
+    const queried = await queryCompletedStepsByAnalysis(pool, meta.analysisId);
+    return queried.match(
+        (pairs) => pairs.filter((pair) => pair.runId === meta.runId && pair.stepId !== meta.stepId).map((pair) => pair.stepId),
+        (error) => {
+            logger.warn("completed-sibling lookup failed — provisioning the sandbox with no sibling watch dirs (provenance under-captures)", {
+                analysisId: meta.analysisId,
+                runId: meta.runId,
+                stepId: meta.stepId,
+                ...logger.errorFields(error),
+            });
+            return [];
+        },
+    );
+}
+
 export function createSandboxClient(config: CreateSandboxClientConfig): SandboxClient {
     const backend = config.backend ?? config.env.backend;
     const transport = config.transport ?? "poll";
@@ -257,7 +291,8 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
             }
             // Clamp to cluster ceilings so the pod is always quota-admissible.
             const resources = clampResources(meta.resources, config.resourceLimits);
-            return unwrapOrThrow(await ops.createSandbox({ ...meta, resources }, identity));
+            const completedSiblingStepIds = await resolveCompletedSiblings(config.pool, meta, config.logger ?? createNoopLogger());
+            return unwrapOrThrow(await ops.createSandbox({ ...meta, resources, completedSiblingStepIds }, identity));
         },
         submitExec: async (ref, body) => submitExec(ref, body, config.submitDeps),
         awaitExec: (ref, execId, emit, deadline) => awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -18,13 +18,12 @@ import { join } from "node:path";
 import type { V1Toleration } from "@kubernetes/client-node";
 import type { Pool } from "pg";
 
-import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { clampResources, type ResourceLimits } from "../config/resource-limits.js";
 import { stepWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { tryMutation } from "../lib/db-result.js";
 import { unwrapOrThrow } from "../lib/result.js";
-import { clearSandboxRef, queryCompletedStepsByAnalysis, setSandboxRef } from "../state/index.js";
+import { clearSandboxRef, setSandboxRef } from "../state/index.js";
 import { awaitExec, type AwaitExecOptions } from "./await-exec.js";
 import type { SandboxClient } from "./client.js";
 import { createDockerSandboxOps } from "./docker-client.js";
@@ -173,39 +172,6 @@ export async function precreateStepTree(
     }
 }
 
-/**
- * Step ids of this step's own run whose executions are already `completed` —
- * the trees `buildMountPlan` may hand the container as watch dirs.
- *
- * Resolved here rather than inside the mount plan: this is the composition edge
- * that already owns I/O (it pre-creates the step tree and writes the registry),
- * so the plan below it stays a pure function of its inputs. Scoped to the
- * step's own run because a watch dir is a path under `runs/{runId}/`; reads of
- * another run's step reach the frame through the in-container hooks, whose
- * prefix filter is the whole mount.
- *
- * A failed query narrows the watch set instead of failing sandbox creation:
- * provenance is best-effort, and the command's own reads under an unwatched
- * tree are still reported by the hooks.
- *
- * Exported for tests.
- */
-export async function resolveCompletedSiblings(pool: Pool, meta: CreateSandboxMeta, logger: Logger): Promise<string[]> {
-    const queried = await queryCompletedStepsByAnalysis(pool, meta.analysisId);
-    return queried.match(
-        (pairs) => pairs.filter((pair) => pair.runId === meta.runId && pair.stepId !== meta.stepId).map((pair) => pair.stepId),
-        (error) => {
-            logger.warn("completed-sibling lookup failed — provisioning the sandbox with no sibling watch dirs (provenance under-captures)", {
-                analysisId: meta.analysisId,
-                runId: meta.runId,
-                stepId: meta.stepId,
-                ...logger.errorFields(error),
-            });
-            return [];
-        },
-    );
-}
-
 export function createSandboxClient(config: CreateSandboxClientConfig): SandboxClient {
     const backend = config.backend ?? config.env.backend;
     const transport = config.transport ?? "poll";
@@ -291,8 +257,7 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
             }
             // Clamp to cluster ceilings so the pod is always quota-admissible.
             const resources = clampResources(meta.resources, config.resourceLimits);
-            const completedSiblingStepIds = await resolveCompletedSiblings(config.pool, meta, config.logger ?? createNoopLogger());
-            return unwrapOrThrow(await ops.createSandbox({ ...meta, resources, completedSiblingStepIds }, identity));
+            return unwrapOrThrow(await ops.createSandbox({ ...meta, resources }, identity));
         },
         submitExec: async (ref, body) => submitExec(ref, body, config.submitDeps),
         awaitExec: (ref, execId, emit, deadline) => awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -277,7 +277,8 @@ describe("docker createSandbox — transport modes", () => {
         const sandbox = sandboxOf(created)!;
         const env = envMapOf(sandbox);
         expect(env.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
-        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
         expect(env.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
 
         expect(sandbox.workingDir).toBe("/an-1/runs/run-1/step-a");
@@ -349,7 +350,27 @@ describe("docker createSandbox — mounts and platform", () => {
         expect(sandbox.binds.some((b) => b.includes("/mnt/libs"))).toBe(false);
         expect(env.R_LIBS_SITE).toBeUndefined();
         expect(env.NODE_PATH).toBeUndefined();
-        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+    });
+
+    test("completed siblings on the meta become watch dirs; the mount root never does", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox({ ...META, completedSiblingStepIds: ["qc"] }, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        const env = envMapOf(sandboxOf(created)!);
+        expect(env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a", "/an-1/runs/run-1/qc"]);
+        // The sibling's tree is watched, but the container still binds only its
+        // own step dir read-write — capture scope is not a mount change.
+        expect(sandboxOf(created)!.binds).toEqual(["/sessions/an-1:/an-1:ro", "/sessions/an-1/runs/run-1/step-a:/an-1/runs/run-1/step-a:rw"]);
     });
 
     test("forwards the configured platform into createContainer options", async () => {

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -277,7 +277,7 @@ describe("docker createSandbox — transport modes", () => {
         const sandbox = sandboxOf(created)!;
         const env = envMapOf(sandbox);
         expect(env.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
-        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
         expect(env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
         expect(env.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
 
@@ -350,10 +350,10 @@ describe("docker createSandbox — mounts and platform", () => {
         expect(sandbox.binds.some((b) => b.includes("/mnt/libs"))).toBe(false);
         expect(env.R_LIBS_SITE).toBeUndefined();
         expect(env.NODE_PATH).toBeUndefined();
-        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(env.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
     });
 
-    test("completed siblings on the meta become watch dirs; the mount root never does", async () => {
+    test("the watch dirs are the step's own tree alone — no data tree, no sibling, no mount root", async () => {
         const { docker, created } = stubDocker();
         const ops = createDockerSandboxOps({
             image: "sandbox-base:latest",
@@ -364,12 +364,15 @@ describe("docker createSandbox — mounts and platform", () => {
             registerSandbox: async () => {},
         });
 
-        (await ops.createSandbox({ ...META, completedSiblingStepIds: ["qc"] }, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
 
         const env = envMapOf(sandboxOf(created)!);
-        expect(env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a", "/an-1/runs/run-1/qc"]);
-        // The sibling's tree is watched, but the container still binds only its
-        // own step dir read-write — capture scope is not a mount change.
+        expect(env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/runs/run-1/step-a"]);
+        // The hooks keep the whole mount as their prefix, so a read of an
+        // unwatched tree still reaches the frame.
+        expect(env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
+        // The watch scope tracks the read-write mount: the container binds
+        // exactly the one tree it watches.
         expect(sandboxOf(created)!.binds).toEqual(["/sessions/an-1:/an-1:ro", "/sessions/an-1/runs/run-1/step-a:/an-1/runs/run-1/step-a:rw"]);
     });
 

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -298,10 +298,14 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                     // noise. A store that appears mid-session is picked up by the next create.
                     const refsMounted = !!config.refStorePath && refStoreUsable(config.refStorePath);
 
-                    const plan = buildMountPlan(meta, {
-                        libs: libsMounted,
-                        refs: refsMounted,
-                    });
+                    const plan = buildMountPlan(
+                        meta,
+                        {
+                            libs: libsMounted,
+                            refs: refsMounted,
+                        },
+                        meta.completedSiblingStepIds,
+                    );
 
                     const hostTreePath = config.resolveWorkspaceRoot(meta.analysisId);
                     // `stepWritePrefix` (not a raw `join`) so the RW bind source runs through

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -298,14 +298,10 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                     // noise. A store that appears mid-session is picked up by the next create.
                     const refsMounted = !!config.refStorePath && refStoreUsable(config.refStorePath);
 
-                    const plan = buildMountPlan(
-                        meta,
-                        {
-                            libs: libsMounted,
-                            refs: refsMounted,
-                        },
-                        meta.completedSiblingStepIds,
-                    );
+                    const plan = buildMountPlan(meta, {
+                        libs: libsMounted,
+                        refs: refsMounted,
+                    });
 
                     const hostTreePath = config.resolveWorkspaceRoot(meta.analysisId);
                     // `stepWritePrefix` (not a raw `join`) so the RW bind source runs through

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -131,7 +131,8 @@ describe("k8s createSandbox", () => {
         expect(envMap.SANDBOX_TRANSPORT).toBe("callback");
         expect(envMap.CORTEX_BASE_URL).toBe("https://cortex.example.com:443");
         expect(envMap.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
-        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(envMap.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
         expect(envMap.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
 
         expect(container.workingDir).toBe("/an-1/runs/run-1/step-a");
@@ -439,7 +440,52 @@ describe("k8s createSandbox", () => {
         const env = podSpec.containers[0].env ?? [];
         const envMap = Object.fromEntries(env.map((e) => [e.name, e.value]));
         expect(envMap.R_LIBS_SITE).toBeUndefined();
-        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+    });
+
+    test("completed siblings on the meta become watch dirs; the mount root never does", async () => {
+        const stub = stubApis([
+            {
+                status: { phase: "Running", podIP: "10.0.0.3" },
+                metadata: { name: "sbx-z" },
+            },
+        ]);
+
+        const ops = createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox(
+                {
+                    runId: "run-1",
+                    stepId: "step-a",
+                    analysisId: "an-1",
+                    childWorkflowId: "run-1-0",
+                    resources: { cpu: 2, memoryGb: 4 },
+                    completedSiblingStepIds: ["qc", "norm"],
+                },
+                mintSandboxIdentity("run-1"),
+            )
+        )._unsafeUnwrap();
+
+        const env = stub.createdJobs[0]!.spec!.template.spec!.containers[0].env ?? [];
+        const envMap = Object.fromEntries(env.map((e) => [e.name, e.value]));
+        expect((envMap.PROVENANCE_WATCH_DIRS ?? "").split(",")).toEqual([
+            "/an-1/data",
+            "/an-1/runs/run-1/step-a",
+            "/an-1/runs/run-1/qc",
+            "/an-1/runs/run-1/norm",
+        ]);
+        expect(envMap.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 });
 

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -131,7 +131,7 @@ describe("k8s createSandbox", () => {
         expect(envMap.SANDBOX_TRANSPORT).toBe("callback");
         expect(envMap.CORTEX_BASE_URL).toBe("https://cortex.example.com:443");
         expect(envMap.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
-        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
         expect(envMap.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
         expect(envMap.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
 
@@ -440,10 +440,10 @@ describe("k8s createSandbox", () => {
         const env = podSpec.containers[0].env ?? [];
         const envMap = Object.fromEntries(env.map((e) => [e.name, e.value]));
         expect(envMap.R_LIBS_SITE).toBeUndefined();
-        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
     });
 
-    test("completed siblings on the meta become watch dirs; the mount root never does", async () => {
+    test("the watch dirs are the step's own tree alone — no data tree, no sibling, no mount root", async () => {
         const stub = stubApis([
             {
                 status: { phase: "Running", podIP: "10.0.0.3" },
@@ -471,7 +471,6 @@ describe("k8s createSandbox", () => {
                     analysisId: "an-1",
                     childWorkflowId: "run-1-0",
                     resources: { cpu: 2, memoryGb: 4 },
-                    completedSiblingStepIds: ["qc", "norm"],
                 },
                 mintSandboxIdentity("run-1"),
             )
@@ -479,12 +478,51 @@ describe("k8s createSandbox", () => {
 
         const env = stub.createdJobs[0]!.spec!.template.spec!.containers[0].env ?? [];
         const envMap = Object.fromEntries(env.map((e) => [e.name, e.value]));
-        expect((envMap.PROVENANCE_WATCH_DIRS ?? "").split(",")).toEqual([
-            "/an-1/data",
-            "/an-1/runs/run-1/step-a",
-            "/an-1/runs/run-1/qc",
-            "/an-1/runs/run-1/norm",
+        expect((envMap.PROVENANCE_WATCH_DIRS ?? "").split(",")).toEqual(["/an-1/runs/run-1/step-a"]);
+        // The hooks keep the whole mount as their prefix, so a read of an
+        // unwatched tree still reaches the frame.
+        expect(envMap.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
+    });
+
+    test("a read-only sandbox carries an empty watch dir list", async () => {
+        // No read-write step mount means the pod writes nowhere, so there is
+        // nothing for inotify to verify.
+        const stub = stubApis([
+            {
+                status: { phase: "Running", podIP: "10.0.0.4" },
+                metadata: { name: "sbx-ro" },
+            },
         ]);
+
+        const ops = createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox(
+                {
+                    runId: "run-1",
+                    stepId: "step-a",
+                    analysisId: "an-1",
+                    childWorkflowId: "run-1-0",
+                    resources: { cpu: 2, memoryGb: 4 },
+                    readOnly: true,
+                },
+                mintSandboxIdentity("run-1"),
+            )
+        )._unsafeUnwrap();
+
+        const env = stub.createdJobs[0]!.spec!.template.spec!.containers[0].env ?? [];
+        const envMap = Object.fromEntries(env.map((e) => [e.name, e.value]));
+        expect(envMap.PROVENANCE_WATCH_DIRS).toBe("");
         expect(envMap.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 });

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -155,14 +155,10 @@ function workspaceSubPathFor(config: K8sClientConfig, analysisId: string): strin
 
 function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity): V1Job {
     const { sandboxId } = identity;
-    const plan = buildMountPlan(
-        meta,
-        {
-            libs: !!config.libStorePvc,
-            refs: !!config.refStorePvc,
-        },
-        meta.completedSiblingStepIds,
-    );
+    const plan = buildMountPlan(meta, {
+        libs: !!config.libStorePvc,
+        refs: !!config.refStorePvc,
+    });
 
     const transport = config.transport ?? "poll";
     const env = [

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -155,10 +155,14 @@ function workspaceSubPathFor(config: K8sClientConfig, analysisId: string): strin
 
 function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity): V1Job {
     const { sandboxId } = identity;
-    const plan = buildMountPlan(meta, {
-        libs: !!config.libStorePvc,
-        refs: !!config.refStorePvc,
-    });
+    const plan = buildMountPlan(
+        meta,
+        {
+            libs: !!config.libStorePvc,
+            refs: !!config.refStorePvc,
+        },
+        meta.completedSiblingStepIds,
+    );
 
     const transport = config.transport ?? "poll";
     const env = [

--- a/harness/src/sandbox/mount-plan.test.ts
+++ b/harness/src/sandbox/mount-plan.test.ts
@@ -29,8 +29,9 @@ describe("buildMountPlan", () => {
         expect(plan.readonlyTreePath).toBe("/an-1");
         expect(plan.libsPath).toBe("/mnt/libs");
         expect(plan.refsPath).toBe("/mnt/refs");
-        // No step tree exists to watch, so only the data tree is enumerated.
-        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data");
+        // A read-only sandbox writes nowhere, so there is nothing for inotify
+        // to verify — while the hooks still report whatever it reads.
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("");
         expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 
@@ -46,42 +47,37 @@ describe("buildMountPlan", () => {
         expect([...plan.stepSubdirs]).toEqual(["output", "scripts", "figures", "logs", "notebooks"]);
     });
 
-    test("watch dirs enumerate the data tree and this step's own tree, never the mount root", () => {
+    test("the step's own run tree is the only watch dir", () => {
+        // inotify collects creates, deletes, and moves — the events only this
+        // step's own read-write mount can raise.
         const plan = buildMountPlan(COORDS, { libs: false, refs: false });
-        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a"]);
-        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).not.toContain("/an-1");
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
     });
 
-    test("a completed sibling is watched whether or not this step declared it", () => {
-        // Membership follows observed completion: a completed step writes no
-        // more, and its reads are admissible under the completion gate anyway.
-        const plan = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc", "norm"]);
-        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a", "/an-1/runs/run-1/qc", "/an-1/runs/run-1/norm"]);
-    });
-
-    test("a sibling absent from the completed list is not watched", () => {
-        // A running sibling mutates its own read-write mount freely; watching it
-        // folds that churn into this step's frame.
-        const dirs = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc"]).env.PROVENANCE_WATCH_DIRS.split(",");
-        expect(dirs).toContain("/an-1/runs/run-1/qc");
+    test("neither the data tree, nor a sibling's tree, nor the mount root is watched", () => {
+        // `data/` is frozen for the run and a completed sibling writes no more,
+        // so a watch on either could never fire; the mount root would pull in
+        // every running sibling's churn.
+        const dirs = buildMountPlan(COORDS, { libs: false, refs: false }).env.PROVENANCE_WATCH_DIRS.split(",");
+        expect(dirs).not.toContain("/an-1/data");
+        expect(dirs).not.toContain("/an-1/runs/run-1/qc");
         expect(dirs).not.toContain("/an-1/runs/run-1/T2S2");
+        expect(dirs).not.toContain("/an-1");
     });
 
-    test("the step's own id in the completed list does not duplicate its tree", () => {
-        const dirs = buildMountPlan(COORDS, { libs: false, refs: false }, ["step-a", "qc"]).env.PROVENANCE_WATCH_DIRS.split(",");
-        expect(dirs.filter((d) => d === "/an-1/runs/run-1/step-a")).toHaveLength(1);
-    });
-
-    test("read-only watches the data tree and completed siblings but no step tree", () => {
-        const plan = buildMountPlan({ ...COORDS, readOnly: true }, { libs: false, refs: false }, ["qc"]);
-        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/qc"]);
+    test("a read-only sandbox configures no watch dirs at all", () => {
+        // No read-write step mount means the container writes nowhere, so no
+        // path under the tree can raise an event it caused.
+        const plan = buildMountPlan({ ...COORDS, readOnly: true }, { libs: false, refs: false });
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("");
     });
 
     test("PROVENANCE_DATA_PREFIXES stays the mount root, independent of the watch dirs", () => {
         // The in-container hooks see only their own process's opens, so a
         // command's own read under an unwatched tree still reaches the frame.
-        const plan = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc"]);
+        const plan = buildMountPlan(COORDS, { libs: false, refs: false });
         expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
+        expect(plan.env.PROVENANCE_DATA_PREFIXES).not.toBe(plan.env.PROVENANCE_WATCH_DIRS);
     });
 
     test("libs enabled injects lib-store env", () => {
@@ -98,7 +94,7 @@ describe("buildMountPlan", () => {
         expect(plan.env.NODE_PATH).toBeUndefined();
         expect(plan.env.PATH).toBeUndefined();
         // Provenance still present even with no stores.
-        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/runs/run-1/step-a");
         expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 
@@ -149,11 +145,5 @@ describe("buildMountPlan id validation", () => {
         expect(() => buildMountPlan({ ...COORDS, analysisId: ".." }, { libs: false, refs: false })).toThrow(/Invalid analysisId/);
         expect(() => buildMountPlan({ ...COORDS, stepId: ".." }, { libs: false, refs: false })).toThrow(/Invalid stepId/);
         expect(() => buildMountPlan({ ...COORDS, runId: ".." }, { libs: false, refs: false })).toThrow(/Invalid runId/);
-    });
-
-    test("rejects a crafted `..` sibling step id", () => {
-        // Sibling ids arrive from a query, but they land in an env value the
-        // container walks — the same validation the mount paths get.
-        expect(() => buildMountPlan(COORDS, { libs: false, refs: false }, [".."])).toThrow(/Invalid stepId/);
     });
 });

--- a/harness/src/sandbox/mount-plan.test.ts
+++ b/harness/src/sandbox/mount-plan.test.ts
@@ -29,7 +29,9 @@ describe("buildMountPlan", () => {
         expect(plan.readonlyTreePath).toBe("/an-1");
         expect(plan.libsPath).toBe("/mnt/libs");
         expect(plan.refsPath).toBe("/mnt/refs");
-        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        // No step tree exists to watch, so only the data tree is enumerated.
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data");
+        expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 
     test("writable mode sets WorkingDir to the writable step path", () => {
@@ -44,9 +46,42 @@ describe("buildMountPlan", () => {
         expect([...plan.stepSubdirs]).toEqual(["output", "scripts", "figures", "logs", "notebooks"]);
     });
 
-    test("PROVENANCE_WATCH_DIRS is always set to the RO tree", () => {
+    test("watch dirs enumerate the data tree and this step's own tree, never the mount root", () => {
         const plan = buildMountPlan(COORDS, { libs: false, refs: false });
-        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a"]);
+        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).not.toContain("/an-1");
+    });
+
+    test("a completed sibling is watched whether or not this step declared it", () => {
+        // Membership follows observed completion: a completed step writes no
+        // more, and its reads are admissible under the completion gate anyway.
+        const plan = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc", "norm"]);
+        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/step-a", "/an-1/runs/run-1/qc", "/an-1/runs/run-1/norm"]);
+    });
+
+    test("a sibling absent from the completed list is not watched", () => {
+        // A running sibling mutates its own read-write mount freely; watching it
+        // folds that churn into this step's frame.
+        const dirs = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc"]).env.PROVENANCE_WATCH_DIRS.split(",");
+        expect(dirs).toContain("/an-1/runs/run-1/qc");
+        expect(dirs).not.toContain("/an-1/runs/run-1/T2S2");
+    });
+
+    test("the step's own id in the completed list does not duplicate its tree", () => {
+        const dirs = buildMountPlan(COORDS, { libs: false, refs: false }, ["step-a", "qc"]).env.PROVENANCE_WATCH_DIRS.split(",");
+        expect(dirs.filter((d) => d === "/an-1/runs/run-1/step-a")).toHaveLength(1);
+    });
+
+    test("read-only watches the data tree and completed siblings but no step tree", () => {
+        const plan = buildMountPlan({ ...COORDS, readOnly: true }, { libs: false, refs: false }, ["qc"]);
+        expect(plan.env.PROVENANCE_WATCH_DIRS.split(",")).toEqual(["/an-1/data", "/an-1/runs/run-1/qc"]);
+    });
+
+    test("PROVENANCE_DATA_PREFIXES stays the mount root, independent of the watch dirs", () => {
+        // The in-container hooks see only their own process's opens, so a
+        // command's own read under an unwatched tree still reaches the frame.
+        const plan = buildMountPlan(COORDS, { libs: false, refs: false }, ["qc"]);
+        expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 
     test("libs enabled injects lib-store env", () => {
@@ -63,7 +98,8 @@ describe("buildMountPlan", () => {
         expect(plan.env.NODE_PATH).toBeUndefined();
         expect(plan.env.PATH).toBeUndefined();
         // Provenance still present even with no stores.
-        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1/data,/an-1/runs/run-1/step-a");
+        expect(plan.env.PROVENANCE_DATA_PREFIXES).toBe("/an-1");
     });
 
     test("refs gating is independent of libs", () => {
@@ -113,5 +149,11 @@ describe("buildMountPlan id validation", () => {
         expect(() => buildMountPlan({ ...COORDS, analysisId: ".." }, { libs: false, refs: false })).toThrow(/Invalid analysisId/);
         expect(() => buildMountPlan({ ...COORDS, stepId: ".." }, { libs: false, refs: false })).toThrow(/Invalid stepId/);
         expect(() => buildMountPlan({ ...COORDS, runId: ".." }, { libs: false, refs: false })).toThrow(/Invalid runId/);
+    });
+
+    test("rejects a crafted `..` sibling step id", () => {
+        // Sibling ids arrive from a query, but they land in an env value the
+        // container walks — the same validation the mount paths get.
+        expect(() => buildMountPlan(COORDS, { libs: false, refs: false }, [".."])).toThrow(/Invalid stepId/);
     });
 });

--- a/harness/src/sandbox/mount-plan.ts
+++ b/harness/src/sandbox/mount-plan.ts
@@ -121,7 +121,54 @@ function libStoreEnv(): Record<string, string> {
     };
 }
 
-export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores): MountPlan {
+/**
+ * The container directories the sandbox's inotify watcher may observe: the
+ * **immutable** set, enumerated.
+ *
+ * `data/` is staged before the run, this step's own tree is written by this
+ * step alone, and a step observed `completed` will never write again — so
+ * nothing under these paths churns while the watcher runs. Every other step of
+ * the run has its own directory mounted read-write in its own container and
+ * mutates it freely, so watching a sibling that is still running attributes
+ * that sibling's scratch churn to this step's exec frame. Completion, not
+ * `dependsOn`, is the criterion: the scheduler already guarantees a declared
+ * dependency completed, so the declared set is a strict subset of this one, and
+ * a read of a completed sibling the step never declared is one classification
+ * admits.
+ *
+ * An enumeration rather than one covering root because the analysis mount is
+ * flat: the only directory that contains all of these is the mount root, and
+ * that root contains every running sibling's tree as well. A path that does not
+ * exist in the container (a completed sibling that produced no tree) is the
+ * watcher's to skip — provenance never fails a command.
+ */
+function immutableWatchDirs(args: {
+    readonlyTreePath: string;
+    writableStepPath: string | undefined;
+    runId: string;
+    stepId: string;
+    completedSiblingStepIds: readonly string[];
+}): string[] {
+    const dirs = new Set<string>([`${args.readonlyTreePath}/data`]);
+    if (args.writableStepPath) dirs.add(args.writableStepPath);
+    for (const siblingStepId of args.completedSiblingStepIds) {
+        // A step is not its own sibling — its tree is already listed, and on a
+        // retry of a step whose prior attempt completed it would arrive here too.
+        if (siblingStepId === args.stepId) continue;
+        dirs.add(`${args.readonlyTreePath}/${stepTail(args.runId, siblingStepId)}`);
+    }
+    return [...dirs];
+}
+
+/**
+ * `completedSiblingStepIds` are the step ids of the SAME run observed
+ * `completed` when this sandbox is created. They are a parameter rather than
+ * something this function looks up: the plan is a pure function of its inputs,
+ * and a query inside it would give sandbox creation a hidden I/O dependency its
+ * tests could not express. Empty means "watch no sibling" — under-capture,
+ * which is the conservative direction.
+ */
+export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores, completedSiblingStepIds: readonly string[] = []): MountPlan {
     const { analysisId, runId, stepId, readOnly } = coords;
     // `analysisId` becomes the RO mount point `/{analysisId}` even in read-only
     // mode (where `stepTail` — which validates runId/stepId — is not reached).
@@ -137,7 +184,15 @@ export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores)
         refsPath: stores.refs ? REFS_CONTAINER_PATH : undefined,
         stepSubdirs: readOnly ? [] : STEP_SUBDIRS,
         env: {
-            PROVENANCE_WATCH_DIRS: readonlyTreePath,
+            PROVENANCE_WATCH_DIRS: immutableWatchDirs({ readonlyTreePath, writableStepPath, runId, stepId, completedSiblingStepIds }).join(","),
+            // The in-container hooks (Python audit hook, R hooks, LD_PRELOAD
+            // interposer) intercept only their own process's opens, so they
+            // cannot observe another container's writes and need no narrowing.
+            // Keeping their filter at the mount root is what leaves a command's
+            // own cross-step or prior-run read capturable where inotify does not
+            // watch — classification, not capture scope, decides whether such a
+            // read may assert lineage.
+            PROVENANCE_DATA_PREFIXES: readonlyTreePath,
             ...(stores.libs ? libStoreEnv() : {}),
         },
     };

--- a/harness/src/sandbox/mount-plan.ts
+++ b/harness/src/sandbox/mount-plan.ts
@@ -122,53 +122,35 @@ function libStoreEnv(): Record<string, string> {
 }
 
 /**
- * The container directories the sandbox's inotify watcher may observe: the
- * **immutable** set, enumerated.
+ * The container directories the sandbox's inotify watcher observes: the step's
+ * own run tree, and nothing else.
  *
- * `data/` is staged before the run, this step's own tree is written by this
- * step alone, and a step observed `completed` will never write again — so
- * nothing under these paths churns while the watcher runs. Every other step of
- * the run has its own directory mounted read-write in its own container and
- * mutates it freely, so watching a sibling that is still running attributes
- * that sibling's scratch churn to this step's exec frame. Completion, not
- * `dependsOn`, is the criterion: the scheduler already guarantees a declared
- * dependency completed, so the declared set is a strict subset of this one, and
- * a read of a completed sibling the step never declared is one classification
- * admits.
+ * The criterion is what this exec *mutates*, not what it may read. inotify
+ * reports creations, deletions, and moves — never reads — and the only tree
+ * this container can write is the one mounted read-write beneath it. `data/` is
+ * staged before the run and frozen for its duration, and a step observed
+ * `completed` writes no more; neither can raise an event the watcher collects,
+ * so a watch on either is a watch that structurally cannot fire while spending
+ * the walk's budget. Excluding them also removes the walk's only unbounded
+ * terms: `data/` and a sibling's outputs are shaped by the dataset, not by
+ * anything the harness bounds, and the walk is a startup cost paid before the
+ * child process spawns.
  *
- * An enumeration rather than one covering root because the analysis mount is
- * flat: the only directory that contains all of these is the mount root, and
- * that root contains every running sibling's tree as well. A path that does not
- * exist in the container (a completed sibling that produced no tree) is the
- * watcher's to skip — provenance never fails a command.
+ * Narrowing costs no lineage edge, because reads never came from inotify. A
+ * read this command performs — of `data/`, of a sibling, of a prior run — is
+ * intercepted by the in-container hooks, whose prefix filter
+ * (`PROVENANCE_DATA_PREFIXES`) is the whole mount root and is configured
+ * independently below. Being unwatched is not being inadmissible: whether such
+ * a read may assert lineage is classification's decision, not capture scope's.
+ *
+ * A read-only sandbox has no read-write step mount and therefore writes
+ * nowhere, so it watches nothing at all.
  */
-function immutableWatchDirs(args: {
-    readonlyTreePath: string;
-    writableStepPath: string | undefined;
-    runId: string;
-    stepId: string;
-    completedSiblingStepIds: readonly string[];
-}): string[] {
-    const dirs = new Set<string>([`${args.readonlyTreePath}/data`]);
-    if (args.writableStepPath) dirs.add(args.writableStepPath);
-    for (const siblingStepId of args.completedSiblingStepIds) {
-        // A step is not its own sibling — its tree is already listed, and on a
-        // retry of a step whose prior attempt completed it would arrive here too.
-        if (siblingStepId === args.stepId) continue;
-        dirs.add(`${args.readonlyTreePath}/${stepTail(args.runId, siblingStepId)}`);
-    }
-    return [...dirs];
+function ownRunTreeWatchDirs(writableStepPath: string | undefined): string[] {
+    return writableStepPath ? [writableStepPath] : [];
 }
 
-/**
- * `completedSiblingStepIds` are the step ids of the SAME run observed
- * `completed` when this sandbox is created. They are a parameter rather than
- * something this function looks up: the plan is a pure function of its inputs,
- * and a query inside it would give sandbox creation a hidden I/O dependency its
- * tests could not express. Empty means "watch no sibling" — under-capture,
- * which is the conservative direction.
- */
-export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores, completedSiblingStepIds: readonly string[] = []): MountPlan {
+export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores): MountPlan {
     const { analysisId, runId, stepId, readOnly } = coords;
     // `analysisId` becomes the RO mount point `/{analysisId}` even in read-only
     // mode (where `stepTail` — which validates runId/stepId — is not reached).
@@ -184,7 +166,7 @@ export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores,
         refsPath: stores.refs ? REFS_CONTAINER_PATH : undefined,
         stepSubdirs: readOnly ? [] : STEP_SUBDIRS,
         env: {
-            PROVENANCE_WATCH_DIRS: immutableWatchDirs({ readonlyTreePath, writableStepPath, runId, stepId, completedSiblingStepIds }).join(","),
+            PROVENANCE_WATCH_DIRS: ownRunTreeWatchDirs(writableStepPath).join(","),
             // The in-container hooks (Python audit hook, R hooks, LD_PRELOAD
             // interposer) intercept only their own process's opens, so they
             // cannot observe another container's writes and need no narrowing.

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -97,10 +97,10 @@ export const ProvenanceFrameSchema = z.object({
      */
     deletes: z.array(ProvenanceFrameEntrySchema).default([]),
     /**
-     * Present only when the sandbox's inotify walk stopped adding watches at
-     * its budget, leaving directories unobserved. Capture past that point is
-     * partial, and the sandbox's own warning never leaves the container — so
-     * the fact rides the frame, where the host can log it against the run.
+     * Present only when the sandbox's inotify walk left directories
+     * unobserved. Capture past that point is partial, and the sandbox's own
+     * warning never leaves the container — so the fact rides the frame, where
+     * the host can log it against the run.
      */
     watchBudget: z
         .object({
@@ -114,6 +114,17 @@ export const ProvenanceFrameSchema = z.object({
              * which the walk therefore never enumerates.
              */
             unwatchedDirs: z.number(),
+            /**
+             * Directories whose watch registration the kernel rejected — the
+             * per-uid `max_user_watches` ceiling, spent by everything on the
+             * host rather than by this sandbox. Kept apart from
+             * `unwatchedDirs` because the two blind spots move under different
+             * levers: the cap is the sandbox's own and is raised in its
+             * environment, this one is the host's. Optional so a sandbox image
+             * that predates the count still parses, its absence reading as
+             * "none reported" rather than "none occurred".
+             */
+            failedWatches: z.number().optional(),
         })
         .optional(),
 });
@@ -257,15 +268,6 @@ export interface CreateSandboxMeta {
     /** Enforced read-only: provision with no read-write step mount, only the
      *  read-only analysis tree. Used by the ephemeral executor. */
     readOnly?: boolean;
-    /**
-     * Step ids of the same run observed `completed` when this sandbox is
-     * created — the siblings whose directories are immutable and can therefore
-     * be inotify-watched without folding another step's churn into this step's
-     * exec frames (see `buildMountPlan`). Resolved by `createSandboxClient` so
-     * the mount plan stays a pure function of its inputs; absent means "watch
-     * no sibling", which under-captures rather than over-attributes.
-     */
-    completedSiblingStepIds?: readonly string[];
 }
 
 /**

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -96,6 +96,26 @@ export const ProvenanceFrameSchema = z.object({
      * future invalidation mapping.
      */
     deletes: z.array(ProvenanceFrameEntrySchema).default([]),
+    /**
+     * Present only when the sandbox's inotify walk stopped adding watches at
+     * its budget, leaving directories unobserved. Capture past that point is
+     * partial, and the sandbox's own warning never leaves the container — so
+     * the fact rides the frame, where the host can log it against the run.
+     */
+    watchBudget: z
+        .object({
+            /** The watcher's cap on watched directories. */
+            limit: z.number(),
+            /** Watches actually added before the cap was hit. */
+            watched: z.number(),
+            /**
+             * Directories the walk reached and refused to watch. A floor, not
+             * an exact count: each refusal also skips that directory's subtree,
+             * which the walk therefore never enumerates.
+             */
+            unwatchedDirs: z.number(),
+        })
+        .optional(),
 });
 export type ProvenanceFrame = z.infer<typeof ProvenanceFrameSchema>;
 
@@ -237,6 +257,15 @@ export interface CreateSandboxMeta {
     /** Enforced read-only: provision with no read-write step mount, only the
      *  read-only analysis tree. Used by the ephemeral executor. */
     readOnly?: boolean;
+    /**
+     * Step ids of the same run observed `completed` when this sandbox is
+     * created — the siblings whose directories are immutable and can therefore
+     * be inotify-watched without folding another step's churn into this step's
+     * exec frames (see `buildMountPlan`). Resolved by `createSandboxClient` so
+     * the mount plan stays a pure function of its inputs; absent means "watch
+     * no sibling", which under-captures rather than over-attributes.
+     */
+    completedSiblingStepIds?: readonly string[];
 }
 
 /**

--- a/harness/src/state/index.ts
+++ b/harness/src/state/index.ts
@@ -39,7 +39,14 @@ export {
 } from "./runs.js";
 export type { InsertRunInput } from "./runs.js";
 
-export { insertStepExecution, seedStepExecutions, sweepPendingStepExecutions, updateStepExecution, queryStepsByRun } from "./step-executions.js";
+export {
+    insertStepExecution,
+    seedStepExecutions,
+    sweepPendingStepExecutions,
+    updateStepExecution,
+    queryStepsByRun,
+    queryCompletedStepsByAnalysis,
+} from "./step-executions.js";
 export type { InsertStepExecutionInput, SeedStepExecutionRow, UpdateStepExecutionInput } from "./step-executions.js";
 
 export { setSandboxRef, setActiveExecId, clearSandboxRef, queryActiveSandboxes, reconcileReapedSandbox } from "./active-sandboxes.js";

--- a/harness/src/state/step-executions.test.ts
+++ b/harness/src/state/step-executions.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import type { Pool } from "pg";
 
 import { withSchema } from "../__tests__/setup/postgres.js";
-import { insertStepExecution, queryStepsByRun, seedStepExecutions, updateStepExecution } from "./step-executions.js";
+import { insertStepExecution, queryCompletedStepsByAnalysis, queryStepsByRun, seedStepExecutions, updateStepExecution } from "./step-executions.js";
 import { createBlockerHolder, createReportBlockerTool } from "../tools/sandbox/report-blocker.js";
 import type { ToolContext } from "../tools/define-tool.js";
 
@@ -143,6 +143,79 @@ describe("step-executions: pending seeding", () => {
         (await seedStepExecutions(pool, []))._unsafeUnwrap();
         const rows = (await queryStepsByRun(pool, "run-empty"))._unsafeUnwrap();
         expect(rows).toHaveLength(0);
+    });
+});
+
+describe("step-executions: completed-step snapshot", () => {
+    let pool: Pool;
+    let drop: () => Promise<void>;
+
+    const ANALYSIS = "analysis-gate";
+    const OTHER_ANALYSIS = "analysis-unrelated";
+
+    type TerminalStatus = "completed" | "failed" | "skipped" | "canceled" | "blocked";
+
+    async function seedStep(runId: string, stepId: string, analysisId: string, status: TerminalStatus | "running"): Promise<void> {
+        (await insertStepExecution(pool, { runId, stepId, analysisId, wave: 0, agentId: "scientific-executor" }))._unsafeUnwrap();
+        if (status !== "running") {
+            (await updateStepExecution(pool, runId, stepId, { status, durationMs: 1 }))._unsafeUnwrap();
+        }
+    }
+
+    beforeAll(async () => {
+        const ctx = await withSchema("step_exec_completed");
+        pool = ctx.pool;
+        drop = ctx.drop;
+
+        // One row per status, so the query has to discriminate rather than
+        // merely return everything terminal.
+        await seedStep("run-a", "a-running", ANALYSIS, "running");
+        await seedStep("run-a", "a-completed", ANALYSIS, "completed");
+        await seedStep("run-a", "a-failed", ANALYSIS, "failed");
+        await seedStep("run-a", "a-skipped", ANALYSIS, "skipped");
+        await seedStep("run-a", "a-canceled", ANALYSIS, "canceled");
+        await seedStep("run-a", "a-blocked", ANALYSIS, "blocked");
+        (
+            await seedStepExecutions(pool, [{ runId: "run-a", stepId: "a-pending", analysisId: ANALYSIS, wave: 0, agentId: "scientific-executor" }])
+        )._unsafeUnwrap();
+
+        // A prior run over the same analysis.
+        await seedStep("run-b", "b-completed", ANALYSIS, "completed");
+        await seedStep("run-b", "b-failed", ANALYSIS, "failed");
+
+        await seedStep("run-c", "c-completed", OTHER_ANALYSIS, "completed");
+    });
+
+    afterAll(async () => {
+        await drop();
+    });
+
+    it("returns only completed pairs", async () => {
+        const pairs = (await queryCompletedStepsByAnalysis(pool, ANALYSIS))._unsafeUnwrap();
+
+        expect(pairs).toEqual([
+            { runId: "run-a", stepId: "a-completed" },
+            { runId: "run-b", stepId: "b-completed" },
+        ]);
+    });
+
+    it("includes completed steps from other runs of the same analysis", async () => {
+        const pairs = (await queryCompletedStepsByAnalysis(pool, ANALYSIS))._unsafeUnwrap();
+
+        expect(pairs).toContainEqual({ runId: "run-b", stepId: "b-completed" });
+    });
+
+    it("excludes another analysis's completed steps", async () => {
+        const pairs = (await queryCompletedStepsByAnalysis(pool, ANALYSIS))._unsafeUnwrap();
+        expect(pairs.map((p) => p.stepId)).not.toContain("c-completed");
+
+        const otherPairs = (await queryCompletedStepsByAnalysis(pool, OTHER_ANALYSIS))._unsafeUnwrap();
+        expect(otherPairs).toEqual([{ runId: "run-c", stepId: "c-completed" }]);
+    });
+
+    it("returns an empty set for an analysis with no rows", async () => {
+        const pairs = (await queryCompletedStepsByAnalysis(pool, "analysis-absent"))._unsafeUnwrap();
+        expect(pairs).toEqual([]);
     });
 });
 

--- a/harness/src/state/step-executions.ts
+++ b/harness/src/state/step-executions.ts
@@ -206,6 +206,38 @@ export function queryStepsByRun(pool: Querier, runId: string): ResultAsync<StepE
     });
 }
 
+/**
+ * The `(runId, stepId)` pairs in an analysis whose producing step has finished
+ * writing — the admissibility snapshot provenance classifies sibling and
+ * prior-run reads against.
+ *
+ * `completed` is the only admissible status, deliberately narrower than
+ * "terminal": `failed`, `canceled`, and `skipped` steps never finalized their
+ * outputs, so anything left in their directories is work in progress rather
+ * than an artifact another step can be said to have consumed.
+ *
+ * Scoped to the analysis, not the run, because what makes an output stable is
+ * that the step writing it finished — not which run it belongs to. One
+ * predicate therefore answers both the same-run sibling and the prior-run
+ * question, so `cortex_runs` (whose `partial`/`failed`/`canceled` count as
+ * terminal) is never consulted. `idx_cortex_step_exec_analysis` serves it.
+ */
+export function queryCompletedStepsByAnalysis(pool: Querier, analysisId: string): ResultAsync<{ runId: string; stepId: string }[], DbError> {
+    return tryQuery("stepExecutions.queryCompletedStepsByAnalysis", async () => {
+        const result = await pool.query({
+            text: `SELECT run_id, step_id
+          FROM cortex_step_executions
+          WHERE analysis_id = $1 AND status = 'completed'
+          ORDER BY run_id, step_id`,
+            values: [analysisId],
+        });
+        return result.rows.map((row: Record<string, unknown>) => ({
+            runId: row.run_id as string,
+            stepId: row.step_id as string,
+        }));
+    });
+}
+
 function mapStepExecutionRow(row: Record<string, unknown>): StepExecutionRow {
     return {
         runId: row.run_id as string,

--- a/harness/src/tools/workspace/execute-command.replay.test.ts
+++ b/harness/src/tools/workspace/execute-command.replay.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Workflow-shape tests for `execute_command`'s completed-step snapshot.
+ *
+ * `execute_command` is `executionMode: "workflow"`: its body runs unwrapped in
+ * the DBOS workflow body, so anything it reads from the database is re-read on
+ * every replay. Completion is monotonic, so a re-read is not merely wasteful —
+ * it returns a strictly larger completed-set and gives the same run a different
+ * lineage graph after a crash. These tests pin the two halves of the fix:
+ *
+ *  1. a replayed exec classifies against the set snapshotted by the ORIGINAL
+ *     execution, even though the ledger has since gained a completed step; and
+ *  2. an exec whose snapshot was unavailable replays as unavailable, even
+ *     though the query would now succeed — the degradation is checkpointed, so
+ *     the error path cannot smuggle the determinism hazard back in.
+ *
+ * Both use the replay pattern from `workflows/__tests__/dbos/workflow-replay.test.ts`:
+ * an UNCONDITIONAL mid-body `cancelWorkflow(self)` (DBOS rejects a step
+ * sequence that diverges between attempts) followed by `resumeWorkflow`. The
+ * world is mutated between the two attempts through module-level wiring the
+ * body re-reads, which is precisely what must NOT change the outcome.
+ *
+ * Registration window: see the same file's note — this module registers a
+ * workflow at import time, so it bounces an already-launched engine (plain
+ * `DBOS.shutdown()`, no deregister) to reopen the registration window and
+ * relaunches in `beforeAll`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { Pool } from "pg";
+
+import { setupDbosForTests, type DbosTestRig } from "../../__tests__/setup/dbos.js";
+import { createCapturingLogger, type CapturingLogger } from "../../__tests__/setup/logger.js";
+import { durableStep } from "../../loop/run-step.js";
+import { ProvenanceCollector } from "../../provenance/collector.js";
+import type { SandboxClient } from "../../sandbox/client.js";
+import type { ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import { insertStepExecution, queryCompletedStepsByAnalysis, updateStepExecution } from "../../state/step-executions.js";
+import { makeToolContext } from "../__fixtures__/tool-context.js";
+import type { ToolContext } from "../define-tool.js";
+import { createExecuteCommandTool } from "./execute-command.js";
+
+if (DBOS.isInitialized()) {
+    await DBOS.shutdown();
+}
+
+const ANALYSIS = "an-replay";
+const RUN = "run-1";
+const OWN_STEP = "S3";
+/** Completed before the first attempt — admissible from the start. */
+const EARLY_SIBLING = "S1";
+/** Completed only BETWEEN the two attempts — must never become an edge. */
+const LATE_SIBLING = "S2";
+
+const MOUNT_ROOT = `/${ANALYSIS}`;
+
+const SANDBOX: SandboxRef = {
+    sandboxId: "sb-replay",
+    host: "127.0.0.1",
+    port: 8765,
+    backend: "docker",
+    callbackSecret: "secret",
+};
+
+/**
+ * One data read plus one read under each sibling's directory. The data read is
+ * the control: it is admissible whatever the snapshot says, so an empty input
+ * list would prove the frame was never fed rather than that the gate held.
+ */
+function frameResult(execId: string): ExecResult {
+    return {
+        execId,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        durationMs: 5,
+        timedOut: false,
+        provenance: {
+            disabled: false,
+            reads: [
+                { path: `${MOUNT_ROOT}/data/inputs/counts.csv`, layers: ["python"] },
+                { path: `${MOUNT_ROOT}/runs/${RUN}/${EARLY_SIBLING}/output/early.csv`, layers: ["python"] },
+                { path: `${MOUNT_ROOT}/runs/${RUN}/${LATE_SIBLING}/output/late.csv`, layers: ["python"] },
+            ],
+            writes: [{ path: `${MOUNT_ROOT}/runs/${RUN}/${OWN_STEP}/output/result.csv`, layers: ["python"] }],
+            deletes: [],
+        },
+    };
+}
+
+function fakeSandboxClient(): SandboxClient {
+    return {
+        async createSandbox() {
+            return SANDBOX;
+        },
+        async submitExec(_ref: SandboxRef, _body: SubmitExecBody) {},
+        async awaitExec(_ref: SandboxRef, execId: string, _emit: ExecEmit, _deadlineMs: number) {
+            return frameResult(execId);
+        },
+        async isAlive() {
+            return true;
+        },
+        async teardown() {},
+        async teardownById() {},
+        async listManagedSandboxes() {
+            return [];
+        },
+    };
+}
+
+/** Per-test wiring the mirror body re-reads on every attempt. */
+interface Wiring {
+    pool: Pool;
+    collector: ProvenanceCollector;
+    logger: CapturingLogger;
+}
+
+let wiring: Wiring | undefined;
+
+/**
+ * Mirror of a sandbox step's shape around one `execute_command` call: the tool
+ * is built and driven inside the workflow body with `durableStep` as its
+ * `runStep`, so its snapshot lands in the DBOS step cache exactly as it does in
+ * `sandbox-step.ts`.
+ *
+ * The self-cancel is unconditional — DBOS rejects a replay whose step sequence
+ * diverges from the original.
+ */
+const execMirror = DBOS.registerWorkflow(
+    async (): Promise<{ inputs: { path: string; source: string }[] }> => {
+        const active = wiring;
+        if (!active) throw new Error("execMirror: wiring not set");
+
+        const tool = createExecuteCommandTool({
+            logger: active.logger,
+            sandboxClient: fakeSandboxClient(),
+            sandbox: SANDBOX,
+            workflowId: DBOS.workflowID!,
+            stepId: OWN_STEP,
+            nextFunctionId: () => "fn1",
+            deadlineMs: () => Date.now() + 60_000,
+            defaultCwd: `${MOUNT_ROOT}/runs/${RUN}/${OWN_STEP}`,
+            lineageCollector: active.collector,
+            mountRoot: MOUNT_ROOT,
+            pool: active.pool,
+            analysisId: ANALYSIS,
+        });
+
+        const ctx: ToolContext = { ...makeToolContext().ctx, runStep: durableStep };
+        await tool.execute({ command: ["python", "scripts/run.py"] }, ctx);
+
+        await DBOS.cancelWorkflow(DBOS.workflowID!);
+
+        // Runs only on the resumed attempt; gives the replay something to move
+        // forward into after the cached steps return.
+        await DBOS.runStep(async () => "tail-ok", { name: "exec-mirror.tail" });
+
+        return { inputs: active.collector.getTrackedInputs().map((ref) => ({ path: ref.path, source: ref.source })) };
+    },
+    { name: "execute-command-snapshot-mirror" },
+);
+
+/**
+ * Poll the durable status rather than awaiting the handle — a rejected
+ * workflow leaves a second reject-chain floating that Bun reports as its own
+ * failure (see `workflow-replay.test.ts`).
+ */
+async function waitForTerminal(workflowId: string, timeoutMs = 10_000): Promise<string | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const status = await DBOS.getWorkflowStatus(workflowId);
+        if (status && (status.status === "SUCCESS" || status.status === "ERROR" || status.status === "CANCELLED")) {
+            return status.status;
+        }
+        await new Promise((r) => setTimeout(r, 25));
+    }
+    return undefined;
+}
+
+async function markCompleted(pool: Pool, stepId: string): Promise<void> {
+    (await insertStepExecution(pool, { runId: RUN, stepId, analysisId: ANALYSIS, wave: 0, agentId: "scientific-executor" }))._unsafeUnwrap();
+    (await updateStepExecution(pool, RUN, stepId, { status: "completed", durationMs: 1 }))._unsafeUnwrap();
+}
+
+/** The checkpointed outputs of every durable step this workflow recorded. */
+async function checkpointedStepOutputs(pool: Pool, workflowId: string): Promise<{ name: string; output: string }[]> {
+    const rows = await pool.query({
+        text: `SELECT function_name, output FROM dbos.operation_outputs WHERE workflow_uuid = $1 ORDER BY function_id`,
+        values: [workflowId],
+    });
+    return rows.rows.map((row: Record<string, unknown>) => ({ name: String(row.function_name ?? ""), output: String(row.output ?? "") }));
+}
+
+/**
+ * A pool that reaches the server but cannot see the ledger — the snapshot query
+ * fails the way a real read failure does, without depending on an unreachable
+ * host. `cortex_step_executions` lives in the rig's per-test schema, which is
+ * not on this connection's `search_path`.
+ */
+function makeLedgerBlindPool(): Pool {
+    const pool = new Pool({
+        host: process.env.DB_PG_HOST,
+        port: Number(process.env.DB_PG_PORT ?? 5432),
+        user: process.env.DB_PG_USER,
+        password: process.env.DB_PG_PASSWORD,
+        database: process.env.DB_PG_NAME,
+        options: "-c search_path=pg_temp",
+    });
+    pool.on("error", () => {});
+    return pool;
+}
+
+let rig: DbosTestRig;
+let blindPool: Pool | undefined;
+
+beforeAll(async () => {
+    rig = await setupDbosForTests("execute_command_replay");
+    if (!DBOS.isInitialized()) await DBOS.launch();
+});
+
+afterAll(async () => {
+    if (blindPool) await blindPool.end();
+    if (rig) await rig.drop();
+});
+
+describe("execute_command completed-step snapshot under replay", () => {
+    it("a replayed exec classifies against the originally snapshotted set, not a re-query", async () => {
+        await markCompleted(rig.pool, EARLY_SIBLING);
+
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: RUN });
+        wiring = { pool: rig.pool, collector, logger: createCapturingLogger() };
+
+        const wfId = rig.nextWorkflowId("exec-snapshot-");
+        const handle = await DBOS.startWorkflow(execMirror, { workflowID: wfId })();
+        handle.getResult().catch(() => {});
+        expect(await waitForTerminal(wfId)).toBe("CANCELLED");
+
+        // The world moves on: the late sibling finishes between the original
+        // execution and the replay.
+        await markCompleted(rig.pool, LATE_SIBLING);
+        const nowCompleted = (await queryCompletedStepsByAnalysis(rig.pool, ANALYSIS))._unsafeUnwrap().map((p) => p.stepId);
+        expect(nowCompleted.sort()).toEqual([EARLY_SIBLING, LATE_SIBLING]);
+
+        const resumed = await DBOS.resumeWorkflow<{ inputs: { path: string; source: string }[] }>(wfId);
+        const result = await resumed.getResult();
+
+        const paths = result.inputs.map((i) => i.path).sort();
+        expect(paths).toEqual([`${MOUNT_ROOT}/data/inputs/counts.csv`, `${MOUNT_ROOT}/runs/${RUN}/${EARLY_SIBLING}/output/early.csv`]);
+        // The load-bearing assertion: a re-queried snapshot would have admitted
+        // the late sibling on the replayed attempt.
+        expect(paths.some((p) => p.includes(LATE_SIBLING))).toBe(false);
+        expect(collector.getTrackedInputs().map((r) => r.path)).toEqual(paths);
+    });
+
+    it("a snapshot that was unavailable replays as unavailable", async () => {
+        await markCompleted(rig.pool, EARLY_SIBLING);
+
+        blindPool ??= makeLedgerBlindPool();
+        const collector = new ProvenanceCollector({ stepId: OWN_STEP, runId: RUN });
+        const logger = createCapturingLogger();
+        wiring = { pool: blindPool, collector, logger };
+
+        const wfId = rig.nextWorkflowId("exec-degraded-");
+        const handle = await DBOS.startWorkflow(execMirror, { workflowID: wfId })();
+        handle.getResult().catch(() => {});
+        expect(await waitForTerminal(wfId)).toBe("CANCELLED");
+
+        // The failure is narrated at error level, through the injected seam.
+        const errors = logger.records.filter((r) => r.level === "error");
+        expect(errors.length).toBeGreaterThanOrEqual(1);
+        expect(errors[0]!.msg).toContain("[execute_command]");
+        expect(errors[0]!.fields.analysisId).toBe(ANALYSIS);
+
+        // ...and the degraded outcome is itself a checkpoint, which is what
+        // stops the replay from re-running the query and succeeding.
+        const steps = await checkpointedStepOutputs(rig.pool, wfId);
+        const snapshotStep = steps.find((s) => s.name.includes("lineage.completed-steps"));
+        expect(snapshotStep).toBeDefined();
+        expect(snapshotStep!.output).toContain('"ok":false');
+
+        // The ledger is readable again on the replayed attempt.
+        wiring = { pool: rig.pool, collector, logger };
+        const readable = (await queryCompletedStepsByAnalysis(rig.pool, ANALYSIS))._unsafeUnwrap();
+        expect(readable.length).toBeGreaterThan(0);
+
+        const resumed = await DBOS.resumeWorkflow<{ inputs: { path: string; source: string }[] }>(wfId);
+        const result = await resumed.getResult();
+
+        // Still degraded: no producing-step read is admissible, and only the
+        // data read survives.
+        expect(result.inputs.map((i) => i.path)).toEqual([`${MOUNT_ROOT}/data/inputs/counts.csv`]);
+    });
+});

--- a/harness/src/tools/workspace/execute-command.test.ts
+++ b/harness/src/tools/workspace/execute-command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
+import { createCapturingLogger } from "../../__tests__/setup/logger.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { SandboxClient } from "../../sandbox/client.js";
+import type { ToolContext } from "../define-tool.js";
 import type { CreateSandboxMeta, ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
 import { createExecuteCommandTool } from "./execute-command.js";
 
@@ -264,5 +266,79 @@ describe("execute_command tool", () => {
 
         await tool.execute({ command: ["ls"], cwd: "/analysis-001/data" }, ctx);
         expect(client.submits[1]!.body.cwd).toBe("/analysis-001/data");
+    });
+
+    it("records a watch-budget exhaustion carried on the frame against the run", async () => {
+        // The sandbox's own warning about the exhausted walk never leaves the
+        // container, so without this record degraded capture is indistinguishable
+        // from an exec that touched nothing.
+        const client = makeFakeClient({
+            result: {
+                execId: "",
+                exitCode: 0,
+                stdout: "",
+                stderr: "",
+                durationMs: 5,
+                timedOut: false,
+                provenance: { disabled: false, reads: [], writes: [], deletes: [], watchBudget: { limit: 1000, watched: 1000, unwatchedDirs: 4 } },
+            },
+        });
+        const logger = createCapturingLogger();
+        const tool = createExecuteCommandTool({
+            sandboxClient: client,
+            sandbox: makeSandboxRef(),
+            workflowId: "wf1",
+            stepId: "step1",
+            nextFunctionId: () => "fn1",
+            deadlineMs: () => 9_999_999,
+            defaultCwd: DEFAULT_CWD,
+            logger,
+        });
+        const { ctx } = makeToolContext();
+        const runScoped: ToolContext = { ...ctx, session: { ...ctx.session, runFrame: { runId: "run-abc", stepId: "step1" } } };
+
+        const out = (await tool.execute({ command: ["ls"] }, runScoped))._unsafeUnwrap();
+
+        expect(out.status).toBe("ok");
+        const warns = logger.records.filter((r) => r.level === "warn");
+        expect(warns).toHaveLength(1);
+        expect(warns[0]!.fields).toMatchObject({
+            execId: "wf1:step1:fn1",
+            stepId: "step1",
+            runId: "run-abc",
+            watchLimit: 1000,
+            watchedDirs: 1000,
+            unwatchedDirs: 4,
+        });
+    });
+
+    it("says nothing when the walk fit inside the watch budget", async () => {
+        const client = makeFakeClient({
+            result: {
+                execId: "",
+                exitCode: 0,
+                stdout: "",
+                stderr: "",
+                durationMs: 5,
+                timedOut: false,
+                provenance: { disabled: false, reads: [], writes: [], deletes: [] },
+            },
+        });
+        const logger = createCapturingLogger();
+        const tool = createExecuteCommandTool({
+            sandboxClient: client,
+            sandbox: makeSandboxRef(),
+            workflowId: "wf1",
+            stepId: "step1",
+            nextFunctionId: () => "fn1",
+            deadlineMs: () => 9_999_999,
+            defaultCwd: DEFAULT_CWD,
+            logger,
+        });
+        const { ctx } = makeToolContext();
+
+        await tool.execute({ command: ["ls"] }, ctx);
+
+        expect(logger.records).toEqual([]);
     });
 });

--- a/harness/src/tools/workspace/execute-command.ts
+++ b/harness/src/tools/workspace/execute-command.ts
@@ -18,18 +18,26 @@
  * `sandbox-provenance-tracking`), and artifact registration reconciles them.
  * The harness-side mutate tools (`write_file`, `edit_file`) hash and record
  * the writes *they* perform, but `execute_command`'s opaque commands do not.
+ *
+ * What the tool does own for lineage is *admissibility*: before each exec is
+ * submitted it snapshots which steps of the analysis have completed, and hands
+ * that set to the frame translation. A read under a producing step's directory
+ * becomes an input edge only if that step had finished; everything else the
+ * command happened to observe is dropped rather than asserted.
  */
 
 import { posix as posixPath } from "node:path";
 
 import { ok } from "neverthrow";
+import type { Pool } from "pg";
 import { z } from "zod";
 
-import { defineTool } from "../define-tool.js";
+import { defineTool, type ToolContext } from "../define-tool.js";
 import type { SandboxClient } from "../../sandbox/client.js";
 import type { SandboxRef } from "../../sandbox/types.js";
-import type { ProvenanceCollector } from "../../provenance/collector.js";
+import { completedStepKey, type CompletedSteps, type ProvenanceCollector } from "../../provenance/collector.js";
 import { feedExecFrame } from "../../provenance/exec-frame.js";
+import { queryCompletedStepsByAnalysis } from "../../state/index.js";
 import { boundExecResult } from "./result-bounds.js";
 import { runSandboxExec } from "./run-exec.js";
 import { createNoopLogger } from "../../lib/console-logger.js";
@@ -91,10 +99,105 @@ export interface ExecuteCommandDeps {
     readonly lineageCollector?: ProvenanceCollector;
     /** Analysis resource mount root (`/{resourceId}`) — strips frame paths to relative. */
     readonly mountRoot?: string;
+    /**
+     * Reads `cortex_step_executions` for the completed-step snapshot that
+     * decides which producing steps this exec may claim as inputs. Belongs
+     * with `lineageCollector`/`mountRoot`: without it no sibling or prior-run
+     * read of this exec is admissible.
+     */
+    readonly pool?: Pool;
+    /**
+     * The analysis whose step completions gate this exec's lineage edges. One
+     * predicate covers same-run siblings and prior runs alike, so the snapshot
+     * is analysis-scoped rather than run-scoped.
+     */
+    readonly analysisId?: string;
+}
+
+/**
+ * What the durable snapshot step resolves to, before it becomes a membership
+ * set.
+ *
+ * The durable shape is an array of pairs, not the `Set` the classifier wants,
+ * because DBOS checkpoints a step's return value as JSON and a `Set` replays
+ * as `{}`. The failure arm is a value rather than a throw for two reasons: a
+ * thrown step would fail the exec, and provenance must never do that; and it
+ * would leave the degradation itself un-checkpointed, so a replay could re-run
+ * the query, succeed where the original failed, and assert edges the first
+ * execution refused.
+ */
+type CompletedStepsSnapshot = { readonly ok: true; readonly pairs: readonly { readonly runId: string; readonly stepId: string }[] } | { readonly ok: false };
+
+/**
+ * Observe which producing steps of this analysis have finished, as of now.
+ *
+ * `undefined` means "no snapshot" and is not the same as an empty set: the
+ * classifier fails closed on it, so every read naming a producing step becomes
+ * inadmissible rather than silently admitted.
+ */
+async function snapshotCompletedSteps(args: {
+    readonly ctx: ToolContext;
+    readonly pool: Pool;
+    readonly analysisId: string;
+    readonly execId: string;
+    readonly logger: Logger;
+}): Promise<CompletedSteps | undefined> {
+    const { ctx, pool, analysisId, execId, logger } = args;
+
+    // `execute_command` is `executionMode: "workflow"`, so this body runs
+    // unwrapped in the DBOS workflow body: an unwrapped query would re-execute
+    // on replay and return a strictly larger completed-set, giving the same run
+    // different lineage on recovery. The step wrapper is what pins the answer.
+    // A DBOS control-flow throw (workflow cancellation) is deliberately not
+    // caught around it — that is not a provenance failure and must reach the
+    // loop's fatal predicate.
+    const snapshot = await ctx.runStep(`lineage.completed-steps.${execId}`, async (): Promise<CompletedStepsSnapshot> => {
+        const queried = await queryCompletedStepsByAnalysis(pool, analysisId);
+        return queried.match<CompletedStepsSnapshot>(
+            (pairs) => ({ ok: true, pairs }),
+            (error) => {
+                logger.error("completed-step snapshot unavailable — no producing-step read of this exec is admissible", {
+                    execId,
+                    analysisId,
+                    ...logger.errorFields(error),
+                });
+                return { ok: false };
+            },
+        );
+    });
+
+    if (!snapshot.ok) return undefined;
+    return new Set(snapshot.pairs.map((pair) => completedStepKey(pair.runId, pair.stepId)));
 }
 
 export function createExecuteCommandTool(deps: ExecuteCommandDeps) {
-    const { sandboxClient, sandbox, workflowId, stepId, nextFunctionId, deadlineMs, defaultCwd, markExecActive, lineageCollector, mountRoot } = deps;
+    const {
+        sandboxClient,
+        sandbox,
+        workflowId,
+        stepId,
+        nextFunctionId,
+        deadlineMs,
+        defaultCwd,
+        markExecActive,
+        lineageCollector,
+        mountRoot,
+        pool,
+        analysisId,
+    } = deps;
+    const logger = (deps.logger ?? createNoopLogger()).named("execute_command");
+
+    /** The snapshot this exec classifies against, or `undefined` for none. */
+    const snapshotForExec = (ctx: ToolContext, execId: string): Promise<CompletedSteps | undefined> => {
+        if (!lineageCollector || !mountRoot) return Promise.resolve(undefined);
+        if (!pool || !analysisId) {
+            logger.error("no completed-step snapshot source wired alongside the lineage collector — no producing-step read of this exec is admissible", {
+                execId,
+            });
+            return Promise.resolve(undefined);
+        }
+        return snapshotCompletedSteps({ ctx, pool, analysisId, execId, logger });
+    };
 
     return defineTool({
         id: "execute_command",
@@ -116,6 +219,15 @@ export function createExecuteCommandTool(deps: ExecuteCommandDeps) {
 
             const effectiveCwd = cwd === undefined ? defaultCwd : cwd.startsWith("/") ? cwd : posixPath.join(defaultCwd, cwd);
 
+            // Submit time is the normative predicate for admissibility, so the
+            // snapshot is taken here rather than after the exec: completion is
+            // monotonic, so a step observed `completed` now was necessarily
+            // completed before any read this command can perform. Observed
+            // afterwards it would also cover siblings that finished *while* the
+            // command ran, and there is no way to tell whether the read landed
+            // before or after such a sibling's final write.
+            const completedSteps = await snapshotForExec(ctx, execId);
+
             const result = await runSandboxExec({
                 sandboxClient,
                 sandbox,
@@ -129,6 +241,23 @@ export function createExecuteCommandTool(deps: ExecuteCommandDeps) {
                 ...(markExecActive ? { markExecActive } : {}),
             });
 
+            // Capture degradation the container cannot report any other way: the
+            // watcher's own warning stays in the sandbox's log, so without this
+            // the frame silently omits whatever lived under the directories the
+            // walk could not watch. Logged whether or not lineage is collected —
+            // the degradation is a fact about the exec, not about this wiring.
+            const watchBudget = result.provenance?.watchBudget;
+            if (watchBudget) {
+                logger.warn("sandbox inotify watch budget exhausted — file operations under unwatched directories were not observed", {
+                    execId,
+                    stepId,
+                    ...(ctx.session.runFrame ? { runId: ctx.session.runFrame.runId } : {}),
+                    watchLimit: watchBudget.limit,
+                    watchedDirs: watchBudget.watched,
+                    unwatchedDirs: watchBudget.unwatchedDirs,
+                });
+            }
+
             // Thread the runtime file-I/O frame into the step's lineage collector.
             // Best-effort: a collector failure must never fail the exec.
             if (lineageCollector && mountRoot) {
@@ -140,9 +269,15 @@ export function createExecuteCommandTool(deps: ExecuteCommandDeps) {
                         exitCode: result.exitCode,
                         durationMs: result.durationMs,
                         ...(result.provenance ? { provenance: result.provenance } : {}),
+                        // Passed through even when absent: the classifier reads a
+                        // missing snapshot as "nothing can be shown to have
+                        // completed" and refuses every producing-step read, which
+                        // is the degraded posture this exec must run under.
+                        completedSteps,
+                        logger,
+                        agentId: ctx.session.provenance.agentId,
                     });
                 } catch (err) {
-                    const logger = (deps.logger ?? createNoopLogger()).named("execute_command");
                     logger.warn("provenance frame handling failed (non-fatal)", { execId, ...logger.errorFields(err) });
                 }
             }

--- a/harness/src/tools/workspace/execute-command.ts
+++ b/harness/src/tools/workspace/execute-command.ts
@@ -248,13 +248,19 @@ export function createExecuteCommandTool(deps: ExecuteCommandDeps) {
             // the degradation is a fact about the exec, not about this wiring.
             const watchBudget = result.provenance?.watchBudget;
             if (watchBudget) {
-                logger.warn("sandbox inotify watch budget exhausted — file operations under unwatched directories were not observed", {
+                logger.warn("sandbox inotify watch coverage was incomplete — file operations under unwatched directories were not observed", {
                     execId,
                     stepId,
                     ...(ctx.session.runFrame ? { runId: ctx.session.runFrame.runId } : {}),
                     watchLimit: watchBudget.limit,
                     watchedDirs: watchBudget.watched,
+                    // The two shortfalls stay separate fields because they name
+                    // different limits: `unwatchedDirs` is the sandbox's own cap
+                    // declining to descend (raise PROVENANCE_MAX_INOTIFY_WATCHES),
+                    // `failedWatches` is the host's per-uid ceiling refusing the
+                    // registration (raise fs.inotify.max_user_watches on the node).
                     unwatchedDirs: watchBudget.unwatchedDirs,
+                    failedWatches: watchBudget.failedWatches ?? 0,
                 });
             }
 

--- a/harness/src/workflows/execute-analysis.test.ts
+++ b/harness/src/workflows/execute-analysis.test.ts
@@ -30,7 +30,7 @@ import { CortexChatPartSchema } from "@inflexa-ai/harness/contracts/schemas/chat
 
 import { makeLocalAuth } from "../auth/local-auth-context.js";
 
-import { runExecuteAnalysisBody } from "./execute-analysis.js";
+import { buildChildInput, runExecuteAnalysisBody } from "./execute-analysis.js";
 import type { ExecuteAnalysisDeps, ExecuteAnalysisInput, RunProvenanceEvent } from "./execute-analysis.js";
 import type { SandboxStepInput, SandboxStepResult } from "./sandbox-step.js";
 import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
@@ -1120,5 +1120,45 @@ describe("executeAnalysis child seed", () => {
 
         const bad: ExecuteAnalysisInput = { ...input([{ id: "A" }]), planStepById: {} };
         await expect(runExecuteAnalysisBody(bad, deps)).rejects.toThrow(/missing from planStepById/);
+    });
+});
+
+// ── Declared dependencies on the child's durable input ───────────────
+
+describe("executeAnalysis child dependsOn", () => {
+    it("dispatches each child with the dependency ids the scheduler gated it on", async () => {
+        const pool = makeFakePool({
+            "SELECT run_id, analysis_id, thread_id, workflow_name, workflow_id": [{ attempt_count: 0 }],
+        });
+        const { deps } = makeDeps({
+            pool,
+            childResults: new Map<string, SandboxStepResult | Error>([
+                ["A", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+                ["B", { status: "complete", durationMs: 1, finishReason: "stop", error: null }],
+            ]),
+        });
+
+        const result = await runExecuteAnalysisBody(input([{ id: "A" }, { id: "B", depends_on: ["A"] }]), deps);
+        expect(result.status).toBe("completed");
+
+        // A root step declares nothing — an EMPTY declaration, which the child
+        // must be able to tell apart from the absent field of a workflow
+        // recovered from before the field existed.
+        expect(dbosState.childInputs.find((i) => i.stepId === "A")!.dependsOn).toEqual([]);
+        expect(dbosState.childInputs.find((i) => i.stepId === "B")!.dependsOn).toEqual(["A"]);
+    });
+
+    it("leaves dependsOn unset for a step absent from the plan DAG rather than declaring it empty", () => {
+        const base = input([{ id: "A", depends_on: ["Z"] }]);
+        const child = buildChildInput({
+            input: { ...base, steps: [] },
+            stepId: "A",
+            level: 0,
+            runId: "run-test",
+            workflowId: "wf-1",
+            prompt: "seed",
+        });
+
+        expect(child.dependsOn).toBeUndefined();
     });
 });

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -324,12 +324,19 @@ export function buildChildInput(args: {
     if (!resources) {
         throw new Error(`executeAnalysis: step "${stepId}" missing from resourcesByStepId — every step must declare resources`);
     }
+    // Declared dependencies, read off `steps` — the same normalized DAG the
+    // scheduler gated this dispatch on, so the child cannot disagree with the
+    // parent about what was declared. A step absent from that DAG is never
+    // dispatched; were one ever to be, leaving the field unset hands the child
+    // "unknown" instead of a fabricated empty declaration.
+    const declaredDependencies = input.steps.find((s) => s.id === stepId)?.depends_on;
     return {
         analysisId: input.analysisId,
         runId,
         stepId,
         agentId: input.agentByStepId[stepId] ?? "scientific-executor",
         level,
+        dependsOn: declaredDependencies,
         prompt,
         parentWorkflowId: workflowId,
         resources,

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -76,6 +76,20 @@ export interface SandboxStepInput {
     readonly agentId: string;
     /** Topological level — persisted on `cortex_step_executions.wave`. */
     readonly level: number;
+    /**
+     * The plan's declared upstream step ids, seeded into this step's
+     * `ProvenanceCollector` so lineage diagnostics can tell a *declared* edge
+     * from a merely *observed* one. It is not the admissibility gate — step
+     * completion is — so nothing may start reading it as authorization.
+     *
+     * MUST stay optional. DBOS persists this interface as the workflow's input
+     * row, and a workflow already in flight was persisted without the field: it
+     * has to deserialize and recover. Absence therefore means "declared
+     * dependencies unknown", which is NOT an empty declaration and must never
+     * widen what a read may be classified as — it only costs the
+     * declared-vs-observed distinction in diagnostics.
+     */
+    readonly dependsOn?: readonly string[];
     /** User-content prompt the agent receives as its initial message. */
     readonly prompt: string;
     /**
@@ -377,9 +391,19 @@ async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxStepDeps
     // input/script edges. Reconstructed deterministically on replay — the
     // frames it consumes are cached recv outputs and the command strings are
     // cached LLM tool-use (see the harness-thread-store and harness-durable-runtime specs).
+    //
+    // `dependsOn` seeds the declared-vs-observed distinction only; admissibility
+    // is gated on step completion, not on declaration. An input recovered from
+    // before the field existed carries none, and that stays `undefined` rather
+    // than collapsing to `[]` — "declared dependencies unknown" must not reach
+    // the collector wearing the shape of "declared nothing".
+    if (input.dependsOn === undefined) {
+        logger.warn("step input carries no declared dependencies — lineage edges cannot be attributed to a declared dependency");
+    }
     const lineageCollector = new ProvenanceCollector({
         stepId: input.stepId,
         runId: input.runId,
+        dependsOn: input.dependsOn === undefined ? undefined : [...input.dependsOn],
     });
 
     // (2a) sandbox.mint — checkpoint the machine's identity (name + HMAC secret)

--- a/images/sandbox-base/server/config.go
+++ b/images/sandbox-base/server/config.go
@@ -15,6 +15,10 @@ const (
 	envTreeDiffInterval = "SANDBOX_TREE_DIFF_INTERVAL_MS"
 	envTransport        = "SANDBOX_TRANSPORT"
 	envEgressFirewall   = "SANDBOX_EGRESS_FIREWALL"
+	// Sits with the other PROVENANCE_* knobs the harness sets on the container
+	// (PROVENANCE_WATCH_DIRS, PROVENANCE_DATA_PREFIXES) rather than with the
+	// SANDBOX_* server settings: it tunes the capture layer, not the server.
+	envInotifyWatchLimit = "PROVENANCE_MAX_INOTIFY_WATCHES"
 )
 
 // transportMode selects how a command's progress events and terminal result

--- a/images/sandbox-base/server/executor.go
+++ b/images/sandbox-base/server/executor.go
@@ -65,6 +65,9 @@ type provenancePayload struct {
 	Reads    []ProvenanceEntry `json:"reads,omitempty"`
 	Writes   []ProvenanceEntry `json:"writes,omitempty"`
 	Deletes  []ProvenanceEntry `json:"deletes,omitempty"`
+	// Set only when the inotify walk ran out of watch budget, so an exec whose
+	// capture was complete carries no signal at all.
+	WatchBudget *watchBudgetSignal `json:"watchBudget,omitempty"`
 }
 
 // executor wires the dedup table to the result-delivery path. One executor per
@@ -163,6 +166,7 @@ func (e *executor) run(req execSubmitRequest, traceID string) {
 	provTracker := NewProvenanceTracker(
 		fmt.Sprintf("%s-%d", sanitizeForFilename(req.ExecID), time.Now().UnixNano()),
 		provenanceWatchDirs(),
+		provenanceDataPrefixes(),
 	)
 	provenanceDisabled := false
 	if err := provTracker.Start(); err != nil {
@@ -235,10 +239,11 @@ func (e *executor) run(req execSubmitRequest, traceID string) {
 
 	provResult := provTracker.Stop()
 	prov := &provenancePayload{
-		Disabled: provenanceDisabled,
-		Reads:    provResult.Reads,
-		Writes:   provResult.Writes,
-		Deletes:  provResult.Deletes,
+		Disabled:    provenanceDisabled,
+		Reads:       provResult.Reads,
+		Writes:      provResult.Writes,
+		Deletes:     provResult.Deletes,
+		WatchBudget: provResult.WatchBudget,
 	}
 
 	stdout := stdoutBuilder.String()

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -53,7 +53,15 @@ type ProvenanceEntry struct {
 type ProvenanceTracker struct {
 	socketPath string
 	rlogPath   string
-	watchDirs  []string
+	// Directories inotify walks. Narrow, and the only layer that needs to be:
+	// inotify is the sole layer watching the shared filesystem, so it is the
+	// sole layer that can observe another container's writes.
+	watchDirs []string
+	// Prefixes bounding what any layer may report — the analysis mount root.
+	// Configured independently of watchDirs and never derived from them: the
+	// in-container hooks intercept only their own process's opens, so a
+	// command's own read of a path no watcher covers still reaches the frame.
+	dataPrefixes []string
 
 	// Socket listener
 	listener net.PacketConn
@@ -71,13 +79,14 @@ type ProvenanceTracker struct {
 // ── Constructor / lifecycle ────────────────────────────────────
 
 // NewProvenanceTracker creates a tracker with a unique socket path.
-func NewProvenanceTracker(id string, watchDirs []string) *ProvenanceTracker {
+func NewProvenanceTracker(id string, watchDirs, dataPrefixes []string) *ProvenanceTracker {
 	socketPath := fmt.Sprintf("/tmp/prov-%s.sock", id)
 	pt := &ProvenanceTracker{
-		socketPath: socketPath,
-		rlogPath:   socketPath + ".rlog",
-		watchDirs:  watchDirs,
-		stopCh:     make(chan struct{}),
+		socketPath:   socketPath,
+		rlogPath:     socketPath + ".rlog",
+		watchDirs:    watchDirs,
+		dataPrefixes: dataPrefixes,
+		stopCh:       make(chan struct{}),
 		ops: map[string]map[string]map[string]bool{
 			"read":   {},
 			"write":  {},
@@ -112,11 +121,28 @@ func (pt *ProvenanceTracker) Start() error {
 	return nil
 }
 
-// provenanceResult holds the three operation arrays.
+// provenanceResult holds the three operation arrays and, when the inotify walk
+// ran out of watch budget, the signal that capture was partial.
 type provenanceResult struct {
-	Reads   []ProvenanceEntry
-	Writes  []ProvenanceEntry
-	Deletes []ProvenanceEntry
+	Reads       []ProvenanceEntry
+	Writes      []ProvenanceEntry
+	Deletes     []ProvenanceEntry
+	WatchBudget *watchBudgetSignal
+}
+
+// watchBudgetSignal reports that the inotify walk stopped adding watches at its
+// cap, leaving directories unobserved. It rides the exec's provenance frame
+// because the watcher's own log line never leaves the container: without it,
+// degraded capture is indistinguishable from a step that touched nothing.
+// Never a failure — capture is best-effort and this accompanies a normal exec.
+type watchBudgetSignal struct {
+	// The cap the walk stopped at.
+	Limit int `json:"limit"`
+	// Watches added before the cap was reached.
+	Watched int `json:"watched"`
+	// Directories the walk reached and refused. A floor, not an exact count:
+	// each refusal also skips that directory's subtree, which is never walked.
+	UnwatchedDirs int `json:"unwatchedDirs"`
 }
 
 // Stop drains remaining messages, reads the R log file, and cleans up.
@@ -164,9 +190,10 @@ func (pt *ProvenanceTracker) Stop() provenanceResult {
 	}
 
 	return provenanceResult{
-		Reads:   buildList(pt.ops["read"]),
-		Writes:  buildList(pt.ops["write"]),
-		Deletes: buildList(pt.ops["delete"]),
+		Reads:       buildList(pt.ops["read"]),
+		Writes:      buildList(pt.ops["write"]),
+		Deletes:     buildList(pt.ops["delete"]),
+		WatchBudget: pt.inotify.budget(),
 	}
 }
 
@@ -194,9 +221,14 @@ func (pt *ProvenanceTracker) Env() []string {
 		env = append(env, "LD_PRELOAD="+ldPreloadPath)
 	}
 
-	// Pass watch dirs to hooks for prefix matching
-	if len(pt.watchDirs) > 0 {
-		env = append(env, "PROVENANCE_DATA_PREFIXES="+strings.Join(pt.watchDirs, ":"))
+	// The hooks filter by prefix on the paths their own process opens, so they
+	// carry the mount root rather than the watch dirs: an LD_PRELOAD interposer
+	// and interpreter-level hooks cannot see another container's writes, and
+	// narrowing them would drop a legitimate cross-step or prior-run read the
+	// command itself performed. Whether such a read may assert lineage is the
+	// host's decision at classification, not this filter's.
+	if len(pt.dataPrefixes) > 0 {
+		env = append(env, "PROVENANCE_DATA_PREFIXES="+strings.Join(pt.dataPrefixes, ":"))
 	}
 
 	return env
@@ -250,12 +282,13 @@ func (pt *ProvenanceTracker) parseDatagram(data []byte) {
 	pt.recordOp(op, dg.Path, dg.Layer)
 }
 
-// underWatchDir reports whether a cleaned absolute path lies within one of the
-// watch dirs. Entries carry a trailing slash, so this also excludes a watch dir
-// itself — a read of the mount root is a directory, never an attestable file.
-func underWatchDir(path string, dirs []string) bool {
-	for _, d := range dirs {
-		if strings.HasPrefix(path, d) {
+// underDataPrefix reports whether a cleaned absolute path lies within one of
+// the configured data prefixes. Entries carry a trailing slash, so this also
+// excludes a prefix root itself — a read of the mount root is a directory,
+// never an attestable file.
+func underDataPrefix(path string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(path, p) {
 			return true
 		}
 	}
@@ -265,14 +298,16 @@ func underWatchDir(path string, dirs []string) bool {
 func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 	// Canonicalize and re-check here, the one point every layer converges on:
 	// each hook filters by string prefix on whatever path its caller passed,
-	// which need not be canonical. "/{id}/.." literally starts with the watch
-	// dir "/{id}/" yet names its parent, so it survives the hook's filter and
+	// which need not be canonical. "/{id}/.." literally starts with the prefix
+	// "/{id}/" yet names its parent, so it survives the hook's filter and
 	// reaches the host as a tracked read that resolves above the mount root —
 	// which the host cannot attest, and fails the step over. Filtering on the
 	// cleaned path makes each hook's own check an optimization and this the
-	// boundary.
+	// boundary. The bound is the data prefixes, not the watch dirs: a report
+	// from a hook is admissible anywhere under the mount, and only inotify is
+	// confined to the watched trees — by what it is able to observe at all.
 	path = filepath.Clean(path)
-	if !underWatchDir(path, pt.watchDirs) {
+	if !underDataPrefix(path, pt.dataPrefixes) {
 		// A dropped report never reaches the host, so nothing over there can
 		// account for it — this line is the only trace of a hook-filter leak.
 		if sandboxLogLevel == logLevelDebug {
@@ -322,6 +357,9 @@ func (pt *ProvenanceTracker) readRlog() {
 type inotifyWatcher interface {
 	start(watchDirs []string)
 	stop()
+	// budget reports exhaustion of the watch cap, or nil when the walk fit
+	// inside it. Read after stop(), so the walk has finished writing it.
+	budget() *watchBudgetSignal
 }
 
 // ── Helpers ────────────────────────────────────────────────────
@@ -331,28 +369,59 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// provenanceWatchDirs returns the list of directories to watch for file reads.
-// Configured via PROVENANCE_WATCH_DIRS env var (comma-separated). Defaults to /data.
+// provenanceWatchDirs returns the directories inotify walks, from
+// PROVENANCE_WATCH_DIRS (comma-separated absolute paths, default /data). The
+// host enumerates the trees that cannot change under the running command — the
+// analysis data tree, this step's own tree, and the tree of every step already
+// completed — so a directory a concurrent step is still writing is absent by
+// construction.
+//
+// A configured dir that does not exist is skipped, not an error: a completed
+// step that produced no tree and a read-only sandbox with no step tree are both
+// ordinary, and provenance never fails a command.
 func provenanceWatchDirs() []string {
 	raw := os.Getenv("PROVENANCE_WATCH_DIRS")
 	if raw == "" {
 		raw = "/data"
 	}
-	dirs := strings.Split(raw, ",")
-	// Only return directories that exist
 	var result []string
-	for _, d := range dirs {
-		d = strings.TrimSpace(d)
-		if d == "" {
-			continue
-		}
-		// Ensure trailing slash for prefix matching
-		if !strings.HasSuffix(d, "/") {
-			d += "/"
-		}
+	for _, d := range normalizePathList(raw, ",") {
 		if info, err := os.Stat(strings.TrimSuffix(d, "/")); err == nil && info.IsDir() {
 			result = append(result, d)
 		}
+	}
+	return result
+}
+
+// provenanceDataPrefixes returns the prefixes bounding what any layer may
+// report, from PROVENANCE_DATA_PREFIXES (colon-separated, matching the form the
+// hooks themselves parse; default /data).
+//
+// Read from its own variable rather than derived from the watch dirs, and
+// deliberately not existence-filtered: the prefixes are the mount root, and a
+// stat that failed would silently discard every report the layers send.
+func provenanceDataPrefixes() []string {
+	raw := os.Getenv("PROVENANCE_DATA_PREFIXES")
+	if raw == "" {
+		raw = "/data"
+	}
+	return normalizePathList(raw, ":")
+}
+
+// normalizePathList splits a separated list of absolute paths and gives each a
+// trailing slash, which is what makes a prefix comparison exclude the directory
+// itself and refuse a sibling whose name merely starts the same.
+func normalizePathList(raw, sep string) []string {
+	var result []string
+	for _, p := range strings.Split(raw, sep) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if !strings.HasSuffix(p, "/") {
+			p += "/"
+		}
+		result = append(result, p)
 	}
 	return result
 }

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,9 @@ const (
 	provenanceBufSize = 65536
 	// Time to wait for late-arriving datagrams after process exit
 	provenanceDrainTimeout = 200 * time.Millisecond
+	// Watches the inotify walk may register before it stops descending, unless
+	// PROVENANCE_MAX_INOTIFY_WATCHES says otherwise.
+	defaultInotifyWatchLimit = 1000
 )
 
 // Paths to provenance hook files in the container image.
@@ -130,11 +134,17 @@ type provenanceResult struct {
 	WatchBudget *watchBudgetSignal
 }
 
-// watchBudgetSignal reports that the inotify walk stopped adding watches at its
-// cap, leaving directories unobserved. It rides the exec's provenance frame
-// because the watcher's own log line never leaves the container: without it,
-// degraded capture is indistinguishable from a step that touched nothing.
-// Never a failure — capture is best-effort and this accompanies a normal exec.
+// watchBudgetSignal reports that the inotify walk left directories unobserved,
+// whether because it hit its own cap or because the kernel refused a
+// registration. It rides the exec's provenance frame because the watcher's own
+// log line never leaves the container: without it, degraded capture is
+// indistinguishable from a step that touched nothing. Never a failure —
+// capture is best-effort and this accompanies a normal exec.
+//
+// The two shortfalls are counted separately because they have different
+// remedies: the cap is this server declining to watch more and is raised with
+// PROVENANCE_MAX_INOTIFY_WATCHES, while a refused registration is the host
+// refusing and is relieved only on the host.
 type watchBudgetSignal struct {
 	// The cap the walk stopped at.
 	Limit int `json:"limit"`
@@ -143,6 +153,33 @@ type watchBudgetSignal struct {
 	// Directories the walk reached and refused. A floor, not an exact count:
 	// each refusal also skips that directory's subtree, which is never walked.
 	UnwatchedDirs int `json:"unwatchedDirs"`
+	// Directories inotify_add_watch rejected, the cap notwithstanding. ENOSPC
+	// here means the kernel's per-uid ceiling
+	// (/proc/sys/fs/inotify/max_user_watches) is exhausted by this host's
+	// processes, which no setting inside the container can relieve.
+	FailedWatches int `json:"failedWatches"`
+}
+
+// inotifyWatchLimit returns the cap on watches the walk may register (env
+// override, else the shipped default).
+//
+// Configurable because the value bounds a walk over a tree whose shape is the
+// workload's: a step that writes per-entity output directories can exceed any
+// number chosen at build time, and the deployment that hits it must be able to
+// raise the bound without waiting on a rebuilt image. An absent or unusable
+// value falls back to the default rather than failing — provenance never fails
+// a command, so a typo in an env var must not either.
+func inotifyWatchLimit() int {
+	raw := strings.TrimSpace(os.Getenv(envInotifyWatchLimit))
+	if raw == "" {
+		return defaultInotifyWatchLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		log.Printf("WARNING: invalid %s=%q, falling back to %d", envInotifyWatchLimit, raw, defaultInotifyWatchLimit)
+		return defaultInotifyWatchLimit
+	}
+	return n
 }
 
 // Stop drains remaining messages, reads the R log file, and cleans up.

--- a/images/sandbox-base/server/provenance_inotify_linux.go
+++ b/images/sandbox-base/server/provenance_inotify_linux.go
@@ -15,12 +15,24 @@ import (
 
 const maxInotifyWatches = 1000
 
+// inotifyWatchMask carries no IN_OPEN. An open attests only that a file
+// descriptor was obtained — it fires for opens for *writing* and for opens by
+// processes unrelated to the command — so it cannot establish that the command
+// consumed the file. The mode-aware Python, R, and LD_PRELOAD hooks classify by
+// open mode and are the authoritative read signal; inotify verifies mutations,
+// which the mask below is exactly the set of.
+const inotifyWatchMask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_FROM | unix.IN_MOVED_TO
+
 type linuxInotifyWatcher struct {
 	pt     *ProvenanceTracker
 	fd     int
 	wds    map[int]string // watch descriptor → directory path
 	stopCh chan struct{}
 	wg     sync.WaitGroup
+	// Written by the walk in start(), read after stop().
+	exhausted     bool
+	watched       int
+	unwatchedDirs int
 }
 
 func newInotifyWatcher(pt *ProvenanceTracker) inotifyWatcher {
@@ -48,16 +60,24 @@ func (w *linuxInotifyWatcher) start(watchDirs []string) {
 	for _, dir := range watchDirs {
 		// Strip trailing slash for Walk
 		dirClean := filepath.Clean(dir)
-		filepath.Walk(dirClean, func(path string, info os.FileInfo, err error) error {
+		// Walk's own error is discarded because every per-entry error is already
+		// handled inside the callback, which never returns one: a configured dir
+		// that does not exist (a completed step that produced no tree) is a
+		// skip, not a failure.
+		_ = filepath.Walk(dirClean, func(path string, info os.FileInfo, err error) error {
 			if err != nil || info == nil || !info.IsDir() {
 				return nil
 			}
 			if watchCount >= maxInotifyWatches {
+				// Counted, not just logged: this line stays in the container,
+				// so without the count on the frame the host cannot tell
+				// degraded capture from an exec that touched nothing.
+				w.exhausted = true
+				w.unwatchedDirs++
 				log.Printf("[provenance] inotify watch limit (%d) reached, skipping deeper dirs", maxInotifyWatches)
 				return filepath.SkipDir
 			}
-			wd, err := unix.InotifyAddWatch(fd, path,
-				unix.IN_OPEN|unix.IN_CREATE|unix.IN_DELETE|unix.IN_MOVED_FROM|unix.IN_MOVED_TO)
+			wd, err := unix.InotifyAddWatch(fd, path, inotifyWatchMask)
 			if err != nil {
 				return nil
 			}
@@ -66,11 +86,19 @@ func (w *linuxInotifyWatcher) start(watchDirs []string) {
 			return nil
 		})
 	}
+	w.watched = watchCount
 
 	if watchCount > 0 {
 		w.wg.Add(1)
 		go w.readLoop()
 	}
+}
+
+func (w *linuxInotifyWatcher) budget() *watchBudgetSignal {
+	if !w.exhausted {
+		return nil
+	}
+	return &watchBudgetSignal{Limit: maxInotifyWatches, Watched: w.watched, UnwatchedDirs: w.unwatchedDirs}
 }
 
 func (w *linuxInotifyWatcher) readLoop() {
@@ -132,9 +160,9 @@ func (w *linuxInotifyWatcher) parseEvents(buf []byte) {
 			name := string(nameBytes[:idx])
 
 			if dir, ok := w.wds[wd]; ok {
-				fullPath := filepath.Join(dir, name)
-				op := classifyInotifyMask(mask)
-				w.pt.recordOp(op, fullPath, "inotify")
+				if op := classifyInotifyMask(mask); op != "" {
+					w.pt.recordOp(op, filepath.Join(dir, name), "inotify")
+				}
 			}
 		}
 
@@ -142,6 +170,13 @@ func (w *linuxInotifyWatcher) parseEvents(buf []byte) {
 	}
 }
 
+// classifyInotifyMask maps an event mask onto a provenance op, or "" for an
+// event that attests nothing and must not be recorded (IN_IGNORED, IN_Q_OVERFLOW,
+// and anything else the kernel raises unasked).
+//
+// It never yields "read". inotify reports that a directory entry changed, not
+// which process changed it or in what mode, so no event here can show that this
+// command consumed a file as an input — that is the mode-aware hooks' signal.
 func classifyInotifyMask(mask uint32) string {
 	switch {
 	case mask&unix.IN_DELETE != 0, mask&unix.IN_MOVED_FROM != 0:
@@ -149,7 +184,7 @@ func classifyInotifyMask(mask uint32) string {
 	case mask&unix.IN_CREATE != 0, mask&unix.IN_MOVED_TO != 0:
 		return "write"
 	default:
-		return "read" // IN_OPEN
+		return ""
 	}
 }
 

--- a/images/sandbox-base/server/provenance_inotify_linux.go
+++ b/images/sandbox-base/server/provenance_inotify_linux.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const maxInotifyWatches = 1000
-
 // inotifyWatchMask carries no IN_OPEN. An open attests only that a file
 // descriptor was obtained — it fires for opens for *writing* and for opens by
 // processes unrelated to the command — so it cannot establish that the command
@@ -30,9 +28,11 @@ type linuxInotifyWatcher struct {
 	stopCh chan struct{}
 	wg     sync.WaitGroup
 	// Written by the walk in start(), read after stop().
+	limit         int
 	exhausted     bool
 	watched       int
 	unwatchedDirs int
+	failedWatches int
 }
 
 func newInotifyWatcher(pt *ProvenanceTracker) inotifyWatcher {
@@ -45,6 +45,9 @@ func newInotifyWatcher(pt *ProvenanceTracker) inotifyWatcher {
 }
 
 func (w *linuxInotifyWatcher) start(watchDirs []string) {
+	// Resolved once per exec and held on the watcher so budget() reports the
+	// bound the walk actually applied, not whatever the env says at drain time.
+	w.limit = inotifyWatchLimit()
 	if len(watchDirs) == 0 {
 		return
 	}
@@ -68,17 +71,30 @@ func (w *linuxInotifyWatcher) start(watchDirs []string) {
 			if err != nil || info == nil || !info.IsDir() {
 				return nil
 			}
-			if watchCount >= maxInotifyWatches {
+			if watchCount >= w.limit {
 				// Counted, not just logged: this line stays in the container,
 				// so without the count on the frame the host cannot tell
 				// degraded capture from an exec that touched nothing.
 				w.exhausted = true
 				w.unwatchedDirs++
-				log.Printf("[provenance] inotify watch limit (%d) reached, skipping deeper dirs", maxInotifyWatches)
+				log.Printf("[provenance] inotify watch limit (%d) reached, skipping deeper dirs", w.limit)
 				return filepath.SkipDir
 			}
 			wd, err := unix.InotifyAddWatch(fd, path, inotifyWatchMask)
 			if err != nil {
+				// The kernel refusing, not this server declining: ENOSPC here
+				// means the per-uid ceiling
+				// (/proc/sys/fs/inotify/max_user_watches) is spent, which
+				// raising this server's own cap cannot fix. Counted separately
+				// from the cap so the host sees which limit it has to move.
+				// Only the first is logged — the walk can meet the same
+				// refusal on every remaining directory.
+				if w.failedWatches == 0 {
+					log.Printf("[provenance] inotify watch registration failed for %s: %v", path, err)
+				}
+				w.failedWatches++
+				// Skipped rather than aborted: a directory nothing watches
+				// under-captures, and provenance never fails a command.
 				return nil
 			}
 			w.wds[wd] = path
@@ -94,11 +110,15 @@ func (w *linuxInotifyWatcher) start(watchDirs []string) {
 	}
 }
 
+// budget reports what the walk failed to cover, or nil when it covered
+// everything. A refused registration counts as much as a reached cap: it leaves
+// exactly the same blind spot on the frame, so silence here would report a
+// partially-blind walk as a clean one.
 func (w *linuxInotifyWatcher) budget() *watchBudgetSignal {
-	if !w.exhausted {
+	if !w.exhausted && w.failedWatches == 0 {
 		return nil
 	}
-	return &watchBudgetSignal{Limit: maxInotifyWatches, Watched: w.watched, UnwatchedDirs: w.unwatchedDirs}
+	return &watchBudgetSignal{Limit: w.limit, Watched: w.watched, UnwatchedDirs: w.unwatchedDirs, FailedWatches: w.failedWatches}
 }
 
 func (w *linuxInotifyWatcher) readLoop() {

--- a/images/sandbox-base/server/provenance_inotify_linux_test.go
+++ b/images/sandbox-base/server/provenance_inotify_linux_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestClassifyInotifyMask_MutationsOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		mask uint32
+		want string
+	}{
+		{"create", unix.IN_CREATE, "write"},
+		{"moved_to", unix.IN_MOVED_TO, "write"},
+		{"delete", unix.IN_DELETE, "delete"},
+		{"moved_from", unix.IN_MOVED_FROM, "delete"},
+		// An open says a descriptor was obtained, not that the command consumed
+		// the file: it fires for write-opens and for unrelated processes alike.
+		{"open", unix.IN_OPEN, ""},
+		{"ignored", unix.IN_IGNORED, ""},
+		{"queue_overflow", unix.IN_Q_OVERFLOW, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyInotifyMask(tc.mask); got != tc.want {
+				t.Fatalf("mask %#x: want %q, got %q", tc.mask, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestInotifyWatchMask_ExcludesOpen(t *testing.T) {
+	// The events never asked for are the ones that cannot be misread later.
+	if inotifyWatchMask&unix.IN_OPEN != 0 {
+		t.Fatal("the watch mask must not request IN_OPEN")
+	}
+	for _, want := range []uint32{unix.IN_CREATE, unix.IN_DELETE, unix.IN_MOVED_FROM, unix.IN_MOVED_TO} {
+		if inotifyWatchMask&want == 0 {
+			t.Fatalf("the watch mask must request %#x", want)
+		}
+	}
+}
+
+func TestInotifyBudget_SilentWhenTheWalkFits(t *testing.T) {
+	w := &linuxInotifyWatcher{watched: 12}
+
+	if got := w.budget(); got != nil {
+		t.Fatalf("a walk inside the budget must carry no signal; got %+v", got)
+	}
+}
+
+func TestInotifyBudget_ReportsExhaustion(t *testing.T) {
+	w := &linuxInotifyWatcher{exhausted: true, watched: maxInotifyWatches, unwatchedDirs: 7}
+
+	got := w.budget()
+	if got == nil {
+		t.Fatal("exhaustion must reach the frame — the container log line never leaves the sandbox")
+	}
+	if got.Limit != maxInotifyWatches || got.Watched != maxInotifyWatches || got.UnwatchedDirs != 7 {
+		t.Fatalf("signal must carry the cap, the watches added, and the dirs refused; got %+v", got)
+	}
+}

--- a/images/sandbox-base/server/provenance_inotify_linux_test.go
+++ b/images/sandbox-base/server/provenance_inotify_linux_test.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -46,21 +48,75 @@ func TestInotifyWatchMask_ExcludesOpen(t *testing.T) {
 }
 
 func TestInotifyBudget_SilentWhenTheWalkFits(t *testing.T) {
-	w := &linuxInotifyWatcher{watched: 12}
+	w := &linuxInotifyWatcher{limit: defaultInotifyWatchLimit, watched: 12}
 
 	if got := w.budget(); got != nil {
-		t.Fatalf("a walk inside the budget must carry no signal; got %+v", got)
+		t.Fatalf("a walk that covered everything must carry no signal; got %+v", got)
 	}
 }
 
 func TestInotifyBudget_ReportsExhaustion(t *testing.T) {
-	w := &linuxInotifyWatcher{exhausted: true, watched: maxInotifyWatches, unwatchedDirs: 7}
+	w := &linuxInotifyWatcher{limit: defaultInotifyWatchLimit, exhausted: true, watched: defaultInotifyWatchLimit, unwatchedDirs: 7}
 
 	got := w.budget()
 	if got == nil {
 		t.Fatal("exhaustion must reach the frame — the container log line never leaves the sandbox")
 	}
-	if got.Limit != maxInotifyWatches || got.Watched != maxInotifyWatches || got.UnwatchedDirs != 7 {
+	if got.Limit != defaultInotifyWatchLimit || got.Watched != defaultInotifyWatchLimit || got.UnwatchedDirs != 7 {
 		t.Fatalf("signal must carry the cap, the watches added, and the dirs refused; got %+v", got)
+	}
+	if got.FailedWatches != 0 {
+		t.Fatalf("a cap refusal is not a registration failure; got %+v", got)
+	}
+}
+
+func TestInotifyBudget_ReportsTheCapItActuallyApplied(t *testing.T) {
+	// The walk holds its bound so the frame names the number that governed it,
+	// not whatever the environment says by the time the exec drains.
+	w := &linuxInotifyWatcher{limit: 25000, exhausted: true, watched: 25000, unwatchedDirs: 3}
+
+	got := w.budget()
+	if got == nil || got.Limit != 25000 {
+		t.Fatalf("signal must carry the configured cap; got %+v", got)
+	}
+}
+
+func TestInotifyStart_AppliesTheConfiguredCap(t *testing.T) {
+	root := t.TempDir()
+	for _, sub := range []string{"a", "b", "c"} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+	}
+	t.Setenv(envInotifyWatchLimit, "1")
+
+	w := &linuxInotifyWatcher{fd: -1, wds: make(map[int]string), stopCh: make(chan struct{})}
+	w.start([]string{root})
+	defer w.stop()
+
+	if w.limit != 1 {
+		t.Fatalf("the walk must apply the configured cap, not the shipped default; got %d", w.limit)
+	}
+	got := w.budget()
+	if got == nil || got.Limit != 1 || got.Watched != 1 || got.UnwatchedDirs == 0 {
+		t.Fatalf("the configured cap must bound the walk and ride the frame; got %+v", got)
+	}
+}
+
+func TestInotifyBudget_ReportsARegistrationFailureWithTheCapUnreached(t *testing.T) {
+	// A kernel ENOSPC against /proc/sys/fs/inotify/max_user_watches leaves the
+	// same blind spot as the cap while the walk is nowhere near it. Reporting
+	// nothing here would tell the host a partially-blind walk was a clean one.
+	w := &linuxInotifyWatcher{limit: defaultInotifyWatchLimit, watched: 4, failedWatches: 2}
+
+	got := w.budget()
+	if got == nil {
+		t.Fatal("a refused registration must reach the frame even with the cap unreached")
+	}
+	if got.FailedWatches != 2 {
+		t.Fatalf("the refusals must be counted; got %+v", got)
+	}
+	if got.UnwatchedDirs != 0 {
+		t.Fatalf("a kernel refusal must stay distinct from a cap refusal; got %+v", got)
 	}
 }

--- a/images/sandbox-base/server/provenance_inotify_stub.go
+++ b/images/sandbox-base/server/provenance_inotify_stub.go
@@ -9,5 +9,6 @@ func newInotifyWatcher(_ *ProvenanceTracker) inotifyWatcher {
 	return &stubInotifyWatcher{}
 }
 
-func (w *stubInotifyWatcher) start(_ []string) {}
-func (w *stubInotifyWatcher) stop()            {}
+func (w *stubInotifyWatcher) start(_ []string)           {}
+func (w *stubInotifyWatcher) stop()                      {}
+func (w *stubInotifyWatcher) budget() *watchBudgetSignal { return nil }

--- a/images/sandbox-base/server/provenance_recordop_test.go
+++ b/images/sandbox-base/server/provenance_recordop_test.go
@@ -1,16 +1,21 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
-// The watch dir as provenanceWatchDirs builds it: absolute, trailing slash.
-const testWatchDir = "/019f6a20-1a3b-7000-a942-ae871e5de040/"
+// The analysis mount root as provenanceDataPrefixes builds it: absolute,
+// trailing slash.
+const testDataPrefix = "/019f6a20-1a3b-7000-a942-ae871e5de040/"
 
 func newTestTracker() *ProvenanceTracker {
 	return &ProvenanceTracker{
-		watchDirs: []string{testWatchDir},
-		ops:       make(map[string]map[string]map[string]bool),
+		// Watch dirs are deliberately narrower than the prefix bound: what a
+		// hook may report is not what inotify watches.
+		watchDirs:    []string{testDataPrefix + "data/", testDataPrefix + "runs/r1/T3S1/"},
+		dataPrefixes: []string{testDataPrefix},
+		ops:          make(map[string]map[string]map[string]bool),
 	}
 }
 
@@ -61,6 +66,60 @@ func TestRecordOp_KeepsInTreeRead(t *testing.T) {
 	got := recordedPaths(pt, "read")
 	if len(got) != 1 || got[0] != want {
 		t.Fatalf("in-tree read must survive; want [%s], got %v", want, got)
+	}
+}
+
+func TestRecordOp_KeepsAReadOutsideTheWatchDirs(t *testing.T) {
+	// A hook intercepts its own process's open, so a read under a tree no
+	// watcher covers — a step that completed after this sandbox started — is
+	// still the command's own read. Whether it may assert lineage is the host's
+	// decision at classification; dropping it here would make it undecidable.
+	pt := newTestTracker()
+	want := "/019f6a20-1a3b-7000-a942-ae871e5de040/runs/r1/norm/output/norm.csv"
+	pt.recordOp("read", want, "ld_preload")
+
+	got := recordedPaths(pt, "read")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("a hook-reported read outside the watch dirs must survive; want [%s], got %v", want, got)
+	}
+}
+
+func TestEnv_DataPrefixesAreNotDerivedFromWatchDirs(t *testing.T) {
+	pt := newTestTracker()
+
+	var got string
+	for _, kv := range pt.Env() {
+		if strings.HasPrefix(kv, "PROVENANCE_DATA_PREFIXES=") {
+			got = strings.TrimPrefix(kv, "PROVENANCE_DATA_PREFIXES=")
+		}
+	}
+
+	if got != testDataPrefix {
+		t.Fatalf("hooks must filter on the mount root, not the watch dirs; want %q, got %q", testDataPrefix, got)
+	}
+}
+
+func TestProvenanceWatchDirs_SkipsAConfiguredDirThatDoesNotExist(t *testing.T) {
+	// A completed sibling that produced no tree, or a read-only sandbox with no
+	// step tree, are ordinary — capture is best-effort and never fails a command.
+	present := t.TempDir()
+	t.Setenv("PROVENANCE_WATCH_DIRS", present+","+present+"/never-created")
+
+	got := provenanceWatchDirs()
+
+	if len(got) != 1 || got[0] != present+"/" {
+		t.Fatalf("only the existing dir must be watched; got %v", got)
+	}
+}
+
+func TestProvenanceDataPrefixes_ReadsItsOwnVariable(t *testing.T) {
+	t.Setenv("PROVENANCE_WATCH_DIRS", "/an-1/data,/an-1/runs/r1/T3S1")
+	t.Setenv("PROVENANCE_DATA_PREFIXES", "/an-1")
+
+	got := provenanceDataPrefixes()
+
+	if len(got) != 1 || got[0] != "/an-1/" {
+		t.Fatalf("data prefixes must come from PROVENANCE_DATA_PREFIXES with a trailing slash; got %v", got)
 	}
 }
 

--- a/images/sandbox-base/server/provenance_recordop_test.go
+++ b/images/sandbox-base/server/provenance_recordop_test.go
@@ -11,9 +11,10 @@ const testDataPrefix = "/019f6a20-1a3b-7000-a942-ae871e5de040/"
 
 func newTestTracker() *ProvenanceTracker {
 	return &ProvenanceTracker{
-		// Watch dirs are deliberately narrower than the prefix bound: what a
-		// hook may report is not what inotify watches.
-		watchDirs:    []string{testDataPrefix + "data/", testDataPrefix + "runs/r1/T3S1/"},
+		// The step's own tree alone, as the harness configures it — deliberately
+		// narrower than the prefix bound: what a hook may report is not what
+		// inotify watches.
+		watchDirs:    []string{testDataPrefix + "runs/r1/T3S1/"},
 		dataPrefixes: []string{testDataPrefix},
 		ops:          make(map[string]map[string]map[string]bool),
 	}
@@ -71,9 +72,9 @@ func TestRecordOp_KeepsInTreeRead(t *testing.T) {
 
 func TestRecordOp_KeepsAReadOutsideTheWatchDirs(t *testing.T) {
 	// A hook intercepts its own process's open, so a read under a tree no
-	// watcher covers — a step that completed after this sandbox started — is
-	// still the command's own read. Whether it may assert lineage is the host's
-	// decision at classification; dropping it here would make it undecidable.
+	// watcher covers — a sibling's output, `data/`, a prior run — is still the
+	// command's own read. Whether it may assert lineage is the host's decision
+	// at classification; dropping it here would make it undecidable.
 	pt := newTestTracker()
 	want := "/019f6a20-1a3b-7000-a942-ae871e5de040/runs/r1/norm/output/norm.csv"
 	pt.recordOp("read", want, "ld_preload")
@@ -100,8 +101,8 @@ func TestEnv_DataPrefixesAreNotDerivedFromWatchDirs(t *testing.T) {
 }
 
 func TestProvenanceWatchDirs_SkipsAConfiguredDirThatDoesNotExist(t *testing.T) {
-	// A completed sibling that produced no tree, or a read-only sandbox with no
-	// step tree, are ordinary — capture is best-effort and never fails a command.
+	// A step tree the host has not pre-created yet is ordinary — capture is
+	// best-effort and never fails a command.
 	present := t.TempDir()
 	t.Setenv("PROVENANCE_WATCH_DIRS", present+","+present+"/never-created")
 
@@ -113,13 +114,44 @@ func TestProvenanceWatchDirs_SkipsAConfiguredDirThatDoesNotExist(t *testing.T) {
 }
 
 func TestProvenanceDataPrefixes_ReadsItsOwnVariable(t *testing.T) {
-	t.Setenv("PROVENANCE_WATCH_DIRS", "/an-1/data,/an-1/runs/r1/T3S1")
+	t.Setenv("PROVENANCE_WATCH_DIRS", "/an-1/runs/r1/T3S1")
 	t.Setenv("PROVENANCE_DATA_PREFIXES", "/an-1")
 
 	got := provenanceDataPrefixes()
 
 	if len(got) != 1 || got[0] != "/an-1/" {
 		t.Fatalf("data prefixes must come from PROVENANCE_DATA_PREFIXES with a trailing slash; got %v", got)
+	}
+}
+
+func TestInotifyWatchLimit_DefaultsWhenUnset(t *testing.T) {
+	t.Setenv(envInotifyWatchLimit, "")
+
+	if got := inotifyWatchLimit(); got != defaultInotifyWatchLimit {
+		t.Fatalf("an unset cap must ship the default; want %d, got %d", defaultInotifyWatchLimit, got)
+	}
+}
+
+func TestInotifyWatchLimit_HonorsTheEnvironment(t *testing.T) {
+	// The knob exists so a deployment whose step trees outgrow the default can
+	// raise it without waiting on a rebuilt image.
+	t.Setenv(envInotifyWatchLimit, "25000")
+
+	if got := inotifyWatchLimit(); got != 25000 {
+		t.Fatalf("the configured cap must win over the default; want 25000, got %d", got)
+	}
+}
+
+func TestInotifyWatchLimit_FallsBackOnAnUnusableValue(t *testing.T) {
+	// Provenance never fails a command, so neither may a typo in its config.
+	for _, raw := range []string{"not-a-number", "0", "-5"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv(envInotifyWatchLimit, raw)
+
+			if got := inotifyWatchLimit(); got != defaultInotifyWatchLimit {
+				t.Fatalf("%q must fall back to the default; got %d", raw, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The failure

Step `T2S2` (immune-focused GSEA) in run `19110b58` died with `errorClass: lineage_attestation` — surfaced to the user as "Step results could not be finalized" — **after its analysis had completed successfully**. It had written every output, every figure, and a well-formed summary.

The log names the culprit:

```
stepId: T2S2   path: .../runs/<runId>/T5S1/output/_ct_for_r_BRAF.csv
source: "upstream"   refStepId: "T5S1"   throwSite: "input-enoent"
```

`T2S2` is the enrichment agent. `_ct_for_r_BRAF.csv` is a scratch file belonging to **`T5S1`**, the statistical-modeling step, which was running concurrently and deleted it before `T2S2` reconciled. A step was killed by bookkeeping about a file it never used.

It is symmetric: `T5S1` was simultaneously failing to attest `T2S2/output/gseapy_hallmark`. Two steps each claimed the other's outputs as inputs, which is not a DAG.

**The crash is the lucky case.** In the same run, `T4S1` recorded three `T2S2` files (`logs/run_gsea.log`, `output/wikipathways_symbols.gmt`, `scripts/run_gsea.py`) as its own inputs while `T2S2` was still running. Those happened to survive to reconcile, hashed cleanly, and were **registered as real lineage edges**. A survival-analysis step did not read a GSEA log. Silent provenance corruption is the worse half of this defect, and nothing surfaces it.

## Why it happened

Two premises were wrong.

1. `classifyReadPath` turned **any** same-run path outside the step's own directory into a mandatory, content-attested `upstream` input. Its justification: *"a read of a same-run step outside `dependsOn` is still a valid upstream input."*
2. Reconcile deferred input hashing to teardown *"because inputs are immutable for the step — the analysis tree is mounted read-only."*

Read-only bounds what **this** step may write. Every other step has its own directory mounted read-write and mutates it freely, scratch files included. The tree is shared mutable state for exactly the paths premise 1 marked attestable.

Concurrency is normal, not exceptional: the CLI's machine budget is a user-chosen fraction of the host, and the scheduler starts every dependency-satisfied step that fits.

## The fix

**An input edge is admissible if and only if the producing step's status was `completed` at the moment the reading exec was submitted** — whichever run it belongs to.

Two steps running concurrently therefore have no lineage relationship in either direction. That falls out of the same predicate rather than needing a rule of its own.

`completed` is the only admissible status. `failed`, `canceled`, and `skipped` are terminal but never finalized their outputs — which is precisely what a `lineage_attestation` failure means.

Three decisions worth a reviewer's attention:

**The snapshot is taken at submit, not at reconcile.** Reconcile runs after sandbox teardown, by which time a sibling that was mid-flight *while the file was read* may have reached `completed` and the edge would wrongly pass. A reconcile-time check would not have caught the `T4S1` case at all.

**The snapshot is durably checkpointed.** `execute_command` is `executionMode: "workflow"`, so its body runs unwrapped in the DBOS workflow body — an unwrapped query re-executes on replay and returns a *larger* completed set, giving the same run different lineage on recovery. It goes through `ctx.runStep`.

**Failure fails closed, loudly, and durably.** A query failure resolves to an explicit "snapshot unavailable" *value* rather than throwing, because provenance must never fail an exec. All sibling reads for that exec become inadmissible, and the degradation is logged and counted. The degraded outcome is itself checkpointed — otherwise a replay could succeed where the original failed.

Two alternatives were considered and rejected. **Gating on `dependsOn`**: it is a scheduling input, and a step may legitimately read a sibling it never declared, so this would drop real edges. **Gating `prior`-run reads on the run being terminal**: `cortex_runs` counts `partial`, `failed`, and `canceled` as terminal, so it would admit a failed step's unfinalized outputs — the very thing the sibling rule exists to reject.

## Supporting changes

- **Seed the collector with `dependsOn`.** The spec always required it; it was never passed, leaving the declared-dependency branch unreachable. This is a durable DBOS workflow-input shape change, so the field is optional and its absence degrades fail-closed for in-flight recovery.
- **Scope inotify to the step's own run tree** (second commit). Dropping `IN_OPEN` left inotify reporting only mutations, and neither `data/` nor a completed sibling can emit those — so watching them registered watches that structurally cannot fire. `data/` was also the only unbounded term in the walk.
- **Decouple `PROVENANCE_DATA_PREFIXES` from the watch dirs**, so the process-local hooks keep full read coverage while inotify narrows. The ordering matters: narrowing the watch dirs first would have silently killed `data/` input lineage.
- **Stop treating a bare `IN_OPEN` as a read.** It fires on opens for writing and on processes unrelated to the command, and inotify cannot attribute an event to a process.
- **Bind the OTel instruments lazily.** `lib/metrics.ts` created its counters at module load, before any `MeterProvider` is registered, and the metrics API has no proxy upgrade — so all three counters, including the two pre-existing ones, were permanently no-op. Without this the spec's "SHALL increment `lineageEdgeRejected`" is unsatisfiable in production.
- **Watch budget.** The cap is now configurable via `PROVENANCE_MAX_INOTIFY_WATCHES`, and a kernel `ENOSPC` is reported distinctly from a cap refusal instead of being silently swallowed.
- **Corrected the false premise** in the `exec-provenance-lineage` and `artifact-manifest` spec prose, which deltas cannot reach.

## What this does not fix

Lineage edges already registered before this change — `T4S1`'s three fabricated links to `T2S2` in run `19110b58` among them — are indistinguishable from real edges by inspection. A read-only audit is scoped as explicit, non-gating follow-up (tasks §9). Nothing mutates registered provenance without a decision.

## Accepted limitation

Reads by processes the hooks cannot instrument — a statically-linked binary, which `LD_PRELOAD` does not apply to — are now unobserved by any layer. This is deliberate. Restoring `IN_OPEN` to recover them would also manufacture reads from other containers' opens of *completed* siblings, which the gate admits, so the gate does not contain the damage. An incomplete lineage graph is recoverable by re-running; a fabricated one is not.

## Verification

`tsc` clean · 1397 pass / 1 skip / 0 fail across 135 files · `go build`, `go vet`, `go test` pass including `GOOS=linux` for the linux-tagged watcher · `openspec validate --strict` valid.

New coverage worth noting: a mutation-checked DBOS replay test proving a replayed exec classifies against the originally snapshotted set (replacing `ctx.runStep` with a plain call makes it fail), and an OTel test that registers a provider *after* module import — the regression guard for the no-op counter class of bug.

## Review guide

| What | Where |
|-|-|
| The admissibility rule | `harness/src/provenance/collector.ts` — `classifyReadPath` |
| Replay-safe snapshot | `harness/src/tools/workspace/execute-command.ts` |
| Where edges are refused | `harness/src/provenance/exec-frame.ts` |
| Full rationale, alternatives, risks | `harness/openspec/changes/gate-lineage-on-step-completion/design.md` |
| Normative requirements | `harness/openspec/changes/gate-lineage-on-step-completion/specs/` |

The sandbox image needs a rebuild and version bump before the Go-side changes take effect; the harness-side gate is independently sufficient for the reported failure.
