### PR TITLE
feat(harness)!: stamp opaque host pod labels on a sandbox

### DIFF
--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/.openspec.yaml
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/design.md
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/design.md
@@ -1,0 +1,73 @@
+# Design — stamp-opaque-sandbox-pod-labels
+
+## Context
+
+`ResolveBilling` gives the final wire headers, not the raw attribution map. The
+managed realization assembles a gateway header set, where the key
+`X-Inflexa-Billing-Context` arrives as `x-bf-lh-billing-context`. The two spawn
+sites read the raw key, thus each read gives `undefined` and each pod spawns with
+no label. A reconciler that filters on a non-empty billing-context pod label sees
+no allocation at all.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A sandbox pod carries the attribution labels that the host asks for.
+- The harness holds no billing vocabulary at the sandbox boundary.
+- No change to the DBOS step sequence, thus an in-flight workflow replays cleanly
+  across the deploy.
+
+**Non-Goals:**
+
+- The `ResolveBilling` seam, the providers, and the LLM/embedding attribution.
+  They keep their own resolver, and this change does not touch them.
+- The Docker backend. A local container has no cost reconciler.
+
+## Decisions
+
+### D1 — The label map is opaque
+
+`CreateSandboxMeta.podLabels` is `Record<string, string>`. The harness stamps
+each entry and reads no key and no value. A label key, a label value, and the
+meaning of both belong to the host. This removes the whole class of defect that
+this change repairs: the harness cannot read the wrong key out of a map that it
+never inspects.
+
+The host gives the map in final form. Nexus pull request #145 gives
+`{ "cortex/billing-context": "<uuid>", "cortex/user-id": "<uuid>" }`.
+
+### D2 — The harness keeps the two identifiers that it holds itself
+
+`cortex/analysis-id` and `cortex/run-id` stay derived from `CreateSandboxMeta`,
+on both the Job and the pod template. They are facts of the run, not host policy,
+and the harness already has them. A host that wants them under a different key
+adds that key to its own map.
+
+### D3 — `sanitizeLabelValue` stays on every value
+
+The host promises a valid label value, but one malformed value makes the API
+server reject the whole Job at admission, and the step then loses its sandbox.
+The guard costs one pass over a small map. Keep it.
+
+### D4 — The resolution stays inside the `sandbox.create` step
+
+A separate `podLabels.resolve` DBOS step would shift the child workflow's step
+sequence, and an in-flight workflow that resumes across the deploy would replay
+against a different sequence. The resolution stays in the same checkpointed
+closure as the spawn, as it did before.
+
+### D5 — Attribution never fails a step
+
+An absent seam spawns with no host label and says nothing: the host chose to
+attribute nothing. A wired seam that throws, or that gives an empty map, warns
+and spawns with no host label. The warning is the loud case, because there the
+host asked for attribution and did not get it.
+
+## Risks / Trade-offs
+
+- [The harness cannot make sure that the labels are correct] → deliberate. A
+  wrong label is a host defect, and the host owns the meaning. The staging check
+  of the pod labels is the control.
+- [`resolvePodLabels` is a breaking dep change] → minor version 0.20.0, and each
+  embedder that wired `resolveBilling` into these two bundles rewires it.

