### PR TITLE
fix(harness,sandbox): drop lineage reads of paths that were never there

### DIFF
--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/proposal.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+A customer's `bulk-transcriptomics-agent` step ran for twelve minutes, finished
+its work, and was then killed by its own bookkeeping:
+
+```
+[reconcile-manifest] cannot attest input — not present at reconcile
+  path:      /{rid}/runs/{run}/T1S1/scripts/hashtable_class_helper.pxi
+  source:    upstream   refStepId: T1S1
+  hostPath:  .../analyses/stroke/runs/{run}/T1S1/scripts/hashtable_class_helper.pxi
+  throwSite: input-enoent
+```
+
+`hashtable_class_helper.pxi` is a pandas Cython source file. No such file has
+ever existed in that directory, and the step never tried to read one. What
+happened is CPython's traceback printer, and it is reproducible in three lines:
+
+- A script the step ran lives in `T1S1/scripts/`, so `sys.path[0]` is that
+  directory — inside the analysis mount, and inside a *declared dependency's*
+  subtree.
+- The script died with an uncaught `KeyError` from pandas. Displaying that
+  traceback means showing the source line of every frame, and a Cython frame's
+  `co_filename` is relative (`hashtable_class_helper.pxi` — the name in the
+  `include` directive). CPython's `_Py_FindSourceFile` resolves a relative frame
+  filename by *opening* `<entry>/<basename>` for **every** `sys.path` entry until
+  one succeeds.
+- `sitecustomize.py`'s audit hook fires on the `open` **audit event**, which
+  CPython raises *before* the open is attempted. Every failed probe is therefore
+  reported exactly like a successful read, `os.path.abspath`-ed against the
+  process cwd.
+
+Verified against the shipped hook, unmodified — a script that only crashes with
+`df["missing_column"]` emits:
+
+```
+{"p": ".../runs/RUN/T1S1/scripts/hashtable_class_helper.pxi", "layer": "python", "op": "read"}
+{"p": ".../runs/RUN/T1S1/scripts/index.pyx",                  "layer": "python", "op": "read"}
+```
+
+The path classifies `upstream` (T1S1 was declared), which is attested, so
+`fillInputHashesFromDisk` stats it, gets `ENOENT`, and throws. The step dies with
+`lineage_attestation`, and the parent's fail-fast cascade takes the run — over a
+file that never existed, after the analysis had already succeeded. The failure
+also *masks* the script error the agent had already recovered from.
+
+This is the third instance of one shape: reconcile treating "a capture layer
+named something I cannot hash" as drift worth killing an analysis over. The two
+prior instances (`/{resourceId}/..`, out-of-mount reads) were fixed by dropping;
+the `ENOENT` throw was explicitly retained then as "genuine drift". That premise
+is what is wrong. **The capture layers report attempted operations, not completed
+ones** — the Python audit hook fires ahead of the open, R's `trace()` at call
+entry over a `normalizePath(mustWork = FALSE)` name — so a read that failed
+arrives indistinguishable from one that succeeded. An absent path is therefore
+at least as likely to mean *nothing was read* as *an artifact vanished*, and
+neither is attestable. Only the LD_PRELOAD layer gets this right today: it
+reports after the call, gated on `fd >= 0`.
+
+Nothing about failing recovers the edge. The step has already run; the outputs
+are already on disk. Dropping upholds the invariant that matters — never register
+a hashless lineage edge — and leaves a warn record and a counter where a dead run
+used to be.
+
+## What Changes
+
+- `fillInputHashesFromDisk` SHALL **drop** a tracked input whose path is not
+  present at reconcile (`ENOENT`) via `collector.dropInput(ref)`, logged at warn
+  with the ref, its resolved `hostPath`, and `dropSite: "input-enoent"`, and
+  counted on `cortex.artifact.reconcile.input_dropped` with `reason: "missing"`.
+  It no longer throws for this condition.
+- Fail-fast is retained for a `stat` that fails any **other** way: the file is
+  there and cannot be read, which says something is wrong with the tree itself.
+- Sandbox-side, `recordOp` — where all four layers converge — SHALL drop a
+  `read` report whose path is not present, so a probe never reaches the frame in
+  the first place. Only absence drops it: a `stat` failing any other way keeps
+  the report rather than losing a real edge to a transient error. Writes and
+  deletes are exempt; a write is reported before the file it creates exists.
+
+The two fixes are independent by design, as in the prior change: the harness one
+ships via npm and holds on any sandbox image, which matters because the image is
+`workflow_dispatch`-only and `:latest`-tagged.
+
+## Capabilities
+
+### New Capabilities
+
+None. This narrows existing requirements in `artifact-manifest`,
+`sandbox-provenance-tracking`, and `exec-provenance-lineage`.

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/artifact-manifest/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: The manifest is reconciled against disk before registration
+
+`reconcileManifestWithDisk(input)` SHALL run after the sandbox is destroyed and
+before any artifact is registered or synced. For each manifest entry it SHALL
+stat the file at `{workspaceRoot}/runs/{runId}/{stepId}/{entry.path}`, bounded
+to the step root, and:
+
+- If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`, `step_id`), and emit a debug log line.
+- If the path is not a regular file (a directory) → drop it the same way.
+- Otherwise → recompute SHA-256 from disk via `computeSha256File` and replace the entry's `hash` and `size` with the on-disk values.
+
+Every surviving entry SHALL be re-hashed from disk — there is no matched-size
+fast path that skips hashing. The reconcile step SHALL also content-attest the
+collector's tracked inputs via `fillInputHashesFromDisk`: for each tracked input
+that is not an `artifacts`-source read and lacks a valid content hash, it maps
+the container path onto the host workspace tree, bounds it to
+`{workspaceRoot}`, and hashes the file from disk.
+
+An input that is not a content-attestable file **of this analysis** SHALL be
+dropped via `collector.dropInput` and SHALL NOT fail the step:
+
+- An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
+- An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref and a `boundSite` discriminator; the workspace-root record also carries the resolved host path (the container-prefix bound rejects the path before a host mapping exists).
+- An input naming a path that is **not present** at reconcile (`ENOENT`) → dropped, logged at **warn** with the ref, its resolved host path, and `dropSite: "input-enoent"`.
+
+Every input drop SHALL increment the `cortex.artifact.reconcile.input_dropped`
+counter, tagged `agent_id`, `step_id`, and `reason` (`directory`,
+`container-prefix`, `workspace-root`, or `missing`).
+
+An out-of-tree read is out of scope rather than drift: the analysis tree mounts
+at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container
+root and describes nothing about the analysis. The capture hooks are meant to
+filter such reads by data prefix, so the lineage graph already describes only
+in-tree inputs — dropping a leaked one restores that graph. Dropping upholds
+"never register a hashless lineage edge" exactly as a throw would, without
+destroying a legitimate analysis over an untracked read, and it mirrors the
+out-of-bounds *output* skip in the same function. Warn rather than debug is
+deliberate: a directory read is ordinary, whereas an out-of-tree read means a
+capture layer reported something it should have filtered — not worth a dead
+analysis, but worth noticing.
+
+An absent path is not drift either, and for a reason that belongs to the capture
+layers: they report **attempted** operations, not completed ones. The Python
+audit hook fires on the `open` audit event, which CPython raises before the open
+is attempted; R's `trace()` fires at call entry over a
+`normalizePath(mustWork = FALSE)` name. A read that failed therefore arrives
+indistinguishable from one that succeeded, and the commonest source of them is
+ordinary: displaying an uncaught traceback whose frame carries a relative
+`co_filename` (every Cython frame — pandas' `.pxi`/`.pyx`) makes CPython open
+`<entry>/<basename>` for every `sys.path` entry until one succeeds, and the
+entries under the analysis mount become reported reads of files that were never
+there. Nothing was consumed, so there is no edge to attest, and the step that
+already produced its outputs is not made more correct by dying. Warn rather than
+debug for the same reason as an out-of-tree read: the count of these is how a
+reader tells a noisy capture layer from an artifact that genuinely vanished
+under a step.
+
+Fail-fast SHALL remain for a `stat` that fails any **other** way — the file is
+there and cannot be read, which says something is wrong with the tree itself —
+and no drop SHALL ever register a hashless lineage edge.
+
+#### Scenario: Phantom file is dropped silently
+
+- **GIVEN** the agent wrote `output/temp.csv` and later deleted it, but the walk had already recorded it (or the collector still holds a record)
+- **WHEN** `reconcileManifestWithDisk` runs and stat fails with `ENOENT`
+- **THEN** the entry for `output/temp.csv` is removed from the returned manifest, `collector.removeRecord("output/temp.csv")` is called, a debug line is logged, and `cortex.artifact.reconcile.dropped` is incremented once
+- **AND** `output/temp.csv` reaches neither registration nor the vector index
+
+#### Scenario: Every surviving output is re-hashed from disk
+
+- **GIVEN** a manifest entry for `output/clean.csv` whose on-disk size equals the entry's size
+- **WHEN** `reconcileManifestWithDisk` runs
+- **THEN** `computeSha256File` IS invoked for `output/clean.csv` and the entry's hash and size are set from the on-disk bytes
+
+#### Scenario: An input that is not present at reconcile is dropped, not failed
+
+- **GIVEN** the collector tracked a non-`artifacts` input read whose file is absent at reconcile time
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `dropSite: "input-enoent"` is emitted, `cortex.artifact.reconcile.input_dropped` is incremented with `reason: "missing"`, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register, and no hashless lineage edge is registered
+
+#### Scenario: A traceback's source-file probe does not fail the step
+
+- **GIVEN** a step whose script lives in a declared dependency's `scripts/` directory and died with an uncaught pandas `KeyError`, so the capture layer reported a read of `runs/{runId}/{depStepId}/scripts/hashtable_class_helper.pxi` — a `sys.path` probe for the Cython frame's source, which never existed
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** the ref is dropped from lineage and the step completes, while the real read of the script itself is attested with its on-disk hash
+
+#### Scenario: A directory read is dropped from lineage, not failed
+
+- **GIVEN** a tracked input that resolves to a directory (e.g. `ls` of a mount)
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref and the step does NOT fail
+
+#### Scenario: A read resolving outside the analysis tree is dropped, not failed
+
+- **GIVEN** a tracked input read of `/{resourceId}/..` — the container root, which maps to a host path above the workspace root
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `boundSite` is emitted, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/exec-provenance-lineage/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Each exec frame is threaded into the step-scoped collector
+
+The sandbox-step body SHALL construct one `ProvenanceCollector` per step, seeded with the step's `stepId`,
+`runId`, and `dependsOn`. The `dependsOn` seeding is load-bearing, not informational: classification admits
+a same-run sibling edge only on declaration, so a collector seeded without it refuses every same-run read
+including legitimate declared dependencies.
+
+`dependsOn` SHALL reach the step body through its durable workflow input. The field SHALL be optional, and
+its absence SHALL be treated as an empty declaration list — a workflow recovered under an input shape that
+predates the field under-captures every same-run cross-step edge, declared dependencies included, rather
+than admitting unstable ones.
+
+The parent SHALL project the field from its keyed plan snapshot (`planStepById`) when building each child's
+input, and SHALL throw when the step is absent from it rather than defaulting to an empty list. An empty
+list is indistinguishable from a step that genuinely declared nothing, so a silent default would delete
+every same-run edge the step was entitled to while leaving no record that it did.
+
+After each `execute_command` resolves its `ExecResult`, the workspace `execute_command` tool SHALL feed that
+result's `provenance` frame into the collector via `feedExecFrame` (`src/provenance/exec-frame.ts`).
+`feedExecFrame` SHALL strip the `/{resourceId}/` mount prefix from each frame path — collapsing separators
+doubled at the boundary so an in-mount name lands on its canonical relative form — classify every read via
+`classifyReadPath(relativePath, stepId, runId, dependsOn)`, call `trackInputAccess` for each read that
+classification admits, and call `recordCommandExecution` once per exec with that exec's own admitted reads
+scoped to its outputs. A read that classification refuses SHALL be dropped and SHALL NOT be tracked. The
+refusal SHALL be logged once per distinct path per step: a refusal reports one fact — a lineage edge that
+will not exist — and that fact does not change when the same file is read again, while reads dedup within a
+frame but not across the many execs a step issues, so an undeduped narration is a steady stream that trains
+a reader to filter away the signal. A frame path that does not lie under the mount SHALL ride onto its `InputRef` verbatim, never with
+the mount root prepended: reconcile drops both a foreign path and a missing in-tree one, but only the
+verbatim name says which of the two happened, and the drop record is the only account a reader gets of a
+hook-filter leak. Read hashes SHALL be left unset at track time and filled from disk by
+`reconcileManifestWithDisk` before registration. When the frame is absent or `disabled`, `feedExecFrame`
+SHALL record the command with no inputs and no writes rather than throw.
+
+#### Scenario: Command reading an input and writing an output produces a lineage edge
+
+- **GIVEN** an `execute_command` whose argv is `["python3", "scripts/tmm.py"]` and whose `ExecResult.provenance` reads `/{rid}/data/inputs/Lab/counts.csv` and writes `/{rid}/runs/{run}/{step}/output/tmm.csv`
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** `getRecords()` contains a record for `output/tmm.csv` with `producer.type: "command"`, an inferred `scriptPath: "scripts/tmm.py"`, and an input with `source: "data"` for `data/inputs/Lab/counts.csv`
+
+#### Scenario: Upstream read is classified by step metadata
+
+- **GIVEN** step `de` in run `run-002` with `dependsOn: ["qc"]` and an exec whose frame reads `/{rid}/runs/run-002/qc/output/qc.csv`
+- **WHEN** the read is classified and tracked
+- **THEN** the resulting `InputRef` has `source: "upstream"`, `stepId: "qc"`, `runId: "run-002"`
+
+#### Scenario: The collector is seeded with the step's declared dependencies
+
+- **GIVEN** a step whose durable workflow input declares `dependsOn: ["qc"]`
+- **WHEN** the sandbox-step body constructs its `ProvenanceCollector`
+- **THEN** the collector's `dependsOn` is `["qc"]`, and a frame read of `runs/{runId}/qc/output/qc.csv` produces an `upstream` edge
+
+#### Scenario: A workflow input without dependsOn fails closed
+
+- **GIVEN** a workflow recovered under an input shape that carries no `dependsOn`
+- **WHEN** an exec frame reports a read of any same-run sibling's directory
+- **THEN** the collector treats the declaration list as empty, the read is refused, and no edge is registered
+
+#### Scenario: A concurrent sibling's scratch file never becomes an attestation target
+
+- **GIVEN** step `T2S2`, whose `dependsOn` does not contain `T5S1`, and an exec frame reporting a read of `/{rid}/runs/{runId}/T5S1/output/_ct_for_r_BRAF.csv`
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** no `InputRef` is tracked for that path, so `reconcileManifestWithDisk` has nothing to attest and the step's lineage never asserted an edge over a sibling that was still writing
+
+#### Scenario: A read outside the mount keeps its own name
+
+- **GIVEN** an exec whose frame reports a read of `/etc/passwd` — naming nothing under the mount, a path the hooks should have filtered
+- **WHEN** the tool feeds the frame via `feedExecFrame`
+- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound, naming that bound rather than reporting a missing in-tree file
+
+#### Scenario: Missing or disabled frame degrades to no inputs
+
+- **GIVEN** an `ExecResult` whose `provenance` is absent or has `disabled: true`
+- **WHEN** the tool feeds it via `feedExecFrame`
+- **THEN** the command is recorded with an empty `inputs` array and no error is thrown

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/sandbox-provenance-tracking/spec.md
@@ -20,7 +20,11 @@ attestable file.
 
 At that same point, the server SHALL drop a report of a **read** whose path is
 not present in the container, and SHALL log the drop when running at debug level.
-Only absence drops a report: a `stat` failing any other way — a permission the
+Presence SHALL be resolved the way the open resolves it — **following
+symlinks** — because the question the check asks is whether the reported read
+could have succeeded: a link whose target is gone fails the open too, and a layer
+that fires before the call cannot tell that from a name that never existed. Only
+absence drops a report: a `stat` failing any other way — a permission the
 server lacks and the workload had — SHALL keep it rather than lose a real lineage
 edge to a transient error. Reports of **writes** and **deletes** SHALL NOT be
 subject to this check: a write is reported before the file it creates exists, and
@@ -73,6 +77,18 @@ name the workload used, and the layers report names, not inodes.
 - **GIVEN** a layer reporting a read of a file that exists under a watch dir
 - **WHEN** the server records the report
 - **THEN** the exec `provenance` frame's `reads` contains it
+
+#### Scenario: A read through a broken symlink is not reported
+
+- **GIVEN** a layer reporting a read of an in-tree path that is a symlink whose target no longer exists
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` does NOT contain it — the open it reports would have failed the same way a name that never existed would
+
+#### Scenario: A read through a live symlink survives under the name the workload used
+
+- **GIVEN** a layer reporting a read of an in-tree symlink whose target exists
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` contains the link's own path, not the target's
 
 #### Scenario: A write to a path that does not exist yet is reported
 

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/specs/sandbox-provenance-tracking/spec.md
@@ -1,0 +1,99 @@
+## MODIFIED Requirements
+
+### Requirement: The sandbox-server activates the in-container layers per command
+
+For each `POST /exec` command, the sandbox-server SHALL inject the provenance
+layers into the child process environment when their files are present:
+`PYTHONPATH` prepended with `/opt/provenance` (Layer 1 Python), `R_PROFILE`
+pointing at `/opt/provenance/Rprofile.site` (Layer 1 R), `LD_PRELOAD` pointing at
+`/opt/provenance/provtrack.so` (Layer 2), `PROVENANCE_SOCKET` set to the
+per-command socket path, and `PROVENANCE_DATA_PREFIXES` set from the server's
+configured watch dirs. After the child exits, the server SHALL drain the socket,
+combine the socket reports with the inotify verification channel, and surface the
+result as the exec `provenance` frame.
+
+The server SHALL canonicalize every reported path — collapsing `.` and `..`
+segments — and SHALL record it only if the canonical path lies **within** a
+configured watch dir, at the single point where all layers converge. A watch dir
+itself SHALL NOT be recorded: a read of the mount root is a directory, never an
+attestable file.
+
+At that same point, the server SHALL drop a report of a **read** whose path is
+not present in the container, and SHALL log the drop when running at debug level.
+Only absence drops a report: a `stat` failing any other way — a permission the
+server lacks and the workload had — SHALL keep it rather than lose a real lineage
+edge to a transient error. Reports of **writes** and **deletes** SHALL NOT be
+subject to this check: a write is reported before the file it creates exists, and
+a phantom write is dropped host-side at reconcile, where the file has had its
+chance to appear.
+
+A read report is a claim of intent, not of consumption. Two of the layers fire
+ahead of the call they observe — the Python audit hook runs on the `open` audit
+event, which CPython raises before the open is attempted, and R's `trace()` runs
+at call entry over a `normalizePath(mustWork = FALSE)` name — so a read that
+fails is reported exactly like one that succeeds. (Only Layer 2 reports after the
+fact, gated on `fd >= 0`.) The commonest source is ordinary rather than exotic:
+displaying an uncaught traceback whose frame carries a relative `co_filename` —
+every Cython frame, e.g. pandas' `.pxi`/`.pyx` — makes CPython open
+`<entry>/<basename>` for every `sys.path` entry until one succeeds, and the
+entries under the analysis mount become reported reads of files that were never
+there. The host can neither tell such a probe from an input nor hash it, so it is
+dropped where the layers converge.
+
+Each in-container layer filters by string prefix on whatever path its caller
+passed, and an absolute path need not be canonical: `/{resourceId}/..` literally
+begins with the watch dir `/{resourceId}/` yet names its parent, so it survives
+every layer's own filter. The host maps such a path to a location above the
+workspace root, where it cannot attest it. The layer filters are therefore an
+optimization — they keep a datagram off the socket — and this re-check is the
+boundary that decides what a frame may contain. Canonicalization is
+**lexical**: resolving symlinks would make the reported path disagree with the
+name the workload used, and the layers report names, not inodes.
+
+#### Scenario: Layers are injected for a Python command
+
+- **GIVEN** a sandbox-server with the provenance files installed at `/opt/provenance`
+- **WHEN** a command is executed via `POST /exec`
+- **THEN** the child process environment carries `PYTHONPATH` including `/opt/provenance`, `R_PROFILE`, `LD_PRELOAD`, `PROVENANCE_SOCKET`, and `PROVENANCE_DATA_PREFIXES`
+
+#### Scenario: Socket reports fold into the exec frame
+
+- **WHEN** a script reads `/{resourceId}/data/inputs/test.csv` via `pandas.read_csv` and the command completes
+- **THEN** the exec `provenance` frame's `reads` contains that path
+- **AND** does not contain stdlib paths like `/usr/lib/python3/...`
+
+#### Scenario: A read of a path that is not there is not reported
+
+- **GIVEN** a script that dies with an uncaught pandas `KeyError`, so the audit hook reports a read of `<sys.path entry>/hashtable_class_helper.pxi` under the analysis mount — CPython's probe for the Cython frame's source, which never existed there
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` does NOT contain that path
+
+#### Scenario: A read of a file that is there survives
+
+- **GIVEN** a layer reporting a read of a file that exists under a watch dir
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` contains it
+
+#### Scenario: A write to a path that does not exist yet is reported
+
+- **GIVEN** a layer reporting a write to `/{resourceId}/runs/{run}/{step}/output/de.csv` before the file has been created
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `writes` contains that path
+
+#### Scenario: A read of the mount's parent is not reported
+
+- **GIVEN** a watch dir of `/{resourceId}/` and a layer reporting a read of `/{resourceId}/..` (the container root, which the workload may legitimately open)
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A traversal out of the tree is not reported
+
+- **GIVEN** a layer reporting a read of `/{resourceId}/../../../etc/passwd`
+- **WHEN** the server records the report
+- **THEN** the canonical path is `/etc/passwd`, which lies outside every watch dir, and the exec `provenance` frame does NOT contain it
+
+#### Scenario: A non-canonical in-tree path folds onto its canonical name
+
+- **GIVEN** R's `normalizePath(mustWork = FALSE)` reporting a write to `/{resourceId}/runs/r1/T3S1/scripts/../output/enrich.csv` (it leaves `..` intact whenever a component does not exist yet — the common case for a new output file), and the inotify layer reporting `/{resourceId}/runs/r1/T3S1/output/enrich.csv`
+- **WHEN** the server records both reports
+- **THEN** the frame carries ONE entry, under the canonical path, attributed to both layers

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/tasks.md
@@ -21,3 +21,8 @@
 - [x] 3.3 Delta on `exec-provenance-lineage`: the verbatim out-of-mount rationale no longer rests on a missing file failing the step — both are dropped, and the verbatim name is what makes the drop diagnosable.
 - [x] 3.4 Hand-rewrite the **Purpose** sections deltas do not carry: `artifact-manifest` and `exec-provenance-lineage` both claimed an unhashable input is terminal.
 - [x] 3.5 Archived (`openspec archive`); main specs updated and all items validate `--strict`.
+
+## 4. Review follow-ups
+
+- [x] 4.1 Probe a read path on first sighting only, inside the fold that already dedups it — inotify reports every open of every file in the tree, so a script reading one file in a loop paid a stat per iteration on the hot path. A later report cannot add a path to the frame, so a second verdict decides nothing. Regression test counts probes; verified it fails (3 probes) with the check hoisted back above the fold.
+- [x] 4.2 State the symlink semantics rather than leaving them implicit: presence follows symlinks because the question is whether the reported open could have succeeded, and a layer firing before the call cannot distinguish a dead link from a name that never existed. Delta + main spec sentence and two scenarios; Go tests for both directions.

--- a/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/tasks.md
+++ b/harness/openspec/changes/archive/2026-07-31-drop-phantom-lineage-reads/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Drop an input that is not present instead of failing the step
+
+- [x] 1.1 `fillInputHashesFromDisk` — replace the `ENOENT` throw with `collector.dropInput(ref)` + `continue`, logged at warn with the ref, its resolved `hostPath`, and `dropSite: "input-enoent"`, counted with `reason: "missing"`.
+- [x] 1.2 Keep the throw for a `stat` that fails any other way — a file that is there and unreadable says something is wrong with the tree.
+- [x] 1.3 Rewrite the `fillInputHashesFromDisk` doc comment around the invariant (never register a hashless edge) rather than around fail-fast, naming why an absent path is not evidence of drift; extend `ProvenanceCollector.dropInput`'s and the `input_dropped` counter description with the third reason.
+- [x] 1.4 Regression test driving the customer's shape through the real `feedExecFrame` path — a `.pxi` probe under a declared dependency's `scripts/` dir — plus the drop, its warn record, and the guard test on the undeclared-sibling refusal. Verified all four fail against the old throw.
+
+## 2. Sandbox-side: never report a read that did not happen
+
+- [x] 2.1 `recordOp` — drop a `read` report whose path is not present, at the same convergence point that canonicalizes and bounds. Only absence drops it; any other `stat` error keeps the report. Writes and deletes exempt.
+- [x] 2.2 Debug-log the drop, mirroring the out-of-tree drop — a dropped report never reaches the host, so this is its only trace.
+- [x] 2.3 Go tests: the phantom `.pxi` read dropped, a present file's read kept, a write to a not-yet-existing path kept. The existing watch-dir tests inject a presence probe so they keep testing the bound rather than passing on absence. Verified the new drop test fails without the fix.
+- [ ] 2.4 Dispatch the image build to rebuild + push the sandbox images — the sandbox-side fix only reaches a host that re-pulls (`workflow_dispatch`-only, `:latest`).
+
+## 3. Spec
+
+- [x] 3.1 Delta on `artifact-manifest`: an input absent at reconcile is dropped and counted (`reason: "missing"`); fail-fast retained only for a non-`ENOENT` `stat` failure.
+- [x] 3.2 Delta on `sandbox-provenance-tracking`: the server drops read reports for absent paths where the layers converge, with the reason those reports exist (the hooks report attempted operations).
+- [x] 3.3 Delta on `exec-provenance-lineage`: the verbatim out-of-mount rationale no longer rests on a missing file failing the step — both are dropped, and the verbatim name is what makes the drop diagnosable.
+- [x] 3.4 Hand-rewrite the **Purpose** sections deltas do not carry: `artifact-manifest` and `exec-provenance-lineage` both claimed an unhashable input is terminal.
+- [x] 3.5 Archived (`openspec archive`); main specs updated and all items validate `--strict`.

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -16,7 +16,7 @@ the `ArtifactRegistry` call, never by the manifest. Disk is the source of truth
 for *what was produced*; the collector is the source of truth for *what it was
 derived from*.
 
-**Content-attested lineage, fail-fast for integrity.** The sandbox provenance
+**Content-attested lineage; no hashless edge ever registered.** The sandbox provenance
 frame is path-only — it reports
 which files were read and written, never their bytes. So Cortex recomputes
 SHA-256 hashes from disk at `reconcileManifestWithDisk` for **every surviving
@@ -31,19 +31,25 @@ mount does not establish that — it bounds what *this* step writes, while every
 sibling has its own directory mounted read-write over the same host inodes and
 mutates it freely. This makes the registered hash equal `sha256sum` of
 the bytes the sync target receives at upload time. The reconcile/register/sync
-stages are pulled out of the best-effort net: a tracked input **file** that is
-missing at reconcile, and a registry rejection, are **terminal** — they fail the
-step loudly rather than orphaning real outputs green.
+stages are pulled out of the best-effort net: a registry rejection is
+**terminal** — it fails the step loudly rather than orphaning real outputs green.
 
-Genuine *file* drift fails fast. A read that is not a content-attestable file of
-this analysis is dropped from lineage instead — a **directory** (e.g. `ls` of a
-mount), and a read **resolving outside the analysis tree** (e.g. `/{resourceId}/..`,
-the container root, which the sandbox may legitimately open). Neither is drift:
-nothing about the analysis changed and no edge is at risk, so dropping upholds
-"never register a hashless lineage edge" exactly as a throw would, without
-destroying a legitimate analysis over an untracked read. The enrichment stages —
-file-metadata, step-summary, vector-index — stay best-effort and keep degrading
-via `safeRun`, because they are search/UX quality, not integrity.
+A ref that cannot be hashed is dropped from lineage, whatever put it out of
+reach: a **directory** (e.g. `ls` of a mount), a read **resolving outside the
+analysis tree** (e.g. `/{resourceId}/..`, the container root, which the sandbox
+may legitimately open), and a read naming a path that is **not there at all**.
+None of the three is drift. The last one is not even evidence that something
+was read: the capture layers report *attempted* operations — the Python audit
+hook fires ahead of the open, R's `trace()` at call entry — so a read that failed
+arrives indistinguishable from one that succeeded, and CPython's own traceback
+printer manufactures them by the dozen (a relative Cython `co_filename` sends it
+opening `<entry>/<basename>` down all of `sys.path`). Dropping upholds "never
+register a hashless lineage edge" exactly as a throw would, without destroying a
+legitimate analysis that has already produced its outputs; what remains terminal
+is a `stat` that fails some *other* way, where the file is there and cannot be
+read. The enrichment stages — file-metadata, step-summary, vector-index — stay
+best-effort and keep degrading via `safeRun`, because they are search/UX quality,
+not integrity.
 
 The ledger is a thin index: identity (`path`, `hash`, `size`), provenance
 (`source_step`, `source_run`), and optional external registration state
@@ -118,10 +124,11 @@ dropped via `collector.dropInput` and SHALL NOT fail the step:
 
 - An input resolving to a **directory** (e.g. `ls` of a mount) → dropped, logged at debug.
 - An input resolving **outside the analysis tree**, at either the container-prefix or the workspace-root bound → dropped, logged at **warn** with the ref and a `boundSite` discriminator; the workspace-root record also carries the resolved host path (the container-prefix bound rejects the path before a host mapping exists).
+- An input naming a path that is **not present** at reconcile (`ENOENT`) → dropped, logged at **warn** with the ref, its resolved host path, and `dropSite: "input-enoent"`.
 
 Every input drop SHALL increment the `cortex.artifact.reconcile.input_dropped`
 counter, tagged `agent_id`, `step_id`, and `reason` (`directory`,
-`container-prefix`, or `workspace-root`).
+`container-prefix`, `workspace-root`, or `missing`).
 
 An out-of-tree read is out of scope rather than drift: the analysis tree mounts
 at `/{resourceId}`, so a reported read of `/{resourceId}/..` names the container
@@ -135,9 +142,25 @@ deliberate: a directory read is ordinary, whereas an out-of-tree read means a
 capture layer reported something it should have filtered — not worth a dead
 analysis, but worth noticing.
 
-Fail-fast SHALL remain for genuine drift: an input **file** that is missing at
-reconcile (`ENOENT`) SHALL throw, as SHALL an unexpected `stat` failure, never
-registering a hashless lineage edge.
+An absent path is not drift either, and for a reason that belongs to the capture
+layers: they report **attempted** operations, not completed ones. The Python
+audit hook fires on the `open` audit event, which CPython raises before the open
+is attempted; R's `trace()` fires at call entry over a
+`normalizePath(mustWork = FALSE)` name. A read that failed therefore arrives
+indistinguishable from one that succeeded, and the commonest source of them is
+ordinary: displaying an uncaught traceback whose frame carries a relative
+`co_filename` (every Cython frame — pandas' `.pxi`/`.pyx`) makes CPython open
+`<entry>/<basename>` for every `sys.path` entry until one succeeds, and the
+entries under the analysis mount become reported reads of files that were never
+there. Nothing was consumed, so there is no edge to attest, and the step that
+already produced its outputs is not made more correct by dying. Warn rather than
+debug for the same reason as an out-of-tree read: the count of these is how a
+reader tells a noisy capture layer from an artifact that genuinely vanished
+under a step.
+
+Fail-fast SHALL remain for a `stat` that fails any **other** way — the file is
+there and cannot be read, which says something is wrong with the tree itself —
+and no drop SHALL ever register a hashless lineage edge.
 
 #### Scenario: Phantom file is dropped silently
 
@@ -152,11 +175,18 @@ registering a hashless lineage edge.
 - **WHEN** `reconcileManifestWithDisk` runs
 - **THEN** `computeSha256File` IS invoked for `output/clean.csv` and the entry's hash and size are set from the on-disk bytes
 
-#### Scenario: A missing input file fails the step
+#### Scenario: An input that is not present at reconcile is dropped, not failed
 
 - **GIVEN** the collector tracked a non-`artifacts` input read whose file is absent at reconcile time
 - **WHEN** `fillInputHashesFromDisk` runs
-- **THEN** it throws, the step fails loudly, and no hashless lineage edge is registered
+- **THEN** `collector.dropInput` is called for that ref, a warn record naming the ref, its resolved `hostPath`, and `dropSite: "input-enoent"` is emitted, `cortex.artifact.reconcile.input_dropped` is incremented with `reason: "missing"`, and the step does NOT fail
+- **AND** the step's real outputs still reconcile and register, and no hashless lineage edge is registered
+
+#### Scenario: A traceback's source-file probe does not fail the step
+
+- **GIVEN** a step whose script lives in a declared dependency's `scripts/` directory and died with an uncaught pandas `KeyError`, so the capture layer reported a read of `runs/{runId}/{depStepId}/scripts/hashtable_class_helper.pxi` — a `sys.path` probe for the Cython frame's source, which never existed
+- **WHEN** `fillInputHashesFromDisk` runs
+- **THEN** the ref is dropped from lineage and the step completes, while the real read of the script itself is attested with its on-disk hash
 
 #### Scenario: A directory read is dropped from lineage, not failed
 

--- a/harness/openspec/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/specs/exec-provenance-lineage/spec.md
@@ -9,7 +9,7 @@ contributes a lineage record (which inputs the command read, which script ran),
 and at step teardown the populated collector is handed to registration so the
 injected `ArtifactRegistry` sees real input/script edges instead of empty ones.
 
-Lineage is content-attested and fail-fast (see the artifact-manifest spec). The
+Lineage is content-attested (see the artifact-manifest spec). The
 sandbox provenance frame is path-only: it names the files a
 command read and wrote but never carries their bytes, so input refs arrive with
 empty hashes. `reconcileManifestWithDisk` fills those hashes from disk just
@@ -19,8 +19,8 @@ was a declared dependency, which the scheduler guarantees completed before this
 step started, and a completed step never writes into its tree again. The
 read-only mount does NOT establish this: it bounds what *this* step writes,
 while every other step has its own directory mounted read-write over the same
-host inodes. An input that cannot be hashed is terminal rather than registered
-hashless (see the artifact-manifest spec for the reconcile rules).
+host inodes. An input that cannot be hashed is dropped from lineage rather than
+registered hashless (see the artifact-manifest spec for the reconcile rules).
 
 This is the OSS view of the seam. The OSS build exposes the `ArtifactRegistry`
 interface with `createNoopArtifactRegistry` as its local default; the live
@@ -29,9 +29,7 @@ provenance ledger). The seam result is a flat per-path outcome and carries no
 managed signing vocabulary. The structured
 signing-method payload and any synthesized empty-input collector are a managed
 adapter's concern and are not part of OSS core.
-
 ## Requirements
-
 ### Requirement: Each exec frame is threaded into the step-scoped collector
 
 The sandbox-step body SHALL construct one `ProvenanceCollector` per step, seeded with the step's `stepId`,
@@ -60,9 +58,9 @@ refusal SHALL be logged once per distinct path per step: a refusal reports one f
 will not exist — and that fact does not change when the same file is read again, while reads dedup within a
 frame but not across the many execs a step issues, so an undeduped narration is a steady stream that trains
 a reader to filter away the signal. A frame path that does not lie under the mount SHALL ride onto its `InputRef` verbatim, never with
-the mount root prepended: forging an in-tree name for a foreign path would surface at reconcile as phantom
-drift (a missing file, which fails the step) instead of the out-of-tree read it is (which reconcile drops
-from lineage). Read hashes SHALL be left unset at track time and filled from disk by
+the mount root prepended: reconcile drops both a foreign path and a missing in-tree one, but only the
+verbatim name says which of the two happened, and the drop record is the only account a reader gets of a
+hook-filter leak. Read hashes SHALL be left unset at track time and filled from disk by
 `reconcileManifestWithDisk` before registration. When the frame is absent or `disabled`, `feedExecFrame`
 SHALL record the command with no inputs and no writes rather than throw.
 
@@ -94,13 +92,13 @@ SHALL record the command with no inputs and no writes rather than throw.
 
 - **GIVEN** step `T2S2`, whose `dependsOn` does not contain `T5S1`, and an exec frame reporting a read of `/{rid}/runs/{runId}/T5S1/output/_ct_for_r_BRAF.csv`
 - **WHEN** the tool feeds the frame via `feedExecFrame`
-- **THEN** no `InputRef` is tracked for that path, so `reconcileManifestWithDisk` has nothing to attest and the step does not fail with `lineage_attestation` when `T5S1` later deletes the file
+- **THEN** no `InputRef` is tracked for that path, so `reconcileManifestWithDisk` has nothing to attest and the step's lineage never asserted an edge over a sibling that was still writing
 
 #### Scenario: A read outside the mount keeps its own name
 
 - **GIVEN** an exec whose frame reports a read of `/etc/passwd` — naming nothing under the mount, a path the hooks should have filtered
 - **WHEN** the tool feeds the frame via `feedExecFrame`
-- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound rather than failing the step
+- **THEN** the tracked `InputRef` carries `path: "/etc/passwd"` verbatim, and `reconcileManifestWithDisk` later drops it at the container-prefix bound, naming that bound rather than reporting a missing in-tree file
 
 #### Scenario: Missing or disabled frame degrades to no inputs
 
@@ -204,3 +202,4 @@ and the bidirectional last-write-wins unlinking applies to both feeds.
 
 - **WHEN** the mutate seam performs its sandbox byte-write exec
 - **THEN** that exec's provenance frame is not threaded through `feedExecFrame` — the in-process file-tool record is the sole attestation, and no command record naming the write interpreter exists for the path
+

--- a/harness/openspec/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/specs/sandbox-provenance-tracking/spec.md
@@ -28,8 +28,11 @@ result into the exec frame.
 **The server, not the layers, is the boundary.** Each layer filters by string
 prefix on the path its caller passed, which need not be canonical — so a layer
 can report a path that matches a watch dir textually while naming somewhere
-else. Every report is canonicalized and re-checked against the watch dirs where
-the layers converge; a layer's own filter only keeps a datagram off the socket.
+else. Layer 1 also reports *attempted* operations: both of its hooks fire ahead
+of the call they observe, so a read that fails arrives looking exactly like one
+that succeeded. Every report is canonicalized, re-checked against the watch dirs, and
+— for a read — checked for the path being there at all, where the layers
+converge; a layer's own filter only keeps a datagram off the socket.
 
 This tracking is **production-wired**, not a prototype: the harness's
 `buildMountPlan` sets `PROVENANCE_WATCH_DIRS` to each step's analysis resource
@@ -302,6 +305,28 @@ configured watch dir, at the single point where all layers converge. A watch dir
 itself SHALL NOT be recorded: a read of the mount root is a directory, never an
 attestable file.
 
+At that same point, the server SHALL drop a report of a **read** whose path is
+not present in the container, and SHALL log the drop when running at debug level.
+Only absence drops a report: a `stat` failing any other way — a permission the
+server lacks and the workload had — SHALL keep it rather than lose a real lineage
+edge to a transient error. Reports of **writes** and **deletes** SHALL NOT be
+subject to this check: a write is reported before the file it creates exists, and
+a phantom write is dropped host-side at reconcile, where the file has had its
+chance to appear.
+
+A read report is a claim of intent, not of consumption. Two of the layers fire
+ahead of the call they observe — the Python audit hook runs on the `open` audit
+event, which CPython raises before the open is attempted, and R's `trace()` runs
+at call entry over a `normalizePath(mustWork = FALSE)` name — so a read that
+fails is reported exactly like one that succeeds. (Only Layer 2 reports after the
+fact, gated on `fd >= 0`.) The commonest source is ordinary rather than exotic:
+displaying an uncaught traceback whose frame carries a relative `co_filename` —
+every Cython frame, e.g. pandas' `.pxi`/`.pyx` — makes CPython open
+`<entry>/<basename>` for every `sys.path` entry until one succeeds, and the
+entries under the analysis mount become reported reads of files that were never
+there. The host can neither tell such a probe from an input nor hash it, so it is
+dropped where the layers converge.
+
 Each in-container layer filters by string prefix on whatever path its caller
 passed, and an absolute path need not be canonical: `/{resourceId}/..` literally
 begins with the watch dir `/{resourceId}/` yet names its parent, so it survives
@@ -323,6 +348,24 @@ name the workload used, and the layers report names, not inodes.
 - **WHEN** a script reads `/{resourceId}/data/inputs/test.csv` via `pandas.read_csv` and the command completes
 - **THEN** the exec `provenance` frame's `reads` contains that path
 - **AND** does not contain stdlib paths like `/usr/lib/python3/...`
+
+#### Scenario: A read of a path that is not there is not reported
+
+- **GIVEN** a script that dies with an uncaught pandas `KeyError`, so the audit hook reports a read of `<sys.path entry>/hashtable_class_helper.pxi` under the analysis mount — CPython's probe for the Cython frame's source, which never existed there
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` does NOT contain that path
+
+#### Scenario: A read of a file that is there survives
+
+- **GIVEN** a layer reporting a read of a file that exists under a watch dir
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` contains it
+
+#### Scenario: A write to a path that does not exist yet is reported
+
+- **GIVEN** a layer reporting a write to `/{resourceId}/runs/{run}/{step}/output/de.csv` before the file has been created
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `writes` contains that path
 
 #### Scenario: A read of the mount's parent is not reported
 

--- a/harness/openspec/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/specs/sandbox-provenance-tracking/spec.md
@@ -307,7 +307,11 @@ attestable file.
 
 At that same point, the server SHALL drop a report of a **read** whose path is
 not present in the container, and SHALL log the drop when running at debug level.
-Only absence drops a report: a `stat` failing any other way — a permission the
+Presence SHALL be resolved the way the open resolves it — **following
+symlinks** — because the question the check asks is whether the reported read
+could have succeeded: a link whose target is gone fails the open too, and a layer
+that fires before the call cannot tell that from a name that never existed. Only
+absence drops a report: a `stat` failing any other way — a permission the
 server lacks and the workload had — SHALL keep it rather than lose a real lineage
 edge to a transient error. Reports of **writes** and **deletes** SHALL NOT be
 subject to this check: a write is reported before the file it creates exists, and
@@ -360,6 +364,18 @@ name the workload used, and the layers report names, not inodes.
 - **GIVEN** a layer reporting a read of a file that exists under a watch dir
 - **WHEN** the server records the report
 - **THEN** the exec `provenance` frame's `reads` contains it
+
+#### Scenario: A read through a broken symlink is not reported
+
+- **GIVEN** a layer reporting a read of an in-tree path that is a symlink whose target no longer exists
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` does NOT contain it — the open it reports would have failed the same way a name that never existed would
+
+#### Scenario: A read through a live symlink survives under the name the workload used
+
+- **GIVEN** a layer reporting a read of an in-tree symlink whose target exists
+- **WHEN** the server records the report
+- **THEN** the exec `provenance` frame's `reads` contains the link's own path, not the target's
 
 #### Scenario: A write to a path that does not exist yet is reported
 

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -1,7 +1,9 @@
 /**
  * Reconcile content-attests inputs (see the artifact-manifest spec): the path-only provenance frame
  * leaves every input ref hashless; reconcile fills the hash from the immutable
- * on-disk bytes, and fails fast when an attested input is missing.
+ * on-disk bytes, and drops from lineage every ref it cannot hash — a directory,
+ * a resolution outside the analysis tree, a path that is not there — so no
+ * hashless edge is ever registered and no step dies over one.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -244,59 +246,126 @@ describe("reconcileManifestWithDisk — input content attestation", () => {
         }
     });
 
-    test("throws when an attested input is missing at reconcile (fail-fast)", async () => {
-        const { sessionPath, root, collector, manifest } = await setup({ writeUpstream: false });
+    test("drops an input that is not present at reconcile instead of failing the step", async () => {
+        const { sessionPath, root, upstreamRel, collector, manifest } = await setup({ writeUpstream: false });
         try {
-            await expect(
-                reconcileManifestWithDisk({
-                    workspaceRoot: root,
-                    resourceId: RID,
-                    runId: "run-001",
-                    stepId: "de",
-                    agentId: "agent-x",
-                    manifest,
-                    collector,
-                }),
-            ).rejects.toThrow(/cannot attest input/);
+            const result = await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+            });
+
+            // The step's own output still reconciles, and the unhashable ref
+            // leaves both the tracked inputs and every record that cited it —
+            // registration never sees a hashless edge.
+            expect(result.manifest).toHaveLength(1);
+            expect(collector.getTrackedInputs().some((r) => r.path === `/${RID}/${upstreamRel}`)).toBe(false);
+            expect(collector.getRecords().flatMap((r) => r.inputs)).toHaveLength(0);
         } finally {
             await rm(sessionPath, { recursive: true, force: true });
         }
     });
 
-    test("names the unattestable input and its throw site in the log", async () => {
-        // The regression this change exists for: a step failed this way repeatedly
-        // in the field and the operator log said nothing, because the throw was
-        // console.error'd (discarded by the host) and the raised message is scrubbed
-        // downstream. The record below is the ONLY account of which input died.
+    test("names the dropped input and its drop site in the log", async () => {
+        // A dropped edge is invisible by nature — the lineage graph simply lacks
+        // it — so this record is the only account of which input the step lost
+        // and why. It is also how a reader tells a noisy capture layer from an
+        // artifact that genuinely vanished under the step.
         const { sessionPath, root, upstreamRel, collector, manifest } = await setup({ writeUpstream: false });
         const logger = createCapturingLogger();
         try {
-            await expect(
-                reconcileManifestWithDisk({
-                    workspaceRoot: root,
-                    resourceId: RID,
-                    runId: "run-001",
-                    stepId: "de",
-                    agentId: "agent-x",
-                    manifest,
-                    collector,
-                    logger,
-                }),
-            ).rejects.toThrow();
+            await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+                logger,
+            });
 
-            const errors = logger.records.filter((r) => r.level === "error");
-            expect(errors).toHaveLength(1);
-            expect(errors[0]!.msg).toBe("[reconcile-manifest] cannot attest input — not present at reconcile");
-            expect(errors[0]!.fields).toMatchObject({
-                // Which step died, which input, and how it was classified — the read's
+            const warns = logger.records.filter((r) => r.level === "warn");
+            expect(warns).toHaveLength(1);
+            expect(warns[0]!.msg).toBe("[reconcile-manifest] dropping input not present at reconcile from lineage");
+            expect(warns[0]!.fields).toMatchObject({
+                // Which step, which input, and how it was classified — the read's
                 // `source` is what says whether the step ever declared this input.
                 runId: "run-001",
                 stepId: "de",
                 agentId: "agent-x",
                 path: `/${RID}/${upstreamRel}`,
                 source: "upstream",
-                throwSite: "input-enoent",
+                dropSite: "input-enoent",
             });
+            expect(logger.records.filter((r) => r.level === "error")).toHaveLength(0);
+        } finally {
+            await rm(sessionPath, { recursive: true, force: true });
+        }
+    });
+
+    test("a traceback's source-file probe under an upstream step does not fail the step", async () => {
+        // The reported failure, end to end. The step ran a script living in its
+        // upstream's `scripts/` directory; the script died with an uncaught
+        // pandas KeyError, and CPython's traceback printer looked for the Cython
+        // source of the frame by probing "<entry>/hashtable_class_helper.pxi"
+        // for every sys.path entry — sys.path[0] being that same directory. The
+        // Python audit hook fires before the open, so the failed probe was
+        // reported as a read; the path classifies `upstream` (a declared
+        // dependency), which is attested. The step had already finished its work
+        // when reconcile killed it over a file that never existed.
+        const sessionPath = await mkdtemp(join(tmpdir(), "cortex-reconcile-"));
+        const root = join(sessionPath, RID);
+        const logger = createCapturingLogger();
+        const phantomRel = "runs/run-001/qc/scripts/hashtable_class_helper.pxi";
+        const scriptRel = "runs/run-001/qc/scripts/qc.py";
+        try {
+            await mkdir(join(root, "runs/run-001/qc/scripts"), { recursive: true });
+            await writeFile(join(root, scriptRel), "import pandas as pd\n");
+            await mkdir(join(root, "runs/run-001/de/output"), { recursive: true });
+            await writeFile(join(root, "runs/run-001/de/output/result.csv"), "result\n1\n");
+
+            const collector = new ProvenanceCollector({ stepId: "de", runId: "run-001", dependsOn: ["qc"] });
+            feedExecFrame({
+                collector,
+                mountRoot: `/${RID}`,
+                command: ["python3", `/${RID}/${scriptRel}`],
+                exitCode: 1,
+                durationMs: 100,
+                provenance: {
+                    disabled: false,
+                    reads: [
+                        { path: `/${RID}/${scriptRel}`, layers: ["python"] },
+                        { path: `/${RID}/${phantomRel}`, layers: ["python"] },
+                    ],
+                    writes: [{ path: `/${RID}/runs/run-001/de/output/result.csv`, layers: ["inotify"] }],
+                    deletes: [],
+                },
+            });
+            const manifest: ArtifactManifestEntry[] = [{ stepId: "de", runId: "run-001", path: "output/result.csv", size: 0, type: "output", hash: "" }];
+
+            const result = await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+                logger,
+            });
+
+            expect(result.manifest).toHaveLength(1);
+            // The probe is gone; the real read of the script it was probing for
+            // survives, attested.
+            const tracked = collector.getTrackedInputs();
+            expect(tracked.map((r) => r.path)).toEqual([`/${RID}/${scriptRel}`]);
+            expect(tracked[0]!.hash).toBe(await computeSha256File(join(root, scriptRel)));
+            expect(logger.records.filter((r) => r.level === "error")).toHaveLength(0);
         } finally {
             await rm(sessionPath, { recursive: true, force: true });
         }
@@ -371,19 +440,23 @@ describe("reconcileManifestWithDisk — undeclared sibling reads", () => {
         }
     });
 
-    test("the same read, if tracked, is still terminal — the refusal is what avoids it", async () => {
+    test("the same read, if tracked, is dropped at reconcile — the refusal is what avoids the edge", async () => {
         // Guards the test above from passing vacuously: force the ref into the
-        // collector the way an admissible classification would, and reconcile
-        // still fails fast. Fail-fast on genuine drift is deliberately retained.
+        // collector the way an admissible classification would, and it reaches
+        // reconcile, which drops it and says so. Refusing at classification is
+        // what keeps the edge from ever being asserted; reconcile is the backstop
+        // that keeps an asserted-then-vanished one from being registered.
         const sessionPath = await mkdtemp(join(tmpdir(), "cortex-reconcile-"));
         const root = join(sessionPath, RID);
         const outRel = "output/result.csv";
+        const scratchRel = "runs/run-001/norm/output/_scratch.csv";
+        const logger = createCapturingLogger();
         try {
             await mkdir(join(root, "runs/run-001/de/output"), { recursive: true });
             await writeFile(join(root, "runs/run-001/de", outRel), "result\n1\n");
 
             const collector = new ProvenanceCollector({ stepId: "de", runId: "run-001", dependsOn: ["qc"] });
-            collector.trackInputAccess(`/${RID}`, "runs/run-001/norm/output/_scratch.csv", null, {
+            collector.trackInputAccess(`/${RID}`, scratchRel, null, {
                 source: "upstream",
                 stepId: "norm",
                 runId: "run-001",
@@ -391,17 +464,22 @@ describe("reconcileManifestWithDisk — undeclared sibling reads", () => {
 
             const manifest: ArtifactManifestEntry[] = [{ stepId: "de", runId: "run-001", path: outRel, size: 0, type: "output", hash: "" }];
 
-            await expect(
-                reconcileManifestWithDisk({
-                    workspaceRoot: root,
-                    resourceId: RID,
-                    runId: "run-001",
-                    stepId: "de",
-                    agentId: "agent-x",
-                    manifest,
-                    collector,
-                }),
-            ).rejects.toThrow(/cannot attest input/);
+            const result = await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+                logger,
+            });
+
+            expect(result.manifest).toHaveLength(1);
+            expect(collector.getTrackedInputs()).toEqual([]);
+            const warns = logger.records.filter((r) => r.level === "warn");
+            expect(warns).toHaveLength(1);
+            expect(warns[0]!.fields).toMatchObject({ path: `/${RID}/${scratchRel}`, dropSite: "input-enoent" });
         } finally {
             await rm(sessionPath, { recursive: true, force: true });
         }

--- a/harness/src/execution/reconcile-manifest.ts
+++ b/harness/src/execution/reconcile-manifest.ts
@@ -128,13 +128,23 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
  *
  * `artifacts`-source reads are the step's OWN files (mutating, dropped by the
  * registration translator), so they are not attested and not hashed here.
- * Lineage attestation is fail-fast for drift: an input that should be on disk
- * and is not (ENOENT) throws rather than registering a hashless edge. A read
- * that resolves OUTSIDE the analysis tree is dropped from lineage instead —
- * the sandbox can legitimately open paths above its mount (`/{resourceId}/..`
- * is the container root) and a capture layer may report them; that is out of
- * scope, not drift, and failing the step over it killed real analyses in the
- * field. Dropping still registers no hashless edge, which is the invariant.
+ *
+ * The invariant is that no hashless edge is ever registered; a ref that cannot
+ * be hashed is therefore dropped from lineage, whatever put it out of reach:
+ * a read resolving to a directory (an `ls` of a mount), one resolving OUTSIDE
+ * the analysis tree (the sandbox can legitimately open paths above its mount —
+ * `/{resourceId}/..` is the container root), and one naming a path that is not
+ * there at all. None of the three is drift, and failing the step over any of
+ * them killed real analyses in the field.
+ *
+ * A missing path in particular is far likelier to be a read that never happened
+ * than an artifact that vanished: the capture layers report *attempted* opens,
+ * not completed ones — the Python audit hook fires ahead of the open, R's
+ * `trace()` at call entry — so every failed open is reported exactly like a
+ * successful one. Nothing was consumed, so there is no edge to attest.
+ *
+ * Fail-fast is retained for a `stat` that fails any OTHER way: the file is there
+ * and cannot be read, which says something is wrong with the tree itself.
  */
 async function fillInputHashesFromDisk(
     collector: ProvenanceCollector,
@@ -151,12 +161,12 @@ async function fillInputHashesFromDisk(
         if (ref.source === "artifacts") continue;
         if (hasValidContentHash(ref.hash)) continue;
 
-        // Every throw below is logged before it is raised, and every drop is
-        // logged as it happens. The thrown message reaches `failStep` as one
+        // Every drop is logged as it happens, and the one remaining throw is
+        // logged before it is raised. The thrown message reaches `failStep` as one
         // opaque string and everything downstream of that is scrubbed, so naming
         // the site and the offending ref HERE is the only account of why a step
-        // died — the read's `source` in particular says whether the step declared
-        // this input at all.
+        // died — or of which edge its lineage lost. The read's `source` in
+        // particular says whether the step declared this input at all.
         const attestation = { path: ref.path, source: ref.source, refRunId: ref.runId, refStepId: ref.stepId };
 
         // `ref.path` is the absolute container path `/{resourceId}/...`; strip the
@@ -185,10 +195,13 @@ async function fillInputHashesFromDisk(
             info = await stat(hostPath);
         } catch (err) {
             if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-                logger.error("cannot attest input — not present at reconcile", { ...attestation, hostPath, throwSite: "input-enoent" });
-                throw new Error(`[reconcile-manifest] cannot attest input ${ref.path}: not present at reconcile (stepId=${stepId} runId=${runId})`, {
-                    cause: err,
-                });
+                // Warn, not debug: a capture layer named a file this step never
+                // consumed, and the count of those is how a reader tells a noisy
+                // hook from an artifact that genuinely vanished under the step.
+                logger.warn("dropping input not present at reconcile from lineage", { ...attestation, hostPath, dropSite: "input-enoent" });
+                lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "missing" });
+                collector.dropInput(ref);
+                continue;
             }
             logger.error("cannot attest input — stat failed", { ...attestation, hostPath, throwSite: "input-stat", ...logger.errorFields(err) });
             throw err;

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -20,5 +20,6 @@ export const lineageInputDropped = meter.createCounter("cortex.artifact.reconcil
     description:
         "Tracked input reads dropped from lineage at reconcile because they are " +
         "not content-attestable files of the analysis (directory reads, " +
-        "out-of-tree resolutions). Tagged by agent_id, step_id, reason.",
+        "out-of-tree resolutions, paths absent at reconcile). Tagged by " +
+        "agent_id, step_id, reason.",
 });

