### PR TITLE
Pin sandbox image versions and clean superseded images

### DIFF
--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -156,7 +156,7 @@ jobs:
           # Stamp the inventory on BEFORE the push: a host that never bind-mounts the
           # store reads the label, so an unlabelled published image is one whose agents
           # cannot tell what is installed.
-          bash scripts/lib-store-label-packages.sh "${IMAGE_PYTHON}:${VERSION}-${ARCH}"
+          bash scripts/lib-store-label-packages.sh "${IMAGE_PYTHON}:${VERSION}-${ARCH}" "$VERSION" "${{ github.sha }}"
           docker push "${IMAGE_PYTHON}:${VERSION}-${ARCH}"
 
       - name: "Build + push: sandbox-python-r"
@@ -176,7 +176,7 @@ jobs:
           # Re-stamp rather than inherit: python-r is built FROM sandbox-python and
           # would otherwise carry its base's label, advertising an inventory missing
           # every R track this image adds.
-          bash scripts/lib-store-label-packages.sh "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}"
+          bash scripts/lib-store-label-packages.sh "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}" "$VERSION" "${{ github.sha }}"
           docker push "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}"
 
       # Extract the per-track tarballs from the HIGHEST image that built for this

--- a/cli/README.md
+++ b/cli/README.md
@@ -57,12 +57,12 @@ Analyses run inside a **sandbox image** that bakes the R / Python / conda / Node
 
 | Command | Does |
 |-|-|
-| `inflexa sandbox pull [variant]` | Pull a sandbox image (`python` = Python + bioconda CLI tools + Node; `python-r` = that plus R) from `ghcr.io/inflexa-ai/sandbox-<variant>` and configure sandboxes to use it |
-| `inflexa sandbox status` | Show the configured variant, its GHCR reference, whether the image is present locally, and its digest |
+| `inflexa sandbox pull [variant]` | Check a variant's `latest` channel, pin the resolved `<date>-<sha>` image in config, and remove unused older versions of that variant |
+| `inflexa sandbox status` | Show the configured variant and pinned version, its GHCR reference, local presence, and digest |
 
-`inflexa sandbox pull` also runs during `inflexa setup`. Before a sandbox launches, a missing image is offered and pulled (`inflexa profile` needs it). The published images are multi-arch manifests, so `docker pull` resolves the host architecture automatically — you pick only the variant, never the architecture. Flags: `--yes` skips the download confirmation.
+`inflexa sandbox pull` also runs during `inflexa setup`. `latest` is used only to discover an update; sandboxes execute the versioned reference recorded in config. Older version tags in the selected Inflexa variant repository are removed without force after the new pin is committed, so an image still used by a container is retained and unrelated Docker/Podman resources are never pruned. Before a sandbox launches, a missing pinned version is restored exactly; a missing bootstrap image is offered, pulled, and pinned. The published images are multi-arch manifests, so the runtime resolves the host architecture automatically — you pick only the variant, never the architecture. Flags: `--yes` skips the download confirmation.
 
-- **No local store** — the packages ship inside the pulled image, so there is no `~/.local/share/inflexa/libs` tree, no `/mnt/libs` bind mount, and no architecture-forcing. `harness.sandboxImage` (in `config.json`) records the pulled image tag; set it to a custom `FROM`-extended image to run your own.
+- **No local store** — the packages ship inside the pulled image, so there is no `~/.local/share/inflexa/libs` tree, no `/mnt/libs` bind mount, and no architecture-forcing. `harness.sandboxImage` (in `config.json`) records the resolved version tag; set it to a custom `FROM`-extended image to run your own.
 - **Extend it** — `FROM ghcr.io/inflexa-ai/sandbox-python-r` then `RUN pip install …` / `install.packages(…)` lands in the store automatically (the image exports `PIP_TARGET`/`R_LIBS_USER`/`INFLEXA_LIB_ROOT`); run `inflexa-libs-refresh` afterward so the additions show up in `list_available_packages`. See [`images/README.md`](../images/README.md).
 - **Managed deployments** still mount per-track tarballs read-only (cold-start friendly); those tarballs are extracted from these same images by the build pipeline and are infra-managed, not a CLI concern.
 

--- a/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/design.md
+++ b/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/design.md
@@ -1,0 +1,117 @@
+## Context
+
+The selectable sandbox images are published under `ghcr.io/inflexa-ai/sandbox-{python,python-r}` with two multi-arch manifest tags: the moving `latest` channel and an immutable-by-policy `<YYYYMMDD>-<7-hex-revision>` version. The CLI currently pulls and persists `latest`. Consequently, config does not identify the installed environment, launch behavior depends on a mutable registry name, and each refresh can leave the former image and its unique multi-gigabyte layers behind.
+
+Docker and Podman do not infer that a locally pulled `:latest` image also has a sibling version tag in the registry. They expose the content digest, but discovering an arbitrary sibling tag would require registry tag enumeration and matching. The publication pipeline must therefore carry the human-readable version with the selected platform image.
+
+The change crosses the image publication workflow and the CLI's `libs` and harness-preflight modules. The public command and config field already exist; no harness-owned capability or new dependency is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist a human-readable, versioned sandbox image reference after every successful published-image pull.
+- Make `latest` an update-discovery channel only; sandbox execution uses the configured version tag.
+- Preserve the previous executable configuration until the new image has been pulled, identified, locally tagged, verified, and durably configured.
+- Reclaim superseded versions and their uniquely unreferenced layers within the exact selected Inflexa sandbox repository.
+- Preserve safety across Docker and Podman by using common image commands, exact references, strict validation, and non-forced removal.
+- Migrate existing moving references without requiring a config schema migration.
+
+**Non-Goals:**
+
+- Docker/Podman-wide image, container, volume, network, or build-cache pruning.
+- Removing a different sandbox variant when the user changes variants.
+- Managing custom images or third-party proxy/Postgres images.
+- Providing rollback retention, a new cleanup command, an update check during passive status, or automatic network refresh on every launch.
+- Changing the sandbox image contents, harness API, or agent command policy.
+
+## Decisions
+
+### Published platform images carry their version
+
+The image publication workflow will stamp `org.opencontainers.image.version` with the existing `<date>-<sha>` value and `org.opencontainers.image.revision` with the source revision on each selectable per-architecture image before it is pushed. The existing label-only inventory rebuild is the natural stamping seam: it already ensures metadata is present on the platform image Docker or Podman inspects after resolving the multi-arch manifest.
+
+The CLI will accept the version label only when it matches the publication grammar `^[0-9]{8}-[0-9a-f]{7}$`. It will construct the pinned reference from the known selected repository plus that validated value; registry-provided text is never accepted as a repository or arbitrary command argument.
+
+Alternatives rejected:
+
+- Persisting only `repo@sha256:<digest>` is immutable but loses the human-readable release identity requested by the config contract.
+- Enumerating GHCR tags and matching digests adds registry API/authentication behavior when the image can carry its own identity.
+- Inferring the version from creation time or revision alone can select a tag that was never published.
+
+### Pull and execution references are separate concepts
+
+For a selected variant, the pull source is always `ghcr.io/inflexa-ai/sandbox-<variant>:latest`; the execution reference written to `harness.sandboxImage` is `ghcr.io/inflexa-ai/sandbox-<variant>:<version>`.
+
+After pulling the channel, the CLI reads and validates the version label, creates the local version tag from the pulled channel image, and verifies that the version tag resolves to the same local image ID. Creating the local tag avoids a redundant second registry pull. Because the identical version tag is also published remotely, launch preflight can restore it later with an exact pull if local storage is cleared.
+
+The local `latest` tag may remain as the target used by future explicit pulls, but no successful provisioning flow writes it to config and runtime composition does not select it once a pin exists.
+
+### Provisioning is an ordered commit
+
+The published-image transition is:
+
+1. Read the prior configured reference and, when it is a moving reference, retain its local image ID for possible rollback.
+2. Pull the selected variant's `latest` channel.
+3. Read and validate the published version label.
+4. Create and verify the local version tag.
+5. Resolve/cache the new image's package inventory as a non-fatal enrichment.
+6. Write the versioned reference to config.
+7. Best-effort clean superseded same-variant versions.
+
+Pull, metadata, tag, verification, or config failures return a typed `PullError` and do not remove the prior pinned reference. If a legacy configured `latest` tag resolved locally before the attempt and the transition fails after the channel moved, the CLI restores that tag to its prior image ID so the unchanged config keeps its prior local meaning. A newly created version alias that was never committed may be removed best-effort.
+
+Cleanup occurs only after the config commit, and cleanup failure does not turn a usable update into a failed pull. The outcome distinguishes a newly selected version from an already-current version and can carry retained-cleanup information for user-facing reporting.
+
+### Cleanup is repository-scoped, version-aware, and non-forced
+
+On a successful pull, the CLI enumerates local tagged references only within the exact selected Inflexa sandbox repository. It considers a reference removable only when its tag matches the strict published-version grammar and it is not the newly configured reference. It attempts removal by exact repository-and-version tag without `--force`.
+
+This approach reclaims more than the immediately previous version, including an older candidate that was retained because a container used it during an earlier pull. A runtime conflict is an ordinary retained outcome: the tag and layers remain and a later explicit pull retries cleanup. Removing a tag lets the engine reclaim only layers no longer referenced by another tag, image, or container.
+
+The migration from a configured `latest` reference is the one bounded exception to tag-based enumeration. The transaction already captured that alias's prior image ID for rollback; after a successful commit, if the channel moved, the CLI attempts to remove that exact old ID without force. This reclaims the newly dangling legacy image while still retaining it if a container or another tag references it.
+
+The other variant, custom repositories, `latest`, digest references, non-version tags, and every unrelated image remain untouched. The CLI never invokes `image prune` or `system prune`.
+
+Alternatives rejected:
+
+- `image prune` and `system prune` operate across the user's daemon and can delete unrelated project state.
+- Removing only the prior config reference cannot retry versions that were in use during an earlier transition.
+- Forced removal weakens container safety and can erase aliases the engine still needs.
+- Keeping one rollback version conflicts with the disk-reclamation goal and introduces retention policy not requested by the user.
+
+### Launch preflight restores identity but does not discover updates
+
+When `harness.sandboxImage` is a published version tag and is absent locally, preflight pulls that exact version. It never substitutes `latest`. Custom-image behavior remains unchanged.
+
+An absent bootstrap/default `latest` reference is provisioned through the same version-resolving path and the returned pinned reference is used for the current launch as well as persisted for later launches. An already-present legacy `latest` reference is accepted without a network update; the next explicit `sandbox pull` migrates it. This avoids silently changing an installed environment merely because the CLI was upgraded.
+
+The provisioning seam must return the effective execution reference so profile, run, and chat launch paths do not continue using the stale pre-resolution `latest` value during the first pinning invocation.
+
+### Status reports configured identity without becoming an updater
+
+`inflexa sandbox status` remains read-only. It reports the configured versioned reference and parsed version when available, identifies legacy `latest` as an unpinned channel reference, and performs no registry request, config migration, retagging, or cleanup.
+
+## Risks / Trade-offs
+
+- **[A published image lacks or misstates its version label]** → Reject the transition before config commit; validate both grammar and local image-ID equivalence.
+- **[A legacy local `latest` alias moves before a later step fails]** → Snapshot its prior image ID and restore the alias on failure.
+- **[A superseded image is still used by a container]** → Remove without force, retain it on conflict, report the retained version, and retry repository-scoped cleanup on a later explicit pull.
+- **[Repository scanning removes a manually cached historical Inflexa version]** → Limit cleanup to the selected first-party repository and documented published-version grammar; accepting automatic current-version-only retention is the disk-reclamation trade-off.
+- **[Version tags are mutable in the registry despite policy]** → The date-plus-source-revision naming convention and publication workflow are the authority. A future hardening change may persist tag-plus-digest, but digest pinning is not required for this human-readable config change.
+- **[Docker and Podman output differ]** → Use structured `image inspect --format`, `image ls --format`, `tag`, and `image rm` commands already common to both supported runtimes, and test argument construction and result classification through an injected runtime-command seam.
+- **[Cleanup reports misleading freed bytes because layers are shared]** → Report removed or retained version references, not estimated reclaimed bytes.
+
+## Migration Plan
+
+No config schema migration runs at startup. Existing custom references and pinned tags retain their meaning. Existing published `latest` references remain supported as a legacy/bootstrap state:
+
+1. A successful explicit `inflexa sandbox pull` replaces them with the resolved version tag.
+2. If the moving image is absent and launch preflight must pull it, that required pull also resolves, persists, and returns the version pin.
+3. If the moving image is already present, launch proceeds without an implicit update; status identifies it as unpinned.
+
+Rollback of the code remains compatible with the versioned string because the existing parser already accepts arbitrary sandbox image strings and version tags are ordinary pullable references. The older CLI will launch or restore the configured version rather than requiring `latest`.
+
+## Open Questions
+
+None. The selected retention policy is current version only within the selected managed variant, with non-forced retention while an image is in use.

