### PR TITLE
Record and replay the conversation display in the CLI

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.15.1",
+        "@inflexa-ai/harness": "0.16.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
@@ -153,7 +153,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.15.1", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.20", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@ai-sdk/provider-utils": "5.0.10", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-t1E9Um0HA88IGmmosYsM6pX7XCYMa8E1uvAF7lr7e887ceXDQud+wDJ3pFBbVa/d56Pjq9l/VsQUdo+wCvXjIQ=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.16.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.20", "@ai-sdk/openai-compatible": "^3.0.10", "@ai-sdk/provider": "^4.0.3", "@ai-sdk/provider-utils": "5.0.10", "@anthropic-ai/sdk": "^0.107.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ai": "^7.0.28", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "fast-xml-parser": "^5.10.0", "hono": "^4.12.30", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "nunjucks": "^3.2.4", "openai": "^4.104.0", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-BnFMlNpn8OHKR4XEZEUkx4wt4BweBzBODYnK8sDDj3P1uTkhfheGx88JJvlbni9giDM7ybEruGh6l4Aaq+Fu7w=="],
 
     "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 

--- a/cli/openspec/changes/record-conversation-display/.openspec.yaml
+++ b/cli/openspec/changes/record-conversation-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/cli/openspec/changes/record-conversation-display/design.md
+++ b/cli/openspec/changes/record-conversation-display/design.md
@@ -33,9 +33,11 @@ The projection is taken once, immediately before `appendTurn`, with `fallbackTex
 
 Not inside the `ok` branch, for the same reason the usage rollup rides all three: an aborted turn displayed real work, and its projection is what the retract window renders. A failed turn likewise displayed whatever it produced before it threw.
 
-### D3 — An interrupted call replays as `running`
+### D3 — An `incomplete` call replays as `running`
 
-A call in flight when a turn was cut off replays with `status: "started"` and no outcome — the harness records what it observed and does not invent an outcome. The local part type has four statuses and none of them means this.
+A call in flight when a turn was cut off replays with `outcome: "incomplete"` — the harness records its whole terminal state in one field and does not invent a result. The local part type has four statuses and none of them means this.
+
+The mapping is exhaustive over the harness union, with a `never` arm rather than a default: nothing is inferred from an absent value, and a state added upstream breaks the build here instead of rendering as something plausible.
 
 It maps to `running`. That does not read as live here because the message carries the interruption badge: the pair says "in flight when the turn was cut off". **The two must not be separated** — the marker alone would look like a call still in progress.
 

--- a/cli/openspec/changes/record-conversation-display/design.md
+++ b/cli/openspec/changes/record-conversation-display/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The harness stores each append's display projection and replays it. The producer is a recorder that wraps an `EmitFn` and forwards every event unchanged while folding it into ordered display messages; the consumer is a synchronous read over stored projections. Neither exists in this host yet.
+
+The turn engine (`runChatTurn`) is shared by the TUI and the clack REPL, so both surfaces inherit whatever it does here.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every turn this host runs stores what it displayed.
+- No event a user saw reaches the surface by a path the recorder did not observe.
+- The transcript read consults stored projections and nothing else.
+
+**Non-Goals:**
+
+- Changing what the live surface renders. The emit reducer is untouched.
+- A new design-system state. See D3.
+
+## Decisions
+
+### D1 — `chat` and `ask` take the sink, rather than closing over it
+
+`RunChatTurnArgs.chat` becomes `(emit: EmitFn) => AgentChat` and `ask` becomes `(request, emit) => Promise<AskApproval>`.
+
+This is the load-bearing decision, and it is not cosmetic. `createStreamingChat` forwards each provider text delta by calling `emit({type: "text-delta", …})`, and the ask gateway emits its `data-ask` parts the same way. Built over the raw sink, both reach the live surface correctly and are invisible to the recorder — so a reloaded turn would be missing its assistant text and its approval cards, which is to say most of what the user saw. Passing the sink in is what makes the recorded path the only path.
+
+Alternative rejected: construct the recorder in each caller and let it pass a pre-wrapped sink as `emit`. It works, but it puts the obligation in two places and makes "did this caller wrap it?" a question a reader has to answer per call site; the engine owning it makes the wrapping unconditional.
+
+### D2 — `finish` runs before the append, on all three phases
+
+The projection is taken once, immediately before `appendTurn`, with `fallbackText` on the `ok` branch and `interrupted` on the `aborted` branch.
+
+Not inside the `ok` branch, for the same reason the usage rollup rides all three: an aborted turn displayed real work, and its projection is what the retract window renders. A failed turn likewise displayed whatever it produced before it threw.
+
+### D3 — An interrupted call replays as `running`
+
+A call in flight when a turn was cut off replays with `status: "started"` and no outcome — the harness records what it observed and does not invent an outcome. The local part type has four statuses and none of them means this.
+
+It maps to `running`. That does not read as live here because the message carries the interruption badge: the pair says "in flight when the turn was cut off". **The two must not be separated** — the marker alone would look like a call still in progress.
+
+Alternative rejected: a fifth `interrupted` status. It is self-describing at the call, but it is a new design-system state — shared type, tool block, gallery exhibit — to distinguish a case the message badge already distinguishes.
+
+Alternative rejected: keep reporting `ok`. It claims a result the tool never returned, which is the false-success defect the harness redesign removed one layer down.
+
+### D4 — The reload seam loses its parameters, its `Promise`, and its error channel
+
+`toCortex` becomes `(messages) => CortexMsg[]`.
+
+Every parameter it dropped existed to serve reconstruction: the pool and analysis id resolved a workspace root for card rebuilding, and the tool roster built the detail resolver. Replay needs none of them, cannot touch the database or filesystem, and cannot fail — so `ResultAsync.fromPromise` around it wrapped something with no failure mode, and its error branch was unreachable.
+
+Consequence accepted: the workspace-root degradation branch goes with it. A moved or deleted anchor used to downgrade preview cards to chips on reload; now it has no effect on a transcript read at all, which is strictly better and one less place local-state desync can surface.
+
+Consequence checked: the seam going synchronous costs no test coverage. The load-interleaving tests gate on `loadPage`, which is still async; `toCortex` fakes were trivially async and never used to sequence anything.
+
+### D5 — A record carries its own projection
+
+`run_completion` appends through the harness's record constructor, which builds both the model message and its `system`-role projection.
+
+The harness owns that mapping for the same reason it owns the synthetic marker: a hand-assembled record can be a message the turn-boundary predicates fail to recognise. Appending one without a projection is the quiet failure mode here — it is stored, the model reads it, and the transcript never shows it.
+
+## Risks / Trade-offs
+
+- **A future call site adds an emit path that bypasses the recorder** → The engine owns the wrapping and both `chat` and `ask` take the sink as a parameter, so a bypass requires deliberately capturing the raw sink rather than merely forgetting to wrap.
+- **An interrupted call's marker is read as live if the badge is missed** → Accepted, and stated at both the renderer and here (D3). The alternative costs a design-system state for a case already distinguished.
+- **The transcript no longer degrades when the workspace moves** → Not a risk; it is the point. Recorded in D4 so the removed branch is not mistaken for a regression.

--- a/cli/openspec/changes/record-conversation-display/proposal.md
+++ b/cli/openspec/changes/record-conversation-display/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The harness persists what a turn displayed, at the moment it displays it, and replays that projection verbatim. It cannot produce the projection on its own: the recorder wraps the turn's event sink, and this host owns the sink.
+
+Until it is wired, every turn this host runs is stored with no display projection. It replays as nothing, and the reload path this change removes — rebuilding cards from tool names and workspace state, re-deriving each call's detail from the tool's current schema — is the only thing keeping the transcript populated. That path is what makes a reloaded conversation a function of today's code rather than a record of what the user saw.
+
+## What Changes
+
+- The turn engine wraps its emit sink in the harness display recorder and hands the recorded projection to `appendTurn` alongside the model messages and the usage rollup.
+- `chat` and `ask` become functions of that sink rather than values closed over the raw one, so the streaming provider's text deltas and the approval gateway's parts cannot reach the surface by a path the recorder never sees.
+- The reload seam collapses to a synchronous read of stored projections: no pool, no analysis id, no tool roster, no card or detail resolver, and nothing that can fail.
+- A run-outcome record is appended through the harness's record constructor, so it carries its own projection instead of being stored, read by the model, and never shown.
+- A call that was in flight when a turn was interrupted replays as `running` rather than as a success.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `tui-harness-chat`: the turn engine records the display projection and persists it with the turn; the reload path replays stored projections and reconstructs nothing.
+
+## Impact
+
+- `src/modules/harness/turn.ts` — the recorder, the `chat`/`ask` sink parameters, and the turn value at `appendTurn`.
+- `src/modules/harness/chat.ts` and `src/tui/hooks/conversation.ts` — both callers supply `chat`/`ask` as functions of the sink.
+- `src/tui/hooks/conversation.ts` — the `toCortex` seam, `loadMessages`, and the reloaded tool part.
+- `src/tui/hooks/run_completion.ts` — the record append.
+- Removed: the workspace-root degradation branch on reload, the `ResultAsync` bridge around the converter, and the card/detail resolver construction. A moved or deleted anchor no longer affects a transcript read, because nothing is resolved at read time.

--- a/cli/openspec/changes/record-conversation-display/specs/tui-harness-chat/spec.md
+++ b/cli/openspec/changes/record-conversation-display/specs/tui-harness-chat/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: A turn records what it displayed and persists it with the turn
+
+The turn engine SHALL wrap its event sink in the harness display recorder and persist the recorded projection in the same append as the turn's model messages and its usage rollup.
+
+Every producer of a displayed event SHALL emit through that recorded sink. The streaming provider wrapper and the approval binding SHALL therefore be constructed over the sink the engine supplies, not over one captured beforehand: both reach the live surface correctly either way, and a turn whose text deltas or approval parts bypassed the recorder replays missing most of what the user saw.
+
+The projection SHALL be taken on every phase that reaches the append — completed, aborted, and failed — for the same reason the rollup is. An aborted turn displayed real work, and its projection is what the retract window renders.
+
+#### Scenario: A completed turn stores its projection
+
+- **GIVEN** a turn that streamed text and emitted a card
+- **WHEN** it completes
+- **THEN** the append carries a display projection holding both, in the order they were shown
+
+#### Scenario: An aborted turn stores what it displayed
+
+- **GIVEN** a turn interrupted after emitting part of its reply
+- **WHEN** the engine persists the partial turn
+- **THEN** the append carries the projection of what was shown, marked interrupted
+
+#### Scenario: Provider text reaches the recorder
+
+- **GIVEN** a turn whose reply arrives as provider text deltas
+- **WHEN** the turn is reloaded
+- **THEN** the reply is present, having been recorded rather than reconstructed
+
+#### Scenario: An approval part reaches the recorder
+
+- **GIVEN** a turn in which a tool requested approval and the user answered
+- **WHEN** the turn is reloaded
+- **THEN** the approval card is present in its terminal state
+
+### Requirement: A run-outcome record carries its own projection
+
+A record of out-of-band work appended to a thread SHALL be appended through the harness's record constructor, so it carries both its model message and its display projection.
+
+A record appended without one is stored and read by the model but never displayed — a durable write that succeeds and then is invisible, with nothing to indicate why.
+
+#### Scenario: An appended run outcome is visible in the transcript
+
+- **GIVEN** a completed run whose outcome is recorded to the thread
+- **WHEN** the thread is reloaded
+- **THEN** the record renders as an event message
+
+### Requirement: A call with no recorded outcome renders as running
+
+A reloaded tool call that carries no outcome SHALL render as running, and MUST NOT be reported as a success or as a failure.
+
+It has no outcome because the harness observed a dispatch and no completion — the turn was cut off mid-call — and deliberately records that rather than inventing one. Reporting `ok` would claim a result the tool never returned; reporting an error would claim a failure it never had. It reads correctly because the message it sits in carries the interruption badge: the marker and the badge together are what say "in flight when the turn was cut off", so a renderer MUST NOT show one without the other.
+
+#### Scenario: An interrupted call renders as running beside the interruption badge
+
+- **GIVEN** a persisted turn interrupted while a tool call was in flight
+- **WHEN** the thread is reloaded
+- **THEN** the call renders as running and its message carries the interruption badge
+
+## MODIFIED Requirements
+
+### Requirement: One generation token orders every write to the message store
+
+One generation token SHALL order every asynchronous write to the message store, so the newest operation STARTED wins regardless of which finishes first. A superseded transcript load MUST NOT reach the store.
+
+The transcript read itself SHALL be a synchronous replay of stored projections. It resolves no workspace root, builds no card or detail resolver, issues no query, and has no failure mode of its own — so the only failure a load reports is a page read's. The generation check SHALL remain immediately before the store write even when no await separates it from the preceding check, because the invariant belongs to the write rather than to any particular await.
+
+A row carrying no stored projection SHALL contribute nothing, rather than being reconstructed from the model transcript.
+
+#### Scenario: A superseded load never reaches the store
+
+- **GIVEN** two transcript loads for the same session, the older resolving last
+- **WHEN** both complete
+- **THEN** the store holds the newer transcript
+
+#### Scenario: A moved workspace does not affect a transcript read
+
+- **GIVEN** a thread whose analysis workspace no longer resolves
+- **WHEN** the thread is reloaded
+- **THEN** the transcript renders from its stored projections, unaffected

--- a/cli/openspec/changes/record-conversation-display/specs/tui-harness-chat/spec.md
+++ b/cli/openspec/changes/record-conversation-display/specs/tui-harness-chat/spec.md
@@ -44,17 +44,25 @@ A record appended without one is stored and read by the model but never displaye
 - **WHEN** the thread is reloaded
 - **THEN** the record renders as an event message
 
-### Requirement: A call with no recorded outcome renders as running
+### Requirement: An incomplete call renders as running
 
-A reloaded tool call that carries no outcome SHALL render as running, and MUST NOT be reported as a success or as a failure.
+A reloaded tool call whose recorded outcome is `incomplete` SHALL render as running, and MUST NOT be reported as a success or as a failure.
 
-It has no outcome because the harness observed a dispatch and no completion — the turn was cut off mid-call — and deliberately records that rather than inventing one. Reporting `ok` would claim a result the tool never returned; reporting an error would claim a failure it never had. It reads correctly because the message it sits in carries the interruption badge: the marker and the badge together are what say "in flight when the turn was cut off", so a renderer MUST NOT show one without the other.
+`incomplete` is what the harness observed: a dispatch and no completion, because the turn was cut off mid-call. Reporting `ok` would claim a result the tool never returned; reporting an error would claim a failure it never had. It reads correctly because the message it sits in carries the interruption badge: the marker and the badge together are what say "in flight when the turn was cut off", so a renderer MUST NOT show one without the other.
+
+The mapping from a recorded outcome to a rendered status SHALL be total and exhaustive over the harness's outcome union, with no default arm and no fallback for an unrecognized value. The harness carries a call's whole terminal state in one field precisely so a host need infer nothing; an exhaustive mapping is what converts a state added later into a build failure here rather than a silent mis-render, and it is what keeps two hosts reading the same projection from disagreeing about what a call did.
 
 #### Scenario: An interrupted call renders as running beside the interruption badge
 
 - **GIVEN** a persisted turn interrupted while a tool call was in flight
 - **WHEN** the thread is reloaded
-- **THEN** the call renders as running and its message carries the interruption badge
+- **THEN** the call's recorded outcome is `incomplete`, it renders as running, and its message carries the interruption badge
+
+#### Scenario: A newly added outcome does not compile silently
+
+- **GIVEN** the harness widens its recorded-outcome union
+- **WHEN** the host is rebuilt
+- **THEN** the status mapping fails to compile until the new state is handled
 
 ## MODIFIED Requirements
 

--- a/cli/openspec/changes/record-conversation-display/tasks.md
+++ b/cli/openspec/changes/record-conversation-display/tasks.md
@@ -1,0 +1,24 @@
+## 1. Record the projection
+
+- [x] 1.1 Wrap the turn engine's event sink in the harness display recorder, using the session's own callPath so sub-agent events are excluded.
+- [x] 1.2 Change `chat` to `(emit) => AgentChat` and `ask` to `(request, emit) => Promise<AskApproval>`, and construct both over the recorded sink at every call site (TUI and REPL).
+- [x] 1.3 Take the projection before the append on all three phases, with `fallbackText` on completion and `interrupted` on abort.
+- [x] 1.4 Persist it in the turn value alongside the model messages and the rollup, keeping absence of the rollup a missing key rather than an `undefined` value.
+
+## 2. Replay it
+
+- [x] 2.1 Collapse the `toCortex` seam to a synchronous read of stored projections; drop the pool, analysis id, tool roster, card resolver and detail resolver.
+- [x] 2.2 Remove the `ResultAsync` bridge and the unreachable error branch in `loadMessages`, keeping the generation check immediately before the store write.
+- [x] 2.3 Retype `CortexMsg` off the replay function and drop the removed harness imports.
+- [x] 2.4 Render a call with no recorded outcome as running.
+
+## 3. Records
+
+- [x] 3.1 Append a run-outcome record through the harness's record constructor so it carries its own projection.
+
+## 4. Verify
+
+- [x] 4.1 Test that an interrupted call replays as running with its recorded detail, beside a denied call that reports its own outcome.
+- [x] 4.2 Update the turn-engine fakes to the turn value, keeping the assertion that a turn reporting nothing carries no rollup key.
+- [x] 4.3 Make the reload seam fakes synchronous; confirm the load-interleaving tests still gate on the page read.
+- [x] 4.4 Run `bun run format:file` on the changed files, then `bun run typecheck`, `bun run lint`, and `bun run test`.

--- a/cli/openspec/changes/record-conversation-display/tasks.md
+++ b/cli/openspec/changes/record-conversation-display/tasks.md
@@ -10,7 +10,7 @@
 - [x] 2.1 Collapse the `toCortex` seam to a synchronous read of stored projections; drop the pool, analysis id, tool roster, card resolver and detail resolver.
 - [x] 2.2 Remove the `ResultAsync` bridge and the unreachable error branch in `loadMessages`, keeping the generation check immediately before the store write.
 - [x] 2.3 Retype `CortexMsg` off the replay function and drop the removed harness imports.
-- [x] 2.4 Render a call with no recorded outcome as running.
+- [x] 2.4 Map the harness's recorded outcome to a rendered status exhaustively, with a `never` arm; `incomplete` renders as running.
 
 ## 3. Records
 
@@ -18,7 +18,7 @@
 
 ## 4. Verify
 
-- [x] 4.1 Test that an interrupted call replays as running with its recorded detail, beside a denied call that reports its own outcome.
+- [x] 4.1 Test that an `incomplete` call replays as running with its recorded detail, beside a denied call that reports its own outcome.
 - [x] 4.2 Update the turn-engine fakes to the turn value, keeping the assertion that a turn reporting nothing carries no rollup key.
 - [x] 4.3 Make the reload seam fakes synchronous; confirm the load-interleaving tests still gate on the page read.
 - [x] 4.4 Run `bun run format:file` on the changed files, then `bun run typecheck`, `bun run lint`, and `bun run test`.

--- a/cli/openspec/changes/render-tool-call-detail/proposal.md
+++ b/cli/openspec/changes/render-tool-call-detail/proposal.md
@@ -18,8 +18,7 @@ Two related faults land with it:
 - `ToolCallPart` and `ToolBlockProps` rename `target` to `detail`. The field is one display string, and `target` claimed a semantic ("what the tool acted on") that a verb phrase like `hypothesis retire h3` does not satisfy. **BREAKING** for the gallery fixtures, which are the only writers today.
 - The tool-call status gains `denied`, rendered with `GLYPHS.warning` in the `warning` role — a soft state, not a fault.
 - The emit reducer and the REPL printer migrate from `isError: boolean` to the harness's `outcome`, and carry `detail` onto the live part.
-- The reload path builds the harness detail resolver over `runtime.conversationAgent.tools` and passes it into `contentToCortexMessages`, so host-contributed tools (`run_inflexa`, `list_launch_dir`, `manage_inputs`) keep their detail after reload.
-- The reload path carries the recovered outcome onto the reconstructed part, replacing the current always-`ok` behaviour.
+- A reloaded call shows its own detail and its own outcome, replacing the current always-`ok` behaviour. This change states that as an outcome; the conversation-display change supplies it by replaying what the turn recorded.
 - The design gallery gains the fitted form, the split form, and the denied status.
 
 ## Capabilities
@@ -31,7 +30,7 @@ Two related faults land with it:
 ### Modified Capabilities
 
 - `tui-stream-blocks`: `ToolBlock` renders a detail that reflows to a continuation row, the status placement rule changes on the split, and the status set gains `denied`.
-- `tui-harness-chat`: the emit reducer consumes `detail` and the three-way `outcome`; the reload path supplies a detail resolver and carries the recovered outcome.
+- `tui-harness-chat`: the emit reducer consumes `detail` and the three-way `outcome`; a reloaded call reports both.
 - `tui-mock-data`: the `Part` union's tool-call kind renames `target` to `detail` and widens its status.
 - `chat-command`: the REPL printer's one-line chips carry the detail and distinguish a denial from an error.
 
@@ -41,7 +40,7 @@ CLI source:
 
 - `src/types/session.ts` — `ToolCallPart`: `target` → `detail`, status gains `denied`.
 - `src/tui/components/tool_block.tsx` — width measurement, the continuation row, the split-form status placement, the denied status view.
-- `src/tui/hooks/conversation.ts` — the emit reducer's `tool-started`/`tool-finished` branches, the `toCortex` seam, and `loadMessages`' resolver construction.
+- `src/tui/hooks/conversation.ts` — the emit reducer's `tool-started`/`tool-finished` branches, and the reloaded tool part.
 - `src/modules/harness/chat_printer.ts` — the REPL chips and `subAgentActivityLabel`.
 - `src/tui/layout/design_gallery.tsx`, `src/tui/layout/design_gallery_fixtures.ts` — the new states and the renamed field.
 

--- a/cli/openspec/changes/render-tool-call-detail/specs/tui-harness-chat/spec.md
+++ b/cli/openspec/changes/render-tool-call-detail/specs/tui-harness-chat/spec.md
@@ -47,31 +47,29 @@ carry the thread id in scope (chat-launched runs stamp `cortex_runs.thread_id`) 
 
 ## ADDED Requirements
 
-### Requirement: A reloaded thread rebuilds tool details and outcomes
+### Requirement: A reloaded thread shows each call's detail and outcome
 
-The reload path SHALL supply the harness detail resolver, constructed over the booted runtime's
-composed conversation tool list, to the stored-message converter. A reloaded tool call SHALL therefore
-show the same detail its live chip showed, including for tools the embedder contributes through the
-host-tools seam.
+A reloaded tool call SHALL show the same detail its live chip showed, including for tools the embedder
+contributes through the host-tools seam, and SHALL report its own outcome — a call that failed live
+renders as failed, a refused call renders as denied. Reporting every reloaded call as a success is a lie
+about work the user already saw fail.
 
-The reload path SHALL also carry the converter's recovered outcome onto the reconstructed part, so a
-call that failed live renders as failed and a refused call renders as denied. Reporting every reloaded
-call as a success is a lie about work the user already saw fail.
-
-The tool list SHALL be read from the runtime handle the reload already resolves, and passed through the
-existing seam rather than reached for inside it, so the seam stays substitutable in tests.
+This requirement states the outcome, not the mechanism. It is satisfied by replaying what the turn
+recorded when it displayed it (see the conversation-display capability); it MUST NOT be satisfied by
+re-deriving either value at read time from a tool's current schema or from workspace state, which would
+make a past turn's transcript a function of today's code.
 
 #### Scenario: A reloaded call shows the detail its live chip showed
 
-- **GIVEN** a persisted turn whose tool declares a call description
+- **GIVEN** a persisted turn whose tool declared a call description
 - **WHEN** the thread is reloaded
-- **THEN** the reconstructed tool part carries the same detail the live turn rendered
+- **THEN** the tool part carries the same detail the live turn rendered
 
 #### Scenario: A host-contributed tool keeps its detail across reload
 
 - **GIVEN** a persisted call to a tool wired through the host-tools seam
 - **WHEN** the thread is reloaded
-- **THEN** its detail is rebuilt rather than dropped
+- **THEN** its detail is present rather than dropped
 
 #### Scenario: A reloaded failed call renders as failed
 

--- a/cli/openspec/changes/render-tool-call-detail/tasks.md
+++ b/cli/openspec/changes/render-tool-call-detail/tasks.md
@@ -23,9 +23,9 @@
 ## 4. Reload path
 
 - [x] 4.1 Extend the `toCortex` seam in `LoadSeams` to take the conversation tool list, and pass `runtime.conversationAgent.tools` from `loadMessages` — the runtime is already resolved there.
-- [x] 4.2 Build the harness detail resolver in `realLoadSeams.toCortex` and pass it to `contentToCortexMessages` alongside the existing card resolver, using the harness's new options-object signature.
+- [x] 4.2 Read the detail from the reloaded part rather than re-deriving it — the projection the turn recorded carries it (see the conversation-display change).
 - [x] 4.3 In the `CortexPart` → `Part` mapping, carry the converter's recovered outcome onto the part and delete the always-`ok` behaviour. Remove the `LIMITATION` comment that documented it.
-- [x] 4.4 Carry the reconstructed `detail` onto the part.
+- [x] 4.4 Carry the `detail` onto the part.
 - [x] 4.5 Confirm the existing test fakes for `LoadSeams` still compile and pass with the widened seam.
 
 ## 5. REPL printer

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.15.1",
+        "@inflexa-ai/harness": "0.16.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",

--- a/cli/src/modules/harness/agent_switch.test.ts
+++ b/cli/src/modules/harness/agent_switch.test.ts
@@ -318,7 +318,7 @@ describe("agent switch — busy schedules, then lands at settlement", () => {
             {
                 pool: {} as unknown as Pool,
                 conversationAgent: { id: "conv" } as unknown as AgentDefinition,
-                chat: {} as unknown as AgentChat,
+                chat: () => ({}) as AgentChat,
                 history,
                 session: buildChatSession("tui-chat", "an-1", "t-1"),
                 emit: (() => {}) as EmitFn,

--- a/cli/src/modules/harness/chat.ts
+++ b/cli/src/modules/harness/chat.ts
@@ -16,7 +16,7 @@
 import { randomUUIDv7 } from "bun";
 import { intro, log, outro, spinner, text, isCancel } from "@clack/prompts";
 import { type ResultAsync } from "neverthrow";
-import { createStreamingChat, createThreadHistory, createThreadStore, type AgentChat, type AgentSession, type DbError, type Thread } from "@inflexa-ai/harness";
+import { createStreamingChat, createThreadHistory, createThreadStore, type AgentSession, type DbError, type Thread } from "@inflexa-ai/harness";
 
 import { describeCause } from "../../lib/cause.ts";
 import { fail } from "../../lib/cli.ts";
@@ -165,19 +165,6 @@ async function runRepl(runtime: HarnessRuntime, analysisId: string, threadId: st
     // paths for their OSC 8 `file://` links.
     const printer = createChatPrinter(sink, { analysisId });
 
