### PR TITLE
feat(cli): tell the rows apart in the input pickers and the analysis switcher

### DIFF
--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/.openspec.yaml
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/design.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/design.md
@@ -1,0 +1,152 @@
+## Context
+
+Three list surfaces share one fault: the row names an item and gives nothing that tells
+two items apart.
+
+- `FilePicker` lists an entry name only. `listDir` reads the directory with
+  `withFileTypes` dirents and takes no `stat`, thus no size and no date exist to render.
+- `RemoveInputDialog` lists `input.path`, which is relative to the anchor. It is a
+  single-select dialog, thus one open removes one input.
+- `SwitchAnalysisDialog` lists the analysis name, with the slug on the cursor detail line.
+  A slug is unique within an anchor only, thus two folders can hold the same name and the
+  same slug.
+
+The list engine already carries the parts that this change needs. `SelectItem` has
+`hint` (right-aligned, on the title line), `meta` (a muted line below the title), and
+`description` (the bottom detail line of the cursor row). `hint` and `meta` are mutually
+exclusive. A `category` groups rows under a header, and the header survives the filter.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make each row of the three surfaces carry the facts that separate it from its siblings.
+- Keep the syscall cost of the file picker bounded and stated.
+- Use the existing helpers. Add no dependency.
+
+**Non-Goals:**
+
+- A detail dialog for a filesystem entry. Refer to Decision 3.
+- A change to the `dialogSize` presets.
+- A change to the input model, the staging path, or the provenance events.
+
+## Decisions
+
+### Decision 1: one `stat` for each entry, and no `access` call
+
+The readability mark needs the answer to "can this user read this entry". The direct
+test is `accessSync(path, R_OK)`. Measured on a warm cache over a 468-entry directory:
+
+| Pass | 468 entries, cold | 468 entries, warm | 35 entries |
+| --- | --- | --- | --- |
+| `readdirSync` with `withFileTypes` | 0.24 ms | 0.21 ms | 0.05 ms |
+| `statSync` for each entry | 48.89 ms | 0.69 ms | 0.07 ms |
+| `accessSync(R_OK)` for each entry | — | 2.51 ms | 0.35 ms |
+
+`access` costs 3 to 7 times what `stat` costs. The row already needs `stat` for the size
+and the date, and a `Stats` object carries the mode bits, `uid`, and `gid`. Thus
+readability is arithmetic over data that the listing holds. The process ids come from
+`process.getuid()`, `getgid()`, and `getgroups()`, read one time for each picker mount.
+
+Alternatives that this decision rejects:
+
+- **`access` for each entry.** It doubles the syscalls and it is the slower call.
+- **A batch syscall.** POSIX has no batch `stat`. Thus "batch" can only mean fewer calls.
+- **A member count on a directory row.** It needs one `readdir` for each directory row.
+  Measured over 467 directories: 54.46 ms cold and 4.91 ms warm, against 1.65 ms and
+  0.68 ms for the `stat` pass. Thus a directory row carries no size field.
+
+Accepted limit: the derivation reads mode bits, thus an ACL, a macOS TCC rule, and an
+immutable flag are invisible to it. It can report "readable" where `open` fails. The
+authoritative refusal stays at staging time, which already exists.
+
+### Decision 2: a synchronous fill with an entry ceiling, not an asynchronous fill
+
+The measurements show that a cold page cache is the real cost, not the syscall. An
+asynchronous fill would keep the first frame fast. It is rejected for a hard reason:
+`ListCore` resets the cursor to row 0 whenever the `items` array is minted again. A fill
+that lands late mints the rows again, thus it moves the cursor while the user navigates.
+
+A synchronous fill cannot have that defect. The ceiling covers the pathological
+directory: above the ceiling the picker lists names alone and reports it in the footer.
+468 entries cost 48.89 ms cold, which is under two frames at 30 frames for each second.
+
+### Decision 3: no detail dialog for a filesystem entry
+
+The first sketch put the permission bits, the owner, and the exact byte count in a
+dialog that stacks over the picker. `dialogPush` keeps a lower entry mounted, hidden, and
+inert, and it stores that entry's focused renderable for restore. Thus the browse state
+costs nothing to preserve, and the objection was never the cost.
+
+The dialog is rejected on value. The row carries the size, the date, and the permission
+bits. Thus the dialog adds only the owner, the exact byte count, and a symlink target.
+That does not earn a new block in the design gallery.
+
+### Decision 4: the picker sets no `description`, thus it grows no detail line
+
+The picker sets no `description` on a row today, thus it renders no bottom detail line.
+The first sketch added one to hold the full path of the cursor row. That is rejected.
+
+The line renders only when the cursor row carries a `description`, and it costs two rows:
+a `space.sm` pad row inside its painted box, and the text row. The breadcrumb gives the
+location, and REVIEW mode lists the selection with root-relative paths. Thus the detail
+line would be a third copy that costs the listing two rows.
+
+### Decision 5: the group key and the group header text become separate fields
+
+`ListCore` keys a group on the `category` string and renders that same string as the
+header. Thus "group on the anchor id, show the anchor path" is not expressible.
+
+The switcher must group on the anchor id, not on the path. Two live anchors can hold one
+cached path: delete a `.inflexa/id` marker, make a new one in the same folder, and the
+old anchor row keeps that path. Keyed on the path the two merge, thus a dead anchor's
+analyses mix with the current ones. That is the confusion that this change removes.
+
+Thus `SelectItem` gains an optional header label. When it is absent the header text stays
+the category string, and each existing caller is unchanged.
+
+### Decision 6: an absolute local date, in two widths
+
+The two custom `Date` extensions, `relativeAge` and `formatDuration`, are both relative.
+The absolute form is the native `toLocaleString`, which `ls.ts`, `prov.ts`, and
+`sidebar_live.ts` already use. A record listing is a durable record, thus the time rule
+of `cli/CLAUDE.md` puts it on the absolute side.
+
+The row uses the compact form, `{ dateStyle: "short", timeStyle: "short" }`, which is
+about 16 columns. The cursor detail line uses the full form.
+
+### Decision 7: the analysis id copies through the existing clipboard writer
+
+`writeClipboard` emits an OSC 52 escape AND runs the native tool, thus it reaches a
+terminal over SSH and a GUI clipboard. The switcher binds `y` to copy the cursor row's
+analysis id, and it reports the copy with a notice, as the chat surface does.
+
+The filter input of `SelectDialog` can hold the focus. Thus `y` needs the bare-printable
+gate that the list engine documents, or it types into the filter.
+
+### Decision 8: the anchor paths come from ONE query
+
+The Switch analysis picker already reads its token totals in one batched query over the
+listed ids, and never one query for each drawn row. The anchor paths obey the same rule:
+one `listAnchors()` call builds a map from anchor id to cached path. A missing anchor
+degrades to the wording that `prov.ts` uses for an unknown folder.
+
+## Risks / Trade-offs
+
+- **A slow or network filesystem makes the listing wait.** → The entry ceiling bounds the
+  work, and the footer states that the metadata is absent for that directory.
+- **The readability mark can be wrong under an ACL.** → Staging keeps the authoritative
+  check, and the mark never blocks a selection. It only colors the row.
+- **Windows has no `process.getuid` and reports synthetic mode bits.** → Windows renders
+  no permission column and no readability mark.
+- **A grouped switcher loses the flat recency order.** → Group order is the first
+  appearance in ranked order, and `listRecentAnalyses` is already sorted by recency. Thus
+  the groups come out ordered by their newest analysis with no sort of their own.
+- **The switcher row becomes two lines with the group header.** → A header renders one
+  time for each group, not for each row. Thus a folder with three analyses costs one line.
+- **Four new visual states arrive at one time.** → Each takes a design gallery entry in
+  the same change, which keeps the gallery the single source of truth.
+
+## Open Questions
+
+None. Each decision above is settled.

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/design.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/design.md
@@ -27,7 +27,6 @@ exclusive. A `category` groups rows under a header, and the header survives the 
 **Non-Goals:**
 
 - A detail dialog for a filesystem entry. Refer to Decision 3.
-- A change to the `dialogSize` presets.
 - A change to the input model, the staging path, or the provenance events.
 
 ## Decisions
@@ -118,11 +117,16 @@ about 16 columns. The cursor detail line uses the full form.
 ### Decision 7: the analysis id copies through the existing clipboard writer
 
 `writeClipboard` emits an OSC 52 escape AND runs the native tool, thus it reaches a
-terminal over SSH and a GUI clipboard. The switcher binds `y` to copy the cursor row's
-analysis id, and it reports the copy with a notice, as the chat surface does.
+terminal over SSH and a GUI clipboard. The switcher binds `ctrl+y` to copy the cursor
+row's analysis id, and it reports the copy with a notice, as the chat surface does.
 
-The filter input of `SelectDialog` can hold the focus. Thus `y` needs the bare-printable
-gate that the list engine documents, or it types into the filter.
+The chord carries the control key. A bare `y` cannot work: the switcher is a single-mode
+picker, thus its filter input holds the focus for the whole life of the dialog. Ctrl, and
+never Alt: a terminal delivers Alt unreliably, and macOS composes Option into a character.
+
+The footer of the dialog names the chord, through a `footerHint` prop. `SelectDialog` owns
+its footer and stays domain-agnostic. Thus a key that the HOST binds had no way to
+advertise itself, and only the WhichKey overlay could find it.
 
 ### Decision 8: the anchor paths come from ONE query
 
@@ -130,6 +134,37 @@ The Switch analysis picker already reads its token totals in one batched query o
 listed ids, and never one query for each drawn row. The anchor paths obey the same rule:
 one `listAnchors()` call builds a map from anchor id to cached path. A missing anchor
 degrades to the wording that `prov.ts` uses for an unknown folder.
+
+### Decision 9: the `lg` preset grows, rather than a fourth tier
+
+Issue #26 asks for a bigger dialog. Three shapes answer it: grow `lg`, add a tier between
+`lg` and `xl`, or move these three dialogs to `xl`.
+
+`lg` grows to 108 columns by 28 rows. Each consumer of `lg` is a list, and each one gains
+together: the picker, the select dialog, the results dialog, the usage dialog, and the run
+detail dialog. The vocabulary stays at three tiers.
+
+A fourth tier is rejected. It buys one more decision at each new dialog, for a role that
+`lg` already names: "pickers, lists, results".
+
+`xl` is rejected. Its role is a full showcase and a gallery, thus a file picker that fills
+the terminal is a different feel from a modal.
+
+The width follows the row. An entry spends about 35 columns on its permissions, its size,
+and its date. The height leaves about 20 rows for the list after the chrome of the panel.
+
+### Decision 10: a footer names only the keys of its own surface
+
+The movement vocabulary is app-wide, and each navigable surface carries the same set. The
+WhichKey overlay documents it live. Thus a footer that restates it spends the width of the
+row on what the user knows, and it reads as though this one list moves differently.
+
+`↑/↓ move` leaves each footer. The mode word stays, because the same keystroke does
+different things in each state and nothing else on the screen says which state is live.
+
+The breathing row above a footer belongs to `DialogPanel`, thus each dialog gets it at one
+time. The pad sits inside the painted box, because a transparent gap under a `flexGrow`
+scrollbox lets the scrolled content bleed through it.
 
 ## Risks / Trade-offs
 

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/proposal.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Three list surfaces name an item but give nothing to tell two items apart. The file
+picker shows a bare entry name, thus the user cannot compare two candidate inputs. An
+unreadable entry also stays hidden until staging fails. The flat inputs list shows
+an anchor-relative path, and it removes one input for each open. The Switch analysis
+picker shows the analysis name only, thus two analyses that carry the same name in
+different folders render as identical rows. GitHub issue #26 records the first two, and
+the third came from the same review.
+
+## What Changes
+
+- The file picker row carries the entry size, the modification date, and the permission
+  bits. An entry that the user cannot read renders in the warning color.
+- The file picker takes ONE `stat` for each entry and derives readability from the mode
+  bits and the owner ids. It takes no `access` call. Above an entry ceiling it lists the
+  names alone and says so in the footer.
+- The file picker adds no bottom detail line for the full path. The breadcrumb gives the
+  location and REVIEW mode gives the selection, thus a third copy costs two rows and
+  tells the user nothing new.
+- The flat inputs list becomes multi-select, and it removes each selected input in one
+  pass. Its row title becomes the absolute path, with the kind, the size, and the date
+  on a meta line below.
+- The Switch analysis picker groups its rows by anchor, under a header that shows the
+  anchor folder. The row carries an absolute local date, not a relative age. The cursor
+  detail line carries the analysis id, the slug, and the full creation date. A `y` key
+  copies the analysis id to the clipboard.
+- `SelectItem` gets an optional field that separates the group key from the group header
+  text. Today the category string is both, thus a group cannot be keyed on an anchor id
+  and titled with a path.
+
+## Capabilities
+
+### New Capabilities
+
+None. Each change modifies an existing capability.
+
+### Modified Capabilities
+
+- `file-picker`: the listing gains entry metadata and a readability mark, the detail line
+  goes away, and the listing declares its syscall budget and its entry ceiling.
+- `list-primitives`: `SelectItem` gains a group header label that is separate from the
+  category key.
+- `analysis-input-management`: the flat inputs surface becomes a multi-select removal
+  list that shows absolute paths.
+- `command-palette`: the Switch analysis picker groups by anchor, renders absolute dates,
+  carries a cursor detail line, and copies the analysis id.
+
+## Impact
+
+Code:
+
+- `src/tui/components/dialog/file_picker.tsx` — the listing, the row hints, the entry
+  ceiling, and the removal of the `description` line.
+- `src/tui/components/list_core.tsx` — the group header label field.
+- `src/tui/commands.tsx` — `RemoveInputDialog` and `SwitchAnalysisDialog`.
+- `src/lib/fs.ts` — the readability derivation from a `Stats` object and the process ids.
+
+Existing helpers that this change uses, and does not duplicate: `Number.formatBytes`,
+`contractHome` (`lib/paths.ts`), `writeClipboard` (`lib/clipboard.ts`), `listAnchors`
+(`db/primary_query.ts`), and the native `toLocaleString`.
+
+Design system: the readability color, the row hint on a picker entry, the group header
+label, and the multi-select inputs list are new states. The design gallery takes an
+entry for each.
+
+Dependencies: none added.
+
+Platform: `process.getuid` does not exist on Windows, and Node reports synthetic mode
+bits there. Windows renders no permission column and no readability mark.

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/proposal.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/proposal.md
@@ -21,10 +21,13 @@ the third came from the same review.
 - The flat inputs list becomes multi-select, and it removes each selected input in one
   pass. Its row title becomes the absolute path, with the kind, the size, and the date
   on a meta line below.
+- The `lg` size preset grows from 88 by 20 to 108 by 28. This is issue #26, point 4.
+- A dialog footer takes a painted row of padding above it, and it names no cursor key.
+  A list row takes one column of right padding, thus a hint clears the scrollbar.
 - The Switch analysis picker groups its rows by anchor, under a header that shows the
   anchor folder. The row carries an absolute local date, not a relative age. The cursor
-  detail line carries the analysis id, the slug, and the full creation date. A `y` key
-  copies the analysis id to the clipboard.
+  detail line carries the analysis id, the slug, and the full creation date. A `ctrl+y`
+  chord copies the analysis id to the clipboard, and the footer names that chord.
 - `SelectItem` gets an optional field that separates the group key from the group header
   text. Today the category string is both, thus a group cannot be keyed on an anchor id
   and titled with a path.
@@ -45,6 +48,10 @@ None. Each change modifies an existing capability.
   list that shows absolute paths.
 - `command-palette`: the Switch analysis picker groups by anchor, renders absolute dates,
   carries a cursor detail line, and copies the analysis id.
+- `tui-design-tokens`: the `lg` preset grows to 108 columns by 28 rows. A row that carries
+  facts beside its name wants the width, and a list wants the rows.
+- `dialog-system`: a footer takes a painted breathing row above it, a footer names no
+  cursor key, and a list row clears the scrollbar.
 
 ## Impact
 

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/analysis-input-management/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/analysis-input-management/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: The flat inputs list removes more than one input in one pass
+
+The TUI MUST give a flat list of the analysis's registered inputs, and that list MUST be
+multi-select. Space toggles a row, and one confirm removes each selected input.
+
+The removals MUST go through the shared `removeInput` operation, one call for each
+selected row. A failed removal MUST NOT stop the removals that follow it, because each
+row is independent.
+
+This surface MUST stay beside the file picker, and MUST NOT fold into it. An analysis can
+span any number of folders. The picker seeds an input outside its browse root, but it
+renders no row for that input until the user browses to its folder. Thus the flat list is
+the one view of the whole input set.
+
+#### Scenario: Two inputs go in one pass
+
+- **WHEN** the user toggles two inputs and confirms
+- **THEN** both rows are removed, and each removal emits `prov.input_removed`
+
+#### Scenario: A far input is reachable without browsing
+
+- **GIVEN** an input that lives outside the anchor folder of the analysis
+- **WHEN** the user opens the flat inputs list
+- **THEN** that input renders as a row, and the user can remove it with no navigation
+
+#### Scenario: One failed removal keeps the others
+
+- **WHEN** one selected row fails to remove and the others succeed
+- **THEN** the others are removed, and the surface reports the failure
+
+### Requirement: The flat inputs list names an input by its absolute path
+
+The row title MUST be the absolute path of the input, resolved through
+`resolveInputPath`. It MUST NOT be the stored `path`, which is relative to the anchor.
+
+A directory row MUST carry a trailing path separator, as the file picker rows do.
+
+The row MUST carry a `meta` line with the kind, the size, and the modification date. The
+row MUST use `meta`, and not `hint`, because an absolute path is long and it wraps.
+
+An input whose file is gone MUST still list, and MUST still be removable. Its `meta` line
+reports that the file is absent. Removal resolves against the registered set, never
+against the filesystem.
+
+#### Scenario: The row names the full path
+
+- **WHEN** the flat inputs list opens for an analysis with an input under its anchor
+- **THEN** the row title is the absolute path, not the anchor-relative stored path
+
+#### Scenario: A directory is distinguishable
+
+- **WHEN** the list holds a directory input and a file input
+- **THEN** the directory row ends with a path separator and its `meta` line says directory
+
+#### Scenario: A deleted file is still removable
+
+- **GIVEN** a registered input whose file was deleted from disk
+- **WHEN** the user opens the flat inputs list
+- **THEN** the row lists, its `meta` line reports the absent file, and removal succeeds

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/analysis-input-management/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/analysis-input-management/spec.md
@@ -32,8 +32,14 @@ the one view of the whole input set.
 
 ### Requirement: The flat inputs list names an input by its absolute path
 
-The row title MUST be the absolute path of the input, resolved through
-`resolveInputPath`. It MUST NOT be the stored `path`, which is relative to the anchor.
+The row title MUST be the absolute path of the input. It MUST NOT be the stored `path`,
+which is relative to the anchor.
+
+The list MUST resolve each distinct anchor one time, and it MUST turn the `lastSeen`
+heartbeat off. A listing is not a sighting of the folder. The per-input helper
+`resolveInputPath` resolves the same anchor again for each row, and it writes a heartbeat
+each time. Thus an open of this dialog would measure the opens of the dialog. It would also
+pay one SQLite write for each row that it draws.
 
 A directory row MUST carry a trailing path separator, as the file picker rows do.
 
@@ -43,6 +49,12 @@ row MUST use `meta`, and not `hint`, because an absolute path is long and it wra
 An input whose file is gone MUST still list, and MUST still be removable. Its `meta` line
 reports that the file is absent. Removal resolves against the registered set, never
 against the filesystem.
