### PR TITLE
fix(harness): read the ref store where it is mounted, and stop reading env for resource ceilings

### DIFF
--- a/harness/openspec/changes/default-store-discovery-to-the-container-mount/proposal.md
+++ b/harness/openspec/changes/default-store-discovery-to-the-container-mount/proposal.md
@@ -1,0 +1,40 @@
+# Default store discovery to the container mount
+
+## Why
+
+Managed Cortex mounts the ref-store PVC into its own pod at `/mnt/refs` and passes `refStorePvc` to the sandbox client, so every sandbox Job receives the store — and every agent is told the store does not exist. `EnvironmentStorePaths.refStorePath` is the only root `list_available_refs` reads; a Kubernetes embedder holds a PVC name, not a host path, so it has nothing to put there; and `scanStore` short-circuits to `unavailable` when the field is absent. The bytes are mounted into the very process that reports them missing, and the planner plans against that report.
+
+The lib store does not have this defect, for exactly one reason: `list_available_packages` falls back to `/mnt/libs/current/packages.txt`. Same topology, same embedder, opposite outcome — one tool has a default and the other does not.
+
+The interface's own prose is what kept them apart. `EnvironmentStorePaths` states that absence must "never [be] papered over with a guessed path", while the `packagesFile` field directly beneath it says to omit the path "when the host mounts the store at the sandbox's own path, which makes the container path correct as-is". Two fields of one interface, opposite meanings for an omitted value, and a rule stated over both that describes only one.
+
+The guess that rule warns about cannot occur here. Every consumer stats its root before it reports anything: `scanStore` lstats and returns `unavailable` on failure, and the packages reader lets `readFile` throw into the unknown-inventory note. A defaulted root with nothing mounted at it yields precisely the answer an omitted path yields. What the rule protects — never report presence you did not verify — lives in that stat, not in the shape of the config field.
+
+## What Changes
+
+- `list_available_refs` resolves its read root as `refStorePath ?? /mnt/refs`, so a host whose own process sees the store where the sandbox does configures nothing.
+- `mount-plan.ts` exports `LIBS_CONTAINER_PATH` / `REFS_CONTAINER_PATH`. That file already calls itself the single source of truth for container-side paths, while `list-available-refs.ts` and `list-available-packages.ts` each carried a second copy of one. Both now import.
+- `EnvironmentStorePaths` documents one meaning for absence across both fields: the container mountpoint, stat-verified. Supplying a path means naming a location the mountpoint does not describe.
+- `scanStore` narrows to `root: string`. Its `if (!root)` branch was the sole producer of the unconfigured-store result and is now unreachable.
+- The mount contract is untouched. "When neither `refStorePath` nor `refStorePvc` is configured, the container SHALL receive no `/mnt/refs` mount" still holds — this change is about what the host may read, never about what the sandbox is given.
+
+No behavior change for the CLI or for Cortex's Docker-backed dev mode: both supply explicit paths, and an explicit path still wins.
+
+Out of scope: replacing `packagesFile` with a `libStoreRoot` to collapse the three encodings of `current/packages.txt` across the harness and its embedders. That is a signature change to a field both embedders pass, so it belongs with an embedder bump; this change is deliberately patch-level.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `ref-store`: discovery falls back to the container mountpoint when the embedder supplies no path. The same requirement stops describing the tool as a sandbox-exec call over the sandbox's own filesystem — it has read host-side since it became a planner tool, and that stale sentence is corrected here rather than edited around.
+
+## Impact
+
+Harness source:
+
+- `src/sandbox/mount-plan.ts` — the two container paths become exported.
+- `src/tools/sandbox/list-available-refs.ts` — fallback root, imported constant, narrowed `scanStore`.
+- `src/tools/sandbox/list-available-packages.ts` — default derived from the shared constant; the value is unchanged.
+- `src/config/environment-stores.ts` — the absence contract.
+
+Embedders: no change required. Managed Cortex gains working reference discovery on the next bump with no configuration at all — `REF_STORE_PATH` becomes an override for hosts that read the store somewhere else, rather than a requirement the Kubernetes chart would otherwise have to carry.

