### PR TITLE
feat(harness): settle the capture, and name the faults of a look

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/design.md
@@ -1,0 +1,23 @@
+## Context
+
+`capturePage` (`lib/page-capture.ts`) navigates, waits for the readiness signal, and screenshots. The page reveals its sections through a `fade-in` transition, and the design CSS collapses every transition under `prefers-reduced-motion` (`report-render/design.ts`). The report-session prompt teaches the look inside its verification section, and it names no concrete fault.
+
+## Goals / Non-Goals
+
+- Goal: the capture reads a settled page, with no mid-fade content.
+- Goal: the agent judges the picture against a named fault list, thus a visible defect cannot pass as clean.
+- Non-goal: a mechanical layout check. The judgment stays with the agent, and the tool blocks nothing.
+
+## Decisions
+
+- **The settle is reduced-motion emulation.** The capture emulates `prefers-reduced-motion: reduce` before the navigation, thus the design CSS shows every element at once and no transition runs. The alternative was a fixed settle delay, and it was rejected: a delay is a race, and the emulation is a contract with the design source.
+- **The checklist lives in the prompt, in the look step.** The faults are judgment work over a picture, thus they belong to the agent guidance and not to the tool result. The list names: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that a fade left invisible.
+- **The emulation sits in `capturePage`.** Both capture sites read one body, thus the old preview path and the eyes settle the same way.
+
+## Risks / Trade-offs
+
+- [The emulation hides a motion defect] → the page is a document, and its motion is decoration. A defect of the settled layout is the defect that matters.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+In the first real session the eyes returned a screenshot with clipped metric cards, and the agent reported a clean layout. The look happened, and the judgment missed a visible defect. The page also animates in on scroll, thus a capture can catch content mid-fade.
+
+## What Changes
+
+- The examination guidance names the concrete faults of a look: clipped text, a truncated number, an overflowing card, a raw column name on an axis, and an unreadable precision.
+- The capture settles the animation before the screenshot, through reduced-motion emulation. The print form respects the same preference already.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-session-agent`: the prompt obligations gain the fault checklist of the look.
+- `report-verification`: the eyes-tool requirement gains the settled capture.
+
+## Impact
+
+- `harness/src/prompts/report-session.ts` — the checklist joins the look step.
+- `harness/src/lib/page-capture.ts` — the reduced-motion emulation before the navigation.
+- No contract change, no tool-surface change, and no store change.

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-session-agent/spec.md
@@ -1,0 +1,34 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The prompt obligations
+The prompt of the agent MUST name its tools and their mechanisms, and it MUST NOT name a dataset, a path, or a format. The prompt MUST carry an explicit "Do NOT" list with the failure modes of report composition. The prompt MUST state that the agent grounds each claim through a reference, and that it does not transcribe a number from memory.
+
+The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
+
+The look step MUST carry the fault checklist. The agent examines the picture for: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that stayed invisible. A found fault is a repair, and never a note.
+
+The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
+
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+
+#### Scenario: The prompt stays free of environment detail
+- **WHEN** a reviewer reads the prompt module
+- **THEN** no dataset name, no path, and no format promise is present
+
+#### Scenario: The prompt teaches the loop order
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the loop order and the visual-spiral anti-pattern are present
+
+#### Scenario: The prompt teaches the path-only rule
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the listing tool is the named orientation source, and the hash-probe anti-pattern is present
+
+#### Scenario: The prompt teaches the citation blocks
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the citation-block rule and the pinned-evidence bound are present
+
+#### Scenario: The prompt carries the fault checklist
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the look step names the clipped text, the truncated number, the overflowing card, the raw axis name, and the precision fault

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-verification/spec.md
@@ -5,7 +5,7 @@
 ### Requirement: The eyes tool
 The eyes tool MUST open the session page through a `file://` navigation of headless Chrome. It MUST give back the screenshot, the console errors, and the failed requests. A missed page MUST be a typed outcome. The tool MUST NOT block the loop on any judgment, because the judgment belongs to the agent.
 
