### PR TITLE
feat(harness): prelaunch audit remediation — run canceler, billing-context drop, sandbox billing labels, ask-sweep predicate

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.19",
+        "@inflexa-ai/harness": "0.19.2",
         "@inflexa-ai/prov-kernel": "^0.5.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",

--- a/cli/src/modules/harness/dev/run.test.ts
+++ b/cli/src/modules/harness/dev/run.test.ts
@@ -136,6 +136,7 @@ function makeSeams(
             revoke: async () => {
                 rec.revoke++;
             },
+            revokeByJti: async () => {},
         },
         launch: async (input, runId) => {
             rec.launch++;

--- a/cli/src/modules/harness/dev/run.ts
+++ b/cli/src/modules/harness/dev/run.ts
@@ -420,7 +420,6 @@ export async function runAnalysis(flags: ContextFlags, planPath: string | undefi
             runtime.pool,
             analysis.id,
             null,
-            null,
             staged.map((f) => f.fileId),
         )
     ).match(

--- a/cli/src/modules/harness/profile_trigger.ts
+++ b/cli/src/modules/harness/profile_trigger.ts
@@ -45,15 +45,14 @@ import type { HarnessRuntime } from "./runtime.ts";
  * product file must never import the dev directory, so of the pair it is the product caller that
  * must hold the shared half.
  *
- * `context` and `billingContext` stay null — neither caller has goal text at profile time, and a
- * fabricated one would pollute the agent prompt. `inputFileIds` is the staged manifest's file ids,
- * the auth is the local OSS value, and the manifest rides into the trigger params verbatim.
+ * `context` stays null — neither caller has goal text at profile time, and a fabricated one would
+ * pollute the agent prompt. `inputFileIds` is the staged manifest's file ids, the auth is the local
+ * OSS value, and the manifest rides into the trigger params verbatim.
  */
 export function seedProfileLedger(pool: Pool, analysisId: string, staged: readonly StagedInput[]): ResultAsync<DataProfileTriggerParams, DbError> {
     return upsertAnalysis(
         pool,
         analysisId,
-        null,
         null,
         staged.map((f) => f.fileId),
     ).map(() => ({ auth: makeLocalAuth(), analysisId, stagedInputs: staged }));

--- a/harness/openspec/changes/add-run-canceler/.openspec.yaml
+++ b/harness/openspec/changes/add-run-canceler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/harness/openspec/changes/add-run-canceler/design.md
+++ b/harness/openspec/changes/add-run-canceler/design.md
@@ -1,0 +1,43 @@
+# Run canceler design
+
+## Context
+
+`executeAnalysis` finalises run-level state in `collectAndComplete`, which a cancelled DBOS workflow can never reach — a cancelled workflow cannot execute steps. External cancel therefore needs a second, host-side convergence path over the same ledgers: run row, step rows, running charge, run mandate. Cortex hand-rolls a partial version today (engine cancel only, no convergence); the harness owns every ledger involved, so the whole path belongs here.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One call a host makes from its cancel route that leaves the run ledger, step ledger, charge bracket, and mandate in the states the workflow's own terminal path would have produced.
+- Safe against the two known races: a run completing concurrently with the cancel, and a child workflow whose `mark-running` step has not yet committed its `child_workflow_id`.
+- Honest reporting: per-phase convergence flags, never a claimed convergence that did not happen.
+
+**Non-Goals:**
+
+- Terminal stream frames — `DBOS.writeStream` is body-only; hosts synthesize the terminal frame read-side.
+- Changing the workflow body's own terminal path or the budget-pause branch.
+- Resume of cancelled runs.
+
+## Decisions
+
+**Engine cancel via `DBOSClient`, reusing the purger's realization.** `createDbosWorkflowPurger({pool}).cancel` already does exactly the required engine call — `client.cancelWorkflows(ids, { cancelChildren: true })` over an injected pool, no launched engine required, ledger-absent recovery included. The canceler defaults its internal `cancelWorkflows` seam to it rather than duplicating a second `DBOSClient` construction. The static `DBOS` facade was rejected for the same reason it was rejected for the purger: it throws without a launched engine, and an embedder's host copy of the SDK may be a different, un-launched instance. The seam is an optional dep with this production default (the BillingFetcher pattern) so unit tests fake it without touching DBOS.
+
+**Child reach is belt-and-braces.** `cancelChildren: true` walks the engine's own `parent_workflow_id` ledger, which has a row the moment a child starts — that alone covers the child whose `mark-running` step has not yet committed to `cortex_step_executions`. The canceler additionally cancels the persisted incomplete `child_workflow_id`s and re-queries once after the parent cancel to sweep late-committing ids, so neither ledger's lag orphans a child.
+
+**Conditional terminal write, not `updateRunStatus`.** A plain `updateRunStatus(runId, "canceled")` would clobber a concurrently-completing run's terminal status. `markRunCanceledIfActive` guards on `status IN ('running','suspended_insufficient_funds')` — the same active set `queryActiveRun` deduplicates on — and reports whether a row transitioned. No transition means the run reached its own terminal state; the canceler re-reads and reports that status as `finalStatus` instead of lying.
+
+**Phases isolated, cancel strict.** The engine cancel itself rejects on failure — converging ledgers under a workflow that is still running would fight the body's own writes, and the host can simply retry. The four convergence phases after it are each try/logged so one failure cannot skip the rest: charge close is best-effort by design (the billing authority self-heals via its defensive open and stale reaper; a failed close loses attribution only), and mandate revoke is best-effort because an expired-mandate revoke failure must not strand the row convergence.
+
+**Mandate revoke is a new seam method, not a reuse of `revoke`.** The terminal path's `revoke(authorization, reason)` runs under the run credential carried in workflow input. The cancel route holds no `RunAuthorization` — the mandate JWT is never persisted; only its jti is, on `cortex_runs`. `revokeByJti({ jti, auth }, reason)` covers exactly this out-of-band path. It takes the opaque `AuthContext` rather than an `orgId` string: the harness carries org identity nowhere outside `auth` (the session-model invariant), and the managed realization downcasts `auth` the same way every managed seam adapter does. Local/OSS authorizers no-op — they mint no jti. Required rather than optional so a managed embedder cannot silently ship an authorizer that strands mandates.
+
+**No-mandate rows converge vacuously.** `converged.mandate` is `true` when the row carries no jti: there is nothing to revoke, and a vacuous `true` lets hosts alert on any `false` flag uniformly instead of special-casing OSS rows.
+
+## Risks / Trade-offs
+
+- [The `workflowId === runId` launch contract is assumed, not queried] → It is the invariant `execute_analysis` establishes (`runLauncher.launch(..., { workflowId: runId }, ...)`) and the result surfaces both ids so a host can cross-check.
+- [A cancel between `queryRun` and the engine call can race a just-completing run] → `markRunCanceledIfActive` refuses the clobber; `sweepPendingStepExecutions` only touches still-`pending` rows, which a completed run no longer has; charge close and revoke are idempotent at their authorities.
+- [`revokeByJti` is breaking for embedder authorizers] → One no-op method; the local factory already satisfies it, so only hand-built fakes and managed realizations change.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/add-run-canceler/proposal.md
+++ b/harness/openspec/changes/add-run-canceler/proposal.md
@@ -1,0 +1,37 @@
+# Expose a fully encapsulated run canceler
+
+## Why
+
+External cancellation of an `executeAnalysis` run converges nothing today. A cancelled DBOS workflow can never execute another step, so `collectAndComplete` — the one block that finalises run-level state — is unreachable on that path (the wedge is documented beside the external-cancellation catch in `src/workflows/execute-analysis.ts`). A host that calls `DBOS.cancelWorkflow` is left holding the pieces: the `cortex_runs` row stays `running` forever (which blocks same-plan relaunch through `queryActiveRun`'s active-status dedup), pending `cortex_step_executions` rows never sweep, the running charge never closes, and the run mandate is never revoked. Every embedder would have to hand-roll the same four-way convergence against ledgers the harness owns.
+
+## What Changes
+
+- New `createRunCanceler(deps)` execution module: cancels the DBOS parent workflow and its children (child-cascading, plus the persisted child ids and one re-query for late-committing children), then converges the run row, the pending step rows, the running charge, and the run mandate — each phase isolated so one failure does not skip the rest. Returns a `CancelRunResult` reporting the outcome and per-phase convergence flags. Idempotent: a second cancel of a terminal run short-circuits to `already_terminal` with no engine call.
+- New `markRunCanceledIfActive(pool, runId, reason)` state accessor: a conditional terminal write that transitions only an active run to `canceled` and reports whether a row transitioned, so an external cancel racing a concurrently-completing run never clobbers the workflow's own terminal status.
+- `RunAuthorizer` gains a required `revokeByJti(ref, reason)` method for out-of-band revocation where only the persisted jti exists (the mandate JWT is never persisted). **BREAKING** for embedder-supplied authorizers: the interface grows a required method. The local/OSS realization no-ops (it mints no jti).
+- Barrel exports for `createRunCanceler`, `RunCanceler`, `CancelRunResult`, and `markRunCanceledIfActive`.
+
+## Capabilities
+
+### New Capabilities
+
+- `run-cancellation`: the encapsulated external-cancel path — engine cancellation reach (parent, children, late-committing children), the four convergence phases and their isolation, idempotency, and the result contract.
+
+### Modified Capabilities
+
+- `run-state-persistence`: adds the conditional `markRunCanceledIfActive` terminal write beside the unconditional `updateRunStatus`.
+- `harness-session-model`: the `RunAuthorizer` seam gains the required out-of-band `revokeByJti`, distinct from the terminal-path `revoke` that runs under the run credential.
+
+## Impact
+
+Harness source:
+
+- `src/state/runs.ts` — `markRunCanceledIfActive`.
+- `src/execution/run-canceler.ts` (new) — `createRunCanceler`, `RunCanceler`, `CancelRunResult`.
+- `src/execution/run-authorizer.ts` — `revokeByJti` on the seam.
+- `src/auth/local-run-authorizer.ts` — no-op `revokeByJti`.
+- `src/index.ts` — barrel exports.
+
+Consumers: managed hosts (Cortex) replace their hand-rolled cancel route body with `runCanceler.cancel(runId, session)` and realize `revokeByJti` in their authorizer. The cli's local authorizer comes from the harness factory and needs no change; embedder test fakes typed as `RunAuthorizer` must add the no-op method.
+
+Out of scope: read-side synthesis of the terminal stream frame (`DBOS.writeStream` is body-only — hosts own that), and the workflow-body terminal path itself, which is unchanged.

--- a/harness/openspec/changes/add-run-canceler/specs/harness-session-model/spec.md
+++ b/harness/openspec/changes/add-run-canceler/specs/harness-session-model/spec.md
@@ -1,0 +1,17 @@
+# harness-session-model Delta
+
+## ADDED Requirements
+
+### Requirement: RunAuthorizer supports out-of-band revocation by persisted jti
+
+`RunAuthorizer` SHALL expose `revokeByJti(ref: { jti: string; auth: AuthContext }, reason: string): Promise<void>` for paths that hold no `RunAuthorization` — external cancellation, where the mandate JWT was never persisted and only its jti survives on `cortex_runs`. The `ref` SHALL carry the caller's opaque `AuthContext` (the sole carrier of credential/org behind a session); the harness never inspects it. The local/OSS realization SHALL no-op — it mints no jti. Normal terminal paths continue to use `revoke(authorization, reason)` under the run credential.
+
+#### Scenario: Local authorizer no-ops
+
+- **WHEN** `createLocalRunAuthorizer().revokeByJti({ jti, auth }, reason)` is called
+- **THEN** it resolves without side effects
+
+#### Scenario: Out-of-band cancel revokes by jti
+
+- **WHEN** the run canceler converges a run whose row carries a `mandate_jti`
+- **THEN** it calls `revokeByJti` with that jti and the cancelling session's `auth`, never reconstructing a `RunAuthorization`

--- a/harness/openspec/changes/add-run-canceler/specs/run-cancellation/spec.md
+++ b/harness/openspec/changes/add-run-canceler/specs/run-cancellation/spec.md
@@ -1,0 +1,60 @@
+# run-cancellation Specification
+
+## ADDED Requirements
+
+### Requirement: The canceler cancels the parent workflow and every child
+
+`createRunCanceler(deps).cancel(runId, session)` SHALL cancel the DBOS parent workflow (whose id equals `runId` by the launch contract) with child-cascading reach, additionally cancel the run's persisted incomplete `child_workflow_id`s, and re-query the step ledger once after the parent cancel to cancel any late-committing child ids. The engine capability SHALL stay internal to the module behind an optional injectable seam whose production default is the `DBOSClient`-backed child-cascading cancel.
+
+#### Scenario: Children reached through both ledgers
+
+- **WHEN** `cancel` runs against an active run with one step row carrying an incomplete `child_workflow_id`
+- **THEN** the engine cancel receives the parent workflow id and that child id, with child-cascading enabled
+
+#### Scenario: Late-committing child swept by the re-query
+
+- **WHEN** a child's `child_workflow_id` commits to the step ledger only after the parent cancel was issued
+- **THEN** the post-cancel re-query finds it and a second engine cancel covers it
+
+#### Scenario: Engine-cancel failure rejects
+
+- **WHEN** the engine cancel itself fails
+- **THEN** `cancel` rejects without converging any ledger, so a host retry finds the run still active
+
+### Requirement: Convergence phases run isolated after the engine cancel
+
+After a successful engine cancel, the canceler SHALL converge in order — conditional run-row terminal write, pending-step sweep, running-charge close (`reason: "canceled"`), out-of-band mandate revoke when the row carries a jti — with each phase guarded so one failure does not skip the rest. The returned `converged` flags SHALL reflect what actually happened; `converged.mandate` SHALL be vacuously true for a row with no persisted jti.
+
+#### Scenario: Full convergence
+
+- **WHEN** every phase succeeds for a running run carrying a mandate jti
+- **THEN** the result is `outcome: "canceled"`, `finalStatus: "canceled"`, and `converged` all true
+
+#### Scenario: Charge-close failure does not skip the revoke
+
+- **WHEN** `runCharge.close` throws
+- **THEN** the mandate is still revoked, `converged.charge` is false, and `cancel` resolves
+
+#### Scenario: No mandate to revoke
+
+- **WHEN** the run row carries no `mandate_jti`
+- **THEN** no revoke is attempted and `converged.mandate` is true
+
+### Requirement: Cancel is idempotent and never clobbers a concurrent completion
+
+A cancel of an already-terminal run SHALL short-circuit to `outcome: "already_terminal"` with the row's status and no engine call. When the run completes concurrently between the active-check and the terminal write, the conditional write SHALL refuse the transition and `finalStatus` SHALL report the run's own terminal status.
+
+#### Scenario: Second cancel short-circuits
+
+- **WHEN** `cancel` runs against a run whose status is `completed`, `partial`, `failed`, or `canceled`
+- **THEN** it returns `outcome: "already_terminal"` with that status, converged flags false, and issues no engine cancel and no charge close
+
+#### Scenario: Concurrent completion wins the row
+
+- **WHEN** the run transitions to `completed` between the canceler's read and its terminal write
+- **THEN** the write reports no transition, `finalStatus` is `completed`, and the pending-step sweep still runs (it touches only still-`pending` rows)
+
+#### Scenario: Unknown run
+
+- **WHEN** `cancel` is called with a `runId` no row exists for
+- **THEN** it rejects with `UnknownRunError`

--- a/harness/openspec/changes/add-run-canceler/specs/run-state-persistence/spec.md
+++ b/harness/openspec/changes/add-run-canceler/specs/run-state-persistence/spec.md
@@ -1,0 +1,17 @@
+# run-state-persistence Delta
+
+## ADDED Requirements
+
+### Requirement: Conditional cancel transition guards concurrent completion
+
+`markRunCanceledIfActive(pool, runId, reason)` SHALL transition the run row to `canceled` — stamping `completed_at` and recording `reason` in `error` — only when its status is in the active set (`running`, `suspended_insufficient_funds`), and SHALL report whether a row transitioned. A terminal row SHALL be left untouched.
+
+#### Scenario: Active run transitions
+
+- **WHEN** `markRunCanceledIfActive` runs against a `running` (or `suspended_insufficient_funds`) run
+- **THEN** the row becomes `canceled` with `completed_at` and `error = reason` stamped, and the call reports a transition
+
+#### Scenario: Terminal run refused
+
+- **WHEN** `markRunCanceledIfActive` runs against a `completed` run
+- **THEN** the row keeps its status, `completed_at`, and `error`, and the call reports no transition

--- a/harness/openspec/changes/add-run-canceler/tasks.md
+++ b/harness/openspec/changes/add-run-canceler/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## 1. State accessor
+
+- [x] 1.1 Add `markRunCanceledIfActive(pool, runId, reason)` to `src/state/runs.ts` — conditional `canceled` write over the active-status set, reporting the transition
+- [x] 1.2 Extend `src/state/runs.test.ts`: transitions running→canceled (stamps `completed_at` + `error`), refuses completed→canceled
+
+## 2. Seam extension
+
+- [x] 2.1 Add required `revokeByJti(ref: { jti; auth }, reason)` to `RunAuthorizer` in `src/execution/run-authorizer.ts` with the out-of-band JSDoc contract
+- [x] 2.2 Add the no-op `revokeByJti` to `createLocalRunAuthorizer` and to every hand-built `RunAuthorizer` fake in the repo
+
+## 3. Canceler module
+
+- [x] 3.1 Create `src/execution/run-canceler.ts` — `createRunCanceler(deps)`, `RunCanceler`, `CancelRunResult`, `UnknownRunError`; engine cancel via the purger's `DBOSClient` realization behind an optional `cancelWorkflows` test seam; four isolated convergence phases
+- [x] 3.2 Unit tests in `src/execution/run-canceler.test.ts` (fakes, no live DBOS): already-terminal short-circuit, happy convergence, late-committing child re-query, charge-close failure isolation, no-mandate vacuous convergence, conditional-write race, unknown run
+
+## 4. Surface
+
+- [x] 4.1 Export `createRunCanceler`, `RunCanceler`, `CancelRunResult`, `UnknownRunError`, and `markRunCanceledIfActive` from `src/index.ts` beside the sibling execution/state exports
+
+## 5. Verification
+
+- [x] 5.1 `npx tsc --noEmit` clean for touched files; `bun test src/execution/run-canceler.test.ts` and `bun test src/state/runs.test.ts` green

--- a/harness/openspec/changes/drop-analysis-billing-context/.openspec.yaml
+++ b/harness/openspec/changes/drop-analysis-billing-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/harness/openspec/changes/drop-analysis-billing-context/design.md
+++ b/harness/openspec/changes/drop-analysis-billing-context/design.md
@@ -1,0 +1,31 @@
+# Design
+
+## Context
+
+`cortex_analysis_state.billing_context` dates from the eager billing model, where the seed wrote attribution headers and `resolveAnalysisBilling` read them back per request. Managed Cortex now resolves attribution lazily at charge-open time (Nexus `resolve-headers`), the OSS path never billed, and the reader lost its last caller. What remains is write-only state that a re-upsert clobbers unconditionally.
+
+## Goals / Non-Goals
+
+- Goal: remove the column, its writer parameter, and its dead reader in one cut.
+- Goal: existing databases converge on the new shape at startup with no operator action.
+- Non-goal: any change to target-assessment billing — `cortex_target_assessments.billing_context_id` is an id the session scope keys on, not a persisted header map.
+- Non-goal: replacing the reader; charge-time resolution is the embedder's, outside the state layer.
+
+## Decisions
+
+- **Drop the column, don't deprecate it.** A nullable column with no reader invites a future caller to trust a value every writer nulls or clobbers. `DROP COLUMN IF EXISTS` in the existing `dropMigrations` array follows the `user_id`/`profile`/`input_files` precedent exactly, and runs before `addMigrations` — so removing the old `ADD COLUMN IF NOT EXISTS billing_context` line means the column never comes back.
+- **Migration lives in the JS array, not the DDL string.** The DDL template is split naively on `';'`; the drop-migration arrays are per-statement `client.query` calls with no such constraint. Matching the existing structure keeps the split hazard untouched.
+- **Positional removal over deprecation of the parameter.** `upsertAnalysis` is pre-1.0 and both known callers pass literal `null`. Keeping an ignored parameter would preserve source compatibility at the cost of a lying signature.
+
+## Risks / Trade-offs
+
+- [Embedder passing the old 4th argument] → compile error against the new types; both known call sites (managed Cortex seed route, CLI ledger seed) pass `null` today, so the fix is deletion.
+- [Rows carrying real billing JSON in some old database] → dropped without backfill. Nothing has read the column since the lazy resolver landed; per-call attribution lives in usage rows.
+
+## Migration Plan
+
+Ships in the harness package; embedders pick it up on upgrade. Startup DDL drops the column idempotently. Rollback is the previous package version — its `ADD COLUMN IF NOT EXISTS` recreates the column (empty), which the old code tolerates because the seed always wrote null anyway.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/drop-analysis-billing-context/proposal.md
+++ b/harness/openspec/changes/drop-analysis-billing-context/proposal.md
@@ -1,0 +1,26 @@
+# Drop the analysis billing_context column
+
+## Why
+
+Managed Cortex resolves billing attribution lazily at charge-open time via its Nexus `resolve-headers` resolver — decided after the prelaunch audit. The persisted `cortex_analysis_state.billing_context` column is a stale-copy trap left over from the eager model: the host's seed route always writes null, a re-upsert overwrites the stored value unconditionally (`SET billing_context = EXCLUDED.billing_context`, no COALESCE — unlike `seed_input_file_ids`, which is coalesced), and `resolveAnalysisBilling` — the only reader — has zero callers in the harness, the CLI, or managed Cortex. The OSS path leaves it null by construction. A column nobody reads, that every writer nulls or clobbers, is not billing state; it is a place for a future caller to find stale identity.
+
+## What Changes
+
+- **BREAKING** `upsertAnalysis` loses its `billingContext` parameter: `upsertAnalysis(pool, resourceId, context, inputFileIds?)`. The INSERT/UPDATE no longer touches `billing_context`.
+- Delete `resolveAnalysisBilling` (zero callers) and its barrel export.
+- Remove `billing_context JSONB` from the `cortex_analysis_state` CREATE TABLE and its additive migration; add an idempotent `ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS billing_context` alongside the other vestigial-column drops.
+- `cortex_target_assessments.billing_context_id` is untouched — TA billing is keyed by id on the session scope, not by a persisted header map, and that model is correct.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cortex-state-layer`: the `cortex_analysis_state` schema requirement loses the `billing_context` column, and the upsert scenarios lose the billing argument. Billing identity is never persisted in the state layer; it is resolved by the embedder at charge time.
+
+## Impact
+
+- `src/state/analyses.ts` — `upsertAnalysis` signature and SQL; `resolveAnalysisBilling` deleted.
+- `src/state/init.ts` — DDL and migrations.
+- `src/state/index.ts` — barrel export removed.
+- CLI call sites (`seedProfileLedger`, `inflexa run` ledger seed) drop the always-null argument.
+- Breaking for embedders that pass the fourth argument; managed Cortex's seed route passes null today and adapts trivially. Pre-1.0, ships in the next minor.

--- a/harness/openspec/changes/drop-analysis-billing-context/specs/cortex-state-layer/spec.md
+++ b/harness/openspec/changes/drop-analysis-billing-context/specs/cortex-state-layer/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: cortex_analysis_state table schema
+
+The `cortex_analysis_state` table SHALL store per-analysis singleton state with
+the columns: `analysis_id` (TEXT, PRIMARY KEY), `status` (TEXT, NOT NULL),
+`context` (TEXT, nullable),
+`data_profile_status` (TEXT, **nullable**, default `'pending'`),
+`data_profile_error` (TEXT, nullable), `data_profile_started_at` (TEXT,
+nullable), `data_profile_completed_at` (TEXT, nullable), `data_profile_result`
+(JSONB, nullable), `data_profile_workflow_id` (TEXT, nullable),
+`seed_input_file_ids` (JSONB, nullable), `created_at` (TEXT,
+NOT NULL), `updated_at` (TEXT, NOT NULL).
+
+The `data_profile_status` column SHALL accept `'pending'`, `'running'`,
+`'completed'`, and `'failed'`; `'running'` covers both initial profiling and
+re-profiling, the distinction being made at the API layer by the presence of
+`data_profile_result`. It SHALL also accept NULL, which means "no profile" —
+`clearDataProfile` writes it when an analysis's input set empties (see the
+data-profile-rerun spec), and startup SHALL drop the legacy NOT NULL constraint
+from databases created before the column became nullable.
+
+`data_profile_workflow_id` SHALL hold the DBOS workflow id of the profile attempt
+that owns the row, written by the workflow body rather than by the trigger — the
+ledger claim happens before the workflow id is minted, so only the body can report
+the id of the attempt that actually started. The write SHALL be conditional on the
+row still being `running`, so a late write cannot stamp an id onto a settled row.
+
+Every claim into `running` SHALL clear the column, and `clearDataProfile` SHALL clear
+it too. The claim is the moment a new attempt takes the row, so any id already there
+belongs to a finished attempt: left in place it would leave a `running` row naming a
+stream that has already drained, and a consumer would subscribe and observe nothing
+with no way to distinguish that from a profile yet to report. NULL says "not
+addressable yet", which is exactly true until the new body records its own id. This
+is deliberately asymmetric with `data_profile_result`, which a re-profile claim
+preserves: the result is content that stays valid until replaced, while the id is a
+pointer to a live stream.
+
+The column is nullable, and absence is a
+normal state with two ordinary causes: a row claimed whose body has not yet
+recorded its id, and a row written before the column existed. Both read back as
+"this profile's stream is not addressable", which is true in each case. A consumer
+resolves which durable event stream carries an analysis's profile activity from
+this column, and SHALL NOT reconstruct it by pattern-matching workflow ids in
+durability-engine tables (see the data-profile-observation spec).
+
+The `data_profile_result` JSONB SHALL hold the profiler's full output, not a
+summary of it: the dataset-level classification (`summary`, `domain`, `subtype`,
+`organism` with its taxon id and confidence, `tissue`, `cellType`, `condition`,
+`accessions`, `experimentalDesign`, `qualityAssessment`) and the per-file records
+(`path`, `description`, `dataType`, `format`, `rows`, `cols`, `tags`, `warnings`,
+`metrics`), alongside `inputFileIds`, `inputFiles`, and `profiledAt`. This row is
+the profile's only durable home — no profile file exists on disk — so the
+projection into it is total (see the data-profile-init spec). Every field past
+`summary`/`files`/`inputFileIds`/`profiledAt` SHALL be optional on read, so a
+snapshot written before the record was widened still renders.
+
+The table SHALL NOT have a `user_id` column — user identity is derived from the
+ambient credential's JWT `sub` claim at request time (the legacy `user_id` column
+is dropped on startup).
+
+The table SHALL NOT have a `billing_context` column — billing attribution is
+resolved by the embedder at charge time, never persisted in the state layer
+(the legacy `billing_context` column is dropped on startup).
+
+#### Scenario: Analysis upserted without user_id column
+
+- **WHEN** an analysis is created via `upsertAnalysis(pool, resourceId, context,
+  inputFileIds?)`
+- **THEN** a row is inserted with `status` `'active'`, `context` from the
+  argument, `data_profile_status` `'pending'`, and `seed_input_file_ids` set
+  from `inputFileIds` when supplied
+- **AND** no `user_id` column exists on the table
+
+#### Scenario: Re-upsert replaces mutable fields
+
+- **WHEN** `upsertAnalysis` is called again for an existing analysis
+- **THEN** `context` and `updated_at` SHALL be replaced, and
+  `seed_input_file_ids` SHALL be coalesced (kept when the new value is null)
+
+#### Scenario: Legacy billing_context column is dropped on startup
+
+- **WHEN** startup runs against a database whose `cortex_analysis_state` still
+  carries the legacy `billing_context` column
+- **THEN** the column SHALL be dropped idempotently (`DROP COLUMN IF EXISTS`),
+  and a database without it SHALL be unaffected
+
+#### Scenario: Data profile completed with input snapshot
+
+- **WHEN** `completeDataProfile` runs after the data-profile task succeeds
+- **THEN** `data_profile_status` SHALL become `'completed'` and
+  `data_profile_result` SHALL be set with the profiler's full output — the
+  dataset classification and the per-file records — alongside `inputFileIds`,
+  `inputFiles`, and `profiledAt`
+
+#### Scenario: Re-run preserves the prior profile result
+
+- **WHEN** a re-profile is claimed for a completed analysis via
+  `tryRerunDataProfile` (or a retry of a failed analysis via
+  `tryRetryDataProfile`)
+- **THEN** `data_profile_status` SHALL transition to `'running'`,
+  `data_profile_started_at` SHALL be refreshed, `data_profile_error` and
+  `data_profile_completed_at` SHALL be cleared, and `data_profile_result` SHALL
+  retain its prior value (NOT cleared)
+
+#### Scenario: The profile workflow id is recorded by the body and read back
+
+- **WHEN** a data-profile workflow body runs its first durable step
+- **THEN** `data_profile_workflow_id` SHALL hold that workflow's DBOS id
+- **AND** the data-profile status read SHALL expose it as `workflowId`
+
+#### Scenario: A re-profile replaces the recorded workflow id
+
+- **WHEN** a new profile attempt claims a row that already recorded a prior
+  attempt's workflow id
+- **THEN** the claim SHALL clear `data_profile_workflow_id`, so the row never names a
+  finished attempt while it is `running`
+- **AND** `data_profile_workflow_id` SHALL become the new attempt's id once that
+  attempt's body records it
+
+#### Scenario: A settled row keeps its recorded id
+
+- **WHEN** a profile reaches `completed` or `failed`
+- **THEN** `data_profile_workflow_id` SHALL retain the id of the attempt that produced
+  it, so a consumer can still address that profile's drained stream
+- **AND** only a subsequent claim or clear SHALL remove it
+
+#### Scenario: A settled row is not stamped by a late write
+
+- **GIVEN** a profile row whose status is `completed` or `failed`
+- **WHEN** a workflow-id write for that analysis is attempted
+- **THEN** the row is unchanged, because the write requires a `running` status
+
+#### Scenario: A row predating the column reads back without one
+
+- **WHEN** the data-profile status is read for a row written before
+  `data_profile_workflow_id` existed
+- **THEN** `workflowId` SHALL be null and the read SHALL otherwise succeed
+  unchanged
+
+#### Scenario: Suspend and resume on budget exhaustion
+
+- **WHEN** `suspendAnalysis` runs after a budget-exceeded error
+- **THEN** `status` SHALL become `'suspended_insufficient_funds'` (idempotent),
+  and `resumeAnalysis` SHALL transition it back to `'active'` only from that
+  suspended state

--- a/harness/openspec/changes/drop-analysis-billing-context/tasks.md
+++ b/harness/openspec/changes/drop-analysis-billing-context/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## 1. State layer
+
+- [x] 1.1 Remove the `billingContext` parameter from `upsertAnalysis` and drop `billing_context` from its INSERT/UPDATE SQL; restate the docstring (the split-attribution paragraph described billing rotation and goes with it).
+- [x] 1.2 Delete `resolveAnalysisBilling` and its `src/state/index.ts` barrel export.
+- [x] 1.3 Remove `billing_context JSONB` from the `cortex_analysis_state` CREATE TABLE and the `ADD COLUMN IF NOT EXISTS billing_context` additive migration; append `ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS billing_context` to the `dropMigrations` array beside the other `cortex_analysis_state` drops.
+
+## 2. Call sites
+
+- [x] 2.1 Update harness test call sites to the 4-arg signature (state, runtime, app, report-session, and DBOS budget-cascade suites).
+- [x] 2.2 Update CLI call sites: `seedProfileLedger` (`cli/src/modules/harness/profile_trigger.ts`) and the `inflexa run` ledger seed (`cli/src/modules/harness/dev/run.ts`); fix the `billingContext` mention in the seed comment.
+
+## 3. Spec
+
+- [x] 3.1 Modify the `cortex_analysis_state table schema` requirement: column gone, upsert scenarios lose the billing argument, startup-drop scenario added.
+- [ ] 3.2 On archive, update the capability's Purpose paragraph, which still lists "billing identity" among the table's contents.
+
+## 4. Verification
+
+- [x] 4.1 `npx tsc --noEmit` clean in the harness; CLI tsc errors confined to the stale published 0.19 types (resolve on next publish).
+- [x] 4.2 `bun test` green on the touched suites: plans, report-session-state, report-versions, record-version, reconcile-orphaned-data-profile, assemble, report-session-runtime, budget-cascade.

--- a/harness/openspec/changes/fix-ask-sweep-predicate/.openspec.yaml
+++ b/harness/openspec/changes/fix-ask-sweep-predicate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/harness/openspec/changes/fix-ask-sweep-predicate/design.md
+++ b/harness/openspec/changes/fix-ask-sweep-predicate/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`sweepExpired` (src/tools/approval/queries.ts) updates every `pending` row in
+`cortex_asks` to `expired` with no age predicate. Hosts call
+`askGateway.sweepExpired()` on every pod boot, so any boot — including each pod
+of a rolling deployment — expires every live pending approval fleet-wide. The
+ledger has no `expires_at`/deadline column; `created_at` is fixed-width UTC ISO
+text written by the gateway. `src/state/init.ts` (DDL) is owned by a concurrent
+change and must not be edited here.
+
+## Goals / Non-Goals
+
+- Goal: a boot sweep cannot expire an ask a live pod is still polling.
+- Goal: smallest change; no DDL, no new config surface beyond one optional arg.
+- Non-goal: per-ask deadlines (`expires_at` column) or TTL enforcement while a
+  turn is live — the poll loop's `ctx.signal` already bounds a live ask's life.
+
+## Decisions
+
+- **Age predicate on `created_at`** over a new deadline column: the column is
+  the only lifetime signal available without touching init.ts. Text comparison
+  (`created_at < $2`) is sound because every write is `Date.toISOString()` —
+  fixed-width UTC, lexicographic = chronological — the same property
+  `selectPending`'s `ORDER BY created_at` already relies on. A `::timestamptz`
+  cast was rejected: it adds failure modes on nothing and diverges from the
+  existing ordering convention.
+- **`sweepExpired(maxAgeMs?: number)` with a 24 h default** over a construction
+  dep or env config: callers keep compiling unchanged, the default is far beyond
+  any plausible live turn (turn aborts mark rows `aborted` long before), and a
+  host wanting a tighter policy passes a number. Exported as
+  `DEFAULT_SWEEP_MAX_AGE_MS`.
+- **Cutoff computed at the gateway**, queries stay dumb: the query takes
+  `expiredAt` + `olderThan` strings; time arithmetic lives in one place.
+
+## Risks / Trade-offs
+
+- [A genuinely orphaned ask lingers `pending` up to 24 h before the next boot
+  sweeps it] → acceptable: `pending()` still surfaces it, `answer` still works
+  against it, and nothing awaits it; the ledger records the loss on the next
+  sweep.
+- [A live human decision outlasting 24 h is swept] → the turn's own lifetime
+  (abort/timeout) ends far earlier in practice; the poll loop then observes
+  `expired` and denies safely via `AskRejectedError`.
+
+## Migration Plan
+
+Behavior-tightening only; zero-arg callers are source-compatible. No data
+migration. Rollback is reverting the predicate.
+
+## Open Questions
+
+- A future `expires_at` column (per-ask deadline at insert) would make expiry
+  exact rather than heuristic — deferred as a DDL ask on the init.ts owner.

--- a/harness/openspec/changes/fix-ask-sweep-predicate/proposal.md
+++ b/harness/openspec/changes/fix-ask-sweep-predicate/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`sweepExpired` expires *every* `pending` ask (`WHERE status = 'pending'`, no age
+predicate). Managed hosts run the sweep on every pod boot, so a rolling
+deployment would expire every live pending approval fleet-wide — an ask being
+actively polled on one pod is killed by another pod booting. Dormant today (no
+production tool calls `ctx.ask` yet) but must be fixed before approval-gated
+tools ship.
+
+## What Changes
+
+- `sweepExpired` gains an age predicate: only `pending` rows whose `created_at`
+  is older than a max age are swept to `expired`. Fresh pending asks survive a
+  boot sweep.
+- `AskGateway.sweepExpired()` becomes `sweepExpired(maxAgeMs?: number)` with a
+  24-hour default (`DEFAULT_SWEEP_MAX_AGE_MS`) — far beyond any plausible live
+  turn, so a rolling-deploy boot cannot expire an ask another pod still polls.
+  Existing zero-arg callers keep compiling and get the safe default.
+- No DDL change: the ledger has no deadline column and `src/state/init.ts` is
+  owned elsewhere; `created_at` (fixed-width UTC ISO text, already relied on for
+  ordering) carries the age predicate.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tool-approval`: the boot-sweep requirement changes from "sweep every pending
+  row" to "sweep only pending rows older than the sweep max age" — a live
+  pending ask survives a concurrent boot.
+
+## Impact
+
+- `src/tools/approval/queries.ts` — sweep SQL gains `AND created_at < $2`.
+- `src/tools/approval/gateway.ts` — `sweepExpired(maxAgeMs?)`, default exported
+  as `DEFAULT_SWEEP_MAX_AGE_MS`.
+- `src/tools/approval/gateway.test.ts` — sweep suite covers survive-fresh,
+  sweep-stale, mixed count, explicit max age.
+- Embedders calling `askGateway.sweepExpired()` at boot are unaffected
+  source-wise; behavior tightens to orphans only.

--- a/harness/openspec/changes/fix-ask-sweep-predicate/specs/tool-approval/spec.md
+++ b/harness/openspec/changes/fix-ask-sweep-predicate/specs/tool-approval/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: The ask status machine covers approval, denial, abort, and expiry
+
+An ask SHALL move from `pending` to exactly one terminal status:
+`resolved` (approved `once` or `always`), `rejected`, `aborted`, or `expired`.
+A pending ask whose turn is cancelled via `ctx.signal` SHALL become `aborted`,
+and its `ctx.ask` SHALL stop polling and re-throw the cancellation so the loop's
+existing turn-abort path engages unchanged. A pending ask left by a process that
+is no longer running SHALL be swept to `expired` at boot, because its turn's
+in-memory continuation cannot be resumed — the ledger records the loss rather than
+leaving a permanently-pending row. The sweep SHALL expire only pending asks older
+than a max age (default 24 hours, overridable per call via
+`sweepExpired(maxAgeMs?)`), so a boot — including each pod of a rolling
+deployment — cannot expire an ask a live process is still polling. The sweep's
+return count SHALL reflect only the rows it swept.
+
+#### Scenario: Turn abort aborts a pending ask
+
+- **GIVEN** a suspended `ctx.ask` on a turn whose `ctx.signal` fires
+- **WHEN** the abort is observed
+- **THEN** the row becomes `aborted` and `ctx.ask` re-throws the cancellation, so the turn ends through the existing abort path
+
+#### Scenario: An orphaned pending ask is expired at boot
+
+- **GIVEN** a `pending` row older than the sweep max age, left by a prior process with no live turn awaiting it
+- **WHEN** the harness boots and sweeps the ledger
+- **THEN** that row becomes `expired`
+
+#### Scenario: A live pending ask survives a boot sweep
+
+- **GIVEN** a fresh `pending` row within the sweep max age
+- **WHEN** another process boots and sweeps the ledger
+- **THEN** the row stays `pending` and the sweep count excludes it
+
+#### Scenario: The sweep count reflects only swept rows
+
+- **GIVEN** one `pending` row older than the max age and one fresh `pending` row
+- **WHEN** the ledger is swept
+- **THEN** the sweep returns 1, the stale row is `expired`, and the fresh row stays `pending`

--- a/harness/openspec/changes/fix-ask-sweep-predicate/tasks.md
+++ b/harness/openspec/changes/fix-ask-sweep-predicate/tasks.md
@@ -1,0 +1,16 @@
+## 1. Sweep predicate
+
+- [x] 1.1 Add `AND created_at < $2` (text ISO cutoff) to the sweep UPDATE in `src/tools/approval/queries.ts`; `sweepExpired(querier, expiredAt, olderThan)`
+- [x] 1.2 Change `AskGateway.sweepExpired()` to `sweepExpired(maxAgeMs?: number)` in `src/tools/approval/gateway.ts`, computing the cutoff from one `Date.now()`; export `DEFAULT_SWEEP_MAX_AGE_MS = 24h`
+
+## 2. Tests
+
+- [x] 2.1 Sweep suite in `src/tools/approval/gateway.test.ts`: stale rows past max age are swept and counted
+- [x] 2.2 A fresh pending ask survives a sweep (status stays `pending`, count 0)
+- [x] 2.3 Mixed stale + fresh: count reflects only swept rows
+- [x] 2.4 Explicit `maxAgeMs` override is honored
+
+## 3. Verify
+
+- [x] 3.1 `npx tsc --noEmit` clean
+- [x] 3.2 `bun test src/tools/approval/` green (17 pass)

--- a/harness/openspec/changes/restore-sandbox-billing-labels/.openspec.yaml
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/harness/openspec/changes/restore-sandbox-billing-labels/design.md
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/design.md
@@ -1,0 +1,50 @@
+# Design — restore-sandbox-billing-labels
+
+Re-lands Cortex's approved `fix-sandbox-compute-billing` design (Cortex commit `71d7dc99`, implemented against the old in-repo harness copy) in the published package source. The decisions below are that design's, adapted to this tree; deviations are listed at the end.
+
+## Context
+
+The metering side polls OpenCost for allocations in the sandbox namespace, aggregated by pod labels, filtered on `label[cortex_billing_context]!:""`. Required labels (OpenCost-sanitized keys): `cortex_billing_context`, `cortex_user_id`, `cortex_analysis_id` — parsed as UUIDs; `cortex_run_id` optional (absent/non-UUID ⇒ one-off `Charge` per analysis instead of run-rollup `AccrueCost`). K8s label keys with `/`, `-` sanitize to `_`, so the keys `cortex/billing-context` etc. match. `buildJobSpec` stamps no billing labels today, so every pod is filtered out before any metric can fire.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every K8s sandbox pod carries valid billing attribution labels ⇒ OpenCost metering resumes.
+- Zero DBOS step-sequence or workflow-input changes — safe for in-flight runs at deploy.
+- Resolution failures are loud (error-level) but never block a run.
+
+**Non-Goals:**
+- Charge open/close changes; one-resolution-per-run BC pinning (per-step resolution accepts rare `AccrueBCMismatch` fallback noise on mid-run VK rotation — still billed).
+- Backfill, alert rules, docker-backend labels, upstream metering changes.
+
+## Decisions
+
+### D1 — Resolve the BC at each spawn site via the existing resolver seam
+
+No new billing mechanism: each spawn path calls the existing `ResolveBilling` seam under its own session and passes `{ billingContextId, userId }` through `CreateSandboxMeta.billing`. The billing-context id is read from the resolved header map's `X-Inflexa-Billing-Context` key; the user id is the session's `identity.user`. Threading one resolution from charge-open through the workflow spine would touch `execute-analysis.ts`, the dep signatures, and `SandboxStepInput` — invasive, and per-step resolution costs one cached resolver call per step.
+
+### D2 — Resolution happens INSIDE the existing `sandbox.create` DBOS step
+
+In `sandbox-step`, the resolve + label construction runs inside the `sandbox.create` runStep closure, not as its own step. A separate `billing.resolve` step inserted before `sandbox.create` would shift the child workflow's step sequence and break replay for in-flight workflows resumed across the deploy; inside the checkpointed step, already-created sandboxes never re-execute it and new runs get resolution atomically with the spawn. Data-profile resolves inline before its `createSandbox` call (no new DBOS step there either).
+
+### D3 — Label set and placement mirror the pre-migration contract exactly
+
+`cortex/billing-context`, `cortex/user-id`, `cortex/analysis-id`, `cortex/run-id` on **both** Job metadata and pod template metadata, all through the existing `sanitizeLabelValue`. The pod template is what OpenCost allocates on; Job metadata aids kubectl triage. Data-profile passes its literal non-UUID run id — the reconciler parses run-id leniently and routes it to the per-analysis one-off Charge path, the designed behavior for run-less workloads.
+
+### D4 — `CreateSandboxMeta.billing` is optional; absence is loud at the spawn site
+
+`billing?: { billingContextId, userId }`. The k8s client stamps labels only when present; the "spawned without billing labels" error log lives at the spawn site (which knows whether a resolver was wired), so no `expectBillingLabels` config threads through the sandbox client. Wirings without a resolver get no `resolveBilling` dep and no noise. `SandboxStepDeps.resolveBilling` and `DataProfileDeps.resolveBilling` are the optional dep seams; both flow through `CoreWorkflowDeps` untouched (structural `Omit`s).
+
+## Risks / Trade-offs
+
+- [Charge appears only when the first allocation lands (~60–120s into a run)] → cosmetic; settlement on close is unchanged.
+- [Mid-run VK rotation ⇒ pod-label BC differs from the auto-opened RC's BC] → billed via the `AccrueBCMismatch` isolated-charge fallback; rare and observable.
+- [Per-spawn resolution failure ⇒ unlabeled pod ⇒ that step unbilled] → error-logged on every occurrence.
+- [`sanitizeLabelValue` could alter a UUID] → UUIDs are label-safe; sanitization is a defensive pass-through.
+
+## Deviations from the original Cortex design
+
+- **Ephemeral runner**: `harness/execution/ephemeral-runner.ts` does not exist in this tree (the runEphemeral port was deferred during the migration) — no port target. When it lands, it takes the same optional `resolveBilling` + inline resolution pattern.
+- **`build-deps.ts` wiring**: this tree has no `workflows/build-deps.ts`; deps are host-supplied via `CoreWorkflowDeps` (`assembleCoreRuntime`). Adding the optional `resolveBilling` fields to `SandboxStepDeps` / `DataProfileDeps` is the whole wiring — embedders bind their resolver at their composition root.
+- **Logging**: `console.error` in the original becomes the `Logger` seam (`logger.error` with the `[billing]` prefix), matching this tree's structured-logging convention.
+- **Header-key constant**: the original imported `HEADERS.BillingContext` from `harness/lib/billing-headers.ts`; that module lives in the managed host now, so the `"X-Inflexa-Billing-Context"` key is a local constant at each of the two spawn sites.

--- a/harness/openspec/changes/restore-sandbox-billing-labels/proposal.md
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/proposal.md
@@ -1,0 +1,32 @@
+# Restore sandbox billing labels
+
+## Why
+
+Sandbox K8s pods spawn with no billing attribution labels, so the OpenCost-based metering reconciler — which filters allocations on a non-empty `cortex_billing_context` pod label — never sees a single sandbox pod: 100% of sandbox compute/storage/network cost is unbilled. The fix was designed and approved as Cortex's `fix-sandbox-compute-billing` change (landed against Cortex's old in-repo harness copy, commit `71d7dc99`), but that copy was deleted in the migration to this published package and the package source never received it. This change re-lands that design here, post-migration; it is a launch blocker.
+
+## What Changes
+
+- `CreateSandboxMeta` gains an optional `billing?: { billingContextId: string; userId: string }` field.
+- The K8s Job spec builder stamps `cortex/billing-context`, `cortex/user-id`, `cortex/analysis-id`, `cortex/run-id` on BOTH the Job metadata and the pod template labels (pod template is what OpenCost allocates on), all values through `sanitizeLabelValue`. Absent `billing` ⇒ no billing labels, spawn unchanged.
+- Each K8s spawn path resolves billing attribution via the existing `ResolveBilling` seam under its own session and passes `meta.billing`: analysis sandbox steps (`src/workflows/sandbox-step.ts`, INSIDE the existing `sandbox.create` DBOS step — replay-safe) and the data-profile task (`src/tasks/data-profile.ts`, inline at spawn). Resolution failure error-logs (`[billing]` prefix) and spawns unlabeled — billing never blocks a run.
+- `SandboxStepDeps` and `DataProfileDeps` gain an optional `resolveBilling` dep; hosts without an upstream resolver (dev/OSS) wire nothing and pods spawn unlabeled with no noise.
+
+## Capabilities
+
+### New Capabilities
+
+- `compute-billing-attribution`: every K8s sandbox spawn path resolves billing attribution (billing-context id, user id) under its session and passes it to the sandbox client for pod-label stamping.
+- `k8s-sandbox-provider`: the K8s Job spec requirement for billing attribution labels on the pod template and Job metadata, sanitized via `sanitizeLabelValue`. (This repo has a `docker-sandbox-provider` spec but no K8s provider spec yet; the billing-label requirement seeds it.)
+
+### Modified Capabilities
+
+(none — no existing spec's requirements change)
+
+## Impact
+
+- `src/sandbox/types.ts` — `CreateSandboxMeta.billing`.
+- `src/sandbox/k8s-client.ts` — billing-label stamping in `buildJobSpec`.
+- `src/workflows/sandbox-step.ts` — optional `resolveBilling` dep; resolution + `meta.billing` inside the `sandbox.create` step.
+- `src/tasks/data-profile.ts` — optional `resolveBilling` dep; inline resolution at spawn.
+- No changes to `execute-analysis.ts`, any DBOS workflow input shape, or the docker backend (label parity deferred, as in the original design). The ephemeral runner named in the original design does not exist in this tree — no port target.
+- Embedders that want labeled pods wire `resolveBilling` into their `CoreWorkflowDeps.sandboxStep` / `dataProfile` bundles; the metering reconciler's label contract (`cortex_billing_context` etc., UUID-parsed, run-id optional) is the fixed interface.

--- a/harness/openspec/changes/restore-sandbox-billing-labels/specs/compute-billing-attribution/spec.md
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/specs/compute-billing-attribution/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Every K8s sandbox spawn path supplies billing attribution
+
+Every code path that creates a K8s sandbox SHALL resolve billing attribution via the billing resolver seam (`ResolveBilling`) under the session it holds and populate `CreateSandboxMeta.billing = { billingContextId, userId }`:
+
+1. **Analysis sandbox steps** (`src/workflows/sandbox-step.ts`): resolved under the step's session **inside the existing `sandbox.create` DBOS step** — the child workflow's step sequence is unchanged, so in-flight workflows resumed across a deploy replay cleanly. `userId` is the `RunSession`'s `identity.user`.
+2. **Data-profile** (`src/tasks/data-profile.ts`): resolved under the profiling session at spawn time.
+
+The billing-context id SHALL be read from the resolved header map's `X-Inflexa-Billing-Context` key. If resolution fails (or yields no `X-Inflexa-Billing-Context`), the spawn SHALL proceed with `billing` unset and an error-level `[billing]` log SHALL be emitted at the spawn site — billing failure never blocks sandbox work. Wirings without a resolver (dev/OSS) supply no `resolveBilling` dep and emit no logs.
+
+#### Scenario: Analysis step resolves and stamps within sandbox.create
+
+- **GIVEN** a sandbox step whose deps carry a billing resolver
+- **WHEN** the `sandbox.create` step executes
+- **THEN** the billing context is resolved under the step's session inside that step
+- **AND** the spawned pod carries the resolved `cortex/billing-context` and the session user's `cortex/user-id`
+
+#### Scenario: Data-profile pods are attributable without a run id
+
+- **WHEN** the data-profile task spawns its sandbox
+- **THEN** the pod carries `cortex/billing-context`, `cortex/user-id`, and `cortex/analysis-id` labels
+- **AND** the metering reconciler meters the allocation per analysis via its one-off `Charge` path (the literal non-UUID run id routes there by design)
+
+#### Scenario: Resolver outage degrades to unlabeled spawn, loudly
+
+- **GIVEN** the billing resolver's upstream is unreachable from a spawn site
+- **WHEN** the sandbox is spawned
+- **THEN** the sandbox is created without billing labels
+- **AND** an error-level log with a `[billing]` prefix identifies the analysis/run/step

--- a/harness/openspec/changes/restore-sandbox-billing-labels/specs/k8s-sandbox-provider/spec.md
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/specs/k8s-sandbox-provider/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Billing attribution labels on Job and pod template
+
+When `CreateSandboxMeta.billing` is present, `buildJobSpec` SHALL stamp the labels `cortex/billing-context` (= `billing.billingContextId`), `cortex/user-id` (= `billing.userId`), `cortex/analysis-id` (= `meta.analysisId`), and `cortex/run-id` (= `meta.runId`) on **both** the Job metadata labels and the pod template metadata labels. All values SHALL pass through `sanitizeLabelValue`. The pod template placement is normative: the OpenCost-based metering reconciler allocates by pod labels and filters on the sanitized key `cortex_billing_context` being non-empty; a Job-only label is invisible to metering.
+
+When `CreateSandboxMeta.billing` is absent, no billing labels SHALL be stamped and the spawn SHALL proceed unchanged — the provider carries no billing policy of its own; loudness for a missing-billing spawn is the spawn site's responsibility.
+
+#### Scenario: Labels present on the pod template
+
+- **GIVEN** `CreateSandboxMeta` with `billing = { billingContextId: B, userId: U }`, `analysisId: A`, `runId: R`
+- **WHEN** the Job spec is built
+- **THEN** the pod template labels include `cortex/billing-context: B`, `cortex/user-id: U`, `cortex/analysis-id: A`, `cortex/run-id: R`
+- **AND** the Job metadata labels include the same four labels
+
+#### Scenario: Absent billing meta stamps nothing and still spawns
+
+- **GIVEN** `CreateSandboxMeta` without `billing`
+- **WHEN** `createSandbox(meta)` runs
+- **THEN** the pod template carries no `cortex/billing-context` / `cortex/user-id` / `cortex/analysis-id` labels
+- **AND** the Job is still created and the sandbox becomes Ready

--- a/harness/openspec/changes/restore-sandbox-billing-labels/tasks.md
+++ b/harness/openspec/changes/restore-sandbox-billing-labels/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — restore-sandbox-billing-labels
+
+## 1. Billing labels on K8s sandbox Jobs
+
+- [x] 1.1 Add `billing?: { billingContextId: string; userId: string }` to `CreateSandboxMeta` in `src/sandbox/types.ts`
+- [x] 1.2 Stamp `cortex/billing-context`, `cortex/user-id`, `cortex/analysis-id`, `cortex/run-id` on BOTH Job metadata and pod template labels in `src/sandbox/k8s-client.ts` `buildJobSpec`, all via `sanitizeLabelValue`
+- [x] 1.3 Tests: four labels on pod template + Job metadata when `billing` set; sanitized values; no billing labels and successful spawn when unset; `sanitizeLabelValue` edge cases (UUID pass-through, cap-then-trim, all-invalid input)
+
+## 2. Spawn sites resolve and supply attribution
+
+- [x] 2.1 `src/workflows/sandbox-step.ts`: optional `resolveBilling` dep on `SandboxStepDeps`; resolve under the step session INSIDE the existing `sandbox.create` runStep (no new DBOS step — replay-safe for in-flight workflows) and pass `meta.billing`; error-log (`[billing]`) and spawn unlabeled on failure
+- [x] 2.2 `src/tasks/data-profile.ts`: optional `resolveBilling` dep on `DataProfileDeps`; resolve under the profiling session inline at spawn; pass `meta.billing`; error-log (`[billing]`) on failure
+
+## 3. Verification
+
+- [x] 3.1 `npx tsc --noEmit`; `bun test src/sandbox/k8s-client.test.ts src/workflows/sandbox-step.test.ts src/tasks/data-profile.trigger.test.ts`
+- [ ] 3.2 Staging end-to-end: run an analysis; `kubectl get pods -n staging-sandbox --show-labels` shows the four labels; metering `allocations_dispatched` > 0 within ~2 min; the run's compute settles on close
+
+## Deferred
+
+- Ephemeral-runner spawn path (module not yet ported to this tree — takes the same pattern when it lands)
+- Docker-backend label parity

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.19.1",
+    "version": "0.19.2",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/app/report-session-runtime.test.ts
+++ b/harness/src/app/report-session-runtime.test.ts
@@ -44,7 +44,7 @@ describe("createReportSessionRuntime", () => {
 
     /** Seed the analysis-state row the session-state foreign key needs. */
     async function seedAnalysis(analysisId: string): Promise<void> {
-        (await upsertAnalysis(pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, analysisId, null))._unsafeUnwrap();
     }
 
     /** Seed the report thread row the anchor operation resolves to an analysis. */

--- a/harness/src/auth/local-run-authorizer.ts
+++ b/harness/src/auth/local-run-authorizer.ts
@@ -2,8 +2,9 @@
  * LocalRunAuthorizer — the OSS realization of the `RunAuthorizer` seam.
  *
  * Issues a durable `RunSession` straight from the async-edge input: no remote
- * authorization, no credential read. It owns nothing revocable, so `revoke` is
- * a no-op. The opaque caller `auth` is forwarded untouched — local code never
+ * authorization, no credential read. It owns nothing revocable (it mints no
+ * jti), so `revoke` and `revokeByJti` are no-ops. The opaque caller `auth` is
+ * forwarded untouched — local code never
  * inspects it (no `getAuth`).
  */
 
@@ -23,5 +24,6 @@ export function createLocalRunAuthorizer(): RunAuthorizer {
             return { runSession, ownsMandate: false }; // oss-core-managed-ok
         },
         async revoke() {},
+        async revokeByJti() {},
     };
 }

--- a/harness/src/execution/run-authorizer.ts
+++ b/harness/src/execution/run-authorizer.ts
@@ -17,6 +17,17 @@
 
 import type { AuthContext, Provenance, RunFrame, RunSession, Scope } from "../auth/types.js";
 
+/**
+ * Locates a run credential when no `RunAuthorization` exists: the persisted
+ * jti from `cortex_runs` plus the revoking caller's opaque `auth` — the sole
+ * carrier of credential/org behind a session, downcast only by managed
+ * realizations.
+ */
+export interface RevokeByJtiRef {
+    readonly jti: string;
+    readonly auth: AuthContext;
+}
+
 /** What an async edge knows when it authorizes a run: the opaque caller auth,
  * the scope + provenance to stamp on the run, and the run frame to mint for. */
 export interface AuthorizeRunInput {
@@ -44,4 +55,12 @@ export interface RunAuthorization {
 export interface RunAuthorizer {
     authorize(input: AuthorizeRunInput): Promise<RunAuthorization>;
     revoke(authorization: RunAuthorization, reason: string): Promise<void>;
+    /**
+     * Out-of-band revocation for paths holding no `RunAuthorization`. Normal
+     * terminal paths use `revoke(authorization, reason)` under the run
+     * credential; `revokeByJti` covers external cancellation, where the run
+     * credential's JWT was never persisted and only its jti survives on
+     * `cortex_runs`. Local/OSS authorizers no-op — they mint no jti.
+     */
+    revokeByJti(ref: RevokeByJtiRef, reason: string): Promise<void>;
 }

--- a/harness/src/execution/run-canceler.test.ts
+++ b/harness/src/execution/run-canceler.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Fakes only, no live DBOS: the engine cancel enters through the injected
+ * `cancelWorkflows` seam, and the ledgers are an in-memory pool that answers
+ * the canceler's four queries and applies the conditional-write rule the real
+ * `markRunCanceledIfActive` enforces — so the race assertions exercise state,
+ * not stubs of it.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Pool } from "pg";
+
+import type { AgentSession } from "../auth/types.js";
+import type { RunCharge } from "../billing/run-charge.js";
+import type { RunAuthorizer } from "./run-authorizer.js";
+import { createRunCanceler, UnknownRunError } from "./run-canceler.js";
+
+const session: AgentSession = {
+    identity: { user: "tester" },
+    scope: { kind: "analysis", analysisId: "analysis-1" },
+    provenance: { agentId: "cancel-route", callPath: ["cancel-route"] },
+    auth: {},
+};
+
+type Row = Record<string, unknown>;
+
+function runRow(overrides: Row = {}): Row {
+    return {
+        run_id: "run-1",
+        analysis_id: "analysis-1",
+        thread_id: null,
+        workflow_name: "executeAnalysis",
+        status: "running",
+        started_at: "2026-08-12T00:00:00.000Z",
+        completed_at: null,
+        error: null,
+        synthesis_status: null,
+        synthesis_reason: null,
+        parts: null,
+        mandate_jti: null,
+        mandate_expires_at: null,
+        plan_id: null,
+        ...overrides,
+    };
+}
+
+function stepRow(stepId: string, childWorkflowId: string | null, completedAt: string | null = null): Row {
+    return {
+        run_id: "run-1",
+        step_id: stepId,
+        analysis_id: "analysis-1",
+        wave: 0,
+        agent_id: "test-agent",
+        status: completedAt === null ? "running" : "completed",
+        started_at: "2026-08-12T00:00:01.000Z",
+        completed_at: completedAt,
+        duration_ms: null,
+        error: null,
+        attempts: 1,
+        last_error_class: null,
+        finish_reason: null,
+        hit_max_steps: false,
+        blocked_reason: null,
+        sandbox_ref: null,
+        exec_id: null,
+        child_workflow_id: childWorkflowId,
+    };
+}
+
+interface FakeDb {
+    pool: Pool;
+    state: { run: Row | null; swept: number };
+}
+
+/** Successive `queryStepsByRun` reads consume `stepBatches`; the last repeats. */
+function fakeDb(run: Row | null, stepBatches: Row[][] = [[]], opts: { sweepFails?: boolean } = {}): FakeDb {
+    const state = { run, swept: 0 };
+    let stepReads = 0;
+    const pool = {
+        query: async ({ text, values }: { text: string; values?: unknown[] }) => {
+            if (text.includes("FROM cortex_runs")) return { rows: state.run === null ? [] : [state.run], rowCount: state.run === null ? 0 : 1 };
+            if (text.includes("SET status = 'canceled'")) {
+                const active = state.run !== null && (state.run.status === "running" || state.run.status === "suspended_insufficient_funds");
+                if (!active || state.run === null) return { rowCount: 0 };
+                state.run = { ...state.run, status: "canceled", completed_at: values?.[1], error: values?.[2] };
+                return { rowCount: 1 };
+            }
+            if (text.includes("FROM cortex_step_executions")) {
+                const batch = stepBatches[Math.min(stepReads, stepBatches.length - 1)] ?? [];
+                stepReads += 1;
+                return { rows: batch };
+            }
+            if (text.includes("SET status = 'skipped'")) {
+                if (opts.sweepFails) throw new Error("sweep exploded");
+                state.swept += 1;
+                return { rowCount: 0 };
+            }
+            throw new Error(`unexpected query: ${text}`);
+        },
+    } as unknown as Pool;
+    return { pool, state };
+}
+
+function recordingCharge(opts: { fail?: boolean } = {}): { charge: RunCharge; closes: Array<{ analysisId: string; runId: string; reason: string }> } {
+    const closes: Array<{ analysisId: string; runId: string; reason: string }> = [];
+    const charge: RunCharge = {
+        open: async () => {
+            throw new Error("open is not reached by the canceler");
+        },
+        close: async ({ analysisId, runId, reason }) => {
+            if (opts.fail) throw new Error("close exploded");
+            closes.push({ analysisId, runId, reason });
+        },
+    };
+    return { charge, closes };
+}
+
+function recordingAuthorizer(): { authorizer: RunAuthorizer; revoked: Array<{ jti: string; reason: string }> } {
+    const revoked: Array<{ jti: string; reason: string }> = [];
+    const authorizer: RunAuthorizer = {
+        authorize: async () => {
+            throw new Error("authorize is not reached by the canceler");
+        },
+        revoke: async () => {
+            throw new Error("terminal-path revoke is not reached by the canceler");
+        },
+        revokeByJti: async ({ jti }, reason) => {
+            revoked.push({ jti, reason });
+        },
+    };
+    return { authorizer, revoked };
+}
+
+function recordingCancel(onCall?: (ids: readonly string[]) => void): { cancelWorkflows: (ids: readonly string[]) => Promise<void>; cancelled: string[][] } {
+    const cancelled: string[][] = [];
+    return {
+        cancelled,
+        cancelWorkflows: async (ids) => {
+            cancelled.push([...ids]);
+            onCall?.(ids);
+        },
+    };
+}
+
+describe("createRunCanceler", () => {
+    it("short-circuits an already-terminal run with no engine call and no charge close", async () => {
+        const db = fakeDb(runRow({ status: "completed", completed_at: "2026-08-12T01:00:00.000Z" }));
+        const { charge, closes } = recordingCharge();
+        const { authorizer, revoked } = recordingAuthorizer();
+        const { cancelWorkflows, cancelled } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(result).toEqual({
+            runId: "run-1",
+            workflowId: "run-1",
+            outcome: "already_terminal",
+            finalStatus: "completed",
+            converged: { steps: false, charge: false, mandate: false },
+        });
+        expect(cancelled).toEqual([]);
+        expect(closes).toEqual([]);
+        expect(revoked).toEqual([]);
+        expect(db.state.swept).toBe(0);
+    });
+
+    it("converges a running run: engine cancel with children, conditional row write, sweep, charge close, revoke", async () => {
+        // One incomplete child is cancelled beside the parent; the completed child is not re-cancelled.
+        const steps = [stepRow("s1", "wf-child-1"), stepRow("s2", "wf-child-2", "2026-08-12T00:30:00.000Z"), stepRow("s3", null)];
+        const db = fakeDb(runRow({ mandate_jti: "jti-1", mandate_expires_at: "2026-08-13T00:00:00.000Z" }), [steps]);
+        const { charge, closes } = recordingCharge();
+        const { authorizer, revoked } = recordingAuthorizer();
+        const { cancelWorkflows, cancelled } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(result).toEqual({
+            runId: "run-1",
+            workflowId: "run-1",
+            outcome: "canceled",
+            finalStatus: "canceled",
+            converged: { steps: true, charge: true, mandate: true },
+        });
+        expect(cancelled).toEqual([["run-1", "wf-child-1"]]);
+        expect(db.state.run?.status).toBe("canceled");
+        expect(db.state.run?.error).toBe("external_cancel");
+        expect(db.state.run?.completed_at).not.toBeNull();
+        expect(db.state.swept).toBe(1);
+        expect(closes).toEqual([{ analysisId: "analysis-1", runId: "run-1", reason: "canceled" }]);
+        expect(revoked).toEqual([{ jti: "jti-1", reason: "external_cancel" }]);
+    });
+
+    it("cancels a child whose workflow id commits only after the parent cancel", async () => {
+        const db = fakeDb(runRow(), [[], [stepRow("s1", "wf-late-1")]]);
+        const { charge } = recordingCharge();
+        const { authorizer } = recordingAuthorizer();
+        const { cancelWorkflows, cancelled } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(cancelled).toEqual([["run-1"], ["wf-late-1"]]);
+        expect(result.outcome).toBe("canceled");
+        expect(result.finalStatus).toBe("canceled");
+    });
+
+    it("still revokes the mandate when the charge close throws, and resolves with converged.charge false", async () => {
+        const db = fakeDb(runRow({ mandate_jti: "jti-1" }));
+        const { charge } = recordingCharge({ fail: true });
+        const { authorizer, revoked } = recordingAuthorizer();
+        const { cancelWorkflows } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(result.converged).toEqual({ steps: true, charge: false, mandate: true });
+        expect(result.finalStatus).toBe("canceled");
+        expect(revoked).toEqual([{ jti: "jti-1", reason: "external_cancel" }]);
+    });
+
+    it("skips the revoke for a row with no mandate jti and reports mandate converged vacuously", async () => {
+        const db = fakeDb(runRow());
+        const { charge } = recordingCharge();
+        const { authorizer, revoked } = recordingAuthorizer();
+        const { cancelWorkflows } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(revoked).toEqual([]);
+        // Vacuously true: nothing to revoke, so a host alerts on any false flag uniformly.
+        expect(result.converged.mandate).toBe(true);
+    });
+
+    it("reports the run's own terminal status when it completes concurrently with the cancel", async () => {
+        // The run completes while the engine cancel is in flight: the conditional
+        // write must refuse the clobber and the result must report the truth.
+        const db = fakeDb(runRow());
+        const { cancelWorkflows } = recordingCancel(() => {
+            db.state.run = { ...(db.state.run as Row), status: "completed", completed_at: "2026-08-12T02:00:00.000Z" };
+        });
+        const { charge } = recordingCharge();
+        const { authorizer } = recordingAuthorizer();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(result.outcome).toBe("canceled");
+        expect(result.finalStatus).toBe("completed");
+        expect(db.state.run?.status).toBe("completed");
+        expect(db.state.run?.error).toBeNull();
+        // The sweep is still safe: it touches only rows a completed run no longer has pending.
+        expect(db.state.swept).toBe(1);
+        expect(result.converged.steps).toBe(true);
+    });
+
+    it("isolates a sweep failure from the phases after it", async () => {
+        const db = fakeDb(runRow({ mandate_jti: "jti-1" }), [[]], { sweepFails: true });
+        const { charge, closes } = recordingCharge();
+        const { authorizer, revoked } = recordingAuthorizer();
+        const { cancelWorkflows } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        const result = await canceler.cancel("run-1", session);
+
+        expect(result.converged).toEqual({ steps: false, charge: true, mandate: true });
+        expect(closes).toHaveLength(1);
+        expect(revoked).toHaveLength(1);
+    });
+
+    it("rejects an unknown run id", async () => {
+        const db = fakeDb(null);
+        const { charge } = recordingCharge();
+        const { authorizer } = recordingAuthorizer();
+        const { cancelWorkflows, cancelled } = recordingCancel();
+        const canceler = createRunCanceler({ pool: db.pool, runCharge: charge, runAuthorizer: authorizer, cancelWorkflows });
+
+        await expect(canceler.cancel("run-missing", session)).rejects.toThrow(UnknownRunError);
+        expect(cancelled).toEqual([]);
+    });
+
+    it("rejects when the engine cancel fails, before converging anything", async () => {
+        const db = fakeDb(runRow());
+        const { charge, closes } = recordingCharge();
+        const { authorizer } = recordingAuthorizer();
+        const canceler = createRunCanceler({
+            pool: db.pool,
+            runCharge: charge,
+            runAuthorizer: authorizer,
+            cancelWorkflows: async () => {
+                throw new Error("engine unreachable");
+            },
+        });
+
+        await expect(canceler.cancel("run-1", session)).rejects.toThrow("engine unreachable");
+        expect(db.state.run?.status).toBe("running");
+        expect(db.state.swept).toBe(0);
+        expect(closes).toEqual([]);
+    });
+});

--- a/harness/src/execution/run-canceler.ts
+++ b/harness/src/execution/run-canceler.ts
@@ -1,0 +1,187 @@
+/**
+ * RunCanceler — the encapsulated external-cancel path for an `executeAnalysis` run.
+ *
+ * A cancelled DBOS workflow can never execute another step, so the body's own
+ * terminal block (`collectAndComplete`) is unreachable on external cancel and
+ * nothing converges: the run row stays `running` (blocking same-plan relaunch
+ * through `queryActiveRun`'s active-status dedup), pending step rows never
+ * sweep, the running charge never closes, and the run mandate is never
+ * revoked. This module is the host-side counterpart: cancel the engine's
+ * parent + children, then converge each ledger the workflow would have.
+ *
+ * The engine capability stays internal — the production default is the
+ * purger's `DBOSClient`-backed child-cascading cancel, which needs no launched
+ * engine (see `dbos-workflow-purger.ts` for why the static `DBOS` facade is
+ * the wrong tool here). `cancelWorkflows` is an optional test seam over it.
+ *
+ * No stream writes: `DBOS.writeStream` is body-only, so hosts synthesize the
+ * terminal frame read-side.
+ */
+
+import type { Pool } from "pg";
+
+import type { AgentSession } from "../auth/types.js";
+import type { RunCharge } from "../billing/run-charge.js";
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { Logger } from "../lib/logger.js";
+import { unwrapOrThrow } from "../lib/result.js";
+import { markRunCanceledIfActive, queryRun } from "../state/runs.js";
+import type { RunStatus } from "../state/schema.js";
+import { queryStepsByRun, sweepPendingStepExecutions } from "../state/step-executions.js";
+import { createDbosWorkflowPurger } from "./dbos-workflow-purger.js";
+import type { RunAuthorizer } from "./run-authorizer.js";
+
+/** The reason stamped on the run row and the revoke — the same literal
+ * `collectAndComplete` records for a cancel it observes from inside. */
+const EXTERNAL_CANCEL_REASON = "external_cancel";
+
+export class UnknownRunError extends Error {
+    constructor(readonly runId: string) {
+        super(`no run exists for id ${runId}`);
+        this.name = "UnknownRunError";
+    }
+}
+
+export interface CancelRunResult {
+    readonly runId: string;
+    /** The DBOS parent workflow id — equal to `runId` by the launch contract
+     * (`execute_analysis` launches with `workflowId: runId`). */
+    readonly workflowId: string;
+    readonly outcome: "canceled" | "already_terminal";
+    /**
+     * The run row's status after the cancel. `canceled` when this cancel won
+     * the row; the run's own terminal status when it completed concurrently
+     * (the conditional write refuses to clobber it).
+     */
+    readonly finalStatus: RunStatus;
+    /** What actually converged. `mandate` is vacuously true for a row with no
+     * persisted jti — nothing to revoke, so hosts alert on any false flag. */
+    readonly converged: {
+        readonly steps: boolean;
+        readonly charge: boolean;
+        readonly mandate: boolean;
+    };
+}
+
+export interface RunCancelerDeps {
+    readonly pool: Pool;
+    readonly runCharge: RunCharge;
+    readonly runAuthorizer: RunAuthorizer;
+    readonly logger?: Logger;
+    /** Test seam over the engine cancel. Production default: the workflow
+     * purger's `DBOSClient`-backed cancel, child-cascading and launch-free. */
+    readonly cancelWorkflows?: (workflowIds: readonly string[]) => Promise<void>;
+}
+
+export interface RunCanceler {
+    /**
+     * Cancel the run's workflows and converge its ledgers. Rejects when the
+     * engine cancel itself fails (retry-safe: nothing converged) or the run is
+     * unknown; convergence-phase failures resolve with their flag false.
+     */
+    cancel(runId: string, session: AgentSession): Promise<CancelRunResult>;
+}
+
+const TERMINAL: ReadonlySet<RunStatus> = new Set(["completed", "partial", "failed", "canceled"]);
+
+export function createRunCanceler(deps: RunCancelerDeps): RunCanceler {
+    const { pool, runCharge, runAuthorizer } = deps;
+    const logger = (deps.logger ?? createNoopLogger()).named("run-canceler");
+
+    // Lazy so a canceler built for a host that never cancels constructs no client;
+    // one purger per factory (its client registers pool handlers — see its comment).
+    let engineCancel = deps.cancelWorkflows;
+    const cancelWorkflows = async (workflowIds: readonly string[]): Promise<void> => {
+        engineCancel ??= (() => {
+            const purger = createDbosWorkflowPurger({ pool, logger });
+            return async (ids: readonly string[]): Promise<void> => {
+                unwrapOrThrow(await purger.cancel([...ids]));
+            };
+        })();
+        await engineCancel(workflowIds);
+    };
+
+    /** Persisted child workflow ids of steps not yet completed. */
+    const incompleteChildIds = async (runId: string): Promise<string[]> =>
+        unwrapOrThrow(await queryStepsByRun(pool, runId)).flatMap((step) =>
+            step.childWorkflowId !== null && step.completedAt === null ? [step.childWorkflowId] : [],
+        );
+
+    return {
+        async cancel(runId, session) {
+            const row = unwrapOrThrow(await queryRun(pool, runId));
+            if (row === null) throw new UnknownRunError(runId);
+            const workflowId = runId;
+
+            if (TERMINAL.has(row.status)) {
+                return {
+                    runId,
+                    workflowId,
+                    outcome: "already_terminal",
+                    finalStatus: row.status,
+                    converged: { steps: false, charge: false, mandate: false },
+                };
+            }
+
+            // The child-cascading cancel walks the engine's own parent ledger, which
+            // has a row the moment a child starts — that covers a child whose
+            // mark-running step has not yet committed its child_workflow_id. The
+            // persisted ids and the post-cancel re-query are belt-and-braces over
+            // both ledgers' lag.
+            const knownChildren = await incompleteChildIds(runId);
+            await cancelWorkflows([workflowId, ...knownChildren]);
+            try {
+                const late = (await incompleteChildIds(runId)).filter((id) => !knownChildren.includes(id));
+                if (late.length > 0) await cancelWorkflows(late);
+            } catch (err) {
+                logger.error("late-child cancel sweep failed", { runId, ...logger.errorFields(err) });
+            }
+
+            // Convergence — each phase isolated so one failure skips nothing after it.
+            let transitioned = false;
+            try {
+                transitioned = unwrapOrThrow(await markRunCanceledIfActive(pool, runId, EXTERNAL_CANCEL_REASON));
+            } catch (err) {
+                logger.error("markRunCanceledIfActive failed", { runId, ...logger.errorFields(err) });
+            }
+
+            let steps = false;
+            try {
+                unwrapOrThrow(await sweepPendingStepExecutions(pool, runId));
+                steps = true;
+            } catch (err) {
+                logger.error("pending-step sweep failed", { runId, ...logger.errorFields(err) });
+            }
+
+            // Best-effort: the billing authority self-heals (defensive open + stale
+            // reaper), so a failed close loses attribution only.
+            let charge = false;
+            try {
+                await runCharge.close({ analysisId: row.analysisId, runId, reason: "canceled", session });
+                charge = true;
+            } catch (err) {
+                logger.error("running-charge close failed", { runId, ...logger.errorFields(err) });
+            }
+
+            let mandate = row.mandateJti === null;
+            if (row.mandateJti !== null) {
+                try {
+                    await runAuthorizer.revokeByJti({ jti: row.mandateJti, auth: session.auth }, EXTERNAL_CANCEL_REASON);
+                    mandate = true;
+                } catch (err) {
+                    logger.error("mandate revoke failed", { runId, jti: row.mandateJti, ...logger.errorFields(err) });
+                }
+            }
+
+            // No transition means the run reached a terminal state on its own (or the
+            // write failed) — report the row as it stands rather than claiming `canceled`.
+            let finalStatus: RunStatus = "canceled";
+            if (!transitioned) {
+                const reread = unwrapOrThrow(await queryRun(pool, runId));
+                finalStatus = reread?.status ?? "canceled";
+            }
+
+            return { runId, workflowId, outcome: "canceled", finalStatus, converged: { steps, charge, mandate } };
+        },
+    };
+}

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -41,7 +41,7 @@ export type { ConversationAgentDeps } from "./agents/conversation-agent.js";
 
 // Seam: run authorization.
 export { createLocalRunAuthorizer } from "./auth/local-run-authorizer.js";
-export type { RunAuthorizer, AuthorizeRunInput, RunAuthorization } from "./execution/run-authorizer.js";
+export type { RunAuthorizer, AuthorizeRunInput, RunAuthorization, RevokeByJtiRef } from "./execution/run-authorizer.js";
 
 // Seam: billing resolution.
 export { createNoopBillingResolver } from "./billing/noop-resolver.js";
@@ -81,6 +81,13 @@ export type { RunLauncher, LaunchOptions } from "./execution/run-launcher.js";
 export { createDbosWorkflowPurger } from "./execution/dbos-workflow-purger.js";
 export type { DbosWorkflowPurgerDeps } from "./execution/dbos-workflow-purger.js";
 export type { WorkflowPurger } from "./execution/workflow-purger.js";
+
+// Run cancellation — the encapsulated external-cancel path: engine cancel
+// (parent + children) plus convergence of the run row, pending step rows,
+// running charge, and run mandate. Hosts call this from their cancel route
+// instead of hand-rolling `DBOS.cancelWorkflow` + partial cleanup.
+export { createRunCanceler, UnknownRunError } from "./execution/run-canceler.js";
+export type { RunCanceler, RunCancelerDeps, CancelRunResult } from "./execution/run-canceler.js";
 
 // Tool primitive.
 export { defineTool, isToolError } from "./tools/define-tool.js";
@@ -502,6 +509,7 @@ export {
     queryActiveRun,
     queryActiveRunsByAnalysis,
     updateRunStatus,
+    markRunCanceledIfActive,
     queryRun,
     queryRunsByAnalysis,
     RunDedupCollisionError,

--- a/harness/src/runtime/assemble.test.ts
+++ b/harness/src/runtime/assemble.test.ts
@@ -95,7 +95,7 @@ describe("the report session handle", () => {
     it("anchors a seeded report thread through the exposed handle", async () => {
         const analysisId = "analysis-assemble";
         const threadId = "thread-assemble";
-        (await upsertAnalysis(pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, analysisId, null))._unsafeUnwrap();
         (await createThreadStore(pool).createThread({ threadId, analysisId, type: "report" }))._unsafeUnwrap();
 
         // The exposed handle is the runtime's turn-start anchor. The assignment proves

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -703,6 +703,107 @@ describe("sanitizeLabelValue", () => {
         const long = "x".repeat(80);
         expect(sanitizeLabelValue(long).length).toBe(63);
     });
+
+    test("UUIDs pass through unaltered and trailing non-alnum is trimmed after the cap", () => {
+        const uuid = "2f9c1f6e-9f4b-4c1e-8a3d-0b1c2d3e4f5a";
+        expect(sanitizeLabelValue(uuid)).toBe(uuid);
+        // 62 alnum chars + "-" at position 63: the cap keeps the dash, the tail trim removes it.
+        expect(sanitizeLabelValue(`${"x".repeat(62)}-tail`)).toBe("x".repeat(62));
+        expect(sanitizeLabelValue("---")).toBe("");
+    });
+});
+
+describe("k8s billing labels", () => {
+    const READY_POD = [
+        {
+            status: { phase: "Running" as const, podIP: "10.0.0.1" },
+            metadata: { name: "sbx-x-abc" },
+        },
+    ];
+
+    function opsWith(stub: ReturnType<typeof stubApis>) {
+        return createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://cortex.internal:443",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+    }
+
+    test("billing meta stamps the four labels on pod template and Job metadata", async () => {
+        const stub = stubApis(READY_POD);
+        (
+            await opsWith(stub).createSandbox(
+                {
+                    runId: "run-1",
+                    stepId: "step-a",
+                    analysisId: "an-1",
+                    childWorkflowId: "run-1-0",
+                    resources: { cpu: 2, memoryGb: 4 },
+                    billing: { billingContextId: "bc-123", userId: "user-9" },
+                },
+                mintSandboxIdentity("run-1"),
+            )
+        )._unsafeUnwrap();
+
+        const job = stub.createdJobs[0]!;
+        for (const labels of [job.metadata!.labels!, job.spec!.template.metadata!.labels!]) {
+            expect(labels["cortex/billing-context"]).toBe("bc-123");
+            expect(labels["cortex/user-id"]).toBe("user-9");
+            expect(labels["cortex/analysis-id"]).toBe("an-1");
+            expect(labels["cortex/run-id"]).toBe("run-1");
+        }
+    });
+
+    test("billing label values are sanitized", async () => {
+        const stub = stubApis(READY_POD);
+        (
+            await opsWith(stub).createSandbox(
+                {
+                    runId: "data-profile",
+                    stepId: "profile",
+                    analysisId: "an-1",
+                    childWorkflowId: "data-profile:x",
+                    resources: { cpu: 1, memoryGb: 1 },
+                    billing: { billingContextId: "bc:123", userId: "user@example.com" },
+                },
+                mintSandboxIdentity("data-profile"),
+            )
+        )._unsafeUnwrap();
+
+        const podLabels = stub.createdJobs[0]!.spec!.template.metadata!.labels!;
+        expect(podLabels["cortex/billing-context"]).toBe("bc-123");
+        expect(podLabels["cortex/user-id"]).toBe("user-example.com");
+        expect(podLabels["cortex/run-id"]).toBe("data-profile");
+    });
+
+    test("absent billing meta stamps no billing labels and still spawns", async () => {
+        const stub = stubApis(READY_POD);
+        const ref = (
+            await opsWith(stub).createSandbox(
+                {
+                    runId: "run-1",
+                    stepId: "step-a",
+                    analysisId: "an-1",
+                    childWorkflowId: "run-1-0",
+                    resources: { cpu: 2, memoryGb: 4 },
+                },
+                mintSandboxIdentity("run-1"),
+            )
+        )._unsafeUnwrap();
+
+        expect(ref.host).toBe("10.0.0.1");
+        for (const labels of [stub.createdJobs[0]!.metadata!.labels!, stub.createdJobs[0]!.spec!.template.metadata!.labels!]) {
+            expect(labels["cortex/billing-context"]).toBeUndefined();
+            expect(labels["cortex/user-id"]).toBeUndefined();
+        }
+        expect(stub.createdJobs[0]!.spec!.template.metadata!.labels!["cortex/analysis-id"]).toBeUndefined();
+    });
 });
 
 describe("k8s teardown", () => {

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -42,6 +42,11 @@ const MANAGED_BY_VALUE = "cortex";
 const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
+// OpenCost sanitizes `/` and `-` to `_`, so these arrive at the metering
+// reconciler as cortex_billing_context / cortex_user_id / cortex_analysis_id.
+const BILLING_CONTEXT_LABEL = "cortex/billing-context";
+const USER_ID_LABEL = "cortex/user-id";
+const ANALYSIS_ID_LABEL = "cortex/analysis-id";
 
 /**
  * Coerce an arbitrary identifier into a valid K8s label value:
@@ -276,6 +281,18 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
     if (config.tolerations) podSpec.tolerations = config.tolerations;
     if (config.runtimeClassName) podSpec.runtimeClassName = config.runtimeClassName;
 
+    // Pod-template placement is load-bearing: the OpenCost reconciler allocates
+    // by pod labels and filters on a non-empty cortex_billing_context — a
+    // Job-only label is invisible to compute metering.
+    const billingLabels: Record<string, string> = meta.billing
+        ? {
+              [BILLING_CONTEXT_LABEL]: sanitizeLabelValue(meta.billing.billingContextId),
+              [USER_ID_LABEL]: sanitizeLabelValue(meta.billing.userId),
+              [ANALYSIS_ID_LABEL]: sanitizeLabelValue(meta.analysisId),
+              [RUN_ID_LABEL]: sanitizeLabelValue(meta.runId),
+          }
+        : {};
+
     return {
         apiVersion: "batch/v1",
         kind: "Job",
@@ -289,6 +306,7 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
                 [OWNER_WORKFLOW_LABEL]: sanitizeLabelValue(meta.childWorkflowId),
                 [RUN_ID_LABEL]: sanitizeLabelValue(meta.runId),
                 [STEP_ID_LABEL]: sanitizeLabelValue(meta.stepId),
+                ...billingLabels,
             },
         },
         spec: {
@@ -299,6 +317,7 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
                     labels: {
                         role: "sandbox",
                         "cortex/sandbox-id": sandboxId,
+                        ...billingLabels,
                     },
                 },
                 spec: podSpec,

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -237,6 +237,9 @@ export interface CreateSandboxMeta {
     /** Enforced read-only: provision with no read-write step mount, only the
      *  read-only analysis tree for generic read-only agents. */
     readOnly?: boolean;
+    /** Billing attribution stamped as pod labels for OpenCost compute metering.
+     *  Absent ⇒ the pod is invisible to the metering reconciler (filter-level). */
+    billing?: { billingContextId: string; userId: string };
 }
 
 /**

--- a/harness/src/state/analyses.ts
+++ b/harness/src/state/analyses.ts
@@ -1,5 +1,5 @@
 /**
- * `cortex_analysis_state` operations — analysis lifecycle and billing context.
+ * `cortex_analysis_state` operations — analysis lifecycle.
  */
 
 import type { ResultAsync } from "neverthrow";
@@ -12,46 +12,24 @@ import type { Querier } from "./db.js";
  *
  * The seed endpoint is called repeatedly; this function handles both the
  * initial INSERT and subsequent UPDATEs by writing ALL mutable fields on
- * every call. Re-upserts replace `context` and `billing_context` wholesale.
+ * every call. Re-upserts replace `context` wholesale.
  *
  * User identity is derived from the ambient credential's JWT `sub` claim
  * at request time — not persisted in this table.
- *
- * INTENTIONAL: split-attribution across a single run.
- * If the seed re-upserts mid-workflow (e.g., the billing context's VK rotates),
- * in-flight steps that have already issued LLM calls keep the old attribution
- * on those calls, while subsequent steps in the same run pick up the new
- * identity on their next `billedAgent` resolution. This is by design —
- * usage rows contain full per-call attribution, so spend is
- * always assignable even when it crosses a rotation boundary.
  */
-export function upsertAnalysis(
-    pool: Querier,
-    resourceId: string,
-    context: string | null,
-    billingContext: Record<string, string> | null,
-    inputFileIds?: string[],
-): ResultAsync<void, DbError> {
+export function upsertAnalysis(pool: Querier, resourceId: string, context: string | null, inputFileIds?: string[]): ResultAsync<void, DbError> {
     const now = new Date().toISOString();
     return tryMutation("analyses.upsertAnalysis", async () => {
         await pool.query({
             text: `INSERT INTO cortex_analysis_state
-            (analysis_id, status, context, billing_context, data_profile_status,
+            (analysis_id, status, context, data_profile_status,
              seed_input_file_ids, created_at, updated_at)
-            VALUES ($1, 'active', $2, $3::jsonb, 'pending', $4::jsonb, $5, $6)
+            VALUES ($1, 'active', $2, 'pending', $3::jsonb, $4, $5)
             ON CONFLICT (analysis_id) DO UPDATE SET
               context = EXCLUDED.context,
-              billing_context = EXCLUDED.billing_context,
               seed_input_file_ids = COALESCE(EXCLUDED.seed_input_file_ids, cortex_analysis_state.seed_input_file_ids),
               updated_at = EXCLUDED.updated_at`,
-            values: [
-                resourceId,
-                context ?? null,
-                billingContext === null ? null : JSON.stringify(billingContext),
-                inputFileIds ? JSON.stringify(inputFileIds) : null,
-                now,
-                now,
-            ],
+            values: [resourceId, context ?? null, inputFileIds ? JSON.stringify(inputFileIds) : null, now, now],
         });
     });
 }
@@ -99,53 +77,5 @@ export function resumeAnalysis(pool: Querier, analysisId: string): ResultAsync<v
             WHERE analysis_id = $2 AND status = 'suspended_insufficient_funds'`,
             values: [new Date().toISOString(), analysisId],
         });
-    });
-}
-
-/**
- * Resolve the persisted billing context for an analysis.
- *
- * Single DB-read chokepoint used by `requireAnalysisBilling` middleware and
- * by any downstream code that needs to re-read billing identity. The driver
- * read is wrapped as a `DbError`; the missing-row / null-billing /
- * unparseable-JSON cases are control-flow throws (a misconfiguration, not a
- * driver failure) that short-circuit the chain and surface verbatim.
- *
- * User identity (`HEADERS.User`) is derived from the ambient credential's
- * JWT `sub` claim by `credential-middleware`, not from the DB.
- */
-export function resolveAnalysisBilling(pool: Querier, analysisId: string): ResultAsync<{ billingContext: Record<string, string> }, DbError> {
-    return tryQuery("analyses.resolveAnalysisBilling", () =>
-        pool.query<{
-            billing_context: Record<string, string> | string | null;
-        }>({
-            text: "SELECT billing_context FROM cortex_analysis_state WHERE analysis_id = $1",
-            values: [analysisId],
-        }),
-    ).map((result) => {
-        const row = result.rows[0];
-        if (!row) {
-            throw new Error(`resolveAnalysisBilling: no cortex_analysis_state row for analysisId=${analysisId}`);
-        }
-        const rawBilling = row.billing_context;
-        if (rawBilling === null || rawBilling === undefined) {
-            throw new Error(`resolveAnalysisBilling: billing_context missing for analysisId=${analysisId}`);
-        }
-        // JSONB is parsed by `pg` into native objects. Legacy TEXT rows (if any
-        // slipped through) arrive as strings — parse them.
-        let billingContext: Record<string, string>;
-        if (typeof rawBilling === "string") {
-            try {
-                billingContext = JSON.parse(rawBilling) as Record<string, string>;
-            } catch (err) {
-                throw new Error(
-                    `resolveAnalysisBilling: billing_context is not valid JSON for analysisId=${analysisId}: ${err instanceof Error ? err.message : err}`,
-                    { cause: err },
-                );
-            }
-        } else {
-            billingContext = rawBilling;
-        }
-        return { billingContext };
     });
 }

--- a/harness/src/state/index.ts
+++ b/harness/src/state/index.ts
@@ -11,7 +11,7 @@ export { initCortexState } from "./init.js";
 
 export type { Querier } from "./db.js";
 
-export { upsertAnalysis, resolveAnalysisBilling, suspendAnalysis, resumeAnalysis, loadAnalysisStatus } from "./analyses.js";
+export { upsertAnalysis, suspendAnalysis, resumeAnalysis, loadAnalysisStatus } from "./analyses.js";
 
 export {
     upsertArtifact,
@@ -31,6 +31,7 @@ export {
     RunDedupCollisionError,
     RunIdentityCollisionError,
     updateRunStatus,
+    markRunCanceledIfActive,
     promoteFailedToPartial,
     setRunMandate, // oss-core-managed-ok: run-mandate ledger (nullable; OSS leaves null)
     setRunSynthesisOutcome,

--- a/harness/src/state/init.ts
+++ b/harness/src/state/init.ts
@@ -16,7 +16,7 @@ import type { Logger } from "../lib/logger.js";
 // splitting on ';' (see `DDL.split` below), so a semicolon inside a comment cuts
 // the statement it precedes in half and Postgres rejects the fragment.
 const DDL = `
--- Analysis-level state (status, context, data-profile tracking, billing identity).
+-- Analysis-level state (status, context, data-profile tracking).
 --
 -- User identity is derived from the ambient credential's JWT sub claim
 -- at request time — not persisted in this table.
@@ -24,7 +24,6 @@ CREATE TABLE IF NOT EXISTS cortex_analysis_state (
   analysis_id               TEXT PRIMARY KEY,
   status                    TEXT NOT NULL,
   context                   TEXT,
-  billing_context           JSONB,
   -- Nullable: NULL is the honest "no profile" state, which loadDataProfileStatus
   -- collapses to null so a cleared profile is indistinguishable from one that never
   -- existed. The 'pending' default still applies to a row inserted without a status --
@@ -501,6 +500,8 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                 "ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS profile",
                 "ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS input_files",
                 "ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS user_id",
+                // Billing identity is resolved lazily at charge-open time, never persisted.
+                "ALTER TABLE cortex_analysis_state DROP COLUMN IF EXISTS billing_context",
                 // v2 vestiges on cortex_runs.
                 "ALTER TABLE cortex_runs DROP COLUMN IF EXISTS plan",
                 "ALTER TABLE cortex_runs DROP COLUMN IF EXISTS plan_version",
@@ -536,7 +537,6 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                 "ALTER TABLE cortex_runs ADD COLUMN IF NOT EXISTS synthesis_status TEXT",
                 "ALTER TABLE cortex_runs ADD COLUMN IF NOT EXISTS synthesis_reason TEXT",
                 "ALTER TABLE cortex_analysis_state ADD COLUMN IF NOT EXISTS data_profile_result JSONB",
-                "ALTER TABLE cortex_analysis_state ADD COLUMN IF NOT EXISTS billing_context JSONB",
                 // Sandbox reliability telemetry (from sandbox-reliability change on main).
                 "ALTER TABLE cortex_step_executions ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 1",
                 "ALTER TABLE cortex_step_executions ADD COLUMN IF NOT EXISTS last_error_class TEXT",

--- a/harness/src/state/plans.test.ts
+++ b/harness/src/state/plans.test.ts
@@ -23,8 +23,8 @@ describe("upsertPlan", () => {
         drop = ctx.drop;
         // cortex_plans.analysis_id has an FK to cortex_analysis_state — seed both
         // analyses the parent-scope cases reference.
-        (await upsertAnalysis(pool, "analysis-1", null, null))._unsafeUnwrap();
-        (await upsertAnalysis(pool, "analysis-2", null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, "analysis-1", null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, "analysis-2", null))._unsafeUnwrap();
     });
 
     afterAll(async () => {

--- a/harness/src/state/reconcile-orphaned-data-profile.test.ts
+++ b/harness/src/state/reconcile-orphaned-data-profile.test.ts
@@ -23,7 +23,7 @@ describe("reconcileOrphanedDataProfile", () => {
         // The seed set is what makes the row claimable: every claim into `running` requires
         // a non-empty `seed_input_file_ids`, so an analysis upserted with no inputs stays
         // at `pending` and there is no orphaned `running` row to reconcile.
-        (await upsertAnalysis(rig.pool, analysisId, null, null, ["file-aaa"]))._unsafeUnwrap();
+        (await upsertAnalysis(rig.pool, analysisId, null, ["file-aaa"]))._unsafeUnwrap();
         const claimed = (await tryStartDataProfile(rig.pool, analysisId))._unsafeUnwrap();
         expect(claimed).toBe(true);
     }

--- a/harness/src/state/report-session-state.test.ts
+++ b/harness/src/state/report-session-state.test.ts
@@ -52,7 +52,7 @@ describe("createReportSessionStateStore", () => {
 
     /** Seed the `cortex_analysis_state` row the session-state foreign key needs. */
     async function seedAnalysis(analysisId: string): Promise<void> {
-        (await upsertAnalysis(pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, analysisId, null))._unsafeUnwrap();
     }
 
     it("keeps the snapshot and the document across two store instances", async () => {

--- a/harness/src/state/report-versions.test.ts
+++ b/harness/src/state/report-versions.test.ts
@@ -53,7 +53,7 @@ describe("createReportVersionStore", () => {
 
     /** Seed the `cortex_analysis_state` row the version foreign key needs. */
     async function seedAnalysis(analysisId: string): Promise<void> {
-        (await upsertAnalysis(pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, analysisId, null))._unsafeUnwrap();
     }
 
     it("records a version and reads the triple back by its id", async () => {

--- a/harness/src/state/runs.test.ts
+++ b/harness/src/state/runs.test.ts
@@ -4,6 +4,7 @@ import type { Pool } from "pg";
 import { withSchema } from "../__tests__/setup/postgres.js";
 import {
     insertRun,
+    markRunCanceledIfActive,
     queryActiveRunsByAnalysis,
     queryNonTerminalRunsByAnalysis,
     queryRun,
@@ -221,5 +222,58 @@ describe("runs: active-run query", () => {
         (await insertRun(pool, { runId: "run-other", analysisId: "a-other", workflowName: "executeAnalysis" }))._unsafeUnwrap();
         expect((await queryActiveRunsByAnalysis(pool, "a-empty"))._unsafeUnwrap()).toEqual([]);
         expect((await queryActiveRunsByAnalysis(pool, "a-other"))._unsafeUnwrap().map((r) => r.runId)).toEqual(["run-other"]);
+    });
+});
+
+describe("runs: markRunCanceledIfActive", () => {
+    let pool: Pool;
+    let drop: () => Promise<void>;
+
+    beforeAll(async () => {
+        const ctx = await withSchema("runs_mark_canceled_if_active");
+        pool = ctx.pool;
+        drop = ctx.drop;
+    });
+
+    afterAll(async () => {
+        await drop();
+    });
+
+    it("transitions a running run to canceled, stamping completed_at and the reason", async () => {
+        (await insertRun(pool, { runId: "run-active", analysisId: "a-1", workflowName: "executeAnalysis" }))._unsafeUnwrap();
+
+        const transitioned = (await markRunCanceledIfActive(pool, "run-active", "external_cancel"))._unsafeUnwrap();
+        expect(transitioned).toBe(true);
+
+        const row = (await queryRun(pool, "run-active"))._unsafeUnwrap();
+        expect(row?.status).toBe("canceled");
+        expect(row?.error).toBe("external_cancel");
+        expect(row?.completedAt).not.toBeNull();
+    });
+
+    it("transitions a fund-suspended run to canceled", async () => {
+        (await insertRun(pool, { runId: "run-susp", analysisId: "a-1", workflowName: "executeAnalysis" }))._unsafeUnwrap();
+        (await updateRunStatus(pool, "run-susp", "suspended_insufficient_funds"))._unsafeUnwrap();
+
+        expect((await markRunCanceledIfActive(pool, "run-susp", "external_cancel"))._unsafeUnwrap()).toBe(true);
+        expect((await queryRun(pool, "run-susp"))._unsafeUnwrap()?.status).toBe("canceled");
+    });
+
+    it("refuses to clobber a completed run and reports no transition", async () => {
+        (await insertRun(pool, { runId: "run-done", analysisId: "a-1", workflowName: "executeAnalysis" }))._unsafeUnwrap();
+        (await updateRunStatus(pool, "run-done", "completed"))._unsafeUnwrap();
+        const before = (await queryRun(pool, "run-done"))._unsafeUnwrap();
+
+        const transitioned = (await markRunCanceledIfActive(pool, "run-done", "external_cancel"))._unsafeUnwrap();
+        expect(transitioned).toBe(false);
+
+        const after = (await queryRun(pool, "run-done"))._unsafeUnwrap();
+        expect(after?.status).toBe("completed");
+        expect(after?.completedAt).toBe(before?.completedAt ?? null);
+        expect(after?.error).toBeNull();
+    });
+
+    it("reports no transition for a run that does not exist", async () => {
+        expect((await markRunCanceledIfActive(pool, "run-nowhere", "external_cancel"))._unsafeUnwrap()).toBe(false);
     });
 });

--- a/harness/src/state/runs.ts
+++ b/harness/src/state/runs.ts
@@ -221,6 +221,28 @@ export function updateRunStatus(
     });
 }
 
+/**
+ * Conditionally transition an ACTIVE run to `canceled`, stamping `completed_at`
+ * and recording `reason` in `error` (the same column `collectAndComplete`
+ * stamps `external_cancel` into). Reports whether a row transitioned — false
+ * means the run was already terminal (e.g. it completed concurrently with an
+ * external cancel), and the caller MUST NOT fall back to `updateRunStatus`,
+ * which would clobber that terminal status. The guarded set is the active set
+ * `queryActiveRun` deduplicates on.
+ */
+export function markRunCanceledIfActive(pool: Querier, runId: string, reason: string): ResultAsync<boolean, DbError> {
+    const now = new Date().toISOString();
+    return tryMutation("runs.markRunCanceledIfActive", async () => {
+        const result = await pool.query({
+            text: `UPDATE cortex_runs
+            SET status = 'canceled', completed_at = $2, error = $3
+            WHERE run_id = $1 AND status IN ('running','suspended_insufficient_funds')`,
+            values: [runId, now, reason],
+        });
+        return (result.rowCount ?? 0) > 0;
+    });
+}
+
 export function promoteFailedToPartial(pool: Querier, runId: string): ResultAsync<boolean, DbError> {
     return tryMutation("runs.promoteFailedToPartial", async () => {
         const result = await pool.query({

--- a/harness/src/tasks/data-profile.trigger.test.ts
+++ b/harness/src/tasks/data-profile.trigger.test.ts
@@ -74,6 +74,7 @@ function parkedDispatchDeps(pool: Pool): DataProfileTriggerDeps {
         runAuthorizer: {
             authorize: () => new Promise(() => {}),
             async revoke() {},
+            async revokeByJti() {},
         },
         workflow: async () => {},
     };

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -33,6 +33,7 @@ import { runToTerminal } from "../loop/run-to-terminal.js";
 import { durableStep } from "../loop/run-step.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import type { ResolveBilling } from "../billing/resolver.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { defineTool } from "../tools/define-tool.js";
@@ -69,6 +70,9 @@ import { DATA_PROFILE_RUN_LITERAL } from "../contracts/data-profile.js";
 const DATA_PROFILE_STEP_LITERAL = "profile" as const;
 const DATA_PROFILE_AGENT_ID = "data-profiler" as const;
 
+/** Resolved-header key carrying the billing-context id (see `ResolveBilling`). */
+const BILLING_CONTEXT_HEADER = "X-Inflexa-Billing-Context";
+
 /** Sandbox-server exec budget for the profile run. */
 const DEFAULT_DEADLINE_MS = 300_000;
 
@@ -98,6 +102,9 @@ export interface DataProfileDeps extends EnvironmentStorePaths {
     readonly skillsDir: string;
     /** LLM usage-accounting seam for the profiler agent loop; omitted falls back to the no-op recorder. */
     readonly usageRecorder?: UsageRecorder;
+    /** Resolves the billing context stamped as the sandbox pod's OpenCost
+     *  labels. Absent in upstream-less (dev/OSS) wiring — pods spawn unlabeled. */
+    readonly resolveBilling?: ResolveBilling;
 }
 
 /**
@@ -333,6 +340,16 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
         // run panel's activity readout was built to remove.
         await activity.sandboxInit();
 
+        let billingContextId: string | undefined;
+        if (deps.resolveBilling) {
+            try {
+                billingContextId = (await deps.resolveBilling(childSession))[BILLING_CONTEXT_HEADER];
+            } catch (err) {
+                logger.error("[billing] data-profile billing resolution failed", logger.errorFields(err));
+            }
+            if (!billingContextId) logger.error("[billing] sandbox spawned without billing labels");
+        }
+
         const sandbox = await deps.sandboxClient.createSandbox(
             {
                 runId: DATA_PROFILE_RUN_LITERAL,
@@ -340,6 +357,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                 analysisId,
                 childWorkflowId: workflowId,
                 resources: estimateDataProfileResources(stagedInputs),
+                billing: billingContextId ? { billingContextId, userId: childSession.identity.user } : undefined,
             },
             mintSandboxIdentity(DATA_PROFILE_RUN_LITERAL),
         );

--- a/harness/src/tools/approval/gateway.test.ts
+++ b/harness/src/tools/approval/gateway.test.ts
@@ -335,12 +335,14 @@ describe("createAskGateway — abort", () => {
 // ── 5.5 — boot sweep ─────────────────────────────────────────────────
 
 describe("createAskGateway — sweep", () => {
-    it("expires orphaned pending rows and returns the count swept", async () => {
-        const now = new Date().toISOString();
-        const rows: AskRow[] = [
-            { id: uuidv7(), analysisId: "analysis-A", threadId: null, title: "t1", command: "c1", detail: null, grantKey: null, createdAt: now },
-            { id: uuidv7(), analysisId: "analysis-A", threadId: null, title: "t2", command: "c2", detail: null, grantKey: null, createdAt: now },
-        ];
+    const STALE = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+
+    function pendingRow(createdAt: string): AskRow {
+        return { id: uuidv7(), analysisId: "analysis-A", threadId: null, title: "t", command: "c", detail: null, grantKey: null, createdAt };
+    }
+
+    it("expires orphaned pending rows past the max age and returns the count swept", async () => {
+        const rows = [pendingRow(STALE), pendingRow(STALE)];
         for (const row of rows) {
             (await insertPendingAsk(pool, row))._unsafeUnwrap();
         }
@@ -351,5 +353,34 @@ describe("createAskGateway — sweep", () => {
             expect((await selectRow(row.id))?.status).toBe("expired");
         }
         expect(await gateway.pending()).toHaveLength(0);
+    });
+
+    it("leaves a fresh pending ask untouched — a boot sweep cannot kill a live ask", async () => {
+        const fresh = pendingRow(new Date().toISOString());
+        (await insertPendingAsk(pool, fresh))._unsafeUnwrap();
+
+        expect(await gateway.sweepExpired()).toBe(0);
+        expect((await selectRow(fresh.id))?.status).toBe("pending");
+        expect(await gateway.pending()).toHaveLength(1);
+    });
+
+    it("counts only the rows it swept when stale and fresh pend together", async () => {
+        const stale = pendingRow(STALE);
+        const fresh = pendingRow(new Date().toISOString());
+        for (const row of [stale, fresh]) {
+            (await insertPendingAsk(pool, row))._unsafeUnwrap();
+        }
+
+        expect(await gateway.sweepExpired()).toBe(1);
+        expect((await selectRow(stale.id))?.status).toBe("expired");
+        expect((await selectRow(fresh.id))?.status).toBe("pending");
+    });
+
+    it("honors an explicit maxAgeMs", async () => {
+        const row = pendingRow(new Date(Date.now() - 60_000).toISOString());
+        (await insertPendingAsk(pool, row))._unsafeUnwrap();
+
+        expect(await gateway.sweepExpired(30_000)).toBe(1);
+        expect((await selectRow(row.id))?.status).toBe("expired");
     });
 });

--- a/harness/src/tools/approval/gateway.ts
+++ b/harness/src/tools/approval/gateway.ts
@@ -55,11 +55,19 @@ export interface AskGateway {
     ask(request: AskRequest, ctx: AskContext): Promise<AskApproval>;
     answer(id: string, reply: AskReply): Promise<AnswerOutcome>;
     pending(): Promise<PendingAsk[]>;
-    sweepExpired(): Promise<number>;
+    /** Expire pending asks older than `maxAgeMs` (default {@link DEFAULT_SWEEP_MAX_AGE_MS}). */
+    sweepExpired(maxAgeMs?: number): Promise<number>;
 }
 
 /** Fixed poll cadence — imperceptible against human decision speed, low chatter. */
 const POLL_INTERVAL_MS = 200;
+
+/**
+ * Pending rows older than this are treated as orphans of a dead process. Far
+ * beyond any plausible live turn, so a boot sweep during a rolling deployment
+ * cannot expire an ask another pod is still polling.
+ */
+export const DEFAULT_SWEEP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 export function createAskGateway(deps: AskGatewayDeps): AskGateway {
     const { pool } = deps;
@@ -129,8 +137,9 @@ export function createAskGateway(deps: AskGatewayDeps): AskGateway {
         return unwrapOrThrow(await selectPending(pool));
     }
 
-    async function sweepExpired(): Promise<number> {
-        return unwrapOrThrow(await sweepExpiredRows(pool, new Date().toISOString()));
+    async function sweepExpired(maxAgeMs: number = DEFAULT_SWEEP_MAX_AGE_MS): Promise<number> {
+        const now = Date.now();
+        return unwrapOrThrow(await sweepExpiredRows(pool, new Date(now).toISOString(), new Date(now - maxAgeMs).toISOString()));
     }
 
     return { ask, answer, pending, sweepExpired };

--- a/harness/src/tools/approval/queries.ts
+++ b/harness/src/tools/approval/queries.ts
@@ -148,12 +148,20 @@ export function selectPending(querier: Querier): ResultAsync<PendingAsk[], DbErr
     });
 }
 
-/** Sweep every `pending` row to `expired`, returning the count swept. */
-export function sweepExpired(querier: Querier, expiredAt: string): ResultAsync<number, DbError> {
+/**
+ * Sweep `pending` rows created before `olderThan` to `expired`, returning the
+ * count swept. The age predicate is what keeps a boot sweep from expiring an ask
+ * another live pod is still polling — only rows old enough to be orphans of a
+ * dead process are touched. Both bounds compare as text: every `created_at` is a
+ * fixed-width UTC ISO string, so lexicographic order is chronological (the same
+ * property `selectPending`'s ORDER BY relies on).
+ */
+export function sweepExpired(querier: Querier, expiredAt: string, olderThan: string): ResultAsync<number, DbError> {
     return tryMutation("asks.sweepExpired", async () => {
         const result = await querier.query({
-            text: `UPDATE cortex_asks SET status = 'expired', resolved_at = $1 WHERE status = 'pending'`,
-            values: [expiredAt],
+            text: `UPDATE cortex_asks SET status = 'expired', resolved_at = $1
+              WHERE status = 'pending' AND created_at < $2`,
+            values: [expiredAt, olderThan],
         });
         return result.rowCount ?? 0;
     });

--- a/harness/src/tools/execute-analysis.test.ts
+++ b/harness/src/tools/execute-analysis.test.ts
@@ -51,6 +51,7 @@ function recordingAuthorizer(): {
         revoke: async (_authorization, reason) => {
             revokes.push(reason);
         },
+        revokeByJti: async () => {},
     };
     return { authorizer, revokes };
 }
@@ -62,6 +63,7 @@ const throwingAuthorizer: RunAuthorizer = {
         throw new Error("authorize should not be reached in this test");
     },
     revoke: async () => {},
+    revokeByJti: async () => {},
 };
 
 const ANALYSIS_ID = "analysis-test-1";
@@ -360,6 +362,7 @@ describe("createExecuteAnalysisTool plan mode", () => {
                 throw new Error("mint exploded");
             },
             revoke: async () => {},
+            revokeByJti: async () => {},
         };
         const tool = createExecuteAnalysisTool({
             ...utilityDeps,

--- a/harness/src/tools/report-session/record-version.test.ts
+++ b/harness/src/tools/report-session/record-version.test.ts
@@ -98,7 +98,7 @@ describe("createRecordVersionTool", () => {
         drop = ctx.drop;
         store = createReportVersionStore({ pool });
         threads = createThreadStore(pool);
-        (await upsertAnalysis(pool, ANALYSIS_ID, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(pool, ANALYSIS_ID, null))._unsafeUnwrap();
     });
 
     afterAll(async () => {

--- a/harness/src/workflows/__tests__/dbos/budget-cascade.test.ts
+++ b/harness/src/workflows/__tests__/dbos/budget-cascade.test.ts
@@ -207,7 +207,7 @@ describe("402 budget-pause cascade — parent self-cancel", () => {
         const analysisId = "a-budget-parent-cancel";
         const planId = "plan-budget-parent-cancel";
 
-        (await upsertAnalysis(rig.pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(rig.pool, analysisId, null))._unsafeUnwrap();
         await rig.pool.query(
             `INSERT INTO cortex_plans (plan_id, analysis_id, plan, parent_plan_id, created_at)
          VALUES ($1, $2, $3::jsonb, NULL, $4)`,
@@ -305,7 +305,7 @@ describe("402 budget-pause cascade — parent self-cancel", () => {
         const analysisId = "a-budget-prod-cancel";
         const planId = "plan-budget-prod-cancel";
 
-        (await upsertAnalysis(rig.pool, analysisId, null, null))._unsafeUnwrap();
+        (await upsertAnalysis(rig.pool, analysisId, null))._unsafeUnwrap();
         await rig.pool.query(
             `INSERT INTO cortex_plans (plan_id, analysis_id, plan, parent_plan_id, created_at)
          VALUES ($1, $2, $3::jsonb, NULL, $4)`,

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -35,6 +35,7 @@ import type { Pool } from "pg";
 import { insertStepExecution, updateStepExecution } from "../state/index.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import type { ResolveBilling } from "../billing/resolver.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { CitationResolver } from "../citations/types.js";
 import { unwrapOrThrow } from "../lib/result.js";
@@ -131,6 +132,9 @@ export interface SandboxStepInput {
  * declare it explicitly.
  */
 export const DEFAULT_STEP_TIMEOUT_SECONDS = 3600;
+
+/** Resolved-header key carrying the billing-context id (see `ResolveBilling`). */
+const BILLING_CONTEXT_HEADER = "X-Inflexa-Billing-Context";
 
 export type SandboxStepStatus = "complete" | "failed" | "canceled" | "blocked";
 
@@ -270,6 +274,9 @@ export interface SandboxStepDeps {
     /** Write-side embedder for the post-step vector index. */
     readonly embedding: EmbeddingProvider;
     readonly sandboxClient: SandboxClient;
+    /** Resolves the billing context stamped as the sandbox pod's OpenCost
+     *  labels. Absent in upstream-less (dev/OSS) wiring — pods spawn unlabeled. */
+    readonly resolveBilling?: ResolveBilling;
     /**
      * External artifact registration + sync seam. The harness's post-step pipeline
      * registers each step's outputs through it (filesystem index in the
@@ -428,7 +435,9 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
 
     // (2b) sandbox.create — spawn (or adopt) the machine under the minted
     // identity. The handle (secret included) is cached so recovery picks the
-    // same machine back up without re-provisioning.
+    // same machine back up without re-provisioning. Billing resolution lives
+    // INSIDE this step (not as its own step) so the child's step sequence is
+    // unchanged — in-flight workflows resumed across a deploy replay cleanly.
     const sandboxMeta: CreateSandboxMeta = {
         runId: input.runId,
         stepId: input.stepId,
@@ -438,7 +447,22 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
         extraEnv: input.extraEnv,
         resources: input.resources,
     };
-    const sandbox = await DBOS.runStep(() => deps.sandboxClient.createSandbox(sandboxMeta, identity), { name: "sandbox.create" });
+    const sandbox = await DBOS.runStep(
+        async () => {
+            let billing: CreateSandboxMeta["billing"];
+            if (deps.resolveBilling) {
+                try {
+                    const bcId = (await deps.resolveBilling(session))[BILLING_CONTEXT_HEADER];
+                    if (bcId) billing = { billingContextId: bcId, userId: input.runSession.identity.user };
+                } catch (err) {
+                    logger.error("[billing] step billing resolution failed", { analysisId: input.analysisId, ...logger.errorFields(err) });
+                }
+                if (!billing) logger.error("[billing] sandbox spawned without billing labels", { analysisId: input.analysisId });
+            }
+            return deps.sandboxClient.createSandbox({ ...sandboxMeta, billing }, identity);
+        },
+        { name: "sandbox.create" },
+    );
 
     // Recovery path: re-check `isAlive` on the persisted ref before continuing.
     // A classified-dead sandbox triggers a fresh `createSandbox` (task 4.6).


### PR DESCRIPTION
Remediates the harness-side gaps from the Cortex prelaunch audit. Four self-contained changes, each with its own openspec change under `harness/openspec/changes/`. Cortex adopts them in a follow-up bump (`bump-harness-0.20-and-converge`) after the next release.

## add-run-canceler (audit blocker 1)

External `DBOS.cancelWorkflow` can never reach the workflow's own terminal cleanup (a cancelled workflow can't run steps — the wedge `execute-analysis` documents), so a host cancel today leaves `cortex_runs` at `running` forever (blocking same-plan relaunch via the active-plan dedup), pending step rows unswept, the running charge open, and the mandate unrevoked.

- `createRunCanceler({ pool, runCharge, runAuthorizer })` → `cancel(runId, session)`: idempotent (`already_terminal` short-circuit), child-cascading DBOS cancel via the purger's client path (also catches children whose `mark-running` step hasn't committed), then per-phase isolated convergence: conditional status write → pending-step sweep → best-effort charge close → out-of-band mandate revoke. Returns `{ outcome, finalStatus, converged: { steps, charge, mandate } }`.
- `markRunCanceledIfActive(pool, runId, reason)` — conditional `UPDATE ... WHERE status IN ('running','suspended_insufficient_funds')` so a concurrently-completing run is never clobbered.
- `RunAuthorizer.revokeByJti({ jti, auth }, reason)` — new seam method for the out-of-band path where only the persisted jti exists (the mandate JWT is never persisted). Local/OSS impl no-ops.
- No stream writes: `DBOS.writeStream` is body-only; hosts synthesize the terminal frame read-side.

## drop-analysis-billing-context (audit blocker 2, harness half)

`cortex_analysis_state.billing_context` was a stale-copy trap: the managed seed route always wrote null, the upsert overwrote unconditionally, and `resolveAnalysisBilling` had zero callers. Hosts now resolve billing lazily at charge-open (Nexus already owns the analysis→billing-context mapping behind `resolve-headers`).

- `upsertAnalysis(pool, resourceId, context, inputFileIds?)` — billing param gone; column dropped from DDL + `DROP COLUMN IF EXISTS` migration; `resolveAnalysisBilling` deleted; CLI call sites updated. `cortex_target_assessments.billing_context_id` untouched.

## restore-sandbox-billing-labels (audit blocker 3)

Re-lands cortex's approved `fix-sandbox-compute-billing` design, which was implemented against the old in-repo harness copy and lost in the migration — sandbox pods currently carry no billing labels, so OpenCost can't attribute compute/storage/network.

- `CreateSandboxMeta.billing?: { billingContextId, userId }`; `cortex/billing-context|user-id|analysis-id|run-id` labels (via `sanitizeLabelValue`) on both Job metadata and pod template; resolution inside the existing `sandbox.create` step (replay-safe) and the data-profile spawn; failure degrades loudly to an unlabeled spawn. Ephemeral-runner port N/A (not in this tree). Hosts wire `resolveBilling` through the new optional dep fields.

## fix-ask-sweep-predicate (audit secondary)

`sweepExpired` updated every pending row with no age predicate — a rolling-deploy boot sweep would expire live approvals fleet-wide. Now `sweepExpired(maxAgeMs?)` only expires pending asks older than the cutoff (default 24h). An `expires_at` column for exact per-ask expiry is recorded as an open question in the change's design doc.

## Verification

- `tsc --noEmit` + eslint clean (harness)
- Full suite (`scripts/test-full.sh`): 2668 pass / 0 fail / 6 skip across 217 files
- CLI compiles clean against this branch via `harness:local` link (96 stale-published-type errors → 0); CLI `node_modules` restored to published afterwards
- All four openspec changes validate (4/4 artifacts each)

No version bump here — release/publish follows the normal flow.