--- a/harness/openspec/changes/default-store-discovery-to-the-container-mount/specs/ref-store/spec.md
+++ b/harness/openspec/changes/default-store-discovery-to-the-container-mount/specs/ref-store/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: References are discoverable via the list_available_refs tool
+
+The harness SHALL expose a dependency-bearing `list_available_refs` tool that inspects the reference store on the HOST filesystem and reports it at `/mnt/refs`, the container path a sandbox mounts it at — read where it lives, render where the caller will open it. Reading host-side is what lets the conversation agent and the planner ask what reference data exists before any sandbox is created, and a step agent asking mid-run observes the same store, because the mount and the read path are the same bytes.
+
+The read root SHALL be the embedder-supplied `refStorePath` when one is given, and `/mnt/refs` otherwise. The fallback SHALL be the same container mountpoint the sandbox backends mount the store at, so a host whose own process sees the store the way a sandbox does — a Kubernetes pod holding the ref-store PVC — configures nothing. The fallback SHALL NOT change what is reported: the scan stats its root before reporting anything, so a host with nothing mounted there SHALL report the store as unavailable exactly as an omitted path always has. An embedder SHALL supply `refStorePath` only to name a location the container mountpoint does not describe, as a native process bind-mounting a host directory into Docker does.
+
+The tool SHALL accept an optional path constrained beneath the render root: an omitted path SHALL return a bounded root summary and a supplied path SHALL drill into that subtree. Results SHALL use absolute `/mnt/refs/...` paths, SHALL NOT follow symlinks, SHALL exclude reserved installer metadata from the data inventory, and SHALL report truncation explicitly when traversal or output limits are reached.
+
+The tool SHALL distinguish an unavailable store, a present but empty store, and a populated store without throwing for any of those expected states.
+
+#### Scenario: Arbitrary mounted files are available without a manifest
+
+- **WHEN** `/mnt/refs/user/cohort/reference.h5ad` exists and no `registry.json` or receipt names it
+- **THEN** `list_available_refs` reports that path through the root summary or a bounded drill-down result
+
+#### Scenario: Store is present but empty
+
+- **WHEN** the read root exists and contains no reference data
+- **THEN** the tool returns an available-but-empty result rather than a missing-store result
+
+#### Scenario: Store is not present
+
+- **WHEN** the read root does not exist or is not a directory
+- **THEN** the tool returns an unavailable data variant with an actionable note, without throwing
+
+#### Scenario: An unconfigured embedder reads the container mountpoint
+
+- **GIVEN** an embedder that supplies no `refStorePath`
+- **WHEN** the tool scans
+- **THEN** it reads `/mnt/refs` and returns exactly what an embedder supplying `/mnt/refs` explicitly would return
+
+#### Scenario: Deep inventory is bounded
+
+- **WHEN** a requested subtree exceeds the traversal or output limit
+- **THEN** the tool returns the bounded entries plus an explicit truncation or drill-down hint
+
+#### Scenario: Traversal outside the store is rejected
+
+- **WHEN** the optional path is absolute outside `/mnt/refs` or contains traversal escaping the root
+- **THEN** the tool returns an out-of-scope data result and performs no scan outside the store

--- a/harness/openspec/changes/default-store-discovery-to-the-container-mount/tasks.md
+++ b/harness/openspec/changes/default-store-discovery-to-the-container-mount/tasks.md
@@ -21,5 +21,5 @@
 
 - [x] 4.1 `bun run typecheck` and `bun run lint` clean.
 - [x] 4.2 `bun test src/tools/sandbox src/sandbox/mount-plan.test.ts` green.
