### PR TITLE
fix(harness): store message envelopes as json so turns survive verbatim

### DIFF
--- a/harness/src/input-sanitization.test.ts
+++ b/harness/src/input-sanitization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { normalizeUnicode, redactSecrets } from "./input-sanitization.js";
+import { normalizeUnicode, redactSecrets, stripNulCharacters } from "./input-sanitization.js";
 
 describe("redactSecrets", () => {
     const cases: ReadonlyArray<{ label: string; secret: string }> = [
@@ -63,5 +63,24 @@ describe("normalizeUnicode", () => {
 
     it("leaves newline and tab intact", () => {
         expect(normalizeUnicode("a\nb\tc")).toBe("a\nb\tc");
+    });
+});
+
+describe("stripNulCharacters", () => {
+    const NUL = String.fromCharCode(0);
+
+    it("removes every NUL from a string", () => {
+        expect(stripNulCharacters(`MAGIC${NUL}rest${NUL}${NUL}end`)).toBe("MAGICrestend");
+    });
+
+    it("leaves a string with no NUL untouched", () => {
+        expect(stripNulCharacters("plain\ttext\nhere")).toBe("plain\ttext\nhere");
+    });
+
+    it("keeps the other control characters a tool result may legitimately carry", () => {
+        // Unlike `normalizeUnicode`, this strips ONE character — an ANSI escape or
+        // a form feed in captured stdout is content, and storage accepts it.
+        const ESC = String.fromCharCode(0x1b);
+        expect(stripNulCharacters(`a${ESC}[0mb`)).toBe(`a${ESC}[0mb`);
     });
 });

--- a/harness/src/input-sanitization.ts
+++ b/harness/src/input-sanitization.ts
@@ -1,9 +1,10 @@
 /**
- * Input sanitization — two pure, always-on functions applied once to the
- * incoming user message by the chat route (change 6). Never applied to
- * assistant messages or tool results.
+ * Input sanitization — pure, always-on text functions, not a plug-in pipeline.
+ * What runs is exactly what is declared here.
  *
- * Two pure functions, not a plug-in pipeline. What runs is exactly these two.
+ * `normalizeUnicode` and `redactSecrets` are applied once to the incoming user
+ * message by the chat route (change 6), and never to assistant messages or tool
+ * results. `stripNulCharacters` is the exception — it applies to tool results.
  */
 
 /**
@@ -22,6 +23,30 @@ const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
  */
 export function normalizeUnicode(text: string): string {
     return text.normalize("NFC").replace(CONTROL_CHARS, "");
+}
+
+/**
+ * NUL (U+0000) — the one character a stored message cannot carry. Postgres
+ * refuses it inside JSON: a `jsonb` column rejects the insert outright, and a
+ * `json` column accepts it but errors the moment a JSON operator reads that row
+ * ("U+0000 cannot be converted to text"), which is what `retractLastTurn`'s
+ * boundary predicate does. Either way one NUL byte poisons a thread, and it
+ * arrives through no fault of the model: tool results carry raw command output
+ * and file bytes, which is why they are otherwise left unsanitized.
+ */
+// eslint-disable-next-line no-control-regex -- matching NUL is the intent; see above.
+const NUL = /\u0000/g;
+
+/**
+ * Strip every NUL from `text`. Applied where a tool result is built — so the
+ * loop's in-memory message and the stored row agree byte-for-byte and the
+ * prompt-cache prefix survives the round trip — and again where the turn is
+ * written, which holds the invariant for writers that are not the loop. User
+ * input needs no separate treatment: `normalizeUnicode` already strips NUL along
+ * with the rest of the C0 range.
+ */
+export function stripNulCharacters(text: string): string {
+    return text.replace(NUL, "");
 }
 
 /**

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -290,6 +290,48 @@ describe("runAgent — tool-error boundary", () => {
         expect(outputValue(result)).toEqual({ answer: 42 });
     });
 
+    it("strips NUL from a tool result so the turn can be stored", async () => {
+        // A NUL byte cannot survive the message store, and tool results are the one
+        // message content built from raw command output and file bytes.
+        const NUL = String.fromCharCode(0);
+        const binary = defineTool({
+            id: "binary_tool",
+            description: "Returns bytes read off disk.",
+            inputSchema: z.object({}),
+            execute: async () => ok({ header: `MAGIC${NUL}rest`, lines: [`a${NUL}b`] }),
+        });
+        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-1", "binary_tool", {})], "tool_use"), makeMessage([textBlock("done")], "end_turn")]);
+
+        const { messages } = await runAgent(agentDef([binary]), GO, makeSession(), opts(provider));
+
+        const result = toolResultParts(messages[2])[0]!;
+        expect(outputValue(result)).toEqual({ header: "MAGICrest", lines: ["ab"] });
+        expect(JSON.stringify(messages)).not.toContain("\\u0000");
+    });
+
+    it("strips NUL from a thrown tool error's message", async () => {
+        const NUL = String.fromCharCode(0);
+        const noisy = defineTool({
+            id: "noisy_tool",
+            description: "Throws with stderr quoted verbatim.",
+            inputSchema: z.object({}),
+            execute: async () => {
+                throw new Error(`segfault${NUL} core dumped`);
+            },
+        });
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "noisy_tool", {})], "tool_use"),
+            makeMessage([textBlock("recovered")], "end_turn"),
+        ]);
+
+        const { messages } = await runAgent(agentDef([noisy]), GO, makeSession(), opts(provider));
+
+        const result = toolResultParts(messages[2])[0]!;
+        expect(isErrorResult(result)).toBe(true);
+        expect(String(outputValue(result))).toContain("segfault core dumped");
+        expect(JSON.stringify(messages)).not.toContain("\\u0000");
+    });
+
     it("maps an err(ToolError) Result to an is_error tool_result verbatim", async () => {
         const errTool = defineTool({
             id: "err_tool",

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -2,6 +2,7 @@ import { jsonSchema, tool as aiTool, type FinishReason, type ToolSet, type ToolC
 import type { z } from "zod";
 
 import type { AgentSession } from "../auth/types.js";
+import { stripNulCharacters } from "../input-sanitization.js";
 import { hintForZodIssue, repairToolInput } from "../lib/zod-issues.js";
 import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-message-storage.js";
 import { classifyProviderError } from "../providers/errors.js";
@@ -368,8 +369,14 @@ async function execute(tu: ToolCallPart, tool: Tool, input: unknown, ctx: ToolCo
     }
 }
 
+/**
+ * Normalize a tool's return value to plain JSON, stripping NUL from every string
+ * it holds ({@link stripNulCharacters}). The reviver sees values, not keys — a
+ * NUL in an object KEY would still reach the row, but keys come from tool result
+ * types rather than scanned bytes, so nothing produces one.
+ */
 function jsonValue(value: unknown) {
-    return JSON.parse(JSON.stringify(value ?? null));
+    return JSON.parse(JSON.stringify(value ?? null), (_key, v: unknown) => (typeof v === "string" ? stripNulCharacters(v) : v));
 }
 
 function successResult(toolCall: ToolCallPart, value: unknown): ToolResultPart {
@@ -381,12 +388,15 @@ function successResult(toolCall: ToolCallPart, value: unknown): ToolResultPart {
     };
 }
 
+// NUL is stripped from the prose BEFORE it is serialized: past the stringify it
+// is the six-character escape \u0000 — legitimate JSON text, and no longer
+// distinguishable from an error that happens to quote that escape.
 function toolErrorContent(value: unknown): string {
     if (isToolError(value)) {
-        return JSON.stringify({ error: value.error, retryable: value.retryable });
+        return JSON.stringify({ error: stripNulCharacters(value.error), retryable: value.retryable });
     }
     const { retryable } = classifyProviderError(value);
-    const error = value instanceof Error ? value.message : String(value);
+    const error = stripNulCharacters(value instanceof Error ? value.message : String(value));
     return JSON.stringify({ error, retryable });
 }
 
@@ -395,7 +405,8 @@ function errorResult(toolCall: ToolCallPart, content: string): ToolResultPart {
         type: "tool-result",
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
-        output: { type: "error-text", value: content },
+        // A thrown tool error routinely quotes stderr verbatim — as exposed to NUL as a success payload.
+        output: { type: "error-text", value: stripNulCharacters(content) },
     };
 }
 

--- a/harness/src/memory/message-backfill.ts
+++ b/harness/src/memory/message-backfill.ts
@@ -28,7 +28,7 @@ export async function backfillAiSdkMessageEnvelopes(client: PoolClient): Promise
                 role: row.role,
                 content: row.content_jsonb,
             });
