### PR TITLE
feat(tui): answer docked asks by clicking options or typing y/a/n in the composer

### DIFF
--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/design.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The docked ask prompt (`src/tui/components/ask_prompt.tsx`) captures approval decisions through ONE key layer gated on the prompt box's focus target — the gate that makes bare `y`/`a`/`n` legal (`ask_prompt.tsx:110-125`). Its choice hints render as inline spans inside a single `<text>`, so no option is a mouse target. The composer path is blocked upstream: while a turn is busy, `handleSubmit` returns before doing anything (`app.tsx:704`), and an ask only pends inside a busy turn. Focus choreography already handles every post-answer transition: `settleAsk` advances the queue, the head-identity effect focuses the next prompt, and a drain refocuses via `askDrainRefocusTarget` — the stream pane (NORMAL) while the turn still runs, the composer once it ended (`app.tsx:550-566`, `app.tsx:273`).
+
+Established idioms this change composes (no new machinery):
+
+- Clickable option boxes on mouse-up: `confirm_dialog.tsx:78-89`.
+- In-chat clickable text with `selectable={false}` ("buttons, not prose") and the live-selection drag guard read off `renderer.getSelection()?.getSelectedText()`: `run_block.tsx:215-289`, `app.tsx:406-419`.
+- The single gateway funnel `answerAsk(askId, reply)` with `answerBusy` double-answer protection and stale-outcome handling: `app.tsx:491-538`.
+- Pure exported app helpers pinned by unit tests: `askDrainRefocusTarget`, `interruptHintFor` (`app.tsx:245-275`).
+- Transient notices via `notify({ kind, text })`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A click on a choice option answers the head ask exactly as its key would — including `n` entering feedback mode.
+- The composer answers the head ask when the submitted buffer is exactly `y`, `a`, or `n` (trimmed, case-insensitive), clearing the buffer and leaving all focus/mode transitions to the existing choreography.
+- A non-answer submit while an ask is docked is refused with a transient notice naming the answer path; the draft is preserved.
+- Gallery exhibits stay fully inert under mouse.
+
+**Non-Goals:**
+
+- Composer-carried reject feedback (`n <text>` → reject with feedback). Deliberately excluded: a mistyped real message would silently become a rejection with feedback. Tracked as a follow-up GitHub issue; the prompt's feedback mode remains the only feedback path.
+- Clickable hints in feedback mode (`enter submit · esc back`). The feedback input already owns that surface; scope stays on the choice options.
+- Answer synonyms (`yes`, `no`, `always`). The tokens mirror the rendered key hints one-for-one.
+- Any change to the harness gateway, the ask ledger, or the pending-asks store.
+
+## Decisions
+
+**D1 — Activate options on mouse-UP with the live-selection guard, never on mouse-down.** Mouse-down fires the instant a user starts a text-selection drag over the hint row; an accidental "approve command execution" from a drag start is the worst possible failure here. Mouse-up alone is not enough either — a drag that *ends* on an option fires its mouse-up (the documented sidebar hazard, `app.tsx:406-411`) — so each activation first reads the live selection and bails when text is selected, the exact idiom of `releaseMarker` (`run_block.tsx:231-234`) and `openRunsFromSidebar`. Live-selection read over remembered press state for the reason documented at `run_block.tsx:226-230`: a flag can outlive its gesture.
+
+**D2 — Each option is its own `<text selectable={false}>` segment in a row box; separators stay muted plain text.** opentui mouse handlers attach to renderables, not inline spans, so the single hint `<text>` must split. `selectable={false}` because options are buttons, not prose (`run_block.tsx:254-257`). The AskPrompt keeps its pure props+callbacks contract except for one addition: `useRenderer()` for the selection guard — the same dependency `run_block.tsx` (also in `components/`) already takes for the same reason.
+
+**D3 — Clicks route through the SAME handlers as the keys** (`approve("once" | "always")`, `enterFeedback()`), inheriting the `busy` gate for free. A click on `n` enters feedback mode exactly like the key — no click-specific shortcut to bare reject, so the two input methods cannot drift.
+
+**D4 — Gallery exhibits gate clicks on `props.inert`.** Without this, clicking "n reject" on a gallery exhibit flips it into feedback mode and its auto-focusing input steals the gallery pane's focus. The click handlers no-op when `inert` is set, and the gallery's choice-mode exhibits (which today rely only on the focus gate for inertness) pass `inert`. Alternative rejected: leaving gallery clicks live with no-op callbacks — the local `setMode("feedback")` still fires, so the exhibit mutates.
+
+**D5 — Composer interception lives in `handleSubmit` after the `/quit` branch, before the busy gate, keyed on `activeAsk()` — not on `chatStatus()`.** The ask queue is the source of truth for "an answer is expected"; busy is merely correlated. A pure exported `parseAskAnswer(text: string): AskReply | null` beside the other pure helpers keeps the token mapping unit-testable without mounting the app. Mapping: `y` → `{ kind: "once" }`, `a` → `{ kind: "always" }`, `n` → `{ kind: "reject" }` after trim + lowercase; everything else → `null`. The decision precedence is itself a second pure helper, `askSubmitAction(text, askDocked, answerBusy)`, returning a discriminated action (`passthrough | swallow | answer | refuse`) that `handleSubmit` merely executes — no test can mount the full App (runtime/DB/providers), so the whole precedence table is pinned at the same pure-derivation altitude `interrupt_hint.test.ts` established.
+
+**D6 — On a parsed answer: clear the buffer, call `answerAsk`, return — and change nothing about focus.** The settle path already runs the head-identity/drain effect, which restores NORMAL (pane) while the turn is busy or advances focus to the next prompt. Duplicating a focus move at submit time would race the drain effect and re-create the double-focus-owner bug class the identity gate exists to prevent (`app.tsx:540-549`). While `answerBusy()` is true a repeated submit is swallowed (no notice): the first answer is in flight and the prompt already renders its busy state.
+
+**D7 — Non-answer text while an ask is docked: keep the refusal (return before clearing — the draft survives), add `notify({ kind: "info", text: "An approval is pending — answer y, a, or n (or use the prompt above)." })`.** Silent refusal is the discoverability hole this change exists to close; turning the submit into a rejection-with-feedback is the rejected dangerous alternative (see Non-Goals).
+
+## Risks / Trade-offs
+
+- [A drag-release lands on an option with an empty selection (zero-length drag) and activates it] → That gesture is indistinguishable from a click by design; the guard only suppresses releases that carry a real selection, matching every existing clickable surface.
+- [Case-insensitive `Y` answers while the hints advertise lowercase `y`] → Accepted: trim+lowercase costs nothing and matches user intent; the hints stay lowercase per the keymap label rule.
+- [A user typing a genuine one-letter message (`y` as "yes" to the *model*) answers the ask instead] → Accepted and intended: while an ask is docked the turn is suspended waiting on exactly this decision — no message can reach the model until it settles anyway.
+- [The composer notice fires on every non-answer submit, potentially repetitive] → The notice slot is single and auto-dismissed; repeated submits just refresh it.
+- [`useRenderer()` in AskPrompt widens its dependency surface] → Matches `run_block.tsx` precedent; the component stays host-agnostic (no store/gateway imports).
+
+## Open Questions
+
+None — token set, bare-`n` semantics, and the notice were decided with the user; composer reject feedback is tracked as a follow-up issue rather than left open here.

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Answering a docked approval prompt today requires focusing the prompt card first (a click on the card) and then pressing a bare `y`/`a`/`n` key — the focus gate that makes bare printables legal also makes the two most natural interactions dead ends: clicking an option label directly does nothing, and typing `y` into the chat composer is silently swallowed by the busy-turn submit gate. Both dead ends read as the TUI ignoring the user at the exact moment it is blocked waiting on them.
+
+## What Changes
+
+- The docked ask prompt's choice options (`y approve`, `a always`, `n reject`) become individually mouse-activatable: a click on an option answers as if its key had been pressed. Activation is on mouse-up, guarded against text-selection drag releases, and inert in design-gallery exhibits.
+- While an ask is docked, the chat composer becomes a second answer path: submitting exactly `y`, `a`, or `n` (trimmed, case-insensitive) answers the head ask through the same gateway funnel, clears the buffer, and the existing drain choreography restores NORMAL / the next prompt. Bare `n` rejects with no feedback (composer-carried reject feedback is deliberately out of scope, tracked as a follow-up issue).
+- Submitting any other text while an ask is docked keeps today's refusal (draft preserved) but now surfaces a transient notice naming the `y`/`a`/`n` answer path instead of failing silently.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tui-ask-approval`: the "prompt captures the decision with focus-gated keys" requirement gains two additional answer paths — mouse activation of the choice options and composer-submitted answer tokens — and the composer's silent busy refusal while an ask is docked becomes a noticed refusal.
+
+## Impact
+
+- `cli/src/tui/components/ask_prompt.tsx` — the choice hint row splits into per-option clickable segments (mouse-up + live-selection guard, `selectable={false}`, inert-gated).
+- `cli/src/tui/app.tsx` — `handleSubmit` intercepts answer tokens before the busy gate; a pure `parseAskAnswer` helper; the docked-ask notice.
+- `cli/src/tui/layout/design_gallery.tsx` — choice-mode ask exhibits become `inert` so gallery clicks cannot flip exhibit state or steal focus.
+- Tests: `ask_prompt.render.test.tsx` (mouse activation + drag guard), app-level submit-interception coverage, gallery render test if exhibit props change.
+- No new dependencies; no schema, storage, or harness changes — the gateway funnel (`answerAsk`) is reused as-is.

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/proposal.md
@@ -23,5 +23,5 @@ None.
 - `cli/src/tui/components/ask_prompt.tsx` — the choice hint row splits into per-option clickable segments (mouse-up + live-selection guard, `selectable={false}`, inert-gated).
 - `cli/src/tui/app.tsx` — `handleSubmit` intercepts answer tokens before the busy gate; a pure `parseAskAnswer` helper; the docked-ask notice.
 - `cli/src/tui/layout/design_gallery.tsx` — choice-mode ask exhibits become `inert` so gallery clicks cannot flip exhibit state or steal focus.
