### PR TITLE
docs: use ASD-STE100 in each agent document, and add a gate for it

### DIFF
--- a/.claude/hooks/ste-check.ts
+++ b/.claude/hooks/ste-check.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env bun
+/**
+ * ASD-STE100 Simplified Technical English gate for this repository.
+ *
+ * Part 2 of the standard (the dictionary) is not redistributable, so nothing here
+ * embeds it. Every lexical rule is read at runtime from the `### Word traps` table
+ * in CLAUDE.md: one source of truth, and no copy of the standard in a public repo.
+ *
+ * Findings carry a confidence class because only the commit surface blocks:
+ *   hard — deterministic; no part-of-speech or context judgment is possible to get
+ *          wrong. Only these can deny a commit.
+ *   soft — heuristic (voice, tense, words whose legality depends on part of speech).
+ *          Advice only.
+ * A gate that denies on a guess teaches people to route around it, so the blocking
+ * set is deliberately the narrow one and grows only if a rule proves deterministic.
+ */
+
+type Severity = "hard" | "soft";
+
+type Finding = {
+  rule: string;
+  severity: Severity;
+  where: string;
+  quote: string;
+  hint: string;
+};
+
+type Trap = { pattern: RegExp; replacement: string; severity: Severity };
+
+/** Rule 5.1 (an instruction) and rule 6.3 (a description). */
+const MAX_WORDS_PROCEDURAL = 20;
+const MAX_WORDS_DESCRIPTIVE = 25;
+/** Rule 6.6. */
+const MAX_SENTENCES_PER_PARAGRAPH = 6;
+
+/**
+ * A word trap whose left cell carries a parenthetical qualifier — `check (verb)`,
+ * `follow (a rule)`, `since (a cause)` — is legal in the other reading, and no regex
+ * can tell the two apart. The qualifier is therefore the marker for "advise, never
+ * deny", which is why CLAUDE.md's notation is load-bearing here.
+ */
+const QUALIFIED = /\s*\(/;
+
+/**
+ * `main` is a branch name, a file name, and an entry point in this repository far
+ * more often than it is the adjective the standard rejects. Denying on it would fire
+ * on `origin/main` in every other commit message.
+ */
+const FORCED_SOFT = new Set(["main"]);
+
+function projectDir(): string {
+  const fromHarness = process.env.CLAUDE_PROJECT_DIR;
+  if (fromHarness) return fromHarness;
+  // .claude/hooks/ste-check.ts -> repository root
+  return new URL("../..", import.meta.url).pathname;
+}
+
+/** Reads the word traps out of CLAUDE.md so the table stays the only place they live. */
+async function loadTraps(): Promise<Trap[]> {
+  const path = `${projectDir()}/CLAUDE.md`;
+  const text = await Bun.file(path).text();
+  const section = text.split(/^### Word traps$/m)[1];
+  if (!section) throw new Error(`no "### Word traps" table in ${path}`);
+
+  const traps: Trap[] = [];
+  for (const line of section.split("\n")) {
+    if (!line.startsWith("|")) {
+      if (traps.length > 0) break; // the table ended
+      continue;
+    }
+    const cells = line.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length < 2) continue;
+    if (cells[0] === "Do not use" || /^-+$/.test(cells[0])) continue;
+
+    for (const raw of cells[0].split(",")) {
+      const entry = raw.trim();
+      if (!entry) continue;
+      const word = entry.replace(/\s*\(.*$/, "").trim();
+      const severity: Severity =
+        QUALIFIED.test(entry) || FORCED_SOFT.has(word) ? "soft" : "hard";
+      traps.push({
+        pattern: new RegExp(`\\b${word.replace(/\s+/g, "\\s+")}\\b`, "gi"),
+        replacement: cells[1],
+        severity,
+      });
+    }
+  }
+  if (traps.length === 0) throw new Error(`empty word-trap table in ${path}`);
+  return traps;
+}
+
+const CONTRACTIONS =
+  /\b(\w+n['’]t|(?:it|that|there|here|what|who|let|he|she)['’]s|\w+['’](?:ll|ve|re|d|m))\b/gi;
+const LATIN = /\b(e\.g\.|i\.e\.|etc\.|viz\.|cf\.|et al\.|vs\.)/gi;
+const GENDERED = /\b(he|she|him|her|his|hers|himself|herself)\b/gi;
+/**
+ * Rule 1.14. British forms only — a word whose American spelling is identical is
+ * absent, so a match is always a real violation.
+ */
+const BRITISH =
+  /\b(colour|colours|behaviour|behaviours|favour|favours|centre|centres|metre|metres|fibre|fibres|licence|defence|catalogue|analyse|analysed|organise|organised|initialise|initialised|normalise|normalised|serialise|serialised|grey|labelled|cancelled|travelled)\b/gi;
+
+const PROGRESSIVE = /\b(is|are|was|were|be|been|being)\s+(\w+ing)\b/gi;
+const PERFECT = /\b(have|has|had)\s+(\w+(?:ed|en))\b/gi;
+/**
+ * Rule 3.6 permits the passive in a description when the agent is unknown, and no
+ * parser can decide whether an agent is knowable. Only the form that names its agent
+ * with `by` is unambiguously rejected, so only that form is reported.
+ */
+const PASSIVE = /\b(is|are|was|were|be|been)\s+\w+(?:ed|en)\s+by\b/gi;
+/** Rule 3.5. Connectives whose `-ing` form is never a technical name. */
+const ING_CONNECTIVE =
+  /\b(following|regarding|according|concerning|depending|including|using|being|having|ensuring|allowing|providing|containing|requiring)\b/gi;
+
+/**
+ * Word count under rules 8.4 thru 8.7: an identifier, a number with its unit, an
+ * abbreviation, quoted text, a parenthetical, and a hyphenated group each count as
+ * one word. Without this the limits would punish exactly the technical prose the
+ * standard exempts.
+ */
+function countWords(sentence: string): number {
+  const collapsed = sentence
+    .replace(/`[^`]*`/g, " X ")
+    .replace(/\([^)]*\)/g, " X ")
+    .replace(/"[^"]*"/g, " X ")
+    .replace(/[“][^”]*[”]/g, " X ")
+    .replace(/\b\d[\d.,]*\s*[A-Za-z%°]*\b/g, " X ")
+    .replace(/\b[A-Z]{2,}(?:-[A-Z0-9]+)*\b/g, " X ")
+    .replace(/\b[\w]+(?:-[\w]+)+\b/g, " X ");
+  return collapsed.split(/\s+/).filter((w) => /[A-Za-z0-9]/.test(w)).length;
+}
+
+/**
+ * Strips everything the standard does not govern. Quoted text (rule 8.6), code, and
+ * table cells are exempt — and the exemption is not cosmetic: CLAUDE.md's own trap
+ * table and its deliberately non-STE example would otherwise report themselves.
+ */
+function markdownProse(source: string): string[] {
+  const body = source.replace(/^---\n[\s\S]*?\n---\n/, "");
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let inFence = false;
+
+  // Inline spans are stripped only after the wrapped lines are joined: a `code span`
+  // broken across two source lines has no closing backtick on either one, and a
+  // per-line strip would leave its contents exposed as prose.
+  const flush = () => {
+    if (current.length === 0) return;
+    blocks.push(
+      current
+        .join(" ")
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/`[^`]*`/g, " `X` ")
+        .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+        .replace(/https?:\/\/\S+/g, "X"),
+    );
+    current = [];
+  };
+
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (/^(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      flush();
+      continue;
+    }
+    if (inFence) continue;
+    if (line === "" || line.startsWith("|") || line.startsWith(">") || line.startsWith("#")) {
+      flush();
+      continue;
+    }
+    // A list item is its own unit; a wrapped paragraph line continues the previous one.
+    if (/^([-*+]|\d+\.)\s/.test(line)) flush();
+    current.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+/** Rule 8.4: a colon that introduces a vertical list ends the sentence, like a period. */
+function splitSentences(block: string): string[] {
+  return block
+    .split(/(?<=[a-zA-Z0-9`)"'”])[.!?:](?=\s|$)/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function checkText(where: string, traps: Trap[], maxWords: number, blocks: string[]): Finding[] {
+  // Every lexical rule reads the stripped prose, never the raw source. Code, quoted
+  // text, and table cells are outside STE, and scanning them would make any document
+  // that discusses the rules — CLAUDE.md above all — report itself.
+  const text = blocks.join("\n");
+  const findings: Finding[] = [];
+  const add = (rule: string, severity: Severity, quote: string, hint: string) =>
+    findings.push({ rule, severity, where, quote: quote.trim(), hint });
+
+  for (const [re, rule, severity, hint] of [
+    [CONTRACTIONS, "contraction", "hard", "Write the words in full (rule 4.2)"],
+    [LATIN, "latin-abbreviation", "hard", "Write `for example` or `that is` (GR-6)"],
+    [GENDERED, "gendered-pronoun", "hard", "Use a gender-neutral word (GR-7)"],
+    [BRITISH, "british-spelling", "hard", "Use American English spelling (rule 1.14)"],
+    [PROGRESSIVE, "progressive-tense", "soft", "Use the simple present tense (rule 3.2)"],
+    [PERFECT, "perfect-tense", "soft", "Use the simple past tense (rule 3.4)"],
+    [PASSIVE, "passive-voice", "soft", "Use the active voice (rule 3.6)"],
+    [ING_CONNECTIVE, "ing-form", "soft", "Use a clause with a verb (rule 3.5)"],
+  ] as const) {
+    for (const m of text.matchAll(re)) add(rule, severity, m[0], hint);
+  }
+
+  for (const trap of traps) {
+    for (const m of text.matchAll(trap.pattern)) {
+      add("word-trap", trap.severity, m[0], `Use \`${trap.replacement}\``);
+    }
+  }
+
+  if (text.includes(";")) add("semicolon", "hard", ";", "Write two sentences (rule 8.1)");
+
+  for (const block of blocks) {
+    const sentences = splitSentences(block);
+    if (sentences.length > MAX_SENTENCES_PER_PARAGRAPH) {
+      add(
+        "paragraph-length",
+        "soft",
+        `${sentences.length} sentences`,
+        `Use a maximum of ${MAX_SENTENCES_PER_PARAGRAPH} sentences (rule 6.6)`,
+      );
+    }
+    for (const sentence of sentences) {
+      const n = countWords(sentence);
+      if (n > maxWords) {
+        add("sentence-length", "hard", `${n} words: ${sentence.slice(0, 60)}…`, `Use a maximum of ${maxWords} words`);
+      }
+    }
+  }
+  return findings;
+}
+
+/** Pulls the quoted value of a repeated flag out of a shell command. */
+function flagValues(command: string, flag: string): string[] {
+  const re = new RegExp(`${flag}\\s+(?:"((?:[^"\\\\]|\\\\.)*)"|'([^']*)')`, "g");
+  return [...command.matchAll(re)].map((m) => (m[1] ?? m[2] ?? "").replace(/\\"/g, '"'));
+}
+
+/**
+ * Drops every quoted span, so a flag scan reads only real flags. Without this,
+ * a message such as -m "use -s to sign off" would look like a signed commit.
+ */
+function withoutQuotedText(command: string): string {
+  return command.replace(/"(?:[^"\\]|\\.)*"/g, " ").replace(/'[^']*'/g, " ");
+}
+
+/**
+ * CLAUDE.md requires a sign-off on each commit. Three details decide the match:
+ * `-s` bundles into a short-flag cluster such as `-sm`; git reads uppercase `-S` as
+ * GPG signing, which is a different thing, so the scan is case-sensitive; and
+ * `--no-signoff` cancels an earlier flag. `--amend` gets no exemption, because git
+ * does not repeat an identical trailer, thus the flag there costs nothing and keeps
+ * the sign-off through a rewrite.
+ */
+function hasSignoff(command: string, message: string): boolean {
+  const flags = withoutQuotedText(command);
+  if (/(?:^|\s)--no-signoff(?=\s|$)/.test(flags)) return false;
+  if (/(?:^|\s)--signoff(?=\s|$)/.test(flags)) return true;
+  if (/(?:^|\s)-[a-zA-Z]*s[a-zA-Z]*(?=\s|$)/.test(flags)) return true;
+  return /^Signed-off-by:\s*\S+/m.test(message);
+}
+
+function report(findings: Finding[], subject: string): string {
+  const lines = [`Repository gate — ${subject}:`];
+  for (const f of findings) {
+    lines.push(`  [${f.severity}] ${f.rule}: "${f.quote}" — ${f.hint}`);
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const input = JSON.parse((await Bun.stdin.text()) || "{}");
+  const tool: string = input.tool_name ?? "";
+  const event: string = input.hook_event_name ?? (input.tool_response ? "PostToolUse" : "PreToolUse");
+  const traps = await loadTraps();
+
+  let findings: Finding[] = [];
+  let subject = "";
+  let blocking = false;
+
+  if (tool === "Bash") {
+    const command: string = input.tool_input?.command ?? "";
+
+    if (/\bgit\s+commit\b/.test(command)) {
+      const message = flagValues(command, "-m").join("\n\n");
+      subject = "the commit";
+      blocking = true;
+      // No -m means an editor or a file supplies the message; there is nothing to read.
+      // The sign-off is still visible in the command, so that check runs either way.
+      if (message) {
+        findings = checkText(subject, traps, MAX_WORDS_PROCEDURAL, markdownProse(message));
+      }
+      if (!hasSignoff(command, message)) {
+        findings.push({
+          rule: "sign-off",
+          severity: "hard",
+          where: subject,
+          quote: "no Signed-off-by trailer",
+          hint: "Use the `-s` option of `git commit` (CLAUDE.md, Commits)",
+        });
+      }
+    } else if (/\bgh\s+pr\s+(create|edit)\b/.test(command)) {
+      const parts = [...flagValues(command, "--title"), ...flagValues(command, "--body")];
+      if (parts.length > 0) {
+        subject = "the pull request text";
+        findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(parts.join("\n\n")));
+      }
+    }
+  } else if (tool === "Write" || tool === "Edit" || tool === "MultiEdit") {
+    const file: string = input.tool_input?.file_path ?? "";
+    if (file.endsWith(".md")) {
+      const source = await Bun.file(file).text();
+      subject = file.replace(`${projectDir()}/`, "");
+      findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(source));
+    }
+  }
+
+  if (findings.length === 0) process.exit(0);
+
+  const hard = findings.filter((f) => f.severity === "hard");
+  if (blocking && hard.length > 0) {
+    console.log(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: `${report(hard, subject)}\n\nCLAUDE.md gives these rules. Correct the commit, then commit again.`,
+        },
+      }),
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: event, additionalContext: report(findings, subject) },
+      suppressOutput: true,
+    }),
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // A broken checker must never stop work, but a silent one is a fake gate: say so.
+  console.log(
+    JSON.stringify({ systemMessage: `STE hook did not run: ${err instanceof Error ? err.message : err}` }),
+  );
+  process.exit(0);
+});

--- a/.claude/hooks/ste-check.ts
+++ b/.claude/hooks/ste-check.ts
@@ -13,6 +13,10 @@
  *          Advice only.
  * A gate that denies on a guess teaches people to route around it, so the blocking
  * set is deliberately the narrow one and grows only if a rule proves deterministic.
+ *
+ * Two entry points share one checker. As a hook it reads the tool call on stdin and
+ * answers with the hook protocol. As `ste-check.ts --file <path>` it prints a plain
+ * report and exits 1 on a hard finding, so a person and a CI job get the same verdict.
  */
 
 type Severity = "hard" | "soft";
@@ -272,6 +276,161 @@ function hasSignoff(command: string, message: string): boolean {
   return /^Signed-off-by:\s*\S+/m.test(message);
 }
 
+/**
+ * A word of a shell command. `expands` marks a `$name`, a `$(…)`, or a backtick, which
+ * only the shell resolves. The gate must report such a word as unreadable, never guess
+ * at the text that it carries.
+ */
+type Word = { text: string; expands: boolean };
+
+/** The flags that carry prose directly, across `gh pr` and `gh issue`. */
+const TEXT_FLAGS = new Set(["--title", "-t", "--body", "-b"]);
+/** The flags that name a file, or `-` for standard input. */
+const FILE_FLAGS = new Set(["--body-file", "-F"]);
+
+/**
+ * A heredoc holds data, not shell words, and it is the usual source of `--body-file -`.
+ * It comes out before the tokenizer runs, because a body that contains a line such as
+ * `-b something` would otherwise read as a flag and its value.
+ */
+const HEREDOC = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1\r?\n([\s\S]*?)\r?\n[ \t]*\2(?=\s|$)/g;
+
+function takeHeredocs(command: string): { rest: string; bodies: Word[] } {
+  const bodies: Word[] = [];
+  const rest = command.replace(HEREDOC, (_all, quote: string, _delimiter: string, body: string) => {
+    // An unquoted delimiter lets the shell expand the body, thus this text is not final.
+    bodies.push({ text: body, expands: quote === "" && /[$`]/.test(body) });
+    return " ";
+  });
+  return { rest, bodies };
+}
+
+/**
+ * Splits a command into words under the quoting rules of the shell. A regex on the raw
+ * text cannot do this: it misses an unquoted value, and it cannot tell `--body` from
+ * `--body-file`, which is how a description reached a pull request unchecked.
+ */
+function tokenize(command: string): Word[] {
+  const words: Word[] = [];
+  let text = "";
+  let expands = false;
+  let open = false;
+
+  const end = () => {
+    if (open) words.push({ text, expands });
+    text = "";
+    expands = false;
+    open = false;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const c = command[i];
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      end();
+      continue;
+    }
+    open = true;
+    if (c === "'") {
+      const close = command.indexOf("'", i + 1);
+      text += command.slice(i + 1, close === -1 ? undefined : close);
+      i = close === -1 ? command.length : close;
+      continue;
+    }
+    if (c === '"') {
+      let j = i + 1;
+      for (; j < command.length && command[j] !== '"'; j += 1) {
+        if (command[j] === "\\" && j + 1 < command.length) {
+          j += 1;
+          text += command[j];
+          continue;
+        }
+        if (command[j] === "$" || command[j] === "`") expands = true;
+        text += command[j];
+      }
+      i = j;
+      continue;
+    }
+    if (c === "\\" && i + 1 < command.length) {
+      i += 1;
+      text += command[i];
+      continue;
+    }
+    if (c === "$" || c === "`") expands = true;
+    text += c;
+  }
+  end();
+  return words;
+}
+
+/**
+ * Collects each piece of prose that a `gh` command publishes, from whichever flag
+ * carries it. A source that the gate cannot resolve goes into `unreadable` and becomes
+ * a hard finding. A silent skip of an unknown source is a gate in name only.
+ */
+async function ghPayload(command: string): Promise<{ texts: string[]; unreadable: string[] }> {
+  const { rest, bodies } = takeHeredocs(command);
+  const words = tokenize(rest);
+  const texts: string[] = [];
+  const unreadable: string[] = [];
+  let nextHeredoc = 0;
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    if (!word) continue;
+    const split = word.text.indexOf("=");
+    const name = split > 0 ? word.text.slice(0, split) : word.text;
+    const isText = TEXT_FLAGS.has(name);
+    if (!isText && !FILE_FLAGS.has(name)) continue;
+
+    // `--body=text` holds its value inline. `--body text` holds it in the next word.
+    // An inline value inherits the mark of its word, because half of a word that the
+    // shell expands cannot be separated from the other half.
+    const value: Word | undefined =
+      split > 0 ? { text: word.text.slice(split + 1), expands: word.expands } : words[i + 1];
+
+    if (!value) {
+      unreadable.push(`${name} has no value`);
+      continue;
+    }
+    if (isText) {
+      if (value.expands) unreadable.push(`${name} holds a shell expansion`);
+      else texts.push(value.text);
+      continue;
+    }
+    if (value.text === "-") {
+      const body = bodies[nextHeredoc];
+      nextHeredoc += 1;
+      if (!body) unreadable.push(`${name} reads standard input, and no heredoc supplies it`);
+      else if (body.expands) unreadable.push(`${name} reads a heredoc that the shell expands`);
+      else texts.push(body.text);
+      continue;
+    }
+    if (value.expands) {
+      unreadable.push(`${name} holds a shell expansion`);
+      continue;
+    }
+    // The path resolves against the directory of the hook, which is not always the
+    // directory of the command. A relative path that misses is reported, not skipped.
+    const file = Bun.file(value.text);
+    if (!(await file.exists())) {
+      unreadable.push(`${name} names ${value.text}, which the gate cannot open`);
+      continue;
+    }
+    texts.push(await file.text());
+  }
+  return { texts, unreadable };
+}
+
+/** The `gh` subcommands that publish prose. `--editor` and `--web` hand the text to a
+ * person instead, and a person is outside the reach of a tool hook. */
+const GH_TEXT_COMMAND = /\bgh\s+(pr|issue)\s+(create|edit|comment|review)\b/;
+
+function ghSubject(kind: string, action: string): string {
+  if (action === "comment") return "the comment";
+  if (action === "review") return "the review";
+  return kind === "issue" ? "the issue text" : "the pull request text";
+}
+
 function report(findings: Finding[], subject: string): string {
   const lines = [`Repository gate — ${subject}:`];
   for (const f of findings) {
@@ -280,7 +439,38 @@ function report(findings: Finding[], subject: string): string {
   return lines.join("\n");
 }
 
+/**
+ * The command entry point. It gives one checker to the hook, to a person, and to a CI
+ * job, and it gives a `gh` body the one payload source that the gate always opens.
+ *
+ * Exit 0 for a clean file or a soft finding. Exit 1 for a hard finding.
+ */
+async function checkFile(path: string): Promise<number> {
+  const traps = await loadTraps();
+  const where = path.replace(`${projectDir()}/`, "");
+  const source = await Bun.file(path).text();
+  const findings = checkText(where, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(source));
+  if (findings.length === 0) {
+    console.log(`Repository gate — ${where}: no finding.`);
+    return 0;
+  }
+  console.log(report(findings, where));
+  return findings.some((f) => f.severity === "hard") ? 1 : 0;
+}
+
 async function main() {
+  // The command entry point answers before any read of standard input. With no hook to
+  // close the stream, a read there waits on a terminal that never sends an end.
+  const flag = process.argv[2] ?? "";
+  if (flag === "--file" || flag.startsWith("--file=")) {
+    const path = flag.startsWith("--file=") ? flag.slice("--file=".length) : process.argv[3];
+    if (!path) {
+      console.error("usage: ste-check.ts --file <path>");
+      process.exit(2);
+    }
+    process.exit(await checkFile(path));
+  }
+
   const input = JSON.parse((await Bun.stdin.text()) || "{}");
   const tool: string = input.tool_name ?? "";
   const event: string = input.hook_event_name ?? (input.tool_response ? "PostToolUse" : "PreToolUse");
@@ -311,11 +501,26 @@ async function main() {
           hint: "Use the `-s` option of `git commit` (CLAUDE.md, Commits)",
         });
       }
-    } else if (/\bgh\s+pr\s+(create|edit)\b/.test(command)) {
-      const parts = [...flagValues(command, "--title"), ...flagValues(command, "--body")];
-      if (parts.length > 0) {
-        subject = "the pull request text";
-        findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(parts.join("\n\n")));
+    } else {
+      const gh = GH_TEXT_COMMAND.exec(command);
+      if (gh) {
+        subject = ghSubject(gh[1] ?? "", gh[2] ?? "");
+        // A description and a comment go to other people, and neither one comes back.
+        // The commit surface denies for that reason, thus this surface denies too.
+        blocking = true;
+        const { texts, unreadable } = await ghPayload(command);
+        if (texts.length > 0) {
+          findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(texts.join("\n\n")));
+        }
+        for (const reason of unreadable) {
+          findings.push({
+            rule: "unreadable-payload",
+            severity: "hard",
+            where: subject,
+            quote: reason,
+            hint: "Write the text to a file. Then give `--body-file <absolute path>`",
+          });
+        }
       }
     }
   } else if (tool === "Write" || tool === "Edit" || tool === "MultiEdit") {
@@ -336,7 +541,7 @@ async function main() {
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
           permissionDecision: "deny",
-          permissionDecisionReason: `${report(hard, subject)}\n\nCLAUDE.md gives these rules. Correct the commit, then commit again.`,
+          permissionDecisionReason: `${report(hard, subject)}\n\nCLAUDE.md gives these rules. Correct ${subject}, then run the command again.`,
         },
       }),
     );
@@ -353,9 +558,14 @@ async function main() {
 }
 
 main().catch((err) => {
-  // A broken checker must never stop work, but a silent one is a fake gate: say so.
-  console.log(
-    JSON.stringify({ systemMessage: `STE hook did not run: ${err instanceof Error ? err.message : err}` }),
-  );
+  const message = err instanceof Error ? err.message : String(err);
+  // Under the command entry point a broken checker must fail loudly, because a CI job
+  // that reads exit 0 would call the text clean.
+  if (process.argv.includes("--file") || process.argv.some((a) => a.startsWith("--file="))) {
+    console.error(`STE check did not run: ${message}`);
+    process.exit(2);
+  }
+  // As a hook it must never stop work, but a silent one is a fake gate: say so.
+  console.log(JSON.stringify({ systemMessage: `STE hook did not run: ${message}` }));
   process.exit(0);
 });

