### PR TITLE
feat(harness): pin the citation evidence at the spawn

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`pinReportSnapshot` (`report-model/pin-snapshot.ts`) reads the artifact ledger and fills `ReportSnapshot.artifacts`. It fills no citation, and its comment claims that nothing consumes a pinned citation list. That claim is stale: the production resolver and the fixture resolver both refuse a citation whose `idKind:id` key is absent from `snapshot.citations`. The `keyReferences` of a run live in `runs/{runId}/synthesis.json`, on disk under the workspace root. `cortex_runs` carries only a synthesis status, thus the disk is the one source.
+
+## Goals / Non-Goals
+
+- Goal: a citation block over a synthesis PMID resolves, and the References section returns.
+- Goal: the pin stays one idempotent operation, and a degraded collection never fails it.
+- Non-goal: a literature-search tool. The snapshot is the reproducibility boundary.
+- Non-goal: a resolver change. The membership check exists and stays.
+
+## Decisions
+
+- **The collection lives beside the pin.** A function in `pin-snapshot.ts` takes the pool, the workspace root, and the analysis id. It lists the runs with `queryRunsByAnalysis`, and it reads `runs/{runId}/synthesis.json` for each run. The alternative was a collection at the spawn, and it was rejected: the gateway load pins too, and the two paths must pin one shape.
+- **The extraction is lenient.** The read parses the JSON and takes `keyReferences[].pmid` where it is a non-empty string. A whole-schema parse was rejected, because a legacy synthesis would then empty the citation list of the whole analysis.
+- **The key shape is the resolver shape.** Each PMID becomes `pmid:<id>`, trimmed. The keys dedupe, and they sort in code-unit order, thus the pin is deterministic over one disk state.
+- **Absence is a normal condition.** An absent synthesis file, an unreadable file, and malformed JSON each give no keys and no error. An absent workspace-root seam pins no citations, logs one warning, and the pin lands. A failed run listing fails the pin, the same as a failed ledger read, because a store fault is not absence.
+- **The runtime carries the seam.** `ReportSessionRuntimeDeps` gains an optional `resolveWorkspaceRoot`. The composition root that already resolves roots for the session tools passes the same seam here.
+- **The read is bounded.** A synthesis file is small by construction, but the read still caps at 1 MiB. A file over the cap gives no keys, because a truncated JSON parse cannot be trusted.
+
+## Risks / Trade-offs
+
+- [A PMID in the synthesis is malformed] → the lenient extraction keeps any non-empty string, and the resolver echo simply never matches a real citation. The loss is one unresolvable citation, not a failed pin.
+- [Two runs cite one paper] → the dedupe keeps one key, and the citation resolves the same way.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Every citation block of the first real session failed with "not in the pinned evidence", although each PMID sits in the synthesis `keyReferences`. The agent removed the References section and inlined each citation into prose. The pin fills the artifact map, and it fills no citation list.
+
+## What Changes
+
+- The pin collects the `keyReferences` of each run synthesis into the snapshot citation list, as `pmid:` keys.
+- The collection reads `runs/{runId}/synthesis.json` under the workspace root. An absent or unparsable synthesis gives no keys and no error.
+- The session runtime gains the workspace-root seam for that read. A composition without the seam pins no citations, and the pin still lands.
+- The report-session prompt states that the literature references compose as citation blocks against the pinned evidence.
+
+## The decided boundary
+
+The report agent gets no literature-search tool. A report version must be reproducible from its snapshot. A search at compose time cites papers that the snapshot never held. The synthesis references are the curated set that the analysis engaged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-snapshot`: a new requirement gives the citation evidence of the pin: the source, the key shape, and the absence rules.
+- `report-session-agent`: the pin requirement names the citation collection, and the prompt obligations gain the References teaching.
+
+## Impact
+
+- `harness/src/report-model/pin-snapshot.ts` — the collection, and the correction of the stale comment.
+- `harness/src/app/report-session-runtime.ts` — the workspace-root dep, threaded into the pin.
+- The composition root that builds the runtime — the seam wiring.
+- `harness/src/prompts/report-session.ts` — the References teaching.
+- No resolver change: the citation membership check exists and stays.

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-session-agent/spec.md
@@ -54,7 +54,7 @@ The prompt MUST teach the verification loop: preview, look, repair, and record o
 
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
-The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
 
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-session-agent/spec.md
@@ -1,0 +1,73 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The snapshot pins at session start
+The runtime MUST give an idempotent operation that makes sure that the session state of a thread exists. The first run of the operation MUST pin the snapshot with `pinReportSnapshot`, and it MUST write the row. The pin MUST carry the citation evidence of the analysis beside the artifact map, through the workspace-root seam of the runtime. Every later call MUST read the stored snapshot, and it MUST NOT pin again. A pin failure MUST return as typed data, and a later call can pin again, because no row was written.
+
+The spawn MUST run the operation directly after the seed of the child lands. The spawn mints one moment, and the two pins of that moment are the anchor of the transcript and the snapshot of the data. A pin at the first tool call of a later turn reads a different moment. A run can register an artifact between the two, and the session then cites an artifact that the anchor never held.
+
+A failed pin at the spawn MUST NOT fail the spawn, and it MUST NOT remove the child. The operation is idempotent, thus a later call pins again. The failure MUST reach the injected logger.
+
+The serving path of a report turn MUST run the operation at the start of the turn. Thus a session that the spawn could not pin still anchors before its first tool call.
+
+#### Scenario: The spawn pins the snapshot
+
+- **WHEN** the spawn makes a report child
+- **THEN** the session state of the child holds the snapshot before the first turn runs
+
+#### Scenario: An artifact of a later run is not a member
+
+- **GIVEN** a spawned report child
+- **WHEN** a run registers a new artifact, and the first turn of the child then runs
+- **THEN** the stored snapshot holds no entry for that artifact
+
+#### Scenario: A failed pin at the spawn keeps the child
+
+- **WHEN** the pin fails at the spawn
+- **THEN** the spawn gives the child, and the next call pins again
+
+#### Scenario: The first served turn pins before any tool call
+- **WHEN** the first turn of a report thread starts
+- **THEN** the row holds the snapshot before a tool of the roster runs
+
+#### Scenario: The pin runs one time
+- **WHEN** a thread makes two authoring calls
+- **THEN** the artifact ledger query runs one time, and both calls read one snapshot
+
+#### Scenario: The membership survives a restart
+- **WHEN** the process restarts after the pin, and a new artifact lands in the ledger
+- **THEN** the next call reads the stored snapshot, and the new artifact is not a member
+
+#### Scenario: A pin failure does not poison the thread
+- **WHEN** the first pin fails and the store recovers
+- **THEN** the next call pins again, and the session continues
+
+#### Scenario: The stored snapshot carries the citation evidence
+- **WHEN** the spawn pins a session of an analysis whose run synthesis carries key references
+- **THEN** the stored snapshot citation list holds the `pmid:` key of each reference
+
+### Requirement: The prompt obligations
+The prompt of the agent MUST name its tools and their mechanisms, and it MUST NOT name a dataset, a path, or a format. The prompt MUST carry an explicit "Do NOT" list with the failure modes of report composition. The prompt MUST state that the agent grounds each claim through a reference, and that it does not transcribe a number from memory.
+
+The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
+
+The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
+
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+
+#### Scenario: The prompt stays free of environment detail
+- **WHEN** a reviewer reads the prompt module
+- **THEN** no dataset name, no path, and no format promise is present
+
+#### Scenario: The prompt teaches the loop order
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the loop order and the visual-spiral anti-pattern are present
+
+#### Scenario: The prompt teaches the path-only rule
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the listing tool is the named orientation source, and the hash-probe anti-pattern is present
+
+#### Scenario: The prompt teaches the citation blocks
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the citation-block rule and the pinned-evidence bound are present

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-snapshot/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-snapshot/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: The pin collects the citation evidence
-The pin MUST collect the key references of each run synthesis into the snapshot citation list. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
+The pin MUST collect the citation ids of each run synthesis into the snapshot citation list: the key references, and the per-finding references. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
 
 #### Scenario: A synthesis PMID becomes a pinned citation key
 - **WHEN** the pin runs for an analysis whose run synthesis carries the key reference PMID `12345`

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-snapshot/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/specs/report-snapshot/spec.md
@@ -1,0 +1,22 @@
+# Delta: report-snapshot
+
+## ADDED Requirements
+
+### Requirement: The pin collects the citation evidence
+The pin MUST collect the key references of each run synthesis into the snapshot citation list. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
+
+#### Scenario: A synthesis PMID becomes a pinned citation key
+- **WHEN** the pin runs for an analysis whose run synthesis carries the key reference PMID `12345`
+- **THEN** the stored snapshot citation list holds `pmid:12345`
+
+#### Scenario: A citation block over a pinned PMID resolves
+- **WHEN** a citation reference names `pmid:12345` and the snapshot citation list holds that key
+- **THEN** the resolution gives the citation echo, and no refusal names the pinned evidence
+
+#### Scenario: An absent synthesis pins no key and no error
+- **WHEN** the pin runs for an analysis whose run directory holds no synthesis record
+- **THEN** the pin lands with an empty citation list, and no failure returns
+
+#### Scenario: Two runs that cite one paper pin one key
+- **WHEN** two run syntheses carry one PMID
+- **THEN** the citation list holds the key one time

--- a/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-pin-the-citation-evidence-at-the-spawn/tasks.md
@@ -1,0 +1,20 @@
+## 1. The collection
+
+- [x] 1.1 Make the citation collection in `src/report-model/pin-snapshot.ts`. It lists the runs, reads each synthesis record under a 1 MiB cap, and extracts the PMID keys leniently.
+- [x] 1.2 Fill `snapshot.citations` with the deduped keys in code-unit order. Correct the stale comment that says nothing consumes a pinned citation list.
+- [x] 1.3 Unit tests: the key shape, the dedupe, the sort, the absent file, the malformed JSON, the over-cap file, and the failed run listing.
+
+## 2. The seam
+
+- [x] 2.1 Give `ReportSessionRuntimeDeps` an optional `resolveWorkspaceRoot`, and thread it into the pin. An absent seam pins no citations, and it logs one warning.
+- [x] 2.2 Wire the seam at the composition root that builds the runtime, from the resolver that the session tools already use.
+- [x] 2.3 Tests: the pin with the seam carries the citations, and the pin without the seam lands with none.
+
+## 3. The teaching
+
+- [x] 3.1 Extend `src/prompts/report-session.ts`: the literature references compose as citation blocks, against the pinned citation ids. A citation outside the pinned evidence does not resolve, and the agent reports it.
+
+## 4. The gates
+
+- [x] 4.1 Run the targeted suites of the touched modules only. The pin suite is a Postgres suite, thus it runs with `CORTEX_TEST_PG_URL` at the podman container.
+- [x] 4.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -98,7 +98,7 @@ The in-progress document and the pinned snapshot of a thread MUST live in one du
 ### Requirement: The read-only roster
 The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_files`, `file_stat`, and `grep`), the workspace search, `inspect_run`, `inspect_data_profile`, the authoring tools, the pinned-artifact listing tool, and the render-and-preview tool. The roster MUST NOT hold a planner, a run launcher, a working-memory write, or a sandbox mutate surface. Thus no tool starts a run, and no tool changes an analysis.
 
