### PR TITLE
Release harness v0.14.2

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
Patch-bumps `harness/package.json` to `0.14.2`.

Merging this publishes `@inflexa-ai/harness@0.14.2` to npm (`release-harness.yml` triggers on a `harness/package.json` version change landing on `main`) and cuts the `harness-v0.14.2` tag.

Picks up since `0.14.1`:

- #284 — `fix(harness): lift the output-token ceiling off the SDK's 4096 fallback`

The CLI still pins `@inflexa-ai/harness@0.14.1`; bumping that dependency is a separate follow-up PR, once this version is live on npm.