### PR TITLE
feat(harness): add the report block and grounding type system

### DIFF
--- a/harness/bun.lock
+++ b/harness/bun.lock
@@ -32,6 +32,7 @@
         "neverthrow": "^8.2.0",
         "nunjucks": "^3.2.4",
         "openai": "^4.104.0",
+        "p-queue": "^9.3.3",
         "pdf-parse": "^2.4.5",
         "pg": "^8.22.0",
         "puppeteer-core": "^23.11.1",
@@ -455,6 +456,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
@@ -662,6 +665,10 @@
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-queue": ["p-queue@9.3.3", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA=="],
+
+    "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/design.md
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/design.md
@@ -1,0 +1,168 @@
+## Context
+
+Issue #221 rebuilds the report subsystem. Issue #222 is its foundation. The block
+model and the grounding contract are the types that context transfer (#221),
+composition, and verification all bind to. Thus this change comes first.
+
+The current state is a 6-variant discriminated union of report sections
+(`harness/src/tools/iterate-report.ts:186`). It has two limits. The sections are a
+flat list and do not nest. No number binds to a real artifact. The only provenance
+is a free-text `source` or `transform` footnote.
+
+The coordinate space already exists. A run is `cortex_runs.run_id`, a bare UUID that
+is also the DBOS workflow id. A file is a row in `cortex_artifacts`, keyed on
+`(analysis_id, path)`, with a `hash` in the form `sha256:<hex>`
+(`harness/src/lib/fs-helpers.ts:14`). No sub-file locator exists today. A citations
+subsystem exists (`harness/src/citations/`) with `resolve_citation` and a stable
+`cit-<hash>` id, but no report code imports it.
+
+The harness is host-agnostic. These types cross the #221 session seam. Thus they
+belong in `harness/src/contracts/`, and a consumer imports them by a deep path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the composable block tree of eight kinds with a content grammar.
+- Define one canonical `Reference` shape that reuses the existing coordinates.
+- Make fabrication a condition that mechanical validation rejects.
+- Land prototype Zod types, a mechanical validator, a `ReferenceResolver` seam, and
+  a test.
+
+**Non-Goals:**
+
+- No change to the `iterative-report` capability or its runtime.
+- No Report Builder agent (#225), no context transfer (#221), and no composition or
+  render step.
+- No semantic verification. A model-judged pass on whether the prose follows from
+  the value stays in a later verification pass.
+- No production resolver against live storage. The prototype resolver reads a
+  fixture snapshot.
+- No public barrel export, and no schema versioning. The types stay deep-importable,
+  and an unknown kind fails validation.
+
+## Decisions
+
+### D1. New capabilities beside `iterative-report`, not a modification
+
+Issue #221 moves the report into its own session with its own runtime. The block
+model is a new host-agnostic concept, and the current model keeps shipping
+untouched. The alternative, a modification of `iterative-report` in place, couples
+the new model to the old in-process runtime and risks the shipping path. Rejected.
+
+### D2. A composable tree, not a flat list
+
+A `section` becomes a block and nests other blocks. Thus a new report shape is a new
+arrangement of existing blocks, not a new type. This breaks the flat ceiling. The
+alternative, the flat six kinds plus a binding, adds grounding but keeps the
+non-composable ceiling. Rejected.
+
+### D3. The block set is eight kinds
+
+The kinds are `section`, `text`, `claim`, `metric`, `table`, `chart`, `figure`, and
+`citation`. The split of `claim` from `text` is load-bearing. A `claim` asserts
+something about the data and must bind. A `text` block is connective prose and must
+not carry a data assertion. A `metric` is a narrow `claim` with exactly one scalar
+reference. A `citation` binds to an external record.
+
+A `group` layout container was considered and dropped, because it is not necessary
+yet. The flat catalog of domain sections (Differential Expression, TF Activity, and
+so on) was the misread premise. Those strings are section titles, not a kind set.
+Rejected.
+
+### D4. One canonical `Reference` object
+
+One shape unifies `artifact-value`, `artifact-table`, `derivation`, and `citation`
+under a `locator`, so the #221 seam carries one type. It reuses `run`, `path`, and
+`hash`. A bare URI string was considered as the source of truth, but a string is
+hard to validate field by field. Thus the object is the source of truth, and a
+canonical URI is a serialized carrier form. A PROV-style derivation triple is the
+right model for the whole-report lineage, but it is too heavy as a per-claim
+binding. Rejected for the binding.
+
+### D5. `rowFilter` is the default row locator
+
+A scientific table row order is not semantically stable. A stable predicate survives
+a re-sort of the artifact. Thus the `locator` carries `column`, `rowFilter`, and
+`row`, and `rowFilter` is the default. A `row` by index is permitted for a
+fixed-order artifact. A locator resolves to exactly one value. Zero matches give
+`locator-out-of-range`, and many matches give `ambiguous-match`.
+
+### D6. A split of mechanical and semantic validation
+
+Mechanical validation runs schema conformance, binding presence, resolution, and
+assertion match. It uses no model, and it gives a hard guarantee that the number is
+real and correctly transcribed. Semantic validation judges whether the prose follows
+from the value. It is model-dependent, so it stays in the verification pass. To fold
+the semantic pass into the contract gives false confidence. Rejected.
+
+### D7. Derived numbers use materialize-first, with a derivation escape hatch
+
+The default writes a derived value to a hashed artifact, then the claim binds to a
+cell. This keeps validation a pure lookup and gives the strongest anti-fabrication
+guarantee. The `derivation` node is the escape hatch, and it prevents a junk
+one-cell file for a cheap ratio. Its `op` is `ratio`, `delta`, or `pctChange`. Each
+input is a non-derivation reference that resolves, so a derivation cannot nest.
+
+Materialize-first only is heavy for a trivial ratio. A derivation as a co-equal path
+makes the validator compute routinely and the contract heavier. Both were rejected
+for the hybrid.
+
+### D8. Types in `contracts/`, logic in a sibling module
+
+The block model and the reference cross the #221 session seam. They live in
+`harness/src/contracts/`, and a consumer imports them by a deep path. The public
+barrel export lands with the consuming change, so an unused prototype does not widen
+the published surface. The validator and the `ReferenceResolver` seam are logic, so
+they live in the sibling module `harness/src/report-model/`. To put the types under
+`tools/report/` ties a shared contract to the old runtime. Rejected.
+
+### D9. Keep the prototype minimal
+
+The prototype carries only the necessary parts for the fail-a-fabricated-claim
+benchmark. Thus the `locator` carries `column`, `rowFilter`, and `row`. The variants `cellRange`,
+`jsonPointer`, and `textSpan` are for the artifact types that use them. The
+`derivation` op is `ratio`, `delta`, or `pctChange`. An opaque `aggregate` or `expr`
+was dropped, because it undermines a transparent transform.
+
+A document `schemaVersion` and an unknown-kind degrade path were dropped. An unknown
+kind fails validation, and versioning lands with a second version. A `citation` binds
+to a thin external id (`doi`, `pmid`, or `arxiv`) and the raw string. The prototype
+does not call `resolve_citation`. That wiring is a later change.
+
+### D10. A whole-file pin is its own reference kind
+
+An image and a table both pin a whole file, but they are not the same thing. Thus
+`artifact-file` is a separate kind, and a `figure` binds to it. To bind an image to
+`artifact-table` describes a picture as a table, and a reader meets a false term.
+Rejected.
+
+The rows of a snapshot artifact are optional, because a pinned image has a hash and
+no rows. An empty array would claim that the file holds zero rows, which is a
+different statement.
+
+## Risks / Trade-offs
+
+- [The spec gate bans `SHALL`, but the 70 existing specs use `SHALL`] → Use `MUST`
+  as the normative keyword. It satisfies the gate and the OpenSpec parser. Confirm
+  with `openspec validate --strict`.
+- [The prototype resolver does not read live storage] → Resolve a fixture snapshot
+  for the benchmark. A production resolver against `cortex_artifacts` and the
+  workspace tree is a later change.
+- [A `rowFilter` can match zero rows or many rows] → A locator resolves to exactly
+  one value. Zero matches give `locator-out-of-range`, and many give `ambiguous-match`.
+- [A seam consumer can want a field the shape lacks] → Add a field additively. The
+  prototype has no version field, because a versionless additive change is enough.
+- [A name collision with `target-synthesis-grounding`] → The new capability is named
+  `report-grounding`. The two are distinct groundings.
+
+## Migration Plan
+
+The change is additive. It adds files and a test. It does not change
+`iterative-report`, and it wires no runtime. The new types are deep-importable and
+sit unused until #221 and #225 consume them. Thus there is no rollback concern.
+
+## Open Questions
+
+None. The block set, the locator set, the derivation op set, the resolver form, and
+the module path are settled above.

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+Report generation is a core part of the product, but its ceiling is low. Two
+structural limits cause this.
+
+First, the report section model is a flat list of six types, and the types do not
+nest (`harness/src/tools/iterate-report.ts:186`). A new report shape needs a new
+type, and a section cannot hold another section.
+
+Second, no number in a report binds to a real analysis artifact. Every figure
+comes from the memory of the agent. Only a free-text footnote records the source.
+
+Issue #221 rebuilds the subsystem. Issue #222 is its foundation: the typed block
+model and the grounding-by-reference contract. Context transfer, composition, and
+verification all bind to the types that this change defines. Thus the change comes
+first.
+
+## What Changes
+
+- Add a composable block model. A report becomes a tree of typed blocks. The union
+  discriminates on `kind`: `section`, `text`, `claim`, `metric`, `table`, `chart`,
+  `figure`, and `citation`. A `section` holds other blocks, so a new report shape
+  is a new arrangement, not a new type.
+- Add a content grammar. The grammar constrains which block can hold which. A
+  validator rejects a violation, for example a `chart` inside a `metric`.
+- Add a grounding-by-reference contract. Each evidentiary block carries one
+  canonical `Reference` object. A reference pins to a run, a file path, and a
+  content hash, and it addresses a value with a locator. It reuses the coordinates
+  that the harness already keys on (`cortex_runs.run_id`,
+  `cortex_artifacts(path, hash)`).
+- Turn fabrication into a condition that mechanical validation rejects. The
+  validator resolves each reference against a pinned snapshot and matches an
+  optional assertion. A `claim` whose reference does not resolve fails validation.
+- Ground a derived number two ways. The default writes the value to a hashed
+  artifact, then the claim binds to a cell. The `derivation` escape hatch carries a
+  transform over input references, and each input must resolve.
+- Land prototype Zod types, the mechanical validator, and a `ReferenceResolver`
+  seam. Add a test that one of each block kind validates, and that a fabricated
+  claim fails with a typed reason.
+- No change to the current `iterative-report` capability. The block model
+  supersedes its section union in a later rebuild change, not here.
+
+## Capabilities
+
+### New Capabilities
+
+- `report-block-model`: the typed, composable block tree — the block kinds, the
+  stable `id`, the discriminant `kind`, and the content grammar that constrains
+  nesting.
+- `report-grounding`: the canonical `Reference` shape, its resolution against a
+  pinned snapshot, and the mechanical validation that a binding resolves and that
+  an assertion matches.
+
+### Modified Capabilities
+
+<!-- None. `iterative-report` is unchanged; the new model lives beside it until the
+     rebuild supersedes the old section union in a separate change. -->
+
+## Impact
+
+- **Code**: new prototype types in `harness/src/contracts/`, because the block
+  model and the reference cross the #221 session seam and export through the
+  barrel. A mechanical validator and a `ReferenceResolver` seam live in a sibling
+  module. New tests accompany them.
+- **Agent-facing behavior**: none yet. The Report Builder agent (#225) and
+  composition consume these types later. This change adds no tool and no prompt.
+- **Consumers**: the `Reference` type is defined one time, here. Context transfer
+  (#221), composition, and verification import it. A consumer must not invent a
+  parallel pointer shape.
+- **Naming**: a capability `target-synthesis-grounding` already exists, and it is a
+  different grounding (FDA precedent as prompt context). The new capability is
+  named `report-grounding` to prevent a collision.

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/specs/report-block-model/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: A report is a tree of typed blocks
+
+The report document MUST be a tree of blocks, not a flat list. Each block MUST carry
+a stable `id` and a `kind` discriminant. A block MUST be addressable by its `id`
+across a version.
+
+#### Scenario: A well-formed tree validates
+
+- **WHEN** a document holds a root of blocks, each with an `id` and a `kind`
+- **THEN** the block model validates the document as a tree
+
+#### Scenario: A block without an id is rejected
+
+- **WHEN** a block has a `kind` but no `id`
+- **THEN** validation rejects the block
+
+#### Scenario: A block without a kind is rejected
+
+- **WHEN** a block has an `id` but no `kind`
+- **THEN** validation rejects the block
+
+### Requirement: The block set is a closed discriminated union
+
+The `kind` field MUST be one of `section`, `text`, `claim`, `metric`, `table`,
+`chart`, `figure`, or `citation`. The union MUST discriminate on `kind`. An unknown
+`kind` MUST fail validation.
+
+#### Scenario: Each of the eight kinds validates
+
+- **WHEN** a document holds one block of each of the eight kinds, each well-formed
+- **THEN** validation accepts every block
+
+#### Scenario: A nested section validates
+
+- **WHEN** a `section` holds another `section` that holds a `claim`
+- **THEN** validation accepts the nested tree
+
+#### Scenario: An unknown kind is rejected
+
+- **WHEN** a block carries a `kind` that is not one of the eight
+- **THEN** validation rejects the block
+
+### Requirement: A content grammar constrains nesting
+
+The grammar MUST define which block can hold which. A `section` MUST hold any block
+kind. A `text` block and a `claim` block MUST be leaves that hold inline text only. A
+`table`, a `chart`, a `figure`, and a `metric` MUST be atoms with no block children.
+The root MUST hold at least one section, and a `section` MUST hold at least one
+block.
+
+#### Scenario: A chart inside a metric is rejected
+
+- **WHEN** a `metric` block holds a `chart` block as a child
+- **THEN** validation rejects the document for a grammar violation
+
+#### Scenario: A claim inside a section validates
+
+- **WHEN** a `section` holds a `claim` block
+- **THEN** validation accepts the block
+
+#### Scenario: An empty report is rejected
+
+- **WHEN** a document holds a root with no section
+- **THEN** validation rejects the document
+
+#### Scenario: An empty section is rejected
+
+- **WHEN** a `section` holds no block
+- **THEN** validation rejects the section
+
+### Requirement: Each evidentiary kind carries a binding field
+
+A `claim`, a `metric`, a `table`, a `chart`, a `figure`, and a `citation` MUST each
+carry a non-empty binding field. The type MUST enforce the presence, not a lint
+rule. A `text` block MUST NOT carry a binding. A `metric` MUST carry exactly one
+scalar binding. The resolution of a binding is the concern of the `report-grounding`
+capability.
+
+#### Scenario: A claim with no binding is rejected
+
+- **WHEN** a `claim` block carries no binding
+- **THEN** validation rejects the block at the type level
+
+#### Scenario: A text block with a binding is rejected
+
+- **WHEN** a `text` block carries a binding
+- **THEN** validation rejects the block
+
+#### Scenario: A metric with two bindings is rejected
+
+- **WHEN** a `metric` block carries two bindings
+- **THEN** validation rejects the block, because a metric carries exactly one scalar binding

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/specs/report-grounding/spec.md
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/specs/report-grounding/spec.md
@@ -1,0 +1,190 @@
+## ADDED Requirements
+
+### Requirement: A reference is one canonical shape
+
+The harness MUST define one `Reference` object, and every evidentiary block MUST
+carry it. A reference MUST carry a `kind` of `artifact-value`, `artifact-table`,
+`artifact-file`, `derivation`, or `citation`. An artifact reference MUST pin `run`,
+`path`, and `hash`, and it can carry a `snapshot`. It can carry an `assert`, a
+`unit`, and a `format`. The reference MUST reuse the coordinates that the harness
+already keys on, the run id `cortex_runs.run_id` and the file key
+`cortex_artifacts(path, hash)`.
+
+An `artifact-value` reference MUST address one value with a `locator`. An
+`artifact-table` and an `artifact-file` reference MUST pin the whole file, and they
+MUST carry no `locator`. A `figure` binds to an `artifact-file`, because an image has
+no per-cell address.
+
+#### Scenario: A complete artifact-value reference validates
+
+- **WHEN** a reference carries `kind: "artifact-value"`, a `run`, a `path`, a `hash`, and a `locator`
+- **THEN** the grounding contract accepts the reference shape
+
+#### Scenario: A reference without a hash is rejected
+
+- **WHEN** an artifact reference carries a `run` and a `path` but no `hash`
+- **THEN** validation rejects the reference, because the hash is the identity under immutability
+
+#### Scenario: A whole-file reference with a locator is rejected
+
+- **WHEN** an `artifact-file` reference carries a `locator`
+- **THEN** validation rejects the reference, because a whole-file pin addresses no cell
+
+#### Scenario: A figure resolves through a whole-file pin
+
+- **WHEN** a `figure` binds to an `artifact-file` whose path and hash match the snapshot
+- **THEN** resolution returns the pinned file
+
+### Requirement: The row locator defaults to a stable predicate
+
+The `locator` MUST support `column`, `rowFilter`, and `row`. The default row selector
+MUST be `rowFilter`, a stable predicate, because scientific table row order is not
+semantically stable. A `row` by index MUST be permitted, but it MUST NOT be the
+default. A locator MUST resolve to exactly one value. Zero matches MUST give
+`locator-out-of-range`, and more than one match MUST give `ambiguous-match`.
+
+#### Scenario: A rowFilter selects a row by a key column
+
+- **WHEN** a locator carries a `rowFilter` that names a column, an operator, and a value that matches one row
+- **THEN** resolution selects the matching row independent of its position
+
+#### Scenario: A row index resolves when the order is fixed
+
+- **WHEN** a locator carries a `row` index against an artifact with a fixed order
+- **THEN** resolution selects the row at that index
+
+#### Scenario: A rowFilter with many matches returns ambiguous-match
+
+- **WHEN** a locator carries a `rowFilter` that matches more than one row
+- **THEN** resolution returns an `UnresolvedReference` with reason `ambiguous-match`
+
+### Requirement: A reference resolves against a pinned snapshot
+
+The harness MUST expose a `ReferenceResolver` seam. Its `resolve(reference,
+snapshot)` operation MUST return the concrete value, or a typed
+`UnresolvedReference`. The `reason` MUST be one of `artifact-missing`,
+`hash-mismatch`, `locator-out-of-range`, `ambiguous-match`, or `assertion-failed`.
+Resolution MUST target the pinned snapshot, so a version resolves to the same value
+over time.
+
+#### Scenario: A reference to a real cell resolves to its value
+
+- **WHEN** a reference addresses a real cell in a pinned artifact
+- **THEN** resolution returns the value at that cell
+
+#### Scenario: A missing artifact returns artifact-missing
+
+- **WHEN** a reference names a path that the snapshot does not hold
+- **THEN** resolution returns an `UnresolvedReference` with reason `artifact-missing`
+
+#### Scenario: A hash mismatch returns hash-mismatch
+
+- **WHEN** a reference names a path whose content hash differs from the pinned `hash`
+- **THEN** resolution returns an `UnresolvedReference` with reason `hash-mismatch`
+
+#### Scenario: A locator past the last row returns locator-out-of-range
+
+- **WHEN** a locator addresses a row or a cell that the artifact does not contain
+- **THEN** resolution returns an `UnresolvedReference` with reason `locator-out-of-range`
+
+### Requirement: An assertion is matched on resolve
+
+If a reference carries an `assert.value` or an `assert.hash`, resolution MUST
+re-read the artifact and match the resolved value within `tolerance`. A mismatch
+MUST return an `UnresolvedReference` with reason `assertion-failed`. Thus a
+transcription error or a hallucinated number fails even when the coordinate
+resolves.
+
+#### Scenario: A correct assertion passes
+
+- **WHEN** a reference carries an `assert.value` that equals the resolved value
+- **THEN** resolution returns the value
+
+#### Scenario: A wrong assertion fails
+
+- **WHEN** a reference carries an `assert.value` that differs from the resolved value beyond `tolerance`
+- **THEN** resolution returns an `UnresolvedReference` with reason `assertion-failed`
+
+### Requirement: Mechanical validation rejects fabrication
+
+Mechanical validation MUST run these steps in order, schema conformance, binding
+presence, resolution, and assertion match. A `claim` whose binding does not resolve
+MUST fail validation. The validation MUST use no model. This is the mechanism that
+prevents fabrication.
+
+#### Scenario: A fully grounded report validates
+
+- **WHEN** a report holds one of each block kind, and each binding resolves against the snapshot
+- **THEN** mechanical validation accepts the report
+
+#### Scenario: A claim with a non-resolving coordinate fails
+
+- **WHEN** a `claim` binds to a coordinate that the snapshot does not resolve
+- **THEN** mechanical validation fails the report with a typed `UnresolvedReference`
+
+#### Scenario: A claim with a wrong asserted value fails
+
+- **WHEN** a `claim` binds to a real coordinate but carries a wrong `assert.value`
+- **THEN** mechanical validation fails the report with reason `assertion-failed`
+
+### Requirement: A metric slot holds a reference, never a numeral
+
+A `metric` value slot MUST hold a resolved reference, and it MUST NOT hold a numeric
+literal. A numeral in `claim` or `text` prose outside a slot MUST raise a warning,
+not a failure, because a natural-language numeral is brittle to enforce.
+
+#### Scenario: A metric with a literal number is rejected
+
+- **WHEN** a `metric` value slot holds a numeric literal instead of a reference
+- **THEN** validation rejects the metric
+
+#### Scenario: A free numeral in claim prose raises a warning
+
+- **WHEN** a `claim` prose holds a numeral outside a bound slot
+- **THEN** validation raises a warning and does not fail the report
+
+### Requirement: A derived number is grounded two ways
+
+The default MUST materialize a derived value as a hashed artifact, and the claim MUST
+bind to a cell in that artifact. A `derivation` reference MUST be the escape hatch,
+and it carries an `op` of `ratio`, `delta`, or `pctChange` and an `inputs` array.
+Each input MUST be a non-derivation reference that resolves, so a derivation cannot
+nest. Validation MUST resolve each input, run the transform, then match the
+assertion.
+
+#### Scenario: A materialize-first derived value validates
+
+- **WHEN** a builder writes a derived value to a hashed artifact and a claim binds to that cell
+- **THEN** validation resolves the cell and accepts the claim
+
+#### Scenario: A derivation over grounded cells validates
+
+- **WHEN** a `derivation` reference carries a ratio over two inputs that each resolve to a real cell
+- **THEN** validation resolves the inputs, runs the ratio, and matches the assertion
+
+#### Scenario: A derivation with a non-resolving input fails
+
+- **WHEN** a `derivation` reference carries an input that does not resolve
+- **THEN** validation fails the reference
+
+#### Scenario: A derivation whose input is a derivation is rejected
+
+- **WHEN** a `derivation` reference carries an input that is itself a `derivation`
+- **THEN** validation rejects the reference, because a derivation cannot nest
+
+### Requirement: The reference serializes for cross-session transfer
+
+The `Reference` MUST serialize to a compact JSON object, and to a canonical URI
+string form for a carrier. It MUST carry no live object reference and no
+session-local state. A later session MUST deserialize it and resolve it against the
+same pinned snapshot to the same value.
+
+#### Scenario: A reference round-trips through serialization
+
+- **WHEN** a reference serializes to JSON and a later reader deserializes it
+- **THEN** the deserialized reference equals the original
+
+#### Scenario: A reference authored in one session resolves in another
+
+- **WHEN** a reference authored in one session resolves in a second session against the same pinned snapshot
+- **THEN** the second session reads the same value

--- a/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-04-add-report-block-grounding-model/tasks.md
@@ -1,0 +1,52 @@
+## 1. Block model types
+
+- [x] 1.1 Add `harness/src/contracts/report-blocks.ts` with the `Block` Zod discriminated union on `kind` (`section`, `text`, `claim`, `metric`, `table`, `chart`, `figure`, `citation`), each with an `id`, a `kind`, and a type-specific content payload
+- [x] 1.2 Add the content-grammar refinement so that a `section` holds any kind, and `text` and `claim` are leaf blocks with inline text only
+- [x] 1.3 Make the atoms (`table`, `chart`, `figure`, `metric`) hold no block children, and reject a grammar violation
+- [x] 1.4 Make the root hold at least one section, and a `section` hold at least one block
+- [x] 1.5 Make the binding field non-optional on `claim`, `metric`, `table`, `chart`, `figure`, and `citation`, absent on `text`, and exactly one scalar reference on `metric`
+- [x] 1.6 Infer the TypeScript types from the Zod schemas
+
+## 2. Grounding reference types
+
+- [x] 2.1 Add `harness/src/contracts/report-reference.ts` with the `Reference` Zod object (`kind` of `artifact-value`, `artifact-table`, `derivation`, `citation`), the artifact pin (`run`, `path`, `hash`, optional `snapshot`), the optional `assert`, `unit`, and `format`, and the `derivation` transform (`op` of `ratio`, `delta`, or `pctChange`, plus `inputs`)
+- [x] 2.2 Add the `locator` union (`column`, `rowFilter`, `row`), make `rowFilter` the default row selector, permit `row` by index, and resolve to exactly one value
+- [x] 2.3 Add the `UnresolvedReference` type with the reason set (`artifact-missing`, `hash-mismatch`, `locator-out-of-range`, `ambiguous-match`, `assertion-failed`)
+- [x] 2.4 Add the canonical URI serialize and deserialize for a reference, and make the round-trip preserve it
+- [x] 2.5 Constrain a `derivation` input to a non-derivation reference, so a derivation cannot nest
+
+## 3. Validator and resolver seam
+
+- [x] 3.1 Add the `ReferenceResolver` seam interface with a `resolve(reference, snapshot)` operation in `harness/src/report-model/reference-resolver.ts`
+- [x] 3.2 Add a local fixture resolver that reads a fixture snapshot (a map of `path` and `hash` to rows) for the prototype benchmark
+- [x] 3.3 Add the mechanical validator in `harness/src/report-model/validate.ts` that runs schema conformance, binding presence, resolution, and assertion match in order
+- [x] 3.4 Add the materialize-first cell lookup and the `derivation` path that resolves each input, runs the `op`, then matches the `assert`
+- [x] 3.5 Add the metric-slot numeral rule as a hard failure, and the free-numeral warning as an advisory result
+
+## 4. Tests
+
+- [x] 4.1 Add a fixture report that holds one of each block kind, each grounded, and a test that it validates
+- [x] 4.2 Add a test that a `claim` with a non-resolving coordinate fails with `artifact-missing` or `locator-out-of-range`
+- [x] 4.3 Add a test that a `claim` with a correct coordinate but a wrong `assert.value` fails with `assertion-failed`
+- [x] 4.4 Add a test that a grammar violation (a `chart` inside a `metric`) fails, and that an empty report and an empty section fail
+- [x] 4.5 Add a test that a `rowFilter` with many matches fails with `ambiguous-match`
+- [x] 4.6 Add a test that a `derivation` over two grounded cells validates, one with a non-resolving input fails, and a nested derivation is rejected
+- [x] 4.7 Add a test that a reference round-trips through serialize and deserialize
+
+## 5. Verify
+
+- [x] 5.1 Run `tsc -p tsconfig.json` and make sure it passes
+- [x] 5.2 Run the new test files with `bun test` and make sure they pass
+- [x] 5.3 Run `bun run format:file` on the changed `src/` files
+- [x] 5.4 Run `openspec validate add-report-block-grounding-model --type change --strict` and make sure it passes
+
+## 6. Verification follow-ups
+
+- [x] 6.1 Add the `artifact-file` reference kind for a whole-file pin, and bind a `figure` to it instead of `artifact-table`
+- [x] 6.2 Make the `rows` of a snapshot artifact optional, because a pinned image has a hash and no rows
+- [x] 6.3 Resolve an `artifact-file` in the fixture resolver, and add the file variant to `ResolvedValue`
+- [x] 6.4 Add the block-level rejection tests for a missing `id`, an empty `id`, a missing `kind`, and an unknown `kind`
+- [x] 6.5 Add the block-level rejection test for a `metric` that carries a second binding
+- [x] 6.6 Add the whole-file pin tests for a figure that resolves, a missing path, a hash mismatch, and a derivation over a file input
+- [x] 6.7 Add the cross-session test that resolves a serialized and parsed reference to the same value
+- [x] 6.8 Update the `report-grounding` delta for the `artifact-file` kind, then run the typecheck, the tests, and the strict validation again

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -1,0 +1,113 @@
+# report-block-model Specification
+
+## Purpose
+
+Define the composable block tree that a report is made of. A report is a tree of
+typed blocks, not a flat list of sections. A `section` is itself a block, and it
+nests. Thus a new report shape is a new arrangement of existing blocks, and not a
+new type.
+
+The block set is closed. Each block carries a stable `id` and a `kind`
+discriminant, and the shape of each kind carries its own grammar. A `text` block
+holds no binding field, a `metric` value slot admits one scalar reference only, and
+no atom holds a child-block array. Thus a forbidden construction is unrepresentable,
+and a schema parse rejects it. The grammar is the shape, and not a separate pass
+that runs later.
+
+The resolution of a binding is the concern of the `report-grounding` capability.
+This capability defines which block carries a binding, and where a block can sit.
+
+## Requirements
+
+### Requirement: A report is a tree of typed blocks
+
+The report document MUST be a tree of blocks, not a flat list. Each block MUST carry
+a stable `id` and a `kind` discriminant. A block MUST be addressable by its `id`
+across a version.
+
+#### Scenario: A well-formed tree validates
+
+- **WHEN** a document holds a root of blocks, each with an `id` and a `kind`
+- **THEN** the block model validates the document as a tree
+
+#### Scenario: A block without an id is rejected
+
+- **WHEN** a block has a `kind` but no `id`
+- **THEN** validation rejects the block
+
+#### Scenario: A block without a kind is rejected
+
+- **WHEN** a block has an `id` but no `kind`
+- **THEN** validation rejects the block
+
+### Requirement: The block set is a closed discriminated union
+
+The `kind` field MUST be one of `section`, `text`, `claim`, `metric`, `table`,
+`chart`, `figure`, or `citation`. The union MUST discriminate on `kind`. An unknown
+`kind` MUST fail validation.
+
+#### Scenario: Each of the eight kinds validates
+
+- **WHEN** a document holds one block of each of the eight kinds, each well-formed
+- **THEN** validation accepts every block
+
+#### Scenario: A nested section validates
+
+- **WHEN** a `section` holds another `section` that holds a `claim`
+- **THEN** validation accepts the nested tree
+
+#### Scenario: An unknown kind is rejected
+
+- **WHEN** a block carries a `kind` that is not one of the eight
+- **THEN** validation rejects the block
+
+### Requirement: A content grammar constrains nesting
+
+The grammar MUST define which block can hold which. A `section` MUST hold any block
+kind. A `text` block and a `claim` block MUST be leaves that hold inline text only. A
+`table`, a `chart`, a `figure`, and a `metric` MUST be atoms with no block children.
+The root MUST hold at least one section, and a `section` MUST hold at least one
+block.
+
+#### Scenario: A chart inside a metric is rejected
+
+- **WHEN** a `metric` block holds a `chart` block as a child
+- **THEN** validation rejects the document for a grammar violation
+
+#### Scenario: A claim inside a section validates
+
+- **WHEN** a `section` holds a `claim` block
+- **THEN** validation accepts the block
+
+#### Scenario: An empty report is rejected
+
+- **WHEN** a document holds a root with no section
+- **THEN** validation rejects the document
+
+#### Scenario: An empty section is rejected
+
+- **WHEN** a `section` holds no block
+- **THEN** validation rejects the section
+
+### Requirement: Each evidentiary kind carries a binding field
+
+A `claim`, a `metric`, a `table`, a `chart`, a `figure`, and a `citation` MUST each
+carry a non-empty binding field. The type MUST enforce the presence, not a lint
+rule. A `text` block MUST NOT carry a binding. A `metric` MUST carry exactly one
+scalar binding. The resolution of a binding is the concern of the `report-grounding`
+capability.
+
+#### Scenario: A claim with no binding is rejected
+
+- **WHEN** a `claim` block carries no binding
+- **THEN** validation rejects the block at the type level
+
+#### Scenario: A text block with a binding is rejected
+
+- **WHEN** a `text` block carries a binding
+- **THEN** validation rejects the block
+
+#### Scenario: A metric with two bindings is rejected
+
+- **WHEN** a `metric` block carries two bindings
+- **THEN** validation rejects the block, because a metric carries exactly one scalar binding

--- a/harness/openspec/specs/report-grounding/spec.md
+++ b/harness/openspec/specs/report-grounding/spec.md
@@ -1,0 +1,211 @@
+# report-grounding Specification
+
+## Purpose
+
+Define how a report block binds to the evidence that justifies it, and how that
+binding resolves to a concrete value. One canonical `Reference` object carries the
+binding. It reuses the coordinates that the harness already keys on, the run id
+`cortex_runs.run_id` and the file key `cortex_artifacts(path, hash)`.
+
+Mechanical validation resolves each reference against a pinned snapshot and matches
+the authored assertion. It uses no model, and it gives a hard guarantee that a number
+in a report is real and correctly transcribed. A `claim` whose binding does not
+resolve fails validation. This is the mechanism that prevents fabrication.
+
+Semantic validation is a different concern. Whether the prose follows from the value
+is model-dependent, thus it stays in a later verification pass and never in this
+contract.
+
+This capability is distinct from `target-synthesis-grounding`, which supplies FDA
+approval precedents as prompt context for a target dossier.
+
+## Requirements
+
+### Requirement: A reference is one canonical shape
+
+The harness MUST define one `Reference` object, and every evidentiary block MUST
+carry it. A reference MUST carry a `kind` of `artifact-value`, `artifact-table`,
+`artifact-file`, `derivation`, or `citation`. An artifact reference MUST pin `run`,
+`path`, and `hash`, and it can carry a `snapshot`. It can carry an `assert`, a
+`unit`, and a `format`. The reference MUST reuse the coordinates that the harness
+already keys on, the run id `cortex_runs.run_id` and the file key
+`cortex_artifacts(path, hash)`.
+
+An `artifact-value` reference MUST address one value with a `locator`. An
+`artifact-table` and an `artifact-file` reference MUST pin the whole file, and they
+MUST carry no `locator`. A `figure` binds to an `artifact-file`, because an image has
+no per-cell address.
+
+#### Scenario: A complete artifact-value reference validates
+
+- **WHEN** a reference carries `kind: "artifact-value"`, a `run`, a `path`, a `hash`, and a `locator`
+- **THEN** the grounding contract accepts the reference shape
+
+#### Scenario: A reference without a hash is rejected
+
+- **WHEN** an artifact reference carries a `run` and a `path` but no `hash`
+- **THEN** validation rejects the reference, because the hash is the identity under immutability
+
+#### Scenario: A whole-file reference with a locator is rejected
+
+- **WHEN** an `artifact-file` reference carries a `locator`
+- **THEN** validation rejects the reference, because a whole-file pin addresses no cell
+
+#### Scenario: A figure resolves through a whole-file pin
+
+- **WHEN** a `figure` binds to an `artifact-file` whose path and hash match the snapshot
+- **THEN** resolution returns the pinned file
+
+### Requirement: The row locator defaults to a stable predicate
+
+The `locator` MUST support `column`, `rowFilter`, and `row`. The default row selector
+MUST be `rowFilter`, a stable predicate, because scientific table row order is not
+semantically stable. A `row` by index MUST be permitted, but it MUST NOT be the
+default. A locator MUST resolve to exactly one value. Zero matches MUST give
+`locator-out-of-range`, and more than one match MUST give `ambiguous-match`.
+
+#### Scenario: A rowFilter selects a row by a key column
+
+- **WHEN** a locator carries a `rowFilter` that names a column, an operator, and a value that matches one row
+- **THEN** resolution selects the matching row independent of its position
+
+#### Scenario: A row index resolves when the order is fixed
+
+- **WHEN** a locator carries a `row` index against an artifact with a fixed order
+- **THEN** resolution selects the row at that index
+
+#### Scenario: A rowFilter with many matches returns ambiguous-match
+
+- **WHEN** a locator carries a `rowFilter` that matches more than one row
+- **THEN** resolution returns an `UnresolvedReference` with reason `ambiguous-match`
+
+### Requirement: A reference resolves against a pinned snapshot
+
+The harness MUST expose a `ReferenceResolver` seam. Its `resolve(reference,
+snapshot)` operation MUST return the concrete value, or a typed
+`UnresolvedReference`. The `reason` MUST be one of `artifact-missing`,
+`hash-mismatch`, `locator-out-of-range`, `ambiguous-match`, or `assertion-failed`.
+Resolution MUST target the pinned snapshot, so a version resolves to the same value
+over time.
+
+#### Scenario: A reference to a real cell resolves to its value
+
+- **WHEN** a reference addresses a real cell in a pinned artifact
+- **THEN** resolution returns the value at that cell
+
+#### Scenario: A missing artifact returns artifact-missing
+
+- **WHEN** a reference names a path that the snapshot does not hold
+- **THEN** resolution returns an `UnresolvedReference` with reason `artifact-missing`
+
+#### Scenario: A hash mismatch returns hash-mismatch
+
+- **WHEN** a reference names a path whose content hash differs from the pinned `hash`
+- **THEN** resolution returns an `UnresolvedReference` with reason `hash-mismatch`
+
+#### Scenario: A locator past the last row returns locator-out-of-range
+
+- **WHEN** a locator addresses a row or a cell that the artifact does not contain
+- **THEN** resolution returns an `UnresolvedReference` with reason `locator-out-of-range`
+
+### Requirement: An assertion is matched on resolve
+
+If a reference carries an `assert.value` or an `assert.hash`, resolution MUST
+re-read the artifact and match the resolved value within `tolerance`. A mismatch
+MUST return an `UnresolvedReference` with reason `assertion-failed`. Thus a
+transcription error or a hallucinated number fails even when the coordinate
+resolves.
+
+#### Scenario: A correct assertion passes
+
+- **WHEN** a reference carries an `assert.value` that equals the resolved value
+- **THEN** resolution returns the value
+
+#### Scenario: A wrong assertion fails
+
+- **WHEN** a reference carries an `assert.value` that differs from the resolved value beyond `tolerance`
+- **THEN** resolution returns an `UnresolvedReference` with reason `assertion-failed`
+
+### Requirement: Mechanical validation rejects fabrication
+
+Mechanical validation MUST run these steps in order, schema conformance, binding
+presence, resolution, and assertion match. A `claim` whose binding does not resolve
+MUST fail validation. The validation MUST use no model. This is the mechanism that
+prevents fabrication.
+
+#### Scenario: A fully grounded report validates
+
+- **WHEN** a report holds one of each block kind, and each binding resolves against the snapshot
+- **THEN** mechanical validation accepts the report
+
+#### Scenario: A claim with a non-resolving coordinate fails
+
+- **WHEN** a `claim` binds to a coordinate that the snapshot does not resolve
+- **THEN** mechanical validation fails the report with a typed `UnresolvedReference`
+
+#### Scenario: A claim with a wrong asserted value fails
+
+- **WHEN** a `claim` binds to a real coordinate but carries a wrong `assert.value`
+- **THEN** mechanical validation fails the report with reason `assertion-failed`
+
+### Requirement: A metric slot holds a reference, never a numeral
+
+A `metric` value slot MUST hold a resolved reference, and it MUST NOT hold a numeric
+literal. A numeral in `claim` or `text` prose outside a slot MUST raise a warning,
+not a failure, because a natural-language numeral is brittle to enforce.
+
+#### Scenario: A metric with a literal number is rejected
+
+- **WHEN** a `metric` value slot holds a numeric literal instead of a reference
+- **THEN** validation rejects the metric
+
+#### Scenario: A free numeral in claim prose raises a warning
+
+- **WHEN** a `claim` prose holds a numeral outside a bound slot
+- **THEN** validation raises a warning and does not fail the report
+
+### Requirement: A derived number is grounded two ways
+
+The default MUST materialize a derived value as a hashed artifact, and the claim MUST
+bind to a cell in that artifact. A `derivation` reference MUST be the escape hatch,
+and it carries an `op` of `ratio`, `delta`, or `pctChange` and an `inputs` array.
+Each input MUST be a non-derivation reference that resolves, so a derivation cannot
+nest. Validation MUST resolve each input, run the transform, then match the
+assertion.
+
+#### Scenario: A materialize-first derived value validates
+
+- **WHEN** a builder writes a derived value to a hashed artifact and a claim binds to that cell
+- **THEN** validation resolves the cell and accepts the claim
+
+#### Scenario: A derivation over grounded cells validates
+
+- **WHEN** a `derivation` reference carries a ratio over two inputs that each resolve to a real cell
+- **THEN** validation resolves the inputs, runs the ratio, and matches the assertion
+
+#### Scenario: A derivation with a non-resolving input fails
+
+- **WHEN** a `derivation` reference carries an input that does not resolve
+- **THEN** validation fails the reference
+
+#### Scenario: A derivation whose input is a derivation is rejected
+
+- **WHEN** a `derivation` reference carries an input that is itself a `derivation`
+- **THEN** validation rejects the reference, because a derivation cannot nest
+
+### Requirement: The reference serializes for cross-session transfer
+
+The `Reference` MUST serialize to a compact JSON object, and to a canonical URI
+string form for a carrier. It MUST carry no live object reference and no
+session-local state. A later session MUST deserialize it and resolve it against the
+same pinned snapshot to the same value.
+
+#### Scenario: A reference round-trips through serialization
+
+- **WHEN** a reference serializes to JSON and a later reader deserializes it
+- **THEN** the deserialized reference equals the original
+
+#### Scenario: A reference authored in one session resolves in another
+
+- **WHEN** a reference authored in one session resolves in a second session against the same pinned snapshot
+- **THEN** the second session reads the same value

--- a/harness/openspec/specs/report-grounding/spec.md
+++ b/harness/openspec/specs/report-grounding/spec.md
@@ -154,6 +154,19 @@ resolved value within `tolerance`. A mismatch MUST return an `UnresolvedReferenc
 with reason `assertion-failed`. Thus a transcription error or a hallucinated number
 fails even when the coordinate resolves.
 
+A match on a numeral MUST compare the numeric value. It MUST NOT compare the storage
+type of the cell. A text-backed artifact such as a CSV holds each cell as a string,
+thus the cell `"0.01"` matches the authored number 0.01. A cell that does not read as
+a finite number stays text, thus `"12 genes"` never matches 12.
+
+With no `tolerance`, the match MUST absorb the noise of float arithmetic and nothing
+more. Thus a computed 0.19999999999999998 matches an authored 0.2. An author who
+wants a rounded figure to pass MUST state a `tolerance`.
+
+A `citation` assert MUST carry a `value` that is text, and it MUST carry no
+`tolerance`. The value is the prefixed `idKind:id` key, for example `pmid:12345`.
+Resolution gives that key as text, thus a number could never match it.
+
 An `assert` MUST carry no hash. An artifact reference already pins `hash`, and
 resolution compares that pin against the fresh read. A second hash compares the
 reference against itself, thus it adds no evidence.
@@ -181,6 +194,26 @@ the only belief that an author can hold about the bytes.
 
 - **WHEN** an `artifact-table` or an `artifact-file` reference carries an `assert`
 - **THEN** validation rejects the reference
+
+#### Scenario: A numeric assert matches a text cell
+
+- **WHEN** an artifact holds the cell `"0.01"` as text and a reference asserts the number 0.01
+- **THEN** resolution matches the two and returns the value
+
+#### Scenario: A cell that holds text never matches a number
+
+- **WHEN** an artifact holds the cell `"12 genes"` and a reference asserts the number 12
+- **THEN** resolution returns an `UnresolvedReference` with reason `assertion-failed`
+
+#### Scenario: A rounded figure needs a tolerance
+
+- **WHEN** a derivation computes 0.19999999999999998 and the reference asserts 0.19 with no `tolerance`
+- **THEN** resolution returns an `UnresolvedReference` with reason `assertion-failed`
+
+#### Scenario: A numeric citation assert is rejected
+
+- **WHEN** a `citation` reference carries an `assert.value` that is a number
+- **THEN** validation rejects the reference, because the resolved key is always text
 
 ### Requirement: Mechanical validation rejects fabrication
 
@@ -225,8 +258,9 @@ not a failure, because a natural-language numeral is brittle to enforce.
 The default MUST materialize a derived value as a hashed artifact, and the claim MUST
 bind to a cell in that artifact. A `derivation` reference MUST be the escape hatch,
 and it carries an `op` of `ratio`, `delta`, or `pctChange` and an `inputs` array.
-Each input MUST be a non-derivation reference that resolves, so a derivation cannot
-nest. Validation MUST resolve each input, run the transform, then match the
+Each input MUST be an `artifact-value` reference, the one kind that resolves to a
+scalar. Thus a derivation cannot nest, and a table, a file, and a citation cannot sit
+in an input. Validation MUST resolve each input, run the transform, then match the
 assertion.
 
 Over the inputs `a` and `b`, `ratio` MUST give `a / b` and `delta` MUST give
@@ -253,6 +287,16 @@ fraction.
 
 - **WHEN** a `derivation` reference carries an input that is itself a `derivation`
 - **THEN** validation rejects the reference, because a derivation cannot nest
+
+#### Scenario: A derivation whose input resolves to no scalar is rejected
+
+- **WHEN** a `derivation` reference carries an input that is an `artifact-table`, an `artifact-file`, or a `citation`
+- **THEN** validation rejects the reference, because none of the three resolves to a scalar
+
+#### Scenario: A derivation runs the arithmetic over text cells
+
+- **WHEN** a `derivation` reference carries two inputs whose cells hold numerals as text
+- **THEN** resolution reads each cell as a number and runs the transform
 
 ### Requirement: The reference serializes for cross-session transfer
 

--- a/harness/openspec/specs/report-grounding/spec.md
+++ b/harness/openspec/specs/report-grounding/spec.md
@@ -25,11 +25,20 @@ approval precedents as prompt context for a target dossier.
 
 The harness MUST define one `Reference` object, and every evidentiary block MUST
 carry it. A reference MUST carry a `kind` of `artifact-value`, `artifact-table`,
-`artifact-file`, `derivation`, or `citation`. An artifact reference MUST pin `run`,
-`path`, and `hash`, and it can carry a `snapshot`. It can carry an `assert`, a
-`unit`, and a `format`. The reference MUST reuse the coordinates that the harness
-already keys on, the run id `cortex_runs.run_id` and the file key
-`cortex_artifacts(path, hash)`.
+`artifact-file`, `derivation`, or `citation`. An artifact reference MUST pin `path`
+and `hash`, and it can carry a `run` and a `snapshot`. It can carry a `unit` and a
+`format`. The reference MUST reuse the coordinates that the harness already keys on,
+the run id `cortex_runs.run_id` and the file key `cortex_artifacts(path, hash)`. The
+`path` MUST be analysis-relative, because `cortex_artifacts` keys on `(analysis_id,
+path)` and that path already holds the run segment of a run output.
+
+The `run` MUST be optional. A staged input file under `data/inputs/` has no run that
+produced it. Thus a mandatory `run` prevents a binding to an input file.
+
+#### Scenario: A staged input artifact binds without a run
+
+- **WHEN** a reference names an input file that no run produced, with a `path` and a `hash` but no `run`
+- **THEN** the grounding contract accepts the reference shape
 
 An `artifact-value` reference MUST address one value with a `locator`. An
 `artifact-table` and an `artifact-file` reference MUST pin the whole file, and they
@@ -79,6 +88,35 @@ default. A locator MUST resolve to exactly one value. Zero matches MUST give
 - **WHEN** a locator carries a `rowFilter` that matches more than one row
 - **THEN** resolution returns an `UnresolvedReference` with reason `ambiguous-match`
 
+### Requirement: A column name must address a real column
+
+A column name that no row of the bound table holds MUST give
+`locator-out-of-range`. This covers the `columns` subset of an `artifact-table`
+reference and each channel of a `chart` encoding. A projection onto a name that
+addresses nothing gives an empty cell for each row. Thus without this rule an
+invented column resolves, and the report renders as grounded.
+
+A table with no rows MUST accept each name. There is no evidence against a name, and
+an empty result table is a real outcome.
+
+A column that only some rows hold MUST resolve. A table tolerates a ragged row, thus
+a sparse column is different from a column that does not exist.
+
+#### Scenario: An invented column subset is rejected
+
+- **WHEN** an `artifact-table` reference names a `columns` entry that no row holds
+- **THEN** resolution returns an `UnresolvedReference` with reason `locator-out-of-range`
+
+#### Scenario: A chart channel that names no real column is rejected
+
+- **WHEN** a `chart` encoding names a column that the bound table does not hold
+- **THEN** validation fails the block with reason `locator-out-of-range`
+
+#### Scenario: A ragged column resolves
+
+- **WHEN** an `artifact-table` reference names a column that only some rows hold
+- **THEN** resolution returns the table
+
 ### Requirement: A reference resolves against a pinned snapshot
 
 The harness MUST expose a `ReferenceResolver` seam. Its `resolve(reference,
@@ -110,11 +148,19 @@ over time.
 
 ### Requirement: An assertion is matched on resolve
 
-If a reference carries an `assert.value` or an `assert.hash`, resolution MUST
-re-read the artifact and match the resolved value within `tolerance`. A mismatch
-MUST return an `UnresolvedReference` with reason `assertion-failed`. Thus a
-transcription error or a hallucinated number fails even when the coordinate
-resolves.
+An `assert` MUST carry a mandatory `value` and an optional `tolerance`. If a
+reference carries an `assert`, resolution MUST read the artifact again and match the
+resolved value within `tolerance`. A mismatch MUST return an `UnresolvedReference`
+with reason `assertion-failed`. Thus a transcription error or a hallucinated number
+fails even when the coordinate resolves.
+
+An `assert` MUST carry no hash. An artifact reference already pins `hash`, and
+resolution compares that pin against the fresh read. A second hash compares the
+reference against itself, thus it adds no evidence.
+
+Only a reference that resolves to one scalar MUST carry an `assert`. An
+`artifact-table` and an `artifact-file` MUST carry none, because the pinned `hash` is
+the only belief that an author can hold about the bytes.
 
 #### Scenario: A correct assertion passes
 
@@ -125,6 +171,16 @@ resolves.
 
 - **WHEN** a reference carries an `assert.value` that differs from the resolved value beyond `tolerance`
 - **THEN** resolution returns an `UnresolvedReference` with reason `assertion-failed`
+
+#### Scenario: An assert with a tolerance but no value is rejected
+
+- **WHEN** a reference carries an `assert` that holds a `tolerance` and no `value`
+- **THEN** validation rejects the reference, because the tolerance has nothing to compare against
+
+#### Scenario: An assert on a whole-file reference is rejected
+
+- **WHEN** an `artifact-table` or an `artifact-file` reference carries an `assert`
+- **THEN** validation rejects the reference
 
 ### Requirement: Mechanical validation rejects fabrication
 
@@ -172,6 +228,11 @@ and it carries an `op` of `ratio`, `delta`, or `pctChange` and an `inputs` array
 Each input MUST be a non-derivation reference that resolves, so a derivation cannot
 nest. Validation MUST resolve each input, run the transform, then match the
 assertion.
+
+Over the inputs `a` and `b`, `ratio` MUST give `a / b` and `delta` MUST give
+`a - b`. `pctChange` MUST give `(a - b) / b` as a fraction and not as a percent.
+Thus a change of one half resolves to 0.5, and an `assert.value` states the
+fraction.
 
 #### Scenario: A materialize-first derived value validates
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -71,6 +71,7 @@
         "neverthrow": "^8.2.0",
         "nunjucks": "^3.2.4",
         "openai": "^4.104.0",
+        "p-queue": "^9.3.3",
         "pdf-parse": "^2.4.5",
         "pg": "^8.22.0",
         "puppeteer-core": "^23.11.1",

--- a/harness/src/contracts/report-blocks.ts
+++ b/harness/src/contracts/report-blocks.ts
@@ -1,0 +1,155 @@
+/**
+ * The composable block tree of a report.
+ *
+ * A block is one of eight kinds. The shape of each kind carries its grammar. A `text` block has no
+ * binding field, thus an unbound claim is unrepresentable. A `metric` value slot admits one scalar
+ * reference only, thus a numeric literal cannot sit there. No atom holds a child-block array, thus a
+ * chart inside a metric is unrepresentable. The grammar is the shape, and not a separate pass.
+ *
+ * The tree is recursive: a `section` holds child blocks, and a child can be another section.
+ *
+ * Every object schema here and in the reference module is strict. A strict object makes an extra field
+ * a parse failure, and not a field that the parser strips in silence. Thus a forbidden field, such as a
+ * binding on a `text` block or a child-block array on an atom, is rejected. The absence of a field is a
+ * rule only when an extra field fails the parse.
+ */
+
+import { z } from "zod";
+import {
+    ArtifactFileReferenceSchema,
+    ArtifactTableReferenceSchema,
+    CitationReferenceSchema,
+    ReferenceSchema,
+    ScalarReferenceSchema,
+} from "./report-reference.js";
+
+/** The chart vocabulary. Each value names one plot form. */
+const ChartTypeSchema = z.enum(["bar", "line", "scatter", "histogram", "box", "heatmap", "pie"]);
+
+/** The mapping from a data column to a visual channel. Each channel is optional. */
+const ChartEncodingSchema = z.strictObject({
+    x: z.string().optional().describe("The column on the x axis."),
+    y: z.string().optional().describe("The column on the y axis."),
+    group: z.string().optional().describe("The column that splits and colors the series."),
+    value: z.string().optional().describe("The value column for a pie or heatmap."),
+});
+
+/** Prose with no binding. The absence of a binding field is the rule for this kind. */
+const TextBlockSchema = z.strictObject({
+    kind: z.literal("text"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    content: z.strictObject({ prose: z.string() }),
+});
+
+/** Prose with at least one reference that justifies it. */
+const ClaimBlockSchema = z.strictObject({
+    kind: z.literal("claim"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    content: z.strictObject({ prose: z.string() }),
+    bindings: z.array(ReferenceSchema).min(1).describe("The evidence that justifies the claim."),
+});
+
+/** A labeled number whose value comes from one scalar reference. */
+const MetricBlockSchema = z.strictObject({
+    kind: z.literal("metric"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    label: z.string(),
+    value: ScalarReferenceSchema.describe("The one scalar reference that gives the metric value."),
+});
+
+/** A whole-table artifact rendered as a table. */
+const TableBlockSchema = z.strictObject({
+    kind: z.literal("table"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    title: z.string().optional(),
+    binding: ArtifactTableReferenceSchema.describe("The whole-table artifact to render."),
+    caption: z.string().optional(),
+});
+
+/** A whole-table artifact rendered as a chart, with the plot form and the channel mapping. */
+const ChartBlockSchema = z.strictObject({
+    kind: z.literal("chart"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    title: z.string().optional(),
+    binding: ArtifactTableReferenceSchema.describe("The whole-table artifact to plot."),
+    chartType: ChartTypeSchema,
+    encoding: ChartEncodingSchema,
+    caption: z.string().optional(),
+});
+
+/** A static image artifact. An image has no per-cell address, thus it is pinned whole-file. */
+const FigureBlockSchema = z.strictObject({
+    kind: z.literal("figure"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    binding: ArtifactFileReferenceSchema.describe("The image artifact, pinned whole-file by path and hash."),
+    caption: z.string().optional(),
+});
+
+/** An external source, rendered from a citation reference. */
+const CitationBlockSchema = z.strictObject({
+    kind: z.literal("citation"),
+    id: z.string().min(1).describe("The stable identity of the block."),
+    binding: CitationReferenceSchema,
+    note: z.string().optional(),
+});
+
+/**
+ * The section shape as a plain type. TypeScript cannot infer the block tree through the union cycle,
+ * thus the recursive members carry an explicit type. `SectionBlock` and `Block` break the cycle.
+ */
+export interface SectionBlock {
+    kind: "section";
+    id: string;
+    title: string;
+    blocks: Block[];
+}
+
+/** One block of any of the eight kinds. An unknown kind fails validation by construction. */
+export type Block =
+    | z.infer<typeof TextBlockSchema>
+    | z.infer<typeof ClaimBlockSchema>
+    | z.infer<typeof MetricBlockSchema>
+    | z.infer<typeof TableBlockSchema>
+    | z.infer<typeof ChartBlockSchema>
+    | z.infer<typeof FigureBlockSchema>
+    | z.infer<typeof CitationBlockSchema>
+    | SectionBlock;
+
+/**
+ * A section holds at least one child block, thus an empty section is invalid. The `blocks` field is a
+ * `z.lazy` and not a getter, so the discriminated union reads the `kind` discriminator at construction
+ * time without a reference to `BlockSchema` before it exists.
+ */
+export const SectionBlockSchema = z.strictObject({
+    kind: z.literal("section"),
+    id: z.string().min(1),
+    title: z.string(),
+    blocks: z.lazy(() => z.array(BlockSchema).min(1)),
+});
+
+/** The block union. A `z.ZodType<Block>` annotation gives the recursive members a stable type. */
+export const BlockSchema: z.ZodType<Block> = z.discriminatedUnion("kind", [
+    SectionBlockSchema,
+    TextBlockSchema,
+    ClaimBlockSchema,
+    MetricBlockSchema,
+    TableBlockSchema,
+    ChartBlockSchema,
+    FigureBlockSchema,
+    CitationBlockSchema,
+]);
+
+/** The root of a report. It holds at least one section, thus an empty report is invalid. */
+export const ReportDocumentSchema = z.strictObject({
+    title: z.string(),
+    sections: z.array(SectionBlockSchema).min(1).describe("The top-level sections, each with at least one block."),
+});
+
+export type TextBlock = z.infer<typeof TextBlockSchema>;
+export type ClaimBlock = z.infer<typeof ClaimBlockSchema>;
+export type MetricBlock = z.infer<typeof MetricBlockSchema>;
+export type TableBlock = z.infer<typeof TableBlockSchema>;
+export type ChartBlock = z.infer<typeof ChartBlockSchema>;
+export type FigureBlock = z.infer<typeof FigureBlockSchema>;
+export type CitationBlock = z.infer<typeof CitationBlockSchema>;
+export type ReportDocument = z.infer<typeof ReportDocumentSchema>;

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { createFixtureResolver } from "../report-model/fixture-resolver.js";
 import type { ReportSnapshot } from "../report-model/reference-resolver.js";
-import { parseReference, serializeReference, type Reference } from "./report-reference.js";
+import { parseReference, serializeReference, type ParseReferenceError, type Reference } from "./report-reference.js";
 
 const HASH = `sha256:${"a".repeat(64)}`;
 
@@ -12,6 +12,25 @@ const HASH = `sha256:${"a".repeat(64)}`;
  */
 function encodeUnchecked(value: unknown): string {
     return serializeReference(value as unknown as Reference);
+}
+
+/** Assert that a reference survives a serialize then parse round trip unchanged. */
+function expectRoundTrip(reference: Reference): void {
+    const parsed = parseReference(serializeReference(reference));
+    expect(parsed.isOk()).toBe(true);
+    expect(parsed._unsafeUnwrap()).toEqual(reference);
+}
+
+/** Assert that a URI fails to parse, with the given error kind. */
+function expectParseError(uri: string, kind: ParseReferenceError["kind"]): void {
+    parseReference(uri).match(
+        () => {
+            throw new Error(`expected a parse error but the URI parsed: ${uri}`);
+        },
+        (error) => {
+            expect(error.kind).toBe(kind);
+        },
+    );
 }
 
 describe("serializeReference/parseReference — round trip", () => {
@@ -24,7 +43,7 @@ describe("serializeReference/parseReference — round trip", () => {
             locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
             unit: "log2",
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("round-trips an artifact-table with columns", () => {
@@ -35,7 +54,7 @@ describe("serializeReference/parseReference — round trip", () => {
             hash: HASH,
             columns: ["gene", "log2FoldChange", "padj"],
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("round-trips a derivation with two inputs and an assert", () => {
@@ -48,7 +67,7 @@ describe("serializeReference/parseReference — round trip", () => {
             ],
             assert: { value: 2, tolerance: 0.01 },
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("round-trips a citation", () => {
@@ -58,7 +77,7 @@ describe("serializeReference/parseReference — round trip", () => {
             id: "12345",
             raw: "Author et al. 2020",
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("round-trips an artifact-file", () => {
@@ -68,7 +87,7 @@ describe("serializeReference/parseReference — round trip", () => {
             path: "runs/run-1/step-b/figures/volcano.png",
             hash: HASH,
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 });
 
@@ -90,16 +109,17 @@ describe("parseReference — cross-session resolution", () => {
             locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
         };
         const parsed = parseReference(serializeReference(reference));
-        if (parsed === null) {
+        if (parsed.isErr()) {
             throw new Error("expected the serialized reference to parse");
         }
 
         const resolver = createFixtureResolver();
         const fromOriginal = await resolver.resolve(reference, snapshot);
-        const fromParsed = await resolver.resolve(parsed, snapshot);
+        const fromParsed = await resolver.resolve(parsed.value, snapshot);
 
-        expect(fromParsed).toEqual(fromOriginal);
-        expect(fromParsed).toEqual({ ok: true, value: { type: "scalar", value: 6 } });
+        expect(fromParsed.isOk()).toBe(fromOriginal.isOk());
+        expect(fromParsed._unsafeUnwrap()).toEqual(fromOriginal._unsafeUnwrap());
+        expect(fromParsed._unsafeUnwrap()).toEqual({ type: "scalar", value: 6 });
     });
 });
 
@@ -134,87 +154,91 @@ describe("serializeReference — determinism", () => {
     });
 });
 
-describe("parseReference — null outcomes", () => {
-    it("returns null for a wrong prefix", () => {
-        expect(parseReference("wrong-prefix:v1:abc")).toBeNull();
+describe("parseReference — error outcomes", () => {
+    it("gives a bad-prefix error for a wrong prefix", () => {
+        expectParseError("wrong-prefix:v1:abc", "bad-prefix");
     });
 
-    it("returns null for a corrupt payload", () => {
+    it("gives an invalid-json error for a payload that is not JSON", () => {
         const sample = serializeReference({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text" });
         // The payload is base64url and holds no colon, thus the last colon marks the end of the prefix.
         const prefix = sample.slice(0, sample.lastIndexOf(":") + 1);
         const corrupt = prefix + Buffer.from("{ this is not json", "utf8").toString("base64url");
-        expect(parseReference(corrupt)).toBeNull();
+        expectParseError(corrupt, "invalid-json");
     });
 
-    it("returns null for valid JSON that fails the schema", () => {
-        expect(parseReference(encodeUnchecked({ foo: "bar" }))).toBeNull();
+    it("gives a schema-mismatch error for valid JSON that fails the schema", () => {
+        expectParseError(encodeUnchecked({ foo: "bar" }), "schema-mismatch");
     });
 });
 
 describe("parseReference — schema rejection", () => {
     it("rejects an artifact reference without a hash", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", locator: { column: "c", row: 0 } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", locator: { column: "c", row: 0 } }), "schema-mismatch");
+    });
+
+    it("rejects an uppercase hash", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: "sha256:ABCDEF", locator: { column: "c", row: 0 } }),
+            "schema-mismatch",
+        );
     });
 
     it("rejects a derivation whose input is a derivation", () => {
-        expect(
-            parseReference(
-                encodeUnchecked({
-                    kind: "derivation",
-                    op: "ratio",
-                    inputs: [
-                        {
-                            kind: "derivation",
-                            op: "ratio",
-                            inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
-                        },
-                    ],
-                }),
-            ),
-        ).toBeNull();
+        expectParseError(
+            encodeUnchecked({
+                kind: "derivation",
+                op: "ratio",
+                inputs: [
+                    {
+                        kind: "derivation",
+                        op: "ratio",
+                        inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
+                    },
+                ],
+            }),
+            "schema-mismatch",
+        );
     });
 
     it("rejects a locator with both rowFilter and row", () => {
-        expect(
-            parseReference(
-                encodeUnchecked({
-                    kind: "artifact-value",
-                    run: "r",
-                    path: "p",
-                    hash: HASH,
-                    locator: { column: "c", row: 0, rowFilter: { column: "c", op: "eq", value: 1 } },
-                }),
-            ),
-        ).toBeNull();
+        expectParseError(
+            encodeUnchecked({
+                kind: "artifact-value",
+                run: "r",
+                path: "p",
+                hash: HASH,
+                locator: { column: "c", row: 0, rowFilter: { column: "c", op: "eq", value: 1 } },
+            }),
+            "schema-mismatch",
+        );
     });
 
     it("rejects a locator with neither rowFilter nor row", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c" } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c" } }), "schema-mismatch");
     });
 
     it("rejects an unknown kind", () => {
-        expect(parseReference(encodeUnchecked({ kind: "made-up", run: "r", path: "p", hash: HASH }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "made-up", run: "r", path: "p", hash: HASH }), "schema-mismatch");
     });
 
     it("rejects an extra unknown key", () => {
-        expect(parseReference(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", extra: "nope" }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", extra: "nope" }), "schema-mismatch");
     });
 
     it("rejects a locator on an artifact-file", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }), "schema-mismatch");
     });
 
     it("rejects a derivation with one input", () => {
-        expect(
-            parseReference(
-                encodeUnchecked({
-                    kind: "derivation",
-                    op: "delta",
-                    inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
-                }),
-            ),
-        ).toBeNull();
+        expectParseError(
+            encodeUnchecked({
+                kind: "derivation",
+                op: "delta",
+                inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
+            }),
+            "schema-mismatch",
+        );
     });
 });
 
@@ -234,31 +258,31 @@ describe("parseReference — the per-kind assert shape", () => {
             locator: { column: "value", row: 0 },
             assert: { hash: HASH },
         };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("round-trips a hash-only assert on an artifact-table", () => {
         const reference: Reference = { kind: "artifact-table", run: "run-1", path: "a.csv", hash: HASH, assert: { hash: HASH } };
-        expect(parseReference(serializeReference(reference))).toEqual(reference);
+        expectRoundTrip(reference);
     });
 
     it("rejects an asserted value on an artifact-table", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { value: 5 } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { value: 5 } }), "schema-mismatch");
     });
 
     it("rejects an asserted value on an artifact-file", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, assert: { value: 5 } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, assert: { value: 5 } }), "schema-mismatch");
     });
 
     it("rejects an asserted hash on a derivation", () => {
-        expect(parseReference(encodeUnchecked({ kind: "derivation", op: "ratio", inputs: derivationInputs, assert: { hash: HASH } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "derivation", op: "ratio", inputs: derivationInputs, assert: { hash: HASH } }), "schema-mismatch");
     });
 
     it("rejects an asserted hash on a citation", () => {
-        expect(parseReference(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: { hash: HASH } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: { hash: HASH } }), "schema-mismatch");
     });
 
     it("rejects a tolerance on an artifact-table", () => {
-        expect(parseReference(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { tolerance: 0.1 } }))).toBeNull();
+        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { tolerance: 0.1 } }), "schema-mismatch");
     });
 });

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -204,4 +204,61 @@ describe("parseReference — schema rejection", () => {
     it("rejects a locator on an artifact-file", () => {
         expect(parseReference(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }))).toBeNull();
     });
+
+    it("rejects a derivation with one input", () => {
+        expect(
+            parseReference(
+                encodeUnchecked({
+                    kind: "derivation",
+                    op: "delta",
+                    inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
+                }),
+            ),
+        ).toBeNull();
+    });
+});
+
+describe("parseReference — the per-kind assert shape", () => {
+    /** Two grounded inputs, so that a rejected derivation is rejected for its assert and nothing else. */
+    const derivationInputs = [
+        { kind: "artifact-value", run: "r", path: "a.csv", hash: HASH, locator: { column: "value", row: 0 } },
+        { kind: "artifact-value", run: "r", path: "b.csv", hash: HASH, locator: { column: "value", row: 0 } },
+    ];
+
+    it("round-trips a hash-only assert on an artifact-value", () => {
+        const reference: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: "a.csv",
+            hash: HASH,
+            locator: { column: "value", row: 0 },
+            assert: { hash: HASH },
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("round-trips a hash-only assert on an artifact-table", () => {
+        const reference: Reference = { kind: "artifact-table", run: "run-1", path: "a.csv", hash: HASH, assert: { hash: HASH } };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("rejects an asserted value on an artifact-table", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { value: 5 } }))).toBeNull();
+    });
+
+    it("rejects an asserted value on an artifact-file", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, assert: { value: 5 } }))).toBeNull();
+    });
+
+    it("rejects an asserted hash on a derivation", () => {
+        expect(parseReference(encodeUnchecked({ kind: "derivation", op: "ratio", inputs: derivationInputs, assert: { hash: HASH } }))).toBeNull();
+    });
+
+    it("rejects an asserted hash on a citation", () => {
+        expect(parseReference(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: { hash: HASH } }))).toBeNull();
+    });
+
+    it("rejects a tolerance on an artifact-table", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { tolerance: 0.1 } }))).toBeNull();
+    });
 });

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+
+import { createFixtureResolver } from "../report-model/fixture-resolver.js";
+import type { ReportSnapshot } from "../report-model/reference-resolver.js";
+import { parseReference, serializeReference, type Reference } from "./report-reference.js";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+
+/**
+ * serializeReference validates nothing; it only encodes. A cast lets a test feed a malformed object
+ * through the exact wire encoding, then assert that parseReference rejects it on the way back.
+ */
+function encodeUnchecked(value: unknown): string {
+    return serializeReference(value as unknown as Reference);
+}
+
+describe("serializeReference/parseReference — round trip", () => {
+    it("round-trips an artifact-value with a rowFilter", () => {
+        const reference: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: "runs/run-1/step-a/output/de.csv",
+            hash: HASH,
+            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+            unit: "log2",
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("round-trips an artifact-table with columns", () => {
+        const reference: Reference = {
+            kind: "artifact-table",
+            run: "run-1",
+            path: "runs/run-1/step-a/output/de.csv",
+            hash: HASH,
+            columns: ["gene", "log2FoldChange", "padj"],
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("round-trips a derivation with two inputs and an assert", () => {
+        const reference: Reference = {
+            kind: "derivation",
+            op: "ratio",
+            inputs: [
+                { kind: "artifact-value", run: "run-1", path: "a.csv", hash: HASH, locator: { column: "value", row: 0 } },
+                { kind: "artifact-value", run: "run-1", path: "b.csv", hash: HASH, locator: { column: "value", row: 0 } },
+            ],
+            assert: { value: 2, tolerance: 0.01 },
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("round-trips a citation", () => {
+        const reference: Reference = {
+            kind: "citation",
+            idKind: "pmid",
+            id: "12345",
+            raw: "Author et al. 2020",
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+
+    it("round-trips an artifact-file", () => {
+        const reference: Reference = {
+            kind: "artifact-file",
+            run: "run-1",
+            path: "runs/run-1/step-b/figures/volcano.png",
+            hash: HASH,
+        };
+        expect(parseReference(serializeReference(reference))).toEqual(reference);
+    });
+});
+
+describe("parseReference — cross-session resolution", () => {
+    it("resolves a parsed reference to the same value as the original", async () => {
+        const snapshot: ReportSnapshot = {
+            artifacts: {
+                "runs/run-1/step-a/output/de.csv": {
+                    hash: HASH,
+                    rows: [{ gene: "TP53", log2FoldChange: 6 }],
+                },
+            },
+        };
+        const reference: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: "runs/run-1/step-a/output/de.csv",
+            hash: HASH,
+            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+        };
+        const parsed = parseReference(serializeReference(reference));
+        if (parsed === null) {
+            throw new Error("expected the serialized reference to parse");
+        }
+
+        const resolver = createFixtureResolver();
+        const fromOriginal = await resolver.resolve(reference, snapshot);
+        const fromParsed = await resolver.resolve(parsed, snapshot);
+
+        expect(fromParsed).toEqual(fromOriginal);
+        expect(fromParsed).toEqual({ ok: true, value: { type: "scalar", value: 6 } });
+    });
+});
+
+describe("serializeReference — determinism", () => {
+    it("gives the identical string on two calls", () => {
+        const reference: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: "a.csv",
+            hash: HASH,
+            locator: { column: "gene", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+        };
+        expect(serializeReference(reference)).toBe(serializeReference(reference));
+    });
+
+    it("ignores key insertion order", () => {
+        const ordered: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: "a.csv",
+            hash: HASH,
+            locator: { column: "gene", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+        };
+        const shuffled: Reference = {
+            locator: { rowFilter: { value: "TP53", op: "eq", column: "gene" }, column: "gene" },
+            hash: HASH,
+            path: "a.csv",
+            run: "run-1",
+            kind: "artifact-value",
+        };
+        expect(serializeReference(ordered)).toBe(serializeReference(shuffled));
+    });
+});
+
+describe("parseReference — null outcomes", () => {
+    it("returns null for a wrong prefix", () => {
+        expect(parseReference("wrong-prefix:v1:abc")).toBeNull();
+    });
+
+    it("returns null for a corrupt payload", () => {
+        const sample = serializeReference({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text" });
+        // The payload is base64url and holds no colon, thus the last colon marks the end of the prefix.
+        const prefix = sample.slice(0, sample.lastIndexOf(":") + 1);
+        const corrupt = prefix + Buffer.from("{ this is not json", "utf8").toString("base64url");
+        expect(parseReference(corrupt)).toBeNull();
+    });
+
+    it("returns null for valid JSON that fails the schema", () => {
+        expect(parseReference(encodeUnchecked({ foo: "bar" }))).toBeNull();
+    });
+});
+
+describe("parseReference — schema rejection", () => {
+    it("rejects an artifact reference without a hash", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", locator: { column: "c", row: 0 } }))).toBeNull();
+    });
+
+    it("rejects a derivation whose input is a derivation", () => {
+        expect(
+            parseReference(
+                encodeUnchecked({
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        {
+                            kind: "derivation",
+                            op: "ratio",
+                            inputs: [{ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }],
+                        },
+                    ],
+                }),
+            ),
+        ).toBeNull();
+    });
+
+    it("rejects a locator with both rowFilter and row", () => {
+        expect(
+            parseReference(
+                encodeUnchecked({
+                    kind: "artifact-value",
+                    run: "r",
+                    path: "p",
+                    hash: HASH,
+                    locator: { column: "c", row: 0, rowFilter: { column: "c", op: "eq", value: 1 } },
+                }),
+            ),
+        ).toBeNull();
+    });
+
+    it("rejects a locator with neither rowFilter nor row", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c" } }))).toBeNull();
+    });
+
+    it("rejects an unknown kind", () => {
+        expect(parseReference(encodeUnchecked({ kind: "made-up", run: "r", path: "p", hash: HASH }))).toBeNull();
+    });
+
+    it("rejects an extra unknown key", () => {
+        expect(parseReference(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", extra: "nope" }))).toBeNull();
+    });
+
+    it("rejects a locator on an artifact-file", () => {
+        expect(parseReference(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 } }))).toBeNull();
+    });
+});

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -217,6 +217,33 @@ describe("parseReference — schema rejection", () => {
             "schema-mismatch",
         );
     });
+
+    /**
+     * The arithmetic needs a scalar, and only an `artifact-value` resolves to one. Each other kind is
+     * rejected by the grammar, thus it never parses into a reference that always fails at resolution.
+     */
+    const scalarInput = { kind: "artifact-value", run: "r", path: "a.csv", hash: HASH, locator: { column: "value", row: 0 } };
+
+    it("rejects a derivation whose input is an artifact-table", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "derivation", op: "ratio", inputs: [scalarInput, { kind: "artifact-table", run: "r", path: "t.csv", hash: HASH }] }),
+            "schema-mismatch",
+        );
+    });
+
+    it("rejects a derivation whose input is an artifact-file", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "derivation", op: "ratio", inputs: [scalarInput, { kind: "artifact-file", run: "r", path: "f.png", hash: HASH }] }),
+            "schema-mismatch",
+        );
+    });
+
+    it("rejects a derivation whose input is a citation", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "derivation", op: "ratio", inputs: [scalarInput, { kind: "citation", idKind: "pmid", id: "1", raw: "t" }] }),
+            "schema-mismatch",
+        );
+    });
 });
 
 describe("parseReference — the per-kind assert shape", () => {
@@ -262,6 +289,21 @@ describe("parseReference — the per-kind assert shape", () => {
 
     it("rejects an asserted hash on a citation", () => {
         expectParseError(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: { hash: HASH } }), "schema-mismatch");
+    });
+
+    it("round-trips a citation assert that holds the prefixed key", () => {
+        expectRoundTrip({ kind: "citation", idKind: "pmid", id: "12345", raw: "text", assert: { value: "pmid:12345" } });
+    });
+
+    it("rejects a numeric citation assert, because the resolved key is always text", () => {
+        expectParseError(encodeUnchecked({ kind: "citation", idKind: "pmid", id: "12345", raw: "text", assert: { value: 12345 } }), "schema-mismatch");
+    });
+
+    it("rejects a tolerance on a citation assert, because a key match is exact", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "citation", idKind: "pmid", id: "12345", raw: "text", assert: { value: "pmid:12345", tolerance: 1 } }),
+            "schema-mismatch",
+        );
     });
 
     it("rejects a tolerance with no asserted value", () => {

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "bun:test";
 
-import { createFixtureResolver } from "../report-model/fixture-resolver.js";
-import type { ReportSnapshot } from "../report-model/reference-resolver.js";
 import { parseReference, serializeReference, type ParseReferenceError, type Reference } from "./report-reference.js";
 
 const HASH = `sha256:${"a".repeat(64)}`;
@@ -91,38 +89,6 @@ describe("serializeReference/parseReference — round trip", () => {
     });
 });
 
