### PR TITLE
feat(harness)!: select the agent that runs a thread from the thread's type

### DIFF
--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/design.md
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/design.md
@@ -1,0 +1,68 @@
+# Design: add-thread-agent-resolution
+
+## Context
+
+`assembleCoreRuntime` builds exactly one agent and returns it as `CoreRuntime.conversationAgent` (`src/runtime/assemble.ts:103-111`). Two consumers hold that field: the boot-time display backfill, which needs the conversation tool roster (`src/runtime/boot.ts:108`), and the embedder, which passes the field into every turn's `runAgent`. `prepareChatTurn` loads the thread row for its ownership check (`src/app/chat-turn.ts:57`) and discards `threadType`. The type itself landed in #292: a closed two-member set, `conversation` and `report` (`src/memory/thread-store.ts:66-67`), closed precisely because type→agent selection must be exhaustive over a known membership.
+
+Constraints from the surrounding system:
+
+- An embedder may wrap providers in delegating handles it re-points at idle (the CLI's live model switch). Assembled tools capture those handles at construction (`src/agents/conversation-agent.ts:283`), so agent identity must be stable across turns.
+- The current report-builder constructs its roster per invocation with closure-bound state (`src/execution/report-runner.ts:196`) — the shape this seam deliberately does not accommodate.
+- The harness error channel is neverthrow `Result`; store-refused inputs are `DomainError` unions with a string `type` discriminator (`ThreadInputError`, `src/memory/thread-store.ts:135`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The harness owns the type→agent selection rule; an embedder plumbs a value and never maps.
+- One registration point, at assembly, where #225's Report Builder plugs in without touching any embedder.
+- The turn path learns the thread's type at zero extra query cost.
+
+**Non-Goals:**
+
+- The Report Builder agent, its roster, and its tool-binding redesign (#225).
+- Type-dependent message assembly — what a `report` turn's `prepareChatTurn` should assemble is #225's decision; this seam selects the agent only.
+- Parent/child semantics (`parentThreadId`/`parentSeq` are not read here).
+- Any embedder wiring (the CLI turn engine adopts at the pin bump).
+
+## Decisions
+
+### D1: The registry holds assembled singletons, never per-call factories
+
+The registry is a `Partial<Record<ThreadType, AgentDefinition>>` built inside `assembleCoreRuntime`, next to `createConversationAgent`. Resolution returns the same object assembly built, every call.
+
+The resolver wrapping is a small pure exported function (`createThreadAgentResolver`) rather than an inline closure: `DBOS.registerWorkflow` refuses duplicate names and any post-launch registration, so `assembleCoreRuntime` is single-shot per process and untestable as an offline unit — the pure function is what the resolver tests drive, while the registry literal stays inline in `assembleCoreRuntime` under tsc's eye.
+
+*Alternative rejected — factory shape `forThread(type, ctx) => AgentDefinition`.* It would let #225 keep the report-runner's construction-time closures, but it rebuilds the roster per turn: new tool identities the boot backfill cannot enumerate and, in the CLI, orphaned swappable-provider captures. Issue #236 names the consequence as intended: registering at assembly forces the report tools to read their per-thread state from `ToolContext.session` at call time.
+
+### D2: Partial today, typed refusal for the unregistered type
+
+`report` is a valid `ThreadType` with no agent until #225 registers one. Resolution returns `Result<AgentDefinition, UnregisteredThreadType>` where the error is a `DomainError`-conventioned variant: `{ type: "unregistered_thread_type"; threadType: ThreadType }`. Resolution is synchronous (a record lookup), so the channel is plain `Result`, not `ResultAsync`.
+
+*Alternative rejected — total record with a stub `report` agent that refuses at run time.* Same observable behavior, more code, and the stub would masquerade as a registered agent in any roster enumeration.
+
+*Alternative rejected — land this change after #225 so the record is total from birth.* #236 is the registration point #225 plugs into; the dependency runs the other way.
+
+The error channel is permanent, not interim scaffolding. When #225 registers `report` the record becomes total for today's membership, but `forThread` keeps the `Result` signature: `ThreadType` grows over the product's life, and a bare-`AgentDefinition` signature would force every future type to register its agent in the same commit that adds the type — re-coupling exactly what this seam decouples. A stable public signature across #225 also spares one more breaking surface change.
+
+The refusal path is unreachable today — nothing creates `report` threads — so a unit test drives it directly against the resolver.
+
+### D3: `prepareChatTurn` returns the type; `CoreRuntime` resolves
+
+`PrepareChatTurnResult`'s `ok` variant gains a required `threadType: ThreadType`. Both branches already know it: an existing thread carries it on the loaded row, and an absent thread is created as `conversation` (the store default). The caller then resolves via `CoreRuntime.agents.forThread(threadType)`.
+
+*Alternative rejected — hand the registry into `prepareChatTurn` and return the resolved agent.* It couples a deliberately dep-light prep function (`{ pool, logger }`) to agent resolution. The look-ahead cuts the other way, though: when #225 makes assembly itself type-dependent, the type switch belongs inside the harness prepare path — the resolution surface introduced here is the seam it will grow behind, which is why the new spec is named `thread-agent-resolution`, not `conversation-agent-resolution`.
+
+### D4: `CoreRuntime.conversationAgent` is removed, not deprecated beside the registry
+
+`CoreRuntime` becomes `{ agents, workflows }` with `agents.forThread(type)`. The boot backfill resolves `conversation` explicitly — correct by construction, since legacy display envelopes predate `report` threads. Keeping both surfaces would leave two ways to reach the same agent and invite drift; the unpublished release already carries #292's breaking `Thread` changes, so this rides at zero extra release cost.
+
+## Risks / Trade-offs
+
+- [A future `report` thread reaching `prepareChatTurn` assembles conversation-shaped context before the refusal] → the refusal fires before `runAgent`, so the wasted assembly is the whole cost; #225 owns assembly redesign.
+- [The `unregistered_thread_type` refusal is dead code until #225] → direct unit test on the resolver; the type-level `Partial` keeps the compiler honest at the registration site.
+- [Embedders on the published harness break at the pin bump] → expected cross-subsystem shape (root `CLAUDE.md`); the barrel exports the new types so the fix is mechanical.
+
+## Open Questions
+
+None. The error-channel question raised during exploration is decided in D2: the `Result` channel is permanent.

--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: add-thread-agent-resolution
+
+## Why
+
+PR #292 gave every thread a `threadType` precisely so the type can select the agent that runs it, but nothing reads the type on the turn path: the harness assembles exactly one agent, exposes it as `CoreRuntime.conversationAgent` (`src/runtime/assemble.ts:90`), and the embedder hardcodes that one agent into every turn. The selection rule must be harness-owned — a managed deployment must get the same type→agent behavior with zero embedder involvement — and the Report Builder (#225) needs a registration point that is not "rewire the CLI".
+
+## What Changes
+
+- `assembleCoreRuntime` builds a type-keyed registry of the agents it assembles — one entry today, `conversation` → the conversation agent — and returns a resolution surface on `CoreRuntime` (`agents.forThread(type)`).
+- Resolution is total over registered types and refuses unregistered ones with a typed error on the `Result` channel. `report` is a valid `ThreadType` with no registered agent until #225 registers the Report Builder at this same point; the refusal path is typed now even though no code creates `report` threads yet.
+- The registry holds the assembled singleton `AgentDefinition`s, never per-call factories — resolution returns the same object assembly built, so construction-time captures (an embedder's swappable provider handles, closure-wired tools) stay valid across every turn.
+- `prepareChatTurn`'s `ok` result gains `threadType`, read from the thread row the ownership check already loads (`src/app/chat-turn.ts:57`) — zero extra queries. A turn's caller resolves the agent from that value instead of receiving one from configuration.
+- **BREAKING**: `CoreRuntime.conversationAgent` is removed; consumers reach agents only through the resolution surface. The boot backfill (`src/runtime/boot.ts:108`) reads the conversation roster through it.
+- The new resolution types are re-exported from the package barrel.
+
+## Capabilities
+
+### New Capabilities
+
+- `thread-agent-resolution`: how a thread's type selects the agent that runs its turns — the registry built at assembly, the resolution surface on `CoreRuntime`, singleton semantics, the typed refusal for an unregistered type, and `prepareChatTurn` surfacing the thread's type.
+
+### Modified Capabilities
+
+- `harness-durable-runtime`: the composition-root requirement changes — `assembleCoreRuntime` builds the type-keyed agent registry over the conversation agent it constructs, and `CoreRuntime` exposes the resolution surface instead of a bare `conversationAgent` field.
+
+## Impact
+
+- **Code**: `src/runtime/assemble.ts` (registry + `CoreRuntime` shape), `src/runtime/boot.ts` (backfill call site), `src/app/chat-turn.ts` (result type), `src/index.ts` (barrel exports), plus tests beside each.
+- **API (breaking)**: `CoreRuntime.conversationAgent` disappears from the package surface; `PrepareChatTurnResult`'s `ok` variant widens by one required field. Rides the same unpublished breaking release as #292's `Thread` changes.
+- **Embedder**: the CLI turn engine stops receiving a hardcoded agent and resolves per turn from `prepared.threadType`; that wiring is CLI-side work adopted at the harness pin bump, outside this change.
+- **Not touched**: `parent_thread_id`/`parent_seq` (selection is type-only), the Report Builder agent and its tool-binding redesign (#225), message assembly per type (#225 decides what a report turn assembles).

--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/specs/harness-durable-runtime/spec.md
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/specs/harness-durable-runtime/spec.md
@@ -1,0 +1,28 @@
+# harness-durable-runtime Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: assembleCoreRuntime is the single host-neutral composition root
+
+`assembleCoreRuntime` SHALL be the one assembly point that registers the durable
+workflows with DBOS AND builds the conversation agent over the registered
+callables, registering that agent in the type-keyed agent registry `CoreRuntime`
+exposes as its resolution surface (`agents` — see the thread-agent-resolution
+spec); `CoreRuntime` SHALL NOT expose a bare `conversationAgent` field.
+Registration order SHALL be preserved because the parent's child
+dispatch closes over the registered child callable: the sandbox-step workflow
+SHALL register before `executeAnalysis`, which receives that callable. All
+workflows SHALL register in this one call before `launchDbos`, so they land under
+one `applicationVersion` cohort.
+
+#### Scenario: The parent workflow is built over the registered child callable
+
+- **WHEN** `assembleCoreRuntime` runs
+- **THEN** the sandbox-step workflow is registered first
+- **AND** `executeAnalysis` is built with the registered sandbox-step callable, not a pre-built one
+
+#### Scenario: The runtime exposes agents only through the resolution surface
+
+- **WHEN** `assembleCoreRuntime` returns
+- **THEN** `CoreRuntime` carries the agent resolution surface (`agents`) and the registered workflows
+- **AND** the conversation agent is reachable only via `agents.forThread("conversation")`

--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/specs/thread-agent-resolution/spec.md
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/specs/thread-agent-resolution/spec.md
@@ -1,0 +1,58 @@
+# thread-agent-resolution Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: The harness owns type→agent selection through a registry built at assembly
+
+`assembleCoreRuntime` SHALL build a type-keyed registry of the agents it assembles and expose resolution on `CoreRuntime` (`agents.forThread(type)`) as the only way to reach an agent by thread type. The `conversation` type SHALL resolve to the assembled conversation agent. The registry SHALL be the single registration point for every future typed agent, so a new thread type's agent plugs in at assembly with no embedder change, and the resolution surface types SHALL be re-exported from the package barrel.
+
+#### Scenario: The conversation type resolves to the conversation agent
+
+- **WHEN** `assembleCoreRuntime` returns and the caller resolves `agents.forThread("conversation")`
+- **THEN** the result is ok and carries the same conversation `AgentDefinition` the assembly built
+
+#### Scenario: An embedder reaches resolution through the package barrel
+
+- **WHEN** an embedder imports from `@inflexa-ai/harness`
+- **THEN** the resolution surface and its error type are importable from the barrel, without a deep path
+
+### Requirement: Resolution returns assembled singletons
+
+Resolution SHALL return the same assembled `AgentDefinition` object on every call for a given type, never a per-call reconstruction, so references captured at construction time (an embedder's delegating provider handles, closure-wired tools) stay valid across every turn.
+
+#### Scenario: Repeated resolution yields one identity
+
+- **WHEN** `agents.forThread("conversation")` is called twice on one `CoreRuntime`
+- **THEN** both calls return the identical object
+
+### Requirement: An unregistered type refuses with a typed error
+
+Resolution SHALL be synchronous and SHALL refuse a `ThreadType` with no registered agent by returning the `unregistered_thread_type` error variant — carrying the refused `threadType` — on the `Result` error channel, never by throwing. The error channel is permanent: registration of an agent for every current `ThreadType` member SHALL NOT narrow the signature, so adding a future member never forces an agent registration in the same commit.
+
+#### Scenario: The report type refuses before its agent exists
+
+- **GIVEN** a `CoreRuntime` assembled with no `report` agent registered
+- **WHEN** the caller resolves `agents.forThread("report")`
+- **THEN** the result is an error of type `unregistered_thread_type` with `threadType: "report"`
+
+### Requirement: prepareChatTurn surfaces the thread's type
+
+`prepareChatTurn` SHALL include the thread's `threadType` on its `ok` result, read from the thread row its ownership check already loads — or, for a thread it creates, the type it created — so a caller resolves the turn's agent without a second thread read.
+
+#### Scenario: An existing thread reports its stored type
+
+- **GIVEN** a thread row whose `thread_type` is `conversation`
+- **WHEN** `prepareChatTurn` prepares a turn on that thread
+- **THEN** the `ok` result carries `threadType: "conversation"`
+
+#### Scenario: A first-turn thread reports the type it was created with
+
+- **GIVEN** a `threadId` with no row
+- **WHEN** `prepareChatTurn` prepares the turn and creates the thread
+- **THEN** the `ok` result carries `threadType: "conversation"`, matching the created row
+
+#### Scenario: A report thread reports its stored type
+
+- **GIVEN** a thread row whose `thread_type` is `report`, written directly through the store (no production path creates one yet)
+- **WHEN** `prepareChatTurn` prepares a turn on that thread
+- **THEN** the `ok` result carries `threadType: "report"`

--- a/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-03-add-thread-agent-resolution/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: add-thread-agent-resolution
+
+## 1. Resolution surface
+
+- [x] 1.1 Define the resolution types in `src/runtime/assemble.ts`: the resolver shape (`agents.forThread(type): Result<AgentDefinition, UnregisteredThreadType>`) and the `unregistered_thread_type` error variant (`DomainError`-conventioned, carries the refused `threadType`). Synchronous `Result`, not `ResultAsync`.
+- [x] 1.2 Build the `Partial<Record<ThreadType, AgentDefinition>>` registry inside `assembleCoreRuntime` (entry: `conversation` → the assembled conversation agent) and replace `CoreRuntime.conversationAgent` with the `agents` resolution surface.
+- [x] 1.3 Update every in-harness reader of `CoreRuntime.conversationAgent` — the boot backfill at `src/runtime/boot.ts:108` resolves `conversation` through the registry (unreachable-err bridge justified: assembly registers `conversation` unconditionally) — and sweep `src/` + tests for remaining readers.
+- [x] 1.4 Tests beside `assemble.ts`: `forThread("conversation")` returns ok with the assembled agent; two calls return the identical object; `forThread("report")` returns the `unregistered_thread_type` error (direct drive — the path is dead in production until #225).
+
+## 2. prepareChatTurn surfaces the type
+
+- [x] 2.1 Add required `threadType: ThreadType` to `PrepareChatTurnResult`'s `ok` variant in `src/app/chat-turn.ts` — existing thread: the loaded row's type; created thread: `conversation`.
+- [x] 2.2 Extend the chat-turn tests: an existing `conversation` thread reports its stored type; a first-turn create reports `conversation`; a store-written `report` row reports `report`.
+
+## 3. Package surface
+
+- [x] 3.1 Re-export the resolver surface types and the error type from `src/index.ts`; remove any barrel mention of the deleted `conversationAgent` field.
+
+## 4. Verify
+
+- [x] 4.1 `tsc -p tsconfig.json` — exit 0.
+- [x] 4.2 Targeted `bun test` over the changed areas only (assemble/boot, chat-turn) with `CORTEX_TEST_PG_URL` set — never the full suite.
+- [x] 4.3 `bun run format:file` on every changed file under `src/`.

--- a/harness/openspec/specs/harness-durable-runtime/spec.md
+++ b/harness/openspec/specs/harness-durable-runtime/spec.md
@@ -78,7 +78,10 @@ and SHALL NOT be reformatted at the adapter.
 
 `assembleCoreRuntime` SHALL be the one assembly point that registers the durable
 workflows with DBOS AND builds the conversation agent over the registered
-callables. Registration order SHALL be preserved because the parent's child
+callables, registering that agent in the type-keyed agent registry `CoreRuntime`
+exposes as its resolution surface (`agents` — see the thread-agent-resolution
+spec); `CoreRuntime` SHALL NOT expose a bare `conversationAgent` field.
+Registration order SHALL be preserved because the parent's child
 dispatch closes over the registered child callable: the sandbox-step workflow
 SHALL register before `executeAnalysis`, which receives that callable. All
 workflows SHALL register in this one call before `launchDbos`, so they land under
@@ -89,6 +92,12 @@ one `applicationVersion` cohort.
 - **WHEN** `assembleCoreRuntime` runs
 - **THEN** the sandbox-step workflow is registered first
 - **AND** `executeAnalysis` is built with the registered sandbox-step callable, not a pre-built one
+
+#### Scenario: The runtime exposes agents only through the resolution surface
+
+- **WHEN** `assembleCoreRuntime` returns
+- **THEN** `CoreRuntime` carries the agent resolution surface (`agents`) and the registered workflows
+- **AND** the conversation agent is reachable only via `agents.forThread("conversation")`
 
 ### Requirement: Dependencies are split by lifetime with no ambient lookups
 

--- a/harness/openspec/specs/thread-agent-resolution/spec.md
+++ b/harness/openspec/specs/thread-agent-resolution/spec.md
@@ -1,0 +1,70 @@
+# thread-agent-resolution Specification
+
+## Purpose
+
+Define how a thread's type selects the agent that runs its turns. The selection
+rule is harness-owned: `assembleCoreRuntime` builds a type-keyed registry of the
+agents it assembles and exposes resolution as `CoreRuntime.agents`
+(`ThreadAgentResolver`, `src/runtime/assemble.ts`), so an embedder plumbs a
+thread's type into `forThread` and never maps types to agents itself. The
+registry is the single registration point for every typed agent — a future
+thread type's agent (e.g. the Report Builder) plugs in at assembly with no
+embedder change. `prepareChatTurn` surfaces the type from the row it already
+loads, so the turn path learns it at zero extra query cost.
+
+## Requirements
+
+### Requirement: The harness owns type→agent selection through a registry built at assembly
+
+`assembleCoreRuntime` SHALL build a type-keyed registry of the agents it assembles and expose resolution on `CoreRuntime` (`agents.forThread(type)`) as the only way to reach an agent by thread type. The `conversation` type SHALL resolve to the assembled conversation agent. The registry SHALL be the single registration point for every future typed agent, so a new thread type's agent plugs in at assembly with no embedder change, and the resolution surface types SHALL be re-exported from the package barrel.
+
+#### Scenario: The conversation type resolves to the conversation agent
+
+- **WHEN** `assembleCoreRuntime` returns and the caller resolves `agents.forThread("conversation")`
+- **THEN** the result is ok and carries the same conversation `AgentDefinition` the assembly built
+
+#### Scenario: An embedder reaches resolution through the package barrel
+
+- **WHEN** an embedder imports from `@inflexa-ai/harness`
+- **THEN** the resolution surface and its error type are importable from the barrel, without a deep path
+
+### Requirement: Resolution returns assembled singletons
+
+Resolution SHALL return the same assembled `AgentDefinition` object on every call for a given type, never a per-call reconstruction, so references captured at construction time (an embedder's delegating provider handles, closure-wired tools) stay valid across every turn.
+
+#### Scenario: Repeated resolution yields one identity
+
+- **WHEN** `agents.forThread("conversation")` is called twice on one `CoreRuntime`
+- **THEN** both calls return the identical object
+
+### Requirement: An unregistered type refuses with a typed error
+
+Resolution SHALL be synchronous and SHALL refuse a `ThreadType` with no registered agent by returning the `unregistered_thread_type` error variant — carrying the refused `threadType` — on the `Result` error channel, never by throwing. The error channel is permanent: registration of an agent for every current `ThreadType` member SHALL NOT narrow the signature, so adding a future member never forces an agent registration in the same commit.
+
+#### Scenario: The report type refuses before its agent exists
+
+- **GIVEN** a `CoreRuntime` assembled with no `report` agent registered
+- **WHEN** the caller resolves `agents.forThread("report")`
+- **THEN** the result is an error of type `unregistered_thread_type` with `threadType: "report"`
+
+### Requirement: prepareChatTurn surfaces the thread's type
+
+`prepareChatTurn` SHALL include the thread's `threadType` on its `ok` result, read from the thread row its ownership check already loads — or, for a thread it creates, the type it created — so a caller resolves the turn's agent without a second thread read.
+
+#### Scenario: An existing thread reports its stored type
+
+- **GIVEN** a thread row whose `thread_type` is `conversation`
+- **WHEN** `prepareChatTurn` prepares a turn on that thread
+- **THEN** the `ok` result carries `threadType: "conversation"`
+
+#### Scenario: A first-turn thread reports the type it was created with
+
+- **GIVEN** a `threadId` with no row
+- **WHEN** `prepareChatTurn` prepares the turn and creates the thread
+- **THEN** the `ok` result carries `threadType: "conversation"`, matching the created row
+
+#### Scenario: A report thread reports its stored type
+
+- **GIVEN** a thread row whose `thread_type` is `report`, written directly through the store (no production path creates one yet)
+- **WHEN** `prepareChatTurn` prepares a turn on that thread
+- **THEN** the `ok` result carries `threadType: "report"`

--- a/harness/src/app/chat-turn.test.ts
+++ b/harness/src/app/chat-turn.test.ts
@@ -167,4 +167,51 @@ describe("prepareChatTurn", () => {
         expect(joined).toContain("Run status is temporarily unavailable.");
         expect(joined).not.toContain("No runs are currently running or suspended.");
     });
+
+    it("carries the stored conversation type on an existing thread", async () => {
+        const store = createThreadStore(pool);
+        (
+            await store.createThread({
+                threadId: "t-conv",
+                analysisId: ANALYSIS_A,
+                title: "A conversation",
+            })
+        )._unsafeUnwrap();
+
+        const result = await prepareChatTurn({ pool }, { analysisId: ANALYSIS_A, threadId: "t-conv", userInput: "hello" });
+
+        expect(result.kind).toBe("ok");
+        if (result.kind !== "ok") throw new Error("unreachable");
+        expect(result.threadType).toBe("conversation");
+    });
+
+    it("carries the conversation type on a first-turn thread it creates", async () => {
+        const result = await prepareChatTurn({ pool }, { analysisId: ANALYSIS_A, threadId: "t-first", userInput: "hello" });
+
+        expect(result.kind).toBe("ok");
+        if (result.kind !== "ok") throw new Error("unreachable");
+        expect(result.threadType).toBe("conversation");
+
+        // The created row matches the surfaced type.
+        const created = (await createThreadStore(pool).getThread("t-first"))._unsafeUnwrap();
+        expect(created!.threadType).toBe("conversation");
+    });
+
+    it("carries the stored report type on a report thread", async () => {
+        // No production path creates a report thread yet — write one directly.
+        (
+            await createThreadStore(pool).createThread({
+                threadId: "t-report",
+                analysisId: ANALYSIS_A,
+                title: "A report",
+                type: "report",
+            })
+        )._unsafeUnwrap();
+
+        const result = await prepareChatTurn({ pool }, { analysisId: ANALYSIS_A, threadId: "t-report", userInput: "hello" });
+
+        expect(result.kind).toBe("ok");
+        if (result.kind !== "ok") throw new Error("unreachable");
+        expect(result.threadType).toBe("report");
+    });
 });

--- a/harness/src/app/chat-turn.ts
+++ b/harness/src/app/chat-turn.ts
@@ -18,7 +18,7 @@ import type { Pool } from "pg";
 import { unwrapOrThrow } from "../lib/result.js";
 import { deriveThreadTitle } from "../memory/derive-thread-title.js";
 import { createThreadHistory } from "../memory/thread-history.js";
-import { createThreadStore } from "../memory/thread-store.js";
+import { createThreadStore, type ThreadType } from "../memory/thread-store.js";
 import { createWorkingMemory } from "../memory/working-memory.js";
 import { loadAnalysisStatus, queryNonTerminalRunsByAnalysis } from "../state/index.js";
 import { assembleMessages, type AssembledMessages } from "./message-assembly.js";
@@ -38,7 +38,7 @@ export interface PrepareChatTurnParams {
     readonly userInput: string;
 }
 
-export type PrepareChatTurnResult = ({ readonly kind: "ok" } & AssembledMessages) | { readonly kind: "not_found" };
+export type PrepareChatTurnResult = ({ readonly kind: "ok"; readonly threadType: ThreadType } & AssembledMessages) | { readonly kind: "not_found" };
 
 /**
  * Prepare one chat turn: resolve thread ownership, seed the title, load
@@ -56,6 +56,12 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
     if (existing && existing.analysisId !== analysisId) {
         return { kind: "not_found" };
     }
+
+    // The type a caller resolves the turn's agent from. An existing row carries
+    // its own; an absent one is created below with no type, which the store
+    // writes as `conversation` — so even a best-effort create that fails
+    // non-fatally leaves this the type the turn proceeds under.
+    const threadType: ThreadType = existing ? existing.threadType : "conversation";
 
     // Seed the thread title from the first user message. Best-effort.
     try {
@@ -92,5 +98,5 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
         workingMemory: createWorkingMemory(pool),
     });
 
-    return { kind: "ok", messages, userMessage };
+    return { kind: "ok", threadType, messages, userMessage };
 }

--- a/harness/src/app/chat-turn.ts
+++ b/harness/src/app/chat-turn.ts
@@ -58,21 +58,25 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
     }
 
     // The type a caller resolves the turn's agent from. An existing row carries
-    // its own; an absent one is created below with no type, which the store
-    // writes as `conversation` — so even a best-effort create that fails
-    // non-fatally leaves this the type the turn proceeds under.
-    const threadType: ThreadType = existing ? existing.threadType : "conversation";
+    // its own. An absent one defaults to `conversation` — the store's own
+    // default — so a best-effort create that fails non-fatally still leaves a
+    // usable type; a successful create overrides it from the returned row.
+    let threadType: ThreadType = existing ? existing.threadType : "conversation";
 
     // Seed the thread title from the first user message. Best-effort.
     try {
         if (!existing) {
-            unwrapOrThrow(
+            // `createThread` is idempotent (ON CONFLICT reads the row back), so
+            // the returned row is authoritative for the type: a create that
+            // races another writer reflects the stored type, not an assumed one.
+            const created = unwrapOrThrow(
                 await store.createThread({
                     threadId,
                     analysisId,
                     title: deriveThreadTitle(userInput),
                 }),
             );
+            threadType = created.threadType;
         } else if (!existing.title || existing.title.length === 0) {
             unwrapOrThrow(await store.updateTitle(threadId, deriveThreadTitle(userInput)));
         }

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -8,6 +8,10 @@
 // Runtime assembly + composition root.
 export { assembleCoreRuntime } from "./runtime/assemble.js";
 export type { CoreRuntime, CoreRuntimeDeps, CoreWorkflowDeps, RegisteredWorkflows, ConversationAssemblyDeps, SandboxStepCallable } from "./runtime/assemble.js";
+// Thread→agent resolution surface `CoreRuntime.agents` carries: an embedder
+// resolves a turn's agent by thread type and matches the typed refusal for a
+// type whose agent is not registered yet.
+export type { ThreadAgentResolver, UnregisteredThreadType } from "./runtime/assemble.js";
 // The harness-owned boot sequence: ordered boot steps around `assembleCoreRuntime`
 // (skill validation → state init → connection budget → assemble → launch) + a
 // `shutdown` handle the embedder wires to its process signals.

--- a/harness/src/runtime/assemble.test.ts
+++ b/harness/src/runtime/assemble.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+
+import { createThreadAgentResolver } from "./assemble.js";
+import type { AgentDefinition } from "../loop/types.js";
+import type { ThreadType } from "../memory/thread-store.js";
+
+// A bare `AgentDefinition` stands in for the assembled conversation agent: the
+// resolver only ever hands back the object the registry holds, so its internals
+// never matter to resolution.
+const conversationAgent: AgentDefinition = {
+    id: "conversation",
+    systemPrompt: "",
+    model: "test/model",
+    tools: [],
+    maxIterations: 1,
+};
+
+// The registry `assembleCoreRuntime` builds today: only `conversation`.
+function registry(): Partial<Record<ThreadType, AgentDefinition>> {
+    return { conversation: conversationAgent };
+}
+
+describe("createThreadAgentResolver", () => {
+    it("resolves the conversation type to the assembled conversation agent", () => {
+        const result = createThreadAgentResolver(registry()).forThread("conversation");
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap()).toBe(conversationAgent);
+    });
+
+    it("returns one identity across repeated resolution", () => {
+        const resolver = createThreadAgentResolver(registry());
+        const first = resolver.forThread("conversation");
+        const second = resolver.forThread("conversation");
+        // Singleton semantics: both calls surface the same object, so a handle
+        // captured at construction stays the one every turn resolves.
+        expect(first._unsafeUnwrap()).toBe(second._unsafeUnwrap());
+    });
+
+    it("refuses an unregistered type with a typed error carrying the type", () => {
+        // Reduce the Result to whichever branch fired: a registered type would
+        // yield its agent, `report` yields its refusal.
+        const reduced = createThreadAgentResolver(registry())
+            .forThread("report")
+            .match(
+                (agent) => agent,
+                (refusal) => refusal,
+            );
+        expect(reduced).toEqual({ type: "unregistered_thread_type", threadType: "report" });
+    });
+});

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -171,8 +171,11 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
 
     // The single registration point for every typed agent. One entry today; a
     // future thread type's agent plugs in here at assembly with no embedder
-    // change, and `Partial` keeps the compiler honest that `report` has none yet.
-    const agents: Partial<Record<ThreadType, AgentDefinition>> = {
+    // change. `conversation` is required at the type level because boot resolves
+    // it unconditionally (`boot.ts` backfill) — a dropped registration must fail
+    // tsc here, not surface only as a boot-time throw. The `Partial` over the
+    // rest keeps the compiler honest that `report` has no agent yet.
+    const agents: Record<"conversation", AgentDefinition> & Partial<Record<ThreadType, AgentDefinition>> = {
         conversation: conversationAgent,
     };
 

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -15,11 +15,15 @@
  * before launch — a blue/green drain treats them as a single cohort.
  */
 
+import { err, ok, type Result } from "neverthrow";
+
 import { createConversationAgent, type ConversationAgentDeps } from "../agents/conversation-agent.js";
 import { createNoopUsageRecorder } from "../billing/noop-usage-recorder.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { ResourcePolicy } from "../config/resource-limits.js";
 import type { AgentDefinition } from "../loop/types.js";
+import type { DomainError } from "../lib/result.js";
+import type { ThreadType } from "../memory/thread-store.js";
 import { registerExecuteAnalysis, type ExecuteAnalysisDeps, type ExecuteAnalysisInput, type ExecuteAnalysisResult } from "../workflows/execute-analysis.js";
 import { registerSandboxStep, type SandboxStepDeps, type SandboxStepInput, type SandboxStepResult } from "../workflows/sandbox-step.js";
 import {
@@ -86,8 +90,66 @@ export interface CoreRuntimeDeps {
     readonly usageRecorder?: UsageRecorder;
 }
 
+/**
+ * The refusal a thread type carries no agent yet. `report` is a valid
+ * `ThreadType` with no registered agent until its builder plugs in at assembly,
+ * so resolution has to have a typed way to say "not that one" without throwing.
+ * The channel is permanent, not interim: `ThreadType` grows over the product's
+ * life, and a bare-`AgentDefinition` return would force every future member to
+ * register an agent in the same commit that adds the member.
+ */
+export interface UnregisteredThreadType {
+    readonly type: "unregistered_thread_type";
+    readonly threadType: ThreadType;
+}
+
+// `UnregisteredThreadType` is a `DomainError` (string `type`) — the compile-time
+// check keeps its refusal inside the cross-subsystem error vocabulary.
+type _AssertDomainError = UnregisteredThreadType extends DomainError ? true : never;
+const _assertDomainError: _AssertDomainError = true;
+
+/**
+ * How a thread's type selects the agent that runs its turns. Resolution is a
+ * synchronous record lookup, so the channel is plain `Result`, never
+ * `ResultAsync`: a registered type resolves to its assembled singleton, an
+ * unregistered one refuses on the error channel.
+ */
+export interface ThreadAgentResolver {
+    forThread(type: ThreadType): Result<AgentDefinition, UnregisteredThreadType>;
+}
+
+/**
+ * Wrap a type→agent registry as the resolution surface. Held apart from
+ * `assembleCoreRuntime` so the resolution contract — a registered type resolves
+ * to the very object the registry holds, an unregistered one refuses — is
+ * exercisable without the DBOS registration `assembleCoreRuntime` performs.
+ *
+ * The registry holds assembled singletons, so `forThread` returns the same
+ * `AgentDefinition` object on every call for a given type: construction-time
+ * captures (an embedder's delegating provider handles, closure-wired tools)
+ * stay valid across every turn.
+ */
+export function createThreadAgentResolver(registry: Partial<Record<ThreadType, AgentDefinition>>): ThreadAgentResolver {
+    return {
+        forThread: (type) => {
+            const agent = registry[type];
+            if (agent === undefined) {
+                const refusal: UnregisteredThreadType = { type: "unregistered_thread_type", threadType: type };
+                return err(refusal);
+            }
+            return ok(agent);
+        },
+    };
+}
+
 export interface CoreRuntime {
-    readonly conversationAgent: AgentDefinition;
+    /**
+     * Thread→agent resolution — the only way to reach an assembled agent by
+     * thread type. Holds the singletons this call built; `conversation` resolves
+     * to the assembled conversation agent, every not-yet-registered type refuses
+     * on the `Result` channel.
+     */
+    readonly agents: ThreadAgentResolver;
     readonly workflows: RegisteredWorkflows;
 }
 
@@ -107,8 +169,15 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
         usageRecorder,
     });
 
+    // The single registration point for every typed agent. One entry today; a
+    // future thread type's agent plugs in here at assembly with no embedder
+    // change, and `Partial` keeps the compiler honest that `report` has none yet.
+    const agents: Partial<Record<ThreadType, AgentDefinition>> = {
+        conversation: conversationAgent,
+    };
+
     return {
-        conversationAgent,
+        agents: createThreadAgentResolver(agents),
         workflows: {
             executeAnalysis,
             sandboxStep,

--- a/harness/src/runtime/boot.ts
+++ b/harness/src/runtime/boot.ts
@@ -40,6 +40,7 @@
 import type { Pool } from "pg";
 
 import type { Logger } from "../lib/logger.js";
+import { unwrapOrThrow } from "../lib/result.js";
 import { SANDBOX_AGENT_META } from "../agents/sandbox/index.js";
 import { validateAgentSkills } from "../agents/sandbox/validate-skills.js";
 import { initCortexState } from "../state/init.js";
@@ -102,10 +103,16 @@ export async function bootHarness(deps: BootHarnessDeps): Promise<BootedHarness>
 
     const runtime = assembleCoreRuntime(core);
 
+    // Assembly registers `conversation` unconditionally, so this resolution can
+    // never refuse; `unwrapOrThrow` turns the impossible error branch into a
+    // boot-propagating throw rather than threading a Result through the boot
+    // sequence, whose steps already fail by propagation.
+    const conversationAgent = unwrapOrThrow(runtime.agents.forThread("conversation"));
+
     await backfillConversationDisplayEnvelopes({
         pool,
         resolveWorkspaceRoot: core.conversation.resolveWorkspaceRoot,
-        tools: runtime.conversationAgent.tools,
+        tools: conversationAgent.tools,
     });
 
     await deps.beforeLaunch?.();


### PR DESCRIPTION
## What & why

A thread's type now selects the agent that runs it, and the harness owns that selection. `assembleCoreRuntime` builds a type-keyed registry of the agents it assembles and exposes resolution as `CoreRuntime.agents` — `forThread(type)` is the only way to reach an assembled agent by thread type. `conversation` resolves to the conversation agent; the registry is the single registration point where a future typed agent (the Report Builder) plugs in at assembly, with no embedder change.

Part of #236 — the harness half. The embedder's turn-engine wiring is CLI-side work outside this PR.

## The seam's three properties

**Resolution returns assembled singletons.** `forThread` hands back the same `AgentDefinition` object on every call. An embedder may wrap providers in delegating handles it re-points at idle, and the assembled tools capture those handles at construction — a per-call reconstruction would orphan them. The rejected factory shape is also what forces the Report Builder's tool-binding redesign: per-thread state moves to call-time `ToolContext`, not construction-time closures.

**An unregistered type refuses on the `Result` channel, and the channel is permanent.** `report` is a valid `ThreadType` with no registered agent yet; `forThread("report")` returns `{ type: "unregistered_thread_type", threadType: "report" }`, never a throw. The signature does not narrow once every current member registers — otherwise each future `ThreadType` member would have to arrive with its agent in the same commit.

**`prepareChatTurn` surfaces the thread's type.** The `ok` result carries `threadType`, read from the row the ownership check already loads — zero extra queries. A thread the call creates reports `conversation`, the store default, even when the best-effort create fails non-fatally.

## Breaking change

`CoreRuntime.conversationAgent` is removed; consumers resolve via `agents.forThread("conversation")`. `PrepareChatTurnResult`'s `ok` variant widens by one required field, so a seam fake built from a literal must supply it. `ThreadAgentResolver` and `UnregisteredThreadType` are re-exported from the package barrel.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change

## Checklist

- [ ] Lint, typecheck, and tests pass locally — see "What ran" below, which states this precisely.
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed. The OpenSpec specs carry it (a new `thread-agent-resolution` capability spec, synced); no harness doc names the removed field, verified by grep.
- [x] Commits follow Conventional Commits.
- [x] Commits are signed off for the DCO.
- [x] This PR is focused on a single logical change.

## What ran

- `tsc -p tsconfig.json` — exit 0.
- `bunx eslint` over the six changed files — exit 0. The full `bun run lint` did not run.
- `bun test` over `assemble`, `boot`, and `chat-turn` — 13 pass, 0 fail, against `pgvector/pgvector:pg18`. **The full suite did not run.**

One deviation, recorded in the archived change's `design.md`: the resolver tests drive the extracted pure `createThreadAgentResolver`, not the real `assembleCoreRuntime` — `DBOS.registerWorkflow` refuses duplicate and post-launch registration, so the real call is single-shot per process and untestable as an offline unit. The registry literal stays inline in `assembleCoreRuntime` under the typechecker. The `report` refusal is likewise driven directly in a unit test: no production path creates a `report` thread yet.
