### PR TITLE
feat(cli): manual model-id entry in cliproxy setup when the listing is unavailable

### DIFF
--- a/cli/openspec/specs/model-connection/spec.md
+++ b/cli/openspec/specs/model-connection/spec.md
@@ -161,12 +161,17 @@ agents. On a non-TTY the direct path SHALL write no model, and boot's actionable
 failure remains the contract.
 
 After the CLIProxy login, once the provisioned proxy is answering (setup runs no credential
-probe — that is the launch gate's; the step skips gracefully, writing nothing, when the proxy
-or its listing is not available), interactive setup SHALL present a default-model
+probe — that is the launch gate's), interactive setup SHALL present a default-model
 selection: a preselected **Auto** row labeled with the currently elected model
 (`default-model-election`), followed by the connection-family models from the proxy's `/models`
 list, accessibility-checked via bounded-concurrency `count_tokens` requests — only a definite
 `not_found_error` excludes a model from the list; an inconclusive check keeps it listed.
+When the proxy listing is unavailable — a down or not-yet-answering proxy — or nothing it lists is
+servable, interactive setup SHALL offer free-text manual entry with **Auto** as the blank default
+rather than skipping the step: leaving it blank keeps the adaptive default, and an entered id is
+persisted to BOTH user-facing agents after the SAME `count_tokens` accessibility check the list
+uses — a definite `not_found_error` is rejected with a warning that keeps Auto, an inconclusive
+check persists. Only a non-TTY skips the step entirely (Auto semantics).
 Accepting Auto SHALL write nothing (the default stays adaptive `model: null` resolution).
 Explicitly choosing a model SHALL persist it to `models.agents.<agent>` for BOTH user-facing
 agents (a deliberate pin). The flow SHALL contain no hardcoded model ids, with ONE declared
@@ -225,6 +230,14 @@ SHALL skip the selection (Auto semantics).
 - **WHEN** one listed model answers the accessibility check with `not_found_error` and another's
   check times out
 - **THEN** the 404ing model is excluded from the list and the timed-out one remains listed
