### PR TITLE
ci(harness): run the full DB/DBOS suite against a Postgres service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,32 @@ jobs:
     defaults:
       run:
         working-directory: harness
+
+    # Shared pgvector Postgres for the DB/DBOS suites. The test setup picks it
+    # up via `CORTEX_TEST_PG_URL` (src/__tests__/setup/postgres.ts) and skips
+    # testcontainers entirely — one server serves every test file, and DBOS
+    # reuses the same database (its tables live in a `dbos` schema). This is
+    # what lets the harness job run the full suite instead of a grep-selected
+    # subset.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: cortex
+          POSTGRES_PASSWORD: cortex
+          POSTGRES_DB: cortex
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U cortex -d cortex"
+          --health-interval=2s
+          --health-timeout=3s
+          --health-retries=20
+
+    env:
+      # Point `withSchema`/`withDbos` at the service container above.
+      CORTEX_TEST_PG_URL: postgres://cortex:cortex@localhost:5432/cortex
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -54,13 +80,5 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run unit tests
-        # The DB/DBOS suites need a Postgres + DBOS testcontainer; they are
-        # deferred until a Postgres service is wired into CI. Run every test file
-        # that does NOT pull in the DB/DBOS test setup — selected dynamically so
-        # new unit tests are included and new infra tests are excluded
-        # automatically (grep -L = files that do not match).
-        run: |
-          unit=$(grep -rLE 'setup/postgres|setup/dbos|withSchema|getTestPool|withDbos|setupDbosForTests|CORTEX_TEST_PG_URL|testcontainers' src --include='*.test.ts')
-          echo "Running $(echo "$unit" | wc -l) unit test files; DB/DBOS-dependent files deferred."
-          bun test $unit
+      - name: Run tests
+        run: bun test

--- a/harness/package.json
+++ b/harness/package.json
@@ -40,6 +40,7 @@
         "prepare": "tsc -p tsconfig.json",
         "prepublishOnly": "bun run build && bun run smoke",
         "smoke": "node scripts/smoke.mjs",
