### PR TITLE
refactor(harness): share the durable LLM step and run finalisation

### DIFF
--- a/harness/openspec/changes/share-durable-workflow-mechanics/.openspec.yaml
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/harness/openspec/changes/share-durable-workflow-mechanics/proposal.md
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/proposal.md
@@ -1,0 +1,79 @@
+# Make the two durable-workflow mechanics shareable before a third workflow needs them
+
+## Why
+
+Two mechanisms in the harness are written once and needed twice, and both encode
+subtleties that are invisible in a fresh implementation:
+
+**Run finalisation.** `collectAndComplete` (`src/workflows/execute-analysis.ts`)
+settles every step row, sweeps never-started rows to `skipped`, writes the run's
+terminal status, closes the run charge, revokes owned authorization, and emits
+exactly one terminal event — each in its own named `DBOS.runStep`, none rolling
+back the ones that already succeeded, with the terminal event emitted *before*
+the status write so no reader can observe a terminal run without it, and with the
+402 pause branch selected structurally rather than inferred from the written
+status. Every clause there is a bug that was found once. A second workflow that
+writes its own version does not inherit any of them.
+
+**Durable model calls.** `runLlmStep` and `structuredLlmCall`
+(`src/workflows/target-assessment/lib/`) own the per-call `DBOS.runStep` cache
+slot, the forced-`submit`-tool structured-output pattern, and the
+billing-gateway 402 → self-addressed marker → suspend/self-cancel choreography
+that makes an insufficient-funds pause resumable. They live under
+`target-assessment/` for no reason other than being written there first; nothing
+in them is target-assessment-specific.
+
+`add-manuscript-reference-review` is the second consumer of the finaliser and
+`add-manuscript-editorial-review` is the second consumer of the LLM step. This
+change lands both moves on their own, so a behaviour-preserving refactor of two
+existing workflows is reviewed as a refactor rather than as a diff buried inside
+a new feature.
+
+## What Changes
+
+- `runLlmStep` and `structuredLlmCall` move out of
+  `src/workflows/target-assessment/lib/` into a shared workflow library, with
+  their behaviour, options, and error classification unchanged.
+  `executeTargetAssessment` is repointed at the new path. **Step names are
+  caller-supplied**, so no DBOS cache key moves and no in-flight workflow
+  changes shape mid-replay.
+- The generic part of `collectAndComplete` becomes a reusable finalisation
+  sequence parameterized by the caller's derived status, failure reason, and
+  terminal part. `executeAnalysis` keeps `collectAndComplete` as its binding of
+  that sequence: same durable step names, same ordering, same
+  non-rolling-back rule, same structural selection of the 402 pause branch, and
+  the analysis-specific parts (scheduler-drain results, synthesis outcome note,
+  synthesis-failure forcing) stay in `executeAnalysis`.
+- No behaviour changes, no new dependency, no contract change. The existing
+  `executeAnalysis` and `executeTargetAssessment` suites are the acceptance
+  criteria: they pass unmodified, or the extraction is wrong.
+
+Nothing is generalized speculatively. The sequence is parameterized exactly as
+far as its two known consumers require, and the manuscript-specific status
+derivation stays with the workflow that derives it.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `workflow-failure-lifecycle`: the finalisation sequence is one shared
+  implementation that every durable workflow binds, with `collectAndComplete` as
+  `executeAnalysis`'s binding, preserving every guarantee the hook already makes.
+- `harness-durable-runtime`: a durable workflow's model calls run through one
+  shared named-step wrapper that owns the step cache slot and the 402 →
+  suspend/resume choreography, rather than one copy per workflow.
+
+## Impact
+
+Harness source:
+
+- `src/workflows/lib/llm-step.ts`, `src/workflows/lib/structured-llm.ts` — moved
+  from `src/workflows/target-assessment/lib/`, unchanged.
+- `src/workflows/lib/finalise-run.ts` — the extracted sequence.
+- `src/workflows/execute-analysis.ts` — `collectAndComplete` becomes a binding of
+  the shared sequence.
+- `src/workflows/target-assessment/**` — import paths only.
+
+No embedder change. No spec-visible behaviour change for either existing
+workflow; the deltas record that the mechanism is now shared, which is what makes
+the next two changes small.

--- a/harness/openspec/changes/share-durable-workflow-mechanics/specs/harness-durable-runtime/spec.md
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/specs/harness-durable-runtime/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Durable model calls run through one shared named-step wrapper
+
+A durable workflow SHALL make its model calls through the shared durable
+LLM-step wrapper rather than a per-workflow copy. The wrapper SHALL own the
+per-call `DBOS.runStep` cache slot under a caller-supplied, attempt-numbered
+step name; the forced-tool structured-output pattern for schema-validated
+results; and the billing-gateway 402 handling that self-sends a budget marker
+and returns a sentinel so the workflow's own finalisation writes
+`suspended_insufficient_funds` and materialises the resumable cancelled state.
+Because the step name is supplied by the caller, relocating the wrapper SHALL
+NOT change any existing durable step identity.
+
+#### Scenario: Two workflows share one wrapper
+
+- **WHEN** a target-assessment phase and a manuscript-review phase each make a structured model call
+- **THEN** both run through the same wrapper with their own attempt-numbered step names
+- **AND** neither workflow contains its own copy of the 402 marker-and-suspend choreography
+
+#### Scenario: Relocation preserves step identity
+
+- **WHEN** the wrapper moves to the shared workflow library
+- **THEN** every existing call site's durable step name is unchanged
+- **AND** an in-flight workflow replays against the same cache slots

