### PR TITLE
chore(harness): bump harness to 0.7.2

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
Patch bump of `@inflexa-ai/harness` from 0.7.1 → 0.7.2. The `version` field in `harness/package.json` is the release trigger: landing this on `main` publishes `@inflexa-ai/harness@0.7.2` to npm and tags `harness-v0.7.2`.

## What this releases

The harness fixes that landed since the 0.7.1 bump:

- **Step-failure isolation** — `executeAnalysis` isolates a step failure to that step's dependents instead of failing the whole run.
- **Lineage-edge refusal** — lineage edges to undeclared same-run siblings are refused, with same-run lineage decided off the step segment rather than a path prefix (plus the archived spec sync).
- **Provisioning fixes** — the reference-data and engine provisioning manifests the skills declare are made whole (numbat phasing inputs, and removals no longer treated as regressions).

## Change

One line: `harness/package.json` version `0.7.1` → `0.7.2`.