-The listing tool MUST give the pinned artifacts in a deterministic order: the path, the hash, and the file type. The listing is bounded, and a truncated listing MUST carry the total count and a truncation marker. For a `.csv` or a `.tsv` artifact it also gives the columns, from a bounded read of the header. A header that the bounded read cannot parse whole gives no columns. An unreadable header gives no columns and no error, because absence is a normal condition.
+The listing tool MUST give the pinned artifacts in a deterministic order: the path, the hash, and the file type. It MUST also give the pinned citation ids. The listing is bounded, and a truncated listing MUST carry the total count and a truncation marker. For a `.csv` or a `.tsv` artifact it also gives the columns, from a bounded read of the header. A header that the bounded read cannot parse whole gives no columns. An unreadable header gives no columns and no error, because absence is a normal condition.
 
 #### Scenario: The roster holds no run starter
 - **WHEN** the assembled agent lists its tools
@@ -159,7 +159,7 @@ The prompt MUST teach the verification loop: preview, look, repair, and record o
 
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
-The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
 
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -40,7 +40,7 @@ The session runtime MUST bind the per-session state to the thread, behind the si
 - **THEN** the tool returns typed data that names the missing thread id, and it does not throw
 
 ### Requirement: The snapshot pins at session start
-The runtime MUST give an idempotent operation that makes sure that the session state of a thread exists. The first run of the operation MUST pin the snapshot with `pinReportSnapshot`, and it MUST write the row. Every later call MUST read the stored snapshot, and it MUST NOT pin again. A pin failure MUST return as typed data, and a later call can pin again, because no row was written.
+The runtime MUST give an idempotent operation that makes sure that the session state of a thread exists. The first run of the operation MUST pin the snapshot with `pinReportSnapshot`, and it MUST write the row. The pin MUST carry the citation evidence of the analysis beside the artifact map, through the workspace-root seam of the runtime. Every later call MUST read the stored snapshot, and it MUST NOT pin again. A pin failure MUST return as typed data, and a later call can pin again, because no row was written.
 
 The spawn MUST run the operation directly after the seed of the child lands. The spawn mints one moment, and the two pins of that moment are the anchor of the transcript and the snapshot of the data. A pin at the first tool call of a later turn reads a different moment. A run can register an artifact between the two, and the session then cites an artifact that the anchor never held.
 
@@ -79,6 +79,10 @@ The serving path of a report turn MUST run the operation at the start of the tur
 #### Scenario: A pin failure does not poison the thread
 - **WHEN** the first pin fails and the store recovers
 - **THEN** the next call pins again, and the session continues
+
+#### Scenario: The stored snapshot carries the citation evidence
+- **WHEN** the spawn pins a session of an analysis whose run synthesis carries key references
+- **THEN** the stored snapshot citation list holds the `pmid:` key of each reference
 
 ### Requirement: The session state is durable for each thread
 The in-progress document and the pinned snapshot of a thread MUST live in one durable session-state row, keyed by the thread id. A landed operation MUST persist the document before it reports `applied: true`. A process restart and a replica change MUST NOT lose a landed operation. A purge of the analysis MUST remove the session-state rows of its threads.