-- Tests: `ask_prompt.render.test.tsx` (mouse activation + drag guard), app-level submit-interception coverage, gallery render test if exhibit props change.
+- Tests: `ask_prompt.render.test.tsx` (mouse activation + drag guard), pure-derivation submit-precedence coverage (`parseAskAnswer` + `askSubmitAction`), gallery render test if exhibit props change.
 - No new dependencies; no schema, storage, or harness changes — the gateway funnel (`answerAsk`) is reused as-is.

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/specs/tui-ask-approval/spec.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/specs/tui-ask-approval/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: The choice options are mouse-activatable
+
+Each choice option rendered by the docked prompt (`y` approve, `a` always, `n` reject) SHALL be an individual mouse target that, when clicked, invokes the same handler as its key — a click on `n` enters feedback mode exactly as the key does, so the two input methods cannot diverge. Activation SHALL occur on mouse-up, and a release that carries a live text selection (the tail of a selection drag ending on an option) SHALL NOT activate — the guard SHALL read the renderer's live selection, not press state remembered from mouse-down. The option texts SHALL be excluded from text selection (they are buttons, not prose). While an answer is in flight (`busy`), clicks SHALL be inert like the keys. When the prompt is rendered as an inert gallery exhibit, clicks SHALL be no-ops — an exhibit click must neither mutate the exhibit's mode nor let a mounted feedback input steal the gallery's focus.
+
+#### Scenario: Clicking an option answers the ask
+
+- **GIVEN** a docked prompt in choice mode for a pending ask
+- **WHEN** the user clicks the `y approve` option without any prior focusing click on the card
+- **THEN** the ask is answered approve-once, exactly as if `y` had been pressed while the prompt held focus
+
+#### Scenario: Clicking reject enters feedback mode
+
+- **GIVEN** a docked prompt in choice mode
+- **WHEN** the user clicks the `n reject` option
+- **THEN** the prompt switches to feedback mode with the feedback input focused, identical to pressing `n`
+
+#### Scenario: A selection drag released on an option does not activate it
+
+- **GIVEN** a docked prompt and a text-selection drag in progress
+- **WHEN** the drag is released over the `y approve` option while selected text exists
+- **THEN** the ask is not answered and the release is treated as the tail of the selection gesture
+
+#### Scenario: Gallery exhibit clicks are inert
+
+- **GIVEN** the design gallery's choice-mode ask exhibits
+- **WHEN** an option in an exhibit is clicked
+- **THEN** no callback fires, the exhibit does not switch modes, and gallery focus is not stolen
+
+### Requirement: The composer answers the head ask while one is docked
+
+While an ask is docked, the chat composer SHALL act as a second answer path: submitting a buffer that is exactly `y`, `a`, or `n` after trimming, matched case-insensitively, SHALL answer the head ask through the same gateway funnel as the prompt's keys (`y` approve-once, `a` approve-always, `n` reject with no feedback), and SHALL clear the buffer. The token set SHALL mirror the prompt's rendered key hints exactly — no synonyms. Post-answer focus and mode transitions SHALL be left entirely to the existing settle/drain choreography (the composer path adds no focus moves of its own). Submitting any other text while an ask is docked SHALL be refused with the draft preserved, and SHALL surface a transient notice naming the `y`/`a`/`n` answer path. While an answer is already in flight, a repeated submit SHALL be swallowed without a notice. The composer path SHALL NOT carry reject feedback — the prompt's feedback mode remains the only feedback surface.
+
+#### Scenario: Composer y approves, clears, and lands in NORMAL
+
+- **GIVEN** a docked prompt for a pending ask and the user focused in the composer with `y` typed
+- **WHEN** the user submits
+- **THEN** the ask is answered approve-once, the buffer is cleared, and when the queue drains mid-turn focus lands on the stream pane with the footer showing NORMAL
+
+#### Scenario: Tokens are trimmed and case-insensitive, and n rejects bare
+
+- **GIVEN** a docked prompt for a pending ask
+- **WHEN** the user submits `  N  `
+- **THEN** the ask is answered reject with no feedback
+
+#### Scenario: Non-answer text is refused with a notice
+
+- **GIVEN** a docked prompt for a pending ask and a composer buffer holding `rerun it with more threads`
+- **WHEN** the user submits
+- **THEN** no answer is sent, the buffer keeps the draft, and a transient notice names the `y`/`a`/`n` answer path
+
+#### Scenario: No interception without a docked ask
+
+- **GIVEN** no pending ask and an idle, ready runtime
+- **WHEN** the user submits `y`
+- **THEN** the text is sent to the conversation as a normal message
+
+## MODIFIED Requirements
+
+### Requirement: The prompt captures the decision with focus-gated keys
+
+While the prompt is visible it SHALL hold input focus, which gates the
+composer (the textarea is blurred; a submit while an ask is docked either
+answers the ask — when the buffer is an answer token — or is refused with a
+transient notice, per the composer answer path requirement). Its key layer
+SHALL be gated on the prompt's own focus target so its bare keys never steal
+characters from a focused editor. Choice mode SHALL offer approve-once (`y`),
+approve-always (`a`), and reject (`n`); reject SHALL enter a feedback mode
+with a text input where enter submits (an empty entry means no feedback) and
+escape returns to choice mode. When the ask queue drains, the refocus target
+SHALL be busy-aware: while the turn still runs, focus returns to the stream
+pane (NORMAL — the resting state of a running turn, keeping the interrupt
+affordance live and its hint honest); when the turn has ended, focus returns
+to the composer. The turn-abort chord SHALL remain reachable while the prompt
+is focused.
+
+#### Scenario: Approve resolves the suspended tool
+
+- **GIVEN** a docked prompt for a pending ask
+- **WHEN** the user presses `y`
+- **THEN** the ask is answered approve-once, the suspended tool proceeds, and the turn continues
+
+#### Scenario: Draining mid-turn returns focus to the pane
+
+- **GIVEN** a docked prompt whose approval lets the turn continue
+- **WHEN** the queue drains while the turn is still busy
+- **THEN** focus lands on the stream pane, the footer shows `NORMAL`, and two esc presses interrupt the continuing turn
+
+#### Scenario: Reject with feedback stops the turn
+
+- **GIVEN** a docked prompt in feedback mode with typed feedback
+- **WHEN** the user presses enter
+- **THEN** the ask is answered reject with that feedback, the turn ends with the denial and feedback visible in the transcript, and focus returns to the composer
+
+#### Scenario: Prompt keys never leak into the composer
+
+- **GIVEN** a visible prompt and a composer textarea
+- **WHEN** the prompt holds focus and the user presses `y`
+- **THEN** the key acts on the prompt and no character is inserted into the textarea

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/tasks.md
@@ -14,7 +14,7 @@
 
 - [x] 3.1 `ask_prompt.render.test.tsx`: mouse click on each option activates its handler (mockMouse.click at the option's frame coordinates); a selection drag released over an option does not activate; clicks are inert under `busy` and under `inert`
 - [x] 3.2 Unit-test `parseAskAnswer` (tokens, trim, case, rejects everything else) alongside the existing pure-helper tests
-- [x] 3.3 App-level coverage for the composer path: submit `y` with a docked ask answers approve-once and clears the buffer; submit non-answer text keeps the draft and surfaces the notice; submit `y` with no docked ask sends a normal message
+- [x] 3.3 Pure-derivation submit-precedence coverage for the composer path (`parseAskAnswer` + `askSubmitAction`): submit `y` with a docked ask answers approve-once and clears the buffer; submit non-answer text keeps the draft and surfaces the notice; submit `y` with no docked ask sends a normal message
 - [x] 3.4 Run `bun run typecheck`, `bun run lint`, and the full `bun test` suite in `cli/`; `bun run format:file` on every touched `src/` file
 
 ## 4. Follow-up tracking

--- a/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-24-ask-answer-interactions/tasks.md
@@ -1,0 +1,22 @@
+## 1. Clickable choice options (ask_prompt.tsx)
+
+- [x] 1.1 Split the choice hint row into per-option clickable `<text selectable={false}>` segments (y approve / a always / n reject) inside the existing row box, keeping the middot separators as muted plain text and the queued-count hint unchanged; route clicks through the SAME handlers as the keys (`approve("once")`, `approve("always")`, `enterFeedback()`)
+- [x] 1.2 Guard activation: mouse-up only, bail when `useRenderer()`'s live selection carries text (the `releaseMarker` idiom), and no-op entirely when `props.inert` is set; document the why (drag-release hazard, gallery inertness) per the design's D1/D4
+- [x] 1.3 Pass `inert` on the design gallery's choice-mode ask exhibits so exhibit clicks cannot flip mode or steal focus
+
+## 2. Composer answer path (app.tsx)
+
+- [x] 2.1 Add pure exported `parseAskAnswer(text: string): AskReply | null` beside the other pure helpers (trim + lowercase; `y` → once, `a` → always, `n` → reject with no feedback; else null) with JSDoc
+- [x] 2.2 Intercept in `handleSubmit` after the `/quit` branch and before the `chatStatus() === "busy"` gate, keyed on `activeAsk()`: parsed token → clear buffer, `answerAsk(head.askId, reply)`, return (no focus moves — the drain choreography owns transitions); while `answerBusy()` swallow the submit silently
+- [x] 2.3 Non-answer text while an ask is docked: keep the refusal (return BEFORE clearing so the draft survives) and `notify` the transient info notice naming the y/a/n answer path
+
+## 3. Tests
+
+- [x] 3.1 `ask_prompt.render.test.tsx`: mouse click on each option activates its handler (mockMouse.click at the option's frame coordinates); a selection drag released over an option does not activate; clicks are inert under `busy` and under `inert`
+- [x] 3.2 Unit-test `parseAskAnswer` (tokens, trim, case, rejects everything else) alongside the existing pure-helper tests
+- [x] 3.3 App-level coverage for the composer path: submit `y` with a docked ask answers approve-once and clears the buffer; submit non-answer text keeps the draft and surfaces the notice; submit `y` with no docked ask sends a normal message
+- [x] 3.4 Run `bun run typecheck`, `bun run lint`, and the full `bun test` suite in `cli/`; `bun run format:file` on every touched `src/` file
+
+## 4. Follow-up tracking
+
+- [x] 4.1 Open a GitHub issue for the deliberately-excluded composer reject-feedback path (`n <text>` → reject with feedback), linking this change and the design's Non-Goals rationale

--- a/cli/openspec/specs/tui-ask-approval/spec.md
+++ b/cli/openspec/specs/tui-ask-approval/spec.md
@@ -93,8 +93,10 @@ Two structural properties SHALL be preserved by this layout. The prompt's outer 
 ### Requirement: The prompt captures the decision with focus-gated keys
 
 While the prompt is visible it SHALL hold input focus, which gates the
-composer (the textarea is blurred; submitting is refused while the turn is
-busy). Its key layer SHALL be gated on the prompt's own focus target so its
+composer (the textarea is blurred; a submit while an ask is docked either
+answers the ask — when the buffer is an answer token — or is refused with a
+transient notice, per the composer answer path requirement). Its key layer
+SHALL be gated on the prompt's own focus target so its
 bare keys never steal characters from a focused editor. Choice mode SHALL
 offer approve-once (`y`), approve-always (`a`), and reject (`n`); reject SHALL
 enter a feedback mode with a text input where enter submits (an empty entry
@@ -128,6 +130,62 @@ remain reachable while the prompt is focused.
 - **GIVEN** a visible prompt and a composer textarea
 - **WHEN** the prompt holds focus and the user presses `y`
 - **THEN** the key acts on the prompt and no character is inserted into the textarea
+
+### Requirement: The choice options are mouse-activatable
+
+Each choice option rendered by the docked prompt (`y` approve, `a` always, `n` reject) SHALL be an individual mouse target that, when clicked, invokes the same handler as its key — a click on `n` enters feedback mode exactly as the key does, so the two input methods cannot diverge. Activation SHALL occur on mouse-up, and a release that carries a live text selection (the tail of a selection drag ending on an option) SHALL NOT activate — the guard SHALL read the renderer's live selection, not press state remembered from mouse-down. The option texts SHALL be excluded from text selection (they are buttons, not prose). While an answer is in flight (`busy`), clicks SHALL be inert like the keys. When the prompt is rendered as an inert gallery exhibit, clicks SHALL be no-ops — an exhibit click must neither mutate the exhibit's mode nor let a mounted feedback input steal the gallery's focus.
+
+#### Scenario: Clicking an option answers the ask
+
+- **GIVEN** a docked prompt in choice mode for a pending ask
+- **WHEN** the user clicks the `y approve` option without any prior focusing click on the card
+- **THEN** the ask is answered approve-once, exactly as if `y` had been pressed while the prompt held focus
+
+#### Scenario: Clicking reject enters feedback mode
+
+- **GIVEN** a docked prompt in choice mode
+- **WHEN** the user clicks the `n reject` option
+- **THEN** the prompt switches to feedback mode with the feedback input focused, identical to pressing `n`
+
+#### Scenario: A selection drag released on an option does not activate it
+
+- **GIVEN** a docked prompt and a text-selection drag in progress
+- **WHEN** the drag is released over the `y approve` option while selected text exists
+- **THEN** the ask is not answered and the release is treated as the tail of the selection gesture
+
+#### Scenario: Gallery exhibit clicks are inert
+
+- **GIVEN** the design gallery's choice-mode ask exhibits
+- **WHEN** an option in an exhibit is clicked
+- **THEN** no callback fires, the exhibit does not switch modes, and gallery focus is not stolen
+
+### Requirement: The composer answers the head ask while one is docked
+
+While an ask is docked, the chat composer SHALL act as a second answer path: submitting a buffer that is exactly `y`, `a`, or `n` after trimming, matched case-insensitively, SHALL answer the head ask through the same gateway funnel as the prompt's keys (`y` approve-once, `a` approve-always, `n` reject with no feedback), and SHALL clear the buffer. The token set SHALL mirror the prompt's rendered key hints exactly — no synonyms. Post-answer focus and mode transitions SHALL be left entirely to the existing settle/drain choreography (the composer path adds no focus moves of its own). Submitting any other text while an ask is docked SHALL be refused with the draft preserved, and SHALL surface a transient notice naming the `y`/`a`/`n` answer path. While an answer is already in flight, a repeated submit SHALL be swallowed without a notice. The composer path SHALL NOT carry reject feedback — the prompt's feedback mode remains the only feedback surface.
+
+#### Scenario: Composer y approves, clears, and lands in NORMAL
+
+- **GIVEN** a docked prompt for a pending ask and the user focused in the composer with `y` typed
+- **WHEN** the user submits
+- **THEN** the ask is answered approve-once, the buffer is cleared, and when the queue drains mid-turn focus lands on the stream pane with the footer showing NORMAL
+
+#### Scenario: Tokens are trimmed and case-insensitive, and n rejects bare
+
+- **GIVEN** a docked prompt for a pending ask
+- **WHEN** the user submits `  N  `
+- **THEN** the ask is answered reject with no feedback
+
+#### Scenario: Non-answer text is refused with a notice
+
+- **GIVEN** a docked prompt for a pending ask and a composer buffer holding `rerun it with more threads`
+- **WHEN** the user submits
+- **THEN** no answer is sent, the buffer keeps the draft, and a transient notice names the `y`/`a`/`n` answer path
+
+#### Scenario: No interception without a docked ask
+
+- **GIVEN** no pending ask and an idle, ready runtime
+- **WHEN** the user submits `y`
+- **THEN** the text is sent to the conversation as a normal message
 
 
 ### Requirement: Answers flow through the gateway and every outcome is handled

--- a/cli/openspec/specs/tui-ask-approval/spec.md
+++ b/cli/openspec/specs/tui-ask-approval/spec.md
@@ -95,7 +95,8 @@ Two structural properties SHALL be preserved by this layout. The prompt's outer 
 While the prompt is visible it SHALL hold input focus, which gates the
 composer (the textarea is blurred; a submit while an ask is docked either
 answers the ask — when the buffer is an answer token — or is refused with a
-transient notice, per the composer answer path requirement). Its key layer
+transient notice — quit aliases and in-flight repeats keep their own
+precedence — per the composer answer path requirement). Its key layer
 SHALL be gated on the prompt's own focus target so its
 bare keys never steal characters from a focused editor. Choice mode SHALL
 offer approve-once (`y`), approve-always (`a`), and reject (`n`); reject SHALL
@@ -161,7 +162,7 @@ Each choice option rendered by the docked prompt (`y` approve, `a` always, `n` r
 
 ### Requirement: The composer answers the head ask while one is docked
 
-While an ask is docked, the chat composer SHALL act as a second answer path: submitting a buffer that is exactly `y`, `a`, or `n` after trimming, matched case-insensitively, SHALL answer the head ask through the same gateway funnel as the prompt's keys (`y` approve-once, `a` approve-always, `n` reject with no feedback), and SHALL clear the buffer. The token set SHALL mirror the prompt's rendered key hints exactly — no synonyms. Post-answer focus and mode transitions SHALL be left entirely to the existing settle/drain choreography (the composer path adds no focus moves of its own). Submitting any other text while an ask is docked SHALL be refused with the draft preserved, and SHALL surface a transient notice naming the `y`/`a`/`n` answer path. While an answer is already in flight, a repeated submit SHALL be swallowed without a notice. The composer path SHALL NOT carry reject feedback — the prompt's feedback mode remains the only feedback surface.
+While an ask is docked, the chat composer SHALL act as a second answer path: submitting a buffer that is exactly `y`, `a`, or `n` after trimming, matched case-insensitively, SHALL answer the head ask through the same gateway funnel as the prompt's keys (`y` approve-once, `a` approve-always, `n` reject with no feedback), and SHALL clear the buffer when the answer settles — a failed gateway write keeps the token so the user can retry. The token set SHALL mirror the prompt's rendered key hints exactly — no synonyms. Post-answer focus and mode transitions SHALL be left entirely to the existing settle/drain choreography (the composer path adds no focus moves of its own). Slash-command quit aliases keep their existing precedence ahead of the answer path — they are commands, not answer text, and are neither intercepted nor refused. Submitting any other text while an ask is docked SHALL be refused with the draft preserved, and SHALL surface a transient notice naming the `y`/`a`/`n` answer path. While an answer is already in flight, a repeated submit SHALL be swallowed without a notice. The composer path SHALL NOT carry reject feedback — the prompt's feedback mode remains the only feedback surface.
 
 #### Scenario: Composer y approves, clears, and lands in NORMAL
 

--- a/cli/src/tui/app.tsx
+++ b/cli/src/tui/app.tsx
@@ -274,6 +274,66 @@ export function askDrainRefocusTarget(busy: boolean, pane: Renderable | null, co
     return busy ? pane : composer;
 }
 
+/**
+ * Parse a submitted composer buffer into an ask reply, or `null` when it is not an answer token.
+ *
+ * The tokens mirror the docked prompt's rendered key hints one-for-one — `y` → approve-once,
+ * `a` → approve-always, `n` → bare reject — with NO synonyms: `yes`, `no`, and `always` all fall through
+ * to `null` and reach the model as ordinary text. The composer is a convenience alias for the same three
+ * keys, not a second command vocabulary. Matching is case-insensitive after a trim because a shifted `Y`
+ * costs the user nothing, and the hints stay lowercase per the keymap label rule.
+ *
+ * The reject reply is deliberately bare (no `feedback`): composer-carried reject feedback is out of scope
+ * — a mistyped real message must not silently become a rejection-with-feedback — and is tracked as a
+ * follow-up. The prompt's feedback mode stays the only feedback surface.
+ */
+export function parseAskAnswer(text: string): AskReply | null {
+    switch (text.trim().toLowerCase()) {
+        case "y":
+            return { kind: "once" };
+        case "a":
+            return { kind: "always" };
+        case "n":
+            return { kind: "reject" };
+        default:
+            return null;
+    }
+}
+
+/**
+ * The four outcomes of a composer submit while the ask queue is consulted — the result of
+ * {@link askSubmitAction}, executed by `handleSubmit` after the `/quit` alias and before the busy gate.
+ */
+export type AskSubmitAction =
+    /** No ask is docked: hand the submit to the normal turn path unchanged. */
+    | { readonly kind: "passthrough" }
+    /** An answer is already in flight: drop this repeat with no notice (the prompt renders its busy state). */
+    | { readonly kind: "swallow" }
+    /** The buffer is an answer token: answer the head ask with `reply` through the gateway funnel. */
+    | { readonly kind: "answer"; readonly reply: AskReply }
+    /** The buffer is not a token: keep the draft and surface the y/a/n notice. */
+    | { readonly kind: "refuse" };
+
+/**
+ * The composer-submit decision precedence, keyed on the ask queue — NOT on `chatStatus`: the queue is the
+ * source of truth that an answer is expected (busy is merely correlated). Docked first, then in-flight,
+ * then token shape:
+ *   - no ask docked → `passthrough` (the normal turn path handles it),
+ *   - docked + an answer already in flight → `swallow` (the first answer is resolving; no notice),
+ *   - docked + the buffer is an answer token → `answer` (carry the parsed reply),
+ *   - docked + any other text → `refuse` (keep the draft, name the answer path).
+ *
+ * Pure over its three inputs so the whole precedence is unit-testable without mounting the App. The
+ * `answer` case carries only the reply; the caller supplies the head ask's id at the call site (`answer`
+ * is reachable only when an ask is docked, so a non-null head is guaranteed there).
+ */
+export function askSubmitAction(text: string, askDocked: boolean, answerBusy: boolean): AskSubmitAction {
+    if (!askDocked) return { kind: "passthrough" };
+    if (answerBusy) return { kind: "swallow" };
+    const reply = parseAskAnswer(text);
+    return reply ? { kind: "answer", reply } : { kind: "refuse" };
+}
+
 export function App(props: AppProps) {
     const dims = useTerminalDimensions();
     const renderer = useRenderer();
@@ -698,6 +758,40 @@ export function App(props: AppProps) {
                 renderer.destroy();
                 await shutdown(0);
                 return;
+            }
+        }
+
+        // While an ask is docked the composer is a SECOND answer path. Intercept here — after the /quit
+        // alias, before the busy gate — keyed on the ask queue (`activeAsk()`), not `chatStatus`: the
+        // queue is the source of truth that an answer is expected, and an ask only ever pends inside a
+        // busy turn anyway. The precedence lives in the pure `askSubmitAction`; execute its verdict here.
+        const head = activeAsk();
+        const action = askSubmitAction(text, head !== null, answerBusy());
+        switch (action.kind) {
+            case "swallow":
+                // The first answer is already in flight and the prompt renders its busy state — drop this
+                // repeat silently (no notice, and leave the draft: the composer is blurred while docked).
+                return;
+            case "answer": {
+                // `answer` is reachable only when an ask is docked, so `head` is non-null here; and a
+                // non-empty `text` was read off `textareaRef.editBuffer` above, so the ref is mounted.
+                textareaRef!.setText("");
+                // NO focus move here on purpose: the settle/drain choreography (the head-identity effect
+                // above) owns every post-answer transition. Duplicating a focus move at submit time would
+                // race that effect and re-create the double-focus-owner bug the identity gate prevents.
+                answerAsk(head!.askId, action.reply);
+                return;
+            }
+            case "refuse":
+                // Keep today's refusal — return BEFORE clearing so the draft survives — but no longer
+                // silently: name the y/a/n answer path so the pending approval is discoverable.
+                notify({ kind: "info", text: "An approval is pending — answer y, a, or n (or use the prompt above)." });
+                return;
+            case "passthrough":
+                break;
+            default: {
+                const _exhaustive: never = action;
+                throw new Error(`unhandled ask-submit action: ${JSON.stringify(_exhaustive)}`);
             }
         }
 

--- a/cli/src/tui/app.tsx
+++ b/cli/src/tui/app.tsx
@@ -559,7 +559,12 @@ export function App(props: AppProps) {
     // leaves the entry in place: the write failed, the ask may still be answerable, so the user can
     // retry rather than lose the decision. Bridged through ResultAsync so the harness throw becomes a
     // handled branch (neverthrow-first) rather than a bare try/catch.
-    function answerAsk(askId: string, reply: AskReply): void {
+    //
+    // `onSettled` runs only in the three branches that advance the queue (applied / not_found /
+    // already_terminal) — never on the error branch or the missing-gateway early return. The composer
+    // answer path uses it to defer its buffer clear to settle time: a failed write (or an unbound
+    // gateway) keeps the typed token so the user can retry the submit rather than lose the decision.
+    function answerAsk(askId: string, reply: AskReply, onSettled?: () => void): void {
         const gateway = harnessRuntime()?.askGateway;
         if (!gateway) return;
         setAnswerBusy(true);
@@ -574,14 +579,17 @@ export function App(props: AppProps) {
                         // noteAskFeedback and reconcileAskCard both spread the same card, so they converge.
                         if (reply.kind === "reject" && reply.feedback) conversation.noteAskFeedback(askId, reply.feedback);
                         settleAsk(askId);
+                        onSettled?.();
                         return;
                     case "not_found":
                         notify({ kind: "info", text: "That approval is no longer pending." });
                         settleAsk(askId);
+                        onSettled?.();
                         return;
                     case "already_terminal":
                         notify({ kind: "info", text: "That approval was already answered." });
                         settleAsk(askId);
+                        onSettled?.();
                         return;
                     default: {
                         const _exhaustive: never = outcome;
@@ -769,22 +777,24 @@ export function App(props: AppProps) {
         const action = askSubmitAction(text, head !== null, answerBusy());
         switch (action.kind) {
             case "swallow":
-                // The first answer is already in flight and the prompt renders its busy state — drop this
-                // repeat silently (no notice, and leave the draft: the composer is blurred while docked).
+                // The first answer is already in flight and the prompt renders its busy state, so a
+                // notice would add nothing; drop this repeat and retain the draft so the user can
+                // re-submit if the in-flight answer ultimately fails.
                 return;
             case "answer": {
-                // `answer` is reachable only when an ask is docked, so `head` is non-null here; and a
-                // non-empty `text` was read off `textareaRef.editBuffer` above, so the ref is mounted.
-                textareaRef!.setText("");
+                // `answer` is reachable only when an ask is docked, so `head` is non-null here.
                 // NO focus move here on purpose: the settle/drain choreography (the head-identity effect
                 // above) owns every post-answer transition. Duplicating a focus move at submit time would
                 // race that effect and re-create the double-focus-owner bug the identity gate prevents.
-                answerAsk(head!.askId, action.reply);
+                // The buffer clear is deferred to settle time (onSettled): a failed gateway write keeps
+                // the typed token so this submit can be retried instead of vanishing.
+                answerAsk(head!.askId, action.reply, () => textareaRef?.setText(""));
                 return;
             }
             case "refuse":
-                // Keep today's refusal — return BEFORE clearing so the draft survives — but no longer
-                // silently: name the y/a/n answer path so the pending approval is discoverable.
+                // Refuse without touching the buffer — return before any clear so the draft survives —
+                // and name the y/a/n answer path so the pending approval is discoverable instead of a
+                // silent swallow.
                 notify({ kind: "info", text: "An approval is pending — answer y, a, or n (or use the prompt above)." });
                 return;
             case "passthrough":

--- a/cli/src/tui/ask_answer.test.ts
+++ b/cli/src/tui/ask_answer.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { askSubmitAction, parseAskAnswer } from "./app.tsx";
+
+// The composer answer path is derived by two pure functions in app.tsx: `parseAskAnswer` maps a submitted
+// buffer to an ask reply (or null), and `askSubmitAction` decides what a submit does while the ask queue
+// is consulted. Booting the whole chat App to pin either would drag in a runtime, DB, and providers for
+// what is a token map plus a four-way precedence — so, exactly as interrupt_hint.test.ts does for the
+// footer hint, the derivations are exercised directly. Keeping the decision pure is what lets the
+// answer/swallow/refuse/passthrough precedence be asserted here without a mounted textarea or gateway.
+
+describe("parseAskAnswer — the composer answer-token map", () => {
+    test("the three tokens map one-for-one to the prompt's keys", () => {
+        expect(parseAskAnswer("y")).toEqual({ kind: "once" });
+        expect(parseAskAnswer("a")).toEqual({ kind: "always" });
+        expect(parseAskAnswer("n")).toEqual({ kind: "reject" });
+    });
+
+    test("tokens are trimmed and case-insensitive", () => {
+        expect(parseAskAnswer("  y  ")).toEqual({ kind: "once" });
+        expect(parseAskAnswer("Y")).toEqual({ kind: "once" });
+        expect(parseAskAnswer("A")).toEqual({ kind: "always" });
+        expect(parseAskAnswer("\tN\n")).toEqual({ kind: "reject" });
+    });
+
+    test("reject is bare — no feedback key rides the composer path", () => {
+        // toEqual with an exact object asserts the ABSENCE of `feedback`: composer-carried reject feedback
+        // is deliberately out of scope, so a stray key would be a real regression.
+        expect(parseAskAnswer("  N  ")).toEqual({ kind: "reject" });
+        expect(parseAskAnswer("n")).not.toHaveProperty("feedback");
+    });
+
+    test("anything that is not exactly one token falls through to null (reaches the model as text)", () => {
+        for (const text of ["yes", "no", "always", "y approve", "ya", "", "  ", "y\nplease"]) {
+            expect(parseAskAnswer(text)).toBeNull();
+        }
+    });
+});
+
+describe("askSubmitAction — the composer-submit precedence while the queue is consulted", () => {
+    test("no docked ask → passthrough, even for a token (a bare y is a normal message)", () => {
+        expect(askSubmitAction("y", false, false)).toEqual({ kind: "passthrough" });
+        expect(askSubmitAction("rerun it", false, false)).toEqual({ kind: "passthrough" });
+    });
+
+    test("docked + an answer in flight → swallow, ahead of any token parse", () => {
+        // answerBusy outranks the token shape: even a valid `y` is dropped while the first answer resolves.
+        expect(askSubmitAction("y", true, true)).toEqual({ kind: "swallow" });
+        expect(askSubmitAction("rerun it", true, true)).toEqual({ kind: "swallow" });
+    });
+
+    test("docked + a token → answer carrying the parsed reply", () => {
+        expect(askSubmitAction("y", true, false)).toEqual({ kind: "answer", reply: { kind: "once" } });
+        expect(askSubmitAction("  A  ", true, false)).toEqual({ kind: "answer", reply: { kind: "always" } });
+        expect(askSubmitAction("N", true, false)).toEqual({ kind: "answer", reply: { kind: "reject" } });
+    });
+
+    test("docked + non-token text → refuse (the draft is kept and the notice fires at the call site)", () => {
+        expect(askSubmitAction("rerun it with more threads", true, false)).toEqual({ kind: "refuse" });
+        expect(askSubmitAction("yes", true, false)).toEqual({ kind: "refuse" });
+    });
+});

--- a/cli/src/tui/components/ask_prompt.render.test.tsx
+++ b/cli/src/tui/components/ask_prompt.render.test.tsx
@@ -294,9 +294,17 @@ describe("AskPrompt mouse activation", () => {
     test("clicks are inert when inert is set — no answer, no mode flip", async () => {
         const approvals: Array<"once" | "always"> = [];
         let rejected = 0;
-        const setup = await testRender(() => <Harness inert onApprove={(k) => approvals.push(k)} onReject={() => rejected++} />, { width: 80, height: 10 });
+        let box: BoxRenderable | null = null;
+        const setup = await testRender(() => <Harness inert onBox={(r) => (box = r)} onApprove={(k) => approvals.push(k)} onReject={() => rejected++} />, {
+            width: 80,
+            height: 10,
+        });
         try {
             await setup.renderOnce();
+
+            // Focus hardening: an inert exhibit's box is non-focusable, so opentui's mousedown-autofocus
+            // walk finds no focusable ancestor and cannot yank focus off the gallery pane.
+            expect(box!.focusable).toBe(false);
 
             const yCell = optionCell(setup, "approve");
             await setup.mockMouse.click(yCell.x, yCell.y);
@@ -373,6 +381,9 @@ describe("AskPrompt key gating (bare-printable rule)", () => {
             await settle();
             // The editor grabbed focus on mount; the prompt is mounted but unfocused.
             expect(ta!.focused).toBe(true);
+            // Positive control for the inert-gating of focusability: a live (non-inert) prompt's box IS
+            // focusable, which is what lets the host focus it to engage the bare-key layer below.
+            expect(box!.focusable).toBe(true);
 
             // With the editor focused, y is NOT a prompt key — it types into the editor and never approves.
             setup.mockInput.pressKey("y");

--- a/cli/src/tui/components/ask_prompt.render.test.tsx
+++ b/cli/src/tui/components/ask_prompt.render.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Show } from "solid-js";
 import { testRender } from "@opentui/solid";
-import type { BoxRenderable, TextareaRenderable } from "@opentui/core";
+import type { BoxRenderable, Renderable, TextareaRenderable } from "@opentui/core";
 
 import { AskPrompt } from "./ask_prompt.tsx";
 import { GLYPHS, size, space } from "../../lib/design_system.ts";
@@ -50,6 +50,8 @@ function makeSettle(setup: { renderOnce: () => Promise<void> }): () => Promise<v
 /** Mounts the prompt under a keymap root, optionally beside a focus-grabbing editor (the leak test). */
 function Harness(props: {
     withEditor?: boolean;
+    busy?: boolean;
+    inert?: boolean;
     onBox?: (r: BoxRenderable) => void;
     onTa?: (r: TextareaRenderable) => void;
     onApprove?: (kind: "once" | "always") => void;
@@ -70,6 +72,8 @@ function Harness(props: {
                 title="Run shell command"
                 command="rm -rf build"
                 queuedCount={0}
+                busy={props.busy}
+                inert={props.inert}
                 onApprove={(kind) => props.onApprove?.(kind)}
                 onReject={(feedback) => props.onReject?.(feedback)}
                 onFocusReady={(r) => props.onBox?.(r)}
@@ -202,6 +206,156 @@ describe("AskPrompt feedback mode", () => {
         const lines = frame.split("\n");
         expect(lines[0]).toBe(markerRow(`Reject ${GLYPHS.emDash} add feedback (optional)`));
         expect(lines.slice(1).filter((l) => l.length > 0 && !hangsAtGutter(l))).toEqual([]);
+    });
+});
+
+describe("AskPrompt mouse activation", () => {
+    // Locate a choice option on the rendered hint row by a word unique to it and return a cell inside its
+    // clickable <text>. The word ("approve"/"always"/"reject") sits in that option's segment, so a click
+    // there lands on the option renderable — not the middot separators between them. Clicking without any
+    // prior box.focus() is the whole point: mouse activation must NOT depend on the focus-target gate that
+    // the bare keys require.
+    function optionCell(setup: Awaited<ReturnType<typeof testRender>>, needle: string): { x: number; y: number } {
+        const lines = setup.captureCharFrame().split("\n");
+        const y = lines.findIndex((l) => l.includes(needle));
+        expect(y).toBeGreaterThanOrEqual(0);
+        return { x: lines[y]!.indexOf(needle), y };
+    }
+
+    test("clicking each option runs its handler with no prior focus; n enters feedback like the key", async () => {
+        const approvals: Array<"once" | "always"> = [];
+        let rejected = 0;
+        const setup = await testRender(() => <Harness onApprove={(k) => approvals.push(k)} onReject={() => rejected++} />, { width: 80, height: 10 });
+        try {
+            await setup.renderOnce();
+
+            const yCell = optionCell(setup, "approve");
+            await setup.mockMouse.click(yCell.x, yCell.y);
+            await setup.renderOnce();
+            expect(approvals).toEqual(["once"]);
+
+            const aCell = optionCell(setup, "always");
+            await setup.mockMouse.click(aCell.x, aCell.y);
+            await setup.renderOnce();
+            expect(approvals).toEqual(["once", "always"]);
+
+            // A click on `n reject` enters feedback mode exactly as the key does — it is NOT an onReject call.
+            const nCell = optionCell(setup, "reject");
+            await setup.mockMouse.click(nCell.x, nCell.y);
+            await setup.renderOnce();
+            await setup.renderOnce();
+            expect(setup.captureCharFrame()).toContain("esc back");
+            expect(rejected).toBe(0);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a selection drag released over an option does not activate it", async () => {
+        const approvals: Array<"once" | "always"> = [];
+        let rejected = 0;
+        const setup = await testRender(() => <Harness onApprove={(k) => approvals.push(k)} onReject={() => rejected++} />, { width: 80, height: 10 });
+        try {
+            await setup.renderOnce();
+            const lines = setup.captureCharFrame().split("\n");
+            // Drag STARTS on the selectable command text and RELEASES on the y approve option: the release
+            // fires the option's mouse-up, but a live selection exists, so the guard treats it as the tail
+            // of the selection gesture — not a click.
+            const cmdY = lines.findIndex((l) => l.includes("rm -rf build"));
+            const optY = lines.findIndex((l) => l.includes("approve"));
+            await setup.mockMouse.drag(lines[cmdY]!.indexOf("rm -rf build"), cmdY, lines[optY]!.indexOf("approve"), optY);
+            await setup.renderOnce();
+
+            expect(setup.renderer.getSelection()?.getSelectedText() ?? "").not.toBe("");
+            expect(approvals).toEqual([]);
+            expect(rejected).toBe(0);
+            // And it did not flip to feedback mode either (the drag ended on approve, but a drag onto reject
+            // would be guarded identically).
+            expect(setup.captureCharFrame()).not.toContain("esc back");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("clicks are inert while busy — the same gate the keys inherit", async () => {
+        const approvals: Array<"once" | "always"> = [];
+        const setup = await testRender(() => <Harness busy onApprove={(k) => approvals.push(k)} onReject={() => {}} />, { width: 80, height: 10 });
+        try {
+            await setup.renderOnce();
+            const cell = optionCell(setup, "approve");
+            await setup.mockMouse.click(cell.x, cell.y);
+            await setup.renderOnce();
+            expect(approvals).toEqual([]);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("clicks are inert when inert is set — no answer, no mode flip", async () => {
+        const approvals: Array<"once" | "always"> = [];
+        let rejected = 0;
+        const setup = await testRender(() => <Harness inert onApprove={(k) => approvals.push(k)} onReject={() => rejected++} />, { width: 80, height: 10 });
+        try {
+            await setup.renderOnce();
+
+            const yCell = optionCell(setup, "approve");
+            await setup.mockMouse.click(yCell.x, yCell.y);
+            await setup.renderOnce();
+            expect(approvals).toEqual([]);
+
+            // The exhibit-inertness scenario: clicking `n reject` must NOT flip the exhibit into feedback
+            // mode (which would mount an auto-focusing input and steal the pane's focus).
+            const nCell = optionCell(setup, "reject");
+            await setup.mockMouse.click(nCell.x, nCell.y);
+            await setup.renderOnce();
+            await setup.renderOnce();
+            expect(setup.captureCharFrame()).not.toContain("esc back");
+            expect(rejected).toBe(0);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    // Frames carry no selectability: captureCharFrame proves a glyph landed in a column, never that the
+    // <text> beneath it opted out of selection. So the spec clause "The option texts SHALL be excluded from
+    // text selection" (tui-ask-approval) is unpinnable from any character frame — it lives solely on each
+    // option renderable's `selectable` flag (opentui's TextBufferRenderable.selectable, default true). Assert
+    // it structurally on the renderable tree, with the command prose as a positive control so a read that is
+    // vacuously false for every renderable cannot pass this test.
+    test("the three option buttons are excluded from selection while the command prose stays selectable", async () => {
+        const setup = await testRender(() => <Harness onApprove={() => {}} onReject={() => {}} />, { width: 80, height: 10 });
+        try {
+            await setup.renderOnce();
+
+            // Walk the renderable tree from the root — the same getChildren() recursion app.tsx's
+            // applySelectionColors uses. A <text> exposes `plainText` (its concatenated visible text) and the
+            // `selectable` flag; a <box> exposes neither, so `"plainText" in r` selects exactly the text nodes
+            // and makes the read of those two members sound.
+            type SelectableText = { plainText: string; selectable: boolean };
+            const texts: SelectableText[] = [];
+            const collect = (r: Renderable): void => {
+                if ("plainText" in r) texts.push(r as unknown as SelectableText);
+                for (const child of r.getChildren()) collect(child);
+            };
+            collect(setup.renderer.root);
+
+            // Each option is its own <text>; match on the word unique to that segment ("y approve", etc.).
+            const selectableOf = (needle: string): boolean => {
+                const hit = texts.find((t) => t.plainText.includes(needle));
+                expect(hit).toBeDefined();
+                // Non-null: toBeDefined above throws when the row is absent, so hit is set on this line.
+                return hit!.selectable;
+            };
+
+            expect(selectableOf("approve")).toBe(false);
+            expect(selectableOf("always")).toBe(false);
+            expect(selectableOf("reject")).toBe(false);
+            // Positive control: ordinary prose keeps selection on, proving the reads above read a real flag
+            // rather than reporting false for every renderable regardless.
+            expect(selectableOf("rm -rf build")).toBe(true);
+        } finally {
+            setup.renderer.destroy();
+        }
     });
 });
 

--- a/cli/src/tui/components/ask_prompt.tsx
+++ b/cli/src/tui/components/ask_prompt.tsx
@@ -153,9 +153,11 @@ export function AskPrompt(props: AskPromptProps): JSX.Element {
         <box
             ref={(r: BoxRenderable) => {
                 boxRef = r;
-                // Boxes default to non-focusable; opt this one in so the host can focus it and the
-                // target-gated key layer engages.
-                r.focusable = true;
+                // opentui's mousedown-autofocus walks from the clicked child to the nearest focusable
+                // ancestor, so an inert gallery exhibit must stay non-focusable — otherwise any click on
+                // it (an option, the prose) yanks focus off the gallery pane. Live docks opt in so the
+                // host can focus the box and the target-gated key layer engages.
+                r.focusable = !(props.inert ?? false);
                 props.onFocusReady?.(r);
             }}
             width="100%"
@@ -214,9 +216,10 @@ export function AskPrompt(props: AskPromptProps): JSX.Element {
                     {/* Each option is its own mouse target because opentui mouse handlers attach to
                     renderables, not inline spans — so the one hint <text> splits into a <text> per
                     option, the middot separators becoming their own muted <text> that carry the spacing.
-                    The split is byte-for-byte the old single line: "y approve · a always · n reject". The
-                    options are `selectable={false}` — they are buttons, not prose, so a press must not
-                    highlight the label as if the click did something other than answer. */}
+                    The segments compose one hint line reading "y approve · a always · n reject"; the
+                    per-option split exists only to attach mouse handlers, never to change the rendered
+                    row. The options are `selectable={false}` — they are buttons, not prose, so a press
+                    must not highlight the label as if the click did something other than answer. */}
                     <box flexDirection="row">
                         <text selectable={false} onMouseUp={() => onOptionClick("once")}>
                             <Fg role="accent">

--- a/cli/src/tui/components/ask_prompt.tsx
+++ b/cli/src/tui/components/ask_prompt.tsx
@@ -1,5 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import type { JSX } from "solid-js";
+import { useRenderer } from "@opentui/solid";
 import type { BoxRenderable } from "@opentui/core";
 
 import { GLYPHS, size, space } from "../../lib/design_system.ts";
@@ -33,9 +34,12 @@ export type AskPromptProps = {
      */
     initialMode?: "choice" | "feedback";
     /**
-     * True for a static gallery exhibit: the feedback input mounts blurred so it never steals the
-     * surrounding pane's focus (the same inertness the dialog showcase threads into its editors).
-     * Live docks leave it unset — reaching feedback by pressing `n` should focus the fresh input.
+     * True for a static gallery exhibit — two inertnesses in one flag. The feedback input mounts blurred
+     * so it never steals the surrounding pane's focus (the same inertness the dialog showcase threads
+     * into its editors), AND a click on a choice option is a no-op: a click needs no focus, so without
+     * this an exhibit click on `n` would flip the exhibit into feedback mode and its auto-focusing input
+     * would steal the gallery's focus. Live docks leave it unset — clicks answer, and reaching feedback
+     * by pressing `n` should focus the fresh input.
      */
     inert?: boolean;
     /** Answer the head ask: approve just this call (`once`) or record a standing grant (`always`). */
@@ -81,6 +85,9 @@ export function AskPrompt(props: AskPromptProps): JSX.Element {
     // (below); focusing it is what activates the key layer, and it stays focused-within while the
     // feedback input — its descendant — holds focus.
     let boxRef: BoxRenderable | null = null;
+    // For the choice-option click guard: reading the LIVE selection is how a drag-release is told from a
+    // click (see onOptionClick). The same dependency run_block.tsx (also a components/ widget) takes.
+    const renderer = useRenderer();
 
     function approve(kind: "once" | "always"): void {
         // busy = an answer is already in flight; swallow further presses until the gateway resolves.
@@ -105,6 +112,24 @@ export function AskPrompt(props: AskPromptProps): JSX.Element {
         // The feedback input unmounts on this switch, dropping focus; hand it back to the box so the
         // choice-mode keys stay live (the renderable is not refocusable synchronously — microtask).
         queueMicrotask(() => boxRef?.focus());
+    }
+
+    // A click on a choice option routes into the SAME handler its key would (`approve`/`enterFeedback`),
+    // so click and key can never drift — the `busy` gate lives inside those handlers and is inherited for
+    // free. Two guards fire before it:
+    //   - inert: a gallery exhibit must not answer. A click needs no focus, so the focus-target gate that
+    //     neuters the bare keys does nothing here — without this an exhibit click on `n` flips it into
+    //     feedback mode and its auto-focusing input steals the gallery pane's focus.
+    //   - a live text selection: this runs on mouse-UP (never -down, which would fire the instant a
+    //     selection drag STARTS over the row — an accidental command approval), and a drag that merely
+    //     ENDS on an option fires that mouse-up too. Reading the renderer's LIVE selection distinguishes
+    //     the two: a real click carries none. Read live, never press state remembered on mouse-down — a
+    //     flag can outlive its gesture (the reasoning documented at run_block.tsx:226-234).
+    function onOptionClick(action: "once" | "always" | "reject"): void {
+        if (props.inert) return;
+        if (renderer.getSelection()?.getSelectedText()) return;
+        if (action === "reject") enterFeedback();
+        else approve(action);
     }
 
     // ONE layer, gated on the prompt's focus target. Bare y/a/n are legal ONLY because of that gate:
@@ -186,16 +211,32 @@ export function AskPrompt(props: AskPromptProps): JSX.Element {
                             <Fg role="fgMuted">{props.detail}</Fg>
                         </text>
                     </Show>
+                    {/* Each option is its own mouse target because opentui mouse handlers attach to
+                    renderables, not inline spans — so the one hint <text> splits into a <text> per
+                    option, the middot separators becoming their own muted <text> that carry the spacing.
+                    The split is byte-for-byte the old single line: "y approve · a always · n reject". The
+                    options are `selectable={false}` — they are buttons, not prose, so a press must not
+                    highlight the label as if the click did something other than answer. */}
                     <box flexDirection="row">
-                        <text>
+                        <text selectable={false} onMouseUp={() => onOptionClick("once")}>
                             <Fg role="accent">
                                 <Bold>y</Bold>
                             </Fg>
-                            <Fg role="fgMuted">{` approve ${GLYPHS.middot} `}</Fg>
+                            <Fg role="fgMuted"> approve</Fg>
+                        </text>
+                        <text>
+                            <Fg role="fgMuted">{` ${GLYPHS.middot} `}</Fg>
+                        </text>
+                        <text selectable={false} onMouseUp={() => onOptionClick("always")}>
                             <Fg role="accent">
                                 <Bold>a</Bold>
                             </Fg>
-                            <Fg role="fgMuted">{` always ${GLYPHS.middot} `}</Fg>
+                            <Fg role="fgMuted"> always</Fg>
+                        </text>
+                        <text>
+                            <Fg role="fgMuted">{` ${GLYPHS.middot} `}</Fg>
+                        </text>
+                        <text selectable={false} onMouseUp={() => onOptionClick("reject")}>
                             <Fg role="accent">
                                 <Bold>n</Bold>
                             </Fg>

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -516,18 +516,21 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                     />
                 </State>
                 <State n="21" label="approval prompt & ask cards — docked ctx.ask surface + reconciled transcript cards">
-                    {/* The docked AskPrompt as it sits above the chat bar. Rendered INERT: no onFocusReady
-                        handle is passed, so no host ever focuses the box; its y/a/n key layer is gated on
+                    {/* The docked AskPrompt as it sits above the chat bar, rendered inert. No onFocusReady
+                        handle is passed, so no host ever focuses the box: its y/a/n KEY layer is gated on
                         that box's own focus target (and on MODE_BASE, suspended under this dialog), so it can
-                        never win the keymap or swallow a keystroke from the gallery pane. Callbacks are
-                        no-ops. The feedback surface (reject → optional feedback input) is seeded directly via
-                        initialMode below, with inert threading its embedded input's autoFocus off so it too
-                        stays out of the gallery's focus. */}
+                        never win the keymap or swallow a keystroke from the gallery pane. But a CLICK on a
+                        choice option needs no focus, so the focus gate alone would let a gallery click flip
+                        an exhibit into feedback mode and let its auto-focusing input steal the pane's focus —
+                        so every exhibit passes `inert`, which no-ops the option clicks (and, on the feedback
+                        exhibit, also mounts its embedded input blurred). Callbacks are no-ops; the feedback
+                        surface is seeded directly via initialMode below. */}
                     <text fg={theme().fgMuted}>choice mode — title + command, bare y/a/n keys (focus-gated, inert here):</text>
                     <AskPrompt
                         title={mockAskPrompts.basic.title}
                         command={mockAskPrompts.basic.command}
                         queuedCount={mockAskPrompts.basic.queuedCount}
+                        inert
                         onApprove={noop}
                         onReject={noop}
                     />
@@ -537,6 +540,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         command={mockAskPrompts.withDetail.command}
                         detail={mockAskPrompts.withDetail.detail}
                         queuedCount={mockAskPrompts.withDetail.queuedCount}
+                        inert
                         onApprove={noop}
                         onReject={noop}
                     />
@@ -545,6 +549,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         title={mockAskPrompts.queued.title}
                         command={mockAskPrompts.queued.command}
                         queuedCount={mockAskPrompts.queued.queuedCount}
+                        inert
                         onApprove={noop}
                         onReject={noop}
                     />


### PR DESCRIPTION
## What & why

Answering a docked approval prompt (`ctx.ask`) required focusing the prompt card first and then pressing a bare `y`/`a`/`n` key — the focus gate that makes bare printables legal also made the two most natural interactions dead ends: clicking an option label did nothing, and typing `y` into the chat composer was silently swallowed by the busy-turn submit gate. Both read as the TUI ignoring the user at the exact moment it is blocked waiting on them.

This PR adds two answer paths to the docked prompt, both funneling through the existing `answerAsk` gateway:

- **Clickable options** — each choice option (`y approve` / `a always` / `n reject`) is an individual mouse target routed through the *same handler as its key* (a click on `n` enters feedback mode), so click and key cannot drift. Activation is mouse-up only, and a release carrying a live text selection never activates — a selection drag ending on an option cannot approve a command. Options are `selectable={false}` (buttons, not prose) and design-gallery exhibits pass `inert`, which also no-ops clicks.
- **Composer answers** — while an ask is docked, submitting exactly `y`, `a`, or `n` (trimmed, case-insensitive) answers the head ask; the buffer clears when the answer settles, so a failed gateway write keeps the typed token for a retry. The existing settle/drain choreography owns every focus/mode transition (mid-turn drain lands in NORMAL on the stream pane). Bare `n` rejects without feedback. Any other text keeps the draft-preserving refusal but surfaces a transient notice naming the `y`/`a`/`n` answer path instead of failing silently (`/quit` aliases keep their precedence). An inert gallery exhibit is also non-focusable, so exhibit clicks can't yank focus off the gallery pane.

The decision logic is pure and unit-tested without booting the App (`parseAskAnswer` + `askSubmitAction`, following the `interrupt_hint.test.ts` altitude). The `tui-ask-approval` spec is synced (two added requirements, one reworded) and the OpenSpec change is archived as `2026-07-24-ask-answer-interactions`.

Composer-carried reject feedback (`n <text>`) is deliberately excluded — a mistyped message must not silently become a rejection — and tracked in #217.

**Verification:** TUI suite 456/456 green (5 new render tests — 4 mouse-interaction plus a structural `selectable`/focusability pin — and 8 new pure-helper tests); lint clean; typecheck clean for every touched file. Pre-existing, unrelated failures (missing `p-queue`, harness-contract drift in `modules/harness/turn.ts`, `modules/refs/store.ts`, `hooks/conversation.ts`) predate this branch and are untouched by it.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`) — clean for all touched files; the only failures are the pre-existing `p-queue`/harness-drift ones noted above, unrelated to this PR.
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed (OpenSpec `tui-ask-approval` spec synced + change archived).
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
