### PR TITLE
feat(prov-kernel): report walk truncation and add a reachability primitive

### DIFF
--- a/prov-kernel/CLAUDE.md
+++ b/prov-kernel/CLAUDE.md
@@ -16,7 +16,8 @@ Inflexa PROV dialect, and nothing else:
 - the signing primitives (`src/signing.ts`): the chain hash, Ed25519
   sign/verify, and the `ProvSigner` seam
 - the lineage read model (`src/lineage.ts`): the node/edge model derived from
-  stored PROV-JSON, the generation/usage traversal, and the `(path, hash)`
+  stored PROV-JSON, the generation/usage traversal with self-reported depth
+  truncation, the all-edge-kind reachability closure, and the `(path, hash)`
   file-entity lookup — the one read-side interpretation every consumer shares
 - verification and the signed attestation (`src/verify.ts`)
 - the actor and ref value types the builders accept (`src/types.ts`)

--- a/prov-kernel/README.md
+++ b/prov-kernel/README.md
@@ -3,7 +3,8 @@
 `@inflexa-ai/prov-kernel` is the Inflexa provenance format kernel. It carries the
 Inflexa PROV dialect: the document model (QName derivation, unify options, an
 injectable digest, and the `appendLifecycleAction` extension primitive), the
-lineage read model (`deriveLineageModel`, `computeLineage`, `findFileEntity`),
+lineage read model (`deriveLineageModel`, `computeLineage`, `computeReachable`,
+`findFileEntity`),
 the chain-hash and Ed25519 sign/verify primitives, the signed-attestation
 schema, and the actor and ref value types that the events carry.
 [`SPEC.md`](SPEC.md) gives the exact wire format, sufficient for an independent

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/design.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The 0.4.0 walk (`computeLineage`) is a breadth-first traversal over the
+generation/usage adjacency, keyed by the best remaining edge budget per node.
+It returns the reached sub-model and nothing else. Two consumer-side
+workarounds existed against that surface:
+
+- Truncation by diff: run the same walk at `depth` and `depth + 1`; every edge
+  only the wider walk records whose walk-direction source (backward =
+  `edge.from`, forward = `edge.to`) sits inside the bounded scope marks that
+  source as truncated. Two full walks for one fact the bounded walk already
+  encountered.
+- A private bidirectional traversal: the walk is hardwired to the
+  generation/usage edge set, so a consumer that needs a node's full cone —
+  agents via association/attribution, lifecycle context via derivation — has
+  to re-implement reachability over the raw edge list.
+
+## Goals / Non-Goals
+
+Goals:
+
+- The bounded walk reports its own truncation, in the same single pass,
+  provably equivalent to the depth+1 diff derivation.
+- One reachability primitive over a chosen edge-kind set, so a highlight
+  consumer is one call.
+- One traversal core under both functions.
+
+Non-Goals:
+
+- No change to the lineage walk's depth semantics or edge set. Lineage stays
+  generation/usage; a consumer that wants other kinds uses `computeReachable`.
+- No depth parameter on `computeReachable` — it is reachability, not lineage.
+- No write-path change; the golden fixture bytes must not move.
+
+## Decisions
+
+### Truncation is computed in the walk, not by a wider re-walk
+
+An edge is recorded only by expanding its traversal-direction source, so a
+node whose final budget is exactly 0 while it has qualifying edges at all has
+those edges unexpanded — the walk knows its own frontier. This is equivalent
+to the diff derivation: in the walk one file hop wider, every root budget
+grows by exactly 2 edges, so a node with final budget 0 gains a positive
+budget and records precisely its unexpanded edges, whose source it is. A node
+at the bound with an empty adjacency is genuinely empty in both derivations
+and stays unmarked. The equivalence is asserted by a test that cross-checks
+the in-walk set against the diff derivation over varied fixtures, root sets,
+directions, and depths.
+
+### `truncated` is a QName array on the walk result
+
+`LineageWalk = LineageModel & { truncated: string[] }` — the result stays
+usable wherever a model is accepted (re-walking a sub-model, entity lookup),
+and the addition is additive for every existing consumer. Arrays match the
+model's own collection style (`nodes`, `edges`); the order is the walk's
+deterministic discovery order.
+
+### Reachability is a separate primitive, not a walk option
+
+`computeReachable(model, roots, { direction, edgeKinds? })` returns the
+reached sub-model. Folding edge-kind options into `computeLineage` would
+overload the lineage semantics (file-hop depth is meaningless over
+association or derivation edges). The two share the traversal core; only the
+budget (always unbounded) and the edge-kind set differ.
+
+### `"both"` is the union of two directional closures
+
+Backward follows the asserted edges, forward reverses them, and `"both"` runs
+both from the same roots and unions the result. This is the
+upstream-plus-downstream cone a highlight consumer wants — NOT undirected
+connectivity, which would leak a sibling consumer of a shared input into the
+cone.
+
+## Risks / Trade-offs
+
+- **The walk result type widens.** `computeLineage` now returns `LineageWalk`,
+  a subtype of the old `LineageModel` return. Additive for consumers;
+  accepted for a minor bump.
+- **`computeReachable` default is every edge kind.** A future eighth relation
+  kind would silently join the closure. Accepted: the default serves the
+  full-cone consumer, and `edgeKinds` pins the set for anyone who needs
+  stability.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/proposal.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/proposal.md
@@ -1,0 +1,43 @@
+# Report walk truncation and add a reachability primitive
+
+## Why
+
+The lineage walk returned the reached sub-model with no frontier information,
+and it traverses only the generation/usage edges. Both properties pushed walk
+responsibilities onto consumers: a consumer that renders a bounded lineage had
+to re-derive the truncation by running the walk a second time one file hop
+wider and diffing the edge sets, and a consumer that highlights a node's full
+cone (agents and lifecycle context included) had to keep a private
+bidirectional traversal over the whole edge list. A re-derived truncation and
+a private traversal are both read-side interpretation, and two consumers that
+traverse the same signed document differently can drift — thus both belong in
+the kernel, next to the walk they duplicate.
+
+## What Changes
+
+- `computeLineage` returns `LineageWalk = LineageModel & { truncated: string[] }`:
+  the reached sub-model plus the QNames of the in-scope nodes whose qualifying
+  edges the depth bound left unexpanded. Computed inside the single walk — no
+  wider re-walk. A node at the bound with nothing beyond it is not truncated.
+  Depth semantics (file hops, the `2n`/`2n - 1` edge budget) and the
+  generation/usage edge set are unchanged.
+- Add `computeReachable(model, roots, { direction, edgeKinds? })`: the
+  unbounded reachability closure for subgraph and highlight consumers. Every
+  edge kind traverses by default; `edgeKinds` narrows the set; `"both"` is the
+  union of the backward and forward closures from the same roots — an
+  upstream-plus-downstream cone, not undirected connectivity.
+- The two functions share one traversal core; the additions are additive, so
+  the version bumps 0.4.0 → 0.5.0.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `prov-kernel`: the lineage read model gains self-reported truncation on the
+  bounded walk and the reachability closure over a chosen edge-kind set.
+
+## Impact
+
+- `src/lineage.ts`, `src/lineage.test.ts`, `src/index.ts`, `README.md`,
+  `CLAUDE.md`, `scripts/smoke.mjs`, `package.json`.
+- No write-path change: the golden fixture bytes are untouched.

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/specs/prov-kernel/spec.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/specs/prov-kernel/spec.md
@@ -1,0 +1,82 @@
+## MODIFIED Requirements
+
+### Requirement: The kernel owns the lineage read model
+
+The kernel SHALL provide the one read-side interpretation of a stored dialect
+document. `deriveLineageModel(provJson)` SHALL take the exact stored PROV-JSON
+string, unify it under `PROV_UNIFY_OPTIONS`, and return a
+`{ nodes, edges }` model: typed, presentation-free nodes (`analysis`, `input`,
+and `file` entities, `activity` nodes with the kinds `run`/`step`/`command`/
+`file_tool`/`action`, and `agent` nodes with the kinds
+`system`/`user`/`model`) and edges for exactly the seven relation kinds
+`used`, `generated`, `informed`, `derived`, `attributed`, `associated`, and
+`invalidated`. An edge SHALL point in the PROV assertion orientation (formal
+argument 0 to formal argument 1) and SHALL carry a deterministic id: the
+relation's dialect id when one exists, else the value-derived fallback
+`{kind}:{from}->{to}`. A relation endpoint the document never declares SHALL
+synthesize a minimal node from its QName; a statement kind outside the seven
+SHALL be skipped; bytes that do not parse or unify SHALL return
+`err({ type: "prov_corrupt" })`. `computeLineage(model, roots, options)` SHALL
+traverse ONLY the `generated` and `used` edges, forward or backward, with a
+file-hop `depth` bound of `2n` edges from a file root and `2n - 1` from an
+activity root, so a truncation lands on a file node, and SHALL return the
+reached sub-model plus `truncated`: the QNames of the in-scope nodes with at
+least one qualifying edge the depth bound left unexpanded, computed in the
+same single traversal and equivalent to diffing the walk against the same
+walk one file hop wider. A node at the bound with nothing beyond it SHALL NOT
+be truncated. `computeReachable(model, roots, options)` SHALL return the
+unbounded reachability closure of the roots as a reached sub-model: every
+edge kind traverses by default, `edgeKinds` narrows the set, direction is
+`forward`, `backward`, or `both`, and `both` SHALL be the union of the
+backward and forward closures from the same roots — not undirected
+connectivity. `findFileEntity(model, key)` SHALL return the file entity for a
+`(path, hash)` key. The read model SHALL NOT touch the write path: the golden
+fixture bytes do not change.
+
+#### Scenario: The golden document derives into the shared model
+
+- **GIVEN** the committed golden fixture bytes
+- **WHEN** `deriveLineageModel` runs
+- **THEN** every declared element is a typed node, every undeclared relation
+  endpoint is a synthesized minimal node, and each execution relation keys its
+  edge by its deterministic dialect id
+
+#### Scenario: Tolerance for anonymous and unknown statements
+
+- **GIVEN** a document with an anonymous lifecycle relation and a statement
+  kind outside the seven
+- **WHEN** `deriveLineageModel` runs
+- **THEN** the anonymous relation gets the value-derived fallback id, and the
+  unknown statement kind is skipped with no error
+
+#### Scenario: The walk traverses only generation and usage
+
+- **GIVEN** a derived model of a produced file
+- **WHEN** `computeLineage` walks backward from the file
+- **THEN** the result holds the file-to-command-to-input chain, and the
+  analysis entity, the run spine, and the agents stay out
+
+#### Scenario: Depth counts file hops and truncates on a file node
+
+- **GIVEN** a chain of two commands between three files
+- **WHEN** `computeLineage` walks backward from the last file with depth 1
+- **THEN** the result ends at the intermediate file, and the earlier command
+  and its inputs stay out
+
+#### Scenario: The walk reports its own truncation
+
+- **GIVEN** a chain of two commands between three files
+- **WHEN** `computeLineage` walks backward from the last file with depth 1
+- **THEN** `truncated` holds exactly the intermediate file — the node whose
+  producer lies beyond the bound — and a bound node with nothing beyond it,
+  or an unbounded walk, reports no truncation
+
+#### Scenario: The reachability closure serves a highlight consumer
+
+- **GIVEN** a derived model and one produced file
+- **WHEN** `computeReachable` runs with direction `both` and the default edge
+  kinds
+- **THEN** the reached sub-model holds the file itself, its producing command
+  and the run spine, the agents via association and attribution, and the
+  analysis via derivation, while a sibling command's exclusive output stays
+  out