--- a/harness/src/provenance/collector.ts
+++ b/harness/src/provenance/collector.ts
@@ -391,9 +391,11 @@ export class ProvenanceCollector {
      * are shared objects). `reconcileManifestWithDisk` calls this for a read that
      * is not a content-attestable file of this analysis: one resolving to a
      * directory (e.g. an `ls` / `list.files` of a mount, which the inotify frame
-     * tracks as an open), or one resolving outside the analysis tree (e.g.
-     * `/{resourceId}/..`, the container root). Neither may reach registration.
-     * Mirrors the output-side non-file and out-of-bounds drops.
+     * tracks as an open), one resolving outside the analysis tree (e.g.
+     * `/{resourceId}/..`, the container root), or one naming a path that is not
+     * there at reconcile (a capture layer reports attempted opens, so a read
+     * that failed is reported like one that succeeded). None may reach
+     * registration. Mirrors the output-side non-file and out-of-bounds drops.
      */
     dropInput(ref: InputRef): void {
         for (const [key, val] of this.inputAccesses) {

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -64,6 +64,10 @@ type ProvenanceTracker struct {
 	mu  sync.Mutex
 	ops map[string]map[string]map[string]bool // op → path → layers
 
+	// Presence probe for read reports. Left nil outside tests, where the
+	// watch-dir cases inject one to stay off the real filesystem.
+	pathExists func(string) bool
+
 	// Inotify state (Linux-only, see provenance_inotify_linux.go)
 	inotify inotifyWatcher
 }
@@ -281,6 +285,24 @@ func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 		return
 	}
 
+	// A read report is a claim of intent, not of consumption. Two layers fire
+	// ahead of the call they observe — the Python audit hook runs before the
+	// open, R's trace() at call entry over a normalizePath(mustWork = FALSE)
+	// name — so a read that fails is reported exactly like one that succeeds.
+	// CPython makes that routine rather than exotic: displaying an uncaught
+	// traceback whose frame carries a relative co_filename (every Cython frame
+	// — pandas' .pxi/.pyx) probes "<entry>/<basename>" for every sys.path entry
+	// until one opens, and the entries under the analysis mount become reads of
+	// files that were never there. The host cannot tell such a probe from an
+	// input and cannot hash it either. Writes and deletes are exempt — a write is
+	// reported before the file it creates exists.
+	if op == "read" && !pt.exists(path) {
+		if sandboxLogLevel == logLevelDebug {
+			log.Printf("[provenance] dropping read report for absent path layer=%s path=%q", layer, path)
+		}
+		return
+	}
+
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 	opMap := pt.ops[op]
@@ -292,6 +314,18 @@ func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 		opMap[path] = make(map[string]bool)
 	}
 	opMap[path][layer] = true
