### PR TITLE
feat(harness): add search_gwas_catalog to the conversation agent

### DIFF
--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -92,6 +92,7 @@ describe("createConversationAgent", () => {
             "chembl",
             "pubchem",
             "opentargets",
+            "search_gwas_catalog",
             "pubmed",
             "comptox",
             "generate_plan",

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -52,6 +52,7 @@ import {
     chemblTool,
     pubchemTool,
     openTargetsTool,
+    searchGwasCatalogTool,
     searchPharmgkbTool,
     searchFaersTool,
     searchClinicalTrialsTool,
@@ -214,6 +215,8 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         pubchemTool,
         // Translational medicine.
         openTargetsTool,
+        // Genetic evidence — SNP-trait associations for target validation / MR support.
+        searchGwasCatalogTool,
         searchPharmgkbTool,
         searchFaersTool,
         searchClinicalTrialsTool,


### PR DESCRIPTION
## What

Wire the existing `searchGwasCatalogTool` into the **conversation agent**'s always-on tool roster.

The tool (`harness/src/tools/bio/search-gwas-catalog.ts`) already existed, was exported from the bio index, and already backed the sandbox drug-repurposing agent — it just wasn't reachable by the user-facing conversation agent. It queries the public NHGRI-EBI GWAS Catalog REST API (no key), returning SNP–trait associations with effect sizes, p-values, and mapped genes.

## Why

Genetic association evidence supports target validation and Mendelian-randomization reasoning — a natural fit for the conversation agent's data-discovery / target-validation role. Placed in the translational-medicine group beside `opentargets`.

## Changes

- `harness/src/agents/conversation-agent.ts` — import `searchGwasCatalogTool` and add it to the tools array (pure leaf tool, no host-supplied deps).
- `harness/src/agents/conversation-agent.test.ts` — add `search_gwas_catalog` to the roster assertion so the wiring is pinned.

## Verification

- `tsc -p tsconfig.json` — clean build
- `bun test src/agents/conversation-agent.test.ts` — 9 pass / 0 fail
- `prettier` — both files conform

## Notes

- Harness-side only. The CLI consumes `createConversationAgent` from `@inflexa-ai/harness`, so it picks this up once built against the updated harness — no embedder wiring needed (the tool takes no deps).
- Every conversation-agent tool is always-on, so its description rides in context each turn; this adds one well-scoped genetics-evidence capability.
