### PR TITLE
feat(harness): extract the signed provenance recorder behind sink/signer/actor seams

### DIFF
--- a/harness/bun.lock
+++ b/harness/bun.lock
@@ -11,6 +11,7 @@
         "@ai-sdk/provider-utils": "5.0.10",
         "@anthropic-ai/sdk": "^0.107.0",
         "@dbos-inc/dbos-sdk": "^4.23.6",
+        "@inflexa-ai/tsprov": "^0.5.1",
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.9.0",
@@ -108,6 +109,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@inflexa-ai/tsprov": ["@inflexa-ai/tsprov@0.5.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-F2Q+trPPT0YdAs5aQ8LY6OJ718yaVWYABTg5bN1qNqdIJvjjH/NCThbOA2j5IJvevErhpHJXPEqcixeOHiHzGQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -608,6 +611,8 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/harness/openspec/changes/extract-provenance-recorder/.openspec.yaml
+++ b/harness/openspec/changes/extract-provenance-recorder/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/harness/openspec/changes/extract-provenance-recorder/design.md
+++ b/harness/openspec/changes/extract-provenance-recorder/design.md
@@ -1,0 +1,41 @@
+# Design — extracting the provenance recorder into the harness
+
+## The cut
+
+The CLI recorder decomposes into a generic core and exactly four host couplings. The core moves; each coupling becomes a seam the embedder fills at its composition root:
+
+| Seam | CLI realization | Managed realization (reference) |
+|-|-|-|
+| `ProvSnapshotSink` — `load(analysisId)` / `persist(snapshot)` | SQLite `analyses.provenance` + integrity columns | GET/PUT against the backend's document endpoint |
+| `ProvSigner` — `sign(digestHex)` | `~/.config/inflexa/prov_key.json`, generate-on-first-use | Ed25519 JWK from a mounted secret |
+| `ProvActor` values on each event | `loadAuth()` email / CLI version + baked commit | session identity / service name + version |
+| QName digest (`createProvDocumentModel({ digest })`) | `Bun.hash` (keeps existing documents' QNames stable) | harness default (`node:crypto` SHA-256 fold) |
+
+The event feed is deliberately **not** a seam interface: `ProvenanceRecorder.record(event)` is a plain synchronous function. The CLI keeps its bus and subscribes `record` to it; a managed host calls `record` directly from the two bridges. A bus is one delivery mechanism, not part of the contract.
+
+## Document model as a factory
+
+`document.ts`'s builders were module-level functions closing over `Bun.hash` and `randomUUIDv7`. Both are runtime-coupled (the harness runs on Node) and the digest is identity-load-bearing: every file/command/agent QName embeds it, so changing the function would orphan the QName space of every existing CLI document — re-emission after an upgrade would mint new identifiers for the same files and `unified()` would keep both. `createProvDocumentModel({ digest?, mintActionId? })` makes the derivation explicit and injectable: the harness default is a Node-portable SHA-256 fold; the CLI injects its `Bun.hash` wrapper and its documents stay continuous. The bridges take the same model instance so the `externalId` a registration returns is minted by the same derivation the recorder appends with.
+
+No ambient state anywhere: the recorder is a factory instance (per-instance live-doc/chain/dirty maps), so tests construct fresh instances instead of resetting module globals.
+
+## Recorder lifecycle changes vs the CLI copy
+
+Two deliberate deltas; everything else (revision-guarded dirty tracking, coalesced timer flush, single-flight chain discipline, signed-only persistence, no-progress drain guard) ports as-is:
+
+1. **First-touch load is async.** The CLI's sink is synchronous SQLite; a managed sink is an HTTP round-trip. `record()` stays synchronous fire-and-forget: the first event for an analysis starts the sink load and queues events; when the load settles the queue drains into the (deserialized or fresh) document and the analysis is marked dirty. A failed load or unknown analysis (`load → ok(null)`) drops the queued events with a logged error/warn — recording must never block or fail the emitting execution path, exactly as the CLI's builder-throw guard already establishes.
+2. **Chain-conflict recovery.** The sink may reject a persist with `{ type: "conflict" }` (a compare-and-swap on `prevChainHash`, for sinks that support it). The recorder then refreshes its cached chain head from `sink.load` and retries on the next flush — the chain never forks. Content-level merge of concurrent writers is out of scope: the recorder documents a **single-writer-per-analysis** requirement (the CLI holds an analysis lock; a managed host's workflow ownership provides the same), and the CAS exists to detect violations, not to reconcile them.
+
+## Signing split
+
+The pure primitives (chain hash `SHA-256(prev || json)` with the `SHA-256("")` seed, payload digest, hex Ed25519 sign/verify) move into the harness — they are WebCrypto-only and shared by recorder, sidecar export, and verification. The **keypair lifecycle** (where a key lives, generate-on-first-use, exclusive-create race handling) stays host-side behind `ProvSigner`: key custody is a policy decision the harness must not make. The sidecar schema and the two verification entry points (chained column verify, self-contained sidecar verify) move, parameterized on stored values rather than on any database.
+
+## Actor generalization
+
+The CLI's `system` actor hardcoded the label "inflexa cli". The harness shape carries the host's own identity — `{ kind: "system"; label; version; commit? }` — so a managed host records its service name and build, and the CLI passes its label and stays byte-identical. `user`/`anonymous` are unchanged. The model agent (`ProvModelId`, `{provider}/{model}`) is unchanged and remains per-event, so live model swaps keep working through the CLI's existing swappable wrapper composed over the extracted bridge constructors.
+
+## What deliberately does not move
+
+- The CLI's bus stamping, analysis-ref resolution for `prov` commands, export file layout, and keypair file handling — host policy.
+- `SwappableSandboxEmitters` — a CLI composition detail over the bridge constructors.
+- Any change to `ArtifactRegistry`, `emitProvenance`, or `exec-provenance-lineage` — the recorder consumes their existing shapes.

--- a/harness/openspec/changes/extract-provenance-recorder/proposal.md
+++ b/harness/openspec/changes/extract-provenance-recorder/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The signed provenance recorder — the machinery that folds harness execution facts into a W3C PROV document (`@inflexa-ai/tsprov`), chain-hashes it, Ed25519-signs it, and persists it whole — lives in the `cli` subsystem, wired to the CLI's event bus, SQLite columns, config-dir keypair, and auth module. A managed embedder that wants the same signed document (Cortex, submitting per-analysis documents to its backend) would have to re-implement all of it, and the two copies would drift — the exact failure mode the harness's seam architecture exists to prevent. The recorder's actual inputs are already harness-owned (`ArtifactRegistrationInput` at the `ArtifactRegistry` seam, `RunProvenanceEvent` from `emitProvenance`), and its host couplings are confined to four narrow points: where snapshots load/persist, how a digest is signed, who the responsible actor is, and how events reach it.
+
+## What Changes
+
+- Add a harness-owned provenance recorder capability under `src/provenance/recorder/`: the PROV document model (deterministic QName derivations, append builders, replay-idempotent merge policy), the recorder lifecycle (per-analysis live documents, coalesced single-flight signed flush, drain), the chain-hash/sign/verify primitives, the sidecar schema, and the two bridges that translate `ArtifactRegistry.register` inputs and `RunProvenanceEvent`s into recorder events.
+- Declare the consumer-filled seams: a snapshot sink (`load`/`persist` — the CLI's SQLite columns, a managed host's HTTP backend), a signer (the CLI's config-dir JWK keypair, a managed host's secret-provided key), actor descriptors (user / anonymous / system with label, version, and optional commit), and an injectable QName digest so an embedder with existing documents keeps its identifier space stable.
+- Events reach the recorder through a plain `record(event)` call. An event bus may sit in front of it (the CLI's does), but the push seam is a function, accessible to any consumer without a bus.
+- The `cli` keeps its bus, its keypair lifecycle, its DB columns, and its actor resolution, and re-wires them onto the extracted capability in a separate change in that subsystem.
+
+## Capabilities
+
+### New Capabilities
+
+- `provenance-recorder`: the signed, chain-hashed PROV document recorder — document model, recorder lifecycle, signing primitives, verification, and the two harness-seam bridges — parameterized over sink, signer, actor, and digest seams.
+
+### Modified Capabilities
+
+None. `exec-provenance-lineage` and the `ArtifactRegistry` seam are unchanged; the recorder consumes their existing shapes.
+
+## Impact
+
+- Additive to the public barrel: `createProvenanceRecorder`, `createProvDocumentModel`, `createProvenanceArtifactRegistry`, `createRunProvenanceEmitter`, the seam types (`ProvSnapshotSink`, `ProvSigner`, `ProvEvent`, `ProvActor`, and the ref types), and the signing/verification primitives. No existing export changes shape.
+- Adds `@inflexa-ai/tsprov` to the harness's dependencies.
+- No workflow, provider, storage, or DBOS behavior changes. The recorder is inert unless an embedder constructs it and wires its bridges at the composition root.
+- The `cli` subsystem's re-wire (deleting its local copies and injecting its bus/SQLite/keypair realizations) is a separate change in `cli/`; until it lands, the CLI continues on its own copy with byte-identical output.

--- a/harness/openspec/changes/extract-provenance-recorder/specs/provenance-recorder/spec.md
+++ b/harness/openspec/changes/extract-provenance-recorder/specs/provenance-recorder/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: The recorder is a harness factory over consumer-filled seams
+
+`createProvenanceRecorder({ sink, signer, documentModel?, logger? })` SHALL construct a provenance recorder whose only host contact points are the injected `ProvSnapshotSink` (snapshot load/persist), `ProvSigner` (digest signing), and the `ProvActor`/model values carried on each event. All recorder state (live documents, chain heads, dirty tracking) SHALL be per-instance — no module-level state. Events SHALL be delivered through the plain synchronous call `record(event: ProvEvent)`; a delivery mechanism such as an event bus MAY sit in front of it but is not part of the contract.
+
+#### Scenario: Two recorder instances are independent
+
+- **WHEN** two recorders are constructed over different sinks and each records events for the same analysis id
+- **THEN** each persists through its own sink with its own chain, and neither observes the other's state
+
+#### Scenario: A consumer without a bus records directly
+
+- **WHEN** a host calls `record(event)` from its own call sites with no event bus anywhere
+- **THEN** the event is appended and flushed exactly as it would be behind a bus subscription
+
+### Requirement: Provenance is never persisted unsigned and the chain never forks
+
+Every persisted snapshot SHALL be the whole serialized document (unified last-write-wins), chain-hashed as `SHA-256(prevChainHash || documentJson)` seeded from `SHA-256("")`, and signed via the injected `ProvSigner` before it reaches the sink. A signing or persist failure SHALL leave the analysis dirty for retry and SHALL NOT write unsigned bytes. Flushing SHALL be single-flight per recorder instance, and per-analysis snapshots SHALL be captured synchronously so an append landing mid-flush survives to the next pass (revision guard). `flush()` SHALL drain to quiescence and stop on a pass that makes no progress.
+
+#### Scenario: Signing failure retains the tail
+
+- **WHEN** the signer rejects during a flush and a later append arrives
+- **THEN** no unsigned snapshot is persisted, the analysis remains dirty, and the next flush persists a signed snapshot containing both the earlier and the later records
+
+#### Scenario: Append during flush is not swallowed
+
+- **WHEN** an event is recorded after a flush pass has serialized an analysis's snapshot but before its persist settles
+- **THEN** the analysis remains dirty and a subsequent pass persists the tail
+
+### Requirement: First-touch load is asynchronous and never blocks the emitter
+
+On the first event for an analysis, the recorder SHALL start `sink.load(analysisId)` and queue events for that analysis; `record` SHALL return without awaiting. When the load resolves, a stored document SHALL be deserialized (its chain head adopted) or a fresh document seeded from the returned subject, and the queue drained into it. A load returning `null` (unknown analysis) SHALL drop the queued events with a warning; a load failure or corrupt stored document SHALL start a fresh document and chain with a logged error. A builder failure while appending one event SHALL drop that event only.
+
+#### Scenario: Events queued during load are recorded in order
+
+- **WHEN** three events are recorded while the sink load for their analysis is in flight
+- **THEN** after the load resolves all three are appended in arrival order and one flush persists them
+
+#### Scenario: Unknown analysis is skipped
+
+- **WHEN** `sink.load` resolves `null` for an analysis id
+- **THEN** its queued events are dropped with a warning and nothing is persisted for it
+
+### Requirement: Single writer per analysis, conflict detected via the sink
+
+The recorder SHALL assume one writer per analysis document (the embedder guarantees it — an analysis lock, workflow ownership, or equivalent). A sink whose `persist` supports compare-and-swap on `prevChainHash` SHALL reject a stale write with a `conflict` error; the recorder SHALL respond by refreshing its cached chain head from `sink.load` and retrying on a later flush, so the chain never forks. Content-level reconciliation of concurrent writers is out of scope.
+
+#### Scenario: Conflict refreshes the chain head
+
+- **WHEN** `persist` rejects with `conflict` and the stored chain head has advanced
+- **THEN** the recorder re-reads the head and the next flush persists chained onto it
+
+### Requirement: Deterministic identifiers with an injectable digest
+
+`createProvDocumentModel({ digest?, mintActionId? })` SHALL derive every execution QName and relation identifier deterministically from domain tuples (file `(path, hash)`, command output sets, agent identity), so DBOS re-execution re-emits identical records that `unified()` collapses. The digest function SHALL be injectable so an embedder with existing documents keeps its identifier space stable; the default SHALL be Node-portable. The bridges SHALL mint `externalId` values through the same model instance, so a registration's returned identifiers always match the recorded document.
+
+#### Scenario: Replay re-emission dedupes
+
+- **WHEN** the same execution events are recorded twice (a workflow re-execution) into one document
+- **THEN** the unified serialized document contains one record per QName with no duplicated relations
+
+#### Scenario: Injected digest keeps an existing QName space
+
+- **WHEN** a document model is constructed with a custom digest matching a prior producer
+- **THEN** the same file `(path, hash)` derives the same QName the prior producer minted, and `externalId` values match it
+
+### Requirement: The bridges translate the two harness seams into recorder events
+
+`createProvenanceArtifactRegistry({ emit, actor, model, documentModel })` SHALL realize `ArtifactRegistry`: partition manifest entries by their collector record's producer into command groups and a leaf bucket, emit one `command_executed` per group followed by its `file_written` events (`generation: "command"`), leaf `file_written` events (`generation: "step"`), and one `input_used` per tracked non-`artifacts` read; return each file's model-derived QName as `externalId`; report hash-less entries and hash-less input refs in `failed` (fail-fast attestation); resolve a step's own `artifacts` reads to `source: "step"` command inputs keyed on the surviving registered hash; and keep `sync` a no-op. `createRunProvenanceEmitter({ emit, actor, model })` SHALL map the three `RunProvenanceEvent` arms onto `run_started`/`step_completed`/`run_completed` events, passing checkpointed timestamps through unchanged and never reading a clock.
+
+#### Scenario: Producer group emits declaration before reference
+
+- **WHEN** a registration carries two entries produced by one command and one leaf entry
+- **THEN** the emitted order is the command's `command_executed`, its two `file_written` events with `generation: "command"`, then the leaf's `file_written` with `generation: "step"`, and `registered` carries three model-derived QNames
+
+#### Scenario: Missing hash fails the registration entry
+
+- **WHEN** a manifest entry or tracked input ref arrives without a content hash
+- **THEN** it is reported in `failed` (failing the step upstream) and no event is emitted for it
+
+### Requirement: Verification is exposed for stored and exported documents
+
+The harness SHALL export the chain/payload digest and Ed25519 hex sign/verify primitives, the export sidecar schema (`payloadType`, `payloadDigestAlgorithm`, `payloadDigest`, `payloadDigestMethod`, `signatureAlgorithm`, `signature`, `publicKey`), and two verification entry points parameterized on stored values: chained verification (recompute `SHA-256(prev || json)`, verify the signature over it) and self-contained sidecar verification (recompute `SHA-256(bytes)`, verify). Outcomes SHALL use the `VerifyResult` vocabulary (`valid`/`unsigned`/`tampered`/`no-key`/`empty`/`invalid-sidecar`/`invalid-key`/`verify-error`).
+
+#### Scenario: Tampered stored document fails chained verification
+
+- **WHEN** a stored document's bytes are altered after signing
+- **THEN** chained verification returns `tampered` with detail
+
+#### Scenario: Sidecar verifies without the keypair file
+
+- **WHEN** a sidecar carries the public key JWK and a matching signature over the payload digest
+- **THEN** sidecar verification returns `valid` using only the sidecar and payload bytes

--- a/harness/openspec/changes/extract-provenance-recorder/tasks.md
+++ b/harness/openspec/changes/extract-provenance-recorder/tasks.md
@@ -1,0 +1,29 @@
+## 1. Document model
+
+- [x] 1.1 Port the provenance domain types (`ProvActor` with the generalized `system` variant, `ProvModelId`, the input/run/step/file/command refs, `VerifyResult`) into `src/provenance/recorder/types.ts`, plus the harness-owned `ProvEvent` union.
+- [x] 1.2 Port `document.ts` as `createProvDocumentModel({ digest?, mintActionId? })` — QName derivations, append builders, `PROV_UNIFY_OPTIONS`, `freshDocument`/`loadDocument` over a plain subject value — with a Node-portable default digest.
+- [x] 1.3 Port the document-model tests against the default digest, plus a test proving an injected digest changes every derived QName consistently (bridge `externalId` included).
+
+## 2. Signing primitives and verification
+
+- [x] 2.1 Port `computeChainHash`, `computePayloadDigest`, `signHexDigest`, `verifyHexDigest`, and the hex helpers into `src/provenance/recorder/signing.ts`; declare `ProvSigner` and `ProvSigningError`.
+- [x] 2.2 Port the sidecar schema and the two verification entry points (chained stored-document verify, self-contained sidecar verify) into `src/provenance/recorder/verify.ts`, parameterized on stored values.
+- [x] 2.3 Port the signing/verify tests with an in-memory keypair.
+
+## 3. Recorder lifecycle
+
+- [x] 3.1 Implement `createProvenanceRecorder({ sink, signer, documentModel?, logger? })` with per-instance state: async first-touch load with event queueing, revision-guarded dirty tracking, coalesced single-flight signed flush, chain-conflict refresh, and a `flush()` drain with the no-progress guard.
+- [x] 3.2 Declare `ProvSnapshotSink` (`load` → seed-or-null, `persist` with optional `conflict` rejection) and the snapshot value types.
+- [x] 3.3 Port the recorder tests onto a fake sink/signer: burst coalescing, mid-flush append survival, signed-only persistence, corrupt-stored-document fresh start, unknown-analysis skip, conflict refresh, drain-to-quiescence and no-progress stop.
+
+## 4. Bridges
+
+- [x] 4.1 Port `createProvenanceArtifactRegistry({ emit, actor, model, documentModel })` — producer grouping, leaf partition, self-read resolution, attestation fail-fast, `externalId` from the model's `fileQName`.
+- [x] 4.2 Port `createRunProvenanceEmitter({ emit, actor, model })` mapping the three `RunProvenanceEvent` arms.
+- [x] 4.3 Port the bridge tests (grouping, scoping, hash-less failure, `source: "step"` resolution, event ordering).
+
+## 5. Surface and hygiene
+
+- [x] 5.1 Add `@inflexa-ai/tsprov` to `package.json` dependencies.
+- [x] 5.2 Export the factories, seam types, event/actor/ref types, and signing primitives from the barrel.
+- [x] 5.3 `tsc -p tsconfig.json`, `bun test`, lint, `bun run format:file` on touched sources.

--- a/harness/package.json
+++ b/harness/package.json
@@ -50,6 +50,7 @@
         "@ai-sdk/provider-utils": "5.0.10",
         "@anthropic-ai/sdk": "^0.107.0",
         "@dbos-inc/dbos-sdk": "^4.23.6",
+        "@inflexa-ai/tsprov": "^0.5.1",
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.9.0",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -530,3 +530,46 @@ export { registerWatchdog } from "./sandbox/watchdog.js";
 export type { WatchdogDeps } from "./sandbox/watchdog.js";
 export { registerNotificationSweep } from "./sandbox/notification-sweep.js";
 export type { RegisterNotificationSweepDeps } from "./sandbox/notification-sweep.js";
+
+// The signed provenance recorder: folds execution facts into a per-analysis
+// W3C PROV document (tsprov), chain-hashes and signs every persisted snapshot,
+// and stores it whole through the embedder's snapshot sink. Events reach it by
+// a plain `record()` call — an event bus may sit in front, but the seam is the
+// function. The bridges adapt the two harness seams that observe execution
+// (`ArtifactRegistry.register`, `emitProvenance`) into recorder events; a host
+// wires them at its composition root and composes the registry bridge with its
+// own byte-syncing registry when it has one.
+export { createProvenanceRecorder } from "./provenance/recorder/recorder.js";
+export type {
+    ProvenanceRecorder,
+    ProvenanceRecorderDeps,
+    ProvSnapshotSink,
+    ProvSnapshotSeed,
+    ProvSnapshot,
+    ProvSinkError,
+} from "./provenance/recorder/recorder.js";
+export { createProvDocumentModel, defaultProvDigest, PROV_UNIFY_OPTIONS } from "./provenance/recorder/document.js";
+export type { ProvDocumentModel, ProvDocumentModelOptions, ProvDigest } from "./provenance/recorder/document.js";
+export { createProvenanceArtifactRegistry, createRunProvenanceEmitter } from "./provenance/recorder/bridge.js";
+export type { ProvBridgeDeps } from "./provenance/recorder/bridge.js";
+export { computeChainHash, computePayloadDigest, signHexDigest, verifyHexDigest, createKeypairSigner } from "./provenance/recorder/signing.js";
+export type { ProvSigner, ProvSigningError, ProvPublicKeyJwk } from "./provenance/recorder/signing.js";
+export { verifyProvenance, verifyPayload, verifySidecar, buildSidecar, formatVerifyResult, sidecarSchema } from "./provenance/recorder/verify.js";
+export type { Sidecar } from "./provenance/recorder/verify.js";
+export type {
+    ProvActor,
+    ProvModelId,
+    ProvSubject,
+    ProvEvent,
+    ProvInputRef,
+    ProvRunRef,
+    ProvRunOutcome,
+    ProvStepRef,
+    ProvStepOutcome,
+    ProvUsedInputRef,
+    ProvFileRef,
+    ProvFileKey,
+    ProvCommandInputRef,
+    ProvCommandRef,
+    VerifyResult,
+} from "./provenance/recorder/types.js";

--- a/harness/src/provenance/recorder/bridge.test.ts
+++ b/harness/src/provenance/recorder/bridge.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { ProvenanceCollector } from "../collector.js";
+import type { AgentSession } from "../../auth/types.js";
+import type { ArtifactManifestEntry } from "../../schemas/artifact-manifest.js";
+import { createProvDocumentModel } from "./document.js";
+import { createProvenanceArtifactRegistry, createRunProvenanceEmitter } from "./bridge.js";
+import type { ProvActor, ProvEvent } from "./types.js";
+
+const actor: ProvActor = { kind: "system", label: "test-host", version: "0.0.0" };
+const session = undefined as unknown as AgentSession;
+
+function entry(path: string, hash: string | undefined, type: ArtifactManifestEntry["type"]): ArtifactManifestEntry {
+    return { stepId: "s1", runId: "r1", path, size: 10, type, ...(hash !== undefined ? { hash } : {}) } as ArtifactManifestEntry;
+}
+
+function makeBridge() {
+    const events: ProvEvent[] = [];
+    const documentModel = createProvDocumentModel();
+    const registry = createProvenanceArtifactRegistry({
+        emit: (e) => events.push(e),
+        actor: () => actor,
+        model: "anthropic/test-model",
+        documentModel,
+    });
+    return { events, documentModel, registry };
+}
+
+describe("provenance artifact-registry bridge", () => {
+    test("producer groups emit declaration-before-reference; leaves fall to the step; inputs register", async () => {
+        const { events, documentModel, registry } = makeBridge();
+        const collector = new ProvenanceCollector({ stepId: "s1", runId: "r1", dependsOn: [] });
+        collector.trackInputAccess("/res1", "data/inputs/counts.csv", "sha256:aaa", { source: "data" });
+        collector.recordCommandExecution(
+            "python run.py",
+            [],
+            0,
+            1200,
+            [
+                { path: "output/result.csv", hash: "sha256:bbb", size: 10 },
+                { path: "scripts/run.py", hash: "sha256:ccc", size: 5 },
+            ],
+            "scripts/run.py",
+        );
+
+        const artifacts = [
+            entry("output/result.csv", "sha256:bbb", "output"),
+            entry("scripts/run.py", "sha256:ccc", "script"),
+            entry("logs/run.log", "sha256:ddd", "log"),
+        ];
+        const result = await registry.register({ resourceId: "res1", runId: "r1", stepId: "s1", artifacts, collector }, session);
+
+        expect(result.failedCount).toBe(0);
+        expect(events.map((e) => e.type)).toEqual(["command_executed", "file_written", "file_written", "file_written", "input_used"]);
+
+        const command = events[0]!;
+        if (command.type !== "command_executed" || command.command.kind !== "command") throw new Error("expected a command event");
+        expect(command.command.scriptPath).toBe("runs/r1/s1/scripts/run.py");
+        expect(command.command.inputs).toEqual([{ path: "data/inputs/counts.csv", hash: "sha256:aaa", source: "data" }]);
+        expect(command.command.outputs.map((o) => o.path).sort()).toEqual(["runs/r1/s1/output/result.csv", "runs/r1/s1/scripts/run.py"]);
+        expect(command.model).toBe("anthropic/test-model");
+
+        const generations = events.filter((e) => e.type === "file_written").map((e) => (e.type === "file_written" ? e.generation : ""));
+        expect(generations).toEqual(["command", "command", "step"]);
+
+        const used = events[4]!;
+        if (used.type !== "input_used") throw new Error("expected an input_used event");
+        expect(used.input).toMatchObject({ path: "data/inputs/counts.csv", hash: "sha256:aaa", source: "data" });
+
+        expect(result.registered.map((r) => r.externalId).sort()).toEqual(
+            [
+                documentModel.fileQName({ path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb" }),
+                documentModel.fileQName({ path: "runs/r1/s1/scripts/run.py", hash: "sha256:ccc" }),
+                documentModel.fileQName({ path: "runs/r1/s1/logs/run.log", hash: "sha256:ddd" }),
+            ].sort(),
+        );
+    });
+
+    test("a step's own artifacts read resolves to a command-scoped step input keyed on the surviving hash", async () => {
+        const { events, registry } = makeBridge();
+        const collector = new ProvenanceCollector({ stepId: "s1", runId: "r1", dependsOn: [] });
+        const selfRead = collector.trackInputAccess("/res1", "runs/r1/s1/output/first.csv", "sha256:stale", {
+            source: "artifacts",
+            stepId: "s1",
+            runId: "r1",
+        });
+        collector.recordCommandExecution("python a.py", [], 0, 100, [{ path: "output/first.csv", hash: "sha256:v2", size: 4 }]);
+        collector.recordCommandExecution("python b.py", [], 0, 100, [{ path: "output/second.csv", hash: "sha256:eee", size: 4 }], undefined, [selfRead!]);
+
+        const artifacts = [entry("output/first.csv", "sha256:v2", "output"), entry("output/second.csv", "sha256:eee", "output")];
+        const result = await registry.register({ resourceId: "res1", runId: "r1", stepId: "s1", artifacts, collector }, session);
+
+        expect(result.failedCount).toBe(0);
+        const commandB = events.find((e) => e.type === "command_executed" && e.command.kind === "command" && e.command.command === "python b.py");
+        if (!commandB || commandB.type !== "command_executed" || commandB.command.kind !== "command") throw new Error("expected command b");
+        // Keyed on the surviving registered hash (v2), not the stale read-time hash.
+        expect(commandB.command.inputs).toEqual([{ path: "runs/r1/s1/output/first.csv", hash: "sha256:v2", source: "step" }]);
+        // The step-level loop skips the artifacts self-read entirely.
+        expect(events.filter((e) => e.type === "input_used").length).toBe(0);
+    });
+
+    test("hash-less entries and hash-less input refs fail fast and emit nothing", async () => {
+        const { events, registry } = makeBridge();
+        const collector = new ProvenanceCollector({ stepId: "s1", runId: "r1", dependsOn: [] });
+        collector.trackInputAccess("/res1", "data/inputs/unattested.csv", null, { source: "data" });
+
+        const artifacts = [entry("output/hashless.csv", undefined, "output")];
+        const result = await registry.register({ resourceId: "res1", runId: "r1", stepId: "s1", artifacts, collector }, session);
+
+        expect(result.registered).toEqual([]);
+        expect(result.failedCount).toBe(2);
+        expect(result.failed.map((f) => f.path).sort()).toEqual(["data/inputs/unattested.csv", "runs/r1/s1/output/hashless.csv"]);
+        expect(events).toEqual([]);
+    });
+});
+
+describe("run provenance emitter", () => {
+    test("the three lifecycle arms map with checkpointed timestamps passed through", () => {
+        const events: ProvEvent[] = [];
+        const emitter = createRunProvenanceEmitter({ emit: (e) => events.push(e), actor: () => actor, model: "anthropic/test-model" });
+
+        emitter({ type: "run_started", analysisId: "a1", runId: "r1", planSummary: "plan", stepCount: 2, atMs: 1000 });
+        emitter({ type: "step_completed", analysisId: "a1", runId: "r1", stepId: "s1", status: "completed", durationMs: 50, atMs: 2000 });
+        emitter({ type: "run_completed", analysisId: "a1", runId: "r1", status: "completed", atMs: 3000, durationMs: 2000 });
+
+        expect(events).toEqual([
+            { type: "run_started", analysisId: "a1", actor, run: { runId: "r1", planSummary: "plan", startedAtMs: 1000 } },
+            {
+                type: "step_completed",
+                analysisId: "a1",
+                actor,
+                model: "anthropic/test-model",
+                outcome: { runId: "r1", stepId: "s1", status: "completed", completedAtMs: 2000, durationMs: 50 },
+            },
+            {
+                type: "run_completed",
+                analysisId: "a1",
+                actor,
+                outcome: { runId: "r1", status: "completed", completedAtMs: 3000, durationMs: 2000 },
+            },
+        ]);
+    });
+});
+
+describe("injected digest", () => {
+    test("a custom digest re-derives every QName consistently, bridge externalIds included", async () => {
+        const custom = createProvDocumentModel({ digest: (s) => `x${s.length.toString(36)}` });
+        const fallback = createProvDocumentModel();
+        const key = { path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb" };
+        expect(custom.fileQName(key)).not.toBe(fallback.fileQName(key));
+        expect(custom.fileQName(key)).toBe(custom.fileQName({ ...key }));
+
+        const events: ProvEvent[] = [];
+        const registry = createProvenanceArtifactRegistry({
+            emit: (e) => events.push(e),
+            actor: () => actor,
+            model: "anthropic/test-model",
+            documentModel: custom,
+        });
+        const collector = new ProvenanceCollector({ stepId: "s1", runId: "r1", dependsOn: [] });
+        collector.recordCommandExecution("python run.py", [], 0, 100, [{ path: "output/result.csv", hash: "sha256:bbb", size: 4 }]);
+        const result = await registry.register(
+            { resourceId: "res1", runId: "r1", stepId: "s1", artifacts: [entry("output/result.csv", "sha256:bbb", "output")], collector },
+            session,
+        );
+        expect(result.registered).toEqual([{ path: "runs/r1/s1/output/result.csv", externalId: custom.fileQName(key) }]);
+    });
+});

--- a/harness/src/provenance/recorder/bridge.ts
+++ b/harness/src/provenance/recorder/bridge.ts
@@ -1,0 +1,342 @@
+import type { ArtifactRegistrationInput, ArtifactRegistry, ExternalRegistrationResult } from "../../execution/artifact-registry.js";
+import type { RunProvenanceEvent } from "../../workflows/execute-analysis.js";
+import type { ArtifactManifestEntry } from "../../schemas/artifact-manifest.js";
+import type { InputRef, Producer, ProvenanceRecord } from "../types.js";
+import type { ProvDocumentModel } from "./document.js";
+import type {
+    ProvActor,
+    ProvCommandInputRef,
+    ProvCommandRef,
+    ProvEvent,
+    ProvFileKey,
+    ProvFileRef,
+    ProvModelId,
+    ProvStepRef,
+    ProvUsedInputRef,
+} from "./types.js";
+
+// The execution↔recorder provenance bridges: the two halves that connect the harness's execution
+// machinery to the recorder's event vocabulary. This module is the ONLY place a run-engine
+// artifact/input observation crosses into that vocabulary. It emits through the injected `emit`
+// function and touches no storage, so the registry half satisfies the `ArtifactRegistry` seam's
+// "MUST NOT touch cortex_artifacts" contract by construction — the harness owns that local-ledger
+// write AROUND the seam, and writes the returned `externalId` back onto its row itself.
+//
+// The step-lifecycle split: the registry bridge emits COMMAND, FILE, and USED-INPUT events — the
+// finer-grained command lineage plus per-file generations and per-input reads. Step activities
+// (`step_completed`) come from the scheduler settlement via `createRunProvenanceEmitter` —
+// registration is skipped entirely for a step with an empty reconciled manifest and never reached
+// by a failed step, so it is NOT the site that observes every executed step.
+//
+// Producer grouping: the manifest entries are partitioned by their collector record's `producer`
+// OBJECT reference into command/file-tool groups, with entries that have no record forming the
+// LEAF bucket. The partition is exclusive by construction — a single record lookup decides each
+// entry's bucket — which keeps a file from ever accruing two generation authorities (a command
+// activity AND its step). Each group emits one `command_executed` followed by its `file_written`
+// events with `generation: "command"`; leaf files emit `generation: "step"`, so the
+// produced-vs-leaf decision rides the file event and the recorder never infers it across events.
+
+export interface ProvBridgeDeps {
+    /** Where events go — `recorder.record`, or a host transport that ends there. */
+    readonly emit: (event: ProvEvent) => void;
+    /** The responsible agent for execution records — the host's system actor. */
+    readonly actor: () => ProvActor;
+    /**
+     * The id of the model driving the step agent — resolved at composition, so stamping the
+     * construction-time id on every `command_executed` is exactly "the model this run's steps ran
+     * on". It rides the event so the recorder never infers it across events; a host that swaps
+     * models live rebuilds the bridge with the new id (in-flight work keeps its emitters).
+     */
+    readonly model: ProvModelId;
+    /**
+     * The SAME document model the recorder appends with — `externalId` values are its `fileQName`
+     * derivations, so the returned identifiers always match the recorded document.
+     */
+    readonly documentModel: ProvDocumentModel;
+}
+
+/**
+ * Strip the container mount prefix `/{resourceId}/` off a collector-recorded path, yielding its
+ * analysis-relative form; a path not under that mount passes through unchanged. Container reads
+ * and the recorded script line all arrive mount-absolute, so this is the single normalization
+ * every path crosses before it seeds — or resolves against — a file QName.
+ */
+function stripContainerPrefix(path: string, resourceId: string): string {
+    const prefix = `/${resourceId}/`;
+    return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+/**
+ * Scope a collector-recorded script path into the analysis-scoped file-QName space the group's
+ * outputs live in. `inferScriptPath` records whatever token the command line carried — a
+ * container-absolute `/{resourceId}/…`, an already analysis-rooted `runs/…`/`data/…`, or (the
+ * common case, since the sandbox cwd is the step write dir) a step-relative `scripts/foo.py`.
+ * Need not be exhaustive: an unresolvable result simply fails to match in the builder, which
+ * skips it rather than minting a dangling entity.
+ */
+function scopeScriptPath(scriptPath: string, resourceId: string, runId: string, stepId: string): string {
+    const stripped = stripContainerPrefix(scriptPath, resourceId);
+    const analysisRooted = stripped.startsWith("runs/") || stripped.startsWith("data/") || stripped.startsWith("dataprofile/");
+    return analysisRooted ? stripped : `runs/${runId}/${stepId}/${stripped}`;
+}
+
+/**
+ * Map one command's per-command reads to command-scoped {@link ProvCommandInputRef}s in the shared
+ * file-QName space. `data`/`upstream`/`prior` reads pass through with their `/{resourceId}/` mount
+ * prefix stripped; a hash-less such ref is SKIPPED silently — the step-level `input_used` loop is
+ * the site that reports it in `failed`, so failing it here too would double-count. An
+ * `"artifacts"`-source read is the step's OWN prior output — the intra-step chain signal the
+ * step-level registry drops as noise: it is included as `source: "step"` ONLY when its path names
+ * a file THIS registration produces, keyed on the SURVIVING output hash (`producedHashByPath`),
+ * NOT the read's own `ref.hash` — the collector is last-write-wins per path, so a self-read
+ * recorded against an earlier revision would otherwise point its `used` edge at a `(path, hash)`
+ * entity this registration never registers. Deduped by `(path, hash)`.
+ */
+function toCommandInputs(reads: readonly InputRef[], resourceId: string, producedHashByPath: ReadonlyMap<string, string>): ProvCommandInputRef[] {
+    const seen = new Set<string>();
+    const inputs: ProvCommandInputRef[] = [];
+    for (const ref of reads) {
+        const path = stripContainerPrefix(ref.path, resourceId);
+        if (ref.source === "artifacts") {
+            const producedHash = producedHashByPath.get(path);
+            if (producedHash === undefined) continue;
+            const dedupKey = `${path}|${producedHash}`;
+            if (seen.has(dedupKey)) continue;
+            seen.add(dedupKey);
+            inputs.push({ path, hash: producedHash, source: "step", ...(ref.fileId !== undefined ? { fileId: ref.fileId } : {}) });
+            continue;
+        }
+        const dedupKey = `${path}|${ref.hash}`;
+        if (!ref.hash || seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+        inputs.push({ path, hash: ref.hash, source: ref.source, ...(ref.fileId !== undefined ? { fileId: ref.fileId } : {}) });
+    }
+    return inputs;
+}
+
+/**
+ * Build the {@link ProvCommandRef} for one producer group. A `command` producer carries the full
+ * execution facts, the scoped `scriptPath`, the group's analysis-scoped `(path, hash)` outputs,
+ * and its command-scoped inputs; a `file_tool` producer carries only the tool name and outputs.
+ * The producer's observation `timestamp` is NEVER forwarded — it is re-minted on every DBOS replay
+ * and would poison the document's replay-idempotency if it leaked into an identifier or formal
+ * position.
+ */
+function toCommandRef(
+    record: ProvenanceRecord,
+    outputs: ProvFileKey[],
+    resourceId: string,
+    runId: string,
+    stepId: string,
+    producedHashByPath: ReadonlyMap<string, string>,
+): ProvCommandRef {
+    const producer: Producer = record.producer;
+    if (producer.type === "file_tool") return { kind: "file_tool", tool: producer.tool, outputs };
+    const scriptPath = record.scriptPath !== null ? scopeScriptPath(record.scriptPath, resourceId, runId, stepId) : undefined;
+    return {
+        kind: "command",
+        command: producer.command,
+        ...(producer.args !== undefined ? { args: producer.args } : {}),
+        exitCode: producer.exitCode,
+        ...(producer.durationMs !== undefined ? { durationMs: producer.durationMs } : {}),
+        ...(scriptPath !== undefined ? { scriptPath } : {}),
+        outputs,
+        inputs: toCommandInputs(record.inputs, resourceId, producedHashByPath),
+    };
+}
+
+/**
+ * The recorder-adapter {@link ArtifactRegistry} — translates one step's registration into, per
+ * producer group, one `command_executed` followed by that group's `file_written` events
+ * (`generation: "command"`), then the leaf bucket's `file_written` events (`generation: "step"`),
+ * then one `input_used` per tracked non-`"artifacts"` read. It returns the deterministic file
+ * QNames as `externalId` so the local ledger gains a stable cross-reference into the signed
+ * document, and does NOT emit `step_completed` (see the module note on the split).
+ *
+ * Three seam-contract facts shape the behavior:
+ *
+ *  1. The post-step pipeline fails a step ONLY when `failedCount > 0`. So a hash-less entry OR a
+ *     hash-less input ref reported in `failed` will fail the step — which is intended (fail-fast
+ *     attestation): reconcile rehashes entries and `fillInputHashesFromDisk` attests every input,
+ *     so a missing hash is an upstream defect that must surface, not be papered over.
+ *  2. The harness writes each `registered[].externalId` back onto its `cortex_artifacts` row keyed
+ *     by `registered[].path`, and it only matches rows upserted under the analysis-scoped path
+ *     `runs/{runId}/{stepId}/…`. The manifest entries arrive STEP-relative, so `path` is prefixed
+ *     to that analysis-scoped form here — the event, the QName, and the write-back key are one
+ *     string. Inputs are READS, not registered artifacts — they never enter `registered`.
+ *  3. Tracked input refs and record inputs carry container-absolute paths (`/{resourceId}/…`).
+ *     The step's own outputs re-surface as `source: "artifacts"` — skipped by the step-level
+ *     registry but RESOLVED to a command-scoped `source: "step"` input; the rest strip the mount
+ *     prefix — a `source: "prior"` read then keys onto the SAME file QName the producing run
+ *     emitted, chaining lineage across runs for free.
+ */
+export function createProvenanceArtifactRegistry(deps: ProvBridgeDeps): ArtifactRegistry {
+    const { emit, model, documentModel } = deps;
+    return {
+        register: async (input: ArtifactRegistrationInput): Promise<ExternalRegistrationResult> => {
+            // One actor stamp for the whole step — the actor derivation is stable within a step,
+            // so a single value across the step's events is identical to re-reading per event.
+            const actor = deps.actor();
+            const step: ProvStepRef = { runId: input.runId, stepId: input.stepId };
+            // Manifest entries + collector output records both key on the STEP-relative path; scope
+            // to the analysis-scoped form for the event, the QName seed, and the write-back key.
+            const scopePath = (relativePath: string): string => `runs/${input.runId}/${input.stepId}/${relativePath}`;
+
+            const recordByPath = new Map<string, ProvenanceRecord>();
+            for (const rec of input.collector.getRecords()) recordByPath.set(rec.outputPath, rec);
+
+            // The analysis-scoped path → surviving content hash of every file entity this
+            // registration WILL register — the map an intra-step `"artifacts"` self-read resolves
+            // against. Hash-less entries are excluded: they fail below and never register an
+            // entity, so a read of one finds no key and is dropped rather than dangling.
+            const producedHashByPath = new Map<string, string>();
+            for (const entry of input.artifacts) if (entry.hash) producedHashByPath.set(scopePath(entry.path), entry.hash);
+
+            // Partition: one lookup per entry buckets it by its record's `producer` OBJECT, or into
+            // the leaf bucket when it has no record. Exclusive by construction, so a file can never
+            // land in both a command group and the leaf bucket (which would write two
+            // `wasGeneratedBy` edges for one entity). Insertion order is preserved for emission.
+            const groups = new Map<Producer, { record: ProvenanceRecord; entries: ArtifactManifestEntry[] }>();
+            const leaves: ArtifactManifestEntry[] = [];
+            for (const entry of input.artifacts) {
+                const rec = recordByPath.get(entry.path);
+                if (rec === undefined) {
+                    leaves.push(entry);
+                    continue;
+                }
+                const group = groups.get(rec.producer);
+                if (group !== undefined) group.entries.push(entry);
+                else groups.set(rec.producer, { record: rec, entries: [entry] });
+            }
+
+            const registered: ExternalRegistrationResult["registered"] = [];
+            const failed: ExternalRegistrationResult["failed"] = [];
+
+            // Attest one manifest entry to a `ProvFileRef`, or record a fail-fast rejection and
+            // return null. Reconcile rehashes every surviving entry from disk, so a missing/empty
+            // hash past that point is an attestation-invariant violation. The producer joins from
+            // the entry's record; a leaf (no record) falls back to "command" — an observed sandbox
+            // write with no in-process producer record is by construction a command effect.
+            const attest = (entry: ArtifactManifestEntry): ProvFileRef | null => {
+                const path = scopePath(entry.path);
+                if (!entry.hash) {
+                    failed.push({ path, error: `missing content hash for ${path} — reconcile guarantees one, so its absence is an upstream defect` });
+                    return null;
+                }
+                return { path, hash: entry.hash, size: entry.size, producer: recordByPath.get(entry.path)?.producer.type ?? "command" };
+            };
+
+            // Per producer group, in declaration-before-reference order: one `command_executed`,
+            // then that group's `file_written` events flagged `generation: "command"`.
+            for (const { record, entries } of groups.values()) {
+                const files: ProvFileRef[] = [];
+                for (const entry of entries) {
+                    const file = attest(entry);
+                    if (file !== null) files.push(file);
+                }
+                // A group whose every output failed attestation has no entity to anchor a command
+                // activity's generation edges — skip it rather than mint a zero-output command.
+                if (files.length === 0) continue;
+
+                const outputs: ProvFileKey[] = files.map((f) => ({ path: f.path, hash: f.hash }));
+                const command = toCommandRef(record, outputs, input.resourceId, input.runId, input.stepId, producedHashByPath);
+                emit({ type: "command_executed", analysisId: input.resourceId, actor, step, command, model });
+                for (const file of files) {
+                    emit({ type: "file_written", analysisId: input.resourceId, actor, file, step, generation: "command" });
+                    registered.push({ path: file.path, externalId: documentModel.fileQName(file) });
+                }
+            }
+
+            // Leaf bucket: an observed write with no in-process producer record — no command
+            // activity, so its generation edge falls to the step activity.
+            for (const entry of leaves) {
+                const file = attest(entry);
+                if (file === null) continue;
+                emit({ type: "file_written", analysisId: input.resourceId, actor, file, step, generation: "step" });
+                registered.push({ path: file.path, externalId: documentModel.fileQName(file) });
+            }
+
+            // Step-level attested-input registry: container-absolute reads strip to
+            // analysis-relative so a prior read lands in the producing file's QName space; the
+            // step's own `"artifacts"` reads are skipped, and a hash-less ref fails the step.
+            for (const ref of input.collector.getTrackedInputs()) {
+                const source = ref.source;
+                if (source === "artifacts") continue;
+
+                const path = stripContainerPrefix(ref.path, input.resourceId);
+
+                if (!ref.hash) {
+                    failed.push({
+                        path,
+                        error: `missing content hash for input ${path} — fillInputHashesFromDisk attests every input upstream, so its absence is an upstream defect`,
+                    });
+                    continue;
+                }
+
+                const usedInput: ProvUsedInputRef = { path, hash: ref.hash, source, ...(ref.fileId !== undefined ? { fileId: ref.fileId } : {}) };
+                emit({ type: "input_used", analysisId: input.resourceId, actor, step, input: usedInput });
+            }
+
+            return { registered, failed, failedCount: failed.length };
+        },
+        // No byte movement here: recording is this registry's whole job. A host that also syncs
+        // artifact bytes composes this bridge with its own registry at the composition root.
+        sync: async (): Promise<void> => {},
+    };
+}
+
+/**
+ * Realize the harness's optional `emitProvenance` dep: map each of the three run-lifecycle arms
+ * onto a recorder event stamped with the host's system actor. This is the site that emits
+ * `step_completed` (from the scheduler settlement — the only place every EXECUTED step is
+ * observed), NOT the artifact registry above. `model` stamps `step_completed` only — the run arms
+ * carry no model because model association is scoped to the step and command activities the model
+ * drove.
+ *
+ * Every timestamp (`atMs`, `durationMs`) passes THROUGH from the event — the harness read them
+ * from its checkpointed clock (`DBOS.now()`), replay-stable — so this mapping NEVER reads a
+ * clock; doing so would diverge across replays and defeat the merge. The mapping is
+ * fire-and-forget; the harness guards the call site so a throw here never fails the run.
+ */
+export function createRunProvenanceEmitter(deps: Pick<ProvBridgeDeps, "emit" | "actor" | "model">): (event: RunProvenanceEvent) => void {
+    const { emit, actor, model } = deps;
+    return (event: RunProvenanceEvent): void => {
+        switch (event.type) {
+            case "run_started":
+                emit({
+                    type: "run_started",
+                    analysisId: event.analysisId,
+                    actor: actor(),
+                    run: { runId: event.runId, planSummary: event.planSummary, startedAtMs: event.atMs },
+                });
+                return;
+            case "step_completed":
+                emit({
+                    type: "step_completed",
+                    analysisId: event.analysisId,
+                    actor: actor(),
+                    model,
+                    outcome: {
+                        runId: event.runId,
+                        stepId: event.stepId,
+                        status: event.status,
+                        completedAtMs: event.atMs,
+                        ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
+                    },
+                });
+                return;
+            case "run_completed":
+                emit({
+                    type: "run_completed",
+                    analysisId: event.analysisId,
+                    actor: actor(),
+                    outcome: { runId: event.runId, status: event.status, completedAtMs: event.atMs, durationMs: event.durationMs },
+                });
+                return;
+            default: {
+                const never: never = event;
+                throw new Error(`unhandled run provenance event: ${JSON.stringify(never)}`);
+            }
+        }
+    };
+}

--- a/harness/src/provenance/recorder/document.ts
+++ b/harness/src/provenance/recorder/document.ts
@@ -1,0 +1,557 @@
+import { createHash, randomUUID } from "node:crypto";
+import { type Result, ok, err } from "neverthrow";
+import { ProvDocument, type UnifiedOptions } from "@inflexa-ai/tsprov";
+import type {
+    ProvActor,
+    ProvInputRef,
+    ProvModelId,
+    ProvRunRef,
+    ProvRunOutcome,
+    ProvStepRef,
+    ProvStepOutcome,
+    ProvSubject,
+    ProvUsedInputRef,
+    ProvFileRef,
+    ProvFileKey,
+    ProvCommandRef,
+} from "./types.js";
+
+// The tsprov-facing layer: seeding, appending to, and serializing an analysis's PROV document.
+// The `@inflexa-ai/tsprov` dependency is confined to this file — the recorder (`recorder.ts`) and
+// the bridges drive provenance through these functions, so a tsprov fault is contained to
+// provenance.
+//
+// The document is built INCREMENTALLY (one append per recorded action) rather than projected in a
+// batch: it lives in memory while an analysis is open and is reloaded from its serialized form on
+// reopen. Records that recur across actions are deliberately NOT de-duplicated at append time —
+// tsprov's `_idMap` tolerates duplicate identifiers and the caller collapses them with `unified()`
+// at serialize time.
+
+/** The namespace every inflexa-minted PROV identifier lives under. */
+const NS_PREFIX = "inflexa";
+const NS_URI = "https://inflexa.ai/prov#";
+
+/**
+ * The merge policy every persist/export `unified()` uses: LAST-write-wins. A DBOS recovery replay
+ * re-emits byte-identical execution records (times are checkpointed `DBOS.now()` reads), so
+ * last==first and they dedupe; a budget-pause that later RESUMES to completion re-declares the
+ * run/step activity with a genuinely newer terminal outcome, which must SUPERSEDE the earlier one.
+ * `formalAttributeConflict: "last"` resolves the formal `prov:endTime`; `singleValued` extends the
+ * same last-wins to the custom terminal attributes, which would otherwise union into a
+ * contradictory multi-value. Kept in one place so the flush and any export path agree on the
+ * survivor.
+ */
+export const PROV_UNIFY_OPTIONS: UnifiedOptions = {
+    formalAttributeConflict: "last",
+    singleValued: [`${NS_PREFIX}:status`, `${NS_PREFIX}:durationMs`],
+};
+
+/**
+ * A short stable digest over an identity string — the derivation every QName suffix and relation
+ * id runs through. Injectable because it is IDENTITY-load-bearing: every file/command/agent QName
+ * embeds its output, so a producer with existing documents must keep its own function (the OSS
+ * host injects its historical one) or its identifier space silently forks — re-emission after a
+ * change would mint new QNames for the same files and `unified()` would keep both.
+ */
+export type ProvDigest = (s: string) => string;
+
+/** The default digest: a SHA-256 fold to base36, portable across JS runtimes. */
+export function defaultProvDigest(s: string): string {
+    const bytes = createHash("sha256").update(s).digest();
+    return bytes.readBigUInt64BE(0).toString(36);
+}
+
+export interface ProvDocumentModelOptions {
+    /** QName digest derivation — see {@link ProvDigest}. Defaults to {@link defaultProvDigest}. */
+    readonly digest?: ProvDigest;
+    /** Id minter for analysis-lifecycle action activities (one fresh id per genuine user action). */
+    readonly mintActionId?: () => string;
+}
+
+/** The document model — QName derivations plus append builders, all sharing one digest. */
+export type ProvDocumentModel = ReturnType<typeof createProvDocumentModel>;
+
+/** Replace every character a PROV qualified-name localpart disallows, so any string can seed an identifier. */
+function qnameSafe(s: string): string {
+    return s.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+/**
+ * Build the document model over one digest derivation. Every QName and relation-id derivation
+ * lives here so the file QName the bridge returns as `externalId`, the QNames the builders append
+ * under, and the relation ids that make re-emission dedupe can never drift apart.
+ *
+ * The execution builders use content-deterministic QNames (not random per-event ids) so a run
+ * completing on a later boot's DBOS recovery re-emits identical records, and `unified()` collapses
+ * the re-emission to one record set per QName. Runs and steps are PROV activities; files are
+ * entities.
+ *
+ * The RELATIONS the builders emit carry deterministic identifiers too — a subtler requirement than
+ * the element QNames. `unified()` dedups by identifier ONLY: an anonymous relation never enters
+ * tsprov's `_idMap`, so a re-emitted anonymous relation DUPLICATES instead of merging, even when
+ * byte-identical. Each id is derived from the relation's FULL formal endpoint tuple — the
+ * run/step/file key, plus a hash of the AGENT QName for agent-bearing relations (whose agent
+ * endpoint can differ when a recovery re-derives the actor, e.g. across a host upgrade). The
+ * `time` argument is omitted from every identified relation: two same-id relations with differing
+ * formal times throw on merge, and the occurrence times already live on the run/step activities.
+ */
+export function createProvDocumentModel(options: ProvDocumentModelOptions = {}) {
+    const digest = options.digest ?? defaultProvDigest;
+    const mintActionId = options.mintActionId ?? randomUUID;
+
+    /** The analysis's PROV subject-entity QName — the document's subject, related to by every action. */
+    function analysisQName(analysisId: string): string {
+        return `${NS_PREFIX}:analysis-${analysisId}`;
+    }
+
+    /** A stable input-entity QName keyed by (source anchor, path), so an add and its later removal touch the same entity. */
+    function inputQName(input: ProvInputRef): string {
+        return `${NS_PREFIX}:input-${digest(`${input.anchorId ?? ""}|${input.path}`)}`;
+    }
+
+    /** Declare (re-declare) the responsible agent on `doc`, returning its QName. Re-declaration is fine — `unified()` collapses it later. */
+    function appendAgent(doc: ProvDocument, actor: ProvActor): string {
+        switch (actor.kind) {
+            case "user": {
+                const qn = `${NS_PREFIX}:agent-user-${qnameSafe(actor.email)}`;
+                doc.agent(qn, { "prov:type": "prov:Person", "inflexa:email": actor.email });
+                return qn;
+            }
+            case "anonymous": {
+                const qn = `${NS_PREFIX}:agent-anonymous`;
+                doc.agent(qn, { "prov:type": "prov:Person", "prov:label": "Anonymous user" });
+                return qn;
+            }
+            case "system": {
+                const qn = `${NS_PREFIX}:agent-system`;
+                doc.agent(qn, {
+                    "prov:type": "prov:SoftwareAgent",
+                    "prov:label": actor.label,
+                    "inflexa:version": actor.version,
+                    ...(actor.commit !== undefined ? { "inflexa:commit": actor.commit } : {}),
+                });
+                return qn;
+            }
+            default: {
+                const never: never = actor;
+                throw new Error(`unhandled actor kind: ${String(never)}`);
+            }
+        }
+    }
+
+    /** Declare (re-declare) an input entity on `doc`, returning its QName. */
+    function appendInput(doc: ProvDocument, input: ProvInputRef): string {
+        const qn = inputQName(input);
+        doc.entity(qn, { "prov:type": "inflexa:Input", "inflexa:path": input.path, "inflexa:isDir": input.isDir });
+        return qn;
+    }
+
+    /** A fresh provenance document for an analysis: the namespace plus the subject entity. */
+    function freshDocument(subject: ProvSubject): ProvDocument {
+        const doc = new ProvDocument();
+        doc.addNamespace(NS_PREFIX, NS_URI);
+        doc.entity(analysisQName(subject.analysisId), {
+            "prov:type": "inflexa:Analysis",
+            ...(subject.name !== undefined ? { "inflexa:name": subject.name } : {}),
+            ...(subject.slug !== undefined ? { "inflexa:slug": subject.slug } : {}),
+        });
+        return doc;
+    }
+
+    /** Reconstruct an analysis's live document from its stored PROV-JSON, or seed a fresh one when nothing is stored yet. */
+    function loadDocument(subject: ProvSubject, storedJson: string | null): Result<ProvDocument, { type: "prov_corrupt"; cause: unknown }> {
+        if (!storedJson) return ok(freshDocument(subject));
+        try {
+            return ok(ProvDocument.deserialize(storedJson, "json"));
+        } catch (cause) {
+            return err({ type: "prov_corrupt" as const, cause });
+        }
+    }
+
+    /**
+     * The preamble every builder shares: declare (re-declare) the responsible agent and stamp the
+     * occurrence time, returning the analysis subject QName alongside. It mints NO activity — the
+     * caller owns its own node.
+     */
+    function recordPreamble(doc: ProvDocument, analysisId: string, actor: ProvActor): { analysisQn: string; agentQn: string; time: string } {
+        const analysisQn = analysisQName(analysisId);
+        const time = new Date().toISOString();
+        const agentQn = appendAgent(doc, actor);
+        return { analysisQn, agentQn, time };
+    }
+
+    // The analysis-lifecycle builders (create / add-input / remove-input) each mint a fresh action
+    // activity stamped at append time — one distinct activity per genuinely distinct user action.
+    // The execution builders (run / step / file) instead key off deterministic QNames so DBOS
+    // workflow re-execution on recovery re-emits the same records and unified() dedups them.
+
+    function startAction(
+        doc: ProvDocument,
+        analysisId: string,
+        activityType: string,
+        actor: ProvActor,
+    ): { analysisQn: string; actionQn: string; time: string; agentQn: string } {
+        const { analysisQn, agentQn, time } = recordPreamble(doc, analysisId, actor);
+        const actionQn = `${NS_PREFIX}:action-${mintActionId()}`;
+        doc.activity(actionQn, time, time, { "prov:type": activityType });
+        doc.wasAssociatedWith(actionQn, agentQn);
+        return { analysisQn, actionQn, time, agentQn };
+    }
+
+    /** Append the PROV records for an analysis creation: the subject was generated by and attributed to the actor. */
+    function appendCreation(doc: ProvDocument, analysisId: string, actor: ProvActor): void {
+        const { analysisQn, actionQn, time, agentQn } = startAction(doc, analysisId, "inflexa:CreateAnalysis", actor);
+        doc.wasGeneratedBy(analysisQn, actionQn, time);
+        doc.wasAttributedTo(analysisQn, agentQn);
+    }
+
+    /** Append the PROV records for an input addition: the action used the input, and the analysis derives from it. */
+    function appendInputAdded(doc: ProvDocument, analysisId: string, actor: ProvActor, input: ProvInputRef, derivedFromAnalysisId: string | null): void {
+        const { analysisQn, actionQn, time, agentQn } = startAction(doc, analysisId, "inflexa:AddInput", actor);
+        const inputQn = appendInput(doc, input);
+        doc.used(actionQn, inputQn, time);
+        doc.wasAttributedTo(inputQn, agentQn);
+        doc.wasDerivedFrom(analysisQn, inputQn);
+        if (derivedFromAnalysisId) doc.wasDerivedFrom(inputQn, analysisQName(derivedFromAnalysisId));
+    }
+
+    /** Append the PROV records for an input removal: the input was invalidated by the action. */
+    function appendInputRemoved(doc: ProvDocument, analysisId: string, actor: ProvActor, input: ProvInputRef): void {
+        const { actionQn, time } = startAction(doc, analysisId, "inflexa:RemoveInput", actor);
+        const inputQn = appendInput(doc, input);
+        doc.wasInvalidatedBy(inputQn, actionQn, time);
+    }
+
+    /** The run-activity QName — one activity per run regardless of how many events reference it. */
+    function runQName(runId: string): string {
+        return `${NS_PREFIX}:run-${runId}`;
+    }
+
+    /** The step-activity QName, keyed by `(runId, stepId)` so each step is a distinct activity a file generation can reference. */
+    function stepQName(step: ProvStepRef): string {
+        return `${NS_PREFIX}:step-${step.runId}-${step.stepId}`;
+    }
+
+    /**
+     * The `(path, content hash)` digest that suffixes the file entity's QName. Factored out because
+     * a file's execution relations (`gen`/`attr`/`deriv` ids below) reuse this exact suffix, so the
+     * two derivations stay in one place. Typed on the structural `(path, hash)` pick so an INPUT
+     * read keys into the same space as the output it reads — that shared key is what merges a
+     * `source: "prior"` read onto its producing file's entity under `unified()`.
+     */
+    function fileDigest(file: ProvFileKey): string {
+        return digest(`${file.path}|${file.hash}`);
+    }
+
+    /** A short stable hash of an agent QName, folded into an agent-bearing relation's id. */
+    function agentDigest(agentQn: string): string {
+        return digest(agentQn);
+    }
+
+    /** The model-agent QName, keyed by the vendor-qualified `{provider}/{model}` name — one agent per distinct name. */
+    function modelAgentQName(model: ProvModelId): string {
+        return `${NS_PREFIX}:agent-model-${digest(model)}`;
+    }
+
+    /**
+     * Declare (re-declare) the model agent for `model` — the LLM that reasoned about a model-driven
+     * activity — plus its delegation to the event's responsible agent, plus its association with
+     * the driven activity. The association id is `{assocIdBase}-{agentDigest(modelQn)}` — the SAME
+     * base the caller's actor association uses, disambiguated by the agent digest. The delegation
+     * reads `actedOnBehalfOf(model, responsible)`: the host is the agent the user directed; the
+     * model acted on its behalf. Its id is keyed on both agent digests (activity-independent), so
+     * re-declaration across activities and DBOS re-execution collapses under `unified()`.
+     */
+    function appendModelAgent(doc: ProvDocument, model: ProvModelId, responsibleQn: string, activityQn: string, assocIdBase: string): void {
+        const qn = modelAgentQName(model);
+        doc.agent(qn, {
+            // Both types deliberately: `prov:SoftwareAgent` places it in PROV's agent taxonomy,
+            // `inflexa:Model` marks WHAT KIND of software agent (tsprov attributes are multi-valued).
+            "prov:type": ["prov:SoftwareAgent", `${NS_PREFIX}:Model`],
+            "prov:label": model,
+            "inflexa:model": model,
+        });
+        doc.actedOnBehalfOf(qn, responsibleQn, undefined, `${NS_PREFIX}:delegation-${agentDigest(qn)}-${agentDigest(responsibleQn)}`);
+        doc.wasAssociatedWith(activityQn, qn, undefined, `${assocIdBase}-${agentDigest(qn)}`);
+    }
+
+    /**
+     * The file-entity QName, keyed by `(path, content hash)` so re-writing identical bytes to a
+     * path dedups to one entity. Exported because the bridge returns this same QName as the
+     * artifact's `externalId`, giving the local ledger row a stable cross-reference into the signed
+     * document — so the derivation must live in one place.
+     */
+    function fileQName(file: ProvFileKey): string {
+        return `${NS_PREFIX}:file-${fileDigest(file)}`;
+    }
+
+    /**
+     * The digest that keys a command group — a digest over the group's per-output `(path, hash)`
+     * digests, SORTED and joined with `|`. It suffixes both the command-activity QName and every
+     * command-relation id, so re-emission of the same group lands on the same identifiers.
+     */
+    function commandGroupDigest(outputs: ProvFileKey[]): string {
+        return digest(outputs.map(fileDigest).sort().join("|"));
+    }
+
+    /**
+     * The command-activity QName — `inflexa:cmd-{runId}-{stepId}-{digest(sorted output (path,hash) pairs)}`.
+     *
+     * The group is keyed by its OUTPUT SET, deliberately NOT by the producer's object identity or
+     * its observation timestamp. A DBOS workflow re-execution rebuilds the collector and mints
+     * fresh `Producer` objects with fresh timestamps, so neither is replay-stable; the surviving
+     * output set IS, because the upstream collector is last-write-wins per output path. Rejected
+     * keying on `(command, args)`: the same command line can run twice in one step with different
+     * surviving outputs.
+     */
+    function commandQName(step: ProvStepRef, outputs: ProvFileKey[]): string {
+        return `${NS_PREFIX}:cmd-${step.runId}-${step.stepId}-${commandGroupDigest(outputs)}`;
+    }
+
+    /**
+     * The occurrence time to stamp into an execution activity's `startTime`/`endTime` slot: the
+     * wall clock the first time, but `undefined` once that slot is already populated under this
+     * QName.
+     *
+     * tsprov's `unified()` THROWS when it merges two same-QName activities that set the same
+     * single-valued formal time attribute to *different* values. DBOS re-executes the workflow body
+     * on recovery, so each execution builder can be invoked twice for one logical event with a
+     * *fresh* observer clock; a naive re-stamp would therefore crash the flush's `unified()`.
+     * Omitting the already-recorded time keeps re-emission's record mergeable (the surviving
+     * activity retains the first-recorded time).
+     */
+    function occurrenceTime(doc: ProvDocument, activityQn: string, slot: "prov:startTime" | "prov:endTime", now: string): string | undefined {
+        for (const rec of doc.getRecord(activityQn)) {
+            if (rec.getAttribute(slot).length > 0) return undefined;
+        }
+        return now;
+    }
+
+    /**
+     * Append the run-start records: a run activity opened with a start time, associated with the
+     * actor's agent, and `used`-linked to the analysis entity. It deliberately does NOT
+     * re-generate the analysis — `appendCreation` is the analysis's single generation, and a second
+     * `wasGeneratedBy` would violate PROV generation-uniqueness.
+     */
+    function appendRunStarted(doc: ProvDocument, analysisId: string, actor: ProvActor, run: ProvRunRef): void {
+        const { analysisQn, agentQn } = recordPreamble(doc, analysisId, actor);
+        const rQn = runQName(run.runId);
+        // Formal start time is the ISO of the harness-observed `startedAtMs`, NOT the append-time
+        // wall clock — so the recorded boundary is the true workflow start even when the
+        // flush-surviving observation is a later recovery boot. `occurrenceTime` stays as defense
+        // in depth: the payload ms is replay-identical, so it no-ops here and only guards a
+        // hypothetical upstream writer defect.
+        const startTime = new Date(run.startedAtMs).toISOString();
+        doc.activity(rQn, occurrenceTime(doc, rQn, "prov:startTime", startTime), undefined, {
+            "prov:type": "inflexa:Run",
+            "inflexa:runId": run.runId,
+            ...(run.planSummary ? { "inflexa:planSummary": run.planSummary } : {}),
+        });
+        doc.wasAssociatedWith(rQn, agentQn, undefined, `${NS_PREFIX}:assoc-run-${run.runId}-${agentDigest(agentQn)}`);
+        doc.used(rQn, analysisQn, undefined, `${NS_PREFIX}:used-run-${run.runId}`);
+    }
+
+    /**
+     * Append the run-completion records: the SAME run-activity QName re-declared with an end time
+     * and outcome attributes. `unified()` merges the start-time and end-time records into one
+     * activity.
+     *
+     * `analysisId` and `actor` are genuinely unused here, by design: all execution builders take
+     * the same `(doc, analysisId, actor, payload)` shape because the recorder dispatches them
+     * uniformly, and completion is the one builder that appends no agent- or analysis-referencing
+     * record — the run's `wasAssociatedWith` and `used` edges were written at run start.
+     */
+    function appendRunCompleted(doc: ProvDocument, _analysisId: string, _actor: ProvActor, outcome: ProvRunOutcome): void {
+        const rQn = runQName(outcome.runId);
+        // End time / status / duration are written DIRECTLY, with NO first-wins `occurrenceTime`
+        // guard: a budget-pause that later resumes to completion re-declares this activity with a
+        // genuinely newer terminal outcome, and that outcome must SUPERSEDE the earlier one — the
+        // flush `unified()` resolves the re-declaration last-write-wins ({@link PROV_UNIFY_OPTIONS}).
+        const endTime = new Date(outcome.completedAtMs).toISOString();
+        doc.activity(rQn, undefined, endTime, {
+            "inflexa:status": outcome.status,
+            ...(outcome.durationMs !== undefined ? { "inflexa:durationMs": outcome.durationMs } : {}),
+        });
+    }
+
+    /**
+     * Append the step-completion records: a step activity closed with an end time and terminal
+     * status, `wasInformedBy` its run activity, and associated with BOTH the actor's agent and the
+     * model agent (the step is model-driven; recording which model reasoned about it is the point
+     * of the model agent). The step is an activity (not an entity) so a file's `wasGeneratedBy`
+     * can validly reference it.
+     */
+    function appendStepCompleted(doc: ProvDocument, analysisId: string, actor: ProvActor, outcome: ProvStepOutcome, model: ProvModelId): void {
+        const { agentQn } = recordPreamble(doc, analysisId, actor);
+        const rQn = runQName(outcome.runId);
+        const sQn = stepQName(outcome);
+        // End time / status / duration written directly (no first-wins guard): a resumed step
+        // supersedes its earlier canceled settlement, resolved last-write-wins at the flush.
+        const endTime = new Date(outcome.completedAtMs).toISOString();
+        doc.activity(sQn, undefined, endTime, {
+            "prov:type": "inflexa:Step",
+            "inflexa:runId": outcome.runId,
+            "inflexa:stepId": outcome.stepId,
+            "inflexa:status": outcome.status,
+            ...(outcome.durationMs !== undefined ? { "inflexa:durationMs": outcome.durationMs } : {}),
+        });
+        doc.wasInformedBy(sQn, rQn, `${NS_PREFIX}:informed-${outcome.runId}-${outcome.stepId}`);
+        const assocIdBase = `${NS_PREFIX}:assoc-step-${outcome.runId}-${outcome.stepId}`;
+        doc.wasAssociatedWith(sQn, agentQn, undefined, `${assocIdBase}-${agentDigest(agentQn)}`);
+        appendModelAgent(doc, model, agentQn, sQn, assocIdBase);
+    }
+
+    /**
+     * Append a command execution's records — the finer-grained lineage the step level cannot
+     * express: a command (or file-tool) activity, `wasInformedBy` its step, `wasAssociatedWith` the
+     * actor's agent AND the model agent, a `used` edge per command-scoped input (including the
+     * script when it resolves), and — the load-bearing move — `wasGeneratedBy(output, command)` per
+     * output. The command is the GENERATION AUTHORITY for its outputs: it writes each
+     * `gen-{fileDigest}` edge under the SAME id `appendFileWritten` would have used for the
+     * step-level edge, so a produced file ends up with exactly ONE generation record — this
+     * activity's.
+     */
+    function appendCommandExecuted(
+        doc: ProvDocument,
+        analysisId: string,
+        actor: ProvActor,
+        step: ProvStepRef,
+        command: ProvCommandRef,
+        model: ProvModelId,
+    ): void {
+        const { agentQn } = recordPreamble(doc, analysisId, actor);
+        const sQn = stepQName(step);
+        const groupDigest = commandGroupDigest(command.outputs);
+        const cmdQn = commandQName(step, command.outputs);
+
+        // The command's script: the ref carries only `scriptPath`, no hash, so recover the hash by
+        // matching the path against a `(path,hash)` pair we already hold — the group's own outputs
+        // or its inputs. A path matching NEITHER has no `(path, hash)` key, so it can seed no
+        // entity and no `used` edge — a hash-less entity would corrupt the shared QName space. But
+        // dropping it silently erases that an attribution existed and was lost, so the unresolvable
+        // path rides the activity as `inflexa:unresolvedScript`: deterministic from the payload,
+        // metadata about the activity, not a node.
+        const scriptKey =
+            command.kind === "command" && command.scriptPath !== undefined
+                ? (command.outputs.find((o) => o.path === command.scriptPath) ?? command.inputs.find((i) => i.path === command.scriptPath))
+                : undefined;
+        const unresolvedScript = command.kind === "command" && command.scriptPath !== undefined && scriptKey === undefined ? command.scriptPath : undefined;
+
+        // Per-kind attributes; args are joined into one string. No formal start/end time — the only
+        // timestamp at this seam is replay-unstable.
+        const attributes =
+            command.kind === "command"
+                ? {
+                      "prov:type": "inflexa:Command",
+                      "inflexa:command": command.command,
+                      ...(command.args ? { "inflexa:args": command.args.join(" ") } : {}),
+                      "inflexa:exitCode": command.exitCode,
+                      ...(command.durationMs !== undefined ? { "inflexa:durationMs": command.durationMs } : {}),
+                      ...(unresolvedScript !== undefined ? { "inflexa:unresolvedScript": unresolvedScript } : {}),
+                  }
+                : { "prov:type": "inflexa:FileToolWrite", "inflexa:tool": command.tool };
+        doc.activity(cmdQn, undefined, undefined, attributes);
+        doc.wasInformedBy(cmdQn, sQn, `${NS_PREFIX}:informed-cmd-${step.runId}-${step.stepId}-${groupDigest}`);
+        const assocIdBase = `${NS_PREFIX}:assoc-cmd-${step.runId}-${step.stepId}-${groupDigest}`;
+        doc.wasAssociatedWith(cmdQn, agentQn, undefined, `${assocIdBase}-${agentDigest(agentQn)}`);
+        appendModelAgent(doc, model, agentQn, cmdQn, assocIdBase);
+
+        // Generation authority for each output — SAME `gen-{fileDigest}` id the step-level edge
+        // uses, so a file entity can never accrue two generation records (the bridge's
+        // produced-vs-leaf partition is exclusive; this is the produced side).
+        for (const output of command.outputs) {
+            doc.wasGeneratedBy(fileQName(output), cmdQn, undefined, `${NS_PREFIX}:gen-${fileDigest(output)}`);
+        }
+
+        // Only a `command` kind reads inputs; a `file_tool` write is agent-authored content with none.
+        if (command.kind === "command") {
+            // Every command-scoped `used` id is keyed on (command group + the read entity's
+            // `(path,hash)` digest) — when the script resolves to an entity already among these
+            // inputs, its `used` edge gets the SAME id and merges: the command reads one entity once.
+            const usedId = (key: ProvFileKey): string => `${NS_PREFIX}:used-cmd-${step.runId}-${step.stepId}-${groupDigest}-${fileDigest(key)}`;
+            for (const input of command.inputs) {
+                doc.used(cmdQn, fileQName(input), undefined, usedId(input));
+            }
+            if (scriptKey) doc.used(cmdQn, fileQName(scriptKey), undefined, usedId(scriptKey));
+        }
+    }
+
+    /**
+     * Append the file-write records: a file entity, attributed to the actor's agent, and
+     * `wasDerivedFrom` the analysis entity — the coarse lineage edge. The step-level
+     * `wasGeneratedBy(file, step)` is written ONLY when `generation === "step"`: a LEAF file (no
+     * producing command activity) whose best available attestation is "the step produced it
+     * somehow". A PRODUCED file (`generation === "command"`) receives its generation edge
+     * exclusively from {@link appendCommandExecuted}, under the same `gen-{fileDigest}` id — so
+     * exactly ONE generation edge exists per file entity regardless of which authority wrote it.
+     */
+    function appendFileWritten(
+        doc: ProvDocument,
+        analysisId: string,
+        actor: ProvActor,
+        file: ProvFileRef,
+        step: ProvStepRef,
+        generation: "command" | "step",
+    ): void {
+        const { analysisQn, agentQn } = recordPreamble(doc, analysisId, actor);
+        const sQn = stepQName(step);
+        const suffix = fileDigest(file);
+        const fQn = fileQName(file);
+        doc.entity(fQn, {
+            "prov:type": "inflexa:File",
+            "inflexa:path": file.path,
+            "inflexa:hash": file.hash,
+            "inflexa:size": file.size,
+            "inflexa:producer": file.producer,
+        });
+        if (generation === "step") doc.wasGeneratedBy(fQn, sQn, undefined, `${NS_PREFIX}:gen-${suffix}`);
+        doc.wasAttributedTo(fQn, agentQn, `${NS_PREFIX}:attr-${suffix}-${agentDigest(agentQn)}`);
+        doc.wasDerivedFrom(fQn, analysisQn, undefined, undefined, undefined, `${NS_PREFIX}:deriv-${suffix}`);
+    }
+
+    /**
+     * Append the input-read records: an entity for the file the step consumed, `used` by the
+     * reading step activity. The entity is keyed in the SAME `(path, hash)` space as outputs (via
+     * {@link fileQName}), which is the load-bearing choice — a `source: "prior"` read of
+     * `runs/{priorRun}/{step}/output/x.csv` resolves to the very QName that file's write generated,
+     * so `unified()` merges the two and the cross-run derivation chain falls out with no extra
+     * modeling. A `source: "data"` or cross-analysis read has no `wasGeneratedBy` in this document
+     * — valid PROV (an entity may exist without a recorded generation).
+     */
+    function appendInputUsed(doc: ProvDocument, analysisId: string, actor: ProvActor, step: ProvStepRef, input: ProvUsedInputRef): void {
+        // Called for its agent-declaration side effect only (the `used` edge and the input entity
+        // carry no agent) — so the responsible agent is present even if this input read is the
+        // first execution record recorded.
+        recordPreamble(doc, analysisId, actor);
+        const sQn = stepQName(step);
+        const eQn = fileQName(input);
+        doc.entity(eQn, {
+            "inflexa:path": input.path,
+            "inflexa:hash": input.hash,
+            "inflexa:source": input.source,
+            ...(input.fileId !== undefined ? { "inflexa:fileId": input.fileId } : {}),
+        });
+        doc.used(sQn, eQn, undefined, `${NS_PREFIX}:used-input-${step.runId}-${step.stepId}-${fileDigest(input)}`);
+    }
+
+    return {
+        analysisQName,
+        inputQName,
+        runQName,
+        stepQName,
+        fileQName,
+        commandQName,
+        modelAgentQName,
+        freshDocument,
+        loadDocument,
+        appendCreation,
+        appendInputAdded,
+        appendInputRemoved,
+        appendRunStarted,
+        appendRunCompleted,
+        appendStepCompleted,
+        appendCommandExecuted,
+        appendFileWritten,
+        appendInputUsed,
+    };
+}

--- a/harness/src/provenance/recorder/recorder.test.ts
+++ b/harness/src/provenance/recorder/recorder.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from "bun:test";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { createProvenanceRecorder, type ProvSnapshot, type ProvSnapshotSink } from "./recorder.js";
+import { createKeypairSigner, computePayloadDigest, type ProvSigner } from "./signing.js";
+import { buildSidecar, sidecarSchema, verifyProvenance, verifySidecar } from "./verify.js";
+import { createProvDocumentModel, defaultProvDigest } from "./document.js";
+import type { ProvActor, ProvEvent } from "./types.js";
+
+const actor: ProvActor = { kind: "system", label: "test-host", version: "0.0.0", commit: "abc123" };
+
+async function makeKeypair(): Promise<CryptoKeyPair> {
+    return (await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"])) as CryptoKeyPair;
+}
+
+/**
+ * An in-memory sink with compare-and-swap on `prevChainHash`. `known` analyses load a seed;
+ * everything else loads `null`. Every accepted persist is appended to `persists`.
+ */
+function makeSink(known: string[]) {
+    const stored = new Map<string, { provJson: string | null; chainHash: string | null }>();
+    for (const id of known) stored.set(id, { provJson: null, chainHash: null });
+    const persists: ProvSnapshot[] = [];
+    const sink: ProvSnapshotSink = {
+        load: (analysisId) => {
+            const row = stored.get(analysisId);
+            if (!row) return okAsync(null);
+            return okAsync({ subject: { analysisId, name: "Test Analysis" }, provJson: row.provJson, chainHash: row.chainHash });
+        },
+        persist: (snapshot) => {
+            const row = stored.get(snapshot.analysisId);
+            if (!row) return errAsync({ type: "persist_failed" as const });
+            if (row.chainHash !== snapshot.prevChainHash) return errAsync({ type: "conflict" as const });
+            stored.set(snapshot.analysisId, { provJson: snapshot.provJson, chainHash: snapshot.chainHash });
+            persists.push(snapshot);
+            return okAsync(undefined);
+        },
+    };
+    return { sink, stored, persists };
+}
+
+function runEvents(analysisId: string): ProvEvent[] {
+    const step = { runId: "r1", stepId: "s1" };
+    return [
+        { type: "run_started", analysisId, actor, run: { runId: "r1", planSummary: "test plan", startedAtMs: 1_700_000_000_000 } },
+        {
+            type: "command_executed",
+            analysisId,
+            actor,
+            step,
+            model: "anthropic/test-model",
+            command: {
+                kind: "command",
+                command: "python run.py",
+                exitCode: 0,
+                durationMs: 1200,
+                outputs: [{ path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb" }],
+                inputs: [{ path: "data/inputs/counts.csv", hash: "sha256:aaa", source: "data" }],
+            },
+        },
+        {
+            type: "file_written",
+            analysisId,
+            actor,
+            step,
+            generation: "command",
+            file: { path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb", size: 10, producer: "command" },
+        },
+        {
+            type: "step_completed",
+            analysisId,
+            actor,
+            model: "anthropic/test-model",
+            outcome: { runId: "r1", stepId: "s1", status: "completed", completedAtMs: 1_700_000_100_000, durationMs: 100_000 },
+        },
+        {
+            type: "run_completed",
+            analysisId,
+            actor,
+            outcome: { runId: "r1", status: "completed", completedAtMs: 1_700_000_200_000, durationMs: 200_000 },
+        },
+    ];
+}
+
+describe("provenance recorder", () => {
+    test("a burst of events coalesces into one signed, chained persist that verifies", async () => {
+        const kp = await makeKeypair();
+        const { sink, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        for (const event of runEvents("a1")) recorder.record(event);
+        await recorder.flush();
+
+        expect(persists.length).toBe(1);
+        const snap = persists[0]!;
+        expect(snap.prevChainHash).toBeNull();
+        expect(await verifyProvenance(snap.provJson, snap.prevChainHash, snap.chainHash, snap.signature, kp.publicKey)).toEqual({ status: "valid" });
+
+        const doc = JSON.parse(snap.provJson) as Record<string, Record<string, unknown>>;
+        expect(Object.keys(doc.activity ?? {})).toContain("inflexa:run-r1");
+        expect(Object.keys(doc.activity ?? {})).toContain("inflexa:step-r1-s1");
+        expect(Object.keys(doc.agent ?? {})).toContain("inflexa:agent-system");
+    });
+
+    test("subsequent flushes chain onto the previous hash", async () => {
+        const kp = await makeKeypair();
+        const { sink, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        const [started, command, file, step, completed] = runEvents("a1");
+        recorder.record(started!);
+        await recorder.flush();
+        recorder.record(command!);
+        recorder.record(file!);
+        recorder.record(step!);
+        recorder.record(completed!);
+        await recorder.flush();
+
+        expect(persists.length).toBe(2);
+        expect(persists[1]!.prevChainHash).toBe(persists[0]!.chainHash);
+        expect(await verifyProvenance(persists[1]!.provJson, persists[1]!.prevChainHash, persists[1]!.chainHash, persists[1]!.signature, kp.publicKey)).toEqual(
+            { status: "valid" },
+        );
+    });
+
+    test("re-emission of the same execution events dedupes under unified()", async () => {
+        const kp = await makeKeypair();
+        const { sink, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        for (const event of runEvents("a1")) recorder.record(event);
+        await recorder.flush();
+        for (const event of runEvents("a1")) recorder.record(event);
+        await recorder.flush();
+
+        const doc = JSON.parse(persists.at(-1)!.provJson) as Record<string, Record<string, unknown>>;
+        const model = createProvDocumentModel();
+        const fileQn = model.fileQName({ path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb" });
+        expect(Object.keys(doc.entity ?? {}).filter((k) => k === fileQn).length).toBe(1);
+        // Exactly one generation edge for the file, under its deterministic relation id.
+        const genIds = Object.keys(doc.wasGeneratedBy ?? {});
+        expect(genIds.filter((k) => k.includes(defaultProvDigest(`runs/r1/s1/output/result.csv|sha256:bbb`))).length).toBe(1);
+        // No anonymous (blank-node) relations — every relation must carry its deterministic id.
+        for (const relKind of ["used", "wasGeneratedBy", "wasAssociatedWith", "wasInformedBy", "wasAttributedTo", "wasDerivedFrom"]) {
+            for (const id of Object.keys(doc[relKind] ?? {})) expect(id.startsWith("_:")).toBe(false);
+        }
+    });
+
+    test("a transient signing failure retains the tail and never writes unsigned", async () => {
+        const kp = await makeKeypair();
+        const inner = createKeypairSigner(kp);
+        let failures = 1;
+        const flaky: ProvSigner = {
+            sign: (digestHex) => {
+                if (failures > 0) {
+                    failures -= 1;
+                    return errAsync({ type: "crypto_failed" as const, op: "sign", cause: new Error("transient") });
+                }
+                return inner.sign(digestHex);
+            },
+            exportPublicKeyJwk: () => inner.exportPublicKeyJwk(),
+        };
+        const { sink, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: flaky });
+
+        for (const event of runEvents("a1")) recorder.record(event);
+        await recorder.flush();
+
+        expect(persists.length).toBe(1);
+        expect(await verifyProvenance(persists[0]!.provJson, null, persists[0]!.chainHash, persists[0]!.signature, kp.publicKey)).toEqual({
+            status: "valid",
+        });
+    });
+
+    test("a persistent signing failure stops the drain without spinning", async () => {
+        const broken: ProvSigner = {
+            sign: () => errAsync({ type: "crypto_failed" as const, op: "sign", cause: new Error("permanent") }),
+            exportPublicKeyJwk: () => okAsync(null),
+        };
+        const { sink, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: broken });
+
+        recorder.record(runEvents("a1")[0]!);
+        await recorder.flush();
+
+        expect(persists.length).toBe(0);
+    });
+
+    test("an unknown analysis is skipped", async () => {
+        const kp = await makeKeypair();
+        const { sink, persists } = makeSink([]);
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        for (const event of runEvents("missing")) recorder.record(event);
+        await recorder.flush();
+
+        expect(persists.length).toBe(0);
+    });
+
+    test("a corrupt stored document starts a fresh document and a fresh chain", async () => {
+        const kp = await makeKeypair();
+        const { sink, stored, persists } = makeSink(["a1"]);
+        stored.set("a1", { provJson: "this is not prov-json", chainHash: "ab".repeat(32) });
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        // The CAS sink compares against the corrupt row's chain hash; a fresh chain (prev null)
+        // must still land, so relax the sink to accept it the way a real host's
+        // corrupt-row-recovery would.
+        stored.set("a1", { provJson: "this is not prov-json", chainHash: null });
+        recorder.record(runEvents("a1")[0]!);
+        await recorder.flush();
+
+        expect(persists.length).toBe(1);
+        expect(persists[0]!.prevChainHash).toBeNull();
+        const doc = JSON.parse(persists[0]!.provJson) as Record<string, Record<string, unknown>>;
+        expect(Object.keys(doc.activity ?? {})).toContain("inflexa:run-r1");
+    });
+
+    test("a CAS conflict refreshes the chain head and re-chains onto it", async () => {
+        const kp = await makeKeypair();
+        const { sink, stored, persists } = makeSink(["a1"]);
+        const recorder = createProvenanceRecorder({ sink, signer: createKeypairSigner(kp) });
+
+        recorder.record(runEvents("a1")[0]!);
+        await recorder.flush();
+        expect(persists.length).toBe(1);
+
+        // Another writer advances the stored chain behind this recorder's back.
+        const foreignHead = "cd".repeat(32);
+        stored.set("a1", { provJson: stored.get("a1")!.provJson, chainHash: foreignHead });
+
+        recorder.record(runEvents("a1")[4]!);
+        await recorder.flush();
+
+        expect(persists.length).toBe(2);
+        expect(persists[1]!.prevChainHash).toBe(foreignHead);
+    });
+
+    test("events recorded while the first-touch load is in flight are drained by flush", async () => {
+        const kp = await makeKeypair();
+        const { sink, persists } = makeSink(["a1"]);
+        const slowSink: ProvSnapshotSink = {
+            load: (analysisId) => ResultAsync.fromSafePromise(new Promise((resolve) => setTimeout(resolve, 20))).andThen(() => sink.load(analysisId)),
+            persist: (snapshot) => sink.persist(snapshot),
+        };
+        const recorder = createProvenanceRecorder({ sink: slowSink, signer: createKeypairSigner(kp) });
+
+        for (const event of runEvents("a1")) recorder.record(event);
+        await recorder.flush();
+
+        expect(persists.length).toBe(1);
+        const doc = JSON.parse(persists[0]!.provJson) as Record<string, Record<string, unknown>>;
+        expect(Object.keys(doc.activity ?? {})).toContain("inflexa:run-r1");
+        expect(Object.keys(doc.activity ?? {})).toContain("inflexa:step-r1-s1");
+    });
+});
+
+describe("sidecar", () => {
+    test("buildSidecar output validates and verifies against the payload", async () => {
+        const kp = await makeKeypair();
+        const signer = createKeypairSigner(kp);
+        const provJson = `{"prefix":{"inflexa":"https://inflexa.ai/prov#"}}`;
+
+        const sidecarResult = await buildSidecar(signer, provJson);
+        expect(sidecarResult.isOk()).toBe(true);
+        const sidecar = sidecarSchema.parse(sidecarResult._unsafeUnwrap());
+        expect(sidecar.payloadDigest).toBe((await computePayloadDigest(provJson))._unsafeUnwrap());
+        expect(await verifySidecar(provJson, sidecar)).toEqual({ status: "valid" });
+        expect(await verifySidecar(`${provJson} `, sidecar)).toMatchObject({ status: "tampered" });
+    });
+});

--- a/harness/src/provenance/recorder/recorder.ts
+++ b/harness/src/provenance/recorder/recorder.ts
@@ -1,0 +1,356 @@
+import type { ResultAsync } from "neverthrow";
+import type { ProvDocument } from "@inflexa-ai/tsprov";
+import type { Logger } from "../../lib/logger.js";
+import { createNoopLogger } from "../../lib/console-logger.js";
+import type { ProvEvent, ProvSubject } from "./types.js";
+import { createProvDocumentModel, PROV_UNIFY_OPTIONS, type ProvDocumentModel } from "./document.js";
+import type { ProvSigner } from "./signing.js";
+import { computeChainHash } from "./signing.js";
+
+/**
+ * The provenance recorder: keeps each touched analysis's PROV document in memory (append-only)
+ * and persists it — whole, signed, and chain-hashed — through the injected {@link ProvSnapshotSink}.
+ * Recording is decoupled from the execution paths that drive it: they call {@link ProvenanceRecorder.record}
+ * and forget (directly, or through whatever transport the host already runs); this folds and flushes.
+ *
+ * SINGLE WRITER PER ANALYSIS: the embedder guarantees at most one live recorder appends to an
+ * analysis's document at a time (an analysis lock, durable-workflow ownership, or equivalent). A
+ * sink that supports compare-and-swap on `prevChainHash` detects a violation as a `conflict`
+ * persist error; the recorder then refreshes its chain head and re-persists — the chain never
+ * forks — but content-level reconciliation of concurrent writers is out of scope.
+ */
+
+/** What a sink returns on first touch: the subject to seed a fresh document from, plus the stored form when one exists. */
+export type ProvSnapshotSeed = {
+    subject: ProvSubject;
+    provJson: string | null;
+    chainHash: string | null;
+};
+
+/** One signed snapshot to persist — the whole serialized document plus its chain values. */
+export type ProvSnapshot = {
+    analysisId: string;
+    provJson: string;
+    chainHash: string;
+    prevChainHash: string | null;
+    signature: string;
+};
+
+export type ProvSinkError =
+    | { type: "load_failed"; cause?: unknown }
+    | { type: "persist_failed"; cause?: unknown }
+    /** The sink's compare-and-swap on `prevChainHash` rejected a stale write — another writer advanced the chain. */
+    | { type: "conflict" };
+
+/**
+ * The snapshot persistence seam a host fills at its composition root: the OSS host reads/writes
+ * SQLite columns; a managed host GETs/PUTs its backend's document endpoint. `load` resolves `null`
+ * for an analysis the host does not know — the recorder drops that analysis's events.
+ */
+export interface ProvSnapshotSink {
+    load(analysisId: string): ResultAsync<ProvSnapshotSeed | null, ProvSinkError>;
+    persist(snapshot: ProvSnapshot): ResultAsync<void, ProvSinkError>;
+}
+
+export interface ProvenanceRecorderDeps {
+    readonly sink: ProvSnapshotSink;
+    readonly signer: ProvSigner;
+    /** The QName/document derivations to append with. Defaults to `createProvDocumentModel()`. */
+    readonly documentModel?: ProvDocumentModel;
+    readonly logger?: Logger;
+}
+
+export interface ProvenanceRecorder {
+    /**
+     * Record one event, fire-and-forget: never throws, never blocks the caller. The first event
+     * for an analysis starts the sink load and queues; a builder failure drops that single record.
+     */
+    record(event: ProvEvent): void;
+    /**
+     * Drive the flush loop to quiescence and await it — the shutdown/terminal drain. Returns once
+     * nothing is dirty, or once a pass makes no progress (a persistent signing/persist fault);
+     * looping past that would hang shutdown, and unsigned bytes are never an alternative.
+     */
+    flush(): Promise<void>;
+}
+
+/** Per-analysis lifecycle: sink load in flight (events queue), ready (events append), or skipped (unknown analysis). */
+type DocEntry = { state: "loading"; queue: ProvEvent[]; settled: Promise<void> } | { state: "ready"; doc: ProvDocument } | { state: "skipped" };
+
+export function createProvenanceRecorder(deps: ProvenanceRecorderDeps): ProvenanceRecorder {
+    const log = (deps.logger ?? createNoopLogger()).named("provenance.recorder");
+    const model = deps.documentModel ?? createProvDocumentModel();
+
+    // One live entry per analysis touched by this instance. All state is per-instance — tests
+    // construct fresh recorders instead of resetting globals.
+    const entries = new Map<string, DocEntry>();
+    // Last known chain hash per analysis — seeded from the sink on first touch, updated after each
+    // signed flush so subsequent flushes chain correctly without a re-read. Cleared on a persist
+    // `conflict` so the next flush re-reads the advanced head.
+    const chainHashes = new Map<string, string | null>();
+    // Analyses whose live doc has appends not yet persisted, awaiting the next flush.
+    const dirty = new Set<string>();
+    // Per-analysis append revision, bumped on EVERY append. A flush records the revision of the
+    // bytes it serialized and clears `dirty` only if that revision still holds when the (async)
+    // sign+persist returns — an append that lands mid-flush advances the revision, so the flush
+    // that snapshotted the earlier bytes leaves the analysis dirty and the drain re-serializes the
+    // tail.
+    const revision = new Map<string, number>();
+    // Analyses whose chain head must be refreshed from the sink before the next persist (a CAS
+    // `conflict` was observed).
+    const staleChains = new Set<string>();
+
+    // Flush is single-flight per instance. `flushInProgress` gates re-entry so two passes never
+    // overlap and thus never read the same `prev` chain hash and fork the chain; `flushRequested`
+    // records wakeups that arrive during a pass so the drain loop consumes them without losing
+    // one; `pending` is the in-flight pass the drain awaits.
+    let flushInProgress = false;
+    let flushRequested = false;
+    let pending: Promise<void> = Promise.resolve();
+    let flushScheduled = false;
+
+    /** Record an append against `analysisId`: advance its revision, mark it dirty, and wake the flush. */
+    function markDirty(analysisId: string): void {
+        revision.set(analysisId, (revision.get(analysisId) ?? 0) + 1);
+        dirty.add(analysisId);
+        scheduleFlush();
+    }
+
+    /** Append one event into a ready document. A builder throw MUST NOT unwind into the caller — a defect in one builder drops that single record, never the emitting execution path. */
+    function appendEvent(doc: ProvDocument, event: ProvEvent): boolean {
+        try {
+            switch (event.type) {
+                case "analysis_created":
+                    model.appendCreation(doc, event.analysisId, event.actor);
+                    break;
+                case "input_added":
+                    model.appendInputAdded(doc, event.analysisId, event.actor, event.input, event.derivedFromAnalysisId);
+                    break;
+                case "input_removed":
+                    model.appendInputRemoved(doc, event.analysisId, event.actor, event.input);
+                    break;
+                case "run_started":
+                    model.appendRunStarted(doc, event.analysisId, event.actor, event.run);
+                    break;
+                case "run_completed":
+                    model.appendRunCompleted(doc, event.analysisId, event.actor, event.outcome);
+                    break;
+                case "step_completed":
+                    model.appendStepCompleted(doc, event.analysisId, event.actor, event.outcome, event.model);
+                    break;
+                case "command_executed":
+                    model.appendCommandExecuted(doc, event.analysisId, event.actor, event.step, event.command, event.model);
+                    break;
+                case "file_written":
+                    model.appendFileWritten(doc, event.analysisId, event.actor, event.file, event.step, event.generation);
+                    break;
+                case "input_used":
+                    model.appendInputUsed(doc, event.analysisId, event.actor, event.step, event.input);
+                    break;
+                default: {
+                    event satisfies never;
+                    log.error("unhandled prov event — not recorded", { type: (event as ProvEvent).type });
+                    return false;
+                }
+            }
+            return true;
+        } catch (cause) {
+            log.error("prov builder threw; record dropped", { type: event.type, analysisId: event.analysisId, cause });
+            return false;
+        }
+    }
+
+    /** Resolve the first-touch sink load: seed or rebuild the document, adopt the chain head, drain the queue. */
+    function settleLoad(analysisId: string, queueRef: { queue: ProvEvent[] }): Promise<void> {
+        return deps.sink.load(analysisId).match(
+            (seed) => {
+                if (seed === null) {
+                    log.warn("prov event for unknown analysis; skipping", { analysisId });
+                    entries.set(analysisId, { state: "skipped" });
+                    return;
+                }
+                const docResult = model.loadDocument(seed.subject, seed.provJson);
+                let doc: ProvDocument;
+                if (docResult.isErr()) {
+                    log.error("stored provenance is corrupt; starting fresh document", { analysisId, cause: docResult.error.cause });
+                    // Clear the stale chain hash so the next flush starts a new chain instead of
+                    // chaining from the old (now-disconnected) hash.
+                    chainHashes.delete(analysisId);
+                    doc = model.freshDocument(seed.subject);
+                } else {
+                    doc = docResult.value;
+                    if (seed.chainHash) chainHashes.set(analysisId, seed.chainHash);
+                }
+                entries.set(analysisId, { state: "ready", doc });
+                for (const event of queueRef.queue) {
+                    if (appendEvent(doc, event)) markDirty(analysisId);
+                }
+            },
+            (e) => {
+                // Transient load failure: drop this batch, but forget the entry so a later event
+                // retries the load rather than an analysis staying dark for the process lifetime.
+                log.error("failed to load provenance snapshot; events dropped", { analysisId, error: e.type, cause: "cause" in e ? e.cause : undefined });
+                entries.delete(analysisId);
+            },
+        );
+    }
+
+    function record(event: ProvEvent): void {
+        const entry = entries.get(event.analysisId);
+        if (entry === undefined) {
+            const queueRef = { queue: [event] };
+            const fresh: DocEntry = { state: "loading", queue: queueRef.queue, settled: settleLoad(event.analysisId, queueRef) };
+            entries.set(event.analysisId, fresh);
+            return;
+        }
+        switch (entry.state) {
+            case "loading":
+                entry.queue.push(event);
+                return;
+            case "ready":
+                if (appendEvent(entry.doc, event)) markDirty(event.analysisId);
+                return;
+            case "skipped":
+                return;
+        }
+    }
+
+    // Coalesce a burst of appends into one async flush. The in-memory document is authoritative
+    // between flushes; a crash in that window loses the un-flushed tail — the accepted trade-off
+    // for keeping recording off the synchronous execution path.
+    function scheduleFlush(): void {
+        flushRequested = true;
+        // A pass already running will drain this wakeup itself (its loop re-reads `dirty` while
+        // `flushRequested` is set); a timer already armed will start one. Either way, do NOT arm a
+        // second timer — single-flight is enforced in `runFlush`, and a bare re-arm would let two
+        // passes overlap and read the same `prev` chain hash.
+        if (flushScheduled || flushInProgress) return;
+        flushScheduled = true;
+        setTimeout(() => {
+            flushScheduled = false;
+            launchFlush();
+        }, 0);
+    }
+
+    /** Start a flush pass unless one is already running (which will itself drain the new wakeup). */
+    function launchFlush(): void {
+        if (flushInProgress) return;
+        pending = runFlush();
+    }
+
+    /**
+     * One single-flight flush loop: drain passes until no wakeup is outstanding. The per-analysis
+     * snapshot (revision + bytes) is captured SYNCHRONOUSLY in the loop body — no `await` between
+     * reading `dirty` and serializing — so an append can never interleave into a half-built
+     * snapshot, and each analysis appears at most once per pass so the concurrent
+     * {@link persistSnapshot} calls touch disjoint chains.
+     */
+    async function runFlush(): Promise<void> {
+        if (flushInProgress) return;
+        flushInProgress = true;
+        try {
+            do {
+                flushRequested = false;
+                const inFlight: Promise<void>[] = [];
+                for (const analysisId of [...dirty]) {
+                    const entry = entries.get(analysisId);
+                    if (entry === undefined || entry.state !== "ready") {
+                        dirty.delete(analysisId);
+                        revision.delete(analysisId);
+                        continue;
+                    }
+                    // Last-write-wins merge ({@link PROV_UNIFY_OPTIONS}): a re-emitted terminal
+                    // record (recovery replay → identical; resume → newer) resolves to one survivor
+                    // rather than throwing, so a conflict can never leave the analysis permanently
+                    // unpersistable.
+                    const snapshotRevision = revision.get(analysisId) ?? 0;
+                    let json: string;
+                    try {
+                        json = entry.doc.unified(PROV_UNIFY_OPTIONS).serialize("json");
+                    } catch (cause) {
+                        // Isolate a serialize/unify fault to its own analysis: an uncaught throw
+                        // here would abort the whole pass AND reject `pending` as an unhandled
+                        // rejection. Leave the doc dirty so a later append retries it; a
+                        // persistently-poisoned doc stops making progress, which `flush()`'s
+                        // no-progress guard tolerates.
+                        log.error("provenance serialize failed; leaving dirty for retry", { analysisId, cause });
+                        continue;
+                    }
+                    inFlight.push(persistSnapshot(analysisId, json, snapshotRevision));
+                }
+                await Promise.all(inFlight);
+            } while (flushRequested);
+        } finally {
+            flushInProgress = false;
+        }
+    }
+
+    /**
+     * Sign and persist one already-serialized snapshot. Single-flight (see {@link runFlush})
+     * guarantees no other pass mutates this analysis's chain hash between the `prev` read and the
+     * `set` below, so the chain never forks. On any signing/persist failure the analysis stays
+     * dirty (retried later) and NO unsigned bytes are written. On success, `dirty` is cleared ONLY
+     * when the snapshot revision still holds.
+     */
+    async function persistSnapshot(analysisId: string, json: string, snapshotRevision: number): Promise<void> {
+        // A prior persist saw a CAS conflict: another writer advanced the chain, so re-read the
+        // head before chaining onto it. Content is still this instance's document — single-writer
+        // is the embedder's guarantee; this keeps the CHAIN honest when it is violated.
+        if (staleChains.has(analysisId)) {
+            const refreshed = await deps.sink.load(analysisId).match(
+                (seed) => ({ ok: true as const, chainHash: seed?.chainHash ?? null }),
+                (e) => {
+                    log.error("failed to refresh chain head after conflict", { analysisId, error: e.type });
+                    return { ok: false as const, chainHash: null };
+                },
+            );
+            if (!refreshed.ok) return;
+            chainHashes.set(analysisId, refreshed.chainHash);
+            staleChains.delete(analysisId);
+        }
+
+        const prev = chainHashes.get(analysisId) ?? null;
+        const result = await computeChainHash(prev, json).andThen((chainHash) => deps.signer.sign(chainHash).map((signature) => ({ chainHash, signature })));
+        if (result.isErr()) {
+            log.error("signing failed; provenance not persisted", { analysisId, error: result.error.type });
+            return;
+        }
+        const { chainHash, signature } = result.value;
+        await deps.sink.persist({ analysisId, provJson: json, chainHash, prevChainHash: prev, signature }).match(
+            () => {
+                chainHashes.set(analysisId, chainHash);
+                // Clear dirty only if no append landed after this snapshot; otherwise the tail
+                // stays dirty and the drain re-serializes the mutated document.
+                if ((revision.get(analysisId) ?? 0) === snapshotRevision) dirty.delete(analysisId);
+            },
+            (e) => {
+                if (e.type === "conflict") {
+                    staleChains.add(analysisId);
+                    log.error("persist rejected as stale (chain advanced by another writer); will re-chain", { analysisId });
+                    return;
+                }
+                log.error("failed to persist provenance", { analysisId, error: e.type, cause: "cause" in e ? e.cause : undefined });
+            },
+        );
+    }
+
+    async function flush(): Promise<void> {
+        let previousDirty = Infinity;
+        do {
+            // A first-touch load still in flight holds queued events that are not yet dirty; drain
+            // it first so a terminal flush never returns with those events unpersisted.
+            const loading = [...entries.values()].filter((e) => e.state === "loading").map((e) => e.settled);
+            if (loading.length > 0) await Promise.all(loading);
+            launchFlush();
+            await pending;
+            // Stop if a pass cleared nothing (persistent signing/persist failure); a late append
+            // that re-dirties shrinks `dirty` on the next pass, so a strictly-not-smaller size
+            // means no progress.
+            if (dirty.size >= previousDirty) break;
+            previousDirty = dirty.size;
+        } while (dirty.size > 0);
+        if (dirty.size > 0) log.error("provenance flush could not drain — signing or persist is failing", { analyses: [...dirty] });
+    }
+
+    return { record, flush };
+}

--- a/harness/src/provenance/recorder/signing.ts
+++ b/harness/src/provenance/recorder/signing.ts
@@ -1,0 +1,121 @@
+import { ResultAsync } from "neverthrow";
+
+/**
+ * Provenance signing primitives: the chain-hash and Ed25519 sign/verify operations the recorder,
+ * sidecar builder, and verifier share — plus the {@link ProvSigner} seam through which a host
+ * supplies key custody. Confined to this file so a WebCrypto fault is contained to provenance
+ * integrity, not recording.
+ *
+ * Key LIFECYCLE (where a keypair lives, generate-on-first-use, rotation) is deliberately absent:
+ * that is host policy behind {@link ProvSigner} — the OSS host keeps a config-dir JWK file, a
+ * managed host mounts a secret. Provenance is never written unsigned — every failure surfaces as
+ * a {@link ProvSigningError} on the err channel.
+ */
+
+/** WebCrypto's JsonWebKey is a loose object; it is carried as-is without inspecting fields. */
+export type ProvPublicKeyJwk = Record<string, unknown>;
+
+/** Why a signing/crypto operation failed. Every variant is a hard failure — provenance is never written unsigned. */
+export type ProvSigningError =
+    | { type: "keypair_corrupt"; cause?: unknown }
+    | { type: "keypair_generation_failed"; cause: unknown }
+    | { type: "keypair_race_lost" }
+    | { type: "public_key_export_failed" }
+    | { type: "crypto_failed"; op: string; cause: unknown };
+
+/**
+ * The signing seam a host fills at its composition root. `sign` receives a hex-encoded digest
+ * (the chain hash at flush time, the payload digest at export time) and returns the hex-encoded
+ * Ed25519 signature; `exportPublicKeyJwk` supplies the public half for sidecars and verification,
+ * or `null` when no key exists yet.
+ */
+export interface ProvSigner {
+    sign(digestHex: string): ResultAsync<string, ProvSigningError>;
+    exportPublicKeyJwk(): ResultAsync<ProvPublicKeyJwk | null, ProvSigningError>;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+    }
+    return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let hex = "";
+    for (const b of bytes) {
+        hex += b.toString(16).padStart(2, "0");
+    }
+    return hex;
+}
+
+/** The seed for the initial flush's chain hash: `SHA-256("")`, matching the RFC 6962 empty-tree convention. */
+async function emptySeed(): Promise<Uint8Array> {
+    return new Uint8Array(await crypto.subtle.digest("SHA-256", new Uint8Array(0)));
+}
+
+/**
+ * Compute the chain hash: `SHA-256(prevBytes || provJsonBytes)`. When `prevChainHashHex` is null
+ * (first flush), the seed is `SHA-256("")`.
+ */
+export function computeChainHash(prevChainHashHex: string | null, provJson: string): ResultAsync<string, ProvSigningError> {
+    return ResultAsync.fromPromise(
+        (async () => {
+            const prev = prevChainHashHex ? hexToBytes(prevChainHashHex) : await emptySeed();
+            const jsonBytes = new TextEncoder().encode(provJson);
+            const combined = new Uint8Array(prev.length + jsonBytes.length);
+            combined.set(prev, 0);
+            combined.set(jsonBytes, prev.length);
+            const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", combined));
+            return bytesToHex(hash);
+        })(),
+        (cause): ProvSigningError => ({ type: "crypto_failed", op: "computeChainHash", cause }),
+    );
+}
+
+/** Simple `SHA-256(provJson)` — the self-contained content digest used in the export sidecar. */
+export function computePayloadDigest(provJson: string): ResultAsync<string, ProvSigningError> {
+    return ResultAsync.fromPromise(
+        crypto.subtle.digest("SHA-256", new TextEncoder().encode(provJson)).then((buf) => bytesToHex(new Uint8Array(buf))),
+        (cause): ProvSigningError => ({ type: "crypto_failed", op: "computePayloadDigest", cause }),
+    );
+}
+
+/** Sign a hex-encoded digest with an Ed25519 private key, returning a hex-encoded 64-byte signature. */
+export function signHexDigest(privateKey: CryptoKey, digestHex: string): ResultAsync<string, ProvSigningError> {
+    const data = hexToBytes(digestHex);
+    // Safe: hexToBytes allocates a fresh Uint8Array, so .buffer starts at offset 0 and is not shared.
+    return ResultAsync.fromPromise(
+        crypto.subtle.sign("Ed25519", privateKey, data.buffer as ArrayBuffer).then((sig) => bytesToHex(new Uint8Array(sig))),
+        (cause): ProvSigningError => ({ type: "crypto_failed", op: "signHexDigest", cause }),
+    );
+}
+
+/** Verify a hex-encoded Ed25519 signature against a hex-encoded digest and a public key. */
+export function verifyHexDigest(publicKey: CryptoKey, signatureHex: string, digestHex: string): ResultAsync<boolean, ProvSigningError> {
+    const sig = hexToBytes(signatureHex);
+    const data = hexToBytes(digestHex);
+    // Safe: both Uint8Arrays are freshly allocated by hexToBytes — offset 0, not shared.
+    return ResultAsync.fromPromise(
+        crypto.subtle.verify("Ed25519", publicKey, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer),
+        (cause): ProvSigningError => ({ type: "crypto_failed", op: "verifyHexDigest", cause }),
+    );
+}
+
+/**
+ * A {@link ProvSigner} over an in-memory Ed25519 keypair — for hosts that already hold imported
+ * `CryptoKey`s (a managed host importing a mounted-secret JWK, tests generating a throwaway pair).
+ * Key custody stays with the caller; this only binds the sign/export operations to the pair.
+ */
+export function createKeypairSigner(keypair: { privateKey: CryptoKey; publicKey: CryptoKey }): ProvSigner {
+    return {
+        sign: (digestHex) => signHexDigest(keypair.privateKey, digestHex),
+        exportPublicKeyJwk: () =>
+            ResultAsync.fromPromise(crypto.subtle.exportKey("jwk", keypair.publicKey) as Promise<ProvPublicKeyJwk>, (cause): ProvSigningError => ({
+                type: "crypto_failed",
+                op: "exportPublicKeyJwk",
+                cause,
+            })),
+    };
+}

--- a/harness/src/provenance/recorder/types.ts
+++ b/harness/src/provenance/recorder/types.ts
@@ -1,0 +1,281 @@
+/**
+ * The provenance-recorder domain model: the kinds of tracked actions, the agent responsible for
+ * one, and the event vocabulary the recorder consumes. An analysis's provenance is a W3C PROV
+ * document (serialized as PROV-JSON), built incrementally by the recorder (`recorder.ts`) from
+ * {@link ProvEvent} values — delivered by direct `record()` calls, with or without an event bus
+ * in front.
+ */
+
+/**
+ * The resolved responsible agent for an action — a discriminated union so the call site states
+ * *which* kind it is recording, and so the document builder reads the right fields per kind.
+ * `user` is a logged-in person, `anonymous` an unauthenticated person, `system` the embedding
+ * host acting autonomously — it carries the host's own identity (label, version, and the source
+ * commit when the host has one), so a CLI records itself and a managed service records itself.
+ */
+export type ProvActor =
+    | { kind: "user"; email: string }
+    | { kind: "anonymous" }
+    | {
+          kind: "system";
+          /** The host software's human name (e.g. "inflexa cli", "cortex"). */
+          label: string;
+          /** The host's package/build version. */
+          version: string;
+          /** The exact source commit, when the host knows it. */
+          commit?: string;
+      };
+
+/**
+ * The LLM that reasoned about a model-driven activity — recorded as its own PROV `SoftwareAgent`
+ * (typed `inflexa:Model`) that `actedOnBehalfOf` the responsible agent, so the document answers
+ * *which intelligence entered the process*, not just that the host acted.
+ *
+ * The vendor-qualified `{provider}/{model}` name (e.g. `anthropic/claude-opus-4-8`). The model
+ * part is always the RESOLVED id; the provider part is an OPEN vocabulary recorded verbatim.
+ * NEVER carries API keys, credentialed URLs, or prompt content — the model's identity is the
+ * whole record.
+ */
+export type ProvModelId = `${string}/${string}`;
+
+/**
+ * The subject an analysis document is seeded from — the identity fields written onto the
+ * analysis's PROV subject entity. `name`/`slug` are attributes when the host has them; the id
+ * alone suffices.
+ */
+export type ProvSubject = {
+    analysisId: string;
+    name?: string;
+    slug?: string;
+};
+
+/**
+ * The subset of an analysis input that provenance records: the identity fields for the PROV
+ * entity (stable QName from anchor+path) and the attributes written onto it.
+ */
+export type ProvInputRef = {
+    path: string;
+    isDir: boolean;
+    anchorId: string | null;
+};
+
+/**
+ * A workflow run at its start. Recorded as a PROV **activity**.
+ */
+export type ProvRunRef = {
+    /** The run's identity; the deterministic run-activity QName derives from it. */
+    runId: string;
+    /** The plan summary for this run, when the seam supplies one. */
+    planSummary?: string;
+    /**
+     * Epoch-ms the harness observed the run start, read from its checkpointed clock (`DBOS.now()`)
+     * — the same value across every DBOS replay, NOT a receipt time. Builders convert it to the
+     * run activity's formal `prov:startTime`, so the recorded start is the true workflow boundary
+     * even when the flush-surviving observation happens on a later recovery boot.
+     */
+    startedAtMs: number;
+};
+
+/**
+ * The terminal outcome of a workflow run. Recorded as the run activity's end time and outcome
+ * status.
+ */
+export type ProvRunOutcome = {
+    /** Identifies the run whose activity this completion closes — matches the `run_started` `runId`. */
+    runId: string;
+    /**
+     * The harness's terminal run status. Both boundary sites resolve through `deriveFinalStatus`,
+     * which records a budget pause as `"canceled"` — so `"suspended_insufficient_funds"` is never
+     * emitted and is deliberately absent here.
+     */
+    status: "completed" | "partial" | "failed" | "canceled";
+    /** Epoch-ms the harness observed the run terminate, from its checkpointed clock — replay-stable. */
+    completedAtMs: number;
+    /** Harness-observed run duration (terminal minus start `DBOS.now()` reads). */
+    durationMs?: number;
+};
+
+/**
+ * A pure reference to a workflow step within a run — the identity a file generation or an input
+ * read edges to. Settlement facts (status, times, duration) live on {@link ProvStepOutcome}, not
+ * here — this is deliberately just the `(runId, stepId)` key so a file/input edge never carries
+ * stale lifecycle data.
+ */
+export type ProvStepRef = {
+    /** The owning run — the step activity is `wasInformedBy` this run's activity. */
+    runId: string;
+    /** The step's identity within its run; the step-activity QName derives from `(runId, stepId)`. */
+    stepId: string;
+};
+
+/**
+ * The settlement outcome of a workflow step. Emitted at the harness scheduler settlement (the
+ * only site that observes every executed step — including zero-artifact and failed ones), never
+ * at artifact registration.
+ */
+export type ProvStepOutcome = {
+    /** The owning run — the step activity is `wasInformedBy` this run's activity. */
+    runId: string;
+    /** The step's identity within its run; the step-activity QName derives from `(runId, stepId)`. */
+    stepId: string;
+    /** The settlement outcome mapped to a terminal step status. */
+    status: "completed" | "failed" | "canceled";
+    /** Epoch-ms the harness observed the step settle, from its checkpointed clock — replay-stable. */
+    completedAtMs: number;
+    /** The child's durable execution duration, when the settlement carried one. */
+    durationMs?: number;
+};
+
+/**
+ * A file a step READ — an attested input consumed during execution. Recorded as a PROV **entity**
+ * in the SAME `(path, hash)` QName space as {@link ProvFileRef} outputs, so a `source: "prior"`
+ * read of an earlier run's output resolves to the very entity that run's file write generated
+ * (cross-run lineage merges for free under `unified()`).
+ */
+export type ProvUsedInputRef = {
+    /** Analysis-relative path (container mount prefix stripped); with `hash`, seeds the shared file QName. */
+    path: string;
+    /** Content hash attested from disk — the other half of the deterministic file QName. */
+    hash: string;
+    /** The read-classification, minus the step's own `"artifacts"` outputs. */
+    source: "data" | "upstream" | "prior";
+    /** The staged-input file id, when one was resolved. */
+    fileId?: string;
+};
+
+/**
+ * A file produced under the analysis output tree — a sandbox command output or an agent file-tool
+ * write. Recorded as a PROV **entity** generated by its step or producing command.
+ */
+export type ProvFileRef = {
+    /** Analysis-scoped path (`runs/{runId}/{stepId}/…`); with the hash, seeds the file QName. */
+    path: string;
+    /** Content hash captured at write time — the other half of the deterministic file QName. */
+    hash: string;
+    /** File size in bytes. */
+    size: number;
+    /** How the bytes came to exist, in the collector's bare `Producer.type` vocabulary. */
+    producer: "command" | "file_tool";
+};
+
+/**
+ * The `(path, hash)` identity pick of {@link ProvFileRef} — the QName key space every file entity
+ * lives in. Named (not an inline `Pick`) so the shared key space reads as one type at every use
+ * site.
+ */
+export type ProvFileKey = Pick<ProvFileRef, "path" | "hash">;
+
+/**
+ * A file a COMMAND read — the command-scoped analogue of {@link ProvUsedInputRef}. It widens the
+ * used-input source vocabulary with `"step"`: a resolved intra-step self-read (command B reading
+ * command A's output within one step) — a chain edge the step-level vocabulary never carries,
+ * because at STEP scope "the step read its own output" is noise, while at COMMAND scope it is
+ * exactly the intra-step lineage signal.
+ */
+export type ProvCommandInputRef = {
+    /** Analysis-relative path; with `hash`, keys the shared file QName. */
+    path: string;
+    /** Content hash attested from disk. */
+    hash: string;
+    /** The read classification, plus `"step"` for a resolved intra-step self-read. */
+    source: "data" | "upstream" | "prior" | "step";
+    /** The staged-input file id, when one was resolved. */
+    fileId?: string;
+};
+
+/**
+ * One execution inside a step that produced files — a discriminated union over the collector's two
+ * producer kinds. The `command` variant records as a PROV **activity** typed `inflexa:Command`,
+ * the `file_tool` variant as `inflexa:FileToolWrite`. One ref per surviving producer group: the
+ * collector is last-write-wins per output path, so after collapse a group is uniquely keyed by its
+ * OUTPUT SET (never the producer's object identity, which is meaningless across a DBOS workflow
+ * re-execution).
+ *
+ * NO timestamp field by design: the producer's observation timestamp is re-minted on every DBOS
+ * replay (replay-unstable), so it must never cross into an identifier or a formal PROV position.
+ * The command activity therefore carries no formal start/end time at all — its ordering lives on
+ * the `wasInformedBy` edge to its step, and the step carries replay-stable settlement times.
+ */
+export type ProvCommandRef =
+    | {
+          kind: "command";
+          /** The command line the sandbox executed. */
+          command: string;
+          /** The command's argument vector, when the collector captured one. */
+          args?: string[];
+          /** The process exit code. */
+          exitCode: number;
+          /** Execution duration in ms, when captured — a relative span (replay-stable), NOT an observation timestamp. */
+          durationMs?: number;
+          /** The script the command ran, when it read one; resolved against the group's own outputs/inputs by the builder. */
+          scriptPath?: string;
+          /** The files this command wrote — its generation authority; each keys a file entity. */
+          outputs: ProvFileKey[];
+          /** The command's command-scoped reads: data/upstream/prior reads plus resolved intra-step self-reads. */
+          inputs: ProvCommandInputRef[];
+      }
+    | {
+          kind: "file_tool";
+          /** The agent file-tool that authored the content (e.g. `write_file`). */
+          tool: string;
+          /** The files the tool wrote; a file-tool write carries no inputs by construction. */
+          outputs: ProvFileKey[];
+      };
+
+/**
+ * The event vocabulary the recorder consumes — every fact that appends to an analysis's document.
+ * Every event carries the owning `analysisId` and the responsible {@link ProvActor}; model-driven
+ * execution events additionally carry the {@link ProvModelId} that drove them. Hosts deliver these
+ * through `ProvenanceRecorder.record()` directly, or via whatever transport they already run (the
+ * OSS host stamps them onto its event bus and subscribes the recorder to it).
+ */
+export type ProvEvent =
+    | { type: "analysis_created"; analysisId: string; actor: ProvActor }
+    | {
+          type: "input_added";
+          analysisId: string;
+          actor: ProvActor;
+          input: ProvInputRef;
+          derivedFromAnalysisId: string | null;
+      }
+    | { type: "input_removed"; analysisId: string; actor: ProvActor; input: ProvInputRef }
+    | { type: "run_started"; analysisId: string; actor: ProvActor; run: ProvRunRef }
+    | { type: "run_completed"; analysisId: string; actor: ProvActor; outcome: ProvRunOutcome }
+    | {
+          type: "step_completed";
+          analysisId: string;
+          actor: ProvActor;
+          outcome: ProvStepOutcome;
+          model: ProvModelId;
+      }
+    | {
+          type: "command_executed";
+          analysisId: string;
+          actor: ProvActor;
+          step: ProvStepRef;
+          command: ProvCommandRef;
+          model: ProvModelId;
+      }
+    | {
+          type: "file_written";
+          analysisId: string;
+          actor: ProvActor;
+          file: ProvFileRef;
+          step: ProvStepRef;
+          generation: "command" | "step";
+      }
+    | { type: "input_used"; analysisId: string; actor: ProvActor; step: ProvStepRef; input: ProvUsedInputRef };
+
+/**
+ * The outcome of a provenance verification: one of several mutually exclusive states, each with
+ * enough detail for a host to render a clear message.
+ */
+export type VerifyResult =
+    | { status: "valid" }
+    | { status: "unsigned" }
+    | { status: "tampered"; detail: string }
+    | { status: "no-key" }
+    | { status: "empty" }
+    | { status: "invalid-sidecar"; detail: string }
+    | { status: "invalid-key" }
+    | { status: "verify-error"; detail: string };

--- a/harness/src/provenance/recorder/verify.ts
+++ b/harness/src/provenance/recorder/verify.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+import { err, type Result } from "neverthrow";
+import type { VerifyResult } from "./types.js";
+import { computeChainHash, computePayloadDigest, verifyHexDigest, type ProvPublicKeyJwk, type ProvSigner, type ProvSigningError } from "./signing.js";
+
+/**
+ * Provenance verification, parameterized on stored values — no database, no filesystem. Hosts wrap
+ * these with their own storage reads (the OSS host's integrity columns and `.sig.json` files, a
+ * managed host's document rows).
+ */
+
+/**
+ * Chained verification: recompute the rolling chain hash from `prevChainHash` and the stored
+ * PROV-JSON, then check the Ed25519 signature over it.
+ *
+ * `prevChainHash` is the chain hash from the PREVIOUS flush — needed to recompute the current one
+ * (`H_n = SHA-256(H_{n-1} || json_n)`). `null` on the first flush, where the seed is SHA-256("").
+ */
+export async function verifyProvenance(
+    provJson: string | null,
+    prevChainHash: string | null,
+    storedChainHash: string | null,
+    storedSignature: string | null,
+    publicKey: CryptoKey | null,
+): Promise<VerifyResult> {
+    if (provJson === null) return { status: "empty" };
+    if (storedChainHash === null || storedSignature === null) return { status: "unsigned" };
+    if (publicKey === null) return { status: "no-key" };
+
+    const hashResult = await computeChainHash(prevChainHash, provJson);
+    if (hashResult.isErr())
+        return {
+            status: "verify-error",
+            detail: `chain hash computation failed: ${String("cause" in hashResult.error ? hashResult.error.cause : hashResult.error.type)}`,
+        };
+    if (hashResult.value !== storedChainHash) {
+        return { status: "tampered", detail: "chain hash mismatch: the PROV-JSON has been modified since it was signed" };
+    }
+
+    const sigResult = await verifyHexDigest(publicKey, storedSignature, storedChainHash);
+    if (sigResult.isErr())
+        return {
+            status: "verify-error",
+            detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
+        };
+    if (!sigResult.value) {
+        return { status: "tampered", detail: "signature verification failed: the chain hash or signature has been modified" };
+    }
+
+    return { status: "valid" };
+}
+
+/**
+ * Self-contained verification: check a simple `SHA-256(provJson)` content digest and its Ed25519
+ * signature — the sidecar path, no chain mechanics needed.
+ */
+export async function verifyPayload(provJson: string, storedDigest: string, storedSignature: string, publicKey: CryptoKey): Promise<VerifyResult> {
+    const digestResult = await computePayloadDigest(provJson);
+    if (digestResult.isErr())
+        return {
+            status: "verify-error",
+            detail: `payload digest computation failed: ${String("cause" in digestResult.error ? digestResult.error.cause : digestResult.error.type)}`,
+        };
+    if (digestResult.value !== storedDigest) {
+        return { status: "tampered", detail: "payload digest mismatch: the provenance file has been modified since it was signed" };
+    }
+
+    const sigResult = await verifyHexDigest(publicKey, storedSignature, storedDigest);
+    if (sigResult.isErr())
+        return {
+            status: "verify-error",
+            detail: `signature verification failed: ${String("cause" in sigResult.error ? sigResult.error.cause : sigResult.error.type)}`,
+        };
+    if (!sigResult.value) {
+        return { status: "tampered", detail: "signature verification failed: the digest or signature has been modified" };
+    }
+
+    return { status: "valid" };
+}
+
+/** Format a {@link VerifyResult} as a human-readable line. */
+export function formatVerifyResult(result: VerifyResult): string {
+    switch (result.status) {
+        case "valid":
+            return "Provenance integrity verified: chain hash and signature are valid.";
+        case "unsigned":
+            return "Provenance is unsigned (recorded before integrity was enabled, or without a signing key).";
+        case "tampered":
+            return `Provenance integrity FAILED: ${result.detail}`;
+        case "no-key":
+            return "Cannot verify: a signature exists but the signing key is missing.";
+        case "empty":
+            return "No provenance has been recorded for this analysis.";
+        case "invalid-sidecar":
+            return `Invalid sidecar: ${result.detail}`;
+        case "invalid-key":
+            return "The public key in the sidecar is invalid or unsupported.";
+        case "verify-error":
+            return `Verification could not complete (internal error): ${result.detail}`;
+    }
+}
+
+/**
+ * The self-describing export sidecar. A recipient verifies integrity with just the provenance
+ * payload and this sidecar — no database, no chain history, no internal state needed.
+ *
+ * Zod-validated on read so a corrupt or hand-edited sidecar surfaces a clear "invalid sidecar"
+ * error instead of a downstream type confusion.
+ */
+export const sidecarSchema = z.object({
+    /** MIME type of the payload. */
+    payloadType: z.literal("application/json; profile=prov-json"),
+    /** Hash algorithm used to compute {@link payloadDigest}. */
+    payloadDigestAlgorithm: z.literal("SHA-256"),
+    /** `SHA-256(payload bytes)` — the recipient recomputes this and compares. */
+    payloadDigest: z.string(),
+    /** How the digest input was derived — "verbatim" means exact payload bytes, no canonicalization. */
+    payloadDigestMethod: z.literal("verbatim"),
+    /** Signature algorithm. */
+    signatureAlgorithm: z.literal("Ed25519"),
+    /** Ed25519 signature over the {@link payloadDigest} — proves it was produced by the key holder. */
+    signature: z.string(),
+    /** The signer's public key as JWK — lets the recipient verify without any key file. */
+    publicKey: z.record(z.string(), z.unknown()),
+});
+
+/** The validated sidecar shape — inferred from the schema so the type never drifts. */
+export type Sidecar = z.infer<typeof sidecarSchema>;
+
+/**
+ * Build a sidecar for an exported provenance payload. Computes `SHA-256(provJson)` as the content
+ * digest and signs it through the injected {@link ProvSigner}. Returns `err(ProvSigningError)`
+ * when signing is unavailable — provenance is never exported unsigned. The sidecar is
+ * self-contained: a recipient verifies with just the payload and the sidecar.
+ */
+export async function buildSidecar(signer: ProvSigner, provJson: string): Promise<Result<Sidecar, ProvSigningError>> {
+    const pubKeyResult = await signer.exportPublicKeyJwk();
+    if (pubKeyResult.isErr()) return err(pubKeyResult.error);
+    const publicKeyJwk: ProvPublicKeyJwk | null = pubKeyResult.value;
+    if (!publicKeyJwk) return err({ type: "public_key_export_failed" });
+
+    return computePayloadDigest(provJson).andThen((digest) =>
+        signer.sign(digest).map((signature): Sidecar => ({
+            payloadType: "application/json; profile=prov-json" as const,
+            payloadDigestAlgorithm: "SHA-256" as const,
+            payloadDigest: digest,
+            payloadDigestMethod: "verbatim" as const,
+            signatureAlgorithm: "Ed25519" as const,
+            signature,
+            publicKey: publicKeyJwk,
+        })),
+    );
+}
+
+/**
+ * Verify a provenance payload against its parsed sidecar: import the sidecar's public key and run
+ * {@link verifyPayload}. Corrupt keys are returned as `VerifyResult` statuses, not thrown.
+ *
+ * The public key is trusted solely because it travels in the sidecar — an attacker who replaces
+ * both the payload and the sidecar (with their own key) passes verification. For sharing over
+ * trusted channels this is fine; for stronger trust a host pins the signer's public key and
+ * checks the sidecar's key against the pinned one before calling this.
+ */
+export async function verifySidecar(provJson: string, sidecar: Sidecar): Promise<VerifyResult> {
+    let publicKey: CryptoKey;
+    try {
+        publicKey = await crypto.subtle.importKey("jwk", sidecar.publicKey, "Ed25519", true, ["verify"]);
+    } catch {
+        return { status: "invalid-key" };
+    }
+    return verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, publicKey);
+}


### PR DESCRIPTION
## Why

The signed provenance recorder — the machinery that folds harness execution facts into a W3C PROV document (`@inflexa-ai/tsprov`), chain-hashes it, Ed25519-signs it, and persists it whole — lives in `cli/`, wired to the CLI's event bus, SQLite columns, config-dir keypair, and auth module. A managed embedder that wants the same signed document (Cortex, submitting per-analysis documents to Nexus) would have to re-implement all of it, and the two copies would drift. The recorder's actual inputs are already harness-owned (`ArtifactRegistry.register` input, `RunProvenanceEvent`), and its host couplings reduce to four narrow points — so it moves into the harness, and consumers fill the seams.

## What

New capability under `harness/src/provenance/recorder/`, additive to the public barrel:

- **Document model** — `createProvDocumentModel({ digest?, mintActionId? })`: all QName/relation-id derivations and append builders, replay-idempotent (deterministic ids, `unified()` last-write-wins merge policy). The digest is **injectable** because it is identity-load-bearing: the CLI keeps its historical `Bun.hash` derivation so existing documents' QName spaces stay continuous; the harness default is a Node-portable SHA-256 fold.
- **Recorder** — `createProvenanceRecorder({ sink, signer, documentModel?, logger? })`: per-instance live documents, revision-guarded dirty tracking, coalesced single-flight signed flush, `flush()` drain with a no-progress guard. Events arrive via a plain `record(event)` call — a bus may sit in front (the CLI's does), but the seam is the function.
- **Seams** — `ProvSnapshotSink` (`load`/`persist`; a sink may reject a stale write with `conflict` via compare-and-swap on `prevChainHash` — the recorder then refreshes its chain head and re-chains, so the chain never forks), `ProvSigner` (+ `createKeypairSigner` for hosts holding imported `CryptoKey`s), and actor descriptors — the `system` actor now carries the host's own `label`/`version`/`commit` instead of a hardcoded CLI identity.
- **Bridges** — `createProvenanceArtifactRegistry` (producer grouping, leaf partition, intra-step self-read resolution keyed on surviving hashes, fail-fast attestation, `externalId` = the model's `fileQName`) and `createRunProvenanceEmitter` (the three `RunProvenanceEvent` arms, checkpointed timestamps passed through untouched).
- **Signing/verification** — chain-hash + payload-digest + hex Ed25519 primitives, the export sidecar schema, and value-parameterized `verifyProvenance`/`verifyPayload`/`verifySidecar`/`buildSidecar`.

Two deliberate behavior deltas from the CLI copy, both in the change's `design.md`:

1. **First-touch load is async** (a managed sink is an HTTP round-trip): `record()` stays fire-and-forget, events queue during the load and drain into the (deserialized or fresh) document; `flush()` awaits in-flight loads so a terminal drain cannot lose queued events.
2. **Chain-conflict recovery** via the sink's optional CAS, with a documented single-writer-per-analysis requirement (the CLI's analysis lock / a managed host's workflow ownership); content-level merge of concurrent writers is explicitly out of scope.

OpenSpec: `harness/openspec/changes/extract-provenance-recorder` (new `provenance-recorder` capability). `@inflexa-ai/tsprov@^0.5.1` added to harness dependencies.

## Out of scope

The `cli/` re-wire onto the extracted recorder (deleting its local copies, injecting its bus/SQLite/keypair/digest realizations) is a separate change in that subsystem, per repo convention. Until it lands the CLI stays on its own byte-identical copy. Release/version sequencing is the driver's, as usual.

## Testing

- `bun test` (full harness suite incl. Postgres/DBOS testcontainer rigs): **1868 pass, 0 fail**
- New suites: recorder lifecycle over a fake CAS sink + real Ed25519 keypair (coalescing, chaining + `verifyProvenance` round-trip, replay re-emission dedupe with a no-blank-node assertion, transient/permanent signing failure, unknown-analysis skip, corrupt-document fresh chain, CAS-conflict re-chain, queued-during-load drain, sidecar round-trip) and bridge behavior over the real `ProvenanceCollector` (group ordering, script scoping, `source: "step"` self-read resolution on surviving hashes, hash-less fail-fast, emitter mapping, injected-digest consistency).
- `tsc --noEmit` and `eslint` clean; sources formatted via `format:file`.