### PR TITLE
fix(cli,harness): decouple the call-detail cap, and mark a reference or package search

### DIFF
--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -204,8 +204,13 @@ persistence functions with their types (`prepareChatTurn`, the thread store/hist
 factories, `StoredMessage`), the history display readers (`contentToCortexMessages`,
 `createCardResolver`), the streaming-chat provider wrapper (`createStreamingChat`) and
 `AgentChat`, the pass-through run step (`passthroughStep`), the ephemeral pre-launch
-sweep (`sweepEphemeralWorkflows`), the unavailable preview publisher, and the
-`contracts/` chat-event and chat-part types.
+sweep (`sweepEphemeralWorkflows`), the unavailable preview publisher, the
+`contracts/` chat-event and chat-part types, and the tool-call-detail authoring
+aids (`DETAIL_MAX_LENGTH`, `normalizeDetail`).
+
+A cli `describeCall` hook that pre-empts truncation SHALL gate on `DETAIL_MAX_LENGTH`
+from the barrel. A copy of the number in cli code drifts when the harness retunes
+its own cap. The hook then states a bound the emit site does not enforce.
 
 #### Scenario: No deep imports in cli code
 

--- a/cli/src/modules/harness/inflexa_tool.test.ts
+++ b/cli/src/modules/harness/inflexa_tool.test.ts
@@ -2,8 +2,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { AskRejectedError, UnavailableAsk, type AgentSession, type AskApproval, type AskRequest, type ToolContext } from "@inflexa-ai/harness";
-import { normalizeDetail } from "@inflexa-ai/harness/loop/tool-detail.js";
+import { AskRejectedError, UnavailableAsk, normalizeDetail, type AgentSession, type AskApproval, type AskRequest, type ToolContext } from "@inflexa-ai/harness";
 import { describe, expect, test } from "bun:test";
 
 import type { AgentPolicy } from "../../cli/agent_policy.ts";

--- a/cli/src/modules/harness/inputs_tool.test.ts
+++ b/cli/src/modules/harness/inputs_tool.test.ts
@@ -4,8 +4,7 @@ import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { AgentSession, AskApproval, AskRequest, ToolContext } from "@inflexa-ai/harness";
-import { DETAIL_MAX_LENGTH } from "@inflexa-ai/harness/loop/tool-detail.js";
+import { DETAIL_MAX_LENGTH, type AgentSession, type AskApproval, type AskRequest, type ToolContext } from "@inflexa-ai/harness";
 
 import { Bus } from "../../lib/bus.ts";
 import { acquireInstanceLock, releaseInstanceLock } from "../../lib/lock.ts";

--- a/cli/src/modules/harness/inputs_tool.ts
+++ b/cli/src/modules/harness/inputs_tool.ts
@@ -15,10 +15,7 @@
 
 import { existsSync } from "node:fs";
 
-import { defineTool, scopeResource, type AskRequest, type ToolError } from "@inflexa-ai/harness";
-// A deep subpath: the cap is not on the barrel. The alternative is a copy of the
-// number here, which drifts the moment the harness retunes its own cap.
-import { DETAIL_MAX_LENGTH } from "@inflexa-ai/harness/loop/tool-detail.js";
+import { defineTool, scopeResource, DETAIL_MAX_LENGTH, type AskRequest, type ToolError } from "@inflexa-ai/harness";
 import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 

--- a/harness/openspec/specs/tool-call-detail/spec.md
+++ b/harness/openspec/specs/tool-call-detail/spec.md
@@ -49,6 +49,8 @@ When the cap actually shortens a detail, the emitted string SHALL carry a trunca
 
 A tool author is therefore free to return whatever reads best. A leak or a runaway string is one auditable line's responsibility, not thirty authors'.
 
+The bound and the emit-site transform SHALL be reachable from the package barrel (`DETAIL_MAX_LENGTH`, `normalizeDetail`). An embedder contributes its own tool through the host-tools seam, thus its hook pre-empts the same cap the loop enforces. It SHALL read the one number, and not a copy that drifts when the harness retunes the cap.
+
 #### Scenario: A multi-line detail becomes one line
 
 - **GIVEN** a `describeCall` that returns a string containing newlines
@@ -110,3 +112,39 @@ A detail that names something other than what the call did is worse than no deta
 - **GIVEN** a tool that ships a hook
 - **WHEN** the test suite runs
 - **THEN** at least one assertion covers the exact string that hook produces for a representative call
