### PR TITLE
fix: harden sandbox Dockerfile pipelines

### DIFF
--- a/droast.toml
+++ b/droast.toml
@@ -1,0 +1,21 @@
+# All sandbox Dockerfiles are built with the repository root as their context,
+# so the root .dockerignore is the effective ignore file.
+[[overrides]]
+paths = [
+  "images/sandbox-base/Dockerfile",
+  "images/sandbox-python/Dockerfile",
+  "images/sandbox-python-r/Dockerfile",
+]
+skip = ["DF033"]
+
+# wget is intentionally installed as an agent-facing runtime utility. Droast
+# mistakes the apt package name for a second downloader invocation.
+[[overrides]]
+paths = ["images/sandbox-base/Dockerfile"]
+skip = ["DF058"]
+
+# These append to PATH inherited from the parent stage. Docker expands the old
+# value before applying the ENV assignment; droast treats that as self-reference.
+[[overrides]]
+paths = ["images/sandbox-python/Dockerfile"]
+skip = ["DF062"]

--- a/images/sandbox-base/Dockerfile
+++ b/images/sandbox-base/Dockerfile
@@ -40,6 +40,10 @@ RUN gcc -shared -fPIC -O2 -pthread -fstack-protector-strong -Wformat -Wformat-se
 
 FROM ${BASE_IMAGE}
 
+# A failed producer in a pipeline must fail the layer, not be hidden by a
+# successful shell/checksum/filter command on the right-hand side.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # OCI metadata: link the published package to its source repo (so GHCR files it
 # under the repo and it inherits repo access) and give it a specific description.
 LABEL org.opencontainers.image.source="https://github.com/inflexa-ai/inflexa"
@@ -114,6 +118,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 # =============================================================================
 
 ENV UV_VERSION=0.7.12
+ENV RUFF_VERSION=0.16.0
 # TODO(supply-chain): `| sh` runs Astral's installer before anything can verify it.
 # UV_VERSION pins which uv is installed, but the install.sh itself is fetched
 # unpinned; hardening means downloading the versioned uv tarball and checking it
@@ -121,7 +126,7 @@ ENV UV_VERSION=0.7.12
 RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh \
     && cp /root/.local/bin/uv /usr/local/bin/uv \
     && cp /root/.local/bin/uvx /usr/local/bin/uvx \
-    && uv pip install --system --break-system-packages --no-cache ruff
+    && uv pip install --system --break-system-packages --no-cache "ruff==${RUFF_VERSION}"
 
 # =============================================================================
 # Tailwind CSS standalone CLI
@@ -242,7 +247,7 @@ RUN echo "/mnt/libs/current/python/site-packages" > /usr/lib/python3/dist-packag
 # reads $CELLTYPIST_FOLDER) can have one exported per-command, by the agent that
 # just learned the real path.
 
-RUN useradd -m -u 1000 -s /bin/bash sandbox \
+RUN useradd -l -m -u 1000 -s /bin/bash sandbox \
     && mkdir -p /workspace && chown -R sandbox:sandbox /workspace
 
 # Declared explicitly rather than left to the runtime's passwd lookup, which