-            await client.query("UPDATE messages SET message_envelope = $1::jsonb WHERE thread_id = $2 AND seq = $3::bigint", [
+            await client.query("UPDATE messages SET message_envelope = $1::json WHERE thread_id = $2 AND seq = $3::bigint", [
                 JSON.stringify(envelopeMessage(message)),
                 row.thread_id,
                 row.seq,

--- a/harness/src/memory/thread-history.test.ts
+++ b/harness/src/memory/thread-history.test.ts
@@ -148,6 +148,115 @@ describe("appendTurn / loadRecent round-trip", () => {
     });
 });
 
+// --- marshalling fidelity (prompt-cache regression guard) -------------------
+
+/**
+ * Assert a loaded window matches what was sent as SERIALIZED BYTES — the form
+ * the provider receives, and the form its prompt cache keys on. `toEqual` is
+ * key-order-blind and cannot see a store that re-sorts object keys, which is
+ * exactly what a re-sent prefix must not do.
+ */
+function assertMarshalsVerbatim(sent: readonly ModelMessage[], loaded: readonly ModelMessage[]): void {
+    expect(loaded).toHaveLength(sent.length);
+    for (const [i, message] of sent.entries()) {
+        expect(JSON.stringify(loaded[i])).toBe(JSON.stringify(message));
+    }
+}
+
+describe("envelope marshalling fidelity", () => {
+    it("re-sends a persisted tool-calling turn byte-identical to the turn it stored", async () => {
+        // Keys deliberately out of alphabetical and length order — a store that
+        // sorts them rewrites every one of these payloads.
+        const turn: ModelMessage[] = [
+            userText("profile the staged counts matrix"),
+            assistantToolUse("toolu_1", "execute_command", {
+                script: "summarize.R",
+                timeout: 600,
+                env: { OMP_NUM_THREADS: "4", R_LIBS: "/mnt/libs" },
+            }),
+            {
+                role: "tool",
+                content: [
+                    {
+                        type: "tool-result",
+                        toolCallId: "toolu_1",
+                        toolName: "execute_command",
+                        output: { type: "json", value: { stdout: "done", exitCode: 0, artifacts: ["counts.rds"] } },
+                    },
+                ],
+            },
+            assistantText("The matrix has 18,204 genes across 12 samples."),
+        ];
+        (await history.appendTurn(THREAD, turn))._unsafeUnwrap();
+
+        assertMarshalsVerbatim(turn, (await history.loadRecent(THREAD, 1_000_000))._unsafeUnwrap());
+    });
+
+    it("preserves key order in every free-form payload a ModelMessage can carry", async () => {
+        // The three payloads with no schema to be normalized back against on read:
+        // a tool call's `input`, a json tool result's `value`, a `providerOptions` bag.
+        const turn: ModelMessage[] = [
+            {
+                role: "user",
+                content: "run it",
+                providerOptions: { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } },
+            },
+            assistantToolUse("toolu_2", "write_file", { path: "/a/b.R", mode: "w", content: "x", nested: { z: 1, a: 2 } }),
+            {
+                role: "tool",
+                content: [
+                    {
+                        type: "tool-result",
+                        toolCallId: "toolu_2",
+                        toolName: "write_file",
+                        output: { type: "json", value: { zebra: 1, alpha: 2, nested: { z: "last", a: "first" } } },
+                    },
+                ],
+            },
+            {
+                role: "assistant",
+                content: [{ type: "reasoning", text: "weighing options", providerOptions: { anthropic: { signature: "SIG-abc==", zebra: "z", alpha: "a" } } }],
+            },
+        ];
+        (await history.appendTurn(THREAD, turn))._unsafeUnwrap();
+
+        assertMarshalsVerbatim(turn, (await history.loadRecent(THREAD, 1_000_000))._unsafeUnwrap());
+    });
+
+    it("holds the earlier turns of a thread byte-identical as later turns land on top", async () => {
+        // The cache guarantee end to end: a prefix already sent reads back
+        // unchanged after more turns land behind it.
+        const turn1 = [userText("first question"), assistantToolUse("toolu_3", "search_gene", { symbol: "EGFR", species: "human", limit: 5 })];
+        const turn2 = [userToolResult("toolu_3", JSON.stringify({ hits: 3 })), assistantText("EGFR is well characterized.")];
+        (await history.appendTurn(THREAD, turn1))._unsafeUnwrap();
+        const afterFirst = (await history.loadRecent(THREAD, 1_000_000))._unsafeUnwrap();
+
+        (await history.appendTurn(THREAD, turn2))._unsafeUnwrap();
+        const afterSecond = (await history.loadRecent(THREAD, 1_000_000))._unsafeUnwrap();
+
+        assertMarshalsVerbatim(turn1, afterFirst);
+        expect(JSON.stringify(afterSecond.slice(0, turn1.length))).toBe(JSON.stringify(afterFirst));
+        assertMarshalsVerbatim([...turn1, ...turn2], afterSecond);
+    });
+
+    it("drops a NUL byte from a tool result instead of losing the whole turn", async () => {
+        // A `jsonb` column rejected the insert outright, taking the turn's whole
+        // transaction with it; a `json` column stores the byte but then refuses to
+        // run the boundary predicate's JSON operators over that row. So the write
+        // scrubs it: the turn survives, and its tail stays retractable. The loop
+        // strips NUL where it builds a tool result, so on the harness's own path
+        // the stored row and the message it sent live are already identical.
+        const NUL = String.fromCharCode(0);
+        (await history.appendTurn(THREAD, [userText("read the binary header"), userToolResult("toolu_4", `MAGIC${NUL}rest`)]))._unsafeUnwrap();
+
+        assertMarshalsVerbatim(
+            [userText("read the binary header"), userToolResult("toolu_4", "MAGICrest")],
+            (await history.loadRecent(THREAD, 1_000_000))._unsafeUnwrap(),
+        );
+        expect((await history.retractLastTurn(THREAD))._unsafeUnwrap()).toEqual({ kind: "retracted", messages: 2 });
+    });
+});
+
 // --- thread activity --------------------------------------------------------
 
 describe("appendTurn thread activity", () => {

--- a/harness/src/memory/thread-history.ts
+++ b/harness/src/memory/thread-history.ts
@@ -26,6 +26,7 @@ import { type Histogram, metrics } from "@opentelemetry/api";
 import { ResultAsync, ok, okAsync } from "neverthrow";
 import type { Pool } from "pg";
 
+import { stripNulCharacters } from "../input-sanitization.js";
 import { type DbError, tryMutation, tryQuery, withTransaction } from "../lib/db-result.js";
 import { countTokens } from "./count-tokens.js";
 import {
@@ -162,6 +163,23 @@ const GENUINE_USER_START_SQL = `message_envelope->'message'->>'role' = 'user'
                          AND message_envelope->'message'->'providerOptions'->'${HARNESS_PROVIDER_NAMESPACE}'->>'${SYNTHETIC_MESSAGE_KEY}' IS DISTINCT FROM 'true'`;
 
 /**
+ * Serialize a message's storage envelope, dropping NUL from every string it
+ * carries ({@link stripNulCharacters}).
+ *
+ * A stored NUL does not break the insert on a `json` column, nor the whole-row
+ * reads — it breaks {@link GENUINE_USER_START_SQL}, whose JSON operators refuse
+ * to walk a document containing one, so a single poisoned row would make the
+ * thread's tail unretractable. The loop already strips NUL where it builds a
+ * tool result, so this scrubs nothing on the harness's own path; it holds the
+ * invariant for every other writer.
+ *
+ * The replacer sees values, not keys — the same accepted limit as the loop's.
+ */
+function serializeEnvelope(message: ModelMessage): string {
+    return JSON.stringify(envelopeMessage(message), (_key, value: unknown) => (typeof value === "string" ? stripNulCharacters(value) : value));
+}
+
+/**
  * Group rows (oldest-first) into turns at genuine-user-start boundaries.
  * Generic over the row shape so the token-windowed read (`loadRecent`) and
  * the display read (`loadPage`) share it, each supplying its own start
@@ -266,12 +284,13 @@ export function createThreadHistory(pool: Pool): ThreadHistory {
                             chain.andThen(() =>
                                 tryMutation("thread-history.appendTurn.insert", () =>
                                     client.query(
+                                        // `::json`, never `::jsonb` — see the column comment in the state-init DDL.
                                         `INSERT INTO messages (thread_id, seq, message_envelope, tokens)
-                     VALUES ($1, $2, $3::jsonb, $4)
+                     VALUES ($1, $2, $3::json, $4)
                      ON CONFLICT (thread_id, seq) DO UPDATE
                        SET message_envelope = EXCLUDED.message_envelope,
                            tokens = EXCLUDED.tokens`,
-                                        [threadId, startSeq + i, JSON.stringify(envelopeMessage(message)), countTokens(message.content)],
+                                        [threadId, startSeq + i, serializeEnvelope(message), countTokens(message.content)],
                                     ),
                                 ).map(() => undefined),
                             ),

--- a/harness/src/state/init.ts
+++ b/harness/src/state/init.ts
@@ -211,12 +211,20 @@ CREATE INDEX IF NOT EXISTS idx_cortex_regulatory_chunks_metadata
 -- workflow and sandbox agent loops use the DBOS step cache, never this
 -- table (see the harness-thread-store spec). The (thread_id, seq) primary key already serves
 -- (thread_id, seq DESC) reads, so no separate index is needed.
+--
+-- message_envelope is JSON, not JSONB, and must stay that way. JSONB stores a
+-- re-sorted parse tree rather than the document it was given, so a tool call's
+-- input — and every other free-form payload, which has no schema to be
+-- normalized back against on read — comes back key-reordered. Those bytes are
+-- re-sent to the provider on the next turn, where a reordered prefix misses the
+-- prompt cache. JSON stores the text verbatim. Nothing indexes this column, and
+-- the JSON operators retractLastTurn uses work the same on either type.
 CREATE TABLE IF NOT EXISTS messages (
   thread_id     TEXT NOT NULL,
   seq           BIGINT NOT NULL,
   role          TEXT,
   content_jsonb JSONB,
-  message_envelope JSONB,
+  message_envelope JSON,
   tokens        INTEGER NOT NULL,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (thread_id, seq)
@@ -424,7 +432,22 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                 // carry the NOT NULL floor, which would reject a clear. Idempotent:
                 // dropping an absent NOT NULL no-ops, so this is a no-op on fresh DBs.
                 "ALTER TABLE cortex_analysis_state ALTER COLUMN data_profile_status DROP NOT NULL",
-                "ALTER TABLE messages ADD COLUMN IF NOT EXISTS message_envelope JSONB",
+                "ALTER TABLE messages ADD COLUMN IF NOT EXISTS message_envelope JSON",
+                // Demote an existing JSONB envelope column to JSON (see the CREATE
+                // TABLE comment). Type-guarded because ALTER ... TYPE rewrites the
+                // whole table and this runs at every boot; scoped to
+                // current_schema() so parallel test schemas never see each other.
+                // Rows already written as JSONB carry over as they stand — their
+                // original key order is not recoverable.
+                `DO $$ BEGIN
+                  IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = current_schema() AND table_name = 'messages'
+                      AND column_name = 'message_envelope' AND data_type = 'jsonb'
+                  ) THEN
+                    ALTER TABLE messages ALTER COLUMN message_envelope TYPE JSON USING message_envelope::text::json;
+                  END IF;
+                END $$`,
                 // Grant key an 'always' records the standing grant under. Nullable
                 // and unbackfilled: every new row writes it (command when absent), and
                 // orphaned legacy pending rows are swept to 'expired' before any answer

--- a/harness/src/state/message-envelope-column.test.ts
+++ b/harness/src/state/message-envelope-column.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `messages.message_envelope` must be `json`, not `jsonb`.
+ *
+ * JSONB re-sorts object keys on the way in, so a stored turn reads back with
+ * every free-form payload rewritten and no longer matches the prefix the
+ * provider's prompt cache holds. The fidelity of the round trip is asserted in
+ * `memory/thread-history.test.ts`; this pins the column type that makes it hold,
+ * on a fresh database and on one created before the type changed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Pool } from "pg";
+
+import { withSchema } from "../__tests__/setup/postgres.js";
+import { initCortexState } from "./init.js";
+
+let pool: Pool;
+let drop: () => Promise<void>;
+
+async function envelopeColumnType(): Promise<string | undefined> {
+    const { rows } = await pool.query<{ data_type: string }>(
+        `SELECT data_type FROM information_schema.columns
+          WHERE table_schema = current_schema() AND table_name = 'messages' AND column_name = 'message_envelope'`,
+    );
+    return rows[0]?.data_type;
+}
+
+beforeEach(async () => {
+    ({ pool, drop } = await withSchema("message-envelope-column"));
+});
+
+afterEach(async () => {
+    await drop?.();
+});
+
+describe("messages.message_envelope column type", () => {
+    it("is json on a freshly initialized schema", async () => {
+        expect(await envelopeColumnType()).toBe("json");
+    });
+
+    it("converts an existing jsonb column to json, preserving its rows", async () => {
+        await pool.query("ALTER TABLE messages ALTER COLUMN message_envelope TYPE jsonb USING message_envelope::text::jsonb");
+        await pool.query(
+            `INSERT INTO messages (thread_id, seq, message_envelope, tokens)
+             VALUES ('legacy', 0, $1::jsonb, 3)`,
+            [JSON.stringify({ kind: "ai-sdk-model-message", aiSdkMajor: 7, message: { role: "user", content: "kept" } })],
+        );
+        expect(await envelopeColumnType()).toBe("jsonb");
+
+        await initCortexState(pool);
+
+        expect(await envelopeColumnType()).toBe("json");
+        const { rows } = await pool.query<{ envelope: { message: { content: string } } }>(
+            "SELECT message_envelope AS envelope FROM messages WHERE thread_id = 'legacy'",
+        );
+        expect(rows[0]?.envelope.message.content).toBe("kept");
+    });
+
+    it("leaves the column alone when it is already json", async () => {
+        // The conversion rewrites the whole table, and init runs at every boot —
+        // so re-running it must not re-alter a column already at the target type.
+        await pool.query("INSERT INTO messages (thread_id, seq, message_envelope, tokens) VALUES ('t', 0, $1::json, 1)", [
+            JSON.stringify({ kind: "ai-sdk-model-message", aiSdkMajor: 7, message: { role: "user", content: "hi" } }),
+        ]);
+        const { rows: before } = await pool.query<{ ctid: string }>("SELECT ctid::text FROM messages WHERE thread_id = 't'");
+
+        await initCortexState(pool);
+
+        expect(await envelopeColumnType()).toBe("json");
+        // An unchanged physical row location is the observable proof no rewrite ran.
+        const { rows: after } = await pool.query<{ ctid: string }>("SELECT ctid::text FROM messages WHERE thread_id = 't'");
+        expect(after[0]?.ctid).toBe(before[0]!.ctid);
+    });
+});


### PR DESCRIPTION
## Problem

`messages.message_envelope` was `JSONB`. JSONB does not store the document it is handed — it stores a parse tree with object keys re-sorted by (length, bytes). The AI SDK's `modelMessageSchema` re-normalizes the keys it *knows* on read, which hid this for plain text messages. Every free-form payload has no schema to be normalized back against and came back reordered:

| Shape | Round-tripped byte-identical? |
|-|-|
| user/assistant text, `output.type: "text"` | yes |
| assistant tool-call `input` | **no** |
| tool-result `output.type: "json"` | **no** |
| multi-key `providerOptions` bag | **no** — incl. `cacheControl: {type,ttl}` → `{ttl,type}` |

```
sent: "input":{"zebra":1,"alpha":2,"nested":{"z":1,"a":2}}
back: "input":{"alpha":2,"zebra":1,"nested":{"a":2,"z":1}}
```

Those bytes go straight to the provider on the next turn. Turn N sends its messages live in the model's original key order; turn N+1 loads them back reordered, so the prefix diverges exactly where turn N's messages begin. JSONB's ordering is deterministic, so this is not thrash — it is a permanent one-turn-wide cache miss on **every** turn, landing on the tail turn that is still warm inside the 5m TTL. That is precisely what `EVICTION_BLOCK_TURNS` was built to protect.

Second, harder bug: JSONB rejects NUL (`unsupported Unicode escape sequence`). One NUL byte in a tool result — routine for `execute_command` / `read_file` over binary-ish content — failed the insert and rolled back the whole turn.

The DBOS step cache is unaffected (`operation_outputs.output` is `text` + superjson, key order preserved), so workflow and sandbox loops were never at risk.

## Change

- `message_envelope` is now `JSON`, which stores the text verbatim, with a type-guarded migration for existing databases. Nothing indexes the column, and the JSON operators `retractLastTurn`'s boundary predicate uses work the same on either type. Rows already written as JSONB carry over as they stand — their original key order is not recoverable, so the switch costs one final cache miss per live thread.
- `stripNulCharacters` in `input-sanitization.ts`, applied where the loop builds a tool result (keeping the in-memory message and the stored row byte-identical) and again at the write (holding the invariant for other writers). A `json` column stores NUL but then refuses to run the boundary predicate's operators over that row, so the byte still cannot be kept.

## Tests

There were none for this. The existing round-trip tests asserted with `toEqual`, which is key-order-blind and passed happily against the reordering column.

- `memory/thread-history.test.ts` — a new `envelope marshalling fidelity` block comparing **serialized bytes**, the form the provider receives: a realistic tool-calling turn, a table of every free-form payload a `ModelMessage` can carry, prefix stability as later turns land on top, and the NUL case. Verified load-bearing: all three ordering tests fail against a `jsonb` column and pass against `json`.
- `state/message-envelope-column.test.ts` — pins the column type on a fresh schema, on one created before the change, and asserts a re-run does not rewrite the table (`ctid` unchanged).
- `loop/run-agent.test.ts` — NUL stripped from a tool result and from a thrown tool error's message.
- `input-sanitization.test.ts` — `stripNulCharacters` unit tests.

Full suite green: 1543 pass, 1 skip, 0 fail across 142 files. `tsc` clean.

No OpenSpec change (per request).