### PR TITLE
feat(cli): narrate a slow exit instead of leaving a dead prompt

### DIFF
--- a/cli/src/lib/shutdown.test.ts
+++ b/cli/src/lib/shutdown.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { startExitIndicator } from "./shutdown.ts";
+import { exitIndicatorFrame, startExitIndicator } from "./shutdown.ts";
 
 // The indicator's grace period is a module constant (500ms). These tests exercise the real timers
 // rather than injecting a clock: the whole contract is "stay silent unless the drain is genuinely
@@ -8,6 +8,7 @@ import { startExitIndicator } from "./shutdown.ts";
 const PAST_GRACE_MS = 640;
 
 const realIsTTY = process.stderr.isTTY;
+const realColumns = process.stderr.columns;
 const realWrite = process.stderr.write.bind(process.stderr);
 
 /** Capture stderr for the duration of one test, returning the frames written. */
@@ -29,6 +30,7 @@ function sleep(ms: number): Promise<void> {
 
 afterEach(() => {
     process.stderr.isTTY = realIsTTY;
+    process.stderr.columns = realColumns;
     process.stderr.write = realWrite;
 });
 
@@ -56,7 +58,7 @@ describe("startExitIndicator", () => {
         const drawn = frames.join("");
         expect(drawn).toContain("Exiting");
         expect(drawn).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
-        // Elapsed seconds are what tell the reader the process is alive rather than wedged.
+        // The age is what tells the reader the process is alive rather than wedged.
         expect(drawn).toMatch(/\(\d+s\)/);
     });
 
@@ -66,5 +68,79 @@ describe("startExitIndicator", () => {
         await sleep(PAST_GRACE_MS);
         stop();
         expect(frames.at(-1)).toBe("\r\x1b[2K");
+    });
+
+    test("survives a stderr that throws, so a dead terminal cannot crash the exit it narrates", async () => {
+        process.stderr.isTTY = true;
+        process.stderr.write = (() => {
+            // What a real stderr does once the terminal goes away mid-drain (the SIGHUP path).
+            throw Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+        }) as typeof process.stderr.write;
+
+        const stop = startExitIndicator();
+        await sleep(PAST_GRACE_MS);
+        expect(() => stop()).not.toThrow();
+    });
+
+    test("fits the row it is given, so a frame never wraps and smears down the screen", async () => {
+        const frames = captureStderr(true);
+        // Narrow enough that even the short variant with an age (`⠋ Exiting… (0s)`) overflows, so the
+        // live path is proven to consult the width rather than merely happening to fit.
+        process.stderr.columns = 12;
+        const stop = startExitIndicator();
+        await sleep(PAST_GRACE_MS);
+        stop();
+
+        const drawn = frames.map((f) => f.replace("\r\x1b[2K", "")).filter((f) => f.length > 0);
+        expect(drawn.length).toBeGreaterThan(0);
+        for (const frame of drawn) expect(frame.length).toBeLessThanOrEqual(11);
+    });
+});
+
+describe("exitIndicatorFrame", () => {
+    const GLYPH = "⠋";
+    const WIDE = 200;
+
+    test("renders the age through the shared formatter, not a hand-rolled one", () => {
+        // 16 minutes is the drain this feature exists to explain; `960s` is the shape to avoid.
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 16 * 60_000, WIDE)).toContain("(16m00s)");
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 31_000, WIDE)).toContain("(31s)");
+    });
+
+    test("explains itself only once the drain outlives the explain threshold", () => {
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 1_000, WIDE)).toBe("⠋ Exiting… (1s)");
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 6_000, WIDE)).toContain("waiting for in-flight work");
+    });
+
+    test("still explains itself on a conventional 80-column row", () => {
+        // The full explain variant is 80 columns with a two-unit age, so it cannot fit here. The
+        // reader must still get an explanation rather than a bare `Exiting…` — this width is the
+        // common case, not an edge one.
+        const frame = exitIndicatorFrame(GLYPH, Date.now() - 16 * 60_000, 80);
+        expect(frame).toBe("⠋ Exiting — waiting for in-flight work to finish (16m00s)");
+        expect(frame.length).toBeLessThanOrEqual(79);
+    });
+
+    test("uses the full explanation when the row is wide enough for it", () => {
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 16 * 60_000, 120)).toBe(
+            "⠋ Exiting — waiting for in-flight work to finish, this can take a while (16m00s)",
+        );
+    });
+
+    test("degrades to the short message rather than truncating the age away", () => {
+        // Too narrow for any explanation, wide enough to keep the age — which is the part that
+        // distinguishes a live drain from a wedged one, and the part a plain truncation would cut.
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 16 * 60_000, 24)).toBe("⠋ Exiting… (16m00s)");
+    });
+
+    test("degrades to the bare glyph on a row too narrow for any message", () => {
+        expect(exitIndicatorFrame(GLYPH, Date.now() - 6_000, 6)).toBe(GLYPH);
+    });
+
+    test("never exceeds its budget at any width, down to a degenerate row", () => {
+        for (const columns of [0, 1, 2, 5, 12, 20, 40, 79, 80, 81, 120]) {
+            const frame = exitIndicatorFrame(GLYPH, Date.now() - 6_000, columns);
+            expect(frame.length).toBeLessThanOrEqual(Math.max(0, columns - 1));
+        }
     });
 });

