### PR TITLE
fix(lib-store): publish packages.txt + meta.json, and hold the builders inside their disk budget

### DIFF
--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -112,7 +112,9 @@ jobs:
         # Use the docker daemon's built-in builder (not a docker-container builder):
         # its BuildKit cache lives in /var/lib/docker — the persistent EBS volume —
         # so warm layers survive the box's stop/start with no long-lived builder to
-        # leave stale state, and no runner-writable cache dir to provision.
+        # leave stale state, and no runner-writable cache dir to provision. The
+        # disk-guard step below caps that cache: persistent plus uncapped fills
+        # the volume.
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver: docker
@@ -121,6 +123,13 @@ jobs:
         # AL2023 ships zstd; fail loudly rather than install (the runner user has no
         # sudo on the self-hosted builders).
         run: command -v zstd >/dev/null || { echo "::error::zstd not found on the builder"; exit 1; }
+
+      - name: Reclaim disk, then check the free-space floor
+        # The box's EBS volume is persistent and nothing else reclaims it, so a run
+        # starts by capping the BuildKit cache and dropping the last run's debris.
+        # A box that is still short fails here, with the shortfall named, rather
+        # than mid-build.
+        run: bash scripts/lib-store-disk-guard.sh preflight
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -282,8 +291,7 @@ jobs:
         run: |
           docker rmi "${IMAGE_BASE}:${VERSION}-${ARCH}" "${IMAGE_PYTHON}:${VERSION}-${ARCH}" "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}" 2>/dev/null || true
           rm -rf staging dist candidate
-          docker image prune -f 2>/dev/null || true
-          docker container prune -f 2>/dev/null || true
+          bash scripts/lib-store-disk-guard.sh cleanup
 
   # Combine the per-arch image tags into multi-arch manifest lists so
   # `docker pull` resolves the host arch automatically. Only the arch tags that

--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -203,6 +203,18 @@ jobs:
           echo "top_image=$TOP" >> "$GITHUB_OUTPUT"
           bash scripts/lib-store-extract-tarballs.sh "$TOP" staging
 
+      - name: Free the built images
+        # The images are pushed and their tracks are in `staging/`, so the ~29 GB
+        # they hold in overlay2 is dead weight for the rest of the job. Free it
+        # here, before the pack — the pack is where the box runs out of disk.
+        # Newest first, so each image drops its own layers as it goes. Cleanup
+        # removes them again, because this step does not run when an earlier one
+        # fails.
+        run: |
+          docker rmi "${IMAGE_PYTHON_R}:${VERSION}-${ARCH}" "${IMAGE_PYTHON}:${VERSION}-${ARCH}" "${IMAGE_BASE}:${VERSION}-${ARCH}" 2>/dev/null || true
+          docker image prune -f >/dev/null 2>&1 || true
+          df -h .
+
       - name: Coverage report (want vs loaded, regression diff)
         id: coverage
         env:

--- a/.github/workflows/lib-store.yml
+++ b/.github/workflows/lib-store.yml
@@ -233,21 +233,6 @@ jobs:
             --out dist/coverage.json "${PREV_ARG[@]}" | tee coverage.out
           cat coverage.out >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Pack per-track tarballs
