### PR TITLE
feat(harness): enhance the report tables without a framework

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The table view emits every resolved row as plain markup (`views/values.tsx`). The page scripts live in `page.ts` as browser source text. The design rules live in `design.ts` under the emitter invariant. The page must stay deterministic and self-contained. Thus the enhancer is presentation over a complete DOM, and never a data layer.
+
+## Goals / Non-Goals
+
+- Goal: a reader sorts, filters, and expands a table on the page, with no dependency.
+- Goal: a noisy set name reads clean, and the full text stays reachable.
+- Non-goal: a framework, a build step, or hydration. The verifier and the eyes pin a static document.
+- Non-goal: a block field for the cap. The renderer owns the default, and the column subset stays the content-level knob.
+
+## Decisions
+
+- **The sort reads a data attribute, never the shown text.** The view emits the raw cell value on each cell as `data-value`, thus the formatted text stays presentation. A column sorts numerically when every non-empty value parses as a number, and by code-unit text order otherwise. A click cycles ascending, descending, and the document order. The document order is recoverable because the script records the initial index on each row.
+- **The filter is one input for each table.** A substring match against the text of a row hides the misses with the hidden class. The filter and the cap compose: the cap counts only the rows that the filter keeps.
+- **The cap is a renderer constant of 20 rows.** The view marks each row past the cap with the hidden class. When the rows exceed the cap, the view emits the toggle with the total count. The toggle flips between "show all N" and "show fewer". The print rules reveal every hidden row, because paper has no toggle.
+- **The trim is a renderer rule with one shape.** A cell whose text holds two or more percent-delimited segments shows the first segment, and the full text rides the `title` attribute. This serves the encoded set names, and it touches no ordinary cell.
+- **The enhancer is one script beside the spy.** It follows the conventions of the page scripts: browser source text, no module binding, interpolated constants, and a no-support path that leaves plain markup usable.
+
+## Risks / Trade-offs
+
+- [A sorted table contradicts the capped subset] → the cap hides by count over the current order. The visible rows are the first of the current view. The script applies the cap again after each sort and each filter.
+- [The toggle steals the readiness signal] → the enhancer registers no reveal work and touches neither the gate nor the sentinel.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+A table block dumps every CSV row as plain HTML. On the first real report the GSEA table printed every row with raw set names that carry encoded noise. The table scrolled horizontally, and nothing sorts, nothing filters, and nothing bounds the visible rows.
+
+## What Changes
+
+- A vanilla enhancer joins the page script: click-to-sort on a header, one filter input for each table, and a row cap with a "show all N" toggle. No framework, no dependency, and no hydration.
+- The rows stay in the DOM. The cap hides rows with a class, and the toggle reveals them, thus no data moves and the page stays a self-contained document.
+- The renderer trims a display name with encoded noise, and the full text rides the `title` attribute.
+- The default row cap lives in the renderer. No block gains a field, because the column subset already covers the content-level choice.
+
+## The decided boundary
+
+No React and no table framework on the page. The page is a self-contained deterministic document, and a runtime with hydration works against the verifier, the eyes, and the design system.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-render`: a new requirement gives the table enhancer: the sort, the filter, the row cap with the toggle, and the name trim.
+- `report-design-system`: the table component names the enhancer controls.
+
+## Impact
+
+- `harness/src/report-render/page.ts` — the enhancer script.
+- `harness/src/report-render/design.ts` — the control rules and the hidden-row rule.
+- `harness/src/report-render/views/values.tsx` — the sort attributes, the trim, and the cap markup.
+- No contract change, no tool change, and no store change.

--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/specs/report-design-system/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/specs/report-design-system/spec.md
@@ -1,0 +1,36 @@
+# Delta: report-design-system
+
+## MODIFIED Requirements
+
+### Requirement: A considered component for each block kind
+The renderer MUST give each block kind its identity component:
+
+- A `text` block renders as prose that fills the content column.
+- A `claim` block renders as prose with the styled evidence markers.
+- A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
+- A consecutive run of `metric` siblings renders as one responsive grid.
+- A `table` block renders as a data table inside a corner-accent card. The card carries the sort headers, the filter input, and the row-cap toggle.
+- A `chart` block renders as a corner-accent card with a mono title line and a fixed-height chart body. The card carries no window chrome, no dots, no badge, and no hover raise, because a report is a document and not an application window.
+- A `figure` block renders as a corner-accent card with its caption.
+- A `citation` block renders as a card in the reference form.
+- A `section` block renders as a heading by depth.
+
+#### Scenario: Consecutive metrics form one grid
+- **WHEN** the caller renders a section with three metric blocks in a row
+- **THEN** one grid holds the three stat cards
+
+#### Scenario: A lone metric stays a card
+- **WHEN** the caller renders a section with one metric block between two text blocks
+- **THEN** the metric renders as one stat card, and no grid wraps the text
+
+#### Scenario: A chart card carries no window costume
+- **WHEN** the caller renders a chart block
+- **THEN** the title line sits over the card, and the card holds the fixed-height chart body with no dot, no badge, and no raise
+
+#### Scenario: A long metric value stays inside its card
+- **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
+- **THEN** the value stays inside the card bounds, and no character paints past the card edge
+
+#### Scenario: The table carries the enhancer controls
+- **WHEN** the caller renders a table block
+- **THEN** the card holds the sort headers and the filter input, in the identity styles of the design source

--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/specs/report-render/spec.md
@@ -1,0 +1,32 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The table enhancer
+The page MUST enhance each rendered table with a header sort, one filter input, and a row cap, through a page script with no dependency. The DOM MUST hold every resolved row, and the enhancer hides a row with a class and never removes one. The sort MUST read a raw value attribute that the view emits, thus the formatted text stays presentation. A numeric column sorts numerically, and every other column sorts in code-unit order. The cap is a renderer constant, and a table over the cap MUST carry a toggle that names the total row count. The print form MUST show every row. A browser without script keeps the complete plain table.
+
+The renderer MUST trim a percent-delimited display name to its first segment. The full text rides the `title` attribute.
+
+#### Scenario: The rows stay in the DOM under the cap
+- **WHEN** the caller renders a table with more rows than the cap
+- **THEN** the markup holds every row, the rows past the cap carry the hidden class, and the toggle names the total
+
+#### Scenario: A sort reads the raw value
+- **WHEN** the view renders a numeric cell with a formatted text
+- **THEN** the cell carries the raw value in a data attribute, and the enhancer sorts by that value
+
+#### Scenario: A small table carries no toggle
+- **WHEN** the caller renders a table at or under the cap
+- **THEN** no row carries the hidden class, and no toggle renders
+
+#### Scenario: A noisy name trims with the full text on hover
+- **WHEN** a cell holds a percent-delimited set name
+- **THEN** the cell shows the first segment, and the `title` attribute holds the full text
+
+#### Scenario: The print form shows every row
+- **WHEN** the reader prints a page with a capped table
+- **THEN** the print rules reveal each hidden row
+
+#### Scenario: A scriptless browser sees the whole plain table
+- **WHEN** the page loads with scripting disabled
+- **THEN** every row paints, and no inert control shows, because the sheet hides and shows only under the live marker

--- a/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-enhance-the-report-tables/tasks.md
@@ -1,0 +1,18 @@
+## 1. The markup
+
+- [x] 1.1 Emit the raw cell value as a data attribute on each table cell in `src/report-render/views/values.tsx`.
+- [x] 1.2 Add the cap markup: the hidden class on each row past the renderer cap, and the toggle with the total count.
+- [x] 1.3 Add the filter input and the sortable header markup.
+- [x] 1.4 Add the name trim: a percent-delimited value shows its first segment, with the full text on the `title` attribute.
+
+## 2. The script and the styles
+
+- [x] 2.1 Make the enhancer script in `src/report-render/page.ts` beside the spy: the sort cycle, the filter, and the cap that composes with both.
+- [x] 2.2 Wire the script into the page assembly, after the spy.
+- [x] 2.3 Add the design rules: the control styles, the hidden-row rule, the sort indicators, and the print reveal.
+
+## 3. The gates
+
+- [x] 3.1 Update and run the targeted render and view tests only.
+- [x] 3.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.
+- [x] 3.3 Render the fixture to the scratchpad, and confirm the enhancer markup, the script, and the trim by inspection.

--- a/harness/openspec/specs/report-design-system/spec.md
+++ b/harness/openspec/specs/report-design-system/spec.md
@@ -49,7 +49,7 @@ The renderer MUST give each block kind its identity component:
 - A `claim` block renders as prose with the styled evidence markers.
 - A `metric` block renders as a stat card with a mono value and an accent. The value MUST stay inside the card: the card carries an overflow guard, thus a long value can never paint past the card edge.
 - A consecutive run of `metric` siblings renders as one responsive grid.
-- A `table` block renders as a data table inside a corner-accent card.
+- A `table` block renders as a data table inside a corner-accent card. The card carries the sort headers, the filter input, and the row-cap toggle.
 - A `chart` block renders as a corner-accent card with a mono title line and a fixed-height chart body. The card carries no window chrome, no dots, no badge, and no hover raise, because a report is a document and not an application window.
 - A `figure` block renders as a corner-accent card with its caption.
 - A `citation` block renders as a card in the reference form.
@@ -70,6 +70,10 @@ The renderer MUST give each block kind its identity component:
 #### Scenario: A long metric value stays inside its card
 - **WHEN** the caller renders a metric whose formatted value still runs wide on a narrow card
 - **THEN** the value stays inside the card bounds, and no character paints past the card edge
+
+#### Scenario: The table carries the enhancer controls
+- **WHEN** the caller renders a table block
+- **THEN** the card holds the sort headers and the filter input, in the identity styles of the design source
 
 ### Requirement: The geometric identity rules
 A data card MUST hold square corners with the corner accents. The theme MUST stay light: white and slate surfaces, with dark only in the footer.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -105,6 +105,35 @@ When the shown form hides digits, the element MUST carry the full digits in its 
 - **WHEN** the caller derives a histogram option
 - **THEN** the count axis carries a whole-tick bound, thus no count tick shows a fraction
 
+### Requirement: The table enhancer
+The page MUST enhance each rendered table with a header sort, one filter input, and a row cap, through a page script with no dependency. The DOM MUST hold every resolved row, and the enhancer hides a row with a class and never removes one. The sort MUST read a raw value attribute that the view emits, thus the formatted text stays presentation. A numeric column sorts numerically, and every other column sorts in code-unit order. The cap is a renderer constant, and a table over the cap MUST carry a toggle that names the total row count. The print form MUST show every row. A browser without script keeps the complete plain table.
+
+The renderer MUST trim a percent-delimited display name to its first segment. The full text rides the `title` attribute.
+
+#### Scenario: The rows stay in the DOM under the cap
+- **WHEN** the caller renders a table with more rows than the cap
+- **THEN** the markup holds every row, the rows past the cap carry the hidden class, and the toggle names the total
+
+#### Scenario: A sort reads the raw value
+- **WHEN** the view renders a numeric cell with a formatted text
+- **THEN** the cell carries the raw value in a data attribute, and the enhancer sorts by that value
+
+#### Scenario: A small table carries no toggle
+- **WHEN** the caller renders a table at or under the cap
+- **THEN** no row carries the hidden class, and no toggle renders
+
+#### Scenario: A noisy name trims with the full text on hover
+- **WHEN** a cell holds a percent-delimited set name
+- **THEN** the cell shows the first segment, and the `title` attribute holds the full text
+
+#### Scenario: The print form shows every row
+- **WHEN** the reader prints a page with a capped table
+- **THEN** the print rules reveal each hidden row
+
+#### Scenario: A scriptless browser sees the whole plain table
+- **WHEN** the page loads with scripting disabled
+- **THEN** every row paints, and no inert control shows, because the sheet hides and shows only under the live marker
+
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.
 

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -438,6 +438,36 @@ img {
   text-transform: uppercase;
   color: var(--color-primary-500);
 }
+/* The control strip of a table card. It holds the filter input of the page enhancer.
+
+   The strip shows under the live marker alone. The page script writes that marker on each card that it
+   enhances, thus a browser with no script sees no input that it cannot drive. */
+.report-table-controls {
+  display: none;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-card);
+}
+.report-table-live .report-table-controls {
+  display: block;
+}
+.report-table-filter {
+  width: 100%;
+  max-width: 320px;
+  padding: 7px 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-strong);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+}
+.report-table-filter:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+}
+.report-table-filter::placeholder {
+  color: var(--color-text-muted);
+}
 .data-table-scroll {
   overflow-x: auto;
 }
@@ -463,6 +493,27 @@ img {
   color: var(--color-text-strong);
   border-bottom: 1px solid var(--color-border-subtle);
 }
+/* A sortable header. The page script adds one of the two mark classes to the header that orders the table,
+   and it holds that class on one header at a time. */
+.data-table-sort {
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.data-table-sort:hover {
+  color: var(--color-heading);
+}
+.data-table-sort-asc::after,
+.data-table-sort-desc::after {
+  padding-left: 4px;
+  color: var(--color-primary-500);
+}
+.data-table-sort-asc::after {
+  content: "\\2191";
+}
+.data-table-sort-desc::after {
+  content: "\\2193";
+}
 .report-row {
   transition: background-color 0.15s ease;
 }
@@ -471,6 +522,40 @@ img {
 }
 .report-row:last-child td {
   border-bottom: 0;
+}
+/* The cap hides each row past it, and the toggle and the filter both write this class. The row stays in the
+   document, thus the page keeps every resolved value and no data moves.
+
+   The rule takes effect under the live marker alone. The page script writes that marker on each card that it
+   enhances. Thus a browser with no script shows the complete plain table, and no row hides behind a toggle
+   that cannot open. */
+.report-table-live .report-row-hidden {
+  display: none;
+}
+/* The toggle of the row cap. It sits under the table, and it names the total row count. It shows under the
+   live marker alone, thus a browser with no script sees no button that it cannot drive. */
+.report-table-toggle {
+  display: none;
+  width: 100%;
+  padding: 10px 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--color-primary-500);
+  background: var(--color-bg-alt);
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  cursor: pointer;
+}
+.report-table-live .report-table-toggle {
+  display: block;
+}
+.report-table-toggle:hover {
+  color: var(--color-primary-700);
+  background: var(--color-border-subtle);
 }
 
 /* ── Figure and citation cards ────────────────────────── */
@@ -706,6 +791,15 @@ img {
   .texture-grid::before,
   .texture-noise::after {
     display: none;
+  }
+  /* Paper carries no filter and no toggle. Thus the controls drop out, and each hidden row prints. Each
+     selector matches its live rule above, thus print wins on the same specificity and by its position. */
+  .report-table-live .report-table-controls,
+  .report-table-live .report-table-toggle {
+    display: none;
+  }
+  .report-table-live .report-row-hidden {
+    display: table-row;
   }
   .report-footer {
     background: var(--color-bg);

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -494,13 +494,16 @@ img {
   border-bottom: 1px solid var(--color-border-subtle);
 }
 /* A sortable header. The page script adds one of the two mark classes to the header that orders the table,
-   and it holds that class on one header at a time. */
-.data-table-sort {
+   and it holds that class on one header at a time.
+
+   The affordance shows under the live marker alone. A zero-row table never takes the marker, thus its
+   headers stay plain and no pointer promises a sort that does nothing. */
+.report-table-live .data-table-sort {
   cursor: pointer;
   -webkit-user-select: none;
   user-select: none;
 }
-.data-table-sort:hover {
+.report-table-live .data-table-sort:hover {
   color: var(--color-heading);
 }
 .data-table-sort-asc::after,
@@ -552,6 +555,11 @@ img {
 }
 .report-table-live .report-table-toggle {
   display: block;
+}
+/* The filter can keep the cap or less. No row then waits behind the toggle, thus the script hides it. The
+   rule comes after the rule that shows the toggle, thus it wins on the same specificity. */
+.report-table-live .report-table-toggle-off {
+  display: none;
 }
 .report-table-toggle:hover {
   color: var(--color-primary-700);

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -1,5 +1,5 @@
 /**
- * The page constants: the head references, the readiness names, and the three page-side scripts.
+ * The page constants: the head references, the readiness names, and the four page-side scripts.
  *
  * A script here is browser source text, not module code. Thus it reads no module binding, and each value
  * that it needs is interpolated at build time. The style rules and the ECharts theme live in `design.ts`.
@@ -7,6 +7,7 @@
 
 import { assetSource, ECHARTS_ASSET } from "./assets.js";
 import { ECHARTS_THEME_NAME } from "./design.js";
+import { TABLE_ROW_CAP } from "./views/values.js";
 
 /**
  * The head references of the staged assets. The page loads the chart runtime from the sibling assets
@@ -61,6 +62,34 @@ const REVEAL_SETTLE_TIMEOUT_MS = 2_000;
  */
 const NAV_ACTIVE_CLASS = "report-nav-link-active";
 const SPY_BOTTOM_MARGIN_PERCENT = 70;
+
+/**
+ * The class that hides one table row, and the two classes that mark the sorted header.
+ *
+ * The table view emits the hidden class on each row past the cap, and the enhancer below writes the same
+ * class as the filter and the toggle change what shows. The design sheet holds the matching rule of each of
+ * the three names.
+ */
+const ROW_HIDDEN_CLASS = "report-row-hidden";
+const SORT_ASCENDING_CLASS = "data-table-sort-asc";
+const SORT_DESCENDING_CLASS = "data-table-sort-desc";
+
+/**
+ * The marker class of a card that the enhancer took.
+ *
+ * The rule that hides a row takes effect under this marker alone. The script writes the marker when it binds
+ * a card, thus a browser with no script shows the complete plain table and no row hides behind a toggle that
+ * cannot open.
+ */
+const TABLE_LIVE_CLASS = "report-table-live";
+
+/**
+ * The label of the toggle while every row that the filter keeps shows.
+ *
+ * The view composes the collapsed label, because the view holds the total row count. Thus the enhancer keeps
+ * the label that it finds and it restores that text, and the two sites cannot disagree over the count.
+ */
+const SHOW_FEWER_LABEL = "Show fewer";
 
 /**
  * The page-side script that wires each chart. It finds every chart container, reads the option JSON from
@@ -308,6 +337,182 @@ export const SECTION_SPY = `(function () {
     }, { rootMargin: "0px 0px -${SPY_BOTTOM_MARGIN_PERCENT}% 0px", threshold: 0 });
     for (var k = 0; k < sections.length; k++) {
       observer.observe(sections[k]);
+    }
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start);
+  } else {
+    start();
+  }
+})();`;
+
+/**
+ * The page-side script that gives each table its sort, its filter, and its row cap.
+ *
+ * The enhancer is presentation over a complete DOM. Every resolved row is already in the markup, thus the
+ * script moves a row and hides a row, and it never adds one and never removes one.
+ *
+ * The script marks each card that it takes. The rule that hides a row reads that marker, thus a browser with
+ * no script keeps the plain table with every row, and the cap costs the reader nothing there.
+ *
+ * A click on a header cycles the column: ascending, then descending, then the document order. The script
+ * records the initial index of each row at start, thus the document order is always recoverable. The sort
+ * reads the `data-value` attribute of a cell, thus a rounded number still orders by its full magnitude. A
+ * column sorts numerically when every non-empty value of it parses as a number, and in code-unit order at
+ * every other time. An empty cell holds no rank, thus it stays at the end under both directions. Two equal
+ * cells keep the document order, thus one sort gives one order and not the order of the engine.
+ *
+ * The filter hides each row whose text misses the query. The comparison lowercases both texts with
+ * `toLowerCase`. That method reads no locale, and it is exact over the ASCII range of a gene name and an
+ * accession.
+ *
+ * The cap composes with both. After each change the first rows that the filter keeps show, up to the cap,
+ * and the rest hide. The toggle opens the table, and each row that the filter keeps then shows. The label of
+ * the toggle flips between the collapsed label of the view and the label above.
+ *
+ * The script registers no reveal work. It touches neither the reveal gate nor the readiness sentinel, thus a
+ * capture of the page still signals at the same point.
+ */
+export const TABLE_ENHANCER = `(function () {
+  var CAP = ${TABLE_ROW_CAP};
+  var HIDDEN = ${JSON.stringify(ROW_HIDDEN_CLASS)};
+  var ASCENDING = ${JSON.stringify(SORT_ASCENDING_CLASS)};
+  var DESCENDING = ${JSON.stringify(SORT_DESCENDING_CLASS)};
+  var LIVE = ${JSON.stringify(TABLE_LIVE_CLASS)};
+  var FEWER = ${JSON.stringify(SHOW_FEWER_LABEL)};
+  function rawValue(row, index) {
+    var cell = row.cells[index];
+    return cell ? cell.getAttribute("data-value") || "" : "";
+  }
+  function numericColumn(rows, index) {
+    var seen = false;
+    for (var i = 0; i < rows.length; i++) {
+      var value = rawValue(rows[i], index);
+      if (value === "") {
+        continue;
+      }
+      if (isNaN(Number(value))) {
+        return false;
+      }
+      seen = true;
+    }
+    return seen;
+  }
+  function enhance(card) {
+    var table = card.querySelector("table.data-table");
+    var body = table ? table.querySelector("tbody") : null;
+    if (!body || body.rows.length === 0) {
+      return;
+    }
+    var rows = [];
+    var order = [];
+    for (var r = 0; r < body.rows.length; r++) {
+      rows.push(body.rows[r]);
+      order.push(r);
+    }
+    var headers = table.querySelectorAll("th[data-sort-index]");
+    var filter = card.querySelector(".report-table-filter");
+    var toggle = card.querySelector(".report-table-toggle");
+    var collapsed = toggle ? toggle.textContent : "";
+    var query = "";
+    var open = false;
+    var sorted = null;
+    var descending = false;
+    function paint() {
+      var kept = 0;
+      for (var i = 0; i < order.length; i++) {
+        var row = rows[order[i]];
+        if (query !== "" && (row.textContent || "").toLowerCase().indexOf(query) < 0) {
+          row.classList.add(HIDDEN);
+          continue;
+        }
+        kept += 1;
+        if (open || kept <= CAP) {
+          row.classList.remove(HIDDEN);
+        } else {
+          row.classList.add(HIDDEN);
+        }
+      }
+      if (toggle) {
+        toggle.textContent = open ? FEWER : collapsed;
+      }
+      for (var h = 0; h < headers.length; h++) {
+        headers[h].classList.remove(ASCENDING);
+        headers[h].classList.remove(DESCENDING);
+      }
+      if (sorted) {
+        sorted.classList.add(descending ? DESCENDING : ASCENDING);
+      }
+    }
+    function place() {
+      for (var p = 0; p < order.length; p++) {
+        body.appendChild(rows[order[p]]);
+      }
+    }
+    function sort(index) {
+      var numeric = numericColumn(rows, index);
+      var direction = descending ? -1 : 1;
+      order.sort(function (left, right) {
+        var a = rawValue(rows[left], index);
+        var b = rawValue(rows[right], index);
+        if (a === "" || b === "") {
+          return a === b ? left - right : a === "" ? 1 : -1;
+        }
+        var rank = numeric ? Number(a) - Number(b) : a < b ? -1 : a > b ? 1 : 0;
+        return rank === 0 ? left - right : rank * direction;
+      });
+      place();
+    }
+    function reset() {
+      order.sort(function (left, right) {
+        return left - right;
+      });
+      place();
+    }
+    function cycle(header, index) {
+      if (sorted !== header) {
+        sorted = header;
+        descending = false;
+        sort(index);
+      } else if (!descending) {
+        descending = true;
+        sort(index);
+      } else {
+        sorted = null;
+        descending = false;
+        reset();
+      }
+      paint();
+    }
+    function bind(header, index) {
+      header.addEventListener("click", function () {
+        cycle(header, index);
+      });
+    }
+    for (var k = 0; k < headers.length; k++) {
+      bind(headers[k], parseInt(headers[k].getAttribute("data-sort-index") || "0", 10) || 0);
+    }
+    if (filter) {
+      filter.addEventListener("input", function () {
+        query = (filter.value || "").toLowerCase();
+        paint();
+      });
+    }
+    if (toggle) {
+      toggle.addEventListener("click", function () {
+        open = !open;
+        paint();
+      });
+    }
+    card.classList.add(LIVE);
+  }
+  function start() {
+    if (!document.querySelectorAll || typeof document.documentElement.classList === "undefined") {
+      return;
+    }
+    var cards = document.querySelectorAll(".report-table");
+    for (var c = 0; c < cards.length; c++) {
+      enhance(cards[c]);
     }
   }
   if (document.readyState === "loading") {

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -7,7 +7,7 @@
 
 import { assetSource, ECHARTS_ASSET } from "./assets.js";
 import { ECHARTS_THEME_NAME } from "./design.js";
-import { TABLE_ROW_CAP } from "./views/values.js";
+import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
 
 /**
  * The head references of the staged assets. The page loads the chart runtime from the sibling assets
@@ -82,6 +82,14 @@ const SORT_DESCENDING_CLASS = "data-table-sort-desc";
  * cannot open.
  */
 const TABLE_LIVE_CLASS = "report-table-live";
+
+/**
+ * The class that hides the toggle of the row cap.
+ *
+ * A filter that keeps the cap or less leaves no row behind the toggle. The script writes this class at that
+ * time, thus the reader sees a control only while the control does something.
+ */
+const TOGGLE_HIDDEN_CLASS = "report-table-toggle-off";
 
 /**
  * The label of the toggle while every row that the filter keeps shows.
@@ -355,20 +363,27 @@ export const SECTION_SPY = `(function () {
  * The script marks each card that it takes. The rule that hides a row reads that marker, thus a browser with
  * no script keeps the plain table with every row, and the cap costs the reader nothing there.
  *
- * A click on a header cycles the column: ascending, then descending, then the document order. The script
- * records the initial index of each row at start, thus the document order is always recoverable. The sort
- * reads the `data-value` attribute of a cell, thus a rounded number still orders by its full magnitude. A
- * column sorts numerically when every non-empty value of it parses as a number, and in code-unit order at
- * every other time. An empty cell holds no rank, thus it stays at the end under both directions. Two equal
- * cells keep the document order, thus one sort gives one order and not the order of the engine.
+ * A click on a header cycles the column: ascending, then descending, then the document order. The Enter key
+ * and the Space key give the same cycle, thus a reader sorts from the keyboard. The script records the
+ * initial index of each row at start, thus the document order is always recoverable.
  *
- * The filter hides each row whose text misses the query. The comparison lowercases both texts with
- * `toLowerCase`. That method reads no locale, and it is exact over the ASCII range of a gene name and an
- * accession.
+ * The sort reads the `data-value` attribute of a cell, thus a rounded number still orders by its full
+ * magnitude. A column sorts numerically when one non-empty value of it parses as a number, thus a sentinel
+ * such as `NA` cannot drop the column to text order and rank `10` before `9`. A value that holds no rank,
+ * which is an empty cell and a cell that the numeric column cannot parse, stays at the end under both
+ * directions. Two equal cells keep the document order, thus one sort gives one order and not the order of
+ * the engine.
+ *
+ * The filter reads the `data-value` attributes of a row, and never the shown text. Thus a reader finds the
+ * accession that the trim hides, and a match cannot form across two cells. The comparison lowercases both
+ * texts with `toLowerCase`. That method reads no locale, and it is exact over the ASCII range of a gene name
+ * and an accession.
  *
  * The cap composes with both. After each change the first rows that the filter keeps show, up to the cap,
  * and the rest hide. The toggle opens the table, and each row that the filter keeps then shows. The label of
- * the toggle flips between the collapsed label of the view and the label above.
+ * the toggle flips between the collapsed label and the label above, and the collapsed label counts the rows
+ * that the filter keeps. A filter that keeps the cap or less hides the toggle, because nothing then waits
+ * behind it.
  *
  * The script registers no reveal work. It touches neither the reveal gate nor the readiness sentinel, thus a
  * capture of the page still signals at the same point.
@@ -379,24 +394,31 @@ export const TABLE_ENHANCER = `(function () {
   var ASCENDING = ${JSON.stringify(SORT_ASCENDING_CLASS)};
   var DESCENDING = ${JSON.stringify(SORT_DESCENDING_CLASS)};
   var LIVE = ${JSON.stringify(TABLE_LIVE_CLASS)};
+  var TOGGLE_OFF = ${JSON.stringify(TOGGLE_HIDDEN_CLASS)};
   var FEWER = ${JSON.stringify(SHOW_FEWER_LABEL)};
+  var ALL = ${JSON.stringify(SHOW_ALL_PREFIX)};
   function rawValue(row, index) {
     var cell = row.cells[index];
     return cell ? cell.getAttribute("data-value") || "" : "";
   }
+  function rowValues(row) {
+    var joined = "";
+    for (var c = 0; c < row.cells.length; c++) {
+      joined += (row.cells[c].getAttribute("data-value") || "") + "\\n";
+    }
+    return joined.toLowerCase();
+  }
   function numericColumn(rows, index) {
-    var seen = false;
     for (var i = 0; i < rows.length; i++) {
       var value = rawValue(rows[i], index);
-      if (value === "") {
-        continue;
+      if (value !== "" && !isNaN(Number(value))) {
+        return true;
       }
-      if (isNaN(Number(value))) {
-        return false;
-      }
-      seen = true;
     }
-    return seen;
+    return false;
+  }
+  function rankless(value, numeric) {
+    return value === "" || (numeric && isNaN(Number(value)));
   }
   function enhance(card) {
     var table = card.querySelector("table.data-table");
@@ -406,14 +428,15 @@ export const TABLE_ENHANCER = `(function () {
     }
     var rows = [];
     var order = [];
+    var values = [];
     for (var r = 0; r < body.rows.length; r++) {
       rows.push(body.rows[r]);
       order.push(r);
+      values.push(rowValues(body.rows[r]));
     }
     var headers = table.querySelectorAll("th[data-sort-index]");
     var filter = card.querySelector(".report-table-filter");
     var toggle = card.querySelector(".report-table-toggle");
-    var collapsed = toggle ? toggle.textContent : "";
     var query = "";
     var open = false;
     var sorted = null;
@@ -421,8 +444,9 @@ export const TABLE_ENHANCER = `(function () {
     function paint() {
       var kept = 0;
       for (var i = 0; i < order.length; i++) {
-        var row = rows[order[i]];
-        if (query !== "" && (row.textContent || "").toLowerCase().indexOf(query) < 0) {
+        var index = order[i];
+        var row = rows[index];
+        if (query !== "" && values[index].indexOf(query) < 0) {
           row.classList.add(HIDDEN);
           continue;
         }
@@ -434,14 +458,21 @@ export const TABLE_ENHANCER = `(function () {
         }
       }
       if (toggle) {
-        toggle.textContent = open ? FEWER : collapsed;
+        toggle.textContent = open ? FEWER : ALL + kept;
+        if (kept > CAP) {
+          toggle.classList.remove(TOGGLE_OFF);
+        } else {
+          toggle.classList.add(TOGGLE_OFF);
+        }
       }
       for (var h = 0; h < headers.length; h++) {
         headers[h].classList.remove(ASCENDING);
         headers[h].classList.remove(DESCENDING);
+        headers[h].setAttribute("aria-sort", "none");
       }
       if (sorted) {
         sorted.classList.add(descending ? DESCENDING : ASCENDING);
+        sorted.setAttribute("aria-sort", descending ? "descending" : "ascending");
       }
     }
     function place() {
@@ -455,8 +486,10 @@ export const TABLE_ENHANCER = `(function () {
       order.sort(function (left, right) {
         var a = rawValue(rows[left], index);
         var b = rawValue(rows[right], index);
-        if (a === "" || b === "") {
-          return a === b ? left - right : a === "" ? 1 : -1;
+        var aOut = rankless(a, numeric);
+        var bOut = rankless(b, numeric);
+        if (aOut || bOut) {
+          return aOut === bOut ? left - right : aOut ? 1 : -1;
         }
         var rank = numeric ? Number(a) - Number(b) : a < b ? -1 : a > b ? 1 : 0;
         return rank === 0 ? left - right : rank * direction;
@@ -486,6 +519,15 @@ export const TABLE_ENHANCER = `(function () {
     }
     function bind(header, index) {
       header.addEventListener("click", function () {
+        cycle(header, index);
+      });
+      header.addEventListener("keydown", function (event) {
+        if (event.key !== "Enter" && event.key !== " ") {
+          return;
+        }
+        // The Space key scrolls the page by default. The header takes the key instead, thus the keyboard
+        // gives the same cycle as the pointer.
+        event.preventDefault();
         cycle(header, index);
       });
     }

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -5,9 +5,10 @@ import type { Block, CitationBlock, MetricBlock, ReportDocument, TextBlock } fro
 import { ASSETS_DIR, PAGE_ASSETS } from "./assets.js";
 import { DESIGN_CSS } from "./design.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "./fixture.js";
-import { CHART_BOOTSTRAP, SECTION_SPY } from "./page.js";
+import { CHART_BOOTSTRAP, SECTION_SPY, TABLE_ENHANCER } from "./page.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
+import { TABLE_ROW_CAP } from "./views/values.js";
 
 /**
  * The site of the navigation brand. It is the one reference of the page that names a remote host.
@@ -662,6 +663,123 @@ describe("the section scrollspy", () => {
         const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
         expect(html).toContain(SECTION_SPY);
         expect(DESIGN_CSS).toContain(`.${ACTIVE_CLASS}`);
+    });
+});
+
+describe("the table enhancer", () => {
+    /** The print block of the sheet. It is the last block, thus the tail from its opening is its body. */
+    const PRINT_BLOCK = DESIGN_CSS.slice(DESIGN_CSS.indexOf("@media print"));
+
+    /** A page with one table of `count` rows and two columns. */
+    function tablePage(count: number): { document: ReportDocument; values: RenderValues } {
+        const rows = [];
+        for (let index = 0; index < count; index += 1) {
+            rows.push({ gene: `G${index}`, padj: 0.01 });
+        }
+        return {
+            document: {
+                title: "T",
+                sections: [
+                    {
+                        kind: "section",
+                        id: "s",
+                        title: "S",
+                        blocks: [{ kind: "table", id: "tbl", binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" } }],
+                    },
+                ],
+            },
+            values: { tbl: { type: "table", rows } },
+        };
+    }
+
+    it("rides the page after the scrollspy", () => {
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        expect(html).toContain(TABLE_ENHANCER);
+        expect(html.indexOf(TABLE_ENHANCER)).toBeGreaterThan(html.indexOf(SECTION_SPY));
+    });
+
+    it("bounds the markup and the script at one cap", () => {
+        // The view hides the rows past the cap, and the script applies the same cap again after each sort
+        // and each filter. Two numbers here would show one count and then show a different one.
+        expect(TABLE_ENHANCER).toContain(`var CAP = ${TABLE_ROW_CAP};`);
+    });
+
+    it("writes the classes that the view emits and that the design source styles", () => {
+        expect(TABLE_ENHANCER).toContain(`"report-row-hidden"`);
+        expect(TABLE_ENHANCER).toContain(`"data-table-sort-asc"`);
+        expect(TABLE_ENHANCER).toContain(`"data-table-sort-desc"`);
+        expect(DESIGN_CSS).toContain(".report-row-hidden");
+        expect(DESIGN_CSS).toContain(".data-table-sort-asc");
+        expect(DESIGN_CSS).toContain(".data-table-sort-desc");
+    });
+
+    it("reads no locale in the filter comparison and no locale in the sort", () => {
+        // `toLowerCase` is exact over the ASCII range of a gene name. A locale method gives different text
+        // and a different order on a different host, thus the page would stop being deterministic.
+        expect(TABLE_ENHANCER).toContain("toLowerCase()");
+        expect(TABLE_ENHANCER).not.toContain("localeCompare");
+        expect(TABLE_ENHANCER).not.toContain("toLocale");
+    });
+
+    it("touches neither the reveal gate nor the readiness sentinel", () => {
+        // The enhancer registers no reveal work. A page that waited on the enhancer would signal late.
+        expect(TABLE_ENHANCER).not.toContain("__inflexa");
+    });
+
+    it("hides a row under the live marker alone, thus a browser with no script shows every row", () => {
+        // The script writes the marker on each card that it takes. Without the marker no rule hides a row,
+        // thus the plain table stays complete and no row hides behind a toggle that cannot open.
+        const selectors = [...DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(/[^{}]*\.report-row-hidden[^{}]*\{/g)].map((match) => match[0]);
+        expect(selectors.length).toBeGreaterThan(0);
+        for (const selector of selectors) {
+            expect(selector).toContain(".report-table-live");
+        }
+        expect(TABLE_ENHANCER).toContain(`var LIVE = "report-table-live";`);
+        expect(TABLE_ENHANCER).toContain("card.classList.add(LIVE);");
+    });
+
+    it("shows a control under the live marker alone", () => {
+        const css = DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+        for (const control of ["report-table-controls", "report-table-toggle"]) {
+            const rules = [...css.matchAll(new RegExp(`([^{}]*\\.${control}[^{}]*)\\{([^}]*)\\}`, "g"))];
+            const withDisplay = rules.filter((rule) => /display:\s*[a-z-]+/.test(rule[2]));
+            expect(withDisplay.length).toBeGreaterThan(0);
+            for (const rule of withDisplay) {
+                if (/display:\s*none/.test(rule[2])) {
+                    continue;
+                }
+                // A rule that shows the control must name the marker. Without it a browser with no script
+                // paints an input and a button that nothing drives.
+                expect(rule[1]).toContain(".report-table-live");
+            }
+            // The default is hidden, thus the control appears only after the script takes the card.
+            const hiddenByDefault = withDisplay.some((rule) => !rule[1].includes(".report-table-live") && /display:\s*none/.test(rule[2]));
+            expect(hiddenByDefault).toBe(true);
+        }
+    });
+
+    it("shows every row in the print form and drops the controls", () => {
+        // The base rule hides a capped row. The print rule comes after it, thus it wins on paper.
+        expect(DESIGN_CSS.indexOf(".report-row-hidden")).toBeLessThan(DESIGN_CSS.indexOf("@media print"));
+        expect(PRINT_BLOCK).toMatch(/\.report-row-hidden\s*\{[^}]*display:\s*table-row/);
+        expect(PRINT_BLOCK).toMatch(/\.report-table-live \.report-table-controls,\s*\.report-table-live \.report-table-toggle\s*\{[^}]*display:\s*none/);
+    });
+
+    it("puts the sort headers, the filter, the hidden rows, and the toggle on a page over the cap", () => {
+        const over = tablePage(TABLE_ROW_CAP + 3);
+        const page = load(renderReportPage(over.document, over.values)._unsafeUnwrap());
+        expect(page("th.data-table-sort").length).toBe(2);
+        expect(page(".report-table-filter").length).toBe(1);
+        expect(page("tbody tr").length).toBe(TABLE_ROW_CAP + 3);
+        expect(page("tbody tr.report-row-hidden").length).toBe(3);
+        expect(page(".report-table-toggle").text()).toBe(`Show all ${TABLE_ROW_CAP + 3}`);
+    });
+
+    it("leaves a page at the cap with no hidden row and no toggle", () => {
+        const atCap = tablePage(TABLE_ROW_CAP);
+        const page = load(renderReportPage(atCap.document, atCap.values)._unsafeUnwrap());
+        expect(page("tbody tr.report-row-hidden").length).toBe(0);
+        expect(page(".report-table-toggle").length).toBe(0);
     });
 });
 

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -8,7 +8,7 @@ import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "./fixture.js";
 import { CHART_BOOTSTRAP, SECTION_SPY, TABLE_ENHANCER } from "./page.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
-import { TABLE_ROW_CAP } from "./views/values.js";
+import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
 
 /**
  * The site of the navigation brand. It is the one reference of the page that names a remote host.
@@ -758,6 +758,17 @@ describe("the table enhancer", () => {
         }
     });
 
+    it("gives the sort affordance under the live marker alone", () => {
+        const css = DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+        const rules = [...css.matchAll(/([^{}]*\.data-table-sort[^{}]*)\{([^}]*)\}/g)];
+        const affordance = rules.filter((rule) => /cursor:/.test(rule[2]) || /:hover/.test(rule[1]));
+        expect(affordance.length).toBeGreaterThan(0);
+        for (const rule of affordance) {
+            // A zero-row table never takes the marker. Its headers must then promise no sort.
+            expect(rule[1]).toContain(".report-table-live");
+        }
+    });
+
     it("shows every row in the print form and drops the controls", () => {
         // The base rule hides a capped row. The print rule comes after it, thus it wins on paper.
         expect(DESIGN_CSS.indexOf(".report-row-hidden")).toBeLessThan(DESIGN_CSS.indexOf("@media print"));
@@ -780,6 +791,218 @@ describe("the table enhancer", () => {
         const page = load(renderReportPage(atCap.document, atCap.values)._unsafeUnwrap());
         expect(page("tbody tr.report-row-hidden").length).toBe(0);
         expect(page(".report-table-toggle").length).toBe(0);
+    });
+});
+
+describe("the table enhancer behavior", () => {
+    /** The event that a header handler reads. The key selects the branch, and the guard stops the scroll. */
+    interface FakeEvent {
+        key?: string;
+        preventDefault: () => void;
+    }
+
+    /** One element in the shape that the script reads: a class set, an attribute map, and its handlers. */
+    interface FakeNode {
+        classes: Set<string>;
+        attributes: Record<string, string>;
+        classList: { add: (name: string) => void; remove: (name: string) => void };
+        addEventListener: (name: string, handler: (event: FakeEvent) => void) => void;
+        setAttribute: (name: string, value: string) => void;
+        getAttribute: (name: string) => string | null;
+        fire: (name: string, key?: string) => void;
+    }
+
+    type FakeRow = FakeNode & { cells: { getAttribute: (name: string) => string | null }[] };
+    type FakeFilter = FakeNode & { value: string };
+    type FakeToggle = FakeNode & { textContent: string };
+    type FakeCard = FakeNode & { querySelector: (selector: string) => unknown };
+
+    /** The handles of one mounted table: the elements, the painted order, and the two readings of it. */
+    interface Mounted {
+        card: FakeNode;
+        headers: FakeNode[];
+        filter: FakeFilter;
+        toggle: FakeToggle;
+        column: (index: number) => string[];
+        visible: () => string[];
+    }
+
+    function fakeNode(initial: string[] = []): FakeNode {
+        const classes = new Set(initial);
+        const attributes: Record<string, string> = {};
+        const handlers: Record<string, ((event: FakeEvent) => void)[]> = {};
+        return {
+            classes,
+            attributes,
+            classList: {
+                add: (name) => {
+                    classes.add(name);
+                },
+                remove: (name) => {
+                    classes.delete(name);
+                },
+            },
+            addEventListener: (name, handler) => {
+                handlers[name] = [...(handlers[name] ?? []), handler];
+            },
+            setAttribute: (name, value) => {
+                attributes[name] = value;
+            },
+            getAttribute: (name) => attributes[name] ?? null,
+            fire: (name, key) => {
+                for (const handler of handlers[name] ?? []) {
+                    handler({ key, preventDefault: () => undefined });
+                }
+            },
+        };
+    }
+
+    /**
+     * Mount one table of raw cell values and run the emitted enhancer over it.
+     *
+     * The script is browser source text. Each global arrives as a parameter, thus these fakes are the whole
+     * DOM that it drives and no real browser is necessary. `appendChild` moves a row to the end, as the
+     * browser method does, thus the painted order is the order that a reader sees.
+     */
+    function mount(cells: string[][], withToggle = false): Mounted {
+        const rows: FakeRow[] = cells.map((values) => ({
+            ...fakeNode(["report-row"]),
+            cells: values.map((value) => ({ getAttribute: (name: string) => (name === "data-value" ? value : null) })),
+        }));
+        const headers = (cells[0] ?? []).map((_, index) => {
+            const header = fakeNode(["data-table-sort"]);
+            header.attributes["data-sort-index"] = String(index);
+            return header;
+        });
+        const filter: FakeFilter = { ...fakeNode(), value: "" };
+        const toggle: FakeToggle = { ...fakeNode(["report-table-toggle"]), textContent: `${SHOW_ALL_PREFIX}${rows.length}` };
+        const painted = [...rows];
+        const body = {
+            rows,
+            appendChild: (node: FakeRow) => {
+                const at = painted.indexOf(node);
+                if (at >= 0) {
+                    painted.splice(at, 1);
+                }
+                painted.push(node);
+            },
+        };
+        const table = { querySelector: () => body, querySelectorAll: () => headers };
+        const card: FakeCard = {
+            ...fakeNode(["report-table"]),
+            querySelector: (selector: string): unknown => {
+                if (selector === "table.data-table") {
+                    return table;
+                }
+                if (selector === ".report-table-filter") {
+                    return filter;
+                }
+                return withToggle ? toggle : null;
+            },
+        };
+        const doc = {
+            readyState: "complete",
+            documentElement: { classList: { add: () => undefined } },
+            querySelectorAll: () => [card],
+            addEventListener: () => undefined,
+        };
+        new Function("document", TABLE_ENHANCER)(doc);
+        return {
+            card,
+            headers,
+            filter,
+            toggle,
+            column: (index) => painted.map((row) => row.cells[index].getAttribute("data-value") ?? ""),
+            visible: () => painted.filter((row) => !row.classes.has("report-row-hidden")).map((row) => row.cells[0].getAttribute("data-value") ?? ""),
+        };
+    }
+
+    it("sorts a numeric column that holds a sentinel by magnitude", () => {
+        const table = mount([["10"], ["NA"], ["9"]]);
+        table.headers[0].fire("click");
+        // One value that parses keeps the column numeric. Under a text order `10` would rank before `9`.
+        expect(table.column(0)).toEqual(["9", "10", "NA"]);
+        table.headers[0].fire("click");
+        // The sentinel holds no rank, thus it stays at the end under both directions.
+        expect(table.column(0)).toEqual(["10", "9", "NA"]);
+        table.headers[0].fire("click");
+        expect(table.column(0)).toEqual(["10", "NA", "9"]);
+    });
+
+    it("sorts a text column in code-unit order", () => {
+        const table = mount([["b"], ["A"], ["a"]]);
+        table.headers[0].fire("click");
+        expect(table.column(0)).toEqual(["A", "a", "b"]);
+    });
+
+    it("cycles from the keyboard and writes the sort state of each header", () => {
+        const table = mount([
+            ["2", "x"],
+            ["1", "y"],
+        ]);
+        table.headers[0].fire("keydown", "Enter");
+        expect(table.column(0)).toEqual(["1", "2"]);
+        expect(table.headers[0].attributes["aria-sort"]).toBe("ascending");
+        expect(table.headers[1].attributes["aria-sort"]).toBe("none");
+        table.headers[0].fire("keydown", " ");
+        expect(table.headers[0].attributes["aria-sort"]).toBe("descending");
+        // A key that names no action leaves the order and the state as they are.
+        table.headers[0].fire("keydown", "a");
+        expect(table.headers[0].attributes["aria-sort"]).toBe("descending");
+    });
+
+    it("filters on the raw values of a row and forms no match across two cells", () => {
+        const table = mount([
+            ["AB", "CD"],
+            ["ZZ", "YY"],
+        ]);
+        table.filter.value = "bc";
+        table.filter.fire("input");
+        expect(table.visible()).toEqual([]);
+        table.filter.value = "cd";
+        table.filter.fire("input");
+        expect(table.visible()).toEqual(["AB"]);
+    });
+
+    it("finds the text that the trim hides, because the filter reads the raw value", () => {
+        const table = mount([["HALLMARK_HYPOXIA%MSigDB%M5891"], ["TP53"]]);
+        table.filter.value = "m5891";
+        table.filter.fire("input");
+        expect(table.visible()).toEqual(["HALLMARK_HYPOXIA%MSigDB%M5891"]);
+    });
+
+    it("counts the kept rows on the toggle and hides the toggle at the cap", () => {
+        const cells: string[][] = [];
+        for (let index = 0; index < TABLE_ROW_CAP + 5; index += 1) {
+            cells.push([`G${index}`]);
+        }
+        const table = mount(cells, true);
+        table.filter.fire("input");
+        expect(table.visible().length).toBe(TABLE_ROW_CAP);
+        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}${TABLE_ROW_CAP + 5}`);
+        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(false);
+
+        table.toggle.fire("click");
+        expect(table.visible().length).toBe(TABLE_ROW_CAP + 5);
+        expect(table.toggle.textContent).toBe("Show fewer");
+        table.toggle.fire("click");
+
+        // The filter keeps 11 rows: `G1` and `G10` through `G19`. Nothing then waits behind the toggle.
+        table.filter.value = "g1";
+        table.filter.fire("input");
+        expect(table.visible().length).toBe(11);
+        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}11`);
+        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(true);
+
+        table.filter.value = "";
+        table.filter.fire("input");
+        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}${TABLE_ROW_CAP + 5}`);
+        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(false);
+    });
+
+    it("marks a card that it takes and leaves a zero-row card unmarked", () => {
+        expect(mount([["a"]]).card.classes.has("report-table-live")).toBe(true);
+        expect(mount([]).card.classes.has("report-table-live")).toBe(false);
     });
 });
 

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -1,12 +1,13 @@
 /**
  * The page assembly: the hero, the bands, the reference band, and the footer.
  *
- * The skeleton inlines the style rules in the head, and it puts the four scripts at the end of the body.
+ * The skeleton inlines the style rules in the head, and it puts the five scripts at the end of the body.
  * The order of the first three scripts is a contract. The theme registration runs before the chart
  * bootstrap, thus each chart finds its theme. The fade-in observer also runs before the chart bootstrap,
  * thus the bootstrap finds the reveal gate and it signals readiness after the first reveal pass. The
- * scrollspy reads the sections alone, thus its position is free. The navigation, the main content, and the
- * reference frame arrive as already-escaped markup strings, thus `raw()` inserts them byte for byte.
+ * scrollspy reads the sections alone, and the table enhancer reads the tables alone, thus the position of
+ * each of the two is free. The navigation, the main content, and the reference frame arrive as
+ * already-escaped markup strings, thus `raw()` inserts them byte for byte.
  *
  * One band holds one top-level section. The band index drives the alternation of the background and of the
  * texture, thus a caller that adds a band passes the next index.
@@ -18,7 +19,7 @@
 
 import { raw } from "hono/html";
 
-import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY } from "../page.js";
+import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_ENHANCER } from "../page.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { ReferenceLedger } from "../references.js";
 import { renderReferenceList } from "./references-view.js";
@@ -123,6 +124,7 @@ export function assemblePage(title: string, nav: string, content: string, refere
                     <script>{raw(FADE_IN_OBSERVER)}</script>
                     <script>{raw(CHART_BOOTSTRAP)}</script>
                     <script>{raw(SECTION_SPY)}</script>
+                    <script>{raw(TABLE_ENHANCER)}</script>
                 </body>
             </html>,
         )

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import type { ScalarReference } from "../../contracts/report-reference.js";
-import { renderCitation, renderFigure, renderMetric, renderTable } from "./values.js";
+import { renderCitation, renderFigure, renderMetric, renderTable, TABLE_ROW_CAP } from "./values.js";
 import { ReferenceLedger } from "../references.js";
 
 const scalarBinding: ScalarReference = { kind: "artifact-value", path: "runs/r1/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
@@ -49,6 +49,15 @@ describe("renderMetric", () => {
 describe("renderTable", () => {
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
 
+    /** One table value of `count` rows. The gene column numbers each row, thus a sorted order is readable. */
+    function rowsOf(count: number) {
+        const rows = [];
+        for (let index = 0; index < count; index += 1) {
+            rows.push({ gene: `G${index}`, padj: 0.01 });
+        }
+        return { type: "table", rows } as const;
+    }
+
     it("renders one header cell for each column and one row for each resolved row", () => {
         const html = renderTable(block, {
             type: "table",
@@ -58,14 +67,14 @@ describe("renderTable", () => {
                 { gene: "EGFR", padj: 0.03 },
             ],
         });
-        expect(html.split("<th>").length - 1).toBe(2);
+        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
         expect(html.split(`<tr class="report-row`).length - 1).toBe(3);
         expect(html).toContain("TP53");
     });
 
     it("renders the header alone for a zero-row table with named columns", () => {
         const html = renderTable(block, { type: "table", rows: [], columns: ["gene", "padj"] });
-        expect(html.split("<th>").length - 1).toBe(2);
+        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
         expect(html).not.toContain(`<tr class="report-row`);
     });
 
@@ -75,41 +84,78 @@ describe("renderTable", () => {
             rows: [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }],
             columns: ["gene", "padj"],
         });