+
+### Requirement: A hook marks a field that narrows, and joins two facts with words
+
+A required field is the subject of the call, because the tool cannot run without it. A hook SHALL name the value of that field directly.
+
+An optional field that narrows a result is a filter. The tool returns that result with the field or without it. A hook SHALL mark such a field. An unmarked value reads as the thing the call acted on, and that statement is false.
+
+A free-form text needle SHALL ride behind `matching "<needle>"`. An enumerated restriction SHALL ride as a qualifier in parentheses at the end, or as a noun phrase when it names the whole call.
+
+A hook SHALL bound a free-form needle at 32 code points. A hook SHALL also bound each part of a detail that carries two parts. The emit-site cap cuts the tail. Thus a hook that leaves the bound to the emit site loses the mark that closes the needle. It also loses a filter behind a target that runs long.
+
+A detail SHALL carry nothing from the visual vocabulary of a host. A host owns its separators, its glyphs, and the width of its own line. A hook that states two facts SHALL join them with a word.
+
+#### Scenario: A bare needle does not read as a target
+
+- **GIVEN** a tool whose optional needle filters a store it browses, and a call that supplies the needle alone
+- **WHEN** the hook describes that call
+- **THEN** the detail marks the needle, and it does not render the needle bare
+
+#### Scenario: A long needle keeps the mark that closes it
+
+- **GIVEN** a call whose needle is longer than the needle bound
+- **WHEN** the hook describes that call
+- **THEN** the needle carries a truncation mark inside the marked form, and the marked form is closed
+
+#### Scenario: A long target does not swallow the filter
+
+- **GIVEN** a call that supplies a needle and a target longer than the cap
+- **WHEN** the hook describes that call
+- **THEN** the detail names both parts within the cap, and the emit site shortens nothing
+
+#### Scenario: A detail joins two facts without a host separator
+
+- **GIVEN** a hook that states a target and a filter in one detail
+- **WHEN** the hook describes that call
+- **THEN** the two parts join with a word, and the detail carries no separator glyph

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -68,6 +68,16 @@ export type { WorkflowPurger } from "./execution/workflow-purger.js";
 export { defineTool, isToolError } from "./tools/define-tool.js";
 export type { Tool, ToolDefinition, ToolContext, ToolError } from "./tools/define-tool.js";
 
+// Tool-call-detail authoring aids for an embedder that contributes a host tool.
+// A `describeCall` hook that pre-empts truncation — a count in place of a
+// mid-value cut that would name a file that does not exist — must gate on the
+// SAME bound the harness enforces at the emit site. Thus `DETAIL_MAX_LENGTH`
+// rides the curated surface, so a host reads the one number rather than copying
+// it and drifting when the harness retunes the cap. `normalizeDetail` is that
+// emit-site transform, exported so a host can assert a hook's output against
+// exactly what the harness will render.
+export { normalizeDetail, DETAIL_MAX_LENGTH } from "./loop/tool-detail.js";
+
 // Host-agnostic citation verification service and its public contracts.
 export { createCitationResolver } from "./citations/resolve.js";
 export type { CitationResolverConfig, CitationResolverDependencies, CitationResolverSourceConfig } from "./citations/resolve.js";

--- a/harness/src/loop/tool-detail.ts
+++ b/harness/src/loop/tool-detail.ts
@@ -31,7 +31,27 @@ export type { ToolCallDetail };
 export const DETAIL_MAX_LENGTH = 120;
 
 /**
+ * The bound a hook gives a free-form needle that it marks inside a detail.
+ *
+ * A needle is model-authored text of no fixed length, thus it is the one part of
+ * a detail that can run away. Left to {@link DETAIL_MAX_LENGTH}, a long needle
+ * takes the whole line, and the cut lands inside the mark that names it: the
+ * closing quote goes, and a second fact behind it goes with no trace. A hook
+ * bounds the needle first. Then the mark always closes, and the rest of the
+ * detail keeps its room.
+ *
+ * 32 code points shows the shape of a search — enough to recognize the needle a
+ * caller typed, and short enough that a target beside it survives whole.
+ */
+export const DETAIL_NEEDLE_MAX_LENGTH = 32;
+
+/**
  * Cap `text` at `max` CODE POINTS, not UTF-16 units.
+ *
+ * A hook calls this to pre-empt the emit-site cap: that cap cuts the TAIL, so a
+ * detail with two parts loses the second one when the first runs long. One
+ * implementation serves both sites, thus a hook's own bound cuts and marks
+ * exactly as {@link normalizeDetail} does.
  *
  * `String.prototype.slice` cuts at a fixed unit index, which can land between the
  * two halves of a surrogate pair and emit a lone surrogate — a terminal paints
@@ -50,7 +70,7 @@ export const DETAIL_MAX_LENGTH = 120;
  * hard bound. `trimEnd` runs BEFORE the append, because a cut that lands on a
  * space must give `word…` and not `word …`.
  */