--- a/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/tasks.md
+++ b/prov-kernel/openspec/changes/archive/2026-08-10-add-walk-truncation-and-reachability/tasks.md
@@ -1,0 +1,38 @@
+## 1. The walk core
+
+- [x] 1.1 Extract the shared traversal core from `computeLineage`: directed
+  adjacency over a selected edge-kind set, budget-keyed breadth-first
+  expansion, and the in-walk truncation collection (final budget 0 with a
+  nonempty qualifying adjacency).
+- [x] 1.2 `computeLineage` returns `LineageWalk` — the reached sub-model plus
+  `truncated` — with unchanged depth semantics and the unchanged
+  generation/usage edge set.
+- [x] 1.3 Add `computeReachable` over the same core: unbounded budgets, every
+  edge kind by default, `edgeKinds` narrowing, and `"both"` as the union of
+  the backward and forward closures.
+- [x] 1.4 Export `computeReachable` and `LineageWalk` from `src/index.ts`.
+
+## 2. Tests
+
+- [x] 2.1 Truncation: the cut file is truncated, the unbounded walk reports
+  none, a bound node with nothing beyond it stays unmarked, the activity-root
+  and forward variants, and a second root un-truncating what it re-expands.
+- [x] 2.2 Equivalence: the in-walk `truncated` matches the depth+1 diff
+  derivation over four fixture models, every single-node root, multi-root and
+  mixed-kind root sets, both directions, depths 0–4.
+- [x] 2.3 Reachability: the full dataflow cone from a consumed input, agents
+  reached via association/attribution and the analysis via derivation from a
+  produced file, a sibling's exclusive output excluded, `edgeKinds`
+  narrowing, an absent root, directional closures, and the
+  generation/usage-restricted closure equal to the unbounded lineage scope.
+- [x] 2.4 The golden fixture stays byte-identical — the change is read-side
+  only.
+
+## 3. Documents and version
+
+- [x] 3.1 Update `README.md`, `CLAUDE.md`, the module doc comment, and the
+  smoke script's export list.
+- [x] 3.2 Bump `package.json` to 0.5.0.
+- [x] 3.3 `bun run typecheck`, `bun run lint`, `bun test`,
+  `bun run build && bun run smoke`, `openspec validate --all --strict`.
+- [x] 3.4 `bun run format:file` on every touched file under `src/`.