-- [ ] 4.3 Release as a patch — an additive fallback, no signature an embedder passes. The bump is its own `Release harness` commit, per repo convention, because landing one on main publishes to npm.
+- [x] 4.3 Patch bump to 0.19.1 — an additive fallback, no signature an embedder passes. Kept as its own release commit; merging it publishes to npm.
 - [ ] 4.4 After publish: bump Cortex's pin and confirm `list_available_refs` reports the staging store with no `REF_STORE_PATH` set.

--- a/harness/openspec/changes/default-store-discovery-to-the-container-mount/tasks.md
+++ b/harness/openspec/changes/default-store-discovery-to-the-container-mount/tasks.md
@@ -1,0 +1,25 @@
+## 1. One source for the container paths
+
+- [x] 1.1 Export `LIBS_CONTAINER_PATH` and `REFS_CONTAINER_PATH` from `src/sandbox/mount-plan.ts`, documenting that they are also the discovery tools' default read root.
+- [x] 1.2 Import `REFS_CONTAINER_PATH` in `src/tools/sandbox/list-available-refs.ts` as the `REFS_ROOT` it re-declared, keeping the name so every render site is untouched.
+- [x] 1.3 Derive `DEFAULT_PACKAGES_FILE` in `src/tools/sandbox/list-available-packages.ts` from `LIBS_CONTAINER_PATH`; the value is unchanged, so the lib-store behaviour and its spec are untouched.
+
+## 2. The fallback
+
+- [x] 2.1 Resolve the read root once in `createListAvailableRefsTool` as `deps.refStorePath ?? REFS_ROOT`, so the default is named where the dep is consumed rather than at the scan site.
+- [x] 2.2 Narrow `scanStore` to `root: string` and drop the `!root` branch, which no caller can now reach.
+- [x] 2.3 Test that an omitted path and an explicit `/mnt/refs` produce identical results. Asserting the equivalence rather than a fixed state keeps the test from depending on whether the machine running it happens to have that mount.
+- [x] 2.4 Move the "No reference store is provisioned" content assertion onto the configured-but-missing case, which still exercises that render path.
+
+## 3. The contract
+
+- [x] 3.1 Rewrite the `EnvironmentStorePaths` absence paragraph so both fields mean the same thing by an omitted path, and state the stat-before-report invariant that makes the fallback safe.
+- [x] 3.2 Restate `refStorePath`'s field doc in terms of where the HOST reads the store, naming both cases: a K8s pod holding the PVC (omit) and a native process bind-mounting a directory into Docker (set).
+- [x] 3.3 Correct the ref-store discovery requirement — the tool reads the host filesystem and declares no execution mode; the sandbox-exec sentence described a shape the code has not had since the tool became a planner tool.
+
+## 4. Verification
+
+- [x] 4.1 `bun run typecheck` and `bun run lint` clean.
+- [x] 4.2 `bun test src/tools/sandbox src/sandbox/mount-plan.test.ts` green.
+- [ ] 4.3 Release as a patch — an additive fallback, no signature an embedder passes. The bump is its own `Release harness` commit, per repo convention, because landing one on main publishes to npm.
+- [ ] 4.4 After publish: bump Cortex's pin and confirm `list_available_refs` reports the staging store with no `REF_STORE_PATH` set.

