### PR TITLE
feat(harness): add deferred tool loading hints

### DIFF
--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -117,6 +117,16 @@ describe("createConversationAgent", () => {
         }
     });
 
+    test("defers the broad research catalog while keeping orchestration tools eager", () => {
+        const tools = new Map(buildAgent().tools.map((tool) => [tool.id, tool]));
+        for (const id of ["search_gene", "pubmed", "chembl", "comptox", "literature_reviewer", "generate_analogy_report"]) {
+            expect(tools.get(id)?.deferLoading, id).toBe(true);
+        }
+        for (const id of ["list_available_refs", "inspect_data_profile", "generate_plan", "execute_analysis", "show_user", "workspace_search"]) {
+            expect(tools.get(id)?.deferLoading, id).toBe(false);
+        }
+    });
+
     test("tool ids are unique and definitions() emits valid AI SDK schemas", () => {
         const agent = buildAgent();
         // createRegistry throws on a duplicate id.

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -194,35 +194,36 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
     const workingMemory = createWorkingMemory(pool);
     const ncbi = createNcbiTools(bioKeys);
     const chemDb = createChemDbTools(bioKeys);
+    const deferred = (tool: Tool): Tool => ({ ...tool, deferLoading: true });
 
     const tools: Tool[] = [
         // Bio-lookup.
-        searchGeneTool,
-        searchPathwayTool,
-        lookupGoTermTool,
-        searchInteractionsTool,
+        deferred(searchGeneTool),
+        deferred(searchPathwayTool),
+        deferred(lookupGoTermTool),
+        deferred(searchInteractionsTool),
         // Literature (search / details / fulltext behind one action).
-        ncbi.pubmed,
+        deferred(ncbi.pubmed),
         // ChEMBL (compounds / drug / mechanism / bioactivity / targets behind one action).
-        chemblTool,
+        deferred(chemblTool),
         // PubChem (compound / crossrefs / assays behind one action).
-        pubchemTool,
+        deferred(pubchemTool),
         // Translational medicine.
-        openTargetsTool,
+        deferred(openTargetsTool),
         // Genetic evidence — SNP-trait associations for target validation / MR support.
-        searchGwasCatalogTool,
-        searchPharmgkbTool,
-        searchFaersTool,
-        searchClinicalTrialsTool,
-        searchGeoDatasetsTool,
-        createSearchDgidbTool({ ...(deps.logger ? { logger: deps.logger } : {}) }),
+        deferred(searchGwasCatalogTool),
+        deferred(searchPharmgkbTool),
+        deferred(searchFaersTool),
+        deferred(searchClinicalTrialsTool),
+        deferred(searchGeoDatasetsTool),
+        deferred(createSearchDgidbTool({ ...(deps.logger ? { logger: deps.logger } : {}) })),
         // Preclinical.
-        searchBgeeExpressionTool,
-        getImpcKoProfileTool,
+        deferred(searchBgeeExpressionTool),
+        deferred(getImpcKoProfileTool),
         // Off-target liability.
-        checkSafetyPanelTool,
+        deferred(checkSafetyPanelTool),
         // EPA CompTox (toxcast / hazard / chemical / exposure behind one dataset).
-        chemDb.comptox,
+        deferred(chemDb.comptox),
         // What reference data this install actually holds. The conversation agent is
         // where provisioning is decided — an embedder may give it a way to install more,
         // and a host that does asks the user to approve the download. Deciding that
@@ -268,9 +269,9 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         createShowPlanTool(pool),
         showFileTool,
         // Batch literature/biology research (sub-agent as a loop-driving tool).
-        createLiteratureReviewerTool({ provider, model, bioKeys }),
+        deferred(createLiteratureReviewerTool({ provider, model, bioKeys })),
         // Cross-domain analogy generation (sub-agent as a loop-driving tool).
-        createGenerateAnalogyReportTool({ provider, model, bioKeys }),
+        deferred(createGenerateAnalogyReportTool({ provider, model, bioKeys })),
         // Workspace semantic search + raw read/grep over the read seam.
         createWorkspaceSearchTool(pool, embedding),
         createReadFileTool(workspaceFs),

--- a/harness/src/loop/__fixtures__/scripted-provider.ts
+++ b/harness/src/loop/__fixtures__/scripted-provider.ts
@@ -5,7 +5,7 @@ import type { AgentSession as Session } from "../../auth/types.js";
 
 export type TextBlock = { type: "text"; text: string };
 export type ThinkingBlock = { type: "reasoning"; text: string; providerOptions?: { anthropic: { signature: string } } };
-export type ToolUseBlock = { type: "tool-call"; toolCallId: string; toolName: string; input: unknown };
+export type ToolUseBlock = { type: "tool-call"; toolCallId: string; toolName: string; input: unknown; providerExecuted?: boolean };
 export type ContentBlock = TextBlock | ThinkingBlock | ToolUseBlock;
 
 function mapFinishReason(finishReason: ChatResponse["finishReason"] | "tool_use" | "end_turn" | "max_tokens" | "refusal"): ChatResponse["finishReason"] {
@@ -43,8 +43,8 @@ export function thinkingBlock(thinking: string, signature: string): ThinkingBloc
     return { type: "reasoning", text: thinking, providerOptions: { anthropic: { signature } } };
 }
 
-export function toolUseBlock(id: string, name: string, input: unknown): ToolUseBlock {
-    return { type: "tool-call", toolCallId: id, toolName: name, input };
+export function toolUseBlock(id: string, name: string, input: unknown, providerExecuted = false): ToolUseBlock {
+    return { type: "tool-call", toolCallId: id, toolName: name, input, ...(providerExecuted ? { providerExecuted: true } : {}) };
 }
 
 export interface ScriptedProvider extends ChatProvider {

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -196,6 +196,43 @@ describe("runAgent — provider capability gate", () => {
     });
 });
 
+describe("runAgent — deferred tool loading", () => {
+    it("forwards one stable loading plan on every ordinary model call", async () => {
+        const deferredEcho = defineTool({
+            id: "echo",
+            description: "Echo the label.",
+            inputSchema: z.object({ label: z.string() }),
+            deferLoading: true,
+            execute: async ({ label }) => ok({ label }),
+        });
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "echo", { label: "x" })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        await runAgent(agentDef([deferredEcho]), GO, makeSession(), opts(provider));
+
+        expect(provider.calls[0]!.deferredToolNames).toEqual(["echo"]);
+        expect(provider.calls[1]!.deferredToolNames).toBe(provider.calls[0]!.deferredToolNames);
+    });
+
+    it("does not dispatch provider-executed tool-search calls", async () => {
+        const provider = scriptedProvider([
+            makeMessage(
+                [toolUseBlock("srv-1", "__harness_anthropic_tool_search", { query: "echo" }, true), toolUseBlock("tu-1", "echo", { label: "x" })],
+                "tool_use",
+            ),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const { messages } = await runAgent(agentDef([echoTool()]), GO, makeSession(), opts(provider));
+
+        const results = toolResultParts(messages[2]);
+        expect(results.map((result) => result.toolCallId)).toEqual(["tu-1"]);
+        expect(outputValue(results[0]!)).toEqual({ label: "x" });
+    });
+});
+
 // ── executionMode partition (see the harness-tools spec) ─────────────
 
 describe("runAgent — workflow tools run unwrapped, in order", () => {

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -98,6 +98,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             }),
         ]),
     );
+    const deferredToolNames = agent.tools.filter((tool) => tool.deferLoading).map((tool) => tool.id);
 
     // Approval resolves once to the caller's seam, or the deny-by-default one
     // when it wires none: a tool that pauses for a user decision where no
@@ -140,6 +141,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             system: agent.systemPrompt,
             messages,
             tools: toolDefs,
+            deferredToolNames,
             providerOptions,
         };
         const reply = await resultStep(runStep)(formatStepName.llm(i), () => provider.chat(request, session, signal));