-    // Live token streaming. `runAgent`'s `provider` option is `AgentChat` (one
-    // collapsed response per call — `RunAgentOptions`, harness loop/run-agent.ts),
-    // and the raw `ChatProvider` satisfies it NON-streaming: its `chat` never
-    // emits deltas, so answers would only render whole at turn end.
-    // `createStreamingChat` builds an `AgentChat` over the provider's `chatStream`
-    // primitive instead, forwarding each text delta into the printer's own
-    // text-delta channel (through `emit`, so the printer's per-turn streamed flag
-    // and copy-on-receive rules apply unchanged). Only THIS top-level loop runs
-    // on the wrapper — sub-agent loops (planner, literature reviewer) were wired
-    // to the plain provider at assembly, so their tokens never reach the sink.
-    // Abort semantics are untouched: the wrapper re-throws an AbortError verbatim.
-    const chat = createStreamingChat(runtime.conversation.provider, (text) => void printer.emit({ type: "text-delta", text }));
-
     // The REPL runs as the `"cli-chat"` agent. `buildChatSession` puts `threadId`
     // in scope (so a chat-launched plan stamps `cortex_runs.thread_id`) and gives
     // a length-1 callPath (so this agent's events pass the printer's sub-agent
@@ -194,7 +181,7 @@ async function runRepl(runtime: HarnessRuntime, analysisId: string, threadId: st
         }
         const userInput = answer.trim();
         if (userInput.length === 0) continue;