--- a/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/proposal.md
+++ b/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/proposal.md
@@ -1,0 +1,31 @@
+# Remove the env-reading resource-limits loader
+
+## Why
+
+`loadResourceLimits` reads `SANDBOX_MAX_CPU`, `SANDBOX_MAX_MEMORY_GB`, and `SANDBOX_MAX_GPU_COUNT` straight off `process.env`. Nothing calls it — not the harness, not the CLI, not managed Cortex. It is not exported from the barrel either, so it is reachable only through a deep import of `config/resource-limits.js`.
+
+Both embedders already do this the supported way, and neither goes near the function. Cortex validates those three variables in its own Zod schema and passes the result as `SandboxClientConfig.resourceLimits`; the CLI passes `cfg.resourcePolicy.perStep`. The harness receives ceilings as configuration and validates their shape with `ResourceLimitsSchema` / `parseResourcePolicy`.
+
+So the function is not merely unused, it is a trap. It reads like the supported entry point for loading ceilings, and a caller who took it would silently bypass the embedder's validated configuration and pick up raw environment instead — two views of the same three values, free to disagree, with the environment winning in whichever code path happened to call it. Deleting it leaves one way to configure ceilings.
+
+This is the harness's only remaining ambient environment read outside telemetry. `lib/otel.ts` reads `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME`, but only inside `initOtel`, which the harness never calls itself — `bootHarness` takes `initTelemetry` as an injected dep defaulting to a noop, and those two variables are OpenTelemetry's own standard contract. That one stays.
+
+## What Changes
+
+- Delete `loadResourceLimits` and the two parsing helpers it alone used (`parsePositiveNumber`, `parseNonNegativeInt`).
+- `ResourceLimitsConfigError`, every schema, `clampResources`, and `parseResourcePolicy` are untouched — the embedder-supplied path is the whole surface now.
+- Restate the module header: ceilings arrive as configuration, and nothing in this module reads the environment.
+
+No embedder change. `SANDBOX_MAX_*` keeps its meaning for hosts that choose to name their ceilings that way — Cortex does — but reading it is now unambiguously the host's job, done once, in the host's own validated schema.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `dynamic-resource-allocation`: cluster ceilings are supplied by the embedder as configuration rather than read from the environment by the harness. The clamping contract is unchanged.
+
+## Impact
+
+- `src/config/resource-limits.ts` — the loader and its two helpers.
+
+Reachable through the `./*` export map, so a consumer deep-importing `loadResourceLimits` would break. There is none: not in this repo, not in managed Cortex, and the CLI takes only types from the module. It also could never have been used by the CLI, which requires no `SANDBOX_MAX_*` and would have hard-failed at boot on a machine with none set. Shipped as a patch on that basis.

--- a/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/specs/dynamic-resource-allocation/spec.md
+++ b/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/specs/dynamic-resource-allocation/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Resource ceilings are supplied by the embedder
+
+The harness SHALL receive cluster ceilings as configuration and SHALL NOT read them from the environment. `SandboxClientConfig.resourceLimits` carries `ResourceLimits { maxCpu, maxMemoryGb, maxGpuCount }`, and `parseResourcePolicy` validates an embedder-supplied `ResourcePolicy` against `ResourcePolicySchema`, throwing `ResourceLimitsConfigError` when the shape is invalid or when a per-step ceiling exceeds the machine budget. `maxCpu` and `maxMemoryGb` MUST be positive numbers; `maxGpuCount` MUST be a non-negative integer. GPU is bounded by count only, never by type.
+
+Where those values come from is the host's business — an environment variable, a file, a control plane. Reading them is the host's, done once against the host's own validated configuration, so the harness and its embedder cannot hold two views of one ceiling.
+
+#### Scenario: Valid ceilings are accepted as configuration
+
+- **GIVEN** an embedder supplying `{ maxCpu: 16, maxMemoryGb: 64, maxGpuCount: 2 }`
+- **WHEN** the sandbox client is constructed
+- **THEN** those ceilings are the ones `clampResources` caps each step's request against
+
+#### Scenario: A malformed ceiling is rejected
+
+- **GIVEN** an embedder supplying a resource policy whose `maxGpuCount` is `1.5`
+- **WHEN** `parseResourcePolicy` runs
+- **THEN** it throws `ResourceLimitsConfigError` identifying the value must be a non-negative integer
+
+#### Scenario: The harness reads no ceiling from the environment
+
+- **GIVEN** `SANDBOX_MAX_CPU`, `SANDBOX_MAX_MEMORY_GB`, and `SANDBOX_MAX_GPU_COUNT` set in the process environment
+- **WHEN** the harness bounds a step's resources
+- **THEN** it uses only the embedder-supplied ceilings, and no harness code path consults those variables
+
+## REMOVED Requirements
+
+### Requirement: Resource ceilings loaded from the environment
+
+**Reason**: `loadResourceLimits` had no caller in the harness, the CLI, or managed Cortex, and was absent from the package barrel. Both embedders already pass ceilings as configuration. Keeping an env-reading loader alongside that path offered a second, unvalidated source for the same three values.
+
+**Migration**: The embedder reads its own configuration — however it chooses to name it — validates it, and passes `SandboxClientConfig.resourceLimits` / `resourcePolicy`. Cortex already does exactly this with the same `SANDBOX_MAX_*` variable names in its own schema.

