### PR TITLE
fix(cli,harness): connect the Logger seam and deepen generate_plan's …

### DIFF
--- a/cli/src/lib/log.ts
+++ b/cli/src/lib/log.ts
@@ -1,6 +1,9 @@
 import { mkdirSync, openSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import pino from "pino";
+// Type-only: erased at compile, so this low-level module gains no runtime edge on the
+// harness package. The realization below is a pure adapter over our own pino instance.
+import type { LogFields, Logger } from "@inflexa-ai/harness";
 
 import { env } from "./env.ts";
 
@@ -95,6 +98,60 @@ const root = pino(
 
 export function getLogger(module: string): pino.Logger {
     return root.child({ module });
+}
+
+/**
+ * Realize the harness's `Logger` seam over a pino child.
+ *
+ * The harness names no logging library — pino is the cli's choice, so the mapping
+ * belongs here rather than in the published package. Two shape differences to
+ * bridge: the seam is message-first (`slog`/winston/console order) where pino is
+ * object-first, and `named()` renders a `[a.b]` prefix onto the message where
+ * pino's `child` binds fields.
+ *
+ * `named` deliberately prefixes the message rather than binding a `module` field:
+ * `getLogger("harness")` already owns that field, and the harness's records have
+ * always read `[dbos] launched` in the log file. Binding it instead would silently
+ * restyle every existing line.
+ *
+ * `errorFields` defers to pino's own `err` serializer by handing the raw value
+ * through under `err` — pino renders type/message/stack from it, which is strictly
+ * richer than the harness's string mapping and is exactly why the seam puts this
+ * on the interface.
+ *
+ * It lives beside `getLogger` rather than at a composition root because it has two
+ * callers that reach the harness independently: the embedder root wiring
+ * `bootHarness`, and the chat turn engine wiring `runAgent`. A private copy in
+ * either is how one of them ends up silent.
+ */
+function pinoAsHarnessLogger(pino: pino.Logger, names: readonly string[] = []): Logger {
+    function prefixed(msg: string): string {
+        return names.length > 0 ? `[${names.join(".")}] ${msg}` : msg;
+    }
+    function emit(level: "debug" | "info" | "warn" | "error"): (msg: string, fields?: LogFields) => void {
+        return (msg, fields) => pino[level](fields ?? {}, prefixed(msg));
+    }
+    return {
+        debug: emit("debug"),
+        info: emit("info"),
+        warn: emit("warn"),
+        error: emit("error"),
+        with: (fields) => pinoAsHarnessLogger(pino.child(fields), names),
+        named: (name) => pinoAsHarnessLogger(pino, [...names, name]),
+        errorFields: (err) => ({ err }),
+    };
+}
+
+/**
+ * The harness `Logger` for one module namespace — the seam realization every
+ * harness entry point in the cli passes down.
+ *
+ * Every path that hands the harness a logger MUST come through here. A harness
+ * deps bag that omits it resolves to `createNoopLogger()` and the component goes
+ * silent, which reads exactly like a component that never ran.
+ */
+export function harnessLogger(module: string): Logger {
+    return pinoAsHarnessLogger(getLogger(module));
 }
 
 export function addLogStream(stream: pino.DestinationStream): void {

--- a/cli/src/lib/otel.test.ts
+++ b/cli/src/lib/otel.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { logs } from "@opentelemetry/api-logs";
+
+import { createOtelLogStream } from "./otel.ts";
+
+const captured: Record<string, unknown>[] = [];
+
+// The OTel API accepts a global logger provider ONCE and ignores every later
+// registration, so the stub is installed at module scope and the sink is drained
+// per call. Registering inside the helper silently kept the first stub and left
+// every subsequent capture empty.
+//
+// The SDK's `LoggerProvider` type is far wider than the two members the stream
+// touches (`getLogger` → `emit`); a structural stub is sound because the stream
+// calls nothing else, and a real provider would need a live exporter.
+logs.setGlobalLoggerProvider({
+    getLogger: () => ({ emit: (r: { attributes?: Record<string, unknown> }) => captured.push(r.attributes ?? {}) }),
+} as unknown as Parameters<typeof logs.setGlobalLoggerProvider>[0]);
+
+/**
+ * What the OTLP stream would export for one pino line.
+ *
+ * The test drives the real stream rather than rebuilding its projection: the
+ * attribute set is the thing under test, and a reimplementation of it here would
+ * assert nothing about production.
+ */
+function exportedAttributes(record: Record<string, unknown>): Record<string, unknown> {
+    captured.length = 0;
+    createOtelLogStream().write(JSON.stringify(record));
+    return captured[0] ?? {};
+}
+
+describe("createOtelLogStream", () => {
+    test("drops model-authored prose, so a planner's words about the user's data stay on the machine", () => {
+        const attributes = exportedAttributes({
+            level: 40,
+            time: 1,
+            msg: "[generate-plan] plan generation finished",
+            analysisId: "an-1",
+            outcome: "no_outcome",
+            modelAuthored: { plannerFinalProse: "atopic dermatitis skin biopsies; sample S7 is a QC outlier" },
+        });
+
+        expect(attributes).not.toHaveProperty("modelAuthored");
+        expect(JSON.stringify(attributes)).not.toContain("atopic dermatitis");
+        // Everything structural still exports — the drop is scoped to the one key the
+        // harness nests free-form model text under, not to the diagnostic itself.
+        expect(attributes.outcome).toBe("no_outcome");
+        expect(attributes.analysisId).toBe("an-1");
+    });
+
+    test("exports structural diagnostic fields, including nested objects, as attributes", () => {
+        const attributes = exportedAttributes({
+            level: 50,
+            time: 1,
+            msg: "[generate-plan] plan generation finished",
+            submitAttempts: 16,
+            loop: { finishReason: "max_iterations", cappedOut: true },
+        });
+
+        expect(attributes.submitAttempts).toBe(16);
+        expect(attributes.loop).toBe(JSON.stringify({ finishReason: "max_iterations", cappedOut: true }));
+    });
+});

--- a/cli/src/lib/otel.ts
+++ b/cli/src/lib/otel.ts
@@ -76,9 +76,30 @@ export function initOtel(consented: boolean): boolean {
 }
 
 /**
+ * Record key carrying free-form model-authored prose, dropped before export.
+ *
+ * The harness nests every such field under this one key (see `MODEL_AUTHORED_KEY`
+ * in `harness/src/tools/research/generate-plan.ts`) precisely so a host has a
+ * single rule to apply instead of a field-name list that goes stale. A planner's
+ * closing words quote the analysis it was given — the user's own data — which is
+ * fine in a log file on the user's machine and is not ours to send anywhere else.
+ *
+ * The literal is duplicated rather than imported: this module loads from
+ * `src/index.ts` at startup, and importing a value from `@inflexa-ai/harness`
+ * would pull that whole package (DBOS included) into the entry module graph for
+ * one string. Tests on both sides pin the same literal.
+ */
+const MODEL_AUTHORED_KEY = "modelAuthored";
+
+/**
  * Pino destination stream that forwards each record to the OTel Logs API.
  * Runs in-process (no worker threads, no module patching). Records are
  * already redacted by the root logger before they reach this stream.
+ *
+ * Root redaction is not where model-authored prose is handled: it applies to
+ * every stream, so it would blank the field in the local log file too — deleting
+ * the diagnostic the user needs. It is dropped HERE, at the boundary that leaves
+ * the machine.
  */
 export function createOtelLogStream(): DestinationStream {
     const otelLogger = logs.getLogger("inflexa");
@@ -94,6 +115,7 @@ export function createOtelLogStream(): DestinationStream {
                 const attributes: Record<string, AttributeValue> = {};
                 for (const [key, value] of Object.entries(record)) {
                     if (key === "level" || key === "time" || key === "msg" || value == null) continue;
+                    if (key === MODEL_AUTHORED_KEY) continue;
                     attributes[key] = typeof value === "object" ? JSON.stringify(value) : (value as AttributeValue);
                 }
 

--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -151,6 +151,15 @@ function recordingSeams(calls: string[]): BootSeams {
             expect(conversation.skillsDir).toBe(skillsDir);
             expect(conversation.createPreviewPublisher).toBeInstanceOf(Function);
             expect(conversation.runLauncher.launch).toBeInstanceOf(Function);
+            // The Logger seam reaches every conversation tool that takes one — `generate_plan`
+            // above all, which drives a whole sub-agent loop and writes no ledger row, so its
+            // records are the only account of an invocation. `ConversationAgentDeps.logger` is
+            // OPTIONAL and falls back to `createNoopLogger()`, so omitting this field is not a
+            // type error and not a runtime error: it silently discards every diagnostic. That
+            // is how a planner failing for nine minutes produced an empty log, and this
+            // assertion is what makes the omission fail loudly instead.
+            expect(conversation.logger).toBeDefined();
+            expect(conversation.logger?.named).toBeInstanceOf(Function);
             // The embedder hands the harness its skills root and its own no-op
             // telemetry (the CLI owns OTel); the boot handle owns skills validation,
             // state init, the connection budget, assemble, and launch itself.

--- a/cli/src/modules/harness/runtime.ts
+++ b/cli/src/modules/harness/runtime.ts
@@ -35,17 +35,14 @@ import {
     type RunAuthorizer,
     type RunLauncher,
     type WatchdogDeps,
-    type LogFields,
-    type Logger,
 } from "@inflexa-ai/harness";
-import type pinoLib from "pino";
 
 import { ensureRuntime, readConfig } from "../../lib/config.ts";
 import { resolveEngineSocket, type ContainerRuntime, type ContainerRuntimeError } from "../../lib/container.ts";
 import { env, providerApiKeyVar, resolveModelApiKey } from "../../lib/env.ts";
 import { createCredentialSource, credentialErrorMessage, type Credential, type CredentialSource } from "../../lib/credential.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";
-import { getLogger } from "../../lib/log.ts";
+import { harnessLogger } from "../../lib/log.ts";
 import { onShutdown } from "../../lib/shutdown.ts";
 import { workspaceRootForAnalysisId } from "../analysis/output.ts";
 import { resolvePackagesFile } from "../libs/packages.ts";
@@ -72,43 +69,6 @@ import { createManageInputsTool } from "./inputs_tool.ts";
 import { createSwappableSandboxEmitters } from "./prov_bridge.ts";
 import { buildExecuteAnalysisDeps, buildExecuteTargetAssessmentDeps, buildSandboxStepDeps, type RunEngineComposition, type AgentBackend } from "./run_deps.ts";
 import { clearAgentSwitch, createSwappableProvider, installAgentSwitch } from "./agent_switch.ts";
-
-/**
- * Realize the harness's `Logger` seam over the cli's pino instance.
- *
- * The harness names no logging library — pino is the cli's choice, so the
- * mapping belongs here rather than in the published package. Two shape
- * differences to bridge: the seam is message-first (`slog`/winston/console
- * order) where pino is object-first, and `named()` renders a `[a.b]` prefix onto
- * the message where pino's `child` binds fields.
- *
- * `named` deliberately prefixes the message rather than binding a `module`
- * field: `getLogger("harness")` already owns that field, and the harness's
- * records have always read `[dbos] launched` in the log file. Binding it
- * instead would silently restyle every existing line.
- *
- * `errorFields` defers to pino's own `err` serializer by handing the raw value
- * through under `err` — pino renders type/message/stack from it, which is
- * strictly richer than the harness's string mapping and is exactly why the seam
- * puts this on the interface.
- */
-function pinoAsHarnessLogger(pino: pinoLib.Logger, names: readonly string[] = []): Logger {
-    const prefixed = (msg: string): string => (names.length > 0 ? `[${names.join(".")}] ${msg}` : msg);
-    const emit =
-        (level: "debug" | "info" | "warn" | "error") =>
-        (msg: string, fields?: LogFields): void => {
-            pino[level](fields ?? {}, prefixed(msg));
-        };
-    return {
-        debug: emit("debug"),
-        info: emit("info"),
-        warn: emit("warn"),
-        error: emit("error"),
-        with: (fields) => pinoAsHarnessLogger(pino.child(fields), names),
-        named: (name) => pinoAsHarnessLogger(pino, [...names, name]),
-        errorFields: (err) => ({ err }),
-    };
-}
 
 // The embedded-harness composition root. Boots lazily on the first profile
 // trigger (never from a passive flow — no-litter policy) and holds a process
@@ -517,7 +477,7 @@ async function bootHarnessRuntimeOnce(
     cfg: ResolvedHarnessConfig,
     connection: ResolvedModelConnection,
 ): Promise<Result<HarnessRuntime, HarnessBootError>> {
-    const logger = pinoAsHarnessLogger(getLogger("harness"));
+    const logger = harnessLogger("harness");
 
     // A `harness` config block that was present but failed validation: report the
     // offending fields, not a misleading downstream error. Checked first so a bad
@@ -783,7 +743,12 @@ async function bootHarnessRuntimeOnce(
                         fetch: authFetch,
                         capabilities: { toolCalling: true },
                     };
-        const buildProvider = (agentModel: string): ChatProvider => createConfiguredAiSdkProvider({ resolveBilling, config: providerConfigFor(agentModel) });
+        // The logger is what makes the retry envelope visible. It backs off up to 10 times
+        // at up to 30s a wait, so a provider outage shows up as minutes of apparent silence
+        // inside one tool call — indistinguishable, without these records, from a model
+        // thinking hard about a hard question.
+        const buildProvider = (agentModel: string): ChatProvider =>
+            createConfiguredAiSdkProvider({ resolveBilling, config: providerConfigFor(agentModel), logger });
         // Coincident role models share one INNER instance. Each role still gets
         // its own swappable handle below, so switching one never repoints another.
         const providerByModel = new Map<string, ChatProvider>();
@@ -942,6 +907,12 @@ async function bootHarnessRuntimeOnce(
         // with the unavailable preview publisher, report preview short-circuits before
         // any Chrome connection.
         const conversation: ConversationAssemblyDeps = {
+            // Reaches every conversation tool that takes a logger — `generate_plan` above all,
+            // which drives a whole sub-agent loop on `passthroughStep`: no ledger row, no
+            // durable stream, so its records are the only account of an invocation that
+            // outlives the turn. Omitted, it resolves to `createNoopLogger()` and a planner
+            // that failed reports nothing at all.
+            logger,
             provider: conversationProvider,
             utilityProvider,
             pool,

--- a/cli/src/modules/harness/turn.test.ts
+++ b/cli/src/modules/harness/turn.test.ts
@@ -98,6 +98,26 @@ describe("buildChatSession", () => {
 });
 
 describe("runChatTurn", () => {
+    test("hands runAgent a logger, so the loop's account of the turn is not discarded", async () => {
+        // `RunAgentOptions.logger` is optional and falls back to `createNoopLogger()`.
+        // Omitting it is neither a type error nor a runtime error — the loop just stops
+        // reporting its iteration count, stop reason, and tool-error tally, and
+        // `runToTerminal` stops reporting that it salvaged a run. Every sub-agent loop a
+        // turn drives goes dark with it, because hosts filter that traffic off the chat
+        // surface by `callPath` depth and the record is what survives instead.
+        let seen: Parameters<ChatTurnSeams["run"]>[3] | undefined;
+        const captureRun: ChatTurnSeams["run"] = (agent, initial, session, opts) => {
+            seen = opts;
+            return runOk(agent, initial, session, opts);
+        };
+
+        const { history } = recordingHistory();
+        await runWith({ prepare: prepareOk, run: captureRun, history, signal: new AbortController().signal });
+
+        expect(seen?.logger).toBeDefined();
+        expect(seen?.logger?.named).toBeInstanceOf(Function);
+    });
+
     test("ok path persists [userMessage, ...loopOutput] and returns finalText", async () => {
         const { history, appended } = recordingHistory();
         const outcome = await runWith({ prepare: prepareOk, run: runOk, history, signal: new AbortController().signal });

--- a/cli/src/modules/harness/turn.ts
+++ b/cli/src/modules/harness/turn.ts
@@ -19,7 +19,7 @@ import {
     type ThreadHistory,
 } from "@inflexa-ai/harness";
 
-import { getLogger } from "../../lib/log.ts";
+import { getLogger, harnessLogger } from "../../lib/log.ts";
 import { enterChatTurn } from "./agent_switch.ts";
 
 // The headless chat turn engine. One transport-free sequence —
@@ -181,7 +181,18 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
         const userMessage = prepared.userMessage;
 
         const run = await ResultAsync.fromPromise(
-            seams.run(conversationAgent, initial, session, { provider: chat, signal, emit, runStep: passthroughStep, ...(ask ? { ask } : {}) }),
+            seams.run(conversationAgent, initial, session, {
+                provider: chat,
+                signal,
+                emit,
+                runStep: passthroughStep,
+                // The loop's own account of the turn: iteration count, stop reason, whether it
+                // capped out, and its tool-call/error tallies. `emit` does not cover this — the
+                // surface filters sub-agent traffic off by `callPath` depth, so a planner or
+                // literature-reviewer loop is emitted and then dropped. This is where it survives.
+                logger: harnessLogger("harness"),
+                ...(ask ? { ask } : {}),
+            }),
             (e): unknown => e,
         ).match(
             (result): { readonly phase: RunPhase; readonly toPersist: ModelMessage[] } => {

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -175,6 +175,30 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         logFinish("warn", "denied", false);
         return { messages, finish: { reason: "denied", cappedOut: false, truncationRecoveries } };
     };
+    /**
+     * Fold one dispatch round into the run's counters and the event sink, returning the
+     * tools whose results the model will read as errors.
+     *
+     * Shared by both dispatch paths so a truncated round and a normal one cannot drift
+     * in what they count. An error tool result is otherwise invisible to every sink —
+     * it is not a thrown failure, so nothing reports it and the loop simply feeds it
+     * back — and a run that ends badly is usually a run whose tool calls were failing.
+     */
+    const settleRound = async (calls: readonly ToolCallPart[], results: readonly ToolResultPart[]): Promise<string[]> => {
+        const errored: string[] = [];
+        for (let idx = 0; idx < calls.length; idx++) {
+            const tu = calls[idx]!;
+            const isError = isErrorOutput(results[idx]!);
+            toolCallCount++;
+            if (isError) {
+                toolErrorCount++;
+                errored.push(tu.toolName);
+            }
+            await emit({ type: "tool-finished", source, toolUseId: tu.toolCallId, name: tu.toolName, isError });
+        }
+        return errored;
+    };
+
     const stopOnResolved = async (i: number): Promise<RunAgentResult> => {
         await emit({ type: "iteration", source, index: i, final: true });
         recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
@@ -228,14 +252,16 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
                 await emit({ type: "tool-started", source, toolUseId: tu.toolCallId, name: tu.toolName, input: tu.input });
             }
             const results = await dispatchTools(earlier, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool);
-            for (let idx = 0; idx < earlier.length; idx++) {
-                const tu = earlier[idx]!;
-                const isError = isErrorOutput(results[idx]!);
-                toolCallCount++;
-                if (isError) toolErrorCount++;
-                await emit({ type: "tool-finished", source, toolUseId: tu.toolCallId, name: tu.toolName, isError });
-            }
+            const errored = await settleRound(earlier, results);
             results.push(errorResult(trailing, TRUNCATED_TOOL_USE_ERROR));
+            // The trailing call was never dispatched, but it reaches the model as an error
+            // result like any other — so it counts, or `toolErrors` reports a cleaner run
+            // than the model actually read. It gets no `tool-finished` event: no
+            // `tool-started` was emitted for it either, and the pair must stay balanced.
+            toolCallCount++;
+            toolErrorCount++;
+            errored.push(trailing.toolName);
+            log.debug("tool results returned errors", { iteration: i, tools: errored });
             messages.push({ role: "tool", content: results });
             if (hasDenial(results)) return stopOnDenial(i);
             if (opts.resolved?.()) return stopOnResolved(i);
@@ -255,22 +281,8 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             await emit({ type: "tool-started", source, toolUseId: tu.toolCallId, name: tu.toolName, input: tu.input });
         }
         const results = await dispatchTools(toolCalls, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool);
-        const erroredTools: string[] = [];
-        for (let idx = 0; idx < toolCalls.length; idx++) {
-            const tu = toolCalls[idx]!;
-            const isError = isErrorOutput(results[idx]!);
-            toolCallCount++;
-            if (isError) {
-                toolErrorCount++;
-                erroredTools.push(tu.toolName);
-            }
-            await emit({ type: "tool-finished", source, toolUseId: tu.toolCallId, name: tu.toolName, isError });
-        }
-        // A tool result the model sees as an error is otherwise invisible to every sink:
-        // it is not a thrown failure, so nothing else reports it, and the loop simply
-        // feeds it back and continues. A run that ends badly is usually a run whose tool
-        // calls were failing, and this is where that shows.
-        if (erroredTools.length > 0) log.debug("tool results returned errors", { iteration: i, tools: erroredTools });
+        const errored = await settleRound(toolCalls, results);
+        if (errored.length > 0) log.debug("tool results returned errors", { iteration: i, tools: errored });
         messages.push({ role: "tool", content: results });
         if (hasDenial(results)) return stopOnDenial(i);
         if (opts.resolved?.()) return stopOnResolved(i);

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -144,6 +144,12 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
 
     let iterations = 0;
     let truncationRecoveries = 0;
+    // Counted rather than listed: the finish record stays one bounded line for a run of
+    // any length, and "50 iterations, 49 tool calls, 47 of them errored" already separates
+    // a productive long run from a loop stuck retrying one failing call. The per-iteration
+    // `debug` records name the tools when that distinction is not enough.
+    let toolCallCount = 0;
+    let toolErrorCount = 0;
 
     // Resolved once, not per iteration: an identical options object across every
     // call is itself part of the cache contract — the request prefix has to be
@@ -155,7 +161,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // what keeps the default level affordable for an agent that runs long; the
     // per-iteration detail lives at `debug`, where paying per iteration is the point.
     const logFinish = (level: "info" | "warn", reason: AgentFinish["reason"], cappedOut: boolean): void => {
-        log[level]("run finished", { iterations, reason, cappedOut, truncationRecoveries, usage });
+        log[level]("run finished", { iterations, reason, cappedOut, truncationRecoveries, toolCalls: toolCallCount, toolErrors: toolErrorCount, usage });
     };
 
     // The user said no. A subsequent model call would only let the agent argue
@@ -224,13 +230,10 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             const results = await dispatchTools(earlier, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool);
             for (let idx = 0; idx < earlier.length; idx++) {
                 const tu = earlier[idx]!;
-                await emit({
-                    type: "tool-finished",
-                    source,
-                    toolUseId: tu.toolCallId,
-                    name: tu.toolName,
-                    isError: isErrorOutput(results[idx]!),
-                });
+                const isError = isErrorOutput(results[idx]!);
+                toolCallCount++;
+                if (isError) toolErrorCount++;
+                await emit({ type: "tool-finished", source, toolUseId: tu.toolCallId, name: tu.toolName, isError });
             }
             results.push(errorResult(trailing, TRUNCATED_TOOL_USE_ERROR));
             messages.push({ role: "tool", content: results });
@@ -252,16 +255,22 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             await emit({ type: "tool-started", source, toolUseId: tu.toolCallId, name: tu.toolName, input: tu.input });
         }
         const results = await dispatchTools(toolCalls, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool);
+        const erroredTools: string[] = [];
         for (let idx = 0; idx < toolCalls.length; idx++) {
             const tu = toolCalls[idx]!;
-            await emit({
-                type: "tool-finished",
-                source,
-                toolUseId: tu.toolCallId,
-                name: tu.toolName,
-                isError: isErrorOutput(results[idx]!),
-            });
+            const isError = isErrorOutput(results[idx]!);
+            toolCallCount++;
+            if (isError) {
+                toolErrorCount++;
+                erroredTools.push(tu.toolName);
+            }
+            await emit({ type: "tool-finished", source, toolUseId: tu.toolCallId, name: tu.toolName, isError });
         }
+        // A tool result the model sees as an error is otherwise invisible to every sink:
+        // it is not a thrown failure, so nothing else reports it, and the loop simply
+        // feeds it back and continues. A run that ends badly is usually a run whose tool
+        // calls were failing, and this is where that shows.
+        if (erroredTools.length > 0) log.debug("tool results returned errors", { iteration: i, tools: erroredTools });
         messages.push({ role: "tool", content: results });
         if (hasDenial(results)) return stopOnDenial(i);
         if (opts.resolved?.()) return stopOnResolved(i);

--- a/harness/src/loop/run-to-terminal.ts
+++ b/harness/src/loop/run-to-terminal.ts
@@ -24,11 +24,33 @@
 import type { AgentSession } from "../auth/types.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Tool } from "../tools/define-tool.js";
-import { DEFAULT_STEP_NAME_FORMATTER, runAgent, type RunAgentOptions, type RunAgentResult, type StepNameFormatter } from "./run-agent.js";
+import { DEFAULT_STEP_NAME_FORMATTER, runAgent, type AgentFinish, type RunAgentOptions, type RunAgentResult, type StepNameFormatter } from "./run-agent.js";
 import type { AgentDefinition, LoopMessage } from "./types.js";
 
 /** Default salvage budget: one submit plus a validation-fix retry or two. */
 export const DEFAULT_SALVAGE_ITERATIONS = 3;
+
+/**
+ * What a salvage continuation was and how it went — present only when one ran.
+ *
+ * The two finishes answer different questions and a diagnostician needs both: a
+ * first run that ended `max_iterations` spent its whole budget failing to submit,
+ * while one that ended `stop` gave up on prose after a single turn. Those call for
+ * opposite responses, and the returned `RunAgentResult` carries only the second
+ * run's finish, which is the same for either.
+ */
+export interface SalvageRecord {
+    /** How the FIRST run ended — the reason a salvage was needed at all. */
+    readonly firstFinish: AgentFinish;
+    /** How the salvage continuation itself ended. */
+    readonly finish: AgentFinish;
+}
+
+/** A `runToTerminal` outcome: the driving run's result, plus the salvage account. */
+export interface RunToTerminalResult extends RunAgentResult {
+    /** Null when the first run reached its terminal tool and no salvage was needed. */
+    readonly salvage: SalvageRecord | null;
+}
 
 /** Describes how to salvage a run that never reached its terminal tool. */
 export interface TerminalSalvage {
@@ -59,25 +81,34 @@ export async function runToTerminal(
     session: AgentSession,
     opts: RunAgentOptions,
     salvage: TerminalSalvage,
-): Promise<RunAgentResult> {
+): Promise<RunToTerminalResult> {
     const first = await runAgent(agent, initial, session, opts);
-    if (opts.resolved?.() || opts.signal.aborted) return first;
+    if (opts.resolved?.() || opts.signal.aborted) return { ...first, salvage: null };
 
+    const salvageBudget = salvage.maxIterations ?? DEFAULT_SALVAGE_ITERATIONS;
     // Reported here rather than in `runAgent` because the loop cannot know it is being
     // salvaged: it sees an ordinary run with a small budget and a restricted tool set.
     // Only this wrapper holds the fact that a first attempt ended without its outcome.
-    (opts.logger ?? createNoopLogger())
-        .named("loop")
-        .warn("salvaging a run that never reached its terminal tool", { agentId: agent.id, callPath: session.provenance.callPath });
+    // The first run's finish rides along because it is the whole diagnosis of WHY a
+    // salvage was needed, and it is the field the second run's result overwrites.
+    (opts.logger ?? createNoopLogger()).named("loop").warn("salvaging a run that never reached its terminal tool", {
+        agentId: agent.id,
+        callPath: session.provenance.callPath,
+        firstFinishReason: first.finish.reason,
+        firstCappedOut: first.finish.cappedOut,
+        salvageTools: salvage.tools.map((t) => t.id),
+        salvageMaxIterations: salvageBudget,
+    });
 
     const salvageAgent: AgentDefinition = {
         ...agent,
         tools: [...salvage.tools],
-        maxIterations: salvage.maxIterations ?? DEFAULT_SALVAGE_ITERATIONS,
+        maxIterations: salvageBudget,
     };
     const salvageOpts: RunAgentOptions = {
         ...opts,
         formatStepName: salvageStepNames(opts.formatStepName ?? DEFAULT_STEP_NAME_FORMATTER),
     };
-    return runAgent(salvageAgent, [...first.messages, { role: "user", content: salvage.nudge }], session, salvageOpts);
+    const salvaged = await runAgent(salvageAgent, [...first.messages, { role: "user", content: salvage.nudge }], session, salvageOpts);
+    return { ...salvaged, salvage: { firstFinish: first.finish, finish: salvaged.finish } };
 }

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -584,7 +584,36 @@ describe("generatePlan loop-driving tool", () => {
             expect(record.fields.loop).toMatchObject({ finishReason: "stop", salvaged: true, firstFinishReason: "stop", toolCalls: [] });
             // The planner's last words — the single artifact that explains a run which stopped
             // talking instead of calling a terminal tool, and which nothing else preserves.
-            expect(record.fields.plannerFinalProse).toContain("think about this out loud");
+            expect(record.fields.modelAuthored).toMatchObject({ plannerFinalProse: expect.stringContaining("think about this out loud") });
+        });
+
+        it("nests model prose under one key and omits it where something else explains the outcome", async () => {
+            const analysisId = "an-log-prose";
+            await seedAnalysis(pool, analysisId, { dpStatus: "completed", result: RICH_PROFILE, seed: RICH_PROFILE.inputFileIds });
+            // A real planner narrates alongside its tool call, and that narration quotes the
+            // dataset it was handed. On a submitted plan nothing needs it: the terminal tool
+            // already recorded what was decided, so the prose would be model output describing
+            // the user's data sitting in a record that has no use for it.
+            const { tool, logger } = loggedToolFor(
+                scriptedProvider([
+                    makeMessage(
+                        [
+                            textBlock("These are atopic dermatitis skin biopsies; S7 is a QC outlier."),
+                            toolUseBlock("t1", "submit_plan", { plan: validCandidate() }),
+                        ],
+                        "tool_use",
+                    ),
+                ]),
+            );
+
+            const result = (await tool.execute(INPUT, toolContext(analysisId)))._unsafeUnwrap() as PlanResult;
+            expect(result.event).toBe("plan_complete");
+
+            const record = outcomeRecord(logger);
+            expect(record.fields).not.toHaveProperty("modelAuthored");
+            expect(JSON.stringify(record.fields)).not.toContain("atopic dermatitis");
+            // The structural account still lands in full — the omission is scoped to prose.
+            expect(record.fields.loop).toMatchObject({ finishReason: "stop", toolCalls: ["submit_plan"] });
         });
 
         it("shows a budget spent on rejected submits as exactly that, not as a silent no-outcome", async () => {
@@ -652,7 +681,12 @@ describe("generatePlan loop-driving tool", () => {
             const blocker = logger.records.filter((r) => r.msg.endsWith("planner reported a blocker"));
             expect(blocker).toHaveLength(1);
             expect(blocker[0]!.level).toBe("warn");
-            expect(blocker[0]!.fields).toMatchObject({ reason: "measurement complete", submitAttempts: 0 });
+            expect(blocker[0]!.fields.submitAttempts).toBe(0);
+            // The reason is the planner's own prose, so it rides under the key an embedder
+            // can act on wholesale. A loose `reason` would also collide with the loop's
+            // structural `reason` (its finish reason) in any sink that filters by name.
+            expect(blocker[0]!.fields).not.toHaveProperty("reason");
+            expect(blocker[0]!.fields.modelAuthored).toMatchObject({ blockerReason: "measurement complete" });
         });
     });
 });

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -524,10 +524,14 @@ describe("generatePlan loop-driving tool", () => {
 
             await tool.execute(INPUT, toolContext());
 
-            const rejection = logger.records.filter((r) => r.level === "debug" && r.msg.includes("submit_plan rejected"));
+            // `warn`, not `debug`: a rejection costs an iteration and is otherwise unreported,
+            // so it must survive the default level a host actually runs at.
+            const rejection = logger.records.filter((r) => r.level === "warn" && r.msg.includes("submit_plan rejected"));
             expect(rejection).toHaveLength(1);
+            expect(rejection[0]!.fields).toMatchObject({ attempt: 1, codes: { schema: 0, semantic: 1 } });
             expect(rejection[0]!.fields.issueCount).toBeGreaterThan(0);
-            expect(Array.isArray(rejection[0]!.fields.issues)).toBe(true);
+            expect(rejection[0]!.fields.paths).toEqual(["plan"]);
+            expect(rejection[0]!.fields.messages).toBeArrayOfSize(1);
         });
 
         it("records no rejection when the first submit is accepted", async () => {
@@ -541,6 +545,114 @@ describe("generatePlan loop-driving tool", () => {
             await accepted.tool.execute(INPUT, toolContext("an-log-accept"));
 
             expect(accepted.logger.records.filter((r) => r.msg.includes("rejected"))).toHaveLength(0);
+        });
+
+        it("opens with a seed census, so a run that never returns can be weighed against what it was handed", async () => {
+            const analysisId = "an-log-seed";
+            await seedAnalysis(pool, analysisId, { dpStatus: "completed", result: RICH_PROFILE, seed: RICH_PROFILE.inputFileIds });
+            const { tool, logger } = loggedToolFor(blockImmediately());
+
+            await tool.execute({ ...INPUT, userConstraints: "Use limma-voom." }, toolContext(analysisId));
+
+            const started = logger.records.filter((r) => r.msg.endsWith("plan generation started"));
+            expect(started).toHaveLength(1);
+            expect(started[0]!.level).toBe("info");
+            expect(started[0]!.fields).toMatchObject({ grounding: "ready", analysisId });
+
+            // Sizes, never content: the seed carries the research question and the dataset's
+            // facts, which belong in the model's context and not in a log file.
+            const seedChars = started[0]!.fields.seedChars as Record<string, number>;
+            expect(seedChars.total).toBeGreaterThan(0);
+            expect(seedChars.dataContext).toBeGreaterThan(0);
+            expect(seedChars.userConstraints).toBe("Use limma-voom.".length);
+            expect(seedChars.priorRuns).toBe(0);
+            const census = JSON.stringify(started[0]!.fields);
+            expect(census).not.toContain(INPUT.researchQuestion);
+            expect(census).not.toContain("limma-voom");
+        });
+
+        it("carries the loop account on a run that ended with no terminal outcome", async () => {
+            // The reported failure: three identical `no_outcome` returns taught nobody
+            // anything, because the word covers a budget spent on rejected submits, a planner
+            // answering in prose, and a reply cut off mid-tool-call alike.
+            const { tool, logger } = loggedToolFor(scriptedProvider(() => makeMessage([textBlock("Let me think about this out loud.")], "end_turn")));
+
+            await tool.execute(INPUT, toolContext());
+
+            const record = outcomeRecord(logger);
+            expect(record.fields.outcome).toBe("no_outcome");
+            expect(record.fields.loop).toMatchObject({ finishReason: "stop", salvaged: true, firstFinishReason: "stop", toolCalls: [] });
+            // The planner's last words — the single artifact that explains a run which stopped
+            // talking instead of calling a terminal tool, and which nothing else preserves.
+            expect(record.fields.plannerFinalProse).toContain("think about this out loud");
+        });
+
+        it("shows a budget spent on rejected submits as exactly that, not as a silent no-outcome", async () => {
+            const analysisId = "an-log-thrash";
+            await seedAnalysis(pool, analysisId, { dpStatus: "completed", result: RICH_PROFILE, seed: RICH_PROFILE.inputFileIds });
+            // Every turn submits a plan whose `depends_on` names a step that does not exist:
+            // schema-valid, semantically impossible, rejected forever. This is the shape that
+            // burns a whole iteration budget while `holder.outcome` stays null.
+            const { tool, logger } = loggedToolFor(
+                scriptedProvider((i) => makeMessage([toolUseBlock(`t${i}`, "submit_plan", { plan: validCandidate({ depends_on: ["T9S9"] }) })], "tool_use")),
+            );
+
+            const result = (await tool.execute(INPUT, toolContext(analysisId)))._unsafeUnwrap() as PlanResult;
+            expect(result.event).toBe("error");
+
+            const record = outcomeRecord(logger);
+            expect(record.fields.outcome).toBe("no_outcome");
+            expect(record.fields.submitAttempts).toBeGreaterThan(1);
+            expect(record.fields.rejectedAttempts).toBeGreaterThan(1);
+            expect(record.fields.loop).toMatchObject({ finishReason: "max_iterations", cappedOut: true, salvaged: true });
+            expect(record.fields.loop).toHaveProperty("toolCalls");
+            expect((record.fields.loop as { toolCalls: string[] }).toolCalls).toContain("submit_plan");
+
+            // Identical `paths` across attempts is the planner stuck on one fault — the
+            // difference between "give it more budget" and "the plan can never be made valid".
+            const rejections = record.fields.rejections as { attempt: number; paths: string[] }[];
+            expect(rejections.length).toBeGreaterThan(1);
+            expect(rejections[0]!.attempt).toBe(1);
+            expect(rejections[0]!.paths).toEqual(rejections[1]!.paths);
+
+            // The kept rejections are capped, the COUNT is not. A record pairing 16 attempts
+            // with 6 rejections reads as ten accepted plans — the opposite of what happened —
+            // so the truncation is stated and the count stays whole.
+            expect(record.fields.rejectedAttempts).toBe(record.fields.submitAttempts);
+            expect(rejections.length).toBeLessThan(record.fields.rejectedAttempts as number);
+            expect(record.fields.rejectionsTruncated).toBe(true);
+        });
+
+        it("names the attempt a plan was accepted on — a success that nearly was not one", async () => {
+            const analysisId = "an-log-late";
+            await seedAnalysis(pool, analysisId, { dpStatus: "completed", result: RICH_PROFILE, seed: RICH_PROFILE.inputFileIds });
+            const { tool, logger } = loggedToolFor(
+                scriptedProvider([
+                    makeMessage([toolUseBlock("t1", "submit_plan", { plan: validCandidate({ depends_on: ["T9S9"] }) })], "tool_use"),
+                    makeMessage([toolUseBlock("t2", "submit_plan", { plan: validCandidate() })], "tool_use"),
+                    makeMessage([textBlock("Submitted.")], "end_turn"),
+                ]),
+            );
+
+            await tool.execute(INPUT, toolContext(analysisId));
+
+            const accepted = logger.records.filter((r) => r.msg.endsWith("submit_plan accepted a plan"));
+            expect(accepted).toHaveLength(1);
+            expect(accepted[0]!.fields).toMatchObject({ attempt: 2, stepCount: 1 });
+
+            const record = outcomeRecord(logger);
+            expect(record.fields).toMatchObject({ outcome: "plan_submitted", submitAttempts: 2, rejectedAttempts: 1 });
+        });
+
+        it("reports a blocker with the attempt count, separating giving up from never trying", async () => {
+            const { tool, logger } = loggedToolFor(blockImmediately());
+
+            await tool.execute(INPUT, toolContext());
+
+            const blocker = logger.records.filter((r) => r.msg.endsWith("planner reported a blocker"));
+            expect(blocker).toHaveLength(1);
+            expect(blocker[0]!.level).toBe("warn");
+            expect(blocker[0]!.fields).toMatchObject({ reason: "measurement complete", submitAttempts: 0 });
         });
     });
 });

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -94,6 +94,34 @@ function bounded(value: string, max: number): string {
 }
 
 /**
+ * Record key under which free-form MODEL-authored text rides — never a structural
+ * field, only prose a language model wrote.
+ *
+ * The segregation exists because these two things need different handling and are
+ * otherwise indistinguishable in a flat record. A planner's own words routinely
+ * quote the analysis: "atopic dermatitis skin biopsies; sample S7 is a QC outlier"
+ * is a real example. That is the user's data. It belongs in a local diagnostic
+ * file, where the user already holds it — and an embedder shipping records off the
+ * machine needs one rule to keep it there, not a list of field names that goes
+ * stale the moment a new field is added.
+ *
+ * The harness cannot enforce that rule: it does not own the sink. It owns the
+ * declaration, so a host has something to act on. The cli drops this key at its
+ * OTLP export boundary (`cli/src/lib/otel.ts`) while keeping it in the log file.
+ *
+ * Redaction at the logger root was the alternative and is wrong here: it applies
+ * to every stream, so it would blank the field in the local file too — deleting
+ * the one artifact that explains a planner which stopped on prose.
+ */
+const MODEL_AUTHORED_KEY = "modelAuthored";
+
+/** Nest model-authored prose under {@link MODEL_AUTHORED_KEY}, or contribute nothing when there is none. */
+function modelAuthored(fields: Record<string, string | undefined>): LogFields {
+    const present = Object.entries(fields).filter((entry): entry is [string, string] => entry[1] !== undefined && entry[1].length > 0);
+    return present.length === 0 ? {} : { [MODEL_AUTHORED_KEY]: Object.fromEntries(present) };
+}
+
+/**
  * One `submit_plan` rejection, in the shape a log query wants.
  *
  * `codes` separates the two failure families that call for different fixes: a
@@ -578,8 +606,8 @@ function buildInnerTools(
             // user through the conversation agent, which may paraphrase it into something
             // that no longer identifies the missing fact.
             logger.info("planner requested clarification", {
-                question: bounded(input.question, MAX_LOGGED_PROSE_CHARS),
                 submitAttempts: trace.submitAttempts,
+                ...modelAuthored({ clarificationQuestion: bounded(input.question, MAX_LOGGED_PROSE_CHARS) }),
             });
             return ok({ recorded: true as const });
         },
@@ -600,8 +628,8 @@ function buildInnerTools(
             // could not make valid — a validation problem wearing a blocker's clothes. The
             // attempt count is what tells those apart, and only this record carries both.
             logger.warn("planner reported a blocker", {
-                reason: bounded(outcome.reason, MAX_LOGGED_PROSE_CHARS),
                 submitAttempts: trace.submitAttempts,
+                ...modelAuthored({ blockerReason: bounded(outcome.reason, MAX_LOGGED_PROSE_CHARS) }),
             });
         },
         blockedWhen:
@@ -680,7 +708,7 @@ function readTranscript(messages: readonly LoopMessage[]): { toolCalls: string[]
  * answered in prose (`stop`), and a reply cut off at the output-token limit
  * (`length`) — which is why three identical-looking retries taught nobody anything.
  */
-function loopFields(run: RunToTerminalResult): LogFields {
+function loopFields(run: RunToTerminalResult, kind: OutcomeKind): LogFields {
     const transcript = readTranscript(run.messages);
     return {
         loop: {
@@ -692,9 +720,20 @@ function loopFields(run: RunToTerminalResult): LogFields {
             toolCalls: transcript.toolCalls,
             ...(transcript.truncatedToolCalls ? { toolCallsTruncated: true } : {}),
         },
-        ...(transcript.finalProse ? { plannerFinalProse: transcript.finalProse } : {}),
+        ...(PROSE_EXPLAINS_OUTCOME.has(kind) ? modelAuthored({ plannerFinalProse: transcript.finalProse }) : {}),
     };
 }
+
+/**
+ * The endings whose only account is what the planner said last.
+ *
+ * Everywhere else something better already explains the outcome: a terminal tool
+ * recorded its own argument, or a thrown cause carries the fault. Logging the
+ * prose there would put model output describing the user's data into a record
+ * that had no use for it — including on every successful plan, where the closing
+ * text is the planner narrating work that demonstrably went fine.
+ */
+const PROSE_EXPLAINS_OUTCOME: ReadonlySet<OutcomeKind> = new Set<OutcomeKind>(["no_outcome", "loop_error", "timeout"]);
 
 // ── Outcome shaping ─────────────────────────────────────────────────
 
@@ -1068,21 +1107,19 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 runError = err;
             }
 
-            return finish(
-                shapeOutcome({
-                    holder,
-                    runError,
-                    timedOut: signal.aborted && !ctx.signal.aborted,
-                    outerAborted: ctx.signal.aborted,
-                }),
-                {
-                    // A throw leaves no result to read the transcript off, so the cause takes its
-                    // place — `shapeOutcome` folds it into one prose sentence for the model, and
-                    // this is the only place its type and stack survive.
-                    ...(run ? loopFields(run) : {}),
-                    ...(runError ? logger.errorFields(runError) : {}),
-                },
-            );
+            const shaped = shapeOutcome({
+                holder,
+                runError,
+                timedOut: signal.aborted && !ctx.signal.aborted,
+                outerAborted: ctx.signal.aborted,
+            });
+            return finish(shaped, {
+                // A throw leaves no result to read the transcript off, so the cause takes its
+                // place — `shapeOutcome` folds it into one prose sentence for the model, and
+                // this is the only place its type and stack survive.
+                ...(run ? loopFields(run, shaped.kind) : {}),
+                ...(runError ? logger.errorFields(runError) : {}),
+            });
         },
     });
 }

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -30,9 +30,9 @@ import { z } from "zod";
 
 import { formatAgentCatalog } from "../../agents/sandbox-catalog.js";
 import { composeSystemPrompt } from "../../agents/system-prompt.js";
-import { runToTerminal } from "../../loop/run-to-terminal.js";
+import { DEFAULT_SALVAGE_ITERATIONS, runToTerminal, type RunToTerminalResult } from "../../loop/run-to-terminal.js";
 import { passthroughStep } from "../../loop/run-step.js";
-import type { AgentDefinition } from "../../loop/types.js";
+import type { AgentDefinition, LoopMessage } from "../../loop/types.js";
 import { forSubAgent, scopeResource } from "../../auth/types.js";
 import { type ChatProvider } from "../../providers/types.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
@@ -49,7 +49,7 @@ import { hydratePlanSteps, PlannerPlanSchema, type PlannerPlan, type PlanningAge
 import { validatePlan } from "../../schemas/validate-plan.js";
 import { AnalysisPlanSchema } from "../../schemas/workflow-state.js";
 import { createNoopLogger } from "../../lib/console-logger.js";
-import type { Logger } from "../../lib/logger.js";
+import type { LogFields, Logger } from "../../lib/logger.js";
 import { unwrapOrThrow } from "../../lib/result.js";
 import { hintForZodIssue } from "../../lib/zod-issues.js";
 import { insertPlan, loadDataProfileStatus, loadPlan, type DataProfileResult, type DataProfileStatus } from "../../state/index.js";
@@ -67,6 +67,91 @@ const PLANNER_MAX_ITERATIONS = 13;
 
 /** Wall-clock guard for a single plan-generation invocation. */
 const PLAN_TIMEOUT_MS = 600_000;
+
+// ── Diagnostic bounds ───────────────────────────────────────────────
+//
+// This tool runs on `passthroughStep`: it writes no ledger row and owns no
+// durable stream, so its log records are the ONLY account of an invocation that
+// survives the turn. That makes them worth spending detail on — and makes every
+// one of them a place an unbounded model-authored string could reach a log file.
+// Each bound below is what keeps a record readable and a sink affordable when the
+// planner is behaving at its worst, which is exactly when the record gets read.
+
+/** Issues kept per rejection record. A plan bounces on a handful of distinct faults; the tail repeats. */
+const MAX_LOGGED_ISSUES = 8;
+/** Per-issue message budget — enough to identify the fault, not to reproduce the plan. */
+const MAX_LOGGED_ISSUE_CHARS = 240;
+/** Rejections kept on the finish record. Enough to show whether the planner converged or thrashed. */
+const MAX_LOGGED_REJECTIONS = 6;
+/** Excerpt of the planner's last words — the one artifact that explains a run ending on prose. */
+const MAX_LOGGED_PROSE_CHARS = 800;
+/** Tool-call trace length. The planner's whole budget is ~16 turns, so this rarely truncates. */
+const MAX_LOGGED_TOOL_CALLS = 48;
+
+/** Trim to `max`, marking the cut so a truncated value never reads as a complete one. */
+function bounded(value: string, max: number): string {
+    return value.length <= max ? value : `${value.slice(0, max)}…[+${value.length - max} chars]`;
+}
+
+/**
+ * One `submit_plan` rejection, in the shape a log query wants.
+ *
+ * `codes` separates the two failure families that call for different fixes: a
+ * `schema` count means the planner cannot produce the declared shape, a `semantic`
+ * count means it produces valid JSON describing an impossible DAG. `paths` is what
+ * makes repeated rejections comparable at a glance — identical paths across
+ * attempts is a planner stuck, moving paths is a planner making progress and
+ * merely running out of budget.
+ */
+interface RejectionRecord {
+    readonly attempt: number;
+    readonly issueCount: number;
+    readonly codes: { readonly schema: number; readonly semantic: number };
+    readonly paths: readonly string[];
+    readonly messages: readonly string[];
+}
+
+function toRejectionRecord(attempt: number, issues: readonly ValidationIssue[]): RejectionRecord {
+    const kept = issues.slice(0, MAX_LOGGED_ISSUES);
+    return {
+        attempt,
+        issueCount: issues.length,
+        codes: {
+            schema: issues.filter((i) => i.code === "schema").length,
+            semantic: issues.filter((i) => i.code === "semantic").length,
+        },
+        paths: kept.map((i) => i.path),
+        messages: kept.map((i) => bounded(i.message, MAX_LOGGED_ISSUE_CHARS)),
+    };
+}
+
+/**
+ * What the planner did over one invocation, accumulated by the inner tools.
+ *
+ * The failure this exists for is invisible from the outcome alone: `submit_plan`
+ * is non-terminal on rejection by design, so a planner can spend its entire
+ * iteration budget on submit → reject → fix → reject and end with `holder.outcome`
+ * still null. That reads as "the planner never called a terminal tool" — the same
+ * ending as a planner that stopped on prose after one turn, and the opposite
+ * problem.
+ */
+interface PlannerTrace {
+    submitAttempts: number;
+    /**
+     * True count of rejected attempts — NOT `rejections.length`, which stops at
+     * {@link MAX_LOGGED_REJECTIONS}. A record reporting 16 attempts and 6 rejections
+     * says ten of them were accepted, which is the opposite of what happened.
+     */
+    rejectedAttempts: number;
+    /** The first {@link MAX_LOGGED_REJECTIONS} rejections, in full. */
+    rejections: RejectionRecord[];
+    /** Terminal calls made after an outcome was already recorded — a planner ignoring "stop after this". */
+    duplicateTerminalCalls: number;
+}
+
+function createPlannerTrace(): PlannerTrace {
+    return { submitAttempts: 0, rejectedAttempts: 0, rejections: [], duplicateTerminalCalls: 0 };
+}
 
 // ── Prompt / catalog ────────────────────────────────────────────────
 
@@ -267,8 +352,18 @@ function renderDataContext(grounding: DataGrounding): string {
 /**
  * Persist a validated plan. Returns the planId, or an outcome-ready error
  * with a sanitized message — DB-shape errors never leak to the planner.
+ *
+ * The sanitization is for the model, not for the operator: "plan could not be
+ * saved, please try again" is all the planner may see, and it is useless to
+ * whoever has to fix the cause. The record here is the only place the real
+ * failure survives, so it is written before the message is flattened.
  */
-async function persistPlan(plan: PlannerPlan, ctx: PersistContext, pool: Pool): Promise<{ ok: true; planId: string } | { ok: false; message: string }> {
+async function persistPlan(
+    plan: PlannerPlan,
+    ctx: PersistContext,
+    pool: Pool,
+    logger: Logger,
+): Promise<{ ok: true; planId: string } | { ok: false; message: string }> {
     try {
         const planId = unwrapOrThrow(
             await insertPlan(pool, {
@@ -281,6 +376,12 @@ async function persistPlan(plan: PlannerPlan, ctx: PersistContext, pool: Pool): 
     } catch (err) {
         const raw = err instanceof Error ? err.message : String(err);
         const isParentValidation = /^parent plan .* (?:not found|belongs to a different analysis)$/i.test(raw);
+        logger.error("plan persistence failed", {
+            parentPlanId: ctx.parentPlanId,
+            stepCount: plan.steps.length,
+            classified: isParentValidation ? "invalid_parent_plan" : "write_failed",
+            ...logger.errorFields(err),
+        });
         return {
             ok: false,
             message: isParentValidation ? "parentPlanId is not a valid plan for this analysis" : "plan could not be saved, please try again",
@@ -359,6 +460,7 @@ interface InnerTools {
  */
 function buildInnerTools(
     holder: OutcomeHolder,
+    trace: PlannerTrace,
     persistCtx: PersistContext,
     pool: Pool,
     resourcePolicy: ResourcePolicy | undefined,
@@ -384,6 +486,11 @@ function buildInnerTools(
         }),
         execute: async (input): Promise<Result<SubmitPlanOutput, ToolError>> => {
             if (holder.outcome !== null) {
+                trace.duplicateTerminalCalls++;
+                logger.warn("submit_plan called after a terminal outcome was recorded", {
+                    recordedOutcome: holder.outcome.kind,
+                    duplicateTerminalCalls: trace.duplicateTerminalCalls,
+                });
                 return ok({
                     accepted: false as const,
                     issues: [
@@ -396,13 +503,21 @@ function buildInnerTools(
                 });
             }
 
+            const attempt = ++trace.submitAttempts;
             const result = fullyValidate(input.plan, resourcePolicy);
             if (!result.valid) {
-                logger.debug("submit_plan rejected a plan", { issueCount: result.issues.length, issues: result.issues });
+                trace.rejectedAttempts++;
+                const rejection = toRejectionRecord(attempt, result.issues);
+                if (trace.rejections.length < MAX_LOGGED_REJECTIONS) trace.rejections.push(rejection);
+                // `warn`, not `debug`: a rejection is non-terminal by design, so the model
+                // reads the issues and the invocation carries on — nothing else reports that
+                // an attempt was spent. A run that exhausts its budget on rejections ends
+                // looking identical to one that never tried, and this is the difference.
+                logger.warn("submit_plan rejected a plan", { ...rejection });
                 return ok({ accepted: false as const, issues: result.issues });
             }
 
-            const persisted = await persistPlan(result.plan, persistCtx, pool);
+            const persisted = await persistPlan(result.plan, persistCtx, pool, logger);
             if (!persisted.ok) {
                 holder.outcome = { kind: "persist_error", message: persisted.message };
                 return ok({
@@ -423,6 +538,14 @@ function buildInnerTools(
                 planId: persisted.planId,
                 plan: result.plan,
             };
+            // The attempt count is the cost of this plan, and it is only knowable here.
+            // A plan accepted on attempt 5 is a success that nearly was not one.
+            logger.info("submit_plan accepted a plan", {
+                planId: persisted.planId,
+                attempt,
+                stepCount: result.plan.steps.length,
+                agents: [...new Set(result.plan.steps.map((s) => s.agent))],
+            });
             return ok({ accepted: true as const, planId: persisted.planId });
         },
     });
@@ -438,20 +561,48 @@ function buildInnerTools(
             questionContext: z.string().optional(),
         }),
         execute: async (input) => {
-            if (holder.outcome === null) {
-                holder.outcome = {
-                    kind: "clarification",
-                    question: input.question,
-                    questionContext: input.questionContext,
-                };
+            if (holder.outcome !== null) {
+                trace.duplicateTerminalCalls++;
+                logger.warn("request_clarification called after a terminal outcome was recorded", {
+                    recordedOutcome: holder.outcome.kind,
+                    duplicateTerminalCalls: trace.duplicateTerminalCalls,
+                });
+                return ok({ recorded: true as const });
             }
+            holder.outcome = {
+                kind: "clarification",
+                question: input.question,
+                questionContext: input.questionContext,
+            };
+            // The question is the answer to "why did planning stop?" — and it reaches the
+            // user through the conversation agent, which may paraphrase it into something
+            // that no longer identifies the missing fact.
+            logger.info("planner requested clarification", {
+                question: bounded(input.question, MAX_LOGGED_PROSE_CHARS),
+                submitAttempts: trace.submitAttempts,
+            });
             return ok({ recorded: true as const });
         },
     });
 
     const reportBlockerTool = createReportBlockerToolFor({
         record: (outcome) => {
-            if (holder.outcome === null) holder.outcome = outcome;
+            if (holder.outcome !== null) {
+                trace.duplicateTerminalCalls++;
+                logger.warn("report_blocker called after a terminal outcome was recorded", {
+                    recordedOutcome: holder.outcome.kind,
+                    duplicateTerminalCalls: trace.duplicateTerminalCalls,
+                });
+                return;
+            }
+            holder.outcome = outcome;
+            // A blocker after several rejected submits is a planner giving up on a plan it
+            // could not make valid — a validation problem wearing a blocker's clothes. The
+            // attempt count is what tells those apart, and only this record carries both.
+            logger.warn("planner reported a blocker", {
+                reason: bounded(outcome.reason, MAX_LOGGED_PROSE_CHARS),
+                submitAttempts: trace.submitAttempts,
+            });
         },
         blockedWhen:
             "Ends plan generation with no plan saved. Use it when no valid plan can " +
@@ -464,13 +615,85 @@ function buildInnerTools(
     return { terminal };
 }
 
-function inventoryContent(label: string, result: Awaited<ReturnType<Tool["execute"]>>): string {
-    if (result.isErr()) return `## ${label}\n\nInventory lookup failed: ${result.error.error}`;
+/**
+ * Render one environment inventory into the seed, reporting a lookup that failed.
+ *
+ * A failed lookup is written INTO the prompt as prose the planner then plans
+ * around — a silent degradation of its grounding that no caller is told about and
+ * no outcome distinguishes. The record is what makes "the planner produced a plan
+ * naming packages this install does not have" traceable to its cause.
+ */
+function inventoryContent(label: string, result: Awaited<ReturnType<Tool["execute"]>>, logger: Logger): string {
+    if (result.isErr()) {
+        logger.warn("planner grounding inventory lookup failed", { inventory: label, error: result.error.error });
+        return `## ${label}\n\nInventory lookup failed: ${result.error.error}`;
+    }
     const value = result.value;
     if (typeof value === "object" && value !== null && "content" in value && typeof value.content === "string") {
         return `## ${label}\n\n${value.content}`;
     }
     return `## ${label}\n\n${JSON.stringify(value)}`;
+}
+
+// ── Transcript reading (diagnostics only) ───────────────────────────
+
+/**
+ * The planner's own account of the run, read off the message array `runToTerminal`
+ * returns. Nothing else can produce it: the transcript is ephemeral — a sub-agent
+ * loop on `passthroughStep` persists no messages anywhere — so it is read here or
+ * it is lost with the turn.
+ *
+ * `toolCalls` in order is what shows the SHAPE of a failure at a glance:
+ * `[submit_plan × 13]` is a planner thrashing on validation, `[]` is a planner
+ * that never called anything, and a trailing `report_blocker` on a run that ended
+ * with no outcome means the terminal call was cut off before it executed.
+ */
+function readTranscript(messages: readonly LoopMessage[]): { toolCalls: string[]; truncatedToolCalls: boolean; finalProse: string } {
+    const toolCalls: string[] = [];
+    let finalProse = "";
+    for (const message of messages) {
+        if (message.role !== "assistant" || typeof message.content === "string") {
+            if (message.role === "assistant" && typeof message.content === "string" && message.content.length > 0) finalProse = message.content;
+            continue;
+        }
+        for (const part of message.content) {
+            if (part.type === "tool-call") toolCalls.push(part.toolName);
+            // Last one wins: the closing text of the run is what explains a run that
+            // stopped talking instead of calling its terminal tool.
+            else if (part.type === "text" && part.text.trim().length > 0) finalProse = part.text;
+        }
+    }
+    return {
+        toolCalls: toolCalls.slice(0, MAX_LOGGED_TOOL_CALLS),
+        truncatedToolCalls: toolCalls.length > MAX_LOGGED_TOOL_CALLS,
+        finalProse: bounded(finalProse.trim(), MAX_LOGGED_PROSE_CHARS),
+    };
+}
+
+/**
+ * The loop half of the finish record: how the planner's run ended, and what it
+ * did to get there.
+ *
+ * Built from the `runToTerminal` result that the tool previously discarded
+ * entirely. Without it, `no_outcome` is a single word covering three unrelated
+ * failures — a budget spent on rejected submits (`max_iterations`), a planner that
+ * answered in prose (`stop`), and a reply cut off at the output-token limit
+ * (`length`) — which is why three identical-looking retries taught nobody anything.
+ */
+function loopFields(run: RunToTerminalResult): LogFields {
+    const transcript = readTranscript(run.messages);
+    return {
+        loop: {
+            finishReason: run.finish.reason,
+            cappedOut: run.finish.cappedOut,
+            truncationRecoveries: run.finish.truncationRecoveries,
+            salvaged: run.salvage !== null,
+            ...(run.salvage ? { firstFinishReason: run.salvage.firstFinish.reason, salvageFinishReason: run.salvage.finish.reason } : {}),
+            toolCalls: transcript.toolCalls,
+            ...(transcript.truncatedToolCalls ? { toolCallsTruncated: true } : {}),
+        },
+        ...(transcript.finalProse ? { plannerFinalProse: transcript.finalProse } : {}),
+    };
 }
 
 // ── Outcome shaping ─────────────────────────────────────────────────
@@ -661,13 +884,27 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             // the construction-time deps the factory closes over.
             const logger = baseLogger.with({ analysisId });
             const startedAt = Date.now();
+            const trace = createPlannerTrace();
 
             // Every exit routes through here, so "recorded exactly once per invocation" holds
             // by construction rather than by remembering. `elapsedMs` is what separates a
             // planner that gave up early from one still working when the guard cut it — the
             // fixed budget above makes the number readable without any other context.
-            const finish = (shaped: ShapedOutcome): Result<PlanningAgentOutput, ToolError> => {
-                logger[OUTCOME_LEVEL[shaped.kind]]("plan generation finished", { outcome: shaped.kind, elapsedMs: Date.now() - startedAt });
+            //
+            // `extra` carries the loop account on the paths that reached the loop. The two
+            // parent-plan early returns never do, and a record claiming `loop.finishReason`
+            // for a run that never started would be worse than one that omits the field.
+            const finish = (shaped: ShapedOutcome, extra: LogFields = {}): Result<PlanningAgentOutput, ToolError> => {
+                logger[OUTCOME_LEVEL[shaped.kind]]("plan generation finished", {
+                    outcome: shaped.kind,
+                    elapsedMs: Date.now() - startedAt,
+                    submitAttempts: trace.submitAttempts,
+                    rejectedAttempts: trace.rejectedAttempts,
+                    ...(trace.rejections.length > 0 ? { rejections: trace.rejections } : {}),
+                    ...(trace.rejectedAttempts > trace.rejections.length ? { rejectionsTruncated: true } : {}),
+                    ...(trace.duplicateTerminalCalls > 0 ? { duplicateTerminalCalls: trace.duplicateTerminalCalls } : {}),
+                    ...extra,
+                });
                 return ok(shaped.output);
             };
 
@@ -689,7 +926,14 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                         });
                     }
                     priorPlanBlock = formatPriorPlan(input.parentPlanId, priorPlan);
-                } catch {
+                    // `formatPriorPlan` returns null on a stored plan that no longer parses as an
+                    // `AnalysisPlan`. Iteration then silently becomes generation-from-scratch, and
+                    // the user gets a plan that ignored everything they asked to keep.
+                    if (priorPlanBlock === null) {
+                        logger.warn("prior plan did not parse — iterating without it", { parentPlanId: input.parentPlanId });
+                    }
+                } catch (err) {
+                    logger.error("parent plan could not be loaded", { parentPlanId: input.parentPlanId, ...logger.errorFields(err) });
                     return finish({
                         output: { event: "error", error: "Plan iteration failed — parent plan could not be loaded." },
                         kind: "parent_plan_load_failed",
@@ -705,8 +949,22 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             // without dataset facts is a real, supported state (see `renderDataContext`),
             // so a ledger read that fails must cost the planner its grounding — never
             // the user their plan.
-            const profileStatus = await loadDataProfileStatus(deps.pool, analysisId).unwrapOr(null);
-            const dataContextBlock = renderDataContext(classifyGrounding(profileStatus));
+            const profileStatus = await loadDataProfileStatus(deps.pool, analysisId).match(
+                (status) => status,
+                (error) => {
+                    // Degrading to "no profile" is correct behaviour and indistinguishable, from
+                    // the outcome, from an analysis that genuinely has none — so the read failure
+                    // is reported here or it is never known to have happened.
+                    logger.warn("data profile read failed — planning without dataset facts", {
+                        dbErrorType: error.type,
+                        ...("op" in error ? { dbOp: error.op } : {}),
+                        ...("cause" in error ? logger.errorFields(error.cause) : {}),
+                    });
+                    return null;
+                },
+            );
+            const grounding = classifyGrounding(profileStatus);
+            const dataContextBlock = renderDataContext(grounding);
 
             // Reference data and package availability are mandatory grounding,
             // not optional planner lookups. Read both inventories host-side before
@@ -717,9 +975,9 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             // tool's recursive leaf scan, so the seed contains usable file paths,
             // not only top-level directory summaries.
             const [refsResult, packagesResult] = await Promise.all([listAvailableRefs.execute({ query: "/" }, ctx), listAvailablePackages.execute({}, ctx)]);
-            const groundingBlock = [inventoryContent("Available Reference Data", refsResult), inventoryContent("Available Packages", packagesResult)].join(
-                "\n\n",
-            );
+            const refsBlock = inventoryContent("Available Reference Data", refsResult, logger);
+            const packagesBlock = inventoryContent("Available Packages", packagesResult, logger);
+            const groundingBlock = [refsBlock, packagesBlock].join("\n\n");
 
             const prompt = [
                 ...(priorPlanBlock ? [priorPlanBlock, ""] : []),
@@ -733,12 +991,40 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 ...(input.userConstraints ? ["", "## User Constraints", input.userConstraints] : []),
             ].join("\n");
 
+            // Opens the invocation. Two things are only knowable here and both are
+            // first-order suspects when a planner runs long and returns nothing: the size
+            // of the seed it was handed, and which of its blocks made it that size. The
+            // reference inventory in particular is a recursive leaf scan of whatever this
+            // install has staged — a quantity the harness does not control and no other
+            // record reports. The census is sizes only: the seed carries the user's
+            // research question and dataset facts, which belong in the model's context and
+            // not in a log file.
+            logger.info("plan generation started", {
+                model: deps.conversation.model,
+                maxIterations: PLANNER_MAX_ITERATIONS,
+                salvageIterations: DEFAULT_SALVAGE_ITERATIONS,
+                timeoutMs: PLAN_TIMEOUT_MS,
+                grounding: grounding.kind,
+                ...(input.parentPlanId ? { parentPlanId: input.parentPlanId } : {}),
+                seedChars: {
+                    total: prompt.length,
+                    priorPlan: priorPlanBlock?.length ?? 0,
+                    dataContext: dataContextBlock.length,
+                    referenceData: refsBlock.length,
+                    packages: packagesBlock.length,
+                    researchQuestion: input.researchQuestion.length,
+                    analystNotes: input.analystNotes?.length ?? 0,
+                    priorRuns: input.priorRuns?.length ?? 0,
+                    userConstraints: input.userConstraints?.length ?? 0,
+                },
+            });
+
             const holder: OutcomeHolder = { outcome: null };
             const persistCtx: PersistContext = {
                 analysisId,
                 parentPlanId: input.parentPlanId ?? null,
             };
-            const innerTools = buildInnerTools(holder, persistCtx, deps.pool, deps.resourcePolicy, logger);
+            const innerTools = buildInnerTools(holder, trace, persistCtx, deps.pool, deps.resourcePolicy, logger);
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),
@@ -752,8 +1038,9 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             const signal = AbortSignal.any([ctx.signal, AbortSignal.timeout(PLAN_TIMEOUT_MS)]);
 
             let runError: unknown = null;
+            let run: RunToTerminalResult | null = null;
             try {
-                await runToTerminal(
+                run = await runToTerminal(
                     planner,
                     [{ role: "user", content: prompt }],
                     forSubAgent(ctx.session, PLANNER_AGENT_ID),
@@ -788,6 +1075,13 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                     timedOut: signal.aborted && !ctx.signal.aborted,
                     outerAborted: ctx.signal.aborted,
                 }),
+                {
+                    // A throw leaves no result to read the transcript off, so the cause takes its
+                    // place — `shapeOutcome` folds it into one prose sentence for the model, and
+                    // this is the only place its type and stack survive.
+                    ...(run ? loopFields(run) : {}),
+                    ...(runError ? logger.errorFields(runError) : {}),
+                },
             );
         },
     });


### PR DESCRIPTION
…records

A user hit three consecutive generate_plan failures, ~9 minutes each, all reported as "no terminal outcome". The session log held 129 lines and not one of them came from the planner. The diagnostic records added for exactly this case were writing to a noop.

The CLI never wired the Logger seam into three places. The ConversationAssemblyDeps literal omitted `logger`, and assembleCoreRuntime forwards that object verbatim into createConversationAgent, so createGeneratePlanTool resolved `deps.logger ?? createNoopLogger()` and every record it wrote was discarded. runAgent's opts in the chat turn omitted it too, taking the loop's own account and runToTerminal's salvage warning with it. So did createConfiguredAiSdkProvider, hiding a retry envelope that backs off ten times at up to 30s a wait — minutes of apparent silence inside one tool call, indistinguishable from a model thinking. The seam realization moves beside getLogger because it has two independent callers, which is how one of them ended up silent in the first place.

Wiring alone would still have under-reported. `no_outcome` collapses three unrelated endings: a budget spent on rejected submits, a planner answering in prose, and a reply cut off at the output-token limit. Those call for opposite responses, and the retries taught nobody anything because the word was the same each time. runToTerminal now reports whether it salvaged and how the first run ended, generate_plan keeps the result it previously discarded, and the finish record carries the loop's stop reason, the tool-call trace, and the planner's closing prose — read off an ephemeral transcript that is otherwise lost with the turn, since this tool runs on passthroughStep and writes no ledger row.

submit_plan rejections move from debug to warn: a rejection is non-terminal by design, so the model reads the issues and the run carries on with nothing else recording that an attempt was spent. Each one names its attempt number and splits schema from semantic faults, and the paths make repeated rejections comparable — identical paths across attempts is a planner stuck, moving paths is one merely out of budget. The kept list is capped; the COUNT is not, because a record pairing 16 attempts with 6 rejections says ten were accepted.

The opening record measures the seed per block. The reference inventory is a recursive leaf scan of whatever an install has staged, a quantity the harness does not control and nothing else reported. Sizes only — the seed carries the research question and the dataset's facts, which belong in the model's context and not in a log file.

Four swallowed causes now survive: the DB error behind "plan could not be saved", the parent-plan load failure, the profile read that degrades a planner to no dataset facts, and an inventory lookup that fails into the prompt as prose the planner then plans around.

<!--
Thanks for contributing to Inflexa! Keep PRs focused — one logical change per PR.
See CONTRIBUTING.md for the full guidelines.
-->

## What & why

<!-- What does this change do, and why? -->

Closes #<!-- issue number, if any -->

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

<!-- Delete this section if it does not apply. -->

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [ ] **Sandbox:** the security model is preserved (unprivileged uid-1000 workload, all capabilities dropped, `no-new-privileges`; no network egress in poll mode — the in-container firewall on Docker, a NetworkPolicy on K8s; signature-authenticated exec endpoints; read-only analysis tree with writes confined to the step's output directory; resource limits; and no host credentials in spawned commands); any loosening is called out and justified.
- [ ] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
