### PR TITLE
feat(harness): oblige the report narrative, the chart, and the headline

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The report-session prompt (`prompts/report-session.ts`) teaches the tools, the grounding, the path-only rule, the citations, and the look. It carries no obligation about the shape of the story, the choice between a chart and a figure, or the headline set. The agent showed that it knows the better metric set when asked, thus the gap is obligation and not capability.
+
+## Goals / Non-Goals
+
+- Goal: the report reads as one argument, and the evidence illustrates the prose.
+- Goal: the native chart replaces a foreign PNG wherever a table artifact holds the data.
+- Goal: the headline row orients the reader before any effect size.
+- Non-goal: a mechanical check of the narrative. The obligations are prompt guidance.
+- Non-goal: a change to the run agents or to the sandbox standards. The run phase keeps its own plots.
+
+## Decisions
+
+- **The spine is an explicit pre-composition step.** The prompt tells the agent to compose the outline before the first block. A spine that exists before the tree prevents the folder-of-results shape, and the outline tools make the order cheap to change.
+- **The chapter names stay out.** The prompt states the flow and bans the literal headings, because the issue decided a paper feel and not a paper template.
+- **The chart-first rule names the decision input.** The choice reads the pinned listing: a table artifact with the columns of the story prefers a chart block. A PNG stays for what no table carries.
+- **The headline obligations name the set.** Cohort and yield first, no caveated value as a headline, contrast inside the card set, and prose that rounds as the cards round. The renderer formats both surfaces with one helper, thus the rounding rule costs the agent nothing.
+- **The anti-pattern list extends.** Three entries: evidence before its sentence, a figure where a table serves, and a caveated headline.
+
+## Risks / Trade-offs
+
+- [A longer prompt costs each turn] → the three obligations are compact, and the cached prefix carries them one time.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Three quality faults of the first report trace to absent prompt obligations, not to absent capability. The agent led its headline row with an unshrunken fold-change that shrinkage collapses toward zero. It reused run-agent PNGs where a table artifact held the data. It knew the better metric set when asked, and it did not apply it unprompted.
+
+## What Changes
+
+Three obligations join the report-session prompt, and the anti-pattern list extends with their failure modes.
+
+- **The narrative spine.** Before the first block, the agent composes the argument outline: the question, the approach, the findings in order of strength, the negative result in its honest place, the interpretation, and the limits. The flow of a paper without the chapter names. No table and no chart appears before the sentence that tells the reader what to see in it. The summary mirrors the spine, and the angle of the brief decides the order. Each section opens with its topic sentence.
+- **The chart-first rule.** Prefer a chart block when a table artifact holds the data. Reach for a figure PNG only when no table does. The run phase keeps its own plots.
+- **The headline metrics.** The headline row leads with the cohort and the yield: n, the group split, the yield count, the event count. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds as the cards round.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-session-agent`: the prompt obligations gain the three rules and their anti-patterns.
+
+## Impact
+
+- `harness/src/prompts/report-session.ts` — the three obligations.
+- `harness/src/agents/report-session-agent.test.ts` — the prompt assertions.
+- No contract change, and no renderer change.

--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/specs/report-session-agent/spec.md
@@ -7,7 +7,16 @@ The prompt of the agent MUST name its tools and their mechanisms, and it MUST NO
 
 The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
 
-The look step MUST carry the fault checklist. The agent examines the picture for: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that stayed invisible. A found fault is a repair, and never a note.
+The look step MUST carry the fault checklist. The agent examines the picture for these faults:
+
+- clipped text, and a truncated number
+- an overflowing card
+- a raw column name on an axis
+- an unreadable precision
+- content that stayed invisible
+- a number in the prose that disagrees with its card
+
+A found fault is a repair, and never a note.
 
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
@@ -17,7 +26,7 @@ The prompt MUST carry the narrative spine. Before the first block, the agent com
 
 The prompt MUST carry the chart-first rule: prefer a chart block when a table artifact holds the data, and reach for a figure image only when no table does.
 
-The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds as the cards round.
+The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. When the pinned evidence gives no cohort value, the headline leads with what the evidence gives, and the agent says so. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds to the short form that the look confirms.
 
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module

--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/specs/report-session-agent/spec.md
@@ -1,0 +1,52 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The prompt obligations
+The prompt of the agent MUST name its tools and their mechanisms, and it MUST NOT name a dataset, a path, or a format. The prompt MUST carry an explicit "Do NOT" list with the failure modes of report composition. The prompt MUST state that the agent grounds each claim through a reference, and that it does not transcribe a number from memory.
+
+The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
+
+The look step MUST carry the fault checklist. The agent examines the picture for: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that stayed invisible. A found fault is a repair, and never a note.
+
+The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
+
+The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
+
+The prompt MUST carry the narrative spine. Before the first block, the agent composes the argument outline: the question, the approach, the findings in order of strength, the negative result in its honest place, the interpretation, and the limits. The flow of a paper, without the chapter names. No table and no chart appears before the sentence that tells the reader what to see in it. The summary mirrors the spine, and the angle of the brief decides the order. Each section opens with its topic sentence.
+
+The prompt MUST carry the chart-first rule: prefer a chart block when a table artifact holds the data, and reach for a figure image only when no table does.
+
+The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds as the cards round.
+
+#### Scenario: The prompt stays free of environment detail
+- **WHEN** a reviewer reads the prompt module
+- **THEN** no dataset name, no path, and no format promise is present
+
+#### Scenario: The prompt teaches the loop order
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the loop order and the visual-spiral anti-pattern are present
+
+#### Scenario: The prompt teaches the path-only rule
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the listing tool is the named orientation source, and the hash-probe anti-pattern is present
+
+#### Scenario: The prompt teaches the citation blocks
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the citation-block rule and the pinned-evidence bound are present
+
+#### Scenario: The prompt carries the fault checklist
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the look step names the clipped text, the truncated number, the overflowing card, the raw axis name, and the precision fault
+
+#### Scenario: The prompt carries the narrative spine
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the spine order, the topic-sentence rule, and the evidence-after-its-sentence rule are present
+
+#### Scenario: The prompt carries the chart-first rule
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the chart-over-figure preference and its table condition are present
+
+#### Scenario: The prompt carries the headline obligations
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the cohort-and-yield lead, the caveated-value ban, and the rounding agreement are present

--- a/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-oblige-the-report-narrative/tasks.md
@@ -1,0 +1,15 @@
+## 1. The obligations
+
+- [x] 1.1 Add the narrative spine to `src/prompts/report-session.ts`, as a compose-first section before the block guidance.
+- [x] 1.2 Add the chart-first rule beside the block guidance.
+- [x] 1.3 Add the headline obligations beside the metric guidance.
+- [x] 1.4 Extend the "Do NOT" list: evidence before its sentence, a figure where a table serves, and a caveated headline.
+
+## 2. The assertions
+
+- [x] 2.1 Extend the prompt tests of `src/agents/report-session-agent.test.ts` for the three obligations.
+
+## 3. The gates
+
+- [x] 3.1 Run the targeted agent test file only.
+- [x] 3.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -163,6 +163,12 @@ The prompt MUST name the listing tool as the orientation source for the pinned e
 
 The prompt MUST state that the literature references compose as citation blocks, against the citation ids of the pinned evidence. It MUST name the listing tool as the route to the pinned citation ids. It MUST state that a citation outside the pinned evidence does not resolve, and that the agent reports it instead of an inline workaround.
 
+The prompt MUST carry the narrative spine. Before the first block, the agent composes the argument outline: the question, the approach, the findings in order of strength, the negative result in its honest place, the interpretation, and the limits. The flow of a paper, without the chapter names. No table and no chart appears before the sentence that tells the reader what to see in it. The summary mirrors the spine, and the angle of the brief decides the order. Each section opens with its topic sentence.
+
+The prompt MUST carry the chart-first rule: prefer a chart block when a table artifact holds the data, and reach for a figure image only when no table does.
+
+The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds as the cards round.
+
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module
 - **THEN** no dataset name, no path, and no format promise is present
@@ -182,6 +188,18 @@ The prompt MUST state that the literature references compose as citation blocks,
 #### Scenario: The prompt carries the fault checklist
 - **WHEN** a reviewer reads the prompt module
 - **THEN** the look step names the clipped text, the truncated number, the overflowing card, the raw axis name, and the precision fault
+
+#### Scenario: The prompt carries the narrative spine
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the spine order, the topic-sentence rule, and the evidence-after-its-sentence rule are present
+
+#### Scenario: The prompt carries the chart-first rule
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the chart-over-figure preference and its table condition are present
+
+#### Scenario: The prompt carries the headline obligations
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the cohort-and-yield lead, the caveated-value ban, and the rounding agreement are present
 
 ### Requirement: The report turn reads the copied narrative, never the live memory
 

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -157,7 +157,16 @@ The prompt of the agent MUST name its tools and their mechanisms, and it MUST NO
 
 The prompt MUST teach the verification loop: preview, look, repair, and record only after a look at the current page. The "Do NOT" list MUST name the visual spiral. The agent does not loop on a cosmetic doubt, and it records when the page reads clean.
 
-The look step MUST carry the fault checklist. The agent examines the picture for: clipped text, a truncated number, an overflowing card, a raw column name on an axis, an unreadable precision, and content that stayed invisible. A found fault is a repair, and never a note.
+The look step MUST carry the fault checklist. The agent examines the picture for these faults:
+
+- clipped text, and a truncated number
+- an overflowing card
+- a raw column name on an axis
+- an unreadable precision
+- content that stayed invisible
+- a number in the prose that disagrees with its card
+
+A found fault is a repair, and never a note.
 
 The prompt MUST name the listing tool as the orientation source for the pinned evidence. It MUST state that a reference names the path alone, and that the session stamps the hash. The "Do NOT" list MUST name the hash probe: the agent never guesses a hash, and it never adds a block to read a hash from a refusal.
 
@@ -167,7 +176,7 @@ The prompt MUST carry the narrative spine. Before the first block, the agent com
 
 The prompt MUST carry the chart-first rule: prefer a chart block when a table artifact holds the data, and reach for a figure image only when no table does.
 
-The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds as the cards round.
+The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. When the pinned evidence gives no cohort value, the headline leads with what the evidence gives, and the agent says so. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds to the short form that the look confirms.
 
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -137,7 +137,9 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("preview, look, repair");
         expect(reportSessionPrompt).toContain("examine_page");
         expect(reportSessionPrompt).toContain("record_report_version");
-        expect(reportSessionPrompt).toContain("only after");
+        // The record gate is the look, thus the substring carries that clause and
+        // not the bare "only after" that a line wrap cuts.
+        expect(reportSessionPrompt).toContain("you look at the current page");
         // The anti-pattern entry names the visual spiral.
         expect(reportSessionPrompt).toContain("visual spiral");
         expect(reportSessionPrompt).toContain("cosmetic doubt");
@@ -151,6 +153,7 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("an overflowing card");
         expect(reportSessionPrompt).toContain("a raw column name on an axis");
         expect(reportSessionPrompt).toContain("an unreadable precision");
+        expect(reportSessionPrompt).toContain("a number that disagrees");
         expect(reportSessionPrompt).toContain("content that stayed invisible");
         // A found fault ends in a repair, thus the agent never reports one instead.
         expect(reportSessionPrompt).toContain("A found fault is a repair, and never a note");
@@ -180,10 +183,10 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("never take an id out of a refusal");
     });
 
-    test("the prompt carries the narrative spine", () => {
+    test("the prompt carries the argument spine", () => {
         // The spine order and the two prose rules are stable substrings, thus the
         // assertion does not couple to the full prose.
-        expect(reportSessionPrompt).toContain("compose the argument outline");
+        expect(reportSessionPrompt).toContain("compose the argument spine");
         expect(reportSessionPrompt).toContain("the findings, in order of strength");
         expect(reportSessionPrompt).toContain("the negative result, in its honest place");
         expect(reportSessionPrompt).toContain("the limits of the evidence");
@@ -196,29 +199,31 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("opens with its topic sentence");
         expect(reportSessionPrompt).toContain("before the sentence that tells the reader what to see");
         expect(reportSessionPrompt).toContain("The evidence illustrates the prose");
-        expect(reportSessionPrompt).toContain("The angle of the brief decides the");
+        expect(reportSessionPrompt).toContain("The angle of the brief decides the order of the findings");
         // The anti-pattern entry names evidence that precedes its sentence.
         expect(reportSessionPrompt).toContain("Show evidence before its sentence");
     });
 
     test("the prompt carries the chart-first rule", () => {
-        // The preference, its table condition, and the run-phase bound are stable
+        // The preference, its table condition, and the report-page bound are stable
         // substrings, thus the assertion does not couple to the full prose.
         expect(reportSessionPrompt).toContain("Prefer a chart block when a table artifact holds the data");
         expect(reportSessionPrompt).toContain("a figure image only when no table carries the data");
-        expect(reportSessionPrompt).toContain("The run phase keeps its own");
+        expect(reportSessionPrompt).toContain("this rule is about the report page alone");
         // The anti-pattern entry names the figure that stands where a table serves.
         expect(reportSessionPrompt).toContain("Reach for a figure where a table serves");
     });
 
     test("the prompt carries the headline obligations", () => {
-        // The cohort-and-yield lead, the caveat ban, the contrast rule, and the
-        // rounding agreement are stable substrings.
+        // The cohort-and-yield lead, the caveat ban, the absence branch, the
+        // contrast rule, and the rounding rule are stable substrings.
         expect(reportSessionPrompt).toContain("leads with the cohort and the yield");
         expect(reportSessionPrompt).toContain("the group split");
         expect(reportSessionPrompt).toContain("carries a caveat is not a headline");
+        expect(reportSessionPrompt).toContain("the pinned evidence holds no cohort value");
+        expect(reportSessionPrompt).toContain("headline leads with what the evidence gives");
         expect(reportSessionPrompt).toContain("The card set carries its own contrast");
-        expect(reportSessionPrompt).toContain("rounds as the cards round");
+        expect(reportSessionPrompt).toContain("Round a number in the prose to the short form");
         // The anti-pattern entry names the caveated headline.
         expect(reportSessionPrompt).toContain("Lead with a caveated value");
     });

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -180,6 +180,49 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("never take an id out of a refusal");
     });
 
+    test("the prompt carries the narrative spine", () => {
+        // The spine order and the two prose rules are stable substrings, thus the
+        // assertion does not couple to the full prose.
+        expect(reportSessionPrompt).toContain("compose the argument outline");
+        expect(reportSessionPrompt).toContain("the findings, in order of strength");
+        expect(reportSessionPrompt).toContain("the negative result, in its honest place");
+        expect(reportSessionPrompt).toContain("the limits of the evidence");
+        // The flow of a paper carries no chapter name of one.
+        expect(reportSessionPrompt).toContain("never gives the chapter names");
+        expect(reportSessionPrompt).toContain('"Abstract"');
+        expect(reportSessionPrompt).toContain('"Literature review"');
+        expect(reportSessionPrompt).toContain('"Prior work"');
+        // Each section opens with its topic sentence, and no evidence precedes it.
+        expect(reportSessionPrompt).toContain("opens with its topic sentence");
+        expect(reportSessionPrompt).toContain("before the sentence that tells the reader what to see");
+        expect(reportSessionPrompt).toContain("The evidence illustrates the prose");
+        expect(reportSessionPrompt).toContain("The angle of the brief decides the");
+        // The anti-pattern entry names evidence that precedes its sentence.
+        expect(reportSessionPrompt).toContain("Show evidence before its sentence");
+    });
+
+    test("the prompt carries the chart-first rule", () => {
+        // The preference, its table condition, and the run-phase bound are stable
+        // substrings, thus the assertion does not couple to the full prose.
+        expect(reportSessionPrompt).toContain("Prefer a chart block when a table artifact holds the data");
+        expect(reportSessionPrompt).toContain("a figure image only when no table carries the data");
+        expect(reportSessionPrompt).toContain("The run phase keeps its own");
+        // The anti-pattern entry names the figure that stands where a table serves.
+        expect(reportSessionPrompt).toContain("Reach for a figure where a table serves");
+    });
+
+    test("the prompt carries the headline obligations", () => {
+        // The cohort-and-yield lead, the caveat ban, the contrast rule, and the
+        // rounding agreement are stable substrings.
+        expect(reportSessionPrompt).toContain("leads with the cohort and the yield");
+        expect(reportSessionPrompt).toContain("the group split");
+        expect(reportSessionPrompt).toContain("carries a caveat is not a headline");
+        expect(reportSessionPrompt).toContain("The card set carries its own contrast");
+        expect(reportSessionPrompt).toContain("rounds as the cards round");
+        // The anti-pattern entry names the caveated headline.
+        expect(reportSessionPrompt).toContain("Lead with a caveated value");
+    });
+
     test("the definition carries no per-session value in the prompt", () => {
         const { systemPrompt } = buildAgent();
         // A per-session value (a thread id, an analysis id, a resolved path) breaks

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -23,6 +23,29 @@ tool only where the context is thin, and reach in a targeted way:
 Do not orient again when a prior turn already read what you need — its results are
 still in your context. To reach further is targeted, not a fresh sweep.
 
+## Compose the Narrative Spine
+
+Before the first block, compose the argument outline. The spine is the order of the
+whole report, and it holds six parts:
+
+- the question that the report answers.
+- the approach that answers the question.
+- the findings, in order of strength.
+- the negative result, in its honest place.
+- the interpretation that the findings give together.
+- the limits of the evidence.
+
+The spine gives the flow of a paper, and it never gives the chapter names of one.
+Write no section that carries the title "Abstract", "Literature review", or
+"Prior work". Name each section for what that section says.
+
+Each section opens with its topic sentence, and it closes toward the next section.
+No table and no chart appears before the sentence that tells the reader what to see
+in it. The evidence illustrates the prose, thus it never replaces the prose.
+
+The summary is the spine again, in short form. The angle of the brief decides the
+order of the findings, thus the finding that the user asked about leads.
+
 ## Compose from Typed Blocks
 
 A report is a tree of typed blocks, and you build it with the authoring tools:
@@ -38,6 +61,19 @@ A report is a tree of typed blocks, and you build it with the authoring tools:
 
 Build the report as a shape first, then fill each section. Keep the outline as your
 map, and read one block only when the label does not tell you enough.
+
+Prefer a chart block when a table artifact holds the data. The pinned listing names
+each table artifact and its columns, thus it shows what a chart can plot. Reach for
+a figure image only when no table carries the data. The run phase keeps its own
+plots, and this rule is about the report page alone.
+
+The headline row leads with the cohort and the yield: the n, the group split, the
+yield count, and the event count. A value that carries a caveat is not a headline.
+An unshrunken effect size that shrinkage collapses is such a value, thus it reads in
+the body under its caveat.
+
+The card set carries its own contrast, thus a value reads against its neighbor and
+the label does not do all the work. The prose rounds as the cards round.
 
 ## Ground Every Claim
 
@@ -137,6 +173,13 @@ failed. When the page reads clean, record.
 - **Inline a citation that does not resolve.** A citation block binds to a citation
   id of the pinned evidence. When the pinned evidence holds no such id, tell the
   user, and do not carry the citation as plain prose.
+- **Show evidence before its sentence.** A table and a chart land after the sentence
+  that tells the reader what to see in it. The evidence illustrates the prose, and
+  it never carries the point alone.
+- **Reach for a figure where a table serves.** When a table artifact holds the data,
+  compose a chart block. A figure image is for the data that no table carries.
+- **Lead with a caveated value.** A headline states the cohort and the yield. A value
+  that a caveat qualifies reads in the body, under that caveat.
 - **Rebuild when one amend serves.** One feedback is one block change. Change, move,
   or remove that block by its id, and do not re-author the report.
 - **Leave a gap unread.** When \`finish_draft\` or \`preview_report\` reports a gap or

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -23,10 +23,10 @@ tool only where the context is thin, and reach in a targeted way:
 Do not orient again when a prior turn already read what you need — its results are
 still in your context. To reach further is targeted, not a fresh sweep.
 
-## Compose the Narrative Spine
+## Compose the Argument Spine
 
-Before the first block, compose the argument outline. The spine is the order of the
-whole report, and it holds six parts:
+Before the first block, compose the argument spine. The argument spine is the
+order of the whole report, and it holds six parts:
 
 - the question that the report answers.
 - the approach that answers the question.
@@ -35,16 +35,17 @@ whole report, and it holds six parts:
 - the interpretation that the findings give together.
 - the limits of the evidence.
 
-The spine gives the flow of a paper, and it never gives the chapter names of one.
-Write no section that carries the title "Abstract", "Literature review", or
+The argument spine gives the flow of a paper. It never gives the chapter names of
+one. Write no section that carries the title "Abstract", "Literature review", or
 "Prior work". Name each section for what that section says.
 
 Each section opens with its topic sentence, and it closes toward the next section.
 No table and no chart appears before the sentence that tells the reader what to see
 in it. The evidence illustrates the prose, thus it never replaces the prose.
 
-The summary is the spine again, in short form. The angle of the brief decides the
-order of the findings, thus the finding that the user asked about leads.
+The summary is the argument spine again, in short form.
+The angle of the brief decides the order of the findings, thus the finding that
+the user asked about leads.
 
 ## Compose from Typed Blocks
 
@@ -62,18 +63,20 @@ A report is a tree of typed blocks, and you build it with the authoring tools:
 Build the report as a shape first, then fill each section. Keep the outline as your
 map, and read one block only when the label does not tell you enough.
 
-Prefer a chart block when a table artifact holds the data. The pinned listing names
-each table artifact and its columns, thus it shows what a chart can plot. Reach for
-a figure image only when no table carries the data. The run phase keeps its own
-plots, and this rule is about the report page alone.
+Prefer a chart block when a table artifact holds the data. \`list_pinned_artifacts\`
+names each table artifact and its columns, thus it shows what a chart can plot.
+Reach for a figure image only when no table carries the data. The run phase keeps
+its own plots, and this rule is about the report page alone.
 
 The headline row leads with the cohort and the yield: the n, the group split, the
 yield count, and the event count. A value that carries a caveat is not a headline.
 An unshrunken effect size that shrinkage collapses is such a value, thus it reads in
-the body under its caveat.
+the body under its caveat. When the pinned evidence holds no cohort value, the
+headline leads with what the evidence gives. Tell the user which value is absent.
 
 The card set carries its own contrast, thus a value reads against its neighbor and
-the label does not do all the work. The prose rounds as the cards round.
+the label does not do all the work. Round a number in the prose to the short form.
+The look then shows a number that does not agree with its card.
 
 ## Ground Every Claim
 
@@ -142,6 +145,8 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
     a written label, not the name that the evidence carries.
   - an unreadable precision: a number with too many digits to read, or a rounding
     that hides the result.
+  - a number that disagrees: a value in the prose that is not the value on the
+    card beside it.
   - content that stayed invisible: an empty band, a blank card, or a section that
     the picture does not show.
 


### PR DESCRIPTION
## What & why

Three quality faults of the first report trace to absent prompt obligations, not to absent capability. The agent led its headline row with an unshrunken fold-change. It reused run-agent images where a table artifact held the data. It knew the better metric set when asked, and it did not apply it unprompted.

The report-session prompt now carries three obligations:

- The narrative spine: the agent composes the argument outline before the first block, in the flow of a paper without the chapter names. No table and no chart appears before the sentence that tells the reader what to see in it.
- The chart-first rule: prefer a chart block when a table artifact holds the data, and reach for a figure image only when no table does.
- The headline obligations: the cohort and the yield lead, a caveated value is not a headline, and the prose rounds as the cards round.

Notes for the reviewer:

- This change edits the prompt module and its test file alone. No contract, no renderer, and no run-agent change.
- The prompt names no dataset, no path, and no format. The existing ban assertions stay green.

Refs #375

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
