### PR TITLE
feat(harness): polish the report page identity

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/design.md
@@ -1,0 +1,26 @@
+## Context
+
+The identity lives in one design source (`report-render/design.ts`), the page scripts live in `page.ts`, and the views emit the markup. The chart panel carries `window-chrome` rules with dots, a hover raise, and a `CORTEX` badge (`views/chart-view.tsx`). The footer names the engine (`views/page-view.tsx`). The prose measure caps at `72ch` inside a `1600px` container, thus a prose section shows a dead right band.
+
+## Goals / Non-Goals
+
+- Goal: the page reads as one centered document with the Inflexa identity, and the navigation tracks the reader.
+- Non-goal: a contract change. Every item lands in the design source, the page scripts, and the views.
+- Non-goal: a new dependency. The scrollspy is a plain observer in the page script.
+
+## Decisions
+
+- **The scrollspy is a second small script beside the reveal script.** An `IntersectionObserver` over the section anchors drives one active class on the matching navigation link. The observer picks the section nearest the top through a negative bottom root margin, thus one link is active at a time. A browser with no observer keeps the plain links, because the spy is decoration.
+- **The chart card joins the identity.** The chart renders in the square corner-accent card, with the mono title line of the table component and the fixed-height chart body. The `window-chrome` rules, the dots, the hover raise, and the badge leave the design source. Thus the geometric rule loses its one rounded exception, and every data card reads the same.
+- **The centered column is a new content width.** A `--content-max` token (about `1100px`) centers inside the container, and every block kind fills it. The `72ch` cap on the prose goes, thus prose, tables, and charts share one width and no half-empty band remains.
+- **The identity wording is three strings.** The badge goes with the chrome. The footer reads `Powered by Inflexa`. The navigation brand becomes a link to `https://inflexa.ai/`, and it is the one external reference of the page: a link costs no request, thus the page still stands alone.
+- **The provenance appendix is a rename and a tone.** The auto-generated list takes the title "Data provenance" and the muted appendix styling. The literature section is citation blocks, and it stays separate.
+
+## Risks / Trade-offs
+
+- [A dead class rule after the chrome removal] → the design source invariant stands: each class rule matches an emitter. The removal sweeps the rules and the emitters together, and the render tests hold the pair.
+- [The scrollspy fights the reveal script] → the two observers read different targets, and neither writes what the other reads.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Five presentation faults, each verified on the first real report. The navigation shows no reading position. The page names the internal engine. The chart panel wears an application-window costume. The content sits left with a capped prose measure and a dead right margin. The auto-generated appendix wears the title "References", where a reader expects literature.
+
+## What Changes
+
+- **The scrollspy.** The page script highlights the anchor of the section in view, through an observer over the section anchors, with no dependency.
+- **The wording.** The panel badge `CORTEX` goes. The footer reads `Powered by Inflexa`. The navigation brand links to the Inflexa site.
+- **The chart frame.** The three-dot window chrome and the hover raise go. The chart renders in the square corner-accent card of the identity, with a fixed-height body.
+- **The layout.** One centered content column holds every block kind, and the prose fills that column completely. The inner `72ch` cap goes.
+- **The provenance appendix.** The auto-generated list renames to "Data provenance", styled as a muted appendix. The literature section stays separate.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-design-system`: the chart component loses the window chrome, the geometry loses its rounded exception, and the architecture gains the centered column and the identity wording.
+- `report-render`: the navigation gains the scrollspy, and the reference list becomes the provenance appendix.
+
+## Impact
+
+- `harness/src/report-render/design.ts`, `page.ts`, and the views. No contract change, no tool change, and no store change.

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-design-system/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-design-system/spec.md
@@ -25,7 +25,7 @@ The renderer MUST give each block kind its identity component:
 
 #### Scenario: A chart card carries no window costume
 - **WHEN** the caller renders a chart block
-- **THEN** the card holds the title line and the fixed-height chart body, and no dot, no badge, and no hover raise is present
+- **THEN** the title line sits over the card, and the card holds the fixed-height chart body with no dot, no badge, and no raise
 
 #### Scenario: A long metric value stays inside its card
 - **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-design-system/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-design-system/spec.md
@@ -1,0 +1,70 @@
+# Delta: report-design-system
+
+## MODIFIED Requirements
+
+### Requirement: A considered component for each block kind
+The renderer MUST give each block kind its identity component:
+
+- A `text` block renders as prose that fills the content column.
+- A `claim` block renders as prose with the styled evidence markers.
+- A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
+- A consecutive run of `metric` siblings renders as one responsive grid.
+- A `table` block renders as a data table inside a corner-accent card.
+- A `chart` block renders as a corner-accent card with a mono title line and a fixed-height chart body. The card carries no window chrome, no dots, no badge, and no hover raise, because a report is a document and not an application window.
+- A `figure` block renders as a corner-accent card with its caption.
+- A `citation` block renders as a card in the reference form.
+- A `section` block renders as a heading by depth.
+
+#### Scenario: Consecutive metrics form one grid
+- **WHEN** the caller renders a section with three metric blocks in a row
+- **THEN** one grid holds the three stat cards
+
+#### Scenario: A lone metric stays a card
+- **WHEN** the caller renders a section with one metric block between two text blocks
+- **THEN** the metric renders as one stat card, and no grid wraps the text
+
+#### Scenario: A chart card carries no window costume
+- **WHEN** the caller renders a chart block
+- **THEN** the card holds the title line and the fixed-height chart body, and no dot, no badge, and no hover raise is present
+
+#### Scenario: A long metric value stays inside its card
+- **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
+- **THEN** the value stays inside the card bounds, and no character paints past the card edge
+
+### Requirement: The geometric identity rules
+A data card MUST hold square corners with the corner accents. The theme MUST stay light: white and slate surfaces, with dark only in the footer.
+
+#### Scenario: A figure card keeps the square corners
+- **WHEN** the caller renders a figure block
+- **THEN** its card carries the corner accents and no border radius
+
+#### Scenario: A chart card keeps the square corners
+- **WHEN** the caller renders a chart block
+- **THEN** its card carries the corner accents and no border radius
+
+### Requirement: The page architecture
+The page MUST hold these regions in this order: the hero, one full-bleed band for each top-level section, the reference band, and the dark footer. The hero MUST show a constant eyebrow and the document title. The band backgrounds MUST alternate between white and slate, and each band MUST carry a texture. The left navigation MUST shift the page body on a large viewport.
+
+One centered content column MUST hold every block kind, and the prose MUST fill that column completely. No inner measure caps the prose below the column width.
+
+The navigation brand MUST link to the Inflexa site, and the footer MUST read `Powered by Inflexa`. No page surface names the internal engine.
+
+#### Scenario: The bands alternate
+- **WHEN** the caller renders a document with three top-level sections
+- **THEN** the second band carries the slate background, and the first and the third carry the white background
+
+#### Scenario: The hero shows the title
+- **WHEN** the caller renders a document with the title "Study X"
+- **THEN** the hero shows "Study X" as the display heading, under the eyebrow
+
+#### Scenario: The footer closes the page
+- **WHEN** the caller renders any valid document
+- **THEN** the dark footer renders after the reference band
+
+#### Scenario: The blocks share one centered column
+- **WHEN** the caller renders a document with prose, a table, and a chart
+- **THEN** the three blocks share one content column, and no prose rule caps a narrower measure
+
+#### Scenario: The page carries the identity wording
+- **WHEN** the caller renders any valid document
+- **THEN** the navigation brand links to the Inflexa site, the footer reads `Powered by Inflexa`, and no surface names the engine

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-render/spec.md
@@ -5,7 +5,7 @@
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
 
-The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. One anchor is active at a time. A browser without the observer keeps the plain links, because the highlight is decoration.
+The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. Exactly one anchor is active on a page with sections, at every scroll position. A browser without the observer keeps the plain links, because the highlight is decoration.
 
 #### Scenario: The navigation lists the top-level sections
 - **WHEN** the caller renders a document with three top-level sections

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/specs/report-render/spec.md
@@ -1,0 +1,32 @@
+# Delta: report-render
+
+## MODIFIED Requirements
+
+### Requirement: The page navigation
+The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
+
+The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. One anchor is active at a time. A browser without the observer keeps the plain links, because the highlight is decoration.
+
+#### Scenario: The navigation lists the top-level sections
+- **WHEN** the caller renders a document with three top-level sections
+- **THEN** the navigation holds three anchors, and each anchor targets its section id
+
+#### Scenario: The page carries the scrollspy script
+- **WHEN** the caller renders a document with sections
+- **THEN** the page script observes the section anchors, and it drives one active class on the matching link
+
+### Requirement: The claim evidence renders as markers and a provenance appendix
+A claim MUST render its prose with evidence markers. The references MUST list at the end of the page under the title "Data provenance", styled as a muted appendix. The literature renders from citation blocks, and it stays separate from the appendix. The markers number by first appearance. An identical reference MUST appear one time in the list. Reference identity is the full reference value after a stable serialization, thus two references are identical only when every field matches. A derivation reference MUST list as its operation with its two pinned inputs, each named by path and locator.
+
+#### Scenario: Two claims share one reference
+- **WHEN** the caller renders two claim blocks that carry the same reference
+- **THEN** both claims show the same marker number, and the list holds one entry for it
+
+#### Scenario: The appendix wears the provenance title
+- **WHEN** the caller renders a document with a claim
+- **THEN** the list at the end of the page is titled "Data provenance", and no auto-generated surface is titled "References"
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: The claim evidence renders as markers and a reference list`
+- TO: `### Requirement: The claim evidence renders as markers and a provenance appendix`