--- a/images/sandbox-python-r/Dockerfile
+++ b/images/sandbox-python-r/Dockerfile
@@ -134,6 +134,8 @@ ARG INFLEXA_LIB_ROOT
 ARG TARGETARCH
 ARG R_NCPUS
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN CRAN_PKGS=$(python3 -c "\
 import yaml; \
 m = yaml.safe_load(open('/tmp/manifest.yaml')); \
@@ -148,6 +150,7 @@ print('\n'.join(m.get('r',{}).get('cran',[])))" 2>/dev/null) \
          && grep -E '^(Setting up|E:|Err:|dpkg:)' /tmp/cran-apt.log || true \
          && cp -a /usr/lib/R/site-library/* ${INFLEXA_LIB_ROOT}/r/cran/ 2>/dev/null || true \
          && cp -a /usr/local/lib/R/site-library/* ${INFLEXA_LIB_ROOT}/r/cran/ 2>/dev/null || true; \
+         rm -rf /var/lib/apt/lists/*; \
        else \
          echo "Installing CRAN packages via the base image's P3M snapshot (binary) on $TARGETARCH..." \
          && R -e "\
@@ -173,6 +176,8 @@ print('\n'.join(m.get('r',{}).get('cran',[])))" 2>/dev/null) \
 FROM cran AS bioconductor
 ARG INFLEXA_LIB_ROOT
 ARG R_NCPUS
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Stream install output live through an allow-based filter that drops only
 # gcc/boost compile noise (RBGL's boost-template warnings alone blow past GHA's
@@ -253,6 +258,8 @@ print('\n'.join(m.get('r',{}).get('bioconductor',[])))" 2>/dev/null) \
 # stage runnable locally without a token (with the anonymous limit caveat).
 FROM bioconductor AS github
 ARG INFLEXA_LIB_ROOT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=secret,id=github_token,required=false \
     GH_PKGS=$(python3 -c "\

--- a/images/sandbox-python/Dockerfile
+++ b/images/sandbox-python/Dockerfile
@@ -40,6 +40,9 @@ ARG TARGETARCH
 FROM ${BASE_IMAGE} AS toolchain
 ARG INFLEXA_LIB_ROOT
 
+# Make failures on the left of installer pipelines fail the layer.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Build toolchain + dev headers (Python C extensions, some conda-built wheels).
 # The apt build-dep set + retry config is shared with sandbox-python-r's R
 # toolchain stage; see the script header for the apt-retry rationale.
@@ -59,7 +62,8 @@ RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh \
     && cp /root/.local/bin/uv /usr/local/bin/uv
 
 # pyyaml for reading the manifest (use uv, not pip — pip's apt postinst fails under QEMU)
-RUN uv pip install --system --break-system-packages --no-cache pyyaml
+ARG PYYAML_VERSION=6.0.3
+RUN uv pip install --system --break-system-packages --no-cache "pyyaml==${PYYAML_VERSION}"
 
 COPY images/lib-store-manifest.yaml /tmp/manifest.yaml
 
@@ -240,6 +244,9 @@ FROM toolchain AS conda-builder
 ARG INFLEXA_LIB_ROOT
 ARG TARGETARCH
 
+# Re-declare the shell for this stage so pipeline failure semantics are explicit.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # micromamba (deterministic binary from the official image).
 COPY --from=mambaorg/micromamba:2.5.0 /bin/micromamba /usr/local/bin/micromamba
 
@@ -301,6 +308,9 @@ RUN chmod -R a+rX ${INFLEXA_LIB_ROOT}
 # =============================================================================
 FROM toolchain AS node-builder
 ARG INFLEXA_LIB_ROOT
+
+# `npm install | tail` must preserve npm's failure status.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # The node package set is the manifest's flat `node:` list — parsed the same way
 # the conda stage parses `system_tools`.


### PR DESCRIPTION
Closes #213.

## What changed

- enable Bash `pipefail` in every sandbox build stage that uses meaningful pipelines
- pin the runtime `ruff` install to 0.16.0 and the build-only PyYAML install to 6.0.3
- clean apt lists after the CRAN builder's apt installation
- pass `-l` to `useradd` to disable lastlog initialization
- add path-scoped droast suppressions for confirmed false positives:
  - the repository-root `.dockerignore` used by all three image builds
  - `wget` being installed as an agent-facing utility rather than invoked as a downloader
  - PATH appends that expand the value inherited from the parent stage

## Why

Several installer and output-filter pipelines could report the final command's success while hiding a producer failure. The remaining actionable findings were reproducibility or builder-cache hygiene gaps. The suppressions are scoped to the affected Dockerfiles so the same rules remain active elsewhere in the repository.

The existing `curl | sh` supply-chain TODOs remain intentionally separate: pipefail makes transport failures visible but does not authenticate remote installer contents.

## Impact

Failed downloads and package installs now fail their Docker build stages reliably. Sandbox tool versions are reproducible, and manual droast scans retain signal without globally disabling useful rules.

## Validation

- `git diff --check`
- droast 1.4.11 parser check (`DF071`) across all three Dockerfiles
- droast 1.4.11 targeted scan for `DF004,DF033,DF051,DF057,DF058,DF062,DF064,DF066` — zero findings
- `bash -n images/install-build-toolchain.sh`

A full image build was not run locally because Docker is unavailable in the execution environment.