--- a/harness/openspec/changes/share-durable-workflow-mechanics/specs/workflow-failure-lifecycle/spec.md
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/specs/workflow-failure-lifecycle/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: collectAndComplete is the single finalisation hook
+
+The run finalisation sequence SHALL be one shared implementation that every
+durable workflow binds, parameterized by the binding workflow's derived terminal
+status, failure reason, terminal part, and whether the pending-row sweep applies.
+`collectAndComplete` SHALL be `executeAnalysis`'s binding of that sequence, and a
+second independent implementation of it SHALL NOT be written for another
+workflow. Analysis-specific finalisation — scheduler-drain results, the run
+synthesis outcome note, and synthesis-failure status forcing — SHALL remain in
+`executeAnalysis` rather than moving into the shared sequence.
+
+`collectAndComplete` SHALL remain the only block that finalises run-level state
+for an analysis run, and it SHALL run on every terminal path: success, runs with
+step failures (which drain the scheduler loop and typically finalise `partial`),
+the budget halt, external cancel, synthesis failure, and the 402 pause. Within
+it the status write, charge close, and run-authorization revoke SHALL each be
+their own named `DBOS.runStep`, and a failure of any one SHALL be logged without
+rolling back the side effects that did succeed. There SHALL be NO separate
+`onError`-style hook racing it; child step bodies SHALL NOT call
+`updateRunStatus` or any run-fail helper directly. These guarantees SHALL hold
+identically for every workflow that binds the shared sequence.
+
+On its genuinely-terminal paths (success, runs with step failures, external
+cancel, synthesis failure) `collectAndComplete` SHALL additionally sweep the
+run's still-`pending` step rows to `skipped` (stamping `completed_at`) in its
+own named `DBOS.runStep`, so a finished run never advertises steps that read as
+still waiting to start — including dependents that were never dispatched
+because an upstream step failed or blocked. The sweep SHALL NOT run on the
+resumable 402 budget-pause branch — the branch is selected structurally (the
+pause path itself), never inferred from the written run status (the pause also
+writes `"canceled"`) — because the resumed workflow still needs those `pending`
+rows. A sweep-step failure SHALL be logged without rolling back the other
+finalisation side effects, matching the hook's non-rolling-back rule.
+
+#### Scenario: Step bodies do not write run status
+
+- **WHEN** a child workflow body encounters an error
+- **THEN** the body lets the error propagate (it does not write `cortex_runs.status`)
+- **AND** the parent's `collectAndComplete` owns the run-status transition
+
+#### Scenario: A partial finalisation failure is non-rolling-back
+
+- **WHEN** the charge close succeeds but the run-authorization revoke step throws
+- **THEN** the revoke failure is logged with the `runId` and reason
+- **AND** the already-closed charge and already-written status are not rolled back
+
+#### Scenario: Unreachable dependents are swept to skipped
+
+- **GIVEN** a plan `A → B → D` and `A → C → E` where B failed, D was therefore never dispatched, and C and E completed
+- **WHEN** `collectAndComplete` runs after the scheduler loop drains
+- **THEN** D's seeded `pending` row reaches `status="skipped"` with `completed_at` stamped and the run finalises `partial`
+
+#### Scenario: The budget pause preserves pending rows
+
+- **GIVEN** a run paused on the 402 budget path with unstarted steps seeded `pending`
+- **WHEN** `collectAndComplete` runs on the pause branch
+- **THEN** the `pending` rows are left untouched for the resumed workflow to execute
+
+#### Scenario: Extraction preserves the analysis run's observable finalisation
+
+- **WHEN** `executeAnalysis` finalises through the shared sequence
+- **THEN** its durable step names, the terminal-event-before-status ordering, and the emitted terminal part are identical to before the extraction

--- a/harness/openspec/changes/share-durable-workflow-mechanics/tasks.md
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/tasks.md
@@ -1,0 +1,21 @@
+## 1. Shared Durable LLM Step
+
+- [ ] 1.1 Move `runLlmStep` and `structuredLlmCall` from `src/workflows/target-assessment/lib/` to a shared `src/workflows/lib/`, with no change to their options, behaviour, budget-marker handling, or error classification.
+- [ ] 1.2 Repoint `executeTargetAssessment` and its phase modules at the new paths and delete the old files.
+- [ ] 1.3 Confirm every call site still supplies its own attempt-numbered step name, so no DBOS cache key changes.
+- [ ] 1.4 Run the target-assessment suite unmodified and confirm it passes, including the 402 suspend/resume coverage.
+
+## 2. Shared Run Finalisation
+
+- [ ] 2.1 Extract the generic finalisation sequence from `collectAndComplete` into `src/workflows/lib/finalise-run.ts`, parameterized by derived terminal status, failure reason, terminal part, and whether the pending-row sweep applies.
+- [ ] 2.2 Keep each side effect in its own named `DBOS.runStep`, keep the terminal-event-before-status-write ordering, and keep the log-don't-roll-back rule for a partial finalisation failure.
+- [ ] 2.3 Rebind `executeAnalysis`'s `collectAndComplete` onto the shared sequence with byte-identical durable step names, leaving scheduler-drain handling, the synthesis outcome note, and synthesis-failure status forcing in `executeAnalysis`.
+- [ ] 2.4 Keep the 402 pause branch structurally selected by the pause path itself, never inferred from the written run status, and keep the sweep suppressed on that branch.
+- [ ] 2.5 Run the execute-analysis suite unmodified and confirm it passes, including partial finalisation failure, unreachable-dependent sweep, budget pause, and external cancel.
+
+## 3. Verification
+
+- [ ] 3.1 Format the changed source files with the subsystem formatter.
+- [ ] 3.2 Run `tsc -p tsconfig.json`, `bun run lint`, and `bun run test:full` from `harness` and resolve regressions.
+- [ ] 3.3 Confirm no durable step name, emitted part, or run-status transition differs from before the refactor.
+- [ ] 3.4 Run `openspec validate share-durable-workflow-mechanics --strict`.

--- a/harness/openspec/changes/share-durable-workflow-mechanics/tasks.md
+++ b/harness/openspec/changes/share-durable-workflow-mechanics/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Shared Durable LLM Step
 
-- [ ] 1.1 Move `runLlmStep` and `structuredLlmCall` from `src/workflows/target-assessment/lib/` to a shared `src/workflows/lib/`, with no change to their options, behaviour, budget-marker handling, or error classification.
-- [ ] 1.2 Repoint `executeTargetAssessment` and its phase modules at the new paths and delete the old files.
-- [ ] 1.3 Confirm every call site still supplies its own attempt-numbered step name, so no DBOS cache key changes.
-- [ ] 1.4 Run the target-assessment suite unmodified and confirm it passes, including the 402 suspend/resume coverage.
+- [x] 1.1 Move `runLlmStep` and `structuredLlmCall` from `src/workflows/target-assessment/lib/` to a shared `src/workflows/lib/`, with no change to their options, behaviour, budget-marker handling, or error classification.
+- [x] 1.2 Repoint `executeTargetAssessment` and its phase modules at the new paths and delete the old files.
+- [x] 1.3 Confirm every call site still supplies its own attempt-numbered step name, so no DBOS cache key changes.
+- [x] 1.4 Run the target-assessment suite unmodified and confirm it passes, including the 402 suspend/resume coverage.
 
 ## 2. Shared Run Finalisation
 