--- a/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-polish-the-report-page-identity/tasks.md
@@ -1,0 +1,20 @@
+## 1. The chart card and the geometry
+
+- [x] 1.1 Replace the window-chrome markup of the chart view with the corner-accent card and the mono title line. Remove the badge.
+- [x] 1.2 Remove the window-chrome rules, the dots, and the hover raise from `DESIGN_CSS`. Sweep each dead class rule with its emitter.
+
+## 2. The layout and the wording
+
+- [x] 2.1 Add the centered content column token, and make every block kind fill it. Remove the `72ch` prose cap.
+- [x] 2.2 The footer reads `Powered by Inflexa`, and the navigation brand links to the Inflexa site.
+
+## 3. The scrollspy and the appendix
+
+- [x] 3.1 Add the scrollspy script beside the reveal script: an observer over the section anchors drives one active class on the matching link. Add the active-link rule.
+- [x] 3.2 Rename the auto-generated list to "Data provenance", and style it as a muted appendix.
+
+## 4. The gates
+
+- [x] 4.1 Update and run the targeted render and view tests only.
+- [x] 4.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.
+- [x] 4.3 Re-render the proof document of the first session through the harness fixtures, and confirm the five items on the page.

--- a/harness/openspec/specs/report-design-system/spec.md
+++ b/harness/openspec/specs/report-design-system/spec.md
@@ -18,6 +18,10 @@ The inline style sheet MUST define the identity tokens as CSS custom properties.
 ### Requirement: The page architecture
 The page MUST hold these regions in this order: the hero, one full-bleed band for each top-level section, the reference band, and the dark footer. The hero MUST show a constant eyebrow and the document title. The band backgrounds MUST alternate between white and slate, and each band MUST carry a texture. The left navigation MUST shift the page body on a large viewport.
 
+One centered content column MUST hold every block kind, and the prose MUST fill that column completely. No inner measure caps the prose below the column width.
+
+The navigation brand MUST link to the Inflexa site, and the footer MUST read `Powered by Inflexa`. No page surface names the internal engine.
+
 #### Scenario: The bands alternate
 - **WHEN** the caller renders a document with three top-level sections
 - **THEN** the second band carries the slate background, and the first and the third carry the white background
@@ -30,15 +34,23 @@ The page MUST hold these regions in this order: the hero, one full-bleed band fo
 - **WHEN** the caller renders any valid document
 - **THEN** the dark footer renders after the reference band
 
+#### Scenario: The blocks share one centered column
+- **WHEN** the caller renders a document with prose, a table, and a chart
+- **THEN** the three blocks share one content column, and no prose rule caps a narrower measure
+
+#### Scenario: The page carries the identity wording
+- **WHEN** the caller renders any valid document
+- **THEN** the navigation brand links to the Inflexa site, the footer reads `Powered by Inflexa`, and no surface names the engine
+
 ### Requirement: A considered component for each block kind
 The renderer MUST give each block kind its identity component:
 
-- A `text` block renders as prose with a capped measure.
+- A `text` block renders as prose that fills the content column.
 - A `claim` block renders as prose with the styled evidence markers.
 - A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
 - A consecutive run of `metric` siblings renders as one responsive grid.
 - A `table` block renders as a data table inside a corner-accent card.
-- A `chart` block renders as a window-chrome panel with a fixed-height chart body.
+- A `chart` block renders as a corner-accent card with a mono title line and a fixed-height chart body. The card carries no window chrome, no dots, no badge, and no hover raise, because a report is a document and not an application window.
 - A `figure` block renders as a corner-accent card with its caption.
 - A `citation` block renders as a card in the reference form.
 - A `section` block renders as a heading by depth.
@@ -51,19 +63,23 @@ The renderer MUST give each block kind its identity component:
 - **WHEN** the caller renders a section with one metric block between two text blocks
 - **THEN** the metric renders as one stat card, and no grid wraps the text
 
-#### Scenario: A chart panel carries the chrome and a height
+#### Scenario: A chart card carries no window costume
 - **WHEN** the caller renders a chart block
-- **THEN** the panel holds the chrome header with the dots and the `CORTEX` badge, and the chart container carries a fixed height
+- **THEN** the card holds the title line and the fixed-height chart body, and no dot, no badge, and no hover raise is present
 
 #### Scenario: A long metric value stays inside its card
 - **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
 - **THEN** the value stays inside the card bounds, and no character paints past the card edge
 
 ### Requirement: The geometric identity rules
-A data card MUST hold square corners with the corner accents. The window-chrome panel is the one exception, and it MUST hold rounded corners. The theme MUST stay light: white and slate surfaces, with dark only in the footer.
+A data card MUST hold square corners with the corner accents. The theme MUST stay light: white and slate surfaces, with dark only in the footer.
 
 #### Scenario: A figure card keeps the square corners
 - **WHEN** the caller renders a figure block
+- **THEN** its card carries the corner accents and no border radius
+
+#### Scenario: A chart card keeps the square corners
+- **WHEN** the caller renders a chart block
 - **THEN** its card carries the corner accents and no border radius
 
 ### Requirement: The print form and the reduced motion

--- a/harness/openspec/specs/report-design-system/spec.md
+++ b/harness/openspec/specs/report-design-system/spec.md
@@ -65,7 +65,7 @@ The renderer MUST give each block kind its identity component:
 
 #### Scenario: A chart card carries no window costume
 - **WHEN** the caller renders a chart block
-- **THEN** the card holds the title line and the fixed-height chart body, and no dot, no badge, and no hover raise is present
+- **THEN** the title line sits over the card, and the card holds the fixed-height chart body with no dot, no badge, and no raise
 
 #### Scenario: A long metric value stays inside its card
 - **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -108,7 +108,7 @@ When the shown form hides digits, the element MUST carry the full digits in its 
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
 