--- a/prov-kernel/openspec/specs/prov-kernel/spec.md
+++ b/prov-kernel/openspec/specs/prov-kernel/spec.md
@@ -140,8 +140,17 @@ SHALL be skipped; bytes that do not parse or unify SHALL return
 `err({ type: "prov_corrupt" })`. `computeLineage(model, roots, options)` SHALL
 traverse ONLY the `generated` and `used` edges, forward or backward, with a
 file-hop `depth` bound of `2n` edges from a file root and `2n - 1` from an
-activity root, so a truncation lands on a file node.
-`findFileEntity(model, key)` SHALL return the file entity for a
+activity root, so a truncation lands on a file node, and SHALL return the
+reached sub-model plus `truncated`: the QNames of the in-scope nodes with at
+least one qualifying edge the depth bound left unexpanded, computed in the
+same single traversal and equivalent to diffing the walk against the same
+walk one file hop wider. A node at the bound with nothing beyond it SHALL NOT
+be truncated. `computeReachable(model, roots, options)` SHALL return the
+unbounded reachability closure of the roots as a reached sub-model: every
+edge kind traverses by default, `edgeKinds` narrows the set, direction is
+`forward`, `backward`, or `both`, and `both` SHALL be the union of the
+backward and forward closures from the same roots — not undirected
+connectivity. `findFileEntity(model, key)` SHALL return the file entity for a
 `(path, hash)` key. The read model SHALL NOT touch the write path: the golden
 fixture bytes do not change.
 