--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/proposal.md
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/proposal.md
@@ -1,0 +1,54 @@
+# Stamp opaque sandbox pod labels
+
+## Why
+
+The sandbox pods still carry no attribution labels, and the cost reconciler still
+sees none of them. `restore-sandbox-billing-labels` read the billing-context id
+out of the `ResolveBilling` seam by the raw map key `X-Inflexa-Billing-Context`,
+but that seam is typed `(session) => Promise<BillingHeaders>` — the FINAL wire
+headers. A managed host assembles them for its gateway, where each key becomes
+`x-bf-lh-<name>`. The raw key is thus never present, the lookup gives
+`undefined`, `meta.billing` stays unset, and `buildJobSpec` stamps nothing. The
+staging cluster confirms it.
+
+The key mismatch is a symptom. The cause is that the harness knows what a billing
+context is. It must not. A billing context is a coordinate of one host's metering
+system, and the harness has no use for the value that it reads.
+
+## What Changes
+
+- `CreateSandboxMeta.billing` becomes `podLabels?: Record<string, string>` — an
+  opaque map of labels that the harness stamps and never reads.
+- `buildJobSpec` stamps `meta.podLabels` on both the Job metadata and the pod
+  template. It keeps its own two identifiers, `cortex/analysis-id` and
+  `cortex/run-id`, and it keeps `sanitizeLabelValue` on each value.
+- `SandboxStepDeps.resolveBilling` and `DataProfileDeps.resolveBilling` become
+  `resolvePodLabels?: (session: RunSession) => Promise<Record<string, string>>`.
+  The step resolves the labels inside the existing `sandbox.create` DBOS step.
+- An absent seam, a seam that throws, and a seam that gives an empty map each
+  spawn the sandbox with no host labels. Attribution never blocks compute.
+
+The host supplies the labels in their final form. Nexus pull request #145 does
+this: `resolve-headers` becomes `resolve-attribution` and it gives back
+`{ headers, podLabels }`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `compute-billing-attribution`: the spawn paths resolve an opaque label map
+  through a host seam. They no longer read a billing-context id, and they no
+  longer name a header key.
+- `k8s-sandbox-provider`: the Job spec stamps the host's label map, in place of
+  the four billing labels that it derived itself.
+
+## Impact
+
+- `src/sandbox/types.ts` — `CreateSandboxMeta.podLabels`.
+- `src/sandbox/k8s-client.ts` — the label stamping in `buildJobSpec`; the
+  `BILLING_CONTEXT_LABEL` and `USER_ID_LABEL` constants are gone.
+- `src/workflows/sandbox-step.ts`, `src/tasks/data-profile.ts` — the
+  `resolvePodLabels` seam in place of `resolveBilling`.
+- Breaking for an embedder that wires either dep: version 0.20.0.
+- The `ResolveBilling` seam itself, the providers, and the billing resolver are
+  untouched. Each LLM call and each embedding call keeps its own resolver.

--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/specs/compute-billing-attribution/spec.md
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/specs/compute-billing-attribution/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Every sandbox spawn path offers the host a pod-label seam
+
+Every code path that creates a sandbox SHALL offer an optional
+`resolvePodLabels: (session) => Promise<Record<string, string>>` dep, call it
+under the session that the path holds, and pass the result as
+`CreateSandboxMeta.podLabels`:
+
+1. **Analysis sandbox steps** (`src/workflows/sandbox-step.ts`): called under the
+   step's session **inside the existing `sandbox.create` DBOS step**, thus the
+   child workflow's step sequence is unchanged and an in-flight workflow that
+   resumes across a deploy replays cleanly.
+2. **Data profile** (`src/tasks/data-profile.ts`): called under the profiling
+   session, inline at the spawn.
+
+The map is opaque. A spawn path SHALL NOT read a key of it, and it SHALL NOT
+derive a value from the meaning of one. The host owns what a label means.
+
+Attribution SHALL NOT block compute. When the dep is absent, the sandbox SHALL
+spawn with no host label and the path SHALL log nothing — the host chose to
+attribute nothing. When a wired dep throws, or gives an empty map, the sandbox
+SHALL spawn with no host label and the path SHALL log a warning.
+
+#### Scenario: The resolved map reaches the spawn
+
+- **GIVEN** a sandbox step whose deps carry a `resolvePodLabels` seam
+- **WHEN** the `sandbox.create` step executes
+- **THEN** the seam is called under the step's own session
+- **AND** the spawn carries exactly the map that the seam gave
+
+#### Scenario: An absent seam spawns a clean sandbox
+
+- **GIVEN** a sandbox step whose deps carry no `resolvePodLabels` seam
+- **WHEN** the step runs
+- **THEN** the sandbox spawns with no host label
+- **AND** the step completes
+
+#### Scenario: A seam that throws does not fail the step
+
+- **GIVEN** a `resolvePodLabels` seam whose upstream is unreachable
+- **WHEN** the sandbox spawns
+- **THEN** the sandbox spawns with no host label
+- **AND** a warning records the failure
+- **AND** the step completes
+
+## REMOVED Requirements
+
+### Requirement: Every K8s sandbox spawn path supplies billing attribution
+
+**Reason**: The spawn paths read a billing-context id out of the `ResolveBilling`
+seam by the raw map key `X-Inflexa-Billing-Context`. That seam gives the FINAL
+wire headers, where a managed host has rewritten each key, thus the read always
+gave `undefined` and every pod spawned unlabeled. The harness holds no billing
+vocabulary at the sandbox boundary now.
+
+**Migration**: `SandboxStepDeps.resolveBilling` and `DataProfileDeps.resolveBilling`
+become `resolvePodLabels`. The host resolves the labels in final form and gives
+them as an opaque map. The `ResolveBilling` seam keeps its own consumers, which
+are the chat provider and the embedding provider.

