### PR TITLE
fix(harness): omit the api_key parameter when the NCBI key is empty

### DIFF
--- a/harness/src/literature/sources/pubmed.ts
+++ b/harness/src/literature/sources/pubmed.ts
@@ -73,7 +73,8 @@ export interface PubmedSource {
 
 export function ncbiUrl(apiKey: string | undefined, base: string, params: Record<string, string | number | undefined>): string {
     const url = new URL(base);
-    if (apiKey !== undefined) url.searchParams.set("api_key", apiKey);
+    // The URL must not include an empty key. NCBI rejects `api_key=` with HTTP 400.
+    if (apiKey) url.searchParams.set("api_key", apiKey);
     for (const [key, value] of Object.entries(params)) if (value !== undefined) url.searchParams.set(key, String(value));
     return url.toString();
 }

--- a/harness/src/literature/sources/sources.test.ts
+++ b/harness/src/literature/sources/sources.test.ts
@@ -95,4 +95,20 @@ describe("shared literature authority sources", () => {
         expect(seen.map((url) => url.pathname.split("/").at(-1))).toEqual(["esearch.fcgi", "efetch.fcgi"]);
         expect(seen.every((url) => url.searchParams.get("api_key") === "ncbi-key")).toBe(true);
     });
+
+    it("omits the NCBI api_key parameter when the key is empty", async () => {
+        const seen: URL[] = [];
+        const source = createPubmedSource({
+            apiKey: "",
+            fetch: async (url) => {
+                seen.push(new URL(String(url)));
+                return Response.json({ esearchresult: { idlist: ["12345678"], count: "1" } });
+            },
+        });
+
+        const ids = await source.searchIds("shared source[Title]", 5);
+
+        expect(ids).toEqual({ status: "ok", value: ["12345678"] });
+        expect(seen[0]?.searchParams.has("api_key")).toBe(false);
+    });
 });


### PR DESCRIPTION
## What & why

`ncbiUrl` set the `api_key` parameter if the key was not `undefined`, but an empty string is not `undefined`. A host that gives an empty `NCBI_API_KEY` thus sent `api_key=` to NCBI, and NCBI refuses that parameter with HTTP 400 (`{"error":"API key invalid","api-key":"",...}`). Each call of the `pubmed` tool failed as a result, on the `esearch`, `esummary`, and `efetch` paths alike. This change tests the key for a non-empty value.

Notes for the reviewer:

- An empty value is the documented way to disable a keyed tool. The Cortex chart records this convention for the `cortex-bio` secret, thus the empty key is deliberate, not a misconfiguration. NCBI accepts a request that carries no key, at the lower rate limit for an anonymous client.
- `ncbiUrl` is the one function that sets `api_key`, thus the ClinVar client gets the same correction. `tools/bio/keys.ts` gives the key to the PubMed tool without a guard (line 37) and to ClinVar with one (line 62). That difference is now harmless, so this change leaves it as it is.
- A failure of this class is invisible in the logs. `literature/sources/http.ts` discards the response body, thus only `HTTP 400` survives, and the loop returns it to the model as tool data. Staging showed 5 consecutive failures with no error-level log line.

Observed in Cortex staging on `@inflexa-ai/harness` 0.19.2.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.