### PR TITLE
fix(harness): close three embedder gaps at the harness boundary

### DIFF
--- a/harness/openspec/specs/agent-skill-assignment/spec.md
+++ b/harness/openspec/specs/agent-skill-assignment/spec.md
@@ -186,7 +186,9 @@ validation before the first analysis runs, naming the offending agent and skill.
 
 This check SHALL be invoked from the harness-owned boot sequence
 `bootHarness` (`runtime/boot.ts`), using the `skillsDir` the embedder threads in
-and the harness-owned agent catalog (`SANDBOX_AGENT_META`). It SHALL run before
+and every harness-owned agent that declares packs: the sandbox catalog
+(`SANDBOX_AGENT_META`) and the report path (`REPORT_BUILDER_SKILLS`), which
+declares a pack without being plannable. It SHALL run before
 DBOS launch — after the injected telemetry init and before state init, the
 connection-budget guard, `assembleCoreRuntime`, and `launchDbos` — so a
 `meta.skills` typo or a `skillsDir` / image drift fails in milliseconds, before
@@ -198,6 +200,12 @@ any Postgres or DBOS cost is paid. `bootHarness` therefore SHALL require
 - **GIVEN** an agent declaring a skill whose `SKILL.md` does not exist under `skillsDir`
 - **WHEN** `validateAgentSkills` runs at boot
 - **THEN** it throws, naming the agent id, the missing skill, and the expected path
+
+#### Scenario: The report path's pack is validated too
+
+- **GIVEN** a `skillsDir` holding every pack the sandbox catalog declares but no `report-html`
+- **WHEN** the harness boots
+- **THEN** `bootHarness` SHALL reject, naming `report-builder` and `report-html`, rather than deferring the failure to a render
 
 #### Scenario: Boot fails on an unreadable pack before any launch work
 

--- a/harness/src/agents/report-builder.ts
+++ b/harness/src/agents/report-builder.ts
@@ -24,6 +24,9 @@ import { composeSystemPrompt } from "./system-prompt.js";
 
 export const REPORT_BUILDER_AGENT_ID = "report-builder";
 
+/** Skill pack the report-builder prompt directs the model to read (design-system reference). */
+export const REPORT_BUILDER_SKILLS = ["report-html"] as const;
+
 /** Runaway guard — Jinja recovery may take several build/edit cycles. */
 const REPORT_BUILDER_MAX_ITERATIONS = 75;
 

--- a/harness/src/execution/report-runner.ts
+++ b/harness/src/execution/report-runner.ts
@@ -52,7 +52,7 @@ import {
     type ReportOutcome,
     type PreviewUrlCell,
 } from "../tools/report/index.js";
-import { createReportBuilderAgent, REPORT_BUILDER_AGENT_ID } from "../agents/report-builder.js";
+import { createReportBuilderAgent, REPORT_BUILDER_AGENT_ID, REPORT_BUILDER_SKILLS } from "../agents/report-builder.js";
 import type { PreviewPublisher } from "../tools/report/preview-publisher.js";
 import { createSkillTools } from "../tools/sandbox/skills.js";
 import type { ChromeConfig } from "../lib/chrome.js";
@@ -60,9 +60,6 @@ import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { AgentRunUsage } from "../loop/metrics.js";
-
-/** Skill pack the report-builder prompt directs the model to read (design-system reference). */
-const REPORT_BUILDER_SKILLS = ["report-html"] as const;
 
 const REPORT_AGENT_MAX_STEPS = 75;
 

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -317,6 +317,13 @@ export type { CortexChatPartType, PartDescriptor, PartEmitter, PartConsumer } fr
 // otherwise re-dispatch. No current workflow creates that prefix.
 export { launchDbos, shutdownDbos, sweepEphemeralWorkflows } from "./runtime/dbos.js";
 export type { DbosConfig } from "./runtime/dbos.js";