--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/specs/k8s-sandbox-provider/spec.md
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/specs/k8s-sandbox-provider/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Host-supplied pod labels on the Job and the pod template
+
+When `CreateSandboxMeta.podLabels` is present, `buildJobSpec` SHALL stamp each of
+its entries on **both** the Job metadata labels and the pod template metadata
+labels. The map is opaque: the provider SHALL read no key and no value of it, and
+it SHALL derive no label from the meaning of one. The pod template placement is
+normative, because a cost reconciler allocates by pod labels — a Job-only label is
+invisible to it.
+
+`buildJobSpec` SHALL also stamp `cortex/analysis-id` (= `meta.analysisId`) and
+`cortex/run-id` (= `meta.runId`) on both, because these two are facts of the run
+that the provider already holds.
+
+Every value SHALL pass through `sanitizeLabelValue`, including a host value. One
+invalid value makes the API server reject the whole Job at admission, thus the
+guard stays even though the host promises a valid value.
+
+When `CreateSandboxMeta.podLabels` is absent, the Job SHALL carry the provider's
+own labels only, and the spawn SHALL proceed unchanged.
+
+#### Scenario: The host labels reach the pod template
+
+- **GIVEN** `CreateSandboxMeta` with `podLabels = { "cortex/billing-context": B, "cortex/user-id": U }`, `analysisId: A`, and `runId: R`
+- **WHEN** the Job spec is built
+- **THEN** the pod template labels include `cortex/billing-context: B`, `cortex/user-id: U`, `cortex/analysis-id: A`, and `cortex/run-id: R`
+- **AND** the Job metadata labels include the same four labels
+
+#### Scenario: A host value is sanitized
+
+- **GIVEN** `podLabels = { "cortex/user-id": "user@example.com" }`
+- **WHEN** the Job spec is built
+- **THEN** the pod template carries `cortex/user-id: user-example.com`
+
+#### Scenario: An arbitrary host key passes through
+
+- **GIVEN** `podLabels = { "example.com/tenant": "acme" }`
+- **WHEN** the Job spec is built
+- **THEN** the pod template carries `example.com/tenant: acme`
+
+#### Scenario: An absent map stamps nothing extra and still spawns
+
+- **GIVEN** `CreateSandboxMeta` without `podLabels`
+- **WHEN** `createSandbox(meta)` runs
+- **THEN** the pod template carries `cortex/analysis-id` and `cortex/run-id` and no host label
+- **AND** the Job is still created and the sandbox becomes Ready
+
+## REMOVED Requirements
+
+### Requirement: Billing attribution labels on Job and pod template
+
+**Reason**: The provider derived `cortex/billing-context` and `cortex/user-id`
+from `CreateSandboxMeta.billing`, thus it held a billing vocabulary that belongs
+to the host. The host now gives the labels in final form.
+
+**Migration**: `CreateSandboxMeta.billing` becomes `podLabels`. A host that wants
+the same two labels puts them in the map under the same two keys.

--- a/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/tasks.md
+++ b/harness/openspec/changes/stamp-opaque-sandbox-pod-labels/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — stamp-opaque-sandbox-pod-labels
+
+## 1. The opaque label map
+
+- [x] 1.1 Replace `CreateSandboxMeta.billing` with `podLabels?: Record<string, string>` in `src/sandbox/types.ts`, documented as opaque host labels.
+- [x] 1.2 Stamp `meta.podLabels` on both the Job metadata and the pod template in `src/sandbox/k8s-client.ts`; keep `cortex/analysis-id` and `cortex/run-id` derived from `meta`; keep `sanitizeLabelValue` on each value; delete the `BILLING_CONTEXT_LABEL` and `USER_ID_LABEL` constants.
+
+## 2. The spawn seam
+
+- [x] 2.1 `src/workflows/sandbox-step.ts`: replace `resolveBilling` with `resolvePodLabels` on `SandboxStepDeps`; call it inside the existing `sandbox.create` step; warn and spawn unlabeled when it throws or gives an empty map.
+- [x] 2.2 `src/tasks/data-profile.ts`: the same replacement on `DataProfileDeps`, resolved inline at the spawn.
+
+## 3. Tests
+
+- [x] 3.1 `src/sandbox/k8s-client.test.ts`: the host labels reach both the Job and the pod template; each value is sanitized; an arbitrary host key passes through; an absent map keeps the harness's own two labels and still spawns.
+- [x] 3.2 `src/workflows/sandbox-step.test.ts`: the resolved map reaches the spawn; the seam sees the step's own session; an absent seam and a seam that throws each spawn with no labels and complete the step.
+
+## 4. Release
+
+- [x] 4.1 Bump `harness/package.json` to 0.20.0 — the dep change is breaking.
+
+## 5. Verification
+
+- [x] 5.1 `npx tsc --noEmit`, `npx eslint .`, and `bun test`.
+- [ ] 5.2 Staging: run an analysis and read the pod labels with `kubectl get pods -n staging-sandbox --show-labels`; the reconciler dispatches allocations for the run.
+
+## Notes
+
+- `restore-sandbox-billing-labels` is the superseded change. Archive it before
+  this one, so that the removed requirements resolve against the main specs.

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.19.2",
+    "version": "0.20.0",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -713,7 +713,7 @@ describe("sanitizeLabelValue", () => {
     });
 });
 