+}
+
+// exists reports whether a reported path is present in the container. Only
+// absence answers false: a stat failing any other way — a permission the server
+// lacks and the workload had, a mount hiccup — keeps the report rather than
+// losing a real lineage edge to a transient error.
+func (pt *ProvenanceTracker) exists(path string) bool {
+	if pt.pathExists != nil {
+		return pt.pathExists(path)
+	}
+	_, err := os.Stat(path)
+	return err == nil || !os.IsNotExist(err)
 }
 
 // ── R log file reader ──────────────────────────────────────────

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -285,24 +285,6 @@ func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 		return
 	}
 
-	// A read report is a claim of intent, not of consumption. Two layers fire
-	// ahead of the call they observe — the Python audit hook runs before the
-	// open, R's trace() at call entry over a normalizePath(mustWork = FALSE)
-	// name — so a read that fails is reported exactly like one that succeeds.
-	// CPython makes that routine rather than exotic: displaying an uncaught
-	// traceback whose frame carries a relative co_filename (every Cython frame
-	// — pandas' .pxi/.pyx) probes "<entry>/<basename>" for every sys.path entry
-	// until one opens, and the entries under the analysis mount become reads of
-	// files that were never there. The host cannot tell such a probe from an
-	// input and cannot hash it either. Writes and deletes are exempt — a write is
-	// reported before the file it creates exists.
-	if op == "read" && !pt.exists(path) {
-		if sandboxLogLevel == logLevelDebug {
-			log.Printf("[provenance] dropping read report for absent path layer=%s path=%q", layer, path)
-		}
-		return
-	}
-
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 	opMap := pt.ops[op]
@@ -311,15 +293,43 @@ func (pt *ProvenanceTracker) recordOp(op, path, layer string) {
 		pt.ops[op] = opMap
 	}
 	if opMap[path] == nil {
+		// A read report is a claim of intent, not of consumption. Two layers fire
+		// ahead of the call they observe — the Python audit hook runs before the
+		// open, R's trace() at call entry over a normalizePath(mustWork = FALSE)
+		// name — so a read that fails is reported exactly like one that succeeds.
+		// CPython makes that routine rather than exotic: displaying an uncaught
+		// traceback whose frame carries a relative co_filename (every Cython frame
+		// — pandas' .pxi/.pyx) probes "<entry>/<basename>" for every sys.path entry
+		// until one opens, and the entries under the analysis mount become reads of
+		// files that were never there. The host cannot tell such a probe from an
+		// input and cannot hash it either. Writes and deletes are exempt — a write is
+		// reported before the file it creates exists.
+		//
+		// Probed on first sighting only, which is what keeps a syscall off the hot
+		// path: a frame holds one entry per path however many times it is reported,
+		// and inotify reports EVERY open of every file in the tree, so a script
+		// reading one file in a loop would otherwise pay a stat per iteration. A
+		// later report of a path already in the frame cannot add a path to it, so
+		// there is nothing a second verdict could decide.
+		if op == "read" && !pt.exists(path) {
+			if sandboxLogLevel == logLevelDebug {
+				log.Printf("[provenance] dropping read report for absent path layer=%s path=%q", layer, path)
+			}
+			return
+		}
 		opMap[path] = make(map[string]bool)
 	}
 	opMap[path][layer] = true
 }
 