-describe("parseReference — cross-session resolution", () => {
-    it("resolves a parsed reference to the same value as the original", async () => {
-        const snapshot: ReportSnapshot = {
-            artifacts: {
-                "runs/run-1/step-a/output/de.csv": {
-                    hash: HASH,
-                    rows: [{ gene: "TP53", log2FoldChange: 6 }],
-                },
-            },
-        };
-        const reference: Reference = {
-            kind: "artifact-value",
-            run: "run-1",
-            path: "runs/run-1/step-a/output/de.csv",
-            hash: HASH,
-            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
-        };
-        const parsed = parseReference(serializeReference(reference));
-        if (parsed.isErr()) {
-            throw new Error("expected the serialized reference to parse");
-        }
-
-        const resolver = createFixtureResolver();
-        const fromOriginal = await resolver.resolve(reference, snapshot);
-        const fromParsed = await resolver.resolve(parsed.value, snapshot);
-
-        expect(fromParsed.isOk()).toBe(fromOriginal.isOk());
-        expect(fromParsed._unsafeUnwrap()).toEqual(fromOriginal._unsafeUnwrap());
-        expect(fromParsed._unsafeUnwrap()).toEqual({ type: "scalar", value: 6 });
-    });
-});
-
 describe("serializeReference — determinism", () => {
     it("gives the identical string on two calls", () => {
         const reference: Reference = {
@@ -169,6 +135,17 @@ describe("parseReference — error outcomes", () => {
 
     it("gives a schema-mismatch error for valid JSON that fails the schema", () => {
         expectParseError(encodeUnchecked({ foo: "bar" }), "schema-mismatch");
+    });
+
+    it("gives an invalid-payload error for a character outside the base64url alphabet", () => {
+        // `Buffer.from` drops such a character and decodes what is left, thus without an explicit check
+        // this payload would report as malformed JSON and name the wrong failure.
+        expectParseError("inflexa-ref:v1:not base64!!", "invalid-payload");
+        expectParseError("inflexa-ref:v1:eyJraW5kIjoiY2l0YXRpb24ifQ==", "invalid-payload");
+    });
+
+    it("gives an invalid-payload error for an empty payload", () => {
+        expectParseError("inflexa-ref:v1:", "invalid-payload");
     });
 });
 
@@ -249,28 +226,33 @@ describe("parseReference — the per-kind assert shape", () => {
         { kind: "artifact-value", run: "r", path: "b.csv", hash: HASH, locator: { column: "value", row: 0 } },
     ];
 
-    it("round-trips a hash-only assert on an artifact-value", () => {
+    it("round-trips a value assert with a tolerance on an artifact-value", () => {
         const reference: Reference = {
             kind: "artifact-value",
             run: "run-1",
             path: "a.csv",
             hash: HASH,
             locator: { column: "value", row: 0 },
-            assert: { hash: HASH },
+            assert: { value: 5, tolerance: 0.01 },
         };
         expectRoundTrip(reference);
     });
 
-    it("round-trips a hash-only assert on an artifact-table", () => {
-        const reference: Reference = { kind: "artifact-table", run: "run-1", path: "a.csv", hash: HASH, assert: { hash: HASH } };
-        expectRoundTrip(reference);
+    it("rejects an asserted hash on an artifact-value, because the pin already carries it", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 }, assert: { hash: HASH } }),
+            "schema-mismatch",
+        );
     });
 
-    it("rejects an asserted value on an artifact-table", () => {
+    it("rejects any assert on an artifact-table", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { hash: HASH } }), "schema-mismatch");
         expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { value: 5 } }), "schema-mismatch");
+        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { tolerance: 0.1 } }), "schema-mismatch");
     });
 