-describe("k8s billing labels", () => {
+describe("k8s host-supplied pod labels", () => {
     const READY_POD = [
         {
             status: { phase: "Running" as const, podIP: "10.0.0.1" },
@@ -735,7 +735,9 @@ describe("k8s billing labels", () => {
         });
     }
 
-    test("billing meta stamps the four labels on pod template and Job metadata", async () => {
+    test("host labels reach the pod template and the Job metadata, beside the harness's own", async () => {
+        // The pod template is the placement that a cost reconciler allocates on;
+        // a Job-only label never reaches it.
         const stub = stubApis(READY_POD);
         (
             await opsWith(stub).createSandbox(
@@ -745,7 +747,7 @@ describe("k8s billing labels", () => {
                     analysisId: "an-1",
                     childWorkflowId: "run-1-0",
                     resources: { cpu: 2, memoryGb: 4 },
-                    billing: { billingContextId: "bc-123", userId: "user-9" },
+                    podLabels: { "cortex/billing-context": "bc-123", "cortex/user-id": "user-9" },
                 },
                 mintSandboxIdentity("run-1"),
             )
@@ -760,7 +762,7 @@ describe("k8s billing labels", () => {
         }
     });
 
-    test("billing label values are sanitized", async () => {
+    test("host label values are sanitized, because one invalid value loses the whole Job", async () => {
         const stub = stubApis(READY_POD);
         (
             await opsWith(stub).createSandbox(
@@ -770,7 +772,7 @@ describe("k8s billing labels", () => {
                     analysisId: "an-1",
                     childWorkflowId: "data-profile:x",
                     resources: { cpu: 1, memoryGb: 1 },
-                    billing: { billingContextId: "bc:123", userId: "user@example.com" },
+                    podLabels: { "cortex/billing-context": "bc:123", "cortex/user-id": "user@example.com" },
                 },
                 mintSandboxIdentity("data-profile"),
             )
@@ -782,7 +784,26 @@ describe("k8s billing labels", () => {
         expect(podLabels["cortex/run-id"]).toBe("data-profile");
     });
 
-    test("absent billing meta stamps no billing labels and still spawns", async () => {
+    test("an arbitrary host key is stamped verbatim — the harness reads no key", async () => {
+        const stub = stubApis(READY_POD);
+        (
+            await opsWith(stub).createSandbox(
+                {
+                    runId: "run-1",
+                    stepId: "step-a",
+                    analysisId: "an-1",
+                    childWorkflowId: "run-1-0",
+                    resources: { cpu: 2, memoryGb: 4 },
+                    podLabels: { "example.com/tenant": "acme" },
+                },
+                mintSandboxIdentity("run-1"),
+            )
+        )._unsafeUnwrap();
+
+        expect(stub.createdJobs[0]!.spec!.template.metadata!.labels!["example.com/tenant"]).toBe("acme");
+    });
+
+    test("absent pod labels stamp nothing extra and still spawn", async () => {
         const stub = stubApis(READY_POD);
         const ref = (
             await opsWith(stub).createSandbox(
@@ -801,8 +822,10 @@ describe("k8s billing labels", () => {
         for (const labels of [stub.createdJobs[0]!.metadata!.labels!, stub.createdJobs[0]!.spec!.template.metadata!.labels!]) {
             expect(labels["cortex/billing-context"]).toBeUndefined();
             expect(labels["cortex/user-id"]).toBeUndefined();
+            // The two identifiers the harness holds itself stay on both.
+            expect(labels["cortex/analysis-id"]).toBe("an-1");
+            expect(labels["cortex/run-id"]).toBe("run-1");
         }
-        expect(stub.createdJobs[0]!.spec!.template.metadata!.labels!["cortex/analysis-id"]).toBeUndefined();
     });
 });
 

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -42,10 +42,6 @@ const MANAGED_BY_VALUE = "cortex";
 const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
-// OpenCost sanitizes `/` and `-` to `_`, so these arrive at the metering
-// reconciler as cortex_billing_context / cortex_user_id / cortex_analysis_id.
-const BILLING_CONTEXT_LABEL = "cortex/billing-context";
-const USER_ID_LABEL = "cortex/user-id";
 const ANALYSIS_ID_LABEL = "cortex/analysis-id";
 
 /**
@@ -281,17 +277,15 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
     if (config.tolerations) podSpec.tolerations = config.tolerations;
     if (config.runtimeClassName) podSpec.runtimeClassName = config.runtimeClassName;
 
-    // Pod-template placement is load-bearing: the OpenCost reconciler allocates
-    // by pod labels and filters on a non-empty cortex_billing_context — a
-    // Job-only label is invisible to compute metering.
-    const billingLabels: Record<string, string> = meta.billing
-        ? {
-              [BILLING_CONTEXT_LABEL]: sanitizeLabelValue(meta.billing.billingContextId),
-              [USER_ID_LABEL]: sanitizeLabelValue(meta.billing.userId),
-              [ANALYSIS_ID_LABEL]: sanitizeLabelValue(meta.analysisId),
-              [RUN_ID_LABEL]: sanitizeLabelValue(meta.runId),
-          }
-        : {};
+    // Pod-template placement is load-bearing: a cost reconciler allocates by pod
+    // labels, thus a Job-only label is invisible to it. The host labels stay
+    // opaque — every value passes through `sanitizeLabelValue`, because one
+    // malformed value makes the API server reject the whole Job at admission.
+    const attributionLabels: Record<string, string> = {
+        [ANALYSIS_ID_LABEL]: sanitizeLabelValue(meta.analysisId),
+        [RUN_ID_LABEL]: sanitizeLabelValue(meta.runId),
+        ...Object.fromEntries(Object.entries(meta.podLabels ?? {}).map(([key, value]) => [key, sanitizeLabelValue(value)])),
+    };
 
     return {
         apiVersion: "batch/v1",
@@ -304,9 +298,8 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
                 role: "sandbox",
                 "cortex/sandbox-id": sandboxId,
                 [OWNER_WORKFLOW_LABEL]: sanitizeLabelValue(meta.childWorkflowId),
-                [RUN_ID_LABEL]: sanitizeLabelValue(meta.runId),
                 [STEP_ID_LABEL]: sanitizeLabelValue(meta.stepId),
-                ...billingLabels,
+                ...attributionLabels,
             },
         },
         spec: {
@@ -317,7 +310,7 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
                     labels: {
                         role: "sandbox",
                         "cortex/sandbox-id": sandboxId,
-                        ...billingLabels,
+                        ...attributionLabels,
                     },
                 },
                 spec: podSpec,

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -237,9 +237,10 @@ export interface CreateSandboxMeta {
     /** Enforced read-only: provision with no read-write step mount, only the
      *  read-only analysis tree for generic read-only agents. */
     readOnly?: boolean;
-    /** Billing attribution stamped as pod labels for OpenCost compute metering.
-     *  Absent ⇒ the pod is invisible to the metering reconciler (filter-level). */
-    billing?: { billingContextId: string; userId: string };
+    /** Host-supplied labels stamped onto the sandbox pod, verbatim. Opaque here:
+     *  the harness reads no key and no value, it only sanitizes each value into a
+     *  valid label. Absent ⇒ the pod carries the harness's own labels only. */
+    podLabels?: Record<string, string>;
 }
 
 /**

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -33,7 +33,6 @@ import { runToTerminal } from "../loop/run-to-terminal.js";
 import { durableStep } from "../loop/run-step.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
-import type { ResolveBilling } from "../billing/resolver.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { defineTool } from "../tools/define-tool.js";
@@ -70,9 +69,6 @@ import { DATA_PROFILE_RUN_LITERAL } from "../contracts/data-profile.js";
 const DATA_PROFILE_STEP_LITERAL = "profile" as const;
 const DATA_PROFILE_AGENT_ID = "data-profiler" as const;
 
-/** Resolved-header key carrying the billing-context id (see `ResolveBilling`). */
-const BILLING_CONTEXT_HEADER = "X-Inflexa-Billing-Context";
-
 /** Sandbox-server exec budget for the profile run. */
 const DEFAULT_DEADLINE_MS = 300_000;
 
@@ -102,9 +98,13 @@ export interface DataProfileDeps extends EnvironmentStorePaths {
     readonly skillsDir: string;
     /** LLM usage-accounting seam for the profiler agent loop; omitted falls back to the no-op recorder. */
     readonly usageRecorder?: UsageRecorder;
-    /** Resolves the billing context stamped as the sandbox pod's OpenCost
-     *  labels. Absent in upstream-less (dev/OSS) wiring — pods spawn unlabeled. */
-    readonly resolveBilling?: ResolveBilling;
+    /**
+     * Host-supplied labels for the profiler's sandbox pod, resolved under the
+     * profiling session. The map is opaque to the harness: it stamps each entry
+     * and interprets none of it. Absent in a wiring that attributes nothing —
+     * the pod then carries the harness's own labels only.
+     */
+    readonly resolvePodLabels?: (session: RunSession) => Promise<Record<string, string>>;
 }
 
 /**
@@ -340,14 +340,16 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
         // run panel's activity readout was built to remove.
         await activity.sandboxInit();
 
-        let billingContextId: string | undefined;
-        if (deps.resolveBilling) {
+        let podLabels: Record<string, string> | undefined;
+        if (deps.resolvePodLabels) {
             try {
-                billingContextId = (await deps.resolveBilling(childSession))[BILLING_CONTEXT_HEADER];
+                podLabels = await deps.resolvePodLabels(childSession);
             } catch (err) {
-                logger.error("[billing] data-profile billing resolution failed", logger.errorFields(err));
+                logger.warn("pod-label resolution failed", logger.errorFields(err));
             }
-            if (!billingContextId) logger.error("[billing] sandbox spawned without billing labels");
+            // A wired resolver that yields nothing is the one loud case: the host
+            // asked for attribution and the pod spawns without it.
+            if (!podLabels || Object.keys(podLabels).length === 0) logger.warn("sandbox spawned with no pod labels");
         }
 
         const sandbox = await deps.sandboxClient.createSandbox(
@@ -357,7 +359,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                 analysisId,
                 childWorkflowId: workflowId,
                 resources: estimateDataProfileResources(stagedInputs),
-                billing: billingContextId ? { billingContextId, userId: childSession.identity.user } : undefined,
+                podLabels,
             },
             mintSandboxIdentity(DATA_PROFILE_RUN_LITERAL),
         );

--- a/harness/src/workflows/sandbox-step.test.ts
+++ b/harness/src/workflows/sandbox-step.test.ts
@@ -9,6 +9,9 @@
  *   - The `data-step-usage` run-event part: what the step's loop spent reaches
  *     the run stream once the loop completes, under the step's stable part id,
  *     and is absent entirely when the loop reported nothing.
+ *   - The host's sandbox pod labels: what the `resolvePodLabels` seam returns is
+ *     what the spawn carries, and a seam that is absent or that throws still
+ *     spawns the step.
  *
  * The usage tests drive `runSandboxStepBody` against a fake DBOS surface and a
  * fake deps bundle, the same shape `execute-analysis.test.ts` uses for the
@@ -30,7 +33,7 @@ import { silentLogger } from "../__tests__/setup/logger.js";
 import { classifyReadPath } from "../provenance/collector.js";
 import type { AgentChat, ChatResponse, ChatUsage, EmbeddingProvider } from "../providers/types.js";
 import type { SandboxClient } from "../sandbox/client.js";
-import type { SandboxRef } from "../sandbox/types.js";
+import type { CreateSandboxMeta, SandboxRef } from "../sandbox/types.js";
 import type { ArtifactRegistry } from "../execution/artifact-registry.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
 import { createLineageCollector, runSandboxStepBody, type SandboxStepDeps, type SandboxStepInput } from "./sandbox-step.js";
@@ -163,9 +166,12 @@ const SANDBOX_REF: SandboxRef = {
     callbackSecret: "base64:unused",
 };
 
-function makeSandboxClient(): SandboxClient {
+function makeSandboxClient(spawns: CreateSandboxMeta[] = []): SandboxClient {
     return {
-        createSandbox: async () => SANDBOX_REF,
+        createSandbox: async (meta: CreateSandboxMeta) => {
+            spawns.push(meta);
+            return SANDBOX_REF;
+        },
         submitExec: async () => undefined,
         awaitExec: async () => {
             throw new Error("awaitExec: the usage tests run a tool-less agent");
@@ -360,5 +366,66 @@ describe("sandbox-step data-step-usage part", () => {
 
         const folded = usageParts(foldStream(dbosState.emittedParts));
         expect(folded.map((p) => p.stepId).sort()).toEqual(["T1S1", "T1S2"]);
+    });
+});
+
+// ── host-supplied sandbox pod labels ─────────────────────────────────
+
+describe("sandbox-step pod labels", () => {
+    /** Deps whose spawns are recorded, under the given `resolvePodLabels` seam. */
+    function podLabelDeps(resolvePodLabels?: SandboxStepDeps["resolvePodLabels"]): { deps: SandboxStepDeps; spawns: CreateSandboxMeta[] } {
+        const spawns: CreateSandboxMeta[] = [];
+        const deps: SandboxStepDeps = {
+            ...usageStepDeps(undefined),
+            sandboxClient: makeSandboxClient(spawns),
+            ...(resolvePodLabels ? { resolvePodLabels } : {}),
+        };
+        return { deps, spawns };
+    }
+
+    it("carries what the host resolved into the spawn, verbatim", async () => {
+        const labels = { "cortex/billing-context": "bc-1", "example.com/tenant": "acme" };
+        const { deps, spawns } = podLabelDeps(async () => labels);
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(spawns.length).toBe(1);
+        expect(spawns[0]!.podLabels).toEqual(labels);
+    });
+
+    it("resolves under the step's own session, so the labels name the step that spawns", async () => {
+        const seen: RunSession[] = [];
+        const { deps } = podLabelDeps(async (session) => {
+            seen.push(session);
+            return {};
+        });
+
+        await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(seen.length).toBe(1);
+        expect(seen[0]!.provenance.agentId).toBe(USAGE_AGENT_ID);
+        expect(seen[0]!.runFrame).toEqual({ runId: USAGE_RUN_ID, stepId: USAGE_STEP_ID });
+    });
+
+    it("spawns with no labels and completes when no seam is wired", async () => {
+        const { deps, spawns } = podLabelDeps();
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(spawns[0]!.podLabels).toBeUndefined();
+    });
+
+    it("spawns with no labels and completes when the seam throws", async () => {
+        // Attribution is never a gate on compute: the step runs unlabeled.
+        const { deps, spawns } = podLabelDeps(async () => {
+            throw new Error("upstream unreachable");
+        });
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(spawns[0]!.podLabels).toBeUndefined();
     });
 });

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -35,7 +35,6 @@ import type { Pool } from "pg";
 import { insertStepExecution, updateStepExecution } from "../state/index.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
-import type { ResolveBilling } from "../billing/resolver.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { CitationResolver } from "../citations/types.js";
 import { unwrapOrThrow } from "../lib/result.js";
@@ -132,9 +131,6 @@ export interface SandboxStepInput {
  * declare it explicitly.
  */
 export const DEFAULT_STEP_TIMEOUT_SECONDS = 3600;
-
-/** Resolved-header key carrying the billing-context id (see `ResolveBilling`). */
-const BILLING_CONTEXT_HEADER = "X-Inflexa-Billing-Context";
 
 export type SandboxStepStatus = "complete" | "failed" | "canceled" | "blocked";
 
@@ -274,9 +270,13 @@ export interface SandboxStepDeps {
     /** Write-side embedder for the post-step vector index. */
     readonly embedding: EmbeddingProvider;
     readonly sandboxClient: SandboxClient;
-    /** Resolves the billing context stamped as the sandbox pod's OpenCost
-     *  labels. Absent in upstream-less (dev/OSS) wiring — pods spawn unlabeled. */
-    readonly resolveBilling?: ResolveBilling;
+    /**
+     * Host-supplied labels for this step's sandbox pod, resolved under the
+     * step's session. The map is opaque to the harness: it stamps each entry
+     * and interprets none of it. Absent in a wiring that attributes nothing —
+     * the pod then carries the harness's own labels only.
+     */
+    readonly resolvePodLabels?: (session: RunSession) => Promise<Record<string, string>>;
     /**
      * External artifact registration + sync seam. The harness's post-step pipeline
      * registers each step's outputs through it (filesystem index in the
@@ -435,7 +435,7 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
 
     // (2b) sandbox.create — spawn (or adopt) the machine under the minted
     // identity. The handle (secret included) is cached so recovery picks the
-    // same machine back up without re-provisioning. Billing resolution lives
+    // same machine back up without re-provisioning. Pod-label resolution lives
     // INSIDE this step (not as its own step) so the child's step sequence is
     // unchanged — in-flight workflows resumed across a deploy replay cleanly.
     const sandboxMeta: CreateSandboxMeta = {
@@ -449,17 +449,18 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
     };
     const sandbox = await DBOS.runStep(
         async () => {
-            let billing: CreateSandboxMeta["billing"];
-            if (deps.resolveBilling) {
+            let podLabels: Record<string, string> | undefined;
+            if (deps.resolvePodLabels) {
                 try {
-                    const bcId = (await deps.resolveBilling(session))[BILLING_CONTEXT_HEADER];
-                    if (bcId) billing = { billingContextId: bcId, userId: input.runSession.identity.user };
+                    podLabels = await deps.resolvePodLabels(session);
                 } catch (err) {
-                    logger.error("[billing] step billing resolution failed", { analysisId: input.analysisId, ...logger.errorFields(err) });
+                    logger.warn("pod-label resolution failed", { analysisId: input.analysisId, ...logger.errorFields(err) });
                 }
-                if (!billing) logger.error("[billing] sandbox spawned without billing labels", { analysisId: input.analysisId });
+                // A wired resolver that yields nothing is the one loud case: the
+                // host asked for attribution and the pod spawns without it.
+                if (!podLabels || Object.keys(podLabels).length === 0) logger.warn("sandbox spawned with no pod labels", { analysisId: input.analysisId });
             }
-            return deps.sandboxClient.createSandbox({ ...sandboxMeta, billing }, identity);
+            return deps.sandboxClient.createSandbox({ ...sandboxMeta, podLabels }, identity);
         },
         { name: "sandbox.create" },
     );


### PR DESCRIPTION
## What & why

Sandbox pods carry no attribution labels, thus the OpenCost reconciler — which filters allocations on a non-empty billing-context pod label — sees no sandbox pod at all. `restore-sandbox-billing-labels` read the billing-context id out of the `ResolveBilling` seam by the raw map key `X-Inflexa-Billing-Context`. That seam is typed `(session) => Promise<BillingHeaders>`, which is the FINAL wire headers: a managed host rewrites each key to `x-bf-lh-<name>` for its gateway. The raw key is thus never present, the read always gives `undefined`, `meta.billing` stays unset, and `buildJobSpec` stamps nothing. Staging confirms it.

The key mismatch is the symptom. The cause is that the harness knows what a billing context is. It must not: a billing context is a coordinate of one host's metering system, and the harness has no use for the value that it reads.

`CreateSandboxMeta.billing` becomes `podLabels?: Record<string, string>` — an opaque map that the harness stamps on both the Job metadata and the pod template and never reads. The host supplies the labels in final form; Nexus pull request #145 does this (`resolve-headers` becomes `resolve-attribution`, which gives `{ headers, podLabels }`).

## Notes for the reviewer

- **The pod template placement is load-bearing.** The reconciler allocates by pod labels, thus a Job-only label is invisible to it. Both placements carry the same map.
- **`sanitizeLabelValue` stays on every value**, including a host value. One invalid value makes the API server reject the whole Job at admission, and the step then loses its sandbox.
- **The resolution stays inside the existing `sandbox.create` DBOS step.** A separate step would shift the child workflow's step sequence and break replay for an in-flight workflow that resumes across the deploy.
- **Attribution never blocks compute.** An absent seam spawns unlabeled and silent — the host chose to attribute nothing. A wired seam that throws, or that gives an empty map, warns and spawns unlabeled.
- **No LLM call loses its billing.** `deps.resolveBilling` had exactly one consumer in each of the two touched files, which is the lookup that this change deletes. The providers keep their own separately wired resolvers, and `src/providers/*` and `src/billing/resolver.ts` are untouched.
- **Breaking** for an embedder that wires `resolveBilling` into `SandboxStepDeps` or `DataProfileDeps`: version 0.20.0.
- OpenSpec change: `harness/openspec/changes/stamp-opaque-sandbox-pod-labels/`. It supersedes `restore-sandbox-billing-labels`, which must archive first so that the removed requirements resolve.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Sandbox:** the security model is preserved. Only the label metadata of the Job and the pod template changes. The pod spec, the security context, the mounts, the network posture, and the exec authentication are untouched.