+
+#### Scenario: An unavailable listing offers manual entry with Auto default
+
+- **WHEN** interactive cliproxy setup reaches the default-model step but the proxy listing is
+  unavailable (or nothing it lists is servable)
+- **THEN** setup offers a free-text model-id prompt with Auto as the blank default; leaving it
+  blank keeps the adaptive default, entering an id the account can serve pins both agents, and a
+  definite `not_found_error` id is rejected with a warning that keeps Auto
 
 #### Scenario: Non-interactive setup skips the model step
 

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -1158,6 +1158,7 @@ describe("selectDefaultModel", () => {
             candidates: async () => ["claude-a"],
             check: async () => "served",
             prompt: async () => ({ auto: true }),
+            promptManual: async () => null,
             writeBoth,
             warn: () => {},
             ...over,
@@ -1246,18 +1247,60 @@ describe("selectDefaultModel", () => {
         expect(readConfig().models).toBeUndefined();
     });
 
-    test("a down/unreachable proxy (no candidates) skips gracefully — no prompt, no write", async () => {
-        let prompted = false;
+    test("no offerable list → manual entry: a served typed id pins BOTH agents", async () => {
         await selectDefaultModel(
             deps({
                 candidates: async () => [],
+                promptManual: async () => "claude-x",
+                check: async () => "served",
+            }),
+        );
+        expect(persistedAgents()).toEqual({ conversation: "claude-x", sandbox: "claude-x" });
+    });
+
+    test("no offerable list → manual entry left blank keeps Auto — nothing persisted", async () => {
+        await selectDefaultModel(
+            deps({
+                candidates: async () => [],
+                promptManual: async () => null,
+            }),
+        );
+        expect(readConfig().models).toBeUndefined();
+    });
+
+    test("no offerable list → a manually typed not_found id is rejected — warns, keeps Auto", async () => {
+        const warnings: string[] = [];
+        await selectDefaultModel(
+            deps({
+                candidates: async () => [],
+                promptManual: async () => "bad",
+                check: async () => "not_found",
+                warn: (m) => warnings.push(m),
+            }),
+        );
+        expect(readConfig().models).toBeUndefined();
+        expect(warnings.length).toBe(1);
+    });
+
+    test("a sweep that rules out EVERY candidate also routes to manual entry", async () => {
+        let manualCalled = false;
+        let listPrompted = false;
+        await selectDefaultModel(
+            deps({
+                candidates: async () => ["claude-404a", "claude-404b"],
+                check: async () => "not_found",
                 prompt: async () => {
-                    prompted = true;
+                    listPrompted = true;
                     return { auto: true };
+                },
+                promptManual: async () => {
+                    manualCalled = true;
+                    return null;
                 },
             }),
         );
-        expect(prompted).toBe(false);
+        expect(manualCalled).toBe(true);
+        expect(listPrompted).toBe(false);
         expect(readConfig().models).toBeUndefined();
     });
 });

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -500,9 +500,11 @@ async function runSandboxImageSetup(): Promise<void> {
 // (labeled with the currently elected id) followed by the account's accessible models. Auto writes
 // nothing — the default stays adaptive `model: null` resolution, which keeps electing the newest served
 // model across launches. An explicit pick pins BOTH user-facing agents (per-agent divergence stays a
-// picker power feature). Every id is discovered live from the proxy — none is ever hardcoded — so a
-// proxy that is down or not yet answering simply skips the step: an optional convenience must not add a
-// new way for setup to fail.
+// picker power feature). Every id is discovered live from the proxy — none is ever hardcoded — so when
+// the proxy is down or not yet answering (nothing to offer), the interactive step falls back to free-text
+// manual entry with Auto (blank) as the default, letting the user pin an id the listing can't enumerate;
+// a non-TTY still skips. The step stays optional — blank keeps Auto — so an optional convenience never
+// adds a new way for setup to fail.
 
 /**
  * How many accessibility checks the setup sweep runs at once. Small and fixed: it overlaps the
@@ -539,37 +541,57 @@ type DefaultModelChoice = { auto: true } | { auto: false; modelId: string };
  */
 type DefaultModelDeps = {
     isInteractive: () => boolean;
-    /** The ranked, connection-family candidate ids to sweep; empty (no listing / down proxy) → skip. */
+    /** The ranked, connection-family candidate ids to sweep; empty (no listing / down proxy) → manual entry. */
     candidates: () => Promise<string[]>;
     /** One model's accessibility check, bounded like every probe round-trip. */
     check: (modelId: string) => Promise<ModelAccess>;
     /** Present Auto (preselected, labeled with `electedId`) atop `models`; returns the user's choice. */
     prompt: (electedId: string, models: string[]) => Promise<DefaultModelChoice>;
+    /** Free-text manual id when no list is offerable (listing down/empty, or nothing servable); null = left blank → keep Auto. */
+    promptManual: () => Promise<string | null>;
     /** Persist the chosen id to BOTH user-facing agents. */
     writeBoth: (modelId: string) => Result<void, ConfigError>;
     warn: (message: string) => void;
 };
 
 /**
- * The interactive default-model step. A non-TTY skips entirely (writes nothing — Auto semantics). An
- * empty candidate list (a down/unreachable proxy) or a sweep that rules out EVERY candidate skips
- * gracefully rather than turning an optional step into a failure or recommending a model the account
- * cannot serve. The Auto label is the first accessible candidate in rank order — the SAME id the launch
- * election resolves (both walk the ranked list past `not_found` to the first servable) — read straight
- * from the sweep, so the recommendation and the offered list can never disagree, and so setup makes ONE
- * `/models` pass rather than a separate election round-trip whose per-process cache this setup process
- * (which exits before any chat launch) would only discard. Accepting Auto writes nothing (the default
- * stays adaptive `model: null` resolution). An explicit pick persists to BOTH agents; a write failure
- * only warns — setup's real work is already done.
+ * The interactive default-model step. A non-TTY skips entirely (writes nothing — Auto semantics). When
+ * there is no offerable list — an empty candidate set (a down/unreachable proxy) or a sweep that rules
+ * out EVERY candidate — the interactive step offers free-text manual entry with Auto (blank) as the
+ * default, so a user can still pin an id the listing can't enumerate instead of being stranded; a
+ * committed id is validated with the SAME accessibility check the list uses, and only a definite
+ * `not_found` is rejected (keeping Auto). A non-TTY never reaches this fallback — the `isInteractive`
+ * guard returns first. When a list IS offerable, the Auto label is the first accessible candidate in rank
+ * order — the SAME id the launch election resolves (both walk the ranked list past `not_found` to the
+ * first servable) — read straight from the sweep, so the recommendation and the offered list can never
+ * disagree, and so setup makes ONE `/models` pass rather than a separate election round-trip whose
+ * per-process cache this setup process (which exits before any chat launch) would only discard. Accepting
+ * Auto — or leaving manual entry blank — writes nothing (the default stays adaptive `model: null`
+ * resolution). An explicit pick persists to BOTH agents; a write failure only warns — setup's real work
+ * is already done.
  */
 export async function selectDefaultModel(deps: DefaultModelDeps): Promise<void> {
     if (!deps.isInteractive()) return;
     const ranked = await deps.candidates();
-    if (ranked.length === 0) return;
-    const models = await sweepAccessibleModels(deps.check, ranked);
-    // Every candidate answered `not_found` — no servable model to recommend, so skip rather than preselect
-    // a known-inaccessible id. This guard also makes `models[0]` provably present for the Auto label.
-    if (models.length === 0) return;
+    const models = ranked.length === 0 ? [] : await sweepAccessibleModels(deps.check, ranked);
+    if (models.length === 0) {
+        // No offerable list — the proxy listing is down/empty, or nothing it lists is servable. Rather than
+        // silently skip (stranding a user who wants to pin an id the listing can't enumerate), offer free-text
+        // manual entry with Auto (blank) as the default. The step stays optional: blank keeps the adaptive
+        // `model: null` default, so this never becomes a new way for setup to fail. A committed id is validated
+        // with the SAME accessibility check the list uses — only a definite `not_found` is rejected (keep Auto).
+        const entered = await deps.promptManual();
+        if (entered === null) return; // left blank → keep Auto
+        if ((await deps.check(entered)) === "not_found") {
+            deps.warn(`The account cannot serve "${entered}" — keeping Auto.`);
+            return;
+        }
+        deps.writeBoth(entered).match(
+            () => {},
+            (e) => deps.warn(`Could not save the model selection: ${e.type}`),
+        );
+        return;
+    }
     const electedId = models[0]!;
     const choice = await deps.prompt(electedId, models);
     if (choice.auto) return;
@@ -615,6 +637,14 @@ async function runDefaultModelSetup(mode: ConnectionMode): Promise<void> {
                 ...models.map((id) => ({ value: id, label: id })),
             ]);
             return chosen === AUTO_MODEL_SENTINEL ? { auto: true } : { auto: false, modelId: chosen };
+        },
+        promptManual: async () => {
+            const entered = (
+                await promptText("Default chat model (leave blank for Auto)", {
+                    validate: () => undefined, // blank is allowed — it means "keep Auto"
+                })
+            ).trim();
+            return entered === "" ? null : entered;
         },
         writeBoth: (modelId) => writeAgentModel("conversation", modelId).andThen(() => writeAgentModel("sandbox", modelId)),
         warn: (message) => log.warn(message),


### PR DESCRIPTION
## What & why

`inflexa setup` (CLIPROXY mode) previously **skipped** the default-model step entirely whenever the proxy `/models` listing was down/empty or listed nothing the account can serve — leaving no way to pin a model id the listing could not enumerate. Direct-mode setup and the palette picker both allow free-text entry in that situation, so cliproxy setup was the odd one out.

This routes the empty-list case to a **free-text manual-entry prompt** with **Auto** (blank) as the default, instead of skipping:

- Blank keeps the adaptive `model: null` default — the step stays optional, so it never becomes a new way for setup to fail.
- A typed id is validated with the **same** `count_tokens` accessibility check the list uses: a definite `not_found_error` is rejected with a warning that keeps Auto; a `served`/inconclusive outcome persists the id to **both** user-facing agents.
- A non-TTY still skips (the `isInteractive` guard returns first).

This is the setup-side companion to #227 (manual entry in the palette picker); together they make manual model-id entry uniformly available wherever the `/models` listing is unavailable.

**Changes**

- `src/modules/infra/setup.ts` — `selectDefaultModel` now falls back to `promptManual` when there is no offerable list (empty candidates, or a sweep that rules out every candidate); wired in `runDefaultModelSetup` via `promptText`. New `promptManual` seam on `DefaultModelDeps`.
- `openspec/specs/model-connection/spec.md` — updated in place: the CLIProxy default-model requirement now specifies the manual-entry fallback, plus a covering scenario.
- `src/modules/infra/setup.test.ts` — four new cases (served id pins both agents; blank keeps Auto; typed `not_found` warns and keeps Auto; an all-inaccessible sweep also routes to manual entry).

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change

## Checklist

- [x] Lint and tests pass locally (`bun run lint`; `bun test src/modules/infra/setup.test.ts` → 110 pass / 0 fail). No new `typecheck` errors in the setup files; the repo's pre-existing `typecheck` failures are unrelated harness-API drift.
- [x] Tests added or updated for the change.
- [x] Documentation updated (the `model-connection` spec is updated in place).
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