-- [ ] 2.1 Extract the generic finalisation sequence from `collectAndComplete` into `src/workflows/lib/finalise-run.ts`, parameterized by derived terminal status, failure reason, terminal part, and whether the pending-row sweep applies.
-- [ ] 2.2 Keep each side effect in its own named `DBOS.runStep`, keep the terminal-event-before-status-write ordering, and keep the log-don't-roll-back rule for a partial finalisation failure.
-- [ ] 2.3 Rebind `executeAnalysis`'s `collectAndComplete` onto the shared sequence with byte-identical durable step names, leaving scheduler-drain handling, the synthesis outcome note, and synthesis-failure status forcing in `executeAnalysis`.
-- [ ] 2.4 Keep the 402 pause branch structurally selected by the pause path itself, never inferred from the written run status, and keep the sweep suppressed on that branch.
-- [ ] 2.5 Run the execute-analysis suite unmodified and confirm it passes, including partial finalisation failure, unreachable-dependent sweep, budget pause, and external cancel.
+- [x] 2.1 Extract the generic finalisation sequence from `collectAndComplete` into `src/workflows/lib/finalise-run.ts`, parameterized by derived terminal status, failure reason, terminal part, and whether the pending-row sweep applies.
+- [x] 2.2 Keep each side effect in its own named `DBOS.runStep`, keep the terminal-event-before-status-write ordering, and keep the log-don't-roll-back rule for a partial finalisation failure.
+- [x] 2.3 Rebind `executeAnalysis`'s `collectAndComplete` onto the shared sequence with byte-identical durable step names, leaving scheduler-drain handling, the synthesis outcome note, and synthesis-failure status forcing in `executeAnalysis`.
+- [x] 2.4 Keep the 402 pause branch structurally selected by the pause path itself, never inferred from the written run status, and keep the sweep suppressed on that branch.
+- [x] 2.5 Run the execute-analysis suite unmodified and confirm it passes, including partial finalisation failure, unreachable-dependent sweep, budget pause, and external cancel.
 
 ## 3. Verification
 
-- [ ] 3.1 Format the changed source files with the subsystem formatter.
-- [ ] 3.2 Run `tsc -p tsconfig.json`, `bun run lint`, and `bun run test:full` from `harness` and resolve regressions.
-- [ ] 3.3 Confirm no durable step name, emitted part, or run-status transition differs from before the refactor.
-- [ ] 3.4 Run `openspec validate share-durable-workflow-mechanics --strict`.
+- [x] 3.1 Format the changed source files with the subsystem formatter.
+- [x] 3.2 Run `tsc -p tsconfig.json`, `bun run lint`, and `bun run test:full` from `harness` and resolve regressions.
+- [x] 3.3 Confirm no durable step name, emitted part, or run-status transition differs from before the refactor.
+- [x] 3.4 Run `openspec validate share-durable-workflow-mechanics --strict`.

--- a/harness/src/workflows/__tests__/dbos/target-assessment-internals.test.ts
+++ b/harness/src/workflows/__tests__/dbos/target-assessment-internals.test.ts
@@ -28,7 +28,7 @@ import { toProviderError } from "../../../providers/errors.js";
 import { setupDbosForTests, type DbosTestRig } from "../../../__tests__/setup/dbos.js";
 import { silentLogger } from "../../../__tests__/setup/logger.js";
 import { insertAssessment, getAssessment } from "../../../state/target-assessments.js";
-import { BUDGET_EXCEEDED_SENTINEL, BUDGET_EXCEEDED_TOPIC, runLlmStep, type BudgetExceededMarker } from "../../target-assessment/lib/llm-step.js";
+import { BUDGET_EXCEEDED_SENTINEL, BUDGET_EXCEEDED_TOPIC, runLlmStep, type BudgetExceededMarker } from "../../lib/llm-step.js";
 import { emitProgress } from "../../target-assessment/progress.js";
 import type { AgentChat, ChatRequest, ChatResponse } from "../../../providers/types.js";
 import { makeMessage, textBlock } from "../../../loop/__fixtures__/scripted-provider.js";

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -51,10 +51,17 @@
  *  5. `synthesizeFindings` (single sequential block, no sandbox)
  *  6. `collectAndComplete` (terminal — runs on ALL paths)
  *     - determine final status from completed/cancelled/failed counts
+ *     - hand that status to the shared `finaliseRun` sequence
+ *       (`lib/finalise-run.ts`), which owns the ORDER of what follows —
+ *       terminal provenance before the status write, the sweep-vs-suspend
+ *       split keyed on the branch rather than the written status, and exactly
+ *       one terminal part last
  *     - update `cortex_runs.status` + `error`
  *     - close running charge with matching reason
  *     - revoke run authorization via the injected `runAuthorizer` seam
  *     - emit terminal stream part
+ *     - what stays here: the status derivation, the synthesis-outcome note,
+ *       and building the terminal part (whose artifact count is its own step)
  *     - WRITES NOTHING to the conversation thread (results are pull-only
  *       via `inspectRun`)
  */
@@ -67,7 +74,7 @@ import type { Pool } from "pg";
 import type { MachineBudget, ResourceSpec } from "../config/resource-limits.js";
 import { forStep } from "../auth/types.js";
 import type { RunSession } from "../auth/types.js";
-import type { RunAuthorization, RunAuthorizer } from "../execution/run-authorizer.js";
+import type { RunAuthorizer } from "../execution/run-authorizer.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
@@ -82,9 +89,6 @@ import {
     queryStepArtifactPaths,
     seedStepExecutions,
     setRunSynthesisOutcome,
-    suspendAnalysis as suspendAnalysisQuery,
-    sweepPendingStepExecutions,
-    updateRunStatus,
     updateStepExecution,
 } from "../state/index.js";
 import type { SynthesisStatus, UpdateStepExecutionInput } from "../state/index.js";
@@ -102,6 +106,7 @@ import { SYNTHESIS_STEP_ID, runDir, runStepDir, stepSubdir, stepWritePrefix, toS
 import { isChatDataPart } from "../sandbox/sandbox-step-translate.js";
 import { synthesizeRun } from "../app/synthesize-run.js";
 import { type PlanStep, computeTopologicalLevels, scheduleReady, validatePlanDag } from "./execute-analysis-scheduler.js";
+import { finaliseRun } from "./lib/finalise-run.js";
 import { recordCancelledChild } from "./metrics.js";
 import { BUDGET_EXCEEDED_TOPIC, type BudgetExceededNotification, type SandboxStepInput, type SandboxStepResult } from "./sandbox-step.js";
 
@@ -1436,163 +1441,103 @@ async function collectAndComplete(args: CollectAndCompleteArgs): Promise<Execute
               budgetExceeded,
           });
 