@@ -155,6 +159,8 @@ The prompt MUST teach the verification loop: preview, look, repair, and record o
 
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module
 - **THEN** no dataset name, no path, and no format promise is present
@@ -166,6 +172,10 @@ The prompt MUST name the listing tool as the orientation source for the pinned e
 #### Scenario: The prompt teaches the path-only rule
 - **WHEN** a reviewer reads the prompt module
 - **THEN** the listing tool is the named orientation source, and the hash-probe anti-pattern is present
+
+#### Scenario: The prompt teaches the citation blocks
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the citation-block rule and the pinned-evidence bound are present
 
 ### Requirement: The report turn reads the copied narrative, never the live memory
 

--- a/harness/openspec/specs/report-snapshot/spec.md
+++ b/harness/openspec/specs/report-snapshot/spec.md
@@ -79,6 +79,25 @@ necessary.
 - **WHEN** the pin runs for an analysis that holds a table of one million rows
 - **THEN** the snapshot holds the entry of that table, and it holds no row of it
 
+### Requirement: The pin collects the citation evidence
+The pin MUST collect the key references of each run synthesis into the snapshot citation list. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
+
+#### Scenario: A synthesis PMID becomes a pinned citation key
+- **WHEN** the pin runs for an analysis whose run synthesis carries the key reference PMID `12345`
+- **THEN** the stored snapshot citation list holds `pmid:12345`
+
+#### Scenario: A citation block over a pinned PMID resolves
+- **WHEN** a citation reference names `pmid:12345` and the snapshot citation list holds that key
+- **THEN** the resolution gives the citation echo, and no refusal names the pinned evidence
+
+#### Scenario: An absent synthesis pins no key and no error
+- **WHEN** the pin runs for an analysis whose run directory holds no synthesis record
+- **THEN** the pin lands with an empty citation list, and no failure returns
+
+#### Scenario: Two runs that cite one paper pin one key
+- **WHEN** two run syntheses carry one PMID
+- **THEN** the citation list holds the key one time
+
 ### Requirement: The snapshot is the membership boundary of a session
 
 Resolution MUST refuse a path that the snapshot does not hold. The refusal MUST

--- a/harness/openspec/specs/report-snapshot/spec.md
+++ b/harness/openspec/specs/report-snapshot/spec.md
@@ -80,7 +80,7 @@ necessary.
 - **THEN** the snapshot holds the entry of that table, and it holds no row of it
 
 ### Requirement: The pin collects the citation evidence
-The pin MUST collect the key references of each run synthesis into the snapshot citation list. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
+The pin MUST collect the citation ids of each run synthesis into the snapshot citation list: the key references, and the per-finding references. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
 
 #### Scenario: A synthesis PMID becomes a pinned citation key
 - **WHEN** the pin runs for an analysis whose run synthesis carries the key reference PMID `12345`
@@ -93,6 +93,10 @@ The pin MUST collect the key references of each run synthesis into the snapshot 
 #### Scenario: An absent synthesis pins no key and no error
 - **WHEN** the pin runs for an analysis whose run directory holds no synthesis record
 - **THEN** the pin lands with an empty citation list, and no failure returns
+
+#### Scenario: A per-finding PMID pins too
+- **WHEN** a synthesis carries a PMID only inside the references of one finding
+- **THEN** the stored snapshot citation list holds its key
 
 #### Scenario: Two runs that cite one paper pin one key
 - **WHEN** two run syntheses carry one PMID

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -153,6 +153,15 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("Probe for a hash");
     });
 