+
+#### Scenario: An open records no sighting
+
+- **GIVEN** an analysis whose inputs share one anchor
+- **WHEN** the user opens the flat inputs list
+- **THEN** the `lastSeen` of that anchor does not change
 
 #### Scenario: The row names the full path
 

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/command-palette/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/command-palette/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: The Switch analysis picker groups its rows by anchor
+
+The picker MUST group its rows on the anchor id of the analysis, and MUST title each
+group with the anchor folder. The path MUST render in its contracted form, through
+`contractHome`.
+
+The group key MUST be the anchor id, and never the path. Two live anchors can hold one
+cached path: a user deletes a `.inflexa/id` marker and makes a new one in that folder.
+Keyed on the path the two groups merge, and a dead anchor's analyses mix with the current
+ones.
+
+The anchor paths MUST come from ONE `listAnchors()` query over the local database, and
+never one query for each drawn row. This matches the batched read of the token totals,
+and it keeps the picker open with the harness runtime stopped.
+
+The read MUST use the cached path directly, with no reconciliation, because the picker is
+a read-only display. An anchor that the database no longer holds MUST degrade to the
+wording that the provenance surface uses for an unknown folder.
+
+Group order MUST be the first appearance in ranked order. `listRecentAnalyses` is already
+sorted by recency. Thus a group carries the position of its newest analysis.
+
+#### Scenario: Two analyses of one name are distinguishable
+
+- **GIVEN** two analyses that carry the name `A1` in two different folders
+- **WHEN** the Switch analysis picker opens
+- **THEN** each row renders under the header of its own anchor folder
+
+#### Scenario: The folder is searchable
+
+- **WHEN** the user types part of an anchor folder into the filter
+- **THEN** the analyses of that folder survive the filter, and the header stays above them
+
+#### Scenario: One query reads every anchor
+
+- **WHEN** the picker opens over 20 analyses
+- **THEN** exactly one `listAnchors()` query runs, and no query runs for each row
+
+#### Scenario: A missing anchor degrades
+
+- **GIVEN** an analysis whose anchor row is gone from the database
+- **WHEN** the picker opens
+- **THEN** its group header reports an unknown folder, and the row stays selectable
+
+### Requirement: The Switch analysis picker renders an absolute local date
+
+Each row MUST carry the creation date of its analysis as an absolute local time, through
+the native `toLocaleString`. A row MUST NOT carry a relative age.
+
+The row MUST use the compact form of that call, with a short date style and a short time
+style. The picker is a record listing, thus the time rule puts it on the absolute side.
+
+The picker MUST carry a cursor detail line with the analysis id, the slug, and the full
+creation date. This line is the one place that gives an unambiguous handle for the row.
+
+#### Scenario: The row shows a date, not an age
+
+- **WHEN** the picker renders an analysis created on 24 July 2026
+- **THEN** the row shows that local date and time, and never a text such as `12d`
+
+#### Scenario: The cursor row gives its id
+
+- **WHEN** the cursor moves to an analysis row
+- **THEN** the detail line shows that analysis's id, its slug, and its full creation date
+
+### Requirement: The Switch analysis picker copies the analysis id
+
+The picker MUST bind `ctrl+y` to copy the analysis id of the cursor row to the clipboard.
+The copy MUST go through the shared `writeClipboard`, which emits an OSC 52 escape AND
+runs the native tool. Thus the copy reaches a terminal over SSH and a graphical clipboard.
+
+The picker MUST report the copy with a notice, as the chat surface does.
+
+The chord MUST carry the control key, and MUST NOT be a bare printable key. The filter
+input of this picker holds the focus for the whole life of the dialog, because a
+single-mode dialog has no NORMAL state. Thus a bare key would enter the filter as text.
+
+The binding MUST declare a description and a group. The WhichKey overlay reads those, thus
+the key is discoverable without a footer of its own.
+
+#### Scenario: The id reaches the clipboard
+
+- **WHEN** the cursor is on an analysis row and the user pushes `ctrl+y`
+- **THEN** that analysis's id is written to the clipboard and a notice reports the copy
+
+#### Scenario: The filter still receives a typed `y`
+
+- **WHEN** the filter input holds the focus and the user types `y`
+- **THEN** the character enters the filter, and no copy happens

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/dialog-system/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/dialog-system/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: The footer of a panel carries a painted breathing row above it
+
+`DialogPanel` MUST render one row of top padding above its footer text. That padding MUST sit
+INSIDE the painted footer box, and never as a transparent gap above that box.
+
+A fixed chrome row that sits directly below a `flexGrow` scrollbox lands one cell inside the
+last row of that scrollbox. This is the yoga overlap that `cli/CLAUDE.md` records. Thus an
+unpainted pad lets the scrolled content bleed through it.
+
+A painted pad row does two things at one time. It reclaims the bled cell, and it separates the
+keys from the content of the dialog.
+
+#### Scenario: The keys do not touch the last row of the list
+
+- **WHEN** a picker fills its list to the bottom of the panel
+- **THEN** one blank painted row separates the last list row from the footer text
+
+#### Scenario: Scrolled content does not bleed into the pad
+
+- **WHEN** the user scrolls a full list under the footer
+- **THEN** the pad row stays blank, and no list content shows through it
+
+### Requirement: A footer names only the keys of its own surface
+
+A footer MUST name the verbs that belong to that surface. Examples are `space toggle`, `enter
+confirm`, `i filter`, `c apply`, and `esc cancel`.
+
+A footer MUST NOT name a key that moves the cursor. The movement vocabulary is app-wide, and
+each navigable surface carries the same set: the arrows, `ctrl+p` and `ctrl+n`, the page keys,
+and in NORMAL the vim keys `j`, `k`, `gg`, and `G`. The WhichKey overlay documents them live.
+
+A restatement of that vocabulary spends the width of the row on what the user knows. It also
+reads as though this one list moves differently from each other list.
+
+A multi-select footer MUST lead with its mode word, `NORMAL` or `INSERT`. The same keystroke
+does different things in each state, and nothing else on the screen says which state is live.
+
+#### Scenario: A picker footer names no arrow
+
+- **WHEN** a file picker renders its footer in NORMAL or in INSERT
+- **THEN** the footer names no cursor key, and it keeps its own verbs
+
+#### Scenario: The mode word leads a multi-select footer
+
+- **WHEN** a multi-select dialog holds the focus in its filter input
+- **THEN** the footer starts with `INSERT`, and a blurred filter starts it with `NORMAL`
+
+### Requirement: A row of a list clears the scrollbar
+
+A list row MUST carry one column of right padding. The scrollbox paints its scrollbar over the
+right edge of the content. Thus a right-aligned hint touches the bar without that padding.
+
+#### Scenario: The hint does not touch the bar
+
+- **WHEN** a list is long enough to show its scrollbar
+- **THEN** one blank column separates the end of the hint from the bar

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: The listing resolves entry metadata with one stat for each entry
+
+The listing MUST take one `statSync` for each entry that it lists. It MUST take no
+`accessSync` call. The `Stats` object gives the size, the modification time, the mode
+bits, the owner uid, and the owner gid.
+
+The listing MUST derive readability from those mode bits and owner ids, against the ids
+of the process. It MUST read `process.getuid()`, `process.getgid()`, and
+`process.getgroups()` one time for each mount of the picker, and never for each entry.
+
+A `stat` that fails MUST NOT remove the row. That row lists with no metadata.
+
+The listing MUST apply an entry ceiling. Above the ceiling it lists the names alone, it
+takes no `stat`, and the footer reports the absent metadata.
+
+The fill MUST be synchronous. The picker MUST NOT fill the metadata asynchronously. A
+late fill mints the items array again, and the list engine then moves the cursor to row 0.
+
+#### Scenario: One syscall for each entry
+
+- **WHEN** the picker lists a directory below the entry ceiling
+- **THEN** it takes one `statSync` for each entry and no `accessSync` call
+
+#### Scenario: A failed stat keeps the row
+
+- **WHEN** an entry disappears between the `readdirSync` and its `statSync`
+- **THEN** the row still lists, with no size, no date, and no permission bits
+
+#### Scenario: A large directory skips the metadata
+
+- **WHEN** the directory holds more entries than the ceiling
+- **THEN** the rows carry names alone, no `stat` runs, and the footer reports it
+
+#### Scenario: The process ids are read once
+
+- **WHEN** the picker lists a directory of 400 entries
+- **THEN** `process.getuid`, `process.getgid`, and `process.getgroups` each run one time
+
+### Requirement: An entry row carries its size, its date, and its permission bits
+
+An entry row MUST carry a `hint` with the permission bits, the size, and the modification
+date. The list engine renders a `hint` inline, after the title, on the same row.
+
+A directory row MUST carry no size field. A member count needs one `readdir` for each
+directory row, which breaks the syscall budget above. Measured over 467 directories, that
+pass cost 54.46 ms cold against 1.65 ms for the `stat` pass.
+
+The size MUST render through `Number.formatBytes`. The date MUST render through the
+native `toLocaleString` in its compact form, and never as a relative age.
+
+The row MUST use `hint`, and not `meta`, because an entry name is short. Thus a row stays
+one line and the listing keeps its height.
+
+An entry that the process cannot read MUST render in the warning color of the theme. The
+mark MUST NOT refuse the selection. The authoritative refusal belongs to staging.
+
+On Windows the row MUST carry no permission bits and no readability mark. `process.getuid`
+does not exist there, and Node reports synthetic mode bits.
+
+#### Scenario: A file row is comparable to its siblings
+
+- **WHEN** a folder holds two data files of different sizes and ages
+- **THEN** each row shows its own permission bits, its size, and its date
+
+#### Scenario: A directory row carries no size
+
+- **WHEN** the listing holds a directory and a file
+- **THEN** the directory row shows its permission bits and its date, and no size
+
+#### Scenario: An unreadable entry is marked
+
+- **GIVEN** a file whose mode bits deny read to this user, this group, and other users
+- **WHEN** the picker lists its folder
+- **THEN** the row renders in the warning color, and space still toggles it
+
+#### Scenario: Windows renders no permission column
+
+- **WHEN** the picker lists a folder on Windows
+- **THEN** the row carries the size and the date, with no permission bits and no mark
+
+### Requirement: The picker renders no cursor detail line
+
+The picker MUST set no `description` on a row. Thus the list renders no bottom detail
+line, and the listing keeps the two rows that the painted detail box costs.
+
+The picker MUST NOT give the full path of the cursor row this way. The breadcrumb gives
+the location, and REVIEW mode lists the whole selection with root-relative paths.
+
+#### Scenario: No detail line under the listing
+
+- **WHEN** the cursor moves to any row
+- **THEN** no bottom detail line renders, and the list keeps its full height

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
@@ -40,15 +40,30 @@ late fill mints the items array again, and the list engine then moves the cursor
 
 ### Requirement: An entry row carries its size, its date, and its permission bits
 
-An entry row MUST carry a `hint` with the permission bits, the size, and the modification
-date. The list engine renders a `hint` inline, after the title, on the same row.
+An entry row MUST carry the permission bits in its `prefix`, LEFT of the name. This is the
+reading order of `ls -l`, and a shell user already has that habit. The triple is always 9
+characters, thus the column aligns with no padding.
 
-A directory row MUST carry no size field. A member count needs one `readdir` for each
-directory row, which breaks the syscall budget above. Measured over 467 directories, that
-pass cost 54.46 ms cold against 1.65 ms for the `stat` pass.
+An entry row MUST carry the size and the modification date in its `hint`, right of the
+name. The list engine renders a `hint` inline, at the right edge of the row.
 
-The size MUST render through `Number.formatBytes`. The date MUST render through the
-native `toLocaleString` in its compact form, and never as a relative age.
+The size MUST render through `Number.formatBytes`, right-aligned in a field as wide as the
+widest size of that listing. The eye compares a magnitude down a column, thus a ragged
+field defeats the purpose of the number.
+
+The date MUST render through the native `toLocaleString`, with `year`, `month`, `day`,
+`hour`, and `minute` each set to `2-digit`. It MUST never render as a relative age.
+
+That form is fixed-width, and the compact `dateStyle` form is not. Measured in en-US, the
+compact form gives 15 to 17 columns and this form gives 18. Thus the date column aligns
+with no padding of its own, and the value stays locale-ordered.
+
+A directory row MUST carry no size. A member count needs one `readdir` for each directory
+row, which breaks the syscall budget above. Measured over 467 directories, that pass cost
+54.46 ms cold against 1.65 ms for the `stat` pass.
+
+The blank size field of a directory row MUST span its separator too. Thus the date of a
+directory row lands in the same column as the date of a file row beside it.
 
 The row MUST use `hint`, and not `meta`, because an entry name is short. Thus a row stays
 one line and the listing keeps its height.
@@ -64,10 +79,22 @@ does not exist there, and Node reports synthetic mode bits.
 - **WHEN** a folder holds two data files of different sizes and ages
 - **THEN** each row shows its own permission bits, its size, and its date
 
+#### Scenario: The mode sits left of the name
+
+- **WHEN** the picker renders a file row
+- **THEN** the permission triple renders before the name, and it never ranks in the filter
+
+#### Scenario: The columns land under each other
+
+- **GIVEN** a folder that holds a 600-byte file and a 140-kilobyte file
+- **WHEN** the picker lists it
+- **THEN** the two separators share one column, and the two dates start in one column
+
 #### Scenario: A directory row carries no size
 
 - **WHEN** the listing holds a directory and a file
 - **THEN** the directory row shows its permission bits and its date, and no size
+- **AND** its date starts in the same column as the date of the file row
 
 #### Scenario: An unreadable entry is marked
 

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/file-picker/spec.md
@@ -15,6 +15,19 @@ A `stat` that fails MUST NOT remove the row. That row lists with no metadata.
 The listing MUST apply an entry ceiling. Above the ceiling it lists the names alone, it
 takes no `stat`, and the footer reports the absent metadata.
 
+The listing MUST carry the ceiling decision as a flag beside its rows. The footer MUST
+report from that flag. It MUST NOT infer the decision from the rows, because a folder that
+holds one broken symbolic link also gives rows with no metadata. Such a folder is not
+large, thus a footer that names the ceiling states a cause that is not the one at hand.
+
+The listing MUST format the size and the date ONE time for each row, and it MUST keep the
+two strings. The items of the picker are built again on each keystroke of the filter. A
+format at that point costs the whole listing for one typed character.
+
+The date MUST come from one `Intl.DateTimeFormat` for the process. A call to
+`toLocaleString` with options builds a formatter each time, which measured 48.6 ms over
+2000 rows against 2.5 ms for the shared formatter.
+
 The fill MUST be synchronous. The picker MUST NOT fill the metadata asynchronously. A
 late fill mints the items array again, and the list engine then moves the cursor to row 0.
 
@@ -27,11 +40,18 @@ late fill mints the items array again, and the list engine then moves the cursor
 
 - **WHEN** an entry disappears between the `readdirSync` and its `statSync`
 - **THEN** the row still lists, with no size, no date, and no permission bits
+- **AND** its name starts in the same column as the name of each row beside it
 
 #### Scenario: A large directory skips the metadata
 
 - **WHEN** the directory holds more entries than the ceiling
 - **THEN** the rows carry names alone, no `stat` runs, and the footer reports it
+
+#### Scenario: A failed stat is not a large folder
+
+- **GIVEN** a directory below the ceiling that holds one broken symbolic link
+- **WHEN** the picker lists it
+- **THEN** the row lists with no metadata, and the footer reports no ceiling
 
 #### Scenario: The process ids are read once
 
@@ -44,6 +64,13 @@ An entry row MUST carry the permission bits in its `prefix`, LEFT of the name. T
 reading order of `ls -l`, and a shell user already has that habit. The triple is always 9
 characters, thus the column aligns with no padding.
 
+A row with no metadata, in a listing that has metadata, MUST hold the column as blanks. A
+name that starts 9 columns left reads as a mode string, and not as an absent one. It also
+breaks the alignment that each other row of the listing wants.
+
+A listing with no metadata at all MUST drop the column. An empty column on each row spends
+the width of the name to say nothing.
+
 An entry row MUST carry the size and the modification date in its `hint`, right of the
 name. The list engine renders a `hint` inline, at the right edge of the row.
 
@@ -51,8 +78,8 @@ The size MUST render through `Number.formatBytes`, right-aligned in a field as w
 widest size of that listing. The eye compares a magnitude down a column, thus a ragged
 field defeats the purpose of the number.
 
-The date MUST render through the native `toLocaleString`, with `year`, `month`, `day`,
-`hour`, and `minute` each set to `2-digit`. It MUST never render as a relative age.
+The date MUST render with `year`, `month`, `day`, `hour`, and `minute` each set to
+`2-digit`. It MUST never render as a relative age.
 
 That form is fixed-width, and the compact `dateStyle` form is not. Measured in en-US, the
 compact form gives 15 to 17 columns and this form gives 18. Thus the date column aligns

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
@@ -10,9 +10,13 @@ Both MUST consume a row as `SelectItem<T>`: `value`, `title`, and the optional
 `description`, `hint`, `meta`, `prefix`, `category`, `categoryLabel`, `tone`, and `pinned`.
 Both MUST share one internal core (ranking, grouping, cursor, selection, row rendering).
 
-`prefix` renders BEFORE the title, in the recessive `fgSubtle` tier, and it MUST NOT rank.
+`prefix` renders BEFORE the title, in the secondary `fgMuted` tier, and it MUST NOT rank.
 A fixed-width column that folds into `title` would score against the fuzzy filter. Thus a
 query of `rwx` would match each directory of the file picker.
+
+`prefix` MUST NOT use the recessive `fgSubtle` tier. That tier is for content whose loss
+costs the user nothing. A permission triple is the one place its bits appear, because a
+`tone` marks a denied read alone. Thus the column holds the 4.5:1 text floor.
 
 `prefix` MUST NOT shrink. A short mode string reads as a DIFFERENT mode, and not as a
 short one.

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
@@ -7,8 +7,15 @@ list surfaces. They MUST render no dialog chrome (no `DialogPanel`) and no filte
 They MUST NOT bind esc, because dismissal is the structural concern of the dialog host.
 
 Both MUST consume a row as `SelectItem<T>`: `value`, `title`, and the optional
-`description`, `hint`, `meta`, `category`, `categoryLabel`, `tone`, and `pinned`. Both
-MUST share one internal core (ranking, grouping, cursor, selection, row rendering).
+`description`, `hint`, `meta`, `prefix`, `category`, `categoryLabel`, `tone`, and `pinned`.
+Both MUST share one internal core (ranking, grouping, cursor, selection, row rendering).
+
+`prefix` renders BEFORE the title, in the recessive `fgSubtle` tier, and it MUST NOT rank.
+A fixed-width column that folds into `title` would score against the fuzzy filter. Thus a
+query of `rwx` would match each directory of the file picker.
+
+`prefix` MUST NOT shrink. A short mode string reads as a DIFFERENT mode, and not as a
+short one.
 
 `tone` names a MEANING, and never a color. It MUST stay a closed union, and today it
 holds `"warning"` alone. A row that could name any theme role would let a caller paint
@@ -28,6 +35,12 @@ A single component with a matrix of mode flags and chrome flags MUST NOT come ba
 
 - **WHEN** a caller maps domain data to rows
 - **THEN** it produces `SelectItem<T>` values and handles selection callbacks generically over `T`
+
+#### Scenario: A prefix does not rank
+
+- **GIVEN** rows whose `prefix` holds a permission triple, and a row titled `data`
+- **WHEN** the query is `d`
+- **THEN** the `data` row ranks first, and no row ranks on its prefix
 
 #### Scenario: A tone survives the cursor
 

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/list-primitives/spec.md
@@ -1,0 +1,119 @@
+## MODIFIED Requirements
+
+### Requirement: Two pure list components
+
+The system MUST give `FixedList<T>` and `DynamicList<T>` in `src/tui/components/` as pure
+list surfaces. They MUST render no dialog chrome (no `DialogPanel`) and no filter input.
+They MUST NOT bind esc, because dismissal is the structural concern of the dialog host.
+
+Both MUST consume a row as `SelectItem<T>`: `value`, `title`, and the optional
+`description`, `hint`, `meta`, `category`, `categoryLabel`, `tone`, and `pinned`. Both
+MUST share one internal core (ranking, grouping, cursor, selection, row rendering).
+
+`tone` names a MEANING, and never a color. It MUST stay a closed union, and today it
+holds `"warning"` alone. A row that could name any theme role would let a caller paint
+for decoration, and the tier vocabulary would drift.
+
+A `tone` MUST outrank the cursor highlight of the row. The user lands on a row to read it,
+thus the mark that gives the reason to notice that row MUST stay.
+
+A single component with a matrix of mode flags and chrome flags MUST NOT come back.
+
+#### Scenario: Lists render no chrome
+
+- **WHEN** a `FixedList` or `DynamicList` is mounted outside any dialog
+- **THEN** it renders only its rows (plus empty-state/detail lines) — no panel border, no title bar, no input, and esc is not consumed by the list
+
+#### Scenario: Shared item shape
+
+- **WHEN** a caller maps domain data to rows
+- **THEN** it produces `SelectItem<T>` values and handles selection callbacks generically over `T`
+
+#### Scenario: A tone survives the cursor
+
+- **GIVEN** a row that carries `tone: "warning"`
+- **WHEN** the cursor lands on that row
+- **THEN** the title keeps the warning color of the theme, and the cursor color does not take it
+
+### Requirement: Category grouping survives filtering
+
+Both lists MUST derive the grouped representation `[category, SelectItem<T>[]][]` from the
+**ranked** rows. An uncategorized row groups under the empty key and takes no header.
+
+`category` is the group KEY. `categoryLabel` is the header TEXT. When a row carries no
+`categoryLabel`, the header text MUST be the `category` string.
+
+A caller that groups on an opaque identity MUST use this pair. An example is the analysis
+switcher, which groups on an anchor id and titles the group with the anchor folder.
+
+Grouping happens after ranking. Thus a category whose items match in part MUST keep its
+header above the items that survive. The cursor MUST index a flat projection of the
+grouped tuples.
+
+#### Scenario: One survivor keeps its header
+
+- **WHEN** a query leaves exactly one item in a category
+- **THEN** that category header renders above the single item
+
+#### Scenario: Headers are not cursor targets
+
+- **WHEN** the user navigates with the cursor
+- **THEN** the cursor lands only on item rows, never on category headers
+
+#### Scenario: The key and the header text are separate
+
+- **GIVEN** two rows that carry the same `categoryLabel` and different `category` values
+- **WHEN** the list groups them
+- **THEN** they render as two groups, each under its own header of that same text
+
+#### Scenario: An absent label keeps the old behavior
+
+- **WHEN** a row carries a `category` and no `categoryLabel`
+- **THEN** the header text is the `category` string
+
+### Requirement: Query-driven filtering
+
+Both lists MUST accept an optional reactive `query` string prop, and MUST NOT own a
+filter input. When `query` is empty or absent, the items render in the given order.
+
+When `query` is not empty, the list MUST rank with the shared `rankBy`
+(`src/lib/fuzzy.ts`) over weighted fields: `title` at weight 2, and the group header text
+at weight 1.
+
+The group header text is `categoryLabel` when the row carries one, and `category`
+otherwise. The ranked field MUST be the text that the user can read. A caller that groups
+on an opaque id would otherwise score that id, which no user types.
+
+A row can declare `pinned`, which exempts it from that ranking. A pinned row that the
+query drops MUST be appended again after the ranked matches. A pinned row that the query
+matches MUST keep its earned rank, and MUST NOT appear two times.
+
+`pinned` exists for an ESCAPE-HATCH row, which is a row whose action is "supply a value
+that these rows cannot express". There the query is text that the label of the row does
+not match. Thus a rank of that row would hide it at the keystroke that calls for it.
+`pinned` MUST NOT give an ordinary row priority.
+
+#### Scenario: Host owns the input
+
+- **WHEN** a host renders a filterable list
+- **THEN** the host renders its own `TextInput` and passes the typed value as `query`
+- **AND** the list renders no input
+
+#### Scenario: Ranking matches the shared scorer
+
+- **WHEN** `query` is not empty
+- **THEN** row order is `rankBy` order, and a title hit weighs 2 times a header-only hit
+- **AND** an empty query keeps the input order
+
+#### Scenario: The visible label is what ranks
+
+- **GIVEN** rows grouped on an opaque anchor id, with a folder path as the label
+- **WHEN** the query holds part of that folder path
+- **THEN** those rows survive the filter, and the anchor id itself matches nothing
+
+#### Scenario: A pinned row outlives a query nothing matches
+
+- **WHEN** the query matches no title of a row, and no title of the pinned row
+- **THEN** the pinned row is still listed, thus `emptyText` does not render
+- **AND** it is the cursor row, and it is selectable
+- **AND** a cleared query restores the full set, with the pinned row present one time

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/tui-design-tokens/spec.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/specs/tui-design-tokens/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Dialog size presets use clamped fixed dimensions; only static-content dialogs are content-height
+
+`src/lib/design_system.ts` MUST define the dialog size presets (`dialogSize`, keys `md`, `lg`,
+and `xl`) as fixed column widths with a percentage clamp, and never as a pair of percentages.
+
+Each preset MUST carry a fixed `width` in columns, which is a calibration value that you can
+tune: `md: 64`, `lg: 108`, and `xl: 116`. Each preset MUST carry a `maxWidth` clamp of `90%`.
+Thus a panel becomes smaller on a narrow terminal, and it never grows on a wide one.
+
+`lg` MUST hold a row that carries facts beside its name. A file entry spends about 35 columns
+on its permissions, its size, and its date. A picker that then truncates the names defeats its
+own purpose.
+
+A height obeys the same fixed-and-clamp shape, for each tier whose content changes while the
+dialog is open. `lg` (a picker, whose list filters) MUST fix its height at `28` rows, with a
+`maxHeight` clamp of `80%`. That leaves about 20 rows for the list after the chrome of the
+panel, which is a working set and not a keyhole. `xl` MUST fix its height at `85%`.
+
+A panel that resizes as its content changes is worse than trailing empty rows.
+
+Only `md` MUST be content-height (`height: undefined`, `maxHeight: 80%`). Its content is a
+prompt line or a confirm message, and that content is static for the life of the dialog.
+
+No preset MUST pair a percentage width with a percentage height. A terminal cell is about 2
+times taller than it is wide. Thus a pair of percentages gives a square panel or a portrait
+panel, whose proportions track the terminal instead of the content.
+
+A test of these dimensions MUST read them from `dialogSize`, and MUST NOT restate the numbers.
+A duplicated number turns each legitimate change of the calibration into a red test. It also
+proves nothing about the fixed-against-fraction behavior that the test claims.
+
+#### Scenario: A wide terminal gives the fixed width
+
+- **WHEN** an `lg` panel renders on a 200-column terminal
+- **THEN** it measures the `width` of the preset, and not a fraction of 200
+
+#### Scenario: A narrow terminal gives the clamp
+
+- **WHEN** an `lg` panel renders on a 40-column terminal
+- **THEN** it measures 36 columns, which is the `maxWidth` clamp
+
+#### Scenario: A filter does not resize the panel
+
+- **WHEN** a filter reduces a picker from 30 rows to 2 rows
+- **THEN** the panel holds the `height` of the preset, with trailing empty rows
+
+#### Scenario: A short terminal clamps the height
+
+- **WHEN** an `lg` panel renders on a 15-row terminal
+- **THEN** it measures 12 rows or fewer, and its chrome stays complete

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
@@ -72,3 +72,13 @@
 - [x] 9.4 Mount a multi-select dialog in NORMAL, as the file picker does
 - [x] 9.5 Name the copy chord in the footer of the switcher
 - [x] 9.6 Grow the `lg` preset to 108 by 28, and derive its tests from the preset