@@ -225,7 +227,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // because it is the one call whose write is pure waste, and the
     // cache_write_tokens counter is what makes that waste visible.
     const wrapUp = await resultStep(runStep)(formatStepName.llm(agent.maxIterations), () =>
-        provider.chat({ system: agent.systemPrompt, messages, tools: {}, toolChoice: "none", providerOptions }, session, signal),
+        provider.chat({ system: agent.systemPrompt, messages, tools: {}, deferredToolNames: [], toolChoice: "none", providerOptions }, session, signal),
     );
     addChatUsage(usage, wrapUp.usage);
 
@@ -251,7 +253,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
 
 function toolCallParts(message: Extract<ModelMessage, { role: "assistant" }>): ToolCallPart[] {
     if (typeof message.content === "string") return [];
-    return message.content.filter((part): part is ToolCallPart => part.type === "tool-call");
+    return message.content.filter((part): part is ToolCallPart => part.type === "tool-call" && part.providerExecuted !== true);
 }
 
 /** Whether an aborted partial carries any content worth persisting — an empty partial contributes no message. */

--- a/harness/src/providers/ai-sdk.ts
+++ b/harness/src/providers/ai-sdk.ts
@@ -9,8 +9,9 @@ import { scopeWorkloadId, type AgentSession } from "../auth/types.js";
 import type { ResolveBilling } from "../billing/resolver.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { prepareAnthropicDeferredTools } from "./deferred-tools.js";
 import { classifyProviderError, type ProviderError, toProviderError } from "./errors.js";