@@ -174,3 +183,22 @@ fixture bytes do not change.
 - **WHEN** `computeLineage` walks backward from the last file with depth 1
 - **THEN** the result ends at the intermediate file, and the earlier command
   and its inputs stay out
+
+#### Scenario: The walk reports its own truncation
+
+- **GIVEN** a chain of two commands between three files
+- **WHEN** `computeLineage` walks backward from the last file with depth 1
+- **THEN** `truncated` holds exactly the intermediate file — the node whose
+  producer lies beyond the bound — and a bound node with nothing beyond it,
+  or an unbounded walk, reports no truncation
+
+#### Scenario: The reachability closure serves a highlight consumer
+
+- **GIVEN** a derived model and one produced file
+- **WHEN** `computeReachable` runs with direction `both` and the default edge
+  kinds
+- **THEN** the reached sub-model holds the file itself, its producing command
+  and the run spine, the agents via association and attribution, and the
+  analysis via derivation, while a sibling command's exclusive output stays
+  out
+

--- a/prov-kernel/package.json
+++ b/prov-kernel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/prov-kernel",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Inflexa provenance format kernel — the PROV dialect document model, the lineage read model, chain-hash + Ed25519 signing, and the signed-attestation schema.",
     "license": "Apache-2.0",
     "type": "module",