-    const chargeReason =
-        status === "completed" || status === "partial" ? "ok" : status === "failed" ? "error" : budgetExceeded ? "budget_exceeded" : "canceled";
-    const revokeReason =
-        status === "completed" || status === "partial"
-            ? "workflow-completed"
-            : status === "failed"
-              ? "workflow-failed"
-              : budgetExceeded
-                ? "workflow-suspended"
-                : "workflow-canceled";
-
-    // Terminal clock read + run-completion provenance, emitted BEFORE the `cortex_runs`
-    // status write below — and thus before any of the terminal cleanup steps. The CLI
-    // watches the run by POLLING that row (`run.ts` `waitForRunTerminal`) and shuts down
-    // the instant it leaves `running`, flushing provenance and then `process.exit()`ing;
-    // emitting the record only after the status write races that shutdown and can drop
-    // the run's terminal provenance entirely. Emitting first makes the record dirty
-    // (synchronously, via the bus) before the row can be observed terminal, so the CLI's
-    // flush always captures it. Not step-wrapped — a DBOS recovery replay must re-fire it;
-    // `DBOS.now()` is checkpointed, so the span stays replay-stable (see `RunProvenanceEvent`).
-    // The duration measures from the `run_started` read threaded in as `startedAtMs`.
-    const terminalAtMs = await DBOS.now();
-    emitProvenanceGuarded(deps, {
-        type: "run_completed",
-        analysisId: input.analysisId,
-        runId,
-        status,
-        atMs: terminalAtMs,
-        durationMs: terminalAtMs - startedAtMs,
-    });
-
-    try {
-        await DBOS.runStep(
-            async () => {
-                unwrapOrThrow(
-                    await updateRunStatus(deps.pool, runId, status, failureReason ?? (status === "canceled" && !budgetExceeded ? "external_cancel" : null)),
-                );
-            },
-            { name: "persist-final-status" },
-        );
-    } catch (err) {
-        logger.error("persist-final-status failed", { status, ...logger.errorFields(err) });
-    }
-
-    // Record the run's synthesis outcome AFTER the status write — a reader that
-    // sees a terminal status then also sees whether (and why) synthesis ran. A
-    // null outcome means synthesis never ran; leave the columns NULL ("unknown").
-    // Log-don't-rollback, like the sibling terminal steps: a failed ledger note
-    // must not undo an otherwise-complete run.
-    const outcome = args.synthesisOutcome;
-    if (outcome !== null) {
-        try {
-            await DBOS.runStep(
-                async () => {
-                    unwrapOrThrow(await setRunSynthesisOutcome(deps.pool, runId, outcome.status, outcome.reason));
-                },
-                { name: "persist-synthesis-outcome" },
-            );
-        } catch (err) {
-            logger.error("persist-synthesis-outcome failed", { synthesisStatus: outcome.status, ...logger.errorFields(err) });
-        }
-    }
-
-    // Sweep never-started steps to `skipped` — but ONLY on genuinely-terminal
-    // paths. The gate is the BRANCH, not the written run status: the resumable
-    // 402 pause below also writes "canceled", yet its pending rows must survive
-    // for the resumed workflow to execute. Log-don't-rollback, like every other
-    // finalisation step here.
-    if (!(budgetExceeded && !forceFailed)) {
-        try {
-            await DBOS.runStep(
-                async () => {
-                    unwrapOrThrow(await sweepPendingStepExecutions(deps.pool, runId));
-                },
-                { name: "sweep-pending-steps" },
-            );
-        } catch (err) {
-            logger.error("sweep-pending-steps failed", logger.errorFields(err));
-        }
-    }
-
     // A forced failure (synthesis threw) is terminal, not a resumable budget
-    // pause — never suspend it, even when the budget was also exceeded.
-    if (budgetExceeded && !forceFailed) {
-        try {
-            await DBOS.runStep(
-                async () => {
-                    unwrapOrThrow(await suspendAnalysisQuery(deps.pool, input.analysisId));
-                },
-                { name: "suspend-analysis" },
-            );
-        } catch (err) {
-            logger.error("suspend-analysis failed", logger.errorFields(err));
-        }
-    }
+    // pause — never suspend it, even when the budget was also exceeded. This
+    // branch, not the written status, is what the finaliser splits its
+    // sweep-vs-suspend decision on: the pause also writes "canceled".
+    const pausedByBudget = budgetExceeded && !forceFailed;
 