-// exists reports whether a reported path is present in the container. Only
-// absence answers false: a stat failing any other way — a permission the server
-// lacks and the workload had, a mount hiccup — keeps the report rather than
-// losing a real lineage edge to a transient error.
+// exists reports whether a reported path is present in the container. The
+// question it answers is "would the read this reports have succeeded", so it
+// follows symlinks exactly as the open would: a link whose target is gone fails
+// the open too, and the layer that reported it — firing before the call — could
+// not have told that from a name that never existed. Only absence answers false:
+// a stat failing any other way — a permission the server lacks and the workload
+// had, a mount hiccup — keeps the report rather than losing a real lineage edge
+// to a transient error.
 func (pt *ProvenanceTracker) exists(path string) bool {
 	if pt.pathExists != nil {
 		return pt.pathExists(path)

--- a/images/sandbox-base/server/provenance_recordop_test.go
+++ b/images/sandbox-base/server/provenance_recordop_test.go
@@ -113,6 +113,66 @@ func TestRecordOp_KeepsReadOfPresentPath(t *testing.T) {
 	}
 }
 
+func TestRecordOp_ProbesEachReadPathOnce(t *testing.T) {
+	// inotify reports every open of every file in the tree, so a script reading
+	// one file in a loop reaches here thousands of times for one frame entry.
+	// The probe belongs to the entry, not to the report.
+	probes := 0
+	pt := &ProvenanceTracker{
+		watchDirs: []string{testWatchDir},
+		ops:       make(map[string]map[string]map[string]bool),
+		pathExists: func(string) bool {
+			probes++
+			return true
+		},
+	}
+	path := testWatchDir + "data/inputs/f1/counts.csv"
+	pt.recordOp("read", path, "python")
+	pt.recordOp("read", path, "preload")
+	pt.recordOp("read", path, "inotify")
+
+	if probes != 1 {
+		t.Fatalf("a path already in the frame must not be re-probed; got %d probes", probes)
+	}
+	if layers := pt.ops["read"][path]; len(layers) != 3 {
+		t.Fatalf("every layer must still be attributed; got %v", layers)
+	}
+}
+
+func TestRecordOp_DropsReadOfBrokenSymlink(t *testing.T) {
+	// A link whose target is gone fails the open exactly as a name that never
+	// existed does, and the layer reporting it fired before finding that out.
+	pt, root := realTracker(t)
+	link := filepath.Join(root, "counts.csv")
+	if err := os.Symlink(filepath.Join(root, "gone.csv"), link); err != nil {
+		t.Fatalf("symlink fixture: %v", err)
+	}
+	pt.recordOp("read", link, "python")
+
+	if got := recordedPaths(pt, "read"); len(got) != 0 {
+		t.Fatalf("a read through a broken symlink must not be recorded; got %v", got)
+	}
+}
+
+func TestRecordOp_KeepsReadThroughSymlink(t *testing.T) {
+	pt, root := realTracker(t)
+	target := filepath.Join(root, "counts.csv")
+	if err := os.WriteFile(target, []byte("gene,count\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	link := filepath.Join(root, "latest.csv")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink fixture: %v", err)
+	}
+	pt.recordOp("read", link, "python")
+
+	// Under the name the workload used: the layers report names, not inodes.
+	got := recordedPaths(pt, "read")
+	if len(got) != 1 || got[0] != link {
+		t.Fatalf("a read through a live symlink must survive; want [%s], got %v", link, got)
+	}
+}
+
 func TestRecordOp_KeepsWriteOfAbsentPath(t *testing.T) {
 	// A write is reported before the file it creates exists — the presence rule
 	// is about reads only. Phantom writes are dropped host-side at reconcile,

--- a/images/sandbox-base/server/provenance_recordop_test.go
+++ b/images/sandbox-base/server/provenance_recordop_test.go
@@ -1,16 +1,23 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 // The watch dir as provenanceWatchDirs builds it: absolute, trailing slash.
 const testWatchDir = "/019f6a20-1a3b-7000-a942-ae871e5de040/"
 
+// The watch-dir cases assert what the bound does, so they answer every presence
+// probe with true: none of their paths exists on the machine running the test,
+// and a tracker on the real filesystem would drop them for being absent — the
+// guard under test would then pass while doing nothing.
 func newTestTracker() *ProvenanceTracker {
 	return &ProvenanceTracker{
-		watchDirs: []string{testWatchDir},
-		ops:       make(map[string]map[string]map[string]bool),
+		watchDirs:  []string{testWatchDir},
+		ops:        make(map[string]map[string]map[string]bool),
+		pathExists: func(string) bool { return true },
 	}
 }
 
@@ -61,6 +68,62 @@ func TestRecordOp_KeepsInTreeRead(t *testing.T) {
 	got := recordedPaths(pt, "read")
 	if len(got) != 1 || got[0] != want {
 		t.Fatalf("in-tree read must survive; want [%s], got %v", want, got)
+	}
+}
+
+// realTracker watches a temp dir and probes the real filesystem, so the
+// presence rule is exercised against actual files rather than a stub.
+func realTracker(t *testing.T) (*ProvenanceTracker, string) {
+	t.Helper()
+	root := t.TempDir()
+	return &ProvenanceTracker{
+		watchDirs: []string{root + string(filepath.Separator)},
+		ops:       make(map[string]map[string]map[string]bool),
+	}, root
+}
+
+func TestRecordOp_DropsReadOfAbsentPath(t *testing.T) {
+	// The reported failure: a step's script died with an uncaught pandas
+	// KeyError, and CPython's traceback printer looked for the Cython source of
+	// the frame by probing "<entry>/hashtable_class_helper.pxi" for every
+	// sys.path entry. The script's own directory is sys.path[0] and lives in the
+	// analysis tree, so the audit hook — which fires before the open, not after
+	// — reported an in-tree read of a file that never existed. The host then
+	// failed the step trying to hash it.
+	pt, root := realTracker(t)
+	phantom := filepath.Join(root, "runs", "r1", "T1S1", "scripts", "hashtable_class_helper.pxi")
+	pt.recordOp("read", phantom, "python")
+
+	if got := recordedPaths(pt, "read"); len(got) != 0 {
+		t.Fatalf("a read of a path that is not there must not be recorded; got %v", got)
+	}
+}
+
+func TestRecordOp_KeepsReadOfPresentPath(t *testing.T) {
+	pt, root := realTracker(t)
+	want := filepath.Join(root, "counts.csv")
+	if err := os.WriteFile(want, []byte("gene,count\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	pt.recordOp("read", want, "python")
+
+	got := recordedPaths(pt, "read")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("a read of a file that is there must survive; want [%s], got %v", want, got)
+	}
+}
+
+func TestRecordOp_KeepsWriteOfAbsentPath(t *testing.T) {
+	// A write is reported before the file it creates exists — the presence rule
+	// is about reads only. Phantom writes are dropped host-side at reconcile,
+	// where the file has had its chance to appear.
+	pt, root := realTracker(t)
+	want := filepath.Join(root, "runs", "r1", "T1S2", "output", "de.csv")
+	pt.recordOp("write", want, "python")
+
+	got := recordedPaths(pt, "write")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("a write must survive an absent path; want [%s], got %v", want, got)
 	}
 }
 


### PR DESCRIPTION
## What & why

A customer's `bulk-transcriptomics-agent` step ran for twelve minutes, finished its work, and was then killed by its own bookkeeping:

```
[reconcile-manifest] cannot attest input — not present at reconcile
  path:      /{rid}/runs/{run}/T1S1/scripts/hashtable_class_helper.pxi
  source:    upstream   refStepId: T1S1
  throwSite: input-enoent
```

`hashtable_class_helper.pxi` is a **pandas Cython source file**. No such file has ever existed in that directory, and the step never tried to read one. Three links produce it:

1. **A script under the upstream step's `scripts/` directory** puts that directory on `sys.path` — inside the analysis mount, and inside a *declared dependency's* subtree.
2. **The script died with an uncaught pandas exception.** A Cython frame's `co_filename` is *relative* (the name in pandas' `include` directive), and CPython's `_Py_FindSourceFile` resolves a relative frame filename by **opening** `<entry>/<basename>` for every `sys.path` entry until one succeeds. All of them ENOENT.
3. **`sitecustomize.py` hooks the `open` audit event**, which CPython raises *before* the open is attempted (`sitecustomize.py:88`), so every failed probe is reported exactly like a real read and `abspath`'d against cwd (`:51`).

Reproduced against the shipped hook, unmodified — a script whose only fault is `df["missing_column"]` emits:

```
{"p": ".../runs/RUN/T1S1/scripts/hashtable_class_helper.pxi", "layer": "python", "op": "read"}
{"p": ".../runs/RUN/T1S1/scripts/index.pyx",                  "layer": "python", "op": "read"}
```

The path classifies `upstream`, which is content-attested, so `fillInputHashesFromDisk` stat'd it, got ENOENT, and threw — taking the run with it through the parent's fail-fast cascade, and *masking* the script error the agent had already recovered from.

### Why the throw was wrong

This is the third instance of one shape. Both prior fixes (`/{resourceId}/..`, out-of-mount reads) explicitly retained the ENOENT throw as "genuine drift". **That premise is false: the capture layers report *attempted* operations, not completed ones** — the Python audit hook fires ahead of the open, R's `trace()` at call entry over a `normalizePath(mustWork = FALSE)` name (`Rprofile.site:32`). Only LD_PRELOAD gets this right, gated on `fd >= 0` (`provtrack.c:225`). An absent path is therefore at least as likely to mean *nothing was read* as *an artifact vanished*, and neither is attestable. Nothing about failing recovers the edge: the step has already run and its outputs are already on disk.

### The change

- **Harness** (`reconcile-manifest.ts:201`) — an input absent at reconcile is **dropped** from lineage (warn naming the ref, its resolved `hostPath`, and `dropSite: "input-enoent"`; counted with `reason: "missing"`), joining the directory and out-of-tree drops. Dropping upholds "never register a hashless lineage edge" exactly as the throw did. Fail-fast is retained for a `stat` that fails any **other** way — the file is there and cannot be read, which says something is wrong with the tree itself.
- **Sandbox** (`provenance.go:299`) — `recordOp`, where all four layers converge, drops a `read` report whose path is not present, so a probe never reaches the frame. Only absence drops it; a `stat` failing any other way keeps the report rather than losing a real edge to a transient error. Writes and deletes are exempt, since a write is reported before the file it creates exists.
- **Specs** — deltas on `artifact-manifest`, `sandbox-provenance-tracking`, and `exec-provenance-lineage`, archived into the main specs, plus the **Purpose** sections deltas do not carry (two still claimed an unhashable input is terminal).

The two fixes are independent by design: the harness one ships via npm and holds on any sandbox image, which matters because the image is `workflow_dispatch`-only and `:latest`-tagged.

### Shipping

- The sandbox half reaches a host only when it re-pulls — `lib-store.yml` still needs a dispatch (the one unchecked task in the archived change).
- The harness half needs a harness release (`0.14.2` → next) and a cli dep bump; `cli/package.json:25` pins the published version.

### Not in scope

- The inotify `IN_OPEN`-as-read classification (carried over from the prior change).
- The `stat`→hash TOCTOU: same shape, but the sandbox is destroyed before reconcile so there is no writer, and it cannot be failed deterministically in a test — untested defensive code was the worse trade.


## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally. Harness suite **1349 pass** against a **1348 baseline on the unchanged tree**; the 181 failures are pre-existing Postgres-testcontainer failures on this machine, identical before and after. `tsc` clean, eslint clean on changed files, `gofmt`/`go vet` clean, Go tests green, 68 openspec items validate `--strict`.
- [x] Tests added or updated for the change. 4 new/rewritten harness tests, including the customer's exact shape end-to-end through `feedExecFrame` — **verified all 4 fail against the old throw**. 3 new Go tests — **verified the drop test fails without the fix**. The existing watch-dir tests now inject a presence probe so they keep testing the bound rather than passing on absence.
- [x] Documentation updated if user-facing behavior changed (specs; no user-facing surface changes).
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** n/a — no analytical method changes.
- [x] **Sandbox:** the security model is unchanged. No change to the workload uid, capabilities, `no-new-privileges`, egress policy, exec authentication, mount read-only-ness, write confinement, or resource limits. The sandbox-side change is one `stat` inside `recordOp`, on a path already bounded to a watch dir, and it only ever *removes* a report from the frame.
- [x] **Provenance:** prior analyses remain reproducible, and the recorded graph gets strictly more accurate — the only edges removed are ones naming files that do not exist, which could never have been content-attested. Every drop is observable: a warn record with the ref and `dropSite` host-side, a debug line sandbox-side, and `cortex.artifact.reconcile.input_dropped{reason="missing"}`.