-The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content.
+The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content. The capture MUST show the whole page at a reader viewport, thus a defect below the fold is visible and the checklist is answerable.
 
 The tool MUST reach the browser through the eyes seam of the composition. One look MUST acquire one lease, and the tool MUST release the lease after the look. The release runs on a pass and on a failed capture alike.
 

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/specs/report-verification/spec.md
@@ -1,0 +1,18 @@
+# Delta: report-verification
+
+## MODIFIED Requirements
+
+### Requirement: The eyes tool
+The eyes tool MUST open the session page through a `file://` navigation of headless Chrome. It MUST give back the screenshot, the console errors, and the failed requests. A missed page MUST be a typed outcome. The tool MUST NOT block the loop on any judgment, because the judgment belongs to the agent.
+
+The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content.
+
+The tool MUST reach the browser through the eyes seam of the composition. One look MUST acquire one lease, and the tool MUST release the lease after the look. The release runs on a pass and on a failed capture alike.
+
+A failed release MUST NOT change the outcome of the look, and the log names the failed release. A failed acquire MUST be a typed outcome, and nothing throws.
+
+An injected capture seam MUST win over the eyes seam, because it replaces the whole transport. A composition with no capture seam, no eyes seam, and no configured endpoint has no eyes. The tool MUST report that condition as a typed outcome, one time for each look.
+
+#### Scenario: The capture settles the page
+- **WHEN** the capture navigates to a page with reveal transitions
+- **THEN** the emulated reduced-motion preference is active before the navigation, and the screenshot shows the settled state

--- a/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-name-the-faults-of-a-look/tasks.md
@@ -1,0 +1,15 @@
+## 1. The settled capture
+
+- [x] 1.1 Emulate `prefers-reduced-motion: reduce` in `capturePage`, before the navigation. Make sure that the page object of the chrome connection gives the emulation method.
+- [x] 1.2 Extend the capture comments: the design source collapses each transition under the preference, thus the picture shows the final state.
+- [x] 1.3 A test where the rig admits it, or a stated reason where the chrome connection blocks one.
+
+## 2. The checklist
+
+- [x] 2.1 Extend the look step of `src/prompts/report-session.ts` with the fault checklist: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and invisible content. A found fault is a repair, and never a note.
+- [x] 2.2 Extend the prompt assertions of the agent test for the checklist.
+
+## 3. The gates
+
+- [x] 3.1 Run the targeted suites of the touched modules only.
+- [x] 3.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -157,6 +157,8 @@ The prompt of the agent MUST name its tools and their mechanisms, and it MUST NO
 
 The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
 
+The look step MUST carry the fault checklist. The agent examines the picture for: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that stayed invisible. A found fault is a repair, and never a note.
+
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
 The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
@@ -176,6 +178,10 @@ The prompt MUST state that the literature references compose as citation blocks,
 #### Scenario: The prompt teaches the citation blocks
 - **WHEN** a reviewer reads the prompt module
 - **THEN** the citation-block rule and the pinned-evidence bound are present
+
+#### Scenario: The prompt carries the fault checklist
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the look step names the clipped text, the truncated number, the overflowing card, the raw axis name, and the precision fault
 
 ### Requirement: The report turn reads the copied narrative, never the live memory
 

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -82,7 +82,7 @@ The harness MUST ship the static realization over a standing sidecar. It returns
 ### Requirement: The eyes tool
 The eyes tool MUST open the session page through a `file://` navigation of headless Chrome. It MUST give back the screenshot, the console errors, and the failed requests. A missed page MUST be a typed outcome. The tool MUST NOT block the loop on any judgment, because the judgment belongs to the agent.
 
-The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content.
+The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content. The capture MUST show the whole page at a reader viewport, thus a defect below the fold is visible and the checklist is answerable.
 
 The tool MUST reach the browser through the eyes seam of the composition. One look MUST acquire one lease, and the tool MUST release the lease after the look. The release runs on a pass and on a failed capture alike.
 

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -82,6 +82,8 @@ The harness MUST ship the static realization over a standing sidecar. It returns
 ### Requirement: The eyes tool
 The eyes tool MUST open the session page through a `file://` navigation of headless Chrome. It MUST give back the screenshot, the console errors, and the failed requests. A missed page MUST be a typed outcome. The tool MUST NOT block the loop on any judgment, because the judgment belongs to the agent.
 