+
+## 10. The `ls` layout pass
+
+- [x] 10.1 Add the `prefix` field to `SelectItem`, in the recessive tier, that never ranks
+- [x] 10.2 Move the permission triple to the prefix, left of the name
+- [x] 10.3 Render the date with the 2-digit fields, which are fixed-width
+- [x] 10.4 Right-align the size in a field as wide as the listing needs
+- [x] 10.5 Span the separator in the blank size field of a directory row
+- [x] 10.6 Cover the column alignment and the rank of a prefix
+- [x] 10.7 Show the layout in the design gallery

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
@@ -1,0 +1,65 @@
+## 1. The list engine
+
+- [x] 1.1 Add the optional `categoryLabel` field to `SelectItem` in `list_core.tsx`
+- [x] 1.2 Carry the label into `RowMeta`, and render it as the group header text
+- [x] 1.3 Keep the `category` string as the header text when no label is present
+- [x] 1.4 Cover the key and the label as separate values with a render test
+
+## 2. The readability helper
+
+- [x] 2.1 Add a readability function to `lib/fs.ts` that takes a `Stats` object
+- [x] 2.2 Take the uid, the gid, and the group list of the process as parameters
+- [x] 2.3 Give a `null` result on Windows, where `process.getuid` does not exist
+- [x] 2.4 Cover the owner case, the group case, the other case, and the root case
+
+## 3. The file picker listing
+
+- [x] 3.1 Add the size, the modification time, and the mode bits to the `Row` type
+- [x] 3.2 Take one `statSync` for each entry in `listDir`, and take no `accessSync`
+- [x] 3.3 Keep a row whose `stat` failed, with no metadata on it
+- [x] 3.4 Add the entry ceiling, above which `listDir` takes no `stat`
+- [x] 3.5 Read the process ids one time for each mount, not for each entry
+- [x] 3.6 Cover the ceiling and the failed `stat` with unit tests
+
+## 4. The file picker row
+
+- [x] 4.1 Build the row `hint` from the mode bits, the size, and the compact date
+- [x] 4.2 Render a directory row with its date and no size field
+- [x] 4.3 Render an unreadable row in the warning color of the theme
+- [x] 4.4 Report the absent metadata in the footer above the ceiling
+- [x] 4.5 Set no `description` on any row
+- [x] 4.6 Assert the resolved span color of an unreadable row with `captureSpans`
+
+## 5. The flat inputs list
+
+- [x] 5.1 Change `RemoveInputDialog` to a multi-select list
+- [x] 5.2 Remove each selected input through `removeInput`, one call for each row
+- [x] 5.3 Collect the failures, and report them without stopping the pass
+- [x] 5.4 Title each row with the absolute path from `resolveInputPath`
+- [x] 5.5 Add the `meta` line with the kind, the size, and the date
+- [x] 5.6 Report an absent file on the `meta` line, and keep the row removable
+- [x] 5.7 Rename the palette entry to match the new multi-select behavior
+- [x] 5.8 Cover a two-input removal and an input outside the anchor folder
+
+## 6. The analysis switcher
+
+- [x] 6.1 Read every anchor with ONE `listAnchors()` call, into a map by anchor id
+- [x] 6.2 Group the rows on the anchor id, and title each group with `contractHome`
+- [x] 6.3 Degrade a missing anchor to the unknown-folder wording
+- [x] 6.4 Build the row `hint` from the compact absolute date and the token figure
+- [x] 6.5 Add the cursor detail line with the id, the slug, and the full date
+- [x] 6.6 Bind `ctrl+y` to copy the analysis id through `writeClipboard`, and notify
+- [x] 6.7 Use a control chord, because the filter input never releases the focus
+- [x] 6.8 Cover the duplicate-name case, the missing anchor, and the copy
+
+## 7. The design gallery
+
+- [x] 7.1 Add the file picker row with its metadata hint and its unreadable state
+- [x] 7.2 Add the multi-select inputs list with its absolute paths
+- [x] 7.3 Add the grouped switcher with its header label and its detail line
+
+## 8. The close-out
+
+- [x] 8.1 Run `bun run format:file` on each changed file under `src/`
+- [x] 8.2 Run `bun run typecheck` and `bun run lint`
+- [x] 8.3 Run `bun run test`

--- a/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
+++ b/cli/openspec/changes/improve-inputs-and-switcher-ux/tasks.md
@@ -63,3 +63,12 @@
 - [x] 8.1 Run `bun run format:file` on each changed file under `src/`
 - [x] 8.2 Run `bun run typecheck` and `bun run lint`
 - [x] 8.3 Run `bun run test`
+
+## 9. The review pass
+
+- [x] 9.1 Right-align the hint column, and clear the scrollbar with a right pad
+- [x] 9.2 Add a painted breathing row above each dialog footer
+- [x] 9.3 Drop each cursor key from each footer, and keep the mode word
+- [x] 9.4 Mount a multi-select dialog in NORMAL, as the file picker does
+- [x] 9.5 Name the copy chord in the footer of the switcher
+- [x] 9.6 Grow the `lg` preset to 108 by 28, and derive its tests from the preset

--- a/cli/src/lib/clipboard.ts
+++ b/cli/src/lib/clipboard.ts
@@ -38,13 +38,8 @@ export function nativeCopyCommand(platform: typeof process.platform, wayland: bo
     return ["xclip", "-selection", "clipboard"];
 }
 
