### PR TITLE
feat(cli): move model connection detail from sidebar to status dialog

### DIFF
--- a/cli/src/tui/commands.test.ts
+++ b/cli/src/tui/commands.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { GLYPHS } from "../lib/design_system.ts";
+import { __setAgentModelsForTest, __setBootStateForTest } from "./hooks/boot.ts";
+import { modelStatusLines } from "./commands.tsx";
+
+// modelStatusLines reads the module-level boot + agentModels stores, so each test seeds them via the
+// test hooks and the reset below keeps one test's seed from bleeding into the next (the same pairing
+// sidebar.render.test.tsx uses for the rail's MODELS section).
+afterEach(() => {
+    __setAgentModelsForTest({ current: { conversation: "", sandbox: "" }, pending: new Map() });
+    __setBootStateForTest({ phase: "idle" });
+});
+
+describe("modelStatusLines", () => {
+    test("before boot reaches ready it mirrors the rail's placeholder", () => {
+        expect(modelStatusLines()).toEqual(["models: runtime not ready"]);
+    });
+
+    test("a failed boot surfaces its actionable message", () => {
+        __setBootStateForTest({ phase: "failed", message: "proxy unreachable — run inflexa up" });
+        const [line] = modelStatusLines();
+        expect(line).toContain("boot failed");
+        expect(line).toContain("proxy unreachable — run inflexa up");
+    });
+
+    test("ready: spells out the cliproxy connection and each agent's live model", () => {
+        __setBootStateForTest({ phase: "ready", model: "claude-opus-4-8", connection: { provider: "anthropic", mode: "cliproxy" } });
+        __setAgentModelsForTest({ current: { conversation: "claude-opus-4-8", sandbox: "claude-sonnet-4-5" }, pending: new Map() });
+        const lines = modelStatusLines();
+        expect(lines[0]).toContain("anthropic");
+        expect(lines[0]).toContain("cliproxy (managed local proxy)");
+        expect(lines[1]).toBe("chat model: claude-opus-4-8");
+        expect(lines[2]).toBe("sandbox model: claude-sonnet-4-5");
+    });
+
+    test("ready: a direct connection glosses the user-configured endpoint", () => {
+        __setBootStateForTest({ phase: "ready", model: "deepseek-chat", connection: { provider: "deepseek", mode: "direct" } });
+        __setAgentModelsForTest({ current: { conversation: "deepseek-chat", sandbox: "deepseek-reasoner" }, pending: new Map() });
+        expect(modelStatusLines()[0]).toContain("direct (user-configured endpoint)");
+    });
+
+    test("a scheduled switch renders as current → pending on the agent's line", () => {
+        __setBootStateForTest({ phase: "ready", model: "claude-opus-4-8", connection: { provider: "anthropic", mode: "cliproxy" } });
+        __setAgentModelsForTest({
+            current: { conversation: "claude-opus-4-8", sandbox: "claude-sonnet-4-5" },
+            pending: new Map([["sandbox", "claude-haiku-4-5"]]),
+        });
+        expect(modelStatusLines()[2]).toContain(`claude-sonnet-4-5 ${GLYPHS.arrowRight} claude-haiku-4-5 (pending)`);
+    });
+
+    test("an agent whose model the switch has not installed yet renders the em-dash placeholder", () => {
+        __setBootStateForTest({ phase: "ready", model: "claude-opus-4-8", connection: { provider: "anthropic", mode: "cliproxy" } });
+        expect(modelStatusLines()[1]).toBe(`chat model: ${GLYPHS.emDash}`);
+    });
+});

--- a/cli/src/tui/commands.tsx
+++ b/cli/src/tui/commands.tsx
@@ -18,7 +18,7 @@ import { notify } from "./hooks/notice.ts";
 import { loadPlan, queryRunsByAnalysis, queryStepsByRun } from "@inflexa-ai/harness";
 import type { CortexRunRow } from "@inflexa-ai/harness";
 