-The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. One anchor is active at a time. A browser without the observer keeps the plain links, because the highlight is decoration.
+The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. Exactly one anchor is active on a page with sections, at every scroll position. A browser without the observer keeps the plain links, because the highlight is decoration.
 
 #### Scenario: The navigation lists the top-level sections
 - **WHEN** the caller renders a document with three top-level sections

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -108,9 +108,15 @@ When the shown form hides digits, the element MUST carry the full digits in its 
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
 
+The page script MUST highlight the anchor of the section in view, through an observer over the section anchors and with no dependency. One anchor is active at a time. A browser without the observer keeps the plain links, because the highlight is decoration.
+
 #### Scenario: The navigation lists the top-level sections
 - **WHEN** the caller renders a document with three top-level sections
 - **THEN** the navigation holds three anchors, and each anchor targets its section id
+
+#### Scenario: The page carries the scrollspy script
+- **WHEN** the caller renders a document with sections
+- **THEN** the page script observes the section anchors, and it drives one active class on the matching link
 
 ### Requirement: Escaping is always on
 The renderer MUST escape every interpolated string through the markup runtime, which escapes each child and each attribute value by default. A raw insertion of serialized document data MUST occur only at a JSON script sink. Each serialized JSON MUST replace every `<` with `\u003c` before the insertion. A raw insertion is otherwise legal only for a trusted page constant, and for sibling markup that the runtime escaped already. Markup inside agent prose MUST reach the page as text, and never as an element.
@@ -157,12 +163,16 @@ The renderer MUST hold one fixed derivation rule for each chart type. A chart wh
 - **WHEN** the caller renders a bar chart whose categories first appear as Day2, Day10, Day1
 - **THEN** the category axis lists Day2, Day10, Day1 in that order
 
-### Requirement: The claim evidence renders as markers and a reference list
-A claim MUST render its prose with evidence markers, and the references MUST list at the end of the page. The markers number by first appearance. An identical reference MUST appear one time in the list. Reference identity is the full reference value after a stable serialization, thus two references are identical only when every field matches. A derivation reference MUST list as its operation with its two pinned inputs, each named by path and locator.
+### Requirement: The claim evidence renders as markers and a provenance appendix
+A claim MUST render its prose with evidence markers. The references MUST list at the end of the page under the title "Data provenance", styled as a muted appendix. The literature renders from citation blocks, and it stays separate from the appendix. The markers number by first appearance. An identical reference MUST appear one time in the list. Reference identity is the full reference value after a stable serialization, thus two references are identical only when every field matches. A derivation reference MUST list as its operation with its two pinned inputs, each named by path and locator.
 
 #### Scenario: Two claims share one reference
 - **WHEN** the caller renders two claim blocks that carry the same reference
 - **THEN** both claims show the same marker number, and the list holds one entry for it
+
+#### Scenario: The appendix wears the provenance title
+- **WHEN** the caller renders a document with a claim
+- **THEN** the list at the end of the page is titled "Data provenance", and no auto-generated surface is titled "References"
 
 ### Requirement: The page stands alone
 The skeleton MUST inline the style rules. The page MUST reference each script and each font as a relative `assets/<name>` path, and it MUST reference no CDN host. The renderer MUST export one asset manifest, and each entry MUST name the staged file and its package source. The caller MUST stage each manifest entry beside the page, in the same pipeline that stages the figures.

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -375,14 +375,36 @@ describe("renderChart", () => {
         expect(html).toMatch(/<div[^>]*\bdata-echarts-id="b3"[^>]*\bclass="chart-container"[^>]*>/);
     });
 
-    it("wraps the chart in the chrome header with its three dots and the product badge", () => {
+    it("wraps the chart in the corner-accent card under the mono title line", () => {
         const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b4", title: "Panel title" });
         const html = renderChart(block, derive(block, [{ day: "Mon", count: 1 }]));
-        expect(html).toContain(`class="window-chrome-bar"`);
-        // The three dots are the window-chrome signature of the panel.
-        expect(html.match(/class="chrome-dot dot-\d"/g)).toHaveLength(3);
-        expect(html).toContain(`<span class="window-chrome-badge">CORTEX</span>`);
-        expect(html).toContain(`<span class="window-chrome-title">Panel title</span>`);
+        expect(html).toContain(`<div class="report-chart-title">Panel title</div>`);
+        expect(html).toContain(`class="report-chart-card corner-accents"`);
+    });
+
+    it("wears no window costume", () => {
+        const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b5", title: "Panel title" });
+        const html = renderChart(block, derive(block, [{ day: "Mon", count: 1 }]));
+        // A report is a document. The dots, the badge, and the chrome bar make a data card read as an
+        // application window, thus the card carries none of them.
+        expect(html).not.toContain("window-chrome");
+        expect(html).not.toContain("chrome-dot");
+        expect(html).not.toContain("CORTEX");
+        // Each dead class rule leaves the design source with its emitter.
+        expect(DESIGN_CSS).not.toContain("window-chrome");
+        expect(DESIGN_CSS).not.toContain("chrome-dot");
+        expect(DESIGN_CSS).not.toContain("chrome-dots");
+    });
+
+    it("gives the card the square corners and no hover raise", () => {
+        // The corner-accent card is the one geometry of a data card. A border radius on the chart, or a
+        // transform under hover, brings the window costume back through the style sheet.
+        const cardRules = [...DESIGN_CSS.matchAll(/\.report-chart-card[^{]*\{([^}]*)\}/g)].map((match) => match[1]);
+        expect(cardRules.length).toBeGreaterThan(0);
+        for (const body of cardRules) {
+            expect(body).not.toContain("border-radius");
+            expect(body).not.toContain("transform");
+        }
     });
 });
 

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -115,6 +115,7 @@ export const DESIGN_CSS = `${FONT_FACES}
   --font-sans: "Space Grotesk Variable", system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, monospace;
   --layout-max: 1600px;
+  --content-max: 1100px;
   --nav-width: 15rem;
 }
 
@@ -177,6 +178,13 @@ img {
   max-width: var(--layout-max);
   padding-left: 24px;
   padding-right: 24px;
+}
+/* The one content column of the page. The container gives the full-bleed gutter, and this column carries
+   every block kind. Thus the prose, the metric grid, the tables, and the charts read at one measure. */
+.report-content {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: var(--content-max);
 }
 
 .report-hero {
@@ -264,11 +272,13 @@ img {
   padding: 20px;
   border-bottom: 1px solid var(--color-border);
 }
+/* The brand is the one link of the page that leaves it. It reads as the brand, not as a link. */
 .report-nav-brand-name {
   font-family: var(--font-mono);
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.08em;
+  text-decoration: none;
   color: var(--color-primary-500);
 }
 .report-nav-list {
@@ -293,6 +303,13 @@ img {
   background-color: var(--color-bg-alt);
   border-left-color: var(--color-primary-500);
 }
+/* The page script adds this class to the link of the section in view. One link carries it at a time. */
+.report-nav-link-active {
+  font-weight: 600;
+  color: var(--color-heading);
+  background-color: var(--color-bg-alt);
+  border-left-color: var(--color-primary-500);
+}
 .report-nav-index {
   flex-shrink: 0;
   width: 16px;
@@ -310,8 +327,8 @@ img {
 }
 
 /* ── Prose and evidence markers ───────────────────────── */
+/* The prose fills the content column. No inner measure caps it, thus a band carries no half-empty side. */
 .report-prose {
-  max-width: 72ch;
   margin-bottom: 16px;
   line-height: 1.7;
   color: var(--color-text);
@@ -410,7 +427,9 @@ img {
 .report-table {
   margin-bottom: 32px;
 }
-.report-table-title {
+/* The title line of a data card. A table and a chart carry the same line, thus one rule serves both. */
+.report-table-title,
+.report-chart-title {
   margin-bottom: 12px;
   font-family: var(--font-mono);
   font-size: 12px;
@@ -478,70 +497,12 @@ img {
   color: var(--color-text-muted);
 }
 
-/* ── Window-chrome chart panel ────────────────────────── */
-/* The chart panel is the one component with rounded corners. */
+/* ── Chart card ───────────────────────────────────────── */
+/* The chart is a data card, thus it takes the square corner-accent form of the table and the figure. */
 .report-chart {
   margin-bottom: 32px;
 }
-.window-chrome {
-  overflow: hidden;
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  background: var(--color-card);
-  box-shadow: 0 8px 30px -8px rgba(15, 23, 42, 0.08), 0 4px 12px -4px rgba(15, 23, 42, 0.04);
-  transition: transform 0.5s ease, box-shadow 0.5s ease, border-color 0.5s ease;
-}
-.window-chrome:hover {
-  transform: translateY(-4px);
-  border-color: var(--color-border-hover);
-  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.18), 0 12px 24px -8px rgba(15, 23, 42, 0.1);
-}
-.window-chrome-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 16px;
-  background-color: var(--color-bg-alt);
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-.chrome-dots {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.chrome-dot {
-  display: block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background-color: var(--color-border-hover);
-  transition: background-color 0.3s ease;
-}
-.window-chrome:hover .dot-1 {
-  background-color: #fb7185;
-}
-.window-chrome:hover .dot-2 {
-  background-color: #fbbf24;
-}
-.window-chrome:hover .dot-3 {
-  background-color: #4ade80;
-}
-.window-chrome-title {
-  flex: 1 1 auto;
-  text-align: center;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-heading);
-}
-.window-chrome-badge {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  color: var(--color-primary-500);
-}
-.window-chrome-body {
+.report-chart-card {
   padding: 16px;
 }
 /* The chart runtime measures the container. A container with no height shows no chart. */
@@ -550,30 +511,37 @@ img {
   height: 400px;
 }
 
-/* ── Reference list ───────────────────────────────────── */
+/* ── Provenance appendix ──────────────────────────────── */
+/* The appendix is a record of where each value came from. A reader consults it, and a reader does not read
+   it through. Thus it stays smaller and quieter than the body of the report. */
+.report-ref-title {
+  color: var(--color-text-secondary);
+}
 .report-references {
   padding-left: 24px;
   list-style: decimal;
+  color: var(--color-text-muted);
 }
 .report-ref-item {
-  margin-bottom: 8px;
-  font-size: 14px;
-  color: var(--color-text);
+  margin-bottom: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
 }
 .report-ref-kind {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 .report-ref-path {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: 12px;
   color: var(--color-primary-700);
 }
 .report-ref-detail {
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
 /* ── Section textures ─────────────────────────────────── */
@@ -745,9 +713,6 @@ img {
   .report-footer-title,
   .report-footer-note {
     color: var(--color-text-strong);
-  }
-  .window-chrome {
-    box-shadow: none;
   }
 }`;
 

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -1,5 +1,5 @@
 /**
- * The page constants: the head references, the readiness names, and the two page-side scripts.
+ * The page constants: the head references, the readiness names, and the three page-side scripts.
  *
  * A script here is browser source text, not module code. Thus it reads no module binding, and each value
  * that it needs is interpolated at build time. The style rules and the ECharts theme live in `design.ts`.
@@ -50,6 +50,17 @@ const REVEAL_GATE = "__inflexaWhenRevealed";
  * signal in that condition, thus such a page still signals and the capture returns on the signal.
  */
 const REVEAL_SETTLE_TIMEOUT_MS = 2_000;