-    try {
-        await DBOS.runStep(
-            () =>
-                deps.runCharge.close({
-                    analysisId: input.analysisId,
+    const outcome = args.synthesisOutcome;
+
+    await finaliseRun({
+        logger,
+        pool: deps.pool,
+        runCharge: deps.runCharge,
+        runAuthorizer: deps.runAuthorizer,
+        runId,
+        analysisId: input.analysisId,
+        status,
+        failureReason,
+        pausedByBudget,
+        session: input.runSession,
+        // Ownership defaults to true for inputs persisted before the field
+        // existed (a workflow recovered across that deploy) — those were always
+        // Cortex-owned.
+        authorization: {
+            runSession: input.runSession,
+            ownsMandate: input.ownsMandate ?? true, // oss-core-managed-ok
+        },
+        // The run-completion provenance record, emitted before the status write
+        // so a host polling `cortex_runs` cannot shut down between the two and
+        // lose it. The duration measures from the `run_started` read threaded in
+        // as `startedAtMs`; both ends are `DBOS.now()` reads, so a recovery
+        // replay re-emits the identical span (see `RunProvenanceEvent`).
+        onTerminalClock: (terminalAtMs) => {
+            emitProvenanceGuarded(deps, {
+                type: "run_completed",
+                analysisId: input.analysisId,
+                runId,
+                status,
+                atMs: terminalAtMs,
+                durationMs: terminalAtMs - startedAtMs,
+            });
+        },
+        // Record the run's synthesis outcome AFTER the status write — a reader
+        // that sees a terminal status then also sees whether (and why) synthesis
+        // ran. A null outcome means synthesis never ran; leave the columns NULL
+        // ("unknown"). Log-don't-rollback, like every sibling terminal step: a
+        // failed ledger note must not undo an otherwise-complete run.
+        ...(outcome !== null
+            ? {
+                  afterStatusWrite: async () => {
+                      try {
+                          await DBOS.runStep(
+                              async () => {
+                                  unwrapOrThrow(await setRunSynthesisOutcome(deps.pool, runId, outcome.status, outcome.reason));
+                              },
+                              { name: "persist-synthesis-outcome" },
+                          );
+                      } catch (err) {
+                          logger.error("persist-synthesis-outcome failed", { synthesisStatus: outcome.status, ...logger.errorFields(err) });
+                      }
+                  },
+              }
+            : {}),
+        // Only the UI stream part differs by outcome — the provenance record
+        // above does not. Artifact counting is a durable step of its own, which
+        // is why the part is built here rather than handed over as a value.
+        buildTerminalPart: async () => {
+            if (status === "completed" || status === "partial") {
+                const artifactCount = await DBOS.runStep(() => countArtifactsForRun(deps.pool, input.analysisId, runId), { name: "count-run-artifacts" }).catch(
+                    () => 0,
+                );
+                return {
+                    type: "data-run-completed",
                     runId,
-                    reason: chargeReason,
-                    session: input.runSession,
-                }),
-            { name: "close-running-charge" },
-        );
-    } catch (err) {
-        logger.error("closeRunningCharge failed", { chargeReason, ...logger.errorFields(err) });
-    }
-
-    // Revoke the run authorization for the terminal run state. Ownership
-    // defaults to true for inputs persisted before the field existed (a
-    // workflow recovered across this deploy) — those were always Cortex-owned.
-    const authorization: RunAuthorization = {
-        runSession: input.runSession,
-        ownsMandate: input.ownsMandate ?? true, // oss-core-managed-ok
-    };
-    try {
-        await DBOS.runStep(() => deps.runAuthorizer.revoke(authorization, revokeReason), { name: "revoke-run-auth" });
-    } catch (err) {
-        logger.error("revokeRunAuthorization failed", { revokeReason, ...logger.errorFields(err) });
-    }
-
-    // The `run_completed` provenance was already emitted above (before the status write, to
-    // beat the CLI's poll-and-shutdown). These branches only fan out the UI stream part, whose
-    // completed/failed shapes genuinely differ — the provenance record does not.
-    if (status === "completed" || status === "partial") {
-        const artifactCount = await DBOS.runStep(() => countArtifactsForRun(deps.pool, input.analysisId, runId), { name: "count-run-artifacts" }).catch(
-            () => 0,
-        );
-        await emitStreamPart({
-            type: "data-run-completed",
-            runId,
-            status,
-            completedSteps: completed.size,
-            totalSteps: input.steps.length,
-            artifactCount,
-            findings: args.findings.map((f) => ({
-                title: f.title,
-                confidence: f.confidence,
-            })),
-            ...(status === "partial"
-                ? {
-                      note: `${completed.size} of ${input.steps.length} steps completed; results are partial.`,
-                  }
-                : {}),
-            ...(args.usage ? { usage: args.usage } : {}),
-        });
-    } else {
-        await emitStreamPart({
-            type: "data-run-failed",
-            runId,
-            error: failureReason ?? (budgetExceeded ? "Run paused: insufficient budget" : "Run canceled before completion"),
-            ...(budgetExceeded ? { reason: "budget_exceeded" } : {}),
-        });
-    }
+                    status,
+                    completedSteps: completed.size,
+                    totalSteps: input.steps.length,
+                    artifactCount,
+                    findings: args.findings.map((f) => ({
+                        title: f.title,
+                        confidence: f.confidence,
+                    })),
+                    ...(status === "partial"
+                        ? {
+                              note: `${completed.size} of ${input.steps.length} steps completed; results are partial.`,
+                          }
+                        : {}),
+                    ...(args.usage ? { usage: args.usage } : {}),
+                };
+            }
+            return {
+                type: "data-run-failed",
+                runId,
+                error: failureReason ?? (budgetExceeded ? "Run paused: insufficient budget" : "Run canceled before completion"),
+                ...(budgetExceeded ? { reason: "budget_exceeded" } : {}),
+            };
+        },
+    });
 
     return {
         runId,

--- a/harness/src/workflows/execute-target-assessment.ts
+++ b/harness/src/workflows/execute-target-assessment.ts
@@ -67,7 +67,7 @@ import {
     type TrialItem,
 } from "./target-assessment/fanout/index.js";
 import { fetchApprovalPrecedents, pickIndicationForPrecedents, renderApprovalPrecedents } from "./target-assessment/lib/approval-precedents.js";
-import { readBudgetExceededMarker } from "./target-assessment/lib/llm-step.js";
+import { readBudgetExceededMarker } from "./lib/llm-step.js";
 import { recordTerminalReason } from "./target-assessment/metrics.js";
 import { phase4Assemble } from "./target-assessment/phase4-assemble.js";
 import { DossierDerivedInvariantError, DossierSchemaViolationError, phase5Persist } from "./target-assessment/phase5-persist.js";

--- a/harness/src/workflows/lib/finalise-run.ts
+++ b/harness/src/workflows/lib/finalise-run.ts
@@ -1,0 +1,172 @@
+/**
+ * The terminal sequence every durable run shares.
+ *
+ * A run's finalisation is not a list of independent cleanups — it is an ordering,
+ * and each constraint in it exists because breaking it produced a bug:
+ *
+ *  1. **A checkpointed clock read, then the caller's terminal provenance, BEFORE
+ *     the status write.** A host watching the run polls `cortex_runs.status` and
+ *     may shut down the instant it leaves `running` (the CLI flushes provenance
+ *     and exits). Emitting after the status write races that shutdown and can
+ *     drop the run's terminal record entirely; emitting first makes the record
+ *     dirty before the row can be observed terminal. The clock is `DBOS.now()`,
+ *     so a recovery replay re-emits the identical timestamp and the host's
+ *     ledger merges rather than conflicts.
+ *  2. **The status write, then any caller ledger note.** A reader that sees a
+ *     terminal status then also sees whatever the run recorded about how it got
+ *     there.
+ *  3. **The pending-row sweep, or the budget suspend — never both.** They are
+ *     exact complements of one condition, and that condition is the BRANCH the
+ *     caller took, never the status it wrote: the resumable 402 pause also
+ *     writes `"canceled"`, yet its `pending` rows must survive for the resumed
+ *     workflow to execute. Hence one `pausedByBudget` flag rather than a status
+ *     comparison.
+ *  4. **Charge close, then authorization revoke.**
+ *  5. **Exactly one terminal stream part, last.**
+ *
+ * Every side effect is its own named `DBOS.runStep` and every failure is logged
+ * without rolling back the ones that already succeeded: a run that finished must
+ * not be undone by a failed bookkeeping note. Step names are fixed here so a
+ * workflow recovered across this refactor replays into the same cache slots.
+ *
+ * What stays with the caller: deriving the terminal status, building the
+ * terminal part (which may need its own durable steps), and its own provenance
+ * payload. This module owns the order, not the meaning.
+ */
+
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import type { Pool } from "pg";
+
+import type { RunSession } from "../../auth/types.js";
+import type { RunCharge } from "../../billing/run-charge.js";
+import type { RunAuthorization, RunAuthorizer } from "../../execution/run-authorizer.js";
+import type { Logger } from "../../lib/logger.js";
+import { unwrapOrThrow } from "../../lib/result.js";
+import { suspendAnalysis, sweepPendingStepExecutions, updateRunStatus } from "../../state/index.js";
+
+/** The terminal statuses a run body can derive. `"running"` is not terminal and cannot be finalised. */
+export type TerminalRunStatus = "completed" | "partial" | "failed" | "canceled";
+
+export interface FinaliseRunArgs {
+    /** The caller's already-scoped logger, so a finalisation failure names the workflow that hit it. */
+    readonly logger: Logger;
+    readonly pool: Pool;
+    readonly runCharge: RunCharge;
+    readonly runAuthorizer: RunAuthorizer;
+    readonly runId: string;
+    readonly analysisId: string;
+    /** Derived by the caller — this module never infers a status from step state. */
+    readonly status: TerminalRunStatus;
+    readonly failureReason: string | null;
+    /**
+     * True only on the resumable budget-pause branch, and selected structurally
+     * by the caller taking that branch. Suppresses the sweep and suspends the
+     * analysis instead. MUST NOT be derived from `status`, which reads
+     * `"canceled"` on both the pause and a real cancel.
+     */
+    readonly pausedByBudget: boolean;
+    readonly session: RunSession;
+    readonly authorization: RunAuthorization;
+    /**
+     * Called with the checkpointed terminal clock read, before the status write,
+     * so the caller can emit its own terminal provenance with a replay-stable
+     * timestamp. The caller owns the payload and its own error guard.
+     */
+    readonly onTerminalClock?: (terminalAtMs: number) => void;
+    /** A ledger note that must land immediately after the status write. Log-don't-roll-back applies. */
+    readonly afterStatusWrite?: () => Promise<void>;
+    /** Built once, emitted once, last. May run its own durable steps to compose the payload. */
+    readonly buildTerminalPart: () => Promise<unknown>;
+}
+
+/** `RunCharge.close` reason for a terminal status. A budget pause is a pause, not an error. */
+function chargeReasonFor(status: TerminalRunStatus, pausedByBudget: boolean): "ok" | "error" | "canceled" | "budget_exceeded" {
+    if (status === "completed" || status === "partial") return "ok";
+    if (status === "failed") return "error";
+    return pausedByBudget ? "budget_exceeded" : "canceled";
+}
+
+/** Revoke reason for a terminal status, in the same four-way split. */
+function revokeReasonFor(status: TerminalRunStatus, pausedByBudget: boolean): string {
+    if (status === "completed" || status === "partial") return "workflow-completed";
+    if (status === "failed") return "workflow-failed";
+    return pausedByBudget ? "workflow-suspended" : "workflow-canceled";
+}
+
+/**
+ * Run the shared terminal sequence. Returns once the single terminal stream part
+ * has been written; the caller assembles its own workflow result.
+ */
+export async function finaliseRun(args: FinaliseRunArgs): Promise<void> {
+    const { logger, pool, runId, analysisId, status, failureReason, pausedByBudget } = args;
+
+    // (1) Checkpointed clock read + the caller's terminal provenance, both before
+    //     the status write. Deliberately NOT step-wrapped: a recovery replay must
+    //     re-fire the observation, and `DBOS.now()` keeps it replay-stable.
+    const terminalAtMs = await DBOS.now();
+    args.onTerminalClock?.(terminalAtMs);
+
+    // (2) The status write.
+    try {
+        await DBOS.runStep(
+            async () => {
+                unwrapOrThrow(
+                    await updateRunStatus(pool, runId, status, failureReason ?? (status === "canceled" && !pausedByBudget ? "external_cancel" : null)),
+                );
+            },
+            { name: "persist-final-status" },
+        );
+    } catch (err) {
+        logger.error("persist-final-status failed", { status, ...logger.errorFields(err) });
+    }
+
+    // (2b) The caller's ledger note, after the status write so a reader seeing a
+    //      terminal status also sees it.
+    if (args.afterStatusWrite) {
+        await args.afterStatusWrite();
+    }
+
+    // (3) Sweep never-started rows, or suspend for a resumable pause — complements
+    //     of the branch the caller took, never of the status it wrote.
+    if (!pausedByBudget) {
+        try {
+            await DBOS.runStep(
+                async () => {
+                    unwrapOrThrow(await sweepPendingStepExecutions(pool, runId));
+                },
+                { name: "sweep-pending-steps" },
+            );
+        } catch (err) {
+            logger.error("sweep-pending-steps failed", logger.errorFields(err));
+        }
+    } else {
+        try {
+            await DBOS.runStep(
+                async () => {
+                    unwrapOrThrow(await suspendAnalysis(pool, analysisId));
+                },
+                { name: "suspend-analysis" },
+            );
+        } catch (err) {
+            logger.error("suspend-analysis failed", logger.errorFields(err));
+        }
+    }
+
+    // (4) Charge close, then authorization revoke.
+    const chargeReason = chargeReasonFor(status, pausedByBudget);
+    try {
+        await DBOS.runStep(() => args.runCharge.close({ analysisId, runId, reason: chargeReason, session: args.session }), { name: "close-running-charge" });
+    } catch (err) {
+        logger.error("closeRunningCharge failed", { chargeReason, ...logger.errorFields(err) });
+    }
+
+    const revokeReason = revokeReasonFor(status, pausedByBudget);
+    try {
+        await DBOS.runStep(() => args.runAuthorizer.revoke(args.authorization, revokeReason), { name: "revoke-run-auth" });
+    } catch (err) {
+        logger.error("revokeRunAuthorization failed", { revokeReason, ...logger.errorFields(err) });
+    }
+
+    // (5) Exactly one terminal part on the run-event stream.
+    await DBOS.writeStream("events", await args.buildTerminalPart());
+}

--- a/harness/src/workflows/lib/llm-step.ts
+++ b/harness/src/workflows/lib/llm-step.ts
@@ -1,43 +1,51 @@
 /**
- * LLM step wrapper for the target-assessment DBOS workflow body.
+ * LLM step wrapper shared by every DBOS workflow that makes a model call.
  *
- * Each Phase-2 decision and Phase-5 synthesis LLM call goes through
- * `runLlmStep` — it wraps `DBOS.runStep({name})` around the chat provider
- * call and classifies caught errors:
+ * Each call goes through `runLlmStep` — it wraps `DBOS.runStep({name})` around
+ * the chat provider call and classifies caught errors:
  *
  *   - `isBudgetExceeded(err) === true` (billing-gateway 402): self-send a
  *     `BUDGET_EXCEEDED_TOPIC` marker addressed to this workflow's own
  *     id, then return a sentinel marker. The wrapper does NOT call
- *     `DBOS.cancelWorkflow` itself — the workflow body's terminal block
+ *     `DBOS.cancelWorkflow` itself — the workflow's own terminal block
  *     reads the marker, writes `status = "suspended_insufficient_funds"`
- *     via `DBOS.runStep({name: "ta-terminal-suspended"})`, then issues
- *     `DBOS.cancelWorkflow` + a trailing `runStep` to materialise the
- *     CANCELLED terminal state. Deferring the cancel keeps the terminal
- *     handler's DB writes inside DBOS step boundaries (replay-cached).
- *   - anything else: rethrow so the caller wraps the failure as
- *     `coverage: "queried_no_data"` with `error.kind: "synthesis-unavailable"`
- *     (or `"queried_no_data"` for decisions).
+ *     in its own named `DBOS.runStep`, then issues `DBOS.cancelWorkflow` +
+ *     a trailing `runStep` to materialise the CANCELLED terminal state.
+ *     Deferring the cancel keeps the terminal handler's DB writes inside
+ *     DBOS step boundaries (replay-cached).
+ *   - anything else: rethrow, so the caller decides whether the failure is a
+ *     coverage envelope or a hard error.
  *
  * The step name is attempt-numbered by the caller — e.g.
  * `"ta-synth:liability-bullets:0"`. On 402 + top-up + `DBOS.resumeWorkflow`
  * the caller bumps the attempt counter so the resumed call lands a fresh
- * DBOS cache slot rather than replaying the cancelled prior attempt.
+ * DBOS cache slot rather than replaying the cancelled prior attempt. Because
+ * the name comes from the caller, relocating this module cannot move an
+ * existing step's cache slot.
  */
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 
-import { createNoopLogger } from "../../../lib/console-logger.js";
-import type { Logger } from "../../../lib/logger.js";
-import { unwrapOrThrow } from "../../../lib/result.js";
-import { isBudgetExceeded } from "../../../loop/budget-exceeded.js";
-import type { AgentChat, ChatRequest, ChatResponse } from "../../../providers/types.js";
-import type { AgentSession } from "../../../auth/types.js";
+import { createNoopLogger } from "../../lib/console-logger.js";
+import type { Logger } from "../../lib/logger.js";
+import { unwrapOrThrow } from "../../lib/result.js";
+import { isBudgetExceeded } from "../../loop/budget-exceeded.js";
+import type { AgentChat, ChatRequest, ChatResponse } from "../../providers/types.js";
+import type { AgentSession } from "../../auth/types.js";
 
 /**
  * DBOS message topic the LLM step uses to mark the workflow as
  * self-cancelled on a billing-gateway 402. The terminal handler drains the topic
- * to dispatch to `markAssessmentSuspended` rather than the generic
- * operator-cancel handler.
+ * to dispatch to its suspend path rather than the generic operator-cancel
+ * handler.
+ *
+ * The `ta-` spelling outlives the move: a topic is persisted with the message in
+ * DBOS's notification table, so renaming it would strand a marker sent by a
+ * workflow that was already in flight. The topic is scoped to the receiving
+ * workflow id, so one name serves every workflow.
+ *
+ * Distinct from `sandbox-step.ts`'s `"child-budget-exceeded"`, which carries a
+ * child step's exhaustion to its parent. This one a workflow sends to itself.
  */
 export const BUDGET_EXCEEDED_TOPIC = "ta-budget-exceeded";
 
@@ -65,7 +73,11 @@ export interface RunLlmStepOptions {
  * workflow. The next `DBOS.runStep` after this point raises
  * `DBOSWorkflowCancelledError`, so call sites only see this value on the
  * synchronous return path before the cancel materialises. Callers MUST NOT
- * wrap this as `coverage: "queried_no_data"` — the workflow is unwinding.
+ * wrap this as a coverage envelope — the workflow is unwinding.
+ *
+ * A registry symbol, so identity holds across module realms. Its `ta.` key is
+ * kept for the same reason the topic's is: it is an identity other code already
+ * pins, not a description of who may use it.
  */
 export const BUDGET_EXCEEDED_SENTINEL = Symbol.for("ta.budget-exceeded");
 
@@ -115,7 +127,7 @@ export async function runLlmStep(opts: RunLlmStepOptions): Promise<RunLlmStepRes
         try {
             await DBOS.runStep(() => DBOS.send(workflowId, marker, BUDGET_EXCEEDED_TOPIC), { name: `${stepName}:notify-budget-exceeded` });
         } catch (sendErr) {
-            const logger = (opts.logger ?? createNoopLogger()).named("ta-llm-step");
+            const logger = (opts.logger ?? createNoopLogger()).named("llm-step");
             logger.warn("notify-budget-exceeded send failed (non-fatal)", { stepName, ...logger.errorFields(sendErr) });
         }
 

--- a/harness/src/workflows/lib/structured-llm.ts
+++ b/harness/src/workflows/lib/structured-llm.ts
@@ -1,28 +1,28 @@
 /**
- * Structured-output LLM helper for the target-assessment DBOS workflow.
+ * Structured-output LLM helper shared by every DBOS workflow that needs a
+ * schema-validated single-shot model call.
  *
- * Uses a tool-choice forcing pattern: a single Anthropic tool named `submit`
- * carries the Zod schema as its `input_schema`, and
- * `tool_choice: { type: "tool", name: "submit" }` forces the model to fill
- * it. The tool's `input` IS the structured output.
+ * Uses a tool-choice forcing pattern: a single tool named `submit` carries the
+ * Zod schema as its `input_schema`, and `tool_choice: { type: "tool", name:
+ * "submit" }` forces the model to fill it. The tool's `input` IS the structured
+ * output.
  *
- * This intentionally does NOT pull in the harness `runAgent` loop — Phase-2
- * decisions are zero-tool single-shot calls. Phase-5 syntheses today use
- * regulatory-guidance + approval-precedent retrieval tools; the harness
- * port drops those grounding tools (PR #4 ships single-shot synthesis; a
- * follow-up may reintroduce the retrieval tools through the agent loop).
+ * This intentionally does NOT pull in the harness `runAgent` loop: these are
+ * zero-tool single-shot calls, so the loop's message array, tool dispatch, and
+ * termination rules would all be dead weight. A phase that needs tools belongs
+ * in the loop instead.
  *
  * Calls are routed through `runLlmStep`, so each LLM call lives in its own
- * `DBOS.runStep({name})` cache slot and a billing-gateway 402 self-cancels the
+ * `DBOS.runStep({name})` cache slot and a billing-gateway 402 suspends the
  * workflow rather than returning a coverage envelope.
  */
 
 import { jsonSchema, tool as aiTool, type ToolCallPart } from "ai";
 import { z } from "zod";
 
-import type { AgentSession } from "../../../auth/types.js";
-import type { Logger } from "../../../lib/logger.js";
-import type { AgentChat, ChatRequest } from "../../../providers/types.js";
+import type { AgentSession } from "../../auth/types.js";
+import type { Logger } from "../../lib/logger.js";
+import type { AgentChat, ChatRequest } from "../../providers/types.js";
 
 import { BUDGET_EXCEEDED_SENTINEL, runLlmStep, type RunLlmStepResult } from "./llm-step.js";
 

--- a/harness/src/workflows/target-assessment/decisions/index.ts
+++ b/harness/src/workflows/target-assessment/decisions/index.ts
@@ -22,8 +22,8 @@ import type { AgentSession } from "../../../auth/types.js";
 import type { AgentChat } from "../../../providers/types.js";
 import type { Phase1Bundle } from "../schemas.js";
 
-import { BUDGET_EXCEEDED_SENTINEL, type RunLlmStepResult } from "../lib/llm-step.js";
-import { structuredLlmCall } from "../lib/structured-llm.js";
+import { BUDGET_EXCEEDED_SENTINEL, type RunLlmStepResult } from "../../lib/llm-step.js";
+import { structuredLlmCall } from "../../lib/structured-llm.js";
 
 // ── Output schemas ────────────────────────────────────────────────────
 

--- a/harness/src/workflows/target-assessment/synthesis/index.ts
+++ b/harness/src/workflows/target-assessment/synthesis/index.ts
@@ -33,8 +33,8 @@ import { probeLiabilityBullets, probeRecommendation, probeSafetyFlags, probeTran
 import type { AgentSession } from "../../../auth/types.js";
 import type { AgentChat } from "../../../providers/types.js";
 
-import { BUDGET_EXCEEDED_SENTINEL } from "../lib/llm-step.js";
-import { structuredLlmCall } from "../lib/structured-llm.js";
+import { BUDGET_EXCEEDED_SENTINEL } from "../../lib/llm-step.js";
+import { structuredLlmCall } from "../../lib/structured-llm.js";
 
 // ── Output schemas ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What & why

Two mechanisms in the harness were written once and needed twice, and both encode subtleties that are invisible in a fresh implementation. This lands both moves on their own, so a behaviour-preserving refactor of two existing workflows is reviewed as a refactor rather than as a diff buried inside a feature.

**`runLlmStep` / `structuredLlmCall`** move from `workflows/target-assessment/lib/` to `workflows/lib/`, unchanged. They own the per-call `DBOS.runStep` cache slot, the forced-`submit`-tool structured output, and the billing-gateway 402 → marker → suspend/self-cancel choreography that makes an insufficient-funds pause resumable. They lived under `target-assessment/` only because they were written there.

**`collectAndComplete`'s generic half becomes `finaliseRun`.** What is shared is the *order*, because every constraint in it is a bug found once:

1. a checkpointed clock read and the caller's terminal provenance **before** the status write — a host polling `cortex_runs.status` may shut down the instant it leaves `running`, and emitting after the write races that shutdown;
2. the status write before any ledger note, so a reader seeing a terminal status also sees how it got there;
3. the pending-row sweep and the budget suspend as exact complements of **the branch the caller took, never the status it wrote** — the resumable 402 pause also writes `"canceled"`, yet its `pending` rows must survive for the resumed workflow;
4. charge close, then authorization revoke;
5. exactly one terminal stream part, last.

Each side effect keeps its own named step and the log-don't-roll-back rule: a finished run is not undone by a failed bookkeeping note.

`executeAnalysis` keeps what is genuinely its own — the status derivation, the synthesis-outcome note, and building the terminal part (whose artifact count is its own durable step). Net −150 lines there.

### Durable identities deliberately preserved

- **`BUDGET_EXCEEDED_TOPIC = "ta-budget-exceeded"`** — a topic is persisted with its message in DBOS's notification table, so renaming it would strand a marker sent by a workflow already in flight.
- **`Symbol.for("ta.budget-exceeded")`** — a registry identity other code pins.
- **Every durable step name** — built at the target-assessment call sites (`ta-decision:…:${attempt}`, `ta-synth:…:${attempt}:N`), never inside the moved modules, so no cache key moves and an in-flight workflow replays into the same slots.

The `ta-` spellings are identities, not statements about who may call. One thing *does* change: the log namespace `ta-llm-step` → `llm-step`, since `named()` is the module prefix and a shared module must not mislabel the records of everything that will call it. Nothing asserts it.

### Verification — evidence, not assertion

- The 15 durable step names extracted from `HEAD` and from the new pair of files **diff empty**.
- The emitted part-type multiset and `deriveFinalStatus` are **byte-identical** to `HEAD`.
- `src/workflows` is **118 pass / 0 fail** before and after. The only edit to a test file is one import specifier — no assertion touched.
- `tsc -p tsconfig.json` and `eslint .` clean.

### Known pre-existing failure (not from this PR)

`bun run test:full` reports **2003 pass, 6 skip, 1 fail**. The failure is `src/providers/configured-provider.barrel.test.ts` → *"recognizes claude-opus-5, clamping an over-large ceiling to its real limit"* (expected `128000`, got `200000`).

Confirmed pre-existing by stashing this branch's changes and re-running at `HEAD` — identical failure. Cause is external drift: the installed `@ai-sdk/anthropic` is 4.0.25 against the `^4.0.20` floor, and its model table no longer clamps `claude-opus-5` to 128k. The test's own comment says it guards that dependency floor. Fixing it means deciding whether opus-5's real ceiling is now 200k (update the expectation) or the SDK regressed (pin the dependency) — a separate change either way.

### Follow-on

First of a five-PR series; the specs for the rest are on branches stacked on this one. The consumers of these two extractions are `add-manuscript-reference-review` (the finaliser) and `add-manuscript-editorial-review` (the LLM step).

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `tsc -p tsconfig.json`, `bun run test:full` — see the pre-existing failure noted above).
- [x] Tests added or updated for the change. *No new tests: the existing `executeAnalysis` and `executeTargetAssessment` suites passing unmodified **is** the acceptance criterion for a behaviour-preserving extraction, and step-name/part/status equality is verified against `HEAD` directly.*
- [x] Documentation updated if user-facing behavior changed. *No user-facing behaviour change; the OpenSpec deltas record that the mechanism is now shared.*
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