-        id: pack
-        run: |
-          bash scripts/lib-store-pack.sh staging dist
-          {
-            echo "## Image build ($ARCH)"
-            echo "| Image | Result |"
-            echo "|-|-|"
-            echo "| sandbox-base | pushed |"
-            echo "| sandbox-python | pushed |"
-            echo "| sandbox-python-r | ${{ steps.python_r.outcome }} |"
-            echo "Extracted from: ${{ steps.extract.outputs.top_image }}"
-            echo "Packed tracks: $(tr '\n' ' ' < dist/tracks.txt)"
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Publish configuration
         id: publish
         run: |
@@ -265,8 +250,13 @@ jobs:
           role-to-assume: ${{ vars.LIB_STORE_PUBLISH_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
-      - name: Publish track tarballs + candidate manifest + coverage
-        if: steps.publish.outputs.enabled == 'true'
+      # Packing and publishing are one step because they interleave: each track is
+      # packed, uploaded, and then torn down — tarball and staging subtree both —
+      # before the next track packs. Peak disk is the largest single track rather
+      # than all six. The step runs whether or not S3 is configured, so the pack is
+      # proven and the disk profile is the same either way.
+      - name: Pack, publish and tear down each track
+        id: pack
         env:
           S3_BUCKET: ${{ vars.LIB_STORE_S3_BUCKET }}
           PUBLIC_URL: ${{ vars.LIB_STORE_PUBLIC_URL || 'https://lib-store.inflexa.ai' }}
@@ -274,8 +264,25 @@ jobs:
           PYTHON_VERSION: ${{ needs.prepare.outputs.python_version }}
           GIT_SHA: ${{ github.sha }}
           TOP_IMAGE: ${{ steps.extract.outputs.top_image }}
+          PUBLISH_ENABLED: ${{ steps.publish.outputs.enabled }}
         run: |
-          scripts/lib-store-publish.sh "$ARCH" "$VERSION" dist
+          scripts/lib-store-publish.sh "$ARCH" "$VERSION" staging dist
+          {
+            echo "## Image build ($ARCH)"
+            echo "| Image | Result |"
+            echo "|-|-|"
+            echo "| sandbox-base | pushed |"
+            echo "| sandbox-python | pushed |"
+            echo "| sandbox-python-r | ${{ steps.python_r.outcome }} |"
+            echo "Extracted from: ${{ steps.extract.outputs.top_image }}"
+            echo "Packed tracks: $(tr '\n' ' ' < dist/tracks.txt)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish the coverage baseline
+        if: steps.publish.outputs.enabled == 'true'
+        env:
+          S3_BUCKET: ${{ vars.LIB_STORE_S3_BUCKET }}
+        run: |
           # The coverage baseline travels with the immutable version, and advances
           # latest alongside the manifest (lib-store-publish.sh) so the next build's
           # regression diff references this build. Acceptance is non-gating and moves

--- a/images/sandbox-python-r/Dockerfile
+++ b/images/sandbox-python-r/Dockerfile
@@ -336,7 +336,14 @@ LABEL org.opencontainers.image.description="Inflexa sandbox with the full baked 
 
 USER root
 
-COPY --from=github ${INFLEXA_LIB_ROOT}/r ${INFLEXA_LIB_ROOT}/r
+# One COPY per R track, in the canonical track order. A single COPY of r/ fuses
+# the triple into one 5.3 GB layer, so a change to any one track reships all
+# three and a client can cache none of them apart. The tree the three COPYs
+# produce is identical, modes included — the builder stage already made it
+# world-readable.
+COPY --from=github ${INFLEXA_LIB_ROOT}/r/cran ${INFLEXA_LIB_ROOT}/r/cran
+COPY --from=github ${INFLEXA_LIB_ROOT}/r/bioconductor ${INFLEXA_LIB_ROOT}/r/bioconductor
+COPY --from=github ${INFLEXA_LIB_ROOT}/r/github ${INFLEXA_LIB_ROOT}/r/github
 COPY --from=github ${INFLEXA_LIB_ROOT}/cran.packages.txt ${INFLEXA_LIB_ROOT}/cran.packages.txt
 COPY --from=github ${INFLEXA_LIB_ROOT}/bioconductor.packages.txt ${INFLEXA_LIB_ROOT}/bioconductor.packages.txt
 COPY --from=github ${INFLEXA_LIB_ROOT}/github.packages.txt ${INFLEXA_LIB_ROOT}/github.packages.txt

--- a/scripts/lib-store-common.sh
+++ b/scripts/lib-store-common.sh
@@ -24,6 +24,11 @@ LIB_STORE_ROOT="${INFLEXA_LIB_ROOT:-/mnt/libs/current}"
 # shellcheck disable=SC2034 # consumed by the scripts that source this file
 LIB_STORE_ALL_TRACKS="cran bioconductor github python conda node"
 
+# zstd level for every track tarball. One value, because a tarball packed on the
+# streaming publish path and one packed locally must be the same bytes.
+# shellcheck disable=SC2034 # consumed by the scripts that source this file
+LIB_STORE_ZSTD_LEVEL=3
+
 # packages.txt fragment concat order (R sections, then python, tools, node).
 # shellcheck disable=SC2034 # consumed by the scripts that source this file
 LIB_STORE_CONCAT_ORDER="cran bioconductor github python conda node"
@@ -95,6 +100,30 @@ lib_store_track_members() {
 # True when $2 is a whitespace-delimited member of the list $1.
 lib_store_list_has() {
   case " $1 " in *" $2 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# True when track $2 is complete in staging tree $1 — its subtree AND its
+# fragment are present. A track that did not build has neither.
+lib_store_track_staged() {
+  [ -d "$1/$(lib_store_track_dir "$2")" ] && [ -f "$1/$(lib_store_track_fragment "$2")" ]
+}
+
+# Byte size of a file, on GNU and on BSD stat.
+lib_store_file_size() {
+  stat -c%s "$1" 2>/dev/null || stat -f%z "$1"
+}
+
+# Pack track $3 out of staging tree $1 into <$2>/<track>.tar.zst at zstd level
+# $4, and write the sha256 and the byte size beside it. Those two sidecars are
+# what the manifest pins, and they outlive the tarball when the streaming
+# publish deletes it to hold the disk peak down.
+lib_store_pack_track() {
+  local staging="$1" out="$2" track="$3" level="$4" members
+  members="$(lib_store_track_members "$track")" || return 1
+  # shellcheck disable=SC2086 # members is an intentional word list
+  tar -C "$staging" -cf - $members | zstd -q -f "-${level}" -o "$out/$track.tar.zst"
+  sha256sum "$out/$track.tar.zst" | awk '{print $1}' > "$out/$track.tar.zst.sha256"
+  lib_store_file_size "$out/$track.tar.zst" > "$out/$track.tar.zst.size"
 }
 
 # The two-line header prepended to every assembled packages.txt.

--- a/scripts/lib-store-common.sh
+++ b/scripts/lib-store-common.sh
@@ -11,6 +11,8 @@
 #   r/cran  r/bioconductor  r/github  python/  conda/  node/
 #   <track>.packages.txt          (one fragment per track, at the root)
 #   packages.txt                  (the concatenation the harness reads)
+#   meta.json                     ({version,arch,tracks}; the harness mounts a
+#                                  store only when it and packages.txt are present)
 
 # The runtime mount contract path: where the assembled store lives inside a
 # sandbox image (baked or read-only-mounted). INFLEXA_LIB_ROOT overrides it to

--- a/scripts/lib-store-disk-guard.sh
+++ b/scripts/lib-store-disk-guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Hold the self-hosted builders inside their disk budget, and stop a build early
+# when the box cannot hold one.
+#
+# The BuildKit cache is deliberately persistent: the Buildx step uses the docker
+# driver, so warm layers live in /var/lib/docker on the box's EBS volume and
+# survive its stop/start. The runner user has no sudo, and nothing else reclaims
+# that volume. Persistent plus uncapped is the growth vector — the cache holds one
+# more generation of build records after every run, and `docker image prune -f`
+# drops a dangling image only, never an unused tagged one.
+#
+# Modes:
+#   preflight  Report, reclaim to the cap, and report again. When the box is still
+#              short, drop the unused tagged images and the whole cache, then
+#              report again. Exit 1 with the shortfall when even that is too
+#              little, so the run fails with a legible message instead of a
+#              confusing mid-build error.
+#   cleanup    Report, reclaim to the cap, and report again. Never fails.
+#
+# The floors below come from the measured content of one amd64 build:
+#   * the sandbox-python-r chain is 11.4 GB of GHCR layers, and overlay2 holds
+#     them unpacked — about 29 GB at the 1.9x to 3.4x expansion those layers
+#     measure;
+#   * `staging/` holds the store extracted out of that image with its symlinks
+#     dereferenced — about 27 GB;
+#   * `dist/` holds the zstd track tarballs — about 9 GB.
+# Thus one build touches about 65 GB: about 29 GB under the docker root, and
+# about 36 GB under the workspace. The cap keeps one build generation of warm
+# layers and no more.
+#
+# Usage: lib-store-disk-guard.sh <preflight|cleanup>
+
+set -euo pipefail
+
+MODE="${1:?usage: lib-store-disk-guard.sh <preflight|cleanup>}"
+
+BUILDKIT_CAP="29GB"
+DOCKER_ROOT_FLOOR_GB=32
+WORKSPACE_FLOOR_GB=36
+
+DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
+WORKSPACE="${GITHUB_WORKSPACE:-$PWD}"
+
+# The device of a path, as df names it. Two paths on one device share one budget.
+fs_of() { df -P "$1" | awk 'NR==2 {print $1}'; }
+
+# Free space in whole GB. `df -B1G` prints the count of 1 GB blocks and no unit.
+free_gb() { df -P -B1G "$1" | awk 'NR==2 {print $4}'; }
+
+report() {
+  echo "--- disk ($1) ---"
+  # awk drops the duplicate line when the two paths share one filesystem.
+  df -h "$DOCKER_ROOT" "$WORKSPACE" | awk '!seen[$0]++'
+  docker system df || true
+}
+
+# Reclaim what a finished build leaves behind, and cap the cache instead of
+# clearing it: the warm layers are the reason the volume is persistent.
+reclaim_to_cap() {
+  docker container prune -f >/dev/null 2>&1 || true
+  docker image prune -f >/dev/null 2>&1 || true
+  if ! docker builder prune -f --keep-storage "$BUILDKIT_CAP"; then
+    echo "::warning::Could not cap the BuildKit cache at $BUILDKIT_CAP — \`docker builder prune --keep-storage\` failed on this docker version. The cache is uncapped."
+  fi
+}
+
+# The last resort before a hard failure. It costs the warm layers and a base-image
+# pull on the next run, which is cheaper than a build that dies out of disk.
+reclaim_all() {
+  echo "Still short after the capped reclaim — dropping the unused tagged images and the whole BuildKit cache."
+  docker image prune -af >/dev/null 2>&1 || true
+  docker builder prune -af >/dev/null 2>&1 || true
+}
+
+# Name each path that is under its floor, one tab-delimited
+# "<path> <label> <free> <floor>" per line. Paths on one device share one budget,
+# so their floors add up.
+shortfalls() {
+  local free floor
+  if [ "$(fs_of "$DOCKER_ROOT")" = "$(fs_of "$WORKSPACE")" ]; then
+    floor=$((DOCKER_ROOT_FLOOR_GB + WORKSPACE_FLOOR_GB))
+    free="$(free_gb "$DOCKER_ROOT")"
+    if [ "$free" -lt "$floor" ]; then
+      printf '%s\t%s\t%s\t%s\n' "$DOCKER_ROOT" "docker root + workspace" "$free" "$floor"
+    fi
+    return 0
+  fi
+  free="$(free_gb "$DOCKER_ROOT")"
+  if [ "$free" -lt "$DOCKER_ROOT_FLOOR_GB" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$DOCKER_ROOT" "docker root" "$free" "$DOCKER_ROOT_FLOOR_GB"
+  fi
+  free="$(free_gb "$WORKSPACE")"
+  if [ "$free" -lt "$WORKSPACE_FLOOR_GB" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$WORKSPACE" "workspace" "$free" "$WORKSPACE_FLOOR_GB"
+  fi
+  return 0
+}
+
+case "$MODE" in
+  cleanup)
+    report "before cleanup"
+    reclaim_to_cap
+    report "after cleanup"
+    ;;
+  preflight)
+    report "before reclaim"
+    reclaim_to_cap
+    report "after reclaim"
+    if [ -n "$(shortfalls)" ]; then
+      reclaim_all
+      report "after full reclaim"
+    fi
+    short="$(shortfalls)"
+    if [ -n "$short" ]; then
+      while IFS=$'\t' read -r path label free floor; do
+        [ -n "$path" ] || continue
+        echo "::error::Not enough disk on the builder: $path ($label) has ${free} GB free, and this build needs ${floor} GB — short by $((floor - free)) GB. Grow the EBS volume, or reclaim the box by hand."
+      done <<< "$short"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "ERROR: unknown mode '$MODE' (expected preflight or cleanup)" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib-store-disk-guard.sh
+++ b/scripts/lib-store-disk-guard.sh
@@ -17,16 +17,18 @@
 #              confusing mid-build error.
 #   cleanup    Report, reclaim to the cap, and report again. Never fails.
 #
-# The floors below come from the measured content of one amd64 build:
+# The floors below come from the measured content of one amd64 build. Each figure
+# is the uncompressed byte total of the published image's own layers:
 #   * the sandbox-python-r chain is 11.4 GB of GHCR layers, and overlay2 holds
-#     them unpacked — about 29 GB at the 1.9x to 3.4x expansion those layers
-#     measure;
-#   * `staging/` holds the store extracted out of that image with its symlinks
-#     dereferenced — about 27 GB;
-#   * `dist/` holds the zstd track tarballs — about 9 GB.
-# Thus one build touches about 65 GB: about 29 GB under the docker root, and
-# about 36 GB under the workspace. The cap keeps one build generation of warm
-# layers and no more.
+#     them unpacked — about 23 GB;
+#   * `staging/` holds the store extracted out of that image — about 21 GB
+#     (python 9.2, bioconductor 6.4, conda 3.0, github 1.6, cran 0.9, node 0.04),
+#     and more wherever the extract dereferences a symlink;
+#   * `dist/` holds one track tarball at a time — at most about 4 GB, for python.
+# The build frees the images before the pack, and the pack tears each track down
+# as it publishes, so the two do not add up. One build therefore needs about
+# 23 GB under the docker root and about 25 GB under the workspace. The cap keeps
+# one build generation of warm layers and no more.
 #
 # Usage: lib-store-disk-guard.sh <preflight|cleanup>
 
@@ -34,9 +36,9 @@ set -euo pipefail
 
 MODE="${1:?usage: lib-store-disk-guard.sh <preflight|cleanup>}"
 
-BUILDKIT_CAP="29GB"
-DOCKER_ROOT_FLOOR_GB=32
-WORKSPACE_FLOOR_GB=36
+BUILDKIT_CAP="23GB"
+DOCKER_ROOT_FLOOR_GB=26
+WORKSPACE_FLOOR_GB=27
 
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 WORKSPACE="${GITHUB_WORKSPACE:-$PWD}"

--- a/scripts/lib-store-pack.sh
+++ b/scripts/lib-store-pack.sh
@@ -5,7 +5,7 @@
 # staging dir, emit <out>/<track>.tar.zst plus <out>/<track>.tar.zst.sha256
 # (the digest the manifest pins). Tracks that did not build are skipped, so a
 # partial build packs whatever succeeded. Writes <out>/tracks.txt listing the
-# packed tracks.
+# packed tracks, and <out>/packages.txt assembled from their fragments.
 #
 # Usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]
 
@@ -15,8 +15,9 @@ STAGING="${1:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
 OUT="${2:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
 ZSTD_LEVEL="${3:-3}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-store-common.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib-store-common.sh"
+source "$SCRIPT_DIR/lib-store-common.sh"
 
 [ -d "$STAGING" ] || { echo "ERROR: staging dir not found: $STAGING" >&2; exit 1; }
 mkdir -p "$OUT"
@@ -42,4 +43,10 @@ fi
 
 # shellcheck disable=SC2086 # packed is an intentional word list, one per line
 printf '%s\n' $packed > "$OUT/tracks.txt"
+
+# The assembled packages.txt spans tracks, so no per-track tarball can carry it.
+# It travels beside them as its own object.
+"$SCRIPT_DIR/lib-store-write-packages.sh" "$STAGING" "$packed" > "$OUT/packages.txt"
+
 echo "Packed tracks:$packed"
+echo "assembled $OUT/packages.txt ($(wc -l < "$OUT/packages.txt" | tr -d ' ') lines)"

--- a/scripts/lib-store-pack.sh
+++ b/scripts/lib-store-pack.sh
@@ -2,35 +2,34 @@
 # Pack a staging tree into one content-addressed tarball per track.
 #
 # For each track whose subtree AND packages.txt fragment are present in the
-# staging dir, emit <out>/<track>.tar.zst plus <out>/<track>.tar.zst.sha256
-# (the digest the manifest pins). Tracks that did not build are skipped, so a
-# partial build packs whatever succeeded. Writes <out>/tracks.txt listing the
-# packed tracks, and <out>/packages.txt assembled from their fragments.
+# staging dir, emit <out>/<track>.tar.zst plus its sha256 and byte size (what the
+# manifest pins). Tracks that did not build are skipped, so a partial build packs
+# whatever succeeded. Writes <out>/tracks.txt listing the packed tracks, and
+# <out>/packages.txt assembled from their fragments.
+#
+# This is the whole-tree packer, for the local/offline path — it holds every
+# tarball at once. CI packs through lib-store-publish.sh, which streams one track
+# at a time to hold the disk peak down.
 #
 # Usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]
 
 set -euo pipefail
 
-STAGING="${1:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
-OUT="${2:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
-ZSTD_LEVEL="${3:-3}"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-store-common.sh
 source "$SCRIPT_DIR/lib-store-common.sh"
+
+STAGING="${1:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
+OUT="${2:?usage: lib-store-pack.sh <staging_dir> <out_dir> [zstd_level]}"
+ZSTD_LEVEL="${3:-$LIB_STORE_ZSTD_LEVEL}"
 
 [ -d "$STAGING" ] || { echo "ERROR: staging dir not found: $STAGING" >&2; exit 1; }
 mkdir -p "$OUT"
 
 packed=""
 for track in $LIB_STORE_ALL_TRACKS; do
-  dir="$STAGING/$(lib_store_track_dir "$track")"
-  frag="$STAGING/$(lib_store_track_fragment "$track")"
-  if [ -d "$dir" ] && [ -f "$frag" ]; then
-    members="$(lib_store_track_members "$track")"
-    # shellcheck disable=SC2086 # members is an intentional word list
-    tar -C "$STAGING" -cf - $members | zstd -q -f "-${ZSTD_LEVEL}" -o "$OUT/$track.tar.zst"
-    sha256sum "$OUT/$track.tar.zst" | awk '{print $1}' > "$OUT/$track.tar.zst.sha256"
+  if lib_store_track_staged "$STAGING" "$track"; then
+    lib_store_pack_track "$STAGING" "$OUT" "$track" "$ZSTD_LEVEL"
     echo "packed $track -> $OUT/$track.tar.zst ($(du -h "$OUT/$track.tar.zst" | cut -f1), sha256 $(cut -c1-12 "$OUT/$track.tar.zst.sha256")…)"
     packed="$packed $track"
   fi

--- a/scripts/lib-store-publish.sh
+++ b/scripts/lib-store-publish.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Publish a built library store to S3 — immutable versions, and advance `latest`
 # for this arch (build-floor gated; acceptance is non-gating and moves nothing):
-#   1. Upload each packed track tarball write-once to <version>/linux-<arch>/<track>.tar.zst.
+#   1. Upload each packed track tarball write-once to <version>/linux-<arch>/<track>.tar.zst,
+#      together with the two store files no tarball carries — the assembled
+#      packages.txt and meta.json. The harness mounts a `current/` only when both
+#      are present, so a puller downloads them instead of deriving them.
 #   2. If the arch's full track set built, write the per-arch manifest (the
 #      lockfile the CLI pulls) to <version>/linux-<arch>/manifest.json and
 #      record the candidate pointer — version plus the top image ref — at
@@ -31,25 +34,38 @@ source "$SCRIPT_DIR/lib-store-common.sh"
 
 ARCH_DIR="linux-$ARCH"
 
-# Scratch dir for the intermediate manifest.json / manifest.published.json — keep
-# them off CWD so a stray repo-root file is never clobbered.
+# Scratch dir for the generated meta.json and the intermediate manifest.json /
+# manifest.published.json — keep them off CWD so a stray repo-root file is never
+# clobbered.
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 # Immutable: a version is never rewritten; skip an object that already exists.
+put_once() {
+  local src="$1" key="$VERSION/$ARCH_DIR/$2"
+  if aws s3api head-object --bucket "$S3_BUCKET" --key "$key" >/dev/null 2>&1; then
+    echo "immutable: s3://$S3_BUCKET/$key already exists — skipping"
+  else
+    aws s3 cp "$src" "s3://$S3_BUCKET/$key"
+  fi
+}
+
 while read -r track; do
   [ -n "$track" ] || continue
-  KEY="$VERSION/$ARCH_DIR/$track.tar.zst"
-  if aws s3api head-object --bucket "$S3_BUCKET" --key "$KEY" >/dev/null 2>&1; then
-    echo "immutable: s3://$S3_BUCKET/$KEY already exists — skipping"
-  else
-    aws s3 cp "$DIST/$track.tar.zst" "s3://$S3_BUCKET/$KEY"
-  fi
+  put_once "$DIST/$track.tar.zst" "$track.tar.zst"
 done < "$DIST/tracks.txt"
 
 # Best-effort: publish the manifest for exactly the tracks that packed (the floor
 # already dropped empty tracks). Only guard the R triple's all-or-none invariant.
 lib_store_assert_r_triple "$(tr '\n' ' ' < "$DIST/tracks.txt")" || exit 1
+
+# The two files the harness requires before it mounts a store: packages.txt (what
+# list_available_packages reads) and meta.json (the version the store carries).
+# Neither is in a track tarball, so both travel as their own write-once objects
+# beside them.
+"$SCRIPT_DIR/lib-store-write-meta.sh" "$ARCH" "$VERSION" "$DIST" > "$WORK/meta.json"
+put_once "$DIST/packages.txt" packages.txt
+put_once "$WORK/meta.json" meta.json
 
 # manifest.json is immutable too, not just the tarballs. Nothing pins upstream package
 # versions, so a same-version retry (VERSION = date+sha) can rebuild different bytes: the

--- a/scripts/lib-store-publish.sh
+++ b/scripts/lib-store-publish.sh
@@ -1,36 +1,54 @@
 #!/usr/bin/env bash
 # Publish a built library store to S3 — immutable versions, and advance `latest`
 # for this arch (build-floor gated; acceptance is non-gating and moves nothing):
-#   1. Upload each packed track tarball write-once to <version>/linux-<arch>/<track>.tar.zst,
-#      together with the two store files no tarball carries — the assembled
-#      packages.txt and meta.json. The harness mounts a `current/` only when both
-#      are present, so a puller downloads them instead of deriving them.
-#   2. If the arch's full track set built, write the per-arch manifest (the
-#      lockfile the CLI pulls) to <version>/linux-<arch>/manifest.json and
-#      record the candidate pointer — version plus the top image ref — at
-#      candidate/linux-<arch>.json.
-#      An incomplete build uploads its tarballs (they are content-addressed and
-#      reusable) but publishes no manifest and no candidate.
-#   3. Advance latest/linux-<arch>/manifest.json to this version, mirroring the
+#   1. Pack, upload and TEAR DOWN one track at a time: pack <track>.tar.zst out of
+#      the staging tree, upload it write-once to
+#      <version>/linux-<arch>/<track>.tar.zst, then delete the tarball AND that
+#      track's staging subtree before the next track packs. The peak disk is one
+#      track, not six. This is serial on purpose: a parallel pack raises the peak,
+#      and the job has time to spare. The digest and size sidecars and the
+#      packages.txt fragment stay behind — the manifest and packages.txt are
+#      written from them once the loop ends.
+#   2. Upload the two store files no tarball carries — the assembled packages.txt
+#      and meta.json. The harness mounts a `current/` only when both are present,
+#      so a puller downloads them instead of deriving them.
+#   3. Write the per-arch manifest (the lockfile the CLI pulls) to
+#      <version>/linux-<arch>/manifest.json and record the candidate pointer —
+#      version plus the top image ref — at candidate/linux-<arch>.json. Both land
+#      after the loop, so a track that failed to upload can never reach a
+#      published manifest.
+#   4. Advance latest/linux-<arch>/manifest.json to this version, mirroring the
 #      image :latest tag the build also advances. This is gated by the build's own
 #      load check + non-empty floor + coverage regression guard — the same gate
 #      that decides whether the build publishes at all.
 #
-# Usage: lib-store-publish.sh <amd64|arm64> <version> <dist_dir>
+# PUBLISH_ENABLED=false packs and tears down exactly the same and uploads nothing,
+# so a run with no S3 configuration still proves the pack and still holds the same
+# disk peak.
+#
+# Usage: lib-store-publish.sh <amd64|arm64> <version> <staging_dir> <dist_dir>
 # Env:   S3_BUCKET PUBLIC_URL TOP_IMAGE  (TOP_IMAGE is the extracted top image ref
 #        recorded in the candidate pointer; BASE_IMAGE R_VERSION PYTHON_VERSION
 #        GIT_SHA are forwarded to lib-store-write-manifest.sh as manifest metadata)
+#        PUBLISH_ENABLED  "true" (default) uploads; anything else packs only
 
 set -euo pipefail
-
-ARCH="${1:?usage: lib-store-publish.sh <amd64|arm64> <version> <dist_dir>}"
-VERSION="${2:?version}"
-DIST="${3:?dist_dir}"
-: "${S3_BUCKET:?}" "${PUBLIC_URL:?}" "${TOP_IMAGE:?}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-store-common.sh
 source "$SCRIPT_DIR/lib-store-common.sh"
+
+ARCH="${1:?usage: lib-store-publish.sh <amd64|arm64> <version> <staging_dir> <dist_dir>}"
+VERSION="${2:?version}"
+STAGING="${3:?staging_dir}"
+DIST="${4:?dist_dir}"
+PUBLISH_ENABLED="${PUBLISH_ENABLED:-true}"
+if [ "$PUBLISH_ENABLED" = "true" ]; then
+  : "${S3_BUCKET:?}" "${PUBLIC_URL:?}" "${TOP_IMAGE:?}"
+fi
+
+[ -d "$STAGING" ] || { echo "ERROR: staging dir not found: $STAGING" >&2; exit 1; }
+mkdir -p "$DIST"
 
 ARCH_DIR="linux-$ARCH"
 
@@ -43,6 +61,10 @@ trap 'rm -rf "$WORK"' EXIT
 # Immutable: a version is never rewritten; skip an object that already exists.
 put_once() {
   local src="$1" key="$VERSION/$ARCH_DIR/$2"
+  if [ "$PUBLISH_ENABLED" != "true" ]; then
+    echo "publish disabled: skipped the upload of $key"
+    return 0
+  fi
   if aws s3api head-object --bucket "$S3_BUCKET" --key "$key" >/dev/null 2>&1; then
     echo "immutable: s3://$S3_BUCKET/$key already exists — skipping"
   else
@@ -50,22 +72,46 @@ put_once() {
   fi
 }
 
-while read -r track; do
-  [ -n "$track" ] || continue
-  put_once "$DIST/$track.tar.zst" "$track.tar.zst"
-done < "$DIST/tracks.txt"
+# Decide the track set BEFORE anything uploads, so a partial R triple fails the
+# run rather than leaving half of one in the bucket. Tracks that did not build
+# have neither a subtree nor a fragment and are simply absent; the floor already
+# dropped the empty ones.
+tracks=""
+for track in $LIB_STORE_ALL_TRACKS; do
+  if lib_store_track_staged "$STAGING" "$track"; then tracks="$tracks $track"; fi
+done
+if [ -z "$tracks" ]; then
+  echo "ERROR: no complete tracks (subtree + fragment) found in $STAGING" >&2
+  exit 1
+fi
+lib_store_assert_r_triple "$tracks" || exit 1
 
-# Best-effort: publish the manifest for exactly the tracks that packed (the floor
-# already dropped empty tracks). Only guard the R triple's all-or-none invariant.
-lib_store_assert_r_triple "$(tr '\n' ' ' < "$DIST/tracks.txt")" || exit 1
+packed=""
+for track in $tracks; do
+  lib_store_pack_track "$STAGING" "$DIST" "$track" "$LIB_STORE_ZSTD_LEVEL"
+  echo "packed $track -> $DIST/$track.tar.zst ($(du -h "$DIST/$track.tar.zst" | cut -f1), sha256 $(cut -c1-12 "$DIST/$track.tar.zst.sha256")…)"
+  put_once "$DIST/$track.tar.zst" "$track.tar.zst"
+  rm -rf "${DIST:?}/$track.tar.zst" "${STAGING:?}/$(lib_store_track_dir "$track")"
+  packed="$packed $track"
+  echo "tore down $track — free on $DIST: $(df -Ph "$DIST" | awk 'NR==2 {print $4}')"
+done
+
+# shellcheck disable=SC2086 # packed is an intentional word list, one per line
+printf '%s\n' $packed > "$DIST/tracks.txt"
 
 # The two files the harness requires before it mounts a store: packages.txt (what
 # list_available_packages reads) and meta.json (the version the store carries).
 # Neither is in a track tarball, so both travel as their own write-once objects
-# beside them.
+# beside them. packages.txt reads the fragments, which the teardown keeps.
+"$SCRIPT_DIR/lib-store-write-packages.sh" "$STAGING" "$packed" > "$DIST/packages.txt"
 "$SCRIPT_DIR/lib-store-write-meta.sh" "$ARCH" "$VERSION" "$DIST" > "$WORK/meta.json"
 put_once "$DIST/packages.txt" packages.txt
 put_once "$WORK/meta.json" meta.json
+
+if [ "$PUBLISH_ENABLED" != "true" ]; then
+  echo "publish disabled: packed and tore down [$packed]; no manifest, no latest, no candidate."
+  exit 0
+fi
 
 # manifest.json is immutable too, not just the tarballs. Nothing pins upstream package
 # versions, so a same-version retry (VERSION = date+sha) can rebuild different bytes: the

--- a/scripts/lib-store-write-manifest.sh
+++ b/scripts/lib-store-write-manifest.sh
@@ -28,15 +28,18 @@ tracks="$(tr '\n' ' ' < "$DIST/tracks.txt")"
 lib_store_assert_r_triple "$tracks" || exit 1
 arch_dir="linux-$ARCH"
 
+# The digest and size sidecars, not the tarball: a streaming publish uploads each
+# tarball and deletes it before the next track packs, so the tarball is gone by
+# the time the manifest is written.
 for t in $tracks; do
-  [ -f "$DIST/$t.tar.zst.sha256" ] && [ -f "$DIST/$t.tar.zst" ] \
-    || { echo "ERROR: track '$t' listed in tracks.txt but not packed in $DIST" >&2; exit 1; }
+  [ -f "$DIST/$t.tar.zst.sha256" ] && [ -f "$DIST/$t.tar.zst.size" ] \
+    || { echo "ERROR: track '$t' listed in tracks.txt but has no packed digest and size in $DIST" >&2; exit 1; }
 done
 
 tracks_json=""
 for t in $tracks; do
   sha="$(cat "$DIST/$t.tar.zst.sha256")"
-  size="$(stat -c%s "$DIST/$t.tar.zst" 2>/dev/null || stat -f%z "$DIST/$t.tar.zst")"
+  size="$(cat "$DIST/$t.tar.zst.size")"
   # Emit BOTH a store-relative `path` (the CLI joins it onto its RESOLVED base, so an
   # INFLEXA_LIB_STORE_URL/libStoreUrl mirror redirects the payload downloads too) and the
   # absolute `url` baked at PUBLIC_URL (a compat fallback for a client predating `path`).

--- a/scripts/lib-store-write-meta.sh
+++ b/scripts/lib-store-write-meta.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Emit the store metadata to stdout: `{version, arch, tracks}` — the version the
+# store carries, its arch segment (`linux-<arch>`), and the tracks it holds.
+#
+# The sandbox client refuses to mount a `current/` that lacks meta.json next to
+# packages.txt, so a store without it is never mounted. It is a different thing
+# from manifest.json: manifest.json is the lockfile a puller resolves BEFORE it
+# downloads (track paths, digests, sizes), meta.json describes the store AFTER it
+# is assembled.
+#
+# Usage: lib-store-write-meta.sh <amd64|arm64> <version> <dist_dir>
+
+set -euo pipefail
+
+ARCH="${1:?usage: lib-store-write-meta.sh <amd64|arm64> <version> <dist_dir>}"
+VERSION="${2:?version}"
+DIST="${3:?dist_dir}"
+
+[ -f "$DIST/tracks.txt" ] || { echo "ERROR: $DIST/tracks.txt not found — nothing packed for $ARCH" >&2; exit 1; }
+tracks="$(tr '\n' ' ' < "$DIST/tracks.txt")"
+[ -n "$(printf '%s' "$tracks")" ] || { echo "ERROR: no packed tracks for $ARCH" >&2; exit 1; }
+
+tracks_json=""
+for t in $tracks; do
+  tracks_json="${tracks_json:+$tracks_json,}$(printf '"%s"' "$t")"
+done
+
+printf '{"version":"%s","arch":"linux-%s","tracks":[%s]}\n' "$VERSION" "$ARCH" "$tracks_json"

--- a/scripts/lib-store-write-packages.sh
+++ b/scripts/lib-store-write-packages.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Emit the assembled packages.txt to stdout: the advisory header, then each
+# packed track's fragment in the canonical concat order. This is the file the
+# harness `list_available_packages` tool reads at /mnt/libs/current/packages.txt.
+#
+# No track tarball carries it — a fragment is per-track, the assembled file spans
+# tracks — so the producer publishes it as its own object and a puller downloads
+# it. The canonical order lives in lib-store-common.sh, which is why the assembly
+# lives here and not in a consumer.
+#
+# Usage: lib-store-write-packages.sh <staging_dir> "<t1 t2 ...>"
+
+set -euo pipefail
+
+STAGING="${1:?usage: lib-store-write-packages.sh <staging_dir> \"<t1 t2 ...>\"}"
+TRACKS="${2:?usage: lib-store-write-packages.sh <staging_dir> \"<t1 t2 ...>\"}"
+
+# shellcheck source=scripts/lib-store-common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib-store-common.sh"
+
+lib_store_packages_header
+echo
+for track in $LIB_STORE_CONCAT_ORDER; do
+  lib_store_list_has "$TRACKS" "$track" || continue
+  frag="$STAGING/$(lib_store_track_fragment "$track")"
+  [ -f "$frag" ] || { echo "ERROR: track '$track' has no packages.txt fragment: $frag" >&2; exit 1; }
+  cat "$frag"
+  echo
+done


### PR DESCRIPTION
Five changes to the library-store build pipeline, one commit each.

## 1. Publish the two files the consumer needs

The harness mounts a store only when `current/` holds both `packages.txt` and
`meta.json` (`harness/src/sandbox/docker-client.ts`, `libStoreUsable`). The
publisher wrote neither:

- each track tarball carries its own `<track>.packages.txt` fragment, but the
  assembled `packages.txt` spans tracks, so no tarball can hold it — even though
  `lib-store-common.sh` lists it in the store layout;
- `meta.json` was the work of the CLI `libs pull` activate step, which went away
  with the move to baked images.

Thus a downstream puller (platform-charts) has to make both again, and to do
that it must hold a copy of `LIB_STORE_CONCAT_ORDER` and of the advisory header
— producer logic in a consumer, against a format the harness parses. It drifts
silently.

Both files now travel as their own objects under `<version>/linux-<arch>/`:

- `scripts/lib-store-write-packages.sh` emits the assembled `packages.txt` in
  the canonical order, from the same `lib-store-common.sh` the fragments come
  from. `lib-store-pack.sh` writes it into the dist dir for exactly the tracks
  that packed.
- `scripts/lib-store-write-meta.sh` emits `{version, arch, tracks}`.
- `lib-store-publish.sh` uploads both write-once, the same rule as the tarballs,
  through a shared `put_once` helper the tarball loop now uses too.

`manifest.json` does not change. It is the lockfile a puller resolves before it
downloads; `meta.json` describes the store after it is assembled.

**The `meta.json` shape.** `harness/openspec/specs/lib-store/spec.md` describes
the mount contract and `packages.txt`, but says nothing about `meta.json`. The
shape is fixed by the harness fixture in
`harness/src/sandbox/docker-client.test.ts` — `{ version, arch: "linux-amd64",
tracks: [] }` — and by the retired CLI writer (`StoreMeta` / `isStoreMeta` in
`cli/src/modules/libs/store.ts`, before b12acf4d), whose guard checked `arch`
against `linux-amd64` / `linux-arm64` and every `tracks` entry against the known
track set. The emitted file satisfies both. The CLI's optional `trackDigests`
field is not emitted: it served the CLI's own dedup, and `manifest.json` already
pins the digests.

The published `20260705-76fde06` is older than this change and lacks both files.
A rebuild makes a complete version. There is no backfill.

## 2. Hold the builders inside their disk budget

The Buildx step uses the docker driver on purpose, so the BuildKit cache lives
on the box's persistent EBS volume and warm layers survive its stop/start. But
nothing caps that cache and the runner user has no sudo, so it holds one more
generation of build records after every run. The Cleanup step never touched it,
and `docker image prune -f` drops a dangling image only, never an unused tagged
one.

`scripts/lib-store-disk-guard.sh` has two modes:

- `preflight`, before the first image build: report free space, reclaim to the
  cache cap, report again, and, when the box is still short, drop the unused
  tagged images and the whole cache. When even that is too little, exit 1 and
  name the shortfall, so a run fails legibly instead of dying mid-build.
- `cleanup` replaces the two prune lines in the Cleanup step and never fails.

Both modes print `df -h` and `docker system df` before and after the reclaim, so
the trend is visible in the run logs.

**Sizing.** Measured from the published images rather than guessed. The
`sandbox-python-r` amd64 chain is 11.41 GB of GHCR layers (42 layers; the three
largest are 5.30, 4.21 and 0.99 GB). Streaming those layers through gzip gives
an expansion of 1.86x, 3.39x, 2.95x and 2.49x, so overlay2 holds about 29 GB
unpacked. `staging/` is the same store extracted out of the image with symlinks
dereferenced, about 27 GB, which agrees with the ~8.9 GB of zstd tarballs in
`dist/` at a ~3x ratio. One build therefore touches about 65 GB: about 29 GB
under the docker root and about 36 GB under the workspace. The floors are 32 GB
and 36 GB, added together when the two paths share one filesystem, and the cache
cap is 29 GB — one build generation of warm layers and no more. arm64 measures
about 12% smaller and uses the same floors.

## Validation

- `shellcheck -x` clean on every changed and new script. The one remaining
  finding in `scripts/` is a pre-existing SC2016 in
  `lib-store-extract-tarballs.sh`, which this branch does not touch.
- `actionlint` clean on `.github/workflows/lib-store.yml`.
- `packages.txt`: `lib-store-pack.sh` run against a fabricated 6-track staging
  tree, and the output compared **byte for byte** against the reference format
  (the advisory header, a blank line, then each fragment followed by a newline,
  in `cran bioconductor github python conda node` order). Equal. Repeated for a
  partial arm64 set (`python conda node`) — no R sections, correct order.
- `meta.json`: emitted for both a full and a partial track set, and checked
  against a re-implementation of the harness `isStoreMeta` guard (`arch` in the
  known arch set, every track in the known track set).
- Failure paths exercised: a listed track with no fragment, a missing
  `tracks.txt`, an empty `tracks.txt`, an unknown guard mode.
- `lib-store-publish.sh` run against a stub `aws` CLI: both objects land at
  `<version>/linux-<arch>/{packages.txt,meta.json}`, and both report
  `immutable: … already exists — skipping` on a re-publish.
- `lib-store-disk-guard.sh` run against stub `docker` and `df`: happy path,
  shared-filesystem shortfall, split-filesystem shortfall naming both paths,
  escalation that recovers, and escalation that does not.
- `docker builder prune --keep-storage` is still accepted on docker 29.6.2 (it
  is deprecated in favour of `--max-used-space`, but `--max-used-space` does not
  exist on older daemons, so `--keep-storage` has the wider range). A future
  removal degrades to a `::warning::`, not a failed job.

**Not run:** the workflow itself. The self-hosted builders are not reachable
from here, so the free-space numbers the guard prints have never been observed
on a real box — the floors come from the image measurements above. A first
dispatch should be watched for the `--- disk (before reclaim) ---` block.

**Out of scope, noticed.** The acceptance job (`lib-store-acceptance.yml`) also
runs on `inflexa-builder` and `docker pull`s the ~11 GB image without ever
removing it — another source of unused tagged images on the same volume. The
preflight escalation reclaims them when the box gets short, but the job itself
still leaks. Also, `harness/openspec/specs/lib-store/spec.md` documents
`packages.txt` but not the `meta.json` half of the mount gate, so the harness
contract is written down only in the implementation and its fixture.


---

## 3. Free the built images before the pack

Run `30795486784` (amd64) died at step 11, **Pack per-track tarballs**, with the
step's conclusion `null` rather than `failure` — the runner went down, not a
command. Every step from 11 on is therefore `null`, **including Cleanup**:
`if: always()` does not run when the box dies. So each such failure stranded the
whole working set on the builder and the next run started with less headroom.
Failures on 07-14, 07-15, 07-21 and 08-03 fit that shape.

After the extract the three images are dead weight, but they sat in overlay2 for
the whole pack. They are now removed between extract and pack, newest first so
each image drops its own layers. The Cleanup `docker rmi` stays, because the new
step does not run when an earlier step fails.

## 4. Pack, publish and tear down one track at a time

The pack held all six tarballs and all six staging subtrees at once, and nothing
was reclaimed until Cleanup. `lib-store-publish.sh` now takes the staging dir and
streams: per track, pack -> upload write-once -> delete the tarball and that
track's staging subtree, then the next track. Serial on purpose. Disk falls
monotonically and ends near zero, so a run that dies mid-pack strands far less.

Bookkeeping that must outlive a track is small and stays: the `.sha256` and a new
`.size` sidecar (`lib-store-write-manifest.sh` reads the sidecar instead of
`stat`-ing a tarball that is gone), and the packages.txt fragment. The track set
is decided before anything uploads, so a partial R triple fails with an empty
bucket; `tracks.txt`, `packages.txt`, `meta.json` and `manifest.json` are written
after the loop from the tracks that actually uploaded, so a mid-loop failure can
never publish a manifest advertising a track that is not there. Write-once and
skip-if-exists are unchanged.

Pack and publish fuse into one workflow step because they interleave. It runs
whether or not S3 is configured — `PUBLISH_ENABLED=false` packs and tears down
identically and uploads nothing, so the disk profile does not depend on the
publish configuration. `lib-store-pack.sh` keeps the whole-tree behaviour for the
local path and now shares the per-track pack, the staged-track test and the zstd
level, so both packers emit identical bytes (verified).

**The guard is re-tuned in this commit**, because the peak it guards moved and
because the earlier figures were extrapolated from a 200 MB prefix sample. Every
store layer is now measured in full by streaming the published blob:

| Layer | GHCR (gzip) | Uncompressed | Entries |
|-|-|-|-|
| `COPY .../python` | 4.21 GB | 9.23 GB | 95,266 |
| `COPY .../r` (fused) | 5.30 GB | 8.88 GB | 106,940 |
| `COPY .../conda` | 0.99 GB | 2.98 GB | 55,805 |
| `COPY .../node` | 0.013 GB | ~0.04 GB | — |

So the store is **21 GB** unpacked inside a **23 GB** image graph (11.41 GB of
GHCR layers for the whole amd64 chain). Peak per phase, amd64:

| Phase | Before | After |
|-|-|-|
| extract | 23 img + 21 staging = 44 | unchanged |
| pack | 23 img + 21 staging + 9 dist = **53** | 21 staging + 4 (one tarball) = **25**, falling to ~0 |

Floors move 32/36 -> **26/27 GB**, cache cap 29 -> **23 GB**.

**Honest limit:** the job-wide peak is now set by the *extract* phase (~44 GB),
not the pack. Extraction must hold the images and materialises all six tracks
before the loop starts, so Tasks 3 and 4 cannot reach it. Interleaving extraction
into the per-track loop would, and is the cheapest remaining move — see below.

## 5. One layer per R track (the COPY split only)

`images/sandbox-python-r/Dockerfile` did a single `COPY --from=github .../r .../r`.
Streaming that blob confirms the fusion: **5.30 GB compressed, 106,940 entries**,
8.88 GB unpacked — bioconductor 6.36 GB, github 1.62 GB, cran 0.90 GB. Half the
store in one layer, reshipped whole whenever any one track changes. Split into
three COPYs in canonical track order. The tree is unchanged (same files, same
modes — the builder stage already chmod'd, so the note about chmod copying the
tree up does not apply; `inflexa-libs-refresh --from-fragments` reads fragments,
not the tree). Acceptance pulls and boots the image and is indifferent to layer
count; BuildKit gets three cache records where it had one, and the refresh layer
below was invalidated by any R change either way.

python/conda/node were checked rather than assumed: they are **already one layer
per track** (layers 23/25/27 above), so this makes the R triple match them.

**Per-layer streaming did not pay off — not adopted.** Evidence:

1. **Path shape.** Layer members are `mnt/libs/current/r/cran/...`; a track
   tarball is `r/cran/...` plus a root-level `cran.packages.txt`. Rewriting
   member paths in an archive-to-archive stream is not something GNU tar does
   (`--transform` applies on create-from-disk). It needs libarchive/`bsdtar`,
   which is not on the AL2023 builders and cannot be installed — the workflow's
   own zstd step exists because there is no sudo.
2. **Two layers per track.** Each subtree and its `<track>.packages.txt` are in
   *different* layers, so no track is one layer regardless.
3. **No per-layer read.** Images are `--load`ed locally; `docker save` streams the
   whole ~23 GB image, so per-track passes mean re-reading it six times or
   fanning out six compressors — and the loop must stay serial.
4. **Cheaper alternative for the same win.** What streaming buys is "no staging
   tree". Interleaving the extract into the existing per-track loop gets the same
   peak with no layer machinery and no image-format coupling.

The COPY split is landed on its own merit (pull and cache behaviour), as allowed.

## Validation for 3-5

- `shellcheck -x` clean on every changed script; `actionlint` clean. No Dockerfile
  linter is configured in this repo, so the Dockerfile change is unlinted.
- Streaming publish end-to-end against a stub `aws`: correct upload order, staging
  subtrees gone and fragments kept, `dist/` left with sidecars only, and
  **manifest sizes equal the actual uploaded bytes for all six tracks**.
- Mid-loop upload failure -> exit 1, **no** manifest, no packages.txt, no
  tracks.txt. Partial R triple -> fails with **zero** aws calls.
- `PUBLISH_ENABLED=false` -> zero aws calls, same teardown.
- Both packers cross-checked: `packages.txt`, `tracks.txt` and all six track
  digests byte-identical. `packages.txt` still byte-exact against the reference
  header format.
- `lib-store-write-manifest.sh` verified working with the tarballs deleted, and
  failing loudly when a sidecar is missing.
- Peak measured by sampling `du` of staging+dist during both flows on a scaled
  tree: old peak = staging + all tarballs and **nothing reclaimed**; new peak =
  staging + one tarball, ending at ~0.
- Layer claims verified against the real images by streaming blobs from GHCR, not
  read off the Dockerfile.

**Not run:** the workflow. The builders are unreachable from here, so the new
step order, the `docker rmi` reclaim and the guard's on-box figures are
unverified in situ. A first dispatch should be watched for the per-track
`tore down <track> — free on dist:` lines.