+// The readiness pair. Both flags are mutated by harness-owned code an embedder
+// does not call itself — `launchDbos` flips the DBOS state, and the `shutdown`
+// handle `bootHarness` returns marks draining — so the reads have to come from
+// here for a host's own probe to reflect them at all.
+export { dbosState } from "./runtime/dbos.js";
+export type { DbosState } from "./runtime/dbos.js";
+export { isDraining } from "./runtime/lifecycle.js";
 // DBOS workflow-status vocabulary. An embedder that reads its own
 // `dbos.workflow_status` rows must classify them against the SDK's status set,
 // but must never depend on `@dbos-inc/dbos-sdk` directly — the SDK is

--- a/harness/src/loop/__fixtures__/scripted-provider.test.ts
+++ b/harness/src/loop/__fixtures__/scripted-provider.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+
+import { makeSession } from "../../providers/__fixtures__/session.js";
+import type { ChatRequest, ChatStreamEvent } from "../../providers/types.js";
+import { createStreamingChat } from "../../providers/streaming-chat.js";
+import { makeMessage, scriptedProvider, textBlock, thinkingBlock, toolUseBlock } from "./scripted-provider.js";
+
+const REQUEST: ChatRequest = { system: "s", messages: [{ role: "user", content: "go" }], tools: {} };
+
+async function drain(events: AsyncIterable<ChatStreamEvent>): Promise<ChatStreamEvent[]> {
+    const seen: ChatStreamEvent[] = [];
+    for await (const event of events) seen.push(event);
+    return seen;
+}
+
+describe("scriptedProvider.chatStream", () => {
+    it("streams one delta per text block, then the scripted reply as `done`", async () => {
+        const reply = makeMessage([textBlock("hello "), textBlock("world")], "end_turn");
+        const provider = scriptedProvider([reply]);
+
+        const events = await drain(provider.chatStream(REQUEST, makeSession()));
+
+        expect(events).toEqual([
+            { type: "text-delta", text: "hello " },
+            { type: "text-delta", text: "world" },
+            { type: "done", response: reply },
+        ]);
+    });
+
+    it("carries reasoning and tool calls only on the terminal response", async () => {
+        const reply = makeMessage(
+            [thinkingBlock("pondering", "sig-1"), textBlock("calling"), toolUseBlock("call-1", "read_file", { path: "a.txt" })],
+            "tool_use",
+        );
+        const provider = scriptedProvider([reply]);
+
+        const events = await drain(provider.chatStream(REQUEST, makeSession()));
+
+        expect(events.filter((e) => e.type === "text-delta")).toEqual([{ type: "text-delta", text: "calling" }]);
+        expect(events.at(-1)).toEqual({ type: "done", response: reply });
+    });
+
+    it("advances the script and records the session, as `chat` does", async () => {
+        const provider = scriptedProvider([makeMessage([textBlock("first")], "end_turn"), makeMessage([textBlock("second")], "end_turn")]);
+        const session = makeSession({ user: "user-stream" });
+
+        await drain(provider.chatStream(REQUEST, session));
+        const second = await drain(provider.chatStream(REQUEST, session));
+
+        expect(second).toContainEqual({ type: "text-delta", text: "second" });
+        expect(provider.calls).toHaveLength(2);
+        expect(provider.sessions.map((s) => s.identity.user)).toEqual(["user-stream", "user-stream"]);
+    });
+
+    it("drives `createStreamingChat` to the same collapsed response", async () => {
+        const reply = makeMessage([textBlock("par"), textBlock("tial")], "end_turn");
+        const forwarded: string[] = [];
+        const chat = createStreamingChat(scriptedProvider([reply]), (text) => forwarded.push(text));
+
+        const result = await chat.chat(REQUEST, makeSession());
+
+        expect(forwarded).toEqual(["par", "tial"]);
+        expect(result._unsafeUnwrap()).toEqual(reply);
+    });
+});

--- a/harness/src/loop/__fixtures__/scripted-provider.ts
+++ b/harness/src/loop/__fixtures__/scripted-provider.ts
@@ -47,6 +47,17 @@ export function toolUseBlock(id: string, name: string, input: unknown): ToolUseB
     return { type: "tool-call", toolCallId: id, toolName: name, input };
 }
 