+
+/**
+ * The class that marks the navigation link of the section in view, and the bottom root margin of the
+ * scrollspy in percent.
+ *
+ * The design sheet holds the matching rule under the same class name. The negative bottom margin shrinks the
+ * observation box to the top band of the viewport. Thus the section that sits nearest the top of the page
+ * wins, and a tall section below it never steals the mark.
+ */
+const NAV_ACTIVE_CLASS = "report-nav-link-active";
+const SPY_BOTTOM_MARGIN_PERCENT = 70;
 
 /**
  * The page-side script that wires each chart. It finds every chart container, reads the option JSON from
@@ -196,6 +207,81 @@ export const FADE_IN_OBSERVER = `(function () {
       observer.observe(nodes[k]);
     }
     setTimeout(settle, ${REVEAL_SETTLE_TIMEOUT_MS});
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start);
+  } else {
+    start();
+  }
+})();`;
+
+/**
+ * The page-side script that marks the navigation link of the section in view.
+ *
+ * Each navigation anchor targets one top-level section by its id. The script resolves each anchor to its
+ * section, and an `IntersectionObserver` over those sections drives the active class. The observation box
+ * covers the top band of the viewport alone, thus the script marks the first section of that band in
+ * document order and exactly one link carries the class.
+ *
+ * A section that no anchor targets, and an anchor whose target is absent, drop out of the walk. Thus the
+ * reference band never takes the mark.
+ *
+ * The highlight is decoration. A browser with no `IntersectionObserver`, and a page with no navigation,
+ * keep the plain links. The script writes one class and it reads nothing that the reveal script writes,
+ * thus the two observers never contend.
+ */
+export const SECTION_SPY = `(function () {
+  function start() {
+    var links = document.querySelectorAll(".report-nav-link");
+    if (typeof IntersectionObserver === "undefined" || links.length === 0) {
+      return;
+    }
+    var anchors = [];
+    var sections = [];
+    for (var i = 0; i < links.length; i++) {
+      var href = links[i].getAttribute("href") || "";
+      var section = href.charAt(0) === "#" ? document.getElementById(href.slice(1)) : null;
+      if (!section) {
+        continue;
+      }
+      anchors.push(links[i]);
+      sections.push(section);
+    }
+    if (sections.length === 0) {
+      return;
+    }
+    var inBand = [];
+    for (var s = 0; s < sections.length; s++) {
+      inBand.push(false);
+    }
+    function paint() {
+      var active = -1;
+      for (var a = 0; a < inBand.length; a++) {
+        if (inBand[a]) {
+          active = a;
+          break;
+        }
+      }
+      for (var b = 0; b < anchors.length; b++) {
+        if (b === active) {
+          anchors[b].classList.add(${JSON.stringify(NAV_ACTIVE_CLASS)});
+        } else {
+          anchors[b].classList.remove(${JSON.stringify(NAV_ACTIVE_CLASS)});
+        }
+      }
+    }
+    var observer = new IntersectionObserver(function (entries) {
+      for (var e = 0; e < entries.length; e++) {
+        var index = sections.indexOf(entries[e].target);
+        if (index >= 0) {
+          inBand[index] = entries[e].isIntersecting === true;
+        }
+      }
+      paint();
+    }, { rootMargin: "0px 0px -${SPY_BOTTOM_MARGIN_PERCENT}% 0px", threshold: 0 });
+    for (var k = 0; k < sections.length; k++) {
+      observer.observe(sections[k]);
+    }
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", start);

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -226,6 +226,15 @@ export const FADE_IN_OBSERVER = `(function () {
  * A section that no anchor targets, and an anchor whose target is absent, drop out of the walk. Thus the
  * reference band never takes the mark.
  *
+ * A page can leave the observation box empty. At scroll 0, each section can start below the box. A short
+ * tail also holds the last section below the box for the whole scroll. Thus the paint step has a fallback.
+ * The fallback marks the last section whose top sits at the end of the box or above it. It marks the first
+ * section when every top sits below the box.
+ *
+ * The fallback reads each position with `getBoundingClientRect` at paint time. A scroll moves each section,
+ * thus a cached position names the wrong link. As a result, exactly one link carries the active class on a
+ * page that has a section.
+ *
  * The highlight is decoration. A browser with no `IntersectionObserver`, and a page with no navigation,
  * keep the plain links. The script writes one class and it reads nothing that the reveal script writes,
  * thus the two observers never contend.
@@ -254,6 +263,21 @@ export const SECTION_SPY = `(function () {
     for (var s = 0; s < sections.length; s++) {
       inBand.push(false);
     }
+    function boxEnd() {
+      var root = document.documentElement;
+      var height = root ? root.clientHeight : 0;
+      return (height * (100 - ${SPY_BOTTOM_MARGIN_PERCENT})) / 100;
+    }
+    function nearestAbove() {
+      var end = boxEnd();
+      var last = -1;
+      for (var n = 0; n < sections.length; n++) {
+        if (sections[n].getBoundingClientRect().top <= end) {
+          last = n;
+        }
+      }
+      return last < 0 ? 0 : last;
+    }
     function paint() {
       var active = -1;
       for (var a = 0; a < inBand.length; a++) {
@@ -261,6 +285,9 @@ export const SECTION_SPY = `(function () {
           active = a;
           break;
         }
+      }
+      if (active < 0) {
+        active = nearestAbove();
       }
       for (var b = 0; b < anchors.length; b++) {
         if (b === active) {

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -5,9 +5,17 @@ import type { Block, CitationBlock, MetricBlock, ReportDocument, TextBlock } fro
 import { ASSETS_DIR, PAGE_ASSETS } from "./assets.js";
 import { DESIGN_CSS } from "./design.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "./fixture.js";
-import { CHART_BOOTSTRAP } from "./page.js";
+import { CHART_BOOTSTRAP, SECTION_SPY } from "./page.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
+
+/**
+ * The site of the navigation brand. It is the one reference of the page that names a remote host.
+ *
+ * A brand link is a navigation, and a navigation costs no request. Thus the page still opens with no
+ * network, and the stands-alone gate admits this one value.
+ */
+const BRAND_LINK = "https://inflexa.ai/";
 
 /** One citation reference. A claim binding and a citation binding both admit it. */
 const citation: CitationBlock["binding"] = { kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" };
@@ -111,13 +119,17 @@ describe("the page stands alone", () => {
 
         // The scheme test reads the start of the value. A namespace URI inside a data URI names no host to
         // fetch, thus the test must not read a scheme out of the middle of a value.
-        const remote = references.filter((value) => /^https?:/i.test(value));
+        const remote = references.filter((value) => /^https?:/i.test(value) && value !== BRAND_LINK);
         expect(remote).toEqual([]);
 
         // Each reference resolves inside the page directory: a staged asset, an inline data URI, or an
-        // anchor of the page itself.
-        const foreign = references.filter((value) => !(value.startsWith(`${ASSETS_DIR}/`) || value.startsWith("data:") || value.startsWith("#")));
+        // anchor of the page itself. The brand link is the one exception, and it fetches nothing.
+        const local = (value: string) => value.startsWith(`${ASSETS_DIR}/`) || value.startsWith("data:") || value.startsWith("#") || value === BRAND_LINK;
+        const foreign = references.filter((value) => !local(value));
         expect(foreign).toEqual([]);
+
+        // The one remote value reaches the page one time, thus no second surface names a host.
+        expect(html.split(BRAND_LINK).length - 1).toBe(1);
     });
 
     it("names one manifest entry for each staged asset reference", () => {
@@ -356,6 +368,196 @@ describe("renderReportPage navigation and references", () => {
         expect(html.split(`<li id="ref-`).length - 1).toBe(1);
         // The claim marker and the citation marker point at the same entry.
         expect(html.split(`href="#ref-1"`).length - 1).toBe(2);
+    });
+});
+
+describe("the page identity", () => {
+    const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+
+    it("closes the page with the Inflexa footer note", () => {
+        expect(html).toContain("Powered by Inflexa");
+    });
+
+    it("links the navigation brand to the Inflexa site", () => {
+        const brand = load(html)("a.report-nav-brand-name");
+        expect(brand.length).toBe(1);
+        expect(brand.attr("href")).toBe(BRAND_LINK);
+    });
+
+    it("names the engine on no surface", () => {
+        // The page is the surface that a reader outside the team sees. The engine name is an internal term,
+        // thus no heading, no badge, and no note carries it.
+        expect(html).not.toContain("Cortex");
+        expect(html).not.toContain("CORTEX");
+    });
+});
+
+describe("the one content column", () => {
+    /** A document that carries prose, a table, and a chart. The three kinds must read at one measure. */
+    const columnDocument: ReportDocument = {
+        title: "T",
+        sections: [
+            {
+                kind: "section",
+                id: "s",
+                title: "S",
+                blocks: [
+                    { kind: "text", id: "t", content: { prose: "Prose." } },
+                    { kind: "table", id: "tbl", binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" } },
+                    {
+                        kind: "chart",
+                        id: "cht",
+                        binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" },
+                        chartType: "bar",
+                        encoding: { x: "day", y: "count" },
+                    },
+                ],
+            },
+        ],
+    };
+
+    /** One table value for the table block and one for the chart block. */
+    const columnValues: RenderValues = {
+        tbl: { type: "table", rows: [{ day: "Mon", count: 1 }] },
+        cht: { type: "table", rows: [{ day: "Mon", count: 1 }] },
+    };
+
+    it("holds the prose, the table, and the chart inside the one column", () => {
+        const page = load(renderReportPage(columnDocument, columnValues)._unsafeUnwrap());
+        expect(page(".report-content .report-prose").length).toBe(1);
+        expect(page(".report-content .report-table").length).toBe(1);
+        expect(page(".report-content .report-chart").length).toBe(1);
+        // One column sits inside each container, thus one mechanism serves the hero, each band, and the
+        // footer. A second mechanism would let one region drift away from the rest.
+        expect(page(".report-content").length).toBe(page(".report-container").length);
+    });
+
+    it("caps no prose measure below the column width", () => {
+        const proseRules = [...DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(/\.report-prose\s*\{([^}]*)\}/g)].map((match) => match[1]);
+        expect(proseRules.length).toBeGreaterThan(0);
+        // An inner measure on the prose alone leaves a half-empty band beside a full-width table.
+        for (const body of proseRules) {
+            expect(body).not.toContain("max-width");
+        }
+        // The width rides one token, thus each region reads the same value.
+        expect(DESIGN_CSS).toMatch(/\.report-content\s*\{[^}]*max-width:\s*var\(--content-max\)/);
+        expect(DESIGN_CSS).toMatch(/--content-max:\s*\d+px/);
+    });
+});
+
+describe("the provenance appendix", () => {
+    /** A document with one claim. The ledger then holds one entry, thus the appendix renders. */
+    const claimDocument: ReportDocument = {
+        title: "T",
+        sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "claim", id: "c1", content: { prose: "A claim." }, bindings: [citation] }] }],
+    };
+
+    it("titles the auto-generated list Data provenance", () => {
+        const html = renderReportPage(claimDocument, {})._unsafeUnwrap();
+        expect(html).toContain("Data provenance");
+        // A reader expects literature under "References". The auto-generated list is provenance, thus no
+        // heading of the page carries that word.
+        expect(html).not.toContain(">References<");
+        expect(load(html)("h2.report-ref-title").length).toBe(1);
+    });
+
+    it("reads quieter than the body of the report", () => {
+        const itemRules = [...DESIGN_CSS.matchAll(/\.report-ref-item\s*\{([^}]*)\}/g)].map((match) => match[1]);
+        const sizes = itemRules.flatMap((body) => [...body.matchAll(/font-size:\s*(\d+)px/g)].map((match) => Number(match[1])));
+        expect(sizes.length).toBeGreaterThan(0);
+        // The body reads at 16px. A reader consults one entry of the appendix from a marker, thus the
+        // appendix reads smaller than the text that sent the reader to it.
+        expect(Math.max(...sizes)).toBeLessThan(16);
+    });
+});
+
+describe("the section scrollspy", () => {
+    /** The class that the spy writes. The design source holds the matching rule under the same name. */
+    const ACTIVE_CLASS = "report-nav-link-active";
+
+    /** One navigation link that records each class name that the script writes. */
+    type FakeLink = { getAttribute: () => string; classList: { add: (name: string) => void; remove: (name: string) => void }; classes: Set<string> };
+
+    /** The result of one spy run: the active links, the intersection driver, and the observed root margin. */
+    type SpyRun = { active: () => string[]; intersect: (visible: boolean[]) => void; rootMargin: string };
+
+    function fakeLink(href: string): FakeLink {
+        const classes = new Set<string>();
+        return {
+            getAttribute: () => href,
+            classList: {
+                add: (name: string) => {
+                    classes.add(name);
+                },
+                remove: (name: string) => {
+                    classes.delete(name);
+                },
+            },
+            classes,
+        };
+    }
+
+    /**
+     * Run the emitted spy over fake page globals. The script hands its callback to the fake observer, thus
+     * the test drives the intersection directly and no real browser is necessary.
+     */
+    function runSpy(ids: string[], hasObserver = true): SpyRun {
+        const links = ids.map((id) => fakeLink(`#${id}`));
+        const sections = ids.map((id) => ({ id }));
+        let callback: ((entries: { target: unknown; isIntersecting: boolean }[]) => void) | undefined;
+        let rootMargin = "";
+        const doc = {
+            readyState: "complete",
+            querySelectorAll: () => links,
+            getElementById: (id: string) => sections[ids.indexOf(id)] ?? null,
+            addEventListener: () => undefined,
+        };
+        const observer = hasObserver
+            ? function (cb: (entries: { target: unknown; isIntersecting: boolean }[]) => void, options: { rootMargin: string }) {
+                  callback = cb;
+                  rootMargin = options.rootMargin;
+                  return { observe: () => undefined };
+              }
+            : undefined;
+        new Function("document", "IntersectionObserver", SECTION_SPY)(doc, observer);
+        return {
+            active: () => links.filter((link) => link.classes.has(ACTIVE_CLASS)).map((link) => link.getAttribute()),
+            intersect: (visible: boolean[]) => callback?.(sections.map((target, index) => ({ target, isIntersecting: visible[index] }))),
+            rootMargin,
+        };
+    }
+
+    it("marks the section nearest the top and marks no other", () => {
+        const run = runSpy(["sec-1", "sec-2", "sec-3"]);
+        run.intersect([false, true, true]);
+        expect(run.active()).toEqual(["#sec-2"]);
+    });
+
+    it("moves the mark when a different section reaches the top", () => {
+        const run = runSpy(["sec-1", "sec-2"]);
+        run.intersect([false, true]);
+        run.intersect([true, true]);
+        expect(run.active()).toEqual(["#sec-1"]);
+    });
+
+    it("shrinks the observation box to the top band of the viewport", () => {
+        const run = runSpy(["sec-1"]);
+        run.intersect([true]);
+        // The negative bottom margin is what keeps one section in the box at a time.
+        expect(run.rootMargin).toMatch(/0px 0px -\d+% 0px/);
+    });
+
+    it("keeps the plain links in a browser with no observer", () => {
+        const run = runSpy(["sec-1", "sec-2"], false);
+        run.intersect([true, false]);
+        // The highlight is decoration, thus its absence costs the reader no navigation.
+        expect(run.active()).toEqual([]);
+    });
+
+    it("rides the page beside the other scripts, with its rule in the design source", () => {
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        expect(html).toContain(SECTION_SPY);
+        expect(DESIGN_CSS).toContain(`.${ACTIVE_CLASS}`);
     });
 });
 

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -67,6 +67,27 @@ function attributeReferences(html: string): string[] {
 }
 
 /**
+ * The tag name and the attribute name of each element that carries the given value in a reference
+ * attribute, in document order. One element gives one entry for each attribute that names the value.
+ *
+ * The gate admits one remote value. A navigation to it costs no request, but a subresource with the same
+ * value fetches on open. Thus the admission binds to the element, and a value alone never earns it.
+ */
+function referenceSites(html: string, value: string): string[] {
+    const page = load(html);
+    const sites: string[] = [];
+    for (const element of page("[href], [src], [srcset]").toArray()) {
+        for (const name of ["href", "src", "srcset"]) {
+            const attribute = page(element).attr(name);
+            if (attribute === undefined) continue;
+            const values = name === "srcset" ? srcsetCandidates(attribute) : [attribute];
+            if (values.includes(value)) sites.push(`${element.tagName}[${name}]`);
+        }
+    }
+    return sites;
+}
+
+/**
  * Each remote-capable reference of a style sheet, without its quotes. The `@font-face` rules reach the page
  * through the inline sheet, thus the font references live here and not in an attribute.
  *
@@ -116,6 +137,10 @@ describe("the page stands alone", () => {
         const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
         const references = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)];
         expect(references.length).toBeGreaterThan(0);
+
+        // The brand value reaches the page as a navigation and as nothing else. A `src` that names the same
+        // host fetches on open, thus the exemption below binds to the anchor and not to the value.
+        expect(referenceSites(html, BRAND_LINK)).toEqual(["a[href]"]);
 
         // The scheme test reads the start of the value. A namespace URI inside a data URI names no host to
         // fetch, thus the test must not read a scheme out of the middle of a value.
@@ -169,6 +194,13 @@ describe("the stands-alone extraction", () => {
             `.b { background-image: url("assets/local.svg"); }`,
         ].join("\n");
         expect(remote(styleReferences(doctored))).toEqual(["https://cdn.example.com/sheet.css", "https://cdn.example.com/one.avif"]);
+    });
+
+    it("names the element and the attribute of each site of one value", () => {
+        // The exemption of the gate rides on the anchor. Thus the extraction must divide a navigation from
+        // a subresource that names the same value.
+        const doctored = `<a href="https://inflexa.ai/">brand</a><script src="https://inflexa.ai/"></script>`;
+        expect(referenceSites(doctored, "https://inflexa.ai/")).toEqual(["a[href]", "script[src]"]);
     });
 
     it("keeps a data URI whole and reads no scheme out of the middle of one", () => {
@@ -475,11 +507,25 @@ describe("the section scrollspy", () => {
     /** The class that the spy writes. The design source holds the matching rule under the same name. */
     const ACTIVE_CLASS = "report-nav-link-active";
 