+The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content.
+
 The tool MUST reach the browser through the eyes seam of the composition. One look MUST acquire one lease, and the tool MUST release the lease after the look. The release runs on a pass and on a failed capture alike.
 
 A failed release MUST NOT change the outcome of the look, and the log names the failed release. A failed acquire MUST be a typed outcome, and nothing throws.
@@ -91,6 +93,10 @@ An injected capture seam MUST win over the eyes seam, because it replaces the wh
 #### Scenario: The eyes give the picture and the faults
 - **WHEN** the eyes run after a preview
 - **THEN** the result carries the screenshot, the console errors, and the failed requests
+
+#### Scenario: The capture settles the page
+- **WHEN** the capture navigates to a page with reveal transitions
+- **THEN** the emulated reduced-motion preference is active before the navigation, and the screenshot shows the settled state
 
 #### Scenario: No page is a typed outcome
 - **WHEN** the eyes run before any preview

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -143,6 +143,21 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("cosmetic doubt");
     });
 
+    test("the look step carries the fault checklist", () => {
+        // Each fault of the checklist is a stable substring, thus a look that judges
+        // by taste alone cannot pass as guidance.
+        expect(reportSessionPrompt).toContain("clipped text");
+        expect(reportSessionPrompt).toContain("a truncated number");
+        expect(reportSessionPrompt).toContain("an overflowing card");
+        expect(reportSessionPrompt).toContain("a raw column name on an axis");
+        expect(reportSessionPrompt).toContain("an unreadable precision");
+        expect(reportSessionPrompt).toContain("content that stayed invisible");
+        // A found fault ends in a repair, thus the agent never reports one instead.
+        expect(reportSessionPrompt).toContain("A found fault is a repair, and never a note");
+        // The spiral warning reads against the same checklist, thus the two agree.
+        expect(reportSessionPrompt).toContain("look checklist names");
+    });
+
     test("the prompt names the listing tool as the orientation source and bans the hash probe", () => {
         // The path-only rule and its anti-pattern are stable substrings, thus the
         // assertion does not couple to the full prose.

--- a/harness/src/lib/page-capture.test.ts
+++ b/harness/src/lib/page-capture.test.ts
@@ -1,25 +1,36 @@
 /**
- * Unit tests for the settle of the capture.
+ * Unit tests for the settle and the frame of the capture.
  *
  * The connector seam of the chrome module hands the capture a page that no browser backs. Thus the order of
- * the emulation and the navigation is observable with no sidecar at all.
+ * the steps and the arguments of each setter are observable with no sidecar at all.
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import type { Browser, MediaFeature } from "puppeteer-core";
+import type { Browser, MediaFeature, ScreenshotOptions, Viewport } from "puppeteer-core";
 
 import { setBrowserConnector } from "./chrome.js";
 import { capturePage } from "./page-capture.js";
 
-/** The steps that the capture drove, in order, and the media features that it emulated. */
+/** The steps that the capture drove, in order, and the arguments that it gave to each of the three setters. */
 interface Recorder {
     readonly steps: string[];
     readonly features: MediaFeature[][];
+    readonly viewports: Viewport[];
+    readonly shots: ScreenshotOptions[];
+}
+
+/** A recorder with each list empty, for one test. */
+function makeRecorder(): Recorder {
+    return { steps: [], features: [], viewports: [], shots: [] };
 }
 
 function makeFakeBrowser(recorder: Recorder): Browser {
     const page = {
         on: () => {},
+        setViewport: async (viewport: Viewport) => {
+            recorder.steps.push("viewport");
+            recorder.viewports.push(viewport);
+        },
         emulateMediaFeatures: async (features: MediaFeature[]) => {
             recorder.steps.push("emulate");
             recorder.features.push(features);
@@ -30,8 +41,9 @@ function makeFakeBrowser(recorder: Recorder): Browser {
         evaluate: async () => {
             recorder.steps.push("evaluate");
         },
-        screenshot: async () => {
+        screenshot: async (options: ScreenshotOptions) => {
             recorder.steps.push("screenshot");
+            recorder.shots.push(options);
             return "c2hvdA==";
         },
     };
@@ -44,7 +56,7 @@ function makeFakeBrowser(recorder: Recorder): Browser {
             close: async () => {},
         }),
     };
-    // The capture reads five members of a page, and the connection cache reads four members of a browser. The
+    // The capture reads six members of a page, and the connection cache reads four members of a browser. The
     // fake carries those members, thus no call of the capture reaches the gap between the fake and the class
     // of puppeteer.
     return fake as unknown as Browser;
@@ -58,16 +70,31 @@ afterEach(() => {
 });
 
 describe("the settled capture", () => {
-    it("emulates the reduced-motion preference before the navigation", async () => {
-        const recorder: Recorder = { steps: [], features: [] };
+    it("sizes the window and emulates the reduced-motion preference before the navigation", async () => {
+        const recorder = makeRecorder();
         restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder));
 
         const capture = await capturePage({ browserUrl: "http://capture.test:9222" }, "http://page.test/report");
 
-        // The emulation precedes the navigation, thus the page reveals its sections with each transition
-        // already collapsed. A later emulation would reach a page that ran its transitions already.
-        expect(recorder.steps).toEqual(["emulate", "goto", "evaluate", "screenshot"]);
+        // The size and the emulation both precede the navigation. Thus the layout resolves at the width of a
+        // reader, and the page reveals its sections with each transition already collapsed.
+        expect(recorder.steps).toEqual(["viewport", "emulate", "goto", "evaluate", "screenshot"]);
         expect(recorder.features).toEqual([[{ name: "prefers-reduced-motion", value: "reduce" }]]);
         expect(capture.screenshotBase64).toBe("c2hvdA==");
+    });
+});
+
+describe("the framed capture", () => {
+    it("gives the whole document at a window that clears each breakpoint of the design", async () => {
+        const recorder = makeRecorder();
+        // The connection cache holds one browser for each endpoint, thus this test names its own endpoint.
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder));
+
+        await capturePage({ browserUrl: "http://capture-frame.test:9222" }, "http://page.test/report");
+
+        // A narrow window collapses each multi-column band, and a window-sized picture hides each section
+        // below the fold. Thus the two values together make the look checklist answerable.
+        expect(recorder.viewports).toEqual([{ width: 1440, height: 900 }]);
+        expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }]);
     });
 });