--- a/prov-kernel/scripts/smoke.mjs
+++ b/prov-kernel/scripts/smoke.mjs
@@ -20,6 +20,8 @@ try {
     "createProvDocumentModel",
     "defaultProvDigest",
     "deriveLineageModel",
+    "computeLineage",
+    "computeReachable",
     "createKeypairSigner",
     "computeChainHash",
     "buildAttestation",

--- a/prov-kernel/src/index.ts
+++ b/prov-kernel/src/index.ts
@@ -34,7 +34,7 @@ export type { ProvDigest, ProvDocumentModel, ProvDocumentModelOptions } from "./
 export { applyProvEvent } from "./events.js";
 export type { ProvEvent } from "./events.js";
 
-export { computeLineage, deriveLineageModel, findFileEntity } from "./lineage.js";
+export { computeLineage, computeReachable, deriveLineageModel, findFileEntity } from "./lineage.js";
 export type {
     LineageActivityKind,
     LineageActivityNode,
@@ -47,6 +47,7 @@ export type {
     LineageInputNode,
     LineageModel,
     LineageNode,
+    LineageWalk,
     ProvReadError,
 } from "./lineage.js";
 

--- a/prov-kernel/src/lineage.test.ts
+++ b/prov-kernel/src/lineage.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import type { ProvDocument } from "@inflexa-ai/tsprov";
 import { createProvDocumentModel, PROV_UNIFY_OPTIONS, type ProvDocumentModel } from "./document.js";
 import { applyProvEvent } from "./events.js";
-import { computeLineage, deriveLineageModel, findFileEntity, type LineageModel } from "./lineage.js";
+import { computeLineage, computeReachable, deriveLineageModel, findFileEntity, type LineageModel } from "./lineage.js";
 import type { ProvActor, ProvCommandRef, ProvFileRef, ProvModelId, ProvStepRef } from "./types.js";
 
 // The read model is tested against two sources: the committed golden fixture (the exact stored
@@ -395,7 +395,198 @@ describe("computeLineage — depth", () => {
     });
 
     test("a root the model does not contain adds nothing", () => {
-        expect(computeLineage(chainModel, ["inflexa:file-nope"], { direction: "backward" })).toEqual({ nodes: [], edges: [] });
+        expect(computeLineage(chainModel, ["inflexa:file-nope"], { direction: "backward" })).toEqual({ nodes: [], edges: [], truncated: [] });
+    });
+});
+
+describe("computeLineage — truncated", () => {
+    test("the file cut by the bound is truncated; an unbounded walk reports none", () => {
+        expect(computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward", depth: 1 }).truncated).toEqual([fileQn(deResultsKey)]);
+        expect(computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward" }).truncated).toEqual([]);
+    });
+
+    test("a node at the bound with nothing beyond it stays unmarked", () => {
+        // At depth 2 both counts and the script sit at the bound: the script's write_file producer
+        // lies beyond, counts has no producer at all.
+        const walk = computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward", depth: 2 });
+        expect(qns(walk)).toContain(fileQn(countsKey));
+        expect(walk.truncated).toEqual([fileQn(scriptKey)]);
+    });
+
+    test("an activity root's bound cuts on its file, one edge earlier", () => {
+        expect(computeLineage(chainModel, [bQn], { direction: "backward", depth: 1 }).truncated).toEqual([fileQn(deResultsKey)]);
+    });
+
+    test("a forward walk truncates on the file whose readers lie beyond", () => {
+        const walk = computeLineage(chainModel, [fileQn(countsKey)], { direction: "forward", depth: 1 });
+        expect(walk.truncated).toEqual([fileQn(deResultsKey)]);
+        // The leaf sits at the same bound with no reader beyond it.
+        expect(qns(walk)).toContain(fileQn(leafKey));
+    });
+
+    test("a second root inside the bound un-truncates what it re-expands", () => {
+        const walk = computeLineage(chainModel, [fileQn(heatmapKey), fileQn(deResultsKey)], { direction: "backward", depth: 1 });
+        expect(qns(walk)).toContain(fileQn(countsKey));
+        expect(walk.truncated).toEqual([fileQn(scriptKey)]);
+    });
+});
+
+describe("computeLineage — truncated is equivalent to the depth+1 diff derivation", () => {
+    // The re-derivation a consumer would otherwise run: the same walk one file hop wider reveals
+    // exactly the edges the bounded walk left unexpanded, and each such edge's walk-direction
+    // source that sits inside the bounded scope is a truncation point.
+    function diffTruncated(model: LineageModel, roots: readonly string[], direction: "forward" | "backward", depth: number): string[] {
+        const bounded = computeLineage(model, roots, { direction, depth });
+        const scoped = new Set(qns(bounded));
+        const reached = new Set(bounded.edges.map((e) => e.id));
+        const out = new Set<string>();
+        for (const edge of computeLineage(model, roots, { direction, depth: depth + 1 }).edges) {
+            if (reached.has(edge.id)) continue;
+            const source = direction === "backward" ? edge.from : edge.to;
+            if (scoped.has(source)) out.add(source);
+        }
+        return [...out].sort();
+    }
+
+    function selfReadModel(): LineageModel {
+        const doc = provModel.freshDocument({ analysisId: "a1" });
+        const selfKey = { path: "runs/run-001/step-de/output/self.csv", hash: "hashSelf01" };
+        const selfRead: ProvCommandRef = { kind: "command", command: "bash gen.sh", exitCode: 0, outputs: [selfKey], inputs: [{ ...selfKey, source: "step" }] };
+        applyProvEvent(provModel, doc, { type: "command_executed", analysisId: "a1", actor: system, step: stepRef, command: selfRead, model });
+        applyProvEvent(provModel, doc, {
+            type: "file_written",
+            analysisId: "a1",
+            actor: system,
+            file: fileRefOf(selfKey),
+            step: stepRef,
+            generation: "command",
+        });
+        return modelFrom(doc);
+    }
+
+    function crossRunModel(): LineageModel {
+        const doc = chainDoc(provModel);
+        const readerStep: ProvStepRef = { runId: "run-002", stepId: "step-model" };
+        const modelKey = { path: "runs/run-002/step-model/output/model.bin", hash: "hashModel1" };
+        const fit: ProvCommandRef = {
+            kind: "command",
+            command: "python fit.py",
+            exitCode: 0,
+            outputs: [modelKey],
+            inputs: [{ ...deResultsKey, source: "prior" }],
+        };
+        applyProvEvent(provModel, doc, {
+            type: "step_completed",
+            analysisId: "a1",
+            actor: system,
+            outcome: { runId: "run-002", stepId: "step-model", status: "completed", completedAtMs: 1_700_000_003_000 },
+            model,
+        });
+        applyProvEvent(provModel, doc, { type: "command_executed", analysisId: "a1", actor: system, step: readerStep, command: fit, model });
+        applyProvEvent(provModel, doc, {
+            type: "file_written",
+            analysisId: "a1",
+            actor: system,
+            file: fileRefOf(modelKey),
+            step: readerStep,
+            generation: "command",
+        });
+        return modelFrom(doc);
+    }
+
+    const fixtures: [string, LineageModel][] = [
+        ["chain", chainModel],
+        ["golden", deriveLineageModel(goldenJson)._unsafeUnwrap()],
+        ["self-read", selfReadModel()],
+        ["cross-run", crossRunModel()],
+    ];
+
+    for (const [name, fixture] of fixtures) {
+        test(`${name}: every root set, both directions, depths 0–4`, () => {
+            const rootSets: string[][] = [
+                ...fixture.nodes.map((n) => [n.qn]),
+                fixture.nodes.filter((n) => n.kind === "file").map((n) => n.qn),
+                [fixture.nodes.find((n) => n.kind === "activity")!.qn, fixture.nodes.find((n) => n.kind === "file")!.qn],
+            ];
+            for (const roots of rootSets) {
+                for (const direction of ["backward", "forward"] as const) {
+                    for (let depth = 0; depth <= 4; depth++) {
+                        const inWalk = [...computeLineage(fixture, roots, { direction, depth }).truncated].sort();
+                        expect(inWalk).toEqual(diffTruncated(fixture, roots, direction, depth));
+                    }
+                }
+            }
+        });
+    }
+});
+
+describe("computeReachable — golden document", () => {
+    const golden = deriveLineageModel(goldenJson)._unsafeUnwrap();
+
+    test("both directions from a consumed input reaches the full dataflow cone and nothing else", () => {
+        const sub = computeReachable(golden, ["inflexa:file-2cl35k0tb4udj"], { direction: "both" });
+        expect(qns(sub).sort()).toEqual([
+            "inflexa:cmd-r1-s1-1gmep6ya47zjz",
+            "inflexa:cmd-r1-s1-302d2bs8ad5ko",
+            "inflexa:cmd-r1-s1-3on7qauhakeey",
+            "inflexa:file-18bvqsvo19q9p",
+            "inflexa:file-2cl35k0tb4udj",
+            "inflexa:file-2oo1fa1324nay",
+            "inflexa:file-8cpsktnfc9if",
+            "inflexa:file-c0kyjyc0bmim",
+            "inflexa:file-monvuc8rxoat",
+            "inflexa:step-r1-s1",
+        ]);
+    });
+
+    test("a produced file reaches its agents via associated/attributed and the analysis via derived", () => {
+        const sub = computeReachable(golden, ["inflexa:file-18bvqsvo19q9p"], { direction: "both" });
+        const reached = new Set(qns(sub));
+        expect(reached.has("inflexa:file-18bvqsvo19q9p")).toBe(true);
+        expect(reached.has("inflexa:cmd-r1-s1-302d2bs8ad5ko")).toBe(true);
+        expect(reached.has("inflexa:step-r1-s1")).toBe(true);
+        expect(reached.has("inflexa:run-r1")).toBe(true);
+        expect(reached.has("inflexa:analysis-a-golden")).toBe(true);
+        expect(reached.has("inflexa:agent-system")).toBe(true);
+        // A sibling command's exclusive output is not in this file's cone.
+        expect(reached.has("inflexa:file-c0kyjyc0bmim")).toBe(false);
+    });
+
+    test("edgeKinds narrows the closure", () => {
+        // Generation/usage alone: no spine, no analysis, no agents.
+        const dataflow = computeReachable(golden, ["inflexa:file-18bvqsvo19q9p"], { direction: "both", edgeKinds: ["generated", "used"] });
+        expect(dataflow.nodes.some((n) => n.kind === "agent")).toBe(false);
+        expect(qns(dataflow)).not.toContain("inflexa:analysis-a-golden");
+        expect(qns(dataflow)).not.toContain("inflexa:run-r1");
+        // Adding the informed spine reaches the run; the agents still need associated/attributed.
+        const withSpine = computeReachable(golden, ["inflexa:file-18bvqsvo19q9p"], { direction: "both", edgeKinds: ["generated", "used", "informed"] });
+        expect(qns(withSpine)).toContain("inflexa:run-r1");
+        expect(withSpine.nodes.some((n) => n.kind === "agent")).toBe(false);
+    });
+
+    test("a root the model does not contain adds nothing", () => {
+        expect(computeReachable(golden, ["inflexa:file-nope"], { direction: "both" })).toEqual({ nodes: [], edges: [] });
+    });
+});
+
+describe("computeReachable — directions on the chain", () => {
+    test("backward is the upstream closure only, forward the downstream only", () => {
+        const backward = new Set(qns(computeReachable(chainModel, [fileQn(deResultsKey)], { direction: "backward" })));
+        expect(backward.has(aQn)).toBe(true);
+        expect(backward.has(fileQn(countsKey))).toBe(true);
+        expect(backward.has(bQn)).toBe(false);
+        expect(backward.has(fileQn(heatmapKey))).toBe(false);
+
+        const forward = new Set(qns(computeReachable(chainModel, [fileQn(deResultsKey)], { direction: "forward" })));
+        expect(forward.has(bQn)).toBe(true);
+        expect(forward.has(fileQn(heatmapKey))).toBe(true);
+        expect(forward.has(aQn)).toBe(false);
+    });
+
+    test("restricted to generation/usage it reaches exactly the unbounded lineage scope", () => {
+        const walk = computeLineage(chainModel, [fileQn(heatmapKey)], { direction: "backward" });
+        const sub = computeReachable(chainModel, [fileQn(heatmapKey)], { direction: "backward", edgeKinds: ["generated", "used"] });
+        expect(sub).toEqual({ nodes: walk.nodes, edges: walk.edges });
     });
 });
 

--- a/prov-kernel/src/lineage.ts
+++ b/prov-kernel/src/lineage.ts
@@ -21,10 +21,11 @@ import type { ProvFileKey } from "./types.js";
 // The read side of the dialect: one interpretation of a stored PROV-JSON document, shared by every
 // consumer. `deriveLineageModel` turns the exact stored bytes into a typed, presentation-free
 // node/edge model. `computeLineage` walks the generation/usage edges with the canonical traversal
-// semantics. `findFileEntity` is the `(path, hash)` identity lookup that cross-links an external
-// artifact record to its entity. A consumer that interprets the bytes itself can drift, and two
-// drifted readers show two different lineages for one signed document — thus the interpretation is
-// format and lives in the kernel.
+// semantics and reports its own depth truncation. `computeReachable` is the unbounded reachability
+// closure over a chosen edge-kind set, for subgraph and highlight consumers. `findFileEntity` is
+// the `(path, hash)` identity lookup that cross-links an external artifact record to its entity. A
+// consumer that interprets the bytes itself can drift, and two drifted readers show two different
+// lineages for one signed document — thus the interpretation is format and lives in the kernel.
 
 /** Why a document did not derive: the bytes do not parse or unify as a dialect document. */
 export type ProvReadError = { type: "prov_corrupt"; cause: unknown };
@@ -358,38 +359,43 @@ export function deriveLineageModel(provJson: string): Result<LineageModel, ProvR
     }
 }
 
