### PR TITLE
feat(hooks): add the document contracts and budgets to the STE gate

### DIFF
--- a/.claude/hooks/ste-check.ts
+++ b/.claude/hooks/ste-check.ts
@@ -14,9 +14,12 @@
  * A gate that denies on a guess teaches people to route around it, so the blocking
  * set is deliberately the narrow one and grows only if a rule proves deterministic.
  *
- * Two entry points share one checker. As a hook it reads the tool call on stdin and
- * answers with the hook protocol. As `ste-check.ts --file <path>` it prints a plain
- * report and exits 1 on a hard finding, so a person and a CI job get the same verdict.
+ * Two entry points share one checker. As a hook it reads the event on stdin and
+ * answers with the hook protocol: a tool event gates the payload of the call,
+ * `UserPromptSubmit` injects the reply contract out of CLAUDE.md, and `Stop` gates
+ * the reply itself against the contract budget. As `ste-check.ts --file <path>` it
+ * prints a plain report and exits 1 on a hard finding, so a person and a CI job
+ * get the same verdict.
  */
 
 type Severity = "hard" | "soft";
@@ -36,6 +39,16 @@ const MAX_WORDS_PROCEDURAL = 20;
 const MAX_WORDS_DESCRIPTIVE = 25;
 /** Rule 6.6. */
 const MAX_SENTENCES_PER_PARAGRAPH = 6;
+
+/**
+ * The document budgets of the shape sections in CLAUDE.md. An author who obeys
+ * every sentence cap can still write 775 words. A sentence rule cannot force
+ * selection, and only a total budget does that. The numbers are repository
+ * policy, not STE.
+ */
+const MAX_WORDS_REPLY = 300;
+const MAX_WORDS_GH_PROSE = 300;
+const MAX_WORDS_COMMIT_BODY = 300;
 
 /**
  * A word trap whose left cell carries a parenthetical qualifier — `check (verb)`,
@@ -91,6 +104,58 @@ async function loadTraps(): Promise<Trap[]> {
   }
   if (traps.length === 0) throw new Error(`empty word-trap table in ${path}`);
   return traps;
+}
+
+/** Reads one `## <title>` section of CLAUDE.md, so the contract text lives in one place. */
+async function claudeMdSection(title: string): Promise<string> {
+  const path = `${projectDir()}/CLAUDE.md`;
+  const text = await Bun.file(path).text();
+  const section = text.split(new RegExp(`^## ${title}$`, "m"))[1];
+  if (!section) throw new Error(`no "## ${title}" section in ${path}`);
+  return `## ${title}\n${(section.split(/\n## /)[0] ?? "").trim()}`;
+}
+
+/** A checkbox line comes from the pull request template, and the author does not write it. */
+const CHECKBOX = /^[-*+]\s+\[[ xX]\]/;
+
+/**
+ * The total budget of one document surface. The blocks come from `markdownProse`,
+ * thus code, tables, and headings are already out of the count.
+ */
+function budgetFinding(where: string, blocks: string[], cap: number, hint: string): Finding | null {
+  const words = blocks.reduce((n, b) => n + countWords(b), 0);
+  if (words <= cap) return null;
+  return { rule: "document-budget", severity: "hard", where, quote: `${words} words`, hint };
+}
+
+/**
+ * The last text of the assistant in the transcript is the reply that `Stop`
+ * examines. A sidechain entry comes from a subagent, and its text is not the
+ * reply, thus the scan skips it. The transcript is external JSON with no schema
+ * of ours, so each line is read as an unknown shape and only the narrow fields
+ * are touched.
+ */
+async function lastReplyText(path: string): Promise<string> {
+  if (!path) return "";
+  let last = "";
+  for (const line of (await Bun.file(path).text()).split("\n")) {
+    if (!line.trim()) continue;
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry?.type !== "assistant" || entry?.isSidechain) continue;
+    const content = entry?.message?.content;
+    if (!Array.isArray(content)) continue;
+    const text = content
+      .filter((c: any) => c?.type === "text" && typeof c.text === "string")
+      .map((c: any) => c.text)
+      .join("\n\n");
+    if (text.trim()) last = text;
+  }
+  return last;
 }
 
 const CONTRACTIONS =
@@ -474,7 +539,46 @@ async function main() {
   const input = JSON.parse((await Bun.stdin.text()) || "{}");
   const tool: string = input.tool_name ?? "";
   const event: string = input.hook_event_name ?? (input.tool_response ? "PostToolUse" : "PreToolUse");
+
+  if (event === "UserPromptSubmit") {
+    // The contract beside the prompt is the near instruction, and the model obeys
+    // the near instruction before the far rule at the top of the context.
+    console.log(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: await claudeMdSection("The shape of a reply"),
+        },
+      }),
+    );
+    process.exit(0);
+  }
+
   const traps = await loadTraps();