-        const outcome = await runTurn(runtime, chat, history, printer, sink, session, analysisId, threadId, userInput);
+        const outcome = await runTurn(runtime, history, printer, sink, session, analysisId, threadId, userInput);
         // A second SIGINT during the turn requested a stop. The turn has fully
         // unwound (its `appendTurn` ran against a still-live pool), so drain and
         // exit here — once, deterministically (130 = terminated by SIGINT).
@@ -244,7 +231,6 @@ async function runRepl(runtime: HarnessRuntime, analysisId: string, threadId: st
  */
 async function runTurn(
     runtime: HarnessRuntime,
-    chat: AgentChat,
     history: ReturnType<typeof createThreadHistory>,
     printer: ReturnType<typeof createChatPrinter>,
     sink: ChatSink,
@@ -276,7 +262,7 @@ async function runTurn(
         const outcome = await runChatTurn({
             pool: runtime.pool,
             conversationAgent: runtime.conversationAgent,
-            chat,
+            chat: (emit) => createStreamingChat(runtime.conversation.provider, (text) => void emit({ type: "text-delta", text })),
             history,
             session,
             emit: printer.emit,

--- a/cli/src/modules/harness/turn.test.ts
+++ b/cli/src/modules/harness/turn.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { okAsync, errAsync, type ResultAsync } from "neverthrow";
-import type { AgentChat, AgentDefinition, DbError, EmitFn, LlmUsageRecord, ModelMessage, Pool, ThreadHistory, UsageRecorder } from "@inflexa-ai/harness";
+import type {
+    AgentChat,
+    AgentDefinition,
+    ConversationTurn,
+    DbError,
+    EmitFn,
+    LlmUsageRecord,
+    ModelMessage,
+    Pool,
+    ThreadHistory,
+    UsageRecorder,
+} from "@inflexa-ai/harness";
 
 import { buildChatSession, healTailOrphan, runChatTurn, type ChatTurnSeams, type TurnOutcome } from "./turn.ts";
 
@@ -22,7 +33,7 @@ const DB_ERROR: DbError = { type: "query_failed", op: "thread-store.appendTurn",
 // The injected `run` seam never reads the provider, and the `prepare` seam never
 // reads the pool — bare stubs stand in for the unreachable dependencies rather
 // than constructing a real streaming provider / pg pool for a headless test.
-const chat = {} as unknown as AgentChat;
+const chat = (_emit: EmitFn): AgentChat => ({}) as AgentChat;
 const pool = {} as unknown as Pool;
 
 /** A `prepare` seam that assembles one turn successfully. */
@@ -36,8 +47,10 @@ const runOk: ChatTurnSeams["run"] = (_agent, initial) =>
  * A `run` seam that RESOLVES an interrupted turn: the streaming wrapper surfaces the abort as a
  * resolved "aborted" finish carrying the partial loop output (here one partial assistant message).
  */
-const runResolvesAbortedWithPartial: ChatTurnSeams["run"] = (_agent, initial) =>
-    Promise.resolve({ messages: [...initial, partialAssistant], finish: { reason: "aborted", cappedOut: false, truncationRecoveries: 0 } });
+const runResolvesAbortedWithPartial: ChatTurnSeams["run"] = async (_agent, initial, _session, options) => {
+    await options.emit({ type: "text-delta", text: "the ans" });
+    return { messages: [...initial, partialAssistant], finish: { reason: "aborted", cappedOut: false, truncationRecoveries: 0 } };
+};
 /** A `run` seam that resolves an "aborted" finish whose loop output is empty (nothing streamed before the abort). */
 const runResolvesAbortedEmpty: ChatTurnSeams["run"] = (_agent, initial) =>
     Promise.resolve({ messages: [...initial], finish: { reason: "aborted", cappedOut: false, truncationRecoveries: 0 } });
@@ -82,12 +95,12 @@ const runAborts: ChatTurnSeams["run"] = () => {
 /** A `ThreadHistory` whose `appendTurn` records its payload; the read methods are unused here. */
 function recordingHistory(append: () => ResultAsync<void, DbError> = () => okAsync(undefined)): {
     history: ThreadHistory;
-    appended: { threadId: string; messages: readonly ModelMessage[]; turnUsage: Parameters<ThreadHistory["appendTurn"]>[2] }[];
+    appended: { threadId: string; turn: ConversationTurn }[];
 } {
-    const appended: { threadId: string; messages: readonly ModelMessage[]; turnUsage: Parameters<ThreadHistory["appendTurn"]>[2] }[] = [];
+    const appended: { threadId: string; turn: ConversationTurn }[] = [];
     const history: ThreadHistory = {
-        appendTurn: (threadId, messages, turnUsage) => {
-            appended.push({ threadId, messages, turnUsage });
+        appendTurn: (threadId, turn) => {
+            appended.push({ threadId, turn });
             return append();
         },
         loadRecent: () => okAsync([]),
@@ -173,7 +186,12 @@ describe("runChatTurn", () => {
         }
         // The loop output (only the assistant reply, sliced past `initial`) is
         // appended after the standalone user message.
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage, assistantMessage], turnUsage: undefined }]);
+        expect(appended[0]?.threadId).toBe(THREAD_ID);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage, assistantMessage]);
+        expect(appended[0]?.turn.displayMessages.map((message) => message.role)).toEqual(["user", "assistant"]);
+        // A turn that reported nothing carries no `turnUsage` KEY, not one holding `undefined` — the
+        // engine spreads it conditionally so absence has one representation all the way to storage.
+        expect(appended[0]?.turn && "turnUsage" in appended[0].turn).toBe(false);
     });
 
     test("a resolved aborted finish persists [userMessage, ...partial] and returns aborted", async () => {
@@ -182,7 +200,8 @@ describe("runChatTurn", () => {
         const { history, appended } = recordingHistory();
         const outcome = await runWith({ prepare: prepareOk, run: runResolvesAbortedWithPartial, history, signal: new AbortController().signal });
         expect(outcome.kind).toBe("aborted");
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage, partialAssistant], turnUsage: undefined }]);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage, partialAssistant]);
+        expect(appended[0]?.turn.displayMessages[1]?.metadata).toEqual({ interrupted: true });
     });
 
     test("a resolved aborted finish with an empty partial persists [userMessage] alone", async () => {
@@ -190,7 +209,7 @@ describe("runChatTurn", () => {
         const outcome = await runWith({ prepare: prepareOk, run: runResolvesAbortedEmpty, history, signal: new AbortController().signal });
         expect(outcome.kind).toBe("aborted");
         // No loop output beyond `initial`, so the slice is empty and only the user turn is persisted.
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage], turnUsage: undefined }]);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage]);
     });
 
     test("an AbortError under an aborted signal persists [userMessage] only and returns aborted", async () => {
@@ -201,7 +220,7 @@ describe("runChatTurn", () => {
         controller.abort();
         const outcome = await runWith({ prepare: prepareOk, run: runAborts, history, signal: controller.signal });
         expect(outcome.kind).toBe("aborted");
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage], turnUsage: undefined }]);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage]);
     });
 
     test("a provider failure racing an abort is failed (cause preserved), never masked as aborted", async () => {
@@ -215,7 +234,7 @@ describe("runChatTurn", () => {
         const outcome = await runWith({ prepare: prepareOk, run: () => Promise.reject(cause), history, signal: controller.signal });
         expect(outcome.kind).toBe("failed");
         if (outcome.kind === "failed") expect(outcome.cause).toBe(cause);
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage], turnUsage: undefined }]);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage]);
     });
 
     test("a non-abort throw with a non-aborted signal is a failed outcome carrying the cause", async () => {
@@ -224,7 +243,7 @@ describe("runChatTurn", () => {
         const outcome = await runWith({ prepare: prepareOk, run: () => Promise.reject(cause), history, signal: new AbortController().signal });
         expect(outcome.kind).toBe("failed");
         if (outcome.kind === "failed") expect(outcome.cause).toBe(cause);
-        expect(appended).toEqual([{ threadId: THREAD_ID, messages: [userMessage], turnUsage: undefined }]);
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage]);
     });
 
     test("prepare failure short-circuits before runAgent — nothing is appended", async () => {
@@ -315,7 +334,7 @@ describe("runChatTurn carries the turn's usage rollup", () => {
         const { history, appended } = recordingHistory();
         await runWith({ prepare: prepareOk, run: runOkWithUsage, history, signal: new AbortController().signal });
         expect(appended).toHaveLength(1);
-        expect(appended[0]?.turnUsage).toEqual(TURN_USAGE);
+        expect(appended[0]?.turn.turnUsage).toEqual(TURN_USAGE);
     });
 
     test("an interrupted turn persists what it spent, and a turn that reported nothing persists nothing", async () => {
@@ -323,13 +342,13 @@ describe("runChatTurn carries the turn's usage rollup", () => {
         // the same unreported/nothing-spent conflation the whole ledger is built to avoid...
         const aborted = recordingHistory();
         await runWith({ prepare: prepareOk, run: runResolvesAbortedWithUsage, history: aborted.history, signal: new AbortController().signal });
-        expect(aborted.appended[0]?.turnUsage).toEqual(PARTIAL_USAGE);
+        expect(aborted.appended[0]?.turn.turnUsage).toEqual(PARTIAL_USAGE);
 
         // ...while a turn whose calls reported nothing writes `undefined`, never a zeroed stand-in the
         // reload would then render as a measurement.
         const silent = recordingHistory();
         await runWith({ prepare: prepareOk, run: runOk, history: silent.history, signal: new AbortController().signal });
-        expect(silent.appended[0]?.turnUsage).toBeUndefined();
+        expect(silent.appended[0]?.turn.turnUsage).toBeUndefined();
     });
 
     test("the carried rollup is a snapshot — the harness mutating its accumulator afterwards cannot change it", async () => {

--- a/cli/src/modules/harness/turn.ts
+++ b/cli/src/modules/harness/turn.ts
@@ -1,6 +1,7 @@
 import { ResultAsync, okAsync } from "neverthrow";
 import {
     createThreadHistory,
+    createConversationDisplayRecorder,
     finalText,
     makeLocalAuth,
     passthroughStep,
@@ -102,13 +103,13 @@ export type RunChatTurnArgs = {
     readonly pool: Pool;
     /** The assembled conversation agent (`runtime.conversationAgent`) whose loop this turn runs. */
     readonly conversationAgent: AgentDefinition;
-    /** Streaming provider wrapper — forwards each text delta so answers render as they arrive. */
-    readonly chat: AgentChat;
+    /** Builds the streaming provider over the recorder's emit sink. */
+    readonly chat: (emit: EmitFn) => AgentChat;
     /** The pg thread store — `appendTurn` persists the turn atomically. */
     readonly history: ThreadHistory;
     /** Carries `threadId` in scope, so a plan launched here stamps `cortex_runs.thread_id`. */
     readonly session: AgentSession;
-    /** The surface's event sink — loop/tool/data events flow here during `runAgent`. */
+    /** The surface's live event sink; the display recorder forwards every event here. */
     readonly emit: EmitFn;
     /**
      * The booted runtime's ONE {@link UsageRecorder} (`runtime.usageRecorder`), forwarded into this
@@ -133,7 +134,7 @@ export type RunChatTurnArgs = {
      * its deny-by-default realization, which is how the REPL stays a write-only sink
      * with no mid-turn input path.
      */
-    readonly ask?: (request: AskRequest) => Promise<AskApproval>;
+    readonly ask?: (request: AskRequest, emit: EmitFn) => Promise<AskApproval>;
     /** The resolved analysis this turn is scoped to (ownership check + context load). */
     readonly analysisId: string;
     /** The conversation thread this turn appends to. */
@@ -232,12 +233,18 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
 
         const initial = prepared.messages;
         const userMessage = prepared.userMessage;
+        const display = createConversationDisplayRecorder({
+            userText: userInput,
+            topLevelCallPath: session.provenance.callPath,
+            sink: emit,
+        });
+        const recordedEmit = display.emit;
 
         const run = await ResultAsync.fromPromise(
             seams.run(conversationAgent, initial, session, {
-                provider: chat,
+                provider: chat(recordedEmit),
                 signal,
-                emit,
+                emit: recordedEmit,
                 runStep: passthroughStep,
                 // UNCONDITIONAL, unlike `ask`'s spread: an absent recorder is not a policy the
                 // harness resolves for us, it is the no-op that drops every call this loop makes.
@@ -247,7 +254,7 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
                 // surface filters sub-agent traffic off by `callPath` depth, so a planner or
                 // literature-reviewer loop is emitted and then dropped. This is where it survives.
                 logger: harnessLogger("harness"),
-                ...(ask ? { ask } : {}),
+                ...(ask ? { ask: (request) => ask(request, recordedEmit) } : {}),
             }),
             (e): unknown => e,
         ).match(
@@ -298,7 +305,22 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
         // is false. The harness writes it onto the turn's own assistant row and hands it back on read.
         // Passed on EVERY branch for the same reason it rides on all three phases: an aborted or failed
         // turn spent real tokens, and only a run that never resolved has nothing to record.
-        const appendError = (await history.appendTurn(threadId, run.toPersist, run.phase.turnUsage)).match(
+        //
+        // The display projection rides along for the same reason and on the same three branches: it is
+        // what the transcript replays, so a turn whose projection is dropped reloads as though it had
+        // shown nothing. `finish` is therefore called before the append, not inside the `ok` branch —
+        // an aborted turn displayed real work, and its projection is what the retract window renders.
+        const displayMessages = display.finish({
+            ...(run.phase.kind === "ok" ? { fallbackText: run.phase.fallbackText } : {}),
+            ...(run.phase.kind === "aborted" ? { interrupted: true } : {}),
+        });
+        const appendError = (
+            await history.appendTurn(threadId, {
+                modelMessages: run.toPersist,
+                displayMessages,
+                ...(run.phase.turnUsage ? { turnUsage: run.phase.turnUsage } : {}),
+            })
+        ).match(
             (): DbError | undefined => undefined,
             (e): DbError | undefined => e,
         );

--- a/cli/src/modules/harness/usage_ledger.test.ts
+++ b/cli/src/modules/harness/usage_ledger.test.ts
@@ -240,7 +240,7 @@ describe("a chat turn's calls land in the local ledger", () => {
                 // `prepare` is the only thing that would dereference it, and it is stood in for below.
                 pool: {} as unknown as Pool,
                 conversationAgent: agent("tui-chat", []),
-                chat,
+                chat: () => chat,
                 history,
                 session,
                 emit: () => {},

--- a/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
+++ b/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
@@ -662,7 +662,7 @@ describe("the interrupted marker survives a transcript reload", () => {
         const loadSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => okAsync(emptyPage(2)),
-            toCortex: async () => interruptedTranscript(),
+            toCortex: () => interruptedTranscript(),
         };
         await loadMessages(SID, AID, loadSeams);
 
@@ -697,7 +697,7 @@ describe("a transcript load resolving mid-retract", () => {
         const loadSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => ResultAsync.fromSafePromise(loadGate.then(() => emptyPage(1))),
-            toCortex: async () => staleCortex(),
+            toCortex: () => staleCortex(),
         };
         const load = loadMessages(SID, AID, loadSeams); // parks at its page read
 

--- a/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
+++ b/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
@@ -678,10 +678,10 @@ describe("the interrupted marker survives a transcript reload", () => {
     });
 
     test("a call cut off mid-flight replays as running, never as a success or a failure", async () => {
-        // The harness records what it observed — a dispatch and no completion — and stores the call
-        // `started` with no outcome rather than inventing one. Reporting `ok` here would claim a result
-        // the tool never returned; `error` would claim a failure it never had. `running` is what
-        // happened, and the message's interruption badge is what says it will never finish.
+        // The harness records what it observed — a dispatch and no completion — in the ONE field that
+        // carries a call's terminal state. `incomplete` is not a success and not a failure, and the
+        // mapping to `running` is total, so no reader has to infer anything from an absent value. The
+        // message's interruption badge is what says it will never finish.
         const loadSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => okAsync(emptyPage(1)),
@@ -692,8 +692,8 @@ describe("the interrupted marker survives a transcript reload", () => {
                         role: "assistant",
                         interrupted: true,
                         parts: [
-                            { type: "tool-call", toolCallId: "t1", toolName: "read_file", status: "started", detail: "scripts/run.py" },
-                            { type: "tool-call", toolCallId: "t2", toolName: "grep", status: "finished", outcome: "denied" },
+                            { type: "tool-call", toolCallId: "t1", toolName: "read_file", outcome: "incomplete", detail: "scripts/run.py" },
+                            { type: "tool-call", toolCallId: "t2", toolName: "grep", outcome: "denied" },
                         ],
                     },
                 ] as unknown as CortexMsg[],

--- a/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
+++ b/cli/src/tui/hooks/conversation.interrupt_retract.test.ts
@@ -676,6 +676,36 @@ describe("the interrupted marker survives a transcript reload", () => {
         const part = messages[1]?.parts.find((p) => p.type === "text");
         expect(part?.type === "text" ? part.text : undefined).toBe("partial answer");
     });
+
+    test("a call cut off mid-flight replays as running, never as a success or a failure", async () => {
+        // The harness records what it observed — a dispatch and no completion — and stores the call
+        // `started` with no outcome rather than inventing one. Reporting `ok` here would claim a result
+        // the tool never returned; `error` would claim a failure it never had. `running` is what
+        // happened, and the message's interruption badge is what says it will never finish.
+        const loadSeams: LoadSeams = {
+            runtime: () => stubRuntime,
+            loadPage: () => okAsync(emptyPage(1)),
+            toCortex: () =>
+                [
+                    {
+                        id: "a1",
+                        role: "assistant",
+                        interrupted: true,
+                        parts: [
+                            { type: "tool-call", toolCallId: "t1", toolName: "read_file", status: "started", detail: "scripts/run.py" },
+                            { type: "tool-call", toolCallId: "t2", toolName: "grep", status: "finished", outcome: "denied" },
+                        ],
+                    },
+                ] as unknown as CortexMsg[],
+        };
+        await loadMessages(SID, AID, loadSeams);
+
+        const calls = messages[0]?.parts.filter((p) => p.type === "tool-call") ?? [];
+        expect(calls.map((p) => (p.type === "tool-call" ? p.status : null))).toEqual(["running", "denied"]);
+        // The detail recorded live rides the stored projection — nothing re-derives it on reload.
+        expect(calls[0]?.type === "tool-call" ? calls[0].detail : undefined).toBe("scripts/run.py");
+        expect(messages[0]?.interrupted).toBe(true);
+    });
 });
 
 // The retract is a first-class store writer (it claims the generation token), so it must supersede a

--- a/cli/src/tui/hooks/conversation.test.ts
+++ b/cli/src/tui/hooks/conversation.test.ts
@@ -1329,10 +1329,17 @@ describe("reload maps a reconstructed tool call's outcome and detail", () => {
         expect(reloadToolPart({ outcome: "ok" })?.status).toBe("ok");
     });
 
-    // The converter reports `ok` for a call whose `tool` row was never appended, so an absent outcome
-    // must not be read as a failure — the transcript is incomplete, not unsuccessful.
-    test("a call with no recovered outcome reloads as ok", () => {
-        expect(reloadToolPart({})?.status).toBe("ok");
+    // A call the turn never saw finish carries `incomplete` — the one field says so, rather than a
+    // reader deducing it from an absent value. It renders as `running`, which is what happened; the
+    // message's interruption badge is what says it will never finish.
+    test("a call cut off mid-flight reloads as running, not as a success or a failure", () => {
+        expect(reloadToolPart({ outcome: "incomplete" })?.status).toBe("running");
+    });
+
+    // A replayed part always carries an outcome, so this is the live in-flight shape rather than a
+    // transcript one. It lands on the same honest `running` rather than defaulting to a result.
+    test("a part with no outcome at all is treated as in flight, never as ok", () => {
+        expect(reloadToolPart({})?.status).toBe("running");
     });
 
     test("a rebuilt detail rides the reconstructed part", () => {

--- a/cli/src/tui/hooks/conversation.test.ts
+++ b/cli/src/tui/hooks/conversation.test.ts
@@ -696,7 +696,7 @@ describe("send() binds the ask seam to the turn scope", () => {
         const askFn = seams.last()?.ask;
         expect(askFn).toBeInstanceOf(Function);
         // Asserted a Function on the line above, so the bound closure is present.
-        const approval = await askFn!({ title: "Run refs", command: "inflexa refs list" });
+        const approval = await askFn!({ title: "Run refs", command: "inflexa refs list" }, () => {});
         expect(approval).toEqual({ kind: "once" });
 
         expect(calls).toHaveLength(1);
@@ -916,7 +916,7 @@ describe("loadMessages windows the newest turns past one page", () => {
             },
             // Faithful reconstruction: each stored row (a fixture Row, cast through the seam's harness
             // message type) becomes one CortexMsg carrying its text, so the trailing message cap is exercised.
-            toCortex: async (_pool, _analysisId, rows) =>
+            toCortex: (rows) =>
                 (rows as unknown as Row[]).map((r) => ({ id: `id-${r.seq}`, role: r.role, parts: [{ type: "text", text: r.text }] })) as unknown as CortexMsg[],
             fetched: () => fetched,
         };
@@ -984,12 +984,12 @@ describe("loadMessages staleness guard", () => {
         const oldSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => ResultAsync.fromSafePromise(oldGate.then(() => emptyPage(1))),
-            toCortex: async () => cortexText("old", "old-msg"),
+            toCortex: () => cortexText("old", "old-msg"),
         };
         const newSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => okAsync(emptyPage(1)),
-            toCortex: async () => cortexText("new", "new-msg"),
+            toCortex: () => cortexText("new", "new-msg"),
         };
 
         const oldLoad = loadMessages(SID, AID, oldSeams); // blocks on oldGate at its page read
@@ -1026,7 +1026,7 @@ describe("a turn supersedes a transcript load in flight", () => {
             seams: {
                 runtime: () => stubRuntime,
                 loadPage: () => ResultAsync.fromSafePromise(gate.then(() => emptyPage(1))),
-                toCortex: async () => cortexText("stale", "stale-transcript"),
+                toCortex: () => cortexText("stale", "stale-transcript"),
             },
             release: () => release(),
         };
@@ -1178,7 +1178,7 @@ describe("MESSAGE_CAP is coupled to loadPage's perPage clamp", () => {
                 seen = perPage;
                 return okAsync({ messages: [], total: 0, page: 0, perPage, hasMore: false } as MessagePage);
             },
-            toCortex: async () => [],
+            toCortex: () => [],
             perPage: () => seen,
         };
         let seen = 0;
@@ -1359,7 +1359,7 @@ describe("a superseded initial load is retried after the turn finishes", () => {
         const initialLoad: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => ResultAsync.fromSafePromise(initialGate.then(() => emptyPage(1))),
-            toCortex: async () => [{ id: "old", role: "assistant", parts: [{ type: "text", text: "never-mounted" }] }] as unknown as CortexMsg[],
+            toCortex: () => [{ id: "old", role: "assistant", parts: [{ type: "text", text: "never-mounted" }] }] as unknown as CortexMsg[],
         };
 
         // The post-turn reload seams: the pg thread now holds the prior history AND the just-finished
@@ -1367,7 +1367,7 @@ describe("a superseded initial load is retried after the turn finishes", () => {
         const reloadSeams: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => okAsync(emptyPage(3)),
-            toCortex: async () =>
+            toCortex: () =>
                 [
                     { id: "h1", role: "assistant", parts: [{ type: "text", text: "prior history" }] },
                     { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
@@ -1407,7 +1407,7 @@ describe("a superseded initial load is retried after the turn finishes", () => {
         const completedLoad: LoadSeams = {
             runtime: () => stubRuntime,
             loadPage: () => okAsync(emptyPage(1)),
-            toCortex: async () => [{ id: "h1", role: "assistant", parts: [{ type: "text", text: "history" }] }] as unknown as CortexMsg[],
+            toCortex: () => [{ id: "h1", role: "assistant", parts: [{ type: "text", text: "history" }] }] as unknown as CortexMsg[],
         };
         await loadMessages(SID, AID, completedLoad);
         expect(messages.length).toBe(1);
@@ -1572,7 +1572,7 @@ describe("promptHistory", () => {
                     perPage,
                     hasMore: false,
                 }),
-            toCortex: async (_pool, _analysisId, rows) =>
+            toCortex: (rows) =>
                 (rows as unknown as Turn[]).map((t, i) => ({
                     id: `id-${i}`,
                     role: t.role,
@@ -1638,7 +1638,7 @@ describe("hasPromptHistory", () => {
                     perPage,
                     hasMore: false,
                 }),
-            toCortex: async (_pool, _analysisId, rows) =>
+            toCortex: (rows) =>
                 (rows as unknown as Turn[]).map((t, i) => ({
                     id: `id-${i}`,
                     role: t.role,

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -3,24 +3,20 @@ import { ResultAsync } from "neverthrow";
 import { createSignal } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import {
-    contentToCortexMessages,
-    createCardResolver,
-    createDetailResolver,
     createStreamingChat,
     createThreadHistory,
+    storedMessagesToCortex,
     type DbError,
     type EmitFn,
     type Pool,
     type RetractOutcome,
     type ThreadHistory,
-    type Tool,
 } from "@inflexa-ai/harness";
 
 import { describeCause, findAuthCause } from "../../lib/cause.ts";
 import { getLogger } from "../../lib/log.ts";
 import { resolveModelConnection } from "../../modules/harness/config.ts";
 import { MODEL_API_KEY_VAR, providerKindForSlug } from "../../modules/infra/setup.ts";
-import { workspaceRootForAnalysisId } from "../../modules/analysis/output.ts";
 import { eventDepth, isSubAgentEvent, readAskPart, readPlanCard, readRunCard, subAgentActivityLabel } from "../../modules/harness/chat_printer.ts";
 import { readFileReference, readPresentation, readReportPreview, readReportPreviewFailed } from "../../modules/harness/artifact_open.ts";
 import {
@@ -913,7 +909,7 @@ function finishTurn(outcome: TurnOutcome, assistantId: string, startedAt: number
 }
 
 /** One reconstructed transcript message from the pg thread read path. Exported for the load seams. */
-export type CortexMsg = Awaited<ReturnType<typeof contentToCortexMessages>>[number];
+export type CortexMsg = ReturnType<typeof storedMessagesToCortex>[number];
 
 /**
  * Map a reconstructed {@link CortexMsg} to a {@link UIMessage}: text → text part; a replayed
@@ -1014,38 +1010,20 @@ export type LoadSeams = {
     /** One turn-paginated page of the thread. Real: `createThreadHistory(pool).loadPage`. */
     readonly loadPage: (pool: Pool, threadId: string, page: number, perPage: number) => ReturnType<ThreadHistory["loadPage"]>;
     /**
-     * Reconstruct display messages from a page (builds the card and detail resolvers internally).
-     * Real: below.
+     * Adapt the harness's stored display projections to the local conversation types.
      *
-     * `tools` is the agent's composed tool list. It is passed in rather than reached for here because
-     * the detail resolver must cover embedder-contributed tools (`run_inflexa` and friends), which
-     * exist only on the assembled agent — and because a seam that reaches for the runtime itself would
-     * stop being substitutable by the test fakes below it.
+     * Synchronous, and takes nothing but the rows: the harness records what a turn displayed when it
+     * displays it, so replay reads that projection and consults nothing else. There is no pool to
+     * query, no workspace root to resolve, no tool roster to rebuild a detail from, and nothing that
+     * can fail — which is why this seam no longer carries the card/detail resolvers or a `Promise`.
      */
-    readonly toCortex: (
-        pool: Pool,
-        analysisId: string,
-        messages: Parameters<typeof contentToCortexMessages>[0],
-        tools: readonly Tool[],
-    ) => Promise<CortexMsg[]>;
+    readonly toCortex: (messages: Parameters<typeof storedMessagesToCortex>[0]) => CortexMsg[];
 };
 
 const realLoadSeams: LoadSeams = {
     runtime: harnessRuntime,
     loadPage: (pool, threadId, page, perPage) => createThreadHistory(pool).loadPage(threadId, page, perPage),
-    // The card resolver reaches the pool + workspace tree to rebuild plan/run cards from the persisted
-    // tool_use rows; `unwrapOrThrow` inside it THROWS on a storage fault, so `contentToCortexMessages`
-    // is bridged to a Result in `loadMessages` (neverthrow-first: a harness throw becomes our error state).
-    // An unresolvable workspace root (moved/deleted anchor) degrades preview cards to chips rather than
-    // failing the whole history load (the local-state desync rule). The detail resolver is pure and
-    // storage-free, so it survives that degradation and rides both branches.
-    toCortex: (pool, analysisId, messages, tools) => {
-        const resolveDetail = createDetailResolver(tools);
-        return workspaceRootForAnalysisId(analysisId).match(
-            (root) => contentToCortexMessages(messages, { resolveCard: createCardResolver(pool, analysisId, root), resolveDetail }),
-            () => contentToCortexMessages(messages, { resolveDetail }),
-        );
-    },
+    toCortex: storedMessagesToCortex,
 };
 
 // Monotonic token ordering EVERY asynchronous write to the message store. Two producers write it —
@@ -1126,24 +1104,24 @@ export async function loadMessages(sessionId: string, analysisId: string, seams:
     }
     const rows = rowPages.flat();
 
-    // The composed roster — harness tools plus the host tools wired at the runtime's composition root —
-    // so a reloaded `run_inflexa` call rebuilds its detail instead of dropping to a bare name.
-    const mapped = await ResultAsync.fromPromise(seams.toCortex(runtime.pool, analysisId, rows, runtime.conversationAgent.tools), (e): unknown => e);
+    // Re-checked with no await in between, deliberately: this is the invariant the generation token
+    // exists for — a superseded load must never reach the store — and stating it at the write itself
+    // keeps it true if an await is ever reintroduced above.
     if (myLoad !== loadGeneration) return;
-    mapped.match(
-        // Trailing cap is in MESSAGES (see the unit note in {@link loadMessages}'s doc and on
-        // MESSAGE_CAP): two full turn pages can carry more than MESSAGE_CAP messages, so keep only the
-        // newest MESSAGE_CAP so the mounted window matches the live-append cap. Record the session this
-        // load mounted so `send` knows the history is already on screen and skips its post-turn reload.
-        (cortex) => {
-            setMessages(cortex.map((m) => cortexToUiMessage(m, sessionId, analysisId)).slice(-MESSAGE_CAP));
-            loadedSessionId = sessionId;
-        },
-        (cause) => {
-            setErrorMsg(`Failed to load the conversation: ${describeCause(cause)}`);
-            setChatStatus("error");
-        },
+    // Trailing cap is in MESSAGES (see the unit note in {@link loadMessages}'s doc and on
+    // MESSAGE_CAP): two full turn pages can carry more than MESSAGE_CAP messages, so keep only the
+    // newest MESSAGE_CAP so the mounted window matches the live-append cap. Record the session this
+    // load mounted so `send` knows the history is already on screen and skips its post-turn reload.
+    //
+    // No error branch: the read cannot fail. It maps stored projections and touches neither the
+    // database nor the filesystem, so the only failure this function still reports is a page read's.
+    setMessages(
+        seams
+            .toCortex(rows)
+            .map((m) => cortexToUiMessage(m, sessionId, analysisId))
+            .slice(-MESSAGE_CAP),
     );
+    loadedSessionId = sessionId;
 }
 
 // The in-flight chat request. Module-private: only `send`/`abort`/`resetHotState` touch it, so the
@@ -1346,7 +1324,6 @@ async function sendLocked(opts: { sessionId: string; analysisId: string; userTex
     // Per-turn streaming wrapper: forward each provider text delta into the adapter as a `text-delta`
     // event, so answers accumulate in `streamText` as they arrive. Only this top-level
     // loop runs on the wrapper — sub-agent loops were wired to the plain provider at assembly.
-    const chat = createStreamingChat(runtime.conversation.provider, (text) => void emitForTurn({ type: "text-delta", text }));
     const session = buildChatSession("tui-chat", opts.analysisId, opts.sessionId);
 
     // The engine is contractually non-rejecting — every failure returns a `TurnOutcome`. But `turnSettled`
@@ -1359,7 +1336,7 @@ async function sendLocked(opts: { sessionId: string; analysisId: string; userTex
         .runChatTurn({
             pool: runtime.pool,
             conversationAgent: runtime.conversationAgent,
-            chat,
+            chat: (emit) => createStreamingChat(runtime.conversation.provider, (text) => void emit({ type: "text-delta", text })),
             history: createThreadHistory(runtime.pool),
             session,
             emit: emitForTurn,
@@ -1372,7 +1349,7 @@ async function sendLocked(opts: { sessionId: string; analysisId: string; userTex
             // carrying the turn's analysis/thread, its abort signal, and its guarded emit sink, so the
             // gateway's `data-ask` emissions and its poll ride the same signal and sink as every other
             // turn event (a swap/reset that supersedes the turn drops them at `emitForTurn`).
-            ask: (req) => runtime.askGateway.ask(req, { analysisId: opts.analysisId, threadId: opts.sessionId, signal: myTurn.signal, emit: emitForTurn }),
+            ask: (req, emit) => runtime.askGateway.ask(req, { analysisId: opts.analysisId, threadId: opts.sessionId, signal: myTurn.signal, emit }),
             analysisId: opts.analysisId,
             // The pg thread binds 1:1 to the session, so a plan launched here stamps its run.
             threadId: opts.sessionId,

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -935,10 +935,16 @@ export function cortexToUiMessage(m: CortexMsg, sessionId: string, analysisId = 
                 parts.push({ id: randomUUIDv7(), sessionId, messageId: m.id, type: "text", text: part.text, createdAt: 0 });
                 break;
             case "tool-call":
-                // History-replayed calls arrive `finished`, carrying the outcome the converter recovered
-                // by pairing each stored call with its `tool-result` block. An absent outcome means the
-                // call had no paired result — a transcript whose `tool` row was never appended — which
-                // the converter reports as `ok`, so mirror that rather than inventing a failure.
+                // A replayed call normally arrives `finished` with the outcome the harness recorded as
+                // the call ended. It arrives `started` when the turn was cut off mid-call: the harness
+                // observed a dispatch and no completion, and deliberately does not invent an outcome
+                // for it — reporting `ok` would claim a result the tool never returned, and `error` a
+                // failure it never had.
+                //
+                // `running` is that call's honest state, and it does not read as live here because the
+                // message it sits in carries the interruption badge: the pair says "in flight when the
+                // turn was cut off". This is why the badge and this marker must not be separated — the
+                // marker alone would look like a call still in progress.
                 parts.push({
                     id: part.toolCallId || randomUUIDv7(),
                     sessionId,
@@ -946,7 +952,7 @@ export function cortexToUiMessage(m: CortexMsg, sessionId: string, analysisId = 
                     type: "tool-call",
                     name: part.toolName,
                     ...(part.detail !== undefined ? { detail: part.detail } : {}),
-                    status: part.outcome ?? "ok",
+                    status: part.status === "started" ? "running" : (part.outcome ?? "ok"),
                     createdAt: 0,
                 });
                 break;

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -10,6 +10,7 @@ import {
     type EmitFn,
     type Pool,
     type RetractOutcome,
+    type ToolCallOutcome,
     type ThreadHistory,
 } from "@inflexa-ai/harness";
 
@@ -912,6 +913,36 @@ function finishTurn(outcome: TurnOutcome, assistantId: string, startedAt: number
 export type CortexMsg = ReturnType<typeof storedMessagesToCortex>[number];
 
 /**
+ * The local lifecycle status a replayed call renders as.
+ *
+ * The harness records a call's whole terminal state in one field, so this is a total mapping with
+ * nothing left to infer — which is the point: two hosts reading the same projection cannot disagree
+ * about what a call did, and the `never` branch makes a state added later a build failure here
+ * rather than a silent mis-render.
+ *
+ * `incomplete` — the turn was cut off mid-call — maps to `running`, which is what actually happened.
+ * It does not read as live because the message carries the interruption badge; the marker and that
+ * badge together say "in flight when the turn was cut off", so a renderer must not show one without
+ * the other. An absent outcome means a call still in flight, which a REPLAYED part never is; it is
+ * handled for the live surface's sake and lands on the same honest `running`.
+ */
+function replayedToolStatus(outcome: ToolCallOutcome | undefined): ToolCallPart["status"] {
+    switch (outcome) {
+        case "ok":
+        case "error":
+        case "denied":
+            return outcome;
+        case "incomplete":
+        case undefined:
+            return "running";
+        default: {
+            const unhandled: never = outcome;
+            throw new Error(`unhandled tool call outcome: ${String(unhandled)}`);
+        }
+    }
+}
+
+/**
  * Map a reconstructed {@link CortexMsg} to a {@link UIMessage}: text → text part; a replayed
  * tool-call → a finished tool part; recognized cards (`data-plan`/`data-run-card`) → card parts via
  * the SAME readers the live adapter uses; anything else the harness resolver kept → a visible tagged
@@ -935,16 +966,6 @@ export function cortexToUiMessage(m: CortexMsg, sessionId: string, analysisId = 
                 parts.push({ id: randomUUIDv7(), sessionId, messageId: m.id, type: "text", text: part.text, createdAt: 0 });
                 break;
             case "tool-call":
-                // A replayed call normally arrives `finished` with the outcome the harness recorded as
-                // the call ended. It arrives `started` when the turn was cut off mid-call: the harness
-                // observed a dispatch and no completion, and deliberately does not invent an outcome
-                // for it — reporting `ok` would claim a result the tool never returned, and `error` a
-                // failure it never had.
-                //
-                // `running` is that call's honest state, and it does not read as live here because the
-                // message it sits in carries the interruption badge: the pair says "in flight when the
-                // turn was cut off". This is why the badge and this marker must not be separated — the
-                // marker alone would look like a call still in progress.
                 parts.push({
                     id: part.toolCallId || randomUUIDv7(),
                     sessionId,
@@ -952,7 +973,7 @@ export function cortexToUiMessage(m: CortexMsg, sessionId: string, analysisId = 
                     type: "tool-call",
                     name: part.toolName,
                     ...(part.detail !== undefined ? { detail: part.detail } : {}),
-                    status: part.status === "started" ? "running" : (part.outcome ?? "ok"),
+                    status: replayedToolStatus(part.outcome),
                     createdAt: 0,
                 });
                 break;

--- a/cli/src/tui/hooks/run_completion.ts
+++ b/cli/src/tui/hooks/run_completion.ts
@@ -1,5 +1,5 @@
 import { createEffect } from "solid-js";
-import { createThreadHistory, syntheticRecordMessage, type CortexRunRow, type Pool, type RunStatus } from "@inflexa-ai/harness";
+import { conversationRecordTurn, createThreadHistory, type CortexRunRow, type Pool, type RunStatus } from "@inflexa-ai/harness";
 
 import { getLogger } from "../../lib/log.ts";
 import type { HarnessRuntime } from "../../modules/harness/runtime.ts";
@@ -182,7 +182,7 @@ const realRunCompletionSeams: RunCompletionSeams = {
         // only the record is RENDERED — the plain synthetic is loop machinery the display
         // reconstruction drops, so using it here would store the outcome and show nothing.
         createThreadHistory(pool)
-            .appendTurn(threadId, [syntheticRecordMessage(text)])
+            .appendTurn(threadId, conversationRecordTurn(text))
             .match(
                 () => ({ ok: true }),
                 (e) => ({ ok: false, error: e.type }),


### PR DESCRIPTION
Stacked on #273. The harness persists what a turn displayed, at the moment it displays it, and replays that projection. It cannot produce the projection on its own — the recorder wraps the turn's event sink, and this host owns the sink. This is that half, plus the reload path that stops reconstructing.

## Record the projection

The turn engine wraps its sink in the harness display recorder and hands the result to `appendTurn` with the model messages and the usage rollup.

`chat` and `ask` become functions of that sink rather than values closed over the raw one. This is the load-bearing part: `createStreamingChat` forwards each provider text delta by calling `emit`, and the ask gateway emits its cards the same way. Built over the raw sink they render live and are invisible to the recorder, so a reloaded turn would be missing its assistant text and its approval cards — most of what the user saw. Passing the sink in is what makes the recorded path the only path.

`finish` runs before the append on all three phases, for the same reason the rollup does: an aborted turn displayed real work, and its projection is what the retract window renders.

## Replay it

The reload seam collapses to `storedMessagesToCortex(rows)` — synchronous, no pool, no analysis id, no tool roster, no card or detail resolver. Every parameter it dropped existed to serve reconstruction. Three consequences, all deletions:

- the `ResultAsync` bridge and its now-unreachable error branch go: the read cannot fail;
- the workspace-root degradation branch goes. A moved or deleted anchor used to downgrade preview cards to chips on reload; it now has no effect on a transcript read at all;
- the seam is synchronous. This costs no coverage — the load-interleaving tests gate on `loadPage`, which is still async.

A run-outcome record is appended through `conversationRecordTurn` so it carries its own projection. Appended without one it is stored, read by the model, and never shown.

## Nothing is interpreted host-side

The harness carries a call's terminal state in one field, so the reload maps it exhaustively — `ok`/`error`/`denied` through, `incomplete` to `running` — with a `never` arm and no default.

That removes the last place this host was interpreting a harness-owned fact. `status === "started" ? "running" : (outcome ?? "ok")` put the meaning of an outcome-less call here, where a second consumer would have had to reinvent it and could have reinvented it differently. Now nothing is inferred from an absent value, and a state added upstream breaks this build rather than rendering as something plausible.

`incomplete` renders as `running` beside the message's interruption badge — the pair says "in flight when the turn was cut off". The two must not be separated; the marker alone would read as live. This was chosen over adding a fifth design-system status, since the badge already carries the distinction.

## What is unchanged

The live surface. `updateToolPart` already took the three-way outcome and the detail, so the emit reducer, the continuation row and the gallery are untouched.

## Verification

`bun run typecheck` and `bun run lint` clean. `bun run test`: 2652 pass, 1 skip, 1 fail — `createLocalEmbeddingProvider` loopback bypass, which reproduces with these changes stashed and is unrelated.

## Specs

`record-conversation-display` covers the recorder wiring, the collapsed read, and the record's projection. `render-tool-call-detail` keeps its outcomes and loses its mechanism: its reload requirement was written when a detail was re-derived at read time from the tool's current schema, and now states that a reloaded call shows its detail and its outcome, with re-deriving either explicitly not a way to satisfy it.