--- a/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/tasks.md
+++ b/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/tasks.md
@@ -15,4 +15,4 @@
 
 - [x] 3.1 `bun run typecheck` and `bun run lint` clean.
 - [x] 3.2 `bun test src/config src/sandbox` green.
-- [ ] 3.3 Release as a patch. The function was deep-importable, so the removal is breaking in principle; it ships as a patch because nothing imports it — not this repo, not managed Cortex, and the CLI takes only types from the module.
+- [x] 3.3 Patch bump to 0.19.1. The function was deep-importable, so the removal is breaking in principle; it ships as a patch because nothing imports it — not this repo, not managed Cortex, and the CLI takes only types from the module.

--- a/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/tasks.md
+++ b/harness/openspec/changes/remove-the-env-reading-resource-limits-loader/tasks.md
@@ -1,0 +1,18 @@
+## 1. Delete the loader
+
+- [x] 1.1 Confirm `loadResourceLimits` has no caller in the harness, the CLI, or managed Cortex, and is not re-exported from `src/index.ts`.
+- [x] 1.2 Delete `loadResourceLimits` and the two parsing helpers it alone used (`parsePositiveNumber`, `parseNonNegativeInt`).
+- [x] 1.3 Leave `ResourceLimitsConfigError`, the schemas, `clampResources`, and `parseResourcePolicy` intact — `parseResourcePolicy` still raises the same error type for an invalid embedder policy.
+- [x] 1.4 Restate the module header: ceilings arrive as configuration, and nothing in this module reads the environment. Drop the stale "ported from orchestrator" line while there.
+
+## 2. Spec
+
+- [x] 2.1 Remove the "Resource ceilings loaded from the environment" requirement, recording why it went and what replaces it.
+- [x] 2.2 Add "Resource ceilings are supplied by the embedder", covering the config surface, the validation `parseResourcePolicy` still performs, and that no harness path consults `SANDBOX_MAX_*`.
+- [ ] 2.3 On archive, update the capability's Purpose paragraph, which still says ceilings are "configured once from the environment".
+
+## 3. Verification
+
+- [x] 3.1 `bun run typecheck` and `bun run lint` clean.
+- [x] 3.2 `bun test src/config src/sandbox` green.
+- [ ] 3.3 Release as a patch. The function was deep-importable, so the removal is breaking in principle; it ships as a patch because nothing imports it — not this repo, not managed Cortex, and the CLI takes only types from the module.

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/config/environment-stores.ts
+++ b/harness/src/config/environment-stores.ts
@@ -19,17 +19,22 @@
  * one. Neither store is ever written through these paths.
  *
  * Both are optional, and absence is a NORMAL state rather than an error: an