--- a/harness/src/lib/page-capture.test.ts
+++ b/harness/src/lib/page-capture.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the settle of the capture.
+ *
+ * The connector seam of the chrome module hands the capture a page that no browser backs. Thus the order of
+ * the emulation and the navigation is observable with no sidecar at all.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Browser, MediaFeature } from "puppeteer-core";
+
+import { setBrowserConnector } from "./chrome.js";
+import { capturePage } from "./page-capture.js";
+
+/** The steps that the capture drove, in order, and the media features that it emulated. */
+interface Recorder {
+    readonly steps: string[];
+    readonly features: MediaFeature[][];
+}
+
+function makeFakeBrowser(recorder: Recorder): Browser {
+    const page = {
+        on: () => {},
+        emulateMediaFeatures: async (features: MediaFeature[]) => {
+            recorder.steps.push("emulate");
+            recorder.features.push(features);
+        },
+        goto: async () => {
+            recorder.steps.push("goto");
+        },
+        evaluate: async () => {
+            recorder.steps.push("evaluate");
+        },
+        screenshot: async () => {
+            recorder.steps.push("screenshot");
+            return "c2hvdA==";
+        },
+    };
+    const fake = {
+        connected: true,
+        on: () => {},
+        wsEndpoint: () => "ws://capture.test",
+        createBrowserContext: async () => ({
+            newPage: async () => page,
+            close: async () => {},
+        }),
+    };
+    // The capture reads five members of a page, and the connection cache reads four members of a browser. The
+    // fake carries those members, thus no call of the capture reaches the gap between the fake and the class
+    // of puppeteer.
+    return fake as unknown as Browser;
+}
+
+let restoreConnector: (() => void) | undefined;
+
+afterEach(() => {
+    restoreConnector?.();
+    restoreConnector = undefined;
+});
+
+describe("the settled capture", () => {
+    it("emulates the reduced-motion preference before the navigation", async () => {
+        const recorder: Recorder = { steps: [], features: [] };
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder));
+
+        const capture = await capturePage({ browserUrl: "http://capture.test:9222" }, "http://page.test/report");
+
+        // The emulation precedes the navigation, thus the page reveals its sections with each transition
+        // already collapsed. A later emulation would reach a page that ran its transitions already.
+        expect(recorder.steps).toEqual(["emulate", "goto", "evaluate", "screenshot"]);
+        expect(recorder.features).toEqual([[{ name: "prefers-reduced-motion", value: "reduce" }]]);
+        expect(capture.screenshotBase64).toBe("c2hvdA==");
+    });
+});

