### PR TITLE
Fix planner terminal submission flow

### DIFF
--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -237,7 +237,13 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         createInspectRunTool(pool),
         // The dataset's own record. No file backs it — the DB row is the only copy.
         createInspectDataProfileTool(pool),
-        createGeneratePlanTool({ provider, pool, model, resourcePolicy, ...(refStorePath ? { refStorePath } : {}), ...(packagesFile ? { packagesFile } : {}) }),
+        createGeneratePlanTool({
+            conversation: { provider, model },
+            pool,
+            resourcePolicy,
+            ...(refStorePath ? { refStorePath } : {}),
+            ...(packagesFile ? { packagesFile } : {}),
+        }),
         createExecuteAnalysisTool({
             pool,
             executeAnalysisWorkflow,

--- a/harness/src/execution/report-runner.test.ts
+++ b/harness/src/execution/report-runner.test.ts
@@ -265,17 +265,12 @@ describe("runReportIteration (closure-state outcome)", () => {
         expect(v1Content).toBe("<html>v1</html>");
     });
 
-    test("phantom-success: submit_report ok but index.html missing → fails", async () => {
+    test("terminal submit stops the agent before post-submit mutations", async () => {
         const { workspaceRoot, resourceId } = await setupSession();
         const previewId = "prv-phantom";
 
-        // Agent calls submit_report without ever writing index.html. The
-        // submit-tool's own pre-check rejects when index.html doesn't exist —
-        // outcome stays undefined → failure classification "did not call submit".
-        // To exercise the phantom-success guard specifically, we instead have
-        // the agent write a zero-byte index.html (passes mtime check inside
-        // submit_report? — no, it checks size>0). So we seed a non-empty file
-        // and delete it after submit_report by overwriting with empty content.
+        // The terminal submit must stop the loop before any later tool call can
+        // mutate the submitted version.
         const provider = scriptedProvider([
             makeMessage(
                 [
@@ -291,17 +286,6 @@ describe("runReportIteration (closure-state outcome)", () => {
                 "tool_use",
             ),
             makeMessage([toolUseBlock("s1", "submit_report", { notes: [] })], "tool_use"),
-            // Truncate to zero after submit.
-            makeMessage(
-                [
-                    toolUseBlock("w2", "write_file", {
-                        path: "index.html",
-                        content: "",
-                    }),
-                ],
-                "tool_use",
-            ),
-            makeMessage([textBlock("done")], "end_turn"),
         ]);
 
         const session = makeSession({
@@ -310,10 +294,6 @@ describe("runReportIteration (closure-state outcome)", () => {
             callPath: ["conversation-agent"],
         });
 
-        // write_file rejects 0-byte content (the tool currently allows empty
-        // strings — Buffer.byteLength("") === 0 and the cap is the upper bound).
-        // The version-fs write_file accepts empty content; the post-truncate
-        // stat in the runner's phantom-success guard catches the empty file.
         const result = await runReportIteration(
             {
                 provider,
@@ -336,11 +316,7 @@ describe("runReportIteration (closure-state outcome)", () => {
             },
         );
 
-        // Phantom-success guard fires: outcome was ok but index.html is empty.
-        expect(result.ok).toBe(false);
-        if (!result.ok) {
-            expect(result.errorKind).toBe("build");
-            expect(result.reason).toContain("index.html");
-        }
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.version).toBe(1);
     });
 });

--- a/harness/src/execution/report-runner.ts
+++ b/harness/src/execution/report-runner.ts
@@ -234,9 +234,9 @@ export async function runReportIteration(deps: ReportRunnerDeps, opts: ReportRun
                     signal: opts.signal,
                     emit: opts.emit,
                     runStep: passthroughStep,
+                    resolved: () => outcome !== undefined,
                 },
                 {
-                    resolved: () => outcome !== undefined,
                     tools: [buildReportTool, submitReportTool],
                     nudge:
                         "You stopped without calling submit_report, so this report version " +

--- a/harness/src/execution/run-synthesis.ts
+++ b/harness/src/execution/run-synthesis.ts
@@ -481,10 +481,10 @@ export async function generateRunSynthesis(input: GenerateRunSynthesisInput): Pr
         signal,
         emit,
         runStep: passthroughStep,
+        resolved: () => holder.outcome !== null,
     } as const;
 
     await runToTerminal(agent, [{ role: "user", content: prompt }], input.session, loopDeps, {
-        resolved: () => holder.outcome !== null,
         tools: [submitTool, blockerTool],
         nudge:
             "You ended without calling a terminal tool. You MUST call " +

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -56,6 +56,15 @@ export interface RunAgentOptions {
     readonly runStep: RunStep;
     readonly formatStepName?: StepNameFormatter;
     readonly isFatalLoopError?: (err: unknown) => boolean;
+    /** Tool-selection policy for in-loop model calls. The cap wrap-up remains
+     * tool-less regardless. */
+    readonly toolChoice?: ChatRequest["toolChoice"];
+    /**
+     * Optional outcome predicate for loop-driving agents whose result is
+     * recorded by a tool into closure state. Checked immediately after each
+     * dispatch round, once every sibling tool result has been appended.
+     */
+    readonly resolved?: () => boolean;
     /**
      * Prompt-cache policy for every LLM call this run makes. Defaults to
      * `DEFAULT_PROMPT_CACHE` (5m) — an agent loop always re-sends its prefix, so
@@ -133,6 +142,11 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
         return { messages, finish: { reason: "denied", cappedOut: false, truncationRecoveries } };
     };
+    const stopOnResolved = async (i: number): Promise<RunAgentResult> => {
+        await emit({ type: "iteration", source, index: i, final: true });
+        recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
+        return { messages, finish: { reason: "stop", cappedOut: false, truncationRecoveries } };
+    };
 
     for (let i = 0; i < agent.maxIterations; i++) {
         iterations = i + 1;
@@ -140,6 +154,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             system: agent.systemPrompt,
             messages,
             tools: toolDefs,
+            ...(opts.toolChoice !== undefined ? { toolChoice: opts.toolChoice } : {}),
             providerOptions,
         };
         const reply = await resultStep(runStep)(formatStepName.llm(i), () => provider.chat(request, session, signal));
@@ -190,6 +205,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             results.push(errorResult(trailing, TRUNCATED_TOOL_USE_ERROR));
             messages.push({ role: "tool", content: results });
             if (hasDenial(results)) return stopOnDenial(i);
+            if (opts.resolved?.()) return stopOnResolved(i);
             continue;
         }
 
@@ -216,6 +232,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         }
         messages.push({ role: "tool", content: results });
         if (hasDenial(results)) return stopOnDenial(i);
+        if (opts.resolved?.()) return stopOnResolved(i);
     }
 
     // Cache defeater (known; not fixed here). Emptying the tool set changes the

--- a/harness/src/loop/run-to-terminal.test.ts
+++ b/harness/src/loop/run-to-terminal.test.ts
@@ -58,9 +58,9 @@ describe("runToTerminal", () => {
                 emit: () => {},
                 runStep: passthroughStep,
                 toolChoice: "required",
+                resolved: () => cell.value !== null,
             },
             {
-                resolved: () => cell.value !== null,
                 tools: [submitTool(cell)],
                 nudge: NUDGE,
             },
@@ -96,8 +96,9 @@ describe("runToTerminal", () => {
                 signal: new AbortController().signal,
                 emit: () => {},
                 runStep: passthroughStep,
+                resolved: () => cell.value !== null,
             },
-            { resolved: () => cell.value !== null, tools: [tool], nudge: NUDGE },
+            { tools: [tool], nudge: NUDGE },
         );
 
         expect(cell.value).toBe("salvaged");
@@ -118,8 +119,9 @@ describe("runToTerminal", () => {
                 signal: ac.signal,
                 emit: () => {},
                 runStep: passthroughStep,
+                resolved: () => cell.value !== null,
             },
-            { resolved: () => cell.value !== null, tools: [submitTool(cell)], nudge: NUDGE },
+            { tools: [submitTool(cell)], nudge: NUDGE },
         );
 
         expect(cell.value).toBeNull();
@@ -145,8 +147,9 @@ describe("runToTerminal", () => {
                 signal: new AbortController().signal,
                 emit: () => {},
                 runStep,
+                resolved: () => cell.value !== null,
             },
-            { resolved: () => cell.value !== null, tools: [tool], nudge: NUDGE },
+            { tools: [tool], nudge: NUDGE },
         );
 
         // First run used bare `llm-0`; the salvage run's steps are all prefixed,

--- a/harness/src/loop/run-to-terminal.test.ts
+++ b/harness/src/loop/run-to-terminal.test.ts
@@ -57,6 +57,7 @@ describe("runToTerminal", () => {
                 signal: new AbortController().signal,
                 emit: () => {},
                 runStep: passthroughStep,
+                toolChoice: "required",
             },
             {
                 resolved: () => cell.value !== null,
@@ -66,6 +67,10 @@ describe("runToTerminal", () => {
         );
 
         expect(cell.value).toBe("done");
+        // The terminal tool ends the loop itself; no acknowledgement call is
+        // spent after the closure outcome is recorded.
+        expect(provider.calls).toHaveLength(1);
+        expect(provider.calls[0]!.toolChoice).toBe("required");
         // No salvage continuation — the nudge never reaches the provider.
         const sawNudge = provider.calls.some((c) => c.messages.some((m) => m.content === NUDGE));
         expect(sawNudge).toBe(false);

--- a/harness/src/loop/run-to-terminal.ts
+++ b/harness/src/loop/run-to-terminal.ts
@@ -61,7 +61,11 @@ export async function runToTerminal(
     opts: RunAgentOptions,
     salvage: TerminalSalvage,
 ): Promise<RunAgentResult> {
-    const first = await runAgent(agent, initial, session, opts);
+    const terminalOpts: RunAgentOptions = {
+        ...opts,
+        resolved: salvage.resolved,
+    };
+    const first = await runAgent(agent, initial, session, terminalOpts);
     if (salvage.resolved() || opts.signal.aborted) return first;
 
     const salvageAgent: AgentDefinition = {
@@ -70,7 +74,7 @@ export async function runToTerminal(
         maxIterations: salvage.maxIterations ?? DEFAULT_SALVAGE_ITERATIONS,
     };
     const salvageOpts: RunAgentOptions = {
-        ...opts,
+        ...terminalOpts,
         formatStepName: salvageStepNames(opts.formatStepName ?? DEFAULT_STEP_NAME_FORMATTER),
     };
     return runAgent(salvageAgent, [...first.messages, { role: "user", content: salvage.nudge }], session, salvageOpts);

--- a/harness/src/loop/run-to-terminal.ts
+++ b/harness/src/loop/run-to-terminal.ts
@@ -31,8 +31,6 @@ export const DEFAULT_SALVAGE_ITERATIONS = 3;
 
 /** Describes how to salvage a run that never reached its terminal tool. */
 export interface TerminalSalvage {
-    /** True once the agent recorded its terminal outcome (reads the closure cell). */
-    readonly resolved: () => boolean;
     /** Terminal tools offered on the salvage turn (submit / blocker / …). Must be
      *  the same instances the first run used — they close over the outcome cell. */
     readonly tools: readonly Tool[];
@@ -61,12 +59,8 @@ export async function runToTerminal(
     opts: RunAgentOptions,
     salvage: TerminalSalvage,
 ): Promise<RunAgentResult> {
-    const terminalOpts: RunAgentOptions = {
-        ...opts,
-        resolved: salvage.resolved,
-    };
-    const first = await runAgent(agent, initial, session, terminalOpts);
-    if (salvage.resolved() || opts.signal.aborted) return first;
+    const first = await runAgent(agent, initial, session, opts);
+    if (opts.resolved?.() || opts.signal.aborted) return first;
 
     const salvageAgent: AgentDefinition = {
         ...agent,
@@ -74,7 +68,7 @@ export async function runToTerminal(
         maxIterations: salvage.maxIterations ?? DEFAULT_SALVAGE_ITERATIONS,
     };
     const salvageOpts: RunAgentOptions = {
-        ...terminalOpts,
+        ...opts,
         formatStepName: salvageStepNames(opts.formatStepName ?? DEFAULT_STEP_NAME_FORMATTER),
     };
     return runAgent(salvageAgent, [...first.messages, { role: "user", content: salvage.nudge }], session, salvageOpts);

--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -52,29 +52,24 @@ your work is discarded and the user sees nothing. Every session MUST end
 with exactly one call to \`submit_plan\`, \`request_clarification\`, or
 \`report_blocker\`.
 
-Your very first action must be either \`validate_plan\` (to test a draft)
+Your very first action must be either \`submit_plan\`
 or \`request_clarification\` / \`report_blocker\` (if you cannot draft one).
 Do NOT respond with text before any tool call.
 
 ## Canonical Flow
 
-The plan's shape is the \`validate_plan\` / \`submit_plan\` arg schema —
-read it, and fill every field it declares.
+The plan's shape is the \`submit_plan\` arg schema — read it, and fill
+every field it declares.
 
-\`validate_plan(draft)\` → inspect issues → \`validate_plan(fixed)\` →
-\`valid: true\` → \`submit_plan(fixed)\` → \`accepted: true\`. STOP.
-
-\`validate_plan\` is cheap, deterministic, and non-terminal — call it as
-many times as needed. You MUST get \`valid: true\` from it before calling
-\`submit_plan\`. If issues come back, fix the specific field at the given
-path and validate again.
+\`submit_plan(candidate)\` → if rejected, inspect its structured \`issues\`,
+fix the specific fields, and call \`submit_plan\` again →
+\`accepted: true\`. STOP.
 
 Typical run: 2–4 tool calls total. Every run ends with ONE terminal
 tool call. No exceptions.
 
 ## Do NOT
 - Respond with plain text (even to explain the plan — the user never sees it).
-- Call \`submit_plan\` without first getting \`valid: true\` from \`validate_plan\`.
 - Call any terminal tool twice.
 - Continue generating after \`submit_plan\` returned \`accepted: true\`.
 - End the session without a terminal tool call. That is a failure mode.
@@ -264,7 +259,6 @@ question or data context explicitly supports them.
 - Produce vague step descriptions
 - Ignore prior run results mentioned in context
 - Generate a plan without referencing specific data characteristics
-- Call \`submit_plan\` without first calling \`validate_plan\`
 - Respond with prose instead of a tool call
 `;
 }

--- a/harness/src/schemas/workflow-state.ts
+++ b/harness/src/schemas/workflow-state.ts
@@ -11,8 +11,8 @@ import { z } from "zod";
 
 /**
  * A step of an analysis plan. `PlanStepSchema` (schemas/plan-schemas.ts) narrows
- * this into the planner's output contract and emits it as the `validate_plan` /
- * `submit_plan` arg schema — so each field's meaning belongs in `.describe()`,
+ * this into the planner's output contract and emits it as the `submit_plan`
+ * arg schema — so each field's meaning belongs in `.describe()`,
  * not in a comment the model never sees.
  */
 export const AnalysisStepSchema = z.object({

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -358,9 +358,9 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                     signal,
                     emit: () => {},
                     runStep: durableStep,
+                    resolved: () => capturedProfile !== null,
                 },
                 {
-                    resolved: () => capturedProfile !== null,
                     tools: [submitProfileTool],
                     nudge:
                         "You stopped without calling submit_profile, so no profile was " +

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -198,9 +198,8 @@ describe("generatePlan loop-driving tool", () => {
     // never a positional index into a snapshot that does not exist.
     function refsProbe(): ScriptedProvider {
         return scriptedProvider((callIndex) => {
-            if (callIndex === 0) return makeMessage([toolUseBlock("t1", "list_available_refs", { query: "regulon" })], "tool_use");
-            if (callIndex === 1) return makeMessage([toolUseBlock("t2", "report_blocker", { reason: "probe only" })], "tool_use");
-            // A third call would mean the terminal outcome failed to stop the loop.
+            if (callIndex === 0) return makeMessage([toolUseBlock("t1", "report_blocker", { reason: "probe only" })], "tool_use");
+            // A second call would mean the terminal outcome failed to stop the loop.
             return makeMessage([textBlock("Reported.")], "end_turn");
         });
     }
@@ -218,7 +217,8 @@ describe("generatePlan loop-driving tool", () => {
         const provider = refsProbe();
         await createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, refStorePath: root }).execute(INPUT, toolContext());
 
-        expect(Object.keys(provider.calls[0]!.tools)).toContain("list_available_refs");
+        expect(Object.keys(provider.calls[0]!.tools)).not.toContain("list_available_refs");
+        expect(Object.keys(provider.calls[0]!.tools)).toEqual(expect.arrayContaining(["submit_plan", "request_clarification", "report_blocker"]));
         expect(transcript(provider)).toContain("/mnt/refs/managed/collectri-human/2.0/CollecTRI_regulons.csv");
         // The planner sees the same meaning-bearing labels a sandbox agent does.
         expect(transcript(provider)).toContain("regulon");

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import type { ToolResultPart } from "ai";
 import type { Pool } from "pg";
 
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
@@ -43,33 +42,6 @@ const INPUT = {
     researchQuestion: "Which genes are differentially expressed?",
 };
 
-interface ValidateOutput {
-    valid: boolean;
-    issues: { path: string; code: "schema" | "semantic"; message: string }[];
-}
-
-/** The tool-result part the loop fed back to the model for `toolName`. */
-function toolResultFor(provider: ScriptedProvider, toolName: string): ToolResultPart | undefined {
-    for (const call of provider.calls) {
-        for (const message of call.messages) {
-            if (message.role !== "tool") continue;
-            const part = message.content.find((p) => p.type === "tool-result" && p.toolName === toolName);
-            if (part) return part as ToolResultPart;
-        }
-    }
-    return undefined;
-}
-
-/** Read a successful tool result's JSON payload, failing loudly on an error result. */
-function validateOutput(provider: ScriptedProvider): ValidateOutput {
-    const part = toolResultFor(provider, "validate_plan");
-    expect(part).toBeDefined();
-    // "error-text" is what the loop's Zod boundary emits when it rejects input
-    // before `execute` — validate_plan must never bounce a candidate that way.
-    expect(part!.output.type).toBe("json");
-    return (part!.output as { type: "json"; value: unknown }).value as ValidateOutput;
-}
-
 /** The seed the planner was actually handed — the bytes the model saw, not what the caller passed. */
 function plannerSeed(provider: ScriptedProvider): string {
     const first = provider.calls[0]?.messages[0];
@@ -85,15 +57,6 @@ function dataContextBlock(seed: string): string {
     const rest = seed.slice(start + "## Data Context".length);
     const end = rest.indexOf("\n## ");
     return end === -1 ? rest : rest.slice(0, end);
-}
-
-/** Script: validate a candidate, then bail out terminally so nothing is persisted. */
-function validateThenBlock(candidate: unknown): ScriptedProvider {
-    return scriptedProvider([
-        makeMessage([toolUseBlock("t1", "validate_plan", { plan: candidate })], "tool_use"),
-        makeMessage([toolUseBlock("t2", "report_blocker", { reason: "measurement complete" })], "tool_use"),
-        makeMessage([textBlock("Reported.")], "end_turn"),
-    ]);
 }
 
 /** Script: bail out terminally on the first turn — the seed is all this measures. */
@@ -191,7 +154,7 @@ describe("generatePlan loop-driving tool", () => {
 
     /** Rebuild the tool per test — the provider is the only thing that varies. */
     function toolFor(provider: ScriptedProvider): Tool {
-        return createGeneratePlanTool({ provider, pool, model: "claude-test" });
+        return createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool });
     }
 
     // ── Outcome shaping ──────────────────────────────────────────────
@@ -213,6 +176,8 @@ describe("generatePlan loop-driving tool", () => {
 
         expect(result.event).toBe("error");
         expect(result.error).toBe("Data is incompatible with every available agent.");
+        expect(provider.calls).toHaveLength(1);
+        expect(provider.calls[0]!.toolChoice).toBe("required");
 
         // The planner ran on a derived child Session, offered every terminal tool. Only the
         // terminal set is asserted: those are what can record an outcome, so a missing one
@@ -235,8 +200,7 @@ describe("generatePlan loop-driving tool", () => {
         return scriptedProvider((callIndex) => {
             if (callIndex === 0) return makeMessage([toolUseBlock("t1", "list_available_refs", { query: "regulon" })], "tool_use");
             if (callIndex === 1) return makeMessage([toolUseBlock("t2", "report_blocker", { reason: "probe only" })], "tool_use");
-            // Without a terminal end_turn the loop keeps requesting tools until it hits
-            // its iteration cap — the blocker records an outcome, it does not stop the loop.
+            // A third call would mean the terminal outcome failed to stop the loop.
             return makeMessage([textBlock("Reported.")], "end_turn");
         });
     }
@@ -252,7 +216,7 @@ describe("generatePlan loop-driving tool", () => {
         await writeFile(join(root, "managed", "collectri-human", "2.0", "CollecTRI_regulons.csv"), "source,target");
 
         const provider = refsProbe();
-        await createGeneratePlanTool({ provider, pool, model: "claude-test", refStorePath: root }).execute(INPUT, toolContext());
+        await createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, refStorePath: root }).execute(INPUT, toolContext());
 
         expect(Object.keys(provider.calls[0]!.tools)).toContain("list_available_refs");
         expect(transcript(provider)).toContain("/mnt/refs/managed/collectri-human/2.0/CollecTRI_regulons.csv");
@@ -286,42 +250,6 @@ describe("generatePlan loop-driving tool", () => {
         expect(result.question).toBe("Which two conditions should be contrasted?");
     });
 
-    it("validate_plan reports a malformed candidate as data instead of rejecting it at the input boundary", async () => {
-        // Structurally broken: no title, steps is not an array. A strict
-        // inputSchema would bounce this at the loop's Zod boundary and never
-        // reach `execute` — leaving the planner with nothing to fix.
-        const provider = validateThenBlock({ steps: "one DE step", analytical_narrative: 42 });
-
-        await toolFor(provider).execute(INPUT, toolContext());
-
-        const output = validateOutput(provider);
-        expect(output.valid).toBe(false);
-        expect(output.issues.length).toBeGreaterThan(0);
-        expect(output.issues.some((i) => i.code === "schema")).toBe(true);
-        expect(output.issues.every((i) => i.path.startsWith("plan"))).toBe(true);
-    });
-
-    it("validate_plan reports semantic issues a schema cannot express", async () => {
-        // Schema-valid, semantically broken: depends_on points at a step that
-        // does not exist in the plan.
-        const provider = validateThenBlock(validCandidate({ depends_on: ["T9S9"] }));
-
-        await toolFor(provider).execute(INPUT, toolContext());
-
-        const output = validateOutput(provider);
-        expect(output.valid).toBe(false);
-        expect(output.issues.some((i) => i.code === "semantic")).toBe(true);
-        expect(JSON.stringify(output.issues)).toContain("T9S9");
-    });
-
-    it("validate_plan accepts a clean candidate", async () => {
-        const provider = validateThenBlock(validCandidate());
-
-        await toolFor(provider).execute(INPUT, toolContext());
-
-        expect(validateOutput(provider)).toEqual({ valid: true, issues: [] });
-    });
-
     it("errors when the planner ends without a terminal tool call", async () => {
         // Prose every turn — including the terminal-salvage continuation — so no
         // terminal outcome is ever recorded.
@@ -337,7 +265,7 @@ describe("generatePlan loop-driving tool", () => {
 
     describe("data context", () => {
         it("takes no dataset field from the caller at all", () => {
-            const schema = createGeneratePlanTool({ provider: scriptedProvider([]), pool, model: "claude-test" }).jsonSchema as {
+            const schema = createGeneratePlanTool({ conversation: { provider: scriptedProvider([]), model: "claude-test" }, pool }).jsonSchema as {
                 properties: Record<string, unknown>;
                 required?: string[];
             };
@@ -379,11 +307,7 @@ describe("generatePlan loop-driving tool", () => {
             // A real analysis with a NULL profile status — the honest "never profiled"
             // state `loadDataProfileStatus` collapses to null.
             await seedAnalysis(pool, analysisId, { dpStatus: null });
-            const provider = scriptedProvider([
-                makeMessage([toolUseBlock("t1", "validate_plan", { plan: validCandidate() })], "tool_use"),
-                makeMessage([toolUseBlock("t2", "submit_plan", { plan: validCandidate() })], "tool_use"),
-                makeMessage([textBlock("Submitted.")], "end_turn"),
-            ]);
+            const provider = scriptedProvider([makeMessage([toolUseBlock("t1", "submit_plan", { plan: validCandidate() })], "tool_use")]);
 
             const result = (await toolFor(provider).execute(INPUT, toolContext(analysisId)))._unsafeUnwrap() as PlanResult;
 

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -11,11 +11,10 @@
  * database already holds, and it would lose fidelity at every hop.
  *
  * The tool drives an internal "planner" agent that communicates outcomes
- * EXCLUSIVELY via four terminal tool calls:
+ * EXCLUSIVELY via three terminal tool calls:
  *
- *   - validate_plan(plan)       → non-terminal dry-run: an any-shape candidate
- *                                 in, {valid, issues} out (schema + semantic)
- *   - submit_plan(plan)         → terminal success: re-validates + persists
+ *   - submit_plan(plan)         → terminal success: re-validates + persists;
+ *                                 rejected candidates return structured issues
  *   - request_clarification(…)  → terminal: planner needs more context
  *   - report_blocker(reason)    → terminal: no viable plan
  *
@@ -59,8 +58,8 @@ import { insertPlan, loadDataProfileStatus, loadPlan, type DataProfileResult, ty
 const PLANNER_AGENT_ID = "planner";
 
 /**
- * Budget for the planner's internal loop: 1 draft + ~3 validate/fix
- * cycles + 1 submit + headroom.
+ * Budget for the planner's internal loop: one draft/submit attempt plus
+ * correction retries and headroom.
  */
 const PLANNER_MAX_ITERATIONS = 13;
 
@@ -344,8 +343,7 @@ function fullyValidate(candidate: unknown, resourcePolicy?: ResourcePolicy): { v
 /**
  * The planner's inner tools. `all` is the full surface handed to the loop;
  * `terminal` is the subset that records an outcome (`submit_plan`,
- * `request_clarification`, `report_blocker`) — `validate_plan` is a
- * non-terminal dry-run and is excluded. The terminal subset is what the
+ * `request_clarification`, `report_blocker`). The terminal subset is what the
  * salvage turn re-offers if the planner ends without an outcome.
  */
 interface InnerTools {
@@ -367,31 +365,6 @@ function buildInnerTools(
     // of adjacent optional strings, which would be silently swappable at the call site.
     stores: EnvironmentStorePaths,
 ): InnerTools {
-    const validatePlanTool = defineTool({
-        id: "validate_plan",
-        description:
-            "Dry-run a candidate plan and get back everything that is wrong with it. " +
-            "Takes the plan in ANY shape: a malformed, partial, or wrong-typed " +
-            "candidate is REPORTED, not rejected. Returns {valid, issues[]} covering " +
-            "both schema problems (missing / wrong-typed fields) and the semantic " +
-            "checks a schema cannot express (unknown agent IDs, DAG cycles, dangling " +
-            "depends_on references, duplicate step IDs, resource ceilings). The " +
-            "authoritative field-by-field plan schema is the arg schema of " +
-            "submit_plan — this tool deliberately does not restate it. Non-terminal: " +
-            "call as often as needed to iterate toward a clean plan, then submit_plan.",
-        // Deliberately permissive: a structurally-invalid candidate must reach
-        // `execute` so the model gets a structured {valid:false, issues} result —
-        // including semantic issues — instead of a bare Zod rejection at the loop's
-        // input boundary. `execute` re-parses against PlannerPlanSchema itself.
-        inputSchema: z.object({
-            plan: z.unknown().describe("The candidate plan, in any shape. Field-by-field schema: see submit_plan."),
-        }),
-        execute: async (input) => {
-            const result = fullyValidate(input.plan, resourcePolicy);
-            return ok(result.valid ? { valid: true as const, issues: [] as ValidationIssue[] } : { valid: false as const, issues: result.issues });
-        },
-    });
-
     const submitPlanTool = defineTool({
         id: "submit_plan",
         description:
@@ -400,9 +373,16 @@ function buildInnerTools(
             "rejection returns {accepted: false, issues} — fix and call again, " +
             "or switch to report_blocker if the plan cannot be made valid. This " +
             "arg schema is the authoritative plan contract.",
-        // Strict: a malformed plan must not reach submission. `execute` still
-        // re-validates (schema + semantic) — it does not lean on this boundary.
-        inputSchema: z.object({ plan: PlannerPlanSchema }),
+        // Permissive on purpose: every candidate reaches `execute`, where the
+        // model gets structured schema and semantic issues in one response.
+        // The field-by-field contract remains visible in this tool's description
+        // and the validation below is authoritative.
+        inputSchema: z.object({
+            // Keep the authoritative shape visible to the model while the
+            // permissive branch lets malformed candidates reach execute for
+            // structured issue reporting.
+            plan: z.union([PlannerPlanSchema, z.unknown()]).describe("Candidate plan; malformed values are reported in issues."),
+        }),
         execute: async (input): Promise<Result<SubmitPlanOutput, ToolError>> => {
             if (holder.outcome !== null) {
                 return ok({
@@ -489,7 +469,7 @@ function buildInnerTools(
     const listAvailablePackages = createListAvailablePackagesTool(stores.packagesFile === undefined ? {} : { packagesFile: stores.packagesFile });
 
     const terminal = [submitPlanTool, requestClarificationTool, reportBlockerTool];
-    return { all: [validatePlanTool, listAvailableRefs, listAvailablePackages, ...terminal], terminal };
+    return { all: [listAvailableRefs, listAvailablePackages, ...terminal], terminal };
 }
 
 // ── Outcome shaping ─────────────────────────────────────────────────
@@ -549,15 +529,20 @@ function shapeOutcome(args: ShapeOutcomeArgs): PlanningAgentOutput {
 // ── Outer tool ──────────────────────────────────────────────────────
 
 export interface GeneratePlanDeps extends EnvironmentStorePaths {
-    /** The LLM seam the planner loop runs on. */
-    readonly provider: ChatProvider;
+    /**
+     * The conversation-role backend the planner is pinned to. Keeping the
+     * provider and its model label in one value prevents composition roots from
+     * accidentally pairing the planner with the sandbox or utility role.
+     */
+    readonly conversation: {
+        readonly provider: ChatProvider;
+        readonly model: string;
+    };
     /** Database pool — plan persistence and prior-plan loading. */
     readonly pool: Pool;
-    /** Model id — provenance / metric label; the provider owns the wire model. */
-    readonly model: string;
     /**
      * Host resource policy — stated to the planner as concrete per-step
-     * ceilings and enforced by `validate_plan`. Absent, the prompt keeps its
+     * ceilings and enforced by `submit_plan`. Absent, the prompt keeps its
      * default guidance and validation skips the ceiling check.
      */
     readonly resourcePolicy?: ResourcePolicy;
@@ -663,7 +648,7 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),
-                model: deps.model,
+                model: deps.conversation.model,
                 tools: innerTools.all,
                 maxIterations: PLANNER_MAX_ITERATIONS,
             };
@@ -679,10 +664,14 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                     [{ role: "user", content: prompt }],
                     forSubAgent(ctx.session, PLANNER_AGENT_ID),
                     {
-                        provider: deps.provider,
+                        provider: deps.conversation.provider,
                         signal,
                         emit: ctx.emit,
                         runStep: passthroughStep,
+                        // Planner prose is unusable: every meaningful outcome is
+                        // a tool call, and the terminal predicate stops the loop
+                        // as soon as one is recorded.
+                        toolChoice: "required",
                     },
                     {
                         resolved: () => holder.outcome !== null,

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -668,13 +668,13 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                         signal,
                         emit: ctx.emit,
                         runStep: passthroughStep,
+                        resolved: () => holder.outcome !== null,
                         // Planner prose is unusable: every meaningful outcome is
                         // a tool call, and the terminal predicate stops the loop
                         // as soon as one is recorded.
                         toolChoice: "required",
                     },
                     {
-                        resolved: () => holder.outcome !== null,
                         tools: innerTools.terminal,
                         nudge:
                             "You ended without a terminal outcome. Call submit_plan with " +

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -626,7 +626,10 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             // the loop and put their rendered content in the planner's seed.
             const listAvailableRefs = createListAvailableRefsTool(deps.refStorePath === undefined ? {} : { refStorePath: deps.refStorePath });
             const listAvailablePackages = createListAvailablePackagesTool(deps.packagesFile === undefined ? {} : { packagesFile: deps.packagesFile });
-            const [refsResult, packagesResult] = await Promise.all([listAvailableRefs.execute({}, ctx), listAvailablePackages.execute({}, ctx)]);
+            // A path-separator query matches every reference path and selects the
+            // tool's recursive leaf scan, so the seed contains usable file paths,
+            // not only top-level directory summaries.
+            const [refsResult, packagesResult] = await Promise.all([listAvailableRefs.execute({ query: "/" }, ctx), listAvailablePackages.execute({}, ctx)]);
             const groundingBlock = [inventoryContent("Available Reference Data", refsResult), inventoryContent("Available Packages", packagesResult)].join(
                 "\n\n",
             );

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -341,13 +341,12 @@ function fullyValidate(candidate: unknown, resourcePolicy?: ResourcePolicy): { v
 // ── Inner tools (fresh instance per outer tool invocation) ─────────
 
 /**
- * The planner's inner tools. `all` is the full surface handed to the loop;
- * `terminal` is the subset that records an outcome (`submit_plan`,
- * `request_clarification`, `report_blocker`). The terminal subset is what the
- * salvage turn re-offers if the planner ends without an outcome.
+ * The planner's inner tools. Only terminal tools enter the loop
+ * (`submit_plan`, `request_clarification`, `report_blocker`); environment
+ * inventories are read before the loop and injected into its seed message.
+ * The terminal list is re-offered if salvage is needed.
  */
 interface InnerTools {
-    readonly all: Tool[];
     readonly terminal: Tool[];
 }
 
@@ -356,15 +355,7 @@ interface InnerTools {
  * shared `holder` so the outer `execute` reads the terminal outcome after the
  * loop finishes.
  */
-function buildInnerTools(
-    holder: OutcomeHolder,
-    persistCtx: PersistContext,
-    pool: Pool,
-    resourcePolicy: ResourcePolicy | undefined,
-    // The two environment stores travel together as one bag rather than as a pair
-    // of adjacent optional strings, which would be silently swappable at the call site.
-    stores: EnvironmentStorePaths,
-): InnerTools {
+function buildInnerTools(holder: OutcomeHolder, persistCtx: PersistContext, pool: Pool, resourcePolicy: ResourcePolicy | undefined): InnerTools {
     const submitPlanTool = defineTool({
         id: "submit_plan",
         description:
@@ -460,16 +451,17 @@ function buildInnerTools(
             "could fix and submit.",
     });
 
-    // Environment discovery is non-terminal and read-only: it lets the planner check what
-    // reference data this environment holds, and what a step will actually be able to
-    // import, before committing a step to needing either. Both read host-side, so no
-    // sandbox exists or is needed at plan time — which is the whole point, since a plan
-    // that assumes an absent package fails only once the run reaches that step.
-    const listAvailableRefs = createListAvailableRefsTool(stores.refStorePath === undefined ? {} : { refStorePath: stores.refStorePath });
-    const listAvailablePackages = createListAvailablePackagesTool(stores.packagesFile === undefined ? {} : { packagesFile: stores.packagesFile });
-
     const terminal = [submitPlanTool, requestClarificationTool, reportBlockerTool];
-    return { all: [listAvailableRefs, listAvailablePackages, ...terminal], terminal };
+    return { terminal };
+}
+
+function inventoryContent(label: string, result: Awaited<ReturnType<Tool["execute"]>>): string {
+    if (result.isErr()) return `## ${label}\n\nInventory lookup failed: ${result.error.error}`;
+    const value = result.value;
+    if (typeof value === "object" && value !== null && "content" in value && typeof value.content === "string") {
+        return `## ${label}\n\n${value.content}`;
+    }
+    return `## ${label}\n\n${JSON.stringify(value)}`;
 }
 
 // ── Outcome shaping ─────────────────────────────────────────────────
@@ -629,9 +621,21 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             const profileStatus = await loadDataProfileStatus(deps.pool, analysisId).unwrapOr(null);
             const dataContextBlock = renderDataContext(classifyGrounding(profileStatus));
 
+            // Reference data and package availability are mandatory grounding,
+            // not optional planner lookups. Read both inventories host-side before
+            // the loop and put their rendered content in the planner's seed.
+            const listAvailableRefs = createListAvailableRefsTool(deps.refStorePath === undefined ? {} : { refStorePath: deps.refStorePath });
+            const listAvailablePackages = createListAvailablePackagesTool(deps.packagesFile === undefined ? {} : { packagesFile: deps.packagesFile });
+            const [refsResult, packagesResult] = await Promise.all([listAvailableRefs.execute({}, ctx), listAvailablePackages.execute({}, ctx)]);
+            const groundingBlock = [inventoryContent("Available Reference Data", refsResult), inventoryContent("Available Packages", packagesResult)].join(
+                "\n\n",
+            );
+
             const prompt = [
                 ...(priorPlanBlock ? [priorPlanBlock, ""] : []),
                 ...(dataContextBlock ? [dataContextBlock, ""] : []),
+                groundingBlock,
+                "",
                 "## Research Question",
                 input.researchQuestion,
                 ...(input.analystNotes ? ["", "## Analyst Notes (from the user — facts about the data the profile does not record)", input.analystNotes] : []),
@@ -644,12 +648,12 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 analysisId,
                 parentPlanId: input.parentPlanId ?? null,
             };
-            const innerTools = buildInnerTools(holder, persistCtx, deps.pool, deps.resourcePolicy, deps);
+            const innerTools = buildInnerTools(holder, persistCtx, deps.pool, deps.resourcePolicy);
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),
                 model: deps.conversation.model,
-                tools: innerTools.all,
+                tools: innerTools.terminal,
                 maxIterations: PLANNER_MAX_ITERATIONS,
             };
 


### PR DESCRIPTION
## What changed

- Remove the separate validate_plan tool and make submit_plan return structured schema and semantic issues for correction.
- Pin the internal planner to the conversation provider/model pair.
- Require tool-driven planner completion and stop immediately after a terminal outcome.
- Avoid unnecessary salvage turns after a successful terminal submission.

## Why

Planner runs could spend turns validating separately, continue after recording an outcome, or hit timeout/iteration limits while recovering from provider/tool behavior. The new flow submits, corrects from returned issues, and terminates as soon as the outcome is recorded.

## Validation

- bun run build (harness)
- 42 focused harness tests passing (run-agent, run-to-terminal, conversation-agent)
- git diff --check

The database-backed planner tests require a container runtime, which is unavailable in this environment.