### PR TITLE
fix(harness): lift the output-token ceiling off the SDK's 4096 fallback

### DIFF
--- a/harness/bun.lock
+++ b/harness/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@inflexa-ai/harness",
       "dependencies": {
-        "@ai-sdk/anthropic": "^4.0.15",
+        "@ai-sdk/anthropic": "^4.0.20",
         "@ai-sdk/openai-compatible": "^3.0.10",
         "@ai-sdk/provider": "^4.0.3",
         "@ai-sdk/provider-utils": "5.0.10",
@@ -59,7 +59,7 @@
     "eslint-plugin-neverthrow@1.1.4": "patches/eslint-plugin-neverthrow@1.1.4.patch",
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6iVlzqZjqqoHTmgO1WU9id/33pYykIRasWJFAMf1+d+nhju6d7566VRFsOGZ2W2GzgNtzKs8DGsYN7X5/wOGuw=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.25", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.16" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-cU61cAdOfgiuJngCPq61FI9pD7KB+gTQm1KQRIwvsf09gGJmliTR8UQdw9x9UWOOqvEYaeuE6NrtXUUCLOjsbQ=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.20", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-m3PdYs0yqSxswsrEhVj64wDLgFs35Zxl8liLNuWGzE7bwBLF6Mhu0E5rPpDNJbIjyQpA4aMKOOWBfjERw2zvPw=="],
 
@@ -893,6 +893,10 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@4.0.4", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LWDrmYWkZoAJwMbToUglpR6AmgvtnNtCCGeU9MKlXiSV3Yiu4u73/pVA18sQAAe3kZtCRBY9P31lAfnPekWWyg=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
@@ -1016,6 +1020,8 @@
     "unbzip2-stream/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -44,7 +44,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@ai-sdk/anthropic": "^4.0.15",
+        "@ai-sdk/anthropic": "^4.0.20",
         "@ai-sdk/openai-compatible": "^3.0.10",
         "@ai-sdk/provider": "^4.0.3",
         "@ai-sdk/provider-utils": "5.0.10",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -94,7 +94,7 @@ export type { AnthropicProviderDeps } from "./providers/anthropic.js";
 // union discriminated over the `anthropic` and `openai-compatible` kinds — with
 // `ConfiguredAiSdkProviderDeps` as its argument shape. `createAnthropicProvider`
 // above is a convenience over this union's `anthropic` arm.
-export { createConfiguredAiSdkProvider } from "./providers/ai-sdk.js";
+export { createConfiguredAiSdkProvider, DEFAULT_MAX_OUTPUT_TOKENS } from "./providers/ai-sdk.js";
 export type { AiSdkProviderConfig, ConfiguredAiSdkProviderDeps } from "./providers/ai-sdk.js";
 export { createEmbeddingProvider } from "./providers/embedding.js";
 export type { EmbeddingProviderDeps } from "./providers/embedding.js";

--- a/harness/src/providers/ai-sdk.ts
+++ b/harness/src/providers/ai-sdk.ts
@@ -24,11 +24,46 @@ export const RETRY_INITIAL_DELAY_MS = 2_000;
 export const RETRY_BACKOFF_FACTOR = 2;
 export const RETRY_MAX_DELAY_MS = 30_000;
 