-import type { ChatProvider, ChatRequest, ChatResponse, ChatStreamEvent, ChatUsage, FetchLike, ProviderCapabilities } from "./types.js";
+import type { ChatProvider, ChatRequest, ChatResponse, ChatStreamEvent, ChatUsage, FetchLike, ProviderCapabilities, ToolSet } from "./types.js";
 
 /**
  * The harness-owned retry envelope. The AI SDK's built-in retry exposes only a
@@ -28,6 +29,7 @@ export interface AiSdkProviderDeps {
     readonly model: LanguageModel;
     readonly resolveBilling: ResolveBilling;
     readonly capabilities?: Partial<ProviderCapabilities>;
+    readonly prepareTools?: (tools: ToolSet, deferredToolNames: readonly string[]) => ToolSet;
     readonly logger?: Logger;
 }
 
@@ -297,6 +299,19 @@ function sanitizeMessages(messages: readonly ModelMessage[]): ModelMessage[] {
 export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
     const capabilities: ProviderCapabilities = { toolCalling: deps.capabilities?.toolCalling ?? true };
     const logger = (deps.logger ?? createNoopLogger()).named("providers.ai-sdk");
+    const preparedTools = new WeakMap<ToolSet, Map<string, ToolSet>>();
+
+    function toolsFor(req: ChatRequest): ToolSet {
+        if (deps.prepareTools === undefined || req.deferredToolNames === undefined || req.deferredToolNames.length === 0) return req.tools;
+        const key = [...req.deferredToolNames].sort().join("\0");
+        const byLoadingPlan = preparedTools.get(req.tools);
+        const cached = byLoadingPlan?.get(key);
+        if (cached !== undefined) return cached;
+        const tools = deps.prepareTools(req.tools, req.deferredToolNames);
+        if (byLoadingPlan === undefined) preparedTools.set(req.tools, new Map([[key, tools]]));
+        else byLoadingPlan.set(key, tools);
+        return tools;
+    }
 
     function chat(req: ChatRequest, session: AgentSession, signal?: AbortSignal): ResultAsync<ChatResponse, ProviderError> {
         const run = async (): Promise<Result<ChatResponse, ProviderError>> => {
@@ -310,7 +325,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                         model: deps.model,
                         system: req.system,
                         messages: sanitizeMessages(req.messages),
-                        tools: req.tools,
+                        tools: toolsFor(req),
                         toolChoice: req.toolChoice ?? "auto",
                         stopWhen: [],
                         // The harness envelope owns retries; leaving the SDK default in
@@ -347,7 +362,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                     model: deps.model,
                     system: req.system,
                     messages: sanitizeMessages(req.messages),
-                    tools: req.tools,
+                    tools: toolsFor(req),
                     toolChoice: req.toolChoice ?? "auto",
                     stopWhen: [],
                     maxRetries: 0,
@@ -430,6 +445,7 @@ export function createConfiguredAiSdkProvider(deps: ConfiguredAiSdkProviderDeps)
             model: provider.chat(config.model),
             resolveBilling: deps.resolveBilling,
             capabilities: config.capabilities,
+            prepareTools: prepareAnthropicDeferredTools,
             logger: deps.logger,
         });
     }

--- a/harness/src/providers/configured-provider.barrel.test.ts
+++ b/harness/src/providers/configured-provider.barrel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { jsonSchema, tool as aiTool } from "ai";
 
 import { createConfiguredAiSdkProvider } from "@inflexa-ai/harness";
 import type { AiSdkProviderConfig, ChatRequest, ConfiguredAiSdkProviderDeps } from "@inflexa-ai/harness";
@@ -46,12 +47,12 @@ function openaiJson(text: string, model: string): Response {
  * provider bound at construction (the request itself carries no model field),
  * and replies with a response echoing that body's `model`.
  */