+    test("the prompt teaches the citation blocks and their pinned-evidence bound", () => {
+        // The citation rule and its anti-pattern are stable substrings, thus the
+        // assertion does not couple to the full prose.
+        expect(reportSessionPrompt).toContain("citation blocks");
+        expect(reportSessionPrompt).toContain("citation id of the pinned evidence");
+        expect(reportSessionPrompt).toContain("does not resolve");
+        expect(reportSessionPrompt).toContain("Inline a citation that does not resolve");
+    });
+
     test("the definition carries no per-session value in the prompt", () => {
         const { systemPrompt } = buildAgent();
         // A per-session value (a thread id, an analysis id, a resolved path) breaks

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -160,6 +160,9 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("citation id of the pinned evidence");
         expect(reportSessionPrompt).toContain("does not resolve");
         expect(reportSessionPrompt).toContain("Inline a citation that does not resolve");
+        // The listing tool is the route to a pinned id, thus the agent never learns one from a refusal.
+        expect(reportSessionPrompt).toContain("`citations` field");
+        expect(reportSessionPrompt).toContain("never take an id out of a refusal");
     });
 
     test("the definition carries no per-session value in the prompt", () => {

--- a/harness/src/app/report-session-runtime.test.ts
+++ b/harness/src/app/report-session-runtime.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Pool } from "pg";
 
 import { withSchema } from "../__tests__/setup/postgres.js";
@@ -16,6 +19,7 @@ import { createThreadStore } from "../memory/thread-store.js";
 import type { DraftDocument } from "../report-model/draft.js";
 import { upsertAnalysis } from "../state/analyses.js";
 import { upsertArtifact, type RegisterArtifactInput } from "../state/artifacts.js";
+import { insertRun } from "../state/runs.js";
 import { createReportSessionRuntime } from "./report-session-runtime.js";
 
 const DOC_ONE: DraftDocument = {
@@ -185,5 +189,63 @@ describe("createReportSessionRuntime", () => {
         expect(reloaded.outcome).toBe("found");
         if (reloaded.outcome !== "found") throw new Error("expected found");
         expect(Object.keys(reloaded.state.snapshot.artifacts)).toEqual([earlyPath]);
+    });
+
+    /** Write the synthesis record of a run under a workspace root. */
+    async function writeSynthesis(root: string, runId: string, pmids: string[]): Promise<void> {
+        const dir = join(root, "runs", runId);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "synthesis.json"), JSON.stringify({ runId, keyReferences: pmids.map((pmid) => ({ pmid })) }), "utf8");
+    }
+
+    it("carries the citation evidence into the stored snapshot through the seam", async () => {
+        const analysisId = "analysis-citations";
+        const threadId = "thread-citations";
+        const runId = "run-citations";
+        await seedAnalysis(analysisId);
+        await seedThread(threadId, analysisId);
+        (await insertRun(pool, { runId, analysisId, workflowName: "executeAnalysis" }))._unsafeUnwrap();
+        const root = await mkdtemp(join(tmpdir(), "session-citations-"));
+        try {
+            await writeSynthesis(root, runId, ["12345", "678"]);
+
+            const runtime = createReportSessionRuntime({ pool, resolveWorkspaceRoot: () => root });
+            const ensured = await runtime.ensureSessionState(threadId);
+            expect(ensured.outcome).toBe("ready");
+
+            // The stored row is the anchor. A fresh runtime reads it back, thus the assertion is on the
+            // durable state and not on the return of the pin.
+            const loaded = await createReportSessionRuntime({ pool, resolveWorkspaceRoot: () => root }).gateway.load(threadId);
+            expect(loaded.outcome).toBe("found");
+            if (loaded.outcome !== "found") throw new Error("expected found");
+            expect(loaded.state.snapshot.citations).toEqual(["pmid:12345", "pmid:678"]);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+
+    it("lands the pin with no citation when the deps bind no workspace root", async () => {
+        const analysisId = "analysis-no-seam";
+        const threadId = "thread-no-seam";
+        const runId = "run-no-seam";
+        await seedAnalysis(analysisId);
+        await seedThread(threadId, analysisId);
+        (await insertRun(pool, { runId, analysisId, workflowName: "executeAnalysis" }))._unsafeUnwrap();
+        const root = await mkdtemp(join(tmpdir(), "session-no-seam-"));
+        try {
+            await writeSynthesis(root, runId, ["12345"]);
+
+            // The deps bind no root, thus the record on disk reaches no key.
+            const runtime = createReportSessionRuntime({ pool });
+            const ensured = await runtime.ensureSessionState(threadId);
+            expect(ensured.outcome).toBe("ready");
+
+            const loaded = await runtime.gateway.load(threadId);
+            expect(loaded.outcome).toBe("found");
+            if (loaded.outcome !== "found") throw new Error("expected found");
+            expect(loaded.state.snapshot.citations).toEqual([]);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
     });
 });

--- a/harness/src/app/report-session-runtime.ts
+++ b/harness/src/app/report-session-runtime.ts
@@ -45,6 +45,7 @@ import type {
     SessionStateToken,
     StampResult,
 } from "../tools/report-authoring/authoring-tools.js";
+import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
 
 /** The empty draft of a fresh session. The pin writes the snapshot first, thus the document is empty here. */
 const EMPTY_DRAFT: DraftDocument = { title: "", sections: [] };
@@ -65,6 +66,11 @@ export type EnsureSessionStateResult = { outcome: "ready"; state: StoredSessionS
 
 export interface ReportSessionRuntimeDeps {
     readonly pool: Pool;
+    /**
+     * The workspace-root seam of the pin. The citation evidence of an analysis sits on disk under the
+     * root, thus a composition that binds no seam pins the artifact map alone.
+     */
+    readonly resolveWorkspaceRoot?: ResolveWorkspaceRoot;
     readonly logger?: Logger;
 }
 
@@ -109,12 +115,20 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
      * Pin the snapshot and write the row. A pin failure writes no row, thus a
      * later run pins again. The write is insert-if-absent, thus two concurrent
      * first runs make one row and both read the winner back.
+     *
+     * The pin takes the workspace-root seam for the citation evidence. An absent
+     * seam pins no citation, thus a citation block of the session resolves against
+     * an empty list. The warning names that condition one time for each session.
      */
     async function pinAndWrite(threadId: string, analysisId: string): Promise<EnsureSessionStateResult> {
-        const pinned = await pinReportSnapshot(pool, analysisId);
+        if (deps.resolveWorkspaceRoot === undefined) {
+            log.warn("the composition binds no workspace root, thus the pin carries no citation evidence", { threadId, analysisId });
+        }
+        const pinned = await pinReportSnapshot(pool, analysisId, deps.resolveWorkspaceRoot ? { resolveWorkspaceRoot: deps.resolveWorkspaceRoot } : {});
         if (pinned.isErr()) {
-            log.error("the snapshot pin failed", { threadId, analysisId, ...log.errorFields(pinned.error.cause) });
-            return { outcome: "failed", kind: "unavailable", detail: "the artifact ledger read failed" };
+            log.error("the snapshot pin failed", { threadId, analysisId, kind: pinned.error.kind, ...log.errorFields(pinned.error.cause) });
+            const detail = pinned.error.kind === "run-listing-failed" ? "the run listing read failed" : "the artifact ledger read failed";
+            return { outcome: "failed", kind: "unavailable", detail };
         }
         const written = await store.writeSnapshot({ threadId, analysisId, snapshot: pinned.value });
         return written.match(

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -56,6 +56,11 @@ A reference names the path alone, and the session stamps the hash from the pinne
 evidence when the block lands. A path that the pinned evidence does not hold comes
 back as an unresolved reference, and you repair that path.
 
+The literature of the report composes as citation blocks, and each one binds to a
+citation id of the pinned evidence. A citation that the pinned evidence does not
+hold does not resolve. Report such a citation to the user, and never write it into
+the prose instead.
+
 \`finish_draft\` checks the whole draft against the schema, the id rule, and the
 structural tier. It returns each completeness gap, or the finished document. Read
 the gaps, repair the draft, and finish again.
@@ -112,6 +117,9 @@ page reads clean.
 - **Probe for a hash.** Never guess a content hash, and never add a block to read a
   hash out of a refusal. A reference names the path, and the session stamps the
   hash. \`list_pinned_artifacts\` names the paths that a reference can bind to.
+- **Inline a citation that does not resolve.** A citation block binds to a citation
+  id of the pinned evidence. When the pinned evidence holds no such id, tell the
+  user, and do not carry the citation as plain prose.
 - **Rebuild when one amend serves.** One feedback is one block change. Change, move,
   or remove that block by its id, and do not re-author the report.
 - **Leave a gap unread.** When \`finish_draft\` or \`preview_report\` reports a gap or

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -57,9 +57,10 @@ evidence when the block lands. A path that the pinned evidence does not hold com
 back as an unresolved reference, and you repair that path.
 
 The literature of the report composes as citation blocks, and each one binds to a
-citation id of the pinned evidence. A citation that the pinned evidence does not
-hold does not resolve. Report such a citation to the user, and never write it into
-the prose instead.
+citation id of the pinned evidence. \`list_pinned_artifacts\` names those ids in its
+\`citations\` field: read them there, and never take an id out of a refusal. A
+citation that the pinned evidence does not hold does not resolve. Report such a
+citation to the user, and never write it into the prose instead.
 
 \`finish_draft\` checks the whole draft against the schema, the id rule, and the
 structural tier. It returns each completeness gap, or the finished document. Read

--- a/harness/src/report-model/pin-snapshot.test.ts
+++ b/harness/src/report-model/pin-snapshot.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Pool } from "pg";
 
 import { withSchema } from "../__tests__/setup/postgres.js";
 import { upsertArtifact, upsertArtifacts, type RegisterArtifactInput } from "../state/artifacts.js";
+import { insertRun } from "../state/runs.js";
 import { pinReportSnapshot } from "./pin-snapshot.js";
 
 const ANALYSIS = "analysis-pin";
@@ -111,5 +115,131 @@ describe("pinReportSnapshot", () => {
         expect(entry).toBeDefined();
         expect(Object.hasOwn(entry, "rows")).toBe(false);
         expect(entry.rows).toBeUndefined();
+    });
+});
+
+describe("the citation evidence of the pin", () => {
+    let root: string;
+
+    beforeEach(async () => {
+        root = await mkdtemp(join(tmpdir(), "pin-citations-"));
+    });
+
+    afterEach(async () => {
+        await rm(root, { recursive: true, force: true });
+    });
+
+    /** The seam of the test. One analysis maps onto the one temporary tree. */
+    function resolveRoot(): string {
+        return root;
+    }
+
+    async function seedRun(runId: string): Promise<void> {
+        (await insertRun(pool, { runId, analysisId: ANALYSIS, workflowName: "executeAnalysis" }))._unsafeUnwrap();
+    }
+
+    /** Write the synthesis record of a run as raw text, thus a test can write a record that no schema admits. */
+    async function writeSynthesis(runId: string, text: string): Promise<void> {
+        const dir = join(root, "runs", runId);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "synthesis.json"), text, "utf8");
+    }
+
+    async function pinCitations(): Promise<string[] | undefined> {
+        const snapshot = (await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot }))._unsafeUnwrap();
+        return snapshot.citations;
+    }
+
+    it("gives one `pmid:` key for each key reference of a run synthesis", async () => {
+        await seedRun("run-1");
+        await writeSynthesis(
+            "run-1",
+            JSON.stringify({
+                runId: "run-1",
+                keyReferences: [
+                    { pmid: "12345", citation: "Smith 2020", description: "The primary paper." },
+                    { pmid: " 987 ", citation: "Jones 2019", description: "The second paper." },
+                ],
+            }),
+        );
+
+        // The trim of the second id proves that the key carries the id alone.
+        expect(await pinCitations()).toEqual(["pmid:12345", "pmid:987"]);
+    });
+
+    it("dedupes one paper across two runs and sorts the keys in code-unit order", async () => {
+        await seedRun("run-a");
+        await seedRun("run-b");
+        await writeSynthesis("run-a", JSON.stringify({ keyReferences: [{ pmid: "999" }, { pmid: "12345" }] }));
+        await writeSynthesis("run-b", JSON.stringify({ keyReferences: [{ pmid: "12345" }, { pmid: "42" }] }));
+
+        expect(await pinCitations()).toEqual(["pmid:12345", "pmid:42", "pmid:999"]);
+    });
+
+    it("takes the key references of a record that no whole schema admits", async () => {
+        await seedRun("run-legacy");
+        // The record carries the key references and no other field. A whole-schema parse would refuse it,
+        // and the citation list of the analysis would then hold nothing.
+        await writeSynthesis("run-legacy", JSON.stringify({ keyReferences: [{ pmid: "555" }] }));
+
+        expect(await pinCitations()).toEqual(["pmid:555"]);
+    });
+
+    it("drops a key reference whose pmid is empty or is not a string", async () => {
+        await seedRun("run-thin");
+        await writeSynthesis("run-thin", JSON.stringify({ keyReferences: [{ pmid: "   " }, { pmid: 42 }, {}, "text", { pmid: "77" }] }));
+
+        expect(await pinCitations()).toEqual(["pmid:77"]);
+    });
+
+    it("gives no key and no error for a run that holds no synthesis record", async () => {
+        await seedRun("run-bare");
+
+        const result = await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot });
+
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().citations).toEqual([]);
+    });
+
+    it("gives no key and no error for a malformed record", async () => {
+        await seedRun("run-broken");
+        await writeSynthesis("run-broken", "{ this is not json");
+
+        const result = await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot });
+
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().citations).toEqual([]);
+    });
+
+    it("gives no key for a record over the read cap", async () => {
+        await seedRun("run-huge");
+        // The record parses, but its bytes pass 1 MiB. A cut text cannot parse, thus the read gives none.
+        await writeSynthesis("run-huge", JSON.stringify({ keyReferences: [{ pmid: "12345", description: "x".repeat(1024 * 1024 + 64) }] }));
+
+        const result = await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot });
+
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().citations).toEqual([]);
+    });
+
+    it("pins no citation when the composition gives no workspace-root seam", async () => {
+        await seedRun("run-1");
+        await writeSynthesis("run-1", JSON.stringify({ keyReferences: [{ pmid: "12345" }] }));
+
+        const snapshot = (await pinReportSnapshot(pool, ANALYSIS))._unsafeUnwrap();
+
+        expect(snapshot.citations).toEqual([]);
+    });
+
+    it("fails the pin when the run listing fails", async () => {
+        await seedRun("run-1");
+        // A store fault is not absence. The dropped table makes the listing fail against a real driver
+        // error, thus the pin refuses instead of writing an empty citation list.
+        await pool.query("DROP TABLE cortex_runs");
+
+        const result = await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot });
+
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().kind).toBe("run-listing-failed");
     });
 });

--- a/harness/src/report-model/pin-snapshot.test.ts
+++ b/harness/src/report-model/pin-snapshot.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Pool } from "pg";
 
+import type { CitationReference } from "../contracts/report-reference.js";
 import { withSchema } from "../__tests__/setup/postgres.js";
 import { upsertArtifact, upsertArtifacts, type RegisterArtifactInput } from "../state/artifacts.js";
 import { insertRun } from "../state/runs.js";
+import { createFixtureResolver } from "./fixture-resolver.js";
 import { pinReportSnapshot } from "./pin-snapshot.js";
 
 const ANALYSIS = "analysis-pin";
@@ -167,6 +169,38 @@ describe("the citation evidence of the pin", () => {
         expect(await pinCitations()).toEqual(["pmid:12345", "pmid:987"]);
     });
 
+    it("gives one `pmid:` key for each reference of a finding", async () => {
+        await seedRun("run-findings");
+        // The record names the paper in the references of a finding alone. That field carries the
+        // superset of the literature that the synthesis engaged, thus a citation over it must resolve.
+        await writeSynthesis(
+            "run-findings",
+            JSON.stringify({
+                findings: [
+                    { stepId: "step-1", references: [{ pmid: "31234", citation: "Smith 2020" }, { pmid: " 4567 " }] },
+                    { stepId: "step-2", references: [{ pmid: "" }, { pmid: 42 }, "text", {}] },
+                    "not-an-object",
+                ],
+                keyReferences: [],
+            }),
+        );
+
+        expect(await pinCitations()).toEqual(["pmid:31234", "pmid:4567"]);
+    });
+
+    it("dedupes one paper that both fields of a record name", async () => {
+        await seedRun("run-both");
+        await writeSynthesis(
+            "run-both",
+            JSON.stringify({
+                findings: [{ references: [{ pmid: "12345" }, { pmid: "678" }] }],
+                keyReferences: [{ pmid: "12345", citation: "Smith 2020" }],
+            }),
+        );
+
+        expect(await pinCitations()).toEqual(["pmid:12345", "pmid:678"]);
+    });
+
     it("dedupes one paper across two runs and sorts the keys in code-unit order", async () => {
         await seedRun("run-a");
         await seedRun("run-b");
@@ -229,6 +263,19 @@ describe("the citation evidence of the pin", () => {
         const snapshot = (await pinReportSnapshot(pool, ANALYSIS))._unsafeUnwrap();
 
         expect(snapshot.citations).toEqual([]);
+    });
+
+    it("resolves a citation reference over a pinned synthesis pmid", async () => {
+        await seedRun("run-agree");
+        await writeSynthesis("run-agree", JSON.stringify({ keyReferences: [{ pmid: "31234", citation: "Smith 2020" }] }));
+
+        const snapshot = (await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot }))._unsafeUnwrap();
+        const reference: CitationReference = { kind: "citation", idKind: "pmid", id: "31234", raw: "Smith 2020" };
+        const resolved = await createFixtureResolver().resolve(reference, snapshot);
+
+        // The pin writes the key, and the resolver reads it. One test over the two sides locks the shape
+        // of the key, thus a change on one side alone fails here and not at a session of a user.
+        expect(resolved._unsafeUnwrap()).toEqual({ type: "citation", id: "pmid:31234" });
     });
 
     it("fails the pin when the run listing fails", async () => {

--- a/harness/src/report-model/pin-snapshot.ts
+++ b/harness/src/report-model/pin-snapshot.ts
@@ -7,32 +7,181 @@
  *
  * The artifact ledger holds one row for each path, and it keeps no history. Thus the set at a past
  * moment is not recoverable later, and the pin must run at the anchor itself.
+ *
+ * The snapshot carries the citation evidence beside the artifact map. The key references of a run
+ * synthesis are the papers that the analysis engaged, and they live in the run tree on disk. Thus the
+ * pin reads that tree through the workspace-root seam of the caller.
  */
 
 import { err, ok, type Result } from "neverthrow";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
 
+import { tryFs } from "../lib/fs-result.js";
 import { queryAnalysisArtifacts, type AnalysisArtifactRef } from "../state/artifacts.js";
 import type { Querier } from "../state/db.js";
+import { queryRunsByAnalysis } from "../state/runs.js";
+import { isSafeId, runDir, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import type { ArtifactSnapshot, ReportSnapshot } from "./reference-resolver.js";
 
 /**
- * The reason that the pin gave no snapshot. The read of the ledger is the one operation that can
- * fail. An analysis with no registered artifact is a normal answer, thus absence is not a member of
- * this set. `cause` carries the underlying fault for a log.
+ * The reason that the pin gave no snapshot. The ledger read and the run listing are the two operations
+ * that can fail. An analysis with no registered artifact and an analysis with no synthesis on disk are
+ * normal answers, thus absence is not a member of this set. `cause` carries the underlying fault for a
+ * log.
  */
 export type PinSnapshotError = {
-    kind: "ledger-read-failed";
+    kind: "ledger-read-failed" | "run-listing-failed";
     cause: unknown;
 };
 
+/** The construction options of the pin. */
+export interface PinReportSnapshotOptions {
+    /**
+     * The workspace-root seam of the caller. The citation evidence sits on disk, thus a composition
+     * that binds no seam pins the artifact map alone.
+     */
+    readonly resolveWorkspaceRoot?: ResolveWorkspaceRoot;
+}
+
+/** The file name of the synthesis record inside the run directory. */
+const SYNTHESIS_FILE = "synthesis.json";
+
 /**
- * Pin the snapshot of one analysis from the artifact ledger.
+ * The cap of one synthesis read. A synthesis record is small by construction, and the cap bounds the
+ * cost of a file that is not. A file over the cap gives no key, because a cut JSON text cannot parse.
+ */
+const SYNTHESIS_CAP_BYTES = 1024 * 1024;
+
+/** The page size of the run listing. The listing walks the pages until a short page ends the walk. */
+const RUN_PAGE_SIZE = 200;
+
+/**
+ * Read a synthesis record under the cap, or give `undefined` when the bytes do not come back.
+ *
+ * The read takes a bounded byte window, thus a file of any size costs the cap. An absent file, a genuine
+ * read fault, and a file over the cap each give `undefined`, because the collection reports no error for
+ * one record.
+ */
+async function readSynthesisText(absolute: string): Promise<string | undefined> {
+    return tryFs<string | undefined>(
+        "pinReportSnapshot.readSynthesis",
+        async () => {
+            const handle = await open(absolute, "r");
+            try {
+                // The window takes one byte more than the cap. A read that fills it states that the file
+                // holds more bytes than the cap admits, thus the two conditions stay apart.
+                const buffer = Buffer.alloc(SYNTHESIS_CAP_BYTES + 1);
+                const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+                return bytesRead > SYNTHESIS_CAP_BYTES ? undefined : buffer.subarray(0, bytesRead).toString("utf8");
+            } finally {
+                await handle.close();
+            }
+        },
+        { path: absolute, onAbsent: () => undefined },
+    ).unwrapOr(undefined);
+}
+
+/**
+ * The citation keys of one synthesis text.
+ *
+ * The extraction is lenient: it parses the JSON and it takes each `keyReferences` PMID that is a
+ * non-empty string. A whole-schema parse would empty the citation list of the whole analysis for one
+ * record that a different schema version wrote. Malformed JSON gives no key.
+ */
+function citationKeysOf(text: string): string[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        return [];
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+        return [];
+    }
+    const references = (parsed as { keyReferences?: unknown }).keyReferences;
+    if (!Array.isArray(references)) {
+        return [];
+    }
+    const keys: string[] = [];
+    for (const reference of references) {
+        if (typeof reference !== "object" || reference === null) {
+            continue;
+        }
+        const pmid = (reference as { pmid?: unknown }).pmid;
+        if (typeof pmid !== "string") {
+            continue;
+        }
+        const id = pmid.trim();
+        if (id.length > 0) {
+            keys.push(`pmid:${id}`);
+        }
+    }
+    return keys;
+}
+
+/**
+ * Collect the citation evidence of one analysis from the synthesis record of each of its runs.
+ *
+ * The keys dedupe, and they sort in code-unit order. Thus one disk state gives one list, and a second
+ * pin over that state gives the same list.
+ *
+ * A run listing that fails fails the collection, because a store fault is not absence. Each other fault
+ * is a normal condition: an unresolvable workspace root, an absent record, an unreadable record, and a
+ * malformed record each give no key and no error.
+ */
+export async function collectCitationKeys(
+    pool: Querier,
+    resolveWorkspaceRoot: ResolveWorkspaceRoot,
+    analysisId: string,
+): Promise<Result<string[], PinSnapshotError>> {
+    let root: string;
+    try {
+        root = resolveWorkspaceRoot(analysisId);
+    } catch {
+        // The seam signals an unresolvable resource by a throw. The artifact map still states the
+        // membership of the session, thus the fault costs the citation list alone.
+        return ok([]);
+    }
+
+    const keys = new Set<string>();
+    for (let offset = 0; ; offset += RUN_PAGE_SIZE) {
+        const page = await queryRunsByAnalysis(pool, analysisId, { limit: RUN_PAGE_SIZE, offset });
+        if (page.isErr()) {
+            return err({ kind: "run-listing-failed", cause: page.error.cause });
+        }
+        for (const run of page.value) {
+            // The path builder refuses an id that can escape the run tree. A refusal is a throw, thus
+            // the guard keeps the collection on the value channel.
+            if (!isSafeId(run.runId)) {
+                continue;
+            }
+            const text = await readSynthesisText(join(root, runDir(run.runId), SYNTHESIS_FILE));
+            if (text === undefined) {
+                continue;
+            }
+            for (const key of citationKeysOf(text)) {
+                keys.add(key);
+            }
+        }
+        if (page.value.length < RUN_PAGE_SIZE) {
+            return ok([...keys].sort());
+        }
+    }
+}
+
+/**
+ * Pin the snapshot of one analysis from the artifact ledger and from the synthesis records of its runs.
  *
  * The pin copies no cell and no byte. An entry pins identity alone, thus the snapshot grows with the
  * count of artifacts and never with the size of the data. A read of an artifact belongs to the value
  * tier, which runs one time for each report version.
  */
-export async function pinReportSnapshot(pool: Querier, analysisId: string): Promise<Result<ReportSnapshot, PinSnapshotError>> {
+export async function pinReportSnapshot(
+    pool: Querier,
+    analysisId: string,
+    options: PinReportSnapshotOptions = {},
+): Promise<Result<ReportSnapshot, PinSnapshotError>> {
     let ledgerRows: AnalysisArtifactRef[];
     try {
         ledgerRows = await queryAnalysisArtifacts(pool, analysisId);
@@ -49,8 +198,12 @@ export async function pinReportSnapshot(pool: Querier, analysisId: string): Prom
         artifacts[row.path] = { hash: row.hash, fileType: row.fileType };
     }
 
-    // The pin fills no citation. No store holds the citation ids of an analysis, and validation
-    // matches a citation against the external authorities and never against a pinned list. Thus such
-    // a list would state nothing that a later read consumes.
-    return ok({ artifacts });
+    // A citation reference resolves against this list: the resolver refuses a key that the list does not
+    // hold. Thus the pin must state which external ids the analysis engaged, and a session with an empty
+    // list can bind no citation block.
+    if (options.resolveWorkspaceRoot === undefined) {
+        return ok({ artifacts, citations: [] });
+    }
+    const citations = await collectCitationKeys(pool, options.resolveWorkspaceRoot, analysisId);
+    return citations.map((keys) => ({ artifacts, citations: keys }));
 }

--- a/harness/src/report-model/pin-snapshot.ts
+++ b/harness/src/report-model/pin-snapshot.ts
@@ -8,9 +8,10 @@
  * The artifact ledger holds one row for each path, and it keeps no history. Thus the set at a past
  * moment is not recoverable later, and the pin must run at the anchor itself.
  *
- * The snapshot carries the citation evidence beside the artifact map. The key references of a run
- * synthesis are the papers that the analysis engaged, and they live in the run tree on disk. Thus the
- * pin reads that tree through the workspace-root seam of the caller.
+ * The snapshot carries the citation evidence beside the artifact map. The pinned set is the literature
+ * that the synthesis engaged, and two fields of a run synthesis carry it: the key references and the
+ * references of each finding. The records live in the run tree on disk. Thus the pin reads that tree
+ * through the workspace-root seam of the caller.
  */
 
 import { err, ok, type Result } from "neverthrow";
@@ -72,8 +73,19 @@ async function readSynthesisText(absolute: string): Promise<string | undefined> 
                 // The window takes one byte more than the cap. A read that fills it states that the file
                 // holds more bytes than the cap admits, thus the two conditions stay apart.
                 const buffer = Buffer.alloc(SYNTHESIS_CAP_BYTES + 1);
-                const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
-                return bytesRead > SYNTHESIS_CAP_BYTES ? undefined : buffer.subarray(0, bytesRead).toString("utf8");
+                // One read of a network-backed file can give fewer bytes than the window holds. Such a
+                // short read cuts the text in the middle of the JSON, and the record then parses to no
+                // key at all. Thus the loop reads again from the offset that the last read reached, and
+                // it stops when the window fills or when a read gives no byte.
+                let filled = 0;
+                while (filled < buffer.length) {
+                    const { bytesRead } = await handle.read(buffer, filled, buffer.length - filled, filled);
+                    if (bytesRead === 0) {
+                        break;
+                    }
+                    filled += bytesRead;
+                }
+                return filled > SYNTHESIS_CAP_BYTES ? undefined : buffer.subarray(0, filled).toString("utf8");
             } finally {
                 await handle.close();
             }
@@ -83,28 +95,16 @@ async function readSynthesisText(absolute: string): Promise<string | undefined> 
 }
 
 /**
- * The citation keys of one synthesis text.
+ * Take one `pmid:` key from each entry of one reference list, and add it to `keys`.
  *
- * The extraction is lenient: it parses the JSON and it takes each `keyReferences` PMID that is a
- * non-empty string. A whole-schema parse would empty the citation list of the whole analysis for one
- * record that a different schema version wrote. Malformed JSON gives no key.
+ * The walk is lenient: a value that is not a list, an entry that is not an object, and a PMID that is
+ * not a non-empty string each give no key.
  */
-function citationKeysOf(text: string): string[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(text);
-    } catch {
-        return [];
+function pushPmidKeys(list: unknown, keys: string[]): void {
+    if (!Array.isArray(list)) {
+        return;
     }
-    if (typeof parsed !== "object" || parsed === null) {
-        return [];
-    }
-    const references = (parsed as { keyReferences?: unknown }).keyReferences;
-    if (!Array.isArray(references)) {
-        return [];
-    }
-    const keys: string[] = [];
-    for (const reference of references) {
+    for (const reference of list) {
         if (typeof reference !== "object" || reference === null) {
             continue;
         }
@@ -117,24 +117,53 @@ function citationKeysOf(text: string): string[] {
             keys.push(`pmid:${id}`);
         }
     }
+}
+
+/**
+ * The citation keys of one synthesis text.
+ *
+ * The extraction is lenient: it parses the JSON, and it takes each PMID of `keyReferences` and of the
+ * references of each finding. The key references are the papers that the synthesis names as primary, and
+ * the references of the findings are the superset. Thus a citation over either one resolves. A
+ * whole-schema parse would empty the citation list of the whole analysis for one record that a different
+ * schema version wrote. Malformed JSON gives no key.
+ */
+function citationKeysOf(text: string): string[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        return [];
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+        return [];
+    }
+    const keys: string[] = [];
+    pushPmidKeys((parsed as { keyReferences?: unknown }).keyReferences, keys);
+    const findings = (parsed as { findings?: unknown }).findings;
+    if (Array.isArray(findings)) {
+        for (const finding of findings) {
+            if (typeof finding !== "object" || finding === null) {
+                continue;
+            }
+            pushPmidKeys((finding as { references?: unknown }).references, keys);
+        }
+    }
     return keys;
 }
 
 /**
  * Collect the citation evidence of one analysis from the synthesis record of each of its runs.
  *
- * The keys dedupe, and they sort in code-unit order. Thus one disk state gives one list, and a second
- * pin over that state gives the same list.
+ * The pinned set is the literature that the synthesis engaged, and both fields of a record carry it: the
+ * key references and the references of each finding. The keys dedupe, and they sort in code-unit order.
+ * Thus one disk state gives one list, and a second pin over that state gives the same list.
  *
  * A run listing that fails fails the collection, because a store fault is not absence. Each other fault
  * is a normal condition: an unresolvable workspace root, an absent record, an unreadable record, and a
  * malformed record each give no key and no error.
  */
-export async function collectCitationKeys(
-    pool: Querier,
-    resolveWorkspaceRoot: ResolveWorkspaceRoot,
-    analysisId: string,
-): Promise<Result<string[], PinSnapshotError>> {
+async function collectCitationKeys(pool: Querier, resolveWorkspaceRoot: ResolveWorkspaceRoot, analysisId: string): Promise<Result<string[], PinSnapshotError>> {
     let root: string;
     try {
         root = resolveWorkspaceRoot(analysisId);

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -289,7 +289,13 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
     // tool boundary, thus one instance serves every report thread. It comes before
     // the conversation agent, because `start_report_session` takes its anchor
     // operation and pins the snapshot of a new session at the spawn.
-    const reportSession = createReportSessionRuntime({ pool: conversation.pool, ...(conversation.logger ? { logger: conversation.logger } : {}) });
+    // The runtime takes the same root resolver as the session tools, because the pin reads the citation
+    // evidence out of the run tree of the analysis.
+    const reportSession = createReportSessionRuntime({
+        pool: conversation.pool,
+        resolveWorkspaceRoot: conversation.resolveWorkspaceRoot,
+        ...(conversation.logger ? { logger: conversation.logger } : {}),
+    });
 
     // The eyes of the composition resolve one time here. Thus the agent that looks at a page and
     // the tool that starts a session read one answer. No tool reads the precedence again.

--- a/harness/src/tools/report-session/list-artifacts.test.ts
+++ b/harness/src/tools/report-session/list-artifacts.test.ts
@@ -4,7 +4,7 @@
  * Each test drives the tool through `execute` with a temp directory as the workspace root and an
  * in-memory gateway. The tests cover the order of the listing, the cap of the listing, the columns of a
  * CSV and of a TSV, the extension that carries no header, the cut header line, the quoted header, the
- * absent file, the file type that holds no cell, and the session refusal.
+ * absent file, the file type that holds no cell, the pinned citations, and the session refusal.
  */
 
 import { afterAll, describe, expect, it } from "bun:test";
@@ -341,6 +341,41 @@ describe("the columns", () => {
         if (result.outcome === "listed") {
             expect(result.artifacts[0].hash).toBe("sha256:aaa");
             expect(result.artifacts[0].columns).toBeUndefined();
+        }
+    });
+});
+
+describe("the pinned citations", () => {
+    it("gives the stored citation keys in the order that the pin wrote", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", {
+            artifacts: { "runs/r1/step-a/output/de.csv": { hash: "sha256:aaa", fileType: "output" } },
+            citations: ["pmid:12345", "pmid:42", "pmid:999"],
+        });
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("listed");
+        if (result.outcome === "listed") {
+            // The agent binds a citation block to one of these ids, thus the listing is the route to an
+            // id and a refusal never has to teach one.
+            expect(result.citations).toEqual(["pmid:12345", "pmid:42", "pmid:999"]);
+        }
+    });
+
+    it("gives an empty list for a snapshot that pinned no citation", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { artifacts: { "runs/r1/step-a/output/de.csv": { hash: "sha256:aaa", fileType: "output" } } });
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("listed");
+        if (result.outcome === "listed") {
+            expect(result.citations).toEqual([]);
         }
     });
 });

--- a/harness/src/tools/report-session/list-artifacts.ts
+++ b/harness/src/tools/report-session/list-artifacts.ts
@@ -2,8 +2,8 @@
  * The pinned-artifact listing tool of a report session.
  *
  * The tool reads the frozen snapshot of the thread, and it gives the pinned set: the path, the content
- * hash, the file type, and the header columns of a tabular artifact. Thus one call orients the agent, and
- * a reference binds to a path of that set.
+ * hash, the file type, and the header columns of a tabular artifact, plus the pinned citation ids. Thus
+ * one call orients the agent, and a reference binds to a path or to a citation id of that set.
  *
  * The order is the code-unit order of the path. Two calls over one snapshot give one listing, thus the
  * agent reads a stable set. A snapshot can pin many thousands of staged inputs, thus the listing stops at
@@ -54,9 +54,13 @@ export interface PinnedArtifact {
  *
  * `total` counts the whole pinned set, and `truncated` says that the set holds more entries than
  * `artifacts` names. Thus the agent reads a partial listing as a partial listing.
+ *
+ * `citations` gives the pinned citation ids in the code-unit order that the pin stored. A citation
+ * reference binds to one of them, thus the agent reads an id here and never out of a refusal.
  */
 export type ListPinnedArtifactsResult =
-    { outcome: "refused"; refusal: SessionRefusal } | { outcome: "listed"; artifacts: PinnedArtifact[]; total: number; truncated: boolean };
+    | { outcome: "refused"; refusal: SessionRefusal }
+    | { outcome: "listed"; artifacts: PinnedArtifact[]; total: number; truncated: boolean; citations: string[] };
 
 /**
  * The construction deps of the listing tool.
@@ -176,6 +180,8 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
             "file whose bytes do not read each give no columns. " +
             `The listing gives a maximum of ${LISTING_CAP} entries: "total" gives the size of the pinned set, and "truncated" says that the ` +
             "set holds more artifacts than this listing names. " +
+            '"citations" gives the pinned citation ids of this session, each in the "idKind:id" form. A citation block binds to one of ' +
+            "them, thus take an id from this list and never from a refusal. " +
             "The pin freezes at the start of the session, thus a reference binds to an artifact of this pinned set. " +
             "Read it to orient before you bind a block, and to choose the column that a locator names. " +
             "A reference names the path alone: the session stamps the hash from this evidence.",
@@ -220,7 +226,10 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
                 }
                 artifacts.push(artifact);
             }
-            return ok({ outcome: "listed", artifacts, total: paths.length, truncated: paths.length > listed.length });
+            // The pin stores the citation keys sorted, thus the listing passes them through. A snapshot
+            // that pinned no citation gives an empty list, and an empty list is a complete answer.
+            const citations = state.snapshot.citations ?? [];
+            return ok({ outcome: "listed", artifacts, total: paths.length, truncated: paths.length > listed.length, citations });
         },
     });
 }


### PR DESCRIPTION
## What & why

Every citation block of the first real session failed with "not in the pinned evidence", although each PMID sits in the synthesis `keyReferences`. The agent removed the References section and inlined each citation into prose. The pin now collects the key references of each run synthesis into the snapshot citation list, as `pmid:` keys. The resolvers already read that list, thus citation blocks resolve and the literature section returns.

Notes for the reviewer:

- The collection reads `runs/{runId}/synthesis.json` through a new optional workspace-root seam on the session runtime. The composition root passes the resolver the session tools already take.
- The extraction is lenient: `keyReferences[].pmid` where it is a non-empty string. A whole-schema parse would empty the list for a legacy synthesis.
- Absence is a normal condition: an absent, unreadable, malformed, or over-cap synthesis gives no keys and no error. A failed run listing fails the pin, because a store fault is not absence.
- The decided boundary stands: no literature-search tool. The snapshot is the reproducibility bound of a report version.
- The pin suite ran against the podman pgvector container through `CORTEX_TEST_PG_URL`. The cli typecheck ran against the linked working-copy harness.

Refs #371

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