+    /** The viewport height of the fake page. The observation box is the top band of this height. */
+    const VIEWPORT_HEIGHT = 1000;
+
     /** One navigation link that records each class name that the script writes. */
     type FakeLink = { getAttribute: () => string; classList: { add: (name: string) => void; remove: (name: string) => void }; classes: Set<string> };
 
-    /** The result of one spy run: the active links, the intersection driver, and the observed root margin. */
-    type SpyRun = { active: () => string[]; intersect: (visible: boolean[]) => void; rootMargin: string };
+    /** One section that reports a movable top offset, as `getBoundingClientRect` does in a browser. */
+    type FakeSection = { id: string; box: { top: number }; getBoundingClientRect: () => { top: number } };
+
+    /**
+     * The result of one spy run: the active links, the intersection driver, the section placement, and the
+     * observed root margin.
+     */
+    type SpyRun = { active: () => string[]; intersect: (visible: boolean[]) => void; place: (tops: number[]) => void; rootMargin: string };
+
+    function fakeSection(id: string, top: number): FakeSection {
+        const box = { top };
+        return { id, box, getBoundingClientRect: () => ({ top: box.top }) };
+    }
 
     function fakeLink(href: string): FakeLink {
         const classes = new Set<string>();
@@ -500,14 +546,18 @@ describe("the section scrollspy", () => {
     /**
      * Run the emitted spy over fake page globals. The script hands its callback to the fake observer, thus
      * the test drives the intersection directly and no real browser is necessary.
+     *
+     * The `tops` list places each section in the coordinates of the fake page. The default list puts the
+     * first section at the top of the box and each other section one viewport lower.
      */
-    function runSpy(ids: string[], hasObserver = true): SpyRun {
+    function runSpy(ids: string[], hasObserver = true, tops?: number[]): SpyRun {
         const links = ids.map((id) => fakeLink(`#${id}`));
-        const sections = ids.map((id) => ({ id }));
+        const sections = ids.map((id, index) => fakeSection(id, tops?.[index] ?? index * VIEWPORT_HEIGHT));
         let callback: ((entries: { target: unknown; isIntersecting: boolean }[]) => void) | undefined;
         let rootMargin = "";
         const doc = {
             readyState: "complete",
+            documentElement: { clientHeight: VIEWPORT_HEIGHT },
             querySelectorAll: () => links,
             getElementById: (id: string) => sections[ids.indexOf(id)] ?? null,
             addEventListener: () => undefined,
@@ -523,6 +573,11 @@ describe("the section scrollspy", () => {
         return {
             active: () => links.filter((link) => link.classes.has(ACTIVE_CLASS)).map((link) => link.getAttribute()),
             intersect: (visible: boolean[]) => callback?.(sections.map((target, index) => ({ target, isIntersecting: visible[index] }))),
+            place: (next: number[]) => {
+                for (let index = 0; index < sections.length; index++) {
+                    sections[index].box.top = next[index];
+                }
+            },
             rootMargin,
         };
     }
@@ -545,6 +600,55 @@ describe("the section scrollspy", () => {
         run.intersect([true]);
         // The negative bottom margin is what keeps one section in the box at a time.
         expect(run.rootMargin).toMatch(/0px 0px -\d+% 0px/);
+    });
+
+    it("marks the first link when every section starts below the box", () => {
+        // The page opens at scroll 0, and each section then sits under the box. A capture of that page must
+        // still show the reader a position in the report.
+        const run = runSpy(["sec-1", "sec-2", "sec-3"], true, [400, 1400, 2400]);
+        run.intersect([false, false, false]);
+        expect(run.active()).toEqual(["#sec-1"]);
+    });
+
+    it("marks the last section above the box when a short tail leaves the box empty", () => {
+        // A tail that is shorter than the viewport never lifts the last section into the top band. Without
+        // the fallback the link of that section can never take the mark.
+        const run = runSpy(["sec-1", "sec-2", "sec-3"], true, [-1200, -800, -400]);
+        run.intersect([false, false, false]);
+        expect(run.active()).toEqual(["#sec-3"]);
+    });
+
+    it("prefers the observed section over the fallback", () => {
+        // The fallback holds the mark on the first section here, thus the observed section is the one that
+        // proves which reading wins.
+        const run = runSpy(["sec-1", "sec-2"], true, [-900, 2000]);
+        run.intersect([false, true]);
+        expect(run.active()).toEqual(["#sec-2"]);
+    });
+
+    it("reads the section positions again on each paint", () => {
+        const run = runSpy(["sec-1", "sec-2"], true, [400, 1400]);
+        run.intersect([false, false]);
+        expect(run.active()).toEqual(["#sec-1"]);
+
+        // A scroll moves each section. A cached position would hold the mark on the first link for the
+        // whole page.
+        run.place([-1000, 100]);
+        run.intersect([false, false]);
+        expect(run.active()).toEqual(["#sec-2"]);
+    });
+
+    it("reads the end of the box from the margin that the observer takes", () => {
+        const run = runSpy(["sec-1"]);
+        run.intersect([true]);
+        const margin = /-(\d+)% 0px/.exec(run.rootMargin);
+        expect(margin).not.toBeNull();
+        // The script is browser source text, thus the test reads it as text. The fallback measures the same
+        // box that the observer takes, and one constant feeds both. Thus the two readings cannot drift.
+        expect(SECTION_SPY).toContain(`(100 - ${margin?.[1]})`);
+        expect(SECTION_SPY).toContain("clientHeight");
+        expect(SECTION_SPY).toContain("getBoundingClientRect().top <= end");
+        expect(SECTION_SPY).toContain("active = nearestAbove()");
     });
 
     it("keeps the plain links in a browser with no observer", () => {

--- a/harness/src/report-render/views/chart-view.tsx
+++ b/harness/src/report-render/views/chart-view.tsx
@@ -1,11 +1,11 @@
 /**
- * The chart panel markup.
+ * The chart card markup.
  *
  * The bootstrap in `page.ts` reads the option from the next element sibling of the container. Thus the
  * `<script type="application/json">` element MUST follow the container div with no element between them.
  *
- * The panel is the window-chrome form: the three dots on the left, the title in the center, and the
- * `CORTEX` badge on the right. It is the one component with rounded corners. The chart body carries a fixed
+ * The card is the square corner-accent form of the table and the figure, with the mono title line over it. A
+ * report is a document, thus the card wears no application-window costume. The chart body carries a fixed
  * height, because the chart runtime measures the container and a container with no height shows no chart.
  */
 
@@ -15,10 +15,7 @@ import type { ChartBlock } from "../../contracts/report-blocks.js";
 import type { EchartOption } from "../chart.js";
 import { scriptJson } from "../script-json.js";
 
-/** The product badge of a chart panel. */
-const PANEL_BADGE = "CORTEX";
-
-/** Render the panel markup for a chart. */
+/** Render the card markup for a chart. */
 export function renderChart(block: ChartBlock, option: EchartOption): string {
     const containerId = chartContainerId(block.id);
     // The JSON goes to the page through `raw()`, thus `scriptJson` is the sole guard of this sink. It
@@ -27,20 +24,10 @@ export function renderChart(block: ChartBlock, option: EchartOption): string {
     const json = scriptJson(option);
     return String(
         <div class="report-chart">
-            <div class="window-chrome">
-                <div class="window-chrome-bar">
-                    <div class="chrome-dots">
-                        <span class="chrome-dot dot-1"></span>
-                        <span class="chrome-dot dot-2"></span>
-                        <span class="chrome-dot dot-3"></span>
-                    </div>
-                    {block.title !== undefined ? <span class="window-chrome-title">{block.title}</span> : null}
-                    <span class="window-chrome-badge">{PANEL_BADGE}</span>
-                </div>
-                <div class="window-chrome-body">
-                    <div id={containerId} data-echarts-id={block.id} class="chart-container"></div>
-                    <script type="application/json">{raw(json)}</script>
-                </div>
+            {block.title !== undefined ? <div class="report-chart-title">{block.title}</div> : null}
+            <div class="report-chart-card corner-accents">
+                <div id={containerId} data-echarts-id={block.id} class="chart-container"></div>
+                <script type="application/json">{raw(json)}</script>
             </div>
             {block.caption !== undefined ? <p class="report-caption">{block.caption}</p> : null}
         </div>,

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -1,20 +1,24 @@
 /**
  * The page assembly: the hero, the bands, the reference band, and the footer.
  *
- * The skeleton inlines the style rules in the head, and it puts the three scripts at the end of the body.
- * The order of the three scripts is a contract. The theme registration runs before the chart bootstrap,
- * thus each chart finds its theme. The fade-in observer also runs before the chart bootstrap, thus the
- * bootstrap finds the reveal gate and it signals readiness after the first reveal pass. The navigation, the
- * main content, and the reference frame arrive as already-escaped markup strings, thus `raw()` inserts them
- * byte for byte.
+ * The skeleton inlines the style rules in the head, and it puts the four scripts at the end of the body.
+ * The order of the first three scripts is a contract. The theme registration runs before the chart
+ * bootstrap, thus each chart finds its theme. The fade-in observer also runs before the chart bootstrap,
+ * thus the bootstrap finds the reveal gate and it signals readiness after the first reveal pass. The
+ * scrollspy reads the sections alone, thus its position is free. The navigation, the main content, and the
+ * reference frame arrive as already-escaped markup strings, thus `raw()` inserts them byte for byte.
  *
  * One band holds one top-level section. The band index drives the alternation of the background and of the
  * texture, thus a caller that adds a band passes the next index.
+ *
+ * The container gives the full-bleed gutter of a region, and the content column inside it gives the one
+ * measure of the page. The hero, each band, and the footer use the same pair. Thus every block kind reads at
+ * one width, and the title over them sits on the same left edge.
  */
 
 import { raw } from "hono/html";
 
-import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER } from "../page.js";
+import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY } from "../page.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { ReferenceLedger } from "../references.js";
 import { renderReferenceList } from "./references-view.js";
@@ -24,7 +28,10 @@ import { scriptJson } from "../script-json.js";
 const HERO_EYEBROW = "INFLEXA · ANALYSIS REPORT";
 
 /** The constant note of the footer. */
-const FOOTER_NOTE = "Powered by Inflexa Cortex";
+const FOOTER_NOTE = "Powered by Inflexa";
+
+/** The title of the auto-generated appendix. The literature stays in the citation blocks of the sections. */
+const PROVENANCE_TITLE = "Data provenance";
 
 /**
  * The theme object as script-safe JSON. `scriptJson` replaces every `<` with `\u003c`, thus a later edit
@@ -53,7 +60,9 @@ export function renderBand(index: number, inner: string): string {
     const surface = index % 2 === 0 ? "report-band-white texture-dots" : "report-band-slate texture-grid";
     return String(
         <section class={`report-band ${surface} texture-noise`}>
-            <div class="report-container fade-in">{raw(inner)}</div>
+            <div class="report-container fade-in">
+                <div class="report-content">{raw(inner)}</div>
+            </div>
         </section>,
     );
 }
@@ -67,7 +76,7 @@ export function renderReferenceSection(ledger: ReferenceLedger, index: number): 
     if (list === "") {
         return "";
     }
-    const heading = String(<h2 class="report-heading report-heading-2">References</h2>);
+    const heading = String(<h2 class="report-heading report-heading-3 report-ref-title">{PROVENANCE_TITLE}</h2>);
     return renderBand(index, heading + list);
 }
 
@@ -92,8 +101,10 @@ export function assemblePage(title: string, nav: string, content: string, refere
                     {raw(nav)}
                     <header class="report-hero texture-noise">
                         <div class="report-container">
-                            <p class="report-eyebrow">{HERO_EYEBROW}</p>
-                            <h1 class="report-display">{title}</h1>
+                            <div class="report-content">
+                                <p class="report-eyebrow">{HERO_EYEBROW}</p>
+                                <h1 class="report-display">{title}</h1>
+                            </div>
                         </div>
                     </header>
                     <main>
@@ -101,14 +112,17 @@ export function assemblePage(title: string, nav: string, content: string, refere
                         {references.length > 0 ? raw(references) : null}
                     </main>
                     <footer class="report-footer">
-                        <div class="report-container report-footer-row">
-                            <span class="report-footer-title">{title}</span>
-                            <span class="report-footer-note">{FOOTER_NOTE}</span>
+                        <div class="report-container">
+                            <div class="report-content report-footer-row">
+                                <span class="report-footer-title">{title}</span>
+                                <span class="report-footer-note">{FOOTER_NOTE}</span>
+                            </div>
                         </div>
                     </footer>
                     <script>{raw(THEME_REGISTRATION)}</script>
                     <script>{raw(FADE_IN_OBSERVER)}</script>
                     <script>{raw(CHART_BOOTSTRAP)}</script>
+                    <script>{raw(SECTION_SPY)}</script>
                 </body>
             </html>,
         )

--- a/harness/src/report-render/views/prose.test.ts
+++ b/harness/src/report-render/views/prose.test.ts
@@ -72,4 +72,10 @@ describe("renderNav", () => {
         expect(html).toContain("Overview");
         expect(html).toContain("Results");
     });
+
+    it("links the brand to the Inflexa site", () => {
+        const child: TextBlock = { kind: "text", id: "t", content: { prose: "x" } };
+        const html = renderNav([{ kind: "section", id: "sec-1", title: "Overview", blocks: [child] }]);
+        expect(html).toContain(`<a class="report-nav-brand-name" href="https://inflexa.ai/">inflexa</a>`);
+    });
 });

--- a/harness/src/report-render/views/prose.tsx
+++ b/harness/src/report-render/views/prose.tsx
@@ -12,8 +12,11 @@ import type { ClaimBlock, SectionBlock, TextBlock } from "../../contracts/report
 import type { ReferenceLedger } from "../references.js";
 import { Marker } from "./references-view.js";
 
-/** The paragraph class of a text block and a claim block. The measure caps the line inside the wide band. */
+/** The paragraph class of a text block and a claim block. The paragraph fills the content column. */
 const PARAGRAPH_CLASS = "report-prose";
+
+/** The site that the navigation brand links to. It is the one reference of the page that leaves the page. */
+const BRAND_HREF = "https://inflexa.ai/";
 
 /**
  * Split prose into paragraphs on a blank line. A run of blank lines makes one split. An empty part drops
@@ -98,7 +101,9 @@ export function renderNav(topSections: SectionBlock[]): string {
     return String(
         <aside id="report-sidebar" class="report-nav" aria-label="Report navigation">
             <div class="report-nav-brand">
-                <span class="report-nav-brand-name">inflexa</span>
+                <a class="report-nav-brand-name" href={BRAND_HREF}>
+                    inflexa
+                </a>
             </div>
             <nav class="report-nav-list" aria-label="Report sections">
                 {topSections.map((section, index) => (

--- a/harness/src/report-render/views/references-view.tsx
+++ b/harness/src/report-render/views/references-view.tsx
@@ -1,5 +1,5 @@
 /**
- * The reference markup: the evidence marker and the ordered reference list.
+ * The reference markup: the evidence marker and the ordered provenance list.
  *
  * The runtime escapes each child and each attribute value, thus a hostile path, a hostile id, or a
  * hostile operation reaches the page as text. The list keeps the first-appearance order of the ledger,
@@ -100,8 +100,9 @@ function ReferenceEntry({ reference }: { reference: Reference }) {
 }
 
 /**
- * The ordered reference list for the end of the page. An empty ledger gives an empty string, thus the
- * page shows no empty list.
+ * The ordered provenance list for the end of the page. The list is an appendix: a reader consults one entry
+ * from a marker, thus the design keeps it quieter than the body. An empty ledger gives an empty string, thus
+ * the page shows no empty list.
  */
 export function renderReferenceList(ledger: ReferenceLedger): string {
     const entries = ledger.entries();


### PR DESCRIPTION
## What & why

Five presentation faults, each verified on the first real report page:

- The navigation showed no reading position. The page script now drives one active link through an observer over the section anchors, with no dependency.
- The chart wore an application-window costume. The three-dot chrome, the hover raise, and the `CORTEX` badge go. The chart renders in the square corner-accent card of the identity, with a mono title line.
- The content sat left with a `72ch` prose cap and a dead right margin. One centered content column now holds every block kind, and the prose fills it completely.
- The page named the engine. The footer reads `Powered by Inflexa`, and the navigation brand links to the Inflexa site.
- The auto-generated appendix wore the title "References". It reads "Data provenance" now, styled as a muted appendix, and the literature keeps its own section.

Notes for the reviewer:

- The brand link is the one remote reference of the page. It is a navigation and not a subresource, thus the stands-alone gate exempts exactly that one URL.
- The design-source invariant holds: each removed class rule left with its emitter, and the print rules swept with them.
- A proof render through the fixture confirms the five items by markup inspection.

Refs #376

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
