### PR TITLE
fix: make local test runs green on macOS bun and podman

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -23,7 +23,10 @@ bun run typecheck    # tsc --noEmit
 bun run lint         # Run ESLint
 bun run format       # Format all of src/
 bun run docs:gen     # Generate the CLI reference package (dist-docs/, untracked)
+bun run test         # bun test --isolate — see below
 ```
+
+**Local test runs go through `bun run test` (or `bun test --isolate`), never plain `bun test`.** A Bun runtime bug on macOS corrupts child-process pipe capture once certain module graphs have loaded earlier in the run: the children spawn and write their output fine, but the parent reads zero bytes from the pipe, so dozens of spawn-dependent tests (the provenance bridge, `spawnInflexa` process bounds, the embedding launch drain) fail with empty captured output. `--isolate` runs each test file with a fresh global object, which avoids the corruption entirely. CI on Linux is unaffected.
 
 ## Dependencies
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
         "harness:remote": "rm -rf node_modules/@inflexa-ai/harness && bun install",
         "lint": "eslint .",
         "start": "bun run src/index.ts",
-        "test": "bun test",
+        "test": "bun test --isolate",
         "typecheck": "tsc --noEmit",
         "wipe": "bun scripts/wipe.ts"
     },

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -24,7 +24,7 @@ Design decisions are recorded in the OpenSpec specs (`openspec/specs/`), the sin
 
 ```bash
 tsc -p tsconfig.json    # Build: emit dist/ from src/ (also `npm run build`)
-bun test                # Run unit tests (bun:test)
+bun test                # Unit tests only — DB/DBOS suites need Postgres (see Testing notes)
 ```
 
 **Runtime**: Node.js. Bun is used only for testing (`bun test`).
@@ -257,7 +257,7 @@ If the only thing a comment can say is "this used to be X, now it's Y" or "chang
 
 **Test state, not interactions.** Assert on returned values and database state. Do not assert that method X was called N times with arguments Y — this couples tests to implementation details.
 
-**Postgres testcontainer**: Tests that touch the database use `withSchema(testName)` from `__tests__/setup/postgres.ts`. The helper starts a single `pgvector/pgvector:pg18` container per `bun test` run (cold start ~3s on first use; re-used across every test file afterward) and hands each test an isolated schema scoped via `search_path`. Set `CORTEX_TEST_PG_URL=postgres://cortex:dev@localhost:5433/cortex` to skip container startup and point at a locally-running Postgres — instant feedback during tight iteration. Harness modules receive their `Pool` as an injected construction dep (`createPool`), so a test passes the schema-scoped test pool directly into the factory under test — there is no global pool accessor or test-override seam.
+**Postgres testcontainer**: Tests that touch the database use `withSchema(testName)` from `__tests__/setup/postgres.ts`. The helper starts a single `pgvector/pgvector:pg18` container per `bun test` run (cold start ~3s on first use; re-used across every test file afterward) and hands each test an isolated schema scoped via `search_path`. Set `CORTEX_TEST_PG_URL=postgres://cortex:dev@localhost:5433/cortex` to skip container startup and point at a locally-running Postgres — instant feedback during tight iteration. The container fallback needs a reachable Docker API socket, and testcontainers' ryuk reaper container does not come up under podman — so a bare `bun test` on a podman host errors out the entire DB/DBOS portion of the suite, not just one file. The two supported local routes are `bun run test:full`, which starts the one container itself and reaches podman through its docker-compat socket, and exporting `CORTEX_TEST_PG_URL` at an already-running Postgres. `TESTCONTAINERS_RYUK_DISABLED=true` forces the fallback through as a last resort, at the cost of leaving one unreaped container per DB test file. Harness modules receive their `Pool` as an injected construction dep (`createPool`), so a test passes the schema-scoped test pool directly into the factory under test — there is no global pool accessor or test-override seam.
 
 **DBOS testcontainer**: Tests that need a launched DBOS engine use `setupDbosForTests` from `__tests__/setup/dbos.ts`. The rig launches lazily, shares one DBOS engine across `bun test`, and carves out a fresh per-test cortex schema via `withSchema()`. Use it for workflow/runtime-shape tests; pure body-level unit tests should stay on `passthroughStep`.
 

--- a/harness/scripts/test-full.sh
+++ b/harness/scripts/test-full.sh
@@ -24,6 +24,20 @@ if [ -n "${CORTEX_TEST_PG_URL:-}" ]; then
     exec bun test "$@"
 fi
 
+# The `docker` CLI's active context points at Docker Desktop's socket, which is
+# absent on a machine where podman provides the container runtime. A podman
+# machine serves the same Docker API at /var/run/docker.sock, so pinning
+# DOCKER_HOST there aims the CLI at whichever runtime is actually up — and
+# every docker call below, including the trap, inherits it from the process env.
+if ! docker info >/dev/null 2>&1; then
+    if [ -e /var/run/docker.sock ] && DOCKER_HOST=unix:///var/run/docker.sock docker info >/dev/null 2>&1; then
+        export DOCKER_HOST=unix:///var/run/docker.sock
+    else
+        echo "No reachable container runtime: start Docker, or start a podman machine exposing its docker-compat socket at /var/run/docker.sock." >&2
+        exit 1
+    fi
+fi
+
 CID=$(docker run -d --rm \
     -e POSTGRES_USER=cortex -e POSTGRES_PASSWORD=cortex -e POSTGRES_DB=cortex \
     -p 127.0.0.1::5432 \


### PR DESCRIPTION
cli: route local runs through `bun run test` (bun test --isolate). A Bun runtime bug on macOS corrupts child-process pipe capture once certain module graphs have loaded earlier in a shared-process run, failing every spawn-dependent test with empty captured output; per-file isolation avoids it. CI on Linux runs plain `bun test` unaffected.

harness: test-full.sh probes the docker CLI and falls back to podman's docker-compat socket at /var/run/docker.sock when the default context is unreachable. Document that bare `bun test` needs a Postgres: the testcontainers fallback's ryuk reaper does not come up under podman.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