-function capCodePoints(text: string, max: number): string {
+export function capCodePoints(text: string, max: number): string {
     const points = Array.from(text);
     if (points.length <= max) return text;
     const cut = points.slice(0, max - 1).join("");

--- a/harness/src/tools/describe-call.test.ts
+++ b/harness/src/tools/describe-call.test.ts
@@ -154,17 +154,20 @@ describe("describeCall — conversation roster", () => {
         expect(describeCall(tool, { researchQuestion: "which genes drive resistance in cluster 3" })).toBe("which genes drive resistance in cluster 3");
     });
 
-    it("list_available_refs names what it inspects, never the filter over it", () => {
+    it("list_available_refs names the subtree it inspects, and marks a filter over it", () => {
         const tool = createListAvailableRefsTool(unused);
 
         expect(describeCall(tool, {})).toBe("full reference store");
         expect(describeCall(tool, { path: "managed/collectri" })).toBe("managed/collectri");
         expect(describeCall(tool, { category: "msigdb" })).toBe("msigdb");
-        expect(describeCall(tool, { query: "regulon" })).toBe("regulon");
+        // A bare needle reads as a path, thus a search-only call marks the filter.
+        expect(describeCall(tool, { query: "regulon" })).toBe('matching "regulon"');
         // `execute` resolves `path ?? category`, thus the path wins over the category.
         expect(describeCall(tool, { path: "managed/collectri", category: "msigdb" })).toBe("managed/collectri");
-        // `query` narrows the entries of the named subtree; it does not replace it.
-        expect(describeCall(tool, { category: "msigdb", query: "hallmark" })).toBe("msigdb");
+        // `query` narrows the named subtree; the detail names both halves, so the
+        // filter no longer hides behind the target.
+        expect(describeCall(tool, { category: "msigdb", query: "hallmark" })).toBe('msigdb · matching "hallmark"');
+        expect(describeCall(tool, { path: "human", query: "kinase" })).toBe('human · matching "kinase"');
         // A blank value is no filter and no target inside `execute`, thus the
         // detail names the browse that actually happens.
         expect(describeCall(tool, { query: "   " })).toBe("full reference store");
@@ -178,9 +181,10 @@ describe("describeCall — conversation roster", () => {
 
         expect(describeCall(tool, {})).toBe("full package list");
         expect(describeCall(tool, { names: ["Seurat", "scanpy"] })).toBe("Seurat, scanpy");
-        expect(describeCall(tool, { query: "seurat" })).toBe("seurat");
+        // A bare needle reads as a package name, thus a search marks the filter.
+        expect(describeCall(tool, { query: "seurat" })).toBe('matching "seurat"');
         expect(describeCall(tool, { language: "python" })).toBe("python packages");
-        expect(describeCall(tool, { query: "umap", language: "r" })).toBe("umap (r)");
+        expect(describeCall(tool, { query: "umap", language: "r" })).toBe('matching "umap" (r)');
         // `queryPackages` returns on `names` before it reads `query` or `language`.
         expect(describeCall(tool, { names: ["Seurat"], query: "umap", language: "r" })).toBe("Seurat");
         // An empty array is not a presence check, and `execute` lists the store.

--- a/harness/src/tools/describe-call.test.ts
+++ b/harness/src/tools/describe-call.test.ts
@@ -165,15 +165,38 @@ describe("describeCall — conversation roster", () => {
         // `execute` resolves `path ?? category`, thus the path wins over the category.
         expect(describeCall(tool, { path: "managed/collectri", category: "msigdb" })).toBe("managed/collectri");
         // `query` narrows the named subtree; the detail names both halves, so the
-        // filter no longer hides behind the target.
-        expect(describeCall(tool, { category: "msigdb", query: "hallmark" })).toBe('msigdb · matching "hallmark"');
-        expect(describeCall(tool, { path: "human", query: "kinase" })).toBe('human · matching "kinase"');
+        // filter no longer hides behind the target. A word joins them, because a
+        // separator glyph is the vocabulary of a host.
+        expect(describeCall(tool, { category: "msigdb", query: "hallmark" })).toBe('msigdb matching "hallmark"');
+        expect(describeCall(tool, { path: "human", query: "kinase" })).toBe('human matching "kinase"');
         // A blank value is no filter and no target inside `execute`, thus the
         // detail names the browse that actually happens.
         expect(describeCall(tool, { query: "   " })).toBe("full reference store");
         expect(describeCall(tool, { path: "" })).toBe("full reference store");
         // A blank path still suppresses the category, exactly as `execute` does.
         expect(describeCall(tool, { path: "", category: "msigdb" })).toBe("full reference store");
+    });
+
+    // The emit-site cap cuts the tail. Left to it, a runaway needle loses the quote
+    // that closes its own mark, and a runaway path (the schema admits 4096 bytes)
+    // takes the whole line and drops the filter with no trace. Both halves are
+    // bounded here instead, thus each one reaches a reader and each marks its cut.
+    it("list_available_refs bounds each half, so the cap severs neither the mark nor the filter", () => {
+        const tool = createListAvailableRefsTool(unused);
+
+        const longNeedle = describeCall(tool, { query: "k".repeat(40) });
+        expect(longNeedle).toBe(`matching "${"k".repeat(31)}…"`);
+        expect(normalizeDetail(longNeedle)).toBe(longNeedle);
+
+        const longTarget = describeCall(tool, { path: "p".repeat(200), query: "kinase" });
+        expect(longTarget).toBe(`${"p".repeat(101)}… matching "kinase"`);
+        expect(normalizeDetail(longTarget)).toBe(longTarget);
+
+        // Both halves at once — the worst case, and still one code point inside the cap.
+        const both = describeCall(tool, { path: "p".repeat(200), query: "k".repeat(40) });
+        expect(both).toBe(`${"p".repeat(75)}… matching "${"k".repeat(31)}…"`);
+        expect(Array.from(both)).toHaveLength(120);
+        expect(normalizeDetail(both)).toBe(both);
     });
 
     it("list_available_packages names the presence check before any filter", () => {
@@ -193,6 +216,17 @@ describe("describeCall — conversation roster", () => {
         // blank, thus a blank query never names the call.
         expect(describeCall(tool, { query: "  ", language: "r" })).toBe("r packages");
         expect(describeCall(tool, { query: "" })).toBe("full package list");
+    });
+
+    // A needle the cap cuts loses the quote that closes its mark. The bound is the
+    // hook's, thus the marked form is always whole and the qualifier keeps its place.
+    it("list_available_packages bounds the needle, so the mark always closes", () => {
+        const tool = createListAvailablePackagesTool(unused);
+
+        const detail = describeCall(tool, { query: "s".repeat(40), language: "r" });
+
+        expect(detail).toBe(`matching "${"s".repeat(31)}…" (r)`);
+        expect(normalizeDetail(detail)).toBe(detail);
     });
 
     it("show_plan names the plan", () => {

--- a/harness/src/tools/sandbox/list-available-packages.ts
+++ b/harness/src/tools/sandbox/list-available-packages.ts
@@ -235,12 +235,17 @@ export function createListAvailablePackagesTool(deps: ListAvailablePackagesDeps 
         }),
         // `queryPackages` returns on `names` before it reads another field, thus
         // the presence check comes first. An empty array is not a presence check.
-        // A blank query counts as absent, because `queryPackages` trims the
-        // needle and applies no filter when nothing is left.
+        // `names` are exact identifiers a caller checks for, thus they name the
+        // call as they are. A blank query counts as absent, because `queryPackages`
+        // trims the needle and applies no filter when nothing is left.
+        //
+        // A needle rides behind `matching "…"`, because a bare needle reads as a
+        // package name. `language` stays a trailing qualifier, exactly as `execute`
+        // treats it.
         describeCall: ({ names, query, language }) => {
             if (names !== undefined && names.length > 0) return names.join(", ");
             const needle = query?.trim();
-            if (needle !== undefined && needle !== "") return language === undefined ? needle : `${needle} (${language})`;
+            if (needle !== undefined && needle !== "") return language === undefined ? `matching "${needle}"` : `matching "${needle}" (${language})`;
             if (language !== undefined) return `${language} packages`;
             return "full package list";
         },

--- a/harness/src/tools/sandbox/list-available-packages.ts
+++ b/harness/src/tools/sandbox/list-available-packages.ts
@@ -30,6 +30,7 @@ import { z } from "zod";
 
 import { defineTool, type ToolError } from "../define-tool.js";
 import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
+import { capCodePoints, DETAIL_NEEDLE_MAX_LENGTH } from "../../loop/tool-detail.js";
 
 /**
  * Where the list lives when the host mounts the library store at the same path
@@ -240,12 +241,16 @@ export function createListAvailablePackagesTool(deps: ListAvailablePackagesDeps 
         // trims the needle and applies no filter when nothing is left.
         //
         // A needle rides behind `matching "…"`, because a bare needle reads as a
-        // package name. `language` stays a trailing qualifier, exactly as `execute`
-        // treats it.
+        // package name. The needle takes its own bound, thus the emit-site cap
+        // cannot cut inside the mark and leave the quote open. `language` stays a
+        // trailing qualifier, exactly as `execute` treats it.
         describeCall: ({ names, query, language }) => {
             if (names !== undefined && names.length > 0) return names.join(", ");
             const needle = query?.trim();
-            if (needle !== undefined && needle !== "") return language === undefined ? `matching "${needle}"` : `matching "${needle}" (${language})`;
+            if (needle !== undefined && needle !== "") {
+                const marked = `matching "${capCodePoints(needle, DETAIL_NEEDLE_MAX_LENGTH)}"`;
+                return language === undefined ? marked : `${marked} (${language})`;
+            }
             if (language !== undefined) return `${language} packages`;
             return "full package list";
         },

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -586,19 +586,24 @@ export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
             "The store is provisioned by the host and is NOT frozen: datasets can be added through the host's own provisioning path, and whatever is added shows up on a later call. " +
             "So before you report a gap as permanent, check whether any tool you hold reaches that provisioning path — offer that route if one exists, and call the gap permanent only when none does.",
         inputSchema: ListAvailableRefsInputSchema,
-        // `execute` resolves `path ?? category`, and it ignores `category` when
-        // `path` is present. `query` filters the result of that choice, thus it
-        // names the call only when neither of the two other fields does.
+        // `execute` resolves `path ?? category` for the subtree it inspects, and
+        // it ignores `category` when `path` is present. `query` is an ADDITIVE
+        // filter over that subtree, thus the target keeps naming the call and the
+        // filter rides beside it.
         //
-        // A blank value counts as absent, because `execute` treats it that way:
-        // it browses the store root for a blank target, and it applies no filter
-        // for a blank needle. The precedence stays `??` and never `||`, thus a
-        // blank `path` still suppresses `category` exactly as `execute` does.
+        // A needle rides behind `matching "…"`: a bare needle reads as a path, and
+        // a filtered subtree must name both halves, not the target alone. A blank
+        // value counts as absent, because `execute` treats it that way: it browses
+        // the store root for a blank target, and it applies no filter for a blank
+        // needle. The precedence stays `??` and never `||`, thus a blank `path`
+        // still suppresses `category` exactly as `execute` does.
         describeCall: ({ path, category, query }) => {
             const target = path ?? category;
-            if (target !== undefined && target.trim() !== "") return target;
+            const named = target !== undefined && target.trim() !== "" ? target : undefined;
             const needle = query?.trim();
-            return needle === undefined || needle === "" ? "full reference store" : needle;
+            const filter = needle === undefined || needle === "" ? undefined : `matching "${needle}"`;
+            if (named !== undefined) return filter === undefined ? named : `${named} · ${filter}`;
+            return filter ?? "full reference store";
         },
         execute: async ({ path, category, query, limit }) => {
             // `category` is shorthand for a top-level path; an explicit `path` wins.

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -31,6 +31,7 @@ import { ok } from "neverthrow";
 import { z } from "zod";
 
 import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
+import { capCodePoints, DETAIL_MAX_LENGTH, DETAIL_NEEDLE_MAX_LENGTH } from "../../loop/tool-detail.js";
 import { REFERENCE_DATA_CATALOG } from "../../reference-data/catalog.js";
 import { parseReferenceInstallReceipt } from "../../reference-data/receipt.js";
 import { defineTool } from "../define-tool.js";
@@ -592,18 +593,32 @@ export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
         // filter rides beside it.
         //
         // A needle rides behind `matching "…"`: a bare needle reads as a path, and
-        // a filtered subtree must name both halves, not the target alone. A blank
-        // value counts as absent, because `execute` treats it that way: it browses
-        // the store root for a blank target, and it applies no filter for a blank
-        // needle. The precedence stays `??` and never `||`, thus a blank `path`
-        // still suppresses `category` exactly as `execute` does.
+        // a filtered subtree must name both halves, not the target alone. The two
+        // halves join with a space and a word, as `grep` joins its own two halves.
+        // A separator glyph belongs to a host, which owns its line and its own
+        // vocabulary; the harness renders nothing and thus borrows nothing.
+        //
+        // Each half carries its own bound. The emit-site cap cuts the TAIL, and
+        // `path` admits 4096 bytes, thus one long target would swallow the very
+        // filter this detail exists to state. The needle takes a fixed budget, and
+        // the target takes what the bounded filter leaves. Then both halves reach
+        // a reader, and each one marks its own cut.
+        //
+        // A blank value counts as absent, because `execute` treats it that way: it
+        // browses the store root for a blank target, and it applies no filter for a
+        // blank needle. The precedence stays `??` and never `||`, thus a blank
+        // `path` still suppresses `category` exactly as `execute` does.
         describeCall: ({ path, category, query }) => {
             const target = path ?? category;
             const named = target !== undefined && target.trim() !== "" ? target : undefined;
             const needle = query?.trim();
-            const filter = needle === undefined || needle === "" ? undefined : `matching "${needle}"`;
-            if (named !== undefined) return filter === undefined ? named : `${named} · ${filter}`;
-            return filter ?? "full reference store";
+            const filter = needle === undefined || needle === "" ? undefined : `matching "${capCodePoints(needle, DETAIL_NEEDLE_MAX_LENGTH)}"`;
+            if (named === undefined) return filter ?? "full reference store";
+            if (filter === undefined) return named;
+            // The budget comes off the rendered filter, never off a count of its
+            // parts, thus it cannot drift from the template above. One code point
+            // pays for the joining space.
+            return `${capCodePoints(named, DETAIL_MAX_LENGTH - [...filter].length - 1)} ${filter}`;
         },
         execute: async ({ path, category, query, limit }) => {
             // `category` is shorthand for a top-level path; an explicit `path` wins.


### PR DESCRIPTION
## What & why

This PR closes two findings from the review of #319 (the tool-call-detail work).
Each finding is one commit.

**Decouple the call-detail cap (refactor).** The cli `manage_inputs` hook gates on
the harness cap `DETAIL_MAX_LENGTH`. Thus it replaces a too-long path list with a
count, and not a truncated path that names a file which does not exist. It read the
cap through the deep subpath `@inflexa-ai/harness/loop/tool-detail.js`, which couples
the cli to the internal file layout of the harness. The harness barrel now
re-exports `DETAIL_MAX_LENGTH` and `normalizeDetail`, and the three cli sites import
them from `@inflexa-ai/harness`. The cli depends on the curated surface, and it still
avoids a copy of the number that drifts when the harness retunes the cap.

**Mark a reference or package search (fix).** A `list_available_refs` or
`list_available_packages` call that carried only a `query` rendered the bare needle,
which reads as a path. A call that carried both a target and a `query` rendered the
target alone, thus the filter was invisible. The two hooks now mark a needle as
`matching "<needle>"`, and they name a filtered subtree as
`<target> · matching "<needle>"`. A target-only call, a `names` call, and a
full-store browse do not change.

Examples:

- `list_available_refs({query:"kinase"})` → `matching "kinase"`
- `list_available_refs({path:"human", query:"kinase"})` → `human · matching "kinase"`
- `list_available_packages({query:"scanpy"})` → `matching "scanpy"`

### One finding left open by decision

The review also noted that a reloaded chat shows no tool-call duration while a live
one does. This is the documented non-goal of #319. The duration is a live-surface
diagnostic, and it is not persisted. It stays as is.

### Specs

The change to the two hooks stays inside the current `tool-call-detail` spec. Its
scenario "a filtering field does not displace the field naming the target" still
holds, because the target keeps naming the call. Thus no spec change is necessary.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Verification

| check | harness | cli |
| --- | --- | --- |
| `tsc` (build / `--noEmit`) | 0 errors | 0 errors |
| lint | clean | clean |
| affected tests | `describe-call` + `tool-detail`: 40 pass | `inputs`, `inflexa`, `launch_dir`, `conversation`: 175 pass |

I ran the affected test files, and not the full `bun test`. The full harness suite
needs the podman socket, and no change here touches DB code.

## Checklist

- [x] Lint, typecheck, and tests pass locally (affected files — see Verification).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed. (No doc change is necessary. The spec stays conformant — see the Specs section.)
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change. (Two tidy commits, both from the same review.)
