### PR TITLE
chore(cli): consume harness 0.7.2, release cli 0.4.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ authors:
       orcid: "https://orcid.org/0009-0005-8000-0055"
     - name: "Inflexa, Inc."
 
-version: 0.4.2
-date-released: "2026-07-20"
+version: 0.4.3
+date-released: "2026-07-21"
 url: "https://inflexa.ai"
 repository-code: "https://github.com/inflexa-ai/inflexa"
 

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -6,7 +6,7 @@
       "name": "inflexa",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.7.1",
+        "@inflexa-ai/harness": "0.7.2",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
@@ -151,7 +151,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.7.1", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-zmvg1WnXyZMHZOXbqAHPvWz08ch1wp7Wf/apsouObAuyy/SLNwU9+9ZXDAzj9Cj2eHITe/SbLeNfiVTySzkU7A=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.7.2", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.15", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-gobnlyZM/RQlWtJ5hBBMxUWEO1xHdT2zMzVdw3ogDt0tkcu8TLZyY92tBsYA2p1Ew5Z6OtvIZ/4hwBzzNRknFQ=="],
 
     "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "private": true,
     "type": "module",
     "scripts": {
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.7.1",
+        "@inflexa-ai/harness": "0.7.2",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",


### PR DESCRIPTION
Patch bump of the CLI from 0.4.2 → 0.4.3, moving the `@inflexa-ai/harness` pin from 0.7.1 to the just-published **0.7.2**, and tracking the release in `CITATION.cff`.

## What this consumes

`@inflexa-ai/harness@0.7.2` (published to npm, tagged `harness-v0.7.2`) brings the harness fixes that landed since 0.7.1:

- **Step-failure isolation** — `executeAnalysis` isolates a step failure to that step's dependents instead of failing the whole run.
- **Lineage-edge refusal** — lineage edges to undeclared same-run siblings are refused, decided off the step segment rather than a path prefix.
- **Provisioning fixes** — the reference-data and engine provisioning manifests the skills declare are made whole.

## Changes

- `cli/package.json` — version `0.4.2` → `0.4.3`; `@inflexa-ai/harness` pin `0.7.1` → `0.7.2`.
- `cli/bun.lock` — resolves to the npm `0.7.2` tarball (integrity `sha512-gobnlyZM…`).
- `CITATION.cff` — `version` `0.4.2` → `0.4.3`, `date-released` → `2026-07-21` (concept DOI unchanged — it always resolves to the latest release).

## Verification

`bun install` resolves 0.7.2 from npm; `bun run typecheck` (`tsc --noEmit`) passes against the installed package.