### PR TITLE
feat(prov-kernel): add the lineage read model, rename sidecar to attestation

### DIFF
--- a/prov-kernel/CLAUDE.md
+++ b/prov-kernel/CLAUDE.md
@@ -15,7 +15,10 @@ Inflexa PROV dialect, and nothing else:
   determines the document bytes, thus it is format
 - the signing primitives (`src/signing.ts`): the chain hash, Ed25519
   sign/verify, and the `ProvSigner` seam
-- verification and the signed sidecar (`src/verify.ts`)
+- the lineage read model (`src/lineage.ts`): the node/edge model derived from
+  stored PROV-JSON, the generation/usage traversal, and the `(path, hash)`
+  file-entity lookup — the one read-side interpretation every consumer shares
+- verification and the signed attestation (`src/verify.ts`)
 - the actor and ref value types the builders accept (`src/types.ts`)
 
 The kernel obeys the three-layer rule: the harness observes, the kernel
@@ -28,14 +31,14 @@ QName derivations, and tsprov interop. The package has no dependency on
 
 [`SPEC.md`](SPEC.md) is the wire-format contract. It is derived from the code.
 If you change a derivation, an identifier scheme, the chain rule, or the
-sidecar shape, change `SPEC.md` in the same commit, and expect the golden
+attestation shape, change `SPEC.md` in the same commit, and expect the golden
 fixture test to fail until you regenerate the fixture on purpose.
 
 ### Public interface
 
 `src/index.ts` is the curated front door. It re-exports the document model,
-the signing primitives, the verification functions, the sidecar schema, and
-the value types. `package.json` declares `type: "module"` and the `exports`
+the lineage read model, the signing primitives, the verification functions,
+the attestation schema, and the value types. `package.json` declares `type: "module"` and the `exports`
 map: `.` goes to `dist/index.js`, and `./*` and `./*.js` go to `dist/*.js`.
 
 ## Commands

--- a/prov-kernel/README.md
+++ b/prov-kernel/README.md
@@ -3,9 +3,11 @@
 `@inflexa-ai/prov-kernel` is the Inflexa provenance format kernel. It carries the
 Inflexa PROV dialect: the document model (QName derivation, unify options, an
 injectable digest, and the `appendLifecycleAction` extension primitive), the
-chain-hash and Ed25519 sign/verify primitives, the signed-sidecar schema, and
-the actor and ref value types that the events carry. [`SPEC.md`](SPEC.md) gives
-the exact wire format, sufficient for an independent implementation.
+lineage read model (`deriveLineageModel`, `computeLineage`, `findFileEntity`),
+the chain-hash and Ed25519 sign/verify primitives, the signed-attestation
+schema, and the actor and ref value types that the events carry.
+[`SPEC.md`](SPEC.md) gives the exact wire format, sufficient for an independent
+implementation.
 
 The package is a kernel, not a recorder. The three-layer rule divides the work:
 
@@ -34,7 +36,7 @@ bun test        # run the test suite (Node is the runtime; bun runs tests only)
 ```
 
 ```ts
-import { createProvDocumentModel, applyProvEvent, PROV_UNIFY_OPTIONS, createKeypairSigner, buildSidecar, verifySidecar } from "@inflexa-ai/prov-kernel";
+import { createProvDocumentModel, applyProvEvent, PROV_UNIFY_OPTIONS, createKeypairSigner, buildAttestation, verifyAttestation } from "@inflexa-ai/prov-kernel";
 
 const model = createProvDocumentModel(); // or inject a historical digest
 const doc = model.freshDocument({ analysisId: "a1" });

--- a/prov-kernel/SPEC.md
+++ b/prov-kernel/SPEC.md
@@ -393,14 +393,18 @@ place. Each chain hash is the lowercase hex encoding of the 32-byte digest.
 | Signature encoding | lowercase hex, 128 characters (64 bytes) |
 | Public key | JWK (`kty` `OKP`, `crv` `Ed25519`; key material base64url per JWK) |
 
-The chained path signs the chain hash. The sidecar path signs the payload
+The chained path signs the chain hash. The attestation path signs the payload
 digest `SHA-256(bytes(json))`, hex-encoded. In both paths the signature covers
 the hex-decoded digest bytes, not the hex string.
 
-## The sidecar
+## The attestation
 