-        expect(html).toContain(`<td></td>`);
+        expect(html).toContain(`<td data-value=""></td>`);
         expect(html).not.toContain("undefined");
     });
 
     it("shows a p-value column in the scientific form with the full digits on the title", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.0000427777663038 }] });
-        expect(html).toContain(`<td title="0.0000427777663038">4.3e-5</td>`);
+        expect(html).toContain(`<td data-value="0.0000427777663038" title="0.0000427777663038">4.3e-5</td>`);
     });
 
     it("rounds a long float to three significant digits and keeps the full digits on the title", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109 }] });
-        expect(html).toContain(`<td title="-3.089028528355109">-3.09</td>`);
+        expect(html).toContain(`<td data-value="-3.089028528355109" title="-3.089028528355109">-3.09</td>`);
     });
 
     it("groups a count and gives it no title, because the grouping hides no digit", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
-        expect(html).toContain(`<td>14,201</td>`);
+        expect(html).toContain(`<td data-value="14201">14,201</td>`);
     });
 
     it("keeps an identifier column whole, with no grouping and no title", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", pmid: "31978945" }] });
-        expect(html).toContain(`<td>31978945</td>`);
+        expect(html).toContain(`<td data-value="31978945">31978945</td>`);
         expect(html).not.toContain("31,978,945");
         expect(html).not.toContain("title=");
     });
 
     it("gives a grouped whole number to a large float and keeps the full digits on the title", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
-        expect(html).toContain(`<td title="15234.7">15,235</td>`);
+        expect(html).toContain(`<td data-value="15234.7" title="15234.7">15,235</td>`);
     });
 
     it("passes a non-numeric cell through unchanged and gives it no title", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", direction: "up" }] });
-        expect(html).toContain(`<td>up</td>`);
+        expect(html).toContain(`<td data-value="up">up</td>`);
         expect(html).not.toContain("title=");
+    });
+
+    it("carries the raw value of a shortened cell, thus the sort reads the full magnitude", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
+        // The shown text is a rounded form. A sort over the shown text would order `15,235` as a string.
+        expect(html).toContain(`data-value="15234.7"`);
+    });
+
+    it("hides each row past the cap and names the total on the toggle", () => {
+        const total = TABLE_ROW_CAP + 5;
+        const html = renderTable(block, rowsOf(total));
+        expect(html.split(`<tr class="report-row`).length - 1).toBe(total);
+        expect(html.split(`<tr class="report-row report-row-hidden">`).length - 1).toBe(5);
+        expect(html).toContain(`<button type="button" class="report-table-toggle">Show all ${total}</button>`);
+    });
+
+    it("leaves a table at the cap with no hidden row and no toggle", () => {
+        const html = renderTable(block, rowsOf(TABLE_ROW_CAP));
+        expect(html.split(`<tr class="report-row">`).length - 1).toBe(TABLE_ROW_CAP);
+        expect(html).not.toContain("report-row-hidden");
+        expect(html).not.toContain("report-table-toggle");
+    });
+
+    it("carries one filter input for each table card", () => {
+        const html = renderTable(block, rowsOf(3));
+        expect(html.split(`class="report-table-filter"`).length - 1).toBe(1);
+    });
+
+    it("shows the first segment of a delimited name and keeps the whole name on the title", () => {
+        const name = "HALLMARK_HYPOXIA%MSigDB%M5891";
+        const html = renderTable(block, { type: "table", rows: [{ set: name, padj: 0.01 }] });
+        expect(html).toContain(`<td data-value="${name}" title="${name}">HALLMARK_HYPOXIA</td>`);
+    });
+
+    it("keeps a text whose last segment is empty, thus a percentage stays whole", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", coverage: "95%" }] });
+        expect(html).toContain(`<td data-value="95%">95%</td>`);
     });
 
     it("keeps a hostile cell as text after the format passes it through", () => {

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -158,6 +158,22 @@ describe("renderTable", () => {
         expect(html).toContain(`<td data-value="95%">95%</td>`);
     });
 
+    it("keeps a text of two segments whole, because an encoded name holds three", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", note: "KEGG%hsa04110" }] });
+        expect(html).toContain(`<td data-value="KEGG%hsa04110">KEGG%hsa04110</td>`);
+    });
+
+    it("keeps a sentence with a percentage whole, because a segment of an encoded name holds no space", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", change: "up 20% vs control%cohort" }] });
+        expect(html).toContain(`<td data-value="up 20% vs control%cohort">up 20% vs control%cohort</td>`);
+    });
+
+    it("gives each sortable header the tab order, thus the keyboard reaches the sort", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
+        expect(html.split(`<th class="data-table-sort" data-sort-index="`).length - 1).toBe(2);
+        expect(html.split(`tabindex="0"`).length - 1).toBe(2);
+    });
+
     it("keeps a hostile cell as text after the format passes it through", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
         expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -37,6 +37,20 @@ export const TABLE_ROW_CAP = 20;
 /** The delimiter of an encoded set name, for example `HALLMARK_HYPOXIA%MSigDB%M5891`. */
 const NAME_DELIMITER = "%";
 
+/** The count of segments that an encoded set name holds: the name, the collection, and the accession. */
+const NAME_SEGMENTS = 3;
+
+/** One whitespace character. A segment of an encoded name holds none. */
+const WHITESPACE = /\s/;
+
+/**
+ * The collapsed label of the row-cap toggle.
+ *
+ * The view composes the label at render, and the enhancer composes it again from the count that the filter
+ * keeps. Both read this one prefix, thus the two labels cannot drift apart.
+ */
+export const SHOW_ALL_PREFIX = "Show all ";
+
 /** The scalar value that a metric renders from. */
 type ScalarValue = Extract<RenderValue, { type: "scalar" }>;
 
@@ -93,16 +107,19 @@ function tableColumns(value: TableValue): string[] {
  * The first segment of a delimited name, or `undefined` when the text carries no delimited name.
  *
  * An enrichment tool joins the name of a set, its collection, and its accession with a percent sign. The
- * name alone identifies the row, thus the rest is noise inside a narrow column. A text of two or more
- * non-empty segments is such a name. Every other text, for example `95%`, keeps its whole form, because an
- * empty segment is no segment.
+ * name alone identifies the row, thus the rest is noise inside a narrow column.
+ *
+ * Such a name holds three or more segments, each segment holds a character, and no segment holds a
+ * whitespace character. Every other text keeps its whole form. Thus `95%` stays whole, and a sentence such
+ * as `up 20% vs control` stays whole.
  */
 function firstNameSegment(text: string): string | undefined {
     const segments = text.split(NAME_DELIMITER);
-    if (segments.length < 2) {
+    if (segments.length < NAME_SEGMENTS) {
         return undefined;
     }
-    return segments.every((segment) => segment.length > 0) ? segments[0] : undefined;
+    const encoded = segments.every((segment) => segment.length > 0 && !WHITESPACE.test(segment));
+    return encoded ? segments[0] : undefined;
 }
 
 /**
@@ -145,14 +162,14 @@ function Cell({ column, cell }: { column: string; cell: string | number | undefi
  * block carries one.
  *
  * Each header cell stays a plain `th`. It carries the sort class and the index of its column, thus the
- * enhancer reads the column of a click and a browser with no script keeps a plain header.
+ * enhancer reads the column of a click and a browser with no script keeps a plain header. The header also
+ * takes the tab order, thus a reader sorts the table from the keyboard.
  *
  * The body holds every resolved row. A row past the cap carries the hidden class, and the card then carries
  * the toggle that names the total count. A table at the cap or under it carries no hidden row and no toggle.
  * The hidden class hides a row under the live marker of the enhancer alone, thus a browser with no script
- * shows every row.
- * The label of the toggle is the one site that composes the collapsed text, and the enhancer keeps that text
- * and restores it.
+ * shows every row. The label of the toggle names the total, and the enhancer composes the same label again
+ * from the count that the filter keeps.
  */
 export function renderTable(block: TableBlock, value: TableValue): string {
     const columns = tableColumns(value);
@@ -169,7 +186,7 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                         <thead>
                             <tr>
                                 {columns.map((column, index) => (
-                                    <th class="data-table-sort" data-sort-index={String(index)}>
+                                    <th class="data-table-sort" data-sort-index={String(index)} tabindex={0}>
                                         {column}
                                     </th>
                                 ))}
@@ -186,7 +203,7 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                         </tbody>
                     </table>
                 </div>
-                {total > TABLE_ROW_CAP ? <button type="button" class="report-table-toggle">{`Show all ${total}`}</button> : null}
+                {total > TABLE_ROW_CAP ? <button type="button" class="report-table-toggle">{`${SHOW_ALL_PREFIX}${total}`}</button> : null}
             </div>
             {block.caption !== undefined ? <p class="report-caption">{block.caption}</p> : null}
         </div>,

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -9,6 +9,10 @@
  * A number reaches the page through the number format. The name that stands over the number selects the
  * kind: the label of a metric, and the column name of a table cell.
  *
+ * A table card also carries the markup of the page enhancer: the raw value of each cell, the sortable
+ * header, the filter input, and the row cap with its toggle. The markup alone is a complete plain table,
+ * thus the enhancer adds behavior over it and it never supplies a value.
+ *
  * Each data card carries the `corner-accents` class. Thus the card keeps square corners with the L-shaped
  * accents, which is the geometric identity of the report.
  */
@@ -20,6 +24,18 @@ import { Marker } from "./references-view.js";
 import { formatNumberCell, selectNumberKind } from "../number-format.js";
 import type { ReferenceLedger } from "../references.js";
 import type { RenderValue } from "../types.js";
+
+/**
+ * The count of table rows that the page shows before the toggle.
+ *
+ * The cap is a renderer constant, thus a block carries no field for it and the column subset stays the one
+ * content-level choice. The page enhancer reads the same constant, thus the markup and the script bound the
+ * table at one number.
+ */
+export const TABLE_ROW_CAP = 20;
+
+/** The delimiter of an encoded set name, for example `HALLMARK_HYPOXIA%MSigDB%M5891`. */
+const NAME_DELIMITER = "%";
 
 /** The scalar value that a metric renders from. */
 type ScalarValue = Extract<RenderValue, { type: "scalar" }>;
@@ -74,43 +90,94 @@ function tableColumns(value: TableValue): string[] {
 }
 
 /**
+ * The first segment of a delimited name, or `undefined` when the text carries no delimited name.
+ *
+ * An enrichment tool joins the name of a set, its collection, and its accession with a percent sign. The
+ * name alone identifies the row, thus the rest is noise inside a narrow column. A text of two or more
+ * non-empty segments is such a name. Every other text, for example `95%`, keeps its whole form, because an
+ * empty segment is no segment.
+ */
+function firstNameSegment(text: string): string | undefined {
+    const segments = text.split(NAME_DELIMITER);
+    if (segments.length < 2) {
+        return undefined;
+    }
+    return segments.every((segment) => segment.length > 0) ? segments[0] : undefined;
+}
+
+/**
  * One body cell of a table.
  *
  * The column name selects the number kind, thus a p-value column reads in the scientific form. The full
  * digits ride the `title` attribute when the shown form hides one. An absent cell renders as an empty
  * cell, thus a ragged row keeps its shape.
+ *
+ * Each cell carries its raw value in the `data-value` attribute. The page enhancer sorts on that value, thus
+ * the shown text stays presentation and a rounded number still sorts by its full magnitude.
+ *
+ * A delimited name shows its first segment, and the whole name rides the `title` attribute. Such a name
+ * holds no finite number, thus the number format passed it through and this trim reads the text that the
+ * format gave.
  */
 function Cell({ column, cell }: { column: string; cell: string | number | undefined }) {
     if (cell === undefined) {
-        return <td></td>;
+        return <td data-value=""></td>;
     }
     const shown = formatNumberCell(cell, selectNumberKind(column, cell));
-    return <td title={shown.full}>{shown.text}</td>;
+    const segment = firstNameSegment(shown.text);
+    if (segment !== undefined) {
+        return (
+            <td data-value={String(cell)} title={shown.text}>
+                {segment}
+            </td>
+        );
+    }
+    return (
+        <td data-value={String(cell)} title={shown.full}>
+            {shown.text}
+        </td>
+    );
 }
 
 /**
  * Render a table block. The header holds one cell for each column, and the body holds one row for each
  * resolved row. A zero-row table renders the header alone. The title and the caption render only when the
  * block carries one.
+ *
+ * Each header cell stays a plain `th`. It carries the sort class and the index of its column, thus the
+ * enhancer reads the column of a click and a browser with no script keeps a plain header.
+ *
+ * The body holds every resolved row. A row past the cap carries the hidden class, and the card then carries
+ * the toggle that names the total count. A table at the cap or under it carries no hidden row and no toggle.
+ * The hidden class hides a row under the live marker of the enhancer alone, thus a browser with no script
+ * shows every row.
+ * The label of the toggle is the one site that composes the collapsed text, and the enhancer keeps that text
+ * and restores it.
  */
 export function renderTable(block: TableBlock, value: TableValue): string {
     const columns = tableColumns(value);
+    const total = value.rows.length;
     return String(
         <div class="report-table">
             {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
             <div class="corner-accents">
+                <div class="report-table-controls">
+                    <input class="report-table-filter" type="text" placeholder="Filter rows" aria-label="Filter rows" />
+                </div>
                 <div class="data-table-scroll">
                     <table class="data-table">
                         <thead>
                             <tr>
-                                {columns.map((column) => (
-                                    <th>{column}</th>
+                                {columns.map((column, index) => (
+                                    <th class="data-table-sort" data-sort-index={String(index)}>
+                                        {column}
+                                    </th>
                                 ))}
                             </tr>
                         </thead>
                         <tbody>
-                            {value.rows.map((row) => (
-                                <tr class="report-row">
+                            {value.rows.map((row, index) => (
+                                <tr class={index < TABLE_ROW_CAP ? "report-row" : "report-row report-row-hidden"}>
                                     {columns.map((column) => (
                                         <Cell column={column} cell={row[column]} />
                                     ))}
@@ -119,6 +186,7 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                         </tbody>
                     </table>
                 </div>
+                {total > TABLE_ROW_CAP ? <button type="button" class="report-table-toggle">{`Show all ${total}`}</button> : null}
             </div>
             {block.caption !== undefined ? <p class="report-caption">{block.caption}</p> : null}
         </div>,


### PR DESCRIPTION
## What & why

A table block dumped every CSV row as plain HTML, with raw MSigDB set names and no bound. The decided direction is interactivity without a framework, because the page is a self-contained deterministic document.

- A vanilla page script sorts on a header click, filters with one input, and caps the visible rows at 20 with a "Show all N" toggle.
- The sort reads a raw `data-value` attribute, thus the formatted text stays presentation. The cycle is ascending, descending, and the document order.
- The rows stay in the DOM. The cap and the filter compose: the first 20 filter-passing rows show, and the toggle opens the rest.
- The sheet hides and shows only under a live marker that the script writes. Thus a scriptless browser sees the whole plain table and no inert control, and the print form shows every row.
- A percent-delimited set name trims to its first segment, with the full text on `title` and in `data-value`.

Notes for the reviewer:

- No React, no dependency, and no hydration. The script rides beside the scrollspy under the same conventions.
- The behavior is browser-proved on a 26-row page: the cap, the toggle, the filter composition, and the scriptless state.

Refs #377

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
