### PR TITLE
fix(harness): guard read_file against binary content

### DIFF
--- a/harness/src/tools/workspace/read-file.test.ts
+++ b/harness/src/tools/workspace/read-file.test.ts
@@ -34,6 +34,26 @@ describe("createReadFileTool", () => {
         if (r.status === "ok") expect(r.content).toBe("hello");
     });
 
+    it("reports a NUL-bearing file as binary instead of decoding it", async () => {
+        // gzip magic (1f 8b 08 04) then a NUL — the exact shape that broke the
+        // JSONB append when read_file decoded it into the transcript.
+        const gzipHead = Buffer.from([0x1f, 0x8b, 0x08, 0x04, 0x00, 0x03, 0x41]);
+        const tool = createReadFileTool(fakeFs(() => ({ kind: "ok", content: gzipHead, truncated: false })));
+        const { ctx } = makeToolContext();
+        const r = (await tool.execute({ path: "data/inputs/x.csv.gz", headLines: 5 }, ctx))._unsafeUnwrap();
+        expect(r.status).toBe("binary");
+        if (r.status === "binary") expect(r.mode).toBe("head");
+    });
+
+    it("reports a truncated binary read as binary, not truncated", async () => {
+        const withNul = Buffer.concat([Buffer.from("plausible text"), Buffer.from([0x00]), Buffer.alloc(16, 0x41)]);
+        const tool = createReadFileTool(fakeFs(() => ({ kind: "truncated", content: withNul, totalSize: 5_000_000 })));
+        const { ctx } = makeToolContext();
+        const r = (await tool.execute({ path: "data/inputs/big.bin" }, ctx))._unsafeUnwrap();
+        expect(r.status).toBe("binary");
+        if (r.status === "binary") expect(r.mode).toBe("full");
+    });
+
     it("returns not_found as a data variant — no throw", async () => {
         const tool = createReadFileTool(fakeFs(() => ({ kind: "not_found" })));
         const { ctx } = makeToolContext();

--- a/harness/src/tools/workspace/read-file.test.ts
+++ b/harness/src/tools/workspace/read-file.test.ts
@@ -42,16 +42,23 @@ describe("createReadFileTool", () => {
         const { ctx } = makeToolContext();
         const r = (await tool.execute({ path: "data/inputs/x.csv.gz", headLines: 5 }, ctx))._unsafeUnwrap();
         expect(r.status).toBe("binary");
-        if (r.status === "binary") expect(r.mode).toBe("head");
+        if (r.status === "binary") {
+            expect(r.mode).toBe("head");
+            // A fully-read binary carries no size, mirroring the text `ok` variant.
+            expect(r.totalSize).toBeUndefined();
+        }
     });
 
-    it("reports a truncated binary read as binary, not truncated", async () => {
+    it("reports a truncated binary read as binary, carrying the oversize file size", async () => {
         const withNul = Buffer.concat([Buffer.from("plausible text"), Buffer.from([0x00]), Buffer.alloc(16, 0x41)]);
         const tool = createReadFileTool(fakeFs(() => ({ kind: "truncated", content: withNul, totalSize: 5_000_000 })));
         const { ctx } = makeToolContext();
         const r = (await tool.execute({ path: "data/inputs/big.bin" }, ctx))._unsafeUnwrap();
         expect(r.status).toBe("binary");
-        if (r.status === "binary") expect(r.mode).toBe("full");
+        if (r.status === "binary") {
+            expect(r.mode).toBe("full");
+            expect(r.totalSize).toBe(5_000_000);
+        }
     });
 
     it("returns not_found as a data variant — no throw", async () => {

--- a/harness/src/tools/workspace/read-file.ts
+++ b/harness/src/tools/workspace/read-file.ts
@@ -31,7 +31,10 @@ type ReadFileOutput =
       }
     | { status: "not_found"; path: string }
     | { status: "out_of_scope"; path: string }
-    | { status: "binary"; path: string; mode: "head" | "tail" | "full" };
+    // `totalSize` rides only on an oversize binary read, where the real file size
+    // is a signal the agent can act on (e.g. reach for `execute_command` instead);
+    // a fully-read binary omits it, exactly as the text `ok` variant carries no size.
+    | { status: "binary"; path: string; mode: "head" | "tail" | "full"; totalSize?: number };
 
 /**
  * Treat returned content as binary when it contains a NUL byte — `grep`'s
@@ -123,7 +126,7 @@ export function createReadFileTool(fs: WorkspaceFilesystem, workingDir?: string)
                         content: result.content.toString("utf8"),
                     });
                 case "truncated":
-                    if (looksBinary(result.content)) return ok({ status: "binary" as const, path, mode });
+                    if (looksBinary(result.content)) return ok({ status: "binary" as const, path, mode, totalSize: result.totalSize });
                     return ok({
                         status: "truncated" as const,
                         path,

--- a/harness/src/tools/workspace/read-file.ts
+++ b/harness/src/tools/workspace/read-file.ts
@@ -30,7 +30,21 @@ type ReadFileOutput =
           returnedBytes: number;
       }
     | { status: "not_found"; path: string }
-    | { status: "out_of_scope"; path: string };
+    | { status: "out_of_scope"; path: string }
+    | { status: "binary"; path: string; mode: "head" | "tail" | "full" };
+
+/**
+ * Treat returned content as binary when it contains a NUL byte — `grep`'s
+ * `looksBinary` heuristic, applied here to the whole returned window rather than
+ * a 1 KiB probe. These exact bytes are what would be UTF-8-decoded into the
+ * transcript, and a NUL both renders that decode as lossy garbage (useless to
+ * the model) and cannot be persisted into the JSONB message store — Postgres
+ * rejects U+0000 with 22P05, failing the whole turn's append. Reporting the
+ * read as `binary` keeps a NUL out of both.
+ */
+function looksBinary(content: Buffer): boolean {
+    return content.includes(0);
+}
 
 const ReadFileInputSchema = z.object({
     path: z
@@ -72,8 +86,10 @@ export function createReadFileTool(fs: WorkspaceFilesystem, workingDir?: string)
             "as UTF-8 text. Output is capped at " +
             `${DEFAULT_MAX_BYTES} bytes; pass headLines or tailLines to read a ` +
             "specific window of a large file (typical for bio CSV/TSV/log files). " +
-            "Oversize reads come back truncated with a marker. Missing paths and " +
-            "paths outside the analysis tree return a data variant — not an error.",
+            "Oversize reads come back truncated with a marker. This tool is for " +
+            "text; a binary file (one holding NUL bytes, e.g. a .gz or image) comes " +
+            "back as a `binary` data variant rather than decoded garbage. Missing " +
+            "paths and paths outside the analysis tree return a data variant — not an error.",
         inputSchema: ReadFileInputSchema,
         execute: async ({ path, headLines, tailLines }, ctx): Promise<Result<ReadFileOutput, ToolError>> => {
             if (headLines !== undefined && tailLines !== undefined) {
@@ -99,6 +115,7 @@ export function createReadFileTool(fs: WorkspaceFilesystem, workingDir?: string)
 
             switch (result.kind) {
                 case "ok":
+                    if (looksBinary(result.content)) return ok({ status: "binary" as const, path, mode });
                     return ok({
                         status: "ok" as const,
                         path,
@@ -106,6 +123,7 @@ export function createReadFileTool(fs: WorkspaceFilesystem, workingDir?: string)
                         content: result.content.toString("utf8"),
                     });
                 case "truncated":
+                    if (looksBinary(result.content)) return ok({ status: "binary" as const, path, mode });
                     return ok({
                         status: "truncated" as const,
                         path,


### PR DESCRIPTION
read_file UTF-8-decoded whatever bytes it read, with no binary detection — unlike its sibling grep, which skips files with NULs. Reading a gzipped/binary file (e.g. via headLines) returned lossy garbage to the model AND injected NUL bytes into the transcript, which then failed the JSONB append in appendTurn (Postgres 22P05) and silently dropped the whole turn from thread history.

Detect a NUL in the returned window and return a `binary` data variant instead of decoding, keeping binary content out of the conversation at the source.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