+/**
+ * Output-token ceiling requested when a config names none — a floor against a
+ * provider default, not a target. `@ai-sdk/anthropic` resolves an unset value
+ * from a capability table that lags Anthropic's releases and falls back to 4096
+ * for ids it does not know, so the newest models silently truncate mid
+ * tool-call. The SDK clamps this down per known model (opus-4-x to 32k,
+ * claude-3-haiku to 4096), so it cannot over-request one it recognizes.
+ *
+ * Lower it per-config for servers that validate `prompt + max_tokens <= context`
+ * (vLLM and similar) against a small-context model.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
+
+/**
+ * Point the AI SDK's warning logger at the harness `Logger`.
+ *
+ * The SDK writes warnings itself — `process.emitWarning`, else `console.warn` —
+ * and offers only this process-global hook to redirect them. Left alone it
+ * bypasses the Logger seam entirely and lands on the stdout a TUI host owns;
+ * `maxOutputTokens` makes that routine, since the SDK warns on every request
+ * whose ceiling it clamps. Installed once: the handler is global, and every
+ * provider over a boot shares one sink.
+ */
+function routeSdkWarningsTo(logger: Logger): void {
+    const g = globalThis as { AI_SDK_LOG_WARNINGS?: unknown };
+    if (g.AI_SDK_LOG_WARNINGS !== undefined) return;
+    g.AI_SDK_LOG_WARNINGS = (options: { warnings: readonly unknown[]; provider?: string; model?: string }) => {
+        for (const warning of options.warnings) {
+            logger.warn("ai sdk warning", { provider: options.provider, model: options.model, warning });
+        }
+    };
+}
+
 export interface AiSdkProviderDeps {
     readonly model: LanguageModel;
     readonly resolveBilling: ResolveBilling;
     readonly capabilities?: Partial<ProviderCapabilities>;
     readonly logger?: Logger;
+    /** Output-token ceiling per request. Defaults to {@link DEFAULT_MAX_OUTPUT_TOKENS}. */
+    readonly maxOutputTokens?: number;
 }
 
 /**
@@ -49,6 +84,8 @@ export type AiSdkProviderConfig =
           readonly model: string;
           readonly fetch?: FetchLike;
           readonly capabilities?: Partial<ProviderCapabilities>;
+          /** Output-token ceiling per request. Defaults to {@link DEFAULT_MAX_OUTPUT_TOKENS}. */
+          readonly maxOutputTokens?: number;
       }
     | {
           readonly kind: "openai-compatible";
@@ -58,6 +95,8 @@ export type AiSdkProviderConfig =
           readonly model: string;
           readonly fetch?: FetchLike;
           readonly capabilities?: Partial<ProviderCapabilities>;
+          /** Output-token ceiling per request. Defaults to {@link DEFAULT_MAX_OUTPUT_TOKENS}. */
+          readonly maxOutputTokens?: number;
       };
 
 export interface ConfiguredAiSdkProviderDeps {
@@ -297,6 +336,8 @@ function sanitizeMessages(messages: readonly ModelMessage[]): ModelMessage[] {
 export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
     const capabilities: ProviderCapabilities = { toolCalling: deps.capabilities?.toolCalling ?? true };
     const logger = (deps.logger ?? createNoopLogger()).named("providers.ai-sdk");
+    const maxOutputTokens = deps.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    routeSdkWarningsTo(logger);
 
     function chat(req: ChatRequest, session: AgentSession, signal?: AbortSignal): ResultAsync<ChatResponse, ProviderError> {
         const run = async (): Promise<Result<ChatResponse, ProviderError>> => {
@@ -312,6 +353,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                         messages: sanitizeMessages(req.messages),
                         tools: req.tools,
                         toolChoice: req.toolChoice ?? "auto",
+                        maxOutputTokens,
                         stopWhen: [],
                         // The harness envelope owns retries; leaving the SDK default in
                         // place would multiply attempts (10 outer × 3 inner).
@@ -349,6 +391,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                     messages: sanitizeMessages(req.messages),
                     tools: req.tools,
                     toolChoice: req.toolChoice ?? "auto",
+                    maxOutputTokens,
                     stopWhen: [],
                     maxRetries: 0,
                     headers,
@@ -431,6 +474,7 @@ export function createConfiguredAiSdkProvider(deps: ConfiguredAiSdkProviderDeps)
             resolveBilling: deps.resolveBilling,
             capabilities: config.capabilities,
             logger: deps.logger,
+            ...(config.maxOutputTokens !== undefined ? { maxOutputTokens: config.maxOutputTokens } : {}),
         });
     }
 
@@ -445,5 +489,6 @@ export function createConfiguredAiSdkProvider(deps: ConfiguredAiSdkProviderDeps)
         resolveBilling: deps.resolveBilling,
         capabilities: config.capabilities,
         logger: deps.logger,
+        ...(config.maxOutputTokens !== undefined ? { maxOutputTokens: config.maxOutputTokens } : {}),
     });
 }

--- a/harness/src/providers/anthropic.test.ts
+++ b/harness/src/providers/anthropic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { makeSession } from "./__fixtures__/session.js";
+import { DEFAULT_MAX_OUTPUT_TOKENS } from "./ai-sdk.js";
 import { createAnthropicProvider } from "./anthropic.js";
 import type { ChatRequest, FetchLike } from "./types.js";
 
@@ -134,5 +135,24 @@ describe("createAnthropicProvider", () => {
                 },
             },
         ]);
+    });
+
+    it("carries the output-token ceiling on the streaming path as well as the generate path", async () => {
+        // The cap has to ride both calls: chatStream drives the interactive turn,
+        // so a ceiling applied only to generateText would leave chat truncating.
+        const cap = capturingFetch();
+        const provider = createAnthropicProvider({
+            baseURL: "http://billing.test/anthropic",
+            token: "test-token",
+            model: "claude-opus-4-7",
+            resolveBilling: async () => ({}),
+            fetch: cap.fetch,
+        });
+
+        for await (const _event of provider.chatStream(request, makeSession())) {
+            // drain
+        }
+
+        expect((cap.bodies[0] as { max_tokens?: number }).max_tokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
     });
 });