--- a/cli/src/lib/shutdown.test.ts
+++ b/cli/src/lib/shutdown.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { startExitIndicator } from "./shutdown.ts";
+
+// The indicator's grace period is a module constant (500ms). These tests exercise the real timers
+// rather than injecting a clock: the whole contract is "stay silent unless the drain is genuinely
+// slow", and a fake clock would test the injection instead of the behaviour that matters.
+const PAST_GRACE_MS = 640;
+
+const realIsTTY = process.stderr.isTTY;
+const realWrite = process.stderr.write.bind(process.stderr);
+
+/** Capture stderr for the duration of one test, returning the frames written. */
+function captureStderr(isTTY: boolean): string[] {
+    const frames: string[] = [];
+    // `isTTY` is an own property of the stream in Node and Bun alike, so a plain assignment is the
+    // supported way to simulate a pipe; `afterEach` restores both it and `write`.
+    process.stderr.isTTY = isTTY;
+    process.stderr.write = ((chunk: string) => {
+        frames.push(chunk);
+        return true;
+    }) as typeof process.stderr.write;
+    return frames;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterEach(() => {
+    process.stderr.isTTY = realIsTTY;
+    process.stderr.write = realWrite;
+});
+
+describe("startExitIndicator", () => {
+    test("writes nothing when stderr is not a TTY, however long the drain runs", async () => {
+        const frames = captureStderr(false);
+        const stop = startExitIndicator();
+        await sleep(PAST_GRACE_MS);
+        stop();
+        expect(frames).toEqual([]);
+    });
+
+    test("stays silent for a drain that finishes inside the grace period", () => {
+        const frames = captureStderr(true);
+        startExitIndicator()();
+        expect(frames).toEqual([]);
+    });
+
+    test("draws a spinner frame once the drain outlives the grace period", async () => {
+        const frames = captureStderr(true);
+        const stop = startExitIndicator();
+        await sleep(PAST_GRACE_MS);
+        stop();
+
+        const drawn = frames.join("");
+        expect(drawn).toContain("Exiting");
+        expect(drawn).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
+        // Elapsed seconds are what tell the reader the process is alive rather than wedged.
+        expect(drawn).toMatch(/\(\d+s\)/);
+    });
+
+    test("erases its line on stop, so the shell prompt lands on a clean row", async () => {
+        const frames = captureStderr(true);
+        const stop = startExitIndicator();
+        await sleep(PAST_GRACE_MS);
+        stop();
+        expect(frames.at(-1)).toBe("\r\x1b[2K");
+    });
+});

--- a/cli/src/lib/shutdown.ts
+++ b/cli/src/lib/shutdown.ts
@@ -21,6 +21,70 @@ const INDICATOR_FRAME_MS = 80;
  */
 const INDICATOR_EXPLAIN_AFTER_MS = 5_000;
 
+/** Assumed row width when stderr reports none — the conventional terminal default. */
+const INDICATOR_FALLBACK_COLUMNS = 80;
+
+const INDICATOR_MESSAGE = "Exiting…";
+const INDICATOR_EXPLAIN_MESSAGE = "Exiting — waiting for in-flight work to finish, this can take a while";
+/**
+ * The explanation, shortened to clear a conventional 80-column row once the glyph and a two-unit age
+ * are added. Without this rung the full message — 80 columns exactly — would lose to the fit check on
+ * the most common terminal width there is, and the reader would get the bare `Exiting…` precisely
+ * during the long waits the explanation exists for.
+ */
+const INDICATOR_EXPLAIN_BRIEF = "Exiting — waiting for in-flight work to finish";
+
+/**
+ * Compose one frame, widest variant that fits the row.
+ *
+ * Fitting is not cosmetic. `\r\x1b[2K` erases only the row the cursor is on, so a frame that WRAPS
+ * leaves its first row stranded and the next tick redraws below it — the indicator smears down the
+ * screen instead of animating in place. The explain variant is 80 columns with a two-unit age, i.e.
+ * it wraps on the conventional default width, so this is the common case rather than a narrow-pane
+ * edge case.
+ *
+ * Degrading through variants rather than truncating the full line keeps the age visible: the age is
+ * what distinguishes a live drain from a wedged one, and it sits at the END of the line, so a plain
+ * truncation would cut off precisely the part worth reading. The final fallback is the bare glyph,
+ * which still animates.
+ *
+ * One column is left spare because writing into the last one puts most terminals into a deferred-wrap
+ * state that the following `\r` resolves inconsistently.
+ */
+export function exitIndicatorFrame(glyph: string, startedAt: number, columns: number): string {
+    const age = Date.relativeAge(startedAt);
+    const explaining = Date.now() - startedAt >= INDICATOR_EXPLAIN_AFTER_MS;
+    const budget = Math.max(0, columns - 1);
+    const variants = [
+        ...(explaining ? [`${glyph} ${INDICATOR_EXPLAIN_MESSAGE} (${age})`, `${glyph} ${INDICATOR_EXPLAIN_BRIEF} (${age})`] : []),
+        `${glyph} ${INDICATOR_MESSAGE} (${age})`,
+        `${glyph} ${INDICATOR_MESSAGE}`,
+        glyph,
+    ];
+    return variants.find((variant) => variant.length <= budget) ?? glyph.slice(0, budget);
+}
+
+/**
+ * Write one frame, swallowing any failure.
+ *
+ * The indicator is decoration on the last code path the process ever runs, so it must not be able to
+ * turn a clean exit into a crash — and both of its failure modes are reachable. `process.stderr.write`
+ * throws `EPIPE` when the terminal goes away mid-drain, which is precisely the SIGHUP case
+ * `src/index.ts` routes here; and {@link exitIndicatorFrame} reads `Date.relativeAge`, a runtime
+ * extension installed by the entry point rather than by this module. A throw from either would escape
+ * the `setInterval` callback uncaught, killing the process before {@link shutdown} reaches
+ * `process.exit` and burying whatever the real exit code was meant to be.
+ *
+ * Losing the animation is the correct degradation: the drain itself is unaffected.
+ */
+function draw(frame: string): void {
+    try {
+        process.stderr.write(frame);
+    } catch {
+        // A dead or unwritable stderr means there is no one left to narrate to.
+    }
+}
+
 /**
  * Narrate a slow exit, returning a stop function that erases what it drew.
  *
@@ -43,10 +107,10 @@ export function startExitIndicator(): () => void {
         if (elapsedMs < INDICATOR_DELAY_MS) return;
         // `frame % length` is in range by construction, which `noUncheckedIndexedAccess` cannot see.
         const glyph = GLYPHS.spinner[frame++ % GLYPHS.spinner.length]!;
-        const message = elapsedMs < INDICATOR_EXPLAIN_AFTER_MS ? "Exiting…" : "Exiting — waiting for in-flight work to finish, this can take a while";
         // `\r\x1b[2K` returns to column 0 and clears the row, so each frame overwrites the last
-        // in place instead of scrolling a new line per tick.
-        process.stderr.write(`\r\x1b[2K${glyph} ${message} (${Math.round(elapsedMs / 1000)}s)`);
+        // in place instead of scrolling a new line per tick. Width is re-read every frame so a
+        // resize mid-drain is picked up without a SIGWINCH listener to unregister.
+        draw(`\r\x1b[2K${exitIndicatorFrame(glyph, startedAt, process.stderr.columns ?? INDICATOR_FALLBACK_COLUMNS)}`);
     }, INDICATOR_FRAME_MS);
     // The indicator must never be the reason the process stays alive: `beforeExit` reaches
     // `shutdown()` precisely when nothing else is pending, and a ref'd timer would re-arm the loop.
@@ -56,7 +120,7 @@ export function startExitIndicator(): () => void {
         clearInterval(timer);
         // Erase only what was drawn. Below the delay the indicator never wrote, and clearing the row
         // would wipe whatever the command legitimately left on the last line.
-        if (Date.now() - startedAt >= INDICATOR_DELAY_MS) process.stderr.write("\r\x1b[2K");
+        if (Date.now() - startedAt >= INDICATOR_DELAY_MS) draw("\r\x1b[2K");
     };
 }
 

--- a/cli/src/lib/shutdown.ts
+++ b/cli/src/lib/shutdown.ts
@@ -1,7 +1,64 @@
+import { GLYPHS } from "./design_system.ts";
 import { flushLogs } from "./log.ts";
 import { shutdownOtel } from "./otel.ts";
 
 let shuttingDown = false;
+
+/**
+ * Grace period before the exit indicator's first frame. An idle runtime drains in single-digit
+ * milliseconds, and a spinner that appears for one frame reads as a rendering glitch rather than
+ * progress — only a drain that outlives this window is worth narrating.
+ */
+const INDICATOR_DELAY_MS = 500;
+
+/** Frame cadence — fast enough to read as continuous motion, slow enough to cost nothing. */
+const INDICATOR_FRAME_MS = 80;
+
+/**
+ * Elapsed time after which the indicator stops merely spinning and explains itself. A drain this long
+ * means the harness is waiting on in-flight durable work, whose duration is the work's, not the
+ * process's — the reader needs to know the wait is expected rather than a hang they should kill.
+ */
+const INDICATOR_EXPLAIN_AFTER_MS = 5_000;
+
+/**
+ * Narrate a slow exit, returning a stop function that erases what it drew.
+ *
+ * Writes to stderr, and only to a TTY: {@link shutdown} runs on EVERY exit path, including piped text
+ * commands whose stdout is a machine-readable payload, so the indicator must have no way to reach that
+ * stream. The cursor is deliberately NOT hidden — a second SIGTERM force-exits past the stop function
+ * (`src/index.ts`), and a hidden cursor would survive into the user's shell.
+ *
+ * Callers that own the terminal must restore it first: the TUI's `quit()` calls `renderer.destroy()`
+ * before `shutdown()`, so by the time this draws, the alternate screen is gone and stderr is the
+ * normal scrollback again.
+ */
+export function startExitIndicator(): () => void {
+    if (!process.stderr.isTTY) return () => {};
+
+    const startedAt = Date.now();
+    let frame = 0;
+    const timer = setInterval(() => {
+        const elapsedMs = Date.now() - startedAt;
+        if (elapsedMs < INDICATOR_DELAY_MS) return;
+        // `frame % length` is in range by construction, which `noUncheckedIndexedAccess` cannot see.
+        const glyph = GLYPHS.spinner[frame++ % GLYPHS.spinner.length]!;
+        const message = elapsedMs < INDICATOR_EXPLAIN_AFTER_MS ? "Exiting…" : "Exiting — waiting for in-flight work to finish, this can take a while";
+        // `\r\x1b[2K` returns to column 0 and clears the row, so each frame overwrites the last
+        // in place instead of scrolling a new line per tick.
+        process.stderr.write(`\r\x1b[2K${glyph} ${message} (${Math.round(elapsedMs / 1000)}s)`);
+    }, INDICATOR_FRAME_MS);
+    // The indicator must never be the reason the process stays alive: `beforeExit` reaches
+    // `shutdown()` precisely when nothing else is pending, and a ref'd timer would re-arm the loop.
+    timer.unref();
+
+    return () => {
+        clearInterval(timer);
+        // Erase only what was drawn. Below the delay the indicator never wrote, and clearing the row
+        // would wipe whatever the command legitimately left on the last line.
+        if (Date.now() - startedAt >= INDICATOR_DELAY_MS) process.stderr.write("\r\x1b[2K");
+    };
+}
 
 /** Async cleanup hooks registered by modules (e.g. provenance flush). Runs alongside log/telemetry flush. */
 const asyncHooks: (() => Promise<void>)[] = [];
@@ -14,11 +71,23 @@ export function onShutdown(hook: () => Promise<void>): void {
 /**
  * Flush logs and telemetry, then exit. The CLI is short-lived — without this,
  * the final batch of records is silently dropped on `process.exit()`.
+ *
+ * The drain is not always instant: the harness hook waits for DBOS to settle its in-flight workflows,
+ * which can take as long as the work does. {@link startExitIndicator} covers that window so a slow
+ * exit reads as progress rather than a dead prompt.
  */
 export async function shutdown(code: number): Promise<never> {
     if (!shuttingDown) {
         shuttingDown = true;
-        await Promise.allSettled([...asyncHooks.map((h) => h()), flushLogs(), shutdownOtel()]);
+        const stopIndicator = startExitIndicator();
+        try {
+            await Promise.allSettled([...asyncHooks.map((h) => h()), flushLogs(), shutdownOtel()]);
+        } finally {
+            // `allSettled` never rejects, but a hook that throws SYNCHRONOUSLY throws out of the
+            // `map` before the array exists — the indicator must be torn down on that path too, or a
+            // failed exit leaves a half-drawn frame in the shell.
+            stopIndicator();
+        }
     }
     process.exit(code);
 }


### PR DESCRIPTION
Quitting the TUI after a long session appeared to hang: the shell took ~14s to come back with nothing on screen explaining why. `App.quit` calls `renderer.destroy()` before `shutdown(0)`, so the terminal is already restored to normal scrollback while the drain runs — every second of it silent.

The drain itself is honest work, not a stall. The harness shutdown hook reaches `DBOS.shutdown()`, which awaits `awaitRunningWorkflows()` — it waits for in-flight workflows to finish and never cancels or times out. In the observed session the parent was 14s from the end of a 16-minute `synthesize-findings` step; the same keystroke a few minutes earlier would have blocked for a quarter of an hour. That unbounded wait is a separate defect (#204) and is not addressed here — this change only stops the wait from being invisible.

`shutdown()` is the right home rather than the TUI quit paths: it runs on every exit, including SIGTERM/SIGHUP and `beforeExit`, and all three of them share the symptom. Three gates keep it from corrupting anything it now sits in front of:

- stderr, and only when it is a TTY. `shutdown()` also ends piped text commands whose stdout is a machine-readable payload, so the indicator must have no route into that stream.
- A 500ms grace period before the first frame. An idle runtime drains in single-digit milliseconds, so the ordinary exit prints nothing at all, and the window also covers opentui's asynchronous terminal restore.
- The cursor is never hidden. A second SIGTERM force-exits past the stop function (`src/index.ts`), and a hidden cursor would outlive the process into the user's shell.

Past five seconds the copy stops spinning and explains, because by then the reader's question is no longer "is it working" but "is this expected or should I kill it".

Verified end to end through the real `shutdown()` under a pty with a slow hook: prior command output intact, frames animating in place on one row, the row erased on exit. Full suite 1559 pass / 0 fail; typecheck and lint clean.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