+/**
+ * The text a real provider would have streamed for this reply — one delta per
+ * text block. Reasoning and tool-call blocks carry no text on the wire, so they
+ * arrive only in the terminal `done` response.
+ */
+function textDeltas(response: ChatResponse): string[] {
+    const content = response.message.content;
+    if (typeof content === "string") return content === "" ? [] : [content];
+    return content.filter((part) => part.type === "text").map((part) => part.text);
+}
+
 export interface ScriptedProvider extends ChatProvider {
     readonly calls: ChatRequest[];
     readonly sessions: Session[];
@@ -76,8 +87,17 @@ export function scriptedProvider(script: ChatResponse[] | ((callIndex: number, r
             sessions.push(session);
             return okAsync(reply(i, request));
         },
-        chatStream(): AsyncIterable<ChatStreamEvent> {
-            throw new Error("scriptedProvider: chatStream is not used by runAgent");
+        chatStream(request: ChatRequest, session: Session): AsyncIterable<ChatStreamEvent> {
+            // The call is recorded and the reply resolved eagerly, as in `chat`, so
+            // an unscripted call fails at the same point either primitive is driven.
+            const i = calls.length;
+            calls.push(request);
+            sessions.push(session);
+            const response = reply(i, request);
+            return (async function* () {
+                for (const text of textDeltas(response)) yield { type: "text-delta", text };
+                yield { type: "done", response };
+            })();
         },
     };
 }

--- a/harness/src/providers/__fixtures__/session.ts
+++ b/harness/src/providers/__fixtures__/session.ts
@@ -1,19 +1,20 @@
 /**
  * Test-only harness `RequestSession` builder. Not a `*.test.ts` file, so the test
  * runner ignores it; imported by harness unit tests that need a session but never
- * read its (opaque) auth. The auth is the trivial local one — the harness never
- * inspects it. Managed-adapter tests that exercise `getAuth` / the managed seams
- * use the managed builder in `compose/__fixtures__/session.ts` instead.
+ * read its (opaque) auth. `auth` defaults to the trivial local value the harness
+ * never inspects; an embedder whose adapters downcast `auth` to a concrete type
+ * overrides it rather than re-declaring the whole session shape.
  */
 
 import { makeLocalAuth } from "../../auth/local-auth-context.js";
-import type { RequestSession, Scope } from "../../auth/types.js";
+import type { AuthContext, RequestSession, Scope } from "../../auth/types.js";
 
 export interface SessionOverrides {
     user?: string;
     scope?: Scope;
     agentId?: string;
     callPath?: readonly string[];
+    auth?: AuthContext;
 }
 
 /** Build a fully-populated harness `RequestSession` for tests, with per-field overrides. */
@@ -25,6 +26,6 @@ export function makeSession(overrides: SessionOverrides = {}): RequestSession {
             agentId: overrides.agentId ?? "conversation-agent",
             callPath: overrides.callPath ?? ["conversation-agent"],
         },
-        auth: makeLocalAuth(),
+        auth: overrides.auth ?? makeLocalAuth(),
     };
 }

--- a/harness/src/runtime/boot.test.ts
+++ b/harness/src/runtime/boot.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { silentLogger } from "../__tests__/setup/logger.js";
 import type { Pool } from "pg";
 
+import { REPORT_BUILDER_SKILLS } from "../agents/report-builder.js";
+import { SANDBOX_AGENT_META } from "../agents/sandbox/index.js";
 import { bootHarness, type BootHarnessDeps } from "./boot.js";
 import type { CoreRuntimeDeps } from "./assemble.js";
 import type { DbosConfig } from "./dbos.js";
@@ -11,7 +16,7 @@ import type { ConnectionBudgetConfig } from "./connection-budget.js";
 function explodingPool(onUse: () => void): Pool {
     const trap = () => {
         onUse();
-        throw new Error("pool must not be touched before skill validation");
+        throw new Error("exploding pool: boot reached state init");
     };
     return { query: trap, connect: trap, end: async () => {} } as unknown as Pool;
 }
@@ -27,6 +32,25 @@ function bootDeps(overrides: Partial<BootHarnessDeps>): BootHarnessDeps {
         ...overrides,
     };
 }