-import { bootState, harnessRuntime } from "./hooks/boot.ts";
+import { agentModels, bootState, harnessRuntime } from "./hooks/boot.ts";
 import { latestPlanCard, sessionOpenables, type SessionOpenable } from "./hooks/conversation.ts";
 import { openArtifact } from "./hooks/artifacts.ts";
 import { resolveEntryPath } from "../modules/harness/artifact_open.ts";
@@ -531,13 +531,40 @@ function BrowseArtifactsDialog(): JSX.Element {
     );
 }
 
+/**
+ * The Status dialog's model block: the shared connection spelled out — provider, mode, and what the
+ * mode means — plus each agent's live model and any scheduled switch. This is the home of the
+ * connection detail the sidebar's fixed-width rail deliberately drops (the rail shows only the
+ * provider slug), so the mode glosses stay in the user's vocabulary, not config slugs alone. A failed
+ * boot surfaces its actionable message here; before ready the block mirrors the rail's
+ * "runtime not ready". Exported for tests only — the dialog is the sole production caller.
+ */
+export function modelStatusLines(): string[] {
+    const boot = bootState();
+    if (boot.phase === "failed") return [`models: boot failed ${GLYPHS.emDash} ${boot.message}`];
+    if (boot.phase !== "ready") return ["models: runtime not ready"];
+    const gloss = boot.connection.mode === "cliproxy" ? "managed local proxy" : "user-configured endpoint";
+    const models = agentModels();
+    const agentLine = (label: string, agent: AgentName): string => {
+        // Em dash until the runtime installs the live switch — the same placeholder the sidebar renders.
+        const current = models.current[agent] || GLYPHS.emDash;
+        const pending = models.pending.get(agent);
+        return pending ? `${label}: ${current} ${GLYPHS.arrowRight} ${pending} (pending)` : `${label}: ${current}`;
+    };
+    return [
+        `connection: ${boot.connection.provider} ${GLYPHS.middot} ${boot.connection.mode} (${gloss})`,
+        agentLine("chat model", "conversation"),
+        agentLine("sandbox model", "sandbox"),
+    ];
+}
+
 function StatusDialog(): JSX.Element {
     const ws = useWorkspace();
-    const line = resolveContext(ws.workingDir, {}).match(
+    const contextLine = resolveContext(ws.workingDir, {}).match(
         (c) => describeContext(c),
         (e) => `Failed to resolve context: ${e.type}`,
     );
-    return <ResultsDialog title="Status" lines={[line]} emptyText="No context" onClose={() => ws.closeDialog()} />;
+    return <ResultsDialog title="Status" lines={[contextLine, "", ...modelStatusLines()]} emptyText="No context" onClose={() => ws.closeDialog()} />;
 }
 
 function SettingsDialog(): JSX.Element {
@@ -1350,7 +1377,7 @@ export const commands: Command[] = [
     {
         id: "view.status",
         title: "Show status",
-        description: "What inflexa resolves to here",
+        description: "What inflexa resolves to here, plus the model connection",
         category: "View",
         run: (ctx) => ctx.openDialog(() => <StatusDialog />),
     },

--- a/cli/src/tui/layout/sidebar.render.test.tsx
+++ b/cli/src/tui/layout/sidebar.render.test.tsx
@@ -335,25 +335,27 @@ describe("Sidebar MODELS section", () => {
 
 // The connection line rides the immutable boot-ready state, so each case
 // seeds a `ready` boot with the connection identity AND a non-empty agentModels (the section body is
-// gated on the switch's authority). It renders above the agent rows in both connection modes.
+// gated on the switch's authority). It renders above the agent rows in both connection modes, and
+// carries ONLY the provider slug — the mode is deliberately absent from the rail (the Status dialog
+// owns the full connection detail).
 describe("Sidebar MODELS connection line", () => {
-    test("cliproxy: shows the provider slug and the mode above the agent rows", async () => {
+    test("cliproxy: shows the provider slug above the agent rows, never the mode", async () => {
         __setBootStateForTest({ phase: "ready", model: "claude-opus-4-8", connection: { provider: "anthropic", mode: "cliproxy" } });
         __setAgentModelsForTest({ current: { conversation: "claude-opus-4-8", sandbox: "claude-sonnet-4-5" }, pending: new Map() });
         const frame = await renderFrame(liveNode(), { width: 44, height: 24 });
         expect(frame).toContain("MODELS");
         expect(frame).toContain("conn");
         expect(frame).toContain("anthropic"); // the configured provider slug
-        expect(frame).toContain("cliproxy"); // the connection mode
+        expect(frame).not.toContain("cliproxy"); // the mode belongs to the Status dialog, not the rail
     });
 
-    test("direct: shows the configured provider slug and the direct mode", async () => {
+    test("direct: shows the configured provider slug, never the mode", async () => {
         __setBootStateForTest({ phase: "ready", model: "deepseek-chat", connection: { provider: "deepseek", mode: "direct" } });
         __setAgentModelsForTest({ current: { conversation: "deepseek-chat", sandbox: "deepseek-reasoner" }, pending: new Map() });
         const frame = await renderFrame(liveNode(), { width: 44, height: 24 });
         expect(frame).toContain("conn");
         expect(frame).toContain("deepseek"); // the configured provider slug
-        expect(frame).toContain("direct"); // the connection mode
+        expect(frame).not.toContain("direct"); // the mode belongs to the Status dialog, not the rail
     });
 });
 

--- a/cli/src/tui/layout/sidebar.tsx
+++ b/cli/src/tui/layout/sidebar.tsx
@@ -124,11 +124,14 @@ function AgentModelLine(props: { label: string; agent: AgentName }): JSX.Element
 }
 
 /**
- * The MODELS-section connection line: the shared connection's identity — the configured provider slug and
- * mode — rendered above the per-agent rows so the user sees which backend both agents run on. Reads the
- * immutable boot-ready state, NOT the swap-tracking `agentModels` store, because a live agent-model swap
- * never changes the connection — the connection is shared by both agents, so a swap changes only a model;
- * it is seeded once at the ready edge. Renders nothing before ready, when no identity exists yet.
+ * The MODELS-section connection line: the configured provider slug, rendered above the per-agent rows
+ * so the user sees which vendor both agents run on. The connection MODE (`cliproxy`/`direct`) is
+ * deliberately NOT here — it is transport plumbing, not a fact the user acts on from the rail, and the
+ * fixed-width rail keeps the identity to one word; the full connection detail (mode included) lives in
+ * the Status dialog. Reads the immutable boot-ready state, NOT the swap-tracking `agentModels` store,
+ * because a live agent-model swap never changes the connection — the connection is shared by both
+ * agents, so a swap changes only a model; it is seeded once at the ready edge. Renders nothing before
+ * ready, when no identity exists yet.
  */
 function ConnectionLine(): JSX.Element {
     const identity = (): ModelConnectionIdentity | null => {
@@ -141,7 +144,6 @@ function ConnectionLine(): JSX.Element {
                 <text>
                     <Fg role="fgMuted">{"conn "}</Fg>
                     <Fg role="accent">{c.provider}</Fg>
-                    <Fg role="fgMuted">{` ${GLYPHS.middot} ${c.mode}`}</Fg>
                 </text>
             )}
         </Show>


### PR DESCRIPTION
The sidebar's MODELS connection line now carries only the provider slug — the mode (cliproxy/direct) is transport plumbing, not a fact the user acts on from the fixed-width rail. The Status dialog gains a dedicated models block instead: the connection spelled out with a human gloss for the mode, each agent's live model with any pending switch, and the boot-failure message when the runtime never came up.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