+/** The lineage walk's result: the reached sub-model plus the QNames the depth bound cut. */
+export type LineageWalk = LineageModel & { truncated: string[] };
+
+const LINEAGE_EDGE_KINDS: ReadonlySet<LineageEdgeKind> = new Set(["generated", "used"]);
+
+const ALL_EDGE_KINDS: readonly LineageEdgeKind[] = ["used", "generated", "informed", "derived", "attributed", "associated", "invalidated"];
+
+type Traversal = { best: Map<string, number>; reached: Map<string, LineageEdge>; truncated: string[] };
+
 /**
- * Walk the lineage of `roots` and return the reached sub-model. The walk traverses ONLY the
- * `generated` and `used` edges: the coarse `derived` edge to the analysis and the `informed` spine
- * would pollute a file's lineage, so they stay out. Backward follows the asserted edges (a file to
- * its generator, an activity to what it read); forward reverses them (a file to its readers, an
- * activity to its outputs).
- *
- * `depth` counts file-level hops. One file hop (file to activity to file) is two edges, thus the
- * edge budget is `2n` from a file root and `2n - 1` from an activity root — a truncation always
- * lands on a file node, never between an activity and its files. An unset `depth` walks the whole
- * reachable component. A root the model does not contain adds nothing.
+ * The shared walk core: breadth-first over the directed adjacency of the selected edge kinds, keyed
+ * by the best remaining edge budget per node — a node reached again with a larger budget
+ * re-expands, so the bound is the minimum distance over all roots.
  */