+
+const SANDBOX_SKILLS = [...new Set(Object.values(SANDBOX_AGENT_META).flatMap((meta) => meta.skills))];
+
+const tempRoots: string[] = [];
+
+/** A skills tree holding a readable `SKILL.md` for each named pack, and nothing else. */
+async function skillsDirWith(packs: readonly string[]): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "boot-skills-"));
+    tempRoots.push(root);
+    for (const pack of packs) {
+        await mkdir(join(root, pack), { recursive: true });
+        await writeFile(join(root, pack, "SKILL.md"), "# pack\n");
+    }
+    return root;
+}
+
+afterAll(async () => {
+    await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+});
 
 describe("bootHarness", () => {
     it("fails fast on an invalid skillsDir before any pool or launch work", async () => {
@@ -50,6 +74,40 @@ describe("bootHarness", () => {
         // beforeLaunch hook (which precedes DBOS launch).
         expect(poolUsed).toBe(false);
         expect(beforeLaunchRan).toBe(false);
+    });
+
+    it("fails fast when the report path's pack is absent from an otherwise complete tree", async () => {
+        let poolUsed = false;
+
+        await expect(
+            bootHarness(
+                bootDeps({
+                    skillsDir: await skillsDirWith(SANDBOX_SKILLS),
+                    pool: explodingPool(() => {
+                        poolUsed = true;
+                    }),
+                }),
+            ),
+        ).rejects.toThrow(/report-builder[\s\S]*report-html/);
+
+        expect(poolUsed).toBe(false);
+    });
+
+    it("clears skill validation once every declared pack resolves", async () => {
+        let poolUsed = false;
+
+        await expect(
+            bootHarness(
+                bootDeps({
+                    skillsDir: await skillsDirWith([...SANDBOX_SKILLS, ...REPORT_BUILDER_SKILLS]),
+                    pool: explodingPool(() => {
+                        poolUsed = true;
+                    }),
+                }),
+            ),
+        ).rejects.toThrow(/boot reached state init/);
+
+        expect(poolUsed).toBe(true);
     });
 
     it("runs injected telemetry init before it throws on a bad skillsDir", async () => {

--- a/harness/src/runtime/boot.ts
+++ b/harness/src/runtime/boot.ts
@@ -11,9 +11,9 @@
  *      to a no-op so a library host never acquires process-wide telemetry (or a
  *      console banner) it did not ask for. An embedder that wants harness OTel
  *      passes `initOtel` / `shutdownOtel` here.
- *   2. `validateAgentSkills(skillsDir, SANDBOX_AGENT_META)` — pure fs stat, zero
- *      external deps. A `meta.skills` typo or a `skillsDir` / image drift dies in
- *      milliseconds, before any Postgres or DBOS cost is paid (agent-skill-assignment).
+ *   2. `validateAgentSkills(skillsDir, ...)` — pure fs stat, zero external deps.
+ *      A `meta.skills` typo or a `skillsDir` / image drift dies in milliseconds,
+ *      before any Postgres or DBOS cost is paid (agent-skill-assignment).
  *   3. `initCortexState(pool)` — app tables must exist before launch; recovery
  *      queries them on the first step.
  *   4. `assertConnectionBudget(...)` — needs the live pool; gates launch so a
@@ -42,6 +42,7 @@ import type { Pool } from "pg";
 import type { Logger } from "../lib/logger.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { SANDBOX_AGENT_META } from "../agents/sandbox/index.js";
+import { REPORT_BUILDER_AGENT_ID, REPORT_BUILDER_SKILLS } from "../agents/report-builder.js";
 import { validateAgentSkills } from "../agents/sandbox/validate-skills.js";
 import { initCortexState } from "../state/init.js";
 import { backfillConversationDisplayEnvelopes } from "../memory/conversation-display-backfill.js";
@@ -53,6 +54,17 @@ import { runShutdownSequence } from "./shutdown.js";
 
 const noop = (): void => {};
 const noopAsync = (): Promise<void> => Promise.resolve();
+
+/**
+ * Every agent whose declared packs must resolve before the first run. The
+ * report-builder is not in the sandbox catalog — it is not plannable — but it
+ * declares a pack all the same, and a missing one there surfaces as a failed
+ * render partway through a report rather than at boot.
+ */
+const SKILL_DECLARING_AGENTS = {
+    ...SANDBOX_AGENT_META,
+    [REPORT_BUILDER_AGENT_ID]: { id: REPORT_BUILDER_AGENT_ID, skills: REPORT_BUILDER_SKILLS },
+};
 
 export interface BootHarnessDeps {
     /** Everything `assembleCoreRuntime` needs (workflow + conversation deps, resource policy). */
@@ -96,7 +108,7 @@ export async function bootHarness(deps: BootHarnessDeps): Promise<BootedHarness>
 
     (deps.initTelemetry ?? noop)();
 
-    validateAgentSkills(skillsDir, SANDBOX_AGENT_META);
+    validateAgentSkills(skillsDir, SKILL_DECLARING_AGENTS);
 
     await initCortexState(pool);
     await assertConnectionBudget({ pool, logger, config: deps.connectionBudget });

--- a/harness/src/runtime/dbos.ts
+++ b/harness/src/runtime/dbos.ts
@@ -44,12 +44,13 @@ export interface DbosConfig {
     readonly logLevel?: string;
 }
 
-interface State {
+/** DBOS lifecycle facts a host's readiness probe reports on. */
+export interface DbosState {
     launched: boolean;
     recoveryStarted: boolean;
 }
 
-const state: State = {
+const state: DbosState = {
     launched: false,
     recoveryStarted: false,
 };
@@ -191,7 +192,7 @@ export async function sweepEphemeralWorkflows({
 }
 
 /** Snapshot of DBOS lifecycle state — read by the readiness probe. */
-export function dbosState(): State {
+export function dbosState(): DbosState {
     return { ...state };
 }
 
@@ -202,7 +203,7 @@ export function __resetDbosStateForTest(): void {
 }
 
 /** Test hook: mark launched without calling DBOS. Test-only. */
-export function __setDbosStateForTest(next: Partial<State>): void {
+export function __setDbosStateForTest(next: Partial<DbosState>): void {
     if (next.launched !== undefined) state.launched = next.launched;
     if (next.recoveryStarted !== undefined) state.recoveryStarted = next.recoveryStarted;
 }


### PR DESCRIPTION
Three gaps found while wiring a managed embedder onto the published package. Each one currently forces the consumer to carry code the harness should own. Harness-only; no `cli` change, no version bump.

## 1. Boot never validated the report path's skill

`bootHarness` validated `SANDBOX_AGENT_META` only, so a missing `report-html` pack surfaced as a failed render partway through a report rather than the millisecond boot failure the check exists for. `REPORT_BUILDER_SKILLS` moves from a private const in `execution/report-runner.ts` to `agents/report-builder.ts` (next to the agent id it belongs to) and joins the catalog boot validates.

`openspec/specs/agent-skill-assignment/spec.md` named `SANDBOX_AGENT_META` as the validated catalog, so the requirement and a scenario are updated with it — happy to move that into a change dir if you'd rather it go through the artifact flow.

## 2. The scripted test provider can stream

`chatStream` threw `"not used by runAgent"`, so any embedder testing a streaming chat route had to write a second provider. It now derives the stream from the same scripted reply — one delta per text block, then the reply as the terminal `done` — matching what `providers/ai-sdk.ts` emits. Reasoning and tool-call blocks carry no text on the wire, so they arrive only on `done`. The call and session are recorded eagerly, as in `chat`, so an unscripted call fails at the same point either primitive is driven.

## 3. `dbosState` / `isDraining` were off the barrel

A readiness probe had to deep-import `runtime/dbos.js` and `runtime/lifecycle.js`. Both flags are flipped by harness-owned code an embedder never calls itself (`launchDbos`; the `shutdown` handle `bootHarness` returns marks draining), and `harness-durable-runtime` already places readiness policy with the host — so the reads have to come from the barrel for a host probe to reflect them at all. `State` is renamed `DbosState` and exported so the return type is nameable.

Also: `providers/__fixtures__/session.ts` takes an `auth` override, so an embedder whose adapters downcast the opaque `auth` can use the published builder rather than restating the session shape. Its docstring pointed at `compose/__fixtures__/session.ts`, which does not exist in this repo.

## Gates

`bun run typecheck`, `bun run lint`, `bun test` (2010 pass / 6 skip / 0 fail, Postgres + DBOS containers included), `bun run build`, `node scripts/smoke.mjs` — all green locally.