### PR TITLE
ci: link the local harness in the PR checks, keep the npm pin at release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,13 +33,25 @@ jobs:
         with:
           bun-version-file: .bun-version
 
-      # cli pins @inflexa-ai/harness to an exact version and installs it from
-      # npm (not file:../harness), so a plain install resolves it — no in-repo
-      # harness build. A cli change that needs an unreleased harness must land
-      # AFTER that harness version publishes (release-harness.yml); until then
-      # this frozen install cannot resolve the pin. See the two-step promotion.
+      # cli pins @inflexa-ai/harness to an exact published version and installs
+      # it from npm (not file:../harness), so a plain install resolves it — no
+      # in-repo harness build.
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # A PR can change cli and harness together, and its checks must run
+      # against that pair. The npm pin cannot see an unpublished harness. Thus
+      # this step links the working-copy harness over the installed one, the
+      # same as `bun run harness:local` on a developer machine. The harness
+      # install comes first, because the link script builds the harness. A push
+      # to main keeps the npm pin: release.yml waits on the push checks as its
+      # release gate, and they must run against the harness version that the
+      # shipped binary bundles.
+      - name: Use the local harness
+        if: github.event_name == 'pull_request'
+        run: |
+          bun install --frozen-lockfile --cwd ../harness
+          bun run harness:local
 
       - name: ESLint
         run: bun run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,10 +124,11 @@ jobs:
       # cli pins @inflexa-ai/harness to an exact version and installs it from
       # npm, so the binary bundles the published, attested harness artifact —
       # not a local build. The pinned version is always already on npm here:
-      # the harness bump is promoted first (release-harness.yml), and only a
-      # later, separate cli change consumes it — a combined harness+cli change
-      # cannot pass cli CI (the pin is unresolvable until harness publishes),
-      # so it never reaches this workflow.
+      # the harness bump is promoted first (release-harness.yml), and a later,
+      # separate cli change consumes it. PR checks link the local harness, but
+      # the push checks that the gate above waits on keep this same npm pin —
+      # thus a main commit whose cli wants an unpublished harness fails that
+      # gate, and it never reaches this step.
       - name: Install cli dependencies
         if: steps.gate.outputs.release == 'true'
         working-directory: cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,25 @@ jobs:
         with:
           bun-version-file: .bun-version
 
-      # cli pins @inflexa-ai/harness to an exact version and installs it from
-      # npm (not file:../harness), so a plain install resolves it — no in-repo
-      # harness build. A cli change that needs an unreleased harness must land
-      # AFTER that harness version publishes (release-harness.yml); until then
-      # this frozen install cannot resolve the pin. See the two-step promotion.
+      # cli pins @inflexa-ai/harness to an exact published version and installs
+      # it from npm (not file:../harness), so a plain install resolves it — no
+      # in-repo harness build.
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # A PR can change cli and harness together, and its checks must run
+      # against that pair. The npm pin cannot see an unpublished harness. Thus
+      # this step links the working-copy harness over the installed one, the
+      # same as `bun run harness:local` on a developer machine. The harness
+      # install comes first, because the link script builds the harness. A push
+      # to main keeps the npm pin: release.yml waits on the push checks as its
+      # release gate, and they must run against the harness version that the
+      # shipped binary bundles.
+      - name: Use the local harness
+        if: github.event_name == 'pull_request'
+        run: |
+          bun install --frozen-lockfile --cwd ../harness
+          bun run harness:local
 
       - name: Run tests
         run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,20 +290,23 @@ Do not design a capability as a feature of the embedder.
 
 ### Red CI on a change to the two subsystems
 
-A pull request that changes `cli` and `harness` together has red `cli` CI. This
-result is correct. Do not treat it as a defect.
+The `cli` jobs of `lint.yml` and `test.yml` treat the harness in two ways:
 
-`cli` uses an exact published version of `@inflexa-ai/harness`. The CI job
-installs that version from npm with a frozen lockfile. Thus `cli` code that uses
-a harness version that is not published cannot typecheck there. The jobs `lint
-(cli)` and `test (cli)` fail on a missing export, and the two harness jobs pass.
+- On a pull request, the jobs link the working-copy harness, the same as `bun
+  run harness:local`. Thus a pull request that changes `cli` and `harness`
+  together is green.
+- On a push to main, the jobs install the pinned npm version of
+  `@inflexa-ai/harness` with a frozen lockfile. `release.yml` waits on these
+  checks. Thus the release gate runs against the exact version that the binary
+  bundles.
 
-The `bun run harness:local` command makes a link to the working copy. This is the
-reason that the same code is green on your machine.
+As a result, when a combined change merges, the push run on main has red `cli`
+checks. The red stays until the harness version publishes and the pin bump
+lands on main. This result is correct. Do not treat it as a defect.
 
 Obey these rules:
 
-- Do not report the red CI as a finding.
+- Do not report the red CI on main as a finding.
 - Do not read the workflow files to find the cause again.
 - Do not recommend a branch split or a merge sequence.
 - The developer of the pull request controls the harness release and the version

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -24,8 +24,8 @@ this repository, and leave the coordination to the user.
 - A handoff document or a spec can describe a staged rollout. Read it for the
   technical context. Then change the applicable constraints into implementation
   requirements. Do not echo the orchestration framing back.
-- Red `cli` CI on a pull request that also changes `harness` is correct, and the
-  developer of the pull request controls it. Refer to the root
+- Red `cli` CI on a main push, after a combined `cli` and `harness` change
+  merges, is correct, and the developer controls it. Refer to the root
   [`CLAUDE.md`](../CLAUDE.md). Say nothing about it.
 
 ## Quick Start


### PR DESCRIPTION
## What & why

A pull request that changes `cli` and `harness` together always had red `cli` checks. The `cli` jobs install the pinned npm version of `@inflexa-ai/harness`, and the pin cannot see an unpublished harness.

This PR splits the `cli` jobs of `lint.yml` and `test.yml` by event:

- A pull request installs the harness dependencies, and then it runs `bun run harness:local`. The checks then run against the working-copy pair, and a combined change is green.
- A push to main keeps the pinned npm install. `release.yml` waits on the push checks, thus the release gate still runs against the exact harness version that the binary bundles.

The red thus moves from the PR to the push run on main. It stays there until the harness version publishes and the pin bump lands. That signal is correct, because such a main commit cannot ship.

The PR also updates the text that gave the old rule: the comment in `release.yml`, the "Red CI on a change to the two subsystems" section in the root `CLAUDE.md`, and the scope bullet in `cli/CLAUDE.md`.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [x] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`) — not applicable: no source file changed, and the three edited workflow files parse as YAML.
- [ ] Tests added or updated for the change — not applicable for a workflow change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