- * omitted path makes its tool report the store as unavailable or unknown, which
- * is a truthful answer an agent can act on. Absence must never be reported as a
- * failure, and never papered over with a guessed path.
+ * omitted path falls back to the store's container mountpoint — correct for a
+ * host whose own process sees the store the way a sandbox does, and harmless for
+ * one that does not, because every consumer stats the root before it reports
+ * anything. A host with nothing mounted there gets the same "unavailable" or
+ * "unknown" answer an omitted path has always produced, so the fallback can no
+ * more invent a store than an explicit path can. Set a path only to name a
+ * location the container mountpoint does not describe; absence must never be
+ * reported as a failure.
  */
 export interface EnvironmentStorePaths {
     /**
      * Host path of the reference store — the same bytes sandboxes mount at
-     * `/mnt/refs`. Omit when no store is provisioned; reference discovery then
-     * reports the store as unavailable. Note that an installed store reads as
-     * absent if this is omitted, which is indistinguishable to an agent from
-     * having no data — so omit it only when there is genuinely nothing staged.
+     * `/mnt/refs`. Omit when the host's own process sees the store at that same
+     * path, as a K8s pod holding the ref-store PVC does; set it when the host
+     * reads the store somewhere else, as a native process bind-mounting a host
+     * directory into Docker does.
      */
     readonly refStorePath?: string;
     /**

--- a/harness/src/config/resource-limits.ts
+++ b/harness/src/config/resource-limits.ts
@@ -1,8 +1,11 @@
 /**
- * Resource limits — ported from orchestrator/src/config/resource-limits.ts.
+ * Resource limits — validates sandbox resource requests against cluster
+ * maximums.
  *
- * Validates sandbox resource requests against cluster maximums.
- * Used by K8sSandbox.
+ * The ceilings themselves are the embedder's: they arrive as
+ * `SandboxClientConfig.resourceLimits` and as the `resourcePolicy` this module
+ * validates. Nothing here reads the environment, so a host keeps one validated
+ * view of its own configuration rather than two that can disagree.
  */
 
 import { z } from "zod";
@@ -53,54 +56,6 @@ export class ResourceLimitsConfigError extends Error {
         super(message);
         this.name = "ResourceLimitsConfigError";
     }
-}
-
-// ── Parsing ─────────────────────────────────────────────────────────
-
-function parsePositiveNumber(name: string, value: string | undefined): number {
-    if (!value) {
-        throw new ResourceLimitsConfigError(`${name} environment variable is required`);
-    }
-    const num = Number(value);
-    if (isNaN(num) || num <= 0) {
-        throw new ResourceLimitsConfigError(`${name} must be a positive number, got: ${value}`);
-    }
-    return num;
-}
-
-function parseNonNegativeInt(name: string, value: string | undefined): number {
-    if (!value) {
-        throw new ResourceLimitsConfigError(`${name} environment variable is required`);
-    }
-    const num = Number(value);
-    if (isNaN(num) || num < 0) {
-        throw new ResourceLimitsConfigError(`${name} must be a non-negative number, got: ${value}`);
-    }
-    if (!Number.isInteger(num)) {
-        throw new ResourceLimitsConfigError(`${name} must be an integer, got: ${value}`);
-    }
-    return num;
-}
-
-/**
- * Load resource limits from environment variables.
- *
- * Required: SANDBOX_MAX_CPU, SANDBOX_MAX_MEMORY_GB, SANDBOX_MAX_GPU_COUNT
- * @throws ResourceLimitsConfigError if configuration is invalid
- */
-export function loadResourceLimits(): ResourceLimits {
-    const maxCpu = parsePositiveNumber("SANDBOX_MAX_CPU", process.env.SANDBOX_MAX_CPU);
-    const maxMemoryGb = parsePositiveNumber("SANDBOX_MAX_MEMORY_GB", process.env.SANDBOX_MAX_MEMORY_GB);
-    const maxGpuCount = parseNonNegativeInt("SANDBOX_MAX_GPU_COUNT", process.env.SANDBOX_MAX_GPU_COUNT);
-
-    const limits: ResourceLimits = { maxCpu, maxMemoryGb, maxGpuCount };
-
-    const result = ResourceLimitsSchema.safeParse(limits);
-    if (!result.success) {
-        throw new ResourceLimitsConfigError(`Invalid resource limits configuration: ${result.error.message}`);
-    }
-
-    return result.data;
 }
 
 /**

--- a/harness/src/sandbox/mount-plan.ts
+++ b/harness/src/sandbox/mount-plan.ts
@@ -21,8 +21,13 @@ import { assertSafeId } from "../workspace/paths.js";
 
 export const STEP_SUBDIRS = ["output", "scripts", "figures", "logs", "notebooks"] as const;
 
-const LIBS_CONTAINER_PATH = "/mnt/libs";
-const REFS_CONTAINER_PATH = "/mnt/refs";
+/**
+ * Container mountpoints of the two read-only stores. Exported because they are
+ * also the discovery tools' default read root: a host whose own process sees a
+ * store the way the sandbox does configures nothing further.
+ */
+export const LIBS_CONTAINER_PATH = "/mnt/libs";
+export const REFS_CONTAINER_PATH = "/mnt/refs";
 
 export interface MountPlanCoords {
     analysisId: string;

--- a/harness/src/tools/sandbox/list-available-packages.ts
+++ b/harness/src/tools/sandbox/list-available-packages.ts
@@ -31,13 +31,14 @@ import { z } from "zod";
 import { defineTool, type ToolError } from "../define-tool.js";
 import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 import { capCodePoints, DETAIL_NEEDLE_MAX_LENGTH } from "../../loop/tool-detail.js";
+import { LIBS_CONTAINER_PATH } from "../../sandbox/mount-plan.js";
 
 /**
  * Where the list lives when the host mounts the library store at the same path
  * the sandbox does. Hosts that do not — the store is baked into the image and
  * never bind-mounted — inject their own path instead.
  */
-const DEFAULT_PACKAGES_FILE = "/mnt/libs/current/packages.txt";
+const DEFAULT_PACKAGES_FILE = `${LIBS_CONTAINER_PATH}/current/packages.txt`;
 
 /**
  * Default cap on a listing — high enough that the real store is never truncated.

--- a/harness/src/tools/sandbox/list-available-refs.test.ts
+++ b/harness/src/tools/sandbox/list-available-refs.test.ts
@@ -173,15 +173,19 @@ describe("list_available_refs", () => {
         expect(result.entries).toEqual([{ path: "/mnt/refs/user/observed.csv", kind: "file", bytes: 7 }]);
     });
 
-    it("reports an unprovisioned store as data, not an error", async () => {
-        const result = (await createTool().execute({}, makeToolContext().ctx))._unsafeUnwrap();
-        expect(result).toMatchObject({ state: "unavailable", available: false, entries: [] });
-        expect(result.content).toContain("No reference store is provisioned");
+    // An omitted path reads the container mountpoint, so the two calls are the same
+    // call. Asserting they agree pins the fallback without making the assertion depend
+    // on whether the machine running the test happens to have `/mnt/refs`.
+    it("falls back to the container mount when no store path is configured", async () => {
+        const omitted = (await createTool().execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        const explicit = (await createTool("/mnt/refs").execute({}, makeToolContext().ctx))._unsafeUnwrap();
+        expect(omitted).toEqual(explicit);
     });
 
     it("reports a configured-but-missing store as unavailable", async () => {
         const result = (await createTool(join(tmpdir(), "refs-does-not-exist-xyz")).execute({}, makeToolContext().ctx))._unsafeUnwrap();
         expect(result).toMatchObject({ state: "unavailable", available: false, entries: [] });
+        expect(result.content).toContain("No reference store is provisioned");
     });
 
     it("reports an empty store as data", async () => {

--- a/harness/src/tools/sandbox/list-available-refs.ts
+++ b/harness/src/tools/sandbox/list-available-refs.ts
@@ -14,7 +14,11 @@
  * it at — read where it lives, render where the caller will open it. Reading it
  * host-side is what lets a planner ask what reference data exists before any
  * sandbox is created; a step agent asking mid-run sees the same store, because
- * the mount and this path are the same bytes.
+ * the mount and this path are the same bytes. An omitted `refStorePath` falls
+ * back to that same container path — where a host that mounts the store into its
+ * own process (a K8s pod holding the ref-store PVC) already sees it. The fallback
+ * is stat-verified like any other root, so a host with nothing mounted there
+ * still reports the store as unavailable.
  *
  * The scan reports paths; meaning is joined on afterwards from the install
  * receipt and the catalog it names (organism, format, and each file's internal
@@ -34,10 +38,14 @@ import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 import { capCodePoints, DETAIL_MAX_LENGTH, DETAIL_NEEDLE_MAX_LENGTH } from "../../loop/tool-detail.js";
 import { REFERENCE_DATA_CATALOG } from "../../reference-data/catalog.js";
 import { parseReferenceInstallReceipt } from "../../reference-data/receipt.js";
+import { REFS_CONTAINER_PATH } from "../../sandbox/mount-plan.js";
 import { defineTool } from "../define-tool.js";
 
-/** Container path the ref store is mounted at; every reported path is rendered under it. */
-const REFS_ROOT = "/mnt/refs";
+/**
+ * Container path the ref store is mounted at: every reported path is rendered
+ * under it, and it is the read root when the embedder supplies none.
+ */
+const REFS_ROOT = REFS_CONTAINER_PATH;
 const MAX_ENTRIES = 200;
 const MAX_SCANNED_ENTRIES = 2_000;
 const MAX_PATH_BYTES = 40_000;
@@ -356,9 +364,8 @@ async function collectFiles(
  * summarized), a search walks to the files, because only a file carries the labels a
  * search matches on.
  */
-async function scanStore(root: string | undefined, relative: string, recursive = false): Promise<RawScan> {
+async function scanStore(root: string, relative: string, recursive = false): Promise<RawScan> {
     const empty = (): Omit<RawScan, "state"> => ({ entries: [], scannedEntries: 0, truncated: false });
-    if (!root) return { state: "unavailable", ...empty() };
     try {
         if (!(await lstat(root)).isDirectory()) return { state: "unavailable", ...empty() };
     } catch {
@@ -569,6 +576,7 @@ function renderContent(path: string, scan: RawScan, entries: readonly ReferenceI
 
 /** Create reference discovery over the host-visible reference store. */
 export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
+    const storeRoot = deps.refStorePath ?? REFS_ROOT;
     return defineTool({
         id: "list_available_refs",
         description:
@@ -645,7 +653,7 @@ export function createListAvailableRefsTool(deps: ListAvailableRefsDeps) {
             // recursive pass a search from the store root only ever sees directories,
             // which carry no dataset labels, so "find me a regulon network" finds nothing.
             const needleGiven = (query?.trim() ?? "") !== "";
-            const raw = await scanStore(deps.refStorePath, posixPath.relative(REFS_ROOT, requested.path) || ".", needleGiven);
+            const raw = await scanStore(storeRoot, posixPath.relative(REFS_ROOT, requested.path) || ".", needleGiven);
             const enriched = enrichEntries(raw.entries, raw);
             const categories = collectCategories(enriched);
             const needle = query?.trim().toLowerCase();


### PR DESCRIPTION
`list_available_refs` reads only `EnvironmentStorePaths.refStorePath`, and a Kubernetes embedder has no host path to give it — it holds a PVC name. So managed Cortex mounts the ref store into its own pod and into every sandbox Job, then tells the planner no reference data exists. `list_available_packages` avoids this only because it already defaults to `/mnt/libs/current/packages.txt`; this does the same for refs, making the read root `refStorePath ?? /mnt/refs`. The default is safe because `scanStore` stats its root first — a host with nothing mounted there still reports `unavailable`, exactly as an omitted path did. The two container paths now come from `mount-plan.ts`, which already called itself their single source of truth while both discovery tools kept a second copy.

The second commit deletes `loadResourceLimits`, which read `SANDBOX_MAX_*` off `process.env` and had no caller in the harness, the CLI, or Cortex — both embedders already pass ceilings as config. Clamping, the schemas, and `parseResourcePolicy` are untouched, and the sandbox mount contract is unchanged. Releases 0.19.1 so Cortex can pin it; merging publishes to npm. Both openspec deltas validate `--strict`; the ref-store one also corrects stale prose claiming the tool runs through the sandbox-exec runner, which it hasn't since it became a host-side planner tool.