+
+  if (event === "Stop") {
+    // One correction for each turn. When the model already continues because of
+    // this hook, a second block can make a loop with no end.
+    if (input.stop_hook_active) process.exit(0);
+    const blocks = markdownProse(await lastReplyText(input.transcript_path ?? ""));
+    const findings = checkText("the reply", traps, MAX_WORDS_DESCRIPTIVE, blocks);
+    const budget = budgetFinding(
+      "the reply",
+      blocks,
+      MAX_WORDS_REPLY,
+      `Write a maximum of ${MAX_WORDS_REPLY} words (CLAUDE.md, "The shape of a reply")`,
+    );
+    if (budget) findings.push(budget);
+    const hard = findings.filter((f) => f.severity === "hard");
+    if (hard.length === 0) process.exit(0);
+    console.log(
+      JSON.stringify({
+        decision: "block",
+        reason: `${report(hard, "the reply")}\n\nWrite the reply again. Obey "The shape of a reply" in CLAUDE.md.`,
+      }),
+    );
+    process.exit(0);
+  }
 
   let findings: Finding[] = [];
   let subject = "";
@@ -491,6 +595,15 @@ async function main() {
       // The sign-off is still visible in the command, so that check runs either way.
       if (message) {
         findings = checkText(subject, traps, MAX_WORDS_PROCEDURAL, markdownProse(message));
+        // The subject line carries the Conventional Commits form, thus only the
+        // body takes the budget.
+        const body = budgetFinding(
+          subject,
+          markdownProse(message.split("\n").slice(1).join("\n")),
+          MAX_WORDS_COMMIT_BODY,
+          `Write a maximum of ${MAX_WORDS_COMMIT_BODY} words in the body (CLAUDE.md, Commits)`,
+        );
+        if (body) findings.push(body);
       }
       if (!hasSignoff(command, message)) {
         findings.push({
@@ -510,7 +623,16 @@ async function main() {
         blocking = true;
         const { texts, unreadable } = await ghPayload(command);
         if (texts.length > 0) {
-          findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, markdownProse(texts.join("\n\n")));
+          const blocks = markdownProse(texts.join("\n\n"));
+          findings = checkText(subject, traps, MAX_WORDS_DESCRIPTIVE, blocks);
+          // A checkbox line belongs to the template, thus it stays out of the budget.
+          const budget = budgetFinding(
+            subject,
+            blocks.filter((b) => !CHECKBOX.test(b)),
+            MAX_WORDS_GH_PROSE,
+            `Write a maximum of ${MAX_WORDS_GH_PROSE} words (CLAUDE.md, "The shape of a pull request description")`,
+          );
+          if (budget) findings.push(budget);
         }
         for (const reason of unreadable) {
           findings.push({

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,18 @@
     "pr": ""
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
+            "timeout": 10,
+            "statusMessage": "Reply contract"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -20,6 +32,18 @@
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
+            "timeout": 15,
+            "statusMessage": "STE check"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
         "hooks": [
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,24 @@ Obey these rules:
   short sentences that pad a small point are the same fault.
 - Stop when the answer is complete.
 
+## The shape of a reply
+
+A reply that reports an analysis, a review, or a status uses this shape, in this order:
+
+1. **The facts.** Each claim about code carries a `file:line` reference.
+2. **The decision.** If the work hides a decision, name that decision.
+3. **The call.** Give one recommendation and give the reason for it.
+4. **One question.** If the work cannot continue without an answer, ask one question, and only one.
+
+Drop each sentence that fits no section. A small question gets a small answer, without the shape. Write a maximum of 300 words in a reply.
+
+## The shape of a pull request description
+
+- Give what changed and why in one paragraph.
+- Give the notes that a reviewer must have before the diff.
+- Do not restate the diff, the specs, the tests, or the CI result. The pull request holds them already.
+- Write a maximum of 300 words above the checkboxes of the template.
+
 ## The rule
 
 Do only the work that the last message from the user asks for.
@@ -260,6 +278,8 @@ Sign off each commit with the identity of the user. Use the `-s` option of `git 
 ```
 git commit -s -m "<message>"
 ```
+
+The body of a commit message gives the reason for the change, in a maximum of 300 words. The cap is a limit, not a goal. Prefer a short and precise body. Do not restate the diff.
 
 ## This repository
 


### PR DESCRIPTION
## What & why

The sentence rules of the STE gate cannot cap a document, and PR #330 proved it: a compliant body reached 775 words. This change adds the document layer. CLAUDE.md gains three contracts: the reply, the PR description, and the commit body.

`UserPromptSubmit` injects the reply contract beside each prompt. `Stop` blocks a reply that breaks a hard rule or the reply budget, one time for each turn. The commit body and the `gh` body get hard word budgets, and the deny fires before the command runs.

## Notes for a reviewer

- The budget numbers appear in the hook constants and in the contract prose of CLAUDE.md. A change must touch both places.
- The `Stop` path reads the transcript and skips subagent text. `stop_hook_active` limits it to one correction for each turn.
- No test file ships. Seven fixture events exercised each new branch by hand: the injection, three stop cases, and the two budget denials.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`). The repository root has no build. The hook itself ran clean on the seven fixture events.
- [ ] Tests added or updated for the change. The fixtures were manual. A `bun test` file can come as a different change.
- [x] Documentation updated if user-facing behavior changed. CLAUDE.md is the documentation, and it is part of this PR.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