--- a/harness/src/lib/page-capture.ts
+++ b/harness/src/lib/page-capture.ts
@@ -10,6 +10,10 @@
  * imports them, thus a rename or a retime reaches the waiter at compile time. A second copy of the wait
  * script would instead degrade every capture to the readiness timeout, and no type would break.
  *
+ * The capture emulates the reduced-motion preference before the navigation. The design source collapses each
+ * transition under that preference, and it starts each reveal in its visible state. Thus the picture shows
+ * the final state, and no element appears mid-fade.
+ *
  * The capture speaks the throw protocol, because the chrome connection does. A caller that needs a typed
  * outcome guards the call.
  */
@@ -95,6 +99,10 @@ export function capturePage(chrome: ChromeConfig, url: string, options: CaptureO
         page.on("requestfailed", (req) => {
             failedRequests.push({ url: req.url(), reason: req.failure()?.errorText ?? "unknown" });
         });
+
+        // The preference is active before the navigation, because the page reveals its sections as it loads.
+        // A preference that arrives after the load reaches a page that already runs its transitions.
+        await page.emulateMediaFeatures([{ name: "prefers-reduced-motion", value: "reduce" }]);
 
         await page.goto(url, { waitUntil: "networkidle2", timeout: PAGE_NAV_TIMEOUT_MS });
 

--- a/harness/src/lib/page-capture.ts
+++ b/harness/src/lib/page-capture.ts
@@ -53,6 +53,15 @@ export interface CaptureOptions {
 const SELECTOR_TIMEOUT_MS = 5_000;
 
 /**
+ * The window of one capture, in CSS pixels.
+ *
+ * The width clears each breakpoint of the design source. Thus a multi-column band lays out at the width that a
+ * reader gets, and no band collapses to one column because the window was narrow.
+ */
+const VIEWPORT_WIDTH = 1440;
+const VIEWPORT_HEIGHT = 900;
+
+/**
  * The body of the readiness wait, in the browser context. The sentinel arm resolves a page that dispatched
  * the event before this wait registered, thus a plain listener never blocks forever. The timer arm bounds a
  * page that never signals.
@@ -84,6 +93,9 @@ function waitForThemeReady(sentinel: string, event: string, timeout: number): Pr
 /**
  * Capture one page: the screenshot, the console errors, and the failed requests.
  *
+ * The picture holds the whole document, and not the window alone. Thus a caller can judge a section that a
+ * reader reaches by a scroll.
+ *
  * The readiness wait is best-effort. A page that never signals still captures at the readiness budget, thus
  * a broken page gives a picture that shows what broke.
  */
@@ -99,6 +111,10 @@ export function capturePage(chrome: ChromeConfig, url: string, options: CaptureO
         page.on("requestfailed", (req) => {
             failedRequests.push({ url: req.url(), reason: req.failure()?.errorText ?? "unknown" });
         });
+
+        // The size is set before the navigation, because a layout resolves at load time. The connection gives
+        // a small default window, and that window collapses each multi-column band of the design.
+        await page.setViewport({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
 
         // The preference is active before the navigation, because the page reveals its sections as it loads.
         // A preference that arrives after the load reaches a page that already runs its transitions.
@@ -121,7 +137,9 @@ export function capturePage(chrome: ChromeConfig, url: string, options: CaptureO
             await new Promise((resolve) => setTimeout(resolve, settle));
         }
 
-        const screenshot = await page.screenshot({ encoding: "base64", fullPage: false });
+        // The picture must show the whole document at the layout that a reader gets. Thus a defect below the
+        // fold is visible, and a question about content that never appeared has an answer.
+        const screenshot = await page.screenshot({ encoding: "base64", fullPage: true });
         return {
             screenshotBase64: typeof screenshot === "string" ? screenshot : Buffer.from(screenshot).toString("base64"),
             consoleErrors,

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -95,8 +95,10 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
 - \`preview_report\` renders the current draft to a page. The Preview section above
   gives its rules.
 - \`examine_page\` opens the rendered page in a real browser. It gives back a
-  screenshot, the console errors, and the failed requests. Look at the page, and
-  examine the picture for each of these faults:
+  screenshot, the console errors, and the failed requests. The picture holds the
+  whole page, from the title to the last block, at the width that a reader gets.
+  Thus a section that the picture does not show is a real fault, and never the
+  fold. Look at the page, and examine the picture for each of these faults:
   - clipped text: a word, a label, or a line that a box cuts short.
   - a truncated number: a value that its card, its cell, or its label cuts short.
   - an overflowing card: content that runs past its frame, or past its neighbor.
@@ -115,8 +117,9 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
   you look at the current page. It runs the whole gate first, thus a gap or an
   unresolved reference comes back, and no version lands. A thread holds one version.
 
-Look again after each repair, because a repair changes the page. Record when the
-page reads clean.
+Look again after each repair, because a repair changes the page. The page reads
+clean when the checklist names no fault, no chart is absent, and no request
+failed. When the page reads clean, record.
 
 ## Do NOT
 
@@ -141,5 +144,5 @@ page reads clean.
 - **Spiral on a cosmetic doubt.** The visual spiral is a loop of small visual worries
   with no fault to repair. Look one time, then repair a real fault: a fault that the
   look checklist names, an absent chart, or a failed request. A named fault is real
-  work. A matter of taste is not a fault. When the page carries no named fault, record.
+  work. A matter of taste is not a fault. When the page reads clean, record.
 `;

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -95,9 +95,22 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
 - \`preview_report\` renders the current draft to a page. The Preview section above
   gives its rules.
 - \`examine_page\` opens the rendered page in a real browser. It gives back a
-  screenshot, the console errors, and the failed requests. Look at the page.
-- Repair each fault that the look shows. A broken layout, an absent chart, and a
-  failed request each name a block or a binding that you repair.
+  screenshot, the console errors, and the failed requests. Look at the page, and
+  examine the picture for each of these faults:
+  - clipped text: a word, a label, or a line that a box cuts short.
+  - a truncated number: a value that its card, its cell, or its label cuts short.
+  - an overflowing card: content that runs past its frame, or past its neighbor.
+  - a raw column name on an axis, in a legend, or in a table header. A reader reads
+    a written label, not the name that the evidence carries.
+  - an unreadable precision: a number with too many digits to read, or a rounding
+    that hides the result.
+  - content that stayed invisible: an empty band, a blank card, or a section that
+    the picture does not show.
+
+  A found fault is a repair, and never a note. Never describe such a fault to the
+  user in place of the repair.
+- Repair each fault that the look shows. A named fault of the checklist, an absent
+  chart, and a failed request each name a block or a binding that you repair.
 - \`record_report_version\` records the report as one version. It records only after
   you look at the current page. It runs the whole gate first, thus a gap or an
   unresolved reference comes back, and no version lands. A thread holds one version.
@@ -126,7 +139,7 @@ page reads clean.
 - **Leave a gap unread.** When \`finish_draft\` or \`preview_report\` reports a gap or
   an unresolved reference, repair it. Do not present a report that does not finish.
 - **Spiral on a cosmetic doubt.** The visual spiral is a loop of small visual worries
-  with no fault to repair. Look one time, then repair a real fault: a broken layout, an
-  absent chart, or a failed request. A matter of taste is not a fault. When the page
-  reads clean, record.
+  with no fault to repair. Look one time, then repair a real fault: a fault that the
+  look checklist names, an absent chart, or a failed request. A named fault is real
+  work. A matter of taste is not a fault. When the page carries no named fault, record.
 `;

--- a/harness/src/runtime/assemble.test.ts
+++ b/harness/src/runtime/assemble.test.ts
@@ -206,13 +206,16 @@ function eyesGateway(): ReportSessionStateGateway {
 /**
  * Make a browser that no process backs, and give the screenshot that its one page returns.
  *
- * The capture reads the connected flag, it registers the disconnect listener, it opens one context, it
- * drives one page, and it closes the context. The fake carries those members alone. The two-step assertion
- * names the type of puppeteer, because a fake of a class with private members is no structural match.
+ * The capture reads the connected flag, it registers the disconnect listener, it opens one context, it sizes
+ * one page, it emulates the media features of that page, it drives the page, and it closes the context. The
+ * fake carries those members alone. The two-step assertion names the type of puppeteer, because a fake of a
+ * class with private members is no structural match.
  */
 function fakeBrowser(screenshot: string): Browser {
     const page = {
         on: () => {},
+        setViewport: () => Promise.resolve(),
+        emulateMediaFeatures: () => Promise.resolve(),
         goto: () => Promise.resolve(),
         evaluate: () => Promise.resolve(),
         screenshot: () => Promise.resolve(screenshot),

--- a/harness/src/tools/report-session/examine-page.test.ts
+++ b/harness/src/tools/report-session/examine-page.test.ts
@@ -174,13 +174,16 @@ function makeFakeEyes(options: { browserUrl: string; failAcquire?: Error; failRe
 /**
  * Make a browser that no process backs, and give the screenshot that its one page returns.
  *
- * The capture reads the connected flag, it registers the disconnect listener, it opens one context, it
- * drives one page, and it closes the context. The fake carries those members alone, thus no call of the
- * capture reaches the gap between the fake and the class of puppeteer.
+ * The capture reads the connected flag, it registers the disconnect listener, it opens one context, it sizes
+ * one page, it emulates the media features of that page, it drives the page, and it closes the context. The
+ * fake carries those members alone, thus no call of the capture reaches the gap between the fake and the
+ * class of puppeteer.
  */
 function makeFakeBrowser(screenshot: string): Browser {
     const page = {
         on: () => {},
+        setViewport: () => Promise.resolve(),
+        emulateMediaFeatures: () => Promise.resolve(),
         goto: () => Promise.resolve(),
         evaluate: () => Promise.resolve(),
         screenshot: () => Promise.resolve(screenshot),


### PR DESCRIPTION
## What & why

The eyes of the first real session returned a screenshot with clipped metric cards, and the agent reported a clean layout. The look happened, and the judgment missed a visible defect. The look step of the prompt now carries the fault checklist: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and invisible content. A found fault is a repair, and never a note.

The capture also settles the page. It emulates the reduced-motion preference before the navigation, and the design source collapses each transition under that preference. Thus the picture shows the final state, and no capture catches content mid-fade.

Notes for the reviewer:

- The emulation API is confirmed against the installed puppeteer-core types, not guessed.
- The capture test drives the existing browser-connector seam with a fake page, and it asserts the call order. No test spawns a browser.
- The judgment stays with the agent: the tool blocks nothing, and the checklist is prompt guidance.

Refs #374

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