-    it("rejects an asserted value on an artifact-file", () => {
+    it("rejects any assert on an artifact-file", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, assert: { hash: HASH } }), "schema-mismatch");
         expectParseError(encodeUnchecked({ kind: "artifact-file", run: "r", path: "p", hash: HASH, assert: { value: 5 } }), "schema-mismatch");
     });
 
@@ -282,7 +264,30 @@ describe("parseReference — the per-kind assert shape", () => {
         expectParseError(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: { hash: HASH } }), "schema-mismatch");
     });
 
-    it("rejects a tolerance on an artifact-table", () => {
-        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { tolerance: 0.1 } }), "schema-mismatch");
+    it("rejects a tolerance with no asserted value", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 }, assert: { tolerance: 0.1 } }),
+            "schema-mismatch",
+        );
+        expectParseError(encodeUnchecked({ kind: "derivation", op: "ratio", inputs: derivationInputs, assert: { tolerance: 0.1 } }), "schema-mismatch");
+    });
+
+    it("rejects an empty assert", () => {
+        expectParseError(
+            encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 }, assert: {} }),
+            "schema-mismatch",
+        );
+        expectParseError(encodeUnchecked({ kind: "citation", idKind: "doi", id: "10.1/x", raw: "text", assert: {} }), "schema-mismatch");
+    });
+});
+
+describe("parseReference — the optional run", () => {
+    it("round-trips a staged input artifact that no run produced", () => {
+        const reference: Reference = { kind: "artifact-table", path: "data/inputs/file-1/counts.csv", hash: HASH };
+        expectRoundTrip(reference);
+    });
+
+    it("rejects an empty-string run", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-table", run: "", path: "p", hash: HASH }), "schema-mismatch");
     });
 });

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -130,9 +130,10 @@ export const CitationReferenceSchema = z.strictObject({
     raw: z.string().describe("The original citation text."),
     assert: z
         .strictObject({
-            value: z
-                .union([z.string(), z.number()])
-                .describe("The expected citation key in the prefixed `idKind:id` form, for example `pmid:12345`, and not the bare id."),
+            // The value is a string and not the wider scalar union of a value assert. Resolution gives the
+            // key as text, thus a number here can never match and the schema would admit a belief that
+            // always fails.
+            value: z.string().describe("The expected citation key in the prefixed `idKind:id` form, for example `pmid:12345`, and not the bare id."),
         })
         .optional()
         .describe("The authored belief about the citation key that resolution gives."),
@@ -140,19 +141,18 @@ export const CitationReferenceSchema = z.strictObject({
 });
 
 /**
- * The references that a derivation can consume. A derivation is not in this set, thus a derivation over
- * a derivation is unrepresentable at the type level, and not a rule that a later check must enforce.
+ * The one reference kind that a derivation can consume.
+ *
+ * The arithmetic needs a scalar, and `artifact-value` is the only reference that resolves to one without
+ * itself being a derivation. A table, a file, and a citation resolve to something else, thus each is
+ * unrepresentable here rather than a parse that succeeds and then always fails at resolution. A
+ * derivation is out of the set too, thus a derivation over a derivation stays unrepresentable.
  */
-export const NonDerivationReferenceSchema = z.discriminatedUnion("kind", [
-    ArtifactValueReferenceSchema,
-    ArtifactTableReferenceSchema,
-    ArtifactFileReferenceSchema,
-    CitationReferenceSchema,
-]);
+export const DerivationInputReferenceSchema = ArtifactValueReferenceSchema;
 
 /**
  * A reference to a value computed from other references. Each of the three operations takes two inputs,
- * thus `inputs` holds exactly two non-derivation references and no other count is representable. The
+ * thus `inputs` holds exactly two scalar-resolving references and no other count is representable. The
  * result is computed and not artifact-backed, thus its assert carries the value fields only.
  */
 export const DerivationReferenceSchema = z.strictObject({
@@ -162,7 +162,10 @@ export const DerivationReferenceSchema = z.strictObject({
         .describe(
             "The operation over the two inputs `a` and `b`: `ratio` gives `a / b`, `delta` gives `a - b`, and `pctChange` gives `(a - b) / b` as a fraction and not as a percent. A change of one half resolves to 0.5, thus an `assert.value` states the fraction and a `unit` of `%` is a display hint only.",
         ),
-    inputs: z.array(NonDerivationReferenceSchema).length(2).describe("The two input references. Each operation takes exactly two."),
+    inputs: z
+        .array(DerivationInputReferenceSchema)
+        .length(2)
+        .describe("The two input references. Each operation takes exactly two, and each one must resolve to a scalar."),
     assert: AssertValueSchema.optional().describe("The authored belief that resolution matches against."),
     ...displayShape,
 });
@@ -196,7 +199,7 @@ export type ArtifactValueReference = z.infer<typeof ArtifactValueReferenceSchema
 export type ArtifactTableReference = z.infer<typeof ArtifactTableReferenceSchema>;
 export type ArtifactFileReference = z.infer<typeof ArtifactFileReferenceSchema>;
 export type CitationReference = z.infer<typeof CitationReferenceSchema>;
-export type NonDerivationReference = z.infer<typeof NonDerivationReferenceSchema>;
+export type DerivationInputReference = z.infer<typeof DerivationInputReferenceSchema>;
 export type DerivationReference = z.infer<typeof DerivationReferenceSchema>;
 export type Reference = z.infer<typeof ReferenceSchema>;
 export type ScalarReference = z.infer<typeof ScalarReferenceSchema>;

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -1,0 +1,221 @@
+/**
+ * A reference binds a report block to the evidence that justifies it. It is the one canonical way a
+ * block points at a value, a table, a derived quantity, or an external source.
+ *
+ * The reference lives here, in `contracts/`, because a consumer reads it back after a run. The consumer
+ * imports this module without the harness's own dependencies, thus it holds a reference as plain data.
+ *
+ * Resolution reads the evidence again at render time. The `assert` field is the authored belief, and
+ * the resolver matches the fresh read against it.
+ */
+
+import { z } from "zod";
+
+/**
+ * The shape of a content hash, as `algorithm:hex`, for example `sha256:9f86d0...`. The resolver
+ * compares this text against a fresh read, thus the exact string must survive a round trip.
+ */
+const HASH_PATTERN = /^[a-z0-9]+:[0-9a-f]+$/i;
+
+/**
+ * The pin that ties an artifact reference to one immutable file. It names the run that made the file,
+ * the run-relative path, and the content hash. The optional `snapshot` names a point-in-time copy when
+ * a host keeps one.
+ */
+const artifactPinShape = {
+    run: z.string().min(1).describe("The analysis run id that produced the artifact."),
+    path: z.string().min(1).describe("The run-relative path of the artifact."),
+    hash: z.string().regex(HASH_PATTERN).describe("The content hash as `algorithm:hex`, for example `sha256:...`."),
+    snapshot: z.string().optional().describe("An optional point-in-time snapshot id."),
+};
+
+/**
+ * The authored belief about the value at a reference. `tolerance` gives the permitted numeric
+ * difference. `hash` pins the exact bytes. Resolution matches a fresh read against these fields.
+ */
+const AssertSchema = z.strictObject({
+    value: z.union([z.string(), z.number()]).describe("The value the author expects at resolution time."),
+    tolerance: z.number().optional().describe("The permitted absolute difference for a numeric match."),
+    hash: z.string().optional().describe("An optional content hash that the resolved value must match."),
+});
+
+/**
+ * The fields that every reference kind can carry. `assert` is the authored belief. `unit` and `format`
+ * are hints for how a renderer shows the resolved value.
+ */
+const commonShape = {
+    assert: AssertSchema.optional().describe("The authored belief that resolution matches against."),
+    unit: z.string().optional().describe("The unit of the resolved value, for example `%` or `kb`."),
+    format: z.string().optional().describe("A display format hint for the resolved value."),
+};
+
+/**
+ * The address of exactly one value inside an artifact. `column` names the field. Exactly one of
+ * `rowFilter` or `row` selects the row. The refine makes the "exactly one" rule a parse failure, and
+ * not a separate check that runs later.
+ */
+const LocatorSchema = z
+    .strictObject({
+        column: z.string().describe("The column that holds the value."),
+        rowFilter: z
+            .strictObject({
+                column: z.string(),
+                op: z.literal("eq"),
+                value: z.union([z.string(), z.number()]),
+            })
+            .optional()
+            .describe("The documented default: the row where a column equals a value."),
+        row: z.number().int().nonnegative().optional().describe("A fixed row index. Use it only for an artifact with a stable row order."),
+    })
+    .refine((v) => (v.rowFilter !== undefined) !== (v.row !== undefined), {
+        message: "A locator needs exactly one of `rowFilter` or `row`.",
+    });
+
+/** A reference to one scalar value inside an artifact, addressed by a locator. */
+export const ArtifactValueReferenceSchema = z.strictObject({
+    kind: z.literal("artifact-value"),
+    ...artifactPinShape,
+    locator: LocatorSchema.describe("The address of the one value that this reference binds."),
+    ...commonShape,
+});
+
+/** A reference to a whole table artifact. It carries no locator, because it binds every row. */
+export const ArtifactTableReferenceSchema = z.strictObject({
+    kind: z.literal("artifact-table"),
+    ...artifactPinShape,
+    columns: z.array(z.string()).optional().describe("An optional column subset to render. Omit to bind every column."),
+    ...commonShape,
+});
+
+/**
+ * A reference to a whole artifact file, for example an image. It carries no locator and no columns,
+ * because a file is pinned whole and has no addressable cell inside it.
+ */
+export const ArtifactFileReferenceSchema = z.strictObject({
+    kind: z.literal("artifact-file"),
+    ...artifactPinShape,
+    ...commonShape,
+});
+
+/** A reference to an external source, addressed by an external identifier. */
+export const CitationReferenceSchema = z.strictObject({
+    kind: z.literal("citation"),
+    idKind: z.enum(["doi", "pmid", "arxiv"]).describe("The external identifier space."),
+    id: z.string().describe("The external identifier value."),
+    raw: z.string().describe("The original citation text."),
+    ...commonShape,
+});
+
+/**
+ * The references that a derivation can consume. A derivation is not in this set, thus a derivation over
+ * a derivation is unrepresentable at the type level, and not a rule that a later check must enforce.
+ */
+export const NonDerivationReferenceSchema = z.discriminatedUnion("kind", [
+    ArtifactValueReferenceSchema,
+    ArtifactTableReferenceSchema,
+    ArtifactFileReferenceSchema,
+    CitationReferenceSchema,
+]);
+
+/**
+ * A reference to a value computed from other references. The three operations each take two inputs at
+ * most, thus `inputs` holds one or two non-derivation references.
+ */
+export const DerivationReferenceSchema = z.strictObject({
+    kind: z.literal("derivation"),
+    op: z.enum(["ratio", "delta", "pctChange"]).describe("The operation over the inputs."),
+    inputs: z.array(NonDerivationReferenceSchema).min(1).max(2).describe("The input references. Each operation needs at most two."),
+    ...commonShape,
+});
+
+/** The full reference union. A block binds to one of these. */
+export const ReferenceSchema = z.discriminatedUnion("kind", [
+    ArtifactValueReferenceSchema,
+    ArtifactTableReferenceSchema,
+    ArtifactFileReferenceSchema,
+    DerivationReferenceSchema,
+    CitationReferenceSchema,
+]);
+
+/**
+ * The references that resolve to one scalar value. A metric's value slot admits only these, thus no
+ * numeric literal can sit in the slot: the type admits a reference only.
+ */
+export const ScalarReferenceSchema = z.discriminatedUnion("kind", [ArtifactValueReferenceSchema, DerivationReferenceSchema]);
+
+/** The reason that a reference did not resolve. */
+export const UnresolvedReasonSchema = z.enum(["artifact-missing", "hash-mismatch", "locator-out-of-range", "ambiguous-match", "assertion-failed"]);
+
+/** A reference that resolution could not bind, with the reason and an optional detail. */
+export const UnresolvedReferenceSchema = z.strictObject({
+    reference: ReferenceSchema,
+    reason: UnresolvedReasonSchema,
+    detail: z.string().optional(),
+});
+
+export type ArtifactValueReference = z.infer<typeof ArtifactValueReferenceSchema>;
+export type ArtifactTableReference = z.infer<typeof ArtifactTableReferenceSchema>;
+export type ArtifactFileReference = z.infer<typeof ArtifactFileReferenceSchema>;
+export type CitationReference = z.infer<typeof CitationReferenceSchema>;
+export type NonDerivationReference = z.infer<typeof NonDerivationReferenceSchema>;
+export type DerivationReference = z.infer<typeof DerivationReferenceSchema>;
+export type Reference = z.infer<typeof ReferenceSchema>;
+export type ScalarReference = z.infer<typeof ScalarReferenceSchema>;
+export type UnresolvedReason = z.infer<typeof UnresolvedReasonSchema>;
+export type UnresolvedReference = z.infer<typeof UnresolvedReferenceSchema>;
+
+/** The URI scheme and version for a serialized reference. The payload after it is opaque. */
+const REFERENCE_URI_PREFIX = "inflexa-ref:v1:";
+
+/**
+ * Sort the keys of every object so that serialization is deterministic. An array keeps its order,
+ * because the order of a derivation's inputs carries meaning.
+ */
+function sortKeysDeep(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(sortKeysDeep);
+    }
+    if (value !== null && typeof value === "object") {
+        const sorted: Record<string, unknown> = {};
+        for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+/**
+ * Serialize a reference to a canonical URI.
+ *
+ * The payload is an opaque base64url of the canonical JSON, and not a structured URI with a field for
+ * each property. The reference object is the source of truth. A structured URI re-parses field by
+ * field, and it drifts from the object as the shape grows. An opaque payload cannot drift, because it
+ * round-trips the whole object.
+ */
+export function serializeReference(reference: Reference): string {
+    const json = JSON.stringify(sortKeysDeep(reference));
+    const payload = Buffer.from(json, "utf8").toString("base64url");
+    return REFERENCE_URI_PREFIX + payload;
+}
+
+/**
+ * Parse a reference URI. A malformed prefix, malformed JSON, or a value that the schema rejects gives
+ * `null`. This function never throws, thus a caller treats absence as a normal condition.
+ */
+export function parseReference(uri: string): Reference | null {
+    if (!uri.startsWith(REFERENCE_URI_PREFIX)) {
+        return null;
+    }
+    const payload = uri.slice(REFERENCE_URI_PREFIX.length);
+    const json = Buffer.from(payload, "base64url").toString("utf8");
+    let candidate: unknown;
+    try {
+        candidate = JSON.parse(json);
+    } catch {
+        // `JSON.parse` throws on malformed input. The domain contract returns `null` instead of a throw.
+        return null;
+    }
+    const result = ReferenceSchema.safeParse(candidate);
+    return result.success ? result.data : null;
+}

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -9,13 +9,16 @@
  * the resolver matches the fresh read against it.
  */
 
+import { err, ok, type Result } from "neverthrow";
 import { z } from "zod";
 
 /**
- * The shape of a content hash, as `algorithm:hex`, for example `sha256:9f86d0...`. The resolver
- * compares this text against a fresh read, thus the exact string must survive a round trip.
+ * The shape of a content hash, as lowercase `algorithm:hex`, for example `sha256:9f86d0...`. The
+ * resolver compares this text against a fresh read with exact string equality, and the producer emits
+ * lowercase only. Thus the pattern rejects an uppercase hex digit, which would pass a case-insensitive
+ * match here but never resolve against the lowercase producer.
  */
-const HASH_PATTERN = /^[a-z0-9]+:[0-9a-f]+$/i;
+const HASH_PATTERN = /^[a-z0-9]+:[0-9a-f]+$/;
 
 /**
  * The pin that ties an artifact reference to one immutable file. It names the run that made the file,
@@ -243,22 +246,40 @@ export function serializeReference(reference: Reference): string {
 }
 
 /**
- * Parse a reference URI. A malformed prefix, malformed JSON, or a value that the schema rejects gives
- * `null`. This function never throws, thus a caller treats absence as a normal condition.
+ * The reason that a reference URI did not parse. Each of the four modes is distinct: a wrong prefix, a
+ * base64url payload that does not decode, JSON that does not parse, and a value that the schema rejects.
+ * A caller reads the `kind` to tell them apart. `detail` carries no secret, thus a schema mismatch
+ * gives the kind alone.
  */
-export function parseReference(uri: string): Reference | null {
+export type ParseReferenceError = {
+    kind: "bad-prefix" | "invalid-payload" | "invalid-json" | "schema-mismatch";
+    detail?: string;
+};
+
+/**
+ * Parse a reference URI. Each failure mode gives its own `Err` `kind`, thus a caller tells a wrong
+ * prefix from malformed bytes, malformed JSON, and a schema mismatch. This function never throws, thus a
+ * caller treats a failed parse as a normal condition.
+ */
+export function parseReference(uri: string): Result<Reference, ParseReferenceError> {
     if (!uri.startsWith(REFERENCE_URI_PREFIX)) {
-        return null;
+        return err({ kind: "bad-prefix" });
     }
     const payload = uri.slice(REFERENCE_URI_PREFIX.length);
-    const json = Buffer.from(payload, "base64url").toString("utf8");
+    let json: string;
+    try {
+        json = Buffer.from(payload, "base64url").toString("utf8");
+    } catch {
+        // A base64url decode of external bytes is the boundary. A throw here becomes an `Err`.
+        return err({ kind: "invalid-payload" });
+    }
     let candidate: unknown;
     try {
         candidate = JSON.parse(json);
     } catch {
-        // `JSON.parse` throws on malformed input. The domain contract returns `null` instead of a throw.
-        return null;
+        // `JSON.parse` throws on malformed input. The boundary turns the throw into an `Err`.
+        return err({ kind: "invalid-json" });
     }
     const result = ReferenceSchema.safeParse(candidate);
-    return result.success ? result.data : null;
+    return result.success ? ok(result.data) : err({ kind: "schema-mismatch" });
 }

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -30,21 +30,28 @@ const artifactPinShape = {
 };
 
 /**
- * The authored belief about the value at a reference. `tolerance` gives the permitted numeric
- * difference. `hash` pins the exact bytes. Resolution matches a fresh read against these fields.
+ * The authored belief about the one value that a reference resolves to. `tolerance` gives the permitted
+ * numeric difference.
+ *
+ * Each kind carries only the assert fields that mean something for it. A shared assert would let an
+ * author write a belief that the resolver has no way to match, and silence there defeats the one
+ * mechanism that catches a wrong number.
  */
-const AssertSchema = z.strictObject({
-    value: z.union([z.string(), z.number()]).describe("The value the author expects at resolution time."),
+const assertValueShape = {
+    value: z.union([z.string(), z.number()]).optional().describe("The value the author expects at resolution time."),
     tolerance: z.number().optional().describe("The permitted absolute difference for a numeric match."),
-    hash: z.string().optional().describe("An optional content hash that the resolved value must match."),
-});
+};
+
+/** The authored belief about the bytes behind a reference. It pins the content hash of the artifact. */
+const assertHashShape = {
+    hash: z.string().optional().describe("An optional content hash that the resolved artifact must match."),
+};
 
 /**
- * The fields that every reference kind can carry. `assert` is the authored belief. `unit` and `format`
- * are hints for how a renderer shows the resolved value.
+ * The display hints that every reference kind can carry. `unit` and `format` tell a renderer how to show
+ * the resolved value.
  */
-const commonShape = {
-    assert: AssertSchema.optional().describe("The authored belief that resolution matches against."),
+const displayShape = {
     unit: z.string().optional().describe("The unit of the resolved value, for example `%` or `kb`."),
     format: z.string().optional().describe("A display format hint for the resolved value."),
 };
@@ -71,39 +78,70 @@ const LocatorSchema = z
         message: "A locator needs exactly one of `rowFilter` or `row`.",
     });
 
-/** A reference to one scalar value inside an artifact, addressed by a locator. */
+/**
+ * A reference to one scalar value inside an artifact, addressed by a locator. It resolves to a scalar
+ * and it is artifact-backed, thus its assert carries both the value fields and the hash field.
+ */
 export const ArtifactValueReferenceSchema = z.strictObject({
     kind: z.literal("artifact-value"),
     ...artifactPinShape,
     locator: LocatorSchema.describe("The address of the one value that this reference binds."),
-    ...commonShape,
+    assert: z
+        .strictObject({ ...assertValueShape, ...assertHashShape })
+        .optional()
+        .describe("The authored belief that resolution matches against."),
+    ...displayShape,
 });
 
-/** A reference to a whole table artifact. It carries no locator, because it binds every row. */
+/**
+ * A reference to a whole table artifact. It carries no locator, because it binds every row. A table is
+ * not one value, thus its assert pins the content hash only.
+ */
 export const ArtifactTableReferenceSchema = z.strictObject({
     kind: z.literal("artifact-table"),
     ...artifactPinShape,
     columns: z.array(z.string()).optional().describe("An optional column subset to render. Omit to bind every column."),
-    ...commonShape,
+    assert: z
+        .strictObject({ ...assertHashShape })
+        .optional()
+        .describe("The authored belief about the bytes of the table."),
+    ...displayShape,
 });
 
 /**
  * A reference to a whole artifact file, for example an image. It carries no locator and no columns,
- * because a file is pinned whole and has no addressable cell inside it.
+ * because a file is pinned whole and has no addressable cell inside it. Thus its assert pins the content
+ * hash only.
  */
 export const ArtifactFileReferenceSchema = z.strictObject({
     kind: z.literal("artifact-file"),
     ...artifactPinShape,
-    ...commonShape,
+    assert: z
+        .strictObject({ ...assertHashShape })
+        .optional()
+        .describe("The authored belief about the bytes of the file."),
+    ...displayShape,
 });
 
-/** A reference to an external source, addressed by an external identifier. */
+/**
+ * A reference to an external source, addressed by an external identifier. It resolves to the prefixed
+ * key, thus its assert compares against that key and carries no hash.
+ */
 export const CitationReferenceSchema = z.strictObject({
     kind: z.literal("citation"),
     idKind: z.enum(["doi", "pmid", "arxiv"]).describe("The external identifier space."),
     id: z.string().describe("The external identifier value."),
     raw: z.string().describe("The original citation text."),
-    ...commonShape,
+    assert: z
+        .strictObject({
+            value: z
+                .union([z.string(), z.number()])
+                .optional()
+                .describe("The expected citation key in the prefixed `idKind:id` form, for example `pmid:12345`, and not the bare id."),
+        })
+        .optional()
+        .describe("The authored belief about the citation key that resolution gives."),
+    ...displayShape,
 });
 
 /**
@@ -118,14 +156,19 @@ export const NonDerivationReferenceSchema = z.discriminatedUnion("kind", [
 ]);
 
 /**
- * A reference to a value computed from other references. The three operations each take two inputs at
- * most, thus `inputs` holds one or two non-derivation references.
+ * A reference to a value computed from other references. Each of the three operations takes two inputs,
+ * thus `inputs` holds exactly two non-derivation references and no other count is representable. The
+ * result is computed and not artifact-backed, thus its assert carries the value fields only.
  */
 export const DerivationReferenceSchema = z.strictObject({
     kind: z.literal("derivation"),
     op: z.enum(["ratio", "delta", "pctChange"]).describe("The operation over the inputs."),
-    inputs: z.array(NonDerivationReferenceSchema).min(1).max(2).describe("The input references. Each operation needs at most two."),
-    ...commonShape,
+    inputs: z.array(NonDerivationReferenceSchema).length(2).describe("The two input references. Each operation takes exactly two."),
+    assert: z
+        .strictObject({ ...assertValueShape })
+        .optional()
+        .describe("The authored belief that resolution matches against."),
+    ...displayShape,
 });
 
 /** The full reference union. A block binds to one of these. */

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -21,13 +21,17 @@ import { z } from "zod";
 const HASH_PATTERN = /^[a-z0-9]+:[0-9a-f]+$/;
 
 /**
- * The pin that ties an artifact reference to one immutable file. It names the run that made the file,
- * the run-relative path, and the content hash. The optional `snapshot` names a point-in-time copy when
- * a host keeps one.
+ * The pin that ties an artifact reference to one immutable file. It names the analysis-relative path and
+ * the content hash, and it can name the run that made the file. The optional `snapshot` names a
+ * point-in-time copy when a host keeps one.
+ *
+ * `path` is the key of `cortex_artifacts`, whose primary key is `(analysis_id, path)`. Thus the path
+ * spans the whole analysis and it already holds the run segment for a run output, for example
+ * `runs/{runId}/{stepId}/output/de.csv`.
  */
 const artifactPinShape = {
-    run: z.string().min(1).describe("The analysis run id that produced the artifact."),
-    path: z.string().min(1).describe("The run-relative path of the artifact."),
+    run: z.string().min(1).optional().describe("The analysis run id that produced the artifact. It is absent for a staged input file, which no run produced."),
+    path: z.string().min(1).describe("The analysis-relative path of the artifact, the key of `cortex_artifacts.path`."),
     hash: z.string().regex(HASH_PATTERN).describe("The content hash as `algorithm:hex`, for example `sha256:...`."),
     snapshot: z.string().optional().describe("An optional point-in-time snapshot id."),
 };
@@ -36,19 +40,17 @@ const artifactPinShape = {
  * The authored belief about the one value that a reference resolves to. `tolerance` gives the permitted
  * numeric difference.
  *
- * Each kind carries only the assert fields that mean something for it. A shared assert would let an
- * author write a belief that the resolver has no way to match, and silence there defeats the one
- * mechanism that catches a wrong number.
+ * `value` is mandatory, thus an assert that asserts nothing is unrepresentable. A `tolerance` alone has
+ * nothing to compare against, and an empty assert reads as a belief that the resolver silently ignores.
+ *
+ * There is no hash field here. An artifact reference already pins `hash`, and resolution compares that
+ * pin against the fresh read and gives `hash-mismatch`. A second hash in the assert would compare the
+ * reference against itself, thus it adds no evidence.
  */
-const assertValueShape = {
-    value: z.union([z.string(), z.number()]).optional().describe("The value the author expects at resolution time."),
+const AssertValueSchema = z.strictObject({
+    value: z.union([z.string(), z.number()]).describe("The value the author expects at resolution time."),
     tolerance: z.number().optional().describe("The permitted absolute difference for a numeric match."),
-};
-
-/** The authored belief about the bytes behind a reference. It pins the content hash of the artifact. */
-const assertHashShape = {
-    hash: z.string().optional().describe("An optional content hash that the resolved artifact must match."),
-};
+});
 
 /**
  * The display hints that every reference kind can carry. `unit` and `format` tell a renderer how to show
@@ -82,47 +84,38 @@ const LocatorSchema = z
     });
 
 /**
- * A reference to one scalar value inside an artifact, addressed by a locator. It resolves to a scalar
- * and it is artifact-backed, thus its assert carries both the value fields and the hash field.
+ * A reference to one scalar value inside an artifact, addressed by a locator. It resolves to a scalar,
+ * thus it carries the value assert.
  */
 export const ArtifactValueReferenceSchema = z.strictObject({
     kind: z.literal("artifact-value"),
     ...artifactPinShape,
     locator: LocatorSchema.describe("The address of the one value that this reference binds."),
-    assert: z
-        .strictObject({ ...assertValueShape, ...assertHashShape })
-        .optional()
-        .describe("The authored belief that resolution matches against."),
+    assert: AssertValueSchema.optional().describe("The authored belief that resolution matches against."),
     ...displayShape,
 });
 
 /**
- * A reference to a whole table artifact. It carries no locator, because it binds every row. A table is
- * not one value, thus its assert pins the content hash only.
+ * A reference to a whole table artifact. It carries no locator, because it binds every row.
+ *
+ * It carries no assert. A table is not one value, thus the only belief that an author can hold about it
+ * is its bytes, and the pinned `hash` already carries that belief.
  */
 export const ArtifactTableReferenceSchema = z.strictObject({
     kind: z.literal("artifact-table"),
     ...artifactPinShape,
     columns: z.array(z.string()).optional().describe("An optional column subset to render. Omit to bind every column."),
-    assert: z
-        .strictObject({ ...assertHashShape })
-        .optional()
-        .describe("The authored belief about the bytes of the table."),
     ...displayShape,
 });
 
 /**
  * A reference to a whole artifact file, for example an image. It carries no locator and no columns,
- * because a file is pinned whole and has no addressable cell inside it. Thus its assert pins the content
- * hash only.
+ * because a file is pinned whole and has no addressable cell inside it. It carries no assert, for the
+ * same reason as a table reference.
  */
 export const ArtifactFileReferenceSchema = z.strictObject({
     kind: z.literal("artifact-file"),
     ...artifactPinShape,
-    assert: z
-        .strictObject({ ...assertHashShape })
-        .optional()
-        .describe("The authored belief about the bytes of the file."),
     ...displayShape,
 });
 
@@ -139,7 +132,6 @@ export const CitationReferenceSchema = z.strictObject({
         .strictObject({
             value: z
                 .union([z.string(), z.number()])
-                .optional()
                 .describe("The expected citation key in the prefixed `idKind:id` form, for example `pmid:12345`, and not the bare id."),
         })
         .optional()
@@ -165,12 +157,13 @@ export const NonDerivationReferenceSchema = z.discriminatedUnion("kind", [
  */
 export const DerivationReferenceSchema = z.strictObject({
     kind: z.literal("derivation"),
-    op: z.enum(["ratio", "delta", "pctChange"]).describe("The operation over the inputs."),
+    op: z
+        .enum(["ratio", "delta", "pctChange"])
+        .describe(
+            "The operation over the two inputs `a` and `b`: `ratio` gives `a / b`, `delta` gives `a - b`, and `pctChange` gives `(a - b) / b` as a fraction and not as a percent. A change of one half resolves to 0.5, thus an `assert.value` states the fraction and a `unit` of `%` is a display hint only.",
+        ),
     inputs: z.array(NonDerivationReferenceSchema).length(2).describe("The two input references. Each operation takes exactly two."),
-    assert: z
-        .strictObject({ ...assertValueShape })
-        .optional()
-        .describe("The authored belief that resolution matches against."),
+    assert: AssertValueSchema.optional().describe("The authored belief that resolution matches against."),
     ...displayShape,
 });
 
@@ -214,6 +207,14 @@ export type UnresolvedReference = z.infer<typeof UnresolvedReferenceSchema>;
 const REFERENCE_URI_PREFIX = "inflexa-ref:v1:";
 
 /**
+ * The alphabet of a non-empty base64url payload. The check is explicit because `Buffer.from(text,
+ * "base64url")` never throws: it drops each character outside the alphabet and decodes what is left.
+ * Thus a corrupt payload would otherwise decode to mojibake and report as malformed JSON, which names
+ * the wrong failure.
+ */
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
  * Sort the keys of every object so that serialization is deterministic. An array keeps its order,
  * because the order of a derivation's inputs carries meaning.
  */
@@ -247,9 +248,9 @@ export function serializeReference(reference: Reference): string {
 
 /**
  * The reason that a reference URI did not parse. Each of the four modes is distinct: a wrong prefix, a
- * base64url payload that does not decode, JSON that does not parse, and a value that the schema rejects.
- * A caller reads the `kind` to tell them apart. `detail` carries no secret, thus a schema mismatch
- * gives the kind alone.
+ * payload that is empty or holds a character outside the base64url alphabet, JSON that does not parse,
+ * and a value that the schema rejects. A caller reads the `kind` to tell them apart. `detail` carries no
+ * secret, thus a schema mismatch gives the kind alone.
  */
 export type ParseReferenceError = {
     kind: "bad-prefix" | "invalid-payload" | "invalid-json" | "schema-mismatch";
@@ -266,13 +267,10 @@ export function parseReference(uri: string): Result<Reference, ParseReferenceErr
         return err({ kind: "bad-prefix" });
     }
     const payload = uri.slice(REFERENCE_URI_PREFIX.length);
-    let json: string;
-    try {
-        json = Buffer.from(payload, "base64url").toString("utf8");
-    } catch {
-        // A base64url decode of external bytes is the boundary. A throw here becomes an `Err`.
+    if (!BASE64URL_PATTERN.test(payload)) {
         return err({ kind: "invalid-payload" });
     }
+    const json = Buffer.from(payload, "base64url").toString("utf8");
     let candidate: unknown;
     try {
         candidate = JSON.parse(json);

--- a/harness/src/lib/async-utils.ts
+++ b/harness/src/lib/async-utils.ts
@@ -1,6 +1,8 @@
 /**
- * Shared async utilities — sleep and bounded-concurrency map.
+ * Shared async utilities — sleep and a bounded-concurrency `Promise.all`.
  */
+
+import PQueue from "p-queue";
 
 /** Promise-based delay. */
 export function sleep(ms: number): Promise<void> {
@@ -8,21 +10,28 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Map over items with bounded concurrency.
- * At most `concurrency` items are processed simultaneously.
+ * Run each task with a cap on how many run at the same time, and give back the results in the order of
+ * the input.
+ *
+ * The signature mirrors `Promise.all`. The mapped return type is element-wise, thus a tuple of thunks
+ * with different return types keeps each one, and a plain array of thunks gives a plain array. The input
+ * is an array of thunks and not an array of promises, because a promise is already running when it is
+ * made, and a cap over a set of started promises caps nothing.
+ *
+ * `concurrency` must be a number at or above 1. p-queue throws a `TypeError` for any other value.
+ *
+ * The failure behavior is that of `Promise.all`. The first rejection rejects the whole call, and each
+ * task that the queue already started still runs to completion.
  */
-export async function mapConcurrent<T, R>(items: T[], concurrency: number, fn: (item: T, index: number) => Promise<R>): Promise<R[]> {
-    const results: R[] = new Array(items.length);
-    let nextIndex = 0;
-
-    async function worker(): Promise<void> {
-        while (nextIndex < items.length) {
-            const i = nextIndex++;
-            results[i] = await fn(items[i]!, i);
-        }
-    }
-
-    const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
-    await Promise.all(workers);
-    return results;
+export function allWithConcurrency<T extends readonly (() => unknown)[] | []>(
+    tasks: T,
+    concurrency: number,
+): Promise<{ -readonly [P in keyof T]: Awaited<T[P] extends () => infer R ? R : never> }> {
+    const queue = new PQueue({ concurrency });
+    // `addAll` collapses every task onto one result type, thus it cannot express the element-wise type
+    // above. The cast is sound because `addAll` maps the input array through `Promise.all`, which keeps
+    // the position of each task, and each element is the awaited return of the task at that position.
+    return queue.addAll(tasks as ReadonlyArray<() => unknown>) as Promise<{
+        -readonly [P in keyof T]: Awaited<T[P] extends () => infer R ? R : never>;
+    }>;
 }

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -4,6 +4,8 @@
  * assertion rules without a host.
  */
 
+import { err, ok, type Result } from "neverthrow";
+
 import type {
     ArtifactFileReference,
     ArtifactTableReference,
@@ -15,7 +17,7 @@ import type {
     UnresolvedReason,
     UnresolvedReference,
 } from "../contracts/report-reference.js";
-import type { ReferenceResolver, ReportSnapshot, ResolveOutcome, ResolvedValue } from "./reference-resolver.js";
+import type { ReferenceResolver, ReportSnapshot, ResolvedValue } from "./reference-resolver.js";
 
 /**
  * The relative epsilon of a value match with no authored tolerance.
@@ -26,10 +28,10 @@ import type { ReferenceResolver, ReportSnapshot, ResolveOutcome, ResolvedValue }
  */
 const RELATIVE_EPSILON = 1e-9;
 
-/** Build a failure outcome. The `detail` key is present only when there is a detail to carry. */
-function fail(reference: Reference, reason: UnresolvedReason, detail?: string): ResolveOutcome {
+/** Build an `Err` that carries the unresolved reference. The `detail` key is present only when there is a detail to carry. */
+function fail(reference: Reference, reason: UnresolvedReason, detail?: string): Result<ResolvedValue, UnresolvedReference> {
     const failure: UnresolvedReference = detail !== undefined ? { reference, reason, detail } : { reference, reason };
-    return { ok: false, failure };
+    return err(failure);
 }
 
 /** A short account of a derivation input, for a detail that names which input broke the arithmetic. */
@@ -92,7 +94,7 @@ function checkCitationAssertion(reference: Reference, expected: string | number 
     return { reference, reason: "assertion-failed", detail: `expected ${String(expected)} but resolved citation ${resolved}` };
 }
 
-function resolveArtifactValue(reference: ArtifactValueReference, snapshot: ReportSnapshot): ResolveOutcome {
+function resolveArtifactValue(reference: ArtifactValueReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
     const artifact = snapshot.artifacts[reference.path];
     if (artifact === undefined) {
         return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
@@ -138,16 +140,16 @@ function resolveArtifactValue(reference: ArtifactValueReference, snapshot: Repor
 
     const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
     if (hashFailure !== undefined) {
-        return { ok: false, failure: hashFailure };
+        return err(hashFailure);
     }
     const valueFailure = checkValueAssertion(reference, reference.assert?.value, reference.assert?.tolerance, cell);
     if (valueFailure !== undefined) {
-        return { ok: false, failure: valueFailure };
+        return err(valueFailure);
     }
-    return { ok: true, value: { type: "scalar", value: cell } };
+    return ok({ type: "scalar", value: cell });
 }
 
-function resolveArtifactTable(reference: ArtifactTableReference, snapshot: ReportSnapshot): ResolveOutcome {
+function resolveArtifactTable(reference: ArtifactTableReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
     const artifact = snapshot.artifacts[reference.path];
     if (artifact === undefined) {
         return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
@@ -177,10 +179,10 @@ function resolveArtifactTable(reference: ArtifactTableReference, snapshot: Repor
     }
 
     const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
-    return hashFailure !== undefined ? { ok: false, failure: hashFailure } : { ok: true, value };
+    return hashFailure !== undefined ? err(hashFailure) : ok(value);
 }
 
-function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportSnapshot): ResolveOutcome {
+function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
     const artifact = snapshot.artifacts[reference.path];
     if (artifact === undefined) {
         return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
@@ -191,19 +193,19 @@ function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportS
 
     const value: ResolvedValue = { type: "file", path: reference.path, hash: artifact.hash };
     const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
-    return hashFailure !== undefined ? { ok: false, failure: hashFailure } : { ok: true, value };
+    return hashFailure !== undefined ? err(hashFailure) : ok(value);
 }
 
-async function resolveDerivation(reference: DerivationReference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {
+async function resolveDerivation(reference: DerivationReference, snapshot: ReportSnapshot): Promise<Result<ResolvedValue, UnresolvedReference>> {
     const numbers: number[] = [];
     for (const input of reference.inputs) {
-        const outcome = await resolve(input, snapshot);
-        if (!outcome.ok) {
+        const inputResult = await resolve(input, snapshot);
+        if (inputResult.isErr()) {
             // Keep the inner reason so a reviewer sees the real cause, for example a missing artifact under
             // the derivation. The derivation itself did not fail on its own terms.
-            return fail(reference, outcome.failure.reason, outcome.failure.detail);
+            return fail(reference, inputResult.error.reason, inputResult.error.detail);
         }
-        const resolved = outcome.value;
+        const resolved = inputResult.value;
         if (resolved.type !== "scalar" || typeof resolved.value !== "number" || !Number.isFinite(resolved.value)) {
             // The arithmetic needs a finite number. A table, a citation, or a non-numeric cell does not
             // address a usable scalar, thus the closest reason is that the coordinate is out of range.
@@ -231,20 +233,20 @@ async function resolveDerivation(reference: DerivationReference, snapshot: Repor
     }
 
     const valueFailure = checkValueAssertion(reference, reference.assert?.value, reference.assert?.tolerance, result);
-    return valueFailure !== undefined ? { ok: false, failure: valueFailure } : { ok: true, value: { type: "scalar", value: result } };
+    return valueFailure !== undefined ? err(valueFailure) : ok({ type: "scalar", value: result });
 }
 
-function resolveCitation(reference: CitationReference, snapshot: ReportSnapshot): ResolveOutcome {
+function resolveCitation(reference: CitationReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
     const key = `${reference.idKind}:${reference.id}`;
     if (snapshot.citations === undefined || !snapshot.citations.includes(key)) {
         return fail(reference, "artifact-missing", `the citation ${key} is not in the pinned evidence`);
     }
     const value: ResolvedValue = { type: "citation", id: key };
     const citationFailure = checkCitationAssertion(reference, reference.assert?.value, key);
-    return citationFailure !== undefined ? { ok: false, failure: citationFailure } : { ok: true, value };
+    return citationFailure !== undefined ? err(citationFailure) : ok(value);
 }
 
-async function resolve(reference: Reference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {
+async function resolve(reference: Reference, snapshot: ReportSnapshot): Promise<Result<ResolvedValue, UnresolvedReference>> {
     switch (reference.kind) {
         case "artifact-value":
             return resolveArtifactValue(reference, snapshot);

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -17,8 +17,14 @@ import type {
 } from "../contracts/report-reference.js";
 import type { ReferenceResolver, ReportSnapshot, ResolveOutcome, ResolvedValue } from "./reference-resolver.js";
 
-/** The authored belief that resolution matches against. Every reference kind can carry one. */
-type Assertion = NonNullable<Reference["assert"]>;
+/**
+ * The relative epsilon of a value match with no authored tolerance.
+ *
+ * An author writes a rounded figure, but the resolver computes the value again in floating point. Thus
+ * exact equality would report ordinary float noise as a fabrication. This epsilon absorbs the noise, and
+ * it is still far too small to hide a real mismatch such as 1.5 against 1.05.
+ */
+const RELATIVE_EPSILON = 1e-9;
 
 /** Build a failure outcome. The `detail` key is present only when there is a detail to carry. */
 function fail(reference: Reference, reason: UnresolvedReason, detail?: string): ResolveOutcome {
@@ -40,42 +46,50 @@ function describeReference(reference: NonDerivationReference): string {
     }
 }
 
-/** A numeric match uses the tolerance as an absolute difference. Any other pair matches on exact equality. */
+/**
+ * Match a resolved value against an authored one.
+ *
+ * An authored tolerance is an absolute difference, and it is the author's own statement of how close is
+ * close enough. With no tolerance the comparison is relative, because an exact match would fail on the
+ * float noise of a computed value. Any pair that is not two numbers matches on exact equality.
+ */
 function valuesMatch(expected: string | number, actual: string | number, tolerance: number | undefined): boolean {
     if (typeof expected === "number" && typeof actual === "number") {
-        return Math.abs(expected - actual) <= (tolerance ?? 0);
+        if (tolerance !== undefined) {
+            return Math.abs(expected - actual) <= tolerance;
+        }
+        return Math.abs(expected - actual) <= RELATIVE_EPSILON * Math.max(1, Math.abs(expected), Math.abs(actual));
     }
     return expected === actual;
 }
 
-/**
- * Match the resolved value against the authored belief.
- *
- * `artifactHash` is the fresh hash for an artifact kind, and `undefined` for a derivation or a citation.
- * Thus `assert.hash` compares only where an artifact hash exists. `assert.value` has no meaning for a
- * table or a file, because neither has a single value, thus the value check skips the two of them.
- */
-function checkAssertion(
-    reference: Reference,
-    value: ResolvedValue,
-    assert: Assertion | undefined,
-    artifactHash: string | undefined,
-): UnresolvedReference | undefined {
-    if (assert === undefined) {
+/** Match the fresh content hash of an artifact against the authored one. */
+function checkHashAssertion(reference: Reference, expected: string | undefined, artifactHash: string): UnresolvedReference | undefined {
+    if (expected === undefined || expected === artifactHash) {
         return undefined;
     }
-    if (assert.hash !== undefined && artifactHash !== undefined && assert.hash !== artifactHash) {
-        return { reference, reason: "assertion-failed", detail: `expected hash ${assert.hash} but the artifact hash is ${artifactHash}` };
+    return { reference, reason: "assertion-failed", detail: `expected hash ${expected} but the artifact hash is ${artifactHash}` };
+}
+
+/** Match a resolved scalar against the authored value, under the authored tolerance. */
+function checkValueAssertion(
+    reference: Reference,
+    expected: string | number | undefined,
+    tolerance: number | undefined,
+    resolved: string | number,
+): UnresolvedReference | undefined {
+    if (expected === undefined || valuesMatch(expected, resolved, tolerance)) {
+        return undefined;
     }
-    if (assert.value !== undefined) {
-        if (value.type === "scalar" && !valuesMatch(assert.value, value.value, assert.tolerance)) {
-            return { reference, reason: "assertion-failed", detail: `expected ${String(assert.value)} but resolved ${String(value.value)}` };
-        }
-        if (value.type === "citation" && assert.value !== value.id) {
-            return { reference, reason: "assertion-failed", detail: `expected ${String(assert.value)} but resolved citation ${value.id}` };
-        }
+    return { reference, reason: "assertion-failed", detail: `expected ${String(expected)} but resolved ${String(resolved)}` };
+}
+
+/** Match the resolved citation key against the authored value. The key carries its `idKind:` prefix. */
+function checkCitationAssertion(reference: Reference, expected: string | number | undefined, resolved: string): UnresolvedReference | undefined {
+    if (expected === undefined || expected === resolved) {
+        return undefined;
     }
-    return undefined;
+    return { reference, reason: "assertion-failed", detail: `expected ${String(expected)} but resolved citation ${resolved}` };
 }
 
 function resolveArtifactValue(reference: ArtifactValueReference, snapshot: ReportSnapshot): ResolveOutcome {
@@ -113,12 +127,24 @@ function resolveArtifactValue(reference: ArtifactValueReference, snapshot: Repor
         return fail(reference, "locator-out-of-range", "the locator selects no row");
     }
 
-    if (!(locator.column in selectedRow)) {
-        return fail(reference, "locator-out-of-range", `column ${locator.column} is not in the selected row`);
+    // A real table holds an empty cell, and a parser gives it back as an absent key, `undefined`, or
+    // `null`. None of the three is a value that a scalar reference can bind. An empty string is a value,
+    // thus it stays valid. The wider annotation admits the three, because the row type promises a value
+    // for each key that it holds.
+    const cell: string | number | null | undefined = selectedRow[locator.column];
+    if (cell === undefined || cell === null) {
+        return fail(reference, "locator-out-of-range", `column ${locator.column} holds no value in the selected row`);
     }
-    const scalar: ResolvedValue = { type: "scalar", value: selectedRow[locator.column] };
-    const assertionFailure = checkAssertion(reference, scalar, reference.assert, artifact.hash);
-    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value: scalar };
+
+    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
+    if (hashFailure !== undefined) {
+        return { ok: false, failure: hashFailure };
+    }
+    const valueFailure = checkValueAssertion(reference, reference.assert?.value, reference.assert?.tolerance, cell);
+    if (valueFailure !== undefined) {
+        return { ok: false, failure: valueFailure };
+    }
+    return { ok: true, value: { type: "scalar", value: cell } };
 }
 
 function resolveArtifactTable(reference: ArtifactTableReference, snapshot: ReportSnapshot): ResolveOutcome {
@@ -150,8 +176,8 @@ function resolveArtifactTable(reference: ArtifactTableReference, snapshot: Repor
         value = { type: "table", rows };
     }
 
-    const assertionFailure = checkAssertion(reference, value, reference.assert, artifact.hash);
-    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
+    return hashFailure !== undefined ? { ok: false, failure: hashFailure } : { ok: true, value };
 }
 
 function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportSnapshot): ResolveOutcome {
@@ -164,8 +190,8 @@ function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportS
     }
 
     const value: ResolvedValue = { type: "file", path: reference.path, hash: artifact.hash };
-    const assertionFailure = checkAssertion(reference, value, reference.assert, artifact.hash);
-    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
+    return hashFailure !== undefined ? { ok: false, failure: hashFailure } : { ok: true, value };
 }
 
 async function resolveDerivation(reference: DerivationReference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {
@@ -186,10 +212,6 @@ async function resolveDerivation(reference: DerivationReference, snapshot: Repor
         numbers.push(resolved.value);
     }
 
-    if (numbers.length !== 2) {
-        return fail(reference, "locator-out-of-range", `operation ${reference.op} needs 2 inputs but got ${numbers.length}`);
-    }
-
     const a = numbers[0];
     const b = numbers[1];
     let result: number;
@@ -208,9 +230,8 @@ async function resolveDerivation(reference: DerivationReference, snapshot: Repor
         return fail(reference, "locator-out-of-range", `operation ${reference.op} does not yield a finite value, because the divisor is zero`);
     }
 
-    const scalar: ResolvedValue = { type: "scalar", value: result };
-    const assertionFailure = checkAssertion(reference, scalar, reference.assert, undefined);
-    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value: scalar };
+    const valueFailure = checkValueAssertion(reference, reference.assert?.value, reference.assert?.tolerance, result);
+    return valueFailure !== undefined ? { ok: false, failure: valueFailure } : { ok: true, value: { type: "scalar", value: result } };
 }
 
 function resolveCitation(reference: CitationReference, snapshot: ReportSnapshot): ResolveOutcome {
@@ -219,8 +240,8 @@ function resolveCitation(reference: CitationReference, snapshot: ReportSnapshot)
         return fail(reference, "artifact-missing", `the citation ${key} is not in the pinned evidence`);
     }
     const value: ResolvedValue = { type: "citation", id: key };
-    const assertionFailure = checkAssertion(reference, value, reference.assert, undefined);
-    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+    const citationFailure = checkCitationAssertion(reference, reference.assert?.value, key);
+    return citationFailure !== undefined ? { ok: false, failure: citationFailure } : { ok: true, value };
 }
 
 async function resolve(reference: Reference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -17,7 +17,7 @@ import type {
     UnresolvedReason,
     UnresolvedReference,
 } from "../contracts/report-reference.js";
-import type { ReferenceResolver, ReportSnapshot, ResolvedValue } from "./reference-resolver.js";
+import { columnsHeldByNoRow, type ReferenceResolver, type ReportSnapshot, type ResolvedValue } from "./reference-resolver.js";
 
 /**
  * The relative epsilon of a value match with no authored tolerance.
@@ -63,14 +63,6 @@ function valuesMatch(expected: string | number, actual: string | number, toleran
         return Math.abs(expected - actual) <= RELATIVE_EPSILON * Math.max(1, Math.abs(expected), Math.abs(actual));
     }
     return expected === actual;
-}
-
-/** Match the fresh content hash of an artifact against the authored one. */
-function checkHashAssertion(reference: Reference, expected: string | undefined, artifactHash: string): UnresolvedReference | undefined {
-    if (expected === undefined || expected === artifactHash) {
-        return undefined;
-    }
-    return { reference, reason: "assertion-failed", detail: `expected hash ${expected} but the artifact hash is ${artifactHash}` };
 }
 
 /** Match a resolved scalar against the authored value, under the authored tolerance. */
@@ -138,15 +130,8 @@ function resolveArtifactValue(reference: ArtifactValueReference, snapshot: Repor
         return fail(reference, "locator-out-of-range", `column ${locator.column} holds no value in the selected row`);
     }
 
-    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
-    if (hashFailure !== undefined) {
-        return err(hashFailure);
-    }
     const valueFailure = checkValueAssertion(reference, reference.assert?.value, reference.assert?.tolerance, cell);
-    if (valueFailure !== undefined) {
-        return err(valueFailure);
-    }
-    return ok({ type: "scalar", value: cell });
+    return valueFailure !== undefined ? err(valueFailure) : ok({ type: "scalar", value: cell });
 }
 
 function resolveArtifactTable(reference: ArtifactTableReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
@@ -160,26 +145,30 @@ function resolveArtifactTable(reference: ArtifactTableReference, snapshot: Repor
 
     const rows = artifact.rows ?? [];
     const columns = reference.columns;
-    let value: ResolvedValue;
-    if (columns !== undefined) {
-        // Project each row onto the requested columns. A table tolerates a ragged row, thus a column that
-        // a given row lacks is left out of that row and is not a failure.
-        const projectedRows = rows.map((row) => {
-            const projected: Record<string, string | number> = {};
-            for (const column of columns) {
-                if (column in row) {
-                    projected[column] = row[column];
-                }
-            }
-            return projected;
-        });
-        value = { type: "table", rows: projectedRows, columns };
-    } else {
-        value = { type: "table", rows };
+    if (columns === undefined) {
+        return ok({ type: "table", rows });
     }
 
-    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
-    return hashFailure !== undefined ? err(hashFailure) : ok(value);
+    // A name that no row holds addresses nothing. Without this check a projection onto an invented column
+    // gives an empty cell for each row and still resolves, which is the fabrication that grounding exists
+    // to reject.
+    const absent = columnsHeldByNoRow(rows, columns);
+    if (absent.length > 0) {
+        return fail(reference, "locator-out-of-range", `the table at ${reference.path} holds no column ${absent.join(", ")}`);
+    }
+
+    // Project each row onto the requested columns. A table tolerates a ragged row, thus a column that a
+    // given row lacks is left out of that row and is not a failure.
+    const projectedRows = rows.map((row) => {
+        const projected: Record<string, string | number> = {};
+        for (const column of columns) {
+            if (column in row) {
+                projected[column] = row[column];
+            }
+        }
+        return projected;
+    });
+    return ok({ type: "table", rows: projectedRows, columns });
 }
 
 function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportSnapshot): Result<ResolvedValue, UnresolvedReference> {
@@ -191,9 +180,7 @@ function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportS
         return fail(reference, "hash-mismatch", `expected ${reference.hash} but the artifact hash is ${artifact.hash}`);
     }
 
-    const value: ResolvedValue = { type: "file", path: reference.path, hash: artifact.hash };
-    const hashFailure = checkHashAssertion(reference, reference.assert?.hash, artifact.hash);
-    return hashFailure !== undefined ? err(hashFailure) : ok(value);
+    return ok({ type: "file", path: reference.path, hash: artifact.hash });
 }
 
 async function resolveDerivation(reference: DerivationReference, snapshot: ReportSnapshot): Promise<Result<ResolvedValue, UnresolvedReference>> {
@@ -225,6 +212,8 @@ async function resolveDerivation(reference: DerivationReference, snapshot: Repor
             result = a - b;
             break;
         case "pctChange":
+            // A fraction, not a percent. A change of one half gives 0.5, thus an author asserts 0.5 and a
+            // `unit` of `%` only tells a renderer how to show it.
             result = (a - b) / b;
             break;
     }

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -11,8 +11,8 @@ import type {
     ArtifactTableReference,
     ArtifactValueReference,
     CitationReference,
+    DerivationInputReference,
     DerivationReference,
-    NonDerivationReference,
     Reference,
     UnresolvedReason,
     UnresolvedReference,
@@ -22,9 +22,12 @@ import { columnsHeldByNoRow, type ReferenceResolver, type ReportSnapshot, type R
 /**
  * The relative epsilon of a value match with no authored tolerance.
  *
- * An author writes a rounded figure, but the resolver computes the value again in floating point. Thus
- * exact equality would report ordinary float noise as a fabrication. This epsilon absorbs the noise, and
- * it is still far too small to hide a real mismatch such as 1.5 against 1.05.
+ * Float arithmetic shifts a computed value in its last bits. For example, `0.3 - 0.1` gives
+ * 0.19999999999999998, and exact equality would report that noise as a fabrication.
+ *
+ * The epsilon absorbs the noise and nothing else. It is far below the difference that a rounded figure
+ * makes, thus an author who writes 0.05 against a true 0.0499 still fails. An author who wants a rounded
+ * figure to pass states a `tolerance`, which is the one place where the intent belongs.
  */
 const RELATIVE_EPSILON = 1e-9;
 
@@ -35,32 +38,54 @@ function fail(reference: Reference, reason: UnresolvedReason, detail?: string): 
 }
 
 /** A short account of a derivation input, for a detail that names which input broke the arithmetic. */
-function describeReference(reference: NonDerivationReference): string {
-    switch (reference.kind) {
-        case "artifact-value":
-            return `artifact value at ${reference.path} column ${reference.locator.column}`;
-        case "artifact-table":
-            return `artifact table at ${reference.path}`;
-        case "artifact-file":
-            return `artifact file at ${reference.path}`;
-        case "citation":
-            return `citation ${reference.idKind}:${reference.id}`;
+function describeReference(reference: DerivationInputReference): string {
+    return `artifact value at ${reference.path} column ${reference.locator.column}`;
+}
+
+/**
+ * Read an authored value or a resolved cell as a finite number.
+ *
+ * A text-backed artifact such as a CSV holds every cell as a string, thus a numeric column arrives as
+ * `"0.01"` and not as `0.01`. A comparison that respects the JavaScript type would fail an author who
+ * states the number, and the arithmetic of a derivation could never run over a real CSV.
+ *
+ * The parse reads the whole string, thus `"12 genes"` stays text and never reads as 12. `Number` accepts
+ * the exponent form that a p-value uses, for example `"1.2e-45"`. A blank string is not a number, because
+ * `Number("")` gives 0 and an empty cell must never read as zero.
+ */
+function asFiniteNumber(value: string | number): number | undefined {
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? value : undefined;
     }
+    if (value.trim() === "") {
+        return undefined;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Name a value with its type, so that a failed match never reads as two identical values. */
+function describeValue(value: string | number): string {
+    return typeof value === "string" ? `the string ${JSON.stringify(value)}` : `the number ${value}`;
 }
 
 /**
  * Match a resolved value against an authored one.
  *
- * An authored tolerance is an absolute difference, and it is the author's own statement of how close is
- * close enough. With no tolerance the comparison is relative, because an exact match would fail on the
- * float noise of a computed value. Any pair that is not two numbers matches on exact equality.
+ * The comparison is numeric whenever both sides read as a finite number, thus the CSV cell `"0.01"`
+ * matches the number 0.01 that an author states. An authored tolerance is an absolute difference, and it
+ * is the author's own statement of how close is close enough. With no tolerance the comparison is
+ * relative, because an exact match would fail on the float noise of a computed value. Any other pair
+ * matches on exact equality.
  */
 function valuesMatch(expected: string | number, actual: string | number, tolerance: number | undefined): boolean {
-    if (typeof expected === "number" && typeof actual === "number") {
+    const expectedNumber = asFiniteNumber(expected);
+    const actualNumber = asFiniteNumber(actual);
+    if (expectedNumber !== undefined && actualNumber !== undefined) {
         if (tolerance !== undefined) {
-            return Math.abs(expected - actual) <= tolerance;
+            return Math.abs(expectedNumber - actualNumber) <= tolerance;
         }
-        return Math.abs(expected - actual) <= RELATIVE_EPSILON * Math.max(1, Math.abs(expected), Math.abs(actual));
+        return Math.abs(expectedNumber - actualNumber) <= RELATIVE_EPSILON * Math.max(1, Math.abs(expectedNumber), Math.abs(actualNumber));
     }
     return expected === actual;
 }
@@ -75,11 +100,11 @@ function checkValueAssertion(
     if (expected === undefined || valuesMatch(expected, resolved, tolerance)) {
         return undefined;
     }
-    return { reference, reason: "assertion-failed", detail: `expected ${String(expected)} but resolved ${String(resolved)}` };
+    return { reference, reason: "assertion-failed", detail: `expected ${describeValue(expected)} but resolved ${describeValue(resolved)}` };
 }
 
 /** Match the resolved citation key against the authored value. The key carries its `idKind:` prefix. */
-function checkCitationAssertion(reference: Reference, expected: string | number | undefined, resolved: string): UnresolvedReference | undefined {
+function checkCitationAssertion(reference: Reference, expected: string | undefined, resolved: string): UnresolvedReference | undefined {
     if (expected === undefined || expected === resolved) {
         return undefined;
     }
@@ -193,12 +218,13 @@ async function resolveDerivation(reference: DerivationReference, snapshot: Repor
             return fail(reference, inputResult.error.reason, inputResult.error.detail);
         }
         const resolved = inputResult.value;
-        if (resolved.type !== "scalar" || typeof resolved.value !== "number" || !Number.isFinite(resolved.value)) {
-            // The arithmetic needs a finite number. A table, a citation, or a non-numeric cell does not
-            // address a usable scalar, thus the closest reason is that the coordinate is out of range.
+        const numeric = resolved.type === "scalar" ? asFiniteNumber(resolved.value) : undefined;
+        if (numeric === undefined) {
+            // The arithmetic needs a finite number. A cell that holds text does not address a usable
+            // scalar, thus the closest reason is that the coordinate is out of range.
             return fail(reference, "locator-out-of-range", `input ${describeReference(input)} did not resolve to a finite number`);
         }
-        numbers.push(resolved.value);
+        numbers.push(numeric);
     }
 
     const a = numbers[0];

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -1,0 +1,244 @@
+/**
+ * A local, in-memory realization of the reference resolver. It reads only the snapshot that it is given,
+ * thus it needs no storage and no network. A test and a benchmark use it to exercise the resolution and
+ * assertion rules without a host.
+ */
+
+import type {
+    ArtifactFileReference,
+    ArtifactTableReference,
+    ArtifactValueReference,
+    CitationReference,
+    DerivationReference,
+    NonDerivationReference,
+    Reference,
+    UnresolvedReason,
+    UnresolvedReference,
+} from "../contracts/report-reference.js";
+import type { ReferenceResolver, ReportSnapshot, ResolveOutcome, ResolvedValue } from "./reference-resolver.js";
+
+/** The authored belief that resolution matches against. Every reference kind can carry one. */
+type Assertion = NonNullable<Reference["assert"]>;
+
+/** Build a failure outcome. The `detail` key is present only when there is a detail to carry. */
+function fail(reference: Reference, reason: UnresolvedReason, detail?: string): ResolveOutcome {
+    const failure: UnresolvedReference = detail !== undefined ? { reference, reason, detail } : { reference, reason };
+    return { ok: false, failure };
+}
+
+/** A short account of a derivation input, for a detail that names which input broke the arithmetic. */
+function describeReference(reference: NonDerivationReference): string {
+    switch (reference.kind) {
+        case "artifact-value":
+            return `artifact value at ${reference.path} column ${reference.locator.column}`;
+        case "artifact-table":
+            return `artifact table at ${reference.path}`;
+        case "artifact-file":
+            return `artifact file at ${reference.path}`;
+        case "citation":
+            return `citation ${reference.idKind}:${reference.id}`;
+    }
+}
+
+/** A numeric match uses the tolerance as an absolute difference. Any other pair matches on exact equality. */
+function valuesMatch(expected: string | number, actual: string | number, tolerance: number | undefined): boolean {
+    if (typeof expected === "number" && typeof actual === "number") {
+        return Math.abs(expected - actual) <= (tolerance ?? 0);
+    }
+    return expected === actual;
+}
+
+/**
+ * Match the resolved value against the authored belief.
+ *
+ * `artifactHash` is the fresh hash for an artifact kind, and `undefined` for a derivation or a citation.
+ * Thus `assert.hash` compares only where an artifact hash exists. `assert.value` has no meaning for a
+ * table or a file, because neither has a single value, thus the value check skips the two of them.
+ */
+function checkAssertion(
+    reference: Reference,
+    value: ResolvedValue,
+    assert: Assertion | undefined,
+    artifactHash: string | undefined,
+): UnresolvedReference | undefined {
+    if (assert === undefined) {
+        return undefined;
+    }
+    if (assert.hash !== undefined && artifactHash !== undefined && assert.hash !== artifactHash) {
+        return { reference, reason: "assertion-failed", detail: `expected hash ${assert.hash} but the artifact hash is ${artifactHash}` };
+    }
+    if (assert.value !== undefined) {
+        if (value.type === "scalar" && !valuesMatch(assert.value, value.value, assert.tolerance)) {
+            return { reference, reason: "assertion-failed", detail: `expected ${String(assert.value)} but resolved ${String(value.value)}` };
+        }
+        if (value.type === "citation" && assert.value !== value.id) {
+            return { reference, reason: "assertion-failed", detail: `expected ${String(assert.value)} but resolved citation ${value.id}` };
+        }
+    }
+    return undefined;
+}
+
+function resolveArtifactValue(reference: ArtifactValueReference, snapshot: ReportSnapshot): ResolveOutcome {
+    const artifact = snapshot.artifacts[reference.path];
+    if (artifact === undefined) {
+        return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
+    }
+    if (artifact.hash !== reference.hash) {
+        return fail(reference, "hash-mismatch", `expected ${reference.hash} but the artifact hash is ${artifact.hash}`);
+    }
+
+    // An artifact with no rows is pinned whole, thus it addresses no cell and every locator over it lands
+    // out of range.
+    const rows = artifact.rows ?? [];
+    const locator = reference.locator;
+    let selectedRow: Record<string, string | number>;
+    if (locator.row !== undefined) {
+        if (locator.row < 0 || locator.row >= rows.length) {
+            return fail(reference, "locator-out-of-range", `row ${locator.row} is outside the ${rows.length} rows`);
+        }
+        selectedRow = rows[locator.row];
+    } else if (locator.rowFilter !== undefined) {
+        const filter = locator.rowFilter;
+        const matches = rows.filter((row) => row[filter.column] === filter.value);
+        if (matches.length === 0) {
+            return fail(reference, "locator-out-of-range", `no row where ${filter.column} equals ${String(filter.value)}`);
+        }
+        if (matches.length > 1) {
+            return fail(reference, "ambiguous-match", `${matches.length} rows where ${filter.column} equals ${String(filter.value)}`);
+        }
+        selectedRow = matches[0];
+    } else {
+        // The locator schema forbids a locator with neither selector. The resolver cannot depend on a
+        // prior parse, thus it treats a row that no selector addresses as out of range.
+        return fail(reference, "locator-out-of-range", "the locator selects no row");
+    }
+
+    if (!(locator.column in selectedRow)) {
+        return fail(reference, "locator-out-of-range", `column ${locator.column} is not in the selected row`);
+    }
+    const scalar: ResolvedValue = { type: "scalar", value: selectedRow[locator.column] };
+    const assertionFailure = checkAssertion(reference, scalar, reference.assert, artifact.hash);
+    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value: scalar };
+}
+
+function resolveArtifactTable(reference: ArtifactTableReference, snapshot: ReportSnapshot): ResolveOutcome {
+    const artifact = snapshot.artifacts[reference.path];
+    if (artifact === undefined) {
+        return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
+    }
+    if (artifact.hash !== reference.hash) {
+        return fail(reference, "hash-mismatch", `expected ${reference.hash} but the artifact hash is ${artifact.hash}`);
+    }
+
+    const rows = artifact.rows ?? [];
+    const columns = reference.columns;
+    let value: ResolvedValue;
+    if (columns !== undefined) {
+        // Project each row onto the requested columns. A table tolerates a ragged row, thus a column that
+        // a given row lacks is left out of that row and is not a failure.
+        const projectedRows = rows.map((row) => {
+            const projected: Record<string, string | number> = {};
+            for (const column of columns) {
+                if (column in row) {
+                    projected[column] = row[column];
+                }
+            }
+            return projected;
+        });
+        value = { type: "table", rows: projectedRows, columns };
+    } else {
+        value = { type: "table", rows };
+    }
+
+    const assertionFailure = checkAssertion(reference, value, reference.assert, artifact.hash);
+    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+}
+
+function resolveArtifactFile(reference: ArtifactFileReference, snapshot: ReportSnapshot): ResolveOutcome {
+    const artifact = snapshot.artifacts[reference.path];
+    if (artifact === undefined) {
+        return fail(reference, "artifact-missing", `no artifact at ${reference.path}`);
+    }
+    if (artifact.hash !== reference.hash) {
+        return fail(reference, "hash-mismatch", `expected ${reference.hash} but the artifact hash is ${artifact.hash}`);
+    }
+
+    const value: ResolvedValue = { type: "file", path: reference.path, hash: artifact.hash };
+    const assertionFailure = checkAssertion(reference, value, reference.assert, artifact.hash);
+    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+}
+
+async function resolveDerivation(reference: DerivationReference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {
+    const numbers: number[] = [];
+    for (const input of reference.inputs) {
+        const outcome = await resolve(input, snapshot);
+        if (!outcome.ok) {
+            // Keep the inner reason so a reviewer sees the real cause, for example a missing artifact under
+            // the derivation. The derivation itself did not fail on its own terms.
+            return fail(reference, outcome.failure.reason, outcome.failure.detail);
+        }
+        const resolved = outcome.value;
+        if (resolved.type !== "scalar" || typeof resolved.value !== "number" || !Number.isFinite(resolved.value)) {
+            // The arithmetic needs a finite number. A table, a citation, or a non-numeric cell does not
+            // address a usable scalar, thus the closest reason is that the coordinate is out of range.
+            return fail(reference, "locator-out-of-range", `input ${describeReference(input)} did not resolve to a finite number`);
+        }
+        numbers.push(resolved.value);
+    }
+
+    if (numbers.length !== 2) {
+        return fail(reference, "locator-out-of-range", `operation ${reference.op} needs 2 inputs but got ${numbers.length}`);
+    }
+
+    const a = numbers[0];
+    const b = numbers[1];
+    let result: number;
+    switch (reference.op) {
+        case "ratio":
+            result = a / b;
+            break;
+        case "delta":
+            result = a - b;
+            break;
+        case "pctChange":
+            result = (a - b) / b;
+            break;
+    }
+    if (!Number.isFinite(result)) {
+        return fail(reference, "locator-out-of-range", `operation ${reference.op} does not yield a finite value, because the divisor is zero`);
+    }
+
+    const scalar: ResolvedValue = { type: "scalar", value: result };
+    const assertionFailure = checkAssertion(reference, scalar, reference.assert, undefined);
+    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value: scalar };
+}
+
+function resolveCitation(reference: CitationReference, snapshot: ReportSnapshot): ResolveOutcome {
+    const key = `${reference.idKind}:${reference.id}`;
+    if (snapshot.citations === undefined || !snapshot.citations.includes(key)) {
+        return fail(reference, "artifact-missing", `the citation ${key} is not in the pinned evidence`);
+    }
+    const value: ResolvedValue = { type: "citation", id: key };
+    const assertionFailure = checkAssertion(reference, value, reference.assert, undefined);
+    return assertionFailure !== undefined ? { ok: false, failure: assertionFailure } : { ok: true, value };
+}
+
+async function resolve(reference: Reference, snapshot: ReportSnapshot): Promise<ResolveOutcome> {
+    switch (reference.kind) {
+        case "artifact-value":
+            return resolveArtifactValue(reference, snapshot);
+        case "artifact-table":
+            return resolveArtifactTable(reference, snapshot);
+        case "artifact-file":
+            return resolveArtifactFile(reference, snapshot);
+        case "derivation":
+            return resolveDerivation(reference, snapshot);
+        case "citation":
+            return resolveCitation(reference, snapshot);
+    }
+}
+
+/** Make a resolver that reads only the snapshot. It holds no state, thus one instance serves every call. */
+export function createFixtureResolver(): ReferenceResolver {
+    return { resolve };
+}

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -13,6 +13,11 @@ import type { Reference, UnresolvedReference } from "../contracts/report-referen
 /**
  * One pinned artifact: its content hash, and its rows as plain cells.
  *
+ * A cell is a string or a number, because a realization gives back whatever its store holds. A
+ * text-backed artifact such as a CSV gives a numeric column as a string. Thus a realization is free to
+ * skip a type inference pass, and resolution compares a numeral by its numeric value and never by its
+ * JavaScript type.
+ *
  * `rows` is optional because an image is pinned by its hash alone and holds no cells. An empty array in
  * that position would say that the artifact holds zero rows, which is a different and false claim.
  */

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -6,6 +6,8 @@
  * and a fixture realization can read an in-memory snapshot. The two obey the same contract.
  */
 
+import type { Result } from "neverthrow";
+
 import type { Reference, UnresolvedReference } from "../contracts/report-reference.js";
 
 /**
@@ -41,19 +43,16 @@ export type ResolvedValue =
     | { type: "citation"; id: string };
 
 /**
- * The outcome of one resolution. It is plain, discriminated data, and not a `Result` from neverthrow. An
- * unresolved reference is a normal domain outcome that a reviewer reads, and not an error channel that a
- * caller must bridge. Thus resolution never throws.
- */
-export type ResolveOutcome = { ok: true; value: ResolvedValue } | { ok: false; failure: UnresolvedReference };
-
-/**
  * The capability seam that resolves one reference against a snapshot.
  *
  * The method is async because a production realization reads storage. A synchronous signature would
  * force a local realization onto every host, thus the seam stays async even when a realization is
  * in-memory.
+ *
+ * The `Ok` channel carries the resolved value. The `Err` channel carries the `UnresolvedReference`,
+ * which names the reason and the detail that a reference did not bind. The validator collects each such
+ * `Err` into its report, thus a caller reads the reason as data and resolution never throws.
  */
 export interface ReferenceResolver {
-    resolve(reference: Reference, snapshot: ReportSnapshot): Promise<ResolveOutcome>;
+    resolve(reference: Reference, snapshot: ReportSnapshot): Promise<Result<ResolvedValue, UnresolvedReference>>;
 }

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -1,0 +1,59 @@
+/**
+ * The seam that turns a report reference into a concrete value, and the value model that it gives back.
+ *
+ * A reference is authored belief. A resolver reads the pinned evidence and gives the value that the
+ * belief points at. The harness declares the seam here, thus a production realization can read storage,
+ * and a fixture realization can read an in-memory snapshot. The two obey the same contract.
+ */
+
+import type { Reference, UnresolvedReference } from "../contracts/report-reference.js";
+
+/**
+ * One pinned artifact: its content hash, and its rows as plain cells.
+ *
+ * `rows` is optional because an image is pinned by its hash alone and holds no cells. An empty array in
+ * that position would say that the artifact holds zero rows, which is a different and false claim.
+ */
+export interface ArtifactSnapshot {
+    hash: string;
+    rows?: Array<Record<string, string | number>>;
+}
+
+/**
+ * The pinned evidence that a resolver reads. The `artifacts` map is keyed by the run-relative path, the
+ * same path that an artifact reference names. `citations` holds each known external id as an `idKind:id`
+ * string, for example `pmid:12345`.
+ */
+export interface ReportSnapshot {
+    artifacts: Record<string, ArtifactSnapshot>;
+    citations?: string[];
+}
+
+/**
+ * The concrete value that a reference resolves to. A scalar comes from one artifact cell or one
+ * derivation. A table comes from a whole-table artifact. A file echoes the pin of a whole-file artifact,
+ * for example an image. A citation echo confirms that an external id is in the pinned evidence.
+ */
+export type ResolvedValue =
+    | { type: "scalar"; value: string | number }
+    | { type: "table"; rows: Array<Record<string, string | number>>; columns?: string[] }
+    | { type: "file"; path: string; hash: string }
+    | { type: "citation"; id: string };
+
+/**
+ * The outcome of one resolution. It is plain, discriminated data, and not a `Result` from neverthrow. An
+ * unresolved reference is a normal domain outcome that a reviewer reads, and not an error channel that a
+ * caller must bridge. Thus resolution never throws.
+ */
+export type ResolveOutcome = { ok: true; value: ResolvedValue } | { ok: false; failure: UnresolvedReference };
+
+/**
+ * The capability seam that resolves one reference against a snapshot.
+ *
+ * The method is async because a production realization reads storage. A synchronous signature would
+ * force a local realization onto every host, thus the seam stays async even when a realization is
+ * in-memory.
+ */
+export interface ReferenceResolver {
+    resolve(reference: Reference, snapshot: ReportSnapshot): Promise<ResolveOutcome>;
+}

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -22,9 +22,10 @@ export interface ArtifactSnapshot {
 }
 
 /**
- * The pinned evidence that a resolver reads. The `artifacts` map is keyed by the run-relative path, the
- * same path that an artifact reference names. `citations` holds each known external id as an `idKind:id`
- * string, for example `pmid:12345`.
+ * The pinned evidence that a resolver reads. The `artifacts` map is keyed by the analysis-relative path,
+ * the same path that an artifact reference names and the same key as `cortex_artifacts.path`. That path
+ * is unique across the analysis, thus one map holds the artifacts of every run without a collision.
+ * `citations` holds each known external id as an `idKind:id` string, for example `pmid:12345`.
  */
 export interface ReportSnapshot {
     artifacts: Record<string, ArtifactSnapshot>;
@@ -55,4 +56,21 @@ export type ResolvedValue =
  */
 export interface ReferenceResolver {
     resolve(reference: Reference, snapshot: ReportSnapshot): Promise<Result<ResolvedValue, UnresolvedReference>>;
+}
+
+/**
+ * Give back each name in `columns` that no row holds, in the order of `columns`.
+ *
+ * A table tolerates a ragged row, thus a column that only some rows hold is present. A column that no
+ * row holds is a name that addresses nothing, and it is the difference between a sparse table and a
+ * column that does not exist.
+ *
+ * A table with no rows gives back nothing. There is no evidence to contradict any name, and an empty
+ * result table is a real scientific outcome that must not fail for the shape of its emptiness.
+ */
+export function columnsHeldByNoRow(rows: Array<Record<string, string | number>>, columns: readonly string[]): string[] {
+    if (rows.length === 0) {
+        return [];
+    }
+    return columns.filter((column) => !rows.some((row) => column in row));
 }

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -582,6 +582,94 @@ describe("validateReport — derivations", () => {
         const invalid = expectInvalid(result);
         expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
     });
+
+    it("validates a pctChange over two grounded cells", async () => {
+        // TP53 is 6 and EGFR is 3, thus (6 - 3) / 3 is exactly 1.
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-pctchange",
+                label: "PctChange",
+                value: {
+                    kind: "derivation",
+                    op: "pctChange",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_A_PATH,
+                            hash: TABLE_A_HASH,
+                            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_A_PATH,
+                            hash: TABLE_A_HASH,
+                            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "EGFR" } },
+                        },
+                    ],
+                    assert: { value: 1, tolerance: 0.0001 },
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
+    });
+
+    it("reports locator-out-of-range for a pctChange whose divisor is zero", async () => {
+        // S1 is 10 and S2 is 0, thus (10 - 0) / 0 is not finite.
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-pctchange-divzero",
+                label: "PctChangeDivZero",
+                value: {
+                    kind: "derivation",
+                    op: "pctChange",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_B_PATH,
+                            hash: TABLE_B_HASH,
+                            locator: { column: "value", rowFilter: { column: "sample", op: "eq", value: "S1" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_B_PATH,
+                            hash: TABLE_B_HASH,
+                            locator: { column: "value", rowFilter: { column: "sample", op: "eq", value: "S2" } },
+                        },
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+});
+
+describe("validateReport — an artifact-table with a column subset", () => {
+    it("validates a table bound to a column subset of a wider artifact", async () => {
+        // Table A holds four columns, thus a two-column subset is a strict projection that resolves.
+        const result = await validateReport(
+            reportWith({
+                kind: "table",
+                id: "table-subset",
+                title: "Subset",
+                binding: { kind: "artifact-table", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, columns: ["gene", "log2FoldChange"] },
+            }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
 });
 
 describe("validateReport — free-numeral warnings", () => {

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -10,6 +10,8 @@ const TABLE_A_PATH = "runs/run-1/step-a/output/de.csv";
 const TABLE_B_PATH = "runs/run-1/step-b/output/counts.csv";
 const FLOAT_PATH = "runs/run-1/step-c/output/floats.csv";
 const SPARSE_PATH = "runs/run-1/step-c/output/sparse.csv";
+// A text-backed artifact. A CSV holds every cell as a string, thus a numeric column arrives as text.
+const TEXT_PATH = "runs/run-1/step-d/output/text.csv";
 const FIGURE_PATH = "runs/run-1/step-b/figures/volcano.png";
 // A staged input file, which no run produced. Its reference carries no `run`.
 const INPUT_PATH = "data/inputs/file-1/cohort.csv";
@@ -17,6 +19,7 @@ const TABLE_A_HASH = `sha256:${"a".repeat(64)}`;
 const TABLE_B_HASH = `sha256:${"b".repeat(64)}`;
 const FLOAT_HASH = `sha256:${"e".repeat(64)}`;
 const SPARSE_HASH = `sha256:${"f".repeat(64)}`;
+const TEXT_HASH = `sha256:${"9".repeat(64)}`;
 const FIGURE_HASH = `sha256:${"d".repeat(64)}`;
 const INPUT_HASH = `sha256:${"1".repeat(64)}`;
 const WRONG_HASH = `sha256:${"c".repeat(64)}`;
@@ -61,6 +64,15 @@ const snapshot: ReportSnapshot = {
                 { name: "a", value: 0.3 },
                 { name: "b", value: 0.1 },
                 { name: "c", value: 1.05 },
+            ],
+        },
+        [TEXT_PATH]: {
+            hash: TEXT_HASH,
+            // Each cell is a string, as a CSV parser gives it back. `padj` holds the exponent form that a
+            // p-value uses, and `note` holds a cell that is text and never a number.
+            rows: [
+                { gene: "TP53", padj: "1.2e-45", count: "40", note: "n/a" },
+                { gene: "EGFR", padj: "0.02", count: "10", note: "12 genes" },
             ],
         },
         [SPARSE_PATH]: { hash: SPARSE_HASH, rows: sparseRows },
@@ -463,29 +475,43 @@ describe("validateReport — the whole-file pin", () => {
         expect(failures[0].failure.reason).toBe("hash-mismatch");
     });
 
-    it("reports locator-out-of-range for a derivation given an artifact-file input", async () => {
-        const result = await validateReport(
-            reportWith({
-                kind: "metric",
-                id: "metric-file-input",
-                label: "FileInput",
-                value: {
-                    kind: "derivation",
-                    op: "ratio",
-                    inputs: [
-                        { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 0 } },
-                        // A file pins whole bytes, thus it addresses no numeric scalar for the arithmetic.
-                        { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: FIGURE_HASH },
+    it("rejects a derivation given an artifact-file input, because a file addresses no scalar", async () => {
+        const document = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "metric",
+                            id: "metric-file-input",
+                            label: "FileInput",
+                            value: {
+                                kind: "derivation",
+                                op: "ratio",
+                                inputs: [
+                                    {
+                                        kind: "artifact-value",
+                                        run: "run-1",
+                                        path: TABLE_A_PATH,
+                                        hash: TABLE_A_HASH,
+                                        locator: { column: "log2FoldChange", row: 0 },
+                                    },
+                                    // A file pins whole bytes, thus it addresses no numeric scalar for the
+                                    // arithmetic. The grammar rejects it, and resolution never runs.
+                                    { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: FIGURE_HASH },
+                                ],
+                            },
+                        },
                     ],
                 },
-            }),
-            snapshot,
-            resolver,
-        );
-        const invalid = expectInvalid(result);
-        const failures = invalid.resolutionFailures ?? [];
-        expect(failures[0].blockId).toBe("metric-file-input");
-        expect(failures[0].failure.reason).toBe("locator-out-of-range");
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+        expect(invalid.resolutionFailures).toBeUndefined();
     });
 });
 
@@ -936,8 +962,15 @@ describe("validateReport — a value match with no tolerance", () => {
         };
     }
 
-    it("validates a rounded authored figure against a value that float arithmetic shifts", async () => {
+    it("absorbs the float noise of a computed value", async () => {
         expectValid(await validateReport(reportWith(deltaMetric("metric-delta-ok", 0.2)), snapshot, resolver));
+    });
+
+    it("rejects a rounded authored figure, because only a tolerance permits one", async () => {
+        // The delta is 0.19999999999999998. A rounded 0.19 sits far above the float noise that the
+        // epsilon absorbs, thus the author must state a tolerance to accept it.
+        const rounded = expectInvalid(await validateReport(reportWith(deltaMetric("metric-delta-rounded", 0.19)), snapshot, resolver));
+        expect((rounded.resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
     });
 
     it("reports assertion-failed for a real mismatch with no tolerance", async () => {
@@ -1079,5 +1112,219 @@ describe("validateReport — block id uniqueness", () => {
     it("gives no duplicateIds for a document whose ids are unique", async () => {
         const valid = expectValid(await validateReport(groundedReport(), snapshot, resolver));
         expect(valid).not.toHaveProperty("duplicateIds");
+    });
+});
+
+describe("validateReport — a text-backed artifact", () => {
+    /** Bind a metric to a cell of the text artifact, in the row of the given gene, under the given assert. */
+    function textMetric(id: string, column: string, assert?: { value: string | number; tolerance?: number }, gene = "TP53"): Block {
+        return {
+            kind: "metric",
+            id,
+            label: "Text",
+            value: {
+                kind: "artifact-value",
+                run: "run-1",
+                path: TEXT_PATH,
+                hash: TEXT_HASH,
+                locator: { column, rowFilter: { column: "gene", op: "eq", value: gene } },
+                ...(assert !== undefined ? { assert } : {}),
+            },
+        };
+    }
+
+    it("matches a numeric assert against the string cell that a CSV holds", async () => {
+        expectValid(await validateReport(reportWith(textMetric("metric-text-number", "count", { value: 40 })), snapshot, resolver));
+    });
+
+    it("matches a numeric assert against a cell in the exponent form of a p-value", async () => {
+        expectValid(await validateReport(reportWith(textMetric("metric-text-exponent", "padj", { value: 1.2e-45 })), snapshot, resolver));
+    });
+
+    it("matches a string assert against the same string cell", async () => {
+        expectValid(await validateReport(reportWith(textMetric("metric-text-string", "note", { value: "n/a" })), snapshot, resolver));
+    });
+
+    it("reports assertion-failed for a numeric assert that the string cell does not hold", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(textMetric("metric-text-wrong", "count", { value: 41 })), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
+    });
+
+    it("names the type of each side, thus a failed match never reads as two identical values", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(textMetric("metric-text-typed", "note", { value: 12 }, "EGFR")), snapshot, resolver));
+        const detail = (invalid.resolutionFailures ?? [])[0].failure.detail ?? "";
+        expect(detail).toContain("the number 12");
+        expect(detail).toContain(`the string "12 genes"`);
+    });
+
+    it("reads a cell that holds text as text, thus a leading numeral never matches", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(textMetric("metric-text-prefix", "note", { value: "12" }, "EGFR")), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
+    });
+
+    it("runs the arithmetic of a derivation over two string cells", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-text-ratio",
+                label: "Ratio",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TEXT_PATH,
+                            hash: TEXT_HASH,
+                            locator: { column: "count", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TEXT_PATH,
+                            hash: TEXT_HASH,
+                            locator: { column: "count", rowFilter: { column: "gene", op: "eq", value: "EGFR" } },
+                        },
+                    ],
+                    assert: { value: 4 },
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
+    });
+
+    it("reports locator-out-of-range for a derivation input whose cell holds text", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-text-nonnumeric",
+                label: "Ratio",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TEXT_PATH,
+                            hash: TEXT_HASH,
+                            locator: { column: "note", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TEXT_PATH,
+                            hash: TEXT_HASH,
+                            locator: { column: "count", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                        },
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+        expect((invalid.resolutionFailures ?? [])[0].failure.detail).toContain("note");
+    });
+});
+
+describe("validateReport — a citation assertion", () => {
+    /** Bind a citation block to the pinned pmid, under the given asserted key. */
+    function citationBlock(id: string, assert?: { value: string }): Block {
+        return {
+            kind: "citation",
+            id,
+            binding: { kind: "citation", idKind: "pmid", id: "12345", raw: "Author et al.", ...(assert !== undefined ? { assert } : {}) },
+        };
+    }
+
+    it("validates a citation whose asserted key matches the resolved key", async () => {
+        expectValid(await validateReport(reportWith(citationBlock("cite-ok", { value: "pmid:12345" })), snapshot, resolver));
+    });
+
+    it("reports assertion-failed for an asserted key that names a different source", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(citationBlock("cite-wrong", { value: "pmid:99999" })), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
+    });
+
+    it("reports assertion-failed for a bare id, because the key carries its idKind prefix", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(citationBlock("cite-bare", { value: "12345" })), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
+    });
+});
+
+describe("validateReport — the remaining resolution outcomes", () => {
+    it("reports locator-out-of-range for a fixed row index past the last row", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-row-past-end",
+                label: "Past",
+                value: { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 7 } },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+        expect((invalid.resolutionFailures ?? [])[0].failure.detail).toContain("7");
+    });
+
+    /** Bind to the `value` cell of the sparse row that holds an empty string. */
+    const blankCell = {
+        kind: "artifact-value",
+        run: "run-1",
+        path: SPARSE_PATH,
+        hash: SPARSE_HASH,
+        locator: { column: "value", rowFilter: { column: "label", op: "eq", value: "blank" } },
+    } as const;
+
+    it("reports assertion-failed for a zero asserted against a blank cell", async () => {
+        // `Number("")` gives 0. A blank cell that reads as zero would ground a figure on an absence.
+        const result = await validateReport(
+            reportWith({ kind: "metric", id: "metric-blank-zero", label: "Blank", value: { ...blankCell, assert: { value: 0 } } }),
+            snapshot,
+            resolver,
+        );
+        expect((expectInvalid(result).resolutionFailures ?? [])[0].failure.reason).toBe("assertion-failed");
+    });
+
+    it("reports locator-out-of-range for a derivation over a blank cell", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-blank-input",
+                label: "Blank",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 0 } },
+                        blankCell,
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        expect((expectInvalid(result).resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+
+    it("reports artifact-missing for a table bound to an absent path", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "table",
+                id: "table-absent",
+                binding: { kind: "artifact-table", run: "run-1", path: "runs/run-1/absent-table.csv", hash: TABLE_A_HASH },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("artifact-missing");
     });
 });

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Block, ReportDocument } from "../contracts/report-blocks.js";
+import { createFixtureResolver } from "./fixture-resolver.js";
+import type { ReportSnapshot } from "./reference-resolver.js";
+import { validateReport, type ReportValidation } from "./validate.js";
+
+const TABLE_A_PATH = "runs/run-1/step-a/output/de.csv";
+const TABLE_B_PATH = "runs/run-1/step-b/output/counts.csv";
+const FIGURE_PATH = "runs/run-1/step-b/figures/volcano.png";
+const TABLE_A_HASH = `sha256:${"a".repeat(64)}`;
+const TABLE_B_HASH = `sha256:${"b".repeat(64)}`;
+const FIGURE_HASH = `sha256:${"d".repeat(64)}`;
+const WRONG_HASH = `sha256:${"c".repeat(64)}`;
+
+const resolver = createFixtureResolver();
+
+const snapshot: ReportSnapshot = {
+    artifacts: {
+        [TABLE_A_PATH]: {
+            hash: TABLE_A_HASH,
+            // Two rows share direction "up", thus a rowFilter on direction is ambiguous while gene stays unique.
+            rows: [
+                { gene: "TP53", log2FoldChange: 6, padj: 0.001, direction: "up" },
+                { gene: "EGFR", log2FoldChange: 3, padj: 0.02, direction: "up" },
+            ],
+        },
+        [TABLE_B_PATH]: {
+            hash: TABLE_B_HASH,
+            // The S2 value is zero, thus a ratio with it as the divisor is a division by zero.
+            rows: [
+                { sample: "S1", value: 10 },
+                { sample: "S2", value: 0 },
+            ],
+        },
+        // An image carries a hash and no rows, thus it pins whole and addresses no cell.
+        [FIGURE_PATH]: { hash: FIGURE_HASH },
+    },
+    citations: ["pmid:12345"],
+};
+
+function expectValid(result: ReportValidation): Extract<ReportValidation, { valid: true }> {
+    if (!result.valid) {
+        throw new Error(`expected a valid report but got ${JSON.stringify(result)}`);
+    }
+    return result;
+}
+
+function expectInvalid(result: ReportValidation): Extract<ReportValidation, { valid: false }> {
+    if (result.valid) {
+        throw new Error("expected an invalid report but got a valid one");
+    }
+    return result;
+}
+
+/** Wrap one block in a single-section report, the smallest valid document shape. */
+function reportWith(block: Block): ReportDocument {
+    return { title: "Report", sections: [{ kind: "section", id: "sec", title: "Section", blocks: [block] }] };
+}
+
+/** A fully grounded document with one of each block kind and a section nested in a section. */
+function groundedReport(): ReportDocument {
+    return {
+        title: "Grounded report",
+        sections: [
+            {
+                kind: "section",
+                id: "sec-findings",
+                title: "Findings",
+                blocks: [
+                    { kind: "text", id: "text-intro", content: { prose: "The cohort separates cleanly by condition." } },
+                    {
+                        kind: "claim",
+                        id: "claim-target",
+                        content: { prose: "The primary target rises in the treated arm." },
+                        bindings: [
+                            {
+                                kind: "artifact-value",
+                                run: "run-1",
+                                path: TABLE_A_PATH,
+                                hash: TABLE_A_HASH,
+                                locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                            },
+                        ],
+                    },
+                    {
+                        kind: "metric",
+                        id: "metric-top",
+                        label: "Top effect",
+                        value: { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 0 } },
+                    },
+                    {
+                        kind: "table",
+                        id: "table-counts",
+                        title: "Counts",
+                        binding: { kind: "artifact-table", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH },
+                    },
+                    {
+                        kind: "section",
+                        id: "sec-detail",
+                        title: "Detail",
+                        blocks: [
+                            {
+                                kind: "chart",
+                                id: "chart-counts",
+                                binding: { kind: "artifact-table", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH },
+                                chartType: "bar",
+                                encoding: { x: "sample", y: "value" },
+                            },
+                            {
+                                kind: "figure",
+                                id: "figure-plot",
+                                binding: { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: FIGURE_HASH },
+                            },
+                            {
+                                kind: "citation",
+                                id: "citation-ref",
+                                binding: { kind: "citation", idKind: "pmid", id: "12345", raw: "Author et al." },
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+describe("validateReport — a fully grounded report", () => {
+    it("validates one of each block kind with a nested section and no warnings", async () => {
+        const result = await validateReport(groundedReport(), snapshot, resolver);
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
+});
+
+describe("validateReport — resolution failures", () => {
+    it("reports artifact-missing for a claim bound to an absent path", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "claim",
+                id: "claim-absent",
+                content: { prose: "A grounded claim." },
+                bindings: [{ kind: "artifact-value", run: "run-1", path: "runs/run-1/absent.csv", hash: TABLE_A_HASH, locator: { column: "x", row: 0 } }],
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures).toHaveLength(1);
+        expect(failures[0].blockId).toBe("claim-absent");
+        expect(failures[0].failure.reason).toBe("artifact-missing");
+    });
+
+    it("reports assertion-failed for a wrong asserted value", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "claim",
+                id: "claim-assert",
+                content: { prose: "An asserted claim." },
+                bindings: [
+                    {
+                        kind: "artifact-value",
+                        run: "run-1",
+                        path: TABLE_A_PATH,
+                        hash: TABLE_A_HASH,
+                        locator: { column: "log2FoldChange", row: 0 },
+                        assert: { value: 999 },
+                    },
+                ],
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures).toHaveLength(1);
+        expect(failures[0].failure.reason).toBe("assertion-failed");
+    });
+
+    it("reports locator-out-of-range for a rowFilter that matches no row", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "claim",
+                id: "claim-zero",
+                content: { prose: "A claim with no match." },
+                bindings: [
+                    {
+                        kind: "artifact-value",
+                        run: "run-1",
+                        path: TABLE_A_PATH,
+                        hash: TABLE_A_HASH,
+                        locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "MISSING" } },
+                    },
+                ],
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+
+    it("reports ambiguous-match for a rowFilter that matches two rows", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "claim",
+                id: "claim-ambiguous",
+                content: { prose: "A claim with two matches." },
+                bindings: [
+                    {
+                        kind: "artifact-value",
+                        run: "run-1",
+                        path: TABLE_A_PATH,
+                        hash: TABLE_A_HASH,
+                        locator: { column: "log2FoldChange", rowFilter: { column: "direction", op: "eq", value: "up" } },
+                    },
+                ],
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("ambiguous-match");
+    });
+
+    it("reports hash-mismatch for a pinned hash that differs", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-hash",
+                label: "Pinned",
+                value: { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: WRONG_HASH, locator: { column: "log2FoldChange", row: 0 } },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("metric-hash");
+        expect(failures[0].failure.reason).toBe("hash-mismatch");
+    });
+});
+
+describe("validateReport — grammar rejections", () => {
+    it("rejects a metric that carries a child-block array", async () => {
+        const document = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "metric",
+                            id: "m",
+                            label: "L",
+                            value: {
+                                kind: "artifact-value",
+                                run: "run-1",
+                                path: TABLE_A_PATH,
+                                hash: TABLE_A_HASH,
+                                locator: { column: "log2FoldChange", row: 0 },
+                            },
+                            blocks: [{ kind: "text", id: "child", content: { prose: "child" } }],
+                        },
+                    ],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a text block that carries bindings", async () => {
+        const document = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [{ kind: "text", id: "t", content: { prose: "text" }, bindings: [{ kind: "citation", idKind: "doi", id: "10.1/x", raw: "r" }] }],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a report with no sections", async () => {
+        const invalid = expectInvalid(await validateReport({ title: "R", sections: [] }, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a section with no blocks", async () => {
+        const document = { title: "R", sections: [{ kind: "section", id: "s", title: "S", blocks: [] }] };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a claim with an empty bindings array", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "claim", id: "c", content: { prose: "text" }, bindings: [] }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a metric whose value is a numeric literal", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "metric", id: "m", label: "L", value: 42 }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+});
+
+describe("validateReport — block-level schema rejections", () => {
+    it("rejects a block with no id", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "text", content: { prose: "text" } }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a block with an empty-string id", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "text", id: "", content: { prose: "text" } }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a block with no kind", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ id: "t", content: { prose: "text" } }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a block whose kind is not one of the eight", async () => {
+        const document = {
+            title: "R",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "sidebar", id: "sb", content: { prose: "text" } }] }],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("rejects a metric that carries a second binding", async () => {
+        const document = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "metric",
+                            id: "m",
+                            label: "L",
+                            value: {
+                                kind: "artifact-value",
+                                run: "run-1",
+                                path: TABLE_A_PATH,
+                                hash: TABLE_A_HASH,
+                                locator: { column: "log2FoldChange", row: 0 },
+                            },
+                            bindings: [{ kind: "artifact-value", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH, locator: { column: "value", row: 0 } }],
+                        },
+                    ],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
+    });
+});
+
+describe("validateReport — the whole-file pin", () => {
+    it("validates a figure bound to an artifact-file that resolves", async () => {
+        const result = await validateReport(
+            reportWith({ kind: "figure", id: "figure-ok", binding: { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: FIGURE_HASH } }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
+
+    it("reports artifact-missing for a figure whose file is absent", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "figure",
+                id: "figure-absent",
+                binding: { kind: "artifact-file", run: "run-1", path: "runs/run-1/step-b/figures/absent.png", hash: FIGURE_HASH },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures).toHaveLength(1);
+        expect(failures[0].blockId).toBe("figure-absent");
+        expect(failures[0].failure.reason).toBe("artifact-missing");
+    });
+
+    it("reports hash-mismatch for a figure whose file hash differs", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "figure",
+                id: "figure-hash",
+                binding: { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: WRONG_HASH },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("figure-hash");
+        expect(failures[0].failure.reason).toBe("hash-mismatch");
+    });
+
+    it("reports locator-out-of-range for a derivation given an artifact-file input", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-file-input",
+                label: "FileInput",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 0 } },
+                        // A file pins whole bytes, thus it addresses no numeric scalar for the arithmetic.
+                        { kind: "artifact-file", run: "run-1", path: FIGURE_PATH, hash: FIGURE_HASH },
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("metric-file-input");
+        expect(failures[0].failure.reason).toBe("locator-out-of-range");
+    });
+});
+
+describe("validateReport — derivations", () => {
+    it("validates a ratio over two grounded cells", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-ratio",
+                label: "Ratio",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_A_PATH,
+                            hash: TABLE_A_HASH,
+                            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_A_PATH,
+                            hash: TABLE_A_HASH,
+                            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "EGFR" } },
+                        },
+                    ],
+                    assert: { value: 2, tolerance: 0.0001 },
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
+    });
+
+    it("keeps the inner reason when a derivation input does not resolve", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-broken-input",
+                label: "Broken",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        { kind: "artifact-value", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, locator: { column: "log2FoldChange", row: 0 } },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: "runs/run-1/absent.csv",
+                            hash: TABLE_A_HASH,
+                            locator: { column: "log2FoldChange", row: 0 },
+                        },
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("metric-broken-input");
+        expect(failures[0].failure.reason).toBe("artifact-missing");
+    });
+
+    it("reports locator-out-of-range for a division by zero", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-divzero",
+                label: "DivZero",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_B_PATH,
+                            hash: TABLE_B_HASH,
+                            locator: { column: "value", rowFilter: { column: "sample", op: "eq", value: "S1" } },
+                        },
+                        {
+                            kind: "artifact-value",
+                            run: "run-1",
+                            path: TABLE_B_PATH,
+                            hash: TABLE_B_HASH,
+                            locator: { column: "value", rowFilter: { column: "sample", op: "eq", value: "S2" } },
+                        },
+                    ],
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+});
+
+describe("validateReport — free-numeral warnings", () => {
+    it("warns on a numeral in prose and stays valid", async () => {
+        const result = await validateReport(
+            reportWith({ kind: "text", id: "text-numeral", content: { prose: "Expression increased by 42% overall." } }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([{ blockId: "text-numeral", kind: "free-numeral", detail: "42%" }]);
+    });
+
+    it("gives no warning for clean prose", async () => {
+        const result = await validateReport(
+            reportWith({ kind: "text", id: "text-clean", content: { prose: "Expression increased markedly overall." } }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
+});
+
+describe("validateReport — multiple failures", () => {
+    it("collects every failure across blocks", async () => {
+        const document: ReportDocument = {
+            title: "Broken report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "sec",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "claim",
+                            id: "claim-a",
+                            content: { prose: "A claim." },
+                            bindings: [
+                                { kind: "artifact-value", run: "run-1", path: "runs/run-1/absent.csv", hash: TABLE_A_HASH, locator: { column: "x", row: 0 } },
+                            ],
+                        },
+                        {
+                            kind: "metric",
+                            id: "metric-b",
+                            label: "M",
+                            value: {
+                                kind: "artifact-value",
+                                run: "run-1",
+                                path: TABLE_A_PATH,
+                                hash: WRONG_HASH,
+                                locator: { column: "log2FoldChange", row: 0 },
+                            },
+                        },
+                        {
+                            kind: "citation",
+                            id: "citation-c",
+                            binding: { kind: "citation", idKind: "pmid", id: "99999", raw: "Missing citation." },
+                        },
+                    ],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures).toHaveLength(3);
+        expect(failures.map((f) => f.blockId).sort()).toEqual(["citation-c", "claim-a", "metric-b"]);
+    });
+});

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import type { Block, ReportDocument } from "../contracts/report-blocks.js";
+import { parseReference, serializeReference, type Reference } from "../contracts/report-reference.js";
 import { createFixtureResolver } from "./fixture-resolver.js";
 import type { ReportSnapshot } from "./reference-resolver.js";
 import { validateReport, type ReportValidation } from "./validate.js";
@@ -10,11 +11,14 @@ const TABLE_B_PATH = "runs/run-1/step-b/output/counts.csv";
 const FLOAT_PATH = "runs/run-1/step-c/output/floats.csv";
 const SPARSE_PATH = "runs/run-1/step-c/output/sparse.csv";
 const FIGURE_PATH = "runs/run-1/step-b/figures/volcano.png";
+// A staged input file, which no run produced. Its reference carries no `run`.
+const INPUT_PATH = "data/inputs/file-1/cohort.csv";
 const TABLE_A_HASH = `sha256:${"a".repeat(64)}`;
 const TABLE_B_HASH = `sha256:${"b".repeat(64)}`;
 const FLOAT_HASH = `sha256:${"e".repeat(64)}`;
 const SPARSE_HASH = `sha256:${"f".repeat(64)}`;
 const FIGURE_HASH = `sha256:${"d".repeat(64)}`;
+const INPUT_HASH = `sha256:${"1".repeat(64)}`;
 const WRONG_HASH = `sha256:${"c".repeat(64)}`;
 
 const resolver = createFixtureResolver();
@@ -60,6 +64,7 @@ const snapshot: ReportSnapshot = {
             ],
         },
         [SPARSE_PATH]: { hash: SPARSE_HASH, rows: sparseRows },
+        [INPUT_PATH]: { hash: INPUT_HASH, rows: [{ samples: 24 }] },
         // An image carries a hash and no rows, thus it pins whole and addresses no cell.
         [FIGURE_PATH]: { hash: FIGURE_HASH },
     },
@@ -670,6 +675,100 @@ describe("validateReport — an artifact-table with a column subset", () => {
         const valid = expectValid(result);
         expect(valid.warnings).toEqual([]);
     });
+
+    it("reports locator-out-of-range for a column that no row holds", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "table",
+                id: "table-invented",
+                title: "Invented",
+                binding: { kind: "artifact-table", run: "run-1", path: TABLE_A_PATH, hash: TABLE_A_HASH, columns: ["gene", "pValueAdjusted"] },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("table-invented");
+        expect(failures[0].failure.reason).toBe("locator-out-of-range");
+        expect(failures[0].failure.detail).toContain("pValueAdjusted");
+    });
+
+    it("validates a column that only some rows hold, because a table tolerates a ragged row", async () => {
+        // The sparse rows share `label`, but only three of the four hold `value`.
+        const result = await validateReport(
+            reportWith({
+                kind: "table",
+                id: "table-ragged",
+                title: "Ragged",
+                binding: { kind: "artifact-table", run: "run-1", path: SPARSE_PATH, hash: SPARSE_HASH, columns: ["label", "value"] },
+            }),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
+    });
+});
+
+describe("validateReport — a chart encoding", () => {
+    /** Bind a chart to table B, whose rows hold `sample` and `value`, under the given encoding. */
+    function chartWith(id: string, encoding: { x?: string; y?: string; group?: string; value?: string }): Block {
+        return {
+            kind: "chart",
+            id,
+            binding: { kind: "artifact-table", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH },
+            chartType: "bar",
+            encoding,
+        };
+    }
+
+    it("validates an encoding whose channels name real columns", async () => {
+        expectValid(await validateReport(reportWith(chartWith("chart-ok", { x: "sample", y: "value" })), snapshot, resolver));
+    });
+
+    it("reports locator-out-of-range for a channel that names a column the table does not hold", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(chartWith("chart-invented", { x: "sample", y: "invented" })), snapshot, resolver));
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("chart-invented");
+        expect(failures[0].failure.reason).toBe("locator-out-of-range");
+        expect(failures[0].failure.detail).toContain("invented");
+    });
+
+    it("names each absent channel, across every encoding slot", async () => {
+        const invalid = expectInvalid(
+            await validateReport(
+                reportWith(chartWith("chart-many", { x: "nope-x", y: "value", group: "nope-group", value: "nope-value" })),
+                snapshot,
+                resolver,
+            ),
+        );
+        const detail = (invalid.resolutionFailures ?? [])[0].failure.detail ?? "";
+        expect(detail).toContain("nope-x");
+        expect(detail).toContain("nope-group");
+        expect(detail).toContain("nope-value");
+    });
+
+    it("reports a channel that the bound column subset leaves out", async () => {
+        // The projection drops `value`, thus the y channel addresses nothing in the resolved table.
+        const invalid = expectInvalid(
+            await validateReport(
+                reportWith({
+                    kind: "chart",
+                    id: "chart-outside-subset",
+                    binding: { kind: "artifact-table", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH, columns: ["sample"] },
+                    chartType: "bar",
+                    encoding: { x: "sample", y: "value" },
+                }),
+                snapshot,
+                resolver,
+            ),
+        );
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+
+    it("validates an encoding with no channel at all", async () => {
+        expectValid(await validateReport(reportWith(chartWith("chart-bare", {})), snapshot, resolver));
+    });
 });
 
 describe("validateReport — free-numeral warnings", () => {
@@ -691,6 +790,26 @@ describe("validateReport — free-numeral warnings", () => {
         );
         const valid = expectValid(result);
         expect(valid.warnings).toEqual([]);
+    });
+
+    it("gives no warning for the digits inside a gene symbol", async () => {
+        const result = await validateReport(
+            reportWith({ kind: "text", id: "text-symbols", content: { prose: "TP53, CD8, IL6, and the hg38 build agree." } }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
+
+    it("still warns on a free figure that sits beside a symbol", async () => {
+        const result = await validateReport(
+            reportWith({ kind: "text", id: "text-mixed", content: { prose: "TP53 rose 42% across 3 cohorts." } }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings.map((warning) => warning.detail)).toEqual(["42%", "3"]);
     });
 });
 
@@ -740,35 +859,49 @@ describe("validateReport — multiple failures", () => {
     });
 });
 
-describe("validateReport — the hash assert", () => {
-    /** Bind a metric to the first cell of table A, under the given assert. */
-    function metricWithAssert(id: string, assertion: { hash?: string; value?: string | number; tolerance?: number }): Block {
-        return {
-            kind: "metric",
-            id,
-            label: "Pinned",
-            value: {
-                kind: "artifact-value",
-                run: "run-1",
-                path: TABLE_A_PATH,
-                hash: TABLE_A_HASH,
-                locator: { column: "log2FoldChange", row: 0 },
-                assert: assertion,
-            },
+describe("validateReport — the pin carries the belief about the bytes", () => {
+    it("rejects an assert that carries a hash, because the pin already compares it", async () => {
+        const document = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "metric",
+                            id: "m",
+                            label: "Pinned",
+                            value: {
+                                kind: "artifact-value",
+                                run: "run-1",
+                                path: TABLE_A_PATH,
+                                hash: TABLE_A_HASH,
+                                locator: { column: "log2FoldChange", row: 0 },
+                                assert: { hash: TABLE_A_HASH },
+                            },
+                        },
+                    ],
+                },
+            ],
         };
-    }
-
-    it("validates an artifact-value under a hash-only assert that matches", async () => {
-        const result = await validateReport(reportWith(metricWithAssert("metric-hash-ok", { hash: TABLE_A_HASH })), snapshot, resolver);
-        expectValid(result);
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.schemaIssues?.length ?? 0).toBeGreaterThan(0);
     });
 
-    it("reports assertion-failed for a hash-only assert that differs", async () => {
-        const result = await validateReport(reportWith(metricWithAssert("metric-hash-bad", { hash: WRONG_HASH })), snapshot, resolver);
-        const invalid = expectInvalid(result);
-        const failures = invalid.resolutionFailures ?? [];
-        expect(failures[0].blockId).toBe("metric-hash-bad");
-        expect(failures[0].failure.reason).toBe("assertion-failed");
+    it("validates a metric bound to a staged input artifact that carries no run", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-input",
+                label: "Input",
+                value: { kind: "artifact-value", path: INPUT_PATH, hash: INPUT_HASH, locator: { column: "samples", row: 0 } },
+            }),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
     });
 });
 
@@ -868,6 +1001,29 @@ describe("validateReport — a cell that holds no value", () => {
     it("reports locator-out-of-range for a column that the row does not hold", async () => {
         const invalid = expectInvalid(await validateReport(reportWith(sparseMetric("metric-absent", "absent-cell")), snapshot, resolver));
         expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+});
+
+describe("the resolver — cross-session resolution", () => {
+    it("resolves a parsed reference to the same value as the original", async () => {
+        const reference: Reference = {
+            kind: "artifact-value",
+            run: "run-1",
+            path: TABLE_A_PATH,
+            hash: TABLE_A_HASH,
+            locator: { column: "log2FoldChange", rowFilter: { column: "gene", op: "eq", value: "TP53" } },
+        };
+        const parsed = parseReference(serializeReference(reference));
+        if (parsed.isErr()) {
+            throw new Error("expected the serialized reference to parse");
+        }
+
+        const fromOriginal = await resolver.resolve(reference, snapshot);
+        const fromParsed = await resolver.resolve(parsed.value, snapshot);
+
+        expect(fromParsed.isOk()).toBe(fromOriginal.isOk());
+        expect(fromParsed._unsafeUnwrap()).toEqual(fromOriginal._unsafeUnwrap());
+        expect(fromParsed._unsafeUnwrap()).toEqual({ type: "scalar", value: 6 });
     });
 });
 

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -7,13 +7,29 @@ import { validateReport, type ReportValidation } from "./validate.js";
 
 const TABLE_A_PATH = "runs/run-1/step-a/output/de.csv";
 const TABLE_B_PATH = "runs/run-1/step-b/output/counts.csv";
+const FLOAT_PATH = "runs/run-1/step-c/output/floats.csv";
+const SPARSE_PATH = "runs/run-1/step-c/output/sparse.csv";
 const FIGURE_PATH = "runs/run-1/step-b/figures/volcano.png";
 const TABLE_A_HASH = `sha256:${"a".repeat(64)}`;
 const TABLE_B_HASH = `sha256:${"b".repeat(64)}`;
+const FLOAT_HASH = `sha256:${"e".repeat(64)}`;
+const SPARSE_HASH = `sha256:${"f".repeat(64)}`;
 const FIGURE_HASH = `sha256:${"d".repeat(64)}`;
 const WRONG_HASH = `sha256:${"c".repeat(64)}`;
 
 const resolver = createFixtureResolver();
+
+/**
+ * A row promises a value for each key that it holds. A real parser gives back an empty cell as an absent
+ * key, as `undefined`, or as `null`, thus the cast is the only way to build the rows that the resolver
+ * must reject.
+ */
+const sparseRows = [
+    { label: "blank", value: "" },
+    { label: "undefined-cell", value: undefined },
+    { label: "null-cell", value: null },
+    { label: "absent-cell" },
+] as unknown as Array<Record<string, string | number>>;
 
 const snapshot: ReportSnapshot = {
     artifacts: {
@@ -33,6 +49,17 @@ const snapshot: ReportSnapshot = {
                 { sample: "S2", value: 0 },
             ],
         },
+        [FLOAT_PATH]: {
+            hash: FLOAT_HASH,
+            // A delta over 0.3 and 0.1 gives 0.19999999999999998, thus it exercises the float noise of
+            // ordinary arithmetic against a rounded authored figure.
+            rows: [
+                { name: "a", value: 0.3 },
+                { name: "b", value: 0.1 },
+                { name: "c", value: 1.05 },
+            ],
+        },
+        [SPARSE_PATH]: { hash: SPARSE_HASH, rows: sparseRows },
         // An image carries a hash and no rows, thus it pins whole and addresses no cell.
         [FIGURE_PATH]: { hash: FIGURE_HASH },
     },
@@ -622,5 +649,191 @@ describe("validateReport — multiple failures", () => {
         const failures = invalid.resolutionFailures ?? [];
         expect(failures).toHaveLength(3);
         expect(failures.map((f) => f.blockId).sort()).toEqual(["citation-c", "claim-a", "metric-b"]);
+    });
+});
+
+describe("validateReport — the hash assert", () => {
+    /** Bind a metric to the first cell of table A, under the given assert. */
+    function metricWithAssert(id: string, assertion: { hash?: string; value?: string | number; tolerance?: number }): Block {
+        return {
+            kind: "metric",
+            id,
+            label: "Pinned",
+            value: {
+                kind: "artifact-value",
+                run: "run-1",
+                path: TABLE_A_PATH,
+                hash: TABLE_A_HASH,
+                locator: { column: "log2FoldChange", row: 0 },
+                assert: assertion,
+            },
+        };
+    }
+
+    it("validates an artifact-value under a hash-only assert that matches", async () => {
+        const result = await validateReport(reportWith(metricWithAssert("metric-hash-ok", { hash: TABLE_A_HASH })), snapshot, resolver);
+        expectValid(result);
+    });
+
+    it("reports assertion-failed for a hash-only assert that differs", async () => {
+        const result = await validateReport(reportWith(metricWithAssert("metric-hash-bad", { hash: WRONG_HASH })), snapshot, resolver);
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("metric-hash-bad");
+        expect(failures[0].failure.reason).toBe("assertion-failed");
+    });
+});
+
+describe("validateReport — a value match with no tolerance", () => {
+    /** Bind a metric to the delta of the two float cells, under the given asserted value. */
+    function deltaMetric(id: string, expected: number): Block {
+        return {
+            kind: "metric",
+            id,
+            label: "Delta",
+            value: {
+                kind: "derivation",
+                op: "delta",
+                inputs: [
+                    {
+                        kind: "artifact-value",
+                        run: "run-1",
+                        path: FLOAT_PATH,
+                        hash: FLOAT_HASH,
+                        locator: { column: "value", rowFilter: { column: "name", op: "eq", value: "a" } },
+                    },
+                    {
+                        kind: "artifact-value",
+                        run: "run-1",
+                        path: FLOAT_PATH,
+                        hash: FLOAT_HASH,
+                        locator: { column: "value", rowFilter: { column: "name", op: "eq", value: "b" } },
+                    },
+                ],
+                assert: { value: expected },
+            },
+        };
+    }
+
+    it("validates a rounded authored figure against a value that float arithmetic shifts", async () => {
+        expectValid(await validateReport(reportWith(deltaMetric("metric-delta-ok", 0.2)), snapshot, resolver));
+    });
+
+    it("reports assertion-failed for a real mismatch with no tolerance", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "metric",
+                id: "metric-wrong-value",
+                label: "Wrong",
+                value: {
+                    kind: "artifact-value",
+                    run: "run-1",
+                    path: FLOAT_PATH,
+                    hash: FLOAT_HASH,
+                    locator: { column: "value", rowFilter: { column: "name", op: "eq", value: "c" } },
+                    assert: { value: 1.5 },
+                },
+            }),
+            snapshot,
+            resolver,
+        );
+        const invalid = expectInvalid(result);
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].blockId).toBe("metric-wrong-value");
+        expect(failures[0].failure.reason).toBe("assertion-failed");
+    });
+});
+
+describe("validateReport — a cell that holds no value", () => {
+    /** Bind a metric to the `value` cell of the sparse row that the given label selects. */
+    function sparseMetric(id: string, label: string): Block {
+        return {
+            kind: "metric",
+            id,
+            label: "Sparse",
+            value: {
+                kind: "artifact-value",
+                run: "run-1",
+                path: SPARSE_PATH,
+                hash: SPARSE_HASH,
+                locator: { column: "value", rowFilter: { column: "label", op: "eq", value: label } },
+            },
+        };
+    }
+
+    it("validates a cell that holds an empty string", async () => {
+        expectValid(await validateReport(reportWith(sparseMetric("metric-blank", "blank")), snapshot, resolver));
+    });
+
+    it("reports locator-out-of-range for a cell that holds undefined", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(sparseMetric("metric-undefined", "undefined-cell")), snapshot, resolver));
+        const failures = invalid.resolutionFailures ?? [];
+        expect(failures[0].failure.reason).toBe("locator-out-of-range");
+        expect(failures[0].failure.detail).toContain("value");
+    });
+
+    it("reports locator-out-of-range for a cell that holds null", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(sparseMetric("metric-null", "null-cell")), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+
+    it("reports locator-out-of-range for a column that the row does not hold", async () => {
+        const invalid = expectInvalid(await validateReport(reportWith(sparseMetric("metric-absent", "absent-cell")), snapshot, resolver));
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+    });
+});
+
+describe("validateReport — block id uniqueness", () => {
+    it("rejects a document whose blocks share an id", async () => {
+        const document: ReportDocument = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "sec",
+                    title: "S",
+                    blocks: [
+                        { kind: "text", id: "same", content: { prose: "One." } },
+                        { kind: "text", id: "same", content: { prose: "Two." } },
+                        { kind: "text", id: "same", content: { prose: "Three." } },
+                    ],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.duplicateIds).toEqual(["same"]);
+    });
+
+    it("names each repeated id one time, in sorted order, across nested sections", async () => {
+        const document: ReportDocument = {
+            title: "R",
+            sections: [
+                {
+                    kind: "section",
+                    id: "sec",
+                    title: "S",
+                    blocks: [
+                        { kind: "text", id: "zebra", content: { prose: "One." } },
+                        { kind: "text", id: "alpha", content: { prose: "Two." } },
+                        {
+                            kind: "section",
+                            id: "sec-inner",
+                            title: "Inner",
+                            blocks: [
+                                { kind: "text", id: "zebra", content: { prose: "Three." } },
+                                { kind: "text", id: "alpha", content: { prose: "Four." } },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        const invalid = expectInvalid(await validateReport(document, snapshot, resolver));
+        expect(invalid.duplicateIds).toEqual(["alpha", "zebra"]);
+    });
+
+    it("gives no duplicateIds for a document whose ids are unique", async () => {
+        const valid = expectValid(await validateReport(groundedReport(), snapshot, resolver));
+        expect(valid).not.toHaveProperty("duplicateIds");
     });
 });

--- a/harness/src/report-model/validate.ts
+++ b/harness/src/report-model/validate.ts
@@ -3,9 +3,9 @@
  *
  * The schemas already carry the grammar: a strict object rejects a forbidden field, a binding is present
  * by construction, and a metric value slot admits one scalar reference only. Thus a schema parse failure
- * is the grammar rejection, and the validator does not re-implement it. The validator adds the two
- * checks that a schema cannot make: it resolves each reference against the pinned evidence, and it warns
- * about a free numeral in prose.
+ * is the grammar rejection, and the validator does not re-implement it. The validator adds the three
+ * checks that a schema cannot make: it makes sure that each block id occurs one time only, it resolves
+ * each reference against the pinned evidence, and it warns about a free numeral in prose.
  */
 
 import { ReportDocumentSchema, type Block } from "../contracts/report-blocks.js";
@@ -32,12 +32,19 @@ export interface ReportWarning {
 }
 
 /**
- * The result of validation. `valid` is false only when the schema failed or a reference did not resolve.
- * The warnings ride along in either case.
+ * The result of validation. `valid` is false when the schema failed, a block id repeats, or a reference
+ * did not resolve. `duplicateIds` names each repeated id one time, in sorted order. The warnings ride
+ * along in either case.
  */
 export type ReportValidation =
     | { valid: true; warnings: ReportWarning[] }
-    | { valid: false; schemaIssues?: SchemaIssue[]; resolutionFailures?: ResolutionFailure[]; warnings: ReportWarning[] };
+    | {
+          valid: false;
+          schemaIssues?: SchemaIssue[];
+          duplicateIds?: string[];
+          resolutionFailures?: ResolutionFailure[];
+          warnings: ReportWarning[];
+      };
 
 /**
  * A token that looks like a number, with an optional decimal part and an optional percent sign.
@@ -70,7 +77,18 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
     const references: Array<{ blockId: string; reference: Reference }> = [];
     const warnings: ReportWarning[] = [];
 
+    // An id is what makes a block addressable, thus an amend by id is well defined only while each id
+    // belongs to one block. `seenIds` holds each id that the walk met, and `repeatedIds` holds each id
+    // that it met again.
+    const seenIds = new Set<string>();
+    const repeatedIds = new Set<string>();
+
     const walk = (block: Block): void => {
+        if (seenIds.has(block.id)) {
+            repeatedIds.add(block.id);
+        } else {
+            seenIds.add(block.id);
+        }
         switch (block.kind) {
             case "section":
                 for (const child of block.blocks) {
@@ -117,8 +135,14 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
         }
     }
 
-    if (resolutionFailures.length > 0) {
-        return { valid: false, resolutionFailures, warnings };
+    const duplicateIds = [...repeatedIds].sort();
+    if (duplicateIds.length > 0 || resolutionFailures.length > 0) {
+        return {
+            valid: false,
+            ...(duplicateIds.length > 0 ? { duplicateIds } : {}),
+            ...(resolutionFailures.length > 0 ? { resolutionFailures } : {}),
+            warnings,
+        };
     }
     return { valid: true, warnings };
 }

--- a/harness/src/report-model/validate.ts
+++ b/harness/src/report-model/validate.ts
@@ -123,15 +123,15 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
     }
 
     const resolved = await Promise.all(
-        references.map(({ blockId, reference }) => resolver.resolve(reference, snapshot).then((outcome) => ({ blockId, outcome }))),
+        references.map(({ blockId, reference }) => resolver.resolve(reference, snapshot).then((result) => ({ blockId, result }))),
     );
 
     // Collect every failure. A reviewer must see each block that broke, thus the walk does not stop at
-    // the first unresolved reference.
+    // the first unresolved reference. The `Err` channel carries the unresolved reference itself.
     const resolutionFailures: ResolutionFailure[] = [];
-    for (const { blockId, outcome } of resolved) {
-        if (!outcome.ok) {
-            resolutionFailures.push({ blockId, failure: outcome.failure });
+    for (const { blockId, result } of resolved) {
+        if (result.isErr()) {
+            resolutionFailures.push({ blockId, failure: result.error });
         }
     }
 

--- a/harness/src/report-model/validate.ts
+++ b/harness/src/report-model/validate.ts
@@ -10,7 +10,16 @@
 
 import { ReportDocumentSchema, type Block } from "../contracts/report-blocks.js";
 import type { Reference, UnresolvedReference } from "../contracts/report-reference.js";
-import type { ReferenceResolver, ReportSnapshot } from "./reference-resolver.js";
+import { allWithConcurrency } from "../lib/async-utils.js";
+import { columnsHeldByNoRow, type ReferenceResolver, type ReportSnapshot, type ResolvedValue } from "./reference-resolver.js";
+
+/**
+ * The cap on how many references resolve at the same time.
+ *
+ * A production resolver reads storage for each reference, and a large report holds hundreds of them. An
+ * unbounded fan-out would open one read for each reference at the same moment.
+ */
+const RESOLUTION_CONCURRENCY = 8;
 
 /** One schema conformance problem, reduced to a path and a message. */
 export interface SchemaIssue {
@@ -47,13 +56,18 @@ export type ReportValidation =
       };
 
 /**
- * A token that looks like a number, with an optional decimal part and an optional percent sign.
+ * A free-standing token that looks like a number, with an optional decimal part and an optional percent
+ * sign.
+ *
+ * The left boundary keeps the digits of a name out of the warnings. The domain prose is dense with a
+ * symbol such as `TP53`, `CD8`, or `IL6`, and without the boundary each one warns for its digits and
+ * buries the real free figures.
  *
  * The check is advisory only. A natural-language numeral is brittle to police, because a numeral in
  * prose can be a real free-standing figure or a harmless part of a name. Thus a hit warns, and it never
  * fails the report.
  */
-const NUMERAL_PATTERN = /-?\d+(?:\.\d+)?%?/g;
+const NUMERAL_PATTERN = /(?<![A-Za-z0-9])-?\d+(?:\.\d+)?%?/g;
 
 function numeralWarnings(blockId: string, prose: string): ReportWarning[] {
     const warnings: ReportWarning[] = [];
@@ -61,6 +75,45 @@ function numeralWarnings(blockId: string, prose: string): ReportWarning[] {
         warnings.push({ blockId, kind: "free-numeral", detail: match[0] });
     }
     return warnings;
+}
+
+/**
+ * One reference that the walk met, tied to the block that carries it.
+ *
+ * `encodingColumns` is present for a `chart` only. A chart names its axes as free strings, thus the
+ * names must be matched against the table that the binding resolves to. Nothing else can catch a chart
+ * that plots a column which does not exist.
+ */
+interface CollectedReference {
+    blockId: string;
+    reference: Reference;
+    encodingColumns?: string[];
+}
+
+/**
+ * Match each column that a chart encoding names against the table that its binding resolved to.
+ *
+ * The binding schema admits a table reference only, thus a resolved value of another type means that the
+ * bound resolver broke its own contract. That is reported and never ignored, because a chart with no
+ * table behind it renders nothing and a silent skip would pass it as grounded.
+ */
+function checkChartEncoding(entry: CollectedReference, value: ResolvedValue): UnresolvedReference | undefined {
+    const encodingColumns = entry.encodingColumns;
+    if (encodingColumns === undefined || encodingColumns.length === 0) {
+        return undefined;
+    }
+    if (value.type !== "table") {
+        return { reference: entry.reference, reason: "locator-out-of-range", detail: `the chart binding resolved to a ${value.type} and not to a table` };
+    }
+    const absent = columnsHeldByNoRow(value.rows, encodingColumns);
+    if (absent.length === 0) {
+        return undefined;
+    }
+    return {
+        reference: entry.reference,
+        reason: "locator-out-of-range",
+        detail: `the encoding names column ${absent.join(", ")}, which the bound table does not hold`,
+    };
 }
 
 /** Resolve each reference, collect the schema conformance and the resolution outcomes, and warn on prose. */
@@ -74,7 +127,7 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
         return { valid: false, schemaIssues, warnings: [] };
     }
 
-    const references: Array<{ blockId: string; reference: Reference }> = [];
+    const references: CollectedReference[] = [];
     const warnings: ReportWarning[] = [];
 
     // An id is what makes a block addressable, thus an amend by id is well defined only while each id
@@ -107,8 +160,13 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
             case "metric":
                 references.push({ blockId: block.id, reference: block.value });
                 return;
+            case "chart": {
+                const encoding = block.encoding;
+                const encodingColumns = [encoding.x, encoding.y, encoding.group, encoding.value].filter((column) => column !== undefined);
+                references.push({ blockId: block.id, reference: block.binding, encodingColumns });
+                return;
+            }
             case "table":
-            case "chart":
             case "figure":
                 references.push({ blockId: block.id, reference: block.binding });
                 return;
@@ -122,16 +180,22 @@ export async function validateReport(document: unknown, snapshot: ReportSnapshot
         walk(section);
     }
 
-    const resolved = await Promise.all(
-        references.map(({ blockId, reference }) => resolver.resolve(reference, snapshot).then((result) => ({ blockId, result }))),
+    const resolved = await allWithConcurrency(
+        references.map((entry) => () => resolver.resolve(entry.reference, snapshot).then((result) => ({ entry, result }))),
+        RESOLUTION_CONCURRENCY,
     );
 
     // Collect every failure. A reviewer must see each block that broke, thus the walk does not stop at
     // the first unresolved reference. The `Err` channel carries the unresolved reference itself.
     const resolutionFailures: ResolutionFailure[] = [];
-    for (const { blockId, result } of resolved) {
+    for (const { entry, result } of resolved) {
         if (result.isErr()) {
-            resolutionFailures.push({ blockId, failure: result.error });
+            resolutionFailures.push({ blockId: entry.blockId, failure: result.error });
+            continue;
+        }
+        const encodingFailure = checkChartEncoding(entry, result.value);
+        if (encodingFailure !== undefined) {
+            resolutionFailures.push({ blockId: entry.blockId, failure: encodingFailure });
         }
     }
 

--- a/harness/src/report-model/validate.ts
+++ b/harness/src/report-model/validate.ts
@@ -1,0 +1,124 @@
+/**
+ * The mechanical validator of a report document.
+ *
+ * The schemas already carry the grammar: a strict object rejects a forbidden field, a binding is present
+ * by construction, and a metric value slot admits one scalar reference only. Thus a schema parse failure
+ * is the grammar rejection, and the validator does not re-implement it. The validator adds the two
+ * checks that a schema cannot make: it resolves each reference against the pinned evidence, and it warns
+ * about a free numeral in prose.
+ */
+
+import { ReportDocumentSchema, type Block } from "../contracts/report-blocks.js";
+import type { Reference, UnresolvedReference } from "../contracts/report-reference.js";
+import type { ReferenceResolver, ReportSnapshot } from "./reference-resolver.js";
+
+/** One schema conformance problem, reduced to a path and a message. */
+export interface SchemaIssue {
+    path: string;
+    message: string;
+}
+
+/** One reference that did not resolve, tied to the block that carries it. */
+export interface ResolutionFailure {
+    blockId: string;
+    failure: UnresolvedReference;
+}
+
+/** An advisory warning about the content of one block. A warning never makes a report invalid. */
+export interface ReportWarning {
+    blockId: string;
+    kind: "free-numeral";
+    detail: string;
+}
+
+/**
+ * The result of validation. `valid` is false only when the schema failed or a reference did not resolve.
+ * The warnings ride along in either case.
+ */
+export type ReportValidation =
+    | { valid: true; warnings: ReportWarning[] }
+    | { valid: false; schemaIssues?: SchemaIssue[]; resolutionFailures?: ResolutionFailure[]; warnings: ReportWarning[] };
+
+/**
+ * A token that looks like a number, with an optional decimal part and an optional percent sign.
+ *
+ * The check is advisory only. A natural-language numeral is brittle to police, because a numeral in
+ * prose can be a real free-standing figure or a harmless part of a name. Thus a hit warns, and it never
+ * fails the report.
+ */
+const NUMERAL_PATTERN = /-?\d+(?:\.\d+)?%?/g;
+
+function numeralWarnings(blockId: string, prose: string): ReportWarning[] {
+    const warnings: ReportWarning[] = [];
+    for (const match of prose.matchAll(NUMERAL_PATTERN)) {
+        warnings.push({ blockId, kind: "free-numeral", detail: match[0] });
+    }
+    return warnings;
+}
+
+/** Resolve each reference, collect the schema conformance and the resolution outcomes, and warn on prose. */
+export async function validateReport(document: unknown, snapshot: ReportSnapshot, resolver: ReferenceResolver): Promise<ReportValidation> {
+    const parsed = ReportDocumentSchema.safeParse(document);
+    if (!parsed.success) {
+        const schemaIssues: SchemaIssue[] = parsed.error.issues.map((issue) => ({
+            path: issue.path.map((segment) => String(segment)).join("."),
+            message: issue.message,
+        }));
+        return { valid: false, schemaIssues, warnings: [] };
+    }
+
+    const references: Array<{ blockId: string; reference: Reference }> = [];
+    const warnings: ReportWarning[] = [];
+
+    const walk = (block: Block): void => {
+        switch (block.kind) {
+            case "section":
+                for (const child of block.blocks) {
+                    walk(child);
+                }
+                return;
+            case "text":
+                warnings.push(...numeralWarnings(block.id, block.content.prose));
+                return;
+            case "claim":
+                warnings.push(...numeralWarnings(block.id, block.content.prose));
+                for (const binding of block.bindings) {
+                    references.push({ blockId: block.id, reference: binding });
+                }
+                return;
+            case "metric":
+                references.push({ blockId: block.id, reference: block.value });
+                return;
+            case "table":
+            case "chart":
+            case "figure":
+                references.push({ blockId: block.id, reference: block.binding });
+                return;
+            case "citation":
+                references.push({ blockId: block.id, reference: block.binding });
+                return;
+        }
+    };
+
+    for (const section of parsed.data.sections) {
+        walk(section);
+    }
+
+    const resolved = await Promise.all(
+        references.map(({ blockId, reference }) => resolver.resolve(reference, snapshot).then((outcome) => ({ blockId, outcome }))),
+    );
+
+    // Collect every failure. A reviewer must see each block that broke, thus the walk does not stop at
+    // the first unresolved reference.
+    const resolutionFailures: ResolutionFailure[] = [];
+    for (const { blockId, outcome } of resolved) {
+        if (!outcome.ok) {
+            resolutionFailures.push({ blockId, failure: outcome.failure });
+        }
+    }
+
+    if (resolutionFailures.length > 0) {
+        return { valid: false, resolutionFailures, warnings };
+    }
+    return { valid: true, warnings };
+}


### PR DESCRIPTION
## What & why

A report must be mechanical. It must be a document that a limited set of typed blocks
composes, and each number in it must bind to a real artifact. This pull request lands
that contract. It is the foundation of the report rebuild (#221), and each later part
binds to the types here.

Two limits in the current report path motivate the work:

- **The sections are flat.** The section model is a union of six types
  (`harness/src/tools/iterate-report.ts:186`), and a section cannot hold a section.
  Thus a new report shape needs a new type.
- **No number binds to an artifact.** An agent transcribes each figure from its
  memory. The only provenance is a free-text footnote.

### What this pull request adds

**Two new spec capabilities.**

- `report-block-model` — the composable block tree of eight kinds, and the content
  grammar that constrains nesting.
- `report-grounding` — one canonical reference shape, its resolution against a pinned
  snapshot, and the mechanical validation that rejects fabrication.

**The prototype code.**

- `harness/src/contracts/report-blocks.ts` — the `Block` union of `section`, `text`,
  `claim`, `metric`, `table`, `chart`, `figure`, and `citation`. Each block carries a
  stable `id`. The grammar is the shape of each kind: a `text` block holds no binding
  field, a `metric` value slot holds one scalar reference only, and no atom holds a
  child-block array. Each schema is strict. Thus an extra field fails the parse, and a
  forbidden construction cannot pass as valid.
- `harness/src/contracts/report-reference.ts` — the `Reference` union. An artifact
  reference pins a path and a content hash, and it can pin the run that made the file.
  It reuses the coordinates that the harness already keys on, `cortex_runs.run_id` and
  `cortex_artifacts(path, hash)`. A reference serializes to a canonical URI for a later
  session.
- `harness/src/report-model/` — the `ReferenceResolver` seam, a fixture resolver, and
  the mechanical validator.

### The guarantee

A claim binds by reference. Resolution reads the pinned snapshot again, and it matches
the authored assertion. Thus three failures are mechanical, and none needs a model:

- A claim that binds to a coordinate that does not resolve fails validation.
- A claim that binds to a real coordinate, but states a different number, also fails.
- A column name that no row holds fails. This covers the `columns` subset of a table
  reference and each channel of a chart encoding.

### The merge posture

**This change is additive, and it is dormant.** No caller reaches the new code. The
new types stay out of the package barrel, so the published surface does not grow. The
old report path is untouched, and it still works. Thus no user sees a change in
behavior.

**One caveat on the package.** The harness gains a runtime dependency on `p-queue`,
which bounds the resolution fan-out. It brings `eventemitter3` and `p-timeout` with
it. Thus a consumer of `@inflexa-ai/harness` installs three more packages.

Closes #222

## The review pass

A code review of the first commits found nine gaps, and the last commit closes each
one. Two were defects, and the rest were holes that the later parts of #221 would
inherit.

**The grounding fixes:**

- A column name that no row holds now gives `locator-out-of-range`. A projection onto
  an invented name gave an empty cell for each row and still resolved. A ragged column
  still resolves, and a table with no rows accepts each name.
- The `assert` carries no hash. An artifact reference already pins `hash`, and
  resolution compares that pin against the fresh read. A second hash compared the
  reference against itself. Thus a table reference and a file reference carry no assert
  at all.
- The `assert.value` is mandatory. A tolerance with no value had nothing to compare
  against, and the resolver ignored it in silence.
- The `run` is optional. A staged input file under `data/inputs/` has no run that
  produced it. Thus a mandatory `run` prevented a binding to an input file.

**The contract fixes:**

- The `path` is analysis-relative, the key of `cortex_artifacts`. The comments named it
  run-relative, which addresses a different file.
- A parse of a reference URI matches the payload against the base64url alphabet.
  `Buffer.from` never throws on a bad payload, thus the `invalid-payload` kind was
  unreachable.
- The `pctChange` operation gives a fraction and not a percent. The unit was undefined
  in the spec, the schema, and the resolver.

**The other fixes:**

- A free-numeral warning needs a left boundary. The domain prose is dense with a symbol
  such as `TP53`, and each one warned for its digits.
- Reference resolution runs under a concurrency cap of 8. A large report opened one
  read for each reference at the same moment. `allWithConcurrency` in
  `lib/async-utils.ts` gives the cap, and its signature mirrors `Promise.all`. It
  replaces `mapConcurrent`, which had no caller.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

**A note on the tests.** `bun run lint` and `bun run typecheck` pass on the full
harness, and `openspec validate --strict` passes on the two capabilities. The two new
test files give 82 tests, and each one passes. The full `bun test` suite needs a
Postgres container, and this change adds no code that touches the database.

**A note on the documents.** No user-facing behavior changes, because the code is
dormant. The two spec capabilities are the design record.