--- a/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/proposal.md
+++ b/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The CLI currently stores a moving `:latest` sandbox image reference, so an explicit refresh changes the execution environment without recording which published version was selected and leaves superseded multi-gigabyte image layers behind. Persisting the published version tag makes sandbox execution reproducible and gives cleanup an exact, CLI-owned predecessor to reclaim safely.
+
+## What Changes
+
+- Publish each sandbox image with machine-readable OCI version and revision metadata matching its existing `<date>-<sha>` release tag.
+- Use `:latest` only as the discovery reference for an explicit `inflexa sandbox pull`.
+- After pulling, resolve and validate the published version, create the equivalent local immutable tag, and persist that versioned reference as `harness.sandboxImage`.
+- Treat a configured version tag as the execution identity: launch-time preflight restores that exact tag when missing and does not check for an update.
+- After the new reference is validated and durably configured, best-effort remove superseded versions of the same Inflexa sandbox variant without force so unreferenced layers can be reclaimed.
+- Preserve other variants, custom images, images still used by containers, and all unrelated Docker or Podman resources.
+- Accept existing `:latest` configuration as a bootstrap/migration state and replace it on the next successful explicit or required first pull.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `lib-store-provisioning`: Change sandbox pulls from storing a moving channel reference to storing the resolved published version, define exact-version preflight behavior, and add bounded cleanup of superseded same-variant images.
+
+## Impact
+
+- CLI sandbox image selection, pull, status, config persistence, package-inventory lookup, and launch preflight under `src/modules/libs/` and `src/modules/harness/`.
+- Sandbox image publication metadata in `.github/workflows/lib-store.yml` and the existing label-stamping script.
+- Tests for pull state transitions, failure atomicity, cleanup safety, migration, and Docker/Podman-compatible command behavior.
+- No new dependency, database migration, public command, command option, harness API, or agent-policy classification.

--- a/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/specs/lib-store-provisioning/spec.md
+++ b/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/specs/lib-store-provisioning/spec.md
@@ -1,46 +1,48 @@
-# lib-store-provisioning Specification
+## ADDED Requirements
 
-## Purpose
-TBD - created by archiving change add-lib-store-pull. Update Purpose after archive.
-## Requirements
-### Requirement: The setup flow provisions the store through the same pull handler
+### Requirement: Published sandbox images expose their immutable version identity
 
-`inflexa setup` SHALL hand off to the same image-pull handler that
-`inflexa sandbox pull` uses — it SHALL NOT implement a separate download path —
-which prompts the variant, confirms the pull, and runs inside a `spinner()`.
-Declining the pull SHALL skip the image step and continue setup, never abort it.
-On a non-interactive terminal the setup flow SHALL NOT auto-pull; it SHALL print a
-hint to run `inflexa sandbox pull <variant> --yes` and continue setup
-successfully.
+Each published selectable sandbox platform image SHALL carry `org.opencontainers.image.version` equal to the multi-arch image's published `<YYYYMMDD>-<7-hex-revision>` tag and `org.opencontainers.image.revision` equal to its source revision. The CLI SHALL accept a discovered version only when it matches `^[0-9]{8}-[0-9a-f]{7}$` and SHALL construct the pinned reference from the selected first-party repository rather than treating label content as a repository or command argument.
 
-#### Scenario: Setup reuses the pull handler
+#### Scenario: Published image identifies its version
 
-- **WHEN** setup reaches the sandbox-image step interactively
-- **THEN** provisioning calls the same handler as `inflexa sandbox pull`, which prompts the variant and runs inside a spinner
+- **WHEN** the CLI pulls a selectable sandbox variant through its `latest` channel
+- **THEN** the resolved platform image exposes the same version value as the published multi-arch version tag
 
-#### Scenario: Declining the pull skips the image
+#### Scenario: Invalid publication metadata cannot change config
 
-- **WHEN** the user declines the pull during `inflexa setup`
-- **THEN** the image step is skipped and setup continues to completion rather than aborting
+- **WHEN** a pulled image has a missing or malformed version label
+- **THEN** the pull operation fails without changing `harness.sandboxImage` or removing the previously configured image
 
-#### Scenario: Non-interactive setup does not auto-pull
+### Requirement: Superseded sandbox versions are cleaned within a bounded ownership scope
 
-- **WHEN** `inflexa setup` runs on a non-interactive terminal
-- **THEN** no image is pulled; the CLI prints a hint to run `inflexa sandbox pull <variant> --yes` and setup continues
+After a versioned sandbox reference has been successfully written to config, the CLI SHALL enumerate only local tagged references in that selected Inflexa sandbox variant repository and SHALL attempt to remove every other tag matching the published-version grammar. When migrating a configured `latest` reference, the CLI SHALL additionally attempt to remove the exact prior image ID it captured before the channel moved. Removal SHALL use the exact tag or captured ID without force. Cleanup failure SHALL retain the affected image and SHALL NOT turn the successful pull and config transition into a failure. The CLI SHALL NOT remove `latest`, another sandbox variant, a custom image, a non-version tag, an image from another repository, a container, a volume, a network, or build cache, and SHALL NOT invoke daemon-wide image or system pruning.
 
-### Requirement: A missing store is offered, never fatal
+#### Scenario: Superseded same-variant version is reclaimed
 
-The CLI SHALL, before launching a sandbox when the configured sandbox image is
-not present, surface a one-line, actionable offer to run `inflexa sandbox pull`
-and SHALL allow continuing. A missing image SHALL NOT silently dead-end: the offer
-SHALL name the variant and the pull command, and when an image is genuinely
-required to launch the CLI SHALL pull it (or prompt to) rather than failing out.
+- **GIVEN** two unused published version tags exist locally for the selected variant
+- **WHEN** the newer version is successfully configured
+- **THEN** the CLI removes the older exact version tag and the runtime may reclaim layers no longer referenced elsewhere
 
-#### Scenario: Missing image surfaces an offer
+#### Scenario: Version used by a container is retained
 
-- **GIVEN** the configured sandbox image is not present locally
-- **WHEN** a sandbox is about to launch
-- **THEN** the CLI prints an offer to run `inflexa sandbox pull` (naming the variant) before proceeding to obtain it
+- **GIVEN** a superseded same-variant version is still referenced by a container
+- **WHEN** post-pull cleanup attempts non-forced removal
+- **THEN** the CLI retains and reports that version while the newly configured version remains successful
+
+#### Scenario: First legacy refresh reclaims the former channel image
+
+- **GIVEN** a configured `latest` reference points to an old image with no version tag
+- **WHEN** a successful pull moves the channel and commits the new version
+- **THEN** the CLI attempts non-forced removal of the exact prior image ID captured before the pull
+
+#### Scenario: Other resources remain untouched
+
+- **GIVEN** another sandbox variant, custom images, unrelated dangling images, containers, volumes, networks, or build cache exist
+- **WHEN** post-pull cleanup runs
+- **THEN** none of those resources are selected for removal
+
+## MODIFIED Requirements
 
 ### Requirement: `inflexa sandbox pull` selects and pulls a sandbox image variant
 