--- a/.claude/hooks/ste-check.ts
+++ b/.claude/hooks/ste-check.ts
@@ -150,9 +150,16 @@ function markdownProse(source: string): string[] {
       current
         .join(" ")
         .replace(/<!--[\s\S]*?-->/g, "")
-        .replace(/`[^`]*`/g, " `X` ")
+        // Padded on the left only. A trailing pad would put a space between the
+        // placeholder and a sentence-ending period, and the splitter's lookbehind
+        // would then miss the terminator and merge two sentences into one count.
+        .replace(/`[^`]*`/g, " `X`")
         .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
-        .replace(/https?:\/\/\S+/g, "X"),
+        .replace(/https?:\/\/\S+/g, "X")
+        // The standard regulates content, not formatting, so emphasis markers are
+        // noise here — and worse, a sentence wrapped as **… .** hides its own
+        // terminator behind the asterisks, so two sentences would be counted as one.
+        .replace(/\*\*|\*/g, ""),
     );
     current = [];
   };

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,31 @@
     "pr": ""
   },
   "hooks": {
-    "PreToolUse": []
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
+            "timeout": 15,
+            "statusMessage": "STE check"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
+            "timeout": 15,
+            "statusMessage": "STE check"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,3 +244,103 @@ Sign off each commit with the identity of the user. Use the `-s` option of `git 
 ```
 git commit -s -m "<message>"
 ```
+
+## This repository
+
+Inflexa is a monorepo of independent subsystems. Each subsystem has its own
+dependencies, tools, and documents.
+
+- Read `CONTEXT.md` for the map of the repository. Read `README.md` for the
+  product.
+- The root has no build, no package manager, and no task runner. Thus you must
+  work inside the subsystem that you change.
+- Go into that subsystem first, for example `cd cli` or `cd harness`. Then use
+  the scripts of that subsystem.
+- Read the `CLAUDE.md` of that subsystem before you start. Each subsystem has its
+  own conventions. The root has no shared set of conventions.
+
+## The boundary between the CLI and the harness
+
+The harness is the product core, and it is host-agnostic. Thus a capability, a
+concept, and a configuration option mean the same thing under the CLI and under a
+managed deployment.
+
+The CLI is an embedder, and an embedder is a consumer. It gives values at its
+composition root. These values are the configuration, the policies, and the
+realizations of the seams. An embedder never controls what the harness does.
+
+Design a new capability in the harness first. Then connect it from the embedder.
+Do not design a capability as a feature of the embedder.
+
+### Red CI on a change to the two subsystems
+
+A pull request that changes `cli` and `harness` together has red `cli` CI. This
+result is correct. Do not treat it as a defect.
+
+`cli` uses an exact published version of `@inflexa-ai/harness`. The CI job
+installs that version from npm with a frozen lockfile. Thus `cli` code that uses
+a harness version that is not published cannot typecheck there. The jobs `lint
+(cli)` and `test (cli)` fail on a missing export, and the two harness jobs pass.
+
+The `bun run harness:local` command makes a link to the working copy. This is the
+reason that the same code is green on your machine.
+
+Obey these rules:
+
+- Do not report the red CI as a finding.
+- Do not read the workflow files to find the cause again.
+- Do not recommend a branch split or a merge sequence.
+- The developer of the pull request controls the harness release and the version
+  change. Refer to `cli/CLAUDE.md`, "Scope: implementation only".
+
+## Agent-facing content
+
+A prompt, a skill, and a tool are three layers of one contract. The content gives
+the requirement. The runtime supplies the mechanism.
+
+Do not put the two layers together. Content cannot be typechecked. Thus a
+mismatch shows as a failed analysis, not as a failed build.
+
+| Layer | Holds | Must never |
+| --- | --- | --- |
+| A skill in `skills/` | The work: the dataset by name, and its contract — the key columns, the identifier space, the organism | Name a path, a directory, a file name, a format, or the tool that finds one |
+| A prompt in `harness/src/prompts/` | Which tools exist, and when to use one | List a dataset, or promise a format that the catalog does not give |
+| A tool in `harness/src/tools/` | Makes a path from a description, with the metadata to select between candidates | Make the caller find the location first |
+
+Obey these rules:
+
+- **A skill gives the task. A tool describes itself.** A tool carries its own
+  description into the context of an agent. Thus the name of a tool in a skill
+  gives nothing new, and it connects shared content to the tools of one host.
+- **A capability is not always a file.** Make sure that the data is on disk before
+  you tell a skill to find it. Data that only a tool gives has no path.
+- **A dataset name is not a path.** `CollecTRI` and `MSigDB hallmark` are domain
+  terms, and a skill can use them. The rule is about a location and a format, not
+  about a name.
+- **Describe the data well enough for a search by meaning.** The `format`,
+  `contents`, and `organism` fields in `harness/src/reference-data/catalog.ts` do
+  this work. A dataset with no real `contents` text cannot be found.
+- **Absence is a normal condition, not an error.** Say what to do when a resource
+  is not there. Report it, then continue with the data that you have. Do not use a
+  different resource in its place. Do not invent a path.
+
+Layout is a detail of the installer. Content that holds a layout makes a private
+decision into a public interface.
+
+`validateAgentSkills` reads only if each `SKILL.md` is readable. It never reads
+the prose. Thus a skill can name a tool that has a different name, or a tool that
+does not exist. Such a skill stays green until an agent tries the call. Review
+against this section is the only control.
+
+## Specs
+
+Each subsystem has its own OpenSpec specs. The two spec trees are
+`cli/openspec/specs` and `harness/openspec/specs`. The root has no spec tree.
+
+The harness has no `docs/adr` directory. Its design decisions are in its specs.
+
+Before you run the `openspec` CLI, go into the directory of the subsystem, for
+example `cd harness`. Then the change goes into the correct spec tree.
+
+`AGENTS.md` is a symbolic link to `CLAUDE.md` at each level. The two names give
+one file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,189 @@
 # CLAUDE.md
 
-The open-source Inflexa product monorepo — a set of **independent subsystems**, each self-contained with its own dependencies, tooling, and documentation. There is no root build, package manager, or task runner: **work inside the subsystem you are changing** (`cd cli`, `cd harness`, …) and read that subsystem's own `CLAUDE.md` first. This file is only a map.
+## Language
 
-## Subsystems
+Write all text in ASD-STE100 Simplified Technical English (STE), issue 9.
 
-| Directory | What it is | Read first |
-|-|-|-|
-| `cli/` | Local-first TUI/CLI — the user-facing product. SQLite storage, auth, the local model proxy, the opentui chat app. | `cli/CLAUDE.md`, `cli/CONTEXT.md` |
-| `harness/` | `@inflexa-ai/harness` — the host-agnostic agent harness: agent loop, DBOS-durable workflows, sandbox protocol, providers. | `harness/CLAUDE.md`, `harness/CONTEXT.md` |
-| `skills/` | Shared bioinformatics skill packs the agent loads at runtime. | — |
-| `templates/` | Report-rendering templates (e.g. `report-html`). | — |
-| `images/sandbox-base/` | The sandbox Docker image, its Go `sandbox-server`, and the provenance hooks. | `images/sandbox-base/` |
+Use STE in:
 
-## How the pieces relate
+- each message to the user
+- each commit message
+- each document in this project
+- each comment and each docstring in the code
 
-`cli` and `harness` are **fully independent packages** — each owns its `package.json`, lockfile, and `node_modules`. `cli` is the *embedder*: it consumes `harness` as `@inflexa-ai/harness` (via `file:../harness`, or a published version) and wires the harness's capability seams to trivial local realizations. Nothing else crosses a subsystem boundary except the shared `skills/` and `templates/` content, which `harness` reads at runtime (`skillsDir` / `templatesDir`) — kept at the root precisely so both the OSS host and a managed deployment can load the same content.
+STE controls prose only. It does not control code, an identifier, a command, a
+tool name, or text that you copy from a file.
 
-**A PR that spans both subsystems has red `cli` CI, and that is expected.** `cli` pins an exact published `@inflexa-ai/harness` and CI installs it from npm with a frozen lockfile, so `cli` code written against an unreleased harness cannot typecheck there — `test (cli)` and `lint (cli)` fail on missing exports while both `harness` jobs pass. This is the normal, understood shape of a cross-subsystem change, not a discovery, not a blocker to escalate, and not a defect in the work. Do not report it as a finding, do not re-derive it from the workflow files, and do not propose branch splits or merge ordering to resolve it: sequencing the harness release and the version bump belongs to the developer driving the PR (see `cli/CLAUDE.md` → "Scope: implementation only"). Local `bun run harness:local` symlinks the working copy, which is why the same code is green on the machine and red in CI.
+### Words
 
-**Design rule for the boundary**: the harness is the product core and is designed from its own point of view — its capabilities, concepts, and configuration surface are harness-owned and host-agnostic, meaning the same thing under the CLI or a managed deployment. An embedder is a consumer: it supplies values at its composition root (configuration, policies, seam realizations) and never owns or redefines what the harness does. Design new capabilities harness-first, then wire them from the embedder — never as an embedder feature the harness happens to honor.
+- Give one meaning and one part of speech to each word. `follow` means "come
+  after". Use `obey` for a rule or an instruction.
+- Use one word for one thing each time. Do not change a term for style.
+- Use a short, common word. Use `use`, not `utilize`. Use `start`, not `initiate`.
+- Keep the articles `the`, `a`, and `an`. Write `set the flag`, not `set flag`.
+- Do not put more than three nouns together. Divide a longer group with `of` or
+  `for`.
+- Delete slang, idioms, and metaphors.
+- Use American English spelling.
 
-## Agent-facing content — declare *what*, never *how*
+### Verbs
 
-Prompts, skills, and tools are three layers of one contract: content states the **requirement**, the runtime resolves the **mechanism**. Collapsing the two freezes one environment's shape into content that outlives it — and content is the layer that cannot be typechecked, so the mismatch surfaces as a failed analysis rather than a failed build.
+- Use only these verb forms: the infinitive, the imperative, the simple present
+  tense, the simple past tense, the simple future tense, and the past participle
+  as an adjective.
+- Do not use the perfect tenses. Do not use the progressive tenses. Write `the
+  parser reads the file`, not `the parser is reading the file`.
+- Use the active voice. In a description, use the passive voice only when the
+  agent is unknown.
+- Do not use the `-ing` form as a verb or as an adjective. Write `the hook that
+  runs`, not `the running hook`. An `-ing` word is permitted as a technical name,
+  for example `Testing` or `welding torch`.
+- Use a verb for an action, not a noun. Write `do a check of the battery`, not
+  `check the battery`, when `check` is the noun.
+- Use `must` for a requirement. Do not use `shall` or `should`. Use `can` for a
+  possibility, not `may`.
 
-| Layer | Owns | Must never |
-|-|-|-|
-| **Skill** (`skills/`) | What the work needs: the dataset by name, and its contract — key columns, identifier space, organism | Name a path, directory, filename, or format — **or the tool that locates one** |
-| **System prompt** (`harness/src/prompts/`) | Which tools exist and when to reach for one | Enumerate specific datasets, or promise a format the catalog doesn't guarantee |
-| **Tool** (`harness/src/tools/`) | Turning a described need into a concrete path, with enough metadata to choose between candidates | Require the caller to already know where a thing lives |
+### Sentences
 
-The rules that follow from it:
+- Write one instruction in one sentence. Two actions need two sentences.
+- Write a maximum of 20 words in an instruction. Write a maximum of 25 words in a
+  description.
+- Write a maximum of 6 sentences in a paragraph. Give one topic to each paragraph.
+- Keep the conjunction `that`. Write `make sure that the test passes`.
+- Do not omit words. Do not use contractions. Write `do not`, not `don't`.
+- Put the condition before the action. Write `if the test fails, revert the
+  commit`.
+- Put the warning before the action. A warning shows a risk to a person. A
+  caution shows a risk to equipment or data.
+- Use a vertical list for complex data. Do not use the semicolon.
 
-- **A skill states the task; the tool describes itself.** Say "screen these identifiers against the safety panel" or "resolve the network from the reference inventory" — not `check_safety_panel`, not `list_available_refs`. **A tool carries its own `description` into context when it is attached to an agent**, so the agent already knows what it holds and what each one is for. The skill's job is to say what needs doing; the agent binds that to a tool. Naming the identifier therefore adds nothing the agent lacks, and quietly couples shared content to one host's inventory — `skills/` is loaded by the OSS host and by managed deployments alike. It is unverified by construction: `validateAgentSkills` reads only whether each declared `SKILL.md` is readable, never its prose, so a renamed, unwired, or invented tool name stays green until an agent tries the call. That gap is not a missing check to build — the guard is review against this document, which is why the rule has to hold on the way in.
-- **A capability is not always a file.** Before telling a skill to resolve something, confirm it is actually staged on disk. Data that ships inside the agent runtime and is served only through a tool has no path in any environment, so instructing an agent to go find it is the same failure as naming a stale one. Say it is a lookup, and say how to get its output into a script.
-- **Dataset names are not paths.** "CollecTRI", "MSigDB hallmark", "SILVA" are domain vocabulary and belong in skills. The ban is on locations and formats, not on naming the thing you need.
-- **Describe data well enough to be found by meaning.** This is what makes the rest survivable: an agent told "you need TF-target regulons" can only recognise `CollecTRI_regulons.csv` if something says what that file holds. That is the job of `format`/`contents`/`organism` in `harness/src/reference-data/catalog.ts` — a new dataset without a real `contents` description is effectively invisible.
-- **Absence is a normal state, not an error.** Say what to do when a resource is missing — report it and proceed with what exists. Never substitute silently, never invent a path.
+### Word traps
 
-Layout is an installer detail. Anything that encodes it has made a private decision into a public interface.
+Replace the word on the left with a word on the right.
 
-## Working here
+| Do not use | Use |
+| --- | --- |
+| ensure | make sure |
+| follow (a rule) | obey |
+| however | but |
+| therefore | thus, as a result |
+| prior to | before |
+| in order to | to |
+| via | with, through |
+| utilize | use |
+| perform | do |
+| check (verb) | make sure, examine, measure |
+| rotate | turn |
+| since (a cause) | because |
+| shall, should | must |
+| may | can |
 
-- Pick the subsystem, `cd` into it, then use its scripts (`bun install`, `bun run dev`, …). The root has none.
-- Each subsystem owns its conventions in its own `CLAUDE.md`; there is no shared root convention set.
-- Product orientation for users is [`README.md`](./README.md); the repository domain map is [`CONTEXT.md`](./CONTEXT.md).
+Do not make a phrasal verb from approved words. Write `extinguish the fire`, not
+`put out the fire`. Write `release the fumes`, not `give off the fumes`.
 
-## Specs (OpenSpec)
+Do not use a Latin abbreviation. Write `for example`, not `e.g.`.
 
-Each subsystem owns its own OpenSpec specs — `cli/openspec/specs` and `harness/openspec/specs`. There is no root-level spec set, and `harness` has **no** separate `docs/adr`: its design decisions live in its specs. When changing a subsystem, run the `openspec` CLI inside that subsystem's dir (e.g. `cd harness && openspec …`) so the change lands in the right spec tree. `AGENTS.md` is a symlink alias of `CLAUDE.md` at every level — same file, two names.
+### Example
+
+Non-STE:
+
+> The battery should be checked prior to installation, and if it's low it'll need
+> charging before you proceed.
+
+STE:
+
+> Before you install the battery, do a check of it. If the charge is low, charge
+> the battery. Then continue.
+
+### Technical names
+
+A technical name is permitted. A technical verb is permitted. A domain term such
+as `hook`, `commit`, or `repository` is a technical name. Use it even when the
+STE dictionary does not list it.
+
+## The rule
+
+Do only the work that the last message from the user asks for.
+
+Do not do other work. If the user does not name a thing, do not make that thing.
+
+## Work that is not permitted
+
+Do not make these files if the user does not ask for them:
+
+- configuration files
+- test files
+- document files
+- README files
+- example files
+- empty files for code that comes later
+
+Do not do these tasks if the user does not ask for them:
+
+- Do not make a directory into a package.
+- Do not make a package into a member of the workspace.
+- Do not add a dependency.
+- Do not change code that is not part of the request.
+- Do not clean, rename, or move code that is not part of the request.
+- Do not make code better.
+
+## Questions
+
+Give an answer to a question. Do not start work because of a question.
+
+These are questions:
+
+- "How does this work?"
+- "What are the options?"
+- "Can we do this?"
+- "Does this make sense?"
+
+Give the answer. Then stop.
+
+## Unknown information
+
+Do not guess:
+
+- Do not guess which tools this project uses.
+- Do not guess the structure of this project.
+- Do not use a different project as an example for this project.
+
+If the information is not in this project, ask the user for it.
+
+Do not make a test project to try an approach that the user does not ask for.
+
+## The end of a task
+
+Do not tell the user the next steps:
+
+- Do not give a list of possible tasks.
+- Do not ask the user for approval to continue.
+
+Stop when the work is complete.
+
+## More work
+
+More work can be necessary. Tell the user in one or two sentences. Then stop and wait.
+
+Do not do the work. Do not do the work and then tell the user about it.
+
+If something stops the request, name it. Then wait for a decision from the user.
+
+## The limits of a request
+
+A request includes only the work that it names.
+
+Approval of one task is not approval of a different task.
+
+Approval of a plan is not approval of a step that the request does not name.
+
+If a part of the request is not clear, ask the user about that part. Do not select the meaning that
+gives more work.
+
+## Commits
+
+Sign off each commit with the identity of the user. Use the `-s` option of `git commit`:
+
+```
+git commit -s -m "<message>"
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Use STE in:
 - each comment and each docstring in the code
 
 STE controls prose only. It does not control code, an identifier, a command, a
-tool name, or text that you copy from a file.
+tool name, or text that you copy from a file. Keep the copied text as it is.
 
 ### Words
 
@@ -22,9 +22,15 @@ tool name, or text that you copy from a file.
 - Use a short, common word. Use `use`, not `utilize`. Use `start`, not `initiate`.
 - Keep the articles `the`, `a`, and `an`. Write `set the flag`, not `set flag`.
 - Do not put more than three nouns together. Divide a longer group with `of` or
-  `for`.
-- Delete slang, idioms, and metaphors.
+  `for`, or connect the related words with a hyphen.
+- Write a long technical name in full at the first occurrence. Then use a short
+  form or an abbreviation.
+- Do not use slang, an idiom, a metaphor, or a Latin abbreviation. Write `for
+  example`, not `e.g.`.
+- Do not make a phrasal verb from approved words. Write `extinguish the fire`,
+  not `put out the fire`. Write `release the fumes`, not `give off the fumes`.
 - Use American English spelling.
+- Use gender-neutral words. Do not use `he` or `she`.
 
 ### Verbs
 
@@ -33,29 +39,67 @@ tool name, or text that you copy from a file.
   as an adjective.
 - Do not use the perfect tenses. Do not use the progressive tenses. Write `the
   parser reads the file`, not `the parser is reading the file`.
+- Do not use an auxiliary verb to make a complex construction. Write `you can
+  adjust the value`, not `the value can be adjusted`.
 - Use the active voice. In a description, use the passive voice only when the
   agent is unknown.
 - Do not use the `-ing` form as a verb or as an adjective. Write `the hook that
   runs`, not `the running hook`. An `-ing` word is permitted as a technical name,
   for example `Testing` or `welding torch`.
-- Use a verb for an action, not a noun. Write `do a check of the battery`, not
-  `check the battery`, when `check` is the noun.
+- Use a verb for an action, not a noun. Write `before you remove the unit`, not
+  `before the removal of the unit`.
+- If a word is approved as a noun only, add a verb. Write `do a check of the
+  battery`, not `check the battery`.
 - Use `must` for a requirement. Do not use `shall` or `should`. Use `can` for a
   possibility, not `may`.
+- Do not write `must` before an imperative verb. Write `disconnect the hose`, not
+  `you must disconnect the hose`. A warning is the exception.
 
 ### Sentences
 
-- Write one instruction in one sentence. Two actions need two sentences.
+- Write one instruction in one sentence. Write two sentences for two actions,
+  unless the two actions occur at the same time.
 - Write a maximum of 20 words in an instruction. Write a maximum of 25 words in a
   description.
+- Give one topic to each sentence. Give the information one step at a time.
 - Write a maximum of 6 sentences in a paragraph. Give one topic to each paragraph.
+  Start each paragraph with its topic sentence.
+- Use a key word again to connect a sentence to the next sentence. Use `and`,
+  `but`, `then`, `thus`, and `as a result` to show the relation.
 - Keep the conjunction `that`. Write `make sure that the test passes`.
 - Do not omit words. Do not use contractions. Write `do not`, not `don't`.
-- Put the condition before the action. Write `if the test fails, revert the
-  commit`.
+- Put the condition before the action. Put a comma after the condition. Write `if
+  the test fails, revert the commit`.
+- Make sure that each pronoun refers to one item only. If there is a doubt, write
+  the noun again.
 - Put the warning before the action. A warning shows a risk to a person. A
-  caution shows a risk to equipment or data.
+  caution shows a risk to equipment or data. Give the risk and the possible
+  result.
 - Use a vertical list for complex data. Do not use the semicolon.
+
+### Word count
+
+Count each of these as one word:
+
+- a number, or a number with its unit
+- an abbreviation, or an alphanumeric identifier
+- quoted text, a title, or a heading
+- a hyphenated word
+- the text in parentheses
+
+A colon before a vertical list has the effect of a period. Each item in the list
+is a different sentence.
+
+### A word that is not approved
+
+If a word is not approved, do these steps:
+
+1. Find the meaning of the word in this context.
+2. Find an approved word that has the same meaning and the same part of speech.
+3. If you find one, replace the word.
+4. If you do not find one, write the sentence again with a different construction.
+
+Do not use a replacement that changes the meaning.
 
 ### Word traps
 
@@ -63,25 +107,35 @@ Replace the word on the left with a word on the right.
 
 | Do not use | Use |
 | --- | --- |
-| ensure | make sure |
+| acceptable | permitted |
+| allow, enable | let |
+| avoid | prevent |
+| check (verb), ensure, verify | make sure |
+| create | make |
+| damage (verb) | cause damage |
 | follow (a rule) | obey |
+| handle (verb) | move |
 | however | but |
-| therefore | thus, as a result |
-| prior to | before |
+| implement, perform | do |
 | in order to | to |
-| via | with, through |
-| utilize | use |
-| perform | do |
-| check (verb) | make sure, examine, measure |
-| rotate | turn |
-| since (a cause) | because |
-| shall, should | must |
+| main | primary |
 | may | can |
-
-Do not make a phrasal verb from approved words. Write `extinguish the fire`, not
-`put out the fire`. Write `release the fumes`, not `give off the fumes`.
-
-Do not use a Latin abbreviation. Write `for example`, not `e.g.`.
+| need (verb), require | necessary |
+| people | person, personnel |
+| press | push |
+| prior to | before |
+| proper, properly | correct, correctly |
+| provide | give |
+| repeat | do ... again |
+| rotate | turn |
+| several | some |
+| shall, should | must |
+| since (a cause) | because |
+| test (verb) | do a test |
+| therefore | thus, as a result |
+| utilize | use |
+| various | different |
+| via | with, through |
 
 ### Example
 
@@ -100,6 +154,9 @@ STE:
 A technical name is permitted. A technical verb is permitted. A domain term such
 as `hook`, `commit`, or `repository` is a technical name. Use it even when the
 STE dictionary does not list it.
+
+Select a technical name that is short and easy to understand. Do not change the
+part of speech of a technical name. Write `apply oil`, not `oil the surface`.
 
 ## The rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,22 @@ STE dictionary does not list it.
 Select a technical name that is short and easy to understand. Do not change the
 part of speech of a technical name. Write `apply oil`, not `oil the surface`.
 
+## The length of a reply
+
+Give the answer first. Write one or two sentences. Add the detail only if the
+user asks for it.
+
+Obey these rules:
+
+- Match the length of the reply to the question. A small question gets a small
+  answer.
+- Do not add a preamble. Do not restate the question. Do not add a scope note.
+- If the user does not ask for options, do not give a list of options.
+- Do not write the same point two times in different words.
+- STE controls the sentence. It does not control the length of a reply. Many
+  short sentences that pad a small point are the same fault.
+- Stop when the answer is complete.
+
 ## The rule
 
 Do only the work that the last message from the user asks for.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,18 +1,52 @@
 # Inflexa — repository context
 
-Inflexa turns a plain-language analysis request into sandboxed, reproducible bioinformatics computation with full provenance. This file maps the repository; each subsystem keeps its own deeper `CONTEXT.md`.
+Inflexa changes a plain-language analysis request into sandboxed bioinformatics
+computation. The computation is reproducible, and it has full provenance.
+
+This file maps the repository. Each subsystem has its own deeper `CONTEXT.md`.
 
 ## The product, in one path
 
-A request enters through **`cli/`** (the local host: TUI, SQLite, auth), which drives **`harness/`** (the host-agnostic harness: agent loop + DBOS-durable workflows). Compute-heavy steps run inside the **`images/sandbox-base/`** container, which executes generated R/Python against the user's data and reports back over an HMAC-verified callback. The agent loads task knowledge from **`skills/`** and renders results with **`templates/`**.
+A request starts in `cli/`, which is the local host. `cli/` supplies the terminal
+UI, the SQLite store, and the authentication.
+
+Then `cli/` uses `harness/`, which is the host-agnostic harness. The harness has
+the agent loop and the DBOS durable workflows.
+
+A step with a large computation runs in the `images/sandbox-base/` container. The
+container runs the R code and the Python code that the agent writes, against the
+data of the user. Then the container sends a report through a callback with an
+HMAC signature.
+
+The agent reads the task knowledge from `skills/`. It uses `templates/` to make
+the report of the results.
 
 ## Subsystem boundaries
 
-- **`cli/` — the embedder.** The local-first host that wires the harness's capability seams to trivial local realizations (local auth, filesystem artifact registry, no-op billing). Owns everything host-specific: the terminal UI, on-disk anchors, the SQLite store, provider/key config. See `cli/CONTEXT.md`.
-- **`harness/` — the harness.** Host-agnostic: declares seams and ships local realizations, never reaching a host concern directly. Owns the agent loop, the sandbox submit/recv protocol, the durable workflows, the providers, and the workspace path model. See `harness/CONTEXT.md` and `harness/openspec/specs/`.
-- **`skills/`, `templates/` — shared runtime content.** Read by the harness at runtime; not code, not packaged. They live at the root, not inside either package, so both hosts load the same content.
-- **`images/sandbox-base/` — the execution boundary.** The single sandbox image for every step; its Go `sandbox-server` is the protocol counterpart to the harness's sandbox client.
+- **`cli/` — the embedder.** The local-first host. It connects the capability
+  seams of the harness to simple local realizations. Examples are the local
+  authentication, the artifact registry on the file system, and the billing that
+  does nothing. `cli/` has each host-specific part: the terminal UI, the anchors
+  on disk, the SQLite store, and the configuration of the provider and the key.
+  Refer to `cli/CONTEXT.md`.
+- **`harness/` — the harness.** Host-agnostic. The harness has the seams, and it
+  gives local realizations. It never touches a concern of the host directly. It
+  also has the agent loop, the sandbox submit and receive protocol, the durable
+  workflows, the providers, and the model of the workspace paths. Refer to `harness/CONTEXT.md`
+  and `harness/openspec/specs/`.
+- **`skills/` and `templates/` — shared runtime content.** The harness reads them
+  at runtime. They are not code, and no package holds them. They are at the root,
+  thus the two hosts load the same content.
+- **`images/sandbox-base/` — the execution boundary.** One sandbox image for each
+  step. Its Go `sandbox-server` is the counterpart of the sandbox client in the
+  harness.
 
 ## Why this split
 
-`harness` is written to run under any host, so the OSS product (`cli`) and a managed deployment can share one harness and differ only at the seams — see [`harness/openspec/specs/harness-durable-runtime`](./harness/openspec/specs/harness-durable-runtime/spec.md). The independence of `cli` and `harness` (separate lockfiles, no root workspace) keeps that boundary honest: the host depends on the harness through its published package surface, never the reverse.
+The harness runs under any host. Thus the open-source product `cli` and a managed
+deployment can share one harness, and they are different only at the seams. Refer
+to [`harness/openspec/specs/harness-durable-runtime`](./harness/openspec/specs/harness-durable-runtime/spec.md).
+
+`cli` and `harness` are independent. They have different lockfiles, and the root
+has no workspace. This independence keeps the boundary correct: the host uses the
+harness through its published package, and the harness never uses the host.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,19 +1,32 @@
 ## Formatting
 
-**After editing source files in `src/`, run `bun run format:file <paths>` on the specific files you changed before reporting the task as complete.** Only format files inside `src/` — never format markdown, config, or spec files. Use `bun run format` for full-project formatting.
+**After you edit a source file in `src/`, run `bun run format:file <paths>` on the
+files that you changed.** Do this before you report the task as complete. Format
+only a file inside `src/`. Never format a markdown file, a config file, or a spec
+file. Use `bun run format` for the format of the full project.
 
 ## Postmortems
 
-[`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) documents catastrophic bugs, root cause analyses, and hard-won lessons. **Read the relevant entry before working in the same area.**
+[`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) records the catastrophic bugs,
+their root cause analyses, and the lessons. **Read the applicable entry before you
+work in the same area.**
 
 ## Scope: implementation only
 
-The user owns work orchestration. Stay focused on implementation in this repo and leave coordination to them.
+The user controls the orchestration of the work. Stay on the implementation in
+this repository, and leave the coordination to the user.
 
-- Don't discuss release ordering, PR sequencing, rollout staging, deploy timing, or "signaling" other teams.
-- Don't propose orchestration plans or ask coordination questions ("when should X merge?", "should we mark this consumed?", "how do we signal readiness?").
-- When a handoff doc or spec describes a staged rollout, read it for technical context, then translate the relevant constraints into implementation requirements without echoing the orchestration framing back.
-- Red `cli` CI on a PR that also changes `harness` is expected and owned by the developer driving the PR — see the root [`CLAUDE.md`](../CLAUDE.md). Say nothing about it.
+- Do not discuss the release order, the pull request sequence, the rollout stages,
+  the deploy time, or a signal to a different team.
+- Do not give an orchestration plan. Do not ask a coordination question, for
+  example "when must X merge?", "must we mark this consumed?", or "how do we
+  signal readiness?".
+- A handoff document or a spec can describe a staged rollout. Read it for the
+  technical context. Then change the applicable constraints into implementation
+  requirements. Do not echo the orchestration framing back.
+- Red `cli` CI on a pull request that also changes `harness` is correct, and the
+  developer of the pull request controls it. Refer to the root
+  [`CLAUDE.md`](../CLAUDE.md). Say nothing about it.
 
 ## Quick Start
 
@@ -27,118 +40,264 @@ bun run docs:gen     # Generate the CLI reference package (dist-docs/, untracked
 bun run test         # bun test — the whole suite in one process, exactly what CI runs
 ```
 
-The suite is plain `bun test`: one process, every test file sharing it, ~60s and under 1 GiB. Arguments pass straight through — `bun run test src/lib/lock.test.ts`, `-t <name>`, `--watch`.
+The suite is plain `bun test`. It runs in one process, each test file shares that
+process, and it takes about 60 seconds and less than 1 GiB. The arguments pass
+straight through, for example `bun run test src/lib/lock.test.ts`, `-t <name>`, and
+`--watch`.
 
-**`[test].preload` in `bunfig.toml` must never regain `"@opentui/solid/runtime-plugin-support"`.** Its catch-all `onResolve` leaks the directory handles it opens, and a shared-process run climbs to fd number ~21,400 — past the 10240 macOS `OPEN_MAX` at which `Bun.spawn` silently hands the child `/dev/null` instead of a socketpair. The child then runs fine and exits 0 while the parent reads zero bytes, so spawn-dependent tests fail with empty captured output and nothing in their own code explains why (`spawnInflexa — process bounds` in `src/modules/harness/inflexa_tool.test.ts`; the `launchWithBinary` readiness drain in `src/modules/embedding/local-provider.test.ts`). Without that entry the run peaks at fd 2307 — 4.4× of headroom — and nothing needs it, render tests included.
+**`[test].preload` in `bunfig.toml` must never get
+`"@opentui/solid/runtime-plugin-support"` again.** Its catch-all `onResolve` leaks
+the directory handles that it opens. A run in a shared process then climbs to file
+descriptor number about 21,400. That is past the macOS `OPEN_MAX` of 10240, at
+which `Bun.spawn` silently hands the child `/dev/null` instead of a socketpair.
+
+The child then runs correctly and exits 0, but the parent reads zero bytes. Thus a
+test that depends on spawn fails with empty captured output, and nothing in its own
+code explains why. The two known sites are `spawnInflexa — process bounds` in
+`src/modules/harness/inflexa_tool.test.ts`, and the `launchWithBinary` readiness
+drain in `src/modules/embedding/local-provider.test.ts`. Without that entry the run
+peaks at file descriptor 2307, which is 4.4 times of headroom. Nothing needs it,
+and that includes the render tests.
 
 ## Dependencies
 
-**No new dependencies without explicit approval.** If a task seems to need a new package, ask first — the default is to build on what's already here.
+**No new dependency without your explicit approval.** If a task seems to want a new
+package, ask first. The default is to build on what is already here.
 
 ## Coding
 
-- **Don't extract single-caller helpers or sub-components into separate files.** Keep them in the same file as their caller. A new file is justified only when multiple callers exist — that's when a real reusable pattern emerges.
+- **Do not extract a single-caller helper or sub-component into a separate file.**
+  Keep it in the same file as its caller. A new file is justified only when there
+  are multiple callers, because that is when a real reusable pattern emerges.
 
 ### Agent command policy — ask, never guess
 
-Every command in the registry (`src/cli/index.ts`) declares an `AgentPolicy` at registration via `registerAction(command, policy, handler)` — this is what decides whether the conversation agent's `run_inflexa` tool may run it (`auto` = prompt-free with a `safeFlags` allowlist, `approval` = the default in-chat prompt, `blocked` = never, with a mandatory reason). The required policy parameter makes an unclassified command a compile error; a lint rule bans raw `.action(` there; and a tree-walk + snapshot test (`agent_policy_tree.test.ts`) pins the whole `{grantKey → kind (+ safeFlags)}` table.
+Each command in the registry (`src/cli/index.ts`) declares an `AgentPolicy` at
+registration, through `registerAction(command, policy, handler)`. That policy
+decides if the `run_inflexa` tool of the conversation agent can run the command:
 
-**When adding a command — or adding an option to an `auto` command — ASK the user which classification it gets. Never guess `approval`/`auto`/`blocked` (or which flags are safe) for convenience.** The default is not "whatever compiles": a command that writes anything, however benign, is `approval`, and `auto` requires the user to have verified read-only-ness against the action's implementation. A flag belongs in `safeFlags` only when *every* value it can carry leaves the command read-only (output-shaping like `--json`), and a new option added to an `auto` command is unsafe until the user says otherwise.
+- `auto` — prompt-free, with a `safeFlags` allowlist
+- `approval` — the default in-chat prompt
+- `blocked` — never, with a mandatory reason.
 
-**An option that would change a command's effect class (read↔write) must be a new subcommand with its own policy, not a flag** (`refs refresh`, not `refs list --refresh`) — this keeps `safeFlags` small and each effect class independently classified.
+The policy parameter is required, thus an unclassified command is a compile error.
+A lint rule bans a raw `.action(` there. A tree-walk and a snapshot test
+(`agent_policy_tree.test.ts`) pin the whole `{grantKey → kind (+ safeFlags)}` table.
+
+**When you add a command, or when you add an option to an `auto` command, ASK the
+user which classification it gets.** Never guess `approval`, `auto`, or `blocked`
+for convenience. Never guess which flags are safe.
+
+The default is not "whatever compiles". A command that writes anything, even a small
+thing, is `approval`. `auto` needs the user to make sure of the read-only quality
+against the implementation of the action. A flag belongs in `safeFlags` only when
+*each* value that it can carry leaves the command read-only, for example an
+output-shaping flag such as `--json`. A new option on an `auto` command is unsafe
+until the user says differently.
+
+**An option must never change the effect class of a command, from read to write
+or from write to read.** Make it a new subcommand with its own policy, not a flag.
+Write `refs refresh`, not `refs list --refresh`. This keeps `safeFlags` small, and
+it classifies each effect class independently.
 
 ## Error handling — neverthrow first
 
-**`Result<T, E>` from `neverthrow` is the default error channel.** Every function that can fail returns `Result` (sync) or `ResultAsync` (async). The `eslint-plugin-neverthrow` `must-use-result` rule is set to `error` — an unconsumed `Result` is a build failure.
+**`Result<T, E>` from `neverthrow` is the default error channel.** Each function
+that can fail gives a `Result` (sync) or a `ResultAsync` (async). The
+`must-use-result` rule of `eslint-plugin-neverthrow` is set to `error`, thus a
+`Result` that nothing consumes is a build failure.
 
 ### The rule
 
-1. **Return `Result`, don't `throw`.** A function's failure mode is part of its signature. If it can fail, the return type says so (`Result<T, SomeError>`). Callers handle both branches with `.match`, `.andThen`, `.map`, `.mapErr`, etc.
-2. **`throw` requires explicit user approval.** Before writing a `throw`, get confirmation. The only pre-approved exceptions are:
-   - **Exhaustive-switch defaults** — `throw new Error("unhandled: ...")` (or `never`-typed) in a `default:` branch that the compiler should make unreachable. This is a programmer bug, not a runtime failure.
-   - **Top-level entry-point bail-outs** — `fail()` / `dieOn()` in `lib/cli.ts` at the CLI boundary, where the process is about to exit anyway.
-   - **`throw` inside `bun:sqlite` transactions** — bun's `transaction()` API uses throw-to-rollback; the `TxAbort` pattern in `db/util.ts` bridges this into `Result`.
-3. **Wrap throwing stdlib / external calls at the boundary.** When a function you don't control throws (`readFileSync`, `mkdirSync`, `writeFileSync`, `JSON.parse`, `crypto.*`, `Bun.spawn`, etc.), wrap it in a function that returns `Result`. The wrapper lives beside its callers (in `lib/` if cross-cutting, in the module if local). Existing examples: `tryQuery`/`tryMutation` in `db/util.ts`, `JSON.parseWith` in `extensions/json.ext.ts`.
-4. **`try/catch` is only for bridging throws into `Result`.** A `try/catch` that doesn't produce a `Result` is a code smell — it means either the caught function should return `Result` itself, or the catch block should.
+1. **Give a `Result`. Do not `throw`.** The failure mode of a function is part of
+   its signature. If it can fail, the return type says so (`Result<T, SomeError>`).
+   A caller handles the two branches with `.match`, `.andThen`, `.map`, `.mapErr`,
+   and the others.
+2. **A `throw` needs your explicit approval.** Get confirmation before you write a
+   `throw`. These are the only pre-approved exceptions:
+   - **An exhaustive-switch default** — `throw new Error("unhandled: ...")`, or a
+     `never`-typed branch, in a `default:` that the compiler must make
+     unreachable. This is a programmer bug, not a runtime failure.
+   - **A top-level entry-point bail-out** — `fail()` or `dieOn()` in `lib/cli.ts`,
+     at the CLI boundary, where the process is about to exit.
+   - **A `throw` inside a `bun:sqlite` transaction** — the `transaction()` API of
+     bun uses throw-to-rollback. The `TxAbort` pattern in `db/util.ts` bridges this
+     into a `Result`.
+3. **Wrap a throwing stdlib call or external call at the boundary.** A function
+   that you do not control can throw, for example `readFileSync`, `mkdirSync`,
+   `writeFileSync`, `JSON.parse`, `crypto.*`, or `Bun.spawn`. Wrap it in a function
+   that gives a `Result`. The wrapper lives beside its callers: in `lib/` when it
+   is cross-cutting, and in the module when it is local. The existing examples are
+   `tryQuery` and `tryMutation` in `db/util.ts`, and `JSON.parseWith` in
+   `extensions/json.ext.ts`.
+4. **A `try/catch` is only a bridge from a throw into a `Result`.** A `try/catch`
+   that gives no `Result` is a code smell. It means that the caught function must
+   give a `Result` itself, or that the catch block must.
 
 ### Error types
 
-- **Domain errors are discriminated unions** — `type FooError = { type: "x"; ... } | { type: "y"; ... }`, not `Error` subclasses. This gives exhaustive `switch` and zero prototype overhead.
-- **`DbError`** (in `db/errors.ts`) is the storage-layer error. Absence is `T | null` on the `ok` channel, never an error.
-- **Keep error types as narrow as the function needs.** A function that can only fail one way returns `Result<T, { type: "io_failed"; cause: unknown }>`, not `Result<T, AllErrors>`.
+- **A domain error is a discriminated union** —
+  `type FooError = { type: "x"; ... } | { type: "y"; ... }`, not an `Error`
+  subclass. This gives an exhaustive `switch` and zero prototype overhead.
+- **`DbError`** (in `db/errors.ts`) is the storage-layer error. Absence is
+  `T | null` on the `ok` channel, never an error.
+- **Keep an error type as narrow as the function wants.** A function that can fail
+  one way only gives `Result<T, { type: "io_failed"; cause: unknown }>`, not
+  `Result<T, AllErrors>`.
 
 ### Consuming Results
 
-- **At CLI boundaries:** `result.match(v => v, dieOn("context"))` — print and exit.
-- **In module logic:** `.andThen` / `.map` to chain, `.mapErr` to translate error types across layers.
-- **In the TUI:** the presentation layer may `.match` to render success/error states.
-- **Never `.unwrap()` or `._unsafeUnwrap()` in production code.** These defeat the purpose. If you need the value and want to crash on error, you're at a CLI boundary — use `dieOn`. **Exception:** test files (`*.test.ts`) may use `._unsafeUnwrap()` to extract values where an unexpected `Err` is itself a test failure.
+- **At a CLI boundary:** `result.match(v => v, dieOn("context"))` — print and exit.
+- **In module logic:** `.andThen` and `.map` to chain, and `.mapErr` to translate
+  an error type across a layer.
+- **In the TUI:** the presentation layer can `.match` to render a success state or
+  an error state.
+- **Never use `.unwrap()` or `._unsafeUnwrap()` in production code.** They defeat
+  the purpose. If you want the value and you want to crash on an error, you are at
+  a CLI boundary, thus use `dieOn`. **Exception:** a test file (`*.test.ts`) can
+  use `._unsafeUnwrap()` to extract a value, where an unexpected `Err` is itself a
+  test failure.
 
-### Migrating existing `throw` → `Result`
+### Migration from `throw` to `Result`
 
-The codebase has legacy `throw`/`try-catch` sites being migrated. When touching a function that throws, convert it to return `Result` if the change is contained (the function + its direct callers). Don't leave a half-migrated state where a function both throws AND returns `Result`. Mark sites you notice but can't convert in-scope with `// TODO(slop): neverthrow`.
+The codebase has legacy `throw` and `try-catch` sites in migration. When you touch
+a function that throws, change it to give a `Result`. Do this only if the change
+is contained, which means the function and its direct callers. Do not leave a half-migrated
+state, where a function both throws AND gives a `Result`. Mark a site that you see
+but cannot convert in scope with `// TODO(slop): neverthrow`.
 
 ## Code Comments
 
 Comment the why, not the what.
 
-- Do NOT write comments that restate what the code already says. If a comment paraphrases the line below it, delete it. TypeScript's types and good names already document the "what"; lean on them.
-- DO write comments that capture intent and reasoning: why the code works this way, what problem it solves, and what would otherwise be non-obvious to a future reader.
-- Prefer making the "what" self-evident through the type system (descriptive types, unions, branded types, `readonly`, exhaustive `switch`) so prose doesn't have to carry it.
+- Do NOT write a comment that restates what the code already says. If a comment
+  paraphrases the line below it, delete it. The types of TypeScript and good names
+  already document the "what". Depend on them.
+- DO write a comment that captures the intent and the reasoning: why the code works
+  this way, what problem it solves, and what a future reader would find
+  non-obvious.
+- Prefer to make the "what" self-evident through the type system: a descriptive
+  type, a union, a branded type, `readonly`, an exhaustive `switch`. Then the prose
+  does not have to carry it.
 
-Document the decisions you made.
+Document the decisions that you made.
 
-- Record which alternative approaches were considered and discarded, and why.
-- Record which downsides or trade-offs were explicitly accepted, and why (e.g., why you reached for `any`/`as`, why you disabled a lint rule, why you chose a library).
-- Every `// eslint-disable`, `@ts-expect-error`, `@ts-ignore`, or type assertion (`as X`, `!`) should carry a comment explaining why it is safe and necessary — these are the TS equivalent of escape hatches and must never be silent.
+- Record which alternative approaches you considered and discarded, and why.
+- Record which downsides or trade-offs you accepted, and why. Examples are the
+  reason for an `any` or an `as`, the reason for a disabled lint rule, and the
+  reason for a library.
+- Each `// eslint-disable`, `@ts-expect-error`, `@ts-ignore`, and type assertion
+  (`as X`, `!`) must carry a comment that explains why it is safe and necessary.
+  These are the TypeScript equivalent of an escape hatch, and they must never be
+  silent.
 
 Document what is NOT there.
 
-- Flag shortcuts and unhandled cases explicitly rather than leaving them silent. Use `err({ type: "not_implemented" })` when the function returns `Result`, or `throw new Error("not implemented")` only in exhaustive-switch defaults and pre-approved boundary sites (see [Error handling](#error-handling--neverthrow-first)), instead of a stub that returns a fake value.
-- In exhaustive `switch`/discriminated-union handling, use a `never`-typed default branch so the compiler flags any case you forgot — this documents "everything is handled" and breaks the build when it stops being true.
-- Note future optimization opportunities and the deliberate absence of an implementation (e.g., why a method is intentionally not provided, why a type guard is omitted).
+- Flag a shortcut and an unhandled case explicitly. Do not leave them silent. Use
+  `err({ type: "not_implemented" })` when the function gives a `Result`. Use
+  `throw new Error("not implemented")` only in an exhaustive-switch default and at
+  a pre-approved boundary site — refer to
+  [Error handling](#error-handling--neverthrow-first). Never write a stub that
+  gives a fake value.
+- In an exhaustive `switch` or a discriminated-union handler, use a `never`-typed
+  default branch. Then the compiler flags each case that you forgot. This documents
+  "each case is handled", and it breaks the build when that stops being true.
+- Note a future optimization opportunity, and note the deliberate absence of an
+  implementation. Examples are the reason that a method is intentionally absent,
+  and the reason that a type guard is omitted.
 
-Treat comments as first-class, and write them early.
+Treat a comment as first-class, and write it early.
 
-- Comments are among the most important code you write; treat them with the same care as the logic.
-- Consider writing the comment/contract before the implementation — sketch the intended behavior, inputs, and invariants in prose (or a JSDoc block) first, then fill in the code beneath it.
+- A comment is among the most important code that you write. Treat it with the same
+  care as the logic.
+- Think about the comment or the contract before the implementation. Sketch the
+  intended behavior, the inputs, and the invariants in prose, or in a JSDoc block,
+  first. Then fill in the code beneath it.
 
 Comment the surprising, the unsafe, and the load-bearing.
 
-- Clearly comment anything a reader would find unexpected: reliance on external or global state, mutation of shared objects, ordering or timing requirements (async sequencing, microtask vs. macrotask), subtle invariants, or a non-obvious algorithm choice.
-- The TypeScript analogue of "unsafe" is anywhere you defeat the type checker: `as`/`as unknown as`, non-null assertions (`!`), `any`, `@ts-expect-error`, type predicates (`x is T`), and unchecked casts of external data (JSON, API responses). Each such site needs a comment stating exactly which invariant the surrounding code upholds to make it sound (e.g., "validated by the zod schema above", "guaranteed non-null because we just `.set()` it").
+- Clearly comment anything that a reader would find unexpected. Examples are:
+  - a dependence on external or global state
+  - a mutation of a shared object
+  - an order or timing requirement (async sequence, microtask against macrotask)
+  - a subtle invariant
+  - a non-obvious algorithm choice.
+- The TypeScript analogue of "unsafe" is anywhere that you defeat the type checker:
+  `as`, `as unknown as`, a non-null assertion (`!`), `any`, `@ts-expect-error`, a
+  type predicate (`x is T`), and an unchecked cast of external data (JSON, an API
+  response). Each such site wants a comment that states exactly which invariant the
+  code around it upholds to make it sound. Examples are "the zod schema above
+  validates it" and "it is guaranteed non-null because we just `.set()` it".
 
-**Comments are not changelogs.** Never write change-history phrasing like "Bumped from X to Y", "Refactored to W", "Now does Z", "Renamed from V", "Extracted from U", "Previously did A". Git tracks history; comments describe the static rationale as a fresh reader will encounter it tomorrow. If a value is unusual, justify the value — not the diff.
+**A comment is not a changelog.** Never write change-history phrasing, for example
+"Bumped from X to Y", "Refactored to W", "Now does Z", "Renamed from V", "Extracted
+from U", or "Previously did A". Git tracks the history. A comment describes the
+static rationale as a fresh reader meets it tomorrow. If a value is unusual,
+justify the value, not the diff.
 
 ### Identifiers
 
-**Mint ids inline with `randomUUIDv7()` (`import { randomUUIDv7 } from "bun"`).** It is the single id scheme for everything — DB row ids, the write-once anchor marker, event ids. It is time-sortable (the role `ulid` used to fill), in-runtime (zero-dependency), and the only v7 source available: Node's `crypto` mints v4 only. **Never wrap id generation in a helper** like `newId()`/`newFooUuid()` — a function whose whole body is `return randomUUIDv7()` is pointless ceremony; write `randomUUIDv7()` at the call site. Don't reach for `ulid` or `crypto.randomUUID()`.
+**Mint an id inline with `randomUUIDv7()` (`import { randomUUIDv7 } from "bun"`).**
+It is the single id scheme for each thing: a DB row id, the write-once anchor
+marker, and an event id. It is time-sortable, which is the role that `ulid` used to
+fill. It is in-runtime, with zero dependencies. It is also the only v7 source that
+is available, because the `crypto` of Node mints v4 only.
+
+**Never wrap the id generation in a helper** such as `newId()` or `newFooUuid()`. A
+function whose whole body is `return randomUUIDv7()` is pointless ceremony. Write
+`randomUUIDv7()` at the call site. Do not reach for `ulid` or
+`crypto.randomUUID()`.
 
 ### TODO conventions
 
-Format: `// TODO(<tag>): <reason>`. Never use a bare `// TODO`.
+The format is `// TODO(<tag>): <reason>`. Never use a bare `// TODO`.
 
 | Tag | Purpose | Example |
 |-----|---------|---------|
-| `extend` | Hidden/omitted feature to revisit when capabilities expand | Command flag stubbed out until the real backend lands |
-| `perf` | Acceptable today, optimize at scale | `O(n)` scan that should be indexed |
-| `slop` | Works but should be extracted / cleaned up | Duplicated logic across two modules |
-| `robustness` | Missing hardening for stress conditions | No retry/backoff on a flaky external call |
+| `extend` | Hidden or omitted feature, to revisit when the capabilities expand | Command flag stubbed out until the real backend lands |
+| `perf` | Acceptable today, optimize at scale | `O(n)` scan that must be indexed |
+| `slop` | Works, but must be extracted or cleaned up | Duplicated logic across two modules |
+| `robustness` | Missing hardening for a stress condition | No retry or backoff on a flaky external call |
 
-### Local state can desync from the database — never hard-fail on it
+### Local state can go out of agreement with the database — never fail hard on it
 
-The SQLite database is a file on the **user's own machine**: they may delete it, restore an old copy, or hand-edit it at will, and they are entitled to. Meanwhile other state lives **outside** it and persists independently — on-disk anchor markers (`.inflexa/id`), output folders, config. So the two stores routinely disagree: a marker (or a row's foreign key) can reference an id the database no longer has.
+The SQLite database is a file on the **machine of the user**. The user can delete
+it, restore an old copy, or hand-edit it, and they are entitled to. Meanwhile other
+state lives **outside** it and persists independently: the anchor markers on disk
+(`.inflexa/id`), the output folders, and the configuration. Thus the two stores
+routinely disagree. A marker, or the foreign key of a row, can refer to an id that
+the database no longer has.
 
-**Treat "the referenced row is gone" as a normal, recoverable condition — never a hard error.** When code reads an id/marker/path from one store and looks it up in another, a miss must **heal** (reconstruct from the authoritative source — e.g. re-establish an anchor row from its on-disk marker, but only on a *deliberate* action, never a passive read — see the no-litter policy) or **degrade gracefully** (resolve to `null`/a sensible fallback and carry on), so the user still gets a working command. Returning a `query_failed`/`DbError` for a routine desync is a bug: it turns "your DB and your folders disagree" into a crash the user can't escape without surgery.
+**Treat "the referenced row is gone" as a normal, recoverable condition. It is
+never a hard error.** Code reads an id, a marker, or a path from one store and
+looks it up in another. A miss must **recover** or it must **degrade**.
 
-Concretely: a lookup that can legitimately miss returns `T | null` (the miss is in-band), not an error; the caller picks a fallback. Reserve the error channel for genuine faults (the query itself failed). See `resolveAnchor` (`modules/anchor/anchor.ts`): a marker pointing at a deleted anchor resolves to `null`, and bare `inflexa` then offers to start fresh in that folder rather than dying with `unknown anchor <id>`.
+To recover is to reconstruct from the authoritative source, for example to
+establish an anchor row again from its marker on disk. Do that only on a
+*deliberate* action, never on a passive read — refer to the no-litter policy. To
+degrade is to resolve to `null` or to a sensible fallback and continue. Then the
+user still gets a working command. A `query_failed` or a `DbError` for a routine
+disagreement is a bug: it changes "your DB and your folders disagree" into a crash
+that the user cannot escape without surgery.
+
+Concretely: a lookup that can legitimately miss gives `T | null`, thus the miss is
+in-band and it is not an error. The caller picks a fallback. Reserve the error
+channel for a genuine fault, which is a query that itself failed. Refer to
+`resolveAnchor` (`modules/anchor/anchor.ts`). A marker that points at a deleted
+anchor resolves to `null`. A bare `inflexa` then offers to start fresh in that
+folder, and it does not die with `unknown anchor <id>`.
 
 ### Resolving an id-or-name reference
 
-When a command resolves a user-supplied reference that may be **either an id or a human name/slug** (`inflexa resume <x>`, `--analysis <x>`, …):
+A command resolves a reference from the user that can be **either an id or a human
+name or slug** (`inflexa resume <x>`, `--analysis <x>`, and others). Obey these
+rules:
 
-- **Type the parameter `IdOrName`** (from `lib/types.ts`), never a bare `string` — the alias makes "resolve this by id OR name" legible at the call site.
-- **Resolve it in a SINGLE query, id-first** — never fetch-by-id then fall back to fetch-by-name, and never load all rows to `.find`/`.filter` in JS. Put the priority in SQL:
+- **Type the parameter `IdOrName`** (from `lib/types.ts`), never a bare `string`.
+  The alias makes "resolve this by id OR name" legible at the call site.
+- **Resolve it in a SINGLE query, id-first.** Never fetch by id and then fall back
+  to a fetch by name. Never load each row and then `.find` or `.filter` in JS. Put
+  the priority in SQL:
 
   ```sql
   -- one match (LIMIT 1):
@@ -147,31 +306,72 @@ When a command resolves a user-supplied reference that may be **either an id or 
   WHERE id = $ref OR slug = $ref OR name = $ref ORDER BY (id = $ref) DESC, created_at DESC
   ```
 
-  `(id = $ref)` sorts the exact-id hit first (ids are unique, so it is THE match); the named `$ref` param binds once. The caller takes `[0]`; "more than one row, none by id" means an ambiguous name/slug. The resolver lives in `db/primary_query.ts` (e.g. `findAnalysesByRef`/`findProjectByRef`).
+  `(id = $ref)` sorts the exact-id hit first, because an id is unique, thus it is
+  THE match. The named `$ref` param binds one time. The caller takes `[0]`. "More
+  than one row, none by id" means an ambiguous name or slug. The resolver is in
+  `db/primary_query.ts`, for example `findAnalysesByRef` and `findProjectByRef`.
 
-- **Wrap the resolver in a module `findX`/`matchX` only when the wrapper adds logic.** `matchAnalysis` earns its place — it reshapes the candidate set into `{ analysis, others }` to surface name collisions. When the resolver already returns the single answer (because the lookup column is `UNIQUE`, like `projects.name`), call it directly: a `findProject` whose whole body is `return findProjectByRef(ref)` is pointless ceremony — delete it and let callers import `findProjectByRef`. Same for a one-line write wrapper like `setProject` over `updateAnalysisProject`.
+- **Wrap the resolver in a module `findX` or `matchX` only when the wrapper adds
+  logic.** `matchAnalysis` earns its place, because it reshapes the candidate set
+  into `{ analysis, others }` to surface a name collision. When the resolver
+  already gives the single answer, because the lookup column is `UNIQUE` like
+  `projects.name`, call it directly. A `findProject` whose whole body is
+  `return findProjectByRef(ref)` is pointless ceremony. Delete it, and let a caller
+  import `findProjectByRef`. The same is true for a one-line write wrapper such as
+  `setProject` over `updateAnalysisProject`.
 
-This generalizes: **prefer one query over a read-then-decide round-trip whenever SQL can express the decision** — e.g. a targeted `UPDATE … SET col = ? WHERE id = ?` (rows-changed signals not-found) over read-the-row-then-rewrite-every-column.
+This generalizes. **Prefer one query over a read-then-decide round-trip whenever
+SQL can express the decision.** For example, prefer a targeted
+`UPDATE … SET col = ? WHERE id = ?`, where the rows-changed count signals
+not-found, over a read of the row and then a rewrite of each column.
 
-### Column & field ordering
+### Column and field ordering
 
-Order columns, type fields, and the parameters/bound-args of functions that carry them in three groups, **always in this order**:
+Order the columns, the type fields, and the parameters and bound args of the
+functions that carry them in three groups, **always in this order**:
 
-1. **Identity** — `id`, `created_at`, `updated_at`, colocated at the top. These three are the row's full identity; keep them together even though the timestamps are rarely read beside `id`. A table/type without timestamps has just `id`; a non-entity (e.g. the `analysis_inputs` reference rows) has no identity group at all.
-2. **Core data** — the fields the row is actually about (`name`, `slug`, `path`, `is_dir`, `data`, …).
-3. **Foreign keys** — every `*_id`/`*Id` reference, last (`anchor_id`, `project_id`, `session_id`, …).
+1. **Identity** — `id`, `created_at`, `updated_at`, colocated at the top. These
+   three are the full identity of the row. Keep them together, although the
+   timestamps are rarely read beside `id`. A table or type with no timestamps has
+   `id` only. A non-entity, for example the `analysis_inputs` reference rows, has
+   no identity group at all.
+2. **Core data** — the fields that the row is about (`name`, `slug`, `path`,
+   `is_dir`, `data`, and the others).
+3. **Foreign keys** — each `*_id` or `*Id` reference, last (`anchor_id`,
+   `project_id`, `session_id`, and the others).
 
-This governs `CREATE TABLE` columns, the `COLS` constant + row type + `fromRow` in `db/`, `INSERT`/`UPDATE` column lists **and their bound params**, the persisted entity types in `src/types/`, and the parameter lists of functions that pass these fields through. An `UPDATE … SET` omits `id` (it's the `WHERE`) but still leads with `updated_at`, then core, then FKs. Declare tables parent-before-child so every FK is a backward reference.
+This governs the `CREATE TABLE` columns, the `COLS` constant, the row type, and
+`fromRow` in `db/`. It governs the `INSERT` and `UPDATE` column lists **and their
+bound params**. It governs the persisted entity types in `src/types/`, and the
+parameter lists of the functions that pass these fields through. An
+`UPDATE … SET` omits `id`, because that is the `WHERE`, but it still leads with
+`updated_at`, then the core, then the FKs. Declare a table parent-before-child,
+thus each FK is a backward reference.
 
-A JSON-blob table — one whose payload rides a single `data` column — follows this at the **column** level (`id, data, <fk>`), but the blob's interior shape is application data, not columns, so it keeps its own narrative order. No table in the schema is shaped that way today; every live table is columnar.
+A JSON-blob table, whose payload rides a single `data` column, obeys this at the
+**column** level (`id, data, <fk>`). But the interior shape of the blob is
+application data, not columns, thus it keeps its own narrative order. No table in
+the schema is shaped that way today. Each live table is columnar.
 
 ## TypeScript
 
-- Prefer `type` over `interface`, `const` over `let`, `function` over arrow functions.
-- Always type function parameters and return values (except JSX returns).
-- Comment every `any`/`unknown` usage.
-- **Use domain types, never raw `string` for known value sets.** Shared domain types — persisted entity shapes (`session.ts`, `anchor.ts`, …) and the event contract (`events.ts`) — live in `src/types/`, grouped by domain. Everything else (command options, error unions, wire schemas) co-locates with its owning code. See [Project structure](#project-structure) for why the entity shapes are shared rather than module-local.
-- **Document every exported declaration — types, their properties, and functions — with JSDoc (`/** … */`) blocks, never `//` line comments** — JSDoc is the only form the LSP surfaces on hover and completion, so a `//` above a function is invisible at the call site where you read it. Reserve `//` for inline implementation notes (the WHY) inside a body. Place the block on the line above what it describes.
+- Prefer `type` over `interface`, `const` over `let`, and `function` over an arrow
+  function.
+- Always type the function parameters and the return values, except for a JSX
+  return.
+- Comment each `any` and each `unknown`.
+- **Use a domain type. Never use a raw `string` for a known value set.** The shared
+  domain types are in `src/types/`, grouped by domain: the persisted entity shapes
+  (`session.ts`, `anchor.ts`, and the others) and the event contract (`events.ts`).
+  Each other type (a command option, an error union, a wire schema) is colocated
+  with the code that has it. Refer to [Project structure](#project-structure) for
+  the reason that the entity shapes are shared and not module-local.
+- **Document each exported declaration — a type, its properties, and a function —
+  with a JSDoc (`/** … */`) block, never with a `//` line comment.** JSDoc is the
+  only form that the LSP surfaces on hover and on completion. Thus a `//` above a
+  function is invisible at the call site where you read it. Reserve `//` for an
+  inline implementation note (the WHY) inside a body. Put the block on the line
+  above what it describes.
 
   ```ts
   /** Invisible folder-identity record. Keyed by the marker id, not its path. */
@@ -189,110 +389,415 @@ A JSON-blob table — one whose payload rides a single `data` column — follows
 
 ## Naming conventions
 
-- **Files:** lowercase; snake_case for multi-word names (`primary_query.ts`).
-- **Named exports only.** No default exports, no barrel files, no re-exports. Use inline `export` on declarations.
-- When moving code, update ALL importers to the new location. Never add shims.
+- **Files:** lowercase. Use snake_case for a multi-word name
+  (`primary_query.ts`).
+- **Named exports only.** No default export, no barrel file, and no re-export. Use
+  an inline `export` on the declaration.
+- When you move code, update EACH importer to the new location. Never add a shim.
 
 ## Project structure
 
-Code is grouped **by feature (vertical slice)**, not by technical layer: a feature owns its logic, its CLI command action(s), and its logic-local types under `src/modules/<domain>/`. Shared infrastructure with no single owner stays in the layer directories.
+The code is in groups **by feature (a vertical slice)**, not by technical layer. A
+feature has its logic, its CLI command actions, and its logic-local types, under
+`src/modules/<domain>/`. Shared infrastructure with no single owner stays in the
+layer directories.
 
-- `src/index.ts` — entry point: telemetry/log wiring, shutdown hooks, then `cli.parse()`
-- `src/cli/` — the commander command **registry** (`index.ts`) + help formatting, nothing else. Each command lazy-imports its action: text commands from their module (e.g. `import("../modules/auth/login.ts")`), TUI screens from `tui/` (e.g. `import("../tui/app.launch.tsx")`).
-- `src/modules/<domain>/` — feature slices (see [Modules](#modules)): **headless** domain logic + the text command actions that drive them. Interactive views are NOT here (see `tui/`). Today: `auth/` (Auth0 device flow + `login`/`logout`/`whoami`), `proxy/` (the CLIProxyAPI model helpers in `models.ts` — client API key discovery + default-model ranking; the container lifecycle lives in `infra/`), `analysis/` (analysis lifecycle), `anchor/` (folder-identity markers + lazy path reconciliation), `harness/` (the harness embedder — boots the harness runtime (DBOS/sandbox/providers) and drives the chat turn, the model-free `run --plan` replay engine, data profiling, and the provenance bridge), `embedding/` (config-driven embedding-provider resolution + the in-process bge-small local model: download/verify/lifecycle), `infra/` (the container stack — `setup`/`up`/`down` provisioning CLIProxyAPI + Postgres/pgvector via a generated Docker Compose file), `libs/` (the published sandbox image variants (GHCR refs) + the `sandbox pull`/`status` actions), `project/` (project CRUD command actions — `project new`/`project ls`), `prov/` (the provenance recorder — a bus subscriber that builds, signs, and persists each analysis's PROV document, plus `prov export`/`prov verify`), `staging/` (stages analysis input files under the analysis workspace's `data/` root with content hashes into the harness-compatible `StagedInput` manifest).
-- `src/db/` — shared SQLite layer: `primary.ts` (connection), `primary_migrations.ts`, `primary_query.ts`, `primary_mutation.ts`, `errors.ts`, `util.ts`. Queries/mutations stay here (verb-split, beside the migrations); a module imports the functions it needs.
-- `src/tui/` — the **presentation layer / app shell**: the entry app plus shared, app-level, or reusable Solid/opentui code. Today: `app.tsx` (the root chat screen, launched by every command that opens a chat), `app.launch.tsx` (`launchTui`), `command_palette.tsx` / `commands.tsx` (the palette adapter + command registry), `app_config.tsx` (settings — an app-level screen), `theme.ts` (the reactive accessor — the id list + palette data live in `lib/design_system.ts`; also home to the shared `Notice` type + `noticeColor` mapping, since a notice kind maps onto a palette role), and `components/` (shared, domain-agnostic widgets — see below). Presentation sits *above* the logic modules: it may import module logic (view → logic); modules must never import `tui/`. **Where a view lives** mirrors Lumen's `components/` vs `modules/<m>/components/` split — shared / app-shell / app-level screens go here; a view owned by exactly one feature co-locates in that module. `app_config.tsx` is an app-level exception that lives here — not a license to put every view in `tui/`. Add `tui/<domain>/` (or module-side view folders) when a screen outgrows one file.
-  - `src/tui/components/` — shared TUI widgets. A widget belongs here **iff** it (a) imports only `theme` + opentui/solid (no `modules/`, `db/`, or other domain imports) and (b) has ≥2 callers; one component per file, no barrels. A feature-coupled adapter (e.g. `CommandPalette`, which maps `Command` objects) stays in the `tui/` app-shell, not here. Today: `dialog/` (the dialog subsystem — see below), `list_core.tsx` + `fixed_list.tsx` + `dynamic_list.tsx` (the list primitives — fuzzy-filtered grouped lists; `FixedList` reads its items ONCE and renders with `<For>`, `DynamicList` tracks reactive items and renders with `<Index>`; hosts own the filter input and pass `query` down. A row may be `pinned` to opt out of ranking — for an escape-hatch row whose action is "enter something these rows can't express", where the query is precisely the text its own label cannot match), `text_area.tsx` (`TextArea` — themed textarea with chrome tiers and mode tracking), `text_input.tsx` (`TextInput` — themed single-line input with per-keystroke callback). Both editors take an `autoFocus` opt-out (list-first hosts, gallery exhibits, showcased dialogs) that also seeds their chrome's focus signal, so a blurred mount renders blurred from the first frame.
-  - `src/tui/components/dialog/` — the dialog subsystem: the chrome shell, host/overlay, and reusable content dialogs. `dialog_host.tsx` is the **state machine**: a module-level stack where lower entries stay MOUNTED but hidden and inert (dialog-over-dialog preserves state); every dismissal routes through the single close funnel `dialogClose(reason)` with `reason ∈ cancel (esc) | dismiss (click-outside, ctrl+c, sweeps) | commit (the default — programmatic closes are the tail of a submit flow)`; the host owns the ONE structural esc binding — content dialogs never bind esc. Dialogs participate via hooks: `useDialogBindings` (key layers, auto-suspended while a dialog is stacked above — REQUIRED for all dialog keys, and for screen layers that must suspend under a prompt), `useDialogCancel` (wire an `onCancel` prop to every non-commit close), `useDialogCloseGuard` (veto closes — busy prompts, dirty forms; the app abort chord escalates past a veto on a quick second press), `useDialogEntry().setInitialFocus` (the host applies focus on push and reveal — no per-dialog mount-time focus microtasks), and `DialogShowcase` (render dialogs as inert gallery exhibits — the handle's `inert` flag threads into editors' `autoFocus` so exhibits grab no focus even at mount). Sizing comes from the `dialogSize` presets (fixed columns + `maxWidth` clamp; heights are FIXED for tiers whose content changes while open — `lg` pickers, `xl` — because a panel that resizes as its list filters is worse UX than empty rows; only static-content `md` is content-height — see `design_system.ts`); a percentage-capped panel must NOT be wrapped in an auto-sized box (yoga resolves % against the parent and squeezes the panel — the overlay's per-entry wrapper is full-inset for this reason), and click containment lives on `DialogPanel` itself (`dialogPanelMouseDown/Up`). Content dialogs: `alert_dialog.tsx`, `confirm_dialog.tsx` (+ `tone="danger"` chrome), `export_options_dialog.tsx`, `file_picker.tsx` (`FilePicker` — multi-select file browser on `DynamicList` with INSERT/NORMAL/REVIEW modes), `prompt_dialog.tsx` (`PromptDialog` — single-line `TextInput` by default, `multiline` opts into `TextArea`; busy state vetoes all dismissal), `results_dialog.tsx`, `select_dialog.tsx` (`SelectDialog` — the picker dialog composing a filter `TextInput` + `FixedList`; every "choose one of these" command). All are showcased in the design gallery.
-  - `src/tui/layout/` — the chat app-shell **composition kit**: a full-width status bar atop a main row of (stream + input) beside a toggleable, full-height **sidebar**. Files: `status_bar.tsx`, `message_block.tsx`, `chat_bar.tsx`, `sidebar.tsx` (the gutter marker set lives in `lib/design_system.ts`, not here). Distinguished from `components/` by **role** (shell composition vs reusable widget), it is a deliberate, scoped exception to the single-caller rule — a kit part MAY be single-caller and MAY import domain types/queries, and stays here even when generic + multi-caller (e.g. `StatusBar`, shared by `app.tsx` + `app_config.tsx`). Chat status lives in the reactive `src/tui/hooks/status.ts` store (the `theme.ts` pattern) — the app only renders it.
-  - `src/tui/keymap.ts` — the **keybinding engine**: bindings are DATA dispatched centrally — NEVER write a raw `useKeyboard` or `key.name === …` branch in a component. A component declares a reactive layer with `useBindings(() => ({ enabled?, mode?, target?, priority?, bindings }))`; exactly one `useKeymapRoot()` per renderer (chat `App`; standalone `ConfigApp` only when not embedded) installs the single `useKeyboard` that routes each keystroke to the winning binding. **Modal capture** is the mode stack: an open dialog `pushMode(MODE_MODAL)` (App's effect) suspends every `MODE_BASE` layer at once — no per-binding `if (dialogOpen)`. **Leader + chord sequences**: `leaderSeq("n")` / a `<leader>` spec build timed multi-stroke bindings (escape aborts a half-typed chord, backspace pops one stroke, comma = alternatives); the `WhichKey` overlay (`layout/which_key.tsx`) lists `reachableKeys()` live, free-documented from each binding's `desc`/`group`. **Focus `target`** gates a layer to when a renderable (or descendant) is focused — the fine-grained complement to `mode`. The chord is the single source: display labels are DERIVED (`chordLabel`), never hand-kept beside the chord. App-level keys are remappable via `config.keybinds` (command id → key string, e.g. `app.command-palette`); structural dialog keys come from the shared `KEYS`. Only the root handler + focus check touch opentui — the matcher (`matchChord`) stays structural. **Labels ALWAYS lowercase** (`ctrl+k`, `esc`); chords use **Ctrl, never Alt** (terminals deliver Alt/Option unreliably — macOS composes Option into a character) and never Cmd (not forwarded). Textarea submit/newline stay renderable-level (`text_area.tsx`, cursor-aware), sourced from `SUBMIT_CHORD`/`NEWLINE_CHORD`.
-- `src/lib/` — non-domain infrastructure: `env.ts` (sole `process.env` reader), `config.ts` (user config file), `bus.ts` (event bus), `log.ts` (pino), `otel.ts`, `shutdown.ts`, `design_system.ts` (the single merged source for the TUI's visual primitives — `GLYPHS`, the theme registry + `ThemeColors`, the layout `tokens` (`space`/`size`/`stroke`), the `zIndex` stacking ladder, and the gutter `MARKERS`; the reactive accessor over the theme data is `tui/theme.ts`, and any JSX/signal design helper lives in `tui/components/`. See [Glyphs](#glyphs)).
-- `src/extensions/` — global runtime extensions (see below)
-- `src/types/` — shared domain model, grouped by domain: persisted entity shapes (`session.ts`, `anchor.ts`, …) and the event contract (`events.ts`). These are shared, not module-local, because the `db/` layer references every entity shape and `lib/bus.ts` references the events — homing them in a module would invert the infra→feature dependency.
+- `src/index.ts` — the entry point: the telemetry and log wiring, the shutdown
+  hooks, then `cli.parse()`.
+- `src/cli/` — the commander command **registry** (`index.ts`) plus the help
+  format, and nothing else. Each command lazy-imports its action. A text command
+  comes from its module, for example `import("../modules/auth/login.ts")`. A TUI
+  screen comes from `tui/`, for example `import("../tui/app.launch.tsx")`.
+- `src/modules/<domain>/` — the feature slices (refer to [Modules](#modules)):
+  **headless** domain logic, plus the text command actions that operate them. An
+  interactive view is NOT here (refer to `tui/`). Today the slices are:
+  - `auth/` — the Auth0 device flow, with `login`, `logout`, and `whoami`
+  - `proxy/` — the CLIProxyAPI model helpers in `models.ts`: the client API key
+    discovery and the default-model rank. The container lifecycle is in `infra/`
+  - `analysis/` — the analysis lifecycle
+  - `anchor/` — the folder-identity markers, and the lazy path reconciliation
+  - `harness/` — the harness embedder. It boots the harness runtime (DBOS, the
+    sandbox, the providers) and operates the chat turn, the model-free
+    `run --plan` replay engine, the data profiler, and the provenance bridge
+  - `embedding/` — the embedding-provider resolution from the configuration, plus
+    the in-process bge-small local model: the download, the check, and the
+    lifecycle
+  - `infra/` — the container stack. `setup`, `up`, and `down` provision CLIProxyAPI
+    and Postgres with pgvector, through a generated Docker Compose file
+  - `libs/` — the published sandbox image variants (the GHCR refs), plus the
+    `sandbox pull` and `status` actions
+  - `project/` — the project CRUD command actions (`project new`, `project ls`)
+  - `prov/` — the provenance recorder. It is a bus subscriber that builds, signs,
+    and stores the PROV document of each analysis. It gives `prov export` and
+    `prov verify`
+  - `staging/` — it puts the analysis input files under the `data/` root of the
+    analysis workspace. It gives each file a content hash, and it writes the
+    `StagedInput` manifest that the harness accepts.
+- `src/db/` — the shared SQLite layer: `primary.ts` (the connection),
+  `primary_migrations.ts`, `primary_query.ts`, `primary_mutation.ts`, `errors.ts`,
+  and `util.ts`. The queries and the mutations stay here, verb-split, beside the
+  migrations. A module imports the functions that it wants.
+- `src/tui/` — the **presentation layer and app shell**: the entry app, plus the
+  shared, app-level, or reusable Solid and opentui code. Today it has `app.tsx`
+  (the root chat screen, which each command that opens a chat launches),
+  `app.launch.tsx` (`launchTui`), `command_palette.tsx` and `commands.tsx` (the
+  palette adapter and the command registry), `app_config.tsx` (the settings, an
+  app-level screen), `theme.ts` (the reactive accessor — the id list and the
+  palette data are in `lib/design_system.ts`, and it also has the shared `Notice`
+  type and the `noticeColor` mapping, because a notice kind maps onto a palette
+  role), and `components/` (the shared, domain-agnostic widgets, below).
+
+  The presentation sits *above* the logic modules. It can import module logic
+  (view to logic), but a module must never import `tui/`. **Where a view lives**
+  mirrors the `components/` and `modules/<m>/components/` split of Lumen. A shared,
+  app-shell, or app-level screen goes here. A view that exactly one feature has
+  colocates in that module. `app_config.tsx` is an app-level exception that lives
+  here. It is not a license to put each view in `tui/`. Add `tui/<domain>/`, or a
+  module-side view folder, when a screen outgrows one file.
+  - `src/tui/components/` — the shared TUI widgets. A widget belongs here **only
+    if** it imports `theme` plus opentui and solid only (no `modules/`, no `db/`,
+    and no other domain import), **and** it has 2 or more callers. There is one
+    component for each file, and no barrels. A feature-coupled adapter, for example
+    `CommandPalette`, which maps `Command` objects, stays in the `tui/` app-shell,
+    not here.
+
+    Today it has `dialog/` (the dialog subsystem, below). It has `list_core.tsx`,
+    `fixed_list.tsx`, and `dynamic_list.tsx` (the list primitives — fuzzy-filtered
+    grouped lists). `FixedList` reads its items ONCE and renders with `<For>`.
+    `DynamicList` tracks reactive items and renders with `<Index>`. A host has the
+    filter input and passes `query` down. A row can be `pinned` to opt out of the
+    rank. Use that for an escape-hatch row whose action is "enter something these
+    rows cannot express". There the query is precisely the text that its own label
+    cannot match.
+
+    It also has `text_area.tsx` (`TextArea` — a themed textarea with chrome tiers
+    and mode tracking) and `text_input.tsx` (`TextInput` — a themed single-line
+    input with a callback for each keystroke). The two editors take an `autoFocus`
+    opt-out (a list-first host, a gallery exhibit, a showcased dialog) that also
+    seeds the focus signal of their chrome. Thus a blurred mount renders blurred
+    from the first frame.
+  - `src/tui/components/dialog/` — the dialog subsystem: the chrome shell, the host
+    and overlay, and the reusable content dialogs. `dialog_host.tsx` is the **state
+    machine**. It has a module-level stack, where a lower entry stays MOUNTED but
+    hidden and inert, thus dialog-over-dialog preserves the state.
+
+    Each dismissal routes through the single close funnel `dialogClose(reason)`,
+    where `reason` is `cancel` (esc), `dismiss` (click-outside, ctrl+c, sweeps), or
+    `commit` (the default — a programmatic close is the tail of a submit flow). The
+    host has the ONE structural esc binding, and a content dialog never binds esc.
+
+    A dialog participates through hooks:
+    - `useDialogBindings` — key layers, auto-suspended while a dialog is stacked
+      above. It is REQUIRED for each dialog key, and for a screen layer that must
+      suspend under a prompt.
+    - `useDialogCancel` — wire an `onCancel` prop to each close that is not a
+      commit.
+    - `useDialogCloseGuard` — veto a close, for a busy prompt or a dirty form. The
+      app abort chord escalates past a veto on a quick second push.
+    - `useDialogEntry().setInitialFocus` — the host applies the focus on push and
+      on reveal. There is no mount-time focus microtask for each dialog.
+    - `DialogShowcase` — render a dialog as an inert gallery exhibit. The `inert`
+      flag of the handle threads into the `autoFocus` of an editor, thus an exhibit
+      grabs no focus even at mount.
+
+    The size comes from the `dialogSize` presets: fixed columns plus a `maxWidth`
+    clamp. The height is FIXED for a tier whose content changes while it is open:
+    the `lg` pickers and `xl`. A panel that resizes as its list filters is worse
+    UX than empty rows. Only the static-content `md` is content-height. Refer
+    to `design_system.ts`.
+
+    A percentage-capped panel must NOT be inside an auto-sized box, because yoga
+    resolves the percentage against the parent and squeezes the panel. The per-entry
+    wrapper of the overlay is full-inset for this reason. The click containment is
+    on `DialogPanel` itself (`dialogPanelMouseDown/Up`).
+
+    The content dialogs are `alert_dialog.tsx`, `confirm_dialog.tsx` (with
+    `tone="danger"` chrome), `export_options_dialog.tsx`, `file_picker.tsx`
+    (`FilePicker` — a multi-select file browser on `DynamicList`, with INSERT,
+    NORMAL, and REVIEW modes), `prompt_dialog.tsx` (`PromptDialog` — a single-line
+    `TextInput` by default, and `multiline` opts into `TextArea`. A busy state
+    vetoes each dismissal), `results_dialog.tsx`, and `select_dialog.tsx`
+    (`SelectDialog` — the picker dialog that composes a filter `TextInput` and a
+    `FixedList`, for each "choose one of these" command). The design gallery
+    showcases each one.
+  - `src/tui/layout/` — the **composition kit** of the chat app shell: a full-width
+    status bar above a main row of stream and input, beside a toggleable,
+    full-height **sidebar**. The files are `status_bar.tsx`, `message_block.tsx`,
+    `chat_bar.tsx`, and `sidebar.tsx`. The gutter marker set is in
+    `lib/design_system.ts`, not here.
+
+    Its **role** makes it different from `components/`: it is shell composition,
+    not a reusable widget. It is a deliberate, scoped exception to the
+    single-caller rule. A kit part CAN be single-caller, and it CAN import a domain
+    type or query. It stays here even when it is generic and multi-caller, for
+    example `StatusBar`, which `app.tsx` and `app_config.tsx` share. The chat
+    status is in the reactive `src/tui/hooks/status.ts` store, which is the pattern
+    of `theme.ts`. The app only renders it.
+  - `src/tui/keymap.ts` — the **keybinding engine**. A binding is DATA, dispatched
+    centrally. NEVER write a raw `useKeyboard` or a `key.name === …` branch in a
+    component. A component declares a reactive layer with
+    `useBindings(() => ({ enabled?, mode?, target?, priority?, bindings }))`.
+    Exactly one `useKeymapRoot()` for each renderer installs the single
+    `useKeyboard` that routes each keystroke to the winning binding. The renderers
+    are the chat `App`, and the standalone `ConfigApp` only when it is not
+    embedded.
+
+    **Modal capture** is the mode stack. An open dialog does `pushMode(MODE_MODAL)`
+    (the effect of App), which suspends each `MODE_BASE` layer at one time. There is
+    no `if (dialogOpen)` for each binding.
+
+    **A leader and a chord sequence**: `leaderSeq("n")`, or a `<leader>` spec,
+    builds a timed multi-stroke binding. Escape aborts a half-typed chord,
+    backspace pops one stroke, and a comma gives the alternatives. The `WhichKey`
+    overlay (`layout/which_key.tsx`) lists `reachableKeys()` live, documented free
+    from the `desc` and `group` of each binding.
+
+    **A focus `target`** gates a layer to when a renderable, or a descendant, has
+    the focus. It is the fine-grained complement to `mode`. The chord is the single
+    source: a display label is DERIVED (`chordLabel`), and it is never hand-kept
+    beside the chord. An app-level key is remappable through `config.keybinds`
+    (command id to key string, for example `app.command-palette`). A structural
+    dialog key comes from the shared `KEYS`. Only the root handler and the focus
+    check touch opentui. The matcher (`matchChord`) stays structural.
+
+    **A label is ALWAYS lowercase** (`ctrl+k`, `esc`). A chord uses **Ctrl, never
+    Alt**, because a terminal delivers Alt and Option unreliably, and macOS
+    composes Option into a character. A chord never uses Cmd, because a terminal
+    does not forward it. The textarea submit and newline stay at the renderable
+    level (`text_area.tsx`, cursor-aware), and they come from `SUBMIT_CHORD` and
+    `NEWLINE_CHORD`.
+- `src/lib/` — non-domain infrastructure: `env.ts` (the sole reader of
+  `process.env`), `config.ts` (the user config file), `bus.ts` (the event bus),
+  `log.ts` (pino), `otel.ts`, `shutdown.ts`, and `design_system.ts`.
+
+  `design_system.ts` is the single merged source for the visual primitives of the
+  TUI: `GLYPHS`, the theme registry and `ThemeColors`, the layout `tokens`
+  (`space`, `size`, `stroke`), the `zIndex` stacking ladder, and the gutter
+  `MARKERS`. The reactive accessor over the theme data is `tui/theme.ts`. A JSX or
+  signal design helper is in `tui/components/`. Refer to [Glyphs](#glyphs).
+- `src/extensions/` — the global runtime extensions (below).
+- `src/types/` — the shared domain model, grouped by domain: the persisted entity
+  shapes (`session.ts`, `anchor.ts`, and the others) and the event contract
+  (`events.ts`). These are shared, not module-local, because the `db/` layer refers
+  to each entity shape and `lib/bus.ts` refers to the events. To home them in a
+  module would invert the dependency from infra to feature.
 
 ## Modules
 
-A module under `src/modules/<domain>/` groups everything about one domain: its logic, its CLI command action(s), and its logic-local types. There is **no mandated file layout** — add files as the domain needs them, not preemptively (named exports only, no barrels, per [Naming conventions](#naming-conventions)).
+A module under `src/modules/<domain>/` groups each thing about one domain: its
+logic, its CLI command actions, and its logic-local types. There is **no mandated
+file layout**. Add a file as the domain wants it, not before. Use named exports
+only, and no barrels, per [Naming conventions](#naming-conventions).
 
-- **Public surface.** Whatever other layers import is the module's API; import it directly from the owning file (e.g. `ensureProxyReady` from `modules/proxy/setup.ts`). No barrel/index re-exports.
-- **Dependency direction.** Modules import shared infra (`lib/`, `db/`, `src/types/`, `extensions/`) and **other modules, acyclically** (e.g. `harness` → `proxy`; `analysis` → `anchor`). They must **not** import `tui/` — presentation depends on logic, never the reverse. Infrastructure (`lib/`, `db/`) must **never** import a module. If two modules need the same code, lift it to a shared layer.
+- **Public surface.** Whatever the other layers import is the API of the module.
+  Import it directly from the file that has it, for example `ensureProxyReady` from
+  `modules/proxy/setup.ts`. There is no barrel and no index re-export.
+- **Dependency direction.** A module imports the shared infra (`lib/`, `db/`,
+  `src/types/`, `extensions/`) and **other modules, acyclically**, for example
+  `harness` to `proxy`, and `analysis` to `anchor`. A module must **not** import
+  `tui/`, because the presentation depends on the logic and never the opposite. The
+  infrastructure (`lib/`, `db/`) must **never** import a module. If two modules want
+  the same code, lift it to a shared layer.
 
 ## Global extensions
 
-`src/extensions/*.ext.ts` augment built-in globals with small, broadly-useful methods (`Promise.sleep`, `JSON.parseWith`) so call sites don't each redeclare a one-line helper. Each file:
+`src/extensions/*.ext.ts` augments a built-in global with a small, broadly-useful
+method (`Promise.sleep`, `JSON.parseWith`). Thus a call site does not redeclare a
+one-line helper. Each file:
 
-- Declares the method on the relevant global interface via `declare global { interface PromiseConstructor { … } }` (use `PromiseConstructor`/`JSON`/etc. for statics, the instance interface for prototype methods), assigns the implementation, and ends with `export {}` to stay a module.
-- Is registered by adding one side-effect import to `src/extensions/index.ts` — the central loader, imported once from `src/index.ts` before `cli.parse()`. That loader is side-effect-only (not a re-export barrel, so it doesn't violate the no-barrel rule). Anything depending on an extension must run after the entry point loads it (all CLI commands do, since they lazy-import after startup).
+- Declares the method on the applicable global interface, through
+  `declare global { interface PromiseConstructor { … } }`. Use `PromiseConstructor`
+  or `JSON` for a static, and the instance interface for a prototype method. Then
+  it assigns the implementation, and it ends with `export {}` to stay a module.
+- Is registered by one side-effect import in `src/extensions/index.ts`. That is the
+  central loader, imported one time from `src/index.ts` before `cli.parse()`. The
+  loader is side-effect-only. It is not a re-export barrel, thus it does not
+  violate the no-barrel rule. Anything that depends on an extension must run after
+  the entry point loads it. Each CLI command does, because it lazy-imports after
+  startup.
 
-Reach for an extension only when a helper is genuinely cross-cutting; keep single-caller helpers in their owning file per the Coding rules.
+Reach for an extension only when a helper is genuinely cross-cutting. Keep a
+single-caller helper in the file that has it, per the Coding rules.
 
-## Event bus — single bus, typed events
+## Event bus — one bus, typed events
 
-There is **one bus** (`Bus` in `src/lib/bus.ts`), shared by every domain — session, provenance, and any future concern. Domain separation is by event `type` string, not by bus instance. **Never add a second bus** to separate concerns; if the current event contract feels wrong, the fix is better types, not more buses.
+There is **one bus** (`Bus` in `src/lib/bus.ts`), and each domain shares it:
+session, provenance, and any future concern. The domain separation is by the event
+`type` string, not by a bus instance. **Never add a second bus** to separate the
+concerns. If the current event contract feels wrong, the fix is better types, not
+more buses.
 
-- **One event type per domain action.** Each `BusEvent` member carries exactly the fields its action needs. Never pack multiple sub-actions into a single event discriminated by an interior field with nullable companions — that defeats TypeScript's narrowing and forces consumers to guard against impossible states. E.g. provenance has `prov.analysis_created`, `prov.input_added`, `prov.input_removed` — not one `prov.recorded` with a nullable `input`.
-- **Event types live in `src/types/events.ts`** — the `BusEvent` discriminated union is the contract. Every member today is analysis-scoped provenance (`prov.*`, carrying `analysisId`); the harness conversation path writes the Solid store directly and does not use the bus. Consumers filter by `type`.
-- **Design rationale:** a dedicated bus per domain only earns its keep when that domain needs its own subscriber lifecycle, backpressure, or error isolation. inflexa's bus is a fire-and-forget notification channel with one subscriber per concern — multiplying buses adds wiring overhead for no structural gain. (Validated against OpenCode, which routes ~80+ event types across all domains through a single typed bus.)
+- **One event type for each domain action.** Each `BusEvent` member carries exactly
+  the fields that its action wants. Never pack more than one sub-action into a single
+  event that an interior field discriminates, with nullable companions. That
+  defeats the narrowing of TypeScript, and it forces a consumer to guard against an
+  impossible state. For example, provenance has `prov.analysis_created`,
+  `prov.input_added`, and `prov.input_removed`. It does not have one
+  `prov.recorded` with a nullable `input`.
+- **The event types are in `src/types/events.ts`.** The `BusEvent` discriminated
+  union is the contract. Each member today is analysis-scoped provenance (`prov.*`,
+  which carries an `analysisId`). The harness conversation path writes the Solid
+  store directly, and it does not use the bus. A consumer filters by `type`.
+- **The design rationale:** a dedicated bus for each domain earns its keep only
+  when that domain wants its own subscriber lifecycle, backpressure, or error
+  isolation. The bus of inflexa is a fire-and-forget notification channel, with one
+  subscriber for each concern. To multiply the buses adds wiring overhead for no
+  structural gain. This was validated against OpenCode, which routes more than 80
+  event types across each domain through a single typed bus.
 
-## Solid + opentui (TUI)
+## Solid and opentui (the TUI)
 
-The TUI is Solid (`solid-js`) rendered to the terminal via `@opentui/solid`. Solid is not React: components run once, reactivity lives in signals/stores, and there are no re-renders.
+The TUI is Solid (`solid-js`), rendered to the terminal through `@opentui/solid`.
+Solid is not React: a component runs one time, the reactivity is in signals and
+stores, and there are no re-renders.
 
 ### Design gallery
 
-**Before writing or changing TUI code, consult the design gallery** (`src/tui/layout/design_gallery.tsx`, opened via the "Design gallery" command-palette entry) — the read-only showcase of every existing block/widget and its states. Reuse what it shows; match its patterns.
+**Before you write or change TUI code, consult the design gallery**
+(`src/tui/layout/design_gallery.tsx`, opened through the "Design gallery"
+command-palette entry). It is the read-only showcase of each existing block and
+widget, and of its states. Use again what it shows, and match its patterns.
 
-**If a task needs something the gallery doesn't cover** (a new block, state, or visual pattern), STOP and talk to the user about adding it to the design system / extending the gallery — don't invent ad-hoc UI off to the side. New surfaces become part of the gallery so it stays the single source of truth.
+**A task can want something that the gallery does not cover: a new block, a new
+state, or a new visual pattern. Then STOP, and talk to the user.** The subject is
+an addition to the design system, or an extension of the gallery. Do not invent an ad-hoc UI off to
+the side. A new surface becomes part of the gallery, thus the gallery stays the
+single source of truth.
 
 ### Launch and exit
 
-- Each TUI screen lives in `src/tui/` as its component plus a `launch*` function — co-located in one file (like `app_config.tsx`), or split into a `app.launch.tsx` beside a large component (like the chat `app.tsx`). `launch*` resolves its data (session lookup/creation) first, then calls `void render(...)` with `exitOnCtrlC: false`, `targetFps: 30`, `screenMode: "alternate-screen"`.
-- **Always `renderer.destroy()` before `shutdown(0)`.** `destroy()` restores the terminal (mouse tracking, alternate screen, cooked mode) — `process.exit()` alone skips OpenTUI's cleanup and leaves the shell broken.
-- `exitOnCtrlC` is false, so every TUI app must handle its own quit keys via `useKeyboard`.
+- Each TUI screen is in `src/tui/` as its component plus a `launch*` function. The
+  two are colocated in one file, like `app_config.tsx`, or split into an
+  `app.launch.tsx` beside a large component, like the chat `app.tsx`. `launch*`
+  resolves its data (the session lookup or creation) first. Then it calls
+  `void render(...)` with `exitOnCtrlC: false`, `targetFps: 30`, and
+  `screenMode: "alternate-screen"`.
+- **Always call `renderer.destroy()` before `shutdown(0)`.** `destroy()` restores
+  the terminal: the mouse tracking, the alternate screen, and the cooked mode.
+  `process.exit()` alone skips the cleanup of OpenTUI, and it leaves the shell
+  broken.
+- `exitOnCtrlC` is false, thus each TUI app must handle its own quit keys through
+  `useKeyboard`.
 
 ### Reactivity
 
-- Never destructure `props` — access `props.x` at use sites or reactivity is lost.
-- **`props` as a signal's initial value — `solid/reactivity` will warn; decide seed-once vs stay-in-sync.** Reading `props.x` at component-body top level (e.g. `createSignal(props.x)`) reads it once and drops the reactive link, which the lint rule flags. Two legitimate intents:
-  - **Seed-once** (the value is locally-owned mutable state, the prop is just the initial seed): keep `createSignal(props.x)` and add a scoped `eslint-disable solid/reactivity` with a `--` reason stating *why* a one-time read is safe (e.g. the component mounts once with fixed props). This is the common case in our single-mount screens (`app.tsx`'s `currentSessionId`/`currentWorkingDir`/`currentAnalysis` are seeded from `App`'s props, then mutated by the palette). Type the signal explicitly when the prop's type should be pinned (`createSignal<Analysis>(props.analysis)`).
-  - **Stay-in-sync** (the signal must follow later prop changes): seed it, then `createEffect(() => setX(props.x))`.
-  - Do NOT "fix" the warning by destructuring (forbidden above) or by storing a thunk (`createSignal(() => props.x)` stores a function, not the value). When a whole file's warnings are the same false positive — e.g. reads of a stable `ctx` prop inside opentui `onSelect`/`onSubmit` handlers the rule doesn't recognize (`commands.tsx`) — a file-level `eslint-disable solid/reactivity` with a `--` reason is cleaner than scattering per-line disables.
-- `createSignal` for scalars; `createStore` + `produce` for lists and nested data (e.g. messages).
-- Streaming deltas accumulate in a dedicated signal (`streamText`/`streamPartId` in `app.tsx`) and flush into the store only when the part completes — never write every delta into the store.
-- Control flow with `<For>`/`<Show>`, never `.map()` in JSX.
-- Renderable refs: `let ref: SomeRenderable | null = null` + a ref callback. Focus via `queueMicrotask(() => r.focus())` — the renderable isn't ready synchronously.
+- Never destructure `props`. Access `props.x` at the use site, or the reactivity is
+  lost.
+- **`props` as the initial value of a signal — `solid/reactivity` gives a warning.
+  Decide between seed-once and stay-in-sync.** A read of `props.x` at the top level
+  of the component body, for example `createSignal(props.x)`, reads it one time and
+  drops the reactive link. The lint rule flags that. There are two legitimate
+  intents:
+  - **Seed-once** (the value is locally-owned mutable state, and the prop is only
+    the initial seed): keep `createSignal(props.x)` and add a scoped
+    `eslint-disable solid/reactivity` with a `--` reason. The reason must state
+    *why* a one-time read is safe, for example that the component mounts one time
+    with fixed props. This is the common case in our single-mount screens: the
+    `currentSessionId`, `currentWorkingDir`, and `currentAnalysis` of `app.tsx` are
+    seeded from the props of `App`, and the palette then mutates them. Type the
+    signal explicitly when the type of the prop must be pinned
+    (`createSignal<Analysis>(props.analysis)`).
+  - **Stay-in-sync** (the signal must obey a later prop change): seed it, then
+    `createEffect(() => setX(props.x))`.
+  - Do NOT "fix" the warning by a destructure (forbidden above), and do not store a
+    thunk (`createSignal(() => props.x)` stores a function, not the value). When
+    the warnings of a whole file are the same false positive, a file-level
+    `eslint-disable solid/reactivity` with a `--` reason is cleaner than per-line
+    disables. An example is the reads of a stable `ctx` prop, inside the opentui
+    `onSelect` and `onSubmit` handlers that the rule does not recognize
+    (`commands.tsx`).
+- Use `createSignal` for a scalar. Use `createStore` plus `produce` for a list and
+  for nested data, for example the messages.
+- A streaming delta accumulates in a dedicated signal (`streamText` and
+  `streamPartId` in `app.tsx`). It flushes into the store only when the part
+  completes. Never write each delta into the store.
+- Control the flow with `<For>` and `<Show>`, never with `.map()` in JSX.
+- A renderable ref is `let ref: SomeRenderable | null = null` plus a ref callback.
+  Focus it through `queueMicrotask(() => r.focus())`, because the renderable is not
+  ready synchronously.
 
 ### Layout (flex) — opentui is NOT web CSS
 
-Two opentui-specific facts, both verified against the engine source and reproduced with the headless `testRender`/`captureCharFrame` harness (see "Verifying layout" below). When a layout overlaps, instrument it — do **not** reason by analogy to CSS.
+Two opentui-specific facts. Both were verified against the engine source, and both
+were reproduced with the headless `testRender` and `captureCharFrame` harness —
+refer to "How to do a check of a layout" below. When a layout overlaps, instrument it. Do
+**not** reason by analogy to CSS.
 
-**1. `flexShrink` is derived from the dimensions.** A child with a non-numeric size (`"100%"`, `"auto"`, unset) defaults to `flexShrink: 1`; a numeric size → `0`. So a `width="100%"` box (e.g. the whole input bar) shrinks by default, and on a short terminal it collapses below its own border. Essential chrome that must keep its rows needs an explicit `flexShrink={0}` (see `chat_bar.tsx`), letting the scroll region (`flexGrow` + `minHeight={0}`, as in `app.tsx`/`chat.tsx`) absorb the squeeze instead.
+**1. `flexShrink` comes from the dimensions.** A child with a non-numeric size
+(`"100%"`, `"auto"`, unset) defaults to `flexShrink: 1`. A numeric size gives `0`.
+Thus a `width="100%"` box, for example the whole input bar, shrinks by default, and
+on a short terminal it collapses below its own border. Essential chrome that must
+keep its rows wants an explicit `flexShrink={0}` — refer to `chat_bar.tsx`. Then
+the scroll region (`flexGrow` plus `minHeight={0}`, as in `app.tsx` and `chat.tsx`)
+absorbs the squeeze instead.
 
-**2. A `flexGrow` scrollbox overlaps its next flex sibling by one cell.** In a column, opentui's yoga layout gives a `flexGrow={1}` scrollbox a rendered height **one greater** than the height it contributes to the column flow — yoga places the following sibling at `scrollbox.y + height − 1`, *inside* the scrollbox's last row. The scroll content then bleeds onto whatever sits directly below (a footer hint, a detail line). This is **not** fixable with `minHeight`/`flexShrink`/`overflow`/wrapping/integer panel sizes — all were tried and reproduced the overlap; it is a yoga/scrollbox quirk, present at most panel heights, that only becomes *visible* when that row carries content.
+**2. A `flexGrow` scrollbox overlaps its next flex sibling by one cell.** In a
+column, the yoga layout of opentui gives a `flexGrow={1}` scrollbox a rendered
+height that is **one greater**. It is one greater than the height that the
+scrollbox contributes to the column flow. Yoga
+places the sibling that follows at `scrollbox.y + height − 1`, which is *inside* the
+last row of the scrollbox. The scroll content then bleeds onto whatever sits
+directly below, for example a footer hint or a detail line.
 
-The remedy: **any fixed chrome row placed directly below a `flexGrow` scrollbox must be a full-width box painted with the panel background** (`<box width="100%" flexShrink={0} backgroundColor={…}><text/></box>`), so it opaquely reclaims its whole row. A bare `<text>` is not enough — it paints only its own glyphs, leaving the bled content showing through the gaps. Live sites: `dialog/dialog_panel.tsx` (footer), `list_core.tsx` (detail line).
+This is **not** fixable with `minHeight`, `flexShrink`, `overflow`, a wrap, or an
+integer panel size. Each of those was tried, and each reproduced the overlap. It is
+a yoga and scrollbox quirk. It is present at most panel heights, and it only
+becomes *visible* when that row carries content.
 
-**Verifying layout.** `@opentui/solid`'s `testRender` + `captureCharFrame()` renders any component tree to a text frame at a fixed `{width, height}` with no TTY; `mockInput.pressKeys` drives scrolling, and a renderable's `.x/.y/.width/.height` + `yogaNode.getComputedLayout()` expose the computed boxes. Sweep a range of heights — these bugs are size-dependent and a single size hides them.
+The remedy: **a fixed chrome row that is directly below a `flexGrow` scrollbox must
+be a full-width box, painted with the panel background**
+(`<box width="100%" flexShrink={0} backgroundColor={…}><text/></box>`). Then it
+opaquely reclaims its whole row. A bare `<text>` is not enough, because it paints
+its own glyphs only, and the bled content shows through the gaps. The live sites
+are `dialog/dialog_panel.tsx` (the footer) and `list_core.tsx` (the detail line).
+
+**How to do a check of a layout.** The `testRender` and `captureCharFrame()` of
+`@opentui/solid` render any component tree to a text frame at a fixed
+`{width, height}`, with no TTY. `mockInput.pressKeys` operates the scroll. The
+`.x`, `.y`, `.width`, and `.height` of a renderable, plus
+`yogaNode.getComputedLayout()`, expose the computed boxes. Sweep a range of
+heights, because these bugs depend on the size and a single size hides them.
 
 ### Event bus (TUI consumption)
 
-The bus contract and design rationale live in [Event bus — single bus, typed events](#event-bus--single-bus-typed-events) above. TUI-specific rules:
+The bus contract and its design rationale are in
+[Event bus — one bus, typed events](#event-bus--one-bus-typed-events) above. These
+rules are TUI-specific:
 
-- Subscribe in component setup with `Bus.on("inflexa", handler)` and always pair with `onCleanup(() => Bus.off("inflexa", handler))`.
-- Handlers must filter events by `analysisId` (every bus member is analysis-scoped provenance) and apply only the domains they own.
+- Subscribe in the component setup with `Bus.on("inflexa", handler)`. Always pair
+  it with `onCleanup(() => Bus.off("inflexa", handler))`.
+- A handler must filter the events by `analysisId`, because each bus member is
+  analysis-scoped provenance. It applies only the domains that it has.
 
 ### Colors
 
-All colors come from `theme` in `src/tui/theme.ts` — ten palettes (five dark, then five light; `tokyo-night` is the default) mapped to semantic roles (`bg`, `fg`, `fgMuted`, `fgSubtle`, `border`, `accent`, `user`, `assistant`, `success`, `warning`, `error`, …). **Never inline hex in components.**
+Each color comes from `theme` in `src/tui/theme.ts`. There are ten palettes: five
+dark, then five light, and `tokyo-night` is the default. They map to semantic roles
+(`bg`, `fg`, `fgMuted`, `fgSubtle`, `border`, `accent`, `user`, `assistant`,
+`success`, `warning`, `error`, and others). **Never inline a hex value in a
+component.**
 
-**Every `<text>` resolves an explicit foreground.** opentui's text renderable defaults `fg` to opaque white (`RGBA.fromValues(1, 1, 1, 1)`), so a `<text>` that names no color paints `#ffffff`. On the five dark themes that scores 12–18:1 — off-palette (tokyo-night body text should be `#c0caf5`) but legible, which is exactly why the default hides the bug from anyone checking on the dark default. On the five light themes it scores 1.00–1.13:1: invisible. `github-light` (bg `#ffffff`) measures exactly 1.00:1.
+**Each `<text>` resolves an explicit foreground.** The text renderable of opentui
+defaults `fg` to opaque white (`RGBA.fromValues(1, 1, 1, 1)`). Thus a `<text>` that
+names no color paints `#ffffff`. On the five dark themes that scores 12:1 to 18:1.
+It is off-palette, because the body text of tokyo-night must be `#c0caf5`. But it
+is legible. That is exactly why the default hides the bug from a person who
+examines the dark default only. On the five light themes it scores 1.00:1 to 1.13:1, thus it
+is invisible. `github-light` (bg `#ffffff`) measures exactly 1.00:1.
 
-Two shapes satisfy the rule; both are correct:
+Two shapes satisfy the rule, and both are correct:
 
-- **`fg` on the element** — `<text fg={theme().fg}>…</text>`. The prop propagates into child spans that don't override it, so a nested `<Bold>` inherits it. A block whose whole line shares one color is better served by the prop than by wrapping each child.
-- **Wrap every information-bearing child** in `<Fg role={…}>` or `<Reverse>` — `<text><Fg role="fg">{heading()}</Fg></text>` (`components/plan_card_block.tsx`). Required once a line mixes colors.
+- **`fg` on the element** — `<text fg={theme().fg}>…</text>`. The prop propagates
+  into a child span that does not override it, thus a nested `<Bold>` inherits it.
+  A block whose whole line shares one color is better served by the prop than by a
+  wrap of each child.
+- **Wrap each information-bearing child** in `<Fg role={…}>` or `<Reverse>` —
+  `<text><Fg role="fg">{heading()}</Fg></text>`
+  (`components/plan_card_block.tsx`). This is required once a line mixes colors.
 
-**A bare string literal inside an `fg`-less `<text>` is the defect**, including one sitting beside correctly-wrapped siblings — `<Fg>` colors its own span, never the text next to it:
+**A bare string literal inside an `fg`-less `<text>` is the defect.** That includes
+one that sits beside correctly-wrapped siblings, because `<Fg>` colors its own span
+and never the text next to it:
 
 ```tsx
 // WRONG — the glyph is themed, ` DONE` paints #ffffff
@@ -301,25 +806,64 @@ Two shapes satisfy the rule; both are correct:
 <text fg={theme().fg}><Fg role="accent">{GLYPHS.check}</Fg> DONE</text>
 ```
 
-**Contrast floors.** Information-bearing text holds ≥4.5:1 against every background it lands on; non-text and decorative content — borders, progress-meter cells, separator glyphs, the `fgSubtle` tier — holds ≥3:1. The tiers, and which of them the 4.5:1 threshold exempts, are defined on `ThemeColors` in `src/lib/design_system.ts`; use that vocabulary rather than minting new tiers.
+**Contrast floors.** Information-bearing text holds 4.5:1 or more against each
+background that it lands on. Non-text and decorative content holds 3:1 or more:
+the borders, the progress-meter cells, the separator glyphs, and the `fgSubtle`
+tier. The tiers, and which of them the 4.5:1 threshold exempts, are defined on
+`ThemeColors` in `src/lib/design_system.ts`. Use that vocabulary. Do not mint a new
+tier.
 
-**Check every new or changed surface on a light theme**, never only the dark default — white's 12–18:1 on dark is what lets an unresolved foreground pass review. `github-light` is the sharpest case: `bg` is pure `#ffffff`, so an unresolved foreground is fully invisible rather than merely wrong.
+**Examine each new or changed surface on a light theme**, never on the dark default
+only. The 12:1 to 18:1 of white on dark is what lets an unresolved foreground pass
+a review. `github-light` is the sharpest case, because its `bg` is pure `#ffffff`,
+thus an unresolved foreground is fully invisible and not merely wrong.
 
-**A character-frame assertion cannot prove legibility.** `captureCharFrame()` + `toContain(…)` proves a glyph was emitted; frames carry no color, so an invisible span satisfies them identically to a correct one. Any claim that a surface is *visible* must assert on span color — `captureSpans()` exposes each span's resolved `fg` (`theme_contrast.render.test.tsx`, `diff_contrast.render.test.tsx`). Relatedly, **give fixtures distinct values for fields a frame assertion could confuse**: `openable_card_block.render.test.tsx` asserts `toContain("Volcano plot")` against a fixture where that string is both the card title and the row name, so the assertion passed on the row while the title rendered unpainted.
+**A character-frame assertion cannot prove legibility.** `captureCharFrame()` plus
+`toContain(…)` proves that a glyph was emitted. A frame carries no color, thus an
+invisible span satisfies it identically to a correct one. A claim that a surface is
+*visible* must assert on the span color. `captureSpans()` exposes the resolved `fg`
+of each span (`theme_contrast.render.test.tsx`, `diff_contrast.render.test.tsx`).
+
+Relatedly, **give a fixture distinct values for the fields that a frame assertion
+could confuse**. `openable_card_block.render.test.tsx` asserts
+`toContain("Volcano plot")` against a fixture where that string is both the card
+title and the row name. Thus the assertion passed on the row, while the title
+rendered unpainted.
 
 ### Glyphs
 
-Every non-ASCII glyph the TUI prints comes from `GLYPHS` in `src/lib/design_system.ts`, just as colors go through `theme`. **Never inline a glyph literal in `src/tui/`.** Keys are named by shape (one glyph serves many roles). No emoji or Nerd-Font glyphs — they break the fixed-width gutter. Exempt: ASCII `>`/`<` markers and prose em dashes.
+Each non-ASCII glyph that the TUI prints comes from `GLYPHS` in
+`src/lib/design_system.ts`, exactly as each color goes through `theme`. **Never
+inline a glyph literal in `src/tui/`.** A key is named by shape, because one glyph
+serves many roles. There is no emoji and there is no Nerd-Font glyph, because they
+break the fixed-width gutter. The exempt items are the ASCII `>` and `<` markers,
+and an em dash in prose.
 
 ### Time rendering
 
-Match the readout to the record's permanence. Durable, referenced records (detail dialogs for profiles/runs, record listings, the completed-profile rail line) render absolute local timestamps via `toLocaleString()`. Live / ephemeral fixed-width readouts (sidebar session/run ages, elapsed indicators) render compact relative ages via `Date.relativeAge`. Durations render via `Date.formatDuration` — one vocabulary, never a hand-rolled `ms`/`s`/`m` formatter at the call site.
+Match the readout to the permanence of the record. A durable, referenced record
+renders an absolute local timestamp through `toLocaleString()`. Examples are the
+detail dialogs for a profile or a run, a record listing, and the completed-profile
+rail line. A live or ephemeral fixed-width readout renders a compact relative age
+through `Date.relativeAge`. Examples are a sidebar session age, a run age, and an
+elapsed indicator. A duration renders through `Date.formatDuration` — one
+vocabulary, and never a hand-rolled `ms`, `s`, or `m` formatter at the call site.
 
 ### Text emphasis
 
-The "Type & emphasis" scale (one typeface, one size; hierarchy by weight, dim, color) is exposed as composable inline **JSX components** in `src/tui/components/emphasis.tsx`. **In `src/tui/`, reach for those components — `<Bold>`, `<Italic>`, `<Underline>`, `<Dim>`, `<Reverse>`, `<Fg role={…}>` — never hand-compose opentui's `t`/`bold`/`dim`/`italic`/`underline`/`reverse`/`fg`/`bg` primitives at the call site.** Each emits an inline span, so they nest inside a `<text>` and sit beside each other freely. `emphasis.tsx` is the ONE place the low-level opentui styling (and the `style={{…}}` span escape hatch it requires) is allowed to live.
+The "Type and emphasis" scale is one typeface and one size, with the hierarchy from
+the weight, the dim, and the color. It is exposed as composable inline **JSX
+components** in `src/tui/components/emphasis.tsx`.
 
-**Emphasis → component** (one source: this table):
+**In `src/tui/`, reach for those components — `<Bold>`, `<Italic>`, `<Underline>`,
+`<Dim>`, `<Reverse>`, `<Fg role={…}>`. Never hand-compose the `t`, `bold`, `dim`,
+`italic`, `underline`, `reverse`, `fg`, and `bg` primitives of opentui at the call
+site.** Each component emits an inline span, thus they nest inside a `<text>` and
+sit beside each other freely. `emphasis.tsx` is the ONE place where the low-level
+opentui styling can live. It is also the one place for the `style={{…}}` span
+escape hatch that the styling wants.
+
+**Emphasis to component** (one source: this table):
 
 | component | use for |
 |-----------|---------|
@@ -331,24 +875,55 @@ The "Type & emphasis" scale (one typeface, one size; hierarchy by weight, dim, c
 | `<Reverse>` | selection / cursor row (inverse video) |
 | `<Fg role={…}>` | apply a color — `role` is a `ThemeColors` key, NEVER a hex. The only way to color inline text |
 
-**Only `<Fg>` and `<Reverse>` resolve a color; the rest carry none.** `<Bold>`/`<Italic>`/`<Underline>`/`<Dim>` emit an attribute-only span (`<b>`/`<i>`/`<u>`/`{ dim: true }`) and inherit whatever an ancestor resolved — so **none of them may be the outermost colored element**. This is the mechanism behind the italic/dim guidance above: `<Fg role="fgMuted"><Italic>…</Italic></Fg>` is needed not only so the meaning survives a terminal that drops the ITALIC bit, but because without the `<Fg>` — or an `fg` on the enclosing `<text>` — the text has no color at all and falls through to opentui's white default (see [Colors](#colors)). `<Reverse>` is self-sufficient: it paints both `fg` and `bg` itself.
+**Only `<Fg>` and `<Reverse>` resolve a color. The others carry none.** `<Bold>`,
+`<Italic>`, `<Underline>`, and `<Dim>` emit an attribute-only span (`<b>`, `<i>`,
+`<u>`, `{ dim: true }`), and they inherit whatever an ancestor resolved. Thus none
+of them can be the outermost colored element.
 
-**Composing:** nest to combine — `<Fg role="fgMuted"><Italic>{text}</Italic></Fg>`. For a single whole-line color, `<text fg={theme().role}>…</text>` is still fine (don't wrap one line in `<Fg>`); reach for the components when a line **mixes** colors/styles.
+This is the mechanism behind the italic and dim guidance above.
+`<Fg role="fgMuted"><Italic>…</Italic></Fg>` is necessary for two reasons. The
+meaning must survive a terminal that drops the ITALIC bit. Also, the text has no color at all without
+the `<Fg>`, or without an `fg` on the enclosing `<text>`. It then falls through to
+the white default of opentui (refer to [Colors](#colors)). `<Reverse>`
+is self-sufficient, because it paints both the `fg` and the `bg` itself.
 
-**Never** nest a block `<text>` inside a `<text>` (rejected as a text-node child at runtime). The emphasis components avoid this by emitting spans — if you need new raw inline styling, add it to `emphasis.tsx` (with the `style={{…}}` channel documented there), never at the call site.
+**How to compose:** nest to combine —
+`<Fg role="fgMuted"><Italic>{text}</Italic></Fg>`. For a single whole-line color,
+`<text fg={theme().role}>…</text>` is still correct. Do not wrap one line in
+`<Fg>`. Reach for the components when a line **mixes** colors or styles.
+
+**Never** nest a block `<text>` inside a `<text>`. The runtime rejects it as a
+text-node child. The emphasis components prevent this, because they emit spans. If
+you want new raw inline styling, add it to `emphasis.tsx`, with the `style={{…}}`
+channel documented there. Never add it at the call site.
 
 ## CLI reference docs
 
-`bun run docs:gen` (`scripts/gen_docs.ts`) walks the commander registry and emits the publishable CLI reference package to `dist-docs/` (untracked): SSG-neutral CommonMark pages + `manifest.json`. The contract lives in the `cli-reference-docs` spec; the release workflow regenerates the package at the tagged commit and attaches it to the GitHub release as `cli-docs.tar.gz` (consumed by the website). Invariants:
+`bun run docs:gen` (`scripts/gen_docs.ts`) walks the commander registry. It emits
+the publishable CLI reference package to `dist-docs/` (untracked): SSG-neutral
+CommonMark pages plus `manifest.json`. The contract is in the
+`cli-reference-docs` spec. The release workflow generates the package again at the
+tagged commit, and it attaches it to the GitHub release as `cli-docs.tar.gz`, which
+the website consumes. The invariants are:
 
-- **Never run the generator under `bun test`** — the registry imports `lib/env.ts`, whose data-loss guard throws in a test process without the sandbox marker. Run it as a plain `bun scripts/gen_docs.ts`; CI invokes it as a subprocess.
-- **Dev-channel commands are excluded by design**: the generator bakes a production build channel before importing the registry, so the docs describe exactly the release binary's surface.
-- **Every visible command, argument, and option needs a description** — generation (and the lint CI job that runs it) fails otherwise. Declare positionals via `.argument(name, description)`, never inline in the command string.
+- **Never run the generator under `bun test`.** The registry imports `lib/env.ts`,
+  whose data-loss guard throws in a test process that has no sandbox marker. Run it
+  as a plain `bun scripts/gen_docs.ts`. CI invokes it as a subprocess.
+- **A dev-channel command is excluded by design.** The generator bakes a production
+  build channel before it imports the registry. Thus the docs describe exactly the
+  surface of the release binary.
+- **Each visible command, argument, and option wants a description.** The
+  generation, and the lint CI job that runs it, fails without one. Declare a
+  positional through `.argument(name, description)`, never inline in the command
+  string.
 
 ## References
 
 - [`CONTEXT.md`](./CONTEXT.md) — the cli domain map.
-- [`openspec/specs/`](./openspec/specs/) — feature specs; the source of truth for cli's decisions.
-- [`openspec/changes/`](./openspec/changes/) — active + archived change proposals; cli's decision log (there is no `docs/adr`).
-- [`docs/`](./docs/) — supplementary developer notes (audits, dev guides).
-- [`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) — postmortems; read the relevant entry before working the same area.
+- [`openspec/specs/`](./openspec/specs/) — the feature specs, and the source of
+  truth for the decisions of cli.
+- [`openspec/changes/`](./openspec/changes/) — the active and archived change
+  proposals, and the decision log of cli. There is no `docs/adr`.
+- [`docs/`](./docs/) — supplementary developer notes: audits and dev guides.
+- [`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) — the postmortems. Read the
+  applicable entry before you work in the same area.

--- a/cli/CONTEXT.md
+++ b/cli/CONTEXT.md
@@ -1,32 +1,72 @@
 # Inflexa CLI — context
 
-The local-first host for the Inflexa product, and the **embedder** of `@inflexa-ai/harness`: it owns everything host-specific and wires the harness's capability seams to trivial local realizations. Detailed structure, the event-bus contract, and the TUI/opentui rules live in [`CLAUDE.md`](./CLAUDE.md); this file is the domain map.
+The local-first host for the Inflexa product, and the **embedder** of
+`@inflexa-ai/harness`. It has each host-specific part, and it connects the
+capability seams of the harness to simple local realizations. This file is the
+domain map. The structure, the event-bus contract, and the TUI and opentui rules
+are in [`CLAUDE.md`](./CLAUDE.md).
 
 ## Role
 
-`cli/` runs entirely on the user's machine. It presents the terminal UI, persists state to a local SQLite database, authenticates the user, manages the local model proxy, and invokes `harness` to plan and execute analyses inside the Docker sandbox. The harness stays host-agnostic; the CLI supplies the local seam realizations (local auth, filesystem artifact registry, no-op billing).
+`cli/` runs only on the machine of the user. It shows the terminal UI, stores the
+state in a local SQLite database, authenticates the user, and manages the local
+model proxy. It then uses `harness` to plan an analysis and to run it inside the
+Docker sandbox.
+
+The harness stays host-agnostic. The CLI gives the local seam realizations: the
+local authentication, the artifact registry on the file system, and the billing
+that does nothing.
 
 ## Feature slices (`src/modules/<domain>/`)
 
-Code is grouped by feature, not by layer — a module owns its logic, its text command actions, and its logic-local types.
+The code is in groups by feature, not by layer. A module has its logic, its text
+command actions, and its logic-local types.
 
-- **`auth/`** — Auth0 device flow + `login` / `logout` / `whoami`. Config seeded from `.env` (`INFLEXA_AUTH0_*`).
-- **`proxy/`** — the CLIProxyAPI model helpers (`models.ts`: client key discovery + default-model election — deterministic recency rank walked against the unbilled `count_tokens` accessibility check); the container lifecycle/provisioning lives in `infra/`.
-- **`analysis/`** — analysis lifecycle (creation, resolution, the chat-target launcher). Session identity is not here: a conversation lives only in the harness Postgres thread store.
-- **`anchor/`** — invisible folder-identity markers (`.inflexa/id`) and lazy path reconciliation.
-- **`harness/`** — the harness embedder: boots the harness runtime (DBOS, sandbox, providers) and drives the chat turn, the model-free `run --plan` replay engine, data profiling, and the provenance bridge.
-- **`embedding/`** — config-driven embedding-provider resolution + the in-process bge-small local model (download, verify, lifecycle).
-- **`infra/`** — the container stack: `setup` / `up` / `down` provisioning CLIProxyAPI + Postgres/pgvector via a generated Docker Compose file.
-- **`libs/`** — the published sandbox image variants (GHCR refs) + the `sandbox pull` / `status` actions.
-- **`project/`** — project CRUD command actions (`project new` / `project ls`).
-- **`prov/`** — the provenance recorder: a bus subscriber that builds, signs, and persists each analysis's PROV document, plus `prov export` / `prov verify`.
-- **`staging/`** — stages analysis input files under the analysis workspace's `data/` root with content hashes into the harness-compatible `StagedInput` manifest.
+- **`auth/`** — the Auth0 device flow, with `login`, `logout`, and `whoami`. The
+  configuration comes from `.env` (`INFLEXA_AUTH0_*`).
+- **`proxy/`** — the CLIProxyAPI model helpers. `models.ts` finds the client key
+  and elects the default model: it ranks the models by recency, then it tests
+  each one against the unbilled `count_tokens` accessibility check. The container
+  lifecycle and the provisioning are in `infra/`.
+- **`analysis/`** — the analysis lifecycle: the creation, the resolution, and the
+  chat-target launcher. The session identity is not here, because a conversation
+  is only in the Postgres thread store of the harness.
+- **`anchor/`** — the invisible folder-identity markers (`.inflexa/id`) and the
+  lazy reconciliation of the paths.
+- **`harness/`** — the harness embedder. It boots the harness runtime (DBOS, the
+  sandbox, and the providers), and it operates the chat turn, the model-free
+  `run --plan` replay engine, the data profiler, and the provenance bridge.
+- **`embedding/`** — the resolution of the embedding provider from the
+  configuration, and the in-process bge-small local model: the download, the
+  check, and the lifecycle.
+- **`infra/`** — the container stack. `setup`, `up`, and `down` provision
+  CLIProxyAPI and Postgres with pgvector, through a generated Docker Compose
+  file.
+- **`libs/`** — the published sandbox image variants (the GHCR refs), and the
+  `sandbox pull` and `status` actions.
+- **`project/`** — the project CRUD command actions (`project new` and
+  `project ls`).
+- **`prov/`** — the provenance recorder. It is a bus subscriber that builds,
+  signs, and stores the PROV document of each analysis. It also gives
+  `prov export` and `prov verify`.
+- **`staging/`** — it puts the analysis input files under the `data/` root of the
+  analysis workspace. It gives each file a content hash, and it writes the
+  `StagedInput` manifest that the harness accepts.
 
 ## Shared infrastructure
 
-- **`src/db/`** — the SQLite layer (connection, migrations, verb-split query/mutation, errors). The store is a file on the user's machine and may legitimately desync from on-disk markers — a miss heals or degrades, it never hard-fails.
-- **`src/tui/`** — the presentation layer: the Solid + opentui chat app, the keymap engine, the design system, and shared widgets. Presentation depends on logic; modules never import `tui/`.
-- **`src/lib/`** — non-domain infrastructure (`env`, `config`, `bus`, `log`, `otel`, `design_system`).
-- **`src/types/`** — shared persisted-entity shapes and the typed event contract.
+- **`src/db/`** — the SQLite layer: the connection, the migrations, the
+  verb-split query and mutation, and the errors. The store is a file on the
+  machine of the user, thus it can go out of agreement with the markers on disk.
+  A miss recovers or it degrades. It never fails hard.
+- **`src/tui/`** — the presentation layer: the Solid and opentui chat app, the
+  keymap engine, the design system, and the shared widgets. The presentation
+  depends on the logic, but a module never imports `tui/`.
+- **`src/lib/`** — non-domain infrastructure (`env`, `config`, `bus`, `log`,
+  `otel`, `design_system`).
+- **`src/types/`** — the shared shapes of the persisted entities, and the typed
+  event contract.
 
-See [`CLAUDE.md`](./CLAUDE.md) for the full project structure and coding conventions, and [`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) for postmortems to read before working in those areas.
+Refer to [`CLAUDE.md`](./CLAUDE.md) for the full project structure and the coding
+conventions. Refer to [`HORRIBLE_BUG_FIXES.md`](./HORRIBLE_BUG_FIXES.md) for the
+postmortems. Read the applicable postmortem before you work in that area.

--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -1,103 +1,196 @@
 # CLAUDE.md
 
-Guidance for Claude Code working with the Cortex **harness** package (`@inflexa-ai/harness`).
+Guidance for Claude Code that works with the Cortex **harness** package
+(`@inflexa-ai/harness`).
 
 ## Project Overview
 
-The harness is Cortex's **host-agnostic agent runtime**: a hand-rolled agent loop and execution boundary for long-running bioinformatics analysis. A single Conversation Agent handles all interactive work (data discovery, analysis planning, workflow triggering, result interpretation, hypothesis exploration), while compute-heavy work (R/Python) runs in isolated sandbox containers driven by DBOS-durable workflows.
+The harness is the **host-agnostic agent runtime** of Cortex. It is a hand-rolled
+agent loop and an execution boundary for long-running bioinformatics analysis. One
+Conversation Agent handles each interactive task: data discovery, analysis
+planning, workflow triggers, result interpretation, and hypothesis exploration.
+Compute-heavy work in R and Python runs in isolated sandbox containers, and
+DBOS-durable workflows operate them.
 
-The harness ships everything that does not depend on a particular host: the loop, the two provider interfaces, `defineTool`, the dependency-injection composition pattern, the session value objects, the sandbox submit/recv protocol, memory, storage layout, and the six capability **seams** the harness declares (plus the shared `RunLauncher` seam). Embedders provide their own composition root and may swap the local seam realizations for host-specific ones.
+The harness ships each part that does not depend on a particular host. Those parts
+are:
 
-Source lives under `harness/src/...`; this doc uses those paths.
+- the loop
+- the two provider interfaces
+- `defineTool`
+- the dependency-injection composition pattern
+- the session value objects
+- the sandbox submit and recv protocol
+- the memory
+- the storage layout
+- the six capability **seams** that the harness declares, plus the shared
+  `RunLauncher` seam.
 
-Design decisions are recorded in the OpenSpec specs (`openspec/specs/`), the single source of truth — there is no `docs/adr`. Make spec changes via the openspec CLI from this directory (`cd harness && openspec ...`).
+An embedder gives its own composition root. It can also swap a local seam
+realization for a host-specific one.
+
+The source is under `harness/src/...`, and this document uses those paths.
+
+The OpenSpec specs (`openspec/specs/`) record the design decisions, and they are
+the source of truth. There is no `docs/adr`. Make a spec change with the openspec
+CLI from this directory (`cd harness && openspec ...`).
 
 ### Public interface
 
-`harness/src/index.ts` is the curated front door: it re-exports the embedder-facing surface only — `assembleCoreRuntime`, `createConversationAgent`, the six capability seams + their local adapters (`RunAuthorizer`/`createLocalRunAuthorizer`, `ResolveBilling`/`createNoopBillingResolver`, `ArtifactRegistry`/`createNoopArtifactRegistry`, `RunCharge`/`createNoopRunCharge`, `UsageRecorder`/`createNoopUsageRecorder`, `PreviewPublisher`/`UnavailablePreviewPublisher`), `RunLauncher`/`createDbosRunLauncher`, the `Logger` seam + its realizations (`createConsoleLogger`/`createNoopLogger`/`defaultErrorFields`), `defineTool`, `runAgent`, and the loop/session/provider public types. Prefer importing from `@inflexa-ai/harness` (the bare specifier resolves to this barrel). Every deep subpath (`@inflexa-ai/harness/...`) stays importable for internal wiring; the barrel is additive, not a wall.
+`harness/src/index.ts` is the curated front door. It re-exports only the surface
+that an embedder faces:
 
-`harness/package.json` is the package manifest: it declares the name `@inflexa-ai/harness`, `type: "module"`, the `exports` map (`.` → `dist/index.js`; `./*` and `./*.js` → `dist/*.js` — the extensioned pattern exists because harness-internal self-imports and consumers alike may write `.js`-suffixed deep specifiers, and a lone `./*` would capture the extension into `*` and resolve them to `dist/*.js.js`), and the `tsc -p tsconfig.json` build that emits `dist/`. At publish time consumers resolve the public surface through that `exports` map. During in-repo development the bare and deep specifiers (`@inflexa-ai/harness`, `@inflexa-ai/harness/*`) resolve through `harness/tsconfig.json`'s `paths` map (bare → `src/index.ts`, `/*` → `src/*`). The manifest declares its own `dependencies`, so the harness's third-party packages resolve from its own install — it is a standalone package, not a workspace member.
+- `assembleCoreRuntime` and `createConversationAgent`
+- the six capability seams and their local adapters:
+  `RunAuthorizer`/`createLocalRunAuthorizer`, `ResolveBilling`/`createNoopBillingResolver`,
+  `ArtifactRegistry`/`createNoopArtifactRegistry`, `RunCharge`/`createNoopRunCharge`,
+  `UsageRecorder`/`createNoopUsageRecorder`, `PreviewPublisher`/`UnavailablePreviewPublisher`
+- `RunLauncher`/`createDbosRunLauncher`
+- the `Logger` seam and its realizations (`createConsoleLogger`,
+  `createNoopLogger`, `defaultErrorFields`)
+- `defineTool` and `runAgent`
+- the public types of the loop, the session, and the provider.
+
+Prefer an import from `@inflexa-ai/harness`, because the bare specifier resolves to
+this barrel. Each deep subpath (`@inflexa-ai/harness/...`) stays importable for
+internal wiring. The barrel is additive, not a wall.
+
+`harness/package.json` is the package manifest. It declares the name
+`@inflexa-ai/harness` and `type: "module"`. It declares the `exports` map: `.` goes
+to `dist/index.js`, and `./*` and `./*.js` go to `dist/*.js`.
+
+The pattern with the extension exists because a harness-internal self-import and a
+consumer alike can write a deep specifier with a `.js` suffix. A lone `./*` would
+capture the extension into `*` and resolve them to `dist/*.js.js`. The manifest
+also declares the `tsc -p tsconfig.json` build that emits `dist/`.
+
+At publish time a consumer resolves the public surface through that `exports` map.
+During in-repo development the bare and deep specifiers (`@inflexa-ai/harness`,
+`@inflexa-ai/harness/*`) resolve through the `paths` map of
+`harness/tsconfig.json`: bare goes to `src/index.ts`, and `/*` goes to `src/*`. The
+manifest declares its own `dependencies`, thus the third-party packages of the
+harness resolve from its own install. It is a standalone package, not a workspace
+member.
 
 ## Commands
 
-`@inflexa-ai/harness` is a library; there is no server entry point or task runner here.
+`@inflexa-ai/harness` is a library. There is no server entry point and no task
+runner here.
 
 ```bash
 tsc -p tsconfig.json    # Build: emit dist/ from src/ (also `npm run build`)
 bun test                # Unit tests only — DB/DBOS suites need Postgres (see Testing notes)
 ```
 
-**Runtime**: Node.js. Bun is used only for testing (`bun test`).
+**Runtime**: Node.js. Bun is only for the tests (`bun test`).
 
-**Composition**: `assembleCoreRuntime` is the single host-neutral assembly point — it registers the durable workflows with DBOS and builds the conversation agent over the registered callables. The local, dependency-free seam realizations (`createLocalRunAuthorizer`, `createNoopBillingResolver`, `createNoopRunCharge`, `createNoopUsageRecorder`, `createNoopArtifactRegistry`, `UnavailablePreviewPublisher`, `makeLocalAuth`) are exported from `index.ts`; an embedder constructs them (or its own realizations) and passes them into `assembleCoreRuntime` at its composition root. The local sandbox path creates ephemeral Docker containers per analysis step; session data, lib store, and ref store are host directories bind-mounted into them.
+**Composition**: `assembleCoreRuntime` is the single host-neutral assembly point.
+It registers the durable workflows with DBOS, and it builds the conversation agent
+over the registered callables. The local seam realizations have no dependencies,
+and `index.ts` exports them: `createLocalRunAuthorizer`,
+`createNoopBillingResolver`, `createNoopRunCharge`, `createNoopUsageRecorder`,
+`createNoopArtifactRegistry`, `UnavailablePreviewPublisher`, and `makeLocalAuth`.
+An embedder constructs them, or its own realizations, and passes them into
+`assembleCoreRuntime` at its composition root. The local sandbox path makes an
+ephemeral Docker container for each analysis step. The session data, the lib store,
+and the ref store are host directories, bind-mounted into them.
 
-**LLM backend** is whatever the wired `ChatProvider`/`EmbeddingProvider` points at — an embedder supplies an AI SDK `LanguageModel` instance or endpoint/key/model configuration (Anthropic or OpenAI-compatible). The local billing seam is a no-op (`createNoopBillingResolver`), so no attribution headers are added.
+**LLM backend** is whatever the wired `ChatProvider` and `EmbeddingProvider` point
+at. An embedder supplies an AI SDK `LanguageModel` instance, or an endpoint, key,
+and model configuration (Anthropic or OpenAI-compatible). The local billing seam
+does nothing (`createNoopBillingResolver`), thus no attribution header is added.
 
-The sandbox client includes Docker and Kubernetes backends. The `SANDBOX_BACKEND` value (`docker` | `k8s`) selects the backend the composition root wires.
+The sandbox client includes a Docker backend and a Kubernetes backend. The
+`SANDBOX_BACKEND` value (`docker` or `k8s`) selects the backend that the
+composition root wires.
 
 **After a big change**, run `tsc -p tsconfig.json` and `bun test`.
 
 ## Formatting
 
-**After editing source files in `src/`, run `bun run format:file <paths>` on the specific files you changed before reporting the task as complete.** Only format files inside `src/` — never format markdown, config, or spec files. Use `bun run format` for full-project formatting.
+**After you edit a source file in `src/`, run `bun run format:file <paths>` on the
+files that you changed.** Do this before you report the task as complete. Format
+only a file inside `src/`. Never format a markdown file, a config file, or a spec
+file. Use `bun run format` for the format of the full project.
 
 ## Architecture
 
-**Core Philosophy**: The harness owns the agent loop and the execution boundary. Chat is regular HTTP; durable operations are DBOS workflows. The same `runAgent` primitive runs in both. Operative architectural decisions live in [`CONTEXT.md`](CONTEXT.md) and the OpenSpec specs ([`openspec/specs/`](openspec/specs/)).
+**Core Philosophy**: The harness has the agent loop and the execution boundary.
+Chat is regular HTTP. A durable operation is a DBOS workflow. The same `runAgent`
+primitive runs in both. The operative architectural decisions are in
+[`CONTEXT.md`](CONTEXT.md) and in the OpenSpec specs
+([`openspec/specs/`](openspec/specs/)).
 
 ### Two-Layer Architecture
 
-- **Conversation Layer** — chat is regular HTTP, single-replica per turn ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). The Conversation Agent handles all interactive work: data discovery, analysis planning (via the `generatePlan` tool), workflow triggering, result interpretation, and hypothesis exploration. Has bio-lookup tools, workspace search, run event queries, `inspectDataProfile`, `generatePlan` + `executePlan`, and `showUser`. No sandbox access from the chat route; sandbox work happens inside workflows.
-- **Workflow Layer** — DBOS-durable. `executeAnalysis`, `executeTargetAssessment`, `runEphemeral` (when long-running), and the background `runDataProfile` run as DBOS workflows. Reports render in-process via `iterate_report`, not as a DBOS workflow. Streaming events flow back to the UI via the single DBOS-backed run-event stream.
+Chat is regular HTTP, with one replica for each turn. A durable operation is a
+DBOS workflow. The layer model is in [`CONTEXT.md`](CONTEXT.md), under
+`Workflow scope`.
+
+**There is no sandbox access from the chat route.** Sandbox work happens inside a
+workflow.
 
 ### Design Principles
 
-1. **Hand-rolled `runAgent` loop, ~230 LOC.** `loop/run-agent.ts`. Pure async TypeScript that owns the message loop and nothing else. Durability (`runStep`) and the event sink (`emit`) are injected — the loop runs identically in a host request path (passthrough step) and inside DBOS workflow steps (`DBOS.runStep` wrapper). Same body, two execution modes.
-2. **AI SDK `ModelMessage` is the harness lingua franca** ([harness-providers](openspec/specs/harness-providers/spec.md)). The loop's working message array is AI SDK `ModelMessage`; thread history stores each one in a versioned envelope (`{kind: "ai-sdk-model-message", aiSdkMajor, message}`). Signed provider metadata (Anthropic thinking signatures, cache control) rides provider-scoped in `providerOptions` and round-trips through storage.
-3. **Two narrow provider interfaces** in `providers/types.ts`:
-   - `ChatProvider.chat(req, session, signal?) → ResultAsync<ChatResponse, ProviderError>` — non-streaming; cacheable as a DBOS step.
-   - `ChatProvider.chatStream(req, session, signal?) → AsyncIterable<ChatStreamEvent>` — text deltas then one terminal `done` event; for the chat loop.
-   - `EmbeddingProvider.embed(texts, session) → ResultAsync<number[][], ProviderError>`.
-   Every method takes `session`. You cannot make a wire call without a session; billing headers (if any) are resolved internally through the `ResolveBilling` seam — the OSS default returns none. Providers advertise `capabilities.toolCalling`; `runAgent` rejects a tool-requiring agent before the first model call when the model can't do mature tool calling.
-4. **`defineTool` is the tool primitive.** `defineTool({id, description, inputSchema: ZodSchema, execute(input, ctx) => result, executionMode?})`. `ctx` is `ToolContext = {session, signal, emit, runStep}` — no injected dependencies. Dep-bearing tools are factory closures (`createXTool(deps)`) that capture deps and call `defineTool`. Zod 4's `z.toJSONSchema()` emits the AI SDK-compatible tool input schema (top-level object only — unions are rejected at construction). Every tool declares or defaults to an execution mode: `step` (deterministic durable-step wrap — the default), `workflow` (body-only/multi-operation durable tools: `execute_command`, `write_file`, `edit_file`), or `inline` (pure logic only). See `tools/define-tool.ts`.
-5. **Tool error contract.** Expected outcomes (incl. "not found") return as data variants of the result type; unexpected failures throw or return `err(ToolError)` → the loop maps them to model-visible error tool results. Zod input-validation failure → error tool result at the boundary, without calling `execute`. Errors matched by the injected fatal predicate (cancellation, workflow-fatal failures) propagate out of the loop instead.
-6. **Dependency injection at the composition root** ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). Construction-time deps (`Pool`, `ChatProvider`, `EmbeddingProvider`, `Logger`, sandbox factories, seam implementations) are injected when a module is built. Call-time values (`Session`, `AbortSignal`, `EmitFn`) are passed as explicit parameters. Modules are factory closures: `createX(deps) => {op1, op2}`. No classes, no god-ctx, no ALS, no magic-key bag. Tools are exploded apart inside `createConversationAgent(deps)` (`agents/conversation-agent.ts`).
-7. **Diagnostics go through the injected `Logger`, never `console`** ([structured-logging](openspec/specs/structured-logging/spec.md)). `lib/logger.ts` declares the shape; the harness names no logging library, because it is published and must not push one onto consumers. Message-first (`error(msg, fields?)` — the `slog`/winston/`console` order, deliberately not pino's object-first), with `with(fields)` for context, `named(name)` for the `[a.b]` module prefix, and `errorFields(err)` — on the interface so a realization can defer to its sink's native error handling (pino's `err` serializer, OTel's `exception.*`) instead of the shipped `defaultErrorFields`. Identifiers ride as structured fields, never interpolated into the message — including "which stage failed", which rides as a `named(...)` namespace rather than prose. `bootHarness` **requires** a `logger` (booting is the one place the embedder should consciously decide where diagnostics go); every deps bag below it takes `logger?` and resolves `?? createNoopLogger()` once per entry point, so internal call sites never thread `?.`. The fallback is never console, which a host whose UI owns stdout would discard — that silent loss is why the ban exists, and `no-console` in `eslint.config.js` enforces it (exempting `lib/console-logger.ts` by path, not by inline disable).
-8. **Sub-agents are regular tools.** No special delegation primitive, no message stripping. A child agent is exposed as a tool whose `execute` calls `runAgent(subAgent, prompt, forSubAgent(ctx.session, childAgentId))`. The child's `callPath` extends the parent's. Sub-agent transcripts are ephemeral. Examples: `literature-reviewer`, `analogical-reasoner`.
-9. **No agent framework, no processor pipeline.** SOUL kernel/conversational personality lives as static `systemPrompt` composition in the agent definition. Input sanitization (`normalizeUnicode`, trimmed `redactSecrets`) is two functions applied once in the chat route. Analysis context is injected at chat-route message assembly time.
-10. **Static, dependency-gated, budget-admitted workflows** ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md), [resource-budgeted-scheduling](openspec/specs/resource-budgeted-scheduling/spec.md)). `executeAnalysis` is a DBOS parent workflow that starts a child workflow per sandbox-agent step once all its `depends_on` steps have completed and — when the embedder configures a machine resource budget — the declared resources of concurrently running steps leave room for it (held steps surface as `queued` on the dag-state part). No wave batching; no budget means every dependency-satisfied step starts immediately. Fail-fast: the first step failure cancels in-flight siblings.
-11. **Self-contained step bodies.** Each child workflow runs the sandbox agent, generates file metadata, summarizes, registers artifacts, and indexes — all inside the same DBOS workflow body. Synthesis (cross-step literature-grounded aggregation) is the parent's final step.
-12. **Single DBOS-backed run-event stream per workflow.** Live consumers and historical replay read the same source. All events persisted; reconciling events folded latest-wins by `id` on read. Consumers read Cortex-native typed parts directly — no AI SDK format mapping.
+The loop, the providers, `defineTool`, the dependency injection, and the stream
+model are in [`CONTEXT.md`](CONTEXT.md), under `Loop primitives`,
+`Dependency injection`, and `Stream model`. Read that before you change any of
+them. These two rules bind the code, and `CONTEXT.md` does not carry them:
 
-### Session model — `RequestSession` vs `RunSession`
+1. **Diagnostics go through the injected `Logger`, never through `console`**
+   ([structured-logging](openspec/specs/structured-logging/spec.md)).
+   `lib/logger.ts` declares the shape. The harness names no logging library,
+   because it is published and it must not push one onto a consumer. The shape is
+   message-first (`error(msg, fields?)`), which is the order of `slog`, winston,
+   and `console`, and it is deliberately not the object-first order of pino. It
+   has `with(fields)` for context, `named(name)` for the `[a.b]` module prefix,
+   and `errorFields(err)`.
 
-Per-request identity decomposes into immutable value objects (see `auth/types.ts`):
+   `errorFields` is on the interface for a reason. A realization can then defer to
+   the native error handling of its sink, instead of the shipped
+   `defaultErrorFields`. Examples are the `err` serializer of pino and the
+   `exception.*` of OTel.
 
-- `Identity` — `{ user }`, always complete.
-- `Scope` — discriminated union: `{ kind: "analysis"; analysisId; threadId? }` or `{ kind: "target-assessment"; targetAssessmentId; billingContextId }`.
-- `Credential` — an **opaque brand** the harness never inspects. The harness only forwards it; the concrete credential shape is defined by whatever wraps the harness.
-- `AuthContext` — the **opaque inward auth capability** every session carries (the `auth` field) and the SOLE source of credential/org behind a session. The harness forwards it but never reads it; an embedder downcasts it to its own concrete type at its adapters. The OSS build supplies a trivial empty `auth` (`makeLocalAuth`, `auth/local-auth-context.ts`). There is no top-level `orgId`/`credential` field (serialization cutover — [harness-session-model](openspec/specs/harness-session-model/spec.md)).
-- `Provenance` — `{ agentId; callPath }`. Read-only — code MUST NOT branch on `callPath`.
-- `RunFrame` — `{ runId; stepId? }`, present only inside a workflow run.
+   An identifier rides as a structured field, and it is never interpolated into
+   the message. This includes "which stage failed", which rides as a `named(...)`
+   namespace and not as prose. `bootHarness` **requires** a `logger`, because
+   booting is the one place where the embedder must consciously decide where the
+   diagnostics go. Each deps bag below it takes `logger?` and resolves
+   `?? createNoopLogger()` one time for each entry point, thus an internal call
+   site never threads `?.`. The fallback is never console, which a host with a UI
+   that has stdout would discard. That silent loss is the reason for the ban, and
+   `no-console` in `eslint.config.js` enforces it. It exempts
+   `lib/console-logger.ts` by path, not by an inline disable.
+2. **Keep a step body self-contained.** Each child workflow runs the sandbox
+   agent, generates the file metadata, summarizes, registers the artifacts, and
+   indexes. All of that stays inside the same DBOS workflow body. The synthesis,
+   which is a cross-step literature-grounded aggregation, is the final step of the
+   parent.
 
-Two bundles compose these with honest lifetimes:
+### Session model
 
-- `RequestSession` — live HTTP door; no `RunFrame`. MUST NOT be JSON-serialized into durable state.
-- `RunSession` — durable + JSON-serializable; carries a `RunFrame`. Constructed solely at the run-authorization **seam**, `RunAuthorizer.authorize(...)` (`execution/run-authorizer.ts`). The OSS impl (`auth/local-run-authorizer.ts`) issues a `RunSession` with no remote mint, no jti, no revoke; an embedder may supply a realization that mints a scoped credential at the async edge. The resulting bundle rides in DBOS workflow input. Async/durable APIs accept only `RunSession`, so starting async work without authorizing a run is unrepresentable. See [harness-session-model](openspec/specs/harness-session-model/spec.md).
+The value objects, the two bundles, and their lifetimes are in
+[`CONTEXT.md`](CONTEXT.md), under `Session model`, and in `src/auth/types.ts`.
+Three rules bind the code:
 
-Both bundles satisfy the structural type `AgentSession` consumed by the loop and providers. Neither bundle carries resolved billing headers — billing is resolved lazily at the LLM/embedding call site via the `ResolveBilling` seam.
+- **`RequestSession` MUST NOT be JSON-serialized into durable state.**
+- **`RunAuthorizer.authorize(...)` (`execution/run-authorizer.ts`) is the sole
+  constructor of a `RunSession`.** An async or durable API accepts only a
+  `RunSession`, thus async work that starts without an authorized run is
+  unrepresentable.
+- **Code MUST NOT branch on `callPath`, and it MUST NOT read the `auth`
+  capability.** The harness forwards `auth` untouched. An embedder downcasts it at
+  its own adapters.
 
 ### Capability Seams
 
-The harness declares six external seams as interfaces and ships trivial OSS realizations; an embedder may swap in cloud-backed ones. The harness's code only ever sees the interface.
+The harness declares each external seam as an interface, and it ships a trivial
+OSS realization. An embedder binds one at its composition root. **The code of the
+harness only ever sees the interface, and it never branches on which realization
+is bound.**
 
-- **`RunAuthorizer`** (`execution/run-authorizer.ts`) — the only constructor of a `RunSession`. OSS: `auth/local-run-authorizer.ts` (no remote mint, no revoke).
-- **`ResolveBilling`** (`billing/resolver.ts`) — resolves attribution headers at the wire-call site. OSS: `billing/noop-resolver.ts` (empty headers).
-- **`ArtifactRegistry`** (`execution/artifact-registry.ts`) — records + syncs produced artifacts (`register(input, session)` + `sync(input, session)`, session-scoped). OSS: `createNoopArtifactRegistry` (registers nothing externally — the harness writes the local `cortex_artifacts` ledger itself around the seam; `sync` no-op).
-- **`RunCharge`** (`billing/run-charge.ts`) — run-level billing bracket (`open`/`close`) around `executeAnalysis`. OSS: `createNoopRunCharge`.
-- **`UsageRecorder`** (`billing/usage-recorder.ts`) — per-call LLM token accounting; `record` is fire-and-forget and must not throw or block. OSS: `billing/noop-usage-recorder.ts` (`createNoopUsageRecorder`, drops every record).
-- **`PreviewPublisher`** (`tools/report/preview-publisher.ts`) — publishes report previews. OSS: `UnavailablePreviewPublisher`.
-- **`RunLauncher`** (`execution/run-launcher.ts`) — starts a registered workflow under a caller-chosen id (fire-and-forget `launch` / inline `launchAndAwait`). The DBOS-quarantine seam: tools and the loop never import the durability engine — `execute_plan` / `run_ephemeral` launch through this. Single shared realization `createDbosRunLauncher` (`execution/dbos-run-launcher.ts`).
+Each seam, its path, and its OSS realization are in [`CONTEXT.md`](CONTEXT.md),
+under `The six seams`.
 
 ### Sandbox Architecture
 
@@ -131,42 +224,119 @@ Harness host process
   +- Container removed on completion
 ```
 
-The submit + result protocol ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)) is what makes long sandbox runs survive host restarts: the sandbox worker keeps running separately, and the host retrieves its result by one of two transports selected by `SandboxTransport` (`poll` | `callback`), chosen by the embedder at its composition root and carried to the container as `SANDBOX_TRANSPORT`. The OSS/CLI default is `poll`.
+The submit and result protocol
+([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)) is what lets
+a long sandbox run survive a host restart. The sandbox worker keeps running
+separately, and the host gets its result through one of two transports.
+`SandboxTransport` (`poll` or `callback`) selects the transport. The embedder
+chooses it at its composition root, and it goes to the container as
+`SANDBOX_TRANSPORT`. The default of the OSS build and the CLI is `poll`.
 
-**Poll (default): the host asks; the sandbox initiates nothing.** sandbox-server buffers progress events in a bounded ring and serves a signed `GET /exec/{execId}?since={cursor}` → `{ status, events[], cursor, result? }`. `awaitExec` is a durable poll loop (unique per-attempt step names `sandbox.poll-exec-result.${execId}.${n}`, no `DBOS.recv`, no per-exec topic) that verifies each body against the per-sandbox HMAC, forwards new events, and returns on the terminal `result`. Because the sandbox never dials out, there is no host ingress to be unreachable (closes #27) and a restarted host simply resumes polling from its current identity (closes #41).
+The two transports, the in-container egress firewall of poll mode, and the two
+distinct lifetimes (an exec command against a sandbox machine) are in
+[`CONTEXT.md`](CONTEXT.md) — the `Transport (SandboxTransport)` glossary entry and
+`Sandbox exec`. **Do not conflate the two lifetimes.**
 
-**Callback (opt-in): the sandbox pushes.** sandbox-server POSTs signed event/completion callbacks to `CORTEX_BASE_URL`; the embedder runs the ingress and `awaitExec` uses the `DBOS.recv` loop, with `GET /exec/{execId}` as its recovery backstop for a push that never lands. Every signature (pushed retry or served response) is minted at send time, because the host rejects a stale timestamp as a **hard cancel**, not a retryable condition.
+**A single base image**: one `sandbox-base` image for each sandbox agent. It has
+the R, Python, and Node.js runtimes and the system libraries. No R package and no
+Python package is baked in. The packages are in the shared library store, mounted
+read-only at `/mnt/libs`.
 
-**On Docker, poll mode confines the sandbox with an in-container egress firewall.** The container joins the default bridge with its exec port published to `127.0.0.1` only; a root entrypoint holding `CAP_NET_ADMIN` installs `iptables -P OUTPUT DROP` (allowing loopback and established return traffic) and then `setpriv`-drops to the uid-1000 workload, which can neither reach the network nor flush the rules. The host's inbound poll rides the established path, so polling works with egress hard-blocked. There is **no gateway sidecar and no `--internal` network**: two transports removed the contradiction — carry a callback *and* block egress — that the gateway existed to reconcile. Callback mode permits egress; K8s uses a NetworkPolicy.
+**sandbox-server**: a statically-linked Go binary at
+`images/sandbox-base/server/`. Its endpoints are:
 
-**Two distinct lifetimes** (do not conflate):
+- `GET /health` — unauthenticated.
+- `POST /exec` — an idempotency-keyed submit.
+- `GET /exec/{execId}` — the terminal result, signed fresh at request time. With
+  `?since={cursor}` in poll mode it gives `{ status, events[], cursor, result? }`,
+  always signed.
 
-- **Exec command** — one `submit → recv result`. Many per sandbox; most are near-instant. `execId = "${workflowId}:${stepId}:${functionId}"`. Bounded by `step.timeout`. **No per-exec heartbeats.**
-- **Sandbox machine** — one per step, long-lived; the sandbox-agent loop issues many commands into the same container. Liveness is checked at a per-sandbox-machine cadence by a `@DBOS.scheduled` workflow (`SandboxClient.isAlive(sandboxRef)`); dead + no completion recorded → synthetic failure-`complete` unblocks the recv (callback mode). In poll mode the await loop fail-fasts itself: sustained `unavailable` polls escalate to a durable `isAlive` probe (`sandbox/liveness.ts`) and a dead machine returns the synthetic failure in-loop.
+The two exec endpoints are **signature-authenticated inbound** in the two
+transport modes. The caller signs each request with the per-sandbox secret, over
+the same HMAC construction as the served or pushed bodies. It is a request
+signature, not a bearer, thus a cleartext hop can drop a request but it can never
+mint one. An unsigned, forged, or stale request gives a `401`. This confines the
+siblings: a sandbox that holds only its own secret cannot operate the `/exec` of a
+different one. There is no `kill` route. `SANDBOX_TRANSPORT` selects poll (the
+default, with no outbound, which serves the ring and the result) or callback (which
+POSTs to `CORTEX_BASE_URL`).
 
-**Single base image**: One `sandbox-base` image for all sandbox agents. R, Python, Node.js runtimes + system libraries; no R/Python packages baked in. Packages live in the shared library store mounted read-only at `/mnt/libs`.
+**Workspace storage**: the data and the artifacts of each analysis are in the
+workspace tree of the analysis. The tree is rooted at the workspace root that the
+embedder resolves — refer to Storage Layout. Each sandbox container gets a **flat
+read-only mount** of the full analysis tree at `/{resourceId}`. It also gets a
+**nested read-write mount** at `/{resourceId}/runs/{runId}/{stepId}` for the
+artifacts of the step. The workspace tools enforce the write restriction with
+`allowedWritePrefix`.
 
-**sandbox-server**: Statically-linked Go binary at `images/sandbox-base/server/`. Endpoints: `GET /health` (unauthenticated), `POST /exec` (idempotency-keyed submit), `GET /exec/{execId}` (terminal result, signed fresh at request time; with `?since={cursor}` in poll mode it returns `{ status, events[], cursor, result? }`, always signed). The two exec endpoints are **signature-authenticated inbound** in both transport modes — the caller signs each request with the per-sandbox secret over the same HMAC construction as the served/pushed bodies (a request signature, not a bearer, so any cleartext hop can drop a request but never mint one); an unsigned, forged, or stale request is a `401`. This confines siblings: a sandbox holding only its own secret cannot drive another's `/exec`. There is no `kill` route. `SANDBOX_TRANSPORT` selects poll (default; no outbound, serves the ring + result) or callback (POSTs to `CORTEX_BASE_URL`).
+**Auth and attribution.** These are the seams of the harness. The concrete policy
+is an embedder concern.
 
-**Workspace storage**: Per-analysis data and artifacts live in the analysis's workspace tree (rooted at the embedder-resolved workspace root — see Storage Layout). Each sandbox container gets a **flat read-only mount** of the full analysis tree at `/{resourceId}`, with a **nested read-write mount** at `/{resourceId}/runs/{runId}/{stepId}` for the step's artifacts. Workspace tools enforce write restriction via `allowedWritePrefix`.
-
-**Auth and attribution** (the harness's seams; concrete policy is an embedder concern):
-- **Inbound** — the harness consumes a session built upstream from whatever auth the host runs at its edge; it sees only the opaque `auth` capability (local: `makeLocalAuth`). Per-route authorization is a host concern, not a harness seam.
-- **Async** — workflow steps that outlive the originating HTTP request ride the `RunSession` minted at the `RunAuthorizer` seam. The credential (if any) rides opaque inside the `RunSession` in DBOS workflow input; workflow bodies never re-mint and never read it back from the DB.
-- **Outbound to sandbox-server** — Idempotent submit. Sandbox callbacks are HMAC-verified at recv ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)).
+- **Inbound** — the harness consumes a session that is built upstream, from
+  whatever auth the host runs at its edge. It sees only the opaque `auth`
+  capability (local: `makeLocalAuth`). Per-route authorization is a host concern,
+  not a harness seam.
+- **Async** — a workflow step that outlives the originating HTTP request rides the
+  `RunSession` that the `RunAuthorizer` seam minted. The credential, if there is
+  one, rides opaque inside the `RunSession` in the DBOS workflow input. A workflow
+  body never mints it again, and it never reads it back from the DB.
+- **Outbound to sandbox-server** — an idempotent submit. A sandbox callback is
+  HMAC-verified at recv
+  ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)).
 
 ### Key Components
 
-- **Conversation Agent** (`agents/conversation-agent.ts`): Single user-facing agent. Has bio-lookup tools, workspace search, `inspectRun`, `inspectDataProfile`, `updateWorkingMemory`, `generatePlan`, `executePlan`, `runEphemeral`, `iterateReport`, `generateAnalogyReport`, and `showUser`. `createConversationAgent(deps)` is the composition root that wires every tool's deps.
-- **Literature Reviewer** (`tools/research/literature-reviewer.ts`): Sub-agent exposed as a tool. Receives a research brief, investigates with bio-lookup tools, returns a structured evidence report.
-- **`generatePlan` Tool** (`tools/research/generate-plan.ts`): Internal-LLM tool. Captures the planner outcome via closure-state (`PlannerOutcome`); the planning prompt lives in `prompts/` with an `{{AGENT_CATALOG}}` placeholder populated from sandbox-agent metadata.
-- **`executeAnalysis` Workflow** (`workflows/execute-analysis.ts` + scheduler in `execute-analysis-scheduler.ts`): Validates the plan, gates steps on dependencies, starts one child workflow per step. Per child: sandbox-agent loop → `generateFileMetadata` → `generateStepSummary` → register artifacts (via `ArtifactRegistry`) → index in vector store. Parent's final step is literature-grounded synthesis.
-- **Chat turn** (`app/chat-turn.ts`): The preparation half of one turn only — `prepareChatTurn` resolves thread ownership, seeds the title, loads analysis status, and assembles the message array. It owns none of the transport: the caller runs `runAgent` with its own `emit`, then persists the turn via `appendTurn` (`memory/thread-history.ts`). A turn is `prepareChatTurn → runAgent → appendTurn`. The host wraps this in its own request handler — the harness ships no HTTP route layer.
-- **Run-event stream**: A single DBOS-backed stream per workflow, produced inside the workflow bodies and consumed by readers of the harness's typed run-event parts (`harness/src/contracts/`). No standalone route file in the harness.
-- **Workspace** (`workspace/`): Read surface (`read_file`, `grep`, semantic search) is sandbox-independent and available to the conversation agent. Mutate surface (`write_file`, `edit_file`, `execute_command`) is sandbox-gated.
-- **Composition root** (`runtime/assemble.ts`): `assembleCoreRuntime` is the host-neutral assembly point — it registers the durable workflows and builds the conversation agent over them. The local seam realizations it can be wired with (`auth/local-run-authorizer.ts`, `auth/local-auth-context.ts`, `billing/noop-resolver.ts`, `billing/noop-run-charge.ts`, `execution/noop-artifact-registry.ts`, `tools/report/preview-publisher.ts`'s `UnavailablePreviewPublisher`) carry zero cloud deps and are re-exported from `index.ts`. See [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
-- **Workflow recovery** ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)): no standing component. Each host supplies a stable `executorID`; when that identity launches again, DBOS can reclaim in-flight workflows its predecessor left behind. The harness does not expose an HTTP recovery route.
-- **Shared contracts** (`harness/src/contracts/`): the Cortex-native chat-stream event + data-part types (`CortexChatEvent`, `CortexChatPart`, the part registry), exported from `@inflexa-ai/harness` for consumers rendering the stream.
+- **Conversation Agent** (`agents/conversation-agent.ts`): the single user-facing
+  agent. It has the bio-lookup tools, the workspace search, `inspectRun`,
+  `inspectDataProfile`, `updateWorkingMemory`, `generatePlan`, `executePlan`,
+  `runEphemeral`, `iterateReport`, `generateAnalogyReport`, and `showUser`.
+  `createConversationAgent(deps)` is the composition root that wires the deps of
+  each tool.
+- **Literature Reviewer** (`tools/research/literature-reviewer.ts`): a sub-agent
+  that is a tool. It receives a research brief, investigates with the bio-lookup
+  tools, and gives a structured evidence report.
+- **`generatePlan` Tool** (`tools/research/generate-plan.ts`): an internal-LLM
+  tool. It captures the planner outcome with closure state (`PlannerOutcome`). The
+  planning prompt is in `prompts/`, with an `{{AGENT_CATALOG}}` placeholder that
+  the sandbox-agent metadata fills.
+- **`executeAnalysis` Workflow** (`workflows/execute-analysis.ts`, with the
+  scheduler in `execute-analysis-scheduler.ts`): it validates the plan, gates the
+  steps on their dependencies, and starts one child workflow for each step. For
+  each child: the sandbox-agent loop, then `generateFileMetadata`, then
+  `generateStepSummary`, then the artifact registration through
+  `ArtifactRegistry`, then the index in the vector store. The final step of the
+  parent is the literature-grounded synthesis.
+- **Chat turn** (`app/chat-turn.ts`): the preparation half of one turn only.
+  `prepareChatTurn` resolves the thread ownership, seeds the title, loads the
+  analysis status, and assembles the message array. It has none of the transport.
+  The caller runs `runAgent` with its own `emit`, then it persists the turn with
+  `appendTurn` (`memory/thread-history.ts`). A turn is
+  `prepareChatTurn → runAgent → appendTurn`. The host wraps this in its own
+  request handler, because the harness ships no HTTP route layer.
+- **Run-event stream**: a single DBOS-backed stream for each workflow. The
+  workflow bodies produce it, and a reader of the typed run-event parts of the
+  harness (`harness/src/contracts/`) consumes it. There is no standalone route file
+  in the harness.
+- **Workspace** (`workspace/`): the read surface (`read_file`, `grep`, semantic
+  search) is sandbox-independent, and it is available to the conversation agent.
+  The mutate surface (`write_file`, `edit_file`, `execute_command`) is
+  sandbox-gated.
+- **Composition root** (`runtime/assemble.ts`): `assembleCoreRuntime` is the
+  host-neutral assembly point. It registers the durable workflows, and it builds
+  the conversation agent over them. The local seam realizations that it can be
+  wired with carry zero cloud deps, and `index.ts` re-exports them:
+  `auth/local-run-authorizer.ts`, `auth/local-auth-context.ts`,
+  `billing/noop-resolver.ts`, `billing/noop-run-charge.ts`,
+  `execution/noop-artifact-registry.ts`, and the `UnavailablePreviewPublisher` of
+  `tools/report/preview-publisher.ts`. Refer to
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
+- **Workflow recovery**: there is no standing component. Each host supplies a
+  stable `executorID`. Refer to [`CONTEXT.md`](CONTEXT.md), under
+  `Workflow recovery`.
+- **Shared contracts** (`harness/src/contracts/`): the Cortex-native chat-stream
+  event and data-part types (`CortexChatEvent`, `CortexChatPart`, and the part
+  registry). `@inflexa-ai/harness` exports them for a consumer that renders the
+  stream.
 
 ### Analysis Lifecycle
 
@@ -174,40 +344,109 @@ The submit + result protocol ([harness-sandbox-exec](openspec/specs/harness-sand
 CREATE --> [chat | workflow | ...] --> ARCHIVE (deferred) --> [resume]
 ```
 
-An analysis is created, enters an active state where it can handle chat messages and trigger workflows, and can be archived and later resumed. The `runId` is minted at workflow start, at the same point the `RunAuthorizer` seam issues the `RunSession`.
+An analysis is created. Then it enters an active state, where it can handle a chat
+message and trigger a workflow. It can be archived, and it can resume later. The
+`runId` is minted at the workflow start, at the same point where the
+`RunAuthorizer` seam issues the `RunSession`.
 
 ### Target Assessment
 
-Separate top-level entity (NOT a kind of analysis). Snapshot-style target dossiers. Backed by `cortex_target_assessments` and the `executeTargetAssessment` workflow (`workflows/target-assessment/`). The dossier schema lives in `src/contracts/target-dossier.ts` and is the contract with consumers. Coverage discipline is a hard schema invariant: every enrichment-dependent section carries `coverage: "available" | "queried_no_data" | "not_loaded"`. Hosts choose how to expose progress to clients.
+A separate top-level entity. It is NOT a kind of analysis. It gives snapshot-style
+target dossiers. `cortex_target_assessments` and the `executeTargetAssessment`
+workflow (`workflows/target-assessment/`) back it. The dossier schema is in
+`src/contracts/target-dossier.ts`, and it is the contract with a consumer. The
+coverage discipline is a hard schema invariant: each section that depends on
+enrichment carries `coverage: "available" | "queried_no_data" | "not_loaded"`. A
+host chooses how to show the progress to its clients.
 
 ### Memory
 
-Thread history (`messages` table) and working memory (`cortex_working_memory`, one JSONB row per analysis with `goal`/`constraints`/`hypotheses`/`findings`) are conversation- and analysis-scoped; there is no semantic recall — agents operate inside the token-bounded thread window only. Workflow and sandbox loops keep no `messages` table — durability is the DBOS step cache, debugged by read-side reconstruction from `dbos.operation_outputs` ([harness-thread-store](openspec/specs/harness-thread-store/spec.md)).
+The thread history, the working memory, and the absence of semantic recall are in
+[`CONTEXT.md`](CONTEXT.md), under `Memory`.
 
-See [`CONTEXT.md`](CONTEXT.md) (Memory) for the full model.
-
-**File discovery**: Agents discover files via workspace vector semantic search (file descriptions embedded into pgvector at write time). Vector entries have consistent `type` metadata (`"input"`, `"output"`, `"summary"`, `"synthesis"`, `"profile"`) for filtered searches. Search returns paths + descriptions + metadata — agents must `read_file` separately.
+**File discovery**: an agent finds a file with the workspace vector semantic
+search. The file descriptions are embedded into pgvector at write time. A vector
+entry has consistent `type` metadata (`"input"`, `"output"`, `"summary"`,
+`"synthesis"`, `"profile"`) for a filtered search. The search gives the paths, the
+descriptions, and the metadata. An agent must then call `read_file` separately.
 
 ### Prompt Design Principles
 
-Agent prompts live in `prompts/`. Every prompt follows these conventions:
+The agent prompts are in `prompts/`. Each prompt obeys these conventions:
 
-1. **No run-order assumptions.** Agents must never assume they are operating on a first run. Search broadly for what exists before proceeding.
-2. **Anti-patterns are explicit.** Every prompt has a "Do NOT" section listing specific failure modes. When editing prompts, always maintain and extend these lists. Telling agents what not to do is as important as telling them what to do.
-3. **What the agent was handed is authoritative; look further only where it is thin.** There is no unconditional orient-first pass. A sandbox step's **briefing** (its first user message, composed at dispatch — `prompts/briefing.ts`) already names its task, its working directory and analysis root, the dataset, and what each completed dependency produced and where; the prompt tells it not to re-derive any of that (no filesystem hunt for its inputs, no re-reading an upstream summary it was handed, no re-deriving the organism from raw bytes). The conversation agent likewise does not repeat a search or re-orient when a prior turn's tool results are still in its context. Reaching further is *targeted*: `inspect_data_profile` when the orientation is thin, `read_file` on an upstream summary whose excerpt was not enough, `workspace_search` for a file nothing named.
-4. **Search → Read → Act.** Semantic search discovers, `read_file` inspects, then the agent acts. Search returns descriptions + metadata, not file contents.
-5. **Sandbox agents know their tools.** Shared sandbox-agent composition lives in `agents/sandbox/shared.ts`: the always-on substrate (workspace read/mutate surface + `inspect_data_profile`) plus the agent's `meta.tools` allowlist. Environment lookups are **conditional and narrow**, never a catalog dump up front — `list_available_packages` before importing a package the agent is not sure is staged, `list_available_refs` narrowed to the collection it needs. No assumed paths, no runtime installs, no network.
-6. **The persisted data profile is the one record of what the data is.** No profile file exists on disk (the profiler's scratch tree is deleted on completion), so nothing hand-types a data context: the conversation agent reads it with `inspect_data_profile` and passes that into `generate_plan`, and a step's seed carries a bounded projection of the same persisted profile, composed at dispatch (`app/data-profile-orientation.ts`). Vague context still produces vague plans — but the cure is the profile, not prose.
-7. **Per-step values ride in the seed, never in the system prompt.** A sandbox agent's `systemPrompt` is a pure function of its agent type — byte-identical across every step of every run — so the provider's prompt cache can actually reuse the ~20k-char prefix. One interpolated path or id makes every step's prefix unique, and each step then pays a full cache write and reads nothing back. Paths, dataset, and dependency handoffs belong in the briefing.
-8. **Prompts name tools; they never name data.** The prompt layer owns the *mechanism* — which tool to reach for, and when — and states the rules that constrain it ("never assume a reference path exists and never hardcode one"). It must not enumerate specific datasets or guarantee a format: the prompt is a cached constant and the environment is not, so a roll-call of what is provisioned goes stale the moment provisioning changes, and a format promise is simply false for a store that ships something else. Describe the capability; let the tool return the specifics. A tool's `description` is prompt surface too, and carries the same obligation — it should teach the caller to search by what the data *is*, since anything that teaches searching by location has published an installer detail as an interface. Invest in it: **a tool is self-describing at attach time**, so its `description` is the whole of what an agent knows about it, and the reason nothing downstream needs to restate it. That is what lets `skills/` name a task without naming a tool; see the root [`CLAUDE.md`](../CLAUDE.md).
+1. **No run-order assumptions.** An agent must never assume that it operates on a
+   first run. Search broadly for what exists before you continue.
+2. **Anti-patterns are explicit.** Each prompt has a "Do NOT" section that lists
+   the specific failure modes. When you edit a prompt, always maintain and extend
+   those lists. To tell an agent what not to do is as important as to tell it what
+   to do.
+3. **What the agent was handed is authoritative. Look further only where it is
+   thin.** There is no unconditional orient-first pass. The **briefing** of a
+   sandbox step is its first user message, composed at dispatch
+   (`prompts/briefing.ts`). It already names its task, its working directory, the
+   analysis root, the dataset, and what each completed dependency produced and
+   where. The prompt tells it not to derive any of that again:
+   - no filesystem hunt for its inputs
+   - no second read of an upstream summary that it was handed
+   - no second derivation of the organism from the raw bytes.
+
+   The conversation agent obeys the same rule. When the tool results of a prior
+   turn are still in its context, it does not do a search again. It does not orient
+   again. To reach further is *targeted*:
+   `inspect_data_profile` when the orientation is thin, `read_file` on an upstream
+   summary whose excerpt was not enough, and `workspace_search` for a file that
+   nothing named.
+4. **Search, then read, then act.** The semantic search discovers, `read_file`
+   inspects, then the agent acts. The search gives descriptions and metadata, not
+   file contents.
+5. **A sandbox agent knows its tools.** The shared sandbox-agent composition is in
+   `agents/sandbox/shared.ts`. It has the always-on substrate (the workspace read
+   and mutate surface, plus `inspect_data_profile`) and the `meta.tools` allowlist
+   of the agent. An environment lookup is **conditional and narrow**, and never a
+   catalog dump up front: `list_available_packages` before an import of a package
+   that the agent is not sure is staged, and `list_available_refs` narrowed to the
+   collection that it needs. There are no assumed paths, no runtime installs, and
+   no network.
+6. **The persisted data profile is the one record of what the data is.** No
+   profile file exists on disk, because the scratch tree of the profiler is
+   deleted on completion. Thus nothing hand-types a data context. The conversation
+   agent reads it with `inspect_data_profile` and passes that into
+   `generate_plan`. The seed of a step carries a bounded projection of the same
+   persisted profile, composed at dispatch (`app/data-profile-orientation.ts`). A
+   vague context still produces a vague plan, but the cure is the profile, not
+   prose.
+7. **A per-step value rides in the seed, never in the system prompt.** The
+   `systemPrompt` of a sandbox agent is a pure function of its agent type. It is
+   byte-identical across each step of each run, thus the prompt cache of the
+   provider can reuse the prefix of about 20k characters. One interpolated path or
+   id makes the prefix of each step unique, and each step then pays a full cache
+   write and reads nothing back. The paths, the dataset, and the dependency
+   handoffs belong in the briefing.
+8. **A prompt names a tool. It never names data.** The prompt layer has the
+   *mechanism*: which tool to reach for, and when. It states the rules that
+   constrain it, for example "never assume a reference path exists and never
+   hardcode one". It must not list a specific dataset and it must not promise a
+   format. The prompt is a cached constant, but the environment is not. Thus a
+   roll-call of what is provisioned goes stale the moment that the provisioning
+   changes. A format promise is simply false for a store that ships something else.
+   Describe the capability, and let the tool give the specifics.
+
+   The `description` of a tool is prompt surface too, and it carries the same
+   obligation. It must teach the caller to search by what the data *is*. Anything
+   that teaches a search by location has published an installer detail as an
+   interface. Invest in it: **a tool is self-describing at attach time**. Thus its
+   `description` is the whole of what an agent knows about it. That is also the
+   reason that nothing downstream must restate it, and what lets `skills/` name a task
+   without a name for a tool. Refer to the root [`CLAUDE.md`](../CLAUDE.md).
 
 ## Storage Layout
 
-Each analysis's tree is rooted at the host directory the embedder's
-`resolveWorkspaceRoot(resourceId)` seam returns (the workspace-root-resolution
-spec) — the harness owns the layout *inside* the root, the embedder owns
-*where* the root lives. Host paths carry no `{resourceId}` segment; sandboxes
-still see the tree mounted at `/{resourceId}` (bind mounts decouple the two).
+The tree of each analysis is rooted at the host directory that the
+`resolveWorkspaceRoot(resourceId)` seam of the embedder gives — the
+workspace-root-resolution spec. The harness has the layout *inside* the root, and
+the embedder has *where* the root lives. A host path carries no `{resourceId}`
+segment, but a sandbox still sees the tree mounted at `/{resourceId}`, because a
+bind mount decouples the two.
 
 ```
 {resolveWorkspaceRoot(resourceId)}/
@@ -225,47 +464,134 @@ still see the tree mounted at `/{resourceId}` (bind mounts decouple the two).
 +-- previews/{previewId}/        # Iterative report previews (shared assets/ + v{N}/)
 ```
 
-(The data profiler's file scratch lives under `runs/data-profile/` and is wiped
-when profiling completes — its durable products are the vector index and
-`cortex_analysis_state`, not files.)
+The file scratch of the data profiler is under `runs/data-profile/`, and it is
+wiped when the profiling completes. Its durable products are the vector index and
+`cortex_analysis_state`, not files.
 
-The harness uses Postgres (`pg` directly + pgvector). The DBOS system DB carries workflow state, step cache, and durable streams. App tables (`cortex_runs`, `cortex_step_executions`, `cortex_artifacts`, `cortex_target_assessments`, `messages`, `cortex_working_memory`) are thin ledgers — rich data (summaries, findings, file descriptions) lives in files and the vector index, not in DB columns. Connection parameters come from `DB_PG_HOST`/`DB_PG_PORT`/`DB_PG_NAME`/`DB_PG_USER`/`DB_PG_PASSWORD`/`DB_PG_SSLMODE`. The app pool is owned by `lib/storage.ts:createPool()`; DBOS owns a separate pool ([postgres-storage-backend](openspec/specs/postgres-storage-backend/spec.md)).
+The harness uses Postgres, with `pg` directly and pgvector. The DBOS system DB
+carries the workflow state, the step cache, and the durable streams. The app tables
+(`cortex_runs`, `cortex_step_executions`, `cortex_artifacts`,
+`cortex_target_assessments`, `messages`, `cortex_working_memory`) are thin ledgers.
+The rich data (the summaries, the findings, the file descriptions) is in files and
+in the vector index, not in DB columns. The connection parameters come from
+`DB_PG_HOST`, `DB_PG_PORT`, `DB_PG_NAME`, `DB_PG_USER`, `DB_PG_PASSWORD`, and
+`DB_PG_SSLMODE`. `lib/storage.ts:createPool()` has the app pool, and DBOS has a
+separate pool
+([postgres-storage-backend](openspec/specs/postgres-storage-backend/spec.md)).
 
 ## Debugging
 
-**Harness logs**: the harness writes every diagnostic to the `Logger` the embedder injected — it owns no sink and no level filter, so verbosity and destination are the host's to set (the cli routes its pino at `LOG_LEVEL` into `~/.inflexa/logs`, and on into OTLP when telemetry is consented). An embedder that wires no logger gets `createNoopLogger()` and sees nothing: if harness records are missing entirely, check the composition root before suspecting the harness. Records carry a `[module]` prefix from `named(...)` and their identifiers as structured fields (`runId`, `stepId`, `analysisId`, `execId`, `sandboxId`, `agentId`) — filter on the fields, not the message text. A step failure logs its cause ONLY here: `failStep` scrubs the error before it reaches `cortex_step_executions.error`, the run panel, or the parent's re-raise, so the log line is the sole account of why a step died. Bodies re-emit on DBOS replay — dedup by `runId`/`stepId`, not by line count.
+**Harness logs**: the harness writes each diagnostic to the `Logger` that the
+embedder injected. It has no sink and no level filter, thus the verbosity and the
+destination belong to the host. The cli routes its pino at `LOG_LEVEL` into
+`~/.inflexa/logs`, and on into OTLP when the user consents to telemetry. An
+embedder that wires no logger gets `createNoopLogger()` and sees nothing. If the
+harness records are absent completely, examine the composition root before you
+suspect the harness.
 
-**Sandbox failures**: sandbox-server logs failed commands with exit code and stderr; the run-event stream surfaces `step-activity` failures. For the local Docker backend, inspect with `docker logs <container>`.
+A record carries a `[module]` prefix from `named(...)`, and it carries its
+identifiers as structured fields (`runId`, `stepId`, `analysisId`, `execId`,
+`sandboxId`, `agentId`). Filter on the fields, not on the message text.
 
-**Workflow recovery**: A terminated or crashed host's in-flight workflows are recovered when a host restarts under the same stable `executorID` and DBOS reclaims its own `dbos.workflow_status` rows at launch ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). Operator-facing recovery controls, if any, belong to the embedder.
+A step failure logs its cause ONLY here. `failStep` scrubs the error before it
+reaches `cortex_step_executions.error`, the run panel, or the re-raise of the
+parent. Thus the log line is the sole account of why a step died. A body emits
+again on a DBOS replay, thus dedup by `runId` and `stepId`, not by a line count.
+
+**Sandbox failures**: sandbox-server logs a failed command with its exit code and
+its stderr. The run-event stream surfaces a `step-activity` failure. For the local
+Docker backend, examine it with `docker logs <container>`.
+
+**Workflow recovery**: the in-flight workflows of a host that terminated or
+crashed are recovered when a host starts again under the same stable `executorID`.
+DBOS then reclaims its own `dbos.workflow_status` rows at launch
+([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). An
+operator-facing recovery control, if there is one, belongs to the embedder.
 
 ## Error handling — neverthrow with an exception-speaking core
 
-Failure is modeled as `Result`/`ResultAsync` values (neverthrow), but the durability engine underneath speaks exceptions: **DBOS records a step as failed — and retries / fails fast — only on a thrown exception**. A `Result` err that crosses `DBOS.runStep` as a *return value* is durably cached as a successful step and replayed as success forever. The full house rules live at the top of `src/lib/result.ts`; the two sanctioned bridges are:
+Failure is modeled as a `Result` or `ResultAsync` value (neverthrow). But the
+durability engine underneath speaks exceptions: **DBOS records a step as failed —
+and retries or fails fast — only on a thrown exception.** A `Result` err that
+crosses `DBOS.runStep` as a *return value* is durably cached as a successful step,
+and it replays as a success forever.
 
-- `unwrapOrThrow(result)` (`src/lib/result.ts`) — the canonical Result→throw bridge. Use it only inside DBOS workflow/step bodies, tool `execute` bodies (the loop's dispatch catch maps the throw to an error tool result), and throw-protocol driver edges. Never in composable domain logic — there, keep the `Result` flowing.
-- `resultStep` (`src/loop/run-step.ts`) — the composed seam the agent loop uses (`runStep` + `unwrapOrThrow`).
+The full house rules are at the top of `src/lib/result.ts`. There are two
+sanctioned bridges:
 
-The `must-use-result` lint rule is patched in `eslint.config.js` to recognize `unwrapOrThrow(...)` as consuming its Result — do not rewrite bridge sites into inline `.match`+throw forms, and do not add per-site lint disables for it.
+- `unwrapOrThrow(result)` (`src/lib/result.ts`) — the canonical bridge from Result
+  to throw. Use it only inside a DBOS workflow or step body, inside a tool
+  `execute` body (the dispatch catch of the loop maps the throw to an error tool
+  result), and at a throw-protocol driver edge. Never use it in composable domain
+  logic. There, keep the `Result` flowing.
+- `resultStep` (`src/loop/run-step.ts`) — the composed seam that the agent loop
+  uses (`runStep` plus `unwrapOrThrow`).
+
+The `must-use-result` lint rule is patched in `eslint.config.js` to recognize
+`unwrapOrThrow(...)` as a consumer of its Result. Do not rewrite a bridge site into
+an inline `.match` plus throw form. Do not add a per-site lint disable for it.
 
 ## Code Comments
 
-Comments describe the **current state** of the code, not its history. Do not leave comments explaining what the code *used to do*, why the current change was made versus the prior version, or what was removed. That context belongs in the commit message and PR description — in the code it rots the moment the next change lands.
+A comment describes the **current state** of the code, not its history. Do not
+leave a comment that explains what the code *used to do*. Do not explain why the
+current change was made against the prior version, and do not explain what was
+removed. That context belongs in the commit message and the pull request
+description. In the code it rots the moment that the next change lands.
 
-If the only thing a comment can say is "this used to be X, now it's Y" or "changed from X because Y", delete the comment. If the current state is obvious from the code, no comment is warranted. Only write a comment when a future reader would genuinely be surprised or misled without it — a hidden constraint, a non-obvious invariant, a workaround for a specific bug.
+If the only thing that a comment can say is "this used to be X, now it is Y" or
+"changed from X because Y", delete the comment. If the current state is obvious
+from the code, no comment is warranted. Write a comment only when a future reader
+would genuinely be surprised or misled without it: a hidden constraint, a
+non-obvious invariant, or a workaround for a specific bug.
 
 ## Testing
 
-**Test state, not interactions.** Assert on returned values and database state. Do not assert that method X was called N times with arguments Y — this couples tests to implementation details.
+**Test the state, not the interactions.** Assert on the returned values and on the
+database state. Do not assert that method X was called N times with arguments Y,
+because that couples a test to an implementation detail.
 
-**Postgres testcontainer**: Tests that touch the database use `withSchema(testName)` from `__tests__/setup/postgres.ts`. The helper starts a single `pgvector/pgvector:pg18` container per `bun test` run (cold start ~3s on first use; re-used across every test file afterward) and hands each test an isolated schema scoped via `search_path`. Set `CORTEX_TEST_PG_URL=postgres://cortex:dev@localhost:5433/cortex` to skip container startup and point at a locally-running Postgres — instant feedback during tight iteration. The container fallback needs a reachable Docker API socket, and testcontainers' ryuk reaper container does not come up under podman — so a bare `bun test` on a podman host errors out the entire DB/DBOS portion of the suite, not just one file. The two supported local routes are `bun run test:full`, which starts the one container itself and reaches podman through its docker-compat socket, and exporting `CORTEX_TEST_PG_URL` at an already-running Postgres. `TESTCONTAINERS_RYUK_DISABLED=true` forces the fallback through as a last resort, at the cost of leaving one unreaped container per DB test file. Harness modules receive their `Pool` as an injected construction dep (`createPool`), so a test passes the schema-scoped test pool directly into the factory under test — there is no global pool accessor or test-override seam.
+**Postgres testcontainer**: a test that touches the database uses
+`withSchema(testName)` from `__tests__/setup/postgres.ts`. The helper starts one
+`pgvector/pgvector:pg18` container for each `bun test` run. The cold start is about
+3 seconds on first use, and each subsequent test file uses the same container. The
+helper hands each test an isolated schema, scoped through `search_path`.
 
-**DBOS testcontainer**: Tests that need a launched DBOS engine use `setupDbosForTests` from `__tests__/setup/dbos.ts`. The rig launches lazily, shares one DBOS engine across `bun test`, and carves out a fresh per-test cortex schema via `withSchema()`. Use it for workflow/runtime-shape tests; pure body-level unit tests should stay on `passthroughStep`.
+Set `CORTEX_TEST_PG_URL=postgres://cortex:dev@localhost:5433/cortex` to skip the
+container startup and point at a local Postgres, for instant feedback during tight
+iteration. The container fallback needs a reachable Docker API socket. The ryuk
+reaper container of testcontainers does not come up under podman. Thus a bare
+`bun test` on a podman host errors out the whole DB and DBOS portion of the suite,
+not only one file.
 
-**Integration tests** (`__tests__/integration/`): Hit real external APIs with canonical queries. One file per API provider under `__tests__/integration/`. Assert on response structure and field presence, not exact values. Tools requiring API keys that aren't set are auto-skipped via `describe.skipIf(!process.env.KEY_NAME)`.
+There are two supported local routes. `bun run test:full` starts the one container
+itself and reaches podman through its docker-compat socket. As an alternative,
+export `CORTEX_TEST_PG_URL` at a Postgres that already runs.
+`TESTCONTAINERS_RYUK_DISABLED=true` forces the fallback through as a last resort,
+at the cost of one unreaped container for each DB test file.
+
+A harness module receives its `Pool` as an injected construction dep
+(`createPool`). Thus a test passes the schema-scoped test pool directly into the
+factory under test. There is no global pool accessor and no test-override seam.
+
+**DBOS testcontainer**: a test that needs a launched DBOS engine uses
+`setupDbosForTests` from `__tests__/setup/dbos.ts`. The rig launches lazily, shares
+one DBOS engine across `bun test`, and carves out a fresh cortex schema for each
+test with `withSchema()`. Use it for a workflow test or a runtime-shape test. A
+pure body-level unit test must stay on `passthroughStep`.
+
+**Integration tests** (`__tests__/integration/`): they hit a real external API with
+canonical queries. There is one file for each API provider under
+`__tests__/integration/`. Assert on the response structure and on field presence,
+not on exact values. A tool that needs an API key that is not set is skipped
+automatically, through `describe.skipIf(!process.env.KEY_NAME)`.
 
 ## References
 
-- **Context glossary**: [`CONTEXT.md`](CONTEXT.md) — operative domain language + load-bearing patterns
-- **Specs / ADRs**: [`openspec/specs/`](openspec/specs/) — feature specifications and the source of truth for design decisions. ADR rationale lives here; there is no `docs/adr` and no `docs/`.
-- **Package README**: [`README.md`](README.md) — the embedder-facing surface and how the harness executes
+- **Context glossary**: [`CONTEXT.md`](CONTEXT.md) — the operative domain language
+  and the load-bearing patterns.
+- **Specs and ADRs**: [`openspec/specs/`](openspec/specs/) — the feature
+  specifications, and the source of truth for the design decisions. The ADR
+  rationale is here. There is no `docs/adr` and no `docs/`.
+- **Package README**: [`README.md`](README.md) — the surface that an embedder faces,
+  and how the harness executes.

--- a/harness/CONTEXT.md
+++ b/harness/CONTEXT.md
@@ -1,66 +1,298 @@
 # Cortex Harness — context glossary
 
-Domain language and load-bearing architectural patterns for the OSS agent harness. Hard decisions and their reasoning live in the OpenSpec specs under `openspec/specs/` — the source of truth for harness design decisions.
+The domain language and the load-bearing architectural patterns of the OSS agent
+harness. The hard decisions and their reasons are in the OpenSpec specs under
+`openspec/specs/`, which is the source of truth for the harness design decisions.
 
 ## Domain
 
-- **Analysis** — Long-lived, resource-scoped entity that owns a conversation thread, an input-file tree staged under `data/inputs/` (see **Input staging**), and zero or more runs. Identified by `analysisId` (used as both `threadId` and `resourceId`). Lifecycle: `created → active ↔ suspended → archived`.
-- **Input staging** — Populating an analysis's `data/inputs/` tree is the **embedder's** responsibility, done *before* the harness is invoked, not the harness's ([data-profile-init](openspec/specs/data-profile-init/spec.md)). The harness's workflows and tools assume a populated tree; **there is no staging seam in the harness and no harness code calls stage.** The local CLI stages by copying/linking local files in its own repo. Inputs are immutable and staged exactly once, so a recovered run finds the tree already present (staging is not a durable step). `executeAnalysis` reads the tree directly; `runDataProfile` receives the staged-input manifest (`StagedInput[]`, the one harness staging *type*) in its workflow input. A staging failure is handled embedder-side (the profile is marked `failed`).
-- **Run** — One execution of a workflow against an analysis. Identified by `runId` — a bare UUID that *is* the DBOS `workflowID` (no composite prefix, no separate `workflow_id` column). Holds a run directory at `runs/{runId}/` (in the analysis's workspace tree) with per-step subdirectories. `runId` and the durable `RunSession` are minted at the async edge before `DBOS.startWorkflow` — the session rides in the workflow input and DBOS replay reconstructs it on resume.
-- **Step** — One node in an analysis plan DAG. Each step runs in its own sandbox container. The DAG is **dependency-gated and budget-admitted**: the parent workflow starts a step's child workflow once all its `depends_on` steps have completed *and* the machine resource budget (snapshotted into the workflow input at launch, when the embedder configures one) has capacity for the step's declared resources — no wave batching; without a budget every dependency-satisfied step starts immediately. A dependency-satisfied step held for capacity is emitted as `queued` on the dag-state part (dependency-held steps stay `pending`). A topological *level* may be computed for UI display, but it never gates execution. A step ends in one of three terminal states: **`completed`** (the agent persisted its deliverables and ended cleanly), **`blocked`** (the agent called `report_blocker` to declare — with a reason — that it could not fulfill the step; a distinct, honest terminal status), or **`failed`** (an unexpected error). Execution is **fail-fast**: the first step `failed` *or* `blocked` cancels in-flight siblings and stops scheduling new steps.
-- **Step deliverable** — A step's output is its **persisted files**: the scripts it wrote (`scripts/`), the data those scripts computed (`output/`), and figures (`figures/`). Conclusions are drawn from those computed output files (derived from the input data), never narrated from `execute_command` stdout. An agent that cannot produce them calls `report_blocker` rather than improvising an inline result — the harness does not infer "something went wrong" from output counts; honesty is structural (the blocker tool), and actual errors surface as `failed`.
-- **Blocker** — The terminal escape hatch an agent calls (`report_blocker({ reason })`) when it genuinely cannot do its work — missing data, an unavailable tool, a broken environment. Modeled on the synthesizer's `report_blocker` (shared `OutcomeHolder` mechanism). For a **step** agent it yields the `blocked` status and fails-fast; for the **synthesizer** it yields a non-fatal `skipped` outcome (the analysis steps already delivered — interpretive aggregation honestly having nothing to add is not a run failure).
-- **Sandbox** — Ephemeral container running the sandbox HTTP worker. The harness submits a command (`POST /exec`, signed) and retrieves its result by one of two **transports** (see next entry) rather than holding a long-lived `/exec` stream. `GET /exec/{execId}` returns the terminal result signed fresh at request time — the poll primitive in poll mode, and the recovery pull in callback mode.
-- **Transport (`SandboxTransport`)** — How a command's progress events and terminal result reach the host: **`poll`** (default) or **`callback`**. Backend-independent, chosen by the embedder at its composition root and carried to the container as `SANDBOX_TRANSPORT`. In **poll** mode the host polls `GET /exec/{execId}?since={cursor}` for a signed `{ status, events[], cursor, result? }`; the sandbox initiates nothing, needs no egress, and on Docker is confined by an in-container `iptables -P OUTPUT DROP` firewall (a root entrypoint with `CAP_NET_ADMIN` installs it, then `setpriv`-drops to uid 1000). A dead sandbox in poll mode fast-fails in-loop: sustained `unavailable` polls escalate to a durable `isAlive` probe (`sandbox/liveness.ts`), and an observably dead machine returns the synthetic-failure result without waiting out `step.timeout` (the watchdog's synthetic-complete is the callback-mode path). In **callback** mode the sandbox POSTs signed callbacks to `CORTEX_BASE_URL`, the embedder runs the ingress, and `awaitExec` uses `DBOS.recv` with the pull as its recovery backstop. There is no gateway sidecar and no `--internal` network — two transports removed the contradiction the gateway existed to reconcile. The local CLI defaults to poll.
-- **Active-sandbox registry** — Set of Sandbox machines currently bound to a running Step. Persisted as a projection over `cortex_step_executions` (rows with non-null `sandbox_ref` and `status='running'`). Owned by `state/active-sandboxes.ts`: written by `sandbox/create-sandbox.ts` when a machine is minted, cleared on teardown, and enumerated by the liveness watchdog (`sandbox/watchdog.ts`) which shards the registry and fans out per-shard `isAlive` checks. Dead-but-not-completed entries unblock the recv with a synthetic failure-`complete`.
-- **Orphaned sandbox** — A sandbox machine running in a configured backend that nothing in the harness references: no registry row, no DBOS step-cache entry. Produced when the process dies after the backend create but before the `sandbox.create` step checkpoint. Invisible to the registry-driven watchdog; only a backend inventory sweep can find it.
-- **Stale registry row** — A `cortex_step_executions` row still `status='running'` with a `sandbox_ref` whose owning workflow is terminal (typically a fail-fast-cancelled sibling — cancellation runs no teardown, so the machine may still be running too). The watchdog sees it dead, skips the synthetic send (workflow not PENDING/ENQUEUED). Cleared by the **sandbox reaper**, not the watchdog.
-- **Sandbox reaper** — A `@DBOS.scheduled` workflow (`sandbox/reaper.ts`, registered beside the watchdog) that cleans up orphaned sandboxes and stale registry rows. Distinct from the liveness watchdog: it sweeps **backend→registry** (the watchdog sweeps registry→backend), unsharded, on a slower cadence. Lists sandbox machines via `SandboxClient.listManagedSandboxes()`, reads their owner workflow metadata, and on a terminal/missing workflow status tears the machine down and reconciles the row. Keys off workflow status (written at enqueue, before the machine exists) so an in-flight create is never mistaken for an orphan. Cleanup is separate because DBOS forbids running a teardown step in a cancelled workflow ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)).
-- **Workspace** — The analysis file tree + vector index under one consistent path model shared by every agent (see **Workspace path model** below). The tree's host root comes from the embedder's `resolveWorkspaceRoot(resourceId)` seam ([workspace-root-resolution](openspec/specs/workspace-root-resolution/spec.md)): the embedder owns *where* each analysis's tree lives, the harness owns the layout inside it; sandboxes always see it at `/{resourceId}` regardless. It has two surfaces with different requirements:
-  - **Read surface** (`WorkspaceFilesystem`) — `read_file`, `list_files`, `file_stat`, `grep`, semantic `workspace_search`. Operates on the filesystem and index directly; **sandbox-independent**. Available to non-sandbox agents (the conversation agent reads and searches the workspace without ever holding a sandbox).
-  - **Mutate surface** (`WorkspaceMutator`) — `write_file`, `edit_file`, plus the raw `execute_command` chokepoint. **Sandbox-gated**: `write_file`/`edit_file` resolve, confine to the agent's writable working directory, write through the sandbox, and record provenance — all behind the one `WorkspaceMutator` seam, not re-implemented per tool. `execute_command` defaults its `cwd` to the same working directory.
-- **Workspace working directory** — Each agent run has one writable **working directory**, supplied by the composition root: a plannable step → `runs/{runId}/{stepId}`; the data profiler → `runs/data-profile/profile`; a report build → `reports/{reportId}`; the conversation agent → the analysis root (read-only — chat cannot write). It is the agent's `execute_command` `cwd` and the confinement root for its writes.
-- **Workspace path model** — One resolution rule across every file tool (`read_file`, `list_files`, `file_stat`, `grep`, `write_file`, `edit_file`, `execute_command`) and the scripts agents run:
-  - **Relative paths are frame-local** — they resolve against the agent's working directory. `output/x.csv` names the same byte whether a script writes it, `write_file` writes it, or `read_file` reads it back.
-  - **Absolute `/{resourceId}/…` paths are canonical and frame-independent** — they ignore the working directory and resolve against the analysis root in every frame. This is the interchange format: any path that crosses an agent or frame boundary (passed to a sub-agent, stored in working memory, referenced in a plan) MUST be absolute.
-  - **Reads roam, writes are confined.** Reads resolve anywhere in the analysis tree (read-only outside the working directory); a write outside the working directory returns `out_of_prefix` with no I/O. Out-of-tree or foreign-analysis paths return `out_of_scope`.
-  - The reserved artifact-subdir names (`scripts`, `output`, `figures`, `logs`, `notebooks`) MUST NOT be used as step ids — plan validation rejects them so a step directory never collides with a subdir convention. See [harness-workspace-tools](openspec/specs/harness-workspace-tools/spec.md).
-- **Target assessment** — Separate top-level entity (NOT a kind of analysis). Snapshot-style target dossier. Backed by `cortex_target_assessments`; runs the `executeTargetAssessment` workflow. Schema lives in `src/contracts/target-dossier.ts`.
-- **Skills** — Runtime knowledge packs (`skills/<name>/SKILL.md` + `references/`) declared per-agent via `AgentMeta.skills` and surfaced to sandbox agents by the `skill_search` / `skill_read` tools (keyword search, not vector); `shared/omics-general` loads for every analysis agent.
+- **Analysis** — A long-lived, resource-scoped entity. It has a conversation
+  thread, an input-file tree under `data/inputs/` (refer to **Input staging**),
+  and zero or more runs. Its identifier is `analysisId`, which is also the
+  `threadId` and the `resourceId`. Its lifecycle is
+  `created → active ↔ suspended → archived`.
+- **Input staging** — The **embedder** fills the `data/inputs/` tree of an
+  analysis. This work happens *before* a call to the harness, and it is not the
+  work of the harness ([data-profile-init](openspec/specs/data-profile-init/spec.md)).
+  The workflows and the tools of the harness expect a full tree. **The harness has
+  no staging seam, and no harness code calls stage.** The local CLI stages a file
+  when it copies or links a local file in its own repository. An input is
+  immutable, and it is staged one time only, thus a recovered run finds the tree
+  in place. Staging is not a durable step. `executeAnalysis` reads the tree
+  directly. `runDataProfile` receives the staged-input manifest (`StagedInput[]`,
+  the one staging *type* of the harness) in its workflow input. The embedder
+  handles a staging failure, and it marks the profile `failed`.
+- **Run** — One execution of a workflow against an analysis. Its identifier is
+  `runId`, a bare UUID that *is* the DBOS `workflowID`. There is no composite
+  prefix and no separate `workflow_id` column. A run has a run directory at
+  `runs/{runId}/` in the workspace tree of the analysis, with one subdirectory for
+  each step. The `runId` and the durable `RunSession` are minted at the async edge,
+  before `DBOS.startWorkflow`. The session rides in the workflow input, and DBOS
+  replay builds it again on resume.
+- **Step** — One node in an analysis plan DAG. Each step runs in its own sandbox
+  container. The DAG is **dependency-gated and budget-admitted**. The parent
+  workflow starts the child workflow of a step under two conditions. Each of its
+  `depends_on` steps must be complete. The machine resource budget must have
+  capacity for the declared resources of the step.
 
-## Session & capability seams
+  The budget is a snapshot in the workflow input at launch,
+  when the embedder configures one. There is no wave batching. With no budget,
+  each step with satisfied dependencies starts immediately. A step that has its
+  dependencies but waits for capacity is emitted as `queued` on the dag-state
+  part. A step that waits for a dependency stays `pending`. A topological *level*
+  can be computed for the UI, but it never gates the execution. A step ends in one
+  of three terminal states:
+  - **`completed`** — the agent stored its deliverables and ended cleanly.
+  - **`blocked`** — the agent called `report_blocker` to declare, with a reason,
+    that it could not do the step. This is a distinct, honest terminal status.
+  - **`failed`** — an unexpected error.
 
-The harness's identity model is **host-agnostic**: a session carries an *opaque* auth capability that the harness forwards but never inspects. Everything the harness reaches *outside itself* — issuing a durable run, recording artifacts, resolving call attribution, publishing a report preview — is an injectable **seam** the harness *declares* and an **embedder** *wires* ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). The OSS build wires trivial **local realizations** for all of them. The harness never branches on which realization is bound, and unit tests pass fakes.
+  The execution is **fail-fast**. The first step that is `failed` *or* `blocked`
+  cancels the siblings that still run, and it stops the schedule of new steps.
+- **Step deliverable** — The output of a step is its **persisted files**: the
+  scripts that it wrote (`scripts/`), the data that those scripts computed
+  (`output/`), and the figures (`figures/`). The conclusions come from those
+  computed output files, which come from the input data. A conclusion never comes
+  from the stdout of `execute_command`. An agent that cannot make those files
+  calls `report_blocker`, and it does not improvise an inline result. The harness
+  does not conclude that something went wrong from a count of the outputs. Honesty
+  is structural, because the blocker tool gives it, and a real error shows as
+  `failed`.
+- **Blocker** — The terminal escape hatch. An agent calls
+  `report_blocker({ reason })` when it genuinely cannot do its work. Examples are
+  absent data, a tool that is not available, and a broken environment.
+  The model is the `report_blocker` of the synthesizer (the shared `OutcomeHolder`
+  mechanism). For a **step** agent it gives the `blocked` status and it fails
+  fast. For the **synthesizer** it gives a `skipped` outcome that is not fatal,
+  because the analysis steps already delivered. Interpretive aggregation that
+  honestly has nothing to add is not a run failure.
+- **Sandbox** — An ephemeral container that runs the sandbox HTTP worker. The
+  harness submits a command with a signed `POST /exec`, then it gets the result
+  through one of two **transports** (refer to the next entry). It does not hold a
+  long-lived `/exec` stream. `GET /exec/{execId}` gives the terminal result, and
+  the sandbox signs it fresh at request time. This is the poll primitive in poll
+  mode, and the recovery pull in callback mode.
+- **Transport (`SandboxTransport`)** — How the progress events and the terminal
+  result of a command come to the host: **`poll`** (the default) or
+  **`callback`**. It is backend-independent. The embedder selects it at its
+  composition root, and it goes to the container as `SANDBOX_TRANSPORT`.
+
+  In **poll** mode the host polls `GET /exec/{execId}?since={cursor}` for a signed
+  `{ status, events[], cursor, result? }`. The sandbox initiates nothing and needs
+  no egress. On Docker an in-container `iptables -P OUTPUT DROP` firewall confines
+  it: a root entrypoint with `CAP_NET_ADMIN` installs the rule, then `setpriv`
+  drops to uid 1000. The exec port is published to `127.0.0.1` only. The poll loop
+  is durable, and its per-attempt step names are unique
+  (`sandbox.poll-exec-result.${execId}.${n}`). A dead sandbox in poll mode fails
+  fast in the loop. Sustained
+  `unavailable` polls escalate to a durable `isAlive` probe
+  (`sandbox/liveness.ts`), and a machine that is dead gives the synthetic-failure
+  result without a wait for `step.timeout`. The synthetic-complete of the watchdog
+  is the callback-mode path.
+
+  In **callback** mode the sandbox POSTs signed callbacks to `CORTEX_BASE_URL`,
+  and the embedder runs the ingress. `awaitExec` uses `DBOS.recv`, with the pull
+  as its recovery backstop. There is no gateway sidecar and no `--internal` network,
+  because the two transports removed the contradiction that the gateway existed to
+  reconcile. The local CLI defaults to poll.
+- **Active-sandbox registry** — The set of sandbox machines that are bound to a
+  running step at this time. It is a projection over `cortex_step_executions`: the
+  rows with a non-null `sandbox_ref` and `status='running'`. `state/active-sandboxes.ts`
+  has it. `sandbox/create-sandbox.ts` writes a row when it mints a machine, and
+  the teardown clears it. The liveness watchdog (`sandbox/watchdog.ts`) enumerates
+  the registry, shards it, and fans out one `isAlive` check for each shard. An
+  entry that is dead but not complete unblocks the recv with a synthetic
+  failure-`complete`.
+- **Orphaned sandbox** — A sandbox machine that runs in a configured backend, but
+  nothing in the harness refers to it: no registry row, and no DBOS step-cache
+  entry. It comes from a process that dies after the backend creation but before
+  the `sandbox.create` step checkpoint. The registry-driven watchdog cannot see it.
+  Only a backend inventory sweep finds it.
+- **Stale registry row** — A `cortex_step_executions` row that is still
+  `status='running'` with a `sandbox_ref`, but the workflow that owns it is
+  terminal. This is usually a sibling that fail-fast canceled, because a
+  cancellation runs no teardown, thus the machine can still run too. The watchdog
+  sees it as dead and skips the synthetic send, because the workflow is not
+  PENDING or ENQUEUED. The **sandbox reaper** clears it, not the watchdog.
+- **Sandbox reaper** — A `@DBOS.scheduled` workflow (`sandbox/reaper.ts`,
+  registered beside the watchdog) that cleans up an orphaned sandbox and a stale
+  registry row. It is distinct from the liveness watchdog: it sweeps
+  **backend→registry**, the watchdog sweeps registry→backend. It is unsharded, and
+  it runs on a slower cadence. It lists the sandbox machines with
+  `SandboxClient.listManagedSandboxes()`, and it reads the workflow metadata of the
+  owner. On a terminal or missing workflow status it tears the machine down and it
+  reconciles the row. It keys off the workflow status, which is written at enqueue
+  before the machine exists. Thus a creation that is in flight is never an orphan.
+  The cleanup is separate because DBOS does not permit a teardown step in a
+  canceled workflow ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)).
+- **Workspace** — The analysis file tree and the vector index under one consistent
+  path model that each agent shares (refer to **Workspace path model** below). The
+  host root of the tree comes from the `resolveWorkspaceRoot(resourceId)` seam of
+  the embedder ([workspace-root-resolution](openspec/specs/workspace-root-resolution/spec.md)):
+  the embedder has *where* the tree of each analysis lives, and the harness has the
+  layout inside it. A sandbox always sees it at `/{resourceId}`. The workspace has
+  two surfaces with different requirements:
+  - **Read surface** (`WorkspaceFilesystem`) — `read_file`, `list_files`,
+    `file_stat`, `grep`, and the semantic `workspace_search`. It operates on the
+    file system and the index directly, and it is **sandbox-independent**. It is
+    available to an agent with no sandbox. The conversation agent reads and
+    searches the workspace and never holds a sandbox.
+  - **Mutate surface** (`WorkspaceMutator`) — `write_file` and `edit_file`, plus
+    the raw `execute_command` chokepoint. It is **sandbox-gated**. `write_file`
+    and `edit_file` resolve the path, confine it to the writable working directory
+    of the agent, write through the sandbox, and record the provenance. All of
+    that is behind the one `WorkspaceMutator` seam, and no tool does it again.
+    `execute_command` defaults its `cwd` to the same working directory.
+- **Workspace working directory** — Each agent run has one writable **working
+  directory** that the composition root supplies. A plannable step gets
+  `runs/{runId}/{stepId}`. The data profiler gets `runs/data-profile/profile`. A
+  report build gets `reports/{reportId}`. The conversation agent gets the analysis
+  root, which is read-only, because chat cannot write. The working directory is
+  the `cwd` of `execute_command` for that agent, and it is the confinement root
+  for its writes.
+- **Workspace path model** — One resolution rule across each file tool
+  (`read_file`, `list_files`, `file_stat`, `grep`, `write_file`, `edit_file`,
+  `execute_command`) and the scripts that agents run:
+  - **A relative path is frame-local.** It resolves against the working directory
+    of the agent. `output/x.csv` names the same byte when a script writes it, when
+    `write_file` writes it, and when `read_file` reads it again.
+  - **An absolute `/{resourceId}/…` path is canonical and frame-independent.** It
+    ignores the working directory and resolves against the analysis root in each
+    frame. This is the interchange format. A path that crosses an agent boundary
+    or a frame boundary MUST be absolute. Examples are a path passed to a
+    sub-agent, a path stored in working memory, and a path in a plan.
+  - **A read roams, but a write is confined.** A read resolves anywhere in the
+    analysis tree, and it is read-only outside the working directory. A write
+    outside the working directory gives `out_of_prefix` with no I/O. A path out of
+    the tree or in a different analysis gives `out_of_scope`.
+  - The reserved artifact-subdir names (`scripts`, `output`, `figures`, `logs`,
+    `notebooks`) MUST NOT be step ids. Plan validation rejects them, thus a step
+    directory never collides with a subdir convention. Refer to
+    [harness-workspace-tools](openspec/specs/harness-workspace-tools/spec.md).
+- **Target assessment** — A separate top-level entity. It is NOT a kind of
+  analysis. It is a snapshot-style target dossier. `cortex_target_assessments`
+  holds it, and it runs the `executeTargetAssessment` workflow. Its schema is in
+  `src/contracts/target-dossier.ts`.
+- **Skills** — Runtime knowledge packs (`skills/<name>/SKILL.md` plus
+  `references/`). Each agent declares them with `AgentMeta.skills`, and the
+  `skill_search` and `skill_read` tools surface them to a sandbox agent. The
+  search is by keyword, not by vector. `shared/omics-general` loads for each
+  analysis agent.
+
+## Session and capability seams
+
+The identity model of the harness is **host-agnostic**. A session carries an
+*opaque* auth capability that the harness forwards but never inspects. Each thing
+that the harness reaches *outside itself* is an injectable **seam** that the
+harness *declares* and an **embedder** *wires*
+([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)).
+Examples are:
+
+- the issue of a durable run
+- the record of an artifact
+- the resolution of the call attribution
+- the publication of a report preview.
+
+The OSS build wires a trivial **local realization** for each of them. The harness
+never branches on which realization is bound, and a unit test passes a fake.
 
 ### Session model
 
-- **Session** — Per-request identity is two lifetime-typed bundles built from immutable value objects (`Identity`, `Scope`, `Credential`, `Provenance`, `RunFrame`, `auth`). `RequestSession` is the live request value, has no `RunFrame`, MUST NOT be JSON-serialized into durable state. `RunSession` is durable + JSON-serializable, carries a `RunFrame`, and is constructed solely at the `RunAuthorizer` seam (below) — async/durable APIs accept only `RunSession`, so starting async work without authorizing a run is unrepresentable. Workflow bodies never re-authorize — `RunSession` rides in workflow input, DBOS replay reconstructs it on resume; child workflows derive their input via `forStep(parent.runSession, stepId)`. Both bundles satisfy the structural `AgentSession` type consumed by the loop and providers; neither carries resolved call-attribution headers. See [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md), [harness-session-model](openspec/specs/harness-session-model/spec.md), and `src/auth/types.ts`.
-- **`Identity`** — `{ user }`, always complete. The one piece of caller identity the harness itself reads.
-- **`Scope`** — Discriminated union describing what the session acts on: `{ kind: "analysis"; analysisId; threadId? }` or `{ kind: "target-assessment"; targetAssessmentId; billingContextId }`. Read by the harness for routing and storage; the seams key their behavior off it.
-- **`Provenance`** — `{ agentId; callPath }`, read-only. Code MUST NOT branch on `callPath`; it is for event `source` stamping and sub-agent lineage only.
-- **`RunFrame`** — `{ runId; stepId? }`, present only inside a workflow run. Its presence is what distinguishes a `RunSession` from a `RequestSession` at the type level.
-- **`Credential` (opaque)** — A branded value the harness never reads. The harness only ever *forwards* it; its concrete shape is defined entirely embedder-side. The variant an OSS reader meets is the trivial local one. Branding makes the "never branch on credential kind" promise type-enforced.
-- **`AuthContext` (opaque auth capability)** — The `auth` field every session carries and the **sole source** of credential/scope behind a session (there is no top-level `orgId`/`credential` field). The harness forwards it untouched and never downcasts it; embedder adapters may downcast their own concrete shape. The OSS build supplies a trivial empty `auth` (`makeLocalAuth`, `auth/local-auth-context.ts`); the local harness never inspects it.
+- **Session** — The per-request identity is two lifetime-typed bundles, built from
+  immutable value objects (`Identity`, `Scope`, `Credential`, `Provenance`,
+  `RunFrame`, `auth`). `RequestSession` is the live request value. It has no
+  `RunFrame`, and it MUST NOT be JSON-serialized into durable state. `RunSession`
+  is durable and JSON-serializable, it carries a `RunFrame`, and the
+  `RunAuthorizer` seam (below) is its only constructor. An async or durable API
+  accepts only a `RunSession`, thus async work that starts without an authorized
+  run is unrepresentable. A workflow body never authorizes again: the `RunSession`
+  rides in the workflow input, and DBOS replay builds it again on resume. A child
+  workflow gets its input from `forStep(parent.runSession, stepId)`. The two
+  bundles both satisfy the structural `AgentSession` type that the loop and the
+  providers consume, and neither carries a resolved call-attribution header. Refer
+  to [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md),
+  [harness-session-model](openspec/specs/harness-session-model/spec.md), and
+  `src/auth/types.ts`.
+- **`Identity`** — `{ user }`, always complete. It is the one part of the caller
+  identity that the harness itself reads.
+- **`Scope`** — A discriminated union that describes what the session acts on:
+  `{ kind: "analysis"; analysisId; threadId? }` or
+  `{ kind: "target-assessment"; targetAssessmentId; billingContextId }`. The
+  harness reads it for the routing and the storage, and the seams key their
+  behavior off it.
+- **`Provenance`** — `{ agentId; callPath }`, read-only. Code MUST NOT branch on
+  `callPath`. It is for the `source` stamp of an event and for sub-agent lineage
+  only.
+- **`RunFrame`** — `{ runId; stepId? }`, present only inside a workflow run. Its
+  presence is what makes a `RunSession` different from a `RequestSession` at the
+  type level.
+- **`Credential` (opaque)** — A branded value that the harness never reads. The
+  harness only ever *forwards* it. The embedder side defines its concrete shape
+  fully. The variant that an OSS reader meets is the trivial local one. The brand
+  makes the promise "never branch on the credential kind" a type rule.
+- **`AuthContext` (the opaque auth capability)** — The `auth` field that each
+  session carries, and the **sole source** of the credential and the scope behind
+  a session. There is no top-level `orgId` field and no top-level `credential`
+  field. The harness forwards it untouched and never downcasts it. An embedder
+  adapter can downcast its own concrete shape. The OSS build gives a trivial empty
+  `auth` (`makeLocalAuth`, `auth/local-auth-context.ts`), and the local harness
+  never inspects it.
 
 ### The six seams
 
-Each seam is an interface the harness declares; an embedder binds one realization at the composition root.
+The harness declares each seam as an interface. An embedder binds one realization
+at the composition root.
 
-- **`RunAuthorizer`** (`execution/run-authorizer.ts`) — turns the opaque caller `auth` into a durable `RunSession` at the async edge. The sole constructor of `RunSession`, so it is the single chokepoint where in-process identity becomes durable workflow identity. OSS realization: `auth/local-run-authorizer.ts` issues a `RunSession` with no remote mint and no revoke — authorization is purely structural.
-- **`ResolveBilling`** (`billing/resolver.ts`) — returns a ready-to-attach call-attribution header map the provider spreads at the LLM/embedding call site; resolved lazily, only at the wire boundary. OSS realization: `createNoopBillingResolver` returns `{}` (empty headers).
-- **`ArtifactRegistry`** (`execution/artifact-registry.ts`) — post-step artifact recording (content-attested lineage): `register` the step's manifest + `sync` its bytes to permanent storage, both session-scoped (the adapter authenticates per-run off the session). OSS realization: `createNoopArtifactRegistry` — registers nothing externally and reports zero failures (the local `cortex_artifacts` ledger is written by the harness around the seam); `sync` is a no-op (bytes already live in the local workspace tree).
-- **`RunCharge`** (`billing/run-charge.ts`) — the run-level billing bracket `executeAnalysis` opens at init and closes on the terminal path (one of four reasons). Local realization: `createNoopRunCharge` — no-op.
-- **`UsageRecorder`** (`billing/usage-recorder.ts`) — one attributed `LlmUsageRecord` per completed LLM call, delivered from the loop; fire-and-forget by contract, so a realization must neither throw nor block, and consumers upsert on the record's replay-stable `recordKey`. Local realization: `createNoopUsageRecorder` (`billing/noop-usage-recorder.ts`) — drops every record.
-- **`PreviewPublisher`** (`tools/report/preview-publisher.ts`) — report preview URL publishing. Local realization: `UnavailablePreviewPublisher` — reports still build; preview URL minting is gated.
-- **`RunLauncher`** (`execution/run-launcher.ts`) — starts a registered workflow under a caller-chosen id (`launch` fire-and-forget, `launchAndAwait` inline with cancel-on-abort, cancellation hidden behind a discriminated `LaunchOutcome`). The DBOS quarantine seam: it is why `execute_plan` / `run_ephemeral` do not import the durability engine. Single host-neutral realization `createDbosRunLauncher` (`execution/dbos-run-launcher.ts`) shared by every embedder.
+- **`RunAuthorizer`** (`execution/run-authorizer.ts`) — it changes the opaque
+  caller `auth` into a durable `RunSession` at the async edge. It is the sole
+  constructor of a `RunSession`, thus it is the single chokepoint where the
+  in-process identity becomes the durable workflow identity. OSS realization:
+  `auth/local-run-authorizer.ts` issues a `RunSession` with no remote mint, no jti,
+  and no revoke, thus the authorization is purely structural.
+- **`ResolveBilling`** (`billing/resolver.ts`) — it gives a call-attribution
+  header map that the provider spreads at the LLM or embedding call site. It
+  resolves lazily, only at the wire boundary. OSS realization:
+  `createNoopBillingResolver` gives `{}`, an empty header map.
+- **`ArtifactRegistry`** (`execution/artifact-registry.ts`) — post-step artifact
+  recording with content-attested lineage. `register(input, session)` and
+  `sync(input, session)` are the two methods. `register` takes the manifest of the
+  step, and `sync` copies its bytes to permanent storage. The two are
+  session-scoped, and the adapter authenticates for each run off the session. OSS
+  realization: `createNoopArtifactRegistry` registers nothing outside and reports
+  zero failures, because the harness itself writes the local `cortex_artifacts`
+  ledger around the seam. Its `sync` does nothing, because the bytes are already
+  in the local workspace tree.
+- **`RunCharge`** (`billing/run-charge.ts`) — the run-level billing bracket that
+  `executeAnalysis` opens at the init and closes on the terminal path, for one of
+  four reasons. Local realization: `createNoopRunCharge` does nothing.
+- **`UsageRecorder`** (`billing/usage-recorder.ts`) — one attributed
+  `LlmUsageRecord` for each completed LLM call, delivered from the loop. The
+  contract makes it fire-and-forget, thus a realization must not throw and must
+  not block. A consumer upserts on the replay-stable `recordKey` of the record.
+  Local realization: `createNoopUsageRecorder`
+  (`billing/noop-usage-recorder.ts`) drops each record.
+- **`PreviewPublisher`** (`tools/report/preview-publisher.ts`) — it publishes the
+  URL of a report preview. Local realization: `UnavailablePreviewPublisher`. A
+  report still builds, but the mint of a preview URL is gated.
+- **`RunLauncher`** (`execution/run-launcher.ts`) — it starts a registered
+  workflow under an id that the caller chooses. `launch` is fire-and-forget.
+  `launchAndAwait` is inline with cancel-on-abort, and a discriminated
+  `LaunchOutcome` hides the cancellation. It is the DBOS quarantine seam, and it
+  is the reason that `execute_plan` and `run_ephemeral` do not import the
+  durability engine. One host-neutral realization, `createDbosRunLauncher`
+  (`execution/dbos-run-launcher.ts`), is shared by each embedder.
 
-### Embedder / composition roots
+### Embedder and composition roots
 
-The program that embeds the harness and wires its seams. The harness exports `assembleCoreRuntime` plus local seam realizations; the host owns its transport, process bootstrap, and any non-local adapters.
+The program that embeds the harness and wires its seams. The harness exports
+`assembleCoreRuntime` and the local seam realizations. The host has its transport,
+its process bootstrap, and any adapter that is not local.
 
 ## Streaming
 
-- **Chat data part** — Typed JSON event emitted by workflows. Persisted in the DBOS-backed stream (no separate JSONB blob). Consumers read Cortex-native types directly (no AI SDK mapping).
+- **Chat data part** — A typed JSON event that a workflow emits. It is persisted
+  in the DBOS-backed stream, and there is no separate JSONB blob. A consumer reads
+  the Cortex-native types directly, with no AI SDK mapping.
 
 ---
 
@@ -68,92 +300,423 @@ The program that embeds the harness and wires its seams. The harness exports `as
 
 ### Workflow scope
 
-- **Chat is in-process**, single host per turn. The agent loop runs synchronously in the embedder's request path. If the process dies mid-turn the caller resends — no DBOS workflow rows for chat. See [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
-- **DBOS workflows** are reserved for *durable operations*: `executeAnalysis`, `executeTargetAssessment`, and the background `runDataProfile`. **Every sandbox-backed run is a DBOS workflow** — there is no in-process sandbox consumer, and no in-memory exec transport. Sandbox exec callbacks route exclusively through `DBOS.send`/`recv`.
-- **Turn-scoped workflow** — `runEphemeral` is a DBOS workflow with a deliberately non-durable flavor: started by the `run_ephemeral` chat tool, **awaited inline** (`handle.getResult()` — the only chat tool that blocks on a workflow result), **cancelled** (`DBOS.cancelWorkflow`) when the chat turn disconnects, and **not recovered** after process death (the launch path cancels any `PENDING` `ephemeral:*` workflow for this executor before DBOS launch, so a re-run that would return its result to a dead turn never starts). It is a workflow only so its sandbox callbacks route via DBOS messaging like every other consumer; the **sandbox reaper** reaps its machine on cancel. See [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
+- **Chat is in-process**, one host for each turn. The agent loop runs
+  synchronously in the request path of the embedder. If the process dies in the
+  middle of a turn, the caller sends the message again. There are no DBOS workflow
+  rows for chat. Refer to
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
+- **A DBOS workflow** is reserved for a *durable operation*: `executeAnalysis`,
+  `executeTargetAssessment`, and the background `runDataProfile`. **Each run that
+  a sandbox backs is a DBOS workflow.** A report is the exception: it renders
+  in-process with `iterate_report`, and it is not a DBOS workflow. There is no in-process sandbox consumer,
+  and no in-memory exec transport. A sandbox exec callback routes only through
+  `DBOS.send` and `DBOS.recv`.
+- **Turn-scoped workflow** — `runEphemeral` is a DBOS workflow with a deliberately
+  non-durable flavor. The `run_ephemeral` chat tool starts it. It is **awaited
+  inline** with `handle.getResult()`, and it is the only chat tool that blocks on
+  a workflow result. It is **canceled** with `DBOS.cancelWorkflow` when the chat
+  turn disconnects, and it is **not recovered** after the death of the process:
+  before the DBOS launch, the launch path cancels any `PENDING` `ephemeral:*`
+  workflow for this executor. Thus a re-run never starts, and no result goes to a
+  dead turn. It is a workflow only so that its sandbox callbacks route through
+  DBOS messaging like each other consumer. The **sandbox reaper** reaps its
+  machine on cancel. Refer to
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md).
 
 ### Application service layer
 
-- **Application service (`app/`)** — Host-agnostic *ability* functions lifted out of the transport edge so every embedder can reuse them. Each is an `appFn(deps, params) → result` in the `app/chat-turn.ts` shape: **Deps** are construction-time values/seams (`pool`, `provider`, `embedder`, base paths, model ids), **Params** are call-time (`analysisId`/`runId`/`session`/`emit`), the return is a typed result. An app-fn owns the ability end-to-end — load → compute → persist → emit *domain* events — and owns none of the transport: no streaming/SSE framing, no HTTP status codes, no DBOS step boundary, no choice of which sink `emit` writes to or which billing the injected `embedder` carries. Members include `prepareChatTurn`, `assembleMessages`, `synthesizeRun`, and `data-profile-policy`.
+- **Application service (`app/`)** — Host-agnostic *ability* functions, lifted out
+  of the transport edge so that each embedder can use them again. Each one is an
+  `appFn(deps, params) → result` in the shape of `app/chat-turn.ts`. **Deps** are
+  construction-time values and seams (`pool`, `provider`, `embedder`, the base
+  paths, the model ids). **Params** are call-time (`analysisId`, `runId`,
+  `session`, `emit`). The return is a typed result. An app-fn has the ability from
+  end to end: load, compute, persist, and emit a *domain* event. It has none of
+  the transport:
+  - no stream framing and no SSE framing
+  - no HTTP status code
+  - no DBOS step boundary
+  - no choice of the sink that `emit` writes to
+  - no choice of the billing that the injected `embedder` carries.
+
+  Its members include `prepareChatTurn`,
+  `assembleMessages`, `synthesizeRun`, and `data-profile-policy`.
 
 ### Decomposition
 
-- `executeAnalysis` = parent workflow.
-- Per wave: one **child workflow per sandbox-agent run**, dispatched in parallel via `DBOS.startChildWorkflow`. Each child body is the sandbox-agent loop with per-LLM-call and per-tool-call DBOS steps inside.
-- `executeTargetAssessment` follows the same pattern; its `.foreach` sub-workflows are DBOS child workflows.
+- `executeAnalysis` is the parent workflow.
+- For each wave there is one **child workflow for each sandbox-agent run**,
+  dispatched in parallel with `DBOS.startChildWorkflow`. Each child body is the
+  sandbox-agent loop, with one DBOS step for each LLM call and each tool call
+  inside it.
+- `executeTargetAssessment` obeys the same pattern. Its `.foreach` sub-workflows
+  are DBOS child workflows.
 
 ### Post-step pipeline
 
-After a step's sandbox-agent loop returns, the child workflow body (`sandbox-step.ts`) runs a **typed post-step pipeline**. It walks the step's writable artifact tree **once** into a hashed manifest, then threads that manifest — and each stage's typed output — explicitly through the body: `manifest → file-metadata entries / step summary / reconciled manifest → vector index + step-detail emit`. Stage outputs are values the body holds and passes downstream (`PostStepArtifacts`), not shared mutable state — there is no module-global stash, the producer→consumer ordering is a type constraint, and `collectStepOutputs` is a pure function of the threaded products. **Integrity stages fail-fast, enrichment stages degrade** ([artifact-manifest](openspec/specs/artifact-manifest/spec.md)): artifact **registration** and **sync** are content-attested lineage — a drift, a whole-activity rejection, or an unhashable input is terminal and fails the step loudly (transient registry errors throw and DBOS-retry; an unavailable registry is a skip); **metadata / summary / vector-index** stay best-effort (`safeRun`/`safeRunValue` logs and degrades) so a flaky LLM describer never sinks a multi-hour run. The two post-step **LLM producers** (`generateFileMetadata`, `generateStepSummary`) are `DBOS.runStep`-wrapped so their outputs are checkpointed: the conditional terminal emits they gate become replay-stable and the LLM calls stop re-firing on recovery ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). The remaining stages (walk / reconcile / sync / index) still run inline and re-execute on replay; durably caching them is a deferred follow-up the typed returns enable.
+After the sandbox-agent loop of a step returns, the child workflow body
+(`sandbox-step.ts`) runs a **typed post-step pipeline**. It walks the writable
+artifact tree of the step **one time** into a hashed manifest. Then it threads
+that manifest, and the typed output of each stage, explicitly through the body:
+`manifest → file-metadata entries / step summary / reconciled manifest → vector
+index + step-detail emit`.
 
-**File metadata is lossless.** `generateFileMetadata` describes artifacts via a focused `runAgent` tool-call loop (mirrors `generatePlan`): the describer agent calls `submit_file_metadata` keyed **by path**, and the tool validates each path against the known artifact set — hallucinated paths are rejected with feedback, uncovered files are reported as `remaining`. Descriptions match files by path, never by array position, so a dropped or reordered entry cannot misalign onto the wrong file. Every input artifact yields exactly one result entry: a file the model never describes gets a **deterministic, no-LLM fallback** description (path + inferred type + size) — logged, but never silently dropped or chunked out of the index.
+A stage output is a value that the body holds and passes downstream
+(`PostStepArtifacts`), not shared mutable state. Thus there is no module-global
+stash, the producer-to-consumer order is a type constraint, and
+`collectStepOutputs` is a pure function of the threaded products.
+
+**An integrity stage fails fast, and an enrichment stage degrades**
+([artifact-manifest](openspec/specs/artifact-manifest/spec.md)). Artifact
+**registration** and **sync** are content-attested lineage: a drift, a
+whole-activity rejection, or an input that cannot be hashed is terminal, and it
+fails the step loudly. A transient registry error throws, and DBOS retries it. A
+registry that is not available is a skip. The **metadata, summary, and
+vector-index** stages stay best-effort (`safeRun` and `safeRunValue` log and
+degrade), thus a flaky LLM describer never sinks a run of many hours.
+
+The two post-step **LLM producers** (`generateFileMetadata`,
+`generateStepSummary`) are wrapped in `DBOS.runStep`, thus their outputs are
+checkpointed. The conditional terminal emits that they gate then become
+replay-stable, and the LLM calls stop the re-fire on recovery
+([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). The
+other stages (walk, reconcile, sync, index) still run inline and run again on
+replay. A durable cache for them is a deferred follow-up that the typed returns
+make possible.
+
+**File metadata is lossless.** `generateFileMetadata` describes an artifact
+through a focused `runAgent` tool-call loop, which mirrors `generatePlan`. The
+describer agent calls `submit_file_metadata` keyed **by path**, and the tool
+validates each path against the known artifact set. A path that the model
+invented is rejected with feedback, and a file with no coverage is reported as
+`remaining`. A description matches a file by path, never by array position, thus
+a dropped or reordered entry cannot land on the wrong file. Each input artifact
+gives exactly one result entry. A file that the model never describes gets a
+**deterministic description with no LLM**: the path, the inferred type, and the
+size. That fallback is logged, and a file is never dropped in silence and never
+chunked out of the index.
 
 ### Workflow recovery
 
-No standing component (the harness-durable-runtime spec). The embedder supplies a stable `executorID` to DBOS. When the same executor identity launches again, DBOS recovery can reclaim its predecessor's in-flight workflows. The harness does not provide an HTTP recovery route; any operator-facing recovery control belongs to the host.
+There is no standing component (the harness-durable-runtime spec). The embedder
+supplies a stable `executorID` to DBOS. When the same executor identity launches
+again, DBOS recovery can reclaim the in-flight workflows of its predecessor. The
+harness gives no HTTP recovery route. Any operator-facing recovery control belongs
+to the host.
 
 ### Sandbox exec
 
-See [harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md) (protocol) and [harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md) (callback auth).
+Refer to [harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md) for
+the protocol and for the callback auth.
 
-Two distinct lifetimes — do not conflate them:
+Two distinct lifetimes. Do not conflate them:
 
-- **Exec command** — one `submit → recv result`. Many per sandbox; most are near-instant (`ls`, `find`) and produce only a finished message. `submitExec` POSTs the command with `execId = "${workflowId}:${stepId}:${functionId}"`; sandbox-server runs it in the background and idempotency-dedups duplicate submits. The workflow body `DBOS.recv`s the result, bounded by `step.timeout` (a single command may legitimately run hours). **No per-exec heartbeats.**
-- **Sandbox machine** — one per step, long-lived; the sandbox-agent loop issues many commands into the *same* container. Its concerns are machine-level: did it **start**, is it still **alive** (not crashed/OOMKilled/node-lost). Lifecycle (create/teardown) is owned by the child workflow as DBOS steps.
+- **Exec command** — one submit, then one recv of the result. There are many for
+  each sandbox, and most are near-instant (`ls`, `find`) and make only a finished
+  message. `submitExec` POSTs the command with
+  `execId = "${workflowId}:${stepId}:${functionId}"`. sandbox-server runs it in
+  the background and dedups a duplicate submit by idempotency. The workflow body
+  does `DBOS.recv` for the result, bounded by `step.timeout`, because one command
+  can legitimately run for hours. **There are no per-exec heartbeats.**
+- **Sandbox machine** — one for each step, and long-lived. The sandbox-agent loop
+  issues many commands into the *same* container. Its concerns are machine-level:
+  did it **start**, and is it still **alive** (not crashed, not OOMKilled, not
+  node-lost). The child workflow has the lifecycle (the creation and the teardown)
+  as DBOS steps.
 
-- **Events are sandbox-lifetime, on-change, coalesced.** The sandbox executor diffs its working tree and emits an update only when it changes (not per exec). Meaningful progress events flow sandbox → `POST /sandbox/:execId/event` → `DBOS.send` (per-exec topic) → the workflow body's `recv → verify HMAC → writeStream` forwarding loop. `DBOS.writeStream` is workflow-body-only, so the body — never the HTTP route — is the sole stream writer.
-- **Sandbox events are folded into typed per-step parts in the sandbox-step body.** Raw per-exec events never reach the observer as-is — one translator in the `sandbox-step.ts` `emit` chokepoint maps them to the typed parts the UI renders: the agent loop's `tool-started` → `data-step-activity` (phase `executing`, phrased by the called tool's own `describeCall` hook via `createDetailResolver(agent.tools)`, falling back to the tool name), and the executor's `file-tree` delta → `data-step-file-tree` (the body folds the per-exec `added`/`modified`/`removed` deltas into a per-step path set and emits the **full** tree, paths-only). Both use a stable per-step reconciling id, so the run-stream fold + observer collapse them latest-wins, and the terminal `walkArtifacts` tree reconciles onto the same file-tree id at step end. The fold is replay-stable because it is a 1:1 pure function of the checkpointed `recv` sequence (no Cortex-side timer/debounce — that would re-break [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)). Adding a new sandbox event kind is one case in that one translator.
-- **Completion** — the sandbox worker POSTs the final result to `/sandbox/:execId/complete`; the host callback handler verifies and forwards it with `DBOS.send` on the same per-exec topic with a `done` marker, which the forwarding loop recognizes and returns. One topic, one recv loop, no stuck recv.
-- **Liveness is per-sandbox-machine, not per-exec.** The oracle is always the backend inspect (`SandboxClient.isAlive(sandboxRef)`); who invokes it differs by transport. A `@DBOS.scheduled` workflow fans out over *active sandboxes* (registry = `cortex_step_executions` rows with `sandbox_ref` + status running) — sharded so no single invocation polls all sandboxes — and on dead + no completion recorded sends a synthetic failure-`complete` to unblock the recv (callback mode). In poll mode the await loop is its own fail-fast: sustained `unavailable` polls escalate to a durable `isAlive` probe (`sandbox/liveness.ts`) and a dead machine returns the synthetic failure in-loop — same oracle, same result constructor, no topic. Recovery also re-checks liveness before a recovered child continues a step. The `step.timeout`-bounded await is the durable backstop; the liveness verdict is the fail-fast.
-- **Create is two durable steps; cleanup is a separate reaper.** `sandbox.mint` checkpoints the machine identity (`sbx-{run8}-{uuid4}` + HMAC secret) before `sandbox.create` spawns it, so a crash mid-create re-runs the spawn and **adopts** the existing machine rather than leaking a second one ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)). The **sandbox reaper** is the sole cleanup for the machines this doesn't cover (cancellation leaks, scale-down orphans) — see its glossary entry above.
+Other facts:
+
+- **Events are sandbox-lifetime, on-change, and coalesced.** The sandbox executor
+  diffs its working tree and emits an update only when the tree changes, not for
+  each exec. A meaningful progress event flows on this path:
+  - from the sandbox to `POST /sandbox/:execId/event`
+  - to `DBOS.send` on the per-exec topic
+  - to the forwarding loop of the workflow body.
+
+  That loop does recv, then it verifies the HMAC, then it does `writeStream`.
+- **A sandbox event is folded into a typed per-step part in the sandbox-step
+  body.** A raw per-exec event never reaches the observer as it is. One translator
+  in the `emit` chokepoint of `sandbox-step.ts` maps it to the typed part that the
+  UI renders. The `tool-started` of the agent loop becomes `data-step-activity`
+  with phase `executing`. The `describeCall` hook of the called tool phrases it,
+  through `createDetailResolver(agent.tools)`. The tool name is the fallback.
+  The `file-tree` delta of the executor becomes `data-step-file-tree`: the body
+  folds the per-exec `added`, `modified`, and `removed` deltas into a per-step path
+  set, and it emits the **full** tree, paths only. Both use a stable per-step
+  reconciling id, thus the run-stream fold and the observer collapse them
+  latest-wins. The terminal `walkArtifacts` tree reconciles onto the same file-tree
+  id at the end of the step. The fold is replay-stable because it is a 1:1 pure
+  function of the checkpointed `recv` sequence. There is no Cortex-side timer and
+  no debounce, because that would break
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md) again.
+- **Completion** — the sandbox worker POSTs the final result to
+  `/sandbox/:execId/complete`. The host callback handler verifies it and forwards
+  it with `DBOS.send` on the same per-exec topic, with a `done` marker. The
+  forwarding loop recognizes the marker and returns. One topic, one recv loop, and
+  no stuck recv.
+- **Liveness is per-sandbox-machine, not per-exec.** The oracle is always the
+  backend inspect (`SandboxClient.isAlive(sandboxRef)`), but the transport decides
+  who invokes it. A `@DBOS.scheduled` workflow fans out over the *active
+  sandboxes* (the registry is the `cortex_step_executions` rows with a
+  `sandbox_ref` and status running). It is sharded, thus no single invocation
+  polls each sandbox. On dead with no completion recorded it sends a synthetic
+  failure-`complete` to unblock the recv, which is the callback mode. In poll mode
+  the await loop is its own fail-fast: sustained `unavailable` polls escalate to a
+  durable `isAlive` probe (`sandbox/liveness.ts`), and a dead machine gives the
+  synthetic failure in the loop. Same oracle, same result constructor, and no
+  topic. Recovery also checks the liveness again before a recovered child continues
+  a step. The await that `step.timeout` bounds is the durable backstop, and the
+  liveness verdict is the fail-fast.
+- **The creation is two durable steps, and the cleanup is a separate reaper.**
+  `sandbox.mint` checkpoints the machine identity (`sbx-{run8}-{uuid4}` plus the
+  HMAC secret) before `sandbox.create` spawns it. Thus a crash in the middle of the
+  creation runs the spawn again. The spawn **adopts** the existing machine, and it
+  does not leak a second one
+  ([harness-sandbox-exec](openspec/specs/harness-sandbox-exec/spec.md)). The
+  **sandbox reaper** is the sole cleanup for the machines that this does not
+  cover: a cancellation leak and a scale-down orphan. Refer to its glossary entry
+  above.
 
 ### Stream model
 
-- Single DBOS-backed stream per workflow. Live consumers and historical replay read the same source.
-- No AI SDK format mapping. Consumers read Cortex-native typed events directly.
-- Typed UI parts (RunStarted, DagState, StepActivity, StepOutput, RunCompleted, etc.). **All events persisted, fold-on-read**: every part is written to the one DBOS stream; reconciling events (by `id`) are folded latest-wins on read, keeping the read bounded though storage is append-only. Coalescing (no heartbeats, on-change tree only) keeps volume tractable on multi-hour runs.
-- **Run results are pull-only.** The workflow writes nothing to the conversation thread on completion. The UI run tracker shows completion from the stream, and the conversation agent fetches results on demand via `inspectRun`. DAG scheduling is dependency-gated and budget-admitted, not wave-batched — see [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md) and [resource-budgeted-scheduling](openspec/specs/resource-budgeted-scheduling/spec.md). The scheduler loop selects the next finished child with **`DBOS.waitFirst`** (a checkpointed "who finished first"), not `Promise.race` over `getResult` — the race winner is uncheckpointed and would reorder downstream function-ID-consuming ops on replay ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)).
+- One DBOS-backed stream for each workflow. A live consumer and a historical
+  replay read the same source.
+- No AI SDK format mapping. A consumer reads the Cortex-native typed events
+  directly.
+- Typed UI parts (RunStarted, DagState, StepActivity, StepOutput, RunCompleted,
+  and others). **Each event is persisted, and the fold happens on read**: each
+  part is written to the one DBOS stream, and a reconciling event is folded
+  latest-wins by `id` on read. Thus the read stays bounded although the storage is
+  append-only. The coalescence (no heartbeats, and an on-change tree only) keeps
+  the volume tractable on a run of many hours.
+- **A run result is pull-only.** The workflow writes nothing to the conversation
+  thread on completion. The UI run tracker shows the completion from the stream,
+  and the conversation agent fetches the results on demand with `inspectRun`. The
+  DAG schedule is dependency-gated and budget-admitted, not wave-batched. Refer to
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md) and
+  [resource-budgeted-scheduling](openspec/specs/resource-budgeted-scheduling/spec.md).
+  The scheduler loop selects the next finished child with **`DBOS.waitFirst`**, a
+  checkpointed "who finished first". It does not use `Promise.race` over
+  `getResult`. The race winner is not checkpointed, thus it reorders the
+  downstream operations that consume a function ID on replay
+  ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)).
 
 ### Dependency injection
 
-- **Construction-time dependencies** (long-lived, shared, immutable) — `Pool`, `ChatProvider`, `EmbeddingProvider`, `Logger`, `SandboxClient` factory, plus the five seam realizations — are injected when a module is built. **Call-time values** (request-scoped) — `Session`, `AbortSignal`, `EmitFn` — are passed as explicit parameters.
-- Modules are **factory closures**: `createX(deps) => { op1, op2 }`. Single-operation modules are free functions taking deps as leading params. No classes, no god-ctx, no ALS, no magic-key bag.
-- **No ambient dependency accessors.** A process composition root constructs `env` and `pool` once and threads them as constructor deps. No module reaches for a dependency: `getPool()` is a pool factory/test seam, not a hidden request context. The conversation-agent factory is a nested composition root that receives its deps from the root and explodes them apart per tool; `ToolContext` is `{session, signal, emit, runStep}` — request-scoped seams only, no injected deps.
-- **Process facts are exempt** — one-per-process, write-only, never-faked state (the `lifecycle.ts` draining flag, `otel.ts` init guard, OTel instrument handles) stays module-level; injecting it buys no testability. A dependency is something you might swap or fake; a process fact is a one-per-process truth. See [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md) (incl. the 2026-05-29 amendment).
+- **A construction-time dependency** (long-lived, shared, immutable) is injected
+  when a module is built: `Pool`, `ChatProvider`, `EmbeddingProvider`, `Logger`,
+  the `SandboxClient` factory, and the five seam realizations. **A call-time
+  value** (request-scoped) is passed as an explicit parameter: `Session`,
+  `AbortSignal`, and `EmitFn`.
+- A module is a **factory closure**: `createX(deps) => { op1, op2 }`. A module
+  with one operation is a free function that takes the deps as leading
+  parameters. There are no classes, no god-ctx, no ALS, and no magic-key bag.
+- **There is no ambient dependency accessor.** A process composition root
+  constructs `env` and `pool` one time, and it threads them as constructor deps.
+  No module reaches for a dependency. `getPool()` is a pool factory and a test
+  seam, not a hidden request context. The conversation-agent factory is a nested
+  composition root: it receives its deps from the root and explodes them apart for
+  each tool. `ToolContext` is `{session, signal, emit, runStep}`, which is
+  request-scoped seams only, with no injected deps.
+- **A process fact is exempt.** State that is one for each process, write-only,
+  and never faked stays module-level: the `lifecycle.ts` draining flag, the
+  `otel.ts` init guard, and the OTel instrument handles. Injection of it buys no
+  testability. A dependency is something that you can swap or fake. A process fact
+  is a truth that is one for each process. Refer to
+  [harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md),
+  and to the 2026-05-29 amendment in it.
 
 ### Loop primitives
 
-- **`ChatProvider`** — AI SDK-backed. AI SDK `ModelMessage` is the harness's lingua franca everywhere (loop, memory persistence, DBOS step cache); signed provider metadata (Anthropic thinking signatures, cache control) rides provider-scoped in `providerOptions`. A provider is built from an embedder-supplied AI SDK `LanguageModel` instance or endpoint/key/model configuration (`anthropic` | `openai-compatible`) and advertises `capabilities.toolCalling`. See [harness-providers](openspec/specs/harness-providers/spec.md). Two methods: `chat(req, session, signal?) → ResultAsync<ChatResponse, ProviderError>` (non-streaming — workflow steps, out-of-band calls; cacheable as a DBOS step) and `chatStream(req, session, signal?) → AsyncIterable<ChatStreamEvent>` (text deltas then one terminal `done` event — the chat loop). Output-token truncation surfaces as the AI SDK `finishReason: "length"`, so the loop sees exactly one truncation signal.
-- **`EmbeddingProvider`** — separate narrow interface for embeddings; takes `Session`.
-- **`defineTool({id, description, inputSchema: ZodSchema, execute(input, ctx) => result, executionMode?, describeCall?})`** — `ctx` is `ToolContext = {session, signal, emit, runStep}` (request-scoped seams, no deps). `runStep` is the durability seam a tool uses to wrap its own durable work (passthrough in chat, `DBOS.runStep` in workflows; the loop namespaces the name under the tool's own step name). Dep-bearing tools are factory closures (`createXTool(deps)`) that capture deps and call `defineTool`. Every tool declares or defaults to an **`executionMode`** — `step` | `workflow` | `inline` — see *The loop*. Error contract: expected outcomes (incl. "not found") are returned as data variants of the result type; unexpected failures throw or return `err(ToolError)` → the loop maps them to model-visible error tool results; Zod input-validation failure → error tool result at the boundary, without calling `execute`.
-- **`describeCall(input) => string` is the call-time counterpart of `description`** (the `tool-call-detail` capability). `description` self-describes the tool at attach time; `describeCall` self-describes one invocation, so a surface renders four `update_working_memory` calls as four distinct lines. It is optional, synchronous, pure, and typed against `z.infer<Schema>` — colocated with the schema because that is the one place the compiler checks the two against each other. The loop computes the detail best-effort at dispatch: it `safeParse`s the raw model input first and calls the hook only on success (a `tool-started` event is emitted BEFORE dispatch-time validation, so the value there is unvalidated), guards the call, and drops the detail on any failure. Normalization — one line, control characters stripped, secrets redacted, capped at 120 characters — happens once at the emit site, never in tool code. A host renders the string and parses nothing out of it. `createDetailResolver(tools)` maps `toolName + input → detail` for the surfaces that hold a name rather than a `Tool` (reload conversion, the sandbox and data-profile activity lines); the caller supplies the tool list, because tools contributed through the host-tools seam are invisible to any map the harness holds. Nothing is persisted — storage stays the pure model transcript.
-- **`tool-finished` reports `outcome: "ok" | "error" | "denied"`**, not an error boolean ([harness-agent-loop](openspec/specs/harness-agent-loop/spec.md)). The loop already separates a denial from a recoverable tool error in control flow — a denial hard-stops the turn — so the observation channel carries the same distinction, and a user who rejects an approval no longer sees their own decision reported as a fault. One three-state field rather than two booleans, which would admit the impossible "not an error, but denied".
-- **No processor pipeline.** SOUL kernel/conversational personality is static `systemPrompt` composition in the agent definition. Input sanitization (`normalizeUnicode`, trimmed `redactSecrets`) is two functions applied once to user input in the chat route. Analysis context is injected at chat-route message assembly.
-- **Sub-agents** — exposed as regular tools whose `execute` calls `runAgent(subAgent, prompt, childSession)`, where `childSession` derives agentId + callPath from the parent. No special delegation primitive, no message stripping. Sub-agent transcripts are ephemeral. Workflow-decides path uses `runAgent` directly without the tool wrapper.
-- **The loop** — `runAgent(agent, messages, session, {signal, emit, runStep}) → { messages, finish }`, where `finish = { reason, cappedOut, truncationRecoveries }` (the terminal finish reason, whether the iteration cap was hit, and how many truncations were recovered). `runStep` is injected (passthrough in chat, `DBOS.runStep` in workflows). The loop emits orchestration events stamped with `source` from `session.callPath`; at the iteration cap it forces a final tool-less wrap-up call rather than throwing. A `finishReason: "length"` truncation is a **recoverable soft-error, not a stop**: only the final content part can be truncated, so the loop does **not** execute a truncated trailing tool call (its input may be silently incomplete) — it feeds back a retryable error tool result and continues (earlier complete tool calls still dispatch; truncated prose gets a steer-and-continue turn), so a truncated write never lands a partial file. Step names (`llm-${i}`, `tool-${name}-${id}`) are a documented, deterministic contract — see [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
-- **Execution-mode partitioned dispatch** ([harness-tools](openspec/specs/harness-tools/spec.md)). Dispatch follows each tool's `executionMode`. `step` tools (the default — the ~35 external bio/chem API tools + workspace reads) are wrapped in a deterministic `runStep` and run concurrently (`Promise.all`, each reserving one function-ID synchronously in array order). `workflow` tools run sequentially **after**, unwrapped in the workflow body, so their internal `DBOS.recv` / `writeStream` (body-only) is legal — exactly `execute_command` / `write_file` / `edit_file`, which own their durability (submit is a step, recv is a body call; they reserve multiple function-IDs across awaits, so concurrent ones would race the counter). `inline` tools are pure deterministic logic and run unwrapped. Results are assembled by original index, so tool-result order holds. The loop emits (`iteration`/`tool-started`/`tool-finished`) are `await`ed so each body-path `writeStream` lands at a deterministic function-ID on replay ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)).
+- **`ChatProvider`** — AI SDK-backed. The AI SDK `ModelMessage` is the lingua
+  franca of the harness everywhere: the loop, the memory persistence, and the DBOS
+  step cache. Signed provider metadata (an Anthropic thinking signature, a cache
+  control) rides provider-scoped in `providerOptions`. A provider is built from an
+  AI SDK `LanguageModel` instance that the embedder supplies, or from an endpoint,
+  key, and model configuration (`anthropic` or `openai-compatible`). It advertises
+  `capabilities.toolCalling`. Refer to
+  [harness-providers](openspec/specs/harness-providers/spec.md). It has two
+  methods:
+  - `chat(req, session, signal?) → ResultAsync<ChatResponse, ProviderError>` —
+    non-streaming, for a workflow step and an out-of-band call. It is cacheable as
+    a DBOS step.
+  - `chatStream(req, session, signal?) → AsyncIterable<ChatStreamEvent>` — text
+    deltas, then one terminal `done` event. This is the chat loop.
+
+  An output-token truncation shows as the AI SDK `finishReason: "length"`, thus
+  the loop sees exactly one truncation signal.
+- **`EmbeddingProvider`** — a separate narrow interface for the embeddings, and
+  `providers/types.ts` declares the two provider interfaces. It
+  takes a `Session`.
+- **`defineTool({id, description, inputSchema: ZodSchema, execute(input, ctx) => result, executionMode?, describeCall?})`**
+  — `ctx` is `ToolContext = {session, signal, emit, runStep}`, which is
+  request-scoped seams with no deps. `tools/define-tool.ts` has it. The
+  `z.toJSONSchema()` of Zod 4 emits the tool input schema that the AI SDK accepts:
+  a top-level object only, and it rejects a union at construction. `runStep` is the
+  durability seam that a tool
+  uses to wrap its own durable work: it is a passthrough in chat and
+  `DBOS.runStep` in a workflow, and the loop namespaces the name under the step
+  name of the tool. A tool that carries deps is a factory closure
+  (`createXTool(deps)`) that captures the deps and calls `defineTool`. Each tool
+  declares an **`executionMode`** or defaults to one: `step`, `workflow`, or
+  `inline`. Refer to *The loop*. The error contract: an expected outcome, which
+  includes "not found", is a data variant of the result type. An unexpected
+  failure throws or gives `err(ToolError)`, and the loop maps it to a
+  model-visible error tool result. A Zod input-validation failure gives an error
+  tool result at the boundary, without a call to `execute`.
+- **`describeCall(input) => string` is the call-time counterpart of
+  `description`** (the `tool-call-detail` capability). `description`
+  self-describes the tool at attach time. `describeCall` self-describes one
+  invocation, thus a surface renders four `update_working_memory` calls as four
+  distinct lines. It is optional, synchronous, pure, and typed against
+  `z.infer<Schema>`. It is colocated with the schema, because that is the one
+  place where the compiler checks the two against each other. The loop computes
+  the detail best-effort at dispatch: it does `safeParse` on the raw model input
+  first, and it calls the hook only on success. A `tool-started` event is emitted
+  BEFORE dispatch-time validation, thus the value there is unvalidated. It
+  guards the call, and it drops the detail on any failure. The normalization
+  happens one time at the emit site, never in tool code: one line, control
+  characters stripped, secrets redacted, and a cap of 120 characters. A host
+  renders the string and parses nothing out of it. `createDetailResolver(tools)`
+  maps a tool name and an input to a detail, for the surfaces that hold a name
+  rather than a `Tool`: the reload conversion, and the sandbox and data-profile
+  activity lines. The caller supplies the tool list, because a tool that comes
+  through the host-tools seam is invisible to any map that the harness holds.
+  Nothing is persisted, thus the storage stays the pure model transcript.
+- **`tool-finished` reports `outcome: "ok" | "error" | "denied"`**, not an error
+  boolean ([harness-agent-loop](openspec/specs/harness-agent-loop/spec.md)). The
+  loop already separates a denial from a recoverable tool error in the control
+  flow, because a denial hard-stops the turn. Thus the observation channel carries
+  the same distinction, and a user who rejects an approval no longer sees their
+  own decision reported as a fault. It is one three-state field, not two booleans,
+  which would admit the impossible "not an error, but denied".
+- **There is no processor pipeline.** The SOUL kernel and the conversational
+  personality are a static `systemPrompt` composition in the agent definition. The
+  input sanitization (`normalizeUnicode`, a trimmed `redactSecrets`) is two
+  functions, applied one time to the user input in the chat route. The analysis
+  context is injected at the message assembly of the chat route.
+- **Sub-agents** — exposed as regular tools. The `execute` of such a tool calls
+  `runAgent(subAgent, prompt, childSession)`, where `childSession` derives the
+  agentId and the callPath from the parent, through
+  `forSubAgent(ctx.session, childAgentId)`. The examples are `literature-reviewer`
+  and `analogical-reasoner`. There is no special delegation
+  primitive and no message stripping. A sub-agent transcript is ephemeral. The
+  workflow-decides path uses `runAgent` directly, with no tool wrapper.
+- **The loop** (`loop/run-agent.ts`) —
+  `runAgent(agent, messages, session, {signal, emit, runStep}) → { messages, finish }`,
+  where `finish = { reason, cappedOut, truncationRecoveries }`: the terminal
+  finish reason, whether the iteration cap was hit, and how many truncations were
+  recovered. `runStep` is injected: a passthrough in chat, and `DBOS.runStep` in a
+  workflow. The loop emits orchestration events stamped with `source` from
+  `session.callPath`. At the iteration cap it forces a final tool-less wrap-up
+  call, and it does not throw. A `finishReason: "length"` truncation is a
+  **recoverable soft-error, not a stop**. Only the final content part can be
+  truncated. Thus the loop does **not** execute a truncated trailing tool call,
+  because its input can be incomplete in silence. It feeds back a retryable error
+  tool result and continues: an earlier complete tool call still dispatches, and
+  truncated prose gets a steer-and-continue turn. Thus a truncated write never
+  lands a partial file. The step names (`llm-${i}`, `tool-${name}-${id}`) are a
+  documented, deterministic contract. Refer to
+  [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
+- **Execution-mode partitioned dispatch**
+  ([harness-tools](openspec/specs/harness-tools/spec.md)). The dispatch obeys the
+  `executionMode` of each tool. A `step` tool is the default: the ~35 external bio
+  and chem API tools, and the workspace reads. Each is wrapped in a deterministic
+  `runStep` and runs concurrently (`Promise.all`), and each reserves one function
+  ID synchronously in array order. A `workflow` tool runs sequentially **after**,
+  unwrapped in the workflow body, thus its internal `DBOS.recv` and `writeStream`
+  (body-only) are legal. These are exactly `execute_command`, `write_file`, and
+  `edit_file`, which have their own durability: the submit is a step, and the recv
+  is a body call. They reserve multiple function IDs across awaits, thus
+  concurrent ones would race the counter. An `inline` tool is pure deterministic
+  logic and runs unwrapped. The results are assembled by the original index, thus
+  the tool-result order holds. The loop emits (`iteration`, `tool-started`,
+  `tool-finished`) are awaited, thus each body-path `writeStream` lands at a
+  deterministic function ID on replay
+  ([harness-durable-runtime](openspec/specs/harness-durable-runtime/spec.md)).
 
 ### Memory
 
-- **Thread history** — `messages` table; rows store AI SDK model messages in a versioned envelope (`{kind: "ai-sdk-model-message", aiSdkMajor, message}`; legacy Anthropic rows are backfilled at startup). `appendTurn` writes a turn atomically, `loadRecent` walks newest-first to a token budget and snaps the window to valid turn boundaries (never an orphan tool-result continuation). Conversation-scoped.
-- **Working memory** — `cortex_working_memory`, one JSONB row per analysis. Four sections: `goal`, `constraints`, `hypotheses` (analysis-flat) and `findings` (run-scoped, keyed by `runId`). The agent maintains it section-by-section via one `updateWorkingMemory` tool (not whole-blob rewrites). Rendered to Markdown and injected as a user message in the window tail (cache-safe).
-- **No semantic recall.** Conversations operate inside the token-bounded thread window only. See [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
-- **Workflow / sandbox agent loops** — no `messages` table. Durability is the DBOS step cache; debugging is read-side reconstruction from `dbos.operation_outputs`. See [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
+- **Thread history** — the `messages` table. A row stores an AI SDK model message
+  in a versioned envelope (`{kind: "ai-sdk-model-message", aiSdkMajor, message}`).
+  A legacy Anthropic row is backfilled at startup. `appendTurn` writes a turn
+  atomically. `loadRecent` walks newest-first to a token budget, and it snaps the
+  window to a valid turn boundary, thus it never gives an orphan tool-result
+  continuation. It is conversation-scoped.
+- **Working memory** — `cortex_working_memory`, one JSONB row for each analysis.
+  It has four sections: `goal`, `constraints`, and `hypotheses` are analysis-flat,
+  and `findings` is run-scoped, keyed by `runId`. The agent maintains it section by
+  section with one `updateWorkingMemory` tool, and it does not rewrite the whole
+  blob. It is rendered to Markdown and injected as a user message in the window
+  tail, which is cache-safe.
+- **There is no semantic recall.** A conversation operates inside the
+  token-bounded thread window only. Refer to
+  [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
+- **Workflow and sandbox agent loops** — no `messages` table. The durability is
+  the DBOS step cache, and the debug method is read-side reconstruction from
+  `dbos.operation_outputs`. Refer to
+  [harness-thread-store](openspec/specs/harness-thread-store/spec.md).
 
 ### Call attribution at the wire boundary
 
-- The session is the compile-time obligation. `ChatProvider.chat(req, session, signal?)` and `EmbeddingProvider.embed(texts, session)` both require an `AgentSession` — you cannot construct a wire call without one. The provider resolves call attribution internally via its injected `resolveBilling(session)` seam at call time, then spreads whatever header map the seam returns onto the request. The OSS realization returns an empty map.
-- No ALS, no fetch-patch, no wrapper. Read-only routes never resolve attribution — the seam is lazy and fires only at the LLM/embedding call site.
-- Background tasks (data profile triggers, async memory writes) and the `run_ephemeral` chat tool construct an explicit `RunSession` via the `RunAuthorizer` seam and pass it through; the scope is whatever resource the task acts against. Ephemeral and data-profile both keep their synthetic `RunFrame` literals (`"ephemeral"` / `"data-profile"`) as the run/step tag while the unique DBOS `workflowID` does the routing.
+- The session is the compile-time obligation. `ChatProvider.chat(req, session, signal?)`
+  and `EmbeddingProvider.embed(texts, session)` both take an `AgentSession`, thus
+  you cannot construct a wire call without one. The provider resolves the call
+  attribution internally, with its injected `resolveBilling(session)` seam at call
+  time. Then it spreads the header map that the seam gives onto the request. The
+  OSS realization gives an empty map.
+- There is no ALS, no fetch-patch, and no wrapper. A read-only route never
+  resolves the attribution, because the seam is lazy and fires only at the LLM or
+  embedding call site.
+- A background task (a data profile trigger, an async memory write) and the
+  `run_ephemeral` chat tool construct an explicit `RunSession` through the
+  `RunAuthorizer` seam and pass it through. The scope is whatever resource the
+  task acts against. Ephemeral and data-profile both keep their synthetic
+  `RunFrame` literals (`"ephemeral"` and `"data-profile"`) as the run tag and the
+  step tag. The unique DBOS `workflowID` does the routing.
 
 ### Budget-exceeded resume
 
-Two replay scenarios must not be conflated:
+Do not conflate the two replay scenarios:
 
-- **Pod-crash recovery** (the harness-durable-runtime spec) replays with the **same input** — the `attempt` is unchanged, so every step name is identical and the whole body cache-hits (cheap replay). This is the common case and it "just works."
-- **Budget resume** deliberately **bumps `attempt`** so the failed LLM call re-fires against a now-available budget. The mechanism:
-  - Step names carry the attempt as a suffix. `attemptStepNameFormatter` (in `sandbox-step.ts`) names the loop's steps `llm:${iteration}:${attempt}` and `tool:${name}:${toolUseId}:${attempt}`; the parent names its own steps `open-running-charge:${attempt}` / `close-running-charge:${attempt}` / `revoke-run-auth:${attempt}`. A bumped attempt is a name that has never been cached → the call fires fresh.
-  - On a budget error the caller catches the provider-specific error, calls `DBOS.cancelWorkflow(DBOS.workflowID!)`, and returns; the next step boundary throws `DBOSWorkflowCancelledError` and the status becomes **`CANCELLED`** (not `ERROR` — `ERROR` is terminal in DBOS v4 and cannot be resumed). Cortex marks the analysis `suspended` from the status flip.
-  - On resume, `prepareExecuteAnalysisResume` atomically bumps `cortex_runs.attempt_count`, then the caller calls `DBOS.resumeWorkflow(wfId)`. The parent body replays, re-reads the bumped `attempt`, and re-opens the running charge under a fresh step name. The workflow ID never moves, so `cortex_runs.workflow_id` is stable.
-  - **Why not `ERROR` + `forkWorkflow`?** Resuming from `ERROR` doesn't work — DBOS's resume excludes terminal statuses. `forkWorkflow` works but creates a new workflow ID, forcing Cortex to update its run-to-workflow mapping. `CANCELLED` + `resumeWorkflow` keeps the ID stable.
-- **Known limitation — child-level budget resume is not wired (follow-up).** A budget pause that originates inside a **child** sandbox-step (a sandbox-agent LLM call) is not cleanly resumable today. The parent re-dispatches children with `DBOS.startWorkflow(childWorkflowId)`, which **dedups on the existing (cancelled) child** (`initWorkflowStatus` returns the existing status and ignores the new input — so the bumped attempt never reaches the child); nothing calls `DBOS.resumeWorkflow(childWorkflowId)` (`resume-execute-analysis.ts` resumes only the parent); and the child id `${workflowId}-${idx}` carries **no attempt**, so even an explicit child resume would replay the cached-failed step. Fixing it requires the child id to carry the attempt (or `forkWorkflow`) **and** the resume path to re-fire cancelled children.
+- **Pod-crash recovery** (the harness-durable-runtime spec) replays with the
+  **same input**. The `attempt` does not change, thus each step name is identical
+  and the whole body hits the cache. This is the common case, and it works with no
+  extra work.
+- **Budget resume** deliberately **increases `attempt`**, thus the failed LLM call
+  fires again against a budget that is now available.
+
+The mechanism of the budget resume:
+
+- The step names carry the attempt as a suffix. `attemptStepNameFormatter` (in
+  `sandbox-step.ts`) names the loop steps `llm:${iteration}:${attempt}` and
+  `tool:${name}:${toolUseId}:${attempt}`. The parent names its own steps
+  `open-running-charge:${attempt}`, `close-running-charge:${attempt}`, and
+  `revoke-run-auth:${attempt}`. An increased attempt is a name that the cache has
+  never held, thus the call fires fresh.
+- On a budget error the caller catches the provider-specific error, calls
+  `DBOS.cancelWorkflow(DBOS.workflowID!)`, and returns. The next step boundary
+  throws `DBOSWorkflowCancelledError`, and the status becomes **`CANCELLED`**. It
+  is not `ERROR`, because `ERROR` is terminal in DBOS v4 and it cannot resume.
+  Cortex marks the analysis `suspended` from the status flip.
+- On resume, `prepareExecuteAnalysisResume` atomically increases
+  `cortex_runs.attempt_count`. Then the caller calls `DBOS.resumeWorkflow(wfId)`.
+  The parent body replays, reads the increased `attempt` again, and opens the
+  running charge again under a fresh step name. The workflow ID never moves, thus
+  `cortex_runs.workflow_id` is stable.
+- **Why not `ERROR` plus `forkWorkflow`?** A resume from `ERROR` does not work,
+  because the DBOS resume excludes a terminal status. `forkWorkflow` works, but it
+  makes a new workflow ID, thus Cortex must update its run-to-workflow mapping.
+  `CANCELLED` plus `resumeWorkflow` keeps the ID stable.
+- **A known limitation: child-level budget resume is not wired (a follow-up).** A
+  budget pause that starts inside a **child** sandbox-step (a sandbox-agent LLM
+  call) is not cleanly resumable today. Three facts cause this. The parent
+  dispatches a child again with `DBOS.startWorkflow(childWorkflowId)`, which
+  **dedups on the existing canceled child**: `initWorkflowStatus` gives the
+  existing status and ignores the new input, thus the increased attempt never
+  reaches the child. Nothing calls `DBOS.resumeWorkflow(childWorkflowId)`, because
+  `resume-execute-analysis.ts` resumes only the parent. The child id
+  `${workflowId}-${idx}` carries **no attempt**, thus even an explicit child
+  resume would replay the step that the cache holds as failed. A fix needs the
+  child id to carry the attempt, or it needs `forkWorkflow`. The resume path must
+  also fire the canceled children again.


### PR DESCRIPTION
## What & why

Each agent-facing document in this repository now obeys ASD-STE100 Simplified
Technical English, issue 9. A hook enforces it.

**The language contract.** `CLAUDE.md` gives the rules: the words, the verbs, the
sentences, and the word count. It also gives a table of 29 word traps, and a
procedure for a word that the standard does not approve.

**The gate** is `.claude/hooks/ste-check.ts`. It reads three surfaces:

| Surface | Event | Result |
| --- | --- | --- |
| `git commit` | PreToolUse on Bash | denies on a hard finding, or on an absent sign-off |
| `gh pr` and `gh issue`: create, edit, comment, and review | PreToolUse on Bash | denies on a hard finding |
| a `*.md` file | PostToolUse on Write and Edit | reports to the agent |

A finding has one of two classes. A **hard** finding is deterministic:

- a contraction, or a semicolon
- a Latin abbreviation, or a gendered pronoun
- a British spelling
- an unqualified word trap
- a sentence that is too long
- an absent sign-off
- a payload that the gate cannot read.

Only a hard finding denies a command.

A **soft** finding is a heuristic: the voice, the tenses, and a word whose
legality depends on its part of speech. A gate that denies on a guess makes a
person bypass it, thus the blocking set is deliberately the narrow one.

The hook reads its word traps from the table in `CLAUDE.md` at each run. Thus no
part of the ASD-STE100 dictionary enters this public repository, and the table
stays the one source of truth.

**The payload sources.** A tokenizer obeys the quoting rules of the shell. Thus
the gate reads the prose of a `gh` command from each flag that carries it:

- `--title` and `-t`
- `--body` and `-b`
- `--body-file` and `-F`, which name a file that the gate opens
- `--body-file -`, which reads the heredoc of the command

A source that the gate cannot resolve, such as a `$VAR` or a path that it cannot
open, makes a hard finding. A silent skip of an unknown source is a gate in name
only.

**The command entry point.** `ste-check.ts --file <path>` gives one checker to
the hook, to a person, and to a CI job. It exits 1 on a hard finding, thus a CI
job can use it. This description went through it, and then through the gate as a
`--body-file` payload.

**The documents.** The gate reported 265 hard findings across the four package
documents. It now reports none in each document that this pull request touches.

**The harness deduplication.** `harness/CLAUDE.md` and `harness/CONTEXT.md`
explained the same 13 topics. `CLAUDE.md` now keeps the rules, and `CONTEXT.md`
keeps the domain model. `harness/CLAUDE.md` is 1611 words shorter, which is 26
percent. A session that works in `harness/` loads that file each time, thus the
size is the cost that matters.

An audit of the 316 identifiers in the previous `harness/CLAUDE.md` shows that no
fact is absent from the two files.

The root `CLAUDE.md` also points at `CONTEXT.md` for the repository map. It does
not copy the map.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [x] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change

## Checklist

- [ ] Lint, typecheck, and tests pass locally. **This pull request changes no
      source file.** It touches `.claude/` and markdown only, thus the suites are
      not affected and I did not run them.
- [ ] Tests added or updated. The hook has no test file. Four groups of checks
      cover it:
  - 13 recorded payloads for the sign-off truth table
  - 16 recorded payloads for the `gh` surfaces and the commit surface
  - 6 runs of the `--file` entry point for the exit codes
  - a self-test against each document in the repository
- [x] Documentation updated.
- [ ] Commits obey Conventional Commits. Four of the five do. `f8974eca`
      ("Update CLAUDE.md - first attempt") does not.
- [x] Commits are signed off for the DCO.
- [x] This pull request is focused on a single logical change.

## Known limits

- The gate fires only for a contributor who uses Claude Code. It does not see a
  commit from a terminal, or an edit in the GitHub web form.
- The gate sees a Bash command only. An MCP GitHub tool call carries a different
  tool name, thus it passes.
- `--editor` and `--web` hand the text to a person. A person is outside the
  reach of a tool hook.
- A relative `--body-file` path resolves against the directory of the hook. The
  gate reports a path from another directory as unreadable, thus it denies and
  asks for an absolute path.
- The gate reads the text of each Bash command. A command that only mentions
  `git commit` is gated as a real commit.
- The dictionary of the standard is not in the repository. Thus the gate reads
  the grammar and the 29 traps, and it does not read the full vocabulary.