--- a/harness/src/providers/anthropic.ts
+++ b/harness/src/providers/anthropic.ts
@@ -17,6 +17,8 @@ export interface AnthropicProviderDeps {
     readonly resolveBilling: ResolveBilling;
     readonly fetch?: FetchLike;
     readonly logger?: Logger;
+    /** Output-token ceiling per request. Defaults to `DEFAULT_MAX_OUTPUT_TOKENS`. */
+    readonly maxOutputTokens?: number;
 }
 
 /**
@@ -36,6 +38,7 @@ export function createAnthropicProvider(deps: AnthropicProviderDeps): ChatProvid
             model: deps.model,
             fetch: deps.fetch,
             capabilities: { toolCalling: true },
+            ...(deps.maxOutputTokens !== undefined ? { maxOutputTokens: deps.maxOutputTokens } : {}),
         },
     });
 }

--- a/harness/src/providers/configured-provider.barrel.test.ts
+++ b/harness/src/providers/configured-provider.barrel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createConfiguredAiSdkProvider } from "@inflexa-ai/harness";
+import { createConfiguredAiSdkProvider, DEFAULT_MAX_OUTPUT_TOKENS } from "@inflexa-ai/harness";
 import type { AiSdkProviderConfig, ChatRequest, ConfiguredAiSdkProviderDeps } from "@inflexa-ai/harness";
 
 import { makeSession } from "./__fixtures__/session.js";
@@ -46,10 +46,10 @@ function openaiJson(text: string, model: string): Response {
  * provider bound at construction (the request itself carries no model field),
  * and replies with a response echoing that body's `model`.
  */
