### PR TITLE
fix(lib-store): fail loud when an S3 existence check cannot be answered

### DIFF
--- a/scripts/lib-store-publish.sh
+++ b/scripts/lib-store-publish.sh
@@ -58,6 +58,25 @@ ARCH_DIR="linux-$ARCH"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# Does this key already exist? Only a 404 answers "no". Every other failure —
+# a 403 from a publish role missing s3:GetObject, throttling, a transport error —
+# means the question went unanswered, and the immutability guards below both
+# treat "unanswered" as "absent" if we let them: put_once would re-upload over a
+# published tarball, and the manifest check would skip its drift comparison and
+# overwrite. Both silently destroy exactly what they exist to protect, so an
+# indeterminate HEAD is fatal rather than a shrug.
+object_exists() {
+  local key="$1" err rc=0
+  err="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$key" 2>&1 >/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  case "$err" in
+    *404*|*"Not Found"*) return 1 ;;
+  esac
+  echo "::error::Could not determine whether s3://$S3_BUCKET/$key already exists (aws exited $rc): $err" >&2
+  echo "::error::Refusing to publish — the immutability guard cannot run, and continuing risks overwriting a published object. A 403 here usually means the publish role is missing s3:GetObject on this bucket." >&2
+  exit 1
+}
+
 # Immutable: a version is never rewritten; skip an object that already exists.
 put_once() {
   local src="$1" key="$VERSION/$ARCH_DIR/$2"
@@ -65,7 +84,7 @@ put_once() {
     echo "publish disabled: skipped the upload of $key"
     return 0
   fi
-  if aws s3api head-object --bucket "$S3_BUCKET" --key "$key" >/dev/null 2>&1; then
+  if object_exists "$key"; then
     echo "immutable: s3://$S3_BUCKET/$key already exists — skipping"
   else
     aws s3 cp "$src" "s3://$S3_BUCKET/$key"
@@ -120,7 +139,7 @@ fi
 # and FAIL LOUD on drift (cut a new version) rather than overwrite.
 "$SCRIPT_DIR/lib-store-write-manifest.sh" "$ARCH" "$VERSION" "$DIST" > "$WORK/manifest.json"
 MANIFEST_KEY="$VERSION/$ARCH_DIR/manifest.json"
-if aws s3api head-object --bucket "$S3_BUCKET" --key "$MANIFEST_KEY" >/dev/null 2>&1; then
+if object_exists "$MANIFEST_KEY"; then
   aws s3 cp "s3://$S3_BUCKET/$MANIFEST_KEY" "$WORK/manifest.published.json"
   # Drop buildTimestamp (per-run `date` stamp) before comparing — the check is about
   # integrity, not the publish wall-clock; everything else is deterministic per VERSION.


### PR DESCRIPTION
## What

`scripts/lib-store-publish.sh` decided *"does this object already exist?"* twice with a bare:

```bash
if aws s3api head-object --bucket "$S3_BUCKET" --key "$key" >/dev/null 2>&1; then
```

That collapses **every** failure into "absent". Only a `404` actually means absent — a `403` takes the identical branch.

Both call sites are immutability guards, and on a 403 both do the exact opposite of their job:

| Call site | Intended | On a swallowed 403 |
|-|-|-|
| `put_once` | skip an already-published tarball | re-uploads over it |
| manifest check | compare and **fail loud** on drift | skips the comparison, falls through to the overwrite branch |

The manifest one is the bad one. That comparison exists specifically to refuse to overwrite a published manifest whose bytes changed — the comment says *"FAIL LOUD on drift (cut a new version) rather than overwrite"* — and a 403 silently turns it into a no-op overwrite.

Nothing surfaces as an error. The run quietly does the damage the guards were written to prevent, then dies further down at:

```bash
aws s3 cp "s3://$S3_BUCKET/$MANIFEST_KEY" "s3://$S3_BUCKET/latest/$ARCH_DIR/manifest.json"
```

which needs the same `s3:GetObject` (server-side copy authorizes as GetObject on the source) and is *not* wrapped in a swallowing guard. So the failure mode was: overwrite the manifest, then hard-fail — leaving the version half-published with `latest/` un-advanced and no candidate pointer.

## How this surfaced

The `inflexa-ai/inflexa` publish role was created with `s3:PutObject` + `s3:AbortMultipartUpload` only — no `GetObject` — on the theory that a publish-only workflow never reads. It does read: twice to HEAD, once to GET the published manifest for the diff, and once more for the `latest/` copy. The IAM side is fixed separately in `platform-infra`; this PR makes the script refuse to guess when the grant is wrong, instead of silently corrupting.

## The change

Both call sites now route through `object_exists()`, which treats `404` as absent and **any other outcome as fatal**, naming the missing `s3:GetObject` grant as the likely cause.

No behaviour change once the role is correct — a real 404 still publishes, a real 200 still skips. The `PUBLISH_ENABLED=false` path is untouched: it `exit 0`s at line 132, before either call site, so a pack-only run never reaches the new code and never needs `S3_BUCKET` set.

## Testing

- `bash -n` clean; `shellcheck` reports only the pre-existing SC1091 (`source` not followed), and CI does not run shellcheck.
- Not exercised end-to-end against S3 — the amd64 self-hosted builder is currently down, so I could not dispatch `lib-store.yml`. The logic is a straight refactor of two conditionals plus a new failure branch.