-function capturingFetch(respond: (text: string, model: string) => Response): { fetch: FetchLike; bodies: Array<{ model?: string }> } {
-    const bodies: Array<{ model?: string }> = [];
+function capturingFetch(respond: (text: string, model: string) => Response): { fetch: FetchLike; bodies: Array<Record<string, unknown>> } {
+    const bodies: Array<Record<string, unknown>> = [];
     const fetch: FetchLike = async (_input, init) => {
-        const body = init?.body ? (JSON.parse(String(init.body)) as { model?: string }) : {};
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
         bodies.push(body);
-        return respond("Hello, world", body.model ?? "");
+        return respond("Hello, world", typeof body.model === "string" ? body.model : "");
     };
     return { fetch, bodies };
 }
@@ -60,6 +61,16 @@ const request: ChatRequest = {
     system: "You are a test model.",
     messages: [{ role: "user", content: "Say hello." }],
     tools: {},
+};
+const requestWithDeferredTool: ChatRequest = {
+    ...request,
+    tools: {
+        search_gene: aiTool({
+            description: "Search for a gene.",
+            inputSchema: jsonSchema({ type: "object", properties: { query: { type: "string" } } }),
+        }),
+    },
+    deferredToolNames: ["search_gene"],
 };
 
 describe("provider configuration front door", () => {
@@ -105,6 +116,81 @@ describe("provider configuration front door", () => {
             message: { role: "assistant", content: [{ type: "text", text: "Hello, world" }] },
         });
         expect(provider.capabilities.toolCalling).toBe(true);
+    });
+
+    it("realizes deferred tools as Anthropic tool search plus defer_loading", async () => {
+        const cap = capturingFetch(anthropicJson);
+        const provider = createConfiguredAiSdkProvider({
+            config: {
+                kind: "anthropic",
+                baseURL: "http://models.local/anthropic",
+                apiKey: "test-key",
+                model: "claude-opus-4-7",
+                fetch: cap.fetch,
+            },
+            resolveBilling: async () => ({}),
+        });
+
+        const result = await provider.chat(requestWithDeferredTool, makeSession());
+
+        expect(result.isOk()).toBe(true);
+        const tools = cap.bodies[0]!.tools as Array<Record<string, unknown>>;
+        expect(tools).toContainEqual(
+            expect.objectContaining({
+                name: "search_gene",
+                defer_loading: true,
+            }),
+        );
+        expect(tools).toContainEqual(
+            expect.objectContaining({
+                type: "tool_search_tool_bm25_20251119",
+                name: "tool_search_tool_bm25",
+            }),
+        );
+    });
+
+    it("passes deferred-tool metadata through for any Anthropic model", async () => {
+        const cap = capturingFetch(anthropicJson);
+        const provider = createConfiguredAiSdkProvider({
+            config: {
+                kind: "anthropic",
+                baseURL: "http://models.local/anthropic",
+                apiKey: "test-key",
+                model: "claude-opus-4-1",
+                fetch: cap.fetch,
+            },
+            resolveBilling: async () => ({}),
+        });
+
+        const result = await provider.chat(requestWithDeferredTool, makeSession());
+
+        expect(result.isOk()).toBe(true);
+        const tools = cap.bodies[0]!.tools as Array<Record<string, unknown>>;
+        expect(tools).toContainEqual(expect.objectContaining({ name: "search_gene", defer_loading: true }));
+        expect(tools).toContainEqual(expect.objectContaining({ type: "tool_search_tool_bm25_20251119" }));
+    });
+
+    it("keeps deferred hints eager on an OpenAI-compatible provider", async () => {
+        const cap = capturingFetch(openaiJson);
+        const provider = createConfiguredAiSdkProvider({
+            config: {
+                kind: "openai-compatible",
+                name: "self-hosted",
+                baseURL: "http://models.local/v1",
+                apiKey: "test-key",
+                model: "local-tool-model",
+                fetch: cap.fetch,
+            },
+            resolveBilling: async () => ({}),
+        });
+
+        const result = await provider.chat(requestWithDeferredTool, makeSession());
+
+        expect(result.isOk()).toBe(true);
+        const body = JSON.stringify(cap.bodies[0]);
+        expect(body).not.toContain("defer_loading");
+        expect(body).not.toContain("tool_search");
+        expect(cap.bodies[0]!.tools).toHaveLength(1);
     });
 
     it("builds two provider instances over one connection, each carrying its own bound model", async () => {

--- a/harness/src/providers/deferred-tools.ts
+++ b/harness/src/providers/deferred-tools.ts
@@ -1,0 +1,40 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import type { ToolSet } from "ai";
+
+const TOOL_SEARCH_KEY = "__harness_anthropic_tool_search";
+
+/**
+ * Build the Anthropic realization of the harness's neutral deferred-tool hint.
+ *
+ * The full catalog still goes over the wire. Anthropic excludes marked tools
+ * from the initial model context, then its server-side BM25 tool discovers and
+ * expands matching definitions as provider-executed tool-reference blocks.
+ */
+export function prepareAnthropicDeferredTools(tools: ToolSet, deferredToolNames: readonly string[]): ToolSet {
+    const deferred = new Set(deferredToolNames.filter((name) => tools[name] !== undefined));
+    if (deferred.size === 0) return tools;
+    if (tools[TOOL_SEARCH_KEY] !== undefined) {
+        throw new Error(`Tool id "${TOOL_SEARCH_KEY}" is reserved for Anthropic deferred-tool search`);
+    }
+
+    const prepared: ToolSet = {};
+    for (const [name, definition] of Object.entries(tools)) {
+        if (!deferred.has(name)) {
+            prepared[name] = definition;
+            continue;
+        }
+        const providerOptions = definition.providerOptions;
+        prepared[name] = {
+            ...definition,
+            providerOptions: {
+                ...providerOptions,
+                anthropic: {
+                    ...(providerOptions?.anthropic ?? {}),
+                    deferLoading: true,
+                },
+            },
+        };
+    }
+    prepared[TOOL_SEARCH_KEY] = anthropic.tools.toolSearchBm25_20251119();
+    return prepared;
+}

--- a/harness/src/providers/types.ts
+++ b/harness/src/providers/types.ts
@@ -23,6 +23,11 @@ export interface ChatRequest {
     readonly system: string;
     readonly messages: readonly ModelMessage[];
     readonly tools: ToolSet;
+    /**
+     * Tool names a capable provider may expose through on-demand discovery.
+     * Unsupported providers ignore the hint and send every definition eagerly.
+     */
+    readonly deferredToolNames?: readonly string[];
     readonly toolChoice?: "auto" | "none" | "required" | { readonly type: "tool"; readonly toolName: string };
     readonly providerOptions?: ProviderOptions;
 }

--- a/harness/src/tools/define-tool.test.ts
+++ b/harness/src/tools/define-tool.test.ts
@@ -37,6 +37,25 @@ describe("defineTool", () => {
         expect(tool.executionMode).toBe("step");
     });
 
+    it("defaults to eager loading and preserves an explicit deferred hint", () => {
+        const eager = defineTool({
+            id: "eager-tool",
+            description: "Loaded in the initial context.",
+            inputSchema: z.object({}),
+            execute: async () => ok({ done: true }),
+        });
+        const deferred = defineTool({
+            id: "deferred-tool",
+            description: "Discoverable on demand.",
+            inputSchema: z.object({}),
+            deferLoading: true,
+            execute: async () => ok({ done: true }),
+        });
+
+        expect(eager.deferLoading).toBe(false);
+        expect(deferred.deferLoading).toBe(true);
+    });
+
     it("preserves explicit workflow and inline execution modes", () => {
         const workflow = defineTool({
             id: "workflow-tool",

--- a/harness/src/tools/define-tool.ts
+++ b/harness/src/tools/define-tool.ts
@@ -85,6 +85,12 @@ export interface Tool<Input = unknown, Output = unknown> {
     readonly inputSchema: z.ZodType;
     readonly jsonSchema: Record<string, unknown>;
     readonly executionMode: ToolExecutionMode;
+    /**
+     * Hint that a capable provider may keep this definition out of the initial
+     * model context and make it discoverable on demand. Providers without
+     * deferred-tool support send it eagerly, so this never removes capability.
+     */
+    readonly deferLoading?: boolean;
     execute(input: Input, ctx: ToolContext): Promise<Result<Output, ToolError>>;
 }
 
@@ -93,6 +99,7 @@ export interface ToolDefinition<Schema extends z.ZodType, Output> {
     readonly description: string;
     readonly inputSchema: Schema;
     readonly executionMode?: ToolExecutionMode;
+    readonly deferLoading?: boolean;
     execute(input: z.infer<Schema>, ctx: ToolContext): Promise<Result<Output, ToolError>>;
 }
 
@@ -125,6 +132,7 @@ export function defineTool<Schema extends z.ZodType, Output>(def: ToolDefinition
         inputSchema: def.inputSchema,
         jsonSchema,
         executionMode,
+        deferLoading: def.deferLoading ?? false,
         execute: def.execute,
     };
 }


### PR DESCRIPTION
## Summary

- Add a vendor-neutral `deferLoading` hint to harness tool definitions and forward it through `ChatRequest`.
- Realize deferred Anthropic tools with the AI SDK's server-side BM25 tool search; unsupported provider adapters remain eager.
- Mark broad conversation research tools as deferred while keeping orchestration and workspace tools eager.
- Ignore provider-executed tool-search calls in the local dispatch loop.

## Why

Large tool catalogs consume prompt context even when most tools are irrelevant to a turn. This lets capable Anthropic requests discover broad research tools on demand without changing focused agents or making OpenAI-compatible providers depend on Anthropic-specific behavior.

## Validation

- `bunx tsc -p tsconfig.json --noEmit`
- Focused deferred-tool, provider, agent-loop, and prompt-cache tests: all passing
- `npm run build`
- Changed-file ESLint passing

Repository-wide lint is currently blocked by the existing ESLint typed-rule configuration on `scripts/smoke.mjs`; the full test suite also requires a container runtime for database/DBOS tests.