-/**
- * Copy `text` to the clipboard via OSC 52 AND the native OS tool. Best-effort: a missing native tool
- * (`xclip`/`wl-copy` not installed → spawn throws ENOENT) is swallowed so it never crashes the TUI —
- * the OSC 52 path may still have succeeded, and copy is convenience feedback, not a critical path.
- */
-export async function writeClipboard(text: string): Promise<void> {
-    writeOsc52(text);
+/** Run the platform's clipboard tool. Best-effort — see {@link writeClipboard} for why it swallows. */
+async function nativeCopy(text: string): Promise<void> {
     const cmd = nativeCopyCommand(process.platform, terminalEnv.wayland);
     if (!cmd) return;
     try {
@@ -55,4 +50,32 @@ export async function writeClipboard(text: string): Promise<void> {
         // `err` is an unknown spawn failure (typically ENOENT — tool not installed). Logged, not thrown.
         log.debug({ err, cmd }, "native clipboard copy failed");
     }
+}
+
+let nativeWriter: (text: string) => Promise<void> = nativeCopy;
+
+/**
+ * Swap the native-tool leg for a double, returning its restore function. Mirrors the `__set…ForTest`
+ * accessors elsewhere; production code never calls it.
+ *
+ * A copy has no other observable: the OSC 52 leg is a deliberate no-op off a TTY (so it never leaks
+ * into piped output), and letting a test reach the real `pbcopy` would overwrite the clipboard of
+ * whoever runs the suite — a side effect no assertion is worth.
+ */
+export function __setClipboardWriterForTest(next: (text: string) => Promise<void>): () => void {
+    const previous = nativeWriter;
+    nativeWriter = next;
+    return () => {
+        nativeWriter = previous;
+    };
+}
+
+/**
+ * Copy `text` to the clipboard via OSC 52 AND the native OS tool. Best-effort: a missing native tool
+ * (`xclip`/`wl-copy` not installed → spawn throws ENOENT) is swallowed so it never crashes the TUI —
+ * the OSC 52 path may still have succeeded, and copy is convenience feedback, not a critical path.
+ */
+export async function writeClipboard(text: string): Promise<void> {
+    writeOsc52(text);
+    await nativeWriter(text);
 }

--- a/cli/src/lib/design_system.ts
+++ b/cli/src/lib/design_system.ts
@@ -792,8 +792,15 @@ export type Stroke = keyof typeof stroke;
 export const dialogSize = {
     /** Short prompts, confirms, alerts — static content, content height. */
     md: { width: 64, maxWidth: "90%", height: undefined, maxHeight: "80%" },
-    /** Pickers, lists, results — fixed rows so filtering never resizes the panel. */
-    lg: { width: 88, maxWidth: "90%", height: 20, maxHeight: "80%" },
+    /**
+     * Pickers, lists, results — fixed rows so filtering never resizes the panel.
+     *
+     * Sized for a row that carries FACTS beside its name, not a bare label: a file entry spends ~35
+     * columns on permissions, size, and timestamp, and a picker whose names then truncate defeats the
+     * point of listing them. The height follows the same logic — 28 rows leaves ~20 for the list after
+     * the panel's chrome, which is a working set rather than a keyhole to scroll through.
+     */
+    lg: { width: 108, maxWidth: "90%", height: 28, maxHeight: "80%" },
     /** Full showcases, galleries, large forms — near-full-screen. */
     xl: { width: 116, maxWidth: "90%", height: "85%", maxHeight: undefined },
 } as const satisfies Record<string, DialogDims>;

--- a/cli/src/lib/fs.test.ts
+++ b/cli/src/lib/fs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { Stats } from "node:fs";
+
+import { isReadableBy, type ProcessIdentity } from "./fs.ts";
+
+// Only the four fields `isReadableBy` reads. A cast is the pragmatic shape here: constructing a real
+// `Stats` means touching the filesystem, which would test the OS rather than the class resolution.
+function statLike(mode: number, uid: number, gid: number): Stats {
+    return { mode, uid, gid } as Stats;
+}
+
+const ME: ProcessIdentity = { uid: 501, gid: 20, groups: [20, 12] };
+
+describe("isReadableBy", () => {
+    test("the owner class decides for the owner, and it can DENY", () => {
+        expect(isReadableBy(statLike(0o600, 501, 20), ME)).toBe(true);
+        // POSIX resolves exactly one class: matching the owner means the group and other bits are
+        // never consulted, so a 0044 file owned by this user is unreadable to it despite `r` twice.
+        expect(isReadableBy(statLike(0o044, 501, 20), ME)).toBe(false);
+    });
+
+    test("the group class covers a supplementary group, not just the effective gid", () => {
+        expect(isReadableBy(statLike(0o040, 0, 20), ME)).toBe(true);
+        // gid 12 is supplementary — reachable only through `getgroups()`.
+        expect(isReadableBy(statLike(0o040, 0, 12), ME)).toBe(true);
+        expect(isReadableBy(statLike(0o040, 0, 99), ME)).toBe(false);
+    });
+
+    test("the other class is the fallback for an unrelated file", () => {
+        expect(isReadableBy(statLike(0o004, 0, 0), ME)).toBe(true);
+        expect(isReadableBy(statLike(0o600, 0, 0), ME)).toBe(false);
+    });
+
+    test("root reads regardless of the bits", () => {
+        const root: ProcessIdentity = { uid: 0, gid: 0, groups: [0] };
+        expect(isReadableBy(statLike(0o000, 501, 20), root)).toBe(true);
+    });
+
+    test("the file type bits do not leak into the decision", () => {
+        // A real `st_mode` carries S_IFDIR/S_IFREG above the permission bits; masking must ignore them.
+        const dirMode = 0o040000 | 0o750;
+        expect(isReadableBy(statLike(dirMode, 501, 20), ME)).toBe(true);
+        expect(isReadableBy(statLike(0o040000 | 0o310, 501, 20), ME)).toBe(false);
+    });
+});

--- a/cli/src/lib/fs.ts
+++ b/cli/src/lib/fs.ts
@@ -97,9 +97,14 @@ export function processIdentity(): ProcessIdentity | null {
  * `Stats` object already implies.
  *
  * ACCEPTED IMPRECISION: mode bits are not the whole access story. A POSIX ACL, a macOS TCC rule, or
- * a file flag can deny a read this reports as permitted. The result is therefore advisory — it
- * colors a row, and never refuses a selection. The authoritative refusal stays where the file is
- * actually opened (staging), which already reports a failure the user can act on.
+ * a file flag can deny a read this reports as permitted. A directory is a second such case, and one
+ * this deliberately does not model: `r` lists its names but `x` is what reaches the entries inside,
+ * so a directory with `r` and no `x` reports readable and still refuses every path through it. Both
+ * bits would answer "can I browse it", which is a different question from the one asked here.
+ *
+ * The result is therefore advisory — it colors a row, and never refuses a selection. The
+ * authoritative refusal stays where the file is actually opened (staging), which already reports a
+ * failure the user can act on.
  */
 export function isReadableBy(stats: Stats, identity: ProcessIdentity): boolean {
     // Root bypasses the permission bits for reads, so the mode check below would report false for a

--- a/cli/src/lib/fs.ts
+++ b/cli/src/lib/fs.ts
@@ -65,3 +65,49 @@ export function statResult(path: string, op: string): Result<Stats, FsError> {
         return err({ type: "io_failed", op, cause });
     }
 }
+
+/**
+ * The identity a readability decision is made against: this process's effective user, its effective
+ * group, and every supplementary group it belongs to. Read ONCE per listing (the ids cannot change
+ * mid-render) and passed down, so {@link isReadableBy} stays a pure function of two inputs.
+ */
+export type ProcessIdentity = { uid: number; gid: number; groups: readonly number[] };
+
+/**
+ * This process's identity, or `null` on a platform without POSIX ids.
+ *
+ * `process.getuid` is undefined on Windows, where Node also synthesizes mode bits that describe no
+ * real permission — so "no identity" is the honest answer there, not a fabricated one, and every
+ * caller must render no readability signal rather than a wrong one.
+ */
+export function processIdentity(): ProcessIdentity | null {
+    // Feature-detected rather than branched on `process.platform`: these are documented as
+    // POSIX-only, and the presence of the function is the exact condition that makes the read safe.
+    if (!process.getuid || !process.getgid || !process.getgroups) return null;
+    return { uid: process.getuid(), gid: process.getgid(), groups: process.getgroups() };
+}
+
+/**
+ * Whether `identity` can read the file `stats` describes, decided from the mode bits and the owning
+ * ids alone — NO syscall.
+ *
+ * This exists to avoid an `accessSync(R_OK)` pass over a directory listing. A `stat` is already
+ * taken for the size and the mtime, and it carries everything this needs; measured over a 468-entry
+ * directory, the extra `access` pass cost 2.5–4.7ms against `stat`'s 0.69ms, for an answer the
+ * `Stats` object already implies.
+ *
+ * ACCEPTED IMPRECISION: mode bits are not the whole access story. A POSIX ACL, a macOS TCC rule, or
+ * a file flag can deny a read this reports as permitted. The result is therefore advisory — it
+ * colors a row, and never refuses a selection. The authoritative refusal stays where the file is
+ * actually opened (staging), which already reports a failure the user can act on.
+ */
+export function isReadableBy(stats: Stats, identity: ProcessIdentity): boolean {
+    // Root bypasses the permission bits for reads, so the mode check below would report false for a
+    // 0600 file owned by someone else — a "you cannot read this" that is simply untrue as root.
+    if (identity.uid === 0) return true;
+    if (stats.uid === identity.uid) return (stats.mode & 0o400) !== 0;
+    // Supplementary groups count, not just the effective gid: a file group-readable by `staff` is
+    // readable by a user who merely belongs to `staff`, which `getgid()` alone would miss.
+    if (stats.gid === identity.gid || identity.groups.includes(stats.gid)) return (stats.mode & 0o040) !== 0;
+    return (stats.mode & 0o004) !== 0;
+}

--- a/cli/src/tui/commands.tsx
+++ b/cli/src/tui/commands.tsx
@@ -30,7 +30,7 @@ import { driveForceReprofile, profileWorkInFlight } from "./hooks/profile_parity
 import { absTime, absTimeShort, idTail, shortRunName } from "./hooks/sidebar_live.ts";
 import { restoreActivityPanel } from "./hooks/activity_panel.ts";
 import { chatStatus } from "./hooks/status.ts";
-import { keybindLabel } from "./keymap.ts";
+import { chordLabel, keybindLabel, type Chord } from "./keymap.ts";
 import { useWorkspace, type Workspace } from "./contexts/workspace.ts";
 import type { HarnessRuntime } from "../modules/harness/runtime.ts";
 import { GLYPHS, themes, themeIds, type ThemeId } from "../lib/design_system.ts";
@@ -628,6 +628,14 @@ function NewAnalysisInputsDialog(props: { name: Str256 }): JSX.Element {
 }
 
 /**
+ * Copy the cursor row's analysis id. Ctrl-modified, NOT a bare `y`: the switcher is a single-mode
+ * picker whose filter input holds focus for the whole life of the dialog, so a bare printable would be
+ * swallowed as typed text. Ctrl and never Alt — terminals deliver Alt/Option unreliably, and macOS
+ * composes Option into a character. One constant so the binding and its footer label cannot drift.
+ */
+const COPY_ANALYSIS_ID: Chord = { key: "y", ctrl: true };
+
+/**
  * The analysis switcher — and the ONE place the interface reports a whole-analysis total.
  *
  * Every other surface reports the entity it names or the open working context; this is where analyses
@@ -685,7 +693,7 @@ function SwitchAnalysisDialog(): JSX.Element {
     useDialogBindings(() => ({
         bindings: [
             {
-                chord: { key: "y", ctrl: true },
+                chord: COPY_ANALYSIS_ID,
                 run: () => {
                     const a = cursor();
                     if (!a) return;
@@ -703,6 +711,8 @@ function SwitchAnalysisDialog(): JSX.Element {
             placeholder={`Search analyses${GLYPHS.ellipsis}`}
             items={items}
             emptyText="No analyses yet — use ctrl+k → New analysis to create one"
+            // Derived from the chord itself, so the footer can never advertise a key the binding lost.
+            footerHint={`${chordLabel(COPY_ANALYSIS_ID)} copy id`}
             onCursorChange={setCursor}
             onCancel={() => ws.closeDialog()}
             onSelect={(a: Analysis) => {

--- a/cli/src/tui/commands.tsx
+++ b/cli/src/tui/commands.tsx
@@ -1,7 +1,7 @@
 import { createSignal, Show, type JSX } from "solid-js";
 import { randomUUIDv7 } from "bun";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { ResultAsync } from "neverthrow";
 // Type-only — erased at compile time, so it does NOT pull tsprov/verify into the TUI's startup path.
 import type { BuiltinProvFormat } from "@inflexa-ai/tsprov";
@@ -35,7 +35,7 @@ import { useWorkspace, type Workspace } from "./contexts/workspace.ts";
 import type { HarnessRuntime } from "../modules/harness/runtime.ts";
 import { GLYPHS, themes, themeIds, type ThemeId } from "../lib/design_system.ts";
 import { readConfig, writeConfig } from "../lib/config.ts";
-import { mkdirResult, writeFileResult } from "../lib/fs.ts";
+import { mkdirResult, statResult, writeFileResult } from "../lib/fs.ts";
 import { str256, type Str256 } from "../lib/types.ts";
 import {
     createAnalysis,
@@ -62,12 +62,16 @@ import { createProject, deleteAnalysis, deleteProject, updateAnalysisProject } f
 import {
     listProjects,
     listAnalysisInputs,
+    listAnchors,
     countAnalysesByProject,
     listAnalysisUsageByRun,
     listRunUsageByStep,
     listUsageTotalsByAnalysis,
     type LlmUsageTotals,
 } from "../db/primary_query.ts";
+import { contractHome } from "../lib/paths.ts";
+import { writeClipboard } from "../lib/clipboard.ts";
+import { useDialogBindings } from "./components/dialog/dialog_host.tsx";
 import { formatTokenFigure } from "../lib/usage_format.ts";
 import type { Analysis, AnalysisInput } from "../types/analysis.ts";
 import type { Project } from "../types/project.ts";
@@ -641,24 +645,65 @@ function SwitchAnalysisDialog(): JSX.Element {
         () => [],
     );
     const usageByAnalysis = listUsageTotalsByAnalysis(analyses.map((a) => a.id)).unwrapOr(new Map<string, LlmUsageTotals>());
+    // ONE query for every anchor, matching the batched ledger read above — a lookup per drawn row
+    // would put N queries on the open of a picker whose whole point is that it works with the
+    // runtime cold. The CACHED path is used deliberately: this is a read-only display, so it must
+    // not trigger the reconciliation (and its `lastSeen` write) that resolving by id performs.
+    const anchorPaths = listAnchors().match(
+        (as) => new Map(as.map((anchor) => [anchor.id, anchor.cachedPath])),
+        () => new Map<string, string>(),
+    );
     const items = analyses.map((a) => {
         const totals = usageByAnalysis.get(a.id);
+        const folder = anchorPaths.get(a.anchorId);
         return {
             value: a,
             title: a.name,
-            // An analysis with nothing recorded carries NO hint rather than a zeroed one: absent means
+            // Grouped by anchor ID, headed by its folder. Keying on the path instead would MERGE two
+            // live anchors that share a stale cachedPath (delete `.inflexa/id`, re-init in place, and
+            // the old row keeps that path) — mixing a dead anchor's analyses in with the current ones,
+            // which is the exact ambiguity this grouping exists to remove.
+            category: a.anchorId,
+            categoryLabel: folder === undefined ? "(folder unknown)" : contractHome(folder),
+            // An analysis with nothing recorded carries NO figure rather than a zeroed one: absent means
             // not-reported everywhere the ledger is read, and `formatTokenFigure` returns the empty
             // string for exactly that state.
-            hint: totals ? formatTokenFigure(totals) || undefined : undefined,
-            description: a.slug,
+            hint: [absTimeShort(new Date(a.createdAt).toISOString()), totals ? formatTokenFigure(totals) || undefined : undefined]
+                .filter(Boolean)
+                .join(` ${GLYPHS.middot} `),
+            // The one place a row's unambiguous handle lives: the name repeats across anchors and the
+            // slug repeats within them, so neither identifies a row on its own.
+            description: `${a.id} ${GLYPHS.middot} ${a.slug} ${GLYPHS.middot} created ${absTime(new Date(a.createdAt).toISOString())}`,
         };
     });
+    // Mirrored from the list so the copy binding below can act on the highlighted row: the list owns
+    // the cursor, and `onCursorChange` is the sanctioned way for a host to read it.
+    const [cursor, setCursor] = createSignal<Analysis | undefined>(items[0]?.value);
+    // ctrl+y, NOT a bare `y`: this picker's filter input holds focus for its whole life (single mode
+    // has no NORMAL state to fall back to), so a bare printable would be swallowed as typed text.
+    // Ctrl, never Alt — terminals deliver Alt/Option unreliably and macOS composes it into a glyph.
+    useDialogBindings(() => ({
+        bindings: [
+            {
+                chord: { key: "y", ctrl: true },
+                run: () => {
+                    const a = cursor();
+                    if (!a) return;
+                    void writeClipboard(a.id); // best-effort, never rejects → notify optimistically
+                    notify({ kind: "info", text: `Copied analysis id ${a.id}` });
+                },
+                desc: "Copy analysis id",
+                group: "Analysis",
+            },
+        ],
+    }));
     return (
         <SelectDialog
             title="Switch analysis"
             placeholder={`Search analyses${GLYPHS.ellipsis}`}
             items={items}
             emptyText="No analyses yet — use ctrl+k → New analysis to create one"
+            onCursorChange={setCursor}
             onCancel={() => ws.closeDialog()}
             onSelect={(a: Analysis) => {
                 ws.closeDialog();
@@ -1306,7 +1351,37 @@ function AddInputDialog(): JSX.Element {
     );
 }
 
-function RemoveInputDialog(): JSX.Element {
+/**
+ * One input row's muted second line: what kind of thing it is, how big, and when it last changed.
+ *
+ * A directory contributes no size for the same reason the picker's rows do not — measuring it means
+ * walking it. The two degraded phrasings are deliberately different facts: an input whose anchor no
+ * longer resolves is one we cannot LOCATE, while a resolved path that fails to stat is one we can
+ * locate and cannot FIND. Both stay removable either way, so neither is an error.
+ */
+function inputMetaLine(input: AnalysisInput, abs: string | null): string {
+    const kind = input.isDir ? "directory" : "file";
+    if (abs === null) return `${kind} ${GLYPHS.middot} location unknown`;
+    return statResult(abs, "removeInputs:stat").match(
+        (s) =>
+            [kind, input.isDir ? undefined : s.size.formatBytes(), absTimeShort(new Date(s.mtimeMs).toISOString())].filter(Boolean).join(` ${GLYPHS.middot} `),
+        () => `${kind} ${GLYPHS.middot} not on disk`,
+    );
+}
+
+/**
+ * The flat view of every registered input, with multi-select removal.
+ *
+ * It stays a SEPARATE surface from "Manage inputs" rather than folding into that picker, because an
+ * analysis may span any number of folders (its anchor is a default root, not a fence). The picker
+ * seeds a far-away input into its selection but renders no row for it until the user browses to that
+ * folder — so this list is the only place the whole input set is visible at once, and the only way
+ * to drop an input without navigating to wherever it lives.
+ *
+ * Rows are titled by ABSOLUTE path, not the stored `path`: the stored form is anchor-relative, which
+ * renders two inputs from different anchors as the same string.
+ */
+function RemoveInputsDialog(): JSX.Element {
     const ws = useWorkspace();
     const a = ws.analysis;
     const inputs = a
@@ -1315,25 +1390,39 @@ function RemoveInputDialog(): JSX.Element {
               () => [],
           )
         : [];
-    const items = inputs.map((input: AnalysisInput) => ({
-        value: input,
-        title: input.path,
-        description: input.isDir ? "directory" : "file",
-    }));
+    const items = inputs.map((input: AnalysisInput) => {
+        const abs = resolveInputPath(input).unwrapOr(null);
+        const shown = abs ?? input.path;
+        return {
+            value: input,
+            // The trailing separator is the type marker the picker rows already use.
+            title: input.isDir ? `${shown}${sep}` : shown,
+            meta: inputMetaLine(input, abs),
+        };
+    });
     return (
         <SelectDialog
-            title="Remove input"
+            title="Remove inputs"
             placeholder={`Search inputs${GLYPHS.ellipsis}`}
             items={items}
             emptyText="No inputs to remove"
+            mode="multi"
             onCancel={() => ws.closeDialog()}
-            onSelect={(input: AnalysisInput) => {
+            onConfirm={(chosen: AnalysisInput[]) => {
                 ws.closeDialog();
-                if (!a) return;
-                removeInput(input).match(
-                    () => notify({ kind: "info", text: `Removed input: ${input.path}` }),
-                    (e) => notify({ kind: "error", text: `Failed: ${e.type}` }),
-                );
+                if (!a || chosen.length === 0) return;
+                // Each removal is independent, so one failure must not strand the rest — collect and
+                // report rather than short-circuit (the same reasoning as `applyInputsDiff`'s removals).
+                const failed: string[] = [];
+                for (const input of chosen) {
+                    removeInput(input).match(
+                        () => {},
+                        (e) => failed.push(`${input.path} (${e.type})`),
+                    );
+                }
+                const removed = chosen.length - failed.length;
+                if (failed.length > 0) notify({ kind: "error", text: `Removed ${removed} of ${chosen.length} — failed: ${failed.join(", ")}` });
+                else notify({ kind: "info", text: `Removed ${removed} input${removed === 1 ? "" : "s"}` });
             }}
         />
     );
@@ -2094,12 +2183,14 @@ export const commands: Command[] = [
         run: (ctx) => ctx.openDialog(() => <AddInputDialog />),
     },
     {
+        // The id stays `remove-input` though the surface now takes a batch: it is the key a user's
+        // `config.keybinds` entry can already be bound to, and renaming it would silently orphan that.
         id: "analysis.remove-input",
-        title: "Remove input",
-        description: "Remove an input from this analysis",
+        title: "Remove inputs",
+        description: "Remove one or more inputs from this analysis",
         category: "Analysis",
         enabled: (ctx) => ctx.analysis !== null,
-        run: (ctx) => ctx.openDialog(() => <RemoveInputDialog />),
+        run: (ctx) => ctx.openDialog(() => <RemoveInputsDialog />),
     },
     {
         id: "analysis.reprofile",

--- a/cli/src/tui/commands.tsx
+++ b/cli/src/tui/commands.tsx
@@ -687,9 +687,6 @@ function SwitchAnalysisDialog(): JSX.Element {
     // Mirrored from the list so the copy binding below can act on the highlighted row: the list owns
     // the cursor, and `onCursorChange` is the sanctioned way for a host to read it.
     const [cursor, setCursor] = createSignal<Analysis | undefined>(items[0]?.value);
-    // ctrl+y, NOT a bare `y`: this picker's filter input holds focus for its whole life (single mode
-    // has no NORMAL state to fall back to), so a bare printable would be swallowed as typed text.
-    // Ctrl, never Alt — terminals deliver Alt/Option unreliably and macOS composes it into a glyph.
     useDialogBindings(() => ({
         bindings: [
             {
@@ -1380,6 +1377,44 @@ function inputMetaLine(input: AnalysisInput, abs: string | null): string {
 }
 
 /**
+ * The absolute path of each input, with ONE anchor resolution for each distinct anchor and no
+ * heartbeat write.
+ *
+ * `resolveInputPath` is the per-input form, and it is wrong for a listing twice over. It resolves
+ * the same anchor again for every row that shares it. Its resolve also defaults to `touch: true`,
+ * so opening a dialog to LOOK at the rows would record a sighting of the folder and pay a
+ * synchronous SQLite write for each row. A sighting belongs to a deliberate act (launch, `open`) —
+ * the same reasoning that keeps `detectSourceAnalysis` off `resolveAnchor`, and that makes the
+ * analysis switcher above read the cached path.
+ *
+ * `null` is the unlocatable anchor, which the caller renders rather than treats as an error.
+ */
+function inputAbsolutePaths(inputs: readonly AnalysisInput[]): Map<AnalysisInput, string | null> {
+    const byAnchor = new Map<string, string | null>();
+    const out = new Map<AnalysisInput, string | null>();
+    for (const input of inputs) {
+        // A null anchor means the stored path is already absolute — there is nothing to resolve.
+        if (input.anchorId === null) {
+            out.set(input, input.path);
+            continue;
+        }
+        const anchorId = input.anchorId;
+        if (!byAnchor.has(anchorId)) {
+            byAnchor.set(
+                anchorId,
+                resolveAnchor(anchorId, { touch: false }).match(
+                    (resolved) => resolved?.path ?? null,
+                    () => null,
+                ),
+            );
+        }
+        const dir = byAnchor.get(anchorId) ?? null;
+        out.set(input, dir === null ? null : join(dir, input.path));
+    }
+    return out;
+}
+
+/**
  * The flat view of every registered input, with multi-select removal.
  *
  * It stays a SEPARATE surface from "Manage inputs" rather than folding into that picker, because an
@@ -1400,8 +1435,9 @@ function RemoveInputsDialog(): JSX.Element {
               () => [],
           )
         : [];
+    const absolute = inputAbsolutePaths(inputs);
     const items = inputs.map((input: AnalysisInput) => {
-        const abs = resolveInputPath(input).unwrapOr(null);
+        const abs = absolute.get(input) ?? null;
         const shown = abs ?? input.path;
         return {
             value: input,

--- a/cli/src/tui/components/dialog/dialog_host.render.test.tsx
+++ b/cli/src/tui/components/dialog/dialog_host.render.test.tsx
@@ -397,16 +397,19 @@ describe("dialog host state machine (rendered, real keyboard bus)", () => {
     });
 
     test("multi SelectDialog: space types while filtering, esc unlocks list keys, space toggles, enter confirms", async () => {
-        // The INSERT/NORMAL-lite seam: with the filter focused, space MUST reach the input as a
-        // character (bare-printable rule); the first esc is consumed by the close-guard veto
-        // (blur, dialog stays open), unlocking space-to-toggle.
+        // The INSERT/NORMAL seam: multi mode MOUNTS in NORMAL (the FilePicker convention), `i` enters
+        // the filter, and with it focused space MUST reach the input as a character (bare-printable
+        // rule); esc is then consumed by the close-guard veto (blur, dialog stays open), unlocking
+        // space-to-toggle again.
         const items = [
             { value: "a", title: "alpha" },
             { value: "b", title: "beta" },
             { value: "c", title: "gamma" },
         ];
         const confirmed: string[][] = [];
-        const setup = await testRender(() => <Harness />, { width: 80, height: 20 });
+        // Wider than the other cases: the multi footer leads with its mode word, and at 80 columns the
+        // trailing "N selected" wraps mid-phrase, which no assertion about the COUNT should trip over.
+        const setup = await testRender(() => <Harness />, { width: 110, height: 20 });
         const settle = makeSettle(setup);
         const frame = () => setup.captureCharFrame();
         try {
@@ -425,6 +428,11 @@ describe("dialog host state machine (rendered, real keyboard bus)", () => {
             await settle();
             expect(frame()).toContain(`${GLYPHS.circle} gamma`); // seed renders filled
             expect(frame()).toContain("1 selected");
+
+            expect(frame()).toContain("NORMAL");
+            await setup.mockInput.pressKeys(["i"]); // NORMAL → INSERT
+            await settle();
+            expect(frame()).toContain("INSERT");
 
             await setup.mockInput.typeText("al");
             setup.mockInput.pressKey(" "); // INSERT: types into the filter, must NOT toggle

--- a/cli/src/tui/components/dialog/dialog_panel.test.tsx
+++ b/cli/src/tui/components/dialog/dialog_panel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { renderFrame } from "../../../test_support/tui.ts";
+import { dialogSize } from "../../../lib/design_system.ts";
 import { DialogPanel } from "./dialog_panel.tsx";
 import { ResultsDialog } from "./results_dialog.tsx";
 import { SelectDialog } from "./select_dialog.tsx";
@@ -32,10 +33,12 @@ describe("DialogPanel", () => {
                 <text>b</text>
             </DialogPanel>
         );
-        // Wide terminal: lg renders at its fixed 88 columns, NOT a fraction of the 200 available.
-        const wide = await renderFrame(panel, { width: 200, height: 20 });
+        // Wide terminal: lg renders at its OWN fixed column count, NOT a fraction of the 200 available.
+        // Read from the preset rather than restated here — a duplicated literal turns every legitimate
+        // retune into a red test while proving nothing about fixed-vs-fraction, which is the claim.
+        const wide = await renderFrame(panel, { width: 200, height: 60 });
         const wideCols = Math.max(...wide.split("\n").map((l) => l.length));
-        expect(wideCols).toBe(88);
+        expect(wideCols).toBe(dialogSize.lg.width);
         // Narrow terminal: the fixed width would overflow, so the 90% clamp takes over (36 of 40).
         const narrow = await renderFrame(panel, { width: 40, height: 20 });
         const narrowCols = Math.max(...narrow.split("\n").map((l) => l.length));
@@ -62,8 +65,8 @@ describe("DialogPanel", () => {
                 <text>b</text>
             </DialogPanel>
         );
-        const tall = await renderFrame(panel, { width: 100, height: 40 });
-        expect(tall.split("\n").length).toBe(20);
+        const tall = await renderFrame(panel, { width: 100, height: 60 });
+        expect(tall.split("\n").length).toBe(dialogSize.lg.height);
         const short = await renderFrame(panel, { width: 100, height: 15 });
         expect(short.split("\n").length).toBeLessThanOrEqual(12);
     });
@@ -77,11 +80,11 @@ describe("lg consumers hold a stable height", () => {
 
     test("ResultsDialog is the same height for 1 line and 50 lines, and scrolls the overflow", async () => {
         const render = (lines: string[]) =>
-            renderFrame(() => <ResultsDialog title="Results" lines={lines} emptyText="none" onClose={() => {}} />, { width: 100, height: 40 });
+            renderFrame(() => <ResultsDialog title="Results" lines={lines} emptyText="none" onClose={() => {}} />, { width: 120, height: 60 });
         const many = await render(LINES);
         const one = await render(["only line"]);
-        expect(many.split("\n").length).toBe(20);
-        expect(one.split("\n").length).toBe(20);
+        expect(many.split("\n").length).toBe(dialogSize.lg.height);
+        expect(one.split("\n").length).toBe(dialogSize.lg.height);
         expect(many).toContain("line 0");
         expect(one).toContain("only line");
         expect(many).toContain("close");
@@ -91,13 +94,13 @@ describe("lg consumers hold a stable height", () => {
         const items = Array.from({ length: 30 }, (_, i) => ({ value: i, title: `item ${i}` }));
         const render = (subset: typeof items) =>
             renderFrame(() => <SelectDialog title="Pick" items={subset} emptyText="none" onSelect={() => {}} onCancel={() => {}} />, {
-                width: 100,
-                height: 40,
+                width: 120,
+                height: 60,
             });
         const full = await render(items);
         const filtered = await render(items.slice(0, 2));
-        expect(full.split("\n").length).toBe(20);
-        expect(filtered.split("\n").length).toBe(20);
+        expect(full.split("\n").length).toBe(dialogSize.lg.height);
+        expect(filtered.split("\n").length).toBe(dialogSize.lg.height);
         expect(filtered).toContain("item 0");
         expect(full).toContain("select");
     });

--- a/cli/src/tui/components/dialog/dialog_panel.tsx
+++ b/cli/src/tui/components/dialog/dialog_panel.tsx
@@ -1,7 +1,7 @@
 import { Show } from "solid-js";
 import type { JSX } from "solid-js";
 
-import { dialogSize, stroke, type DialogSize } from "../../../lib/design_system.ts";
+import { dialogSize, space, stroke, type DialogSize } from "../../../lib/design_system.ts";
 import { theme } from "../../theme.ts";
 import { dialogPanelMouseDown, dialogPanelMouseUp } from "./dialog_host.tsx";
 
@@ -57,8 +57,13 @@ export function DialogPanel(props: {
             onMouseUp={dialogPanelMouseUp}
         >
             {props.children}
+            {/* The breathing row above the hint line lives INSIDE this painted box, never as a
+                transparent gap above it: a fixed chrome row directly under a `flexGrow` scrollbox sits one
+                cell inside that scrollbox's last row (the yoga overlap quirk), so an unpainted pad would
+                let scrolled content bleed through it. Painted, the pad reclaims the cell AND separates the
+                keys from the content — the same construction as the list's detail line. */}
             <Show when={props.footer}>
-                <box width="100%" flexShrink={0} backgroundColor={theme().bgRaised}>
+                <box width="100%" flexShrink={0} paddingTop={space.sm} backgroundColor={theme().bgRaised}>
                     <text fg={theme().fgMuted}>{props.footer}</text>
                 </box>
             </Show>

--- a/cli/src/tui/components/dialog/file_picker.render.test.tsx
+++ b/cli/src/tui/components/dialog/file_picker.render.test.tsx
@@ -334,3 +334,137 @@ describe("FilePicker", () => {
         }
     });
 });
+
+describe("FilePicker entry metadata", () => {
+    /** The row line carrying `needle`, or "" — the hint rides the SAME line as the title. */
+    function rowLine(frame: string, needle: string): string {
+        return frame.split("\n").find((l) => l.includes(needle)) ?? "";
+    }
+
+    test("a file row carries its permissions, its size, and an absolute date", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        writeFileSync(join(root, "sized.txt"), "x".repeat(2048));
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            const line = rowLine(frame, "sized.txt");
+            expect(line).toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+            expect(line).toContain("2.0 KB");
+            // Absolute local time, never a relative age — a record listing reads on the absolute side.
+            expect(line).toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/);
+            expect(line).not.toMatch(/\b\d+[dhm]\b/);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a directory row carries a date but no size", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            const line = rowLine(frame, "beta/");
+            expect(line).toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/);
+            // Counting members would cost a readdir per row — the budget this listing protects.
+            expect(line).not.toMatch(/\d+(\.\d+)?\s?(B|KB|MB|GB)/);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("an unreadable file paints its row in the theme's warning color", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        const denied = join(root, "denied.txt");
+        writeFileSync(denied, "x");
+        chmodSync(denied, 0o000);
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            expect(frame).toContain("denied.txt");
+            // A char frame carries no color, so containment alone would pass on an unpainted row:
+            // the claim here is that the row LOOKS different, which only a resolved span proves.
+            const spans = setup.captureSpans().lines.flatMap((l) => l.spans);
+            const deniedFg = spans.find((s) => s.text.includes("denied.txt"))?.fg;
+            const readableFg = spans.find((s) => s.text.includes("zeta.txt"))?.fg;
+            expect(deniedFg).toBeDefined();
+            expect(readableFg).toBeDefined();
+            expect(deniedFg).not.toEqual(readableFg);
+        } finally {
+            chmodSync(denied, 0o644);
+            setup.renderer.destroy();
+        }
+    });
+
+    test("an unreadable file is still selectable — the mark warns, it does not refuse", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        const denied = join(root, "denied.txt");
+        writeFileSync(denied, "x");
+        chmodSync(denied, 0o000);
+        let confirmed: string[] = [];
+        try {
+            await settle(setup);
+            // dirs first, then files alphabetically: .. → beta/ → alpha.txt → denied.txt
+            await openPicker(setup, { onConfirm: (paths) => (confirmed = paths) });
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("down");
+            await setup.mockInput.pressKeys([" "]);
+            await setup.mockInput.pressKeys(["c"]);
+            await settle(setup);
+            expect(confirmed).toEqual([denied]);
+        } finally {
+            chmodSync(denied, 0o644);
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a broken symlink lists with no metadata rather than dropping out", async () => {
+        // The deterministic stand-in for a stat that loses its race with a deletion: statSync
+        // follows the link and throws, which is exactly the path `entryMeta` degrades on.
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        symlinkSync(join(root, "gone.txt"), join(root, "dangling.txt"));
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            const line = rowLine(frame, "dangling.txt");
+            expect(line).not.toBe("");
+            expect(line).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a folder over the ceiling lists names only and says so in the footer", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        const big = join(root, "big");
+        mkdirSync(big);
+        for (let i = 0; i < 2001; i++) writeFileSync(join(big, `f${i}.txt`), "x");
+        try {
+            await settle(setup);
+            await openPicker(setup);
+            // dirs sort first, alphabetically: .. → beta/ → big/
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressEnter();
+            const frame = await settle(setup);
+            expect(frame).toContain("details off (large folder)");
+            const line = rowLine(frame, "f0.txt");
+            expect(line).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("the listing sets no description, so no detail line grows under it", async () => {
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            // The detail line would repeat the cursor row's path on its own row beneath the list.
+            const pathLines = frame.split("\n").filter((l) => l.includes(root));
+            expect(pathLines).toHaveLength(0);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/components/dialog/file_picker.render.test.tsx
+++ b/cli/src/tui/components/dialog/file_picker.render.test.tsx
@@ -479,6 +479,31 @@ describe("FilePicker entry metadata", () => {
             const line = rowLine(frame, "dangling.txt");
             expect(line).not.toBe("");
             expect(line.slice(0, line.indexOf("dangling.txt"))).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+            // And it holds the column as blanks: a name that starts where the mode starts reads as a
+            // mode string, and it breaks the alignment every other row of the listing depends on.
+            expect(line.indexOf("dangling.txt")).toBe(rowLine(frame, "alpha.txt").indexOf("alpha.txt"));
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a listing whose every stat fails is not reported as a large folder", async () => {
+        // The footer states a CAUSE. Inferring "no row has metadata" from the rows cannot tell the
+        // ceiling from a folder holding one broken symlink, and it names the wrong one.
+        const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
+        const onlyBroken = join(root, "broken");
+        mkdirSync(onlyBroken);
+        symlinkSync(join(onlyBroken, "gone.txt"), join(onlyBroken, "dangling.txt"));
+        try {
+            await settle(setup);
+            await openPicker(setup);
+            // dirs sort first, alphabetically: .. → beta/ → broken/
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressEnter();
+            const frame = await settle(setup);
+            expect(frame).toContain("dangling.txt");
+            expect(frame).not.toContain("details off (large folder)");
         } finally {
             setup.renderer.destroy();
         }

--- a/cli/src/tui/components/dialog/file_picker.render.test.tsx
+++ b/cli/src/tui/components/dialog/file_picker.render.test.tsx
@@ -68,6 +68,20 @@ async function openPicker(
     return settle(setup);
 }
 
+/**
+ * The selection gutter of the row carrying `name`, or "" when no row does.
+ *
+ * Read positionally rather than by `toContain("● name")`: the row renders gutter, then the
+ * permission column, then the name, so the glyph and the name are never adjacent in the frame.
+ */
+function gutterOf(frame: string, name: string): string {
+    const line = frame.split("\n").find((l) => l.includes(name)) ?? "";
+    const before = line.slice(0, line.indexOf(name));
+    if (before.includes(GLYPHS.circle)) return GLYPHS.circle;
+    if (before.includes(GLYPHS.circleHollow)) return GLYPHS.circleHollow;
+    return "";
+}
+
 describe("FilePicker", () => {
     test("lists dirs first with a trailing slash, hides dotfiles, prepends ..", async () => {
         const setup = await testRender(() => <Harness />, { width: 90, height: 26 });
@@ -118,7 +132,7 @@ describe("FilePicker", () => {
             setup.mockInput.pressKey(" ");
             frame = await settle(setup);
             expect(frame).toContain("1 selected");
-            expect(frame).toContain(`${GLYPHS.circle} alpha.txt`);
+            expect(gutterOf(frame, "alpha.txt")).toBe(GLYPHS.circle);
 
             // Walk into beta and back: the toggle must survive both listings.
             setup.mockInput.pressArrow("up");
@@ -129,7 +143,7 @@ describe("FilePicker", () => {
 
             setup.mockInput.pressArrow("left");
             frame = await settle(setup);
-            expect(frame).toContain(`${GLYPHS.circle} alpha.txt`);
+            expect(gutterOf(frame, "alpha.txt")).toBe(GLYPHS.circle);
             expect(frame).toContain("1 selected");
         } finally {
             setup.renderer.destroy();
@@ -219,7 +233,7 @@ describe("FilePicker", () => {
             frame = await settle(setup);
             expect(frame).toContain("NORMAL");
             expect(frame).toContain("1 selected");
-            expect(frame).toContain(`${GLYPHS.circleHollow} alpha.txt`); // removed in review → unchecked here
+            expect(gutterOf(frame, "alpha.txt")).toBe(GLYPHS.circleHollow); // removed in review → unchecked here
         } finally {
             setup.renderer.destroy();
         }
@@ -277,7 +291,7 @@ describe("FilePicker", () => {
             await settle(setup);
             // The seed is what classifyInputPath records: the symlink's canonical TARGET.
             const frame = await openPicker(setup, { seed: [outside] });
-            expect(frame).toContain(`${GLYPHS.circle} ext/`);
+            expect(gutterOf(frame, "ext/")).toBe(GLYPHS.circle);
             expect(frame).toContain("1 selected");
         } finally {
             setup.renderer.destroy();
@@ -303,8 +317,8 @@ describe("FilePicker", () => {
             expect(frame).toContain("..");
             expect(frame).toContain("1 selected");
             // Navigation-only row: neither checked nor uncheckable-looking.
-            expect(frame).not.toContain(`${GLYPHS.circle} ..`);
-            expect(frame).not.toContain(`${GLYPHS.circleHollow} ..`);
+            expect(gutterOf(frame, "..")).not.toBe(GLYPHS.circle);
+            expect(gutterOf(frame, "..")).not.toBe(GLYPHS.circleHollow);
         } finally {
             setup.renderer.destroy();
         }
@@ -348,11 +362,47 @@ describe("FilePicker entry metadata", () => {
             await settle(setup);
             const frame = await openPicker(setup);
             const line = rowLine(frame, "sized.txt");
-            expect(line).toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+            // The mode sits LEFT of the name, as `ls -l` puts it.
+            expect(line.slice(0, line.indexOf("sized.txt"))).toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
             expect(line).toContain("2.0 KB");
             // Absolute local time, never a relative age — a record listing reads on the absolute side.
-            expect(line).toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/);
+            expect(line).toMatch(/\d{2}\/\d{2}\/\d{2}/);
             expect(line).not.toMatch(/\b\d+[dhm]\b/);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("the size and date land in aligned columns across rows", async () => {
+        // The whole point of the facts: comparing them down a column. Ragged fields defeat it, and
+        // the two causes are independent — an unpadded size, and a date whose parts are not zero-padded.
+        const setup = await testRender(() => <Harness />, { width: 100, height: 26 });
+        writeFileSync(join(root, "small.txt"), "x".repeat(600));
+        writeFileSync(join(root, "large.txt"), "x".repeat(140_000));
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            const small = rowLine(frame, "small.txt");
+            const large = rowLine(frame, "large.txt");
+            // Sizes of different widths ("600 B" vs "136.7 KB") end at the same column.
+            expect(small.indexOf(GLYPHS.middot)).toBe(large.indexOf(GLYPHS.middot));
+            // And the dates start together, which only holds while every part is zero-padded.
+            const dateAt = (l: string): number => l.search(/\d{2}\/\d{2}\/\d{2}/);
+            expect(dateAt(small)).toBe(dateAt(large));
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a directory keeps the date column despite carrying no size", async () => {
+        const setup = await testRender(() => <Harness />, { width: 100, height: 26 });
+        writeFileSync(join(root, "sized.txt"), "x".repeat(2048));
+        try {
+            await settle(setup);
+            const frame = await openPicker(setup);
+            const dateAt = (l: string): number => l.search(/\d{2}\/\d{2}\/\d{2}/);
+            // The blank size field spans its separator too, or the dir's date would slide left.
+            expect(dateAt(rowLine(frame, "beta/"))).toBe(dateAt(rowLine(frame, "sized.txt")));
         } finally {
             setup.renderer.destroy();
         }
@@ -364,7 +414,7 @@ describe("FilePicker entry metadata", () => {
             await settle(setup);
             const frame = await openPicker(setup);
             const line = rowLine(frame, "beta/");
-            expect(line).toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/);
+            expect(line).toMatch(/\d{2}\/\d{2}\/\d{2}/);
             // Counting members would cost a readdir per row — the budget this listing protects.
             expect(line).not.toMatch(/\d+(\.\d+)?\s?(B|KB|MB|GB)/);
         } finally {
@@ -428,7 +478,7 @@ describe("FilePicker entry metadata", () => {
             const frame = await openPicker(setup);
             const line = rowLine(frame, "dangling.txt");
             expect(line).not.toBe("");
-            expect(line).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+            expect(line.slice(0, line.indexOf("dangling.txt"))).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
         } finally {
             setup.renderer.destroy();
         }
@@ -449,7 +499,7 @@ describe("FilePicker entry metadata", () => {
             const frame = await settle(setup);
             expect(frame).toContain("details off (large folder)");
             const line = rowLine(frame, "f0.txt");
-            expect(line).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
+            expect(line.slice(0, line.indexOf("f0.txt"))).not.toMatch(/[r-][w-][x-][r-][w-][x-][r-][w-][x-]/);
         } finally {
             setup.renderer.destroy();
         }

--- a/cli/src/tui/components/dialog/file_picker.tsx
+++ b/cli/src/tui/components/dialog/file_picker.tsx
@@ -162,34 +162,54 @@ function safeSymlinkIsDir(abs: string): boolean {
  * The permission bits as the `rwxr-xr-x` triple every shell user already reads, or `undefined`
  * where they mean nothing.
  *
+ * It rides the row's `prefix`, LEFT of the name, because that is where `ls -l` puts it and the
+ * habit is worth more than the nine columns it takes from the name. Always exactly 9 characters,
+ * so the column aligns with no padding.
+ *
  * Windows is the `undefined` case: Node synthesizes a mode there that describes no real ACL, so
  * printing it would be a confident lie. The type marker is the row's trailing `/`, so the leading
  * `d` a full `ls -l` mode carries would be a second, redundant one — the triple starts at the bits.
  */
-function modeTriple(mode: number, identity: ProcessIdentity | null): string | undefined {
-    if (identity === null) return undefined;
+function modeTriple(row: Row, identity: ProcessIdentity | null): string | undefined {
+    if (identity === null || !row.meta) return undefined;
     const rwx = (bits: number): string => `${bits & 4 ? "r" : "-"}${bits & 2 ? "w" : "-"}${bits & 1 ? "x" : "-"}`;
+    const mode = row.meta.mode;
     return `${rwx((mode >> 6) & 7)}${rwx((mode >> 3) & 7)}${rwx(mode & 7)}`;
 }
 
 /**
- * The row's right-aligned facts: permissions, size, date. A directory contributes no size —
- * counting its members costs one `readdir` per row (54.46ms cold over 467 directories, against
- * 1.65ms for the whole stat pass), which is the budget this listing exists to protect.
+ * The modification time as a FIXED-WIDTH local timestamp.
  *
- * The date is absolute, never a relative age: this listing is a record of what is on disk, which
- * the time convention puts on the absolute side, and a fixed-width local timestamp also stays
- * comparable down a column in a way "3d" does not.
+ * `{ dateStyle: "short", timeStyle: "short" }` — the app's usual compact form — varies from 15 to 17
+ * columns (`8/5/26, 3:32 PM` against `7/17/26, 11:21 PM`), which makes a column of them ragged. The
+ * explicit 2-digit fields zero-pad every part, so the width is constant with no padding of our own,
+ * and the value stays locale-ordered. This is exactly what `ls` does to its day column.
+ *
+ * Local and absolute, never a relative age: this listing is a record of what is on disk, which the
+ * time convention puts on the absolute side, and "3d" cannot be compared down a column.
  */
-function entryHint(row: Row, identity: ProcessIdentity | null): string | undefined {
+function columnTime(mtimeMs: number): string {
+    return new Date(mtimeMs).toLocaleString(undefined, { year: "2-digit", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+/**
+ * The row's right-aligned facts: size then date, in aligned columns.
+ *
+ * `sizeWidth` comes from the widest size in THIS listing, `ls`-style: right-aligning the number in
+ * that field is what lets the eye compare magnitudes down the column, and sizing the field to the
+ * listing spends no columns on a directory of small files.
+ *
+ * A directory contributes no size — counting its members costs one `readdir` per row (54.46ms cold
+ * over 467 directories, against 1.65ms for the whole stat pass), which is the budget this listing
+ * exists to protect. Its size field becomes blanks INCLUDING the separator, so the date column still
+ * lands in the same place as the file rows around it.
+ */
+function entryHint(row: Row, sizeWidth: number): string | undefined {
     const meta = row.meta;
     if (!meta) return undefined;
-    const parts = [
-        modeTriple(meta.mode, identity),
-        row.isDir ? undefined : meta.size.formatBytes(),
-        new Date(meta.mtimeMs).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" }),
-    ].filter((p): p is string => p !== undefined);
-    return parts.join(` ${GLYPHS.middot} `);
+    const separator = ` ${GLYPHS.middot} `;
+    const size = row.isDir ? "".padStart(sizeWidth + separator.length) : meta.size.formatBytes().padStart(sizeWidth) + separator;
+    return `${size}${columnTime(meta.mtimeMs)}`;
 }
 
 /** The cwd tail, segment-collapsed when deep — head + tail always shown, mid-segments ellipsized. */
@@ -238,13 +258,19 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
     // it, and an unreadable dir drops it so the error surfaces as the list's empty state (← still
     // ascends). Dir titles carry a trailing `/` — the type marker that needs no color.
     const items = createMemo<SelectItem<string>[]>(() => {
+        const listing = rows();
+        // One pass for the size column's width before any row is built: every row must agree on it,
+        // or right-aligning the numbers aligns nothing.
+        let sizeWidth = 0;
+        for (const r of listing) if (!r.isDir && r.meta) sizeWidth = Math.max(sizeWidth, r.meta.size.formatBytes().length);
         const out: SelectItem<string>[] = [];
         if (query().trim() === "" && listError() === null) out.push({ value: parentAbs(), title: ".." });
-        for (const r of rows()) {
+        for (const r of listing) {
             out.push({
                 value: r.abs,
                 title: r.isDir ? `${r.name}/` : r.name,
-                hint: entryHint(r, identity),
+                prefix: modeTriple(r, identity),
+                hint: entryHint(r, sizeWidth),
                 // Advisory only — the row stays selectable. Mode bits do not see an ACL or a macOS
                 // TCC rule, so this warns; staging is where a read is actually attempted and refused.
                 tone: r.meta?.readable === false ? "warning" : undefined,

--- a/cli/src/tui/components/dialog/file_picker.tsx
+++ b/cli/src/tui/components/dialog/file_picker.tsx
@@ -372,7 +372,9 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
         const sel = selected().size;
         const count = sel === 0 ? "none selected" : `${sel} selected`;
         if (review()) return ["REVIEW", `${chordLabel(KEYS.enter)} remove`, `${chordLabel(KEYS.escape)} back`, count].join(sep);
-        if (inputFocused()) return ["INSERT", `${chordLabel(KEYS.up)}/${chordLabel(KEYS.down)} move`, `${chordLabel(KEYS.escape)} normal`, count].join(sep);
+        // No movement keys: the cursor vocabulary is app-wide and the same on every navigable surface —
+        // see the footer rationale in `select_dialog.tsx`.
+        if (inputFocused()) return ["INSERT", `${chordLabel(KEYS.escape)} normal`, count].join(sep);
         return [
             "NORMAL",
             `${chordLabel(KEYS.space)} toggle`,

--- a/cli/src/tui/components/dialog/file_picker.tsx
+++ b/cli/src/tui/components/dialog/file_picker.tsx
@@ -77,7 +77,45 @@ const METADATA_ENTRY_CEILING = 2000;
  * or without its facts. `readable` is `null` where the platform has no POSIX ids to decide it.
  */
 type Row = { name: string; isDir: boolean; abs: string; meta?: RowMeta };
-type RowMeta = { size: number; mtimeMs: number; mode: number; readable: boolean | null };
+
+/**
+ * One row's facts, with the size and the date already RENDERED.
+ *
+ * Strings, not the raw byte count and epoch: the items memo reads `query()`, so it rebuilds every
+ * row on each keystroke of the filter, and formatting there would pay the whole listing's cost per
+ * character. Formatting once per listing keeps that loop to concatenation.
+ */
+type RowMeta = { mode: number; readable: boolean | null; sizeLabel: string; dateLabel: string };
+
+/** A directory listing, and whether it resolved metadata at all — see {@link METADATA_ENTRY_CEILING}. */
+type Listing = { rows: Row[]; withMetadata: boolean };
+
+/**
+ * What an unreadable directory reads as: no rows, and no claim that a ceiling suppressed anything.
+ * A module constant rather than a literal at the call site, because every read of the listing runs
+ * through here and each one would otherwise allocate.
+ */
+const EMPTY_LISTING: Listing = { rows: [], withMetadata: true };
+
+/**
+ * The fixed-width local timestamp of the date column.
+ *
+ * ONE formatter for the process, never `Date.prototype.toLocaleString` per row: the option-bearing
+ * form builds an `Intl.DateTimeFormat` on each call, which measured 48.6ms over 2000 rows against
+ * 2.5ms for this one. The locale is read at module load, which no surface changes at runtime.
+ *
+ * `{ dateStyle: "short", timeStyle: "short" }` — the app's usual compact form — varies from 15 to 17
+ * columns (`8/5/26, 3:32 PM` against `7/17/26, 11:21 PM`), which makes a column of them ragged. The
+ * explicit 2-digit fields zero-pad every part, so the width is constant with no padding of our own,
+ * and the value stays locale-ordered. This is exactly what `ls` does to its day column.
+ *
+ * Local and absolute, never a relative age: this listing is a record of what is on disk, which the
+ * time convention puts on the absolute side, and "3d" cannot be compared down a column.
+ */
+const COLUMN_TIME = new Intl.DateTimeFormat(undefined, { year: "2-digit", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+
+/** The width of the `rwxr-xr-x` triple — the blank a row with no metadata holds the column with. */
+const MODE_COLUMN_BLANK = " ".repeat(9);
 
 /** Props for {@link FilePicker}. All paths are absolute; the caller owns the browse root. */
 export type FilePickerProps = {
@@ -104,7 +142,7 @@ export type FilePickerProps = {
  * channel is the human-readable message (permission, broken mount): the caller renders it as the
  * list's error line and the user ascends — a single unreadable folder must not abort the picker.
  */
-function listDir(dir: string, hideHidden: boolean, identity: ProcessIdentity | null): Result<Row[], string> {
+function listDir(dir: string, hideHidden: boolean, identity: ProcessIdentity | null): Result<Listing, string> {
     let entries: Dirent[];
     try {
         entries = readdirSync(dir, { withFileTypes: true });
@@ -129,7 +167,10 @@ function listDir(dir: string, hideHidden: boolean, identity: ProcessIdentity | n
         rows.push({ name: e.name, isDir, abs, meta: withMetadata ? entryMeta(abs, identity) : undefined });
     }
     rows.sort((a, b) => (a.isDir === b.isDir ? a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) : a.isDir ? -1 : 1));
-    return ok(rows);
+    // The flag travels with the rows rather than being inferred from them downstream: "every row
+    // lost its stat" is ALSO what a folder holding one broken symlink looks like, and reporting that
+    // as a large folder states a cause that is not the one at hand.
+    return ok({ rows, withMetadata });
 }
 
 /**
@@ -144,7 +185,12 @@ function listDir(dir: string, hideHidden: boolean, identity: ProcessIdentity | n
  */
 function entryMeta(abs: string, identity: ProcessIdentity | null): RowMeta | undefined {
     return statResult(abs, "filePicker:entryMeta").match(
-        (s): RowMeta => ({ size: s.size, mtimeMs: s.mtimeMs, mode: s.mode, readable: identity ? isReadableBy(s, identity) : null }),
+        (s): RowMeta => ({
+            mode: s.mode,
+            readable: identity ? isReadableBy(s, identity) : null,
+            sizeLabel: s.size.formatBytes(),
+            dateLabel: COLUMN_TIME.format(s.mtimeMs),
+        }),
         () => undefined,
     );
 }
@@ -160,36 +206,28 @@ function safeSymlinkIsDir(abs: string): boolean {
 
 /**
  * The permission bits as the `rwxr-xr-x` triple every shell user already reads, or `undefined`
- * where they mean nothing.
+ * where the whole listing carries none.
  *
  * It rides the row's `prefix`, LEFT of the name, because that is where `ls -l` puts it and the
- * habit is worth more than the nine columns it takes from the name. Always exactly 9 characters,
- * so the column aligns with no padding.
+ * habit is worth more than the nine columns it takes from the name.
  *
- * Windows is the `undefined` case: Node synthesizes a mode there that describes no real ACL, so
- * printing it would be a confident lie. The type marker is the row's trailing `/`, so the leading
- * `d` a full `ls -l` mode carries would be a second, redundant one — the triple starts at the bits.
+ * A row whose own `stat` failed inside a listing that HAS metadata keeps the column as blanks. It
+ * would otherwise start its name nine columns left, in the mode column — which reads as a mode
+ * string, not as a missing one, and breaks the alignment the column exists for. A listing with no
+ * metadata at all (over the ceiling, or Windows) drops the column instead: holding an empty column
+ * on every row spends the name's width to say nothing.
+ *
+ * Windows is the `undefined` case for a second reason: Node synthesizes a mode there that describes
+ * no real ACL, so printing it would be a confident lie. The type marker is the row's trailing `/`,
+ * so the leading `d` a full `ls -l` mode carries would be a second, redundant one — the triple
+ * starts at the bits.
  */
-function modeTriple(row: Row, identity: ProcessIdentity | null): string | undefined {
-    if (identity === null || !row.meta) return undefined;
+function modeTriple(row: Row, identity: ProcessIdentity | null, withMetadata: boolean): string | undefined {
+    if (identity === null || !withMetadata) return undefined;
+    if (!row.meta) return MODE_COLUMN_BLANK;
     const rwx = (bits: number): string => `${bits & 4 ? "r" : "-"}${bits & 2 ? "w" : "-"}${bits & 1 ? "x" : "-"}`;
     const mode = row.meta.mode;
     return `${rwx((mode >> 6) & 7)}${rwx((mode >> 3) & 7)}${rwx(mode & 7)}`;
-}
-
-/**
- * The modification time as a FIXED-WIDTH local timestamp.
- *
- * `{ dateStyle: "short", timeStyle: "short" }` — the app's usual compact form — varies from 15 to 17
- * columns (`8/5/26, 3:32 PM` against `7/17/26, 11:21 PM`), which makes a column of them ragged. The
- * explicit 2-digit fields zero-pad every part, so the width is constant with no padding of our own,
- * and the value stays locale-ordered. This is exactly what `ls` does to its day column.
- *
- * Local and absolute, never a relative age: this listing is a record of what is on disk, which the
- * time convention puts on the absolute side, and "3d" cannot be compared down a column.
- */
-function columnTime(mtimeMs: number): string {
-    return new Date(mtimeMs).toLocaleString(undefined, { year: "2-digit", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
 }
 
 /**
@@ -208,8 +246,8 @@ function entryHint(row: Row, sizeWidth: number): string | undefined {
     const meta = row.meta;
     if (!meta) return undefined;
     const separator = ` ${GLYPHS.middot} `;
-    const size = row.isDir ? "".padStart(sizeWidth + separator.length) : meta.size.formatBytes().padStart(sizeWidth) + separator;
-    return `${size}${columnTime(meta.mtimeMs)}`;
+    const size = row.isDir ? "".padStart(sizeWidth + separator.length) : meta.sizeLabel.padStart(sizeWidth) + separator;
+    return `${size}${meta.dateLabel}`;
 }
 
 /** The cwd tail, segment-collapsed when deep — head + tail always shown, mid-segments ellipsized. */
@@ -245,7 +283,8 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
     const identity = processIdentity();
 
     const listed = createMemo(() => listDir(cwd(), hideHidden(), identity));
-    const rows = (): Row[] => listed().unwrapOr([]);
+    const listing = (): Listing => listed().unwrapOr(EMPTY_LISTING);
+    const rows = (): Row[] => listing().rows;
     const listError = (): string | null =>
         listed().match(
             () => null,
@@ -258,18 +297,18 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
     // it, and an unreadable dir drops it so the error surfaces as the list's empty state (← still
     // ascends). Dir titles carry a trailing `/` — the type marker that needs no color.
     const items = createMemo<SelectItem<string>[]>(() => {
-        const listing = rows();
+        const { rows: listed, withMetadata } = listing();
         // One pass for the size column's width before any row is built: every row must agree on it,
         // or right-aligning the numbers aligns nothing.
         let sizeWidth = 0;
-        for (const r of listing) if (!r.isDir && r.meta) sizeWidth = Math.max(sizeWidth, r.meta.size.formatBytes().length);
+        for (const r of listed) if (!r.isDir && r.meta) sizeWidth = Math.max(sizeWidth, r.meta.sizeLabel.length);
         const out: SelectItem<string>[] = [];
         if (query().trim() === "" && listError() === null) out.push({ value: parentAbs(), title: ".." });
-        for (const r of listing) {
+        for (const r of listed) {
             out.push({
                 value: r.abs,
                 title: r.isDir ? `${r.name}/` : r.name,
-                prefix: modeTriple(r, identity),
+                prefix: modeTriple(r, identity, withMetadata),
                 hint: entryHint(r, sizeWidth),
                 // Advisory only — the row stays selectable. Mode bits do not see an ACL or a macOS
                 // TCC rule, so this warns; staging is where a read is actually attempted and refused.
@@ -391,7 +430,7 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
 
     // A listing over the ceiling carries names only. Say so where the user is already looking:
     // silence would read as "these files have no size", which is a different and false claim.
-    const metadataSuppressed = (): boolean => rows().length > 0 && rows().every((r) => r.meta === undefined);
+    const metadataSuppressed = (): boolean => rows().length > 0 && !listing().withMetadata;
 
     function footer(): string {
         const sep = ` ${GLYPHS.middot} `;

--- a/cli/src/tui/components/dialog/file_picker.tsx
+++ b/cli/src/tui/components/dialog/file_picker.tsx
@@ -8,7 +8,7 @@ import type { InputRenderable } from "@opentui/core";
 import { GLYPHS, space } from "../../../lib/design_system.ts";
 import { theme } from "../../theme.ts";
 import { KEYS, chordLabel, type Chord } from "../../keymap.ts";
-import { statResult } from "../../../lib/fs.ts";
+import { statResult, isReadableBy, processIdentity, type ProcessIdentity } from "../../../lib/fs.ts";
 import { canonicalPath } from "../../../modules/anchor/marker.ts";
 import { openExternal } from "../../../lib/open_external.ts";
 import { notify } from "../../hooks/notice.ts";
@@ -59,8 +59,25 @@ const PICKER_KEYS = {
     confirm: { key: "c" },
 } as const satisfies Record<string, Chord>;
 
-/** A disk row. `..` is synthesized upstream of these so it never collides with a real entry. */
-type Row = { name: string; isDir: boolean; abs: string };
+/**
+ * How many entries a directory may hold before the listing stops resolving metadata for it.
+ *
+ * The backstop for the pathological folder, not a tuning knob for the common one: a `stat` per
+ * entry measured 0.69ms warm / 48.89ms cold over 468 entries, so a few hundred is invisible and
+ * only a listing an order of magnitude larger can stall a frame. Above it the rows carry names
+ * alone and the footer says so — a stated absence, never a silent one.
+ */
+const METADATA_ENTRY_CEILING = 2000;
+
+/**
+ * A disk row. `..` is synthesized upstream of these so it never collides with a real entry.
+ *
+ * `meta` is absent when the entry's `stat` failed (a file deleted between the readdir and the
+ * stat) or when the listing exceeded {@link METADATA_ENTRY_CEILING} — a row always renders, with
+ * or without its facts. `readable` is `null` where the platform has no POSIX ids to decide it.
+ */
+type Row = { name: string; isDir: boolean; abs: string; meta?: RowMeta };
+type RowMeta = { size: number; mtimeMs: number; mode: number; readable: boolean | null };
 
 /** Props for {@link FilePicker}. All paths are absolute; the caller owns the browse root. */
 export type FilePickerProps = {
@@ -87,13 +104,16 @@ export type FilePickerProps = {
  * channel is the human-readable message (permission, broken mount): the caller renders it as the
  * list's error line and the user ascends — a single unreadable folder must not abort the picker.
  */
-function listDir(dir: string, hideHidden: boolean): Result<Row[], string> {
+function listDir(dir: string, hideHidden: boolean, identity: ProcessIdentity | null): Result<Row[], string> {
     let entries: Dirent[];
     try {
         entries = readdirSync(dir, { withFileTypes: true });
     } catch (cause) {
         return err(cause instanceof Error ? cause.message : String(cause));
     }
+    // Decided from the RAW entry count, not the filtered row count: hiding dot-entries must not be
+    // what brings a 50k-entry folder under the ceiling, or `a` would silently start a huge stat pass.
+    const withMetadata = entries.length <= METADATA_ENTRY_CEILING;
     const rows: Row[] = [];
     for (const e of entries) {
         if (hideHidden && e.name.startsWith(".")) continue;
@@ -106,10 +126,27 @@ function listDir(dir: string, hideHidden: boolean): Result<Row[], string> {
         const raw = resolve(dir, e.name);
         const abs = e.isSymbolicLink() ? canonicalPath(raw) : raw;
         const isDir = e.isDirectory() || (e.isSymbolicLink() && safeSymlinkIsDir(abs));
-        rows.push({ name: e.name, isDir, abs });
+        rows.push({ name: e.name, isDir, abs, meta: withMetadata ? entryMeta(abs, identity) : undefined });
     }
     rows.sort((a, b) => (a.isDir === b.isDir ? a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) : a.isDir ? -1 : 1));
     return ok(rows);
+}
+
+/**
+ * One `stat` for one row's facts — size, mtime, mode bits, and whether this process can read it.
+ *
+ * Readability rides on the SAME stat rather than an `accessSync(R_OK)` pass: measured over a
+ * 468-entry directory, `access` cost 2.5–4.7ms against `stat`'s 0.69ms, for an answer the mode
+ * bits plus the owning ids already give (see `isReadableBy`, which documents what that misses).
+ *
+ * A failed stat yields `undefined`, never a row-dropping error: an entry that vanished between the
+ * readdir and this call is still a real listing the user is browsing, just one fact poorer.
+ */
+function entryMeta(abs: string, identity: ProcessIdentity | null): RowMeta | undefined {
+    return statResult(abs, "filePicker:entryMeta").match(
+        (s): RowMeta => ({ size: s.size, mtimeMs: s.mtimeMs, mode: s.mode, readable: identity ? isReadableBy(s, identity) : null }),
+        () => undefined,
+    );
 }
 
 // Best-effort: a broken symlink (target gone) must not crash the listing — it degrades to a file
@@ -119,6 +156,40 @@ function safeSymlinkIsDir(abs: string): boolean {
         (s) => s.isDirectory(),
         () => false,
     );
+}
+
+/**
+ * The permission bits as the `rwxr-xr-x` triple every shell user already reads, or `undefined`
+ * where they mean nothing.
+ *
+ * Windows is the `undefined` case: Node synthesizes a mode there that describes no real ACL, so
+ * printing it would be a confident lie. The type marker is the row's trailing `/`, so the leading
+ * `d` a full `ls -l` mode carries would be a second, redundant one — the triple starts at the bits.
+ */
+function modeTriple(mode: number, identity: ProcessIdentity | null): string | undefined {
+    if (identity === null) return undefined;
+    const rwx = (bits: number): string => `${bits & 4 ? "r" : "-"}${bits & 2 ? "w" : "-"}${bits & 1 ? "x" : "-"}`;
+    return `${rwx((mode >> 6) & 7)}${rwx((mode >> 3) & 7)}${rwx(mode & 7)}`;
+}
+
+/**
+ * The row's right-aligned facts: permissions, size, date. A directory contributes no size —
+ * counting its members costs one `readdir` per row (54.46ms cold over 467 directories, against
+ * 1.65ms for the whole stat pass), which is the budget this listing exists to protect.
+ *
+ * The date is absolute, never a relative age: this listing is a record of what is on disk, which
+ * the time convention puts on the absolute side, and a fixed-width local timestamp also stays
+ * comparable down a column in a way "3d" does not.
+ */
+function entryHint(row: Row, identity: ProcessIdentity | null): string | undefined {
+    const meta = row.meta;
+    if (!meta) return undefined;
+    const parts = [
+        modeTriple(meta.mode, identity),
+        row.isDir ? undefined : meta.size.formatBytes(),
+        new Date(meta.mtimeMs).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" }),
+    ].filter((p): p is string => p !== undefined);
+    return parts.join(` ${GLYPHS.middot} `);
 }
 
 /** The cwd tail, segment-collapsed when deep — head + tail always shown, mid-segments ellipsized. */
@@ -149,7 +220,11 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
     const [cursorAbs, setCursorAbs] = createSignal<string | undefined>(undefined);
     let inputRef: InputRenderable | null = null;
 
-    const listed = createMemo(() => listDir(cwd(), hideHidden()));
+    // Read ONCE for the picker's life, not per listing or per row: a process cannot change its own
+    // uid/gid mid-render, so re-reading would be three syscalls bought for a value already known.
+    const identity = processIdentity();
+
+    const listed = createMemo(() => listDir(cwd(), hideHidden(), identity));
     const rows = (): Row[] => listed().unwrapOr([]);
     const listError = (): string | null =>
         listed().match(
@@ -165,7 +240,16 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
     const items = createMemo<SelectItem<string>[]>(() => {
         const out: SelectItem<string>[] = [];
         if (query().trim() === "" && listError() === null) out.push({ value: parentAbs(), title: ".." });
-        for (const r of rows()) out.push({ value: r.abs, title: r.isDir ? `${r.name}/` : r.name });
+        for (const r of rows()) {
+            out.push({
+                value: r.abs,
+                title: r.isDir ? `${r.name}/` : r.name,
+                hint: entryHint(r, identity),
+                // Advisory only — the row stays selectable. Mode bits do not see an ACL or a macOS
+                // TCC rule, so this warns; staging is where a read is actually attempted and refused.
+                tone: r.meta?.readable === false ? "warning" : undefined,
+            });
+        }
         return out;
     });
 
@@ -279,6 +363,10 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
         ],
     }));
 
+    // A listing over the ceiling carries names only. Say so where the user is already looking:
+    // silence would read as "these files have no size", which is a different and false claim.
+    const metadataSuppressed = (): boolean => rows().length > 0 && rows().every((r) => r.meta === undefined);
+
     function footer(): string {
         const sep = ` ${GLYPHS.middot} `;
         const sel = selected().size;
@@ -295,6 +383,7 @@ export function FilePicker(props: FilePickerProps): JSX.Element {
             `${chordLabel(PICKER_KEYS.explorer)} explorer`,
             `${chordLabel(PICKER_KEYS.filter)} filter`,
             `${chordLabel(KEYS.escape)} cancel`,
+            ...(metadataSuppressed() ? ["details off (large folder)"] : []),
             count,
         ].join(sep);
     }

--- a/cli/src/tui/components/dialog/select_dialog.tsx
+++ b/cli/src/tui/components/dialog/select_dialog.tsx
@@ -39,6 +39,13 @@ export type SelectDialogProps<T> = {
     onSelect?: (value: T) => void;
     /** Multi mode: the batch was confirmed (enter). The caller closes the dialog. */
     onConfirm?: (values: T[]) => void;
+    /**
+     * One extra footer segment, for a key the HOST binds rather than the dialog (the analysis switcher's
+     * copy-id chord). The dialog owns its footer and stays domain-agnostic, so a host binding would
+     * otherwise be reachable but unadvertised — discoverable only through the WhichKey overlay, which a
+     * user has to already suspect something is there to open.
+     */
+    footerHint?: string;
     /** Wired to every non-commit close (esc, click-outside, ctrl+c) via the dialog funnel. */
     onCancel: () => void;
 };
@@ -49,10 +56,14 @@ export type SelectDialogProps<T> = {
  * input and hands its value down as the list's `query`; the list owns cursor, selection, and
  * submit.
  *
- * Multi mode runs a minimal INSERT/NORMAL split, because space must type into a focused filter
- * yet toggle rows otherwise (the bare-printable-key rule): esc while the input is focused BLURS
- * it (a close-guard veto — dialogs never bind esc themselves) unlocking space/`i`; esc again
- * cancels. Single mode has no such split — enter and arrows don't collide with typing.
+ * Multi mode runs the app's INSERT/NORMAL split, because space must type into a focused filter
+ * yet toggle rows otherwise (the bare-printable-key rule). It MOUNTS IN NORMAL, as FilePicker
+ * does: `i` enters the filter, esc while focused BLURS back (a close-guard veto — dialogs never
+ * bind esc themselves), and esc in NORMAL cancels. The footer leads with the mode word, because
+ * the same keystroke does different things in each state and nothing else on screen says which.
+ *
+ * Single mode has no split and mounts focused — enter and arrows don't collide with typing, and
+ * its only verb is "find one, press enter".
  */
 export function SelectDialog<T>(props: SelectDialogProps<T>): JSX.Element {
     const dialog = useDialogEntry();
@@ -80,20 +91,29 @@ export function SelectDialog<T>(props: SelectDialogProps<T>): JSX.Element {
         bindings: [{ chord: FILTER_KEY, run: () => inputRef?.focus(), desc: "Filter", group: "List" }],
     }));
 
+    // The footer names only what is SPECIFIC to this surface. Cursor movement is app-wide vocabulary —
+    // arrows, ctrl+p/n, page keys, and in NORMAL the vim set (j/k, gg, G) — carried by every navigable
+    // surface and documented live by the WhichKey overlay. Spelling it here costs the row's width to
+    // restate what the user already knows, and it reads as though THIS list navigates differently.
+    //
+    // The mode WORD does earn its place in multi mode: the same keystroke does different things in each
+    // state, and nothing else on screen says which state is live.
     function footer(): string {
         const sep = ` ${GLYPHS.middot} `;
-        const move = `${chordLabel(KEYS.up)}/${chordLabel(KEYS.down)} move`;
+        const extra = props.footerHint ? [props.footerHint] : [];
         if (mode() === "single") {
-            return [move, `${chordLabel(KEYS.enter)} select`, `${chordLabel(KEYS.escape)} cancel`].join(sep);
+            return [`${chordLabel(KEYS.enter)} select`, `${chordLabel(KEYS.escape)} cancel`, ...extra].join(sep);
         }
         const count = `${selCount()} selected`;
         return inputFocused()
-            ? [move, `${chordLabel(KEYS.enter)} confirm`, `${chordLabel(KEYS.escape)} list keys`, count].join(sep)
+            ? ["INSERT", `${chordLabel(KEYS.enter)} confirm`, `${chordLabel(KEYS.escape)} normal`, ...extra, count].join(sep)
             : [
+                  "NORMAL",
                   `${chordLabel(KEYS.space)} toggle`,
                   `${chordLabel(KEYS.enter)} confirm`,
                   `${chordLabel(FILTER_KEY)} filter`,
                   `${chordLabel(KEYS.escape)} cancel`,
+                  ...extra,
                   count,
               ].join(sep);
     }
@@ -102,12 +122,19 @@ export function SelectDialog<T>(props: SelectDialogProps<T>): JSX.Element {
         <DialogPanel title={props.title} size="lg" padY footer={footer()}>
             <TextInput
                 chrome="bare"
-                /* Showcased exhibits must not grab focus at mount — see DialogEntryHandle.inert. */
-                autoFocus={!(dialog?.inert ?? false)}
+                /* Single mode opens in INSERT — its only verb is "find one and press enter", so the filter
+                   is where the hands belong. Multi mode opens in NORMAL, matching FilePicker: its verbs are
+                   space and enter, and mounting focused means the very first space types a character
+                   instead of selecting a row, with no visible cue that a mode even exists.
+                   Showcased exhibits must not grab focus at mount either — see DialogEntryHandle.inert. */
+                autoFocus={mode() === "single" && !(dialog?.inert ?? false)}
                 placeholder={props.placeholder ?? `Type to filter${GLYPHS.ellipsis}`}
                 onRef={(r: InputRenderable) => {
                     inputRef = r;
-                    dialog?.setInitialFocus(r);
+                    // Only claim the entry's initial focus when this dialog means to open focused: the host
+                    // applies it on push AND on reveal, so registering it would re-focus a NORMAL-mode
+                    // dialog every time a stacked dialog above it closes.
+                    if (mode() === "single") dialog?.setInitialFocus(r);
                 }}
                 onFocusChange={setInputFocused}
                 onInput={setQuery}

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -33,18 +33,19 @@ export type SelectItem<T> = {
     /** The primary label, the main fuzzy-match target. */
     readonly title: string;
     /**
-     * Optional fixed-width column rendered BEFORE the title, in the recessive `fgSubtle` tier — the
+     * Optional fixed-width column rendered BEFORE the title, in the secondary `fgMuted` tier — the
      * file picker's `ls`-style permission bits.
      *
      * Separate from `title` because `title` is the weight-2 fuzzy target: folding a mode string into
      * it would make a query of `rwx` match every directory, and `d` rank every folder above a file
      * named `data`. This field never ranks.
      *
-     * Its tier is deliberate. The column is near-constant (most rows read `rw-r--r--`), so it is
-     * scanned for EXCEPTIONS rather than read per row; painting it level with the title would put
-     * nine characters of low-information text in front of the one thing the eye is hunting. That
-     * places it in the design system's 3:1 tier rather than the 4.5:1 one — sound here because the
-     * facts it carries are also available per-row elsewhere, and nothing depends on reading it.
+     * `fgMuted` and NOT the recessive `fgSubtle`, though the column is near-constant and is scanned
+     * for exceptions rather than read per row: the design system reserves `fgSubtle` for content
+     * whose loss costs the user nothing, and a permission triple is the only place these bits appear
+     * — a `tone` marks a denied READ alone, and says nothing about write or execute. Information the
+     * row carries nowhere else holds the 4.5:1 text floor. It stays under the title's own tier, which
+     * is what keeps it from competing with the name.
      */
     readonly prefix?: string;
     /** Optional detail shown for the cursor row in the list's bottom detail line. */
@@ -417,11 +418,11 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                         <Show when={mode() === "multi"}>
                             <text fg={isSel() ? theme().success : theme().fgSubtle}>{gutter()}</text>
                         </Show>
-                        {/* Its own span, so it keeps the recessive tier while the title takes the cursor
+                        {/* Its own span, so it keeps the muted tier while the title takes the cursor
                             and tone colors — see `SelectItem.prefix`. `flexShrink={0}` protects the column:
                             a shortened mode string would read as a DIFFERENT mode, not a shortened one. */}
                         <Show when={item().prefix}>
-                            <text fg={theme().fgSubtle} flexShrink={0}>
+                            <text fg={theme().fgMuted} flexShrink={0}>
                                 {item().prefix}{" "}
                             </text>
                         </Show>

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -396,7 +396,9 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                     </text>
                 </Show>
                 <box width="100%" flexDirection="column" backgroundColor={isCursor() ? theme().bgActive : undefined}>
-                    <box width="100%" flexDirection="row">
+                    {/* The right pad clears the scrollbox's scrollbar, which the scrollbar overlays at the
+                        content's right edge — without it a right-aligned hint reads as one word with the bar. */}
+                    <box width="100%" flexDirection="row" paddingRight={space.sm}>
                         <Show when={mode() === "multi"}>
                             <text fg={isSel() ? theme().success : theme().fgSubtle}>{gutter()}</text>
                         </Show>
@@ -405,9 +407,19 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                             {item().title}
                         </text>
                         {/* An inline hint only when there's no meta line — meta owns the right edge on its
-                            own row, so a same-line hint would double up the trailing metadata. */}
+                            own row, so a same-line hint would double up the trailing metadata.
+
+                            The grown spacer is what makes the hint a right-aligned COLUMN rather than a
+                            ragged tail chasing each title's length: sizes and dates are read by scanning
+                            down, which a left-adjacent hint makes impossible. `flexShrink={0}` keeps the
+                            hint whole and lets the title absorb a narrow panel instead — a truncated name
+                            is still recognizable, a truncated size is a wrong number. */}
                         <Show when={!item().meta && item().hint}>
-                            <text fg={theme().fgMuted}> {item().hint}</text>
+                            <box flexGrow={1} />
+                            <text fg={theme().fgMuted} flexShrink={0}>
+                                {" "}
+                                {item().hint}
+                            </text>
                         </Show>
                     </box>
                     <Show when={item().meta}>

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -32,6 +32,21 @@ export type SelectItem<T> = {
     readonly value: T;
     /** The primary label, the main fuzzy-match target. */
     readonly title: string;
+    /**
+     * Optional fixed-width column rendered BEFORE the title, in the recessive `fgSubtle` tier — the
+     * file picker's `ls`-style permission bits.
+     *
+     * Separate from `title` because `title` is the weight-2 fuzzy target: folding a mode string into
+     * it would make a query of `rwx` match every directory, and `d` rank every folder above a file
+     * named `data`. This field never ranks.
+     *
+     * Its tier is deliberate. The column is near-constant (most rows read `rw-r--r--`), so it is
+     * scanned for EXCEPTIONS rather than read per row; painting it level with the title would put
+     * nine characters of low-information text in front of the one thing the eye is hunting. That
+     * places it in the design system's 3:1 tier rather than the 4.5:1 one — sound here because the
+     * facts it carries are also available per-row elsewhere, and nothing depends on reading it.
+     */
+    readonly prefix?: string;
     /** Optional detail shown for the cursor row in the list's bottom detail line. */
     readonly description?: string;
     /** Optional right-aligned muted hint (e.g. a keybind), rendered inline on the SAME line as the
@@ -401,6 +416,14 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                     <box width="100%" flexDirection="row" paddingRight={space.sm}>
                         <Show when={mode() === "multi"}>
                             <text fg={isSel() ? theme().success : theme().fgSubtle}>{gutter()}</text>
+                        </Show>
+                        {/* Its own span, so it keeps the recessive tier while the title takes the cursor
+                            and tone colors — see `SelectItem.prefix`. `flexShrink={0}` protects the column:
+                            a shortened mode string would read as a DIFFERENT mode, not a shortened one. */}
+                        <Show when={item().prefix}>
+                            <text fg={theme().fgSubtle} flexShrink={0}>
+                                {item().prefix}{" "}
+                            </text>
                         </Show>
                         <text fg={item().tone === "warning" ? theme().warning : isCursor() ? theme().secondary : theme().fg}>
                             {mode() === "single" ? (isCursor() ? `${GLYPHS.chevronRight} ` : "  ") : ""}

--- a/cli/src/tui/components/list_core.tsx
+++ b/cli/src/tui/components/list_core.tsx
@@ -46,8 +46,32 @@ export type SelectItem<T> = {
      * line without it, two with it.
      */
     readonly meta?: string;
-    /** Optional group label; rows sharing a category render under one header, surviving filtering. */
+    /** Optional group KEY; rows sharing a category render under one header, surviving filtering. */
     readonly category?: string;
+    /**
+     * Optional header TEXT for this row's group, when the group key is not what the user should read.
+     * Absent, the header is the `category` string itself — which is why it exists: `category` is both
+     * the grouping key and the printed header, so a caller grouping on an OPAQUE identity (the analysis
+     * switcher groups on an anchor id, not on the anchor's folder path — two live anchors can share one
+     * cached path, and keying on the path would merge them into one group) has no way to title the group
+     * readably. Rows of one `category` are expected to agree on this; the first row of the group wins.
+     *
+     * It is also the ranked field: `rankBy` scores what the user can SEE, so filtering by the visible
+     * folder path works where scoring the anchor UUID would match nothing a user would ever type.
+     */
+    readonly categoryLabel?: string;
+    /**
+     * Optional semantic tone for the row's title. A ROLE, never a color: the row says what it means
+     * ("this one is a problem") and the theme decides how that looks, so all ten palettes stay honest.
+     *
+     * Deliberately a one-member union rather than an open `ThemeColors` key — a row that could name
+     * any role would let callers paint decoratively, and the tier vocabulary would drift. Widen it
+     * only when a second MEANING appears, not when a second color is wanted.
+     *
+     * It outranks the cursor's own highlight: landing on a row must not erase the warning that is
+     * the reason to notice it.
+     */
+    readonly tone?: "warning";
     /**
      * Keep this row listed no matter what the query is, instead of ranking its title against it. For an
      * ESCAPE-HATCH row — one whose action is "do something other than pick from these rows" (the model
@@ -162,7 +186,8 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
         if (q === "") return props.items;
         const matched = rankBy(props.items, q, [
             { get: (it) => it.title, weight: 2 },
-            { get: (it) => it.category ?? "", weight: 1 },
+            // The printed header, not the grouping key — see `SelectItem.categoryLabel`.
+            { get: (it) => it.categoryLabel ?? it.category ?? "", weight: 1 },
         ]);
         // Re-append the pinned rows the ranking dropped (see `SelectItem.pinned`). Membership is tested by
         // reference against the matches, which both primitives guarantee: FixedList's items are immutable,
@@ -208,7 +233,9 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
         let prev = "";
         for (const [i, it] of flat().entries()) {
             const cat = it.category ?? "";
-            m.set(it, { index: i, header: cat !== "" && cat !== prev ? cat : null });
+            // Group boundaries are decided by the KEY, the header prints the LABEL: two groups whose
+            // labels coincide must still render as two, or the distinction the key draws is invisible.
+            m.set(it, { index: i, header: cat !== "" && cat !== prev ? (it.categoryLabel ?? cat) : null });
             prev = cat;
         }
         return m;
@@ -373,7 +400,7 @@ export function ListCore<T>(props: ListCoreProps<T>): JSX.Element {
                         <Show when={mode() === "multi"}>
                             <text fg={isSel() ? theme().success : theme().fgSubtle}>{gutter()}</text>
                         </Show>
-                        <text fg={isCursor() ? theme().secondary : theme().fg}>
+                        <text fg={item().tone === "warning" ? theme().warning : isCursor() ? theme().secondary : theme().fg}>
                             {mode() === "single" ? (isCursor() ? `${GLYPHS.chevronRight} ` : "  ") : ""}
                             {item().title}
                         </text>

--- a/cli/src/tui/components/list_primitives.render.test.tsx
+++ b/cli/src/tui/components/list_primitives.render.test.tsx
@@ -954,6 +954,32 @@ describe("categoryLabel", () => {
         }
     });
 
+    test("hints form a right-aligned column, whatever the titles measure", async () => {
+        // The point of a hint column is scanning DOWN it. Left-adjacent hints chase each title's
+        // length, which makes two sizes on adjacent rows impossible to compare at a glance.
+        const items: SelectItem<string>[] = [
+            { value: "a", title: "x.txt", hint: "1 B" },
+            { value: "b", title: "a-considerably-longer-name.txt", hint: "2 B" },
+        ];
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={items} emptyText="none" />
+                </Harness>
+            ),
+            { width: 44, height: 10 },
+        );
+        try {
+            const frame = await settle(setup);
+            const lines = frame.split("\n");
+            const col = (needle: string): number => (lines.find((l) => l.includes(needle)) ?? "").indexOf(needle);
+            expect(col("1 B")).toBeGreaterThan(0);
+            expect(col("1 B")).toEqual(col("2 B"));
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
     test("a tone outranks the cursor highlight", async () => {
         // Landing on a row must not erase the mark that is the reason to notice it, so the two rows
         // below stay differently colored even as the cursor moves onto the toned one.

--- a/cli/src/tui/components/list_primitives.render.test.tsx
+++ b/cli/src/tui/components/list_primitives.render.test.tsx
@@ -954,6 +954,36 @@ describe("categoryLabel", () => {
         }
     });
 
+    test("a prefix renders before the title and never ranks", async () => {
+        // The reason `prefix` is a field and not a title concatenation: a mode string folded into the
+        // fuzzy target would make `d` rank every directory above a file actually named `data`.
+        const [query, setQuery] = createSignal("");
+        const items: SelectItem<string>[] = [
+            { value: "dir", title: "assets/", prefix: "rwxr-xr-x" },
+            { value: "file", title: "data.csv", prefix: "rw-r--r--" },
+        ];
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={items} query={query()} emptyText="none" />
+                </Harness>
+            ),
+            { width: 44, height: 10 },
+        );
+        try {
+            let frame = await settle(setup);
+            const line = frame.split("\n").find((l) => l.includes("assets/")) ?? "";
+            expect(line.slice(0, line.indexOf("assets/"))).toContain("rwxr-xr-x");
+
+            setQuery("d"); // matches the title `data.csv`, and both prefixes hold a `d`-less triple
+            frame = await settle(setup);
+            expect(frame).toContain("data.csv");
+            expect(frame).not.toContain("assets/");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
     test("hints form a right-aligned column, whatever the titles measure", async () => {
         // The point of a hint column is scanning DOWN it. Left-adjacent hints chase each title's
         // length, which makes two sizes on adjacent rows impossible to compare at a glance.

--- a/cli/src/tui/components/list_primitives.render.test.tsx
+++ b/cli/src/tui/components/list_primitives.render.test.tsx
@@ -880,3 +880,132 @@ describe("two-line meta rows", () => {
         }
     });
 });
+
+describe("categoryLabel", () => {
+    // Rows keyed by an opaque id, labelled by a readable path — the analysis switcher's shape.
+    const ANCHORED: SelectItem<string>[] = [
+        { value: "a1", title: "A1", category: "anchor-111", categoryLabel: "~/repos/one" },
+        { value: "a2", title: "A1", category: "anchor-222", categoryLabel: "~/repos/two" },
+        { value: "a3", title: "Iulia", category: "anchor-222", categoryLabel: "~/repos/two" },
+    ];
+
+    test("the header prints the label, never the key", async () => {
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={ANCHORED} emptyText="none" />
+                </Harness>
+            ),
+            { width: 44, height: 14 },
+        );
+        try {
+            const frame = await settle(setup);
+            expect(frame).toContain("~/repos/one");
+            expect(frame).toContain("~/repos/two");
+            expect(frame).not.toContain("anchor-111");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("two keys sharing one label stay two groups", async () => {
+        // The whole point of separating key from label: a stale cachedPath can make two live
+        // anchors print the same folder, and merging them would hide a dead anchor's analyses
+        // among the live ones. Both headers must render, so the same text appears twice.
+        const collided: SelectItem<string>[] = [
+            { value: "x", title: "alpha", category: "anchor-111", categoryLabel: "~/same" },
+            { value: "y", title: "beta", category: "anchor-222", categoryLabel: "~/same" },
+        ];
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={collided} emptyText="none" />
+                </Harness>
+            ),
+            { width: 44, height: 14 },
+        );
+        try {
+            const frame = await settle(setup);
+            const headers = frame.split("\n").filter((l) => l.includes("~/same"));
+            expect(headers).toHaveLength(2);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("the label is the ranked field, so filtering by it works", async () => {
+        const [query, setQuery] = createSignal("");
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={ANCHORED} query={query()} emptyText="none" />
+                </Harness>
+            ),
+            { width: 44, height: 14 },
+        );
+        try {
+            setQuery("repos/two"); // matches no title — only the visible group label
+            const frame = await settle(setup);
+            expect(frame).toContain("Iulia");
+            expect(frame).toContain("~/repos/two");
+            expect(frame).not.toContain("~/repos/one");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a tone outranks the cursor highlight", async () => {
+        // Landing on a row must not erase the mark that is the reason to notice it, so the two rows
+        // below stay differently colored even as the cursor moves onto the toned one.
+        const items: SelectItem<string>[] = [
+            { value: "ok", title: "readable.txt" },
+            { value: "no", title: "locked.bam", tone: "warning" },
+        ];
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={items} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 10 },
+        );
+        try {
+            await settle(setup);
+            const fgOf = (needle: string): unknown =>
+                setup
+                    .captureSpans()
+                    .lines.flatMap((l) => l.spans)
+                    .find((s) => s.text.includes(needle))?.fg;
+            const cursorFirst = fgOf("readable.txt");
+            const tonedUnfocused = fgOf("locked.bam");
+            expect(tonedUnfocused).toBeDefined();
+            expect(tonedUnfocused).not.toEqual(cursorFirst);
+
+            setup.mockInput.pressArrow("down"); // cursor onto the toned row
+            await settle(setup);
+            expect(fgOf("locked.bam")).toEqual(tonedUnfocused);
+            // And the row it left takes the plain color, proving the cursor moved at all.
+            expect(fgOf("readable.txt")).not.toEqual(cursorFirst);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("no label falls back to the category string", async () => {
+        const setup = await testRender(
+            () => (
+                <Harness>
+                    <FixedList items={FRUIT} emptyText="none" />
+                </Harness>
+            ),
+            { width: 40, height: 14 },
+        );
+        try {
+            const frame = await settle(setup);
+            expect(frame).toContain("fruit");
+            expect(frame).toContain("veg");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -355,12 +355,18 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                     </DialogShowcase>
                     {/* The Switch analysis picker is the ONE surface that reports a whole-analysis total,
                         because comparing analyses is the only question such a total answers. The figure
-                        claims the row's inline `hint` (right-aligned, muted, same line as the title) —
-                        these rows carry no `meta`, which would take the right edge for itself. An
-                        analysis with nothing recorded carries NO hint rather than a zeroed one, which is
-                        why the second row is bare. */}
+                        rides the row's inline `hint` (muted, same line as the title, after it) — these
+                        rows carry no `meta`, which suppresses a hint entirely. An analysis with nothing
+                        recorded carries NO figure rather than a zeroed one, which is why the third row
+                        shows a date alone.
+
+                        Rows GROUP by anchor: `category` is the anchor id and `categoryLabel` is the
+                        folder printed as the header. Both `rna-seq` rows below are the collision this
+                        exists for — one name, two folders, indistinguishable without the header. The
+                        date is absolute (a record listing), and the cursor row's `description` carries
+                        the id and slug, the only unambiguous handle a row has. */}
                     <text fg={theme().fgMuted}>
-                        SelectDialog — the picker dialog composing panel + filter + FixedList (Switch analysis: figure as an inline hint):
+                        SelectDialog — the picker dialog composing panel + filter + FixedList (Switch analysis: grouped by anchor):
                     </text>
                     <DialogShowcase>
                         <SelectDialog
@@ -368,16 +374,71 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                             items={[
                                 {
                                     value: "1",
-                                    title: "rna-seq-2026",
-                                    hint: formatTokenFigure({ inputTokens: 2_140_000, outputTokens: 96_300 }),
-                                    description: "differential expression",
+                                    title: "rna-seq",
+                                    category: "anchor-a",
+                                    categoryLabel: "~/repos/inflexa3/cli",
+                                    hint: `7/24/26, 4:13 PM ${GLYPHS.middot} ${formatTokenFigure({ inputTokens: 2_140_000, outputTokens: 96_300 })}`,
+                                    description: `019f9442-baec-7000-8e9b-97ba98572818 ${GLYPHS.middot} rna-seq ${GLYPHS.middot} created 7/24/2026, 4:13:49 PM`,
                                 },
-                                { value: "2", title: "scrna-atlas" },
+                                {
+                                    value: "2",
+                                    title: "rna-seq",
+                                    category: "anchor-b",
+                                    categoryLabel: "~/repos/cliosstest",
+                                    hint: `7/22/26, 2:28 PM ${GLYPHS.middot} ${formatTokenFigure({ inputTokens: 84_100 })}`,
+                                },
+                                { value: "3", title: "scrna-atlas", category: "anchor-b", categoryLabel: "~/repos/cliosstest", hint: "7/19/26, 6:49 PM" },
                             ]}
                             emptyText="No analyses"
                             onSelect={noop}
                             onCancel={noop}
                         />
+                    </DialogShowcase>
+                    {/* The flat inputs list: multi-select removal over the WHOLE registered set, which is
+                        why it is not the file picker — an input outside the browse root has no row there.
+                        Titles are absolute (the stored path is anchor-relative, so two anchors collide),
+                        which makes them long, which is why the facts take a `meta` line instead of a hint. */}
+                    <text fg={theme().fgMuted}>SelectDialog in multi mode — the flat inputs list (absolute titles, facts on a meta line):</text>
+                    <DialogShowcase>
+                        <SelectDialog
+                            title="Remove inputs"
+                            mode="multi"
+                            items={[
+                                { value: "1", title: "~/repos/inflexa2/cli/data/", meta: `directory ${GLYPHS.middot} 7/24/26, 4:13 PM` },
+                                {
+                                    value: "2",
+                                    title: "~/repos/inflexa2/cli/counts.tsv",
+                                    meta: `file ${GLYPHS.middot} 12.4 MB ${GLYPHS.middot} 7/24/26, 4:13 PM`,
+                                },
+                                { value: "3", title: "/Volumes/scratch/gse12345/matrix.mtx", meta: `file ${GLYPHS.middot} not on disk` },
+                            ]}
+                            emptyText="No inputs to remove"
+                            onConfirm={noop}
+                            onCancel={noop}
+                        />
+                    </DialogShowcase>
+                    {/* An entry the process cannot READ. `tone` names the meaning and the theme picks the
+                        color, so the mark holds on all ten palettes. It is advisory: the row still toggles,
+                        because mode bits do not see an ACL or a macOS TCC rule — staging is where a read is
+                        actually attempted and refused. Shown on a list rather than in the live picker
+                        below, which lists a real cwd where every file happens to be readable. */}
+                    <text fg={theme().fgMuted}>File picker rows — permissions/size/date as a hint, and the unreadable tone:</text>
+                    <DialogShowcase>
+                        <box height={4} width="100%">
+                            <FixedList
+                                items={[
+                                    { value: "d", title: "src/", hint: `drwxr-xr-x ${GLYPHS.middot} 8/2/26, 4:05 PM` },
+                                    { value: "f", title: "counts.tsv", hint: `rw-r--r-- ${GLYPHS.middot} 12.4 MB ${GLYPHS.middot} 8/2/26, 4:05 PM` },
+                                    {
+                                        value: "u",
+                                        title: "locked.bam",
+                                        hint: `rw------- ${GLYPHS.middot} 4.2 GB ${GLYPHS.middot} 7/19/26, 6:49 PM`,
+                                        tone: "warning",
+                                    },
+                                ]}
+                                emptyText="Empty folder"
+                            />
+                        </box>
                     </DialogShowcase>
                     <text fg={theme().fgMuted}>FilePicker — multi-select browser on DynamicList (lists the live cwd, inert keys):</text>
                     <DialogShowcase>

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -422,17 +422,24 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         because mode bits do not see an ACL or a macOS TCC rule — staging is where a read is
                         actually attempted and refused. Shown on a list rather than in the live picker
                         below, which lists a real cwd where every file happens to be readable. */}
-                    <text fg={theme().fgMuted}>File picker rows — permissions/size/date as a hint, and the unreadable tone:</text>
+                    {/* The `ls -l` reading order: mode, then name, then the facts. The mode rides `prefix`
+                        (never the title — it would rank against the fuzzy filter) in the recessive tier, so a
+                        near-constant column does not compete with the names. The size right-aligns in a field
+                        as wide as the listing needs, and the date is zero-padded to a fixed width; together
+                        those are what land the two columns under each other. A directory's blank size field
+                        spans its separator too, so its date does not slide left. */}
+                    <text fg={theme().fgMuted}>File picker rows — mode as a left prefix, aligned size/date columns, the unreadable tone:</text>
                     <DialogShowcase>
                         <box height={4} width="100%">
                             <FixedList
                                 items={[
-                                    { value: "d", title: "src/", hint: `drwxr-xr-x ${GLYPHS.middot} 8/2/26, 4:05 PM` },
-                                    { value: "f", title: "counts.tsv", hint: `rw-r--r-- ${GLYPHS.middot} 12.4 MB ${GLYPHS.middot} 8/2/26, 4:05 PM` },
+                                    { value: "d", title: "src/", prefix: "rwxr-xr-x", hint: "          08/02/26, 04:05 PM" },
+                                    { value: "f", title: "counts.tsv", prefix: "rw-r--r--", hint: ` 12.4 MB ${GLYPHS.middot} 08/02/26, 04:05 PM` },
                                     {
                                         value: "u",
                                         title: "locked.bam",
-                                        hint: `rw------- ${GLYPHS.middot} 4.2 GB ${GLYPHS.middot} 7/19/26, 6:49 PM`,
+                                        prefix: "rw-------",
+                                        hint: `  4.2 GB ${GLYPHS.middot} 07/19/26, 06:49 PM`,
                                         tone: "warning",
                                     },
                                 ]}

--- a/cli/src/tui/layout/design_gallery.tsx
+++ b/cli/src/tui/layout/design_gallery.tsx
@@ -423,14 +423,18 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                         actually attempted and refused. Shown on a list rather than in the live picker
                         below, which lists a real cwd where every file happens to be readable. */}
                     {/* The `ls -l` reading order: mode, then name, then the facts. The mode rides `prefix`
-                        (never the title — it would rank against the fuzzy filter) in the recessive tier, so a
-                        near-constant column does not compete with the names. The size right-aligns in a field
-                        as wide as the listing needs, and the date is zero-padded to a fixed width; together
-                        those are what land the two columns under each other. A directory's blank size field
-                        spans its separator too, so its date does not slide left. */}
+                        (never the title — it would rank against the fuzzy filter) in the muted tier under the
+                        title's own, so a near-constant column does not compete with the names. The size
+                        right-aligns in a field as wide as the listing needs, and the date is zero-padded to a
+                        fixed width; together those are what land the two columns under each other. A
+                        directory's blank size field spans its separator too, so its date does not slide left.
+
+                        The last row is an entry whose `stat` failed — a file deleted between the readdir and
+                        the stat. It holds the mode column as blanks rather than dropping it: a name that
+                        starts nine columns left reads as a mode string, not as a missing one. */}
                     <text fg={theme().fgMuted}>File picker rows — mode as a left prefix, aligned size/date columns, the unreadable tone:</text>
                     <DialogShowcase>
-                        <box height={4} width="100%">
+                        <box height={5} width="100%">
                             <FixedList
                                 items={[
                                     { value: "d", title: "src/", prefix: "rwxr-xr-x", hint: "          08/02/26, 04:05 PM" },
@@ -442,6 +446,7 @@ export function DesignGallery(props: { onClose: () => void }): JSX.Element {
                                         hint: `  4.2 GB ${GLYPHS.middot} 07/19/26, 06:49 PM`,
                                         tone: "warning",
                                     },
+                                    { value: "g", title: "vanished.tmp", prefix: "         " },
                                 ]}
                                 emptyText="Empty folder"
                             />

--- a/cli/src/tui/remove_inputs_dialog.render.test.tsx
+++ b/cli/src/tui/remove_inputs_dialog.render.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { testRender } from "@opentui/solid";
+import type { JSX } from "solid-js";
+
+import { freshDb } from "../test_support/db.ts";
+import { str256 } from "../lib/types.ts";
+import { createAnalysis } from "../modules/analysis/analysis.ts";
+import { listAnalysisInputs } from "../db/primary_query.ts";
+import { useKeymapRoot } from "./keymap.ts";
+import { DialogOverlay, dialogClear, dialogPush } from "./components/dialog/dialog_host.tsx";
+import { WorkspaceContext, type Workspace } from "./contexts/workspace.ts";
+import { commands } from "./commands.tsx";
+import type { Analysis } from "../types/analysis.ts";
+
+// The flat inputs list drives the REAL `analysis.remove-input` command against a REAL database. Two
+// claims are under test and neither is visible from the picker: that a batch of inputs leaves in ONE
+// pass, and that a row names its input by a path the user can act on.
+
+let anchorDir = "";
+let outsideDir = "";
+let analysis: Analysis;
+
+beforeEach(() => {
+    freshDb();
+    // realpath so the anchor markers the analysis mints match macOS's canonical /private/var.
+    anchorDir = realpathSync(mkdtempSync(join(tmpdir(), "rm-inputs-")));
+    outsideDir = realpathSync(mkdtempSync(join(tmpdir(), "rm-inputs-far-")));
+    writeFileSync(join(anchorDir, "counts.tsv"), "x".repeat(2048));
+    mkdirSync(join(anchorDir, "data"));
+    writeFileSync(join(anchorDir, "data", "inner.txt"), "x");
+    writeFileSync(join(outsideDir, "matrix.mtx"), "x");
+    analysis = createAnalysis({
+        cwd: anchorDir,
+        name: str256("rna-seq")._unsafeUnwrap(),
+        inputPaths: [join(anchorDir, "counts.tsv"), join(anchorDir, "data"), join(outsideDir, "matrix.mtx")],
+    })._unsafeUnwrap();
+});
+
+afterEach(() => {
+    dialogClear();
+    for (const dir of [anchorDir, outsideDir]) rmSync(dir, { recursive: true, force: true });
+});
+
+function ws(): Workspace {
+    return {
+        analysis,
+        sessionId: null,
+        workingDir: anchorDir,
+        project: null,
+        openDialog: () => {},
+        closeDialog: () => {},
+        openSession: () => {},
+        quit: async () => {},
+    };
+}
+
+function harnessNode(workspace: Workspace): () => JSX.Element {
+    return () => {
+        useKeymapRoot();
+        return (
+            <WorkspaceContext.Provider value={workspace}>
+                <box width="100%" height="100%">
+                    <DialogOverlay />
+                </box>
+            </WorkspaceContext.Provider>
+        );
+    };
+}
+
+type Setup = Awaited<ReturnType<typeof testRender>>;
+
+async function settle(setup: Setup): Promise<string> {
+    await new Promise((r) => setTimeout(r, 20));
+    await setup.renderOnce();
+    await setup.renderOnce();
+    return setup.captureCharFrame();
+}
+
+/**
+ * The frame with every space, newline, and box-drawing glyph removed. An absolute path is longer
+ * than the panel, so the list wraps it mid-string and a literal `toContain` on the path can never
+ * match. These paths hold no spaces, so collapsing the frame reassembles them exactly.
+ */
+function flat(frame: string): string {
+    return frame.replace(/[\s\u2500-\u257f]/g, "");
+}
+
+/** Run the real `analysis.remove-input` command and push the dialog it opens onto the host. */
+function openRemoveInputs(workspace: Workspace): void {
+    const command = commands.find((c) => c.id === "analysis.remove-input");
+    expect(command).toBeDefined();
+    void command!.run({ ...workspace, openDialog: (render) => dialogPush(render) });
+}
+
+describe("the flat inputs list", () => {
+    test("names each input by its absolute path, marking a directory", async () => {
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            await settle(setup);
+            openRemoveInputs(ws());
+            const frame = await settle(setup);
+
+            // The STORED path is anchor-relative ("counts.tsv"), which says nothing about where the
+            // file is — two inputs from two anchors would render as the same string.
+            expect(flat(frame)).toContain(join(anchorDir, "counts.tsv"));
+            expect(flat(frame)).toContain(`${join(anchorDir, "data")}${sep}`);
+            expect(frame).toContain("2.0 KB");
+            expect(frame).toContain("directory");
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("an input outside the anchor folder is listed without any navigation", async () => {
+        // The reason this surface exists at all: the picker seeds a far input into its selection but
+        // renders no row for it until the user browses to that folder.
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            await settle(setup);
+            openRemoveInputs(ws());
+            const frame = await settle(setup);
+            expect(flat(frame)).toContain(join(outsideDir, "matrix.mtx"));
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("two inputs leave in one pass", async () => {
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            await settle(setup);
+            openRemoveInputs(ws());
+            await settle(setup);
+
+            // Multi mode: esc blurs the filter to NORMAL, then space toggles and enter confirms.
+            setup.mockInput.pressEscape();
+            await settle(setup);
+            await setup.mockInput.pressKeys([" "]);
+            setup.mockInput.pressArrow("down");
+            await setup.mockInput.pressKeys([" "]);
+            setup.mockInput.pressEnter();
+            await settle(setup);
+
+            expect(listAnalysisInputs(analysis.id)._unsafeUnwrap()).toHaveLength(1);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("an input whose file is gone still lists and still removes", async () => {
+        rmSync(join(outsideDir, "matrix.mtx"));
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            await settle(setup);
+            openRemoveInputs(ws());
+            const frame = await settle(setup);
+            // Removal resolves against the REGISTERED set, so a vanished file is a normal row.
+            expect(flat(frame)).toContain(join(outsideDir, "matrix.mtx"));
+            expect(frame).toContain("not on disk");
+
+            // The far input sorts last (creation order), so walk to it and drop it.
+            setup.mockInput.pressEscape();
+            await settle(setup);
+            setup.mockInput.pressArrow("down");
+            setup.mockInput.pressArrow("down");
+            await setup.mockInput.pressKeys([" "]);
+            setup.mockInput.pressEnter();
+            await settle(setup);
+
+            const left = listAnalysisInputs(analysis.id)._unsafeUnwrap();
+            expect(left).toHaveLength(2);
+            expect(left.some((i) => i.path.includes("matrix.mtx"))).toBe(false);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+});

--- a/cli/src/tui/remove_inputs_dialog.render.test.tsx
+++ b/cli/src/tui/remove_inputs_dialog.render.test.tsx
@@ -8,7 +8,7 @@ import type { JSX } from "solid-js";
 import { freshDb } from "../test_support/db.ts";
 import { str256 } from "../lib/types.ts";
 import { createAnalysis } from "../modules/analysis/analysis.ts";
-import { listAnalysisInputs } from "../db/primary_query.ts";
+import { listAnalysisInputs, listAnchors } from "../db/primary_query.ts";
 import { useKeymapRoot } from "./keymap.ts";
 import { DialogOverlay, dialogClear, dialogPush } from "./components/dialog/dialog_host.tsx";
 import { WorkspaceContext, type Workspace } from "./contexts/workspace.ts";
@@ -169,6 +169,30 @@ describe("the flat inputs list", () => {
             await settle(setup);
 
             expect(listAnalysisInputs(analysis.id)._unsafeUnwrap()).toHaveLength(1);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("opening the list records no sighting of the anchor folder", async () => {
+        // A listing is not a sighting. `resolveAnchor` writes a `lastSeen` heartbeat by default, so
+        // the per-input form would make this dialog measure dialog opens and pay one synchronous
+        // SQLite write for each row it draws.
+        const before = listAnchors()
+            ._unsafeUnwrap()
+            .map((anchor) => anchor.lastSeen);
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            // `settle` waits 20ms, so any heartbeat the open writes carries a strictly later stamp.
+            await settle(setup);
+            openRemoveInputs(ws());
+            await settle(setup);
+
+            expect(
+                listAnchors()
+                    ._unsafeUnwrap()
+                    .map((anchor) => anchor.lastSeen),
+            ).toEqual(before);
         } finally {
             setup.renderer.destroy();
         }

--- a/cli/src/tui/remove_inputs_dialog.render.test.tsx
+++ b/cli/src/tui/remove_inputs_dialog.render.test.tsx
@@ -128,6 +128,32 @@ describe("the flat inputs list", () => {
         }
     });
 
+    test("opens in NORMAL, so the first space toggles instead of typing", async () => {
+        // The state a user actually meets. Mounting focused made space type a character into the
+        // filter with nothing on screen explaining why the row would not select.
+        const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
+        try {
+            await settle(setup);
+            openRemoveInputs(ws());
+            let frame = await settle(setup);
+            expect(frame).toContain("NORMAL");
+
+            await setup.mockInput.pressKeys([" "]);
+            frame = await settle(setup);
+            expect(frame).toContain("1 selected");
+
+            // `i` returns to filtering, and the mode word follows.
+            await setup.mockInput.pressKeys(["i"]);
+            frame = await settle(setup);
+            expect(frame).toContain("INSERT");
+            await setup.mockInput.pressKeys([" "]);
+            frame = await settle(setup);
+            expect(frame).toContain("1 selected"); // the space typed, it did not toggle a second row
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
     test("two inputs leave in one pass", async () => {
         const setup = await testRender(harnessNode(ws()), { width: 120, height: 26 });
         try {
@@ -135,9 +161,7 @@ describe("the flat inputs list", () => {
             openRemoveInputs(ws());
             await settle(setup);
 
-            // Multi mode: esc blurs the filter to NORMAL, then space toggles and enter confirms.
-            setup.mockInput.pressEscape();
-            await settle(setup);
+            // Multi mode mounts in NORMAL (the FilePicker convention), so space toggles straight away.
             await setup.mockInput.pressKeys([" "]);
             setup.mockInput.pressArrow("down");
             await setup.mockInput.pressKeys([" "]);
@@ -162,8 +186,6 @@ describe("the flat inputs list", () => {
             expect(frame).toContain("not on disk");
 
             // The far input sorts last (creation order), so walk to it and drop it.
-            setup.mockInput.pressEscape();
-            await settle(setup);
             setup.mockInput.pressArrow("down");
             setup.mockInput.pressArrow("down");
             await setup.mockInput.pressKeys([" "]);

--- a/cli/src/tui/switch_analysis_picker.render.test.tsx
+++ b/cli/src/tui/switch_analysis_picker.render.test.tsx
@@ -6,6 +6,8 @@ import { testRender } from "@opentui/solid";
 import type { JSX } from "solid-js";
 
 import { freshDb } from "../test_support/db.ts";
+import { __setClipboardWriterForTest } from "../lib/clipboard.ts";
+import { contractHome } from "../lib/paths.ts";
 import { str256 } from "../lib/types.ts";
 import { createAnalysis } from "../modules/analysis/analysis.ts";
 import { upsertLlmUsage, type LlmUsageEntry } from "../db/primary_mutation.ts";
@@ -121,9 +123,11 @@ describe("Switch analysis picker figures", () => {
             expect(untouchedRow).toBeDefined();
 
             expect(spentRow).toContain("↑767.6k ↓33.1k");
-            // Never a zero, and never the other analysis's number: absence is absence.
+            // Never a zero, and never the other analysis's number: absence is absence. The arrows ARE
+            // the figure — asserting on bare digits would catch the row's creation date instead, which
+            // every row carries and which says nothing about usage.
             expect(untouchedRow).not.toContain("↑");
-            expect(untouchedRow).not.toContain("0");
+            expect(untouchedRow).not.toContain("↓");
             expect(frame).not.toContain("999.0k");
             // 800.7k is the two arms added — a figure no surface may invent.
             expect(frame).not.toContain("800.7k");
@@ -165,6 +169,115 @@ describe("Switch analysis picker figures", () => {
             await settle(setup);
             expect(chosen).not.toBeNull();
         } finally {
+            setup.renderer.destroy();
+        }
+    });
+});
+
+// A full run of this file emits one `Anchor is the same as the node <id> being inserted, skipping
+// insertBefore` from opentui. It appears only with grouping on, and only across a multi-test run —
+// no single test or pair reproduces it. It is NOT the row-drop of HORRIBLE_BUG_FIXES entry 1: that
+// one is the `Anchor with id <id> does not exist` branch, which skips a node not yet in the tree.
+// This branch is `renderable === anchor`, i.e. inserting a node before ITSELF, where skipping is
+// what the operation already means. Every row and header asserted below renders, and the
+// for_scrollbox sentinel (which covers grouped tuples) stays green.
+describe("Switch analysis picker identity", () => {
+    test("two analyses of one name are told apart by their anchor headers", async () => {
+        // The reason this grouping exists: a slug is unique only WITHIN an anchor, so the same name
+        // in two folders produces two rows that are identical down to the character.
+        const inA = analysisIn(dirA, "A1");
+        const inB = analysisIn(dirB, "A1");
+
+        const workspace = ws();
+        const setup = await testRender(harnessNode(workspace), { width: 100, height: 24 });
+        try {
+            await settle(setup);
+            openSwitchPicker(workspace);
+            const frame = await settle(setup);
+
+            const lines = frame.split("\n");
+            expect(lines.filter((l) => l.includes("A1") && !l.includes(dirA) && !l.includes(dirB))).toHaveLength(2);
+            const headers = lines.filter((l) => l.includes(dirA) || l.includes(dirB));
+            expect(headers).toHaveLength(2);
+            expect(headers.join("\n")).toContain(contractHome(dirA));
+            expect(headers.join("\n")).toContain(contractHome(dirB));
+            // The group KEY is the anchor id, and a header must print the folder instead. (The id is
+            // on screen — the cursor row's detail line carries it deliberately — so this asks the
+            // narrower question the grouping actually owns.)
+            expect(headers.join("\n")).not.toContain(inA.anchorId);
+            expect(headers.join("\n")).not.toContain(inB.anchorId);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("the row date is absolute, and the cursor row gives the id and the slug", async () => {
+        const only = analysisIn(dirA, "rna-seq");
+
+        const workspace = ws();
+        const setup = await testRender(harnessNode(workspace), { width: 110, height: 24 });
+        try {
+            await settle(setup);
+            openSwitchPicker(workspace);
+            const frame = await settle(setup);
+
+            const row = frame.split("\n").find((l) => l.includes("rna-seq")) ?? "";
+            expect(row).toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/);
+            // A record listing reads on the absolute side of the time convention.
+            expect(row).not.toMatch(/\b\d+[dhm] ago\b/);
+
+            // The detail line of the cursor row is the one unambiguous handle for a row.
+            expect(frame).toContain(only.id);
+            expect(frame).toContain(only.slug);
+        } finally {
+            setup.renderer.destroy();
+        }
+    });
+
+    test("ctrl+y copies the cursor row's analysis id", async () => {
+        const only = analysisIn(dirA, "rna-seq");
+        const copied: string[] = [];
+        const restore = __setClipboardWriterForTest(async (text) => {
+            copied.push(text);
+        });
+
+        const workspace = ws();
+        const setup = await testRender(harnessNode(workspace), { width: 100, height: 24 });
+        try {
+            await settle(setup);
+            openSwitchPicker(workspace);
+            await settle(setup);
+
+            await setup.mockInput.pressKeys(["\x19"]); // ctrl+y
+            await settle(setup);
+            expect(copied).toEqual([only.id]);
+        } finally {
+            restore();
+            setup.renderer.destroy();
+        }
+    });
+
+    test("a typed y filters instead of copying — the chord needs ctrl", async () => {
+        analysisIn(dirA, "rna-seq");
+        analysisIn(dirB, "yeast");
+        const copied: string[] = [];
+        const restore = __setClipboardWriterForTest(async (text) => {
+            copied.push(text);
+        });
+
+        const workspace = ws();
+        const setup = await testRender(harnessNode(workspace), { width: 100, height: 24 });
+        try {
+            await settle(setup);
+            openSwitchPicker(workspace);
+            await settle(setup);
+
+            await setup.mockInput.pressKeys(["y"]);
+            const frame = await settle(setup);
+            expect(copied).toEqual([]);
+            expect(frame).toContain("yeast");
+        } finally {
+            restore();
             setup.renderer.destroy();
         }
     });


### PR DESCRIPTION
## What & why

Three list surfaces named an item and gave nothing that told two items apart.

- The file picker listed a bare entry name. Thus a user could not compare two candidate
  inputs. An unreadable entry also stayed hidden until staging failed.
- The flat inputs list showed a path relative to the anchor. It removed one input for each
  open of the dialog.
- The analysis switcher showed the name alone. A slug is unique within an anchor only, thus
  one name in two folders gave two identical rows.

Closes #26

## What changes

**The file picker.** A row carries the permission bits, the size, and an absolute local
date. An entry that the user cannot read renders in the warning color, and it stays
selectable.

The listing takes one `statSync` for each entry, and no `access` call. Readability comes
from the mode bits and the owner ids, which that same `stat` gives. An entry ceiling of
2000 covers the pathological folder, and the footer reports the absent metadata.

**The flat inputs list.** It becomes multi-select, thus one confirm removes each selected
input. A row title becomes the absolute path, and a `meta` line carries the kind, the size,
and the date.

The list stays separate from the picker. An analysis can span any number of folders, and
the picker renders no row for a far input until the user browses to its folder.

**The analysis switcher.** A row groups on the anchor id, under a header that gives the
anchor folder. One `listAnchors()` call reads every path. A row date becomes absolute, and
the cursor detail line carries the id, the slug, and the full creation date. `ctrl+y`
copies the analysis id.

**The design system.** `SelectItem` gains `categoryLabel`, which separates the group key
from the header text. It also gains `tone`, which names a meaning and lets the theme pick
the color.

The `lg` preset grows from 88 by 20 to 108 by 28. Each dialog footer takes a painted
breathing row above it, and it names no cursor key. A list row clears the scrollbar.

## The measurements

The design rejects an `access` pass and a member count on a directory row. Both were
measured on a 468-entry directory, where 467 of the entries are directories.

| Pass | Cold | Warm |
| --- | --- | --- |
| `readdirSync` with `withFileTypes` | 0.24 ms | 0.21 ms |
| `statSync` for each entry | 48.89 ms | 0.69 ms |
| `accessSync(R_OK)` for each entry | — | 2.51 ms |
| `readdir` for each directory row | 54.46 ms | 4.91 ms |

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`) — 2690 pass, 1 skip, 0 fail.
- [x] Tests added or updated for the change.
- [x] The design gallery takes an entry for each new state.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This pull request holds one logical change.