-The export sidecar is one JSON object. A recipient verifies with the payload
-and the sidecar alone.
+Before version 0.4.0 this object was named the "sidecar" — artifacts written
+under that name exist and verify unchanged, because no field name carries the
+old name.
+
+The export attestation is one JSON object. A recipient verifies with the
+payload and the attestation alone.
 
 ```json
 {
@@ -419,8 +423,8 @@ and the sidecar alone.
 `signatureAlgorithm` are literals. `payloadDigestMethod` `verbatim` means the
 digest input is the exact payload bytes. `kid` is optional: when several
 writers sign exports of one document, `kid` says which key signed this one.
-Verification ignores it. The public key travels in the sidecar, thus the
-sidecar proves integrity, not origin. For origin trust a host pins the
+Verification ignores it. The public key travels in the attestation, thus the
+attestation proves integrity, not origin. For origin trust a host pins the
 signer's public key and compares before verification.
 
 ## Unify semantics

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/design.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/design.md
@@ -1,0 +1,102 @@
+## Context
+
+Two reference implementations of the read side existed before this change:
+
+- The CLI's `prov lineage` module: node classification from `prov:type` with a
+  QName-prefix fallback, the run/step spine read as a label off the
+  communication adjacency, and a directional, cycle-safe, depth-bounded walk
+  over ONLY the generation and usage edges.
+- Lumen's `deriveLineageGraph`: a flat node/edge model over the whole document,
+  with synthesized placeholder nodes for undeclared relation endpoints,
+  value-derived fallback ids for anonymous lifecycle relations, and a silent
+  skip of statement kinds outside its edge set.
+
+The two agree on the dialect facts. They differ in shape and in edge
+orientation, and each carries presentation the kernel must not absorb.
+
+## Goals / Non-Goals
+
+Goals:
+
+- One derivation from stored bytes to a typed model, one traversal, one
+  `(path, hash)` lookup — in the kernel, next to the write-side mapping.
+- CLI semantics are canonical for the traversal. Lumen tolerance is adopted
+  for the derivation.
+
+Non-Goals:
+
+- No presentation: no tree/JSON/dot/mermaid rendering, no hash-prefix ref
+  search, no candidate caps, no React Flow layout. Those stay in the hosts.
+- No write-path change. The read model must not touch the builders, and the
+  golden fixture bytes must not move.
+
+## Decisions
+
+### Read drift is why this layer is kernel-owned
+
+The write path determines the signed bytes; the read path does not. Thus read
+drift never corrupts a document — it produces INCONSISTENT VIEWS: two
+consumers show two different lineages for one signed record, which defeats the
+point of a canonical signed document. The interpretation (which attribute
+carries a fact, which relation is a lineage edge, which direction a walk
+follows) is dialect semantics, and the kernel owns the dialect on both sides.
+
+### The input is the PROV-JSON string
+
+`deriveLineageModel` takes the serialized document — the exact bytes a host
+stores and the signature covers — not a tsprov `ProvDocument`. Every consumer
+then interprets one canonical form, no consumer needs tsprov plumbing at its
+boundary, and a parse failure surfaces on one typed err channel
+(`prov_corrupt`). The document unifies under `PROV_UNIFY_OPTIONS` before it is
+read, so the model sees the last-write-wins survivor of each record — the same
+fold the write path serializes under.
+
+### CLI semantics are canonical for the traversal
+
+`computeLineage` ports the CLI's walk exactly: only `generated` and `used`
+edges traverse (the coarse `derived` edge to the analysis and the `informed`
+spine would pollute a file's lineage); `depth` counts file-level hops, bounded
+as `2n` edges from a file root and `2n - 1` from an activity root, so a
+truncation always lands on a file node; a multi-root walk bounds each node by
+its minimum distance over all roots. One deviation: the CLI engine's
+`MAX_WALK_DEPTH` ceiling for the unbounded case is not ported — a
+breadth-first walk over a finite edge list terminates without it.
+
+### Lumen tolerance is adopted for the derivation
+
+Three behaviors port from Lumen: a relation endpoint the document never
+declares synthesizes a minimal node (kind from the QName-localpart prefix); an
+anonymous lifecycle relation gets the deterministic value-derived fallback id
+`{kind}:{from}->{to}`; a statement kind outside the seven — delegation today,
+any future kind — is skipped, never an error. A command's `runId`/`stepId`
+inherit from its informing step (both references do this; the CLI's
+both-undefined guard is taken).
+
+### Edges are in the PROV assertion orientation
+
+The one genuine conflict between the references: the CLI's flat projection
+emits edges in the PROV assertion orientation (a `generated` edge points
+entity to activity), while Lumen flips every edge into dataflow orientation
+for React Flow. The kernel takes the assertion orientation — formal argument 0
+to formal argument 1, exactly as the dialect asserts the relation — because
+the dataflow flip is a rendering concern a consumer can apply in one line.
+
+### The node unions extend the sketch where the dialect requires it
+
+Entity nodes are three kinds (`analysis`, `input`, `file`), not one: the
+dialect declares analysis and input entities, and without them their lifecycle
+relations would dangle into synthesized placeholders. Activity kinds include
+`file_tool`: `inflexa:FileToolWrite` is a distinct dialect type both
+references keep apart from `command`. Lumen's derivation of `runId`/`stepId`
+from an entity's path is NOT ported — it reads host storage layout, not the
+dialect, and stays a Lumen filter concern.
+
+## Risks / Trade-offs
+
+- **The kernel now versions with the read vocabulary.** A new node fact or
+  edge kind bumps the kernel. Accepted: the same argument that moved the event
+  switch — one interpretation, written once.
+- **Hosts keep private readers for host concerns.** The CLI's ref search and
+  Lumen's path-derived run/step filter still read the document directly.
+  Accepted: both are presentation/host-layout concerns; the dialect facts they
+  share now come from one module.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/proposal.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/proposal.md
@@ -1,0 +1,49 @@
+# Add the lineage read model
+
+## Why
+
+The dialect had one write-side interpretation (the event switch) but no
+read-side one. Each consumer interpreted the stored bytes itself: the CLI's
+lineage command classified nodes and walked the graph in its own module, and
+Lumen's provenance view derived its own node/edge model with its own attribute
+readers. Two readers of one signed document can drift, and drifted readers show
+two different lineages for the same bytes. The interpretation of the dialect is
+format semantics, thus it belongs in the kernel, one time.
+
+## What Changes
+
+- Add `src/lineage.ts`: the lineage read model.
+  - `deriveLineageModel(provJson)` parses the exact stored PROV-JSON bytes
+    through tsprov, unifies under `PROV_UNIFY_OPTIONS`, and returns
+    `{ nodes, edges }` — typed, presentation-free nodes (analysis, input, file,
+    activity, agent) and edges for the seven relation kinds with deterministic
+    ids. Bytes that do not parse return `err({ type: "prov_corrupt" })`.
+  - `computeLineage(model, roots, { direction, depth? })` walks the
+    generation/usage edges with the traversal semantics of the CLI's lineage
+    command.
+  - `findFileEntity(model, { path, hash })` is the identity lookup that
+    cross-links an external artifact record to its entity.
+- Port, do not invent: the CLI module is canonical for the traversal semantics
+  and the attribute readers; the Lumen derivation is canonical for tolerance
+  (synthesized nodes for undeclared endpoints, fallback ids for anonymous
+  relations, skipped unknown statement kinds).
+- Export the module from the barrel. tsprov stays the only import surface (an
+  existing peer).
+- Bump the package version from 0.3.0 to 0.4.0 (shared with the
+  rename-sidecar-attestation change).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `prov-kernel`: the kernel gains the read-side requirement — one lineage
+  interpretation of a stored document, owned next to the write-side mapping.
+
+## Impact
+
+- `src/lineage.ts` (new), `src/lineage.test.ts` (new), `src/index.ts`,
+  `README.md`, `CLAUDE.md`, `scripts/smoke.mjs`, `package.json`.
+- No write-path change: the golden fixture bytes are untouched.
+- Consumers adopt the module in their own changes: the CLI keeps its
+  presentation (tree/JSON/dot/mermaid rendering, ref search), Lumen keeps its
+  React Flow layout and filters.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/specs/prov-kernel/spec.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/specs/prov-kernel/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: The kernel owns the lineage read model
+
+The kernel SHALL provide the one read-side interpretation of a stored dialect
+document. `deriveLineageModel(provJson)` SHALL take the exact stored PROV-JSON
+string, unify it under `PROV_UNIFY_OPTIONS`, and return a
+`{ nodes, edges }` model: typed, presentation-free nodes (`analysis`, `input`,
+and `file` entities, `activity` nodes with the kinds `run`/`step`/`command`/
+`file_tool`/`action`, and `agent` nodes with the kinds
+`system`/`user`/`model`) and edges for exactly the seven relation kinds
+`used`, `generated`, `informed`, `derived`, `attributed`, `associated`, and
+`invalidated`. An edge SHALL point in the PROV assertion orientation (formal
+argument 0 to formal argument 1) and SHALL carry a deterministic id: the
+relation's dialect id when one exists, else the value-derived fallback
+`{kind}:{from}->{to}`. A relation endpoint the document never declares SHALL
+synthesize a minimal node from its QName; a statement kind outside the seven
+SHALL be skipped; bytes that do not parse or unify SHALL return
+`err({ type: "prov_corrupt" })`. `computeLineage(model, roots, options)` SHALL
+traverse ONLY the `generated` and `used` edges, forward or backward, with a
+file-hop `depth` bound of `2n` edges from a file root and `2n - 1` from an
+activity root, so a truncation lands on a file node.
+`findFileEntity(model, key)` SHALL return the file entity for a
+`(path, hash)` key. The read model SHALL NOT touch the write path: the golden
+fixture bytes do not change.
+
+#### Scenario: The golden document derives into the shared model
+
+- **GIVEN** the committed golden fixture bytes
+- **WHEN** `deriveLineageModel` runs
+- **THEN** every declared element is a typed node, every undeclared relation
+  endpoint is a synthesized minimal node, and each execution relation keys its
+  edge by its deterministic dialect id
+
+#### Scenario: Tolerance for anonymous and unknown statements
+
+- **GIVEN** a document with an anonymous lifecycle relation and a statement
+  kind outside the seven
+- **WHEN** `deriveLineageModel` runs
+- **THEN** the anonymous relation gets the value-derived fallback id, and the
+  unknown statement kind is skipped with no error
+
+#### Scenario: The walk traverses only generation and usage
+
+- **GIVEN** a derived model of a produced file
+- **WHEN** `computeLineage` walks backward from the file
+- **THEN** the result holds the file-to-command-to-input chain, and the
+  analysis entity, the run spine, and the agents stay out
+
+#### Scenario: Depth counts file hops and truncates on a file node
+
+- **GIVEN** a chain of two commands between three files
+- **WHEN** `computeLineage` walks backward from the last file with depth 1
+- **THEN** the result ends at the intermediate file, and the earlier command
+  and its inputs stay out

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/tasks.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-lineage-read-model/tasks.md
@@ -1,0 +1,40 @@
+## 1. The read module
+
+- [x] 1.1 Add `src/lineage.ts`: the node/edge types, the attribute readers,
+  and `deriveLineageModel` — parse, unify under `PROV_UNIFY_OPTIONS`, derive
+  typed nodes, derive the seven edge kinds in the PROV assertion orientation
+  with deterministic ids, synthesize undeclared endpoints, skip unknown
+  statement kinds, inherit a command's run/step from its informing step.
+- [x] 1.2 Add `computeLineage` with the CLI traversal semantics: generation
+  and usage only, forward/backward, the file-hop depth bound (`2n` from a
+  file root, `2n - 1` from an activity root), minimum distance over all roots.
+- [x] 1.3 Add `findFileEntity`: the `(path, hash)` file-entity lookup, typed
+  on the existing `ProvFileKey`.
+- [x] 1.4 Export the functions and the model types from `src/index.ts`.
+
+## 2. Tests
+
+- [x] 2.1 Golden-fixture derivation: node and edge structure, the
+  deterministic dialect edge ids, the value-derived fallback ids, the
+  synthesized endpoints, the edge-kind census, determinism, and the
+  `prov_corrupt` err channel.
+- [x] 2.2 Traversal tests ported from the CLI semantics: the backward chain,
+  the step-grain leaf, the cross-run prior read, the self-read cycle, the
+  forward walk, the depth bounds for file and activity roots, the multi-root
+  minimum-distance bound.
+- [x] 2.3 Tolerance tests ported from Lumen: the anonymous and the identified
+  invalidation, synthesized endpoint nodes, a skipped statement kind outside
+  the seven.
+- [x] 2.4 `findFileEntity` hit and miss.
+- [x] 2.5 The golden fixture stays byte-identical — the read module touches no
+  write-path code.
+
+## 3. Documents and version
+
+- [x] 3.1 Update `README.md`, `CLAUDE.md`, the barrel doc comment, and the
+  smoke script's export list.
+- [x] 3.2 Bump `package.json` to 0.4.0 (shared with the rename change).
+- [x] 3.3 `bun install --frozen-lockfile`, `bun run typecheck`,
+  `bun run lint`, `bun test`, `bun run build && bun run smoke`,
+  `openspec validate --all --strict`.
+- [x] 3.4 `bun run format:file` on every touched file under `src/`.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/design.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The export verification object entered the kernel as the "sidecar", after the
+CLI's `.sig.json` file that travels next to an exported document. The name
+described the CLI's transport, not the object. A managed host stores the same
+object in a column; nothing there is a sidecar.
+
+## Goals / Non-Goals
+
+Goals:
+
+- One name, "attestation", across the API, the docs, the tests, and the wire
+  contract document.
+- Zero effect on existing artifacts.
+
+Non-Goals:
+
+- No shape change, no field rename, no verification change.
+- No deprecated aliases.
+
+## Decisions
+
+### The JSON payload is untouched
+
+No field of the object contains the word "sidecar" — the fields are
+`payloadType`, `payloadDigestAlgorithm`, `payloadDigest`,
+`payloadDigestMethod`, `signatureAlgorithm`, `signature`, `publicKey`, and
+`kid`. Thus the rename touches only code identifiers and prose, and every
+artifact written under the old name parses and verifies unchanged. The golden
+fixture and the signature scheme do not move.
+
+### A clean rename, no aliases
+
+The package is 0.x and every consumer is an in-flight pull request we control.
+A deprecation window would carry two names through reviews for no reader's
+benefit. The old names are removed in the same change that adds the new ones.
+
+### The `invalid-sidecar` status renames too
+
+The `VerifyResult` status value is API, not wire: it is a returned value a
+host branches on, never a serialized artifact field. A clean rename that keeps
+one API value on the old name would leave the confusion in the one place a
+consumer matches on strings.
+
+### `SPEC.md` keeps one line of history
+
+The wire contract is a public document, and artifacts exist in the wild that
+their producers documented as "sidecars". The renamed section keeps one line
+that gives the former name, so a reader who holds an old artifact finds the
+contract. This is the one permitted history note; code comments carry none.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/proposal.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/proposal.md
@@ -1,0 +1,43 @@
+# Rename the sidecar to the attestation
+
+## Why
+
+"Sidecar" names where the object travels — a file next to another file. It
+does not name what the object is: a signed attestation of a payload — the
+digest, the signature, and the public key that let a recipient verify
+integrity with no other state. Hosts that store the object in a database
+column have no "side" at all, and the name misleads there. "Attestation" names
+the function, in every transport.
+
+## What Changes
+
+- Rename the public surface, with NO deprecated aliases:
+  - `buildSidecar` → `buildAttestation`
+  - `verifySidecar` → `verifyAttestation`
+  - `sidecarSchema` → `attestationSchema`
+  - type `Sidecar` → `ProvAttestation`
+  - the `VerifyResult` status `invalid-sidecar` → `invalid-attestation`
+- Internal names, doc comments, tests, `README.md`, `CLAUDE.md`, and
+  `scripts/smoke.mjs` follow.
+- `SPEC.md`: rename "The sidecar" section to "The attestation", with one line
+  that gives the former name — the wire contract is a public document and
+  artifacts exist in the wild under the old name.
+- The JSON payload itself is UNCHANGED: no field name contains "sidecar", so
+  every existing artifact verifies as before.
+- Bump the package version from 0.3.0 to 0.4.0 (shared with the
+  add-lineage-read-model change).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `prov-kernel`: the boundary, integrity, and wire-format requirements name
+  the attestation instead of the sidecar. The semantics do not change.
+
+## Impact
+
+- `src/verify.ts`, `src/verify.test.ts`, `src/types.ts`, `src/signing.ts`
+  (doc comments), `src/index.ts`, `SPEC.md`, `README.md`, `CLAUDE.md`,
+  `scripts/smoke.mjs`, `package.json`.
+- Breaking for the API surface at 0.x. Every consumer is an in-flight pull
+  request under our control, thus a clean rename beats a deprecation window.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/specs/prov-kernel/spec.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/specs/prov-kernel/spec.md
@@ -1,10 +1,5 @@
-# prov-kernel Specification
+## MODIFIED Requirements
 
-## Purpose
-Define the Inflexa PROV dialect as a standalone package: the document model, the
-deterministic identifier scheme, the chain-hash and signature integrity layer,
-and the wire-format contract that independent producers implement against.
-## Requirements
 ### Requirement: The kernel owns the dialect and nothing else
 
 `@inflexa-ai/prov-kernel` SHALL carry the Inflexa PROV dialect: the document model
@@ -48,29 +43,6 @@ layering rule is: the harness observes, the kernel represents, hosts decide.
   the generic `appendLifecycleAction`
 - **THEN** the kernel needs no change and no version bump
 
-### Requirement: Identifiers are deterministic and digest-parameterized
-
-Every execution QName and every execution relation identifier SHALL derive
-from content through one injected digest function, never from randomness or a
-clock. The default digest SHALL be: SHA-256 of the UTF-8 identity string,
-first 8 bytes, read big-endian, rendered in base36. Re-building the same
-statements SHALL dedupe under `unified()`, and no execution relation SHALL be
-anonymous (no `_:` identifier).
-
-#### Scenario: Re-emission dedupes
-
-- **GIVEN** a document that received one run's statements twice
-- **WHEN** it serializes under `unified()` with `PROV_UNIFY_OPTIONS`
-- **THEN** exactly one entity exists per file key, and exactly one generation
-  edge exists under its deterministic relation id
-
-#### Scenario: An injected digest re-keys the identifier space consistently
-
-- **GIVEN** a document model constructed with a custom digest
-- **WHEN** it derives file, input, command, and model-agent QNames
-- **THEN** every digest-bearing QName differs from the default model's, and
-  the same input always derives the same QName within one model
-
 ### Requirement: Integrity is a chain hash under an Ed25519 signature
 
 The chain rule SHALL be `H_n = SHA-256(bytes(H_{n-1}) || bytes(json_n))`,
@@ -109,9 +81,9 @@ the err channel.
 `prov-kernel/SPEC.md` SHALL state the namespace, the digest definition, the QName
 format per node kind, the relation-id schemes, the chain rule and its seed,
 the signature scheme and encodings, the attestation shape, and the
-last-write-wins unify semantics — derived from the code. A committed golden fixture SHALL pin
-the serialized bytes of a fully deterministic document, so any conforming
-producer can test against it.
+last-write-wins unify semantics — derived from the code. A committed golden
+fixture SHALL pin the serialized bytes of a fully deterministic document, so
+any conforming producer can test against it.
 
 #### Scenario: Drift fails the golden test
 
@@ -120,57 +92,3 @@ producer can test against it.
 - **WHEN** the test suite runs
 - **THEN** the golden fixture comparison fails until the fixture is
   regenerated on purpose and `SPEC.md` is updated in the same change
-
-### Requirement: The kernel owns the lineage read model
-
-The kernel SHALL provide the one read-side interpretation of a stored dialect
-document. `deriveLineageModel(provJson)` SHALL take the exact stored PROV-JSON
-string, unify it under `PROV_UNIFY_OPTIONS`, and return a
-`{ nodes, edges }` model: typed, presentation-free nodes (`analysis`, `input`,
-and `file` entities, `activity` nodes with the kinds `run`/`step`/`command`/
-`file_tool`/`action`, and `agent` nodes with the kinds
-`system`/`user`/`model`) and edges for exactly the seven relation kinds
-`used`, `generated`, `informed`, `derived`, `attributed`, `associated`, and
-`invalidated`. An edge SHALL point in the PROV assertion orientation (formal
-argument 0 to formal argument 1) and SHALL carry a deterministic id: the
-relation's dialect id when one exists, else the value-derived fallback
-`{kind}:{from}->{to}`. A relation endpoint the document never declares SHALL
-synthesize a minimal node from its QName; a statement kind outside the seven
-SHALL be skipped; bytes that do not parse or unify SHALL return
-`err({ type: "prov_corrupt" })`. `computeLineage(model, roots, options)` SHALL
-traverse ONLY the `generated` and `used` edges, forward or backward, with a
-file-hop `depth` bound of `2n` edges from a file root and `2n - 1` from an
-activity root, so a truncation lands on a file node.
-`findFileEntity(model, key)` SHALL return the file entity for a
-`(path, hash)` key. The read model SHALL NOT touch the write path: the golden
-fixture bytes do not change.
-
-#### Scenario: The golden document derives into the shared model
-
-- **GIVEN** the committed golden fixture bytes
-- **WHEN** `deriveLineageModel` runs
-- **THEN** every declared element is a typed node, every undeclared relation
-  endpoint is a synthesized minimal node, and each execution relation keys its
-  edge by its deterministic dialect id
-
-#### Scenario: Tolerance for anonymous and unknown statements
-
-- **GIVEN** a document with an anonymous lifecycle relation and a statement
-  kind outside the seven
-- **WHEN** `deriveLineageModel` runs
-- **THEN** the anonymous relation gets the value-derived fallback id, and the
-  unknown statement kind is skipped with no error
-
-#### Scenario: The walk traverses only generation and usage
-
-- **GIVEN** a derived model of a produced file
-- **WHEN** `computeLineage` walks backward from the file
-- **THEN** the result holds the file-to-command-to-input chain, and the
-  analysis entity, the run spine, and the agents stay out
-
-#### Scenario: Depth counts file hops and truncates on a file node
-
-- **GIVEN** a chain of two commands between three files
-- **WHEN** `computeLineage` walks backward from the last file with depth 1
-- **THEN** the result ends at the intermediate file, and the earlier command
-  and its inputs stay out

--- a/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/tasks.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-rename-sidecar-attestation/tasks.md
@@ -1,0 +1,26 @@
+## 1. Rename the surface
+
+- [x] 1.1 `src/verify.ts`: `buildSidecar` → `buildAttestation`,
+  `verifySidecar` → `verifyAttestation`, `sidecarSchema` →
+  `attestationSchema`, type `Sidecar` → `ProvAttestation`; doc comments
+  follow. The schema fields do not change.
+- [x] 1.2 `src/types.ts`: the `VerifyResult` status `invalid-sidecar` →
+  `invalid-attestation`; `src/verify.ts` renders the renamed status.
+- [x] 1.3 `src/index.ts` re-exports the new names. `src/signing.ts` doc
+  comments follow.
+- [x] 1.4 `src/verify.test.ts` renames its identifiers and descriptions.
+
+## 2. Documents
+
+- [x] 2.1 `SPEC.md`: rename "The sidecar" to "The attestation", with one line
+  that gives the former name, and rename the remaining prose mentions.
+- [x] 2.2 `README.md`, `CLAUDE.md`, and `scripts/smoke.mjs` follow.
+
+## 3. Version and verify
+
+- [x] 3.1 Bump `package.json` to 0.4.0 (shared with the
+  add-lineage-read-model change).
+- [x] 3.2 `bun install --frozen-lockfile`, `bun run typecheck`,
+  `bun run lint`, `bun test` (the golden fixture stays byte-identical),
+  `bun run build && bun run smoke`, `openspec validate --all --strict`.
+- [x] 3.3 `bun run format:file` on every touched file under `src/`.

--- a/prov-kernel/package.json
+++ b/prov-kernel/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@inflexa-ai/prov-kernel",
-    "version": "0.3.0",
-    "description": "Inflexa provenance format kernel — the PROV dialect document model, chain-hash + Ed25519 signing, and the signed-sidecar schema.",
+    "version": "0.4.0",
+    "description": "Inflexa provenance format kernel — the PROV dialect document model, the lineage read model, chain-hash + Ed25519 signing, and the signed-attestation schema.",
     "license": "Apache-2.0",
     "type": "module",
     "main": "dist/index.js",

--- a/prov-kernel/scripts/smoke.mjs
+++ b/prov-kernel/scripts/smoke.mjs
@@ -19,10 +19,11 @@ try {
   const required = [
     "createProvDocumentModel",
     "defaultProvDigest",
+    "deriveLineageModel",
     "createKeypairSigner",
     "computeChainHash",
-    "buildSidecar",
-    "verifySidecar",
+    "buildAttestation",
+    "verifyAttestation",
   ];
   const missing = required.filter((name) => typeof mod[name] !== "function");
   if (missing.length > 0) {
@@ -36,17 +37,17 @@ try {
     throw new Error(`fileQName produced an unexpected shape: ${qn}`);
   }
 
-  // One sign/verify roundtrip through the sidecar path.
+  // One sign/verify roundtrip through the attestation path.
   const keypair = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
   const signer = mod.createKeypairSigner(keypair);
   const provJson = `{"prefix":{"inflexa":"https://inflexa.ai/prov#"}}`;
-  const sidecarResult = await mod.buildSidecar(signer, provJson);
-  if (sidecarResult.isErr()) {
-    throw new Error(`buildSidecar failed: ${JSON.stringify(sidecarResult.error)}`);
+  const attestationResult = await mod.buildAttestation(signer, provJson);
+  if (attestationResult.isErr()) {
+    throw new Error(`buildAttestation failed: ${JSON.stringify(attestationResult.error)}`);
   }
-  const verdict = await mod.verifySidecar(provJson, sidecarResult.value);
+  const verdict = await mod.verifyAttestation(provJson, attestationResult.value);
   if (verdict.status !== "valid") {
-    throw new Error(`sidecar roundtrip did not verify: ${JSON.stringify(verdict)}`);
+    throw new Error(`attestation roundtrip did not verify: ${JSON.stringify(verdict)}`);
   }
 
   console.log(`smoke: OK — barrel loads under node, QName derivation and sign/verify roundtrip pass.`);

--- a/prov-kernel/src/index.ts
+++ b/prov-kernel/src/index.ts
@@ -2,8 +2,8 @@
  * `@inflexa-ai/prov-kernel` — the Inflexa provenance format kernel. The public surface is the Inflexa
  * PROV dialect: the document model (QName derivation, unify options, injectable digest, the
  * `appendLifecycleAction` extension primitive), the core event union and its apply function, the
- * chain-hash and Ed25519 sign/verify primitives, the signed-sidecar schema, and the actor/ref
- * value types the events carry.
+ * lineage read model, the chain-hash and Ed25519 sign/verify primitives, the signed-attestation
+ * schema, and the actor/ref value types the events carry.
  *
  * Deliberately absent: any recorder lifecycle (sink, flush, queue, CAS), signer wiring, or
  * harness dependency. Each host owns its own recorder and emission policy; the kernel owns the
@@ -34,6 +34,22 @@ export type { ProvDigest, ProvDocumentModel, ProvDocumentModelOptions } from "./
 export { applyProvEvent } from "./events.js";
 export type { ProvEvent } from "./events.js";
 
+export { computeLineage, deriveLineageModel, findFileEntity } from "./lineage.js";
+export type {
+    LineageActivityKind,
+    LineageActivityNode,
+    LineageAgentKind,
+    LineageAgentNode,
+    LineageAnalysisNode,
+    LineageEdge,
+    LineageEdgeKind,
+    LineageFileNode,
+    LineageInputNode,
+    LineageModel,
+    LineageNode,
+    ProvReadError,
+} from "./lineage.js";
+
 export {
     computeChainHash,
     computePayloadDigest,
@@ -45,5 +61,5 @@ export {
 } from "./signing.js";
 export type { ProvPublicKeyJwk, ProvSigner, ProvSigningError } from "./signing.js";
 
-export { buildSidecar, formatVerifyResult, sidecarSchema, verifyPayload, verifyProvenance, verifySidecar } from "./verify.js";
-export type { Sidecar } from "./verify.js";
+export { attestationSchema, buildAttestation, formatVerifyResult, verifyAttestation, verifyPayload, verifyProvenance } from "./verify.js";
+export type { ProvAttestation } from "./verify.js";

--- a/prov-kernel/src/lineage.test.ts
+++ b/prov-kernel/src/lineage.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { ProvDocument } from "@inflexa-ai/tsprov";
+import { createProvDocumentModel, PROV_UNIFY_OPTIONS, type ProvDocumentModel } from "./document.js";
+import { applyProvEvent } from "./events.js";
+import { computeLineage, deriveLineageModel, findFileEntity, type LineageModel } from "./lineage.js";
+import type { ProvActor, ProvCommandRef, ProvFileRef, ProvModelId, ProvStepRef } from "./types.js";
+
+// The read model is tested against two sources: the committed golden fixture (the exact stored
+// bytes every consumer reads) and documents built with the real event switch — the record shapes
+// production writes — round-tripped through PROV-JSON like a stored column.
+
+const goldenJson = readFileSync(new URL("./__fixtures__/golden-document.json", import.meta.url), "utf8");
+const provModel = createProvDocumentModel();
+
+function nodeOf(model: LineageModel, qn: string): LineageModel["nodes"][number] | undefined {
+    return model.nodes.find((n) => n.qn === qn);
+}
+
+function edgeOf(model: LineageModel, id: string): LineageModel["edges"][number] | undefined {
+    return model.edges.find((e) => e.id === id);
+}
+
+function qns(model: LineageModel): string[] {
+    return model.nodes.map((n) => n.qn);
+}
+
+describe("deriveLineageModel — golden fixture", () => {
+    const model = deriveLineageModel(goldenJson)._unsafeUnwrap();
+
+    test("derives every PROV element into a node, plus the undeclared endpoints", () => {
+        // 6 declared entities + 2 synthesized from relation endpoints the document references but
+        // never declares (the resolved script and the failed command's output).
+        const entities = model.nodes.filter((n) => n.kind === "analysis" || n.kind === "input" || n.kind === "file");
+        expect(entities.map((n) => n.qn).sort()).toEqual([
+            "inflexa:analysis-a-golden",
+            "inflexa:file-18bvqsvo19q9p",
+            "inflexa:file-2cl35k0tb4udj",
+            "inflexa:file-2oo1fa1324nay",
+            "inflexa:file-8cpsktnfc9if",
+            "inflexa:file-c0kyjyc0bmim",
+            "inflexa:file-monvuc8rxoat",
+            "inflexa:input-39n74a7sqlbvc",
+        ]);
+        expect(model.nodes.filter((n) => n.kind === "activity")).toHaveLength(8);
+        expect(model.nodes.filter((n) => n.kind === "agent")).toHaveLength(3);
+    });
+
+    test("maps the dialect attributes onto entity nodes", () => {
+        expect(nodeOf(model, "inflexa:file-18bvqsvo19q9p")).toMatchObject({
+            kind: "file",
+            label: "runs/r1/s1/output/result.csv",
+            path: "runs/r1/s1/output/result.csv",
+            hash: "sha256:bbb",
+            size: 10,
+            producer: "command",
+        });
+        expect(nodeOf(model, "inflexa:file-2cl35k0tb4udj")).toMatchObject({
+            kind: "file",
+            path: "data/inputs/counts.csv",
+            hash: "sha256:aaa",
+            source: "data",
+            fileId: "file-1",
+        });
+        expect(nodeOf(model, "inflexa:analysis-a-golden")).toMatchObject({
+            kind: "analysis",
+            label: "Golden Analysis",
+            name: "Golden Analysis",
+            slug: "golden-analysis",
+        });
+        expect(nodeOf(model, "inflexa:input-39n74a7sqlbvc")).toMatchObject({ kind: "input", path: "data/inputs/counts.csv", isDir: false });
+    });
+
+    test("a synthesized endpoint node carries the QName-derived kind and label only", () => {
+        const plotQn = provModel.fileQName({ path: "runs/r1/s1/output/plot.png", hash: "sha256:eee" });
+        const plot = nodeOf(model, plotQn);
+        expect(plot).toEqual({ kind: "file", qn: plotQn, label: plotQn.slice("inflexa:".length) });
+    });
+
+    test("classifies activities and reads their terminal attributes", () => {
+        expect(nodeOf(model, "inflexa:run-r1")).toMatchObject({
+            kind: "activity",
+            activity: "run",
+            label: "r1",
+            runId: "r1",
+            status: "completed",
+            durationMs: 200000,
+            planSummary: "golden plan",
+        });
+        const run = nodeOf(model, "inflexa:run-r1");
+        if (run?.kind === "activity") {
+            expect(run.startTime).toBeDefined();
+            expect(run.endTime).toBeDefined();
+        }
+        expect(nodeOf(model, "inflexa:step-r1-s1")).toMatchObject({
+            kind: "activity",
+            activity: "step",
+            runId: "r1",
+            stepId: "s1",
+            status: "completed",
+            durationMs: 100000,
+        });
+        // A command carries no runId/stepId attribute — both inherit from the informing step.
+        expect(nodeOf(model, "inflexa:cmd-r1-s1-302d2bs8ad5ko")).toMatchObject({
+            kind: "activity",
+            activity: "command",
+            label: "python run.py",
+            command: "python run.py",
+            args: "--seed 42",
+            exitCode: 0,
+            durationMs: 1200,
+            runId: "r1",
+            stepId: "s1",
+        });
+        expect(nodeOf(model, "inflexa:cmd-r1-s1-3on7qauhakeey")).toMatchObject({
+            kind: "activity",
+            activity: "command",
+            exitCode: 1,
+            unresolvedScript: "runs/r1/s1/scripts/analyze.R",
+        });
+        expect(nodeOf(model, "inflexa:cmd-r1-s1-1gmep6ya47zjz")).toMatchObject({ kind: "activity", activity: "file_tool", tool: "write_file" });
+        expect(nodeOf(model, "inflexa:action-golden-1")).toMatchObject({ kind: "activity", activity: "action", actionType: "CreateAnalysis" });
+    });
+
+    test("classifies agents", () => {
+        expect(nodeOf(model, "inflexa:agent-user-u-42")).toMatchObject({ kind: "agent", agent: "user", email: "golden@example.com" });
+        expect(nodeOf(model, "inflexa:agent-system")).toMatchObject({
+            kind: "agent",
+            agent: "system",
+            label: "golden-host",
+            version: "1.0.0",
+            commit: "deadbeef",
+        });
+        expect(nodeOf(model, "inflexa:agent-model-1j48pc6rh4s2c")).toMatchObject({
+            kind: "agent",
+            agent: "model",
+            label: "anthropic/golden-model",
+            model: "anthropic/golden-model",
+        });
+    });
+
+    test("keys edges by their deterministic dialect ids, in the PROV assertion orientation", () => {
+        expect(edgeOf(model, "inflexa:gen-18bvqsvo19q9p")).toEqual({
+            id: "inflexa:gen-18bvqsvo19q9p",
+            kind: "generated",
+            from: "inflexa:file-18bvqsvo19q9p",
+            to: "inflexa:cmd-r1-s1-302d2bs8ad5ko",
+        });
+        expect(edgeOf(model, "inflexa:used-cmd-r1-s1-302d2bs8ad5ko-2cl35k0tb4udj")).toEqual({
+            id: "inflexa:used-cmd-r1-s1-302d2bs8ad5ko-2cl35k0tb4udj",
+            kind: "used",
+            from: "inflexa:cmd-r1-s1-302d2bs8ad5ko",
+            to: "inflexa:file-2cl35k0tb4udj",
+        });
+        expect(edgeOf(model, "inflexa:informed-r1-s1")).toEqual({
+            id: "inflexa:informed-r1-s1",
+            kind: "informed",
+            from: "inflexa:step-r1-s1",
+            to: "inflexa:run-r1",
+        });
+        expect(edgeOf(model, "inflexa:assoc-run-r1-71ngm22zaedy")).toEqual({
+            id: "inflexa:assoc-run-r1-71ngm22zaedy",
+            kind: "associated",
+            from: "inflexa:run-r1",
+            to: "inflexa:agent-system",
+        });
+        expect(edgeOf(model, "inflexa:deriv-18bvqsvo19q9p")).toEqual({
+            id: "inflexa:deriv-18bvqsvo19q9p",
+            kind: "derived",
+            from: "inflexa:file-18bvqsvo19q9p",
+            to: "inflexa:analysis-a-golden",
+        });
+        expect(edgeOf(model, "inflexa:attr-18bvqsvo19q9p-71ngm22zaedy")).toEqual({
+            id: "inflexa:attr-18bvqsvo19q9p-71ngm22zaedy",
+            kind: "attributed",
+            from: "inflexa:file-18bvqsvo19q9p",
+            to: "inflexa:agent-system",
+        });
+    });
+
+    test("keys an anonymous lifecycle relation by a value-derived fallback id", () => {
+        expect(edgeOf(model, "generated:inflexa:analysis-a-golden->inflexa:action-golden-1")).toMatchObject({ kind: "generated" });
+        expect(edgeOf(model, "used:inflexa:action-golden-2->inflexa:input-39n74a7sqlbvc")).toMatchObject({ kind: "used" });
+    });
+
+    test("derives exactly the seven edge kinds with no dangling endpoint; delegation is not an edge", () => {
+        // 12 associations + 6 generations + 5 attributions + 5 usages + 4 derivations +
+        // 4 communications; the model delegation is skipped.
+        expect(model.edges).toHaveLength(36);
+        expect(model.edges.some((e) => e.id.startsWith("inflexa:delegation-"))).toBe(false);
+        const nodeQns = new Set(qns(model));
+        for (const edge of model.edges) {
+            expect(nodeQns.has(edge.from)).toBe(true);
+            expect(nodeQns.has(edge.to)).toBe(true);
+        }
+    });
+
+    test("is deterministic — the same bytes give the same model", () => {
+        expect(deriveLineageModel(goldenJson)._unsafeUnwrap()).toEqual(model);
+    });
+
+    test("bytes that do not parse return prov_corrupt", () => {
+        expect(deriveLineageModel("not prov json")._unsafeUnwrapErr().type).toBe("prov_corrupt");
+    });
+});
+
+// The traversal fixtures: the canonical chain counts.csv → command A (Rscript) → de_results.csv →
+// command B (python) → heatmap.png, plus a file-tool-written script read by A, a leaf file with
+// only the step-level generation, and a step-level read of counts.csv.
+const system: ProvActor = { kind: "system", label: "kernel-test", version: "0.0.1" };
+const model: ProvModelId = "anthropic/test-model";
+const stepRef: ProvStepRef = { runId: "run-001", stepId: "step-de" };
+
+const countsKey = { path: "data/inputs/counts.csv", hash: "hashCount1" };
+const deResultsKey = { path: "runs/run-001/step-de/output/de_results.csv", hash: "hashDe0001" };
+const heatmapKey = { path: "runs/run-001/step-de/figures/heatmap.png", hash: "hashHeat01" };
+const scriptKey = { path: "runs/run-001/step-de/scripts/de.R", hash: "hashScr001" };
+const leafKey = { path: "runs/run-001/step-de/output/leaf.txt", hash: "hashLeaf01" };
+
+const cmdA: ProvCommandRef = {
+    kind: "command",
+    command: "Rscript scripts/de.R",
+    exitCode: 0,
+    scriptPath: scriptKey.path,
+    outputs: [deResultsKey],
+    inputs: [
+        { ...countsKey, source: "data", fileId: "file-1" },
+        { ...scriptKey, source: "step" },
+    ],
+};
+const cmdB: ProvCommandRef = { kind: "command", command: "python plot.py", exitCode: 0, outputs: [heatmapKey], inputs: [{ ...deResultsKey, source: "step" }] };
+const writeScript: ProvCommandRef = { kind: "file_tool", tool: "write_file", outputs: [scriptKey] };
+
+function fileRefOf(key: { path: string; hash: string }, producer: "command" | "file_tool" = "command"): ProvFileRef {
+    return { ...key, size: 100, producer };
+}
+
+function chainDoc(m: ProvDocumentModel): ProvDocument {
+    const doc = m.freshDocument({ analysisId: "a1" });
+    applyProvEvent(m, doc, { type: "run_started", analysisId: "a1", actor: system, run: { runId: "run-001", startedAtMs: 1_700_000_000_000 } });
+    applyProvEvent(m, doc, {
+        type: "step_completed",
+        analysisId: "a1",
+        actor: system,
+        outcome: { runId: "run-001", stepId: "step-de", status: "completed", completedAtMs: 1_700_000_001_500 },
+        model,
+    });
+    applyProvEvent(m, doc, { type: "command_executed", analysisId: "a1", actor: system, step: stepRef, command: writeScript, model });
+    applyProvEvent(m, doc, {
+        type: "file_written",
+        analysisId: "a1",
+        actor: system,
+        file: fileRefOf(scriptKey, "file_tool"),
+        step: stepRef,
+        generation: "command",
+    });
+    applyProvEvent(m, doc, { type: "command_executed", analysisId: "a1", actor: system, step: stepRef, command: cmdA, model });
+    applyProvEvent(m, doc, { type: "file_written", analysisId: "a1", actor: system, file: fileRefOf(deResultsKey), step: stepRef, generation: "command" });
+    applyProvEvent(m, doc, { type: "command_executed", analysisId: "a1", actor: system, step: stepRef, command: cmdB, model });
+    applyProvEvent(m, doc, { type: "file_written", analysisId: "a1", actor: system, file: fileRefOf(heatmapKey), step: stepRef, generation: "command" });
+    applyProvEvent(m, doc, { type: "file_written", analysisId: "a1", actor: system, file: fileRefOf(leafKey), step: stepRef, generation: "step" });
+    applyProvEvent(m, doc, { type: "input_used", analysisId: "a1", actor: system, step: stepRef, input: { ...countsKey, source: "data", fileId: "file-1" } });
+    return doc;
+}
+
+/** The model of a built document, read from the same bytes a host stores. */
+function modelFrom(doc: ProvDocument): LineageModel {
+    return deriveLineageModel(doc.unified(PROV_UNIFY_OPTIONS).serialize("json"))._unsafeUnwrap();
+}
+
+const chainModel = modelFrom(chainDoc(provModel));
+const fileQn = (key: { path: string; hash: string }): string => provModel.fileQName(key);
+const aQn = provModel.commandQName(stepRef, cmdA.outputs);
+const bQn = provModel.commandQName(stepRef, cmdB.outputs);
+const writeQn = provModel.commandQName(stepRef, writeScript.outputs);
+const stepQn = provModel.stepQName(stepRef);
+
+describe("computeLineage — backward", () => {
+    const walk = computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward" });
+
+    test("walks the chain heatmap → B → de_results → A → counts + script → write_file", () => {
+        expect(qns(walk).sort()).toEqual([fileQn(heatmapKey), bQn, fileQn(deResultsKey), aQn, fileQn(countsKey), fileQn(scriptKey), writeQn].sort());
+        expect(edgeOf(walk, "inflexa:gen-" + fileQn(heatmapKey).slice("inflexa:file-".length))).toMatchObject({ kind: "generated", to: bQn });
+        expect(walk.edges).toContainEqual(expect.objectContaining({ kind: "used", from: aQn, to: fileQn(countsKey) }));
+        expect(walk.edges).toContainEqual(expect.objectContaining({ kind: "used", from: aQn, to: fileQn(scriptKey) }));
+        expect(walk.edges).toContainEqual(expect.objectContaining({ kind: "generated", from: fileQn(scriptKey), to: writeQn }));
+    });
+
+    test("traverses only generation and usage — the derived edge, the informed spine, and the agents stay out", () => {
+        expect(qns(walk)).not.toContain("inflexa:analysis-a1");
+        expect(qns(walk)).not.toContain("inflexa:run-run-001");
+        expect(walk.nodes.some((n) => n.kind === "agent")).toBe(false);
+        expect(walk.edges.every((e) => e.kind === "generated" || e.kind === "used")).toBe(true);
+    });
+
+    test("a leaf file's generator is its step, and the step's own reads lie behind it", () => {
+        const leafWalk = computeLineage(chainModel, [fileQn(leafKey)], { direction: "backward" });
+        expect(leafWalk.edges).toContainEqual(expect.objectContaining({ kind: "generated", from: fileQn(leafKey), to: stepQn }));
+        // The step-level read of counts.csv is one hop further.
+        expect(qns(leafWalk)).toContain(fileQn(countsKey));
+    });
+
+    test("a cross-run prior read chains into the producing run's command", () => {
+        const doc = chainDoc(provModel);
+        const readerStep: ProvStepRef = { runId: "run-002", stepId: "step-model" };
+        const modelKey = { path: "runs/run-002/step-model/output/model.bin", hash: "hashModel1" };
+        const fit: ProvCommandRef = {
+            kind: "command",
+            command: "python fit.py",
+            exitCode: 0,
+            outputs: [modelKey],
+            inputs: [{ ...deResultsKey, source: "prior" }],
+        };
+        applyProvEvent(provModel, doc, {
+            type: "step_completed",
+            analysisId: "a1",
+            actor: system,
+            outcome: { runId: "run-002", stepId: "step-model", status: "completed", completedAtMs: 1_700_000_003_000 },
+            model,
+        });
+        applyProvEvent(provModel, doc, { type: "command_executed", analysisId: "a1", actor: system, step: readerStep, command: fit, model });
+        applyProvEvent(provModel, doc, {
+            type: "file_written",
+            analysisId: "a1",
+            actor: system,
+            file: fileRefOf(modelKey),
+            step: readerStep,
+            generation: "command",
+        });
+
+        const walk2 = computeLineage(modelFrom(doc), [fileQn(modelKey)], { direction: "backward" });
+        const fitQn = provModel.commandQName(readerStep, fit.outputs);
+        // The prior read IS run-001's entity — the walk continues into its producing command.
+        expect(walk2.edges).toContainEqual(expect.objectContaining({ kind: "used", from: fitQn, to: fileQn(deResultsKey) }));
+        expect(walk2.edges).toContainEqual(expect.objectContaining({ kind: "generated", from: fileQn(deResultsKey), to: aQn }));
+        expect(qns(walk2)).toContain(fileQn(countsKey));
+    });
+
+    test("a write-then-self-read command terminates, with both edges in the result", () => {
+        const doc = provModel.freshDocument({ analysisId: "a1" });
+        const selfKey = { path: "runs/run-001/step-de/output/self.csv", hash: "hashSelf01" };
+        const selfRead: ProvCommandRef = { kind: "command", command: "bash gen.sh", exitCode: 0, outputs: [selfKey], inputs: [{ ...selfKey, source: "step" }] };
+        applyProvEvent(provModel, doc, { type: "command_executed", analysisId: "a1", actor: system, step: stepRef, command: selfRead, model });
+        applyProvEvent(provModel, doc, {
+            type: "file_written",
+            analysisId: "a1",
+            actor: system,
+            file: fileRefOf(selfKey),
+            step: stepRef,
+            generation: "command",
+        });
+
+        const genQn = provModel.commandQName(stepRef, selfRead.outputs);
+        const walk3 = computeLineage(modelFrom(doc), [fileQn(selfKey)], { direction: "backward" });
+        expect(qns(walk3).sort()).toEqual([fileQn(selfKey), genQn].sort());
+        expect(walk3.edges).toContainEqual(expect.objectContaining({ kind: "generated", from: fileQn(selfKey), to: genQn }));
+        expect(walk3.edges).toContainEqual(expect.objectContaining({ kind: "used", from: genQn, to: fileQn(selfKey) }));
+    });
+});
+
+describe("computeLineage — forward", () => {
+    test("walks from the staged input to every derived output", () => {
+        const walk = computeLineage(chainModel, [fileQn(countsKey)], { direction: "forward" });
+        // counts is read by command A and, at step grain, by the step; their outputs chain on.
+        expect(qns(walk)).toContain(aQn);
+        expect(qns(walk)).toContain(stepQn);
+        expect(qns(walk)).toContain(fileQn(deResultsKey));
+        expect(qns(walk)).toContain(fileQn(leafKey));
+        expect(qns(walk)).toContain(bQn);
+        expect(qns(walk)).toContain(fileQn(heatmapKey));
+        expect(walk.edges).toContainEqual(expect.objectContaining({ kind: "used", from: stepQn, to: fileQn(countsKey) }));
+        expect(walk.edges).toContainEqual(expect.objectContaining({ kind: "generated", from: fileQn(leafKey), to: stepQn }));
+    });
+});
+
+describe("computeLineage — depth", () => {
+    test("depth counts file hops from a file root; the truncation lands on a file node", () => {
+        const walk = computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward", depth: 1 });
+        expect(qns(walk).sort()).toEqual([fileQn(heatmapKey), bQn, fileQn(deResultsKey)].sort());
+        // The cut file's own producer lies beyond the bound.
+        expect(walk.edges.some((e) => e.kind === "generated" && e.from === fileQn(deResultsKey))).toBe(false);
+    });
+
+    test("an activity root spends one edge less — its direct files sit at the first file hop", () => {
+        const walk = computeLineage(chainModel, [bQn], { direction: "backward", depth: 1 });
+        expect(qns(walk).sort()).toEqual([bQn, fileQn(deResultsKey)].sort());
+        expect(walk.edges).toEqual([expect.objectContaining({ kind: "used", from: bQn, to: fileQn(deResultsKey) })]);
+    });
+
+    test("a multi-root walk bounds each node by its minimum distance over all roots", () => {
+        // heatmap alone at depth 1 stops at de_results; de_results as a second root reaches on.
+        const walk = computeLineage(chainModel, [fileQn(heatmapKey), fileQn(deResultsKey)], { direction: "backward", depth: 1 });
+        expect(qns(walk)).toContain(aQn);
+        expect(qns(walk)).toContain(fileQn(countsKey));
+    });
+
+    test("a root the model does not contain adds nothing", () => {
+        expect(computeLineage(chainModel, ["inflexa:file-nope"], { direction: "backward" })).toEqual({ nodes: [], edges: [] });
+    });
+});
+
+describe("deriveLineageModel — tolerance", () => {
+    // The dialect records input removal as the anonymous, timed lifecycle relation
+    // wasInvalidatedBy(input, action, time) — SPEC.md.
+    const removalJson = JSON.stringify({
+        prefix: { inflexa: "https://inflexa.ai/prov#" },
+        entity: { "inflexa:input-gone": { "prov:type": "inflexa:Input", "inflexa:path": "data/inputs/old.csv" } },
+        activity: { "inflexa:action-a1-3": { "prov:type": "inflexa:RemoveInput" } },
+        wasInvalidatedBy: {
+            "_:id1": {
+                "prov:entity": "inflexa:input-gone",
+                "prov:activity": "inflexa:action-a1-3",
+                "prov:time": "2023-11-14T22:13:19.500000+00:00",
+            },
+        },
+    });
+
+    test("an anonymous lifecycle relation gets a value-derived fallback id", () => {
+        const derived = deriveLineageModel(removalJson)._unsafeUnwrap();
+        expect(derived.edges).toEqual([
+            {
+                id: "invalidated:inflexa:input-gone->inflexa:action-a1-3",
+                kind: "invalidated",
+                from: "inflexa:input-gone",
+                to: "inflexa:action-a1-3",
+            },
+        ]);
+    });
+
+    test("an identified invalidation keys by its dialect id", () => {
+        const doc = JSON.parse(removalJson) as Record<string, Record<string, unknown>>;
+        doc["wasInvalidatedBy"] = { "inflexa:inv-1": doc["wasInvalidatedBy"]!["_:id1"] };
+        const derived = deriveLineageModel(JSON.stringify(doc))._unsafeUnwrap();
+        expect(derived.edges).toEqual([{ id: "inflexa:inv-1", kind: "invalidated", from: "inflexa:input-gone", to: "inflexa:action-a1-3" }]);
+    });
+
+    test("synthesizes minimal nodes for undeclared relation endpoints", () => {
+        const doc = JSON.parse(removalJson) as Record<string, unknown>;
+        delete doc["entity"];
+        delete doc["activity"];
+        const derived = deriveLineageModel(JSON.stringify(doc))._unsafeUnwrap();
+        expect(derived.nodes).toEqual([
+            { kind: "input", qn: "inflexa:input-gone", label: "input-gone" },
+            { kind: "activity", qn: "inflexa:action-a1-3", activity: "action", label: "action-a1-3" },
+        ]);
+    });
+
+    test("a statement kind outside the seven is skipped, not an error", () => {
+        const doc = JSON.parse(removalJson) as Record<string, unknown>;
+        doc["agent"] = { "inflexa:agent-system": {}, "inflexa:agent-model-x": {} };
+        doc["actedOnBehalfOf"] = {
+            "inflexa:delegation-x-y": { "prov:delegate": "inflexa:agent-model-x", "prov:responsible": "inflexa:agent-system" },
+        };
+        const derived = deriveLineageModel(JSON.stringify(doc))._unsafeUnwrap();
+        // The agents derive as nodes; the delegation contributes no edge.
+        expect(derived.nodes.filter((n) => n.kind === "agent")).toHaveLength(2);
+        expect(derived.edges.map((e) => e.kind)).toEqual(["invalidated"]);
+    });
+});
+
+describe("findFileEntity", () => {
+    const golden = deriveLineageModel(goldenJson)._unsafeUnwrap();
+
+    test("matches a file entity by path + content hash", () => {
+        expect(findFileEntity(golden, { path: "runs/r1/s1/output/result.csv", hash: "sha256:bbb" })?.qn).toBe("inflexa:file-18bvqsvo19q9p");
+        // A read input in the shared (path, hash) space matches too.
+        expect(findFileEntity(golden, { path: "data/inputs/counts.csv", hash: "sha256:aaa" })?.qn).toBe("inflexa:file-2cl35k0tb4udj");
+    });
+
+    test("misses when the hash differs", () => {
+        expect(findFileEntity(golden, { path: "runs/r1/s1/output/result.csv", hash: "sha256:other" })).toBeUndefined();
+    });
+});

--- a/prov-kernel/src/lineage.ts
+++ b/prov-kernel/src/lineage.ts
@@ -1,0 +1,421 @@
+import { err, ok, type Result } from "neverthrow";
+import {
+    Literal,
+    PROV_LABEL,
+    ProvActivity,
+    ProvAgent,
+    ProvAssociation,
+    ProvAttribution,
+    ProvCommunication,
+    ProvDerivation,
+    ProvDocument,
+    ProvEntity,
+    ProvGeneration,
+    ProvInvalidation,
+    ProvUsage,
+    type ProvRecord,
+} from "@inflexa-ai/tsprov";
+import { PROV_UNIFY_OPTIONS } from "./document.js";
+import type { ProvFileKey } from "./types.js";
+
+// The read side of the dialect: one interpretation of a stored PROV-JSON document, shared by every
+// consumer. `deriveLineageModel` turns the exact stored bytes into a typed, presentation-free
+// node/edge model. `computeLineage` walks the generation/usage edges with the canonical traversal
+// semantics. `findFileEntity` is the `(path, hash)` identity lookup that cross-links an external
+// artifact record to its entity. A consumer that interprets the bytes itself can drift, and two
+// drifted readers show two different lineages for one signed document — thus the interpretation is
+// format and lives in the kernel.
+
+/** Why a document did not derive: the bytes do not parse or unify as a dialect document. */
+export type ProvReadError = { type: "prov_corrupt"; cause: unknown };
+
+/** The dialect entity node kinds — the three declared entity types, with a QName-prefix fallback. */
+export type LineageAnalysisNode = { kind: "analysis"; qn: string; label: string; name?: string; slug?: string };
+export type LineageInputNode = { kind: "input"; qn: string; label: string; path?: string; isDir?: boolean };
+export type LineageFileNode = {
+    kind: "file";
+    qn: string;
+    label: string;
+    path?: string;
+    hash?: string;
+    size?: number;
+    /** How the bytes came to exist (`command` or `file_tool`) — present on a written file. */
+    producer?: string;
+    /** The read classification (`data`/`upstream`/`prior`/`step`) — present on a read input. */
+    source?: string;
+    fileId?: string;
+};
+
+export type LineageActivityKind = "run" | "step" | "command" | "file_tool" | "action";
+
+export type LineageActivityNode = {
+    kind: "activity";
+    qn: string;
+    activity: LineageActivityKind;
+    label: string;
+    /** The `inflexa:*` action type localpart, for the `action` kind. */
+    actionType?: string;
+    startTime?: string;
+    endTime?: string;
+    status?: string;
+    durationMs?: number;
+    runId?: string;
+    stepId?: string;
+    command?: string;
+    args?: string;
+    exitCode?: number;
+    tool?: string;
+    unresolvedScript?: string;
+    planSummary?: string;
+};
+
+export type LineageAgentKind = "system" | "user" | "model";
+
+export type LineageAgentNode = {
+    kind: "agent";
+    qn: string;
+    agent: LineageAgentKind;
+    label: string;
+    email?: string;
+    version?: string;
+    commit?: string;
+    model?: string;
+};
+
+export type LineageNode = LineageAnalysisNode | LineageInputNode | LineageFileNode | LineageActivityNode | LineageAgentNode;
+
+export type LineageEdgeKind = "used" | "generated" | "informed" | "derived" | "attributed" | "associated" | "invalidated";
+
+/**
+ * One relation as an edge, in the PROV assertion orientation (formal argument 0 to formal argument
+ * 1): a `generated` edge points entity to activity, a `used` edge activity to entity. The id is the
+ * relation's deterministic dialect id; an anonymous lifecycle relation gets the value-derived
+ * fallback `{kind}:{from}->{to}`.
+ */
+export type LineageEdge = { id: string; kind: LineageEdgeKind; from: string; to: string };
+
+export type LineageModel = { nodes: LineageNode[]; edges: LineageEdge[] };
+
+/** The first value of an `inflexa:*` attribute, unwrapped from its literal. */
+function attr(record: ProvRecord, name: string): unknown {
+    const values = record.getAttribute(`inflexa:${name}`);
+    if (values.length === 0) return undefined;
+    const v = values[0];
+    return v instanceof Literal ? v.value : v;
+}
+
+function attrString(record: ProvRecord, name: string): string | undefined {
+    const v = attr(record, name);
+    return typeof v === "string" ? v : undefined;
+}
+
+function attrNumber(record: ProvRecord, name: string): number | undefined {
+    const v = attr(record, name);
+    return typeof v === "number" ? v : undefined;
+}
+
+function attrBoolean(record: ProvRecord, name: string): boolean | undefined {
+    const v = attr(record, name);
+    return typeof v === "boolean" ? v : undefined;
+}
+
+/** The asserted `inflexa:*` type localparts of a record, for example `File` or `Run`. */
+function dialectTypes(record: ProvRecord): string[] {
+    return record
+        .getAssertedTypes()
+        .map((t) => String(t))
+        .filter((t) => t.startsWith("inflexa:"))
+        .map((t) => t.slice("inflexa:".length));
+}
+
+function provLabel(record: ProvRecord): string | undefined {
+    const values = record.getAttribute(PROV_LABEL);
+    return values.length > 0 ? String(values[0]) : undefined;
+}
+
+/** The QName's localpart, for example `file-18bvqsvo19q9p` from `inflexa:file-…`. */
+function localpart(qn: string): string {
+    const colon = qn.indexOf(":");
+    return colon === -1 ? qn : qn.slice(colon + 1);
+}
+
+function entityKindOf(types: string[], qn: string): "analysis" | "input" | "file" {
+    if (types.includes("Analysis")) return "analysis";
+    if (types.includes("Input")) return "input";
+    if (types.includes("File")) return "file";
+    // A read input carries no prov:type (SPEC.md) — fall back to the QName prefix.
+    const local = localpart(qn);
+    if (local.startsWith("analysis-")) return "analysis";
+    if (local.startsWith("input-")) return "input";
+    return "file";
+}
+
+function toEntityNode(record: ProvEntity): LineageNode {
+    const qn = String(record.identifier);
+    const kind = entityKindOf(dialectTypes(record), qn);
+    const path = attrString(record, "path");
+    if (kind === "analysis") {
+        const name = attrString(record, "name");
+        const slug = attrString(record, "slug");
+        return { kind, qn, label: name ?? localpart(qn), ...(name !== undefined ? { name } : {}), ...(slug !== undefined ? { slug } : {}) };
+    }
+    if (kind === "input") {
+        const isDir = attrBoolean(record, "isDir");
+        return { kind, qn, label: path ?? localpart(qn), ...(path !== undefined ? { path } : {}), ...(isDir !== undefined ? { isDir } : {}) };
+    }
+    const hash = attrString(record, "hash");
+    const size = attrNumber(record, "size");
+    const producer = attrString(record, "producer");
+    const source = attrString(record, "source");
+    const fileId = attrString(record, "fileId");
+    return {
+        kind,
+        qn,
+        label: path ?? localpart(qn),
+        ...(path !== undefined ? { path } : {}),
+        ...(hash !== undefined ? { hash } : {}),
+        ...(size !== undefined ? { size } : {}),
+        ...(producer !== undefined ? { producer } : {}),
+        ...(source !== undefined ? { source } : {}),
+        ...(fileId !== undefined ? { fileId } : {}),
+    };
+}
+
+function activityKindOf(types: string[], qn: string): { activity: LineageActivityKind; actionType?: string } {
+    if (types.includes("Run")) return { activity: "run" };
+    if (types.includes("Step")) return { activity: "step" };
+    if (types.includes("Command")) return { activity: "command" };
+    if (types.includes("FileToolWrite")) return { activity: "file_tool" };
+    const local = localpart(qn);
+    if (local.startsWith("action-")) return { activity: "action", ...(types[0] !== undefined ? { actionType: types[0] } : {}) };
+    if (local.startsWith("run-")) return { activity: "run" };
+    if (local.startsWith("step-")) return { activity: "step" };
+    if (local.startsWith("cmd-")) return { activity: "command" };
+    // A lifecycle action is the only remaining dialect activity kind.
+    return { activity: "action", ...(types[0] !== undefined ? { actionType: types[0] } : {}) };
+}
+
+/** A formal time as its ISO string; dialect times are always UTC. */
+function timeString(value: unknown): string | undefined {
+    if (value === undefined || value === null) return undefined;
+    return String(value);
+}
+
+function toActivityNode(record: ProvActivity): LineageActivityNode {
+    const qn = String(record.identifier);
+    const { activity, actionType } = activityKindOf(dialectTypes(record), qn);
+    const command = attrString(record, "command");
+    const tool = attrString(record, "tool");
+    const runId = attrString(record, "runId");
+    const stepId = attrString(record, "stepId");
+    const label =
+        activity === "command"
+            ? (command ?? localpart(qn))
+            : activity === "file_tool"
+              ? (tool ?? localpart(qn))
+              : activity === "run"
+                ? (runId ?? localpart(qn))
+                : activity === "step"
+                  ? (stepId ?? localpart(qn))
+                  : (actionType ?? localpart(qn));
+    const startTime = timeString(record.getStartTime());
+    const endTime = timeString(record.getEndTime());
+    const status = attrString(record, "status");
+    const durationMs = attrNumber(record, "durationMs");
+    const args = attrString(record, "args");
+    const exitCode = attrNumber(record, "exitCode");
+    const unresolvedScript = attrString(record, "unresolvedScript");
+    const planSummary = attrString(record, "planSummary");
+    return {
+        kind: "activity",
+        qn,
+        activity,
+        label,
+        ...(actionType !== undefined ? { actionType } : {}),
+        ...(startTime !== undefined ? { startTime } : {}),
+        ...(endTime !== undefined ? { endTime } : {}),
+        ...(status !== undefined ? { status } : {}),
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        ...(runId !== undefined ? { runId } : {}),
+        ...(stepId !== undefined ? { stepId } : {}),
+        ...(command !== undefined ? { command } : {}),
+        ...(args !== undefined ? { args } : {}),
+        ...(exitCode !== undefined ? { exitCode } : {}),
+        ...(tool !== undefined ? { tool } : {}),
+        ...(unresolvedScript !== undefined ? { unresolvedScript } : {}),
+        ...(planSummary !== undefined ? { planSummary } : {}),
+    };
+}
+
+function agentKindOf(record: ProvAgent): LineageAgentKind {
+    const types = record.getAssertedTypes().map((t) => String(t));
+    if (types.includes("inflexa:Model")) return "model";
+    if (types.includes("prov:Person")) return "user";
+    return "system";
+}
+
+function toAgentNode(record: ProvAgent): LineageAgentNode {
+    const qn = String(record.identifier);
+    const email = attrString(record, "email");
+    const version = attrString(record, "version");
+    const commit = attrString(record, "commit");
+    const model = attrString(record, "model");
+    return {
+        kind: "agent",
+        qn,
+        agent: agentKindOf(record),
+        label: provLabel(record) ?? email ?? localpart(qn),
+        ...(email !== undefined ? { email } : {}),
+        ...(version !== undefined ? { version } : {}),
+        ...(commit !== undefined ? { commit } : {}),
+        ...(model !== undefined ? { model } : {}),
+    };
+}
+
+type EndpointRole = "entity" | "activity" | "agent";
+
+type EdgeSpec = { kind: LineageEdgeKind; fromRole: EndpointRole; toRole: EndpointRole };
+
+/**
+ * The seven relation kinds the model carries, each in the PROV formal argument order (argument 0 is
+ * `from`, argument 1 is `to`). Any other statement kind — delegation, or a kind a future dialect
+ * adds — returns null and is skipped.
+ */
+function edgeSpecOf(record: ProvRecord): EdgeSpec | null {
+    if (record instanceof ProvUsage) return { kind: "used", fromRole: "activity", toRole: "entity" };
+    if (record instanceof ProvGeneration) return { kind: "generated", fromRole: "entity", toRole: "activity" };
+    if (record instanceof ProvCommunication) return { kind: "informed", fromRole: "activity", toRole: "activity" };
+    if (record instanceof ProvDerivation) return { kind: "derived", fromRole: "entity", toRole: "entity" };
+    if (record instanceof ProvAttribution) return { kind: "attributed", fromRole: "entity", toRole: "agent" };
+    if (record instanceof ProvAssociation) return { kind: "associated", fromRole: "activity", toRole: "agent" };
+    if (record instanceof ProvInvalidation) return { kind: "invalidated", fromRole: "entity", toRole: "activity" };
+    return null;
+}
+
+/** A minimal node for a relation endpoint the document references but never declares. */
+function synthesizeNode(role: EndpointRole, qn: string): LineageNode {
+    if (role === "entity") return { kind: entityKindOf([], qn), qn, label: localpart(qn) };
+    if (role === "activity") return { kind: "activity", qn, activity: activityKindOf([], qn).activity, label: localpart(qn) };
+    return { kind: "agent", qn, agent: "system", label: localpart(qn) };
+}
+
+function modelOf(doc: ProvDocument): LineageModel {
+    const nodes = new Map<string, LineageNode>();
+    const records = doc.getRecords();
+    for (const record of records) {
+        if (record instanceof ProvEntity) nodes.set(String(record.identifier), toEntityNode(record));
+        else if (record instanceof ProvAgent) nodes.set(String(record.identifier), toAgentNode(record));
+        else if (record instanceof ProvActivity) nodes.set(String(record.identifier), toActivityNode(record));
+    }
+
+    const edges = new Map<string, LineageEdge>();
+    const endpointRoles = new Map<string, EndpointRole>();
+    for (const record of records) {
+        const spec = edgeSpecOf(record);
+        if (spec === null) continue;
+        const from = record.args[0];
+        const to = record.args[1];
+        if (from === undefined || to === undefined) continue;
+        const fromQn = String(from);
+        const toQn = String(to);
+        const id = record.identifier ? String(record.identifier) : `${spec.kind}:${fromQn}->${toQn}`;
+        edges.set(id, { id, kind: spec.kind, from: fromQn, to: toQn });
+        endpointRoles.set(fromQn, spec.fromRole);
+        endpointRoles.set(toQn, spec.toRole);
+    }
+
+    // A relation can reference an element the document never declares (for example a resolved
+    // script's file entity) — synthesize a minimal node so no edge dangles.
+    for (const [qn, role] of endpointRoles) {
+        if (!nodes.has(qn)) nodes.set(qn, synthesizeNode(role, qn));
+    }
+
+    // A command carries no runId/stepId attributes of its own — inherit them from the activity
+    // that informed it (its step), read off the `informed` edge.
+    for (const edge of edges.values()) {
+        if (edge.kind !== "informed") continue;
+        const informed = nodes.get(edge.from);
+        const informant = nodes.get(edge.to);
+        if (informed?.kind !== "activity" || informant?.kind !== "activity") continue;
+        if (informed.runId !== undefined || informed.stepId !== undefined) continue;
+        if (informant.runId !== undefined) informed.runId = informant.runId;
+        if (informant.stepId !== undefined) informed.stepId = informant.stepId;
+    }
+
+    return { nodes: [...nodes.values()], edges: [...edges.values()] };
+}
+
+/**
+ * Derive the lineage model from the exact stored PROV-JSON bytes — the same bytes the signature
+ * covers. The document unifies under {@link PROV_UNIFY_OPTIONS} first, thus the model reads the
+ * last-write-wins survivor of each record. Bytes that do not parse or unify return `prov_corrupt`.
+ */
+export function deriveLineageModel(provJson: string): Result<LineageModel, ProvReadError> {
+    try {
+        return ok(modelOf(ProvDocument.deserialize(provJson, "json").unified(PROV_UNIFY_OPTIONS)));
+    } catch (cause) {
+        return err({ type: "prov_corrupt", cause });
+    }
+}
+
+/**
+ * Walk the lineage of `roots` and return the reached sub-model. The walk traverses ONLY the
+ * `generated` and `used` edges: the coarse `derived` edge to the analysis and the `informed` spine
+ * would pollute a file's lineage, so they stay out. Backward follows the asserted edges (a file to
+ * its generator, an activity to what it read); forward reverses them (a file to its readers, an
+ * activity to its outputs).
+ *
+ * `depth` counts file-level hops. One file hop (file to activity to file) is two edges, thus the
+ * edge budget is `2n` from a file root and `2n - 1` from an activity root — a truncation always
+ * lands on a file node, never between an activity and its files. An unset `depth` walks the whole
+ * reachable component. A root the model does not contain adds nothing.
+ */
+export function computeLineage(model: LineageModel, roots: readonly string[], opts: { direction: "forward" | "backward"; depth?: number }): LineageModel {
+    const nodeByQn = new Map(model.nodes.map((n) => [n.qn, n]));
+    const adjacency = new Map<string, { edge: LineageEdge; to: string }[]>();
+    for (const edge of model.edges) {
+        if (edge.kind !== "generated" && edge.kind !== "used") continue;
+        const [from, to] = opts.direction === "backward" ? [edge.from, edge.to] : [edge.to, edge.from];
+        const bucket = adjacency.get(from);
+        if (bucket) bucket.push({ edge, to });
+        else adjacency.set(from, [{ edge, to }]);
+    }
+
+    // Breadth-first over the directed adjacency, keyed by the best remaining edge budget per node —
+    // a node reached again with a larger budget re-expands, so the bound is the minimum distance
+    // over all roots.
+    const best = new Map<string, number>();
+    const queue: { qn: string; remaining: number }[] = [];
+    for (const qn of roots) {
+        const root = nodeByQn.get(qn);
+        if (root === undefined) continue;
+        const remaining = opts.depth === undefined ? Number.POSITIVE_INFINITY : root.kind === "activity" ? 2 * opts.depth - 1 : 2 * opts.depth;
+        if ((best.get(qn) ?? -1) < remaining) {
+            best.set(qn, remaining);
+            queue.push({ qn, remaining });
+        }
+    }
+    const reached = new Map<string, LineageEdge>();
+    for (let i = 0; i < queue.length; i++) {
+        const { qn, remaining } = queue[i]!;
+        if (remaining !== best.get(qn) || remaining <= 0) continue;
+        for (const { edge, to } of adjacency.get(qn) ?? []) {
+            reached.set(edge.id, edge);
+            const next = remaining - 1;
+            if ((best.get(to) ?? -1) < next) {
+                best.set(to, next);
+                queue.push({ qn: to, remaining: next });
+            }
+        }
+    }
+
+    return { nodes: model.nodes.filter((n) => best.has(n.qn)), edges: model.edges.filter((e) => reached.has(e.id)) };
+}
+
+/**
+ * Find the file entity for a `(path, content hash)` key — the identity that cross-links an external
+ * artifact record to its entity in the model (entity QNames are document-internal).
+ */
+export function findFileEntity(model: LineageModel, key: ProvFileKey): LineageFileNode | undefined {
+    return model.nodes.find((n): n is LineageFileNode => n.kind === "file" && n.path === key.path && n.hash === key.hash);
+}

--- a/prov-kernel/src/signing.ts
+++ b/prov-kernel/src/signing.ts
@@ -2,7 +2,7 @@ import { ResultAsync } from "neverthrow";
 
 /**
  * Provenance signing primitives: the chain-hash and Ed25519 sign/verify operations a recorder,
- * the sidecar builder, and the verifier share — plus the {@link ProvSigner} seam through which a
+ * the attestation builder, and the verifier share — plus the {@link ProvSigner} seam through which a
  * host supplies key custody. Confined to this file so a WebCrypto fault is contained to provenance
  * integrity, not recording.
  *
@@ -26,10 +26,10 @@ export type ProvSigningError =
 /**
  * The signing seam a host fills at its composition root. `sign` receives a hex-encoded digest
  * (the chain hash at flush time, the payload digest at export time) and returns the hex-encoded
- * Ed25519 signature; `exportPublicKeyJwk` supplies the public half for sidecars and verification,
+ * Ed25519 signature; `exportPublicKeyJwk` supplies the public half for attestations and verification,
  * or `null` when no key exists yet.
  *
- * `exportPublicKeyJwk` may be called before any `sign` — the sidecar builder exports the public
+ * `exportPublicKeyJwk` may be called before any `sign` — the attestation builder exports the public
  * key first. An implementation backed by a lazily-created keypair must generate the pair on
  * demand at export time, not fail because no `sign` has run yet.
  */
@@ -78,7 +78,7 @@ export function computeChainHash(prevChainHashHex: string | null, provJson: stri
     );
 }
 
-/** Simple `SHA-256(provJson)` — the self-contained content digest used in the export sidecar. */
+/** Simple `SHA-256(provJson)` — the self-contained content digest used in the export attestation. */
 export function computePayloadDigest(provJson: string): ResultAsync<string, ProvSigningError> {
     return ResultAsync.fromPromise(
         crypto.subtle.digest("SHA-256", new TextEncoder().encode(provJson)).then((buf) => bytesToHex(new Uint8Array(buf))),

--- a/prov-kernel/src/types.ts
+++ b/prov-kernel/src/types.ts
@@ -242,6 +242,6 @@ export type VerifyResult =
     | { status: "tampered"; detail: string }
     | { status: "no-key" }
     | { status: "empty" }
-    | { status: "invalid-sidecar"; detail: string }
+    | { status: "invalid-attestation"; detail: string }
     | { status: "invalid-key" }
     | { status: "verify-error"; detail: string };

--- a/prov-kernel/src/verify.test.ts
+++ b/prov-kernel/src/verify.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { computeChainHash, computePayloadDigest, createKeypairSigner, signHexDigest } from "./signing.js";
-import { buildSidecar, formatVerifyResult, sidecarSchema, verifyProvenance, verifySidecar } from "./verify.js";
+import { buildAttestation, formatVerifyResult, attestationSchema, verifyProvenance, verifyAttestation } from "./verify.js";
 
 async function makeKeypair(): Promise<CryptoKeyPair> {
     return (await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"])) as CryptoKeyPair;
@@ -38,35 +38,35 @@ describe("verifyProvenance", () => {
     });
 });
 
-describe("sidecar", () => {
-    test("buildSidecar output parses under sidecarSchema and verifies", async () => {
+describe("attestation", () => {
+    test("buildAttestation output parses under attestationSchema and verifies", async () => {
         const kp = await makeKeypair();
         const signer = createKeypairSigner(kp);
 
-        const sidecarResult = await buildSidecar(signer, provJson);
-        expect(sidecarResult.isOk()).toBe(true);
-        const sidecar = sidecarSchema.parse(sidecarResult._unsafeUnwrap());
-        expect(sidecar.payloadDigest).toBe((await computePayloadDigest(provJson))._unsafeUnwrap());
-        expect(await verifySidecar(provJson, sidecar)).toEqual({ status: "valid" });
+        const attestationResult = await buildAttestation(signer, provJson);
+        expect(attestationResult.isOk()).toBe(true);
+        const attestation = attestationSchema.parse(attestationResult._unsafeUnwrap());
+        expect(attestation.payloadDigest).toBe((await computePayloadDigest(provJson))._unsafeUnwrap());
+        expect(await verifyAttestation(provJson, attestation)).toEqual({ status: "valid" });
     });
 
-    test("a kid rides the sidecar and does not affect verification", async () => {
+    test("a kid rides the attestation and does not affect verification", async () => {
         const kp = await makeKeypair();
-        const sidecar = (await buildSidecar(createKeypairSigner(kp), provJson, { kid: "signer-1" }))._unsafeUnwrap();
-        expect(sidecarSchema.parse(sidecar).kid).toBe("signer-1");
-        expect(await verifySidecar(provJson, sidecar)).toEqual({ status: "valid" });
+        const attestation = (await buildAttestation(createKeypairSigner(kp), provJson, { kid: "signer-1" }))._unsafeUnwrap();
+        expect(attestationSchema.parse(attestation).kid).toBe("signer-1");
+        expect(await verifyAttestation(provJson, attestation)).toEqual({ status: "valid" });
     });
 
     test("a modified payload reads tampered", async () => {
         const kp = await makeKeypair();
-        const sidecar = (await buildSidecar(createKeypairSigner(kp), provJson))._unsafeUnwrap();
-        expect(await verifySidecar(`${provJson} `, sidecar)).toMatchObject({ status: "tampered" });
+        const attestation = (await buildAttestation(createKeypairSigner(kp), provJson))._unsafeUnwrap();
+        expect(await verifyAttestation(`${provJson} `, attestation)).toMatchObject({ status: "tampered" });
     });
 
     test("a corrupt public key reads invalid-key", async () => {
         const kp = await makeKeypair();
-        const sidecar = (await buildSidecar(createKeypairSigner(kp), provJson))._unsafeUnwrap();
-        expect(await verifySidecar(provJson, { ...sidecar, publicKey: { kty: "OKP" } })).toEqual({ status: "invalid-key" });
+        const attestation = (await buildAttestation(createKeypairSigner(kp), provJson))._unsafeUnwrap();
+        expect(await verifyAttestation(provJson, { ...attestation, publicKey: { kty: "OKP" } })).toEqual({ status: "invalid-key" });
     });
 });
 

--- a/prov-kernel/src/verify.ts
+++ b/prov-kernel/src/verify.ts
@@ -60,7 +60,7 @@ export async function verifyProvenance(
 
 /**
  * Self-contained verification: check a simple `SHA-256(provJson)` content digest and its Ed25519
- * signature — the sidecar path, no chain mechanics needed.
+ * signature — the attestation path, no chain mechanics needed.
  */
 export async function verifyPayload(provJson: string, storedDigest: string, storedSignature: string, publicKey: CryptoKey): Promise<VerifyResult> {
     const digestResult = await computePayloadDigest(provJson);
@@ -99,23 +99,23 @@ export function formatVerifyResult(result: VerifyResult): string {
             return "Cannot verify: a signature exists but the signing key is missing.";
         case "empty":
             return "No provenance has been recorded for this analysis.";
-        case "invalid-sidecar":
-            return `Invalid sidecar: ${result.detail}`;
+        case "invalid-attestation":
+            return `Invalid attestation: ${result.detail}`;
         case "invalid-key":
-            return "The public key in the sidecar is invalid or unsupported.";
+            return "The public key in the attestation is invalid or unsupported.";
         case "verify-error":
             return `Verification could not complete (internal error): ${result.detail}`;
     }
 }
 
 /**
- * The self-describing export sidecar. A recipient verifies integrity with just the provenance
- * payload and this sidecar — no database, no chain history, no internal state needed.
+ * The self-describing export attestation. A recipient verifies integrity with just the provenance
+ * payload and this attestation — no database, no chain history, no internal state needed.
  *
- * Zod-validated on read so a corrupt or hand-edited sidecar surfaces a clear "invalid sidecar"
- * error instead of a downstream type confusion.
+ * Zod-validated on read so a corrupt or hand-edited attestation surfaces a clear "invalid
+ * attestation" error instead of a downstream type confusion.
  */
-export const sidecarSchema = z.object({
+export const attestationSchema = z.object({
     /** MIME type of the payload. */
     payloadType: z.literal("application/json; profile=prov-json"),
     /** Hash algorithm used to compute {@link payloadDigest}. */
@@ -134,23 +134,23 @@ export const sidecarSchema = z.object({
     kid: z.string().optional(),
 });
 
-/** The validated sidecar shape — inferred from the schema so the type never drifts. */
-export type Sidecar = z.infer<typeof sidecarSchema>;
+/** The validated attestation shape — inferred from the schema so the type never drifts. */
+export type ProvAttestation = z.infer<typeof attestationSchema>;
 
 /**
- * Build a sidecar for an exported provenance payload. Computes `SHA-256(provJson)` as the content
- * digest and signs it through the injected {@link ProvSigner}. Returns `err(ProvSigningError)`
- * when signing is unavailable — provenance is never exported unsigned. The sidecar is
- * self-contained: a recipient verifies with just the payload and the sidecar.
+ * Build an attestation for an exported provenance payload. Computes `SHA-256(provJson)` as the
+ * content digest and signs it through the injected {@link ProvSigner}. Returns
+ * `err(ProvSigningError)` when signing is unavailable — provenance is never exported unsigned. The
+ * attestation is self-contained: a recipient verifies with just the payload and the attestation.
  */
-export async function buildSidecar(signer: ProvSigner, provJson: string, opts?: { kid?: string }): Promise<Result<Sidecar, ProvSigningError>> {
+export async function buildAttestation(signer: ProvSigner, provJson: string, opts?: { kid?: string }): Promise<Result<ProvAttestation, ProvSigningError>> {
     const pubKeyResult = await signer.exportPublicKeyJwk();
     if (pubKeyResult.isErr()) return err(pubKeyResult.error);
     const publicKeyJwk: ProvPublicKeyJwk | null = pubKeyResult.value;
     if (!publicKeyJwk) return err({ type: "public_key_export_failed" });
 
     return computePayloadDigest(provJson).andThen((digest) =>
-        signer.sign(digest).map((signature): Sidecar => ({
+        signer.sign(digest).map((signature): ProvAttestation => ({
             payloadType: "application/json; profile=prov-json" as const,
             payloadDigestAlgorithm: "SHA-256" as const,
             payloadDigest: digest,
@@ -164,16 +164,16 @@ export async function buildSidecar(signer: ProvSigner, provJson: string, opts?: 
 }
 
 /**
- * Verify a provenance payload against its parsed sidecar: import the sidecar's public key and run
- * {@link verifyPayload}. Corrupt keys are returned as `VerifyResult` statuses, not thrown.
+ * Verify a provenance payload against its parsed attestation: import the attestation's public key
+ * and run {@link verifyPayload}. Corrupt keys are returned as `VerifyResult` statuses, not thrown.
  *
- * The public key is trusted solely because it travels in the sidecar — an attacker who replaces
- * both the payload and the sidecar (with their own key) passes verification. For sharing over
- * trusted channels this is fine; for stronger trust a host pins the signer's public key and
- * checks the sidecar's key against the pinned one before calling this.
+ * The public key is trusted solely because it travels in the attestation — an attacker who
+ * replaces both the payload and the attestation (with their own key) passes verification. For
+ * sharing over trusted channels this is fine; for stronger trust a host pins the signer's public
+ * key and checks the attestation's key against the pinned one before calling this.
  */
-export async function verifySidecar(provJson: string, sidecar: Sidecar): Promise<VerifyResult> {
-    const keyResult = await importPublicKeyJwk(sidecar.publicKey);
+export async function verifyAttestation(provJson: string, attestation: ProvAttestation): Promise<VerifyResult> {
+    const keyResult = await importPublicKeyJwk(attestation.publicKey);
     if (keyResult.isErr()) return { status: "invalid-key" };
-    return verifyPayload(provJson, sidecar.payloadDigest, sidecar.signature, keyResult.value);
+    return verifyPayload(provJson, attestation.payloadDigest, attestation.signature, keyResult.value);
 }


### PR DESCRIPTION
Closes #337. Closes #338.

## Lineage read model

The read-side interpretation of the dialect moves into the kernel — the layer both consumers re-implemented and had already diverged on once:

- `deriveLineageModel(provJson): Result<LineageModel, ProvReadError>` — typed, presentation-free nodes (analysis/input/file entities, run/step/command/file_tool/action activities, system/user/model agents) and edges for the seven relation kinds with deterministic ids.
- `computeLineage(model, roots, { direction, depth? })` — traversal semantics from the CLI implementation (canonical): generation/use edges, forward and backward, file-hop depth bound.
- `findFileEntity(model, { path, hash })` — the identity core cross-links key on.
- Tolerance from the Lumen implementation: synthesized placeholder endpoints, `{kind}:{from}->{to}` fallback ids for anonymous lifecycle relations, unknown statements skipped.
- Where the two sources genuinely conflicted (edge orientation), edges keep PROV assertion order — a dataflow flip is a rendering concern and stays in the consumer.

Consumers converge in their own PRs: the CLI swap folds into #332; Lumen follows once its provenance PR lands (public-npm resolution is already unblocked).

## Attestation rename

`buildAttestation` / `verifyAttestation` / `attestationSchema` / `ProvAttestation` replace the sidecar names outright — no deprecated aliases (0.x, all consumers are in-flight PRs). The JSON field names are unchanged, so existing exported artifacts verify as before. SPEC.md's section is renamed with a one-line former-name note.

## Gates

58/58 tests (26 new lineage; golden fixture byte-identical), typecheck, lint, build + smoke, `openspec validate --all --strict` — both openspec changes synced and archived in-branch. Version 0.4.0; merge publishes via the trusted-publisher workflow.