### PR TITLE
feat(harness): switch the report capability to a report session

### DIFF
--- a/cli/src/modules/harness/turn.test.ts
+++ b/cli/src/modules/harness/turn.test.ts
@@ -107,6 +107,7 @@ function recordingHistory(append: () => ResultAsync<void, DbError> = () => okAsy
         loadPage: () => okAsync({ messages: [], total: 0, page: 1, perPage: 200, hasMore: false }),
         retractLastTurn: () => okAsync({ kind: "empty-thread" }),
         latestSeq: () => okAsync(null),
+        countUserTurnsAfter: () => okAsync(0),
     };
     return { history, appended };
 }
@@ -493,6 +494,7 @@ function stagedHistory(turns: ModelMessage[][]): { history: ThreadHistory; retra
             return okAsync({ kind: "retracted", messages: turns[turns.length - 1]?.length ?? 0 });
         },
         latestSeq: () => okAsync(null),
+        countUserTurnsAfter: () => okAsync(0),
     };
     return { history, retracts: () => retracts };
 }

--- a/cli/src/modules/harness/usage_ledger.test.ts
+++ b/cli/src/modules/harness/usage_ledger.test.ts
@@ -236,6 +236,7 @@ describe("a chat turn's calls land in the local ledger", () => {
             loadPage: () => okAsync({ messages: [], total: 0, page: 1, perPage: 200, hasMore: false }),
             retractLastTurn: () => okAsync({ kind: "empty-thread" }),
             latestSeq: () => okAsync(null),
+            countUserTurnsAfter: () => okAsync(0),
         };
 
         const outcome = await runChatTurn(

--- a/harness/openspec/changes/switch-report-capability-to-session/.openspec.yaml
+++ b/harness/openspec/changes/switch-report-capability-to-session/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/harness/openspec/changes/switch-report-capability-to-session/design.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/design.md
@@ -89,6 +89,14 @@ The spawn takes the anchor operation as an optional dep, and it runs the operati
 
 A failed pin keeps the child, because the operation is idempotent and a later call pins again. A purge on a transient store fault would cost the user the whole session. Thus the failure rides the logger, and the outcome vocabulary of the spawn does not grow. The dep crosses the tool and `ConversationAgentDeps`, and the assembly binds it, thus no embedder changes.
 
+### D11. The window of a report turn keeps its first turn
+
+The seed is the one record of the brief and of the working memory, because the report turn injects no live render. The window evicts the oldest turn first, in blocks (`src/memory/thread-history.ts:504-522`). Thus a long session drops its own charter, and the agent keeps its tools and loses its objective.
+
+The read takes an option that keeps the first turn, and the assembly passes it for a `report` thread. Two alternatives were rejected. A tail copy of the seed duplicates it on each turn, until the eviction makes the copy the only one. A store column for the brief adds a migration for text that the transcript already holds.
+
+The retained turn can carry the window past its token budget. The cost is bounded, because the brief carries a length bound and the render is one row. The retained head also holds `messages[0]` byte-identical for the life of the session, thus the cache prefix of the provider stays still.
+
 ## Risks / Trade-offs
 
 - [The CLI passes `chrome: {}` (`cli/src/modules/harness/runtime.ts:1080`), thus every local spawn refuses `no_browser` until #312 wires the sidecar] → the refusal is typed and names the absent capability. The delivery branch merges as one unit, thus no release carries the gap.

--- a/harness/openspec/changes/switch-report-capability-to-session/design.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/design.md
@@ -1,0 +1,93 @@
+# Design: switch-report-capability-to-session
+
+## Context
+
+The rebuild of #221 is dormant on `main`. The `report` thread type resolves to the Report Builder agent (`src/runtime/assemble.ts:311-314`), and the spawn operation exists (`src/app/spawn-report-session.ts`). But no caller reaches the operation, and the conversation agent still offers `plan_report` and `submit_report` (`src/agents/conversation-agent.ts:273-284`). The conversation prompt describes the brief flow (`src/prompts/conversation.ts`, the "Report Creation" section).
+
+The #221 policy binds this change: a report session is user-initiated, and on a thin delta the agent advises iteration in the existing report chat. The one-version rule itself lives in the `report-versions` spec already.
+
+The #223 decision record binds the context transfer, and its #309 delta names the mechanism. The intent brief is the argument of the spawn tool. The working-memory render copies into the child context at the spawn, because a live read sees state past the anchor. The shipped spawn operation carries neither part yet, and the turn assembly injects a live render on every turn (`src/app/message-assembly.ts:104-107`). Thus this change carries the transfer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One report path on the roster: a tool that starts a report session.
+- The intent brief rides the tool, and the spawn seeds the child context at the anchor.
+- The typed refusals of the spawn reach the agent as data.
+- The zero-delta advice steers to the existing report chat.
+- The prompt describes the session path, and only that path.
+
+**Non-Goals:**
+
+- No removal of the old modules. #313 removes them.
+- No new chat data part. The entry point in the chat surface is #312 work, and a part, if one is necessary, lands there.
+- No turn-start wiring of `ensureSessionState`. The gateway `load` anchors the session on the first tool call (`src/app/report-session-runtime.ts:175-187`).
+- No change to the spawn operation refusal set, and no change to the Report Builder agent.
+
+## Decisions
+
+### D1. The tool id is `start_report_session`, and the module is top-level
+
+The tool id follows the verb-noun form of the conversation roster (`execute_analysis`, `generate_plan`). The module lands at `src/tools/start-report-session.ts`, beside `iterate-report.ts`, because the conversation-agent tools live at the top of `src/tools/`. The `src/tools/report-session/` directory keeps the tools of the report thread only. "Spawn" stays the name of the operation, and the tool surface speaks "start".
+
+### D2. The parent comes from the scope, never from the input
+
+The tool reads `scope.threadId` as the parent conversation. Every chat turn carries it (`cli/src/modules/harness/turn.ts:188`, and `auth/types.ts:37` declares it). A call whose scope carries no thread id refuses as typed data, the same rule as the authoring tools (`src/tools/report-authoring/authoring-tools.ts:277`). An input field for the parent would let the agent name a different thread, thus no such field exists.
+
+### D3. The advice is mechanical, zero-delta, and overridable
+
+The #221 policy says "thin delta", and a prompt cannot compare sequence numbers. Thus the tool computes the delta. The rule is exact at zero. When the parent holds no message past the anchor of the newest report child, the tool spawns nothing. It returns an `existing-session` arm that names that child.
+
+The input carries one optional boolean, `newSessionAnyway`, and a true value skips the advice. A small non-zero delta stays a prompt judgment, because any non-zero threshold is arbitrary.
+
+The eyes gate wins over the advice. A composition without a browser is a permanent condition, and the advice is transient state. Thus the tool checks `hasBrowserUrl(chrome)` first, the same value that the spawn gate reads at its construction (`src/app/spawn-report-session.ts:153`). An advice that masks the permanent fault would hide the deployment gap from the user.
+
+The tool computes the delta from two reads: the children listing narrowed by the parent, and `latestSeq` of the parent (`src/memory/thread-history.ts:204`). Two concurrent spawns can give two children with one anchor (`src/app/spawn-report-session.ts:179-183`), and the newest `created_at` then wins.
+
+The greatest child anchor comes from a walk of the listing pages, because the listing orders by `updated_at` and not by anchor (`src/memory/thread-store.ts:622`). The walk is cheap: the one-version policy keeps the child count small. The two reads land on the spawn module (`ReportSessionSpawn`), because that module already composes the store and the history over one pool.
+
+### D4. Every degraded condition is ok-channel data
+
+The result is a discriminated union, the same contract as the report-session tools: `refused` (no thread id in scope), `existing-session` (the advice), the four spawn refusals passed through (`no_browser`, `parent_not_found`, `parent_not_a_conversation`, `empty_parent_transcript`), `failed` (a store fault, with a short detail), and `started` (the thread id and the title of the child). The `no_browser` arm carries the detail line of the spawn, thus the agent tells the user that this deployment cannot look at a page. The tool never throws for one of these.
+
+### D5. The wiring stays inside `createConversationAgent`
+
+The tool constructs from `pool` and `chrome`, and both already ride `ConversationAgentDeps` (`src/agents/conversation-agent.ts:117,159`). The roster swap replaces the `planReportTool` and `createReportSubmitTool(...)` entries with the one new tool. No new field crosses `CoreRuntimeDeps`, thus no embedder changes. The `capture` seam of the spawn gate stays unbound here: the sidecar decision makes `chrome.browserUrl` the one route to the eyes, and the conversation deps carry no capture field today.
+
+### D6. The prompt describes one path
+
+The "Report Creation" section of `src/prompts/conversation.ts` rewrites: call `start_report_session` when the user wants a report, tell the user where the session is, and steer a change request to the existing report chat. The section keeps the no-unprompted-reports rule. The "Do NOT" list gains the failure mode: do not compose a report in the conversation, and do not paste report prose in place of a session. The prompt names the mechanism only, per the prompt principles.
+
+### D7. Unused old-path deps stay on the deps bag
+
+`createPreviewPublisher`, `templatesDir`, and `skillsDir` stay on `ConversationAgentDeps`, although only the old tools read them. A deps change is an embedder-facing break, and #313 owns the removal. The change stays one commit, thus a revert restores the old roster in one step.
+
+### D8. The brief is the argument of the tool
+
+The #223 record fixes the intent channel: push only what the ask itself creates. The input of the tool carries the brief beside the override: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. Each field is short prose, and the tool description caps the whole brief at approximately 2000 tokens. The conversation agent authors the brief at the moment of the ask, and no field names a path or a dataset.
+
+### D9. The spawn seeds the child context at the anchor
+
+The spawn operation gains the brief as its second argument. After the thread insert, the spawn composes one context message: the brief, then the copy of the working-memory render at that moment. It appends the message to the child transcript through `appendTurn` (`src/memory/thread-history.ts:344`). The transcript is append-only, thus the copy is frozen at the anchor by construction.
+
+A seed write can fail after the thread insert. The spawn then purges the child through `purgeThread` and returns the fault as typed data, because a context-less report thread is a dead end.
+
+The report turn must not inject the live working-memory render, because a live read sees state past the anchor (the #309 delta). The turn assembly reads the thread type that `prepareChatTurn` already loads, and a `report` thread skips that one tail message. The analysis context and the run activity stay, because the #223 record names the working memory alone.
+
+## Risks / Trade-offs
+
+- [The CLI passes `chrome: {}` (`cli/src/modules/harness/runtime.ts:1080`), thus every local spawn refuses `no_browser` until #312 wires the sidecar] → the refusal is typed and names the absent capability. The delivery branch merges as one unit, thus no release carries the gap.
+- [The compiled binary fails `preview_report` without the packed assets] → the #312 asset binding lands on the same branch, before any release (decision D9 of `add-report-design-system`).
+- [An agent can call `submit_report` from habit after the swap] → the loop refuses the unknown tool, and the prompt names the one path.
+- [Two concurrent turns can both pass the zero-delta gate] → the one-per-thread store rule bounds the cost to one extra empty session.
+- [The seed write fails after the thread insert] → the spawn purges the child and returns the fault, thus no context-less thread survives.
+- [A weak brief starves the Report Builder] → the transcript stays readable, and the interactive session is the repair path per the #223 record.
+
+## Migration Plan
+
+The change is user-visible: the report capability of a conversation changes shape. A revert of the one commit restores the old roster and the old prompt. No data migrates, and no store changes.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/switch-report-capability-to-session/design.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/design.md
@@ -69,7 +69,9 @@ The "Report Creation" section of `src/prompts/conversation.ts` rewrites: call `s
 
 ### D8. The brief is the argument of the tool
 
-The #223 record fixes the intent channel: push only what the ask itself creates. The input of the tool carries the brief beside the override: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. Each field is short prose, and the tool description caps the whole brief at approximately 2000 tokens. The conversation agent authors the brief at the moment of the ask, and no field names a path or a dataset.
+The #223 record fixes the intent channel: push only what the ask itself creates. The input of the tool carries the brief beside the override: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. Each field is short prose, and the tool description caps the whole brief at approximately 2000 tokens.
+
+The schema bounds each field as well, because the brief lands in a durable message row. A description alone states the cap to the agent, and it holds no unbounded string out of the store. The conversation agent authors the brief at the moment of the ask, and no field names a path or a dataset.
 
 ### D9. The spawn seeds the child context at the anchor
 
@@ -78,6 +80,14 @@ The spawn operation gains the brief as its second argument. After the thread ins
 A seed write can fail after the thread insert. The spawn then purges the child through `purgeThread` and returns the fault as typed data, because a context-less report thread is a dead end.
 
 The report turn must not inject the live working-memory render, because a live read sees state past the anchor (the #309 delta). The turn assembly reads the thread type that `prepareChatTurn` already loads, and a `report` thread skips that one tail message. The analysis context and the run activity stay, because the #223 record names the working memory alone.
+
+### D10. The spawn pins the snapshot at its own moment
+
+The #223 record mints one T at the spawn: the `parent_seq` pins the transcript, and the snapshot pins the data. The shipped runtime pins the snapshot lazily, on the first session tool call of a report turn (`src/app/report-session-runtime.ts:175-187`). A run can register an artifact between the spawn and that call, thus the session cites an artifact that the anchor never held.
+
+The spawn takes the anchor operation as an optional dep, and it runs the operation after the seed lands. The seed comes first, because a failed seed purges the child and the session-state row holds no key of the thread. The order thus leaves no orphan row.
+
+A failed pin keeps the child, because the operation is idempotent and a later call pins again. A purge on a transient store fault would cost the user the whole session. Thus the failure rides the logger, and the outcome vocabulary of the spawn does not grow. The dep crosses the tool and `ConversationAgentDeps`, and the assembly binds it, thus no embedder changes.
 
 ## Risks / Trade-offs
 

--- a/harness/openspec/changes/switch-report-capability-to-session/design.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/design.md
@@ -15,7 +15,7 @@ The #223 decision record binds the context transfer, and its #309 delta names th
 - One report path on the roster: a tool that starts a report session.
 - The intent brief rides the tool, and the spawn seeds the child context at the anchor.
 - The typed refusals of the spawn reach the agent as data.
-- The zero-delta advice steers to the existing report chat.
+- The thin-delta advice steers to the existing report chat.
 - The prompt describes the session path, and only that path.
 
 **Non-Goals:**
@@ -35,15 +35,19 @@ The tool id follows the verb-noun form of the conversation roster (`execute_anal
 
 The tool reads `scope.threadId` as the parent conversation. Every chat turn carries it (`cli/src/modules/harness/turn.ts:188`, and `auth/types.ts:37` declares it). A call whose scope carries no thread id refuses as typed data, the same rule as the authoring tools (`src/tools/report-authoring/authoring-tools.ts:277`). An input field for the parent would let the agent name a different thread, thus no such field exists.
 
-### D3. The advice is mechanical, zero-delta, and overridable
+### D3. The advice counts user turns, and it is overridable
 
-The #221 policy says "thin delta", and a prompt cannot compare sequence numbers. Thus the tool computes the delta. The rule is exact at zero. When the parent holds no message past the anchor of the newest report child, the tool spawns nothing. It returns an `existing-session` arm that names that child.
+The #221 policy says "thin delta", and a prompt cannot compare sequence numbers. Thus the tool computes the delta. The unit is the user turn of the parent past the anchor of the newest report child. The tool spawns nothing at a count of one or less, and it names that child.
 
-The input carries one optional boolean, `newSessionAnyway`, and a true value skips the advice. A small non-zero delta stays a prompt judgment, because any non-zero threshold is arbitrary.
+The unit is a turn, and it is not a raw sequence number. The turn appends after its own loop runs (`app/chat-turn.ts` gives the messages, and the caller appends). Thus the anchor of a child sits before the rows of the ask that made it, and the ask lands one turn later. A rule at zero over the raw sequence would then never fire again after the spawn. The count admits that one turn, and a second user turn is real investigation.
+
+The count reads the genuine-user-start predicate that the thread history already holds (`src/memory/thread-history.ts:230`). Thus a synthetic record of a host never counts as investigation. The rejected alternative was a fixed non-zero sequence threshold, which no fact of the transcript supports.
+
+The input carries one optional boolean, `newSessionAnyway`, and a true value skips the advice.
 
 The eyes gate wins over the advice. A composition without a browser is a permanent condition, and the advice is transient state. Thus the tool checks `hasBrowserUrl(chrome)` first, the same value that the spawn gate reads at its construction (`src/app/spawn-report-session.ts:153`). An advice that masks the permanent fault would hide the deployment gap from the user.
 
-The tool computes the delta from two reads: the children listing narrowed by the parent, and `latestSeq` of the parent (`src/memory/thread-history.ts:204`). Two concurrent spawns can give two children with one anchor (`src/app/spawn-report-session.ts:179-183`), and the newest `created_at` then wins.
+The tool computes the delta from two reads: the children listing narrowed by the parent, and the count of user turns past the anchor. Two concurrent spawns can give two children with one anchor (`src/app/spawn-report-session.ts:179-183`), and the newest `created_at` then wins.
 
 The greatest child anchor comes from a walk of the listing pages, because the listing orders by `updated_at` and not by anchor (`src/memory/thread-store.ts:622`). The walk is cheap: the one-version policy keeps the child count small. The two reads land on the spawn module (`ReportSessionSpawn`), because that module already composes the store and the history over one pool.
 
@@ -80,7 +84,7 @@ The report turn must not inject the live working-memory render, because a live r
 - [The CLI passes `chrome: {}` (`cli/src/modules/harness/runtime.ts:1080`), thus every local spawn refuses `no_browser` until #312 wires the sidecar] → the refusal is typed and names the absent capability. The delivery branch merges as one unit, thus no release carries the gap.
 - [The compiled binary fails `preview_report` without the packed assets] → the #312 asset binding lands on the same branch, before any release (decision D9 of `add-report-design-system`).
 - [An agent can call `submit_report` from habit after the swap] → the loop refuses the unknown tool, and the prompt names the one path.
-- [Two concurrent turns can both pass the zero-delta gate] → the one-per-thread store rule bounds the cost to one extra empty session.
+- [Two concurrent turns can both pass the delta gate] → the one-per-thread store rule bounds the cost to one extra empty session.
 - [The seed write fails after the thread insert] → the spawn purges the child and returns the fault, thus no context-less thread survives.
 - [A weak brief starves the Report Builder] → the transcript stays readable, and the interactive session is the repair path per the #223 record.
 

--- a/harness/openspec/changes/switch-report-capability-to-session/proposal.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: switch-report-capability-to-session
+
+## Why
+
+The rebuild of #221 is on `main`, and it is dormant: the `report` thread type resolves to the Report Builder agent, but no tool makes a report thread. The conversation agent still offers the old brief tools. Two report paths in one roster select unpredictably, thus the switch is one atomic change (#314).
+
+## What Changes
+
+- Remove `plan_report` and `submit_report` from the roster of the conversation agent. The two modules stay in the source, and #313 removes them later.
+- Add the tool that starts a report session. It runs `createReportSessionSpawn` (`src/app/spawn-report-session.ts`), and it returns each refusal as typed data.
+- Carry the intent brief as the argument of the tool, per the #223 decision record. The conversation agent authors it at the moment of the ask.
+- Seed the child context at the spawn. The seed holds the brief and a copy of the working-memory render, per the #309 delta.
+- Stop the live working-memory render on a report turn. The copy in the child transcript is the record, and a live read breaks the anchor.
+- Add the thin-delta advice. The tool compares the anchor of the newest report child against the transcript end. When no new message exists, the tool advises iteration in that report chat, and it spawns nothing. An explicit input field overrides the advice.
+- Update the conversation prompt. It describes one report path: start a session, and talk to the Report Builder there.
+- **BREAKING** for the agent surface: a conversation turn cannot build a report in place after this change. The user-visible behavior changes here and nowhere else in the rebuild.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-session-spawn`: the capability gains the conversation-agent tool surface. The requirements cover the tool, the brief, the context seed, the one-report-path roster invariant, the typed refusals as data, and the zero-delta advice.
+- `report-session-agent`: the report turn reads the copied narrative from its transcript. The turn assembly injects no live working-memory render.
+- `iterative-report`: the roster requirement changes. The conversation agent no longer offers `plan_report` and `submit_report`. The tools and the builder stay in the source until their removal.
+
+## Impact
+
+- `src/agents/conversation-agent.ts` — the roster swap and the new tool wiring.
+- `src/prompts/conversation.ts` — the "Report Creation" section describes the session path.
+- A new tool module, `src/tools/start-report-session.ts`.
+- `src/app/spawn-report-session.ts` — the spawn gains the brief argument and the context-seed write.
+- `src/app/chat-turn.ts` and `src/app/message-assembly.ts` — the report turn skips the live working-memory tail.
+- The spawn deps (`pool`, `chrome`) already ride `ConversationAgentDeps`. No new seam.
+- The old path stays reachable in the source, thus a revert of this change is one commit.

--- a/harness/openspec/changes/switch-report-capability-to-session/proposal.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/proposal.md
@@ -11,7 +11,7 @@ The rebuild of #221 is on `main`, and it is dormant: the `report` thread type re
 - Carry the intent brief as the argument of the tool, per the #223 decision record. The conversation agent authors it at the moment of the ask.
 - Seed the child context at the spawn. The seed holds the brief and a copy of the working-memory render, per the #309 delta.
 - Stop the live working-memory render on a report turn. The copy in the child transcript is the record, and a live read breaks the anchor.
-- Add the thin-delta advice. The tool compares the anchor of the newest report child against the transcript end. When no new message exists, the tool advises iteration in that report chat, and it spawns nothing. An explicit input field overrides the advice.
+- Add the thin-delta advice. The tool counts the user turns of the parent past the anchor of the newest report child. At one turn or less, the tool advises iteration in that report chat, and it spawns nothing. An explicit input field overrides the advice.
 - Update the conversation prompt. It describes one report path: start a session, and talk to the Report Builder there.
 - **BREAKING** for the agent surface: a conversation turn cannot build a report in place after this change. The user-visible behavior changes here and nowhere else in the rebuild.
 
@@ -23,7 +23,7 @@ None.
 
 ### Modified Capabilities
 
-- `report-session-spawn`: the capability gains the conversation-agent tool surface. The requirements cover the tool, the brief, the context seed, the one-report-path roster invariant, the typed refusals as data, and the zero-delta advice.
+- `report-session-spawn`: the capability gains the conversation-agent tool surface. The requirements cover the tool, the brief, the context seed, the one-report-path roster invariant, the typed refusals as data, and the thin-delta advice.
 - `report-session-agent`: the report turn reads the copied narrative from its transcript. The turn assembly injects no live working-memory render.
 - `iterative-report`: the roster requirement changes. The conversation agent no longer offers `plan_report` and `submit_report`. The tools and the builder stay in the source until their removal.
 

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/iterative-report/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/iterative-report/spec.md
@@ -1,0 +1,39 @@
+# iterative-report Delta
+
+## MODIFIED Requirements
+
+### Requirement: submit_report exposes mutually-exclusive creation and iteration modes
+
+`submit_report` MUST be the brief-submission surface of the old report path, and `plan_report` MUST deliver the brief schema just-in-time. Neither tool is on the roster of the conversation agent. The report capability of a conversation is the report session — refer to the `report-session-spawn` capability. The two modules stay in the source until their removal, and this requirement binds them wherever they are constructed.
+
+The input MUST carry exactly one of `report` (creation) or `modifications` (iteration), and never both. The tool accepts `previewId` (optional lowercase-alphanumeric-dash, auto-generated as `prv-{8 hex}` on first call), `baseVersion` (optional, defaults to latest), `format`, and a top-level `sources` array (iteration-only — `sources` beside `report` is rejected). It MUST return `{ previewId, version, previewPath, error?, notes? }`.
+
+`format` MUST accept only `"html"`, which is also its default. The system produces no other output format: the rendered artifact is always `v{N}/index.html`. The tool MUST reject a request for a different format at the tool boundary. It must not accept the request and silently give HTML.
+
+The `format` field on `preview-meta.json` and on the `data-report-preview` part keeps its wider `"html" | "pdf"` type. Thus a preview persisted before this restriction still parses.
+
+#### Scenario: The pair is off the conversation roster
+
+- **WHEN** the assembled conversation agent lists its tools
+- **THEN** neither `plan_report` nor `submit_report` is present
+
+#### Scenario: Supplying both report and modifications is rejected
+
+- **WHEN** `submit_report` is called with both a `report` object and a `modifications` string
+- **THEN** input validation fails before any work — exactly one of `report` or `modifications` must be provided
+
+#### Scenario: First creation auto-generates a preview id
+
+- **WHEN** the agent calls `submit_report` with a `report` and no `previewId`
+- **THEN** the tool generates a `prv-`-prefixed id, produces version 1, and returns `{ previewId, version: 1, previewPath }`
+
+#### Scenario: A non-HTML format is refused at the boundary
+
+- **WHEN** the agent calls `submit_report` with `format: "pdf"`
+- **THEN** input validation rejects the call, and no preview version is created
+
+#### Scenario: A persisted preview recorded before the restriction still loads
+
+- **GIVEN** a `preview-meta.json` written with `format: "pdf"`
+- **WHEN** that preview's metadata is read for a later iteration
+- **THEN** it parses successfully and the recorded format is preserved

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
@@ -17,3 +17,51 @@ The assembly MUST read the thread type from the row that the turn preparation al
 
 - **WHEN** a turn runs on a `conversation` thread
 - **THEN** the assembled tail holds the working-memory render, as before
+
+## MODIFIED Requirements
+
+### Requirement: The snapshot pins at session start
+
+The runtime MUST give an idempotent operation that makes sure that the session state of a thread exists. The first run of the operation MUST pin the snapshot with `pinReportSnapshot`, and it MUST write the row. Every later call MUST read the stored snapshot, and it MUST NOT pin again. A pin failure MUST return as typed data, and a later call can pin again, because no row was written.
+
+The spawn MUST run the operation directly after the seed of the child lands. The spawn mints one moment, and the two pins of that moment are the anchor of the transcript and the snapshot of the data. A pin at the first tool call of a later turn reads a different moment. A run can register an artifact between the two, and the session then cites an artifact that the anchor never held.
+
+A failed pin at the spawn MUST NOT fail the spawn, and it MUST NOT remove the child. The operation is idempotent, thus a later call pins again. The failure MUST reach the injected logger.
+
+The serving path of a report turn MUST run the operation at the start of the turn. Thus a session that the spawn could not pin still anchors before its first tool call.
+
+#### Scenario: The spawn pins the snapshot
+
+- **WHEN** the spawn makes a report child
+- **THEN** the session state of the child holds the snapshot before the first turn runs
+
+#### Scenario: An artifact of a later run is not a member
+
+- **GIVEN** a spawned report child
+- **WHEN** a run registers a new artifact, and the first turn of the child then runs
+- **THEN** the stored snapshot holds no entry for that artifact
+
+#### Scenario: A failed pin at the spawn keeps the child
+
+- **WHEN** the pin fails at the spawn
+- **THEN** the spawn gives the child, and the next call pins again
+
+#### Scenario: The first served turn pins before any tool call
+
+- **WHEN** the first turn of a report thread starts
+- **THEN** the row holds the snapshot before a tool of the roster runs
+
+#### Scenario: The pin runs one time
+
+- **WHEN** a thread makes two authoring calls
+- **THEN** the artifact ledger query runs one time, and both calls read one snapshot
+
+#### Scenario: The membership survives a restart
+
+- **WHEN** the process restarts after the pin, and a new artifact lands in the ledger
+- **THEN** the next call reads the stored snapshot, and the new artifact is not a member
+
+#### Scenario: A pin failure does not poison the thread
+
+- **WHEN** the first pin fails and the store recovers
+- **THEN** the next call pins again, and the session continues

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
@@ -1,0 +1,19 @@
+# report-session-agent Delta
+
+## ADDED Requirements
+
+### Requirement: The report turn reads the copied narrative, never the live memory
+
+The turn assembly of a `report` thread MUST NOT inject the live working-memory render. The seed message in the child transcript carries the copy at the anchor, and that copy is the narrative record of the session. A live render sees state past the anchor, and that breaks the knowledge cap.
+
+The assembly MUST read the thread type from the row that the turn preparation already loads. A `conversation` thread keeps the live render.
+
+#### Scenario: A report turn carries no live render
+
+- **WHEN** a turn runs on a `report` thread
+- **THEN** the assembled tail holds no working-memory render, and the seed message stays the one narrative source
+
+#### Scenario: A conversation turn keeps the live render
+
+- **WHEN** a turn runs on a `conversation` thread
+- **THEN** the assembled tail holds the working-memory render, as before

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-agent/spec.md
@@ -18,6 +18,24 @@ The assembly MUST read the thread type from the row that the turn preparation al
 - **WHEN** a turn runs on a `conversation` thread
 - **THEN** the assembled tail holds the working-memory render, as before
 
+### Requirement: The window of a report turn keeps the seed
+
+The history window of a report turn MUST keep the first turn of the thread. The seed is that first turn, and it is the one record of the brief and of the working memory. No tail message replaces it.
+
+The window evicts the oldest turn first. Thus a long session would drop the seed, and the agent would keep its tools and lose its objective. The retained seed can carry the window past its token budget. The cost is bounded, because the brief carries a length bound and the render is one row.
+
+A `conversation` thread MUST keep the eviction that it has. The live tail of that thread carries the memory on each turn, thus its first turn holds no record that a later turn needs.
+
+#### Scenario: A long report session keeps its seed
+
+- **WHEN** a report thread holds more turns than the token budget admits
+- **THEN** the window holds the seed, and it holds the most recent turns
+
+#### Scenario: A conversation window evicts its oldest turn
+
+- **WHEN** a conversation thread holds more turns than the token budget admits
+- **THEN** the window drops the oldest turns, as before
+
 ## MODIFIED Requirements
 
 ### Requirement: The snapshot pins at session start

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
@@ -6,7 +6,7 @@
 
 The conversation agent MUST offer the tool `start_report_session`. The tool MUST run the spawn operation with the thread id of the call scope as the parent. The tool MUST NOT accept a parent id as input.
 
-The input MUST carry the intent brief: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. The brief holds intent only, and no field names a path, a dataset, or a format. The input MUST also carry the optional override of the thin-delta advice.
+The input MUST carry the intent brief: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. The brief holds intent only, and no field names a path, a dataset, or a format. Each field MUST carry a length bound in the schema, because the brief lands in a durable message row. The input MUST also carry the optional override of the thin-delta advice.
 
 A call whose scope carries no thread id MUST refuse as typed data in the ok channel. A spawn refusal MUST pass through as typed data, and the arm names the reason. The `no_browser` arm MUST carry the detail of the spawn, thus the agent can tell the user that the deployment has no eyes. A store fault MUST return as typed data with a short detail. A success MUST return the thread id and the title of the child. The tool MUST NOT throw for a degraded condition.
 

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
@@ -6,7 +6,7 @@
 
 The conversation agent MUST offer the tool `start_report_session`. The tool MUST run the spawn operation with the thread id of the call scope as the parent. The tool MUST NOT accept a parent id as input.
 
-The input MUST carry the intent brief: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. The brief holds intent only, and no field names a path, a dataset, or a format. The input MUST also carry the optional override of the zero-delta advice.
+The input MUST carry the intent brief: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. The brief holds intent only, and no field names a path, a dataset, or a format. The input MUST also carry the optional override of the thin-delta advice.
 
 A call whose scope carries no thread id MUST refuse as typed data in the ok channel. A spawn refusal MUST pass through as typed data, and the arm names the reason. The `no_browser` arm MUST carry the detail of the spawn, thus the agent can tell the user that the deployment has no eyes. A store fault MUST return as typed data with a short detail. A success MUST return the thread id and the title of the child. The tool MUST NOT throw for a degraded condition.
 
@@ -66,9 +66,11 @@ The roster of the conversation agent MUST hold `start_report_session`. The roste
 - **WHEN** a reviewer reads the report section of the conversation prompt
 - **THEN** the section names `start_report_session`, and no brief tool is named
 
-### Requirement: The zero-delta advice steers to the existing report chat
+### Requirement: The thin-delta advice steers to the existing report chat
 
-When the parent holds no message past the greatest anchor of its report children, the tool MUST NOT spawn. The tool MUST return an `existing-session` arm that names the report child with the greatest anchor. When two children share the greatest anchor, the newest `created_at` MUST win. The advice MUST read no model judgment.
+The delta MUST count the user turns of the parent past the greatest anchor of its report children. A user turn is a message that opens a turn, and it is not a synthetic record. When the count is one or less, the tool MUST NOT spawn. The tool MUST return an `existing-session` arm that names the report child with the greatest anchor. When two children share the greatest anchor, the newest `created_at` MUST win. The advice MUST read no model judgment.
+
+The count admits one turn, because the ask that made the newest child is itself a user turn past the anchor. The turn appends after the loop of the turn runs, thus the anchor of a child never counts the ask that made it. A count over the raw sequence would name each report child stale one turn after the spawn.
 
 The input MUST carry one optional override field. A true value MUST skip the advice, and the spawn proceeds. A parent with no report child MUST NOT advise. An archived report child MUST NOT advise, because a steer into hidden state is not permitted.
 
@@ -76,7 +78,7 @@ The eyes gate MUST run before the advice. A composition without eyes is a perman
 
 #### Scenario: The eyes gate wins over the advice
 
-- **GIVEN** a composition without eyes, and a report child whose anchor equals the latest seq
+- **GIVEN** a composition without eyes, and a report child at the transcript end
 - **WHEN** the agent calls the tool
 - **THEN** the result carries the `no_browser` arm, and no advice returns
 
@@ -86,21 +88,33 @@ The eyes gate MUST run before the advice. A composition without eyes is a perman
 - **WHEN** the agent calls the tool without the override
 - **THEN** the `existing-session` arm names the child with the newest `created_at`
 
-#### Scenario: A zero delta advises
+#### Scenario: A child at the transcript end advises
 
 - **GIVEN** a report child whose anchor equals the latest seq of the parent
 - **WHEN** the agent calls the tool without the override
 - **THEN** the result carries the `existing-session` arm that names that child, and no thread is written
 
-#### Scenario: A new message clears the advice
+#### Scenario: The turn of the spawning ask does not clear the advice
 
-- **GIVEN** a report child whose anchor is below the latest seq of the parent
+- **GIVEN** a report child, and the one user turn that made it past its anchor
+- **WHEN** the agent calls the tool without the override
+- **THEN** the result carries the `existing-session` arm that names that child
+
+#### Scenario: A second user turn clears the advice
+
+- **GIVEN** a report child, and two user turns of the parent past its anchor
 - **WHEN** the agent calls the tool
 - **THEN** the spawn proceeds, and the result carries the new thread id
 
+#### Scenario: A synthetic record does not clear the advice
+
+- **GIVEN** a report child, and one host record of the parent past its anchor
+- **WHEN** the agent calls the tool
+- **THEN** the result carries the `existing-session` arm, because a record is no user turn
+
 #### Scenario: The override skips the advice
 
-- **GIVEN** a report child whose anchor equals the latest seq of the parent
+- **GIVEN** a report child at the transcript end
 - **WHEN** the agent calls the tool with the override set to true
 - **THEN** the spawn proceeds, and the result carries the new thread id
 

--- a/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/specs/report-session-spawn/spec.md
@@ -1,0 +1,111 @@
+# report-session-spawn Delta
+
+## ADDED Requirements
+
+### Requirement: The conversation agent starts a report session through one tool
+
+The conversation agent MUST offer the tool `start_report_session`. The tool MUST run the spawn operation with the thread id of the call scope as the parent. The tool MUST NOT accept a parent id as input.
+
+The input MUST carry the intent brief: `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`. The brief holds intent only, and no field names a path, a dataset, or a format. The input MUST also carry the optional override of the zero-delta advice.
+
+A call whose scope carries no thread id MUST refuse as typed data in the ok channel. A spawn refusal MUST pass through as typed data, and the arm names the reason. The `no_browser` arm MUST carry the detail of the spawn, thus the agent can tell the user that the deployment has no eyes. A store fault MUST return as typed data with a short detail. A success MUST return the thread id and the title of the child. The tool MUST NOT throw for a degraded condition.
+
+#### Scenario: The tool starts a session
+
+- **WHEN** the agent calls `start_report_session` with a brief, on a live conversation that holds turns
+- **THEN** the result carries the thread id and the title of the child, and the thread listing holds the child
+
+#### Scenario: A scope without a thread id refuses
+
+- **WHEN** the tool runs with a scope that carries no thread id
+- **THEN** the result is typed data that names the missing thread id, and no thread is written
+
+#### Scenario: A composition without eyes refuses
+
+- **WHEN** the composition gives no browser and no capture seam, and the agent calls the tool
+- **THEN** the result carries the `no_browser` arm with its detail, and no thread is written
+
+#### Scenario: A spawn refusal passes through
+
+- **WHEN** the agent calls the tool on a conversation that holds no messages
+- **THEN** the result carries the `empty_parent_transcript` arm, and no thread is written
+
+### Requirement: The spawn seeds the child context at the anchor
+
+The spawn MUST compose one context message and append it to the child transcript. The message MUST hold the brief, and then a copy of the working-memory render at the moment of the spawn. A later change to the working memory MUST NOT change the seed, because the transcript is append-only.
+
+When the seed write fails after the thread insert, the spawn MUST purge the child. The fault MUST return as typed data, and no context-less report thread survives.
+
+#### Scenario: The seed lands with the thread
+
+- **WHEN** the spawn makes a child for a conversation with a working memory
+- **THEN** the child transcript holds one message with the brief and the working-memory render
+
+#### Scenario: The seed is frozen at the anchor
+
+- **GIVEN** a spawned child with its seed
+- **WHEN** the working memory of the analysis changes afterward
+- **THEN** the seed message of the child does not change
+
+#### Scenario: A failed seed removes the child
+
+- **WHEN** the seed write fails after the thread insert
+- **THEN** the spawn purges the child, and the result is typed data that names the fault
+
+### Requirement: The roster of the conversation agent holds one report path
+
+The roster of the conversation agent MUST hold `start_report_session`. The roster MUST NOT hold `plan_report`, and it MUST NOT hold `submit_report`. The prompt of the conversation agent MUST describe the session path, and it MUST NOT describe the brief flow.
+
+#### Scenario: The roster holds the start tool and not the pair
+
+- **WHEN** the assembled conversation agent lists its tools
+- **THEN** `start_report_session` is present, and neither `plan_report` nor `submit_report` is present
+
+#### Scenario: The prompt describes one path
+
+- **WHEN** a reviewer reads the report section of the conversation prompt
+- **THEN** the section names `start_report_session`, and no brief tool is named
+
+### Requirement: The zero-delta advice steers to the existing report chat
+
+When the parent holds no message past the greatest anchor of its report children, the tool MUST NOT spawn. The tool MUST return an `existing-session` arm that names the report child with the greatest anchor. When two children share the greatest anchor, the newest `created_at` MUST win. The advice MUST read no model judgment.
+
+The input MUST carry one optional override field. A true value MUST skip the advice, and the spawn proceeds. A parent with no report child MUST NOT advise. An archived report child MUST NOT advise, because a steer into hidden state is not permitted.
+
+The eyes gate MUST run before the advice. A composition without eyes is a permanent condition, and the advice must not mask it.
+
+#### Scenario: The eyes gate wins over the advice
+
+- **GIVEN** a composition without eyes, and a report child whose anchor equals the latest seq
+- **WHEN** the agent calls the tool
+- **THEN** the result carries the `no_browser` arm, and no advice returns
+
+#### Scenario: A tie on the anchor names the newest child
+
+- **GIVEN** two report children that share the greatest anchor, at the transcript end
+- **WHEN** the agent calls the tool without the override
+- **THEN** the `existing-session` arm names the child with the newest `created_at`
+
+#### Scenario: A zero delta advises
+
+- **GIVEN** a report child whose anchor equals the latest seq of the parent
+- **WHEN** the agent calls the tool without the override
+- **THEN** the result carries the `existing-session` arm that names that child, and no thread is written
+
+#### Scenario: A new message clears the advice
+
+- **GIVEN** a report child whose anchor is below the latest seq of the parent
+- **WHEN** the agent calls the tool
+- **THEN** the spawn proceeds, and the result carries the new thread id
+
+#### Scenario: The override skips the advice
+
+- **GIVEN** a report child whose anchor equals the latest seq of the parent
+- **WHEN** the agent calls the tool with the override set to true
+- **THEN** the spawn proceeds, and the result carries the new thread id
+
+#### Scenario: A parent with no report child never advises
+
+- **GIVEN** a live conversation that holds turns and no report child
+- **WHEN** the agent calls the tool
+- **THEN** the spawn proceeds, and the result carries the new thread id

--- a/harness/openspec/changes/switch-report-capability-to-session/tasks.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: switch-report-capability-to-session
+
+## 1. The spawn payload
+
+- [x] 1.1 Add the brief argument to `spawnReportSession` in `src/app/spawn-report-session.ts`. The fields are `objective`, `audience`, `angle`, optional `exclusions`, and optional `openQuestions`.
+- [x] 1.2 Compose the seed message at the spawn: the brief, then the copy of the working-memory render. Append it through `appendTurn`.
+- [x] 1.3 On a failed seed write, purge the child and return the fault as typed data.
+- [x] 1.4 Cover the seed with tests: the seed lands, the seed stays frozen after a memory change, and a failed seed removes the child.
+
+## 2. The delta reads on the spawn module
+
+- [x] 2.1 Add the delta read to `src/app/spawn-report-session.ts`. It gives the greatest child anchor and the latest seq of the parent.
+- [x] 2.2 Walk each page of the children listing, because the listing orders by `updated_at` and not by anchor. An archived child does not count.
+- [x] 2.3 Cover the read with tests: no child, one child at the end, one child below the end, and two pages of children.
+
+## 3. The tool
+
+- [x] 3.1 Make `src/tools/start-report-session.ts` with `defineTool`. The input carries the brief fields and the optional `newSessionAnyway` boolean.
+- [x] 3.2 Read the parent from `scope.threadId`. A scope with no thread id refuses as typed data in the ok channel.
+- [x] 3.3 Run the eyes gate first, from `hasBrowserUrl(chrome)`. A composition without eyes returns the `no_browser` arm before the advice.
+- [x] 3.4 Run the zero-delta advice before the spawn. On a zero delta with no override, return the `existing-session` arm that names the newest child.
+- [x] 3.5 Run the spawn with the brief, and pass each refusal through as a typed arm.
+- [x] 3.6 Return the thread id and the title on a success. The tool never throws for a degraded condition.
+- [x] 3.7 Cover the tool with tests: each arm of the union, the gate order, and the override path.
+
+## 4. The turn assembly
+
+- [x] 4.1 Thread the thread type into `assembleMessages` (`src/app/message-assembly.ts`), from the row that `prepareChatTurn` loads.
+- [x] 4.2 Skip the live working-memory tail on a `report` thread. A `conversation` thread keeps it.
+- [x] 4.3 Cover the branch with tests: a report turn holds no render, and a conversation turn holds one.
+
+## 5. The roster and the prompt
+
+- [x] 5.1 In `src/agents/conversation-agent.ts`, remove `planReportTool` and `createReportSubmitTool(...)` from the roster. Add the new tool, constructed from `pool` and `chrome`.
+- [x] 5.2 Rewrite the "Report Creation" section of `src/prompts/conversation.ts`. It teaches the brief, the steer to the existing report chat, and the no-unprompted-reports rule.
+- [x] 5.3 Extend the "Do NOT" list: do not compose a report in the conversation.
+- [x] 5.4 Add the roster test: `start_report_session` is present, and neither `plan_report` nor `submit_report` is present.
+- [x] 5.5 Add the prompt test: the report section names the new tool, and no brief tool is named.
+
+## 6. Verification
+
+- [x] 6.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
+- [x] 6.2 Run `bun run format:file` on each changed source file.
+- [x] 6.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.

--- a/harness/openspec/changes/switch-report-capability-to-session/tasks.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/tasks.md
@@ -44,8 +44,16 @@
 - [x] 6.3 Advise at one turn or less in `src/tools/start-report-session.ts`.
 - [x] 6.4 Cover the rule: the ask of the spawn does not clear the advice, a second user turn clears it, and a synthetic record does not.
 
-## 7. Verification
+## 7. The one moment of the spawn
 
-- [x] 7.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
-- [x] 7.2 Run `bun run format:file` on each changed source file.
-- [x] 7.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.
+- [x] 7.1 Add the optional anchor dep to `createReportSessionSpawn`. The spawn runs it after the seed lands.
+- [x] 7.2 Keep the child on a failed pin, and send the failure to the logger.
+- [x] 7.3 Thread the dep from the assembly through `ConversationAgentDeps` and the tool. The embedder supplies nothing.
+- [x] 7.4 Bound each brief field in the schema of the tool.
+- [x] 7.5 Cover the pin: the spawn pins, a later artifact is no member, and a failed pin keeps the child.
+
+## 8. Verification
+
+- [x] 8.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
+- [x] 8.2 Run `bun run format:file` on each changed source file.
+- [x] 8.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.

--- a/harness/openspec/changes/switch-report-capability-to-session/tasks.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/tasks.md
@@ -18,7 +18,7 @@
 - [x] 3.1 Make `src/tools/start-report-session.ts` with `defineTool`. The input carries the brief fields and the optional `newSessionAnyway` boolean.
 - [x] 3.2 Read the parent from `scope.threadId`. A scope with no thread id refuses as typed data in the ok channel.
 - [x] 3.3 Run the eyes gate first, from `hasBrowserUrl(chrome)`. A composition without eyes returns the `no_browser` arm before the advice.
-- [x] 3.4 Run the zero-delta advice before the spawn. On a zero delta with no override, return the `existing-session` arm that names the newest child.
+- [x] 3.4 Run the thin-delta advice before the spawn. At one user turn or less past the anchor, and with no override, return the `existing-session` arm that names the newest child.
 - [x] 3.5 Run the spawn with the brief, and pass each refusal through as a typed arm.
 - [x] 3.6 Return the thread id and the title on a success. The tool never throws for a degraded condition.
 - [x] 3.7 Cover the tool with tests: each arm of the union, the gate order, and the override path.
@@ -37,8 +37,15 @@
 - [x] 5.4 Add the roster test: `start_report_session` is present, and neither `plan_report` nor `submit_report` is present.
 - [x] 5.5 Add the prompt test: the report section names the new tool, and no brief tool is named.
 
-## 6. Verification
+## 6. The unit of the delta
 
-- [x] 6.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
-- [x] 6.2 Run `bun run format:file` on each changed source file.
-- [x] 6.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.
+- [x] 6.1 Add the count of user turns past a seq to `src/memory/thread-history.ts`. It reuses the genuine-user-start predicate.
+- [x] 6.2 Change `reportSessionDelta` to give that count in place of the latest seq.
+- [x] 6.3 Advise at one turn or less in `src/tools/start-report-session.ts`.
+- [x] 6.4 Cover the rule: the ask of the spawn does not clear the advice, a second user turn clears it, and a synthetic record does not.
+
+## 7. Verification
+
+- [x] 7.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
+- [x] 7.2 Run `bun run format:file` on each changed source file.
+- [x] 7.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.

--- a/harness/openspec/changes/switch-report-capability-to-session/tasks.md
+++ b/harness/openspec/changes/switch-report-capability-to-session/tasks.md
@@ -52,8 +52,15 @@
 - [x] 7.4 Bound each brief field in the schema of the tool.
 - [x] 7.5 Cover the pin: the spawn pins, a later artifact is no member, and a failed pin keeps the child.
 
-## 8. Verification
+## 8. The retained seed and the barrel
 
-- [x] 8.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
-- [x] 8.2 Run `bun run format:file` on each changed source file.
-- [x] 8.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.
+- [x] 8.1 Add the option that keeps the first turn to `loadRecent` in `src/memory/thread-history.ts`.
+- [x] 8.2 Pass the option for a `report` thread in `src/app/message-assembly.ts`.
+- [x] 8.3 Export `EnsureSessionStateResult` from `src/index.ts`, because `ConversationAgentDeps` names it.
+- [x] 8.4 Cover the window: a report thread over budget keeps its seed, and a conversation thread evicts as before.
+
+## 9. Verification
+
+- [x] 9.1 Run `tsc -p tsconfig.json` and `bun test` in `harness/`.
+- [x] 9.2 Run `bun run format:file` on each changed source file.
+- [x] 9.3 Search the prompts and the tool descriptions for a stale name of the old pair, per the agent-facing-copy rule.

--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -31,6 +31,9 @@ function buildAgent(hostTools?: readonly Tool[]) {
         executeAnalysisWorkflow: (async () => {
             throw new Error("not used at composition time");
         }) as never,
+        anchorReportSession: (async () => {
+            throw new Error("not used at composition time");
+        }) as never,
         resolveWorkspaceRoot: (id: string) => join("/sessions", id),
         runAuthorizer: {} as RunAuthorizer,
         runLauncher: {} as RunLauncher,

--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { Pool } from "pg";
 
 import { createConversationAgent, CONVERSATION_AGENT_ID } from "./conversation-agent.js";
+import { conversationPrompt } from "../prompts/conversation.js";
 import { createRegistry } from "../tools/registry.js";
 import { defineTool, type Tool } from "../tools/define-tool.js";
 import { AskRejectedError } from "../tools/approval/contract.js";
@@ -114,14 +115,31 @@ describe("createConversationAgent", () => {
             "inspect_run",
             "inspect_data_profile",
             "execute_analysis",
-            "plan_report",
-            "submit_report",
+            "start_report_session",
             "show_user",
             "show_plan",
             "show_file",
         ]) {
             expect(ids.has(expected)).toBe(true);
         }
+    });
+
+    // The roster is the whole guarantee of one report path. No runtime guard
+    // blocks the old pair; the roster omits it.
+    test("holds one report path and neither tool of the old pair", () => {
+        const ids = new Set(buildAgent().tools.map((tool) => tool.id));
+        expect(ids.has("start_report_session")).toBe(true);
+        expect(ids.has("plan_report")).toBe(false);
+        expect(ids.has("submit_report")).toBe(false);
+    });
+
+    // The prompt is agent-facing copy, and no typechecker reads it. A name of a
+    // tool that the roster does not hold spends a turn on a call that cannot
+    // dispatch.
+    test("the prompt names the one report path and neither tool of the old pair", () => {
+        expect(conversationPrompt).toContain("start_report_session");
+        expect(conversationPrompt).not.toContain("plan_report");
+        expect(conversationPrompt).not.toContain("submit_report");
     });
 
     test("places citation verification beside literature discovery", () => {

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -24,6 +24,7 @@
 import type { Pool } from "pg";
 
 import type { ExecuteAnalysisInput, ExecuteAnalysisResult } from "../workflows/execute-analysis.js";
+import type { EnsureSessionStateResult } from "../app/report-session-runtime.js";
 import type { ResourcePolicy } from "../config/resource-limits.js";
 import type { ChromeConfig } from "../lib/chrome.js";
 import type { AgentDefinition } from "../loop/types.js";
@@ -125,6 +126,13 @@ export interface ConversationAgentDeps extends EnvironmentStorePaths {
      * launches it through the `RunLauncher` seam to start the run.
      */
     readonly executeAnalysisWorkflow: (input: ExecuteAnalysisInput) => Promise<ExecuteAnalysisResult>;
+    /**
+     * The anchor operation of the report session runtime — produced by
+     * `createReportSessionRuntime` and wired by `assembleCoreRuntime`. The spawn
+     * of `start_report_session` runs it after the seed of the child lands, thus
+     * the transcript anchor and the data snapshot pin at one moment.
+     */
+    readonly anchorReportSession: (threadId: string) => Promise<EnsureSessionStateResult>;
     /** Workspace-root resolution seam (see workspace/paths.ts). */
     readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
     /**
@@ -261,7 +269,7 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         // The one report path. The tool starts a report thread as a child of the
         // conversation, and the user composes the report there with the Report
         // Builder.
-        createStartReportSessionTool({ pool, chrome, ...(deps.logger ? { logger: deps.logger } : {}) }),
+        createStartReportSessionTool({ pool, chrome, anchorSession: deps.anchorReportSession, ...(deps.logger ? { logger: deps.logger } : {}) }),
         // Display.
         showUserTool,
         createShowPlanTool(pool),

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -14,14 +14,9 @@
  * `execute_analysis` is wired here — it launches the DBOS `executeAnalysis` parent
  * workflow under `workflowId = runId` (the bare run UUID) through the
  * `RunLauncher` seam and returns the runId (results are pull-only via
- * `inspectRun` on a later turn). Report authoring is wired here as the
- * pair `plan_report` (returns the report-brief schema + authoring rules
- * just-in-time as its result) + `submit_report` (validates the composed brief
- * and drives in-process Nunjucks rendering via the `report-builder` agent, no
- * sandbox). The 4 custom tools the builder itself drives (`build_report`, its
- * own terminal `submit_report`, `preview_snapshot`, `mint_preview_url`) are
- * constructed inside the runner so they share closure-captured outcome state +
- * preview-dir paths.
+ * `inspectRun` on a later turn). `start_report_session` is the one report path.
+ * It starts a report thread as a child of the conversation, and the Report
+ * Builder composes the report in that thread.
  * The workspace read surface (`read_file`, `grep`, `workspace_search`) is
  * wired here over the `WorkspaceFilesystem` seam.
  */
@@ -81,7 +76,8 @@ import { createListAvailableRefsTool } from "../tools/sandbox/list-available-ref
 import { createExecuteAnalysisTool } from "../tools/execute-analysis.js";
 import type { RunAuthorizer } from "../execution/run-authorizer.js";
 import type { RunLauncher } from "../execution/run-launcher.js";
-import { planReportTool, createReportSubmitTool, type SubmitReportDeps } from "../tools/iterate-report.js";
+import type { SubmitReportDeps } from "../tools/iterate-report.js";
+import { createStartReportSessionTool } from "../tools/start-report-session.js";
 import type { Logger } from "../lib/logger.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { CitationResolver } from "../citations/types.js";
@@ -144,16 +140,16 @@ export interface ConversationAgentDeps extends EnvironmentStorePaths {
      */
     readonly runLauncher: RunLauncher;
     /**
-     * Preview-publishing seam factory for `submit_report` — injected, not
-     * constructed here. The managed root closes its platform deps over this; the
-     * OSS root returns the "unavailable" publisher.
+     * Preview-publishing seam factory. No tool of the roster reads it. The field
+     * stays, because a change to the deps breaks an embedder at its composition
+     * root.
      */
     readonly createPreviewPublisher: SubmitReportDeps["createPreviewPublisher"];
     /** API keys for the external bio/chem data sources. */
     readonly bioKeys: BioToolKeys;
-    /** Root templates dir for in-process report rendering (`submit_report`). */
+    /** Root templates dir. No tool of the roster reads it. */
     readonly templatesDir: string;
-    /** Skills root; the in-process report-builder gets `report-html` skill tools. */
+    /** Skills root. No tool of the roster reads it. */
     readonly skillsDir: string;
     /** Headless-Chrome config for report snapshot/preview rendering. */
     readonly chrome: ChromeConfig;
@@ -184,13 +180,9 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         utilityProvider,
         utilityModel,
         executeAnalysisWorkflow,
-        resolveWorkspaceRoot,
         runAuthorizer,
         runLauncher,
-        createPreviewPublisher,
         bioKeys,
-        templatesDir,
-        skillsDir,
         chrome,
         resourcePolicy,
         hostTools,
@@ -266,22 +258,10 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
             utilityModel,
             ...(deps.logger ? { logger: deps.logger } : {}),
         }),
-        // Report authoring: the always-on `plan_report` trigger delivers the
-        // heavy brief schema + rules just-in-time as its result; `submit_report`
-        // takes the composed brief as `unknown` and validates it in-execute, so
-        // the ~12k schema never rides the always-on tool surface.
-        planReportTool,
-        createReportSubmitTool({
-            provider,
-            pool,
-            resolveWorkspaceRoot,
-            model,
-            templatesDir,
-            skillsDir,
-            chrome,
-            createPreviewPublisher,
-            usageRecorder,
-        }),
+        // The one report path. The tool starts a report thread as a child of the
+        // conversation, and the user composes the report there with the Report
+        // Builder.
+        createStartReportSessionTool({ pool, chrome, ...(deps.logger ? { logger: deps.logger } : {}) }),
         // Display.
         showUserTool,
         createShowPlanTool(pool),

--- a/harness/src/app/chat-turn.test.ts
+++ b/harness/src/app/chat-turn.test.ts
@@ -5,6 +5,7 @@ import { withSchema } from "../__tests__/setup/postgres.js";
 import { createThreadStore } from "../memory/thread-store.js";
 import { createThreadHistory } from "../memory/thread-history.js";
 import { deriveThreadTitle } from "../memory/derive-thread-title.js";
+import { createWorkingMemory } from "../memory/working-memory.js";
 import { insertRun, updateRunStatus } from "../state/index.js";
 import { prepareChatTurn } from "./chat-turn.js";
 
@@ -213,5 +214,49 @@ describe("prepareChatTurn", () => {
         expect(result.kind).toBe("ok");
         if (result.kind !== "ok") throw new Error("unreachable");
         expect(result.threadType).toBe("report");
+    });
+
+    it("assembles no working-memory render on a report thread", async () => {
+        (await createWorkingMemory(pool).updateSection(ANALYSIS_A, "goal", { text: "Find the driver genes." }))._unsafeUnwrap();
+        (
+            await createThreadStore(pool).createThread({
+                threadId: "t-report-tail",
+                analysisId: ANALYSIS_A,
+                title: "A report",
+                type: "report",
+            })
+        )._unsafeUnwrap();
+
+        const result = await prepareChatTurn({ pool }, { analysisId: ANALYSIS_A, threadId: "t-report-tail", userInput: "draft the summary" });
+
+        expect(result.kind).toBe("ok");
+        if (result.kind !== "ok") throw new Error("unreachable");
+
+        const joined = result.messages.map((message) => contentText(message.content)).join("\n");
+        expect(joined).not.toContain("# Working Memory");
+        expect(joined).not.toContain("Find the driver genes.");
+        // The other two tail messages stay.
+        expect(joined).toContain("[Run Activity]");
+        expect(joined).toContain("draft the summary");
+    });
+
+    it("assembles the working-memory render on a conversation thread", async () => {
+        (await createWorkingMemory(pool).updateSection(ANALYSIS_A, "goal", { text: "Find the driver genes." }))._unsafeUnwrap();
+        (
+            await createThreadStore(pool).createThread({
+                threadId: "t-conv-tail",
+                analysisId: ANALYSIS_A,
+                title: "A conversation",
+            })
+        )._unsafeUnwrap();
+
+        const result = await prepareChatTurn({ pool }, { analysisId: ANALYSIS_A, threadId: "t-conv-tail", userInput: "draft the summary" });
+
+        expect(result.kind).toBe("ok");
+        if (result.kind !== "ok") throw new Error("unreachable");
+
+        const joined = result.messages.map((message) => contentText(message.content)).join("\n");
+        expect(joined).toContain("# Working Memory");
+        expect(joined).toContain("Find the driver genes.");
     });
 });

--- a/harness/src/app/chat-turn.ts
+++ b/harness/src/app/chat-turn.ts
@@ -57,7 +57,8 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
         return { kind: "not_found" };
     }
 
-    // The type a caller resolves the turn's agent from. An existing row carries
+    // The type a caller resolves the turn's agent from, and the type that the
+    // message assembly reads for its tail. An existing row carries
     // its own. An absent one defaults to `conversation` — the store's own
     // default — so a best-effort create that fails non-fatally still leaves a
     // usable type; a successful create overrides it from the returned row.
@@ -94,6 +95,7 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
     const history = createThreadHistory(pool);
     const { messages, userMessage } = await assembleMessages({
         threadId,
+        threadType,
         analysisId,
         userInput,
         analysisContext: analysisState?.context ?? null,

--- a/harness/src/app/message-assembly.test.ts
+++ b/harness/src/app/message-assembly.test.ts
@@ -45,6 +45,7 @@ describe("assembleMessages", () => {
         ];
         const { messages, userMessage } = await assembleMessages({
             threadId: "thread-1",
+            threadType: "conversation",
             analysisId: "analysis-1",
             userInput: "what is BRCA1?",
             analysisContext: "RNA-seq of tumor vs normal.",
@@ -68,6 +69,7 @@ describe("assembleMessages", () => {
     test("the assembled sequence is a valid Anthropic message sequence", async () => {
         const { messages } = await assembleMessages({
             threadId: "thread-1",
+            threadType: "conversation",
             analysisId: "analysis-1",
             userInput: "hello",
             analysisContext: null,
@@ -85,6 +87,7 @@ describe("assembleMessages", () => {
     test("redacts a secret in the user input", async () => {
         const { userMessage } = await assembleMessages({
             threadId: "t",
+            threadType: "conversation",
             analysisId: "a",
             userInput: "my key is AKIAIOSFODNN7EXAMPLE keep it safe",
             analysisContext: null,
@@ -101,6 +104,7 @@ describe("assembleMessages", () => {
         expect(fortyMer.length).toBe(40);
         const { userMessage } = await assembleMessages({
             threadId: "t",
+            threadType: "conversation",
             analysisId: "a",
             userInput: `align this sequence ${fortyMer} please`,
             analysisContext: null,
@@ -111,11 +115,48 @@ describe("assembleMessages", () => {
         expect(userMessage.content).toContain(fortyMer);
     });
 
+    test("a report thread drops the working-memory tail and keeps the other two", async () => {
+        const { messages, userMessage } = await assembleMessages({
+            threadId: "thread-report",
+            threadType: "report",
+            analysisId: "analysis-1",
+            userInput: "draft the summary",
+            analysisContext: "RNA-seq of tumor vs normal.",
+            runActivityContext: RUN_ACTIVITY,
+            history: stubHistory([]),
+            workingMemory: stubWorkingMemory(),
+        });
+
+        // Tail: analysis context, run activity, user input. No live render.
+        expect(messages.length).toBe(3);
+        expect(messages.map(contentText)).not.toContain(WM_RENDER);
+        expect(contentText(messages[0]!)).toContain("[Analysis Context]");
+        expect(contentText(messages[1]!)).toBe(RUN_ACTIVITY);
+        expect(messages[2]).toEqual(userMessage);
+    });
+
+    test("a conversation thread keeps the working-memory tail", async () => {
+        const { messages } = await assembleMessages({
+            threadId: "thread-conversation",
+            threadType: "conversation",
+            analysisId: "analysis-1",
+            userInput: "draft the summary",
+            analysisContext: "RNA-seq of tumor vs normal.",
+            runActivityContext: RUN_ACTIVITY,
+            history: stubHistory([]),
+            workingMemory: stubWorkingMemory(),
+        });
+
+        expect(messages.length).toBe(4);
+        expect(messages.map(contentText)).toContain(WM_RENDER);
+    });
+
     test("sanitization is not applied to history or analysis context", async () => {
         const secret = "AKIAIOSFODNN7EXAMPLE";
         const window: MessageParam[] = [{ role: "user", content: `prior turn mentioned ${secret}` }];
         const { messages } = await assembleMessages({
             threadId: "t",
+            threadType: "conversation",
             analysisId: "a",
             userInput: "continue",
             analysisContext: `context references ${secret}`,

--- a/harness/src/app/message-assembly.test.ts
+++ b/harness/src/app/message-assembly.test.ts
@@ -25,6 +25,28 @@ function stubHistory(window: MessageParam[]): ThreadHistory {
     };
 }
 
+const SEED = "the report brief";
+const RECENT = "a recent turn";
+
+/**
+ * A store that stands in for an over-budget thread: the seed message survives
+ * the eviction only when the read keeps the first turn.
+ */
+function seedKeepingHistory(): ThreadHistory {
+    return {
+        ...stubHistory([]),
+        loadRecent: (_threadId, _budget, options) =>
+            okAsync(
+                options?.keepFirstTurn === true
+                    ? [
+                          { role: "user", content: SEED },
+                          { role: "user", content: RECENT },
+                      ]
+                    : [{ role: "user", content: RECENT }],
+            ),
+    };
+}
+
 function stubWorkingMemory(render = WM_RENDER): WorkingMemoryStore {
     return {
         load: () => okAsync(emptyWorkingMemory()),
@@ -133,6 +155,36 @@ describe("assembleMessages", () => {
         expect(contentText(messages[0]!)).toContain("[Analysis Context]");
         expect(contentText(messages[1]!)).toBe(RUN_ACTIVITY);
         expect(messages[2]).toEqual(userMessage);
+    });
+
+    test("a report thread loads a window that keeps the seed", async () => {
+        const { messages } = await assembleMessages({
+            threadId: "thread-report",
+            threadType: "report",
+            analysisId: "analysis-1",
+            userInput: "draft the summary",
+            analysisContext: null,
+            runActivityContext: RUN_ACTIVITY,
+            history: seedKeepingHistory(),
+            workingMemory: stubWorkingMemory(),
+        });
+
+        expect(contentText(messages[0]!)).toBe(SEED);
+    });
+
+    test("a conversation thread loads a window that evicts the seed", async () => {
+        const { messages } = await assembleMessages({
+            threadId: "thread-conversation",
+            threadType: "conversation",
+            analysisId: "analysis-1",
+            userInput: "draft the summary",
+            analysisContext: null,
+            runActivityContext: RUN_ACTIVITY,
+            history: seedKeepingHistory(),
+            workingMemory: stubWorkingMemory(),
+        });
+
+        expect(messages.map(contentText)).not.toContain(SEED);
     });
 
     test("a conversation thread keeps the working-memory tail", async () => {

--- a/harness/src/app/message-assembly.ts
+++ b/harness/src/app/message-assembly.ts
@@ -19,6 +19,12 @@
  * sees state past that anchor, and that breaks the knowledge cap of a report
  * session. The analysis context and the run activity stay on both thread types.
  *
+ * The history window of a `report` thread also keeps the first turn. That turn
+ * is the seed, and it is the one record of the brief and of the copied render.
+ * The window evicts the oldest turn first, thus a long session would drop its
+ * own charter and keep only its tools. A `conversation` thread evicts as before,
+ * because its live tail carries the working memory on each turn.
+ *
  * Sanitization (`redactSecrets`, `normalizeUnicode`) is applied **once**, to
  * the new user input only — never to history, assistant messages, tool
  * results, the analysis context, or the rendered working memory.
@@ -48,7 +54,7 @@ export const DEFAULT_HISTORY_TOKEN_BUDGET = 120_000;
 export interface AssembleMessagesArgs {
     /** The conversation thread — a UI-generated UUID, never the analysisId. */
     readonly threadId: string;
-    /** The type of the thread. A `report` thread drops the working-memory tail. */
+    /** The type of the thread. A `report` thread drops the working-memory tail, and its window keeps the seed. */
     readonly threadType: ThreadType;
     /** The analysis scope — keys working memory and (separately) the context. */
     readonly analysisId: string;
@@ -84,7 +90,7 @@ export interface AssembledMessages {
 export async function assembleMessages(args: AssembleMessagesArgs): Promise<AssembledMessages> {
     const budget = args.tokenBudget ?? DEFAULT_HISTORY_TOKEN_BUDGET;
 
-    const history = unwrapOrThrow(await args.history.loadRecent(args.threadId, budget));
+    const history = unwrapOrThrow(await args.history.loadRecent(args.threadId, budget, { keepFirstTurn: args.threadType === "report" }));
 
     // Sanitization — applied once, here, to the new user input only.
     const userMessage: ModelMessage = {

--- a/harness/src/app/message-assembly.ts
+++ b/harness/src/app/message-assembly.ts
@@ -6,13 +6,18 @@
  *   [ ...loadRecent(threadId, budget)            ← stable, cacheable prefix
  *     {user: cortex_analysis_state.context},     ← tail
  *     {user: runActivityContext},                 ← tail
- *     {user: render(workingMemory)},             ← tail
+ *     {user: render(workingMemory)},             ← tail, `conversation` thread only
  *     {user: normalizeUnicode(redactSecrets(input))} ]  ← tail
  *
  * `system + tools + history` is the cacheable prefix — it only extends
  * turn-to-turn. Run activity, working memory, and analysis context go in the
  * **tail** as `user` messages: they change every turn, so a system-message
  * placement would bust the Anthropic cache prefix.
+ *
+ * A `report` thread does not get the working-memory tail. The spawn copies the
+ * working-memory render into the child transcript at the anchor. A live render
+ * sees state past that anchor, and that breaks the knowledge cap of a report
+ * session. The analysis context and the run activity stay on both thread types.
  *
  * Sanitization (`redactSecrets`, `normalizeUnicode`) is applied **once**, to
  * the new user input only — never to history, assistant messages, tool
@@ -29,6 +34,7 @@ import type { ModelMessage } from "ai";
 import { unwrapOrThrow } from "../lib/result.js";
 import type { LoopMessage } from "../loop/types.js";
 import type { ThreadHistory } from "../memory/thread-history.js";
+import type { ThreadType } from "../memory/thread-store.js";
 import type { WorkingMemoryStore } from "../memory/working-memory.js";
 import { normalizeUnicode, redactSecrets } from "../input-sanitization.js";
 
@@ -42,6 +48,8 @@ export const DEFAULT_HISTORY_TOKEN_BUDGET = 120_000;
 export interface AssembleMessagesArgs {
     /** The conversation thread — a UI-generated UUID, never the analysisId. */
     readonly threadId: string;
+    /** The type of the thread. A `report` thread drops the working-memory tail. */
+    readonly threadType: ThreadType;
     /** The analysis scope — keys working memory and (separately) the context. */
     readonly analysisId: string;
     /** The raw, untrusted user input for this turn. */
@@ -99,12 +107,15 @@ export async function assembleMessages(args: AssembleMessagesArgs): Promise<Asse
         content: args.runActivityContext,
     });
 
-    // Working memory — agent-authored, trusted. Always injected (its rendered
-    // form names the sections even when empty).
-    tail.push({
-        role: "user",
-        content: unwrapOrThrow(await args.workingMemory.render(args.analysisId)),
-    });
+    // Working memory — agent-authored and trusted. A `conversation` thread
+    // always gets it, because the render names each section even when it is
+    // empty. A `report` thread reads the frozen copy in its seed message.
+    if (args.threadType !== "report") {
+        tail.push({
+            role: "user",
+            content: unwrapOrThrow(await args.workingMemory.render(args.analysisId)),
+        });
+    }
 
     tail.push(userMessage);
 

--- a/harness/src/app/report-session-runtime.ts
+++ b/harness/src/app/report-session-runtime.ts
@@ -70,9 +70,10 @@ export interface ReportSessionRuntimeDeps {
 
 /**
  * The report session-state runtime. The gateway serves the authoring tools, and
- * `ensureSessionState` anchors the session. The serving path of a report turn runs
- * `ensureSessionState` at the turn start, and the gateway `load` runs it too, thus
- * a tool call cannot arrive before the state exists.
+ * `ensureSessionState` anchors the session. The spawn of a report session runs
+ * `ensureSessionState` at the moment of the spawn, the serving path of a report
+ * turn runs it at the turn start, and the gateway `load` runs it too. Thus a tool
+ * call cannot arrive before the state exists.
  */
 export interface ReportSessionRuntime {
     readonly gateway: ReportSessionStateGateway;

--- a/harness/src/app/spawn-report-session.test.ts
+++ b/harness/src/app/spawn-report-session.test.ts
@@ -6,7 +6,8 @@ import type { DbError } from "../lib/db-result.js";
 import { withSchema } from "../__tests__/setup/postgres.js";
 import { createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type ThreadStore } from "../memory/thread-store.js";
-import { createReportSessionSpawn, type ReportSessionSpawn } from "./spawn-report-session.js";
+import { createWorkingMemory, type WorkingMemoryStore } from "../memory/working-memory.js";
+import { createReportSessionSpawn, REPORT_CHILD_PAGE_SIZE, type ReportBrief, type ReportSessionSpawn } from "./spawn-report-session.js";
 
 const ANALYSIS_A = "analysis-a";
 const ANALYSIS_B = "analysis-b";
@@ -14,14 +15,25 @@ const ANALYSIS_B = "analysis-b";
 let pool: Pool;
 let drop: () => Promise<void>;
 let store: ThreadStore;
+let memory: WorkingMemoryStore;
 let spawn: ReportSessionSpawn;
 
 /** A chrome config that names a browser, thus the eyes gate passes and the spawn reaches its own rules. */
 const WITH_BROWSER = { browserUrl: "http://localhost:9222" };
 
+/** The intent brief that each spawn carries. Every field is present, thus the seed shows each label. */
+const BRIEF: ReportBrief = {
+    objective: "Explain the sample quality outcome",
+    audience: "The lab lead",
+    angle: "The samples that the study keeps",
+    exclusions: "The raw alignment logs",
+    openQuestions: "The threshold of the batch correction",
+};
+
 beforeEach(async () => {
     ({ pool, drop } = await withSchema("spawn-report-session"));
     store = createThreadStore(pool);
+    memory = createWorkingMemory(pool);
     spawn = createReportSessionSpawn({ pool, chrome: WITH_BROWSER });
 });
 
@@ -59,13 +71,44 @@ async function reportThreadCount(): Promise<number> {
     return Number(rows[0]!.count);
 }
 
+/** The text of each message of a transcript, oldest first. */
+async function transcriptOf(threadId: string): Promise<string[]> {
+    const page = (await createThreadHistory(pool).loadPage(threadId, 0, 50))._unsafeUnwrap();
+    return page.messages.map((row) => (typeof row.message.content === "string" ? row.message.content : JSON.stringify(row.message.content)));
+}
+
+/**
+ * Make each later insert into `messages` fail. The trigger is real database
+ * state, thus the seed write fails the same way that a driver fault fails it. A
+ * delete stays permitted, thus the purge of the child still runs.
+ */
+async function refuseMessageInserts(): Promise<void> {
+    await pool.query("CREATE FUNCTION refuse_message_insert() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'seed write refused'; END; $$");
+    await pool.query("CREATE TRIGGER refuse_message_insert BEFORE INSERT ON messages FOR EACH ROW EXECUTE FUNCTION refuse_message_insert()");
+}
+
+/**
+ * Insert report children of one parent directly. One statement seeds a whole
+ * page, thus the walk over the pages gets its coverage with no spawn for each
+ * row. `updatedSecondsAgo` places the row in the listing, which orders by
+ * `updated_at`.
+ */
+async function insertReportChildren(prefix: string, count: number, parentThreadId: string, anchor: number, updatedSecondsAgo: number): Promise<void> {
+    await pool.query(
+        `INSERT INTO cortex_analysis_threads (thread_id, analysis_id, title, thread_type, parent_thread_id, parent_seq, created_at, updated_at)
+         SELECT $1 || '-' || g, $2, $1 || ' ' || g, 'report', $3, $4::bigint, NOW(), NOW() - ($5::int * INTERVAL '1 second')
+           FROM generate_series(1, $6::int) AS g`,
+        [prefix, ANALYSIS_A, parentThreadId, anchor, updatedSecondsAgo, count],
+    );
+}
+
 describe("spawnReportSession child shape", () => {
     it("makes a report child holding the parent id, the parent analysis, and the anchor", async () => {
         await seedConversation("p1", ANALYSIS_A, "RNA-seq QC");
         const anchor = await latestSeqOf("p1");
         expect(anchor).not.toBeNull();
 
-        const child = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
 
         expect(child.threadType).toBe("report");
         expect(child.parentThreadId).toBe("p1");
@@ -82,7 +125,7 @@ describe("spawnReportSession child shape", () => {
     it("lists the child under its parent", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
 
-        const child = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
 
         const page = (await store.listThreads({ analysisId: ANALYSIS_A, type: "report", parentThreadId: "p1" }))._unsafeUnwrap();
         expect(page.threads.map((t) => t.threadId)).toEqual([child.threadId]);
@@ -97,14 +140,14 @@ describe("spawnReportSession anchor", () => {
         (await appendTurn("p1"))._unsafeUnwrap();
         const anchor = await latestSeqOf("p1");
 
-        const child = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
 
         expect(child.parentSeq).toBe(anchor);
     });
 
     it("keeps the child anchor when the parent appends a later turn", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
-        const child = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
         const anchorAtSpawn = child.parentSeq;
 
         // The parent moves on. The child records the spawn point, so its anchor
@@ -122,7 +165,7 @@ describe("spawnReportSession refusals", () => {
         // The parent is legal in every other way, thus only the absent eyes route refuses.
         const blind = createReportSessionSpawn({ pool, chrome: {} });
 
-        const failed = (await blind.spawnReportSession("p1"))._unsafeUnwrapErr();
+        const failed = (await blind.spawnReportSession("p1", BRIEF))._unsafeUnwrapErr();
 
         expect(failed.type).toBe("no_browser");
         expect(await reportThreadCount()).toBe(0);
@@ -137,14 +180,14 @@ describe("spawnReportSession refusals", () => {
             capture: () => Promise.resolve({ screenshotBase64: "", consoleErrors: [], failedRequests: [] }),
         });
 
-        const child = (await seamed.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await seamed.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
 
         expect(child.threadType).toBe("report");
         expect(await reportThreadCount()).toBe(1);
     });
 
     it("refuses an unknown parent with parent_not_found and writes no row", async () => {
-        const failed = (await spawn.spawnReportSession("ghost"))._unsafeUnwrapErr();
+        const failed = (await spawn.spawnReportSession("ghost", BRIEF))._unsafeUnwrapErr();
 
         expect(failed).toEqual({ type: "parent_not_found", op: "spawn-report-session", parentThreadId: "ghost" });
         expect(await reportThreadCount()).toBe(0);
@@ -154,7 +197,7 @@ describe("spawnReportSession refusals", () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
         (await store.archiveThread("p1"))._unsafeUnwrap();
 
-        const failed = (await spawn.spawnReportSession("p1"))._unsafeUnwrapErr();
+        const failed = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrapErr();
 
         expect(failed).toEqual({ type: "parent_not_found", op: "spawn-report-session", parentThreadId: "p1" });
         expect(await reportThreadCount()).toBe(0);
@@ -165,7 +208,7 @@ describe("spawnReportSession refusals", () => {
         // The type gate refuses before any transcript read, so it needs no messages.
         (await store.createThread({ threadId: "r1", analysisId: ANALYSIS_A, title: "A report", type: "report" }))._unsafeUnwrap();
 
-        const failed = (await spawn.spawnReportSession("r1"))._unsafeUnwrapErr();
+        const failed = (await spawn.spawnReportSession("r1", BRIEF))._unsafeUnwrapErr();
 
         expect(failed).toEqual({ type: "parent_not_a_conversation", op: "spawn-report-session", parentThreadId: "r1", threadType: "report" });
         // Only the seed report exists — the spawn added none.
@@ -175,7 +218,7 @@ describe("spawnReportSession refusals", () => {
     it("refuses an empty parent transcript with empty_parent_transcript and writes no row", async () => {
         (await store.createThread({ threadId: "p1", analysisId: ANALYSIS_A, title: "Empty" }))._unsafeUnwrap();
 
-        const failed = (await spawn.spawnReportSession("p1"))._unsafeUnwrapErr();
+        const failed = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrapErr();
 
         expect(failed).toEqual({ type: "empty_parent_transcript", op: "spawn-report-session", parentThreadId: "p1" });
         expect(await reportThreadCount()).toBe(0);
@@ -186,10 +229,10 @@ describe("spawnReportSession title", () => {
     it("composes 'T — Report 1' then 'T — Report 2' across two spawns", async () => {
         await seedConversation("p1", ANALYSIS_A, "RNA-seq QC");
 
-        const first = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const first = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
         expect(first.title).toBe("RNA-seq QC — Report 1");
 
-        const second = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const second = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
         expect(second.title).toBe("RNA-seq QC — Report 2");
     });
 
@@ -198,7 +241,7 @@ describe("spawnReportSession title", () => {
         // title stays null so the fallback branch composes the whole title.
         await seedConversation("p1", ANALYSIS_A, null);
 
-        const child = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
         expect(child.title).toBe("Report 1");
     });
 });
@@ -208,7 +251,7 @@ describe("listReportSessions", () => {
         // Two conversations and one report session under one analysis.
         await seedConversation("c1", ANALYSIS_A, "Conversation one");
         (await store.createThread({ threadId: "c2", analysisId: ANALYSIS_A, title: "Conversation two" }))._unsafeUnwrap();
-        const report = (await spawn.spawnReportSession("c1"))._unsafeUnwrap();
+        const report = (await spawn.spawnReportSession("c1", BRIEF))._unsafeUnwrap();
 
         const page = (await spawn.listReportSessions(ANALYSIS_A))._unsafeUnwrap();
 
@@ -220,8 +263,8 @@ describe("listReportSessions", () => {
     it("scopes to one analysis", async () => {
         await seedConversation("a1", ANALYSIS_A, "A parent");
         await seedConversation("b1", ANALYSIS_B, "B parent");
-        (await spawn.spawnReportSession("a1"))._unsafeUnwrap();
-        (await spawn.spawnReportSession("b1"))._unsafeUnwrap();
+        (await spawn.spawnReportSession("a1", BRIEF))._unsafeUnwrap();
+        (await spawn.spawnReportSession("b1", BRIEF))._unsafeUnwrap();
 
         const page = (await spawn.listReportSessions(ANALYSIS_A))._unsafeUnwrap();
 
@@ -230,13 +273,129 @@ describe("listReportSessions", () => {
     });
 });
 
+describe("spawnReportSession seed", () => {
+    it("writes one seed message that holds the brief and the working-memory render", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        (await memory.updateSection(ANALYSIS_A, "goal", { text: "Find the batch effect" }))._unsafeUnwrap();
+
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        const transcript = await transcriptOf(child.threadId);
+        expect(transcript).toHaveLength(1);
+        expect(transcript[0]).toContain(`Objective: ${BRIEF.objective}`);
+        expect(transcript[0]).toContain(`Audience: ${BRIEF.audience}`);
+        expect(transcript[0]).toContain(`Angle: ${BRIEF.angle}`);
+        expect(transcript[0]).toContain(`Exclusions: ${BRIEF.exclusions}`);
+        expect(transcript[0]).toContain(`Open questions: ${BRIEF.openQuestions}`);
+        expect(transcript[0]).toContain("# Working Memory");
+        expect(transcript[0]).toContain("Find the batch effect");
+    });
+
+    it("keeps the seed as it is when the working memory changes after the spawn", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        (await memory.updateSection(ANALYSIS_A, "goal", { text: "The goal at the spawn" }))._unsafeUnwrap();
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        (await memory.updateSection(ANALYSIS_A, "goal", { text: "The goal after the spawn" }))._unsafeUnwrap();
+
+        const transcript = await transcriptOf(child.threadId);
+        expect(transcript).toHaveLength(1);
+        expect(transcript[0]).toContain("The goal at the spawn");
+        expect(transcript[0]).not.toContain("The goal after the spawn");
+    });
+
+    it("purges the child when the seed write fails, and returns the fault", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        // The parent transcript is complete before the refusal, thus only the seed
+        // write fails, and it fails after the thread insert.
+        await refuseMessageInserts();
+
+        const failed = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrapErr();
+
+        expect(failed.type).toBe("mutation_failed");
+        expect(await reportThreadCount()).toBe(0);
+    });
+});
+
+describe("reportSessionDelta", () => {
+    it("gives no child and the latest seq for a parent with no report child", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild).toBeNull();
+        expect(delta.latestSeq).toBe(await latestSeqOf("p1"));
+    });
+
+    it("gives the anchor of the one child at the end of the transcript", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild?.threadId).toBe(child.threadId);
+        expect(delta.newestChild?.title).toBe(child.title);
+        expect(delta.newestChild?.anchor).toBe(delta.latestSeq);
+    });
+
+    it("gives an anchor below the latest seq after a later turn on the parent", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        (await appendTurn("p1"))._unsafeUnwrap();
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild?.threadId).toBe(child.threadId);
+        expect(delta.newestChild!.anchor).toBeLessThan(delta.latestSeq!);
+    });
+
+    it("finds the greatest anchor on a later page of the children listing", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        const anchor = (await latestSeqOf("p1"))!;
+        // The listing orders by `updated_at`, thus the oldest stamp puts the child
+        // with the greatest anchor on the second page, behind one full page.
+        await insertReportChildren("filler", REPORT_CHILD_PAGE_SIZE, "p1", 0, 0);
+        await insertReportChildren("winner", 1, "p1", anchor, 3600);
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild?.threadId).toBe("winner-1");
+        expect(delta.newestChild?.anchor).toBe(anchor);
+        expect(delta.latestSeq).toBe(anchor);
+    });
+
+    it("names the child with the newest createdAt when two children share the greatest anchor", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        const first = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        const second = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        expect(second.parentSeq).toBe(first.parentSeq);
+        // The second child takes the older stamp, thus the tie rule and the order of
+        // the two inserts point at different rows.
+        await pool.query("UPDATE cortex_analysis_threads SET created_at = NOW() - INTERVAL '1 hour' WHERE thread_id = $1", [second.threadId]);
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild?.threadId).toBe(first.threadId);
+    });
+
+    it("gives no child when the one report child is archived", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        (await store.archiveThread(child.threadId))._unsafeUnwrap();
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.newestChild).toBeNull();
+    });
+});
+
 describe("report children narrowed by parent", () => {
     it("gives only the children of the named parent", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent one");
         await seedConversation("p2", ANALYSIS_A, "Parent two");
-        const p1a = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
-        const p1b = (await spawn.spawnReportSession("p1"))._unsafeUnwrap();
-        (await spawn.spawnReportSession("p2"))._unsafeUnwrap();
+        const p1a = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        const p1b = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        (await spawn.spawnReportSession("p2", BRIEF))._unsafeUnwrap();
 
         const page = (await store.listThreads({ analysisId: ANALYSIS_A, type: "report", parentThreadId: "p1" }))._unsafeUnwrap();
 

--- a/harness/src/app/spawn-report-session.test.ts
+++ b/harness/src/app/spawn-report-session.test.ts
@@ -4,7 +4,7 @@ import type { Pool } from "pg";
 
 import type { DbError } from "../lib/db-result.js";
 import { withSchema } from "../__tests__/setup/postgres.js";
-import { createThreadHistory } from "../memory/thread-history.js";
+import { conversationRecordTurn, createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type ThreadStore } from "../memory/thread-store.js";
 import { createWorkingMemory, type WorkingMemoryStore } from "../memory/working-memory.js";
 import { createReportSessionSpawn, REPORT_CHILD_PAGE_SIZE, type ReportBrief, type ReportSessionSpawn } from "./spawn-report-session.js";
@@ -52,6 +52,11 @@ function appendTurn(threadId: string): ResultAsync<void, DbError> {
         ],
         displayMessages: [],
     });
+}
+
+/** Append one record of out-of-band work — a synthetic message that opens no turn. */
+function appendRecord(threadId: string, text: string): ResultAsync<void, DbError> {
+    return createThreadHistory(pool).appendTurn(threadId, conversationRecordTurn(text));
 }
 
 /** A live conversation parent with a first turn — the shape a legal spawn needs. */
@@ -318,16 +323,17 @@ describe("spawnReportSession seed", () => {
 });
 
 describe("reportSessionDelta", () => {
-    it("gives no child and the latest seq for a parent with no report child", async () => {
+    it("gives no child and no count for a parent with no report child", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
 
         const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
 
         expect(delta.newestChild).toBeNull();
-        expect(delta.latestSeq).toBe(await latestSeqOf("p1"));
+        // No child gives no anchor to count from, thus the count is absent.
+        expect(delta.userTurnsSinceAnchor).toBeNull();
     });
 
-    it("gives the anchor of the one child at the end of the transcript", async () => {
+    it("gives the anchor of the one child at the end of the transcript, and a count of zero", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
         const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
 
@@ -335,18 +341,22 @@ describe("reportSessionDelta", () => {
 
         expect(delta.newestChild?.threadId).toBe(child.threadId);
         expect(delta.newestChild?.title).toBe(child.title);
-        expect(delta.newestChild?.anchor).toBe(delta.latestSeq);
+        expect(delta.newestChild?.anchor).toBe(await latestSeqOf("p1"));
+        expect(delta.userTurnsSinceAnchor).toBe(0);
     });
 
-    it("gives an anchor below the latest seq after a later turn on the parent", async () => {
+    it("counts the turns of the parent past the anchor", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
         const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
         (await appendTurn("p1"))._unsafeUnwrap();
+        expect((await spawn.reportSessionDelta("p1"))._unsafeUnwrap().userTurnsSinceAnchor).toBe(1);
 
+        (await appendTurn("p1"))._unsafeUnwrap();
         const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
-
         expect(delta.newestChild?.threadId).toBe(child.threadId);
-        expect(delta.newestChild!.anchor).toBeLessThan(delta.latestSeq!);
+        expect(delta.newestChild!.anchor).toBeLessThan((await latestSeqOf("p1"))!);
+        expect(delta.userTurnsSinceAnchor).toBe(2);
     });
 
     it("finds the greatest anchor on a later page of the children listing", async () => {
@@ -361,7 +371,9 @@ describe("reportSessionDelta", () => {
 
         expect(delta.newestChild?.threadId).toBe("winner-1");
         expect(delta.newestChild?.anchor).toBe(anchor);
-        expect(delta.latestSeq).toBe(anchor);
+        // The count reads the anchor of the winner, not the anchor of a filler
+        // row: a count from seq 0 would report the one turn of the parent.
+        expect(delta.userTurnsSinceAnchor).toBe(0);
     });
 
     it("names the child with the newest createdAt when two children share the greatest anchor", async () => {
@@ -378,7 +390,7 @@ describe("reportSessionDelta", () => {
         expect(delta.newestChild?.threadId).toBe(first.threadId);
     });
 
-    it("gives no child when the one report child is archived", async () => {
+    it("gives no child and no count when the one report child is archived", async () => {
         await seedConversation("p1", ANALYSIS_A, "Parent");
         const child = (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
         (await store.archiveThread(child.threadId))._unsafeUnwrap();
@@ -386,6 +398,20 @@ describe("reportSessionDelta", () => {
         const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
 
         expect(delta.newestChild).toBeNull();
+        expect(delta.userTurnsSinceAnchor).toBeNull();
+    });
+
+    it("does not count a record of the host past the anchor", async () => {
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        (await spawn.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+        // One ask, then one record of out-of-band work. The record carries the
+        // `user` role, and nobody typed it, thus the count stays at the one ask.
+        (await appendTurn("p1"))._unsafeUnwrap();
+        (await appendRecord("p1", "Run GSEA cross-species comparison completed: 3/3 steps."))._unsafeUnwrap();
+
+        const delta = (await spawn.reportSessionDelta("p1"))._unsafeUnwrap();
+
+        expect(delta.userTurnsSinceAnchor).toBe(1);
     });
 });
 

--- a/harness/src/app/spawn-report-session.test.ts
+++ b/harness/src/app/spawn-report-session.test.ts
@@ -7,6 +7,9 @@ import { withSchema } from "../__tests__/setup/postgres.js";
 import { conversationRecordTurn, createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type ThreadStore } from "../memory/thread-store.js";
 import { createWorkingMemory, type WorkingMemoryStore } from "../memory/working-memory.js";
+import { upsertAnalysis } from "../state/analyses.js";
+import { upsertArtifact, type RegisterArtifactInput } from "../state/artifacts.js";
+import { createReportSessionRuntime } from "./report-session-runtime.js";
 import { createReportSessionSpawn, REPORT_CHILD_PAGE_SIZE, type ReportBrief, type ReportSessionSpawn } from "./spawn-report-session.js";
 
 const ANALYSIS_A = "analysis-a";
@@ -105,6 +108,31 @@ async function insertReportChildren(prefix: string, count: number, parentThreadI
            FROM generate_series(1, $6::int) AS g`,
         [prefix, ANALYSIS_A, parentThreadId, anchor, updatedSecondsAgo, count],
     );
+}
+
+/** Seed the analysis-state row that the foreign key of the session state needs. */
+async function seedAnalysisRow(analysisId: string): Promise<void> {
+    (await upsertAnalysis(pool, analysisId, null, null))._unsafeUnwrap();
+}
+
+/** One artifact of the ledger, which the pin reads into the snapshot. */
+function artifact(analysisId: string, path: string, hash: string): RegisterArtifactInput {
+    return { resourceId: analysisId, path, hash, size: 128, role: "step_output", fileType: "output" };
+}
+
+/**
+ * The artifact paths of the stored snapshot of one thread, or `null` when no
+ * session-state row exists. The read goes to the row itself, thus it shows the
+ * state that the spawn left and not a value that a later pin composed.
+ */
+async function storedSnapshotPaths(threadId: string): Promise<string[] | null> {
+    const { rows } = await pool.query<{ snapshot: { artifacts: Record<string, unknown> } | null }>(
+        "SELECT snapshot FROM cortex_report_session_state WHERE thread_id = $1",
+        [threadId],
+    );
+    const row = rows[0];
+    if (row === undefined || row.snapshot === null) return null;
+    return Object.keys(row.snapshot.artifacts);
 }
 
 describe("spawnReportSession child shape", () => {
@@ -319,6 +347,70 @@ describe("spawnReportSession seed", () => {
 
         expect(failed.type).toBe("mutation_failed");
         expect(await reportThreadCount()).toBe(0);
+    });
+});
+
+describe("spawnReportSession pin", () => {
+    const EARLY = "runs/r1/output/de.csv";
+    const LATE = "runs/r2/output/late.csv";
+
+    /** A spawn whose anchor operation is the real session runtime over the same pool. */
+    function pinningSpawn(): ReportSessionSpawn {
+        const runtime = createReportSessionRuntime({ pool });
+        return createReportSessionSpawn({ pool, chrome: WITH_BROWSER, anchorSession: runtime.ensureSessionState });
+    }
+
+    it("pins the snapshot of the child before any turn of the child runs", async () => {
+        await seedAnalysisRow(ANALYSIS_A);
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        await upsertArtifact(pool, artifact(ANALYSIS_A, EARLY, "sha256:aaa"));
+
+        const child = (await pinningSpawn().spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        // The row holds the snapshot at the moment of the spawn, thus the session
+        // anchors with no turn and no tool call.
+        expect(await storedSnapshotPaths(child.threadId)).toEqual([EARLY]);
+    });
+
+    it("keeps an artifact that lands after the spawn out of the stored snapshot", async () => {
+        await seedAnalysisRow(ANALYSIS_A);
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        await upsertArtifact(pool, artifact(ANALYSIS_A, EARLY, "sha256:aaa"));
+        const child = (await pinningSpawn().spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        // A run registers an artifact between the spawn and the first turn.
+        await upsertArtifact(pool, artifact(ANALYSIS_A, LATE, "sha256:bbb"));
+        // The first turn anchors again. The operation is idempotent, thus it reads
+        // the stored snapshot and it pins nothing.
+        const firstTurn = await createReportSessionRuntime({ pool }).ensureSessionState(child.threadId);
+
+        expect(firstTurn.outcome).toBe("ready");
+        if (firstTurn.outcome !== "ready") return;
+        expect(Object.keys(firstTurn.state.snapshot?.artifacts ?? {})).toEqual([EARLY]);
+        expect(await storedSnapshotPaths(child.threadId)).toEqual([EARLY]);
+    });
+
+    it("keeps the child when the pin fails, and the next call pins", async () => {
+        await seedAnalysisRow(ANALYSIS_A);
+        await seedConversation("p1", ANALYSIS_A, "Parent");
+        await upsertArtifact(pool, artifact(ANALYSIS_A, EARLY, "sha256:aaa"));
+        // The anchor operation fails the same way a transient store fault fails it.
+        const failing = createReportSessionSpawn({
+            pool,
+            chrome: WITH_BROWSER,
+            anchorSession: () => Promise.resolve({ outcome: "failed" as const, kind: "unavailable" as const, detail: "the artifact ledger read failed" }),
+        });
+
+        const child = (await failing.spawnReportSession("p1", BRIEF))._unsafeUnwrap();
+
+        // The spawn gives the child, and the child stays on disk.
+        expect((await store.getThread(child.threadId))._unsafeUnwrap()).not.toBeNull();
+        expect(await reportThreadCount()).toBe(1);
+        // A failed pin writes no row, thus a later call pins again.
+        expect(await storedSnapshotPaths(child.threadId)).toBeNull();
+        const later = await createReportSessionRuntime({ pool }).ensureSessionState(child.threadId);
+        expect(later.outcome).toBe("ready");
+        expect(await storedSnapshotPaths(child.threadId)).toEqual([EARLY]);
     });
 });
 

--- a/harness/src/app/spawn-report-session.ts
+++ b/harness/src/app/spawn-report-session.ts
@@ -7,8 +7,9 @@
  * finds the parent, and `latestSeq` gives the anchor. `listThreads` counts the
  * report children, and `createThread` writes the insert. `render` and
  * `appendTurn` make the seed, and `purgeThread` removes a child that holds no
- * seed. The one storage read this capability adds, `latestSeq`, lives on the
- * thread history, because that module owns the `messages` table.
+ * seed. The two storage reads that this capability adds, `latestSeq` and
+ * `countUserTurnsAfter`, live on the thread history, because that module owns
+ * the `messages` table.
  *
  * The reads and the insert take no lock and no transaction. A concurrent turn
  * can append between the anchor read and the insert, and a retract can cut the
@@ -34,10 +35,15 @@
  * fails, the spawn purges the child, because a report thread with no context is
  * a dead end.
  *
- * The delta read gives the two values that a caller compares before a new spawn:
- * the report child with the greatest anchor, and the latest seq of the parent.
- * The listing orders by `updated_at` and not by the anchor, thus the read walks
- * each page of the children.
+ * The delta read gives the state that a caller reads before a new spawn. It
+ * gives the report child with the greatest anchor. It also gives the count of
+ * user turns of the parent past that anchor. The listing orders by `updated_at`
+ * and not by the anchor, thus the read walks each page of the children.
+ *
+ * The unit of the delta is a turn, and it is not a raw seq. A turn appends after
+ * its own loop runs, thus the anchor of a child sits below the rows of the ask
+ * that made it. A raw seq comparison would name each child stale one turn after
+ * the spawn.
  */
 
 import { randomUUID } from "node:crypto";
@@ -135,15 +141,22 @@ export interface NewestReportChild {
 }
 
 /**
- * The two values that a caller compares before a new spawn. `newestChild` is
- * `null` when the parent holds no live report child, and an archived child reads
- * the same way, because a steer into hidden state is not permitted. `latestSeq`
- * is `null` when the parent holds no message, and an absent parent reads the
- * same way.
+ * The state that a caller reads before a new spawn. `newestChild` is `null` when
+ * the parent holds no live report child, and an archived child reads the same
+ * way, because a steer into hidden state is not permitted. An absent parent
+ * reads the same way.
  */
 export interface ReportSessionDelta {
     readonly newestChild: NewestReportChild | null;
-    readonly latestSeq: number | null;
+    /**
+     * The count of the parent turns that a person opened past the anchor of
+     * `newestChild` — the new work of the parent past that spawn point. A
+     * synthetic record of the host adds nothing to it.
+     *
+     * It is `null` when `newestChild` is `null`, because a parent with no child
+     * gives no anchor to count from. No count query runs in that case.
+     */
+    readonly userTurnsSinceAnchor: number | null;
 }
 
 export interface ReportSessionSpawnDeps {
@@ -183,14 +196,18 @@ export interface ReportSessionSpawn {
      */
     listReportSessions(analysisId: string, paging?: ReportSessionPaging): ResultAsync<ThreadPage, DbError>;
     /**
-     * The state that a caller reads before a new spawn: the live report child of
-     * the parent with the greatest anchor, and the latest seq of the parent. A
-     * caller compares the two values, and an equal pair says that the parent
-     * holds no message past the anchor of that child.
+     * The state that a caller reads before a new spawn. It gives the live report
+     * child of the parent with the greatest anchor. It also gives the count of
+     * the parent turns that a person opened past that anchor.
      *
-     * The read walks each page of the children listing, because the listing
-     * orders by `updated_at` and not by the anchor. It reads no model judgment,
-     * and it writes nothing.
+     * The count admits one turn of new work by construction. A turn appends
+     * after its own loop runs, thus the anchor of a child sits below the rows of
+     * the ask that made it, and that ask counts as one.
+     *
+     * The read picks the child first, thus one anchor bounds the count. A parent
+     * with no child needs no anchor, and no count query runs. The read walks each
+     * page of the children listing, because the listing orders by `updated_at`
+     * and not by the anchor. It reads no model judgment, and it writes nothing.
      */
     reportSessionDelta(parentThreadId: string): ResultAsync<ReportSessionDelta, DbError>;
 }
@@ -379,13 +396,15 @@ export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSe
         // read comes first. An absent or archived parent gives no advice, and the
         // spawn refuses it later with `parent_not_found`.
         return store.getThread(parentThreadId).andThen((parent): ResultAsync<ReportSessionDelta, DbError> => {
-            if (parent === null) return okAsync({ newestChild: null, latestSeq: null });
-            return history.latestSeq(parentThreadId).andThen((latestSeq) =>
-                collectReportChildren(parent.analysisId, parentThreadId, 0, []).map((children) => ({
-                    newestChild: pickNewestChild(children),
-                    latestSeq,
-                })),
-            );
+            if (parent === null) return okAsync({ newestChild: null, userTurnsSinceAnchor: null });
+            // The child comes first, because the anchor of that child bounds the
+            // count. A parent with no child gives no anchor, thus the read stops
+            // here and the count query never runs.
+            return collectReportChildren(parent.analysisId, parentThreadId, 0, []).andThen((children): ResultAsync<ReportSessionDelta, DbError> => {
+                const newestChild = pickNewestChild(children);
+                if (newestChild === null) return okAsync({ newestChild: null, userTurnsSinceAnchor: null });
+                return history.countUserTurnsAfter(parentThreadId, newestChild.anchor).map((userTurnsSinceAnchor) => ({ newestChild, userTurnsSinceAnchor }));
+            });
         });
     }
 

--- a/harness/src/app/spawn-report-session.ts
+++ b/harness/src/app/spawn-report-session.ts
@@ -2,12 +2,13 @@
  * Report-session spawn — the host-agnostic operation that makes a `report`
  * child thread from a conversation.
  *
- * The operation owns no table. It composes four reads and writes the store and
- * the thread history already give: `getThread` for the parent, `latestSeq` for
- * the anchor, `listThreads` for the count of report children, and
- * `createThread` for the insert. The one storage read this capability adds,
- * `latestSeq`, lives on the thread history, because that module owns the
- * `messages` table.
+ * The operation owns no table. It composes the reads and the writes that the
+ * store, the thread history, and the working memory already give. `getThread`
+ * finds the parent, and `latestSeq` gives the anchor. `listThreads` counts the
+ * report children, and `createThread` writes the insert. `render` and
+ * `appendTurn` make the seed, and `purgeThread` removes a child that holds no
+ * seed. The one storage read this capability adds, `latestSeq`, lives on the
+ * thread history, because that module owns the `messages` table.
  *
  * The reads and the insert take no lock and no transaction. A concurrent turn
  * can append between the anchor read and the insert, and a retract can cut the
@@ -25,19 +26,32 @@
  * draft that no gate ever accepts. The spawn refuses that session before it
  * writes a row, because a dead-end thread is worse than a refusal that names the
  * absent capability.
+ *
+ * The spawn seeds the context of the child at the anchor. It writes one message
+ * that holds the brief and a copy of the working-memory render. The transcript
+ * is append-only, thus the copy stays frozen at the anchor by construction, and
+ * a later change to the working memory leaves it as it is. When the seed write
+ * fails, the spawn purges the child, because a report thread with no context is
+ * a dead end.
+ *
+ * The delta read gives the two values that a caller compares before a new spawn:
+ * the report child with the greatest anchor, and the latest seq of the parent.
+ * The listing orders by `updated_at` and not by the anchor, thus the read walks
+ * each page of the children.
  */
 
 import { randomUUID } from "node:crypto";
 
-import { type ResultAsync, errAsync } from "neverthrow";
+import { type ResultAsync, errAsync, okAsync } from "neverthrow";
 import type { Pool } from "pg";
 
 import type { DbError } from "../lib/db-result.js";
 import { hasBrowserUrl, type ChromeConfig } from "../lib/chrome.js";
 import type { CapturePage } from "../lib/page-capture.js";
 import type { DomainError } from "../lib/result.js";
-import { createThreadHistory } from "../memory/thread-history.js";
+import { conversationRecordTurn, createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type Thread, type ThreadInputError, type ThreadPage, type ThreadType } from "../memory/thread-store.js";
+import { createWorkingMemory } from "../memory/working-memory.js";
 
 /**
  * A spawn the operation refuses before it writes a row. Distinct from
@@ -88,6 +102,50 @@ export interface ReportSessionPaging {
     readonly perPage?: number;
 }
 
+/**
+ * The intent brief of one report session. The caller writes it at the moment of
+ * the ask, and each field is short prose.
+ *
+ * The brief carries intent alone. No field names a path, a dataset, or a format,
+ * because the report session reads those from the workspace itself.
+ */
+export interface ReportBrief {
+    /** The question that the report must answer. */
+    readonly objective: string;
+    /** The reader of the report. */
+    readonly audience: string;
+    /** The line that the report takes through the evidence. */
+    readonly angle: string;
+    /** The material that the report must leave out. */
+    readonly exclusions?: string;
+    /** The points that the user did not decide yet. */
+    readonly openQuestions?: string;
+}
+
+/**
+ * The report child that carries the greatest anchor. A tie on the anchor comes
+ * from two concurrent spawns, and the newest `createdAt` wins it.
+ */
+export interface NewestReportChild {
+    readonly threadId: string;
+    readonly title: string | null;
+    /** The `parentSeq` of the child — the point of the parent transcript that it was built on. */
+    readonly anchor: number;
+    readonly createdAt: Date;
+}
+
+/**
+ * The two values that a caller compares before a new spawn. `newestChild` is
+ * `null` when the parent holds no live report child, and an archived child reads
+ * the same way, because a steer into hidden state is not permitted. `latestSeq`
+ * is `null` when the parent holds no message, and an absent parent reads the
+ * same way.
+ */
+export interface ReportSessionDelta {
+    readonly newestChild: NewestReportChild | null;
+    readonly latestSeq: number | null;
+}
+
 export interface ReportSessionSpawnDeps {
     readonly pool: Pool;
     /**
@@ -108,26 +166,48 @@ export interface ReportSessionSpawn {
     /**
      * Make a `report` child of the parent conversation and return the full row.
      * The child takes the analysis of the parent, the parent thread id, and the
-     * anchor — the parent's latest `messages.seq` at this moment.
+     * anchor — the parent's latest `messages.seq` at this moment. It also takes
+     * one seed message that holds the brief and the working-memory render.
      *
      * Refused with a `SpawnRefusal`, no row written: a composition with no
      * eyes, an absent or archived parent, a parent that is not a conversation,
      * and a parent with no messages. A store refusal (`DbError`,
-     * `ThreadInputError`) passes through unchanged.
+     * `ThreadInputError`) passes through unchanged. A failed seed write purges
+     * the child and returns the fault, thus no context-less thread survives.
      */
-    spawnReportSession(parentThreadId: string): ResultAsync<Thread, SpawnRefusal | DbError | ThreadInputError>;
+    spawnReportSession(parentThreadId: string, brief: ReportBrief): ResultAsync<Thread, SpawnRefusal | DbError | ThreadInputError>;
     /**
      * The report sessions of one analysis, through the thread listing narrowed
      * to the type `report`. It adds no predicate of its own, so its answer and
      * the thread listing cannot disagree.
      */
     listReportSessions(analysisId: string, paging?: ReportSessionPaging): ResultAsync<ThreadPage, DbError>;
+    /**
+     * The state that a caller reads before a new spawn: the live report child of
+     * the parent with the greatest anchor, and the latest seq of the parent. A
+     * caller compares the two values, and an equal pair says that the parent
+     * holds no message past the anchor of that child.
+     *
+     * The read walks each page of the children listing, because the listing
+     * orders by `updated_at` and not by the anchor. It reads no model judgment,
+     * and it writes nothing.
+     */
+    reportSessionDelta(parentThreadId: string): ResultAsync<ReportSessionDelta, DbError>;
 }
 
 const OP = "spawn-report-session";
 
 /** The line that the caller reads when the composition gives no eyes. */
 const NO_BROWSER_DETAIL = "the composition gives no browser, thus a report session can never record a version";
+
+/**
+ * The page size of the walk over the report children of one parent. The
+ * one-version policy keeps the count of children small, thus the walk reads one
+ * page on each real parent. It is exported because a test seeds one row more
+ * than one page, and a hard-coded count in the test would not follow a change
+ * here.
+ */
+export const REPORT_CHILD_PAGE_SIZE = 100;
 
 /**
  * Compose the child title. N counts the existing report children of the parent
@@ -139,20 +219,112 @@ function composeTitle(parentTitle: string | null, n: number): string {
     return parentTitle && parentTitle.length > 0 ? `${parentTitle} — ${suffix}` : suffix;
 }
 
+/** Whether the caller gave text for an optional field of the brief. */
+function hasText(field: string | undefined): field is string {
+    return field !== undefined && field.trim().length > 0;
+}
+
+/**
+ * Compose the seed message: the brief as short labeled prose, then the copy of
+ * the working-memory render. An empty render adds nothing, because
+ * `renderWorkingMemory` gives the empty string for a memory with no entry.
+ */
+function composeSeed(brief: ReportBrief, workingMemoryRender: string): string {
+    const lines = [`Objective: ${brief.objective}`, `Audience: ${brief.audience}`, `Angle: ${brief.angle}`];
+    if (hasText(brief.exclusions)) lines.push(`Exclusions: ${brief.exclusions}`);
+    if (hasText(brief.openQuestions)) lines.push(`Open questions: ${brief.openQuestions}`);
+    const briefBlock = `# Report Brief\n\n${lines.join("\n")}\n`;
+    const memory = workingMemoryRender.trim();
+    return memory.length === 0 ? briefBlock : `${briefBlock}\n${memory}\n`;
+}
+
+/**
+ * The child with the greatest anchor, or `null` for no candidate. Two concurrent
+ * spawns can write one anchor, and the newest `createdAt` then wins.
+ */
+function pickNewestChild(children: readonly Thread[]): NewestReportChild | null {
+    let newest: NewestReportChild | null = null;
+    for (const child of children) {
+        // The store writes `parentThreadId` and `parentSeq` as one pair, thus a
+        // child with no anchor names no point of the parent transcript and it
+        // cannot advise.
+        if (child.parentSeq === null) continue;
+        const candidate: NewestReportChild = {
+            threadId: child.threadId,
+            title: child.title,
+            anchor: child.parentSeq,
+            createdAt: child.createdAt,
+        };
+        const wins =
+            newest === null ||
+            candidate.anchor > newest.anchor ||
+            (candidate.anchor === newest.anchor && candidate.createdAt.getTime() > newest.createdAt.getTime());
+        if (wins) newest = candidate;
+    }
+    return newest;
+}
+
 /**
  * Build the report-session operations bound to a Postgres pool. The factory
- * closure captures `pool` and constructs the store and the thread history from
- * it, the same way the chat-turn preparation does.
+ * closure captures `pool` and constructs the store, the thread history, and the
+ * working memory from it, the same way the chat-turn preparation does.
  */
 export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSessionSpawn {
     const { pool } = deps;
     const store = createThreadStore(pool);
     const history = createThreadHistory(pool);
+    const workingMemory = createWorkingMemory(pool);
     // The eyes of the composition are fixed at construction, thus the gate reads
     // one boolean and never a live probe of the sidecar.
     const eyesAvailable = deps.capture !== undefined || hasBrowserUrl(deps.chrome);
 
-    function spawnReportSession(parentThreadId: string): ResultAsync<Thread, SpawnRefusal | DbError | ThreadInputError> {
+    /**
+     * Write the one seed message of the child and give the child back. The
+     * message rides as a record, not as user input: nobody typed it in the child
+     * thread, and a record is displayed but it never opens a turn.
+     */
+    function seedChildContext(child: Thread, brief: ReportBrief): ResultAsync<Thread, DbError> {
+        return workingMemory
+            .render(child.analysisId)
+            .andThen((memory) => history.appendTurn(child.threadId, conversationRecordTurn(composeSeed(brief, memory))))
+            .map(() => child)
+            .orElse((fault) =>
+                // A report thread with no context is a dead end, thus the purge
+                // removes the child. The seed fault is the cause, thus it returns
+                // from each route. A failed purge leaves the child, and the caller
+                // still reads why the seed stopped.
+                store
+                    .purgeThread(child.threadId)
+                    .andThen((): ResultAsync<Thread, DbError> => errAsync(fault))
+                    .orElse((): ResultAsync<Thread, DbError> => errAsync(fault)),
+            );
+    }
+
+    /**
+     * Each live report child of the parent, across every page of the listing. The
+     * listing orders by `updated_at`, thus one page can hide the child with the
+     * greatest anchor. The default listing excludes an archived child, and this
+     * walk keeps that scope.
+     */
+    function collectReportChildren(
+        analysisId: string,
+        parentThreadId: string,
+        page: number,
+        found: readonly Thread[],
+    ): ResultAsync<readonly Thread[], DbError> {
+        return store
+            .listThreads({ analysisId, type: "report", parentThreadId, page, perPage: REPORT_CHILD_PAGE_SIZE })
+            .andThen((result): ResultAsync<readonly Thread[], DbError> => {
+                const all = [...found, ...result.threads];
+                // An empty page also stops the walk. `hasMore` compares the offset
+                // against a count from a second statement, thus a concurrent purge
+                // can hold the flag true after the last row.
+                if (!result.hasMore || result.threads.length === 0) return okAsync(all);
+                return collectReportChildren(analysisId, parentThreadId, page + 1, all);
+            });
+    }
+
+    function spawnReportSession(parentThreadId: string, brief: ReportBrief): ResultAsync<Thread, SpawnRefusal | DbError | ThreadInputError> {
         // The gate runs before the parent read. A session with no route to a look
         // reaches the record gate and refuses there forever, thus the spawn is the
         // one honest place to say so.
@@ -181,14 +353,18 @@ export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSe
                 return store
                     .listThreads({ analysisId: parent.analysisId, type: "report", parentThreadId })
                     .andThen((children): ResultAsync<Thread, DbError | ThreadInputError> =>
-                        store.createThread({
-                            threadId: randomUUID(),
-                            analysisId: parent.analysisId,
-                            title: composeTitle(parent.title, children.total + 1),
-                            type: "report",
-                            parentThreadId,
-                            parentSeq: anchor,
-                        }),
+                        store
+                            .createThread({
+                                threadId: randomUUID(),
+                                analysisId: parent.analysisId,
+                                title: composeTitle(parent.title, children.total + 1),
+                                type: "report",
+                                parentThreadId,
+                                parentSeq: anchor,
+                            })
+                            // The seed follows the insert, thus the copy of the working
+                            // memory is the state at the anchor.
+                            .andThen((child) => seedChildContext(child, brief)),
                     );
             });
         });
@@ -198,5 +374,20 @@ export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSe
         return store.listThreads({ analysisId, type: "report", ...paging });
     }
 
-    return { spawnReportSession, listReportSessions };
+    function reportSessionDelta(parentThreadId: string): ResultAsync<ReportSessionDelta, DbError> {
+        // The children listing takes the analysis of the parent, thus the parent
+        // read comes first. An absent or archived parent gives no advice, and the
+        // spawn refuses it later with `parent_not_found`.
+        return store.getThread(parentThreadId).andThen((parent): ResultAsync<ReportSessionDelta, DbError> => {
+            if (parent === null) return okAsync({ newestChild: null, latestSeq: null });
+            return history.latestSeq(parentThreadId).andThen((latestSeq) =>
+                collectReportChildren(parent.analysisId, parentThreadId, 0, []).map((children) => ({
+                    newestChild: pickNewestChild(children),
+                    latestSeq,
+                })),
+            );
+        });
+    }
+
+    return { spawnReportSession, listReportSessions, reportSessionDelta };
 }

--- a/harness/src/app/spawn-report-session.ts
+++ b/harness/src/app/spawn-report-session.ts
@@ -35,6 +35,12 @@
  * fails, the spawn purges the child, because a report thread with no context is
  * a dead end.
  *
+ * The seed takes no redaction pass, and that is deliberate. The two parts are
+ * agent-authored, the same trust tier as the working-memory render of a
+ * conversation turn. The harness redacts the new input of a user one time, at
+ * the assembly of that turn. A second pass here would scrub text that the
+ * assembly already admitted, and it would report a false clean on the rest.
+ *
  * The spawn mints one moment, and that moment carries two pins. The anchor pins
  * the transcript of the parent, and the injected anchor operation pins the data
  * of the analysis. A pin at the first tool call of a later turn reads a

--- a/harness/src/app/spawn-report-session.ts
+++ b/harness/src/app/spawn-report-session.ts
@@ -35,6 +35,12 @@
  * fails, the spawn purges the child, because a report thread with no context is
  * a dead end.
  *
+ * The spawn mints one moment, and that moment carries two pins. The anchor pins
+ * the transcript of the parent, and the injected anchor operation pins the data
+ * of the analysis. A pin at the first tool call of a later turn reads a
+ * different moment, thus the session can cite an artifact that the anchor never
+ * held.
+ *
  * The delta read gives the state that a caller reads before a new spawn. It
  * gives the report child with the greatest anchor. It also gives the count of
  * user turns of the parent past that anchor. The listing orders by `updated_at`
@@ -48,16 +54,19 @@
 
 import { randomUUID } from "node:crypto";
 
-import { type ResultAsync, errAsync, okAsync } from "neverthrow";
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
 import type { Pool } from "pg";
 
 import type { DbError } from "../lib/db-result.js";
 import { hasBrowserUrl, type ChromeConfig } from "../lib/chrome.js";
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { Logger } from "../lib/logger.js";
 import type { CapturePage } from "../lib/page-capture.js";
 import type { DomainError } from "../lib/result.js";
 import { conversationRecordTurn, createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type Thread, type ThreadInputError, type ThreadPage, type ThreadType } from "../memory/thread-store.js";
 import { createWorkingMemory } from "../memory/working-memory.js";
+import type { EnsureSessionStateResult } from "./report-session-runtime.js";
 
 /**
  * A spawn the operation refuses before it writes a row. Distinct from
@@ -173,6 +182,18 @@ export interface ReportSessionSpawnDeps {
      * satisfies the gate on its own.
      */
     readonly capture?: CapturePage;
+    /**
+     * The anchor operation of the report session runtime. The spawn runs it
+     * after the seed of the child lands, thus the transcript anchor and the data
+     * snapshot pin at one moment.
+     *
+     * The dep is optional. A composition that binds none pins no snapshot at the
+     * spawn, and the first session tool call pins instead, because the operation
+     * is idempotent.
+     */
+    readonly anchorSession?: (threadId: string) => Promise<EnsureSessionStateResult>;
+    /** Operational logging seam. An omitted logger falls back to the no-op. */
+    readonly logger?: Logger;
 }
 
 export interface ReportSessionSpawn {
@@ -181,6 +202,10 @@ export interface ReportSessionSpawn {
      * The child takes the analysis of the parent, the parent thread id, and the
      * anchor — the parent's latest `messages.seq` at this moment. It also takes
      * one seed message that holds the brief and the working-memory render.
+     *
+     * The seed lands first, and the injected anchor operation then pins the data
+     * snapshot of the child. A failed pin keeps the child and it keeps this
+     * result on the ok channel, thus the outcome vocabulary holds no pin arm.
      *
      * Refused with a `SpawnRefusal`, no row written: a composition with no
      * eyes, an absent or archived parent, a parent that is not a conversation,
@@ -288,6 +313,7 @@ function pickNewestChild(children: readonly Thread[]): NewestReportChild | null 
  */
 export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSessionSpawn {
     const { pool } = deps;
+    const log = (deps.logger ?? createNoopLogger()).named("spawn-report-session");
     const store = createThreadStore(pool);
     const history = createThreadHistory(pool);
     const workingMemory = createWorkingMemory(pool);
@@ -315,6 +341,44 @@ export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSe
                     .andThen((): ResultAsync<Thread, DbError> => errAsync(fault))
                     .orElse((): ResultAsync<Thread, DbError> => errAsync(fault)),
             );
+    }
+
+    /**
+     * Pin the data snapshot of the child, through the injected anchor operation.
+     * The spawn mints one moment, and the transcript anchor and this snapshot are
+     * the two pins of that moment.
+     *
+     * The pin runs after the seed. A failed seed purges the child, and
+     * `cortex_report_session_state` carries no foreign key to the thread table,
+     * thus a pin before a purged seed would leave an orphan row.
+     *
+     * A failed pin keeps the child. The operation is idempotent, thus the first
+     * session tool call pins again, and a purge on a transient store fault would
+     * cost the user the whole session. Thus the failure rides the logger alone.
+     */
+    async function pinSessionSnapshot(child: Thread): Promise<Thread> {
+        const anchor = deps.anchorSession;
+        if (anchor === undefined) return child;
+        try {
+            const pinned = await anchor(child.threadId);
+            if (pinned.outcome === "failed") {
+                log.warn("the snapshot pin of the new session failed", {
+                    threadId: child.threadId,
+                    analysisId: child.analysisId,
+                    kind: pinned.kind,
+                    detail: pinned.detail,
+                });
+            }
+        } catch (cause) {
+            // The dep speaks a promise, thus a foreign realization can reject.
+            // The spawn keeps the child on that route as well.
+            log.warn("the snapshot pin of the new session did not complete", {
+                threadId: child.threadId,
+                analysisId: child.analysisId,
+                ...log.errorFields(cause),
+            });
+        }
+        return child;
     }
 
     /**
@@ -381,7 +445,10 @@ export function createReportSessionSpawn(deps: ReportSessionSpawnDeps): ReportSe
                             })
                             // The seed follows the insert, thus the copy of the working
                             // memory is the state at the anchor.
-                            .andThen((child) => seedChildContext(child, brief)),
+                            .andThen((child) => seedChildContext(child, brief))
+                            // The pin follows the seed. `pinSessionSnapshot` never
+                            // rejects, thus the safe bridge adds no error variant.
+                            .andThen((child) => ResultAsync.fromSafePromise(pinSessionSnapshot(child))),
                     );
             });
         });

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -34,7 +34,15 @@ export type { ThreadAgentResolver, UnregisteredThreadType } from "./runtime/asse
 // the report sessions of one analysis. An embedder reaches the listing for its
 // navigation surface, thus these names belong on the front door.
 export { createReportSessionSpawn } from "./app/spawn-report-session.js";
-export type { ReportSessionSpawn, ReportSessionSpawnDeps, ReportSessionPaging, SpawnRefusal } from "./app/spawn-report-session.js";
+export type {
+    ReportSessionSpawn,
+    ReportSessionSpawnDeps,
+    ReportSessionPaging,
+    SpawnRefusal,
+    ReportBrief,
+    ReportSessionDelta,
+    NewestReportChild,
+} from "./app/spawn-report-session.js";
 // The harness-owned boot sequence: ordered boot steps around `assembleCoreRuntime`
 // (skill validation → state init → connection budget → assemble → launch) + a
 // `shutdown` handle the embedder wires to its process signals.

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -43,6 +43,9 @@ export type {
     ReportSessionDelta,
     NewestReportChild,
 } from "./app/spawn-report-session.js";
+// The outcome of the report-session anchor operation. `ConversationAgentDeps`
+// names it, thus an embedder cannot type that dep without this name.
+export type { EnsureSessionStateResult } from "./app/report-session-runtime.js";
 // The harness-owned boot sequence: ordered boot steps around `assembleCoreRuntime`
 // (skill validation → state init → connection budget → assemble → launch) + a
 // `shutdown` handle the embedder wires to its process signals.

--- a/harness/src/memory/thread-history.test.ts
+++ b/harness/src/memory/thread-history.test.ts
@@ -466,6 +466,65 @@ describe("loadRecent prefix stability", () => {
     });
 });
 
+// --- the retained first turn ------------------------------------------------
+
+describe("loadRecent retained first turn", () => {
+    const K = EVICTION_BLOCK_TURNS;
+
+    /** Seed 3K equal-cost turns and give a budget that fits K of them. */
+    async function seedOverBudget(): Promise<{ turns: ModelMessage[][]; budget: number }> {
+        const turns = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            .slice(0, 3 * K)
+            .split("")
+            .map(labeledTurn);
+        for (const turn of turns) {
+            (await append(THREAD, turn))._unsafeUnwrap();
+        }
+        return { turns, budget: K * turnCost(turns[0]!) };
+    }
+
+    it("keeps the first turn in front of the retained suffix when the thread is over budget", async () => {
+        const { turns, budget } = await seedOverBudget();
+
+        const evicting = (await history.loadRecent(THREAD, budget))._unsafeUnwrap();
+        const loaded = (await history.loadRecent(THREAD, budget, { keepFirstTurn: true }))._unsafeUnwrap();
+
+        // The window is the first turn plus exactly the suffix the default read
+        // retains — the seed rides at the head, and it rides one time only.
+        expect(loaded).toEqual([...turns[0]!, ...evicting]);
+        expect(loaded.slice(0, 2)).toEqual(turns[0]!);
+        expect(loaded.slice(-2)).toEqual(turns.at(-1)!);
+        assertValidSequence(loaded);
+        // The retained head is the accepted cost: it carries the window past the
+        // budget, and the default read stays under it.
+        expect(windowCost(loaded)).toBeGreaterThan(budget);
+        expect(windowCost(evicting)).toBeLessThanOrEqual(budget);
+    });
+
+    it("evicts the oldest turns when the option is absent", async () => {
+        const { turns, budget } = await seedOverBudget();
+
+        const loaded = (await history.loadRecent(THREAD, budget))._unsafeUnwrap();
+
+        // Two whole blocks go, and the first turn goes with them.
+        expect(loaded).toEqual(turns.slice(2 * K).flat());
+        expect(windowCost(loaded)).toBeLessThanOrEqual(budget);
+        assertValidSequence(loaded);
+    });
+
+    it("returns the whole thread when nothing is evicted", async () => {
+        const turns = ["A", "B", "C"].map(labeledTurn);
+        for (const turn of turns) {
+            (await append(THREAD, turn))._unsafeUnwrap();
+        }
+
+        const loaded = (await history.loadRecent(THREAD, 1_000_000, { keepFirstTurn: true }))._unsafeUnwrap();
+
+        expect(loaded).toEqual(turns.flat());
+        assertValidSequence(loaded);
+    });
+});
+
 // --- boundary snapping ------------------------------------------------------
 
 describe("loadRecent boundary snapping", () => {

--- a/harness/src/memory/thread-history.test.ts
+++ b/harness/src/memory/thread-history.test.ts
@@ -1100,6 +1100,56 @@ describe("latestSeq", () => {
     });
 });
 
+// --- countUserTurnsAfter ----------------------------------------------------
+
+describe("countUserTurnsAfter", () => {
+    it("counts one for each turn a person opened past the seq", async () => {
+        // Three two-row turns land at seq 0..5, so the user starts sit at 0, 2, 4.
+        (await append(THREAD, [userText("question one"), assistantText("answer one")]))._unsafeUnwrap();
+        (await append(THREAD, [userText("question two"), assistantText("answer two")]))._unsafeUnwrap();
+        (await append(THREAD, [userText("question three"), assistantText("answer three")]))._unsafeUnwrap();
+
+        expect((await history.countUserTurnsAfter(THREAD, -1))._unsafeUnwrap()).toBe(3);
+        expect((await history.countUserTurnsAfter(THREAD, 1))._unsafeUnwrap()).toBe(2);
+        expect((await history.countUserTurnsAfter(THREAD, 3))._unsafeUnwrap()).toBe(1);
+        expect((await history.countUserTurnsAfter(THREAD, 5))._unsafeUnwrap()).toBe(0);
+    });
+
+    it("gives zero for a thread with no messages", async () => {
+        expect((await history.countUserTurnsAfter(THREAD, 0))._unsafeUnwrap()).toBe(0);
+    });
+
+    it("counts one turn once, whatever the row count of that turn is", async () => {
+        // A serial-tool turn writes five rows and stays one ask. A row count of
+        // the same span would report five, and the nudge would report two starts.
+        (
+            await append(THREAD, [
+                userText("run the search"),
+                assistantToolUse("c1", "workspace_search", { query: "the staged dataset" }),
+                userToolResult("c1", "one hit"),
+                syntheticUserMessage("Your previous reply was cut off at the output-token limit; continue concisely."),
+                assistantText("here is the hit"),
+            ])
+        )._unsafeUnwrap();
+
+        expect((await history.countUserTurnsAfter(THREAD, -1))._unsafeUnwrap()).toBe(1);
+    });
+
+    it("does not count a host-appended record", async () => {
+        (await append(THREAD, [userText("kick off the analysis"), assistantText("launched")]))._unsafeUnwrap();
+        // The record is the only row past seq 1, and it carries the `user` role.
+        // Nobody typed it, thus it is no new work of the thread.
+        (await append(THREAD, [syntheticRecordMessage("Run GSEA cross-species comparison completed: 3/3 steps.")]))._unsafeUnwrap();
+
+        expect((await history.countUserTurnsAfter(THREAD, 1))._unsafeUnwrap()).toBe(0);
+
+        // The genuine turn that follows the record does count, thus the zero above
+        // reports the marker and not an empty span.
+        (await append(THREAD, [userText("what did it find?"), assistantText("here is the summary")]))._unsafeUnwrap();
+        expect((await history.countUserTurnsAfter(THREAD, 1))._unsafeUnwrap()).toBe(1);
+    });
+});
+
 // --- windowing is independent of the rollup ---------------------------------
 
 describe("loadRecent ignores the stored rollup", () => {

--- a/harness/src/memory/thread-history.ts
+++ b/harness/src/memory/thread-history.ts
@@ -568,9 +568,15 @@ export function createThreadHistory(pool: Pool): ThreadHistory {
 
             const { totalTokens, turnsEvicted: turnsEvictedHist } = getInstruments();
             // A retained head gives one evicted turn back to the window, thus the
-            // metric reports one turn less than the budget walk cut.
+            // histogram reports one turn less than the budget walk cut.
             const turnsDropped = keepsFirstTurn ? turnsEvicted - 1 : turnsEvicted;
-            const attributes = { eviction: turnsDropped > 0 };
+            // The flag reads the cut of the budget walk, and never the count that
+            // the retained head reduced. The two answer different questions: the
+            // flag says that the window lost a turn, and the histogram says how
+            // many. A walk that cut one block, under a block size of one, drops
+            // its whole cut back into the window. The flag must still report the
+            // eviction, because the thread crossed its budget.
+            const attributes = { eviction: turnsEvicted > 0 };
             totalTokens.record(threadTotal, attributes);
             turnsEvictedHist.record(turnsDropped, attributes);
 

--- a/harness/src/memory/thread-history.ts
+++ b/harness/src/memory/thread-history.ts
@@ -202,6 +202,25 @@ export interface ThreadHistory {
      * no guarantee, because the tail can move one append later without it.
      */
     latestSeq(threadId: string): ResultAsync<number | null, DbError>;
+    /**
+     * The count of the thread turns that a person opened past `seq`. A caller
+     * reads it as the new work of the thread past an anchor.
+     *
+     * The unit is a turn, not a row. One turn writes a user row, an assistant
+     * row for each step, and a tool row for each result. Thus a row count of one
+     * span reports the shape of a turn, not the count of the asks.
+     *
+     * A seq comparison alone reports even less. An anchor taken during a turn
+     * sits below the rows of that same turn, thus the difference never reads as
+     * zero again.
+     *
+     * The count reads {@link GENUINE_USER_START_SQL}, the one predicate the turn
+     * grouping and the tail retraction already cut on. Thus the count and the
+     * grouping cannot drift. A synthetic nudge of the loop and a record of the
+     * host both carry the `user` role, and neither one is new work. Thus neither
+     * one adds to the count.
+     */
+    countUserTurnsAfter(threadId: string, seq: number): ResultAsync<number, DbError>;
 }
 
 /**
@@ -655,5 +674,27 @@ export function createThreadHistory(pool: Pool): ThreadHistory {
         });
     }
 
-    return { appendTurn, loadRecent, loadPage, retractLastTurn, latestSeq };
+    function countUserTurnsAfter(threadId: string, seq: number): ResultAsync<number, DbError> {
+        // `GENUINE_USER_START_SQL` is the stored-envelope twin of
+        // `isGenuineUserStart`, and the tail retraction cuts on the same text.
+        // Thus one row matches for each turn that a person opened, and a
+        // synthetic nudge of the loop or a record of the host matches none.
+        //
+        // `$2::bigint` compares the bigint column against a bigint, never against
+        // a text projection, thus an anchor past 2^53 still compares exactly.
+        // `COUNT(*)` is a bigint as well, and the driver hands a bigint back as
+        // text. The explicit cast says so, and `Number` makes the crossing in one
+        // place — the way every other read of this column does.
+        return tryQuery("thread-history.countUserTurnsAfter", () =>
+            pool.query<{ turns: string }>(
+                `SELECT COUNT(*)::text AS turns FROM messages
+              WHERE thread_id = $1
+                AND seq > $2::bigint
+                AND ${GENUINE_USER_START_SQL}`,
+                [threadId, seq],
+            ),
+        ).map(({ rows }) => Number(rows[0]!.turns));
+    }
+
+    return { appendTurn, loadRecent, loadPage, retractLastTurn, latestSeq, countUserTurnsAfter };
 }

--- a/harness/src/memory/thread-history.ts
+++ b/harness/src/memory/thread-history.ts
@@ -142,6 +142,19 @@ export interface MessagePage {
 export type RetractOutcome = { kind: "retracted"; messages: number } | { kind: "empty-thread" } | { kind: "no-user-turn" };
 
 /**
+ * The read options of {@link ThreadHistory.loadRecent}. An absent option gives
+ * the default window.
+ */
+export interface LoadRecentOptions {
+    /**
+     * Keep the first turn of the thread in the window, past the eviction. The
+     * default is `false`, and the eviction then drops the first turn with the
+     * rest of the oldest block.
+     */
+    readonly keepFirstTurn?: boolean;
+}
+
+/**
  * The conversation message store. Two methods, by design — no generic row
  * insert (see the harness-thread-store spec). `threadId` is the conversation scope — one UI thread.
  */
@@ -160,8 +173,18 @@ export interface ThreadHistory {
      * in whole `EVICTION_BLOCK_TURNS` blocks (see the constant) so the prompt-cache
      * prefix stays byte-stable across appends; the window may therefore carry a
      * little less than the budget would strictly allow, but never more.
+     *
+     * `keepFirstTurn` keeps the first turn of the thread. The eviction then drops
+     * the oldest turns after it, and the window holds the first turn and that
+     * retained suffix. The first turn appears one time only.
+     *
+     * The retained turn can carry the window past `tokenBudget`. The cost is
+     * bounded. A report session seeds one turn, its brief carries a length bound,
+     * and its copy of the working-memory render is one row. The retained head also
+     * holds `messages[0]` byte-identical for the life of the thread, thus the
+     * prompt-cache prefix of the provider stays still.
      */
-    loadRecent(threadId: string, tokenBudget: number): ResultAsync<ModelMessage[], DbError>;
+    loadRecent(threadId: string, tokenBudget: number, options?: LoadRecentOptions): ResultAsync<ModelMessage[], DbError>;
     /**
      * Return one page of a thread's messages oldest-first for UI display —
      * NOT token-windowed (that is `loadRecent`'s job for the agent loop). No
@@ -478,7 +501,7 @@ export function createThreadHistory(pool: Pool): ThreadHistory {
         );
     }
 
-    function loadRecent(threadId: string, tokenBudget: number): ResultAsync<ModelMessage[], DbError> {
+    function loadRecent(threadId: string, tokenBudget: number, options?: LoadRecentOptions): ResultAsync<ModelMessage[], DbError> {
         return tryQuery("thread-history.loadRecent", async () => {
             const { rows } = await pool.query<MessageRow>(
                 // ORDER BY must qualify `messages.seq` — a bare `seq` would bind to the
@@ -535,15 +558,24 @@ export function createThreadHistory(pool: Pool): ThreadHistory {
             // suffix is a subset of the budget-minimal one and stays within budget.
             const turnsEvicted = turns.length === 0 ? 0 : Math.min(Math.ceil(minimalEvicted / EVICTION_BLOCK_TURNS) * EVICTION_BLOCK_TURNS, turns.length - 1);
 
-            const { totalTokens, turnsEvicted: turnsEvictedHist } = getInstruments();
-            const attributes = { eviction: turnsEvicted > 0 };
-            totalTokens.record(threadTotal, attributes);
-            turnsEvictedHist.record(turnsEvicted, attributes);
+            // The retained head. The first turn of a report session carries the
+            // brief and the copy of the working-memory render, and no tail message
+            // replaces them. Thus `keepFirstTurn` puts that turn in front of the
+            // retained suffix, and `messages[0]` never moves again. An eviction of
+            // zero already holds the first turn at the head, thus the option adds
+            // nothing there and the window never carries the turn two times.
+            const keepsFirstTurn = options?.keepFirstTurn === true && turnsEvicted > 0;
 
-            return turns
-                .slice(turnsEvicted)
-                .flat()
-                .map((row) => row.message);
+            const { totalTokens, turnsEvicted: turnsEvictedHist } = getInstruments();
+            // A retained head gives one evicted turn back to the window, thus the
+            // metric reports one turn less than the budget walk cut.
+            const turnsDropped = keepsFirstTurn ? turnsEvicted - 1 : turnsEvicted;
+            const attributes = { eviction: turnsDropped > 0 };
+            totalTokens.record(threadTotal, attributes);
+            turnsEvictedHist.record(turnsDropped, attributes);
+
+            const retained = turns.slice(turnsEvicted);
+            return (keepsFirstTurn ? [turns[0]!, ...retained] : retained).flat().map((row) => row.message);
         });
     }
 

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -331,6 +331,10 @@ When the tool returns \`existing-session\`, no new session started. Tell the
 user to continue the report in that chat. Pass \`newSessionAnyway: true\`
 only when the user explicitly wants a separate new report.
 
+When the tool returns any other outcome, no session started and the report
+is not available in this build. Say that in one line, and give the detail
+that the outcome carries. Do not compose the report here instead.
+
 Confirm first only when scope is genuinely ambiguous: several analyses to
 choose from, the user is still exploring options, or the audience matters
 and has not been established.

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -313,13 +313,23 @@ automatically. Your job is to STEER, not re-present:
 
 When the user clearly wants a report ("create a report of the latest run",
 "summarize this for the lab meeting"), proceed without asking for
-confirmation — state briefly what you'll build (audience, sections)
-in the same turn you begin.
+confirmation.
 
-The flow: call \`plan_report\` to get the report-brief schema and authoring
-rules, compose the brief from what it returns, then call \`submit_report\` with
-it. To revise an existing report, skip \`plan_report\` and call \`submit_report\`
-with \`modifications\` + the existing \`previewId\` (never a fresh brief).
+Call \`start_report_session\`. It opens a report chat as a child of this
+conversation. Give it the intent brief: \`objective\` (the question the
+report answers), \`audience\` (the reader), and \`angle\` (the line through
+the evidence). Add \`exclusions\` for material to leave out, and
+\`openQuestions\` for what the user has not settled. The brief carries intent
+only — never a path, never a dataset, never a format, because the session
+reads the workspace itself.
+
+Then tell the user where the report is. The report takes shape in that
+chat, with the Report Builder, and the user talks to it there rather than
+here.
+
+When the tool returns \`existing-session\`, no new session started. Tell the
+user to continue the report in that chat. Pass \`newSessionAnyway: true\`
+only when the user explicitly wants a separate new report.
 
 Confirm first only when scope is genuinely ambiguous: several analyses to
 choose from, the user is still exploring options, or the audience matters
@@ -377,6 +387,9 @@ Instead:
 - **Split one targeted request into multiple ad hoc runs.** Keep one explicit
   computational request in one ad hoc call. Use a user-approved plan when the
   work genuinely requires multiple dependent steps.
+- **Compose a report in the conversation.** The report takes shape in a
+  report session — call \`start_report_session\`. Never write report prose
+  here in place of a session.
 - **Report an environment gap as permanent without checking.** "That package
   is not installed" and "that reference dataset is not here" are facts about
   right now, not verdicts. Before telling the user something cannot be had,

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -84,12 +84,16 @@ export interface RegisteredWorkflows {
 }
 
 /**
- * Conversation-agent deps minus the workflow callable, the resource policy, and
- * the usage recorder — `assembleCoreRuntime` supplies those itself so a caller
- * cannot wire a stale callable, a policy that diverges from the one the
- * workflows see, or a recorder that only half the agent tree reports to.
+ * Conversation-agent deps minus the workflow callable, the resource policy, the
+ * usage recorder, and the report-session anchor — `assembleCoreRuntime` supplies
+ * those itself so a caller cannot wire a stale callable, a policy that diverges
+ * from the one the workflows see, a recorder that only half the agent tree
+ * reports to, or an anchor over a different session runtime.
  */
-export type ConversationAssemblyDeps = Omit<ConversationAgentDeps, "executeAnalysisWorkflow" | "resourcePolicy" | "usageRecorder" | "citationResolver">;
+export type ConversationAssemblyDeps = Omit<
+    ConversationAgentDeps,
+    "executeAnalysisWorkflow" | "resourcePolicy" | "usageRecorder" | "citationResolver" | "anchorReportSession"
+>;
 
 /**
  * What binds one reference resolver: the analysis whose pinned artifacts it reads, and the auth of the tool
@@ -243,20 +247,24 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
         ...(wf.dataProfile.logger ? { logger: wf.dataProfile.logger } : {}),
     });
 
+    // The session runtime binds the per-session state to the thread behind the
+    // tool boundary, thus one instance serves every report thread. It comes before
+    // the conversation agent, because `start_report_session` takes its anchor
+    // operation and pins the snapshot of a new session at the spawn.
+    const reportSession = createReportSessionRuntime({ pool: conversation.pool, ...(conversation.logger ? { logger: conversation.logger } : {}) });
+
     const conversationAgent = createConversationAgent({
         ...conversation,
         executeAnalysisWorkflow: executeAnalysis,
+        anchorReportSession: reportSession.ensureSessionState,
         resourcePolicy,
         usageRecorder,
         citationResolver,
     });
 
-    // The report agent is a singleton over the conversation deps. The session
-    // runtime binds the per-session state to the thread behind the tool boundary,
-    // thus one definition serves every report thread. Its preview tool writes the
-    // page into the analysis tree and returns the path, thus the page write reaches
-    // no host seam.
-    const reportSession = createReportSessionRuntime({ pool: conversation.pool, ...(conversation.logger ? { logger: conversation.logger } : {}) });
+    // The report agent is a singleton over the conversation deps, the same way the
+    // session runtime is. Its preview tool writes the page into the analysis tree
+    // and returns the path, thus the page write reaches no host seam.
     const reportVersionStore = createReportVersionStore({ pool: conversation.pool, ...(conversation.logger ? { logger: conversation.logger } : {}) });
     const reportThreads = createThreadStore(conversation.pool);
 

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -294,6 +294,21 @@ describe("the refusals of the spawn", () => {
     });
 });
 
+describe("the bounds of the brief", () => {
+    it("refuses a field past its bound, and accepts the same field at the bound", async () => {
+        // The bound of `audience` is the smallest of the five, thus one long value
+        // shows the rule with no dependence on the number itself.
+        const atBound = { ...INPUT, audience: "x".repeat(200) };
+        const pastBound = { ...INPUT, audience: "x".repeat(201) };
+
+        expect(tool.inputSchema.safeParse(atBound).success).toBe(true);
+        expect(tool.inputSchema.safeParse(pastBound).success).toBe(false);
+        // The bound is a schema rule, thus the registry refuses the call before the
+        // brief can reach the durable message row.
+        expect(await reportThreadCount()).toBe(0);
+    });
+});
+
 describe("the failed arm", () => {
     it("gives a short detail when the seed write fails, and no child survives", async () => {
         await seedConversation("p1", "Parent");

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ResultAsync } from "neverthrow";
+import type { Pool } from "pg";
+
+import { withSchema } from "../__tests__/setup/postgres.js";
+import type { Scope } from "../auth/types.js";
+import { createReportSessionSpawn } from "../app/spawn-report-session.js";
+import type { DbError } from "../lib/db-result.js";
+import { createThreadHistory } from "../memory/thread-history.js";
+import { createThreadStore, type ThreadStore } from "../memory/thread-store.js";
+import { makeToolContext } from "./__fixtures__/tool-context.js";
+import type { Tool, ToolContext } from "./define-tool.js";
+import { createStartReportSessionTool, type StartReportSessionInput, type StartReportSessionResult } from "./start-report-session.js";
+
+const ANALYSIS = "analysis-a";
+
+/** A chrome config that names a browser. The tool never connects, thus the eyes gate passes with no sidecar. */
+const WITH_BROWSER = { browserUrl: "http://localhost:9222" };
+
+/** The brief of one call. Each field is present, thus the seed of the child shows each label. */
+const INPUT: StartReportSessionInput = {
+    objective: "Explain the sample quality outcome",
+    audience: "The lab lead",
+    angle: "The samples that the study keeps",
+    exclusions: "The raw alignment logs",
+    openQuestions: "The threshold of the batch correction",
+};
+
+let pool: Pool;
+let drop: () => Promise<void>;
+let store: ThreadStore;
+let tool: Tool<StartReportSessionInput, StartReportSessionResult>;
+
+beforeEach(async () => {
+    ({ pool, drop } = await withSchema("start-report-session"));
+    store = createThreadStore(pool);
+    tool = createStartReportSessionTool({ pool, chrome: WITH_BROWSER });
+});
+
+afterEach(async () => {
+    await drop();
+});
+
+// --- seeding ----------------------------------------------------------------
+
+/** Persist one two-message turn on a thread, giving it a transcript to anchor into. */
+function appendTurn(threadId: string): ResultAsync<void, DbError> {
+    return createThreadHistory(pool).appendTurn(threadId, {
+        modelMessages: [
+            { role: "user", content: [{ type: "text", text: "hi" }] },
+            { role: "assistant", content: [{ type: "text", text: "hello" }] },
+        ],
+        displayMessages: [],
+    });
+}
+
+/** A live conversation parent with a first turn — the shape a legal start needs. */
+async function seedConversation(threadId: string, title: string | null): Promise<void> {
+    (await store.createThread({ threadId, analysisId: ANALYSIS, ...(title === null ? {} : { title }) }))._unsafeUnwrap();
+    (await appendTurn(threadId))._unsafeUnwrap();
+}
+
+/** A tool context whose scope names one conversation thread of the analysis. */
+function ctxForThread(threadId: string): ToolContext {
+    const { ctx } = makeToolContext();
+    const scope: Scope = { kind: "analysis", analysisId: ANALYSIS, threadId };
+    return { ...ctx, session: { ...ctx.session, scope } };
+}
+
+/** The count of `report` rows in the schema — 0 says that a refusal wrote nothing. */
+async function reportThreadCount(): Promise<number> {
+    const { rows } = await pool.query<{ count: string }>("SELECT COUNT(*)::text AS count FROM cortex_analysis_threads WHERE thread_type = 'report'");
+    return Number(rows[0]!.count);
+}
+
+/**
+ * Make each later insert into `messages` fail. The trigger is real database
+ * state, thus the seed write of the spawn fails the same way that a driver fault
+ * fails it. A delete stays permitted, thus the purge of the child still runs.
+ */
+async function refuseMessageInserts(): Promise<void> {
+    await pool.query("CREATE FUNCTION refuse_message_insert() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'seed write refused'; END; $$");
+    await pool.query("CREATE TRIGGER refuse_message_insert BEFORE INSERT ON messages FOR EACH ROW EXECUTE FUNCTION refuse_message_insert()");
+}
+
+/** Run the tool and unwrap the ok channel, which each degraded condition also rides. */
+async function run(input: StartReportSessionInput, ctx: ToolContext): Promise<StartReportSessionResult> {
+    return (await tool.execute(input, ctx))._unsafeUnwrap();
+}
+
+describe("the started arm", () => {
+    it("starts a child session and gives its thread id and its title", async () => {
+        await seedConversation("p1", "RNA-seq QC");
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("started");
+        if (result.outcome !== "started") return;
+        expect(result.title).toBe("RNA-seq QC — Report 1");
+        // The row is on disk, not only in the returned value.
+        const child = (await store.getThread(result.threadId))._unsafeUnwrap();
+        expect(child!.threadType).toBe("report");
+        expect(child!.parentThreadId).toBe("p1");
+        expect(await reportThreadCount()).toBe(1);
+    });
+
+    it("starts a session for a parent that holds no report child", async () => {
+        await seedConversation("p1", "Parent");
+        // The brief carries the two optional fields as absent, thus the input with
+        // three fields alone also starts a session.
+        const brief: StartReportSessionInput = { objective: INPUT.objective, audience: INPUT.audience, angle: INPUT.angle };
+
+        const result = await run(brief, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("started");
+        expect(await reportThreadCount()).toBe(1);
+    });
+});
+
+describe("the refused arm", () => {
+    it("refuses a scope that carries no thread id, and writes no row", async () => {
+        await seedConversation("p1", "Parent");
+        const { ctx } = makeToolContext();
+
+        const result = await run(INPUT, { ...ctx, session: { ...ctx.session, scope: { kind: "analysis", analysisId: ANALYSIS } } });
+
+        expect(result.outcome).toBe("refused");
+        if (result.outcome !== "refused") return;
+        expect(result.detail.length).toBeGreaterThan(0);
+        expect(await reportThreadCount()).toBe(0);
+    });
+
+    it("refuses a scope of a different kind, and writes no row", async () => {
+        const { ctx } = makeToolContext();
+        const scope: Scope = { kind: "target-assessment", targetAssessmentId: "ta-1", billingContextId: "b-1" };
+
+        const result = await run(INPUT, { ...ctx, session: { ...ctx.session, scope } });
+
+        expect(result.outcome).toBe("refused");
+        expect(await reportThreadCount()).toBe(0);
+    });
+});
+
+describe("the eyes gate", () => {
+    it("gives the no_browser arm with the detail of the spawn, and writes no row", async () => {
+        await seedConversation("p1", "Parent");
+        const blind = createStartReportSessionTool({ pool, chrome: {} });
+        // The detail comes from the spawn, thus the test reads the one line from
+        // there and no literal drifts between the two modules.
+        const refusal = (await createReportSessionSpawn({ pool, chrome: {} }).spawnReportSession("p1", INPUT))._unsafeUnwrapErr();
+
+        const result = (await blind.execute(INPUT, ctxForThread("p1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("no_browser");
+        if (result.outcome !== "no_browser") return;
+        expect(refusal.type).toBe("no_browser");
+        expect(result.detail).toBe(refusal.type === "no_browser" ? refusal.detail : "");
+        expect(await reportThreadCount()).toBe(0);
+    });
+
+    it("has priority over the advice: a zero delta under a blind composition gives no_browser", async () => {
+        await seedConversation("p1", "Parent");
+        // The one child sits at the end of the parent transcript, thus the delta is
+        // zero and the advice would return, if the gate ran second.
+        const started = await run(INPUT, ctxForThread("p1"));
+        expect(started.outcome).toBe("started");
+        const blind = createStartReportSessionTool({ pool, chrome: {} });
+
+        const result = (await blind.execute(INPUT, ctxForThread("p1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("no_browser");
+        expect(await reportThreadCount()).toBe(1);
+    });
+});
+
+describe("the existing-session arm", () => {
+    it("names the newest child on a zero delta, and starts no second session", async () => {
+        await seedConversation("p1", "Parent");
+        const started = await run(INPUT, ctxForThread("p1"));
+        expect(started.outcome).toBe("started");
+        if (started.outcome !== "started") return;
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("existing-session");
+        if (result.outcome !== "existing-session") return;
+        expect(result.threadId).toBe(started.threadId);
+        expect(result.title).toBe(started.title);
+        expect(await reportThreadCount()).toBe(1);
+    });
+
+    it("starts a session again after a later turn on the parent", async () => {
+        await seedConversation("p1", "Parent");
+        expect((await run(INPUT, ctxForThread("p1"))).outcome).toBe("started");
+        // The parent moves past the anchor of the child, thus the delta is not zero.
+        (await appendTurn("p1"))._unsafeUnwrap();
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("started");
+        expect(await reportThreadCount()).toBe(2);
+    });
+});
+
+describe("the override", () => {
+    it("starts a second session on a zero delta when newSessionAnyway is true", async () => {
+        await seedConversation("p1", "Parent");
+        const started = await run(INPUT, ctxForThread("p1"));
+        expect(started.outcome).toBe("started");
+
+        const result = await run({ ...INPUT, newSessionAnyway: true }, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("started");
+        if (result.outcome !== "started") return;
+        expect(result.title).toBe("Parent — Report 2");
+        expect(await reportThreadCount()).toBe(2);
+    });
+
+    it("keeps the advice when newSessionAnyway is false", async () => {
+        await seedConversation("p1", "Parent");
+        expect((await run(INPUT, ctxForThread("p1"))).outcome).toBe("started");
+
+        const result = await run({ ...INPUT, newSessionAnyway: false }, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("existing-session");
+        expect(await reportThreadCount()).toBe(1);
+    });
+});
+
+describe("the refusals of the spawn", () => {
+    it("passes parent_not_found through, and writes no row", async () => {
+        const result = await run(INPUT, ctxForThread("ghost"));
+
+        expect(result.outcome).toBe("parent_not_found");
+        expect(await reportThreadCount()).toBe(0);
+    });
+
+    it("passes parent_not_a_conversation through, and names the type of the thread", async () => {
+        (await store.createThread({ threadId: "r1", analysisId: ANALYSIS, title: "A report", type: "report" }))._unsafeUnwrap();
+
+        const result = await run(INPUT, ctxForThread("r1"));
+
+        expect(result.outcome).toBe("parent_not_a_conversation");
+        if (result.outcome !== "parent_not_a_conversation") return;
+        expect(result.threadType).toBe("report");
+        // Only the seed report exists — the tool added none.
+        expect(await reportThreadCount()).toBe(1);
+    });
+
+    it("passes empty_parent_transcript through, and writes no row", async () => {
+        (await store.createThread({ threadId: "p1", analysisId: ANALYSIS, title: "Empty" }))._unsafeUnwrap();
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("empty_parent_transcript");
+        expect(await reportThreadCount()).toBe(0);
+    });
+});
+
+describe("the failed arm", () => {
+    it("gives a short detail when the seed write fails, and no child survives", async () => {
+        await seedConversation("p1", "Parent");
+        // The parent transcript is complete before the refusal, thus only the seed
+        // write of the spawn fails, and it fails after the thread insert.
+        await refuseMessageInserts();
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("failed");
+        if (result.outcome !== "failed") return;
+        expect(result.detail).toContain("database write failed");
+        expect(await reportThreadCount()).toBe(0);
+    });
+});

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -6,7 +6,7 @@ import { withSchema } from "../__tests__/setup/postgres.js";
 import type { Scope } from "../auth/types.js";
 import { createReportSessionSpawn } from "../app/spawn-report-session.js";
 import type { DbError } from "../lib/db-result.js";
-import { createThreadHistory } from "../memory/thread-history.js";
+import { conversationRecordTurn, createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore, type ThreadStore } from "../memory/thread-store.js";
 import { makeToolContext } from "./__fixtures__/tool-context.js";
 import type { Tool, ToolContext } from "./define-tool.js";
@@ -52,6 +52,11 @@ function appendTurn(threadId: string): ResultAsync<void, DbError> {
         ],
         displayMessages: [],
     });
+}
+
+/** Append one record of out-of-band work — a synthetic message that opens no turn. */
+function appendRecord(threadId: string, text: string): ResultAsync<void, DbError> {
+    return createThreadHistory(pool).appendTurn(threadId, conversationRecordTurn(text));
 }
 
 /** A live conversation parent with a first turn — the shape a legal start needs. */
@@ -158,10 +163,10 @@ describe("the eyes gate", () => {
         expect(await reportThreadCount()).toBe(0);
     });
 
-    it("has priority over the advice: a zero delta under a blind composition gives no_browser", async () => {
+    it("has priority over the advice: an advised parent under a blind composition gives no_browser", async () => {
         await seedConversation("p1", "Parent");
-        // The one child sits at the end of the parent transcript, thus the delta is
-        // zero and the advice would return, if the gate ran second.
+        // The one child sits at the end of the parent transcript, thus no user
+        // turn follows the anchor and the advice would return, if the gate ran second.
         const started = await run(INPUT, ctxForThread("p1"));
         expect(started.outcome).toBe("started");
         const blind = createStartReportSessionTool({ pool, chrome: {} });
@@ -174,7 +179,7 @@ describe("the eyes gate", () => {
 });
 
 describe("the existing-session arm", () => {
-    it("names the newest child on a zero delta, and starts no second session", async () => {
+    it("names the newest child when no user turn follows the anchor, and starts no second session", async () => {
         await seedConversation("p1", "Parent");
         const started = await run(INPUT, ctxForThread("p1"));
         expect(started.outcome).toBe("started");
@@ -189,10 +194,42 @@ describe("the existing-session arm", () => {
         expect(await reportThreadCount()).toBe(1);
     });
 
-    it("starts a session again after a later turn on the parent", async () => {
+    it("keeps the advice when the turn of the ask that started the session lands past the anchor", async () => {
+        await seedConversation("p1", "Parent");
+        const started = await run(INPUT, ctxForThread("p1"));
+        expect(started.outcome).toBe("started");
+        if (started.outcome !== "started") return;
+        // The caller appends the whole turn after the loop of that turn runs, thus
+        // the ask that started the session lands one user turn past the anchor.
+        (await appendTurn("p1"))._unsafeUnwrap();
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("existing-session");
+        if (result.outcome !== "existing-session") return;
+        expect(result.threadId).toBe(started.threadId);
+        expect(await reportThreadCount()).toBe(1);
+    });
+
+    it("keeps the advice when a record of the host lands past the anchor", async () => {
         await seedConversation("p1", "Parent");
         expect((await run(INPUT, ctxForThread("p1"))).outcome).toBe("started");
-        // The parent moves past the anchor of the child, thus the delta is not zero.
+        // The turn of the ask, and then one record of out-of-band work. A record
+        // opens no turn, thus it never clears the advice on its own.
+        (await appendTurn("p1"))._unsafeUnwrap();
+        (await appendRecord("p1", "Run GSEA cross-species comparison completed: 3/3 steps."))._unsafeUnwrap();
+
+        const result = await run(INPUT, ctxForThread("p1"));
+
+        expect(result.outcome).toBe("existing-session");
+        expect(await reportThreadCount()).toBe(1);
+    });
+
+    it("starts a session again after a second user turn on the parent", async () => {
+        await seedConversation("p1", "Parent");
+        expect((await run(INPUT, ctxForThread("p1"))).outcome).toBe("started");
+        // The turn of the ask, and then one turn of real work past the anchor.
+        (await appendTurn("p1"))._unsafeUnwrap();
         (await appendTurn("p1"))._unsafeUnwrap();
 
         const result = await run(INPUT, ctxForThread("p1"));
@@ -203,7 +240,7 @@ describe("the existing-session arm", () => {
 });
 
 describe("the override", () => {
-    it("starts a second session on a zero delta when newSessionAnyway is true", async () => {
+    it("starts a second session on an advised parent when newSessionAnyway is true", async () => {
         await seedConversation("p1", "Parent");
         const started = await run(INPUT, ctxForThread("p1"));
         expect(started.outcome).toBe("started");

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -1,0 +1,207 @@
+/**
+ * The tool that starts a report session from a conversation.
+ *
+ * The tool is the one report path of the conversation agent. It reads the parent
+ * thread from the scope of the call, thus the agent cannot name a different
+ * conversation. It carries the intent brief of the ask, and the spawn seeds the
+ * context of the child with that brief.
+ *
+ * The order of the checks is fixed. The eyes gate runs first, because a
+ * composition with no browser is a permanent condition and the advice is
+ * transient state. The advice runs next: when the parent holds no message after
+ * the anchor of the newest report child, the tool starts nothing and it names
+ * that child. The spawn runs last.
+ *
+ * Each degraded condition is a typed outcome in the ok channel: a scope with no
+ * thread id, a composition with no eyes, the advice, each refusal of the spawn,
+ * and a store fault. The tool never throws for one of them.
+ */
+
+import { ok, type Result } from "neverthrow";
+import type { Pool } from "pg";
+import { z } from "zod";
+
+import { createReportSessionSpawn, type ReportBrief, type SpawnRefusal } from "../app/spawn-report-session.js";
+import { hasBrowserUrl, type ChromeConfig } from "../lib/chrome.js";
+import { createNoopLogger } from "../lib/console-logger.js";
+import { describeDbError, type DbError } from "../lib/db-result.js";
+import type { Logger } from "../lib/logger.js";
+import type { ThreadInputError, ThreadType } from "../memory/thread-store.js";
+import { defineTool, type Tool, type ToolError } from "./define-tool.js";
+
+/**
+ * The brief of the ask, plus the one override of the advice.
+ *
+ * Each brief field is short prose. No field names a path, a dataset, or a
+ * format, because the report session reads those from the workspace itself.
+ */
+const startReportSessionInput = z.object({
+    objective: z.string().min(1).describe("The question that the report must answer."),
+    audience: z.string().min(1).describe("The reader of the report."),
+    angle: z.string().min(1).describe("The line that the report takes through the evidence."),
+    exclusions: z.string().optional().describe("The material that the report must leave out."),
+    openQuestions: z.string().optional().describe("The points that the user did not decide yet."),
+    newSessionAnyway: z
+        .boolean()
+        .optional()
+        .describe("Set it to true to start a new session when the conversation holds no message after the last report session. The default is false."),
+});
+
+export type StartReportSessionInput = z.infer<typeof startReportSessionInput>;
+
+/**
+ * The typed outcome of the tool. Each arm is ok-channel data, thus the tool
+ * never throws for a degraded condition.
+ *
+ * `started` and `existing-session` name a report thread. `refused` names a call
+ * whose scope carries no conversation thread. The four refusals of the spawn
+ * keep their own names, thus the agent reads one reason from the spawn and from
+ * the tool alike. `failed` is a store fault, and it carries a short line.
+ */
+export type StartReportSessionResult =
+    | { outcome: "started"; threadId: string; title: string | null }
+    | { outcome: "existing-session"; threadId: string; title: string | null }
+    | { outcome: "refused"; detail: string }
+    | { outcome: "no_browser"; detail: string }
+    | { outcome: "parent_not_found" }
+    | { outcome: "parent_not_a_conversation"; threadType: ThreadType }
+    | { outcome: "empty_parent_transcript" }
+    | { outcome: "failed"; detail: string };
+
+/**
+ * The construction deps of the tool.
+ *
+ * `pool` and `chrome` build the spawn operation inside the factory, thus one
+ * singleton tool serves every conversation and it reads the parent from the
+ * scope of each call. The composition binds no capture seam here, thus the
+ * browser endpoint is the one route to the eyes.
+ */
+export interface StartReportSessionToolDeps {
+    readonly pool: Pool;
+    readonly chrome: ChromeConfig;
+    readonly logger?: Logger;
+}
+
+/** The line that a call reads when the scope names no conversation thread. */
+const NO_THREAD_SCOPE_DETAIL = "the scope of the call names no conversation thread, thus the tool cannot start a child session";
+
+/** The line that a call reads when the thread store refuses the shape of the child. */
+const STORE_REFUSED_DETAIL = "the thread store refused the shape of the child session";
+
+/**
+ * Map a fault of the spawn onto its arm. The switch is exhaustive over the three
+ * error unions, thus a new variant fails the build instead of falling into one
+ * arm in silence.
+ */
+function toOutcome(fault: SpawnRefusal | DbError | ThreadInputError): StartReportSessionResult {
+    switch (fault.type) {
+        case "no_browser":
+            return { outcome: "no_browser", detail: fault.detail };
+        case "parent_not_found":
+            return { outcome: "parent_not_found" };
+        case "parent_not_a_conversation":
+            return { outcome: "parent_not_a_conversation", threadType: fault.threadType };
+        case "empty_parent_transcript":
+            return { outcome: "empty_parent_transcript" };
+        case "query_failed":
+        case "mutation_failed":
+        case "connection_failed":
+        case "constraint_violation":
+            return { outcome: "failed", detail: describeDbError(fault) };
+        case "parent_analysis_mismatch":
+        case "parent_anchor_unpaired":
+        case "unknown_thread_type":
+            return { outcome: "failed", detail: STORE_REFUSED_DETAIL };
+    }
+}
+
+/** The cause of a fault, or `undefined` for a fault that carries none. */
+function causeOf(fault: SpawnRefusal | DbError | ThreadInputError): unknown {
+    return "cause" in fault ? fault.cause : undefined;
+}
+
+/**
+ * Make the tool that starts a report session, over one Postgres pool and the
+ * chrome config of the composition.
+ *
+ * The factory builds the spawn operation with the same two values, thus the
+ * spawn and the gate of the tool read one browser endpoint. The tool holds no
+ * per-conversation value.
+ */
+export function createStartReportSessionTool(deps: StartReportSessionToolDeps): Tool<StartReportSessionInput, StartReportSessionResult> {
+    const logger = (deps.logger ?? createNoopLogger()).named("start-report-session");
+    const spawn = createReportSessionSpawn({ pool: deps.pool, chrome: deps.chrome });
+    // The eyes of the composition are fixed at construction, thus the gate reads
+    // one boolean and never a live probe of the sidecar.
+    const eyesAvailable = hasBrowserUrl(deps.chrome);
+
+    return defineTool({
+        id: "start_report_session",
+        description:
+            "Start an interactive report session as a child of this conversation. " +
+            "The user composes the report in that chat, with the report agent. " +
+            "Give the intent brief: the objective, the audience, and the angle of the report. " +
+            "The brief carries intent only. Do not name a path, a dataset, or a format in it, " +
+            "because the session reads those from the workspace. " +
+            "Keep the whole brief under approximately 2000 tokens. " +
+            "When the conversation holds no message after the last report session, the tool starts " +
+            "nothing and it names that session. Then tell the user to continue in that chat.",
+        inputSchema: startReportSessionInput,
+        executionMode: "inline",
+        describeCall: "none",
+        execute: async (input, ctx): Promise<Result<StartReportSessionResult, ToolError>> => {
+            const brief: ReportBrief = {
+                objective: input.objective,
+                audience: input.audience,
+                angle: input.angle,
+                exclusions: input.exclusions,
+                openQuestions: input.openQuestions,
+            };
+
+            const { scope } = ctx.session;
+            if (scope.kind !== "analysis" || scope.threadId === undefined || scope.threadId.length === 0) {
+                return ok({ outcome: "refused", detail: NO_THREAD_SCOPE_DETAIL });
+            }
+            const parentThreadId = scope.threadId;
+
+            // The eyes gate has priority over the advice, and the advice costs two
+            // reads. The spawn holds the same gate before each read of its own,
+            // thus a blind composition reaches the `no_browser` refusal of the
+            // spawn with no read and no write. As a result the tool copies no
+            // detail line of the spawn.
+            if (eyesAvailable) {
+                const delta = await spawn.reportSessionDelta(parentThreadId);
+                if (delta.isErr()) {
+                    logger.warn("the report session delta did not read", {
+                        parentThreadId,
+                        reason: delta.error.type,
+                        ...logger.errorFields(delta.error.cause),
+                    });
+                    return ok(toOutcome(delta.error));
+                }
+                const { newestChild, latestSeq } = delta.value;
+                // The rule is exact at zero: the parent holds no message past the
+                // anchor of the newest child. A small non-zero delta stays a
+                // judgment of the agent, because each non-zero threshold is
+                // arbitrary.
+                if (input.newSessionAnyway !== true && newestChild !== null && latestSeq !== null && latestSeq <= newestChild.anchor) {
+                    return ok({ outcome: "existing-session", threadId: newestChild.threadId, title: newestChild.title });
+                }
+            }
+
+            const spawned = await spawn.spawnReportSession(parentThreadId, brief);
+            return ok(
+                spawned.match(
+                    (child): StartReportSessionResult => ({ outcome: "started", threadId: child.threadId, title: child.title }),
+                    (fault): StartReportSessionResult => {
+                        const outcome = toOutcome(fault);
+                        if (outcome.outcome === "failed") {
+                            logger.warn("the report session did not start", { parentThreadId, reason: fault.type, ...logger.errorFields(causeOf(fault)) });
+                        }
+                        return outcome;
+                    },
+                ),
+            );
+        },
+    });
+}

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -21,6 +21,7 @@ import { ok, type Result } from "neverthrow";
 import type { Pool } from "pg";
 import { z } from "zod";
 
+import type { EnsureSessionStateResult } from "../app/report-session-runtime.js";
 import { createReportSessionSpawn, type ReportBrief, type SpawnRefusal } from "../app/spawn-report-session.js";
 import { hasBrowserUrl, type ChromeConfig } from "../lib/chrome.js";
 import { createNoopLogger } from "../lib/console-logger.js";
@@ -30,17 +31,37 @@ import type { ThreadInputError, ThreadType } from "../memory/thread-store.js";
 import { defineTool, type Tool, type ToolError } from "./define-tool.js";
 
 /**
+ * The character bound of each brief field. The whole brief lands in one durable
+ * message row, thus the schema holds no unbounded string out of the store.
+ *
+ * The description caps the brief at approximately 2000 tokens, and a token is
+ * about four characters. Thus the five bounds sum to 8000 characters, and the
+ * widest brief that the schema admits still meets the cap that the agent reads.
+ *
+ * The share of each field follows its role. `audience` names one reader, thus a
+ * phrase is enough. `objective` and `angle` carry a sentence or two. Each
+ * optional field carries a list of items, thus it takes the largest share.
+ */
+const BRIEF_MAX = {
+    objective: 1500,
+    audience: 200,
+    angle: 1500,
+    exclusions: 2400,
+    openQuestions: 2400,
+} as const;
+
+/**
  * The brief of the ask, plus the one override of the advice.
  *
  * Each brief field is short prose. No field names a path, a dataset, or a
  * format, because the report session reads those from the workspace itself.
  */
 const startReportSessionInput = z.object({
-    objective: z.string().min(1).describe("The question that the report must answer."),
-    audience: z.string().min(1).describe("The reader of the report."),
-    angle: z.string().min(1).describe("The line that the report takes through the evidence."),
-    exclusions: z.string().optional().describe("The material that the report must leave out."),
-    openQuestions: z.string().optional().describe("The points that the user did not decide yet."),
+    objective: z.string().min(1).max(BRIEF_MAX.objective).describe("The question that the report must answer."),
+    audience: z.string().min(1).max(BRIEF_MAX.audience).describe("The reader of the report."),
+    angle: z.string().min(1).max(BRIEF_MAX.angle).describe("The line that the report takes through the evidence."),
+    exclusions: z.string().max(BRIEF_MAX.exclusions).optional().describe("The material that the report must leave out."),
+    openQuestions: z.string().max(BRIEF_MAX.openQuestions).optional().describe("The points that the user did not decide yet."),
     newSessionAnyway: z
         .boolean()
         .optional()
@@ -81,6 +102,12 @@ export type StartReportSessionResult =
 export interface StartReportSessionToolDeps {
     readonly pool: Pool;
     readonly chrome: ChromeConfig;
+    /**
+     * The anchor operation of the report session runtime, which the spawn runs
+     * after the seed of the child lands. The composition binds it, thus the tool
+     * carries no stale value of its own.
+     */
+    readonly anchorSession?: (threadId: string) => Promise<EnsureSessionStateResult>;
     readonly logger?: Logger;
 }
 
@@ -132,7 +159,12 @@ function causeOf(fault: SpawnRefusal | DbError | ThreadInputError): unknown {
  */
 export function createStartReportSessionTool(deps: StartReportSessionToolDeps): Tool<StartReportSessionInput, StartReportSessionResult> {
     const logger = (deps.logger ?? createNoopLogger()).named("start-report-session");
-    const spawn = createReportSessionSpawn({ pool: deps.pool, chrome: deps.chrome });
+    const spawn = createReportSessionSpawn({
+        pool: deps.pool,
+        chrome: deps.chrome,
+        ...(deps.anchorSession ? { anchorSession: deps.anchorSession } : {}),
+        ...(deps.logger ? { logger: deps.logger } : {}),
+    });
     // The eyes of the composition are fixed at construction, thus the gate reads
     // one boolean and never a live probe of the sidecar.
     const eyesAvailable = hasBrowserUrl(deps.chrome);

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -8,9 +8,9 @@
  *
  * The order of the checks is fixed. The eyes gate runs first, because a
  * composition with no browser is a permanent condition and the advice is
- * transient state. The advice runs next: when the parent holds no message after
- * the anchor of the newest report child, the tool starts nothing and it names
- * that child. The spawn runs last.
+ * transient state. The advice runs next. At one user turn or less of the parent
+ * past the anchor of the newest report child, the tool starts nothing and it
+ * names that child. The spawn runs last.
  *
  * Each degraded condition is a typed outcome in the ok channel: a scope with no
  * thread id, a composition with no eyes, the advice, each refusal of the spawn,
@@ -44,7 +44,9 @@ const startReportSessionInput = z.object({
     newSessionAnyway: z
         .boolean()
         .optional()
-        .describe("Set it to true to start a new session when the conversation holds no message after the last report session. The default is false."),
+        .describe(
+            "Set it to true to start a new session when the conversation holds no user turn of new work after the last report session. The default is false.",
+        ),
 });
 
 export type StartReportSessionInput = z.infer<typeof startReportSessionInput>;
@@ -144,8 +146,9 @@ export function createStartReportSessionTool(deps: StartReportSessionToolDeps): 
             "The brief carries intent only. Do not name a path, a dataset, or a format in it, " +
             "because the session reads those from the workspace. " +
             "Keep the whole brief under approximately 2000 tokens. " +
-            "When the conversation holds no message after the last report session, the tool starts " +
-            "nothing and it names that session. Then tell the user to continue in that chat.",
+            "When the conversation holds no user turn of new work after the last report session, the tool " +
+            "starts nothing and it names that session. The ask that started that session is not new work. " +
+            "Then tell the user to continue in that chat.",
         inputSchema: startReportSessionInput,
         executionMode: "inline",
         describeCall: "none",
@@ -179,12 +182,13 @@ export function createStartReportSessionTool(deps: StartReportSessionToolDeps): 
                     });
                     return ok(toOutcome(delta.error));
                 }
-                const { newestChild, latestSeq } = delta.value;
-                // The rule is exact at zero: the parent holds no message past the
-                // anchor of the newest child. A small non-zero delta stays a
-                // judgment of the agent, because each non-zero threshold is
-                // arbitrary.
-                if (input.newSessionAnyway !== true && newestChild !== null && latestSeq !== null && latestSeq <= newestChild.anchor) {
+                const { newestChild, userTurnsSinceAnchor } = delta.value;
+                // The rule admits one turn. A turn appends after its own loop
+                // runs, thus the ask that made the child is itself one user turn
+                // past the anchor. A rule at zero would never advise again after
+                // that turn commits. A second user turn is real work, and a new
+                // session can report on it.
+                if (input.newSessionAnyway !== true && newestChild !== null && userTurnsSinceAnchor !== null && userTurnsSinceAnchor <= 1) {
                     return ok({ outcome: "existing-session", threadId: newestChild.threadId, title: newestChild.title });
                 }
             }


### PR DESCRIPTION
## What & why

This is the switch of #221: the one user-visible change of the report rebuild, and it implements #314. The conversation agent stops the offer of the brief tools, and it offers one tool that starts a report session. The user then composes the report in that child chat, with the Report Builder.

The change also carries the context transfer that the #223 record decided. The tool takes an intent brief, and the spawn writes one frozen seed message at the anchor. The seed holds the brief and a copy of the working-memory render.

Notes for the reviewer, before the diff:

- The seed rides as a record turn (`conversationRecordTurn`), thus it never opens a turn, and a tail retract cannot cut it.
- A report turn drops the live working-memory tail, because a live render sees state past the anchor. The seed copy is the narrative record of the session.
- The zero-delta advice is mechanical and exact at zero. When the parent holds no message past the newest report child, the tool names that child and starts nothing. `newSessionAnyway` overrides it.
- The `no_browser` refusal comes from the spawn's own gate. The tool skips the advice reads under a closed gate, thus the refusal prose has one source.
- The old modules stay in the source, and the unused report deps stay on `ConversationAgentDeps`, because a deps change breaks an embedder. #313 owns the removal.
- On the local CLI the spawn refuses `no_browser` until the Chrome sidecar lands with #312, on this same delivery branch.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