-function capturingFetch(respond: (text: string, model: string) => Response): { fetch: FetchLike; bodies: Array<{ model?: string }> } {
-    const bodies: Array<{ model?: string }> = [];
+function capturingFetch(respond: (text: string, model: string) => Response): { fetch: FetchLike; bodies: Array<{ model?: string; max_tokens?: number }> } {
+    const bodies: Array<{ model?: string; max_tokens?: number }> = [];
     const fetch: FetchLike = async (_input, init) => {
-        const body = init?.body ? (JSON.parse(String(init.body)) as { model?: string }) : {};
+        const body = init?.body ? (JSON.parse(String(init.body)) as { model?: string; max_tokens?: number }) : {};
         bodies.push(body);
         return respond("Hello, world", body.model ?? "");
     };
@@ -127,5 +127,67 @@ describe("provider configuration front door", () => {
         // Same shared connection config; each provider instance's request carries the
         // model it was constructed with — no per-request model.
         expect(cap.bodies.map((body) => body.model)).toEqual(["model-a", "model-b"]);
+    });
+});
+
+describe("output-token ceiling", () => {
+    /** Run one chat over a capturing fetch and report the `max_tokens` that reached the wire. */
+    async function wireMaxTokens(
+        respond: (text: string, model: string) => Response,
+        build: (fetch: FetchLike) => AiSdkProviderConfig,
+    ): Promise<number | undefined> {
+        const cap = capturingFetch(respond);
+        const provider = createConfiguredAiSdkProvider({ config: build(cap.fetch), resolveBilling: async () => ({}) });
+
+        const result = await provider.chat(request, makeSession());
+
+        expect(result.isOk()).toBe(true);
+        return cap.bodies[0]?.max_tokens;
+    }
+
+    const anthropicModel =
+        (model: string, maxOutputTokens?: number) =>
+        (fetch: FetchLike): AiSdkProviderConfig => ({
+            kind: "anthropic",
+            baseURL: "http://models.local/anthropic",
+            apiKey: "test-key",
+            model,
+            fetch,
+            ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+        });
+
+    it("sends the default ceiling for a model the SDK's capability table does not know", async () => {
+        // The regression: an unrecognized id takes the SDK's 4096 fallback when
+        // nothing names a ceiling, truncating plan-sized tool calls mid-payload.
+        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-99-future"))).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+
+    it("lets the SDK clamp the default down to a known model's real limit", async () => {
+        // What makes a high default safe: it never reaches a model the SDK knows
+        // to have a smaller ceiling.
+        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-4-1"))).toBe(32_000);
+    });
+
+    it("recognizes claude-opus-5, clamping an over-large ceiling to its real limit", async () => {
+        // Guards the dependency floor: before @ai-sdk/anthropic 4.0.20 this id was
+        // unknown, so it took the 4096 fallback and skipped the clamp — 200000 would
+        // ride out verbatim instead of landing on the model's real 128k.
+        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-5", 200_000))).toBe(128_000);
+    });
+
+    it("honours a per-config override on the openai-compatible arm", async () => {
+        // The escape hatch for servers that validate prompt + max_tokens against a
+        // small context window.
+        expect(
+            await wireMaxTokens(openaiJson, (fetch) => ({
+                kind: "openai-compatible",
+                name: "self-hosted",
+                baseURL: "http://models.local/v1",
+                apiKey: "test-key",
+                model: "local-tool-model",
+                fetch,
+                maxOutputTokens: 8_192,
+            })),
+        ).toBe(8_192);
     });
 });


### PR DESCRIPTION
## What was wrong

`@ai-sdk/anthropic` resolves an unset `maxOutputTokens` from a per-model capability table, falling back to **4096** for any id it does not recognize. That table lags Anthropic's releases — `claude-opus-5` was missing from it through 4.0.19 — so every request ran with `max_tokens: 4096`.

Plan-sized `submit_plan` payloads do not fit in 4096 tokens. The call truncated mid-JSON, `run-agent` returned the never-dispatched trailing call as an error, and the planner retried into the same wall until it ran out of iterations:

```
iterations:13  toolCalls:13  toolErrors:13  truncationRecoveries:7  reason:"max_iterations"
outcome:"no_outcome"  elapsedMs:474597  submitAttempts:0
```

`submitAttempts: 0` is the tell — the payload never reached plan validation. Every failing run's output tokens came to `truncationRecoveries × 4096` plus a remainder (`12289 = 3×4096 + 1`), each truncated turn burning the full budget. Four of six plan generations ended `no_outcome`, at ~9 minutes and ~250k input tokens each.

The install was also stale three ways: `package.json` declared `^4.0.15`, `bun.lock` pinned 4.0.15, and `node_modules` held **4.0.5**. Since `cli/node_modules/@inflexa-ai/harness` is a symlink to the harness dir, that 4.0.5 is what the running CLI loaded.

## What changed

**Dependency floor → `^4.0.20`** (installs 4.0.25). 4.0.20 is the first release with a `claude-opus-5` entry; it also restores `supportsAdaptiveThinking`, `supportsXhighEffort`, and `supportsStructuredOutput`, which the unknown-model fallback disabled. `ai` also moved 7.0.11 → 7.0.28, its own declared floor.

**Explicit `maxOutputTokens`, defaulting to 64000** on both provider arms, so the next model the table has not caught up to cannot silently fall to 4096.

Why 64000 and not higher: for models the SDK knows, the number above their ceiling is irrelevant — it clamps per-model (opus-4-x → 32k, claude-3-haiku → 4096), so a high default cannot over-request a recognized model. It only reaches the API raw for **unknown** ids, and there 64000 is the largest safe value. A new Haiku is the most likely unrecognized id to appear and Haiku's ceiling is 64k, so 128000 would 400 on every call where 64000 works. It also halves the runaway-cost ceiling on a capped-out 13-iteration run.

Overridable per config (`AiSdkProviderConfig.maxOutputTokens`) for servers that validate `prompt + max_tokens <= context` — vLLM and similar — against a small-context model.

**SDK warnings routed into the `Logger` seam.** The AI SDK logs warnings itself via `process.emitWarning`/`console.warn`. An explicit ceiling makes clamp warnings per-request traffic, and the CLI is a TUI that owns stdout — so `globalThis.AI_SDK_LOG_WARNINGS` now forwards them to the injected logger instead.

## Behavior change worth noting

The `openai-compatible` arm previously **omitted** `max_tokens` entirely and now sends 64000. That is deliberate — the whole point is a floor that does not depend on a provider default — but it is the one path where a self-hosted small-context model may need the override.

## Tests

Four wire-body assertions over a capturing `fetch` in `configured-provider.barrel.test.ts`, plus one on the streaming path:

- unknown id → 64000 on the wire, not 4096 (the regression)
- `claude-opus-4-1` → clamped to 32000 (what makes a high default safe)
- `claude-opus-5` with 200000 → clamped to 128000 (guards the dependency floor: before 4.0.20 this id was unknown, took the 4096 fallback, and skipped the clamp)
- per-config override honored on the openai-compatible arm
- the ceiling rides `chatStream` as well as `generateText`

`tsc` clean, `eslint` clean, full unit suite 1661 pass / 0 fail.

## Follow-up, not in this PR

The CLI consumes `@inflexa-ai/harness@0.14.1` from npm, so this fix reaches it only after a harness release — the usual publish-then-consume ordering.

Two things this incident exposed that are worth separate changes: `runToTerminal` grants a salvage continuation restricted to the terminal tools, which cannot help when the failure is that the terminal payload does not fit — all four salvages here re-ran the same truncation for nothing. And `"iteration truncated at output limit"` is logged at `debug`, so the one line naming the cause is invisible at default verbosity.