@@ -69,26 +71,6 @@ The CLI SHALL provide `inflexa sandbox pull` (the command noun is `sandbox`, not
 - **AND** pulling moves that local alias before a later transition step fails
 - **WHEN** the operation rolls back
 - **THEN** the CLI restores the local `latest` alias to its prior image ID so the unchanged config retains its prior local meaning
-
-### Requirement: The user chooses the image variant; architecture is automatic
-
-The CLI SHALL let the user choose the image variant — `python` (Python libraries
-plus the bioconda CLI tools) or `python-r` (that plus the R libraries). The CLI
-SHALL NOT ask for or force an architecture: the published images are multi-arch
-manifests, so `docker pull` resolves the host architecture automatically. On a
-host with no arm64 R image content, the CLI SHALL surface any variant
-unavailability as an informational note rather than an error.
-
-#### Scenario: The variant is chosen, the arch is not
-
-- **WHEN** `inflexa sandbox pull` runs interactively
-- **THEN** the user is prompted for `python` vs `python-r` and is never asked for an architecture
-
-#### Scenario: Multi-arch pull resolves the host arch
-
-- **GIVEN** the host is arm64
-- **WHEN** the chosen variant image is pulled
-- **THEN** docker resolves the arm64 image from the multi-arch manifest with no explicit platform flag
 
 ### Requirement: The pulled image is configured as the sandbox image
 
@@ -155,45 +137,3 @@ The CLI SHALL provide `inflexa sandbox status` reporting the configured sandbox 
 - **GIVEN** the configured image is absent locally
 - **WHEN** `inflexa sandbox status` runs
 - **THEN** it reports the image is not installed and points the user at `inflexa sandbox pull`
-
-### Requirement: Published sandbox images expose their immutable version identity
-
-Each published selectable sandbox platform image SHALL carry `org.opencontainers.image.version` equal to the multi-arch image's published `<YYYYMMDD>-<7-hex-revision>` tag and `org.opencontainers.image.revision` equal to its source revision. The CLI SHALL accept a discovered version only when it matches `^[0-9]{8}-[0-9a-f]{7}$` and SHALL construct the pinned reference from the selected first-party repository rather than treating label content as a repository or command argument.
-
-#### Scenario: Published image identifies its version
-
-- **WHEN** the CLI pulls a selectable sandbox variant through its `latest` channel
-- **THEN** the resolved platform image exposes the same version value as the published multi-arch version tag
-
-#### Scenario: Invalid publication metadata cannot change config
-
-- **WHEN** a pulled image has a missing or malformed version label
-- **THEN** the pull operation fails without changing `harness.sandboxImage` or removing the previously configured image
-
-### Requirement: Superseded sandbox versions are cleaned within a bounded ownership scope
-
-After a versioned sandbox reference has been successfully written to config, the CLI SHALL enumerate only local tagged references in that selected Inflexa sandbox variant repository and SHALL attempt to remove every other tag matching the published-version grammar. When migrating a configured `latest` reference, the CLI SHALL additionally attempt to remove the exact prior image ID it captured before the channel moved. Removal SHALL use the exact tag or captured ID without force. Cleanup failure SHALL retain the affected image and SHALL NOT turn the successful pull and config transition into a failure. The CLI SHALL NOT remove `latest`, another sandbox variant, a custom image, a non-version tag, an image from another repository, a container, a volume, a network, or build cache, and SHALL NOT invoke daemon-wide image or system pruning.
-
-#### Scenario: Superseded same-variant version is reclaimed
-
-- **GIVEN** two unused published version tags exist locally for the selected variant
-- **WHEN** the newer version is successfully configured
-- **THEN** the CLI removes the older exact version tag and the runtime may reclaim layers no longer referenced elsewhere
-
-#### Scenario: Version used by a container is retained
-
-- **GIVEN** a superseded same-variant version is still referenced by a container
-- **WHEN** post-pull cleanup attempts non-forced removal
-- **THEN** the CLI retains and reports that version while the newly configured version remains successful
-
-#### Scenario: First legacy refresh reclaims the former channel image
-
-- **GIVEN** a configured `latest` reference points to an old image with no version tag
-- **WHEN** a successful pull moves the channel and commits the new version
-- **THEN** the CLI attempts non-forced removal of the exact prior image ID captured before the pull
-
-#### Scenario: Other resources remain untouched
-
-- **GIVEN** another sandbox variant, custom images, unrelated dangling images, containers, volumes, networks, or build cache exist
-- **WHEN** post-pull cleanup runs
-- **THEN** none of those resources are selected for removal

--- a/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/tasks.md
+++ b/cli/openspec/changes/archive/2026-07-27-pin-sandbox-image-versions/tasks.md
@@ -1,0 +1,40 @@
+## 1. Publish Version Identity
+
+- [x] 1.1 Extend the existing sandbox metadata-stamping path to add validated `org.opencontainers.image.version` and `org.opencontainers.image.revision` labels to each selectable per-architecture image.
+- [x] 1.2 Pass the workflow's single computed version and source revision into both Python and Python+R image stamping calls without changing the existing multi-arch tag set.
+- [x] 1.3 Extend image publication or acceptance checks to fail when either selectable image lacks the expected version/revision metadata, and document the metadata contract in the image README.
+
+## 2. Model Channel and Version References
+
+- [x] 2.1 Add domain helpers in the libs module for the selected variant's `latest` channel reference, strict published-version parsing, and construction/parsing of versioned first-party references.
+- [x] 2.2 Add unit tests covering valid versions, malformed or hostile label values, registry-port edge cases, channel references, versioned references, digests, and custom images.
+- [x] 2.3 Define a runtime-command dependency seam for pull provisioning so Docker/Podman command sequences and failure results can be tested without a real daemon.
+
+## 3. Implement the Transactional Pull
+
+- [x] 3.1 Change `sandboxPull` to snapshot any prior moving alias, pull only the selected variant's `latest` channel, inspect and validate its version label, create the local version tag, and verify channel/version image-ID equality.
+- [x] 3.2 Expand `PullError` and `PullOutcome` with typed metadata, tagging, verification, rollback, current-version, and cleanup-reporting states, consuming every `Result` through the established neverthrow conventions.
+- [x] 3.3 Cache package inventory against the verified versioned image, then persist that exact reference while preserving the rest of the opaque harness config.
+- [x] 3.4 Roll back a moved legacy `latest` alias and any uncommitted version alias when a post-pull step fails, without deleting the previously configured pinned reference.
+- [x] 3.5 Add transition tests for first pin, same-version refresh, newer-version commit, each pre-commit failure stage, config-write failure, and legacy-alias restoration.
+
+## 4. Reclaim Superseded Versions Safely
+
+- [x] 4.1 Enumerate exact local tags only within the selected first-party variant repository and filter cleanup candidates through the strict published-version parser.
+- [x] 4.2 After config commit, remove every superseded candidate by exact tag without force; classify removed and retained references without failing the successful pull.
+- [x] 4.3 Report retained in-use versions concisely and avoid reclaimed-byte claims, daemon-wide prune commands, or changes to the existing approval-required command policy.
+- [x] 4.4 Add tests proving cleanup retries older tagged versions, preserves the current version, `latest`, the other variant, non-version/custom/unrelated images and resources, and treats runtime removal conflicts as retained success.
+
+## 5. Pin Launch Preflight
+
+- [x] 5.1 Change the published-image provisioning seam to return the effective execution reference and thread that value through profile, run, and chat launch paths for the current invocation.
+- [x] 5.2 Restore a missing configured published version by pulling that exact tag, with no `latest` substitution or cleanup.
+- [x] 5.3 Route an absent bootstrap/legacy channel through version-resolving provisioning so it is persisted and used immediately, while allowing an already-present legacy channel to launch without a network update.
+- [x] 5.4 Preserve the existing actionable behavior for missing custom images and add preflight tests for exact restoration, first-pull pinning, present-legacy behavior, and current-invocation pin use.
+
+## 6. Status, Documentation, and Verification
+
+- [x] 6.1 Update `sandbox status` to show the parsed pinned version or identify a legacy channel as unpinned while remaining registry-free and read-only.
+- [x] 6.2 Update CLI documentation and the main `lib-store-provisioning` spec-facing language to describe explicit channel refresh, versioned execution, migration, and bounded cleanup.
+- [x] 6.3 Run the focused libs, harness-preflight, CLI policy, and setup tests under both runtime descriptors, then run CLI typecheck and lint.
+- [x] 6.4 Validate the OpenSpec change and verify no source dependency, database migration, public command/flag, harness API, or agent-policy snapshot changed outside the stated scope.

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -617,7 +617,7 @@ export function buildProgram(): Command {
     registerAction(
         sandbox
             .command("pull")
-            .description("Pull a sandbox image (python | python-r) from GitHub Packages and configure sandboxes to use it")
+            .description("Pull a sandbox image update and pin its published version")
             .argument("[variant]", "Image variant: python or python-r (prompted when omitted)")
             .option("--yes", "Skip the download confirmation"),
         { kind: "approval" },
@@ -646,7 +646,7 @@ export function buildProgram(): Command {
 
     // Read-only diagnostic: must not write config (pull.ts); runtime `image inspect` is a query subprocess.
     registerAction(
-        sandbox.command("status").description("Show the configured sandbox image variant, its GHCR reference, and whether it is present locally"),
+        sandbox.command("status").description("Show the configured sandbox image variant, pinned version, and local presence"),
         { kind: "auto", safeFlags: [] },
         async () => {
             const { sandboxStatus } = await import("../modules/libs/pull.ts");

--- a/cli/src/modules/harness/chat.ts
+++ b/cli/src/modules/harness/chat.ts
@@ -93,7 +93,8 @@ export async function runChat(flags: ContextFlags, threadRef: string | undefined
     // misleadingly (same guard `inflexa profile`/`inflexa run` open with).
     if (cfg.configError) fail(describeBootError({ type: "harness_config_invalid", issues: cfg.configError.issues }));
 
-    await ensureSandboxImage(cfg.sandboxImage);
+    const sandboxImage = await ensureSandboxImage(cfg.sandboxImage);
+    const bootConfig = sandboxImage === cfg.sandboxImage ? cfg : { ...cfg, sandboxImage };
 
     // Claim the per-analysis lock before boot, so this analysis stays
     // single-process for the whole chat — a coarse guard so only one provenance
@@ -106,7 +107,7 @@ export async function runChat(flags: ContextFlags, threadRef: string | undefined
 
     const s = spinner();
     s.start("Booting the harness runtime (Postgres, callback listener, DBOS)");
-    const runtime = (await bootHarnessRuntime({ config: cfg })).match(
+    const runtime = (await bootHarnessRuntime({ config: bootConfig })).match(
         (r) => r,
         (e) => {
             s.error("Harness runtime boot failed");

--- a/cli/src/modules/harness/profile.ts
+++ b/cli/src/modules/harness/profile.ts
@@ -19,6 +19,7 @@ import { ensureRuntime, resolvePostgresConfig } from "../../lib/config.ts";
 import { env } from "../../lib/env.ts";
 import { capture, inherit } from "../../lib/container.ts";
 import { variantOfImage } from "../libs/images.ts";
+import { isMovingTag, provisionPublishedVariant } from "../libs/pull.ts";
 import { getLogger } from "../../lib/log.ts";
 import { shutdown } from "../../lib/shutdown.ts";
 import { claimAnalysisOrFail, resolveSingleAnalysis, type ContextFlags } from "../analysis/context.ts";
@@ -34,6 +35,34 @@ import { bootHarnessRuntime, activeHarnessRuntime, type HarnessBootError } from 
 // here); the workflow itself is fire-and-forget and `--status` reads the ledger.
 
 type Spinner = ReturnType<typeof spinner>;
+
+/** Injectable preflight effects for daemon-free image restoration tests. */
+export type SandboxImagePreflightDeps = {
+    /** Resolve the configured container runtime. */
+    readonly ensureRuntime: typeof ensureRuntime;
+    /** Inspect a local image reference. */
+    readonly capture: typeof capture;
+    /** Pull an exact immutable/custom published tag with visible progress. */
+    readonly inherit: typeof inherit;
+    /** Resolve and commit a moving first-party channel. */
+    readonly provisionPublishedVariant: typeof provisionPublishedVariant;
+    /** Ask before a required multi-gigabyte download. */
+    readonly confirm: typeof confirm;
+    /** Bail out at the CLI boundary after a failed prerequisite. */
+    readonly fail: typeof fail;
+    /** Whether prompting is appropriate for this invocation. */
+    readonly isInteractive: () => boolean;
+};
+
+const realSandboxImagePreflightDeps: SandboxImagePreflightDeps = {
+    ensureRuntime,
+    capture,
+    inherit,
+    provisionPublishedVariant,
+    confirm,
+    fail,
+    isInteractive: () => process.stdin.isTTY,
+};
 
 /**
  * Each boot error variant, as one actionable line naming the remedy. Exported so
@@ -126,16 +155,16 @@ export function describeBootError(e: HarnessBootError): string {
  * CUSTOM local tag can't be pulled, so we hint the build. Never a silent dead-end.
  * Exported so `inflexa run` reuses profile's identical image check.
  */
-export async function ensureSandboxImage(image: string): Promise<void> {
-    const rtResult = await ensureRuntime();
-    if (rtResult.isErr()) fail(rtResult.error.message);
+export async function ensureSandboxImage(image: string, deps: SandboxImagePreflightDeps = realSandboxImagePreflightDeps): Promise<string> {
+    const rtResult = await deps.ensureRuntime();
+    if (rtResult.isErr()) deps.fail(rtResult.error.message);
     const rt = rtResult.value;
-    if ((await capture(rt, ["image", "inspect", image])).code === 0) return;
+    if ((await deps.capture(rt, ["image", "inspect", image])).code === 0) return image;
 
     const variant = variantOfImage(image);
     if (variant === null) {
         // A custom local tag (a user's `FROM` image) — we cannot pull it.
-        fail(
+        deps.fail(
             [
                 `Sandbox image "${image}" not found in ${rt.id}.`,
                 `Build it locally (e.g. \`${rt.bin} build -f images/sandbox-python-r/Dockerfile -t ${image} .\`),`,
@@ -146,15 +175,25 @@ export async function ensureSandboxImage(image: string): Promise<void> {
 
     // Published variant: offer + pull. The image is genuinely required to launch a
     // sandbox, so a decline is an actionable stop, not a silent dead-end.
-    if (process.stdin.isTTY) {
+    if (deps.isInteractive()) {
         console.log(`\n  Sandbox image "${image}" (${variant}) is not installed.`);
-        const proceed = await confirm("Pull it from GitHub Packages now? (may be a multi-GB download)");
-        if (!proceed) fail("A sandbox image is required to run a profile. Run `inflexa sandbox pull` and retry.");
+        const proceed = await deps.confirm("Pull it from GitHub Packages now? (may be a multi-GB download)");
+        if (!proceed) deps.fail("A sandbox image is required to run a profile. Run `inflexa sandbox pull` and retry.");
     } else {
         console.log(`  Sandbox image "${image}" not present — pulling ${variant} from GitHub Packages…`);
     }
-    const code = await inherit(rt, ["pull", image]);
-    if (code !== 0) fail(`Failed to pull ${image} (\`${rt.bin} pull\` exited ${code}). Check your network and that ghcr.io is reachable.`);
+    if (isMovingTag(image)) {
+        return (await deps.provisionPublishedVariant(rt, variant)).match(
+            (outcome) => outcome.image,
+            (error) => deps.fail(error.message),
+        );
+    }
+
+    // A configured published version is an execution identity, not an update
+    // channel. Restore that exact tag when local storage was cleared.
+    const code = await deps.inherit(rt, ["pull", image]);
+    if (code !== 0) deps.fail(`Failed to pull ${image} (\`${rt.bin} pull\` exited ${code}). Check your network and that ghcr.io is reachable.`);
+    return image;
 }
 
 /**
@@ -191,7 +230,8 @@ export async function runProfile(flags: ContextFlags): Promise<void> {
     // the same error, but only after the image check it never reaches.
     if (cfg.configError) fail(describeBootError({ type: "harness_config_invalid", issues: cfg.configError.issues }));
 
-    await ensureSandboxImage(cfg.sandboxImage);
+    const sandboxImage = await ensureSandboxImage(cfg.sandboxImage);
+    const bootConfig = sandboxImage === cfg.sandboxImage ? cfg : { ...cfg, sandboxImage };
 
     // Gate the workspace root BEFORE booting — an unresolvable or non-writable
     // workspace fails like any other prerequisite (no fallback location exists).
@@ -212,7 +252,7 @@ export async function runProfile(flags: ContextFlags): Promise<void> {
 
     const s = spinner();
     s.start("Booting the harness runtime (Postgres, callback listener, DBOS)");
-    const bootResult = await bootHarnessRuntime({ config: cfg });
+    const bootResult = await bootHarnessRuntime({ config: bootConfig });
     const runtime = bootResult.match(
         (r) => r,
         (e) => {

--- a/cli/src/modules/harness/profile_image.test.ts
+++ b/cli/src/modules/harness/profile_image.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { ok } from "neverthrow";
+
+import { runtimes, type CaptureResult } from "../../lib/container.ts";
+import type { PullOutcome } from "../libs/pull.ts";
+import { ensureSandboxImage, type SandboxImagePreflightDeps } from "./profile.ts";
+
+function preflightDeps(options: { readonly present?: boolean; readonly provisionedImage?: string }): {
+    readonly deps: SandboxImagePreflightDeps;
+    readonly commands: string[][];
+} {
+    const commands: string[][] = [];
+    const result = (code: number): CaptureResult => ({ code, stdout: "", stderr: "" });
+    const deps: SandboxImagePreflightDeps = {
+        ensureRuntime: async () => ok(runtimes.docker),
+        capture: async (_rt, args) => {
+            commands.push(args);
+            return result(options.present ? 0 : 1);
+        },
+        inherit: async (_rt, args) => {
+            commands.push(args);
+            return 0;
+        },
+        provisionPublishedVariant: async (_rt, variant) => {
+            const outcome: Exclude<PullOutcome, { type: "declined" }> = {
+                type: "pulled",
+                variant,
+                image: options.provisionedImage ?? "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678",
+                cleanup: { removed: [], retained: [] },
+            };
+            return ok(outcome);
+        },
+        confirm: async () => true,
+        fail: (message) => {
+            throw new Error(message);
+        },
+        isInteractive: () => false,
+    };
+    return { deps, commands };
+}
+
+describe("ensureSandboxImage — pinned launch preflight", () => {
+    test("uses an already-present legacy channel without checking for updates", async () => {
+        const image = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+        const fake = preflightDeps({ present: true });
+
+        expect(await ensureSandboxImage(image, fake.deps)).toBe(image);
+        expect(fake.commands).toEqual([["image", "inspect", image]]);
+    });
+
+    test("restores a missing configured version by pulling that exact reference", async () => {
+        const image = "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234";
+        const fake = preflightDeps({ present: false });
+
+        expect(await ensureSandboxImage(image, fake.deps)).toBe(image);
+        expect(fake.commands).toEqual([
+            ["image", "inspect", image],
+            ["pull", image],
+        ]);
+    });
+
+    test("returns the effective pin when a missing bootstrap channel is provisioned", async () => {
+        const image = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+        const pinned = "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678";
+        const fake = preflightDeps({ present: false, provisionedImage: pinned });
+
+        expect(await ensureSandboxImage(image, fake.deps)).toBe(pinned);
+        expect(fake.commands).toEqual([["image", "inspect", image]]);
+    });
+
+    test("preserves the actionable custom-image refusal", async () => {
+        const image = "example.test/custom-sandbox:local";
+        const fake = preflightDeps({ present: false });
+
+        expect(ensureSandboxImage(image, fake.deps)).rejects.toThrow(`Sandbox image "${image}" not found`);
+        expect(fake.commands).toEqual([["image", "inspect", image]]);
+    });
+});

--- a/cli/src/modules/harness/run.ts
+++ b/cli/src/modules/harness/run.ts
@@ -377,7 +377,8 @@ export async function runAnalysis(flags: ContextFlags, planPath: string | undefi
         (e) => fail(describePlanIntakeError(e)),
     );
 
-    await ensureSandboxImage(cfg.sandboxImage);
+    const sandboxImage = await ensureSandboxImage(cfg.sandboxImage);
+    const bootConfig = sandboxImage === cfg.sandboxImage ? cfg : { ...cfg, sandboxImage };
 
     // Claim the per-analysis instance lock before boot, so this analysis stays
     // single-process for the whole run — the interim two-recorder fix of #37, the
@@ -390,7 +391,7 @@ export async function runAnalysis(flags: ContextFlags, planPath: string | undefi
 
     const s = spinner();
     s.start("Booting the harness runtime (Postgres, callback listener, DBOS)");
-    const bootResult = await bootHarnessRuntime({ config: cfg });
+    const bootResult = await bootHarnessRuntime({ config: bootConfig });
     const runtime = bootResult.match(
         (r) => r,
         (e) => {

--- a/cli/src/modules/libs/images.test.ts
+++ b/cli/src/modules/libs/images.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
-import { DEFAULT_SANDBOX_IMAGE, SANDBOX_VARIANTS, parseVariant, variantImage, variantOfImage } from "./images.ts";
+import {
+    DEFAULT_SANDBOX_IMAGE,
+    SANDBOX_VARIANTS,
+    parseSandboxVersion,
+    parseVariant,
+    publishedVersionOfImage,
+    variantImage,
+    variantOfImage,
+    variantRepository,
+    versionedVariantImage,
+} from "./images.ts";
 
 describe("variantImage", () => {
     test("builds the GHCR reference for each variant", () => {
@@ -10,6 +20,33 @@ describe("variantImage", () => {
 
     test("DEFAULT_SANDBOX_IMAGE is the full python-r stack", () => {
         expect(DEFAULT_SANDBOX_IMAGE).toBe(variantImage("python-r"));
+    });
+});
+
+describe("published versions", () => {
+    test("builds channel and version references from the known repository", () => {
+        const version = parseSandboxVersion("20260727-def5678");
+        expect(version).not.toBeNull();
+        if (version === null) return;
+        expect(variantRepository("python")).toBe("ghcr.io/inflexa-ai/sandbox-python");
+        expect(versionedVariantImage("python", version)).toBe("ghcr.io/inflexa-ai/sandbox-python:20260727-def5678");
+    });
+
+    test("accepts only the publication grammar", () => {
+        expect(parseSandboxVersion("20260727-def5678")).not.toBeNull();
+        for (const value of ["latest", "2026-07-27-def5678", "20260727-DEF5678", "20260727-def567", "20260727-def56789", "20260727-abcdef0;rm"]) {
+            expect(parseSandboxVersion(value)).toBeNull();
+        }
+    });
+
+    test("parses exact first-party version refs but not channels, digests, or custom refs", () => {
+        const parsed = publishedVersionOfImage("ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678");
+        expect(parsed?.variant).toBe("python-r");
+        expect(parsed?.version === "20260727-def5678").toBe(true);
+        expect(publishedVersionOfImage("ghcr.io/inflexa-ai/sandbox-python-r:latest")).toBeNull();
+        expect(publishedVersionOfImage("ghcr.io/inflexa-ai/sandbox-python@sha256:deadbeef")).toBeNull();
+        expect(publishedVersionOfImage("localhost:5000/sandbox-python:20260727-def5678")).toBeNull();
+        expect(publishedVersionOfImage("my-registry/sandbox-python:20260727-def5678")).toBeNull();
     });
 });
 

--- a/cli/src/modules/libs/images.ts
+++ b/cli/src/modules/libs/images.ts
@@ -14,6 +14,12 @@
 /** GHCR namespace: the inflexa-ai org's GitHub Packages (linked to the inflexa repo via the image's source label). */
 const GHCR_NAMESPACE = "ghcr.io/inflexa-ai";
 
+/** Strict release tag carried by every published selectable sandbox image. */
+export type SandboxVersion = string & { readonly __sandboxVersion: unique symbol };
+
+/** The OCI label carrying the image's human-readable published version. */
+export const SANDBOX_VERSION_LABEL = "org.opencontainers.image.version";
+
 /** The image variants a user can pull, in menu order (lightest first). */
 export const SANDBOX_VARIANTS = ["python", "python-r"] as const;
 
@@ -32,9 +38,27 @@ export const VARIANT_DESCRIPTIONS: Record<SandboxVariant, string> = {
     "python-r": "everything in python, plus the R libraries",
 };
 
-/** The multi-arch GHCR image reference (`:latest`) for a variant. */
+/** The first-party GHCR repository for a selectable variant, without a tag. */
+export function variantRepository(variant: SandboxVariant): string {
+    return `${GHCR_NAMESPACE}/sandbox-${variant}`;
+}
+
+/** The moving multi-arch discovery reference (`:latest`) for a variant. */
 export function variantImage(variant: SandboxVariant): string {
-    return `${GHCR_NAMESPACE}/sandbox-${variant}:latest`;
+    return `${variantRepository(variant)}:latest`;
+}
+
+/** Validate and brand a published `<YYYYMMDD>-<7-hex-revision>` version. */
+export function parseSandboxVersion(value: string): SandboxVersion | null {
+    // The regex proves the release-tag grammar before the string receives its
+    // domain brand; callers cannot construct repository or command text from
+    // unvalidated registry metadata.
+    return /^[0-9]{8}-[0-9a-f]{7}$/.test(value) ? (value as SandboxVersion) : null;
+}
+
+/** Build the immutable-by-policy execution reference for a validated version. */
+export function versionedVariantImage(variant: SandboxVariant, version: SandboxVersion): string {
+    return `${variantRepository(variant)}:${version}`;
 }
 
 /**
@@ -62,8 +86,18 @@ export function parseVariant(value: string | undefined): SandboxVariant | null {
  */
 export function variantOfImage(ref: string): SandboxVariant | null {
     for (const v of ["python-r", "python"] as const) {
-        const repo = `${GHCR_NAMESPACE}/sandbox-${v}`;
+        const repo = variantRepository(v);
         if (ref === repo || ref.startsWith(`${repo}:`) || ref.startsWith(`${repo}@`)) return v;
     }
     return null;
+}
+
+/** Parse a strict published version reference, excluding `latest`, digests, and custom tags. */
+export function publishedVersionOfImage(ref: string): { readonly variant: SandboxVariant; readonly version: SandboxVersion } | null {
+    const variant = variantOfImage(ref);
+    if (variant === null) return null;
+    const prefix = `${variantRepository(variant)}:`;
+    if (!ref.startsWith(prefix) || ref.includes("@")) return null;
+    const version = parseSandboxVersion(ref.slice(prefix.length));
+    return version === null ? null : { variant, version };
 }

--- a/cli/src/modules/libs/pull.test.ts
+++ b/cli/src/modules/libs/pull.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { err, ok } from "neverthrow";
 
-import { isMovingTag, sandboxStatus } from "./pull.ts";
+import { isMovingTag, provisionPublishedVariant, sandboxStatus, type PullRuntimeOps, type PullStageError } from "./pull.ts";
 import { readConfig } from "../../lib/config.ts";
+import { runtimes, type CaptureResult, type ContainerRuntimeId } from "../../lib/container.ts";
 import { env } from "../../lib/env.ts";
 import { assertTestSandbox } from "../../test_support/sandbox.ts";
 
@@ -42,6 +44,31 @@ describe("sandboxStatus — read-only, never pins", () => {
 
         expect(readConfig().runtime).toBeUndefined();
     });
+
+    test("reports pinned versions and legacy channels without migrating either", async () => {
+        mkdirSync(dirname(env.configPath), { recursive: true });
+        const lines: string[] = [];
+        const originalLog = console.log;
+        console.log = (...values: unknown[]): void => {
+            lines.push(values.join(" "));
+        };
+        try {
+            writeFileSync(
+                env.configPath,
+                JSON.stringify({ telemetry: false, harness: { sandboxImage: "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678" } }),
+            );
+            await sandboxStatus();
+            expect(lines.join("\n")).toContain("Version  20260727-def5678");
+
+            lines.length = 0;
+            writeFileSync(env.configPath, JSON.stringify({ telemetry: false, harness: { sandboxImage: "ghcr.io/inflexa-ai/sandbox-python-r:latest" } }));
+            await sandboxStatus();
+            expect(lines.join("\n")).toContain("Version  (unpinned channel)");
+        } finally {
+            console.log = originalLog;
+        }
+        expect(readConfig().runtime).toBeUndefined();
+    });
 });
 
 describe("isMovingTag — decides when a present image must still be re-pulled", () => {
@@ -60,5 +87,254 @@ describe("isMovingTag — decides when a present image must still be re-pulled",
         // The ':5000' is the registry port, and there is no image tag → moving.
         expect(isMovingTag("localhost:5000/sandbox-python")).toBe(true);
         expect(isMovingTag("localhost:5000/sandbox-python:v1")).toBe(false);
+    });
+});
+
+type FakeOptions = {
+    readonly runtime: ContainerRuntimeId;
+    readonly configured: string;
+    readonly version?: string;
+    readonly oldChannelId?: string;
+    readonly newChannelId?: string;
+    readonly refs?: Readonly<Record<string, string>>;
+    readonly retain?: readonly string[];
+    readonly failPull?: boolean;
+    readonly failConfig?: boolean;
+    readonly failVersionTag?: boolean;
+    readonly verificationMismatch?: boolean;
+    readonly failRollback?: boolean;
+};
+
+function fakePullOps(options: FakeOptions): {
+    readonly rt: (typeof runtimes)[ContainerRuntimeId];
+    readonly ops: PullRuntimeOps;
+    readonly commands: string[][];
+    readonly refs: Map<string, string>;
+    readonly configuredWrites: string[];
+    readonly resolvedPackages: string[];
+} {
+    const channel = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+    const refs = new Map(Object.entries(options.refs ?? {}));
+    if (options.oldChannelId) refs.set(channel, options.oldChannelId);
+    const commands: string[][] = [];
+    const configuredWrites: string[] = [];
+    const resolvedPackages: string[] = [];
+    const retained = new Set(options.retain ?? []);
+    const knownIds = new Set([...refs.values(), ...(options.oldChannelId ? [options.oldChannelId] : []), options.newChannelId ?? "sha256:new"]);
+    const success = (stdout = ""): CaptureResult => ({ code: 0, stdout, stderr: "" });
+    const failure = (): CaptureResult => ({ code: 1, stdout: "", stderr: "fake failure" });
+    const resolveSource = (source: string): string | null => refs.get(source) ?? (knownIds.has(source) ? source : null);
+
+    const ops: PullRuntimeOps = {
+        capture: async (_rt, args) => {
+            commands.push(args);
+            if (args[0] === "pull") {
+                if (options.failPull) return failure();
+                refs.set(channel, options.newChannelId ?? "sha256:new");
+                return success();
+            }
+            if (args[0] === "tag") {
+                const source = args[1];
+                const target = args[2];
+                if (
+                    !source ||
+                    !target ||
+                    (options.failVersionTag && target !== channel) ||
+                    (options.failRollback && target === channel && source === options.oldChannelId)
+                )
+                    return failure();
+                const id = resolveSource(source);
+                if (id === null) return failure();
+                refs.set(target, options.verificationMismatch && target !== channel ? "sha256:mismatch" : id);
+                return success();
+            }
+            if (args[0] === "image" && args[1] === "inspect") {
+                const image = args.at(-1);
+                if (!image) return failure();
+                if (args[3]?.includes("Config.Labels")) return success(`${options.version ?? "20260727-def5678"}\n`);
+                const id = refs.get(image);
+                return id ? success(`${id}\n`) : failure();
+            }
+            if (args[0] === "image" && args[1] === "ls") {
+                const repository = args.at(-1);
+                return success([...refs.keys()].filter((ref) => ref.startsWith(`${repository}:`)).join("\n"));
+            }
+            if (args[0] === "image" && args[1] === "rm") {
+                const image = args[2];
+                if (!image || retained.has(image)) return failure();
+                if (knownIds.has(image)) {
+                    for (const [ref, id] of refs) {
+                        if (id === image) refs.delete(ref);
+                    }
+                    knownIds.delete(image);
+                } else {
+                    refs.delete(image);
+                }
+                return success();
+            }
+            return failure();
+        },
+        inherit: async (_rt, args) => {
+            commands.push(args);
+            refs.set(channel, options.newChannelId ?? "sha256:new");
+            return 0;
+        },
+        configuredImage: () => options.configured,
+        configureImage: (image) => {
+            if (options.failConfig) {
+                const failureError: PullStageError = { type: "config_write_failed", message: "fake config failure" };
+                return err(failureError);
+            }
+            configuredWrites.push(image);
+            return ok(undefined);
+        },
+        resolvePackages: async (_rt, image) => {
+            resolvedPackages.push(image);
+            return "/tmp/packages.txt";
+        },
+    };
+    return { rt: runtimes[options.runtime], ops, commands, refs, configuredWrites, resolvedPackages };
+}
+
+describe("provisionPublishedVariant — version commit and bounded cleanup", () => {
+    for (const runtime of ["docker", "podman"] as const) {
+        test(`${runtime}: pulls the channel, pins the stamped version, and never prunes`, async () => {
+            const fake = fakePullOps({
+                runtime,
+                configured: "ghcr.io/inflexa-ai/sandbox-python-r:latest",
+                oldChannelId: "sha256:old",
+            });
+
+            const outcome = await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops);
+
+            expect(outcome._unsafeUnwrap().image).toBe("ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678");
+            expect(fake.configuredWrites).toEqual(["ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678"]);
+            expect(fake.resolvedPackages).toEqual(["ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678"]);
+            expect(fake.commands).toContainEqual(["tag", "ghcr.io/inflexa-ai/sandbox-python-r:latest", "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678"]);
+            expect(fake.commands.some((args) => args.includes("prune"))).toBe(false);
+            expect(fake.commands).toContainEqual(["image", "rm", "sha256:old"]);
+        });
+    }
+
+    test("reports up to date and retries cleanup of every older strict version tag", async () => {
+        const current = "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678";
+        const older = "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234";
+        const nonVersion = "ghcr.io/inflexa-ai/sandbox-python-r:dev";
+        const otherVariant = "ghcr.io/inflexa-ai/sandbox-python:20260720-abc1234";
+        const fake = fakePullOps({
+            runtime: "docker",
+            configured: current,
+            oldChannelId: "sha256:new",
+            refs: { [current]: "sha256:new", [older]: "sha256:old", [nonVersion]: "sha256:dev", [otherVariant]: "sha256:other" },
+        });
+
+        const outcome = (await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops))._unsafeUnwrap();
+
+        expect(outcome.type).toBe("up_to_date");
+        expect(outcome.cleanup.removed).toEqual([older]);
+        expect(fake.refs.has(older)).toBe(false);
+        expect(fake.refs.has(nonVersion)).toBe(true);
+        expect(fake.refs.has(otherVariant)).toBe(true);
+        expect(fake.refs.has("ghcr.io/inflexa-ai/sandbox-python-r:latest")).toBe(true);
+    });
+
+    test("commits the new version while retaining an old version used by a container", async () => {
+        const older = "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234";
+        const fake = fakePullOps({
+            runtime: "podman",
+            configured: older,
+            refs: { [older]: "sha256:old" },
+            retain: [older],
+        });
+
+        const outcome = (await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops))._unsafeUnwrap();
+
+        expect(outcome.type).toBe("pulled");
+        expect(outcome.cleanup.retained).toEqual([older]);
+        expect(fake.refs.has(older)).toBe(true);
+    });
+
+    test("invalid metadata restores a legacy channel and leaves config unchanged", async () => {
+        const channel = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+        const fake = fakePullOps({
+            runtime: "docker",
+            configured: channel,
+            version: "latest;unsafe",
+            oldChannelId: "sha256:old",
+            newChannelId: "sha256:new",
+        });
+
+        const outcome = await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops);
+
+        expect(outcome._unsafeUnwrapErr().type).toBe("version_unavailable");
+        expect(fake.refs.get(channel)).toBe("sha256:old");
+        expect(fake.configuredWrites).toEqual([]);
+    });
+
+    test("config failure removes the uncommitted version alias and restores legacy latest", async () => {
+        const channel = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+        const pinned = "ghcr.io/inflexa-ai/sandbox-python-r:20260727-def5678";
+        const fake = fakePullOps({
+            runtime: "docker",
+            configured: channel,
+            oldChannelId: "sha256:old",
+            newChannelId: "sha256:new",
+            failConfig: true,
+        });
+
+        const outcome = await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops);
+
+        expect(outcome._unsafeUnwrapErr().type).toBe("config_write_failed");
+        expect(fake.refs.has(pinned)).toBe(false);
+        expect(fake.refs.get(channel)).toBe("sha256:old");
+    });
+
+    test("tag failure is typed and does not write config", async () => {
+        const fake = fakePullOps({
+            runtime: "docker",
+            configured: "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234",
+            failVersionTag: true,
+        });
+
+        const outcome = await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops);
+
+        expect(outcome._unsafeUnwrapErr().type).toBe("tag_failed");
+        expect(fake.configuredWrites).toEqual([]);
+    });
+
+    test("pull and verification failures are typed before config commit", async () => {
+        const pullFailure = fakePullOps({
+            runtime: "docker",
+            configured: "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234",
+            failPull: true,
+        });
+        expect((await provisionPublishedVariant(pullFailure.rt, "python-r", { quiet: true }, pullFailure.ops))._unsafeUnwrapErr().type).toBe("pull_failed");
+        expect(pullFailure.configuredWrites).toEqual([]);
+
+        const verificationFailure = fakePullOps({
+            runtime: "podman",
+            configured: "ghcr.io/inflexa-ai/sandbox-python-r:20260720-abc1234",
+            verificationMismatch: true,
+        });
+        expect((await provisionPublishedVariant(verificationFailure.rt, "python-r", { quiet: true }, verificationFailure.ops))._unsafeUnwrapErr().type).toBe(
+            "verification_failed",
+        );
+        expect(verificationFailure.configuredWrites).toEqual([]);
+    });
+
+    test("reports rollback failure when a legacy alias cannot be restored", async () => {
+        const channel = "ghcr.io/inflexa-ai/sandbox-python-r:latest";
+        const fake = fakePullOps({
+            runtime: "podman",
+            configured: channel,
+            version: "missing",
+            oldChannelId: "sha256:old",
+            failRollback: true,
+        });
+
+        const error = (await provisionPublishedVariant(fake.rt, "python-r", { quiet: true }, fake.ops))._unsafeUnwrapErr();
+
+        expect(error.type).toBe("rollback_failed");
+        if (error.type === "rollback_failed") expect(error.original.type).toBe("version_unavailable");
     });
 });

--- a/cli/src/modules/libs/pull.ts
+++ b/cli/src/modules/libs/pull.ts
@@ -1,17 +1,8 @@
 /**
- * The `inflexa sandbox` command actions — pull, status — plus the config write
- * that records the chosen image. `sandboxPull` is the ONE dogfooded provisioning
- * path: the `sandbox pull` command and the `inflexa setup` wizard both funnel
- * through it. There is no second image-fetch path.
- *
- * The model: the user picks an image VARIANT (`python` | `python-r`), the CLI
- * `docker pull`s `ghcr.io/inflexa-ai/sandbox-<variant>`, and records it as
- * `harness.sandboxImage` so sandboxes launch on the baked image — no local store
- * directory, no `/mnt/libs` bind mount, and no arch-forcing (a multi-arch manifest
- * resolves the host architecture automatically). The pre-flight `ensureSandboxImage`
- * (modules/harness/profile.ts) pulls the configured image on launch when it is
- * absent; the per-track tarballs are managed-only (mounted by infra, not this
- * CLI).
+ * The `inflexa sandbox` command actions. `latest` is an update-discovery
+ * channel only: a successful published-image pull resolves the image's stamped
+ * version, creates the matching local version tag, and persists that stable
+ * execution reference.
  */
 
 import { isCancel, log, select as clackSelect } from "@clack/prompts";
@@ -19,8 +10,21 @@ import { err, ok, type Result } from "neverthrow";
 
 import { confirm } from "../../lib/cli.ts";
 import { ensureRuntime, readConfig, selectedRuntime, writeConfig } from "../../lib/config.ts";
-import { capture, firstReadyRuntime, inherit, runtimeIds, runtimes, type ContainerRuntime } from "../../lib/container.ts";
-import { DEFAULT_SANDBOX_IMAGE, SANDBOX_VARIANTS, VARIANT_DESCRIPTIONS, VARIANT_LABELS, variantImage, variantOfImage, type SandboxVariant } from "./images.ts";
+import { capture, firstReadyRuntime, inherit, runtimeIds, runtimes, type CaptureResult, type ContainerRuntime } from "../../lib/container.ts";
+import {
+    DEFAULT_SANDBOX_IMAGE,
+    SANDBOX_VARIANTS,
+    SANDBOX_VERSION_LABEL,
+    VARIANT_DESCRIPTIONS,
+    VARIANT_LABELS,
+    parseSandboxVersion,
+    publishedVersionOfImage,
+    variantImage,
+    variantOfImage,
+    variantRepository,
+    versionedVariantImage,
+    type SandboxVariant,
+} from "./images.ts";
 import { resolvePackagesFile } from "./packages.ts";
 
 /** Flags accepted by `inflexa sandbox pull` (and reused by setup). */
@@ -29,51 +33,80 @@ export type PullOptions = {
     readonly variant?: SandboxVariant;
     /** Skip the pull-size confirmation (also implied non-interactively). */
     readonly yes?: boolean;
-    /** Suppress the streamed pull progress — used when a caller owns its own spinner. */
+    /** Suppress streamed pull progress and informational cleanup messages. */
     readonly quiet?: boolean;
 };
 
-/** The result of a pull, for the caller to report. */
+/** Best-effort post-commit cleanup results. */
+export type CleanupReport = {
+    /** Exact version tags removed successfully. */
+    readonly removed: readonly string[];
+    /** Exact version tags retained because non-forced removal failed. */
+    readonly retained: readonly string[];
+};
+
+/** The result of resolving and committing a published sandbox version. */
 export type PullOutcome =
-    | { readonly type: "up_to_date"; readonly variant: SandboxVariant; readonly image: string }
-    | { readonly type: "pulled"; readonly variant: SandboxVariant; readonly image: string }
+    | {
+          readonly type: "up_to_date" | "pulled";
+          readonly variant: SandboxVariant;
+          readonly image: string;
+          readonly cleanup: CleanupReport;
+      }
     | { readonly type: "declined" };
 
-/**
- * A pull failed. Each variant names one stage (runtime readiness → variant choice
- * → docker pull → config write); the message is user-facing and the optional
- * `cause` carries the underlying throw for logs.
- */
-export type PullError =
+/** A failure from one stage of the published-image transition. */
+export type PullStageError =
     | { readonly type: "runtime_unavailable"; readonly message: string }
     | { readonly type: "no_variant"; readonly message: string }
-    | { readonly type: "pull_failed"; readonly message: string; readonly cause?: unknown }
+    | { readonly type: "pull_failed"; readonly message: string }
+    | { readonly type: "version_unavailable"; readonly message: string }
+    | { readonly type: "tag_failed"; readonly message: string }
+    | { readonly type: "verification_failed"; readonly message: string }
     | { readonly type: "config_write_failed"; readonly message: string; readonly cause?: unknown };
+
+/** A stage failure or the stronger signal that restoring prior local aliases also failed. */
+export type PullError = PullStageError | { readonly type: "rollback_failed"; readonly message: string; readonly original: PullStageError };
+
+/**
+ * Runtime and persistence seams for the published-image transaction. Production
+ * uses the container/config implementations below; tests inject deterministic
+ * Docker- and Podman-shaped command results without touching a daemon.
+ */
+export type PullRuntimeOps = {
+    /** Execute and capture one runtime command. */
+    readonly capture: (rt: ContainerRuntime, args: string[]) => Promise<CaptureResult>;
+    /** Execute a progress-bearing runtime command with inherited stdio. */
+    readonly inherit: (rt: ContainerRuntime, args: string[]) => Promise<number>;
+    /** Read the currently configured execution reference. */
+    readonly configuredImage: () => string;
+    /** Persist a verified execution reference. */
+    readonly configureImage: (image: string) => Result<void, PullStageError>;
+    /** Resolve/cache package inventory for an already-present image. */
+    readonly resolvePackages: (rt: ContainerRuntime, image: string) => Promise<string | null>;
+};
 
 /**
  * The configured sandbox image from the raw config's opaque `harness` block,
- * defaulting to {@link DEFAULT_SANDBOX_IMAGE}. Reads the raw config (not
- * `resolveHarnessConfig`) so this module does not import modules/harness — keeping
- * the dependency one-directional (harness config → this module for the default).
+ * defaulting to the bootstrap channel. This module deliberately does not import
+ * the harness config resolver, preserving the libs → harness dependency direction.
  */
 export function configuredSandboxImage(): string {
-    // `harness` is declared `unknown` in the config schema (validated downstream in
-    // modules/harness/config.ts); read the one field we own defensively.
     const harness = readConfig().harness;
     if (typeof harness === "object" && harness !== null) {
+        // The harness block is deliberately opaque at the shared config layer; this
+        // feature owns and defensively narrows the one field it writes.
         const img = (harness as Record<string, unknown>).sandboxImage;
         if (typeof img === "string" && img.trim() !== "") return img;
     }
     return DEFAULT_SANDBOX_IMAGE;
 }
 
-/**
- * Record `image` as `harness.sandboxImage`, preserving the rest of the opaque
- * `harness` block. The block is `unknown` in the config schema, so we shallow-merge
- * onto whatever object is there (or a fresh one).
- */
-function configureSandboxImage(image: string): Result<void, PullError> {
+/** Persist the sandbox image while preserving every other opaque harness key. */
+function configureSandboxImage(image: string): Result<void, PullStageError> {
     const cfg = readConfig();
+    // The owning harness schema validates this opaque block later; preserving its
+    // existing keys requires a shallow record view after the object guard.
     const harness = typeof cfg.harness === "object" && cfg.harness !== null ? (cfg.harness as Record<string, unknown>) : {};
     return writeConfig({ ...cfg, harness: { ...harness, sandboxImage: image } }).mapErr((e) => ({
         type: "config_write_failed",
@@ -82,45 +115,176 @@ function configureSandboxImage(image: string): Result<void, PullError> {
     }));
 }
 
-/** Whether `rt` already has `image` locally. */
-async function imagePresent(rt: ContainerRuntime, image: string): Promise<boolean> {
-    return (await capture(rt, ["image", "inspect", image])).code === 0;
-}
+const realPullOps: PullRuntimeOps = {
+    capture,
+    inherit,
+    configuredImage: configuredSandboxImage,
+    configureImage: configureSandboxImage,
+    resolvePackages: resolvePackagesFile,
+};
 
-/**
- * Whether `image` is a MOVING reference — a `:latest` tag or no tag at all (which
- * the runtime treats as `:latest`). A moving ref must be re-pulled even when it is
- * present locally, because a newer remote digest can hide behind the same tag; an
- * immutable ref (a pinned `:<version>` tag or an `@sha256:` digest) that is present
- * is already authoritative and needs no pull. The last path segment carries the
- * tag, so a registry `host:port/` prefix never confuses the check.
- */
+/** Whether an image reference is moving (`latest` explicitly or implicitly). */
 export function isMovingTag(image: string): boolean {
-    if (image.includes("@")) return false; // digest pin — immutable
+    if (image.includes("@")) return false;
     const lastSegment = image.slice(image.lastIndexOf("/") + 1);
     const colon = lastSegment.indexOf(":");
     const tag = colon === -1 ? "latest" : lastSegment.slice(colon + 1);
     return tag === "latest";
 }
 
+async function inspectImageId(rt: ContainerRuntime, image: string, ops: PullRuntimeOps): Promise<string | null> {
+    const result = await ops.capture(rt, ["image", "inspect", "--format", "{{.Id}}", image]);
+    return result.code === 0 && result.stdout.trim() !== "" ? result.stdout.trim() : null;
+}
+
+async function rollbackTransition(
+    rt: ContainerRuntime,
+    channel: string,
+    priorChannelId: string | null,
+    uncommittedImage: string | null,
+    priorConfigured: string,
+    original: PullStageError,
+    ops: PullRuntimeOps,
+): Promise<PullError> {
+    const failures: string[] = [];
+
+    if (uncommittedImage !== null && uncommittedImage !== priorConfigured) {
+        const removed = await ops.capture(rt, ["image", "rm", uncommittedImage]);
+        if (removed.code !== 0) failures.push(`could not remove uncommitted tag ${uncommittedImage}`);
+    }
+
+    if (priorChannelId !== null) {
+        const restored = await ops.capture(rt, ["tag", priorChannelId, channel]);
+        if (restored.code !== 0) failures.push(`could not restore ${channel} to ${priorChannelId}`);
+    }
+
+    if (failures.length === 0) return original;
+    return {
+        type: "rollback_failed",
+        message: `${original.message}\n  Rollback was incomplete: ${failures.join("; ")}.`,
+        original,
+    };
+}
+
+async function cleanupSupersededVersions(
+    rt: ContainerRuntime,
+    variant: SandboxVariant,
+    currentImage: string,
+    legacyImageId: string | null,
+    currentImageId: string,
+    ops: PullRuntimeOps,
+): Promise<CleanupReport> {
+    const repository = variantRepository(variant);
+    const listed = await ops.capture(rt, ["image", "ls", "--format", "{{.Repository}}:{{.Tag}}", repository]);
+    const candidates = [
+        ...new Set(
+            (listed.code === 0 ? listed.stdout : "")
+                .split("\n")
+                .map((line) => line.trim())
+                .filter((ref) => {
+                    const parsed = publishedVersionOfImage(ref);
+                    return ref !== currentImage && parsed?.variant === variant;
+                }),
+        ),
+    ];
+    const removed: string[] = [];
+    const retained: string[] = [];
+    for (const image of candidates) {
+        const result = await ops.capture(rt, ["image", "rm", image]);
+        (result.code === 0 ? removed : retained).push(image);
+    }
+    // A legacy `latest` image has no version tag after the channel moves. Its
+    // captured ID is still an exact target; non-forced removal preserves it when
+    // a container or another tag retains a real dependency.
+    if (legacyImageId !== null && legacyImageId !== currentImageId) {
+        const result = await ops.capture(rt, ["image", "rm", legacyImageId]);
+        (result.code === 0 ? removed : retained).push(legacyImageId);
+    }
+    return { removed, retained };
+}
+
 /**
- * Provision the sandbox image. Resolves a variant (prompting interactively when
- * none is given), `docker pull`s the multi-arch image from GHCR, and records it as
- * `harness.sandboxImage`. Because the variant resolves to a moving `:latest` ref,
- * a pull always refreshes to the current remote digest — even when the image is
- * present locally — so `sandbox pull` doubles as the image-upgrade path (a present
- * image transfers only changed layers, so no size prompt). An immutable pinned ref
- * that is already present short-circuits to `up_to_date` with nothing on the wire.
+ * Pull a variant's update channel and atomically commit its stamped version as
+ * the execution reference. This is shared by the public command, setup, and the
+ * required first-launch bootstrap path.
  */
+export async function provisionPublishedVariant(
+    rt: ContainerRuntime,
+    variant: SandboxVariant,
+    opts: Pick<PullOptions, "quiet"> = {},
+    ops: PullRuntimeOps = realPullOps,
+): Promise<Result<Exclude<PullOutcome, { type: "declined" }>, PullError>> {
+    const channel = variantImage(variant);
+    const priorConfigured = ops.configuredImage();
+    const priorChannelId = priorConfigured === channel ? await inspectImageId(rt, channel, ops) : null;
+    const channelWasPresent = (await inspectImageId(rt, channel, ops)) !== null;
+
+    if (!opts.quiet) log.info(`${channelWasPresent ? "Refreshing" : "Pulling"} ${channel} …`);
+    const pullCode = opts.quiet ? (await ops.capture(rt, ["pull", channel])).code : await ops.inherit(rt, ["pull", channel]);
+    if (pullCode !== 0) {
+        return err({
+            type: "pull_failed",
+            message: `\`${rt.bin} pull ${channel}\` exited ${pullCode}. Check your network and that GitHub Packages (ghcr.io) is reachable.`,
+        });
+    }
+
+    const label = await ops.capture(rt, ["image", "inspect", "--format", `{{index .Config.Labels "${SANDBOX_VERSION_LABEL}"}}`, channel]);
+    const version = label.code === 0 ? parseSandboxVersion(label.stdout.trim()) : null;
+    if (version === null) {
+        const failure: PullStageError = {
+            type: "version_unavailable",
+            message: `${channel} does not carry a valid ${SANDBOX_VERSION_LABEL} label.`,
+        };
+        return err(await rollbackTransition(rt, channel, priorChannelId, null, priorConfigured, failure, ops));
+    }
+
+    const pinnedImage = versionedVariantImage(variant, version);
+    const tagged = await ops.capture(rt, ["tag", channel, pinnedImage]);
+    if (tagged.code !== 0) {
+        const failure: PullStageError = {
+            type: "tag_failed",
+            message: `Could not create the local sandbox version tag ${pinnedImage}.`,
+        };
+        return err(await rollbackTransition(rt, channel, priorChannelId, null, priorConfigured, failure, ops));
+    }
+
+    const [channelId, pinnedId] = await Promise.all([inspectImageId(rt, channel, ops), inspectImageId(rt, pinnedImage, ops)]);
+    if (channelId === null || pinnedId === null || channelId !== pinnedId) {
+        const failure: PullStageError = {
+            type: "verification_failed",
+            message: `The local tag ${pinnedImage} does not resolve to the pulled channel image.`,
+        };
+        return err(await rollbackTransition(rt, channel, priorChannelId, pinnedImage, priorConfigured, failure, ops));
+    }
+
+    if ((await ops.resolvePackages(rt, pinnedImage)) === null && !opts.quiet) {
+        log.warn(`${pinnedImage} carries no package inventory — agents will be told the installed set is unknown.`);
+    }
+
+    const configured = ops.configureImage(pinnedImage);
+    if (configured.isErr()) {
+        return err(await rollbackTransition(rt, channel, priorChannelId, pinnedImage, priorConfigured, configured.error, ops));
+    }
+
+    const cleanup = await cleanupSupersededVersions(rt, variant, pinnedImage, priorChannelId, pinnedId, ops);
+    if (cleanup.retained.length > 0 && !opts.quiet) {
+        log.info(`Retained sandbox version(s) still in use: ${cleanup.retained.join(", ")}`);
+    }
+    return ok({
+        type: priorConfigured === pinnedImage ? "up_to_date" : "pulled",
+        variant,
+        image: pinnedImage,
+        cleanup,
+    });
+}
+
+/** Resolve a variant choice, confirm a first download, then provision its published version. */
 export async function sandboxPull(opts: PullOptions = {}): Promise<Result<PullOutcome, PullError>> {
     const interactive = !opts.quiet && process.stdin.isTTY;
-
     const rtResult = await ensureRuntime();
     if (rtResult.isErr()) return err({ type: "runtime_unavailable", message: rtResult.error.message });
     const rt = rtResult.value;
 
-    // Resolve the variant: an explicit choice, else an interactive prompt. A
-    // non-interactive run without a variant cannot proceed (no way to choose).
     let variant = opts.variant ?? null;
     if (variant === null) {
         if (!interactive) {
@@ -136,60 +300,26 @@ export async function sandboxPull(opts: PullOptions = {}): Promise<Result<PullOu
         if (isCancel(chosen)) return ok({ type: "declined" });
         variant = chosen;
     }
-    const image = variantImage(variant);
-    const present = await imagePresent(rt, image);
 
-    // An IMMUTABLE ref that is already present is authoritative — record the config
-    // and pull nothing. A MOVING `:latest` ref falls through to the pull below even
-    // when present, so `sandbox pull` refreshes to the current remote digest.
-    if (present && !isMovingTag(image)) {
-        const configured = configureSandboxImage(image);
-        if (configured.isErr()) return err(configured.error);
-        return ok({ type: "up_to_date", variant, image });
-    }
-
-    // The size confirmation is only for the FIRST (absent) pull — a multi-GB
-    // download. Refreshing a present `:latest` transfers only changed layers (often
-    // nothing), so it runs without the prompt.
+    const channel = variantImage(variant);
+    const present = (await inspectImageId(rt, channel, realPullOps)) !== null;
     if (!present && interactive && !opts.yes) {
-        const proceed = await confirm(`Pull the ${variant} sandbox image (${image})? This may be a multi-GB download.`);
+        const proceed = await confirm(`Pull the ${variant} sandbox image (${channel})? This may be a multi-GB download.`);
         if (!proceed) return ok({ type: "declined" });
     }
-
-    // Stream progress interactively; capture (buffered) when a caller owns the UI.
-    if (!opts.quiet) log.info(`${present ? "Refreshing" : "Pulling"} ${image} …`);
-    const code = opts.quiet ? (await capture(rt, ["pull", image])).code : await inherit(rt, ["pull", image]);
-    if (code !== 0) {
-        return err({
-            type: "pull_failed",
-            message: `\`${rt.bin} pull ${image}\` exited ${code}. Check your network and that GitHub Packages (ghcr.io) is reachable.`,
-        });
-    }
-
-    const configured = configureSandboxImage(image);
-    if (configured.isErr()) return err(configured.error);
-    // Cache the image's package inventory while the image is definitely present. A
-    // failure here is not a failed pull: the harness reports the package set as
-    // unknown and the run proceeds, so it must not turn a good pull into an error.
-    if ((await resolvePackagesFile(rt, image)) === null && !opts.quiet) {
-        log.warn(`${image} carries no package inventory — agents will be told the installed set is unknown.`);
-    }
-    return ok({ type: "pulled", variant, image });
+    return provisionPublishedVariant(rt, variant, { quiet: opts.quiet });
 }
 
-// --- status ------------------------------------------------------------------
-
-/** `inflexa sandbox status` — configured variant, GHCR reference, local presence, digest. */
+/** `inflexa sandbox status` — configured identity, local presence, and image ID. */
 export async function sandboxStatus(): Promise<void> {
     const image = configuredSandboxImage();
     const variant = variantOfImage(image);
+    const published = publishedVersionOfImage(image);
 
     console.log(`  Image    ${image}`);
     console.log(`  Variant  ${variant ?? "(custom — not a published sandbox-python/-r image)"}`);
+    console.log(`  Version  ${published?.version ?? (variant !== null && isMovingTag(image) ? "(unpinned channel)" : "(custom)")}`);
 
-    // Status is a read-only diagnostic: use the selected runtime, or detect a ready
-    // one WITHOUT pinning it — a passive inspection must not write config (that is
-    // ensureRuntime's job, reserved for commands that create runtime-bound state).
     const rt =
         selectedRuntime() ??
         (await firstReadyRuntime(runtimeIds.map((id) => runtimes[id]))).match(
@@ -201,13 +331,12 @@ export async function sandboxStatus(): Promise<void> {
         return;
     }
 
-    // `--format {{.Id}}` prints the local image digest; a non-zero exit means absent.
     const inspect = await capture(rt, ["image", "inspect", "--format", "{{.Id}}", image]);
     if (inspect.code === 0) {
-        console.log(`  Present  yes`);
+        console.log("  Present  yes");
         console.log(`  Digest   ${inspect.stdout.trim()}`);
     } else {
-        console.log(`  Present  no`);
+        console.log("  Present  no");
         console.log(`  Run \`inflexa sandbox pull${variant ? ` ${variant}` : ""}\` to download it.`);
     }
 }

--- a/cli/src/tui/app.launch.tsx
+++ b/cli/src/tui/app.launch.tsx
@@ -45,7 +45,8 @@ async function renderChat(target: ChatTarget): Promise<void> {
     // render() takes the terminal — never inside the alternate screen.
     const cfg = resolveHarnessConfig();
     if (cfg.configError) fail(describeBootError({ type: "harness_config_invalid", issues: cfg.configError.issues }));
-    await ensureSandboxImage(cfg.sandboxImage);
+    const sandboxImage = await ensureSandboxImage(cfg.sandboxImage);
+    const bootConfig = sandboxImage === cfg.sandboxImage ? cfg : { ...cfg, sandboxImage };
 
     // Claim the analysis before the alternate screen takes over, so a conflict surfaces as a plain
     // stderr line and a clean exit — no flash of TUI. Acquiring here (not in the headless resolvers)
@@ -82,7 +83,7 @@ async function renderChat(target: ChatTarget): Promise<void> {
     // so it runs async behind the boot animation with the input gated — hooks/boot.ts drives the
     // boot-state store the App reads. Reached ONLY from renderChat: the passive
     // bare-`inflexa`-resolves-to-nothing path returns before renderChat and boots nothing (no-litter).
-    void startHarnessBoot(cfg);
+    void startHarnessBoot(bootConfig);
 }
 
 /** `inflexa new [name] [paths...]` — create an analysis (anchor = cwd) and open its chat. */

--- a/images/README.md
+++ b/images/README.md
@@ -29,8 +29,9 @@ machinery. Read it before changing anything under `sandbox-base/`.
 
 ## Getting an image
 
-Through the CLI, which also records the pulled tag in `config.json` so sandboxes
-use it:
+Through the CLI, which checks the moving `latest` channel and records the
+resolved `<date>-<sha>` tag in `config.json` so later sandboxes use that exact
+environment:
 
 ```sh
 inflexa sandbox pull python-r     # or: python
@@ -53,7 +54,10 @@ The store is baked and the resolver env is baked in, so a plain `docker run` —
 `list_available_packages` (it reads `/mnt/libs/current/packages.txt`).
 
 Images publish to `ghcr.io/inflexa-ai/sandbox-{base,python,python-r}`, tagged
-`latest` and `<date>-<sha>`.
+`latest` and `<date>-<sha>`. Each selectable platform image carries the same
+release identity in `org.opencontainers.image.version` and the full source
+revision in `org.opencontainers.image.revision`; the CLI reads those labels
+after a multi-arch pull instead of enumerating registry tags.
 
 ## Extending an image (`FROM`)
 

--- a/scripts/lib-store-label-packages.sh
+++ b/scripts/lib-store-label-packages.sh
@@ -15,12 +15,26 @@
 # LABEL cannot read a file at build time, so this is a label-only rebuild: a one-line
 # `FROM <image>` with `--label`, which adds no filesystem layer and re-tags in place.
 #
-# Usage: lib-store-label-packages.sh <image-tag>
+# Usage: lib-store-label-packages.sh <image-tag> <YYYYMMDD-abcdef0> <source-revision>
 set -euo pipefail
 
-IMAGE="${1:?usage: lib-store-label-packages.sh <image-tag>}"
+IMAGE="${1:?usage: lib-store-label-packages.sh <image-tag> <version> <revision>}"
+VERSION="${2:?usage: lib-store-label-packages.sh <image-tag> <version> <revision>}"
+REVISION="${3:?usage: lib-store-label-packages.sh <image-tag> <version> <revision>}"
 LABEL_KEY="ai.inflexa.lib-store.packages"
+VERSION_LABEL="org.opencontainers.image.version"
+REVISION_LABEL="org.opencontainers.image.revision"
 PACKAGES_PATH="/mnt/libs/current/packages.txt"
+
+if [[ ! "$VERSION" =~ ^[0-9]{8}-[0-9a-f]{7}$ ]]; then
+    echo "::error::invalid sandbox image version '$VERSION' (expected YYYYMMDD-7hex)" >&2
+    exit 1
+fi
+
+if [[ ! "$REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error::invalid sandbox source revision '$REVISION' (expected 40 lowercase hex characters)" >&2
+    exit 1
+fi
 
 # Read the baked inventory out of the image. CI may run the image freely — the
 # no-execution constraint applies to user machines, which read the label instead.
@@ -43,5 +57,14 @@ fi
 
 echo "Stamping $(printf '%s' "$PACKAGES" | grep -cE '^[^#[:space:]]') inventory line(s) onto $IMAGE"
 
-# `--label` carries the value through argv, so newlines and quotes need no escaping.
-printf 'FROM %s\n' "$IMAGE" | docker buildx build --load -f - --label "${LABEL_KEY}=${PACKAGES}" -t "$IMAGE" .
+# `--label` carries the inventory through argv, so newlines and quotes need no escaping.
+printf 'FROM %s\n' "$IMAGE" | docker buildx build --load -f - \
+    --label "${LABEL_KEY}=${PACKAGES}" \
+    --label "${VERSION_LABEL}=${VERSION}" \
+    --label "${REVISION_LABEL}=${REVISION}" \
+    -t "$IMAGE" .
+
+# Fail publication at the stamping seam rather than shipping an image the CLI
+# cannot turn into a stable execution reference.
+test "$(docker image inspect --format "{{index .Config.Labels \"${VERSION_LABEL}\"}}" "$IMAGE")" = "$VERSION"
+test "$(docker image inspect --format "{{index .Config.Labels \"${REVISION_LABEL}\"}}" "$IMAGE")" = "$REVISION"


### PR DESCRIPTION
## Summary

- publish immutable sandbox version and revision metadata on built images
- use `latest` only for discovery, then retag and persist the resolved versioned image reference
- verify pulled image identity before committing configuration and roll back safely on failures
- remove superseded versions only within the managed sandbox repository, without global prune or forced deletion
- restore the exact configured image after preflight checks and expose the pinned version in status output
- sync the provisioning specification and archive the completed OpenSpec change

## Why

Persisting `latest` obscured when an installation moved between sandbox releases and made lifecycle cleanup ambiguous. Recording the immutable version makes upgrades observable and provides a safe ownership boundary for removing old images and unused layers.

## Impact

Existing installs continue to pull through `latest`, but successful pulls now update configuration to the resolved version tag. Superseded managed sandbox versions are cleaned up after the new version is committed, while unrelated images and images still referenced by containers are preserved.

## Validation

- `bun run typecheck`
- `bun run lint`
- shell syntax validation for `scripts/lib-store-label-packages.sh`
- 183 CLI regression tests passed
- focused image and preflight tests passed
- `openspec validate --all --strict` — 77 specs passed
- `git diff --check`
