### PR TITLE
feat(harness): format the report numbers with one render helper

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/design.md
@@ -4,7 +4,7 @@ The render path is pure and deterministic (`report-render/render.ts`), and the i
 
 ## Goals / Non-Goals
 
-- Goal: one number helper in the render layer, three kinds, applied at the metric value, the numeric table cell, and the chart axis label.
+- Goal: one number helper in the render layer, applied at the metric value and at the numeric table cell. The chart takes only the static count-axis bound.
 - Goal: the full digits on hover through the `title` attribute, only when the shown form hides digits. The `Price` component of Lumen is the reference for that rule.
 - Goal: a metric-card overflow guard in the design CSS.
 - Non-goal: a format field on any block. A block names content, never presentation.
@@ -13,8 +13,8 @@ The render path is pure and deterministic (`report-render/render.ts`), and the i
 ## Decisions
 
 - **The helper is a pure function in the render layer, beside the design source.** It takes a cell (`string | number`) and a kind, and it gives `{ text, full? }`. `full` is present only when `text` hides digits, and the view emits `title` from it. The alternative was a formatter inside each view, and that drifts.
-- **The three kinds.** `scientific`: a coefficient with 2 significant digits and an `e` exponent, for example `4.3e-5`. `compact`: an integer with comma grouping, for example `14,201`. `compact-scientific`: a decimal rounded to 3 significant digits, for example `-3.09`, and it falls to the scientific form when the magnitude drops under `1e-3`.
-- **The kind selection is by magnitude and by column meaning.** A column whose lowercase name contains `p`, `padj`, `pval`, `fdr`, or `q` as a p-value token selects `scientific` for a value in `(0, 1)`. An integer value selects `compact`. Every other finite number selects `compact-scientific`. A non-numeric cell passes through unchanged.
+- **The four kinds.** `scientific`: a coefficient with 2 significant digits and an `e` exponent, for example `4.3e-5`. `compact`: an integer with comma grouping, for example `14,201`. `compact-scientific`: a decimal rounded to 3 significant digits, for example `-3.09`. It falls to the scientific form under `1e-3`, and it shows a grouped whole number from `1e3` up to `1e15`. `identifier`: the pass-through of an identifier cell, with no grouping and no title.
+- **The kind selection is by magnitude and by column meaning.** A p-value token in the column name (`p`, `pval`, `pvalue`, `padj`, `fdr`, `q`, `qval`) selects `scientific` for a value in `(0, 1e-2)`. An identifier token (`id`, `pmid`, `doi`, `entrez`, `taxid`, `year`, `accession`) selects the pass-through. The match reads whole tokens only. An integer value selects `compact`. Every other finite number selects `compact-scientific`. A non-numeric cell passes through unchanged.
 - **No locale API.** The grouping writes its own comma insertion, and the exponent form derives from `toExponential`. `toLocaleString` would break the determinism rule of the render function.
 - **The axis labels format inside the option, without a function.** The option rides as inline JSON, thus a function formatter is impossible. A string template of ECharts can carry `{value}` alone. Thus the derivation bounds the tick precision where the option admits text. Where it cannot, the axis keeps the ECharts default, and the scenario stays honest about that bound.
 - **The overflow guard.** `.stat-card-value` gains `overflow-wrap: anywhere` and a smaller size step under a container query is out of scope. The formatted value is short by construction, thus the guard is a backstop and not the fix.

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The render path is pure and deterministic (`report-render/render.ts`), and the identity lives in one design source (`report-render/design.ts`). The views emit plain HTML strings. The chart derivation (`chart.ts`) builds one ECharts option per chart block, and its own doc bans a locale read and a clock read. The first real report showed clipped metric cards, 16-digit table cells, and long float axis ticks.
+
+## Goals / Non-Goals
+
+- Goal: one number helper in the render layer, three kinds, applied at the metric value, the numeric table cell, and the chart axis label.
+- Goal: the full digits on hover through the `title` attribute, only when the shown form hides digits. The `Price` component of Lumen is the reference for that rule.
+- Goal: a metric-card overflow guard in the design CSS.
+- Non-goal: a format field on any block. A block names content, never presentation.
+- Non-goal: prose rounding. The agent authors prose, and the renderer does not rewrite it.
+
+## Decisions
+
+- **The helper is a pure function in the render layer, beside the design source.** It takes a cell (`string | number`) and a kind, and it gives `{ text, full? }`. `full` is present only when `text` hides digits, and the view emits `title` from it. The alternative was a formatter inside each view, and that drifts.
+- **The three kinds.** `scientific`: a coefficient with 2 significant digits and an `e` exponent, for example `4.3e-5`. `compact`: an integer with comma grouping, for example `14,201`. `compact-scientific`: a decimal rounded to 3 significant digits, for example `-3.09`, and it falls to the scientific form when the magnitude drops under `1e-3`.
+- **The kind selection is by magnitude and by column meaning.** A column whose lowercase name contains `p`, `padj`, `pval`, `fdr`, or `q` as a p-value token selects `scientific` for a value in `(0, 1)`. An integer value selects `compact`. Every other finite number selects `compact-scientific`. A non-numeric cell passes through unchanged.
+- **No locale API.** The grouping writes its own comma insertion, and the exponent form derives from `toExponential`. `toLocaleString` would break the determinism rule of the render function.
+- **The axis labels format inside the option, without a function.** The option rides as inline JSON, thus a function formatter is impossible. A string template of ECharts can carry `{value}` alone. Thus the derivation bounds the tick precision where the option admits text. Where it cannot, the axis keeps the ECharts default, and the scenario stays honest about that bound.
+- **The overflow guard.** `.stat-card-value` gains `overflow-wrap: anywhere` and a smaller size step under a container query is out of scope. The formatted value is short by construction, thus the guard is a backstop and not the fix.
+
+## Risks / Trade-offs
+
+- [A p-value token match can misread an unrelated column] → the match reads whole tokens, split on `_` and on case. It never reads a bare substring.
+- [The option admits no text for some ticks] → the axis keeps the default there. The scenario states the bound, thus the spec stays true.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The renderer prints each resolved value at full float precision. On the first real report a metric card clipped `-5.7618623255…`, a p-value wrapped onto a second line, and a table cell printed 16 significant digits. The prose and the cards also round differently.
+
+## What Changes
+
+- One number helper lands in the report-render design source. It has three kinds: `scientific`, `compact`, and `compact-scientific`.
+- The renderer applies the helper to the metric value, to each numeric table cell, and to the chart axis labels.
+- The renderer picks the kind by magnitude and by column meaning. No block gains a format field, because a block names content and never presentation.
+- The full digits appear on hover, through the `title` attribute. The tooltip appears only when the helper hid digits.
+- The metric card gains an overflow guard, thus a value can never paint past its card edge.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-render`: a new requirement gives the number format of a resolved numeric value: the three kinds, the kind selection, and the full-digits hover.
+- `report-design-system`: the metric-card component gains the overflow guard, thus a long value stays inside the card.
+
+## Impact
+
+- `harness/src/report-render/design.ts` — the helper and the guard styles.
+- `harness/src/report-render/views/values.tsx` and the table view — the call sites of the helper.
+- `harness/src/report-render/chart.ts` — the axis-label formatting.
+- No contract change, no agent change, and no store change.

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/proposal.md
@@ -4,8 +4,8 @@ The renderer prints each resolved value at full float precision. On the first re
 
 ## What Changes
 
-- One number helper lands in the report-render design source. It has three kinds: `scientific`, `compact`, and `compact-scientific`.
-- The renderer applies the helper to the metric value, to each numeric table cell, and to the chart axis labels.
+- One number helper lands in the report-render layer, beside the design source. It has three kinds: `scientific`, `compact`, and `compact-scientific`.
+- The renderer applies the helper to the metric value and to each numeric table cell. The chart option admits no formatter, thus only the histogram count axis takes a static whole-tick bound.
 - The renderer picks the kind by magnitude and by column meaning. No block gains a format field, because a block names content and never presentation.
 - The full digits appear on hover, through the `title` attribute. The tooltip appears only when the helper hid digits.
 - The metric card gains an overflow guard, thus a value can never paint past its card edge.
@@ -23,7 +23,8 @@ None.
 
 ## Impact
 
-- `harness/src/report-render/design.ts` — the helper and the guard styles.
-- `harness/src/report-render/views/values.tsx` and the table view — the call sites of the helper.
-- `harness/src/report-render/chart.ts` — the axis-label formatting.
+- `harness/src/report-render/number-format.ts` — the helper.
+- `harness/src/report-render/design.ts` — the overflow guard.
+- `harness/src/report-render/views/values.tsx` — the call sites of the helper.
+- `harness/src/report-render/chart.ts` — the count-axis bound.
 - No contract change, no agent change, and no store change.

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/specs/report-design-system/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/specs/report-design-system/spec.md
@@ -1,0 +1,32 @@
+# Delta: report-design-system
+
+## MODIFIED Requirements
+
+### Requirement: A considered component for each block kind
+The renderer MUST give each block kind its identity component:
+
+- A `text` block renders as prose with a capped measure.
+- A `claim` block renders as prose with the styled evidence markers.
+- A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
+- A consecutive run of `metric` siblings renders as one responsive grid.
+- A `table` block renders as a data table inside a corner-accent card.
+- A `chart` block renders as a window-chrome panel with a fixed-height chart body.
+- A `figure` block renders as a corner-accent card with its caption.
+- A `citation` block renders as a card in the reference form.
+- A `section` block renders as a heading by depth.
+
+#### Scenario: Consecutive metrics form one grid
+- **WHEN** the caller renders a section with three metric blocks in a row
+- **THEN** one grid holds the three stat cards
+
+#### Scenario: A lone metric stays a card
+- **WHEN** the caller renders a section with one metric block between two text blocks
+- **THEN** the metric renders as one stat card, and no grid wraps the text
+
+#### Scenario: A chart panel carries the chrome and a height
+- **WHEN** the caller renders a chart block
+- **THEN** the panel holds the chrome header with the dots and the `CORTEX` badge, and the chart container carries a fixed height
+
+#### Scenario: A long metric value stays inside its card
+- **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
+- **THEN** the value stays inside the card bounds, and no character paints past the card edge

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/specs/report-render/spec.md
@@ -1,0 +1,34 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The number format of a resolved value
+The renderer MUST format each numeric value that it shows, through one number helper with three kinds: `scientific`, `compact`, and `compact-scientific`. The helper applies to the metric value and to each numeric table cell. The renderer picks the kind by magnitude and by column meaning, and no block carries a format field.
+
+The chart option rides as inline JSON, thus no function can format an axis tick. The derivation MUST bound an axis only where a static option field can state the bound. The count axis of a histogram holds whole ticks. Every other axis keeps the tick algorithm of the chart runtime.
+
+When the shown form hides digits, the element MUST carry the full digits in its `title` attribute. When the shown form hides no digit, the element carries no `title` attribute. The helper MUST be deterministic: it reads no locale, thus the same value gives the same text on every host.
+
+#### Scenario: A p-value renders in the scientific kind
+- **WHEN** the caller renders a metric whose value resolves to `0.0000427777663038`
+- **THEN** the card shows a scientific form such as `4.3e-5`, and the `title` attribute holds the full digits
+
+#### Scenario: A long float renders with few significant digits
+- **WHEN** the caller renders a table cell that holds `-3.089028528355109`
+- **THEN** the cell shows a short form such as `-3.09`, and the `title` attribute holds the full digits
+
+#### Scenario: A count renders in the compact kind
+- **WHEN** the caller renders a value that is a large integer count such as `14201`
+- **THEN** the text shows the grouped form `14,201`, and the `title` attribute holds the full digits only when the shown form hides a digit
+
+#### Scenario: A short value carries no tooltip
+- **WHEN** the caller renders a value whose full form already shows every digit, such as `42`
+- **THEN** the text shows `42`, and the element carries no `title` attribute
+
+#### Scenario: A non-numeric cell passes through
+- **WHEN** the caller renders a table cell that holds the text `up`
+- **THEN** the cell shows `up` unchanged
+
+#### Scenario: A count axis holds whole ticks
+- **WHEN** the caller derives a histogram option
+- **THEN** the count axis carries a whole-tick bound, thus no count tick shows a fraction

--- a/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-format-the-report-numbers/tasks.md
@@ -1,0 +1,17 @@
+## 1. The number helper
+
+- [x] 1.1 Make the pure helper in `src/report-render/` beside the design source. It takes a cell and a kind, and it gives `{ text, full? }`. `full` is present only when `text` hides digits. No locale API.
+- [x] 1.2 Make the kind selection: a whole-token p-value column name selects `scientific` for a value in `(0, 1)`, an integer selects `compact`, and every other finite number selects `compact-scientific`. A non-numeric cell passes through.
+- [x] 1.3 Unit tests for the helper: the scientific form, the grouping, the significant digits, the `full` presence rule, and the pass-through.
+
+## 2. The call sites
+
+- [x] 2.1 Apply the helper to the metric value in `src/report-render/views/values.tsx`, with the `title` attribute from `full`.
+- [x] 2.2 Apply the helper to each numeric table cell in the table view, with the `title` attribute from `full`.
+- [x] 2.3 Bound the chart axis tick precision in `src/report-render/chart.ts` where the inline JSON option admits text. Keep the derivation deterministic.
+- [x] 2.4 Add the metric-card overflow guard to `DESIGN_CSS` in `src/report-render/design.ts`.
+
+## 3. The gates
+
+- [x] 3.1 Extend the render tests for the new forms: the metric card, the table cell, and the axis. Run the targeted `report-render` test files only.
+- [x] 3.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-design-system/spec.md
+++ b/harness/openspec/specs/report-design-system/spec.md
@@ -35,7 +35,7 @@ The renderer MUST give each block kind its identity component:
 
 - A `text` block renders as prose with a capped measure.
 - A `claim` block renders as prose with the styled evidence markers.
-- A `metric` block renders as a stat card with a mono value and an accent.
+- A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
 - A consecutive run of `metric` siblings renders as one responsive grid.
 - A `table` block renders as a data table inside a corner-accent card.
 - A `chart` block renders as a window-chrome panel with a fixed-height chart body.
@@ -54,6 +54,10 @@ The renderer MUST give each block kind its identity component:
 #### Scenario: A chart panel carries the chrome and a height
 - **WHEN** the caller renders a chart block
 - **THEN** the panel holds the chrome header with the dots and the `CORTEX` badge, and the chart container carries a fixed height
+
+#### Scenario: A long metric value stays inside its card
+- **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
+- **THEN** the value stays inside the card bounds, and no character paints past the card edge
 
 ### Requirement: The geometric identity rules
 A data card MUST hold square corners with the corner accents. The window-chrome panel is the one exception, and it MUST hold rounded corners. The theme MUST stay light: white and slate surfaces, with dark only in the footer.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -74,6 +74,37 @@ The renderer MUST give each of the eight block kinds a rendered form. The render
 - **WHEN** the caller renders a chart block whose value entry holds zero rows
 - **THEN** the page holds the chart container, and the inline option holds an empty data list
 
+### Requirement: The number format of a resolved value
+The renderer MUST format each numeric value that it shows, through one number helper with three kinds: `scientific`, `compact`, and `compact-scientific`. The helper applies to the metric value and to each numeric table cell. The renderer picks the kind by magnitude and by column meaning, and no block carries a format field.
+
+The chart option rides as inline JSON, thus no function can format an axis tick. The derivation MUST bound an axis only where a static option field can state the bound. The count axis of a histogram holds whole ticks. Every other axis keeps the tick algorithm of the chart runtime.
+
+When the shown form hides digits, the element MUST carry the full digits in its `title` attribute. When the shown form hides no digit, the element carries no `title` attribute. The helper MUST be deterministic: it reads no locale, thus the same value gives the same text on every host.
+
+#### Scenario: A p-value renders in the scientific kind
+- **WHEN** the caller renders a metric whose value resolves to `0.0000427777663038`
+- **THEN** the card shows a scientific form such as `4.3e-5`, and the `title` attribute holds the full digits
+
+#### Scenario: A long float renders with few significant digits
+- **WHEN** the caller renders a table cell that holds `-3.089028528355109`
+- **THEN** the cell shows a short form such as `-3.09`, and the `title` attribute holds the full digits
+
+#### Scenario: A count renders in the compact kind
+- **WHEN** the caller renders a value that is a large integer count such as `14201`
+- **THEN** the text shows the grouped form `14,201`, and the `title` attribute holds the full digits only when the shown form hides a digit
+
+#### Scenario: A short value carries no tooltip
+- **WHEN** the caller renders a value whose full form already shows every digit, such as `42`
+- **THEN** the text shows `42`, and the element carries no `title` attribute
+
+#### Scenario: A non-numeric cell passes through
+- **WHEN** the caller renders a table cell that holds the text `up`
+- **THEN** the cell shows `up` unchanged
+
+#### Scenario: A count axis holds whole ticks
+- **WHEN** the caller derives a histogram option
+- **THEN** the count axis carries a whole-tick bound, thus no count tick shows a fraction
+
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
 

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -153,6 +153,13 @@ describe("deriveChartOption histogram", () => {
         expect(JSON.stringify(first)).toBe(JSON.stringify(second));
     });
 
+    it("holds the count ticks a whole count apart, thus no tick carries a fraction", () => {
+        // The axis counts rows. `minInterval` is the one static field that bounds a tick, because the
+        // option rides as inline JSON and a function formatter cannot cross it.
+        expect(asObj(derive(block, rows).yAxis).minInterval).toBe(1);
+        expect(asObj(derive(block, []).yAxis).minInterval).toBe(1);
+    });
+
     it("shares the same edges across the groups", () => {
         const groupRows: ChartRow[] = [
             { n: 1, g: "G1" },

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -12,6 +12,11 @@
  * The derivation is deterministic. Every object builds in one fixed key order, and the code reads no
  * clock, no random value, and no locale. A string comparison uses the code-unit order (`<`) and never
  * `localeCompare`, thus the same rows give the same bytes on every host.
+ *
+ * The option rides to the page as inline JSON. Thus no axis label can carry a function formatter, and a
+ * string `axisLabel.formatter` substitutes the value without a round. As a result the derivation bounds the
+ * tick precision of the one axis whose unit it declares itself, and every other value axis keeps the tick
+ * values that ECharts computes.
  */
 
 import { err, ok, type Result } from "neverthrow";
@@ -45,6 +50,14 @@ const VIRIDIS = ["#440154", "#482777", "#3e4989", "#31688e", "#26828e", "#1f9e89
  * value is a fixed constant, thus the derivation stays deterministic.
  */
 const X_AXIS_NAME_GAP = 34;
+
+/**
+ * The y axis of a histogram.
+ *
+ * The axis counts rows, thus a fractional tick names no count. `minInterval` holds each tick a whole count
+ * apart from the next one, and it is the one static field that bounds the tick precision of a value axis.
+ */
+const COUNT_AXIS: EchartOption = { type: "value", name: "Count", minInterval: 1 };
 
 /**
  * The name fields of an x axis.
@@ -171,7 +184,7 @@ function deriveHistogram(block: ChartBlock, rows: readonly ChartRow[], columns: 
     if (rows.length === 0) {
         return ok({
             xAxis: { type: "value", scale: true },
-            yAxis: { type: "value", name: "Count" },
+            yAxis: { ...COUNT_AXIS },
             series: [{ type: "bar", barWidth: "99%", data: [] }],
         });
     }
@@ -198,7 +211,7 @@ function deriveHistogram(block: ChartBlock, rows: readonly ChartRow[], columns: 
 
     return ok({
         xAxis: { type: "value", scale: true },
-        yAxis: { type: "value", name: "Count" },
+        yAxis: { ...COUNT_AXIS },
         series,
     });
 }

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -392,6 +392,9 @@ img {
   font-weight: 700;
   line-height: 1.2;
   color: var(--color-stat-primary);
+  /* A value that the number format cannot shorten, for example a long identifier, breaks inside the card
+     instead of past its edge. */
+  overflow-wrap: anywhere;
 }
 .stat-card-label {
   margin-top: 8px;

--- a/harness/src/report-render/number-format.test.ts
+++ b/harness/src/report-render/number-format.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatNumberCell, selectNumberKind } from "./number-format.js";
+
+describe("formatNumberCell scientific", () => {
+    it("gives a coefficient of two significant digits and an exponent", () => {
+        expect(formatNumberCell(0.0000427777663038, "scientific")).toEqual({ text: "4.3e-5", full: "0.0000427777663038" });
+    });
+
+    it("trims the trailing zero of the coefficient", () => {
+        expect(formatNumberCell(0.5, "scientific")).toEqual({ text: "5e-1" });
+    });
+
+    it("keeps a value that the two digits already carry, and gives no full form", () => {
+        expect(formatNumberCell(2.7e-10, "scientific")).toEqual({ text: "2.7e-10" });
+    });
+});
+
+describe("formatNumberCell compact", () => {
+    it("groups the digits of a large integer", () => {
+        expect(formatNumberCell(14201, "compact")).toEqual({ text: "14,201" });
+    });
+
+    it("groups each run of three digits", () => {
+        expect(formatNumberCell(1234567, "compact")).toEqual({ text: "1,234,567" });
+    });
+
+    it("keeps the sign in front of the groups", () => {
+        expect(formatNumberCell(-1234567, "compact")).toEqual({ text: "-1,234,567" });
+    });
+
+    it("gives no full form for a short integer", () => {
+        expect(formatNumberCell(42, "compact")).toEqual({ text: "42" });
+    });
+});
+
+describe("formatNumberCell compact-scientific", () => {
+    it("rounds a long float to three significant digits", () => {
+        expect(formatNumberCell(-3.089028528355109, "compact-scientific")).toEqual({ text: "-3.09", full: "-3.089028528355109" });
+    });
+
+    it("falls to the scientific form under one thousandth", () => {
+        expect(formatNumberCell(-0.00012345, "compact-scientific")).toEqual({ text: "-1.2e-4", full: "-0.00012345" });
+    });
+
+    it("keeps a value that three digits already carry, and gives no full form", () => {
+        expect(formatNumberCell(2.94, "compact-scientific")).toEqual({ text: "2.94" });
+    });
+
+    it("shows zero as one digit", () => {
+        expect(formatNumberCell(0, "compact-scientific")).toEqual({ text: "0" });
+    });
+});
+
+describe("formatNumberCell pass-through", () => {
+    it("passes a non-numeric string through unchanged and gives no full form", () => {
+        expect(formatNumberCell("up", "compact-scientific")).toEqual({ text: "up" });
+    });
+
+    it("passes a value with a unit suffix through unchanged", () => {
+        expect(formatNumberCell("42.6M", "compact")).toEqual({ text: "42.6M" });
+    });
+
+    it("formats a numeric string and keeps the source text as the full form", () => {
+        expect(formatNumberCell("0.0000427777663038", "scientific")).toEqual({ text: "4.3e-5", full: "0.0000427777663038" });
+    });
+
+    it("passes a value that is not finite through unchanged", () => {
+        expect(formatNumberCell(Number.NaN, "compact")).toEqual({ text: "NaN" });
+        expect(formatNumberCell(Number.POSITIVE_INFINITY, "compact")).toEqual({ text: "Infinity" });
+    });
+});
+
+describe("formatNumberCell determinism", () => {
+    it("gives the same text on two calls, and reads no locale", () => {
+        const first = formatNumberCell(1234567, "compact");
+        const second = formatNumberCell(1234567, "compact");
+        expect(first).toEqual(second);
+        // The grouping is written in this module. A locale read would give a point or a space on another host.
+        expect(first.text).toBe("1,234,567");
+    });
+});
+
+describe("selectNumberKind", () => {
+    it("selects the scientific kind for a p-value column and a value between zero and one", () => {
+        expect(selectNumberKind("padj", 0.0001)).toBe("scientific");
+        expect(selectNumberKind("pvalue", 0.0001)).toBe("scientific");
+        expect(selectNumberKind("fdr", 0.0001)).toBe("scientific");
+        expect(selectNumberKind("qval", 0.0001)).toBe("scientific");
+    });
+
+    it("reads a p-value token across a separator and across a case boundary", () => {
+        expect(selectNumberKind("p_value", 0.02)).toBe("scientific");
+        expect(selectNumberKind("padj.BH", 0.02)).toBe("scientific");
+        expect(selectNumberKind("padj-BH", 0.02)).toBe("scientific");
+        expect(selectNumberKind("pValue", 0.02)).toBe("scientific");
+        expect(selectNumberKind("Adjusted p-value", 0.02)).toBe("scientific");
+    });
+
+    it("reads a whole token only, thus a bare substring never matches", () => {
+        expect(selectNumberKind("expression", 0.42)).toBe("compact-scientific");
+        expect(selectNumberKind("proportion", 0.42)).toBe("compact-scientific");
+        expect(selectNumberKind("quantile", 0.42)).toBe("compact-scientific");
+    });
+
+    it("leaves a p-value column outside the zero-to-one range on the other kinds", () => {
+        expect(selectNumberKind("padj", 3)).toBe("compact");
+        expect(selectNumberKind("padj", 1)).toBe("compact");
+        expect(selectNumberKind("padj", 0)).toBe("compact");
+        expect(selectNumberKind("padj", 1.5)).toBe("compact-scientific");
+    });
+
+    it("selects the compact kind for an integer", () => {
+        expect(selectNumberKind("genes", 14201)).toBe("compact");
+        expect(selectNumberKind("genes", -42)).toBe("compact");
+    });
+
+    it("selects the compact-scientific kind for every other finite number", () => {
+        expect(selectNumberKind("log2FoldChange", -3.089028528355109)).toBe("compact-scientific");
+        // An integer above the safe range is no longer exact, thus it reads as a general float.
+        expect(selectNumberKind("count", 1e21)).toBe("compact-scientific");
+    });
+
+    it("selects the compact-scientific kind for a cell that holds no finite number", () => {
+        expect(selectNumberKind("direction", "up")).toBe("compact-scientific");
+        expect(selectNumberKind("padj", "")).toBe("compact-scientific");
+    });
+});

--- a/harness/src/report-render/number-format.test.ts
+++ b/harness/src/report-render/number-format.test.ts
@@ -50,6 +50,46 @@ describe("formatNumberCell compact-scientific", () => {
     it("shows zero as one digit", () => {
         expect(formatNumberCell(0, "compact-scientific")).toEqual({ text: "0" });
     });
+
+    it("gives a grouped whole number from one thousand up, with the full digits", () => {
+        expect(formatNumberCell(15234.7, "compact-scientific")).toEqual({ text: "15,235", full: "15234.7" });
+        expect(formatNumberCell(-15234.7, "compact-scientific")).toEqual({ text: "-15,235", full: "-15234.7" });
+    });
+
+    it("groups a value that rounds up to one thousand", () => {
+        expect(formatNumberCell(999.5, "compact-scientific")).toEqual({ text: "1,000", full: "999.5" });
+        expect(formatNumberCell(1000.5, "compact-scientific")).toEqual({ text: "1,001", full: "1000.5" });
+    });
+
+    it("keeps the three significant digits under one thousand", () => {
+        expect(formatNumberCell(999.4, "compact-scientific")).toEqual({ text: "999", full: "999.4" });
+    });
+
+    it("keeps the scientific form from 1e15 up", () => {
+        expect(formatNumberCell(1e15, "compact-scientific")).toEqual({ text: "1e15" });
+        expect(formatNumberCell(1.234e15, "compact-scientific")).toEqual({ text: "1.23e15", full: "1234000000000000" });
+    });
+});
+
+describe("formatNumberCell identifier", () => {
+    it("gives the digits of an identifier with no grouping and no full form", () => {
+        expect(formatNumberCell(31978945, "identifier")).toEqual({ text: "31978945" });
+        expect(formatNumberCell("31978945", "identifier")).toEqual({ text: "31978945" });
+    });
+
+    it("keeps a leading zero and a non-numeric identifier", () => {
+        expect(formatNumberCell("007", "identifier")).toEqual({ text: "007" });
+        expect(formatNumberCell("10.1038/nature12345", "identifier")).toEqual({ text: "10.1038/nature12345" });
+    });
+
+    it("trims the space around the source text", () => {
+        expect(formatNumberCell("  31978945  ", "identifier")).toEqual({ text: "31978945" });
+    });
+
+    it("keeps a pmid cell whole, thus the grouping never reaches an identifier column", () => {
+        const cell = "31978945";
+        expect(formatNumberCell(cell, selectNumberKind("pmid", cell))).toEqual({ text: "31978945" });
+    });
 });
 
 describe("formatNumberCell pass-through", () => {
@@ -63,6 +103,23 @@ describe("formatNumberCell pass-through", () => {
 
     it("formats a numeric string and keeps the source text as the full form", () => {
         expect(formatNumberCell("0.0000427777663038", "scientific")).toEqual({ text: "4.3e-5", full: "0.0000427777663038" });
+    });
+
+    it("carries the source text when the shown form drops a leading zero", () => {
+        expect(formatNumberCell("007", "compact")).toEqual({ text: "7", full: "007" });
+    });
+
+    it("carries the source text when the shown form drops a trailing zero", () => {
+        expect(formatNumberCell("1.50", "compact-scientific")).toEqual({ text: "1.5", full: "1.50" });
+    });
+
+    it("gives no full form when the grouping is the only difference from the source text", () => {
+        expect(formatNumberCell("14201", "compact")).toEqual({ text: "14,201" });
+    });
+
+    it("gives no full form when the shown text matches the source text", () => {
+        expect(formatNumberCell("2.94", "compact-scientific")).toEqual({ text: "2.94" });
+        expect(formatNumberCell("  2.94  ", "compact-scientific")).toEqual({ text: "2.94" });
     });
 
     it("passes a value that is not finite through unchanged", () => {
@@ -82,7 +139,7 @@ describe("formatNumberCell determinism", () => {
 });
 
 describe("selectNumberKind", () => {
-    it("selects the scientific kind for a p-value column and a value between zero and one", () => {
+    it("selects the scientific kind for a p-value column and a value under one hundredth", () => {
         expect(selectNumberKind("padj", 0.0001)).toBe("scientific");
         expect(selectNumberKind("pvalue", 0.0001)).toBe("scientific");
         expect(selectNumberKind("fdr", 0.0001)).toBe("scientific");
@@ -90,11 +147,11 @@ describe("selectNumberKind", () => {
     });
 
     it("reads a p-value token across a separator and across a case boundary", () => {
-        expect(selectNumberKind("p_value", 0.02)).toBe("scientific");
-        expect(selectNumberKind("padj.BH", 0.02)).toBe("scientific");
-        expect(selectNumberKind("padj-BH", 0.02)).toBe("scientific");
-        expect(selectNumberKind("pValue", 0.02)).toBe("scientific");
-        expect(selectNumberKind("Adjusted p-value", 0.02)).toBe("scientific");
+        expect(selectNumberKind("p_value", 0.002)).toBe("scientific");
+        expect(selectNumberKind("padj.BH", 0.002)).toBe("scientific");
+        expect(selectNumberKind("padj-BH", 0.002)).toBe("scientific");
+        expect(selectNumberKind("pValue", 0.002)).toBe("scientific");
+        expect(selectNumberKind("Adjusted p-value", 0.002)).toBe("scientific");
     });
 
     it("reads a whole token only, thus a bare substring never matches", () => {
@@ -103,11 +160,40 @@ describe("selectNumberKind", () => {
         expect(selectNumberKind("quantile", 0.42)).toBe("compact-scientific");
     });
 
-    it("leaves a p-value column outside the zero-to-one range on the other kinds", () => {
+    it("leaves a p-value column from one hundredth up on the other kinds", () => {
+        expect(selectNumberKind("padj", 0.01)).toBe("compact-scientific");
+        expect(selectNumberKind("padj", 0.05)).toBe("compact-scientific");
+        expect(selectNumberKind("padj", 0.54)).toBe("compact-scientific");
         expect(selectNumberKind("padj", 3)).toBe("compact");
         expect(selectNumberKind("padj", 1)).toBe("compact");
         expect(selectNumberKind("padj", 0)).toBe("compact");
         expect(selectNumberKind("padj", 1.5)).toBe("compact-scientific");
+    });
+
+    it("shows a p-value from one hundredth up as a plain decimal with no full form", () => {
+        expect(formatNumberCell(0.05, selectNumberKind("padj", 0.05))).toEqual({ text: "0.05" });
+        expect(formatNumberCell(0.0123, selectNumberKind("padj", 0.0123))).toEqual({ text: "0.0123" });
+        expect(formatNumberCell(0.54, selectNumberKind("padj", 0.54))).toEqual({ text: "0.54" });
+    });
+
+    it("shows a p-value under one hundredth in the scientific form", () => {
+        expect(formatNumberCell(0.0099, selectNumberKind("padj", 0.0099))).toEqual({ text: "9.9e-3" });
+    });
+
+    it("selects the identifier kind for an identifier column", () => {
+        expect(selectNumberKind("pmid", 31978945)).toBe("identifier");
+        expect(selectNumberKind("gene_id", 7157)).toBe("identifier");
+        expect(selectNumberKind("entrez_id", 7157)).toBe("identifier");
+        expect(selectNumberKind("geneID", 7157)).toBe("identifier");
+        expect(selectNumberKind("taxid", 9606)).toBe("identifier");
+        expect(selectNumberKind("doi", "10.1038/nature12345")).toBe("identifier");
+        expect(selectNumberKind("Year", 2024)).toBe("identifier");
+        expect(selectNumberKind("accession", "GSE12345")).toBe("identifier");
+    });
+
+    it("reads a whole identifier token only, thus a bare substring never matches", () => {
+        expect(selectNumberKind("identity", 95)).toBe("compact");
+        expect(selectNumberKind("yearly", 2024)).toBe("compact");
     });
 
     it("selects the compact kind for an integer", () => {

--- a/harness/src/report-render/number-format.ts
+++ b/harness/src/report-render/number-format.ts
@@ -1,0 +1,205 @@
+/**
+ * The number format of a resolved value.
+ *
+ * The renderer shows a number in one of three kinds. `scientific` gives a coefficient of two significant
+ * digits and an exponent, for example `4.3e-5`. `compact` gives an integer with comma grouping, for example
+ * `14,201`. `compact-scientific` gives three significant digits, for example `-3.09`, and it falls to the
+ * scientific form for a magnitude under one thousandth.
+ *
+ * The module reads no locale. `toLocaleString` gives different text on a different host, thus the render
+ * function would stop being a pure function of its inputs. The comma grouping is written here for that
+ * reason.
+ *
+ * A shown form hides digits when it no longer parses back to the value. The caller puts the full digits in
+ * the `title` attribute at that time, and it emits no attribute at any other time.
+ */
+
+/** The three number kinds that the renderer shows. */
+export type NumberKind = "scientific" | "compact" | "compact-scientific";
+
+/** One formatted cell. `full` holds the full digits, and it is present only when `text` hides one. */
+export interface FormattedNumber {
+    readonly text: string;
+    readonly full?: string;
+}
+
+/** The significant digits of the scientific coefficient, for example the two digits of `4.3e-5`. */
+const SCIENTIFIC_DIGITS = 2;
+
+/** The significant digits of the compact-scientific form, for example the three digits of `-3.09`. */
+const COMPACT_DIGITS = 3;
+
+/** The magnitude under which the compact-scientific form falls to the scientific form. */
+const SCIENTIFIC_FLOOR = 1e-3;
+
+/** The size of one grouped digit run, for example the three digits of `14,201`. */
+const GROUP_SIZE = 3;
+
+/** The whole tokens of a column name that name a p-value. Such a value reads better in the scientific form. */
+const P_VALUE_TOKENS = new Set(["p", "pval", "pvalue", "padj", "fdr", "q", "qval"]);
+
+/** The boundary between a lowercase or numeric character and an uppercase character. */
+const CASE_BOUNDARY = /([a-z0-9])([A-Z])/g;
+
+/** The separators of a column name: whitespace, an underscore, a point, and a hyphen. */
+const SEPARATORS = /[\s_.-]+/;
+
+/** A text that holds decimal digits alone. */
+const DIGIT_RUN = /^[0-9]+$/;
+
+/** Each group comma of a compact form. */
+const GROUP_COMMAS = /,/g;
+
+/**
+ * Format one cell in one kind.
+ *
+ * A cell that holds no finite number passes through as its own text, and it carries no full form. A finite
+ * number formats in the kind, and it carries the full digits only when the shown text parses back to a
+ * different number.
+ */
+export function formatNumberCell(cell: string | number, kind: NumberKind): FormattedNumber {
+    const value = finiteValue(cell);
+    if (value === null) {
+        return { text: String(cell) };
+    }
+    const text = formatValue(value, kind);
+    if (!hidesDigits(text, value)) {
+        return { text };
+    }
+    // A string cell carries its own digits already. Thus the original text is the truer full form, because
+    // a round trip through a number can drop a trailing zero that the source held.
+    return { text, full: typeof cell === "string" ? cell.trim() : String(cell) };
+}
+
+/**
+ * Select the number kind for one cell of one column.
+ *
+ * A p-value column selects the scientific kind for a value between zero and one. A safe integer selects the
+ * compact kind. Every other finite number selects the compact-scientific kind. A cell that holds no finite
+ * number selects the compact-scientific kind too, because the format passes such a cell through unchanged.
+ */
+export function selectNumberKind(column: string, cell: string | number): NumberKind {
+    const value = finiteValue(cell);
+    if (value === null) {
+        return "compact-scientific";
+    }
+    if (value > 0 && value < 1 && isPValueColumn(column)) {
+        return "scientific";
+    }
+    // An integer above the safe range is no longer exact, thus it reads as a general float and not as a count.
+    if (Number.isSafeInteger(value)) {
+        return "compact";
+    }
+    return "compact-scientific";
+}
+
+/** The finite number of one cell, or `null` when the cell holds no finite number. */
+function finiteValue(cell: string | number): number | null {
+    if (typeof cell === "number") {
+        return Number.isFinite(cell) ? cell : null;
+    }
+    const trimmed = cell.trim();
+    if (trimmed === "") {
+        return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** The text of one finite value in one kind. */
+function formatValue(value: number, kind: NumberKind): string {
+    switch (kind) {
+        case "scientific":
+            return scientificForm(value);
+        case "compact":
+            return compactForm(value);
+        case "compact-scientific":
+            if (value !== 0 && Math.abs(value) < SCIENTIFIC_FLOOR) {
+                return scientificForm(value);
+            }
+            return tidy(value.toPrecision(COMPACT_DIGITS));
+    }
+}
+
+/** The scientific form, for example `4.3e-5`. */
+function scientificForm(value: number): string {
+    return tidy(value.toExponential(SCIENTIFIC_DIGITS - 1));
+}
+
+/** The integer form with comma grouping, for example `14,201`. The sign stays in front of the groups. */
+function compactForm(value: number): string {
+    const sign = value < 0 ? "-" : "";
+    return sign + groupDigits(Math.abs(value).toFixed(0));
+}
+
+/**
+ * Insert one comma before each group of three digits. A text that is not a plain digit run passes through,
+ * thus a magnitude that `toFixed` gives in the exponential form stays whole.
+ */
+function groupDigits(digits: string): string {
+    if (!DIGIT_RUN.test(digits)) {
+        return digits;
+    }
+    let grouped = "";
+    for (let index = 0; index < digits.length; index += 1) {
+        if (index > 0 && (digits.length - index) % GROUP_SIZE === 0) {
+            grouped += ",";
+        }
+        grouped += digits[index];
+    }
+    return grouped;
+}
+
+/**
+ * Trim the noise from one numeric form: the trailing zeros of the fraction, the decimal point that they
+ * leave bare, and the plus sign of a positive exponent.
+ */
+function tidy(text: string): string {
+    const marker = text.indexOf("e");
+    if (marker < 0) {
+        return trimTrailingZeros(text);
+    }
+    const mantissa = trimTrailingZeros(text.slice(0, marker));
+    const exponent = text.slice(marker + 1).replace("+", "");
+    return `${mantissa}e${exponent}`;
+}
+
+/** Drop the trailing zeros of a decimal fraction, and the decimal point that they leave bare. */
+function trimTrailingZeros(text: string): string {
+    if (!text.includes(".")) {
+        return text;
+    }
+    let end = text.length;
+    while (end > 0 && text[end - 1] === "0") {
+        end -= 1;
+    }
+    if (text[end - 1] === ".") {
+        end -= 1;
+    }
+    return text.slice(0, end);
+}
+
+/**
+ * True when the shown text no longer parses back to the value. The comparison drops the group commas
+ * first, thus the grouping alone never counts as a hidden digit.
+ */
+function hidesDigits(text: string, value: number): boolean {
+    return Number(text.replace(GROUP_COMMAS, "")) !== value;
+}
+
+/** True when one whole token of the column name names a p-value. A bare substring never matches. */
+function isPValueColumn(column: string): boolean {
+    return columnTokens(column).some((token) => P_VALUE_TOKENS.has(token));
+}
+
+/**
+ * The lowercase tokens of a column name. A separator and a case boundary both end a token, thus `padjBH`
+ * gives `padj` and `bh`, and `p_value` gives `p` and `value`.
+ */
+function columnTokens(column: string): string[] {
+    return column
+        .replace(CASE_BOUNDARY, "$1 $2")
+        .split(SEPARATORS)
+        .filter((token) => token.length > 0)
+        .map((token) => token.toLowerCase());
+}

--- a/harness/src/report-render/number-format.ts
+++ b/harness/src/report-render/number-format.ts
@@ -1,21 +1,23 @@
 /**
  * The number format of a resolved value.
  *
- * The renderer shows a number in one of three kinds. `scientific` gives a coefficient of two significant
+ * The renderer shows a number in one of four kinds. `scientific` gives a coefficient of two significant
  * digits and an exponent, for example `4.3e-5`. `compact` gives an integer with comma grouping, for example
- * `14,201`. `compact-scientific` gives three significant digits, for example `-3.09`, and it falls to the
- * scientific form for a magnitude under one thousandth.
+ * `14,201`. `compact-scientific` gives three significant digits, for example `-3.09`. It gives a grouped
+ * whole number for a magnitude from `1e3` to `1e15`, for example `15,235`, and it falls to the scientific
+ * form under one thousandth and from `1e15` up. `identifier` gives the source text.
  *
  * The module reads no locale. `toLocaleString` gives different text on a different host, thus the render
  * function would stop being a pure function of its inputs. The comma grouping is written here for that
  * reason.
  *
- * A shown form hides digits when it no longer parses back to the value. The caller puts the full digits in
- * the `title` attribute at that time, and it emits no attribute at any other time.
+ * A shown form hides digits when it no longer parses back to the value, or when it no longer matches the
+ * source text of a string cell. The caller puts the full digits in the `title` attribute at that time, and
+ * it emits no attribute at any other time.
  */
 
-/** The three number kinds that the renderer shows. */
-export type NumberKind = "scientific" | "compact" | "compact-scientific";
+/** The four number kinds that the renderer shows. */
+export type NumberKind = "scientific" | "compact" | "compact-scientific" | "identifier";
 
 /** One formatted cell. `full` holds the full digits, and it is present only when `text` hides one. */
 export interface FormattedNumber {
@@ -29,14 +31,26 @@ const SCIENTIFIC_DIGITS = 2;
 /** The significant digits of the compact-scientific form, for example the three digits of `-3.09`. */
 const COMPACT_DIGITS = 3;
 
+/** The magnitude under which a p-value column selects the scientific kind. */
+const SCIENTIFIC_FLOOR = 1e-2;
+
 /** The magnitude under which the compact-scientific form falls to the scientific form. */
-const SCIENTIFIC_FLOOR = 1e-3;
+const COMPACT_SCIENTIFIC_FLOOR = 1e-3;
+
+/** The rounded magnitude from which the compact-scientific form gives a grouped whole number. */
+const GROUPED_FLOOR = 1e3;
+
+/** The rounded magnitude from which the grouped whole number gives way to the scientific form. */
+const GROUPED_CEILING = 1e15;
 
 /** The size of one grouped digit run, for example the three digits of `14,201`. */
 const GROUP_SIZE = 3;
 
 /** The whole tokens of a column name that name a p-value. Such a value reads better in the scientific form. */
 const P_VALUE_TOKENS = new Set(["p", "pval", "pvalue", "padj", "fdr", "q", "qval"]);
+
+/** The whole tokens of a column name that name an identifier. Such a value is a name, not a magnitude. */
+const IDENTIFIER_TOKENS = new Set(["id", "pmid", "doi", "entrez", "taxid", "year", "accession"]);
 
 /** The boundary between a lowercase or numeric character and an uppercase character. */
 const CASE_BOUNDARY = /([a-z0-9])([A-Z])/g;
@@ -54,36 +68,48 @@ const GROUP_COMMAS = /,/g;
  * Format one cell in one kind.
  *
  * A cell that holds no finite number passes through as its own text, and it carries no full form. A finite
- * number formats in the kind, and it carries the full digits only when the shown text parses back to a
- * different number.
+ * number formats in the kind, and it carries the full digits only when the shown text loses one.
  */
 export function formatNumberCell(cell: string | number, kind: NumberKind): FormattedNumber {
+    if (kind === "identifier") {
+        // An identifier is a name that is written with digits. A group comma and a rounded digit both break
+        // the name, thus each character of the source reaches the page.
+        return { text: String(cell).trim() };
+    }
     const value = finiteValue(cell);
     if (value === null) {
         return { text: String(cell) };
     }
     const text = formatValue(value, kind);
-    if (!hidesDigits(text, value)) {
-        return { text };
+    if (typeof cell === "string") {
+        // A string cell carries its own digits already, thus the source text is the truer full form. A
+        // comparison of the two texts also catches a loss that a comparison of two numbers cannot see, for
+        // example the leading zero of `007` and the trailing zero of `1.50`.
+        const source = cell.trim();
+        return ungrouped(text) === source ? { text } : { text, full: source };
     }
-    // A string cell carries its own digits already. Thus the original text is the truer full form, because
-    // a round trip through a number can drop a trailing zero that the source held.
-    return { text, full: typeof cell === "string" ? cell.trim() : String(cell) };
+    return hidesDigits(text, value) ? { text, full: String(cell) } : { text };
 }
 
 /**
  * Select the number kind for one cell of one column.
  *
- * A p-value column selects the scientific kind for a value between zero and one. A safe integer selects the
- * compact kind. Every other finite number selects the compact-scientific kind. A cell that holds no finite
- * number selects the compact-scientific kind too, because the format passes such a cell through unchanged.
+ * An identifier column selects the identifier kind. A p-value column selects the scientific kind for a value
+ * between zero and one hundredth. A safe integer selects the compact kind. Every other finite number selects
+ * the compact-scientific kind. A cell that holds no finite number selects the compact-scientific kind too,
+ * because the format passes such a cell through unchanged.
  */
 export function selectNumberKind(column: string, cell: string | number): NumberKind {
+    if (isIdentifierColumn(column)) {
+        return "identifier";
+    }
     const value = finiteValue(cell);
     if (value === null) {
         return "compact-scientific";
     }
-    if (value > 0 && value < 1 && isPValueColumn(column)) {
+    // From one hundredth up, the plain decimal is as short as the exponent and it is easier to read. Thus
+    // `0.05` stays `0.05` and it does not become `5e-2`.
+    if (value > 0 && value < SCIENTIFIC_FLOOR && isPValueColumn(column)) {
         return "scientific";
     }
     // An integer above the safe range is no longer exact, thus it reads as a general float and not as a count.
@@ -106,18 +132,27 @@ function finiteValue(cell: string | number): number | null {
     return Number.isFinite(parsed) ? parsed : null;
 }
 
-/** The text of one finite value in one kind. */
-function formatValue(value: number, kind: NumberKind): string {
+/** The text of one finite value in one kind. The identifier kind takes no value, thus it is absent here. */
+function formatValue(value: number, kind: Exclude<NumberKind, "identifier">): string {
     switch (kind) {
         case "scientific":
             return scientificForm(value);
         case "compact":
             return compactForm(value);
-        case "compact-scientific":
-            if (value !== 0 && Math.abs(value) < SCIENTIFIC_FLOOR) {
+        case "compact-scientific": {
+            const magnitude = Math.abs(value);
+            if (value !== 0 && magnitude < COMPACT_SCIENTIFIC_FLOOR) {
                 return scientificForm(value);
             }
+            // Above three significant digits `toPrecision` crosses to the exponential form, and `1.52e4`
+            // reads worse than `15,235`. The grouped form holds up to the width where a group run stops
+            // being easy to count.
+            const rounded = Math.round(magnitude);
+            if (rounded >= GROUPED_FLOOR && rounded < GROUPED_CEILING) {
+                return compactForm(value);
+            }
             return tidy(value.toPrecision(COMPACT_DIGITS));
+        }
     }
 }
 
@@ -179,17 +214,24 @@ function trimTrailingZeros(text: string): string {
     return text.slice(0, end);
 }
 
-/**
- * True when the shown text no longer parses back to the value. The comparison drops the group commas
- * first, thus the grouping alone never counts as a hidden digit.
- */
+/** One shown form without its group commas, thus the grouping alone never counts as a hidden digit. */
+function ungrouped(text: string): string {
+    return text.replace(GROUP_COMMAS, "");
+}
+
+/** True when the shown text no longer parses back to the value. */
 function hidesDigits(text: string, value: number): boolean {
-    return Number(text.replace(GROUP_COMMAS, "")) !== value;
+    return Number(ungrouped(text)) !== value;
 }
 
 /** True when one whole token of the column name names a p-value. A bare substring never matches. */
 function isPValueColumn(column: string): boolean {
     return columnTokens(column).some((token) => P_VALUE_TOKENS.has(token));
+}
+
+/** True when one whole token of the column name names an identifier. A bare substring never matches. */
+function isIdentifierColumn(column: string): boolean {
+    return columnTokens(column).some((token) => IDENTIFIER_TOKENS.has(token));
 }
 
 /**

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -419,6 +419,61 @@ describe("the chart bootstrap under a broken chart", () => {
     });
 });
 
+describe("renderReportPage number format", () => {
+    /** A one-section page over one metric block and one table block. */
+    function pageOf(blocks: Block[]): ReportDocument {
+        return { title: "T", sections: [{ kind: "section", id: "s", title: "S", blocks }] };
+    }
+
+    it("shows a long metric value in the short form and the full digits on the title", () => {
+        const document = pageOf([{ kind: "metric", id: "m1", label: "Effect size", value: scalarRef }]);
+        const html = renderReportPage(document, { m1: { type: "scalar", value: -5.7618623255 } })._unsafeUnwrap();
+        const value = load(html)(".stat-card-value");
+        expect(value.text()).toBe("-5.76");
+        expect(value.attr("title")).toBe("-5.7618623255");
+    });
+
+    it("gives a metric whose form hides no digit no title attribute", () => {
+        const document = pageOf([{ kind: "metric", id: "m1", label: "Genes tested", value: scalarRef }]);
+        const html = renderReportPage(document, { m1: { type: "scalar", value: 18432 } })._unsafeUnwrap();
+        const value = load(html)(".stat-card-value");
+        expect(value.text()).toBe("18,432");
+        expect(value.attr("title")).toBeUndefined();
+    });
+
+    it("formats each numeric table cell by its column and passes a text cell through", () => {
+        const document = pageOf([{ kind: "table", id: "tbl", binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" } }]);
+        const values: RenderValues = {
+            tbl: {
+                type: "table",
+                columns: ["gene", "log2FoldChange", "padj", "direction"],
+                rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109, padj: 0.0000427777663038, direction: "up" }],
+            },
+        };
+        const cells = load(renderReportPage(document, values)._unsafeUnwrap())(".data-table tbody td");
+        expect(cells.map((_, cell) => load(cell).text()).get()).toEqual(["TP53", "-3.09", "4.3e-5", "up"]);
+        expect(cells.eq(1).attr("title")).toBe("-3.089028528355109");
+        expect(cells.eq(2).attr("title")).toBe("0.0000427777663038");
+        expect(cells.eq(3).attr("title")).toBeUndefined();
+    });
+});
+
+describe("the stat card value style rule", () => {
+    /** The declaration body of each `.stat-card-value` rule of a style sheet, with each comment removed. */
+    function statValueRules(css: string): string[] {
+        return [...css.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(/\.stat-card-value\s*\{([^}]*)\}/g)].map((match) => match[1]);
+    }
+
+    it("guards the overflow of the value", () => {
+        const rules = statValueRules(DESIGN_CSS);
+        expect(rules.length).toBeGreaterThan(0);
+
+        // A value that the number format cannot shorten, for example a long identifier, would paint past
+        // the card edge without the guard.
+        expect(rules.some((body) => /(?:^|;)\s*overflow-wrap\s*:\s*anywhere\b/.test(body))).toBe(true);
+    });
+});
+
 describe("renderReportPage escaping", () => {
     it("keeps a script tag in the title as text in the title and the heading", () => {
         const document: ReportDocument = {

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -10,11 +10,38 @@ const tableBinding: TableBlock["binding"] = { kind: "artifact-table", path: "run
 const figureBinding: FigureBlock["binding"] = { kind: "artifact-file", path: "runs/r1/plot.png", hash: "sha256:aaa" };
 
 describe("renderMetric", () => {
+    /** One metric block with the given label. The label selects the number kind of the value. */
+    function metric(label: string): MetricBlock {
+        return { kind: "metric", id: "m1", label, value: scalarBinding };
+    }
+
     it("shows the label and the scalar value", () => {
-        const block: MetricBlock = { kind: "metric", id: "m1", label: "Adjusted p-value", value: scalarBinding };
-        const html = renderMetric(block, { type: "scalar", value: 0.0123 });
+        const html = renderMetric(metric("Adjusted p-value"), { type: "scalar", value: 0.0123 });
         expect(html).toContain("Adjusted p-value");
-        expect(html).toContain("0.0123");
+        expect(html).toContain(">1.2e-2<");
+    });
+
+    it("puts the full digits in the title attribute of the value", () => {
+        const html = renderMetric(metric("Effect size"), { type: "scalar", value: -5.7618623255 });
+        expect(html).toContain(`<div class="stat-card-value" title="-5.7618623255">-5.76</div>`);
+    });
+
+    it("shows a p-value label in the scientific form with the full digits on the title", () => {
+        const html = renderMetric(metric("padj"), { type: "scalar", value: 0.0000427777663038 });
+        expect(html).toContain(`title="0.0000427777663038"`);
+        expect(html).toContain(">4.3e-5<");
+    });
+
+    it("groups a count and carries no title, because the grouping hides no digit", () => {
+        const html = renderMetric(metric("Genes tested"), { type: "scalar", value: 18432 });
+        expect(html).toContain(`<div class="stat-card-value">18,432</div>`);
+        expect(html).not.toContain("title=");
+    });
+
+    it("passes a non-numeric value through with no title", () => {
+        const html = renderMetric(metric("Sequencing depth"), { type: "scalar", value: "42.6M" });
+        expect(html).toContain(`<div class="stat-card-value">42.6M</div>`);
+        expect(html).not.toContain("title=");
     });
 });
 
@@ -49,6 +76,33 @@ describe("renderTable", () => {
         });
         expect(html).toContain(`<td></td>`);
         expect(html).not.toContain("undefined");
+    });
+
+    it("shows a p-value column in the scientific form with the full digits on the title", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.0000427777663038 }] });
+        expect(html).toContain(`<td title="0.0000427777663038">4.3e-5</td>`);
+    });
+
+    it("rounds a long float to three significant digits and keeps the full digits on the title", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109 }] });
+        expect(html).toContain(`<td title="-3.089028528355109">-3.09</td>`);
+    });
+
+    it("groups a count and gives it no title, because the grouping hides no digit", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
+        expect(html).toContain(`<td>14,201</td>`);
+    });
+
+    it("passes a non-numeric cell through unchanged and gives it no title", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", direction: "up" }] });
+        expect(html).toContain(`<td>up</td>`);
+        expect(html).not.toContain("title=");
+    });
+
+    it("keeps a hostile cell as text after the format passes it through", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
+        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(html).not.toContain("<script>alert(1)");
     });
 });
 

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -18,7 +18,8 @@ describe("renderMetric", () => {
     it("shows the label and the scalar value", () => {
         const html = renderMetric(metric("Adjusted p-value"), { type: "scalar", value: 0.0123 });
         expect(html).toContain("Adjusted p-value");
-        expect(html).toContain(">1.2e-2<");
+        // A p-value from one hundredth up reads better as a plain decimal than as an exponent.
+        expect(html).toContain(">0.0123<");
     });
 
     it("puts the full digits in the title attribute of the value", () => {
@@ -91,6 +92,18 @@ describe("renderTable", () => {
     it("groups a count and gives it no title, because the grouping hides no digit", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
         expect(html).toContain(`<td>14,201</td>`);
+    });
+
+    it("keeps an identifier column whole, with no grouping and no title", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", pmid: "31978945" }] });
+        expect(html).toContain(`<td>31978945</td>`);
+        expect(html).not.toContain("31,978,945");
+        expect(html).not.toContain("title=");
+    });
+
+    it("gives a grouped whole number to a large float and keeps the full digits on the title", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
+        expect(html).toContain(`<td title="15234.7">15,235</td>`);
     });
 
     it("passes a non-numeric cell through unchanged and gives it no title", () => {

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -3,7 +3,11 @@
  *
  * The caller resolves each value, and it narrows the value to the shape that the block needs. The runtime
  * escapes every interpolated string, thus a hostile label, a hostile cell, a hostile caption, or a
- * hostile source reaches the page as text.
+ * hostile source reaches the page as text. The `title` attribute takes the same escape as every other
+ * attribute value, thus the full digits cannot break out of their slot.
+ *
+ * A number reaches the page through the number format. The name that stands over the number selects the
+ * kind: the label of a metric, and the column name of a table cell.
  *
  * Each data card carries the `corner-accents` class. Thus the card keeps square corners with the L-shaped
  * accents, which is the geometric identity of the report.
@@ -13,6 +17,7 @@ import { raw } from "hono/html";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import { Marker } from "./references-view.js";
+import { formatNumberCell, selectNumberKind } from "../number-format.js";
 import type { ReferenceLedger } from "../references.js";
 import type { RenderValue } from "../types.js";
 
@@ -25,11 +30,19 @@ type TableValue = Extract<RenderValue, { type: "table" }>;
 /** The figure value that a figure renders from. */
 type FigureValue = Extract<RenderValue, { type: "figure" }>;
 
-/** Render a metric block as a stat card with the mono value and the mono label. */
+/**
+ * Render a metric block as a stat card with the mono value and the mono label.
+ *
+ * The label names the value, thus it selects the number kind. The full digits ride the `title` attribute
+ * when the shown form hides one, and no attribute appears at any other time.
+ */
 export function renderMetric(block: MetricBlock, value: ScalarValue): string {
+    const shown = formatNumberCell(value.value, selectNumberKind(block.label, value.value));
     return String(
         <div class="stat-card corner-accents">
-            <div class="stat-card-value">{value.value}</div>
+            <div class="stat-card-value" title={shown.full}>
+                {shown.text}
+            </div>
             <div class="stat-card-label">{block.label}</div>
         </div>,
     );
@@ -61,9 +74,24 @@ function tableColumns(value: TableValue): string[] {
 }
 
 /**
+ * One body cell of a table.
+ *
+ * The column name selects the number kind, thus a p-value column reads in the scientific form. The full
+ * digits ride the `title` attribute when the shown form hides one. An absent cell renders as an empty
+ * cell, thus a ragged row keeps its shape.
+ */
+function Cell({ column, cell }: { column: string; cell: string | number | undefined }) {
+    if (cell === undefined) {
+        return <td></td>;
+    }
+    const shown = formatNumberCell(cell, selectNumberKind(column, cell));
+    return <td title={shown.full}>{shown.text}</td>;
+}
+
+/**
  * Render a table block. The header holds one cell for each column, and the body holds one row for each
  * resolved row. A zero-row table renders the header alone. The title and the caption render only when the
- * block carries one. An absent cell renders as an empty cell, thus a ragged row keeps its shape.
+ * block carries one.
  */
 export function renderTable(block: TableBlock, value: TableValue): string {
     const columns = tableColumns(value);
@@ -84,7 +112,7 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                             {value.rows.map((row) => (
                                 <tr class="report-row">
                                     {columns.map((column) => (
-                                        <td>{row[column]}</td>
+                                        <Cell column={column} cell={row[column]} />
                                     ))}
                                 </tr>
                             ))}


### PR DESCRIPTION
## What & why

The renderer printed each resolved value at full float precision. On the first real report a metric card clipped its value, a p-value wrapped onto a second line, and a table cell showed 16 digits. One pure helper (`report-render/number-format.ts`) now formats each numeric value with three kinds: scientific, compact, and compact-scientific. The kind comes from the magnitude and from the column meaning, thus no block carries a format field. The full digits ride the `title` attribute only when the shown form hides digits.

Notes for the reviewer:

- The chart option rides to the page as inline JSON, thus no function formatter is possible. Only the histogram count axis takes a static whole-tick bound, and every other axis keeps the ECharts tick algorithm. The synced spec states this bound.
- The metric kind selection reads the block label, because a derivation binding carries no column name.
- The stat-card value gains `overflow-wrap: anywhere` as a backstop. The formatted value is short by construction.

Refs #369

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