-export function computeLineage(model: LineageModel, roots: readonly string[], opts: { direction: "forward" | "backward"; depth?: number }): LineageModel {
+function traverse(
+    model: LineageModel,
+    roots: readonly string[],
+    direction: "forward" | "backward",
+    kinds: ReadonlySet<LineageEdgeKind>,
+    budgetOf: (root: LineageNode) => number,
+): Traversal {
     const nodeByQn = new Map(model.nodes.map((n) => [n.qn, n]));
     const adjacency = new Map<string, { edge: LineageEdge; to: string }[]>();
     for (const edge of model.edges) {
-        if (edge.kind !== "generated" && edge.kind !== "used") continue;
-        const [from, to] = opts.direction === "backward" ? [edge.from, edge.to] : [edge.to, edge.from];
+        if (!kinds.has(edge.kind)) continue;
+        const [from, to] = direction === "backward" ? [edge.from, edge.to] : [edge.to, edge.from];
         const bucket = adjacency.get(from);
         if (bucket) bucket.push({ edge, to });
         else adjacency.set(from, [{ edge, to }]);
     }
 
-    // Breadth-first over the directed adjacency, keyed by the best remaining edge budget per node —
-    // a node reached again with a larger budget re-expands, so the bound is the minimum distance
-    // over all roots.
     const best = new Map<string, number>();
     const queue: { qn: string; remaining: number }[] = [];
     for (const qn of roots) {
         const root = nodeByQn.get(qn);
         if (root === undefined) continue;
-        const remaining = opts.depth === undefined ? Number.POSITIVE_INFINITY : root.kind === "activity" ? 2 * opts.depth - 1 : 2 * opts.depth;
+        const remaining = budgetOf(root);
         if ((best.get(qn) ?? -1) < remaining) {
             best.set(qn, remaining);
             queue.push({ qn, remaining });
@@ -409,7 +415,62 @@ export function computeLineage(model: LineageModel, roots: readonly string[], op
         }
     }
 
-    return { nodes: model.nodes.filter((n) => best.has(n.qn)), edges: model.edges.filter((e) => reached.has(e.id)) };
+    // An edge is recorded only by expanding its traversal-direction source, so a node whose final
+    // budget is exactly 0 with any qualifying edge at all has those edges unexpanded — the walk
+    // knows its own truncation, no wider re-walk needed. A node at the bound with an empty
+    // adjacency stays unmarked: its emptiness is genuine.
+    const truncated: string[] = [];
+    for (const [qn, remaining] of best) {
+        if (remaining === 0 && (adjacency.get(qn)?.length ?? 0) > 0) truncated.push(qn);
+    }
+    return { best, reached, truncated };
+}
+
+/**
+ * Walk the lineage of `roots` and return the reached sub-model. The walk traverses ONLY the
+ * `generated` and `used` edges: the coarse `derived` edge to the analysis and the `informed` spine
+ * would pollute a file's lineage, so they stay out. Backward follows the asserted edges (a file to
+ * its generator, an activity to what it read); forward reverses them (a file to its readers, an
+ * activity to its outputs).
+ *
+ * `depth` counts file-level hops. One file hop (file to activity to file) is two edges, thus the
+ * edge budget is `2n` from a file root and `2n - 1` from an activity root — a truncation always
+ * lands on a file node, never between an activity and its files. An unset `depth` walks the whole
+ * reachable component. A root the model does not contain adds nothing.
+ *
+ * `truncated` holds each in-scope node the depth bound cut: a node with at least one qualifying
+ * edge the walk did not expand. A node at the bound with nothing beyond it is not truncated.
+ */
+export function computeLineage(model: LineageModel, roots: readonly string[], opts: { direction: "forward" | "backward"; depth?: number }): LineageWalk {
+    const { best, reached, truncated } = traverse(model, roots, opts.direction, LINEAGE_EDGE_KINDS, (root) =>
+        opts.depth === undefined ? Number.POSITIVE_INFINITY : root.kind === "activity" ? 2 * opts.depth - 1 : 2 * opts.depth,
+    );
+    return { nodes: model.nodes.filter((n) => best.has(n.qn)), edges: model.edges.filter((e) => reached.has(e.id)), truncated };
+}
+
+/**
+ * Compute the reachability closure of `roots` and return the reached sub-model — reachability, not
+ * lineage: no depth, and every edge kind traverses unless `edgeKinds` narrows the set. Backward
+ * follows the asserted edges, forward reverses them, and `"both"` is the union of the two
+ * directional closures from the same roots (an upstream-plus-downstream cone, NOT undirected
+ * connectivity — a sibling consumer of a shared input stays out). A root the model does not
+ * contain adds nothing.
+ */
+export function computeReachable(
+    model: LineageModel,
+    roots: readonly string[],
+    opts: { direction: "forward" | "backward" | "both"; edgeKinds?: readonly LineageEdgeKind[] },
+): LineageModel {
+    const kinds: ReadonlySet<LineageEdgeKind> = new Set(opts.edgeKinds ?? ALL_EDGE_KINDS);
+    const directions = opts.direction === "both" ? (["backward", "forward"] as const) : ([opts.direction] as const);
+    const visited = new Set<string>();
+    const reached = new Set<string>();
+    for (const direction of directions) {
+        const walk = traverse(model, roots, direction, kinds, () => Number.POSITIVE_INFINITY);
+        for (const qn of walk.best.keys()) visited.add(qn);
+        for (const id of walk.reached.keys()) reached.add(id);
+    }
+    return { nodes: model.nodes.filter((n) => visited.has(n.qn)), edges: model.edges.filter((e) => reached.has(e.id)) };
 }
 
 /**


### PR DESCRIPTION
## What / why

Two consumers currently work around the kernel's walk surface, and both workarounds are read-side interpretation the kernel should own:

- The CLI (inf-cli `cli/src/modules/prov/lineage.ts`) re-derives depth truncation by running `computeLineage` twice — at `depth` and `depth + 1` — and diffing the edge sets to find the walk-direction sources the bound cut.
- Lumen (`compute-lineage-path.ts`) keeps a hand-rolled bidirectional BFS for graph highlighting, because the kernel walk is hardwired to generation/usage edges and a highlight cone needs agents (associated/attributed) and the analysis (derived) too.

This PR internalizes both as kernel primitives; the host wrappers can collapse to single calls in their own repos.

## API additions (additive, 0.4.0 → 0.5.0)

- `computeLineage(model, roots, { direction, depth? }): LineageWalk` where `LineageWalk = LineageModel & { truncated: string[] }`. Truncation is computed inside the single traversal: a node whose final edge budget is 0 with any qualifying edge left has those edges unexpanded — no wider re-walk. A bound node with nothing beyond it stays unmarked. Depth semantics (file hops, `2n`/`2n-1` edge budget) and the generation/usage edge set are unchanged.
- `computeReachable(model, roots, { direction: "forward" | "backward" | "both"; edgeKinds?: readonly LineageEdgeKind[] }): LineageModel` — unbounded reachability closure, all seven edge kinds by default, `"both"` = union of the backward and forward closures (not undirected connectivity). Shares one traversal core with the lineage walk.

## Evidence

- 73 tests pass (was 55), typecheck, lint, build + dist smoke import of both new exports all green.
- Equivalence test cross-checks in-walk `truncated` against the depth+1 edge-diff derivation over 4 fixture models × every root (plus multi-root and mixed-kind root sets) × both directions × depths 0–4.
- Lumen's highlight-BFS test semantics ported as kernel tests: agents arrive via associated/attributed, the analysis via derived, the clicked node included, a sibling command's exclusive output excluded.
- Golden fixture `src/__fixtures__/golden-document.json` byte-identical (read-side change only).
- Openspec change authored, synced, and archived in-branch (`2026-08-10-add-walk-truncation-and-reachability`); `openspec validate --all --strict` passes.

Touches `prov-kernel/` only.