+        "test:full": "bash scripts/test-full.sh",
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {

--- a/harness/scripts/test-full.sh
+++ b/harness/scripts/test-full.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Run the FULL harness test suite (unit + DB + DBOS) against ONE pgvector
+# Postgres. Bun isolates module state per test file, so a module-level
+# singleton in src/__tests__/setup/postgres.ts is NOT shared across the DB
+# files — started from inside the process, each would spin its own container.
+# This script starts ONE container, exports `CORTEX_TEST_PG_URL` (a real
+# OS-process env var, inherited by every file), runs `bun test`, and removes
+# the container on exit (pass, fail, or interrupt). CI does the same thing
+# with a `services:` container (see .github/workflows/test.yml).
+#
+# Point at an already-running Postgres instead by setting CORTEX_TEST_PG_URL
+# before invoking — the script then skips container startup:
+#
+#   CORTEX_TEST_PG_URL=postgres://cortex:dev@localhost:5433/cortex bun run test:full
+#
+# Extra args pass through to `bun test`, e.g. `bun run test:full src/state`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -n "${CORTEX_TEST_PG_URL:-}" ]; then
+    echo "Using existing CORTEX_TEST_PG_URL — skipping container startup."
+    exec bun test "$@"
+fi
+
+CID=$(docker run -d --rm \
+    -e POSTGRES_USER=cortex -e POSTGRES_PASSWORD=cortex -e POSTGRES_DB=cortex \
+    -p 127.0.0.1::5432 \
+    pgvector/pgvector:pg18 \
+    postgres -c fsync=off -c synchronous_commit=off)
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+for _ in $(seq 1 60); do
+    docker exec "$CID" pg_isready -U cortex -d cortex >/dev/null 2>&1 && break
+    sleep 0.5
+done
+
+PORT=$(docker port "$CID" 5432/tcp | head -1 | cut -d: -f2)
+export CORTEX_TEST_PG_URL="postgres://cortex:cortex@127.0.0.1:${PORT}/cortex"
+echo "Postgres ready on 127.0.0.1:${PORT} (CORTEX_TEST_PG_URL set)."
+
+bun test "$@"

--- a/harness/src/__tests__/setup/postgres.ts
+++ b/harness/src/__tests__/setup/postgres.ts
@@ -6,19 +6,20 @@
  *
  *  1. Override: `CORTEX_TEST_PG_URL` is a libpq-style connection string and
  *     no container is started — the helper just connects. This is how the
- *     full suite runs: the `just test` recipe starts ONE container, exports
- *     `CORTEX_TEST_PG_URL`, and removes it on exit. It is also how you point
- *     tests at a `just up` dev Postgres for tight iteration.
+ *     full suite runs: `bun run test:full` (scripts/test-full.sh) starts ONE
+ *     container, exports `CORTEX_TEST_PG_URL`, and removes it on exit; CI does
+ *     the same with a `services:` container. It is also how you point tests at
+ *     an already-running dev Postgres for tight iteration.
  *
  *  2. Fallback: with no `CORTEX_TEST_PG_URL`, a testcontainers-managed
  *     container is launched on the first `getTestPool()` call. Cold start
  *     is ~3s; the `ryuk` sidecar reaps it on process exit.
  *
- * Why the recipe owns the container for the full suite: Bun isolates module
+ * Why the runner owns the container for the full suite: Bun isolates module
  * state per test file, so a module-level singleton here is NOT shared across
  * the ~130 test files — each would spin its own container. A real OS-process
- * env var (`CORTEX_TEST_PG_URL`, exported by the recipe before `bun test`)
- * IS inherited by every file, so all of them connect to the one container.
+ * env var (`CORTEX_TEST_PG_URL`, exported before `bun test`) IS inherited by
+ * every file, so all of them connect to the one container.
  *
  * Each test should call `withSchema(testName)` to get a `{ pool, drop }`
  * pair and `afterEach(drop)` to tear it down.

--- a/harness/src/workflows/__tests__/dbos/target-assessment-internals.test.ts
+++ b/harness/src/workflows/__tests__/dbos/target-assessment-internals.test.ts
@@ -13,12 +13,11 @@
  *    `cortex_target_assessments.progress` via a single `DBOS.runStep`.
  *
  * Why one file: DBOS `registerWorkflow` is process-global and rejected once
- * the engine launches. The rig's launch is lazy inside `setupDbosForTests`,
- * so module-top registrations across multiple test files would race the
- * first file's launch and surface as `DBOSConflictingRegistrationError`.
- * `just test-workflow` runs each DBOS test file in its own `bun test`
- * invocation to dodge that — co-locating both suites in one file keeps the
- * file count down without changing that contract.
+ * the engine launches. Each DBOS test file reopens the registration window at
+ * module load (`if (DBOS.isInitialized()) await DBOS.shutdown()` below) so the
+ * whole suite runs in a single `bun test` process; co-locating both suites in
+ * one file keeps the file count — and the number of launch/relaunch cycles —
+ * down without changing that contract.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";


### PR DESCRIPTION
Closes #77.

## Problem

The harness test job grep-selected test files, dropping every file that touches the DB/DBOS test setup. That excluded **23 of 133 files (234 tests)** — not fringe suites, but the entire `state/` layer, the DBOS workflow rig (`workflow-replay`, `budget-cascade`, `target-assessment-internals`), the memory stores, `app/chat-turn`, and several DB-backed tools. A regression in workflow replay, state persistence, or thread history merged green.

## Fix

Wire a `pgvector/pgvector:pg18` `services:` container into the harness job and set `CORTEX_TEST_PG_URL`, so `src/__tests__/setup/postgres.ts` skips testcontainers and every test file shares one server (DBOS reuses the same database via its `dbos` schema). The job now runs plain `bun test`; the grep-selection step and its "deferred until a Postgres service is wired into CI" comment are gone.

Unlike the cortex homespace — which quarantines its DBOS workflow rig into a per-file-process lane (`just test-workflow`) it doesn't even run in CI — inf-cli needs no split: each DBOS test file reopens the registration window at module load (`if (DBOS.isInitialized()) await DBOS.shutdown()`), so the full suite runs green in a single `bun test` process.

Also adds `bun run test:full` (`harness/scripts/test-full.sh`) for local parity — owns one container's lifecycle, exports `CORTEX_TEST_PG_URL`, reaps on exit, and honors a pre-set `CORTEX_TEST_PG_URL` to target a running Postgres. Fixes the two comments that referenced the nonexistent `just test` / `just test-workflow` recipes.

## Testing

Full suite via the runner (container auto-started), and against a shared Postgres exactly as CI will:

```
1351 pass, 1 skip, 0 fail — 1352 tests across 133 files, ~24s
```

The 1 skip is an API-key-gated integration test. Up from CI's current 1118 tests / 110 files. Also verified: the override path skips container startup, and the `--rm` container is reaped on exit.

## Acceptance (from #77)

- [x] Harness job runs plain `bun test` (no grep selection), DB/DBOS suites actually execute (1352 ≥ ~795)
- [x] The dynamic-exclusion step and its comment are removed from `test.yml`
- [x] Runtime stays sane — DB suites run in ~24s once the container is up; the cost is image pull (~2–3 min total job)