### PR TITLE
feat(harness): name the subject of each report tool call

### DIFF
--- a/cli/src/modules/harness/dev/chat.ts
+++ b/cli/src/modules/harness/dev/chat.ts
@@ -479,7 +479,10 @@ export function createChatPrinter(sink: ChatSink, options: PrinterOptions = {}):
                 // Three outcomes get three words. `denied` is the user's own refusal of an approval, so
                 // printing it as `error` would report their decision as a fault of the tool.
                 const outcome = event.outcome === "error" ? "error" : event.outcome === "denied" ? "denied" : `done${dur}`;
-                sink.out(`  [tool] ${name} ${outcome}\n`);
+                // A tool that describes its own result names the outcome here — the page it wrote, the
+                // version it recorded — so the finished line prints what the running line could not know.
+                const detail = event.detail;
+                sink.out(`  [tool] ${name}${detail === undefined ? "" : ` ${detail}`} ${outcome}\n`);
                 return;
             }
             default: {

--- a/cli/src/tui/hooks/conversation.test.ts
+++ b/cli/src/tui/hooks/conversation.test.ts
@@ -246,6 +246,47 @@ describe("send() drives the adapter + engine", () => {
         expect(tool?.status).toBe("ok");
     });
 
+    // A tool that describes its own result names the outcome on the finish — the page it wrote, the
+    // version it recorded. That fact does not exist at dispatch, so the chip must take the newer line.
+    test("a present finished detail replaces the one the start showed", async () => {
+        const seams = fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => {
+            const src = { agentId: "tui-chat", callPath: ["tui-chat"] };
+            void emit({ type: "tool-started", source: src, toolUseId: "t4", name: "preview_report", input: {} });
+            void emit({ type: "tool-finished", source: src, toolUseId: "t4", name: "preview_report", outcome: "ok", detail: "page /w/t4/index.html" });
+        });
+        await send({ sessionId: SID, analysisId: AID, userText: "?" }, seams);
+        const tool = findPart((p): p is ToolCallPart => p.type === "tool-call");
+        expect(tool?.detail).toBe("page /w/t4/index.html");
+        expect(tool?.status).toBe("ok");
+    });
+
+    // The finish can only improve the chip. A tool that describes no result finishes with no detail,
+    // and blanking the started line there would lose the only description the call ever had.
+    test("an absent finished detail never blanks the one the start showed", async () => {
+        const seams = fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => {
+            const src = { agentId: "tui-chat", callPath: ["tui-chat"] };
+            void emit({ type: "tool-started", source: src, toolUseId: "t5", name: "read_file", input: {}, detail: "output/summary.md" });
+            void emit({ type: "tool-finished", source: src, toolUseId: "t5", name: "read_file", outcome: "ok" });
+        });
+        await send({ sessionId: SID, analysisId: AID, userText: "?" }, seams);
+        const tool = findPart((p): p is ToolCallPart => p.type === "tool-call");
+        expect(tool?.detail).toBe("output/summary.md");
+    });
+
+    // An error keeps the started detail by construction: the harness runs no result hook on a failed
+    // call. The chip must show that line beside the failure, and not fall back to the bare tool name.
+    test("a failed call keeps the detail its start showed", async () => {
+        const seams = fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => {
+            const src = { agentId: "tui-chat", callPath: ["tui-chat"] };
+            void emit({ type: "tool-started", source: src, toolUseId: "t6", name: "add_block", input: {}, detail: 'add section "Summary"' });
+            void emit({ type: "tool-finished", source: src, toolUseId: "t6", name: "add_block", outcome: "error", detail: 'add section "Summary"' });
+        });
+        await send({ sessionId: SID, analysisId: AID, userText: "?" }, seams);
+        const tool = findPart((p): p is ToolCallPart => p.type === "tool-call");
+        expect(tool?.detail).toBe('add section "Summary"');
+        expect(tool?.status).toBe("error");
+    });
+
     test("a call from a tool with no hook carries no detail", async () => {
         const seams = fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => {
             const src = { agentId: "tui-chat", callPath: ["tui-chat"] };

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -346,10 +346,17 @@ function updateToolPart(toolUseId: string, name: string, status: "ok" | "error" 
                 // `activity` is dropped, not carried: it described work in flight, and a finished
                 // call has an outcome instead. Leaving it would strand "planner: bash" under a chip
                 // that already says `ok · 14ms`.
-                // `detail` is NOT overwritten from the finished event: the started event already set the
-                // identical value (the loop computes it once per call), so rewriting it would only risk
-                // blanking a good detail if a finish ever arrived without one.
-                msg.parts[idx] = { ...(msg.parts[idx] as ToolCallPart), status, durationMs, activity: undefined };
+                // `detail` is applied only when the finish CARRIES one. A tool that describes its own
+                // result names the outcome there — `page …`, `version …` — and that line supersedes
+                // the one the start showed. An absent detail leaves the started line standing, so a
+                // finish can only ever improve the chip and never blank it.
+                msg.parts[idx] = {
+                    ...(msg.parts[idx] as ToolCallPart),
+                    status,
+                    durationMs,
+                    activity: undefined,
+                    ...(detail !== undefined ? { detail } : {}),
+                };
             } else {
                 msg.parts.push({
                     id: toolUseId,

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/design.md
@@ -1,0 +1,24 @@
+## Context
+
+The detail seam computes one line from the input at dispatch (`loop/tool-detail.ts`), and the finished event echoes the started detail (`contracts/chat-events.ts`). The page path, the recorded version, and the listed count are outcomes, thus no input hook can name them. The CLI part update takes a present finished detail, and it never blanks on an absent one. Thus a richer finished detail reaches the line with no CLI change.
+
+## Goals / Non-Goals
+
+- Goal: a watcher reads what the agent touches and what a call produced, from the call line alone.
+- Non-goal: a payload channel. The result hook rides the same guard, the same normalization, and the same length cap.
+- Non-goal: a CLI change.
+
+## Decisions
+
+- **The seam gains an optional `describeResult` hook.** It takes the parsed input and the ok-channel result, and it gives a string. The same three rules bind it: synchronous, pure, and never able to fail a call. The finished event carries the recomputed detail when the hook gives one, and the started detail otherwise.
+- **The hook runs only on an ok outcome.** An error outcome keeps the started detail. The error already names itself, and a hook over a failed call reads a shape that does not exist.
+- **The compute lives beside `computeDetail`.** One module keeps the guard, the parse discipline, and the normalization in one auditable path. The result is not re-parsed: the tool produced it one line above, thus the value is trusted shape-wise, and the hook stays inside the try guard.
+- **The providers stay small.** `add_block` reads the kind with the title of a section, or the file name of a bound path. `preview_report` gives `page <path>` on a render and the outcome kind otherwise. `record_report_version` gives the version. `examine_page` gives the look outcome. `list_pinned_artifacts` gives the count with the truncation. The `"none"` sentinel extends to the result side: an empty-input tool with a result hook is representable.
+
+## Risks / Trade-offs
+
+- [A result hook leaks a long value] → the emit-site normalization caps and redacts the result detail the same as the call detail.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/design.md
@@ -1,12 +1,12 @@
 ## Context
 
-The detail seam computes one line from the input at dispatch (`loop/tool-detail.ts`), and the finished event echoes the started detail (`contracts/chat-events.ts`). The page path, the recorded version, and the listed count are outcomes, thus no input hook can name them. The CLI part update takes a present finished detail, and it never blanks on an absent one. Thus a richer finished detail reaches the line with no CLI change.
+The detail seam computes one line from the input at dispatch (`loop/tool-detail.ts`), and the finished event echoes the started detail (`contracts/chat-events.ts`). The page path, the recorded version, and the listed count are outcomes, thus no input hook can name them. The CLI part update applies a present finished detail, and it never blanks on an absent one. One line in the conversation hook carries that rule, and the dev printer shows the finished line.
 
 ## Goals / Non-Goals
 
 - Goal: a watcher reads what the agent touches and what a call produced, from the call line alone.
 - Non-goal: a payload channel. The result hook rides the same guard, the same normalization, and the same length cap.
-- Non-goal: a CLI change.
+- Non-goal: a CLI redesign. The conversation hook takes one line, and the dev printer takes one line.
 
 ## Decisions
 

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/proposal.md
@@ -27,4 +27,4 @@ None.
 - `harness/src/tools/define-tool.ts` and `harness/src/loop/tool-detail.ts` — the result hook and its compute.
 - `harness/src/loop/run-agent.ts` — the finished-event detail.
 - `harness/src/tools/report-authoring/` and `harness/src/tools/report-session/` — the providers.
-- The CLI renders the finished detail already, thus no CLI change.
+- The CLI part update applies a present finished detail, and an absent one never blanks the started detail. One line in the conversation hook carries that rule.

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The report-session tools show opaque call lines. A user who watches the session cannot tell which section the agent adds, which table it binds, or where the page landed. The detail seam exists, and the report tools give a thin detail or none.
+
+## What Changes
+
+- The detail seam gains an optional result hook. The finished event can recompute its detail from the outcome, and the started detail stays the fallback.
+- `add_block` names the kind with its title or its bound file: `add section "Summary"`, or `add table de.csv`.
+- `preview_report` names the page path on a pass, and the outcome kind otherwise.
+- `record_report_version` names the recorded version. `examine_page` names the look outcome.
+- `list_pinned_artifacts` names the listed count, with the truncation.
+- `change_block`, `move_block`, and `remove_block` keep the block id that they give.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tool-call-detail`: the seam gains the result hook and the finished-event recompute, under the same guard and the same normalization.
+- `report-session-agent`: the session tools give the named details.
+
+## Impact
+
+- `harness/src/tools/define-tool.ts` and `harness/src/loop/tool-detail.ts` — the result hook and its compute.
+- `harness/src/loop/run-agent.ts` — the finished-event detail.
+- `harness/src/tools/report-authoring/` and `harness/src/tools/report-session/` — the providers.
+- The CLI renders the finished detail already, thus no CLI change.

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/specs/report-session-agent/spec.md
@@ -1,0 +1,18 @@
+# Delta: report-session-agent
+
+## ADDED Requirements
+
+### Requirement: The session tools name their calls
+The report tools MUST give a call detail that names their subject. `add_block` names the kind, with the title of a section or the file name of a bound artifact. `change_block`, `move_block`, and `remove_block` name the block id. On an ok outcome, `preview_report` names the page path, and `record_report_version` names the version. `examine_page` names the look outcome, and the listing tool names the listed count with the truncation.
+
+#### Scenario: An added section names its title
+- **WHEN** the agent adds a section block titled "Summary"
+- **THEN** the call line reads the kind and the title
+
+#### Scenario: An added table names its file
+- **WHEN** the agent adds a table block bound to a workspace path
+- **THEN** the call line reads the kind and the file name of the path
+
+#### Scenario: The preview names the page
+- **WHEN** the preview renders the page
+- **THEN** the finished line names the page path

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/specs/tool-call-detail/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/specs/tool-call-detail/spec.md
@@ -1,0 +1,22 @@
+# Delta: tool-call-detail
+
+## ADDED Requirements
+
+### Requirement: A tool describes its result through an optional hook
+A tool definition MUST accept an optional `describeResult` hook beside `describeCall`. The hook takes the parsed input and the ok-channel result, and it gives a string. It MUST be synchronous and pure, and it MUST never fail a call: a hook that throws or gives an unusable value yields no result detail. The finished event carries the recomputed detail when the hook gives one, and the started detail otherwise. The hook runs only on an ok outcome. The emit site normalizes a result detail exactly as it normalizes a call detail: one line, redaction, and the length cap.
+
+#### Scenario: The finished event carries the result detail
+- **WHEN** a tool with a result hook resolves ok
+- **THEN** the finished event carries the hook's normalized text, and the started event keeps its own detail
+
+#### Scenario: An error keeps the started detail
+- **WHEN** a tool with a result hook resolves with an error outcome
+- **THEN** the finished event carries the started detail, and the hook does not run
+
+#### Scenario: A throwing result hook costs nothing
+- **WHEN** a result hook throws
+- **THEN** the call outcome is unchanged, and the finished event carries the started detail
+
+#### Scenario: A result detail is normalized
+- **WHEN** a result hook gives a multi-line text over the cap
+- **THEN** the finished event carries one capped line

--- a/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-detail-the-report-tool-calls/tasks.md
@@ -1,0 +1,20 @@
+## 1. The seam
+
+- [x] 1.1 Add the optional `describeResult` hook to `src/tools/define-tool.ts`, beside `describeCall`, with the same sentinel discipline.
+- [x] 1.2 Add the result compute to `src/loop/tool-detail.ts`, inside the same guard and the same normalization.
+- [x] 1.3 Carry the recomputed detail on the finished event in `src/loop/run-agent.ts`, only on an ok outcome, with the started detail as the fallback.
+- [x] 1.4 Unit tests: the recompute, the error fallback, the throwing hook, and the normalization.
+
+## 2. The providers
+
+- [x] 2.1 `add_block` names the kind with the title or the bound file name.
+- [x] 2.2 `preview_report` names the page path on a render, and the outcome kind otherwise.
+- [x] 2.3 `record_report_version` names the version, and `examine_page` names the look outcome.
+- [x] 2.4 `list_pinned_artifacts` names the listed count with the truncation.
+- [x] 2.5 Tests for each provider.
+
+## 3. The gates
+
+- [x] 3.1 Run the targeted suites of the touched modules only.
+- [x] 3.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.
+- [x] 3.3 The seam is an exported surface, thus run `bun run harness:local` from `cli/` and the cli typecheck.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -95,6 +95,21 @@ The in-progress document and the pinned snapshot of a thread MUST live in one du
 - **WHEN** one process lands an add, and a different process serves the next turn
 - **THEN** the outline of the next turn holds the added block
 
+### Requirement: The session tools name their calls
+The report tools MUST give a call detail that names their subject. `add_block` names the kind, with the title of a section or the file name of a bound artifact. `change_block`, `move_block`, and `remove_block` name the block id. On an ok outcome, `preview_report` names the page path, and `record_report_version` names the version. `examine_page` names the look outcome, and the listing tool names the listed count with the truncation.
+
+#### Scenario: An added section names its title
+- **WHEN** the agent adds a section block titled "Summary"
+- **THEN** the call line reads the kind and the title
+
+#### Scenario: An added table names its file
+- **WHEN** the agent adds a table block bound to a workspace path
+- **THEN** the call line reads the kind and the file name of the path
+
+#### Scenario: The preview names the page
+- **WHEN** the preview renders the page
+- **THEN** the finished line names the page path
+
 ### Requirement: The read-only roster
 The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_files`, `file_stat`, and `grep`), the workspace search, `inspect_run`, `inspect_data_profile`, the authoring tools, the pinned-artifact listing tool, and the render-and-preview tool. The roster MUST NOT hold a planner, a run launcher, a working-memory write, or a sandbox mutate surface. Thus no tool starts a run, and no tool changes an analysis.
 

--- a/harness/openspec/specs/tool-call-detail/spec.md
+++ b/harness/openspec/specs/tool-call-detail/spec.md
@@ -39,6 +39,25 @@ A tool whose input cannot distinguish its calls — one whose schema admits a si
 - **WHEN** the loop dispatches it
 - **THEN** its tool-call events carry no detail, every other field is unchanged, and the packaged tool exposes no `describeCall` property
 
+### Requirement: A tool describes its result through an optional hook
+A tool definition MUST accept an optional `describeResult` hook beside `describeCall`. The hook takes the parsed input and the ok-channel result, and it gives a string. It MUST be synchronous and pure, and it MUST never fail a call: a hook that throws or gives an unusable value yields no result detail. The finished event carries the recomputed detail when the hook gives one, and the started detail otherwise. The hook runs only on an ok outcome. The emit site normalizes a result detail exactly as it normalizes a call detail: one line, redaction, and the length cap.
+
+#### Scenario: The finished event carries the result detail
+- **WHEN** a tool with a result hook resolves ok
+- **THEN** the finished event carries the hook's normalized text, and the started event keeps its own detail
+
+#### Scenario: An error keeps the started detail
+- **WHEN** a tool with a result hook resolves with an error outcome
+- **THEN** the finished event carries the started detail, and the hook does not run
+
+#### Scenario: A throwing result hook costs nothing
+- **WHEN** a result hook throws
+- **THEN** the call outcome is unchanged, and the finished event carries the started detail
+
+#### Scenario: A result detail is normalized
+- **WHEN** a result hook gives a multi-line text over the cap
+- **THEN** the finished event carries one capped line
+
 ### Requirement: The emit site normalizes every detail
 
 Normalization SHALL happen once, at the emit site, and SHALL NOT be delegated to tool authors. The loop SHALL collapse the detail to a single line, remove control characters, apply the harness secret redaction, and cap the result at 120 code points.

--- a/harness/src/contracts/chat-events.ts
+++ b/harness/src/contracts/chat-events.ts
@@ -61,7 +61,7 @@ export type ToolCallOutcome = ToolOutcome | "incomplete";
 
 /**
  * One line naming what a tool call is doing, produced by the tool's own
- * `describeCall` hook and normalized at the emit site.
+ * `describeCall` or `describeResult` hook and normalized at the emit site.
  *
  * Opaque display text. A consumer renders it and derives nothing from it — no
  * splitting, no keying on separators. The contract is harness-owned so it can
@@ -90,7 +90,12 @@ export interface ToolFinishedEvent {
     name: string;
     /** How the call ended. See {@link ToolOutcome}. */
     outcome: ToolOutcome;
-    /** The same detail the matching `tool-started` carried. */
+    /**
+     * See {@link ToolCallDetail}. It can differ from the detail the matching
+     * `tool-started` carried: a tool that describes its own result names the
+     * outcome here, and a call that produced none carries the started detail
+     * again.
+     */
     detail?: ToolCallDetail;
     /**
      * The time in milliseconds around this call's own dispatch. Absent — never

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -1219,6 +1219,31 @@ describe("runAgent — tool result detail", () => {
         expect("detail" in finished[1]!).toBe(false);
         expect(finished[2]).toMatchObject({ toolUseId: "tu-3", detail: "page last.html" });
     });
+
+    // A step-mode call goes through `runStep`, which hands back what a PRIOR run cached. A workflow
+    // in flight when the shape of that return widened replays the bare result and never re-enters
+    // the body. This step stands for such a replay: it drops the pair and gives the bare value back.
+    it("reads a replayed step that cached the bare result, and keeps the started detail", async () => {
+        const replayBareResult: RunStep = async (_name, fn) => {
+            const settled = (await fn()) as { result?: unknown };
+            // The cast restates the shape the body returns. The step store is untyped across two
+            // builds of the loop, thus only the read site can state which of the two it holds.
+            return (settled.result ?? settled) as never;
+        };
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "render", { path: "draft" })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([describedRender()], provider, { runStep: replayBareResult });
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toMatchObject({ type: "tool-started", detail: "draft" });
+        // A cached bare value carries no result detail, thus the call keeps the line its start showed.
+        expect(events[1]).toMatchObject({ type: "tool-finished", detail: "draft", outcome: "ok" });
+        // The result still reached the model, thus the turn ran to its reply.
+        expect(provider.calls).toHaveLength(2);
+    });
 });
 
 describe("runAgent — tool-finished outcome", () => {

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -1026,6 +1026,27 @@ function describedRead(fail = false): Tool {
     });
 }
 
+/**
+ * A `render` tool that describes its call by path and its result by the page it produced.
+ * `fail` makes `execute` throw, and `breakHook` makes the result hook throw.
+ */
+function describedRender(options: { fail?: boolean; breakHook?: boolean } = {}): Tool<{ path: string }, { page: string }> {
+    return defineTool({
+        id: "render",
+        description: "Render a path to a page.",
+        inputSchema: z.object({ path: z.string() }),
+        describeCall: ({ path }) => path,
+        describeResult: (_input, { page }) => {
+            if (options.breakHook === true) throw new Error("result hook is broken");
+            return `page ${page}`;
+        },
+        execute: async ({ path }) => {
+            if (options.fail === true) throw new Error("disk on fire");
+            return ok({ page: `${path}.html` });
+        },
+    });
+}
+
 describe("runAgent — tool call detail", () => {
     it("carries the same detail on both events of a described call", async () => {
         const provider = scriptedProvider([
@@ -1108,6 +1129,95 @@ describe("runAgent — tool call detail", () => {
 
         expect("detail" in events[0]!).toBe(false);
         expect(events[1]).toMatchObject({ type: "tool-finished", outcome: "error" });
+    });
+});
+
+describe("runAgent — tool result detail", () => {
+    it("names the call on the started event and the outcome on the finished one", async () => {
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "render", { path: "draft" })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([describedRender()], provider);
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toMatchObject({ type: "tool-started", name: "render", detail: "draft" });
+        expect(events[1]).toMatchObject({ type: "tool-finished", name: "render", detail: "page draft.html", outcome: "ok" });
+    });
+
+    // The hook reads the ok value, and a failed call produced none. The started detail is the whole
+    // account of what the call was, thus it stands.
+    it("keeps the started detail when the call fails", async () => {
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "render", { path: "draft" })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([describedRender({ fail: true })], provider);
+
+        expect(events[0]).toMatchObject({ type: "tool-started", detail: "draft" });
+        expect(events[1]).toMatchObject({ type: "tool-finished", detail: "draft", outcome: "error" });
+    });
+
+    it("keeps the started detail when the result hook throws, and the call still succeeds", async () => {
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "render", { path: "draft" })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([describedRender({ breakHook: true })], provider);
+
+        expect(events[1]).toMatchObject({ type: "tool-finished", detail: "draft", outcome: "ok" });
+        // The tool ran and the model read its result, thus the turn continued to the reply.
+        expect(provider.calls).toHaveLength(2);
+    });
+
+    it("normalizes the result detail at the emit site", async () => {
+        const noisy: Tool<{ text: string }, { echoed: string }> = defineTool({
+            id: "noisy_result",
+            description: "Returns an unnormalized result detail.",
+            inputSchema: z.object({ text: z.string() }),
+            describeCall: ({ text }) => text,
+            describeResult: (_input, { echoed }) => `wrote\n${echoed}`,
+            execute: async ({ text }) => ok({ echoed: text }),
+        });
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "noisy_result", { text: `line one ${"z".repeat(400)}` })], "tool_use"),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([noisy], provider);
+        const detail = (events[1] as { detail?: string }).detail!;
+
+        expect(detail.startsWith("wrote line one")).toBe(true);
+        expect(detail).not.toContain("\n");
+        expect(detail).toHaveLength(120);
+        expect(detail.endsWith("…")).toBe(true);
+    });
+
+    // The two events of one call are positionally paired, thus a round of several calls must not let
+    // one tool's result detail reach a sibling's finished event.
+    it("aligns each result detail with its own call across a round", async () => {
+        const provider = scriptedProvider([
+            makeMessage(
+                [
+                    toolUseBlock("tu-1", "render", { path: "first" }),
+                    toolUseBlock("tu-2", "echo", { label: "x" }),
+                    toolUseBlock("tu-3", "render", { path: "last" }),
+                ],
+                "tool_use",
+            ),
+            makeMessage([textBlock("done")], "end_turn"),
+        ]);
+
+        const events = await runCapturingToolEvents([describedRender(), echoTool()], provider);
+        const finished = events.filter((event) => event.type === "tool-finished");
+
+        expect(finished).toHaveLength(3);
+        expect(finished[0]).toMatchObject({ toolUseId: "tu-1", detail: "page first.html" });
+        expect("detail" in finished[1]!).toBe(false);
+        expect(finished[2]).toMatchObject({ toolUseId: "tu-3", detail: "page last.html" });
     });
 });
 

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -682,11 +682,14 @@ async function dispatchTools(
     await Promise.all(
         stepTools.map(({ tu, idx }) => {
             const startedAt = performance.now();
-            return runStep(toolStepName(tu.toolName, tu.toolCallId), () => dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding)).then((r) => {
-                durations[idx] = elapsedMs(startedAt);
-                results[idx] = r.result;
-                if (r.detail !== undefined) resultDetails[idx] = r.detail;
-            });
+            return runStep(toolStepName(tu.toolName, tu.toolCallId), () => dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding)).then(
+                (settled: DispatchedCall | ToolResultPart) => {
+                    durations[idx] = elapsedMs(startedAt);
+                    const dispatched = readDispatchedStep(settled);
+                    results[idx] = dispatched.result;
+                    if (dispatched.detail !== undefined) resultDetails[idx] = dispatched.detail;
+                },
+            );
         }),
     );
 
@@ -725,6 +728,20 @@ function elapsedMs(startedAt: number): number {
 interface DispatchedCall {
     readonly result: ToolResultPart;
     readonly detail?: ToolCallDetail;
+}
+
+/**
+ * Read one settled step-mode dispatch, tolerating the bare result beside the pair.
+ *
+ * A step-mode call goes through `runStep`, which caches what the body returned and hands
+ * that cached value back on a replay. The durable step store therefore holds values that
+ * a DIFFERENT build of this file wrote: a workflow in flight when the shape of the return
+ * widened replays the bare `ToolResultPart` its own run cached, and it never re-enters the
+ * body that would produce the pair. The replay boundary is the whole reason for the test:
+ * a bare value carries no detail, thus the call keeps the line its `tool-started` showed.
+ */
+function readDispatchedStep(settled: DispatchedCall | ToolResultPart): DispatchedCall {
+    return "result" in settled ? settled : { result: settled };
 }
 
 async function dispatchTool(

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -28,7 +28,7 @@ import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderC
 import { AskRejectedError, UnavailableAsk, type AskApproval, type AskRequest } from "../tools/approval/contract.js";
 import { isToolError, readToolResultImage, type Tool, type ToolContext, type ToolResultImage } from "../tools/define-tool.js";
 import { addChatUsage, hasReportedUsage, recordAgentRun, type AgentRunUsage } from "./metrics.js";
-import { computeDetail, type ToolCallDetail } from "./tool-detail.js";
+import { computeDetail, computeResultDetail, type ToolCallDetail } from "./tool-detail.js";
 import { toolOutcomeForOutputType, type ToolOutcome } from "./tool-outcome.js";
 import type { AgentDefinition, EmitFn, EventSource, LoopMessage, RunStep } from "./types.js";
 
@@ -282,7 +282,8 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
      *
      * Computed once per round and carried onto both the `tool-started` and the
      * `tool-finished` event, so the pair a host renders as one chip cannot show
-     * two different descriptions of the same call.
+     * two different descriptions of the same call. A tool that describes its own
+     * result replaces the second half of that pair with the outcome it produced.
      */
     const roundDetails = (calls: readonly ToolCallPart[]): (ToolCallDetail | undefined)[] =>
         calls.map((tu) => {
@@ -299,14 +300,15 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
      * it is not a thrown failure, so nothing reports it and the loop simply feeds it
      * back — and a run that ends badly is usually a run whose tool calls were failing.
      *
-     * `details` and `durations` are positionally aligned with `calls`. `dispatchTools`
-     * measures a duration around the call itself, because this sink emits every finish
-     * event only after the whole round settles.
+     * `details`, `resultDetails` and `durations` are positionally aligned with `calls`.
+     * `dispatchTools` measures a duration around the call itself, because this sink emits
+     * every finish event only after the whole round settles.
      */
     const settleRound = async (
         calls: readonly ToolCallPart[],
         results: readonly ToolResultPart[],
         details: readonly (ToolCallDetail | undefined)[],
+        resultDetails: readonly (ToolCallDetail | undefined)[],
         durations: readonly (number | undefined)[],
     ): Promise<string[]> => {
         const errored: string[] = [];
@@ -327,7 +329,11 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
                 toolUseId: tu.toolCallId,
                 name: tu.toolName,
                 outcome,
-                ...detailField(details[idx]),
+                // The result detail wins where there is one, and the call detail
+                // stands otherwise. Only the ok branch of a dispatch computes a
+                // result detail, thus an error and a denial reach here with none
+                // and keep the line the `tool-started` carried.
+                ...detailField(resultDetails[idx] ?? details[idx]),
                 ...durationField(durations[idx]),
             });
         }
@@ -388,8 +394,16 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             for (const [idx, tu] of earlier.entries()) {
                 await emit({ type: "tool-started", source, toolUseId: tu.toolCallId, name: tu.toolName, input: tu.input, ...detailField(earlierDetails[idx]) });
             }
-            const { results, durations } = await dispatchTools(earlier, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool, encoding);
-            const errored = await settleRound(earlier, results, earlierDetails, durations);
+            const { results, durations, resultDetails } = await dispatchTools(
+                earlier,
+                toolsById,
+                toolCtx,
+                isFatalLoopError,
+                runStep,
+                formatStepName.tool,
+                encoding,
+            );
+            const errored = await settleRound(earlier, results, earlierDetails, resultDetails, durations);
             results.push(errorResult(trailing, TRUNCATED_TOOL_USE_ERROR));
             // The trailing call was never dispatched, but it reaches the model as an error
             // result like any other — so it counts, or `toolErrors` reports a cleaner run
@@ -419,8 +433,16 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         for (const [idx, tu] of toolCalls.entries()) {
             await emit({ type: "tool-started", source, toolUseId: tu.toolCallId, name: tu.toolName, input: tu.input, ...detailField(details[idx]) });
         }
-        const { results, durations } = await dispatchTools(toolCalls, toolsById, toolCtx, isFatalLoopError, runStep, formatStepName.tool, encoding);
-        const errored = await settleRound(toolCalls, results, details, durations);
+        const { results, durations, resultDetails } = await dispatchTools(
+            toolCalls,
+            toolsById,
+            toolCtx,
+            isFatalLoopError,
+            runStep,
+            formatStepName.tool,
+            encoding,
+        );
+        const errored = await settleRound(toolCalls, results, details, resultDetails, durations);
         if (errored.length > 0) log.debug("tool results returned errors", { iteration: i, tools: errored });
         messages.push({ role: "tool", content: results });
         appendDeferredImages(messages, results, encoding.deferredImages);
@@ -566,9 +588,11 @@ interface DeferredImage {
 
 /**
  * How a completed tool result is encoded onto the provider message. `placement`
- * says where the picture of a tool result goes, and `log` is the sink for the drop
- * record. `deferredImages` collects the picture of each tool result of the round
- * under the user-message placement, and the round assembly empties it.
+ * says where the picture of a tool result goes, and `log` is the diagnostic sink
+ * of one dispatch: the record of a dropped picture, and the record of a result
+ * description that failed. `deferredImages` collects the picture of each tool
+ * result of the round under the user-message placement, and the round assembly
+ * empties it.
  *
  * CAUTION: the collector fills as a side effect inside the tool step body. A
  * replayed durable step returns its cached result, and it does not run the body.
@@ -619,7 +643,7 @@ function appendDeferredImages(messages: LoopMessage[], results: readonly ToolRes
 /**
  * Dispatch one round of tool calls, and measure the time of each call.
  *
- * `results` and `durations` are positionally aligned with `toolUses`.
+ * `results`, `durations` and `resultDetails` are positionally aligned with `toolUses`.
  *
  * Each measurement brackets the same unit that the loop awaits for that call. For a
  * step-mode call that unit is `runStep`, thus the figure includes the durable-step
@@ -634,12 +658,16 @@ async function dispatchTools(
     runStep: RunStep,
     toolStepName: (toolName: string, toolUseId: string) => string,
     encoding: ResultEncoding,
-): Promise<{ results: ToolResultPart[]; durations: (number | undefined)[] }> {
+): Promise<{ results: ToolResultPart[]; durations: (number | undefined)[]; resultDetails: (ToolCallDetail | undefined)[] }> {
     const results = new Array<ToolResultPart>(toolUses.length);
     // The array starts with holes, which read as `undefined`. The element type
     // says so, thus it agrees with what `settleRound` accepts. Every index is in
     // fact assigned, because the mode partition below covers each call.
     const durations = new Array<number | undefined>(toolUses.length);
+    // A hole stays a hole for a call that described no result: an error, a
+    // denial, and a tool with no result hook each leave the index unassigned,
+    // and `settleRound` then reads the call detail.
+    const resultDetails = new Array<ToolCallDetail | undefined>(toolUses.length);
     const stepTools: { tu: ToolCallPart; idx: number }[] = [];
     const workflowTools: { tu: ToolCallPart; idx: number }[] = [];
     const inlineTools: { tu: ToolCallPart; idx: number }[] = [];
@@ -656,28 +684,47 @@ async function dispatchTools(
             const startedAt = performance.now();
             return runStep(toolStepName(tu.toolName, tu.toolCallId), () => dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding)).then((r) => {
                 durations[idx] = elapsedMs(startedAt);
-                results[idx] = r;
+                results[idx] = r.result;
+                if (r.detail !== undefined) resultDetails[idx] = r.detail;
             });
         }),
     );
 
     for (const { tu, idx } of workflowTools) {
         const startedAt = performance.now();
-        results[idx] = await dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding);
+        const dispatched = await dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding);
+        results[idx] = dispatched.result;
+        if (dispatched.detail !== undefined) resultDetails[idx] = dispatched.detail;
         durations[idx] = elapsedMs(startedAt);
     }
     for (const { tu, idx } of inlineTools) {
         const startedAt = performance.now();
-        results[idx] = await dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding);
+        const dispatched = await dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding);
+        results[idx] = dispatched.result;
+        if (dispatched.detail !== undefined) resultDetails[idx] = dispatched.detail;
         durations[idx] = elapsedMs(startedAt);
     }
 
-    return { results, durations };
+    return { results, durations, resultDetails };
 }
 
 /** Whole milliseconds since `startedAt`, on the monotonic clock that took that mark. */
 function elapsedMs(startedAt: number): number {
     return Math.round(performance.now() - startedAt);
+}
+
+/**
+ * One settled tool call: the result the model reads, and the line that the tool's
+ * own `describeResult` hook made of its ok value.
+ *
+ * The detail rides beside the result, because the ok value it reads exists only
+ * here. Past this point the value is JSON on a `tool_result` part, which drops a
+ * symbol key and flattens every class, thus a hook that ran later would read a
+ * shape its tool never produced.
+ */
+interface DispatchedCall {
+    readonly result: ToolResultPart;
+    readonly detail?: ToolCallDetail;
 }
 
 async function dispatchTool(
@@ -686,10 +733,10 @@ async function dispatchTool(
     ctx: ToolContext,
     isFatalLoopError: (err: unknown) => boolean,
     encoding: ResultEncoding,
-): Promise<ToolResultPart> {
+): Promise<DispatchedCall> {
     const tool = toolsById.get(tu.toolName);
     if (tool === undefined) {
-        return errorResult(tu, `unknown tool: ${tu.toolName}`);
+        return { result: errorResult(tu, `unknown tool: ${tu.toolName}`) };
     }
 
     const parsed = tool.inputSchema.safeParse(tu.input);
@@ -703,7 +750,7 @@ async function dispatchTool(
     const repaired = repairedInput === undefined ? undefined : tool.inputSchema.safeParse(repairedInput);
     if (repaired?.success === true) return execute(tu, tool, repaired.data, ctx, isFatalLoopError, encoding);
 
-    return errorResult(tu, `input validation failed: ${formatZodIssues(parsed.error, tu.input)}`);
+    return { result: errorResult(tu, `input validation failed: ${formatZodIssues(parsed.error, tu.input)}`) };
 }
 
 async function execute(
@@ -713,15 +760,19 @@ async function execute(
     ctx: ToolContext,
     isFatalLoopError: (err: unknown) => boolean,
     encoding: ResultEncoding,
-): Promise<ToolResultPart> {
+): Promise<DispatchedCall> {
     try {
         const output = await tool.execute(input, ctx);
-        if (output.isErr()) return errorResult(tu, toolErrorContent(output.error));
-        return successResult(tu, output.value, encoding);
+        if (output.isErr()) return { result: errorResult(tu, toolErrorContent(output.error)) };
+        // The one place a result description runs: the ok value in hand, the
+        // input already validated, and the guard inside the compute.
+        const detail = computeResultDetail(tool, input, output.value, encoding.log);
+        const result = successResult(tu, output.value, encoding);
+        return detail === undefined ? { result } : { result, detail };
     } catch (err) {
         if (isFatalLoopError(err)) throw err;
-        if (isAskRejected(err)) return deniedResult(tu, err.feedback);
-        return errorResult(tu, toolErrorContent(err));
+        if (isAskRejected(err)) return { result: deniedResult(tu, err.feedback) };
+        return { result: errorResult(tu, toolErrorContent(err)) };
     }
 }
 

--- a/harness/src/loop/tool-detail.test.ts
+++ b/harness/src/loop/tool-detail.test.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { LogFields, Logger } from "../lib/logger.js";
-import { defineTool, type Tool } from "../tools/define-tool.js";
-import { computeDetail, DETAIL_MAX_LENGTH, normalizeDetail } from "./tool-detail.js";
+import { defineTool, type Tool, type ToolError } from "../tools/define-tool.js";
+import { computeDetail, computeResultDetail, DETAIL_MAX_LENGTH, normalizeDetail } from "./tool-detail.js";
 
 /** A logger that records every `debug` record, for the hook-failure path. */
 function recordingLogger(): { logger: Logger; debugs: { msg: string; fields?: LogFields }[] } {
@@ -31,6 +31,23 @@ function toolWithHook(describeCall: (input: { path: string }) => string): Tool {
         inputSchema: z.object({ path: z.string() }),
         describeCall,
         execute: async () => ok({}),
+    });
+}
+
+/** The ok value that a result-describing tool of these tests gives. */
+interface ReadOutcome {
+    bytes: number;
+}
+
+/** A tool over `{ path }` whose result hook is whatever the test supplies. */
+function toolWithResultHook(describeResult: (input: { path: string }, result: ReadOutcome) => string): Tool {
+    return defineTool({
+        id: "described-result",
+        description: "A tool that describes its own results.",
+        inputSchema: z.object({ path: z.string() }),
+        describeCall: ({ path }) => path,
+        describeResult,
+        execute: async () => ok<ReadOutcome, ToolError>({ bytes: 0 }),
     });
 }
 
@@ -212,5 +229,69 @@ describe("computeDetail", () => {
 
         expect(computeDetail(throwingRefinement, { path: "a.csv" }, logger)).toBeUndefined();
         expect(debugs[0]!.fields).toMatchObject({ tool: "throwing_refinement", error: "refinement is broken" });
+    });
+});
+
+describe("computeResultDetail", () => {
+    const log = createNoopLogger();
+
+    it("returns the normalized hook output for an ok result", () => {
+        const tool = toolWithResultHook((_input, { bytes }) => `${bytes} bytes`);
+
+        expect(computeResultDetail(tool, { path: "a.csv" }, { bytes: 2048 }, log)).toBe("2048 bytes");
+    });
+
+    it("hands the hook the parsed input beside the result", () => {
+        const tool = toolWithResultHook(({ path }, { bytes }) => `${path}: ${bytes} bytes`);
+
+        expect(computeResultDetail(tool, { path: "output/de.csv" }, { bytes: 12 }, log)).toBe("output/de.csv: 12 bytes");
+    });
+
+    it("yields undefined for a tool with no result hook", () => {
+        const tool = toolWithHook(({ path }) => path);
+
+        expect(computeResultDetail(tool, { path: "a.csv" }, { bytes: 1 }, log)).toBeUndefined();
+    });
+
+    it("normalizes at the emit site, not in the tool", () => {
+        const tool = toolWithResultHook((_input, { bytes }) => `wrote\n${bytes}\tbytes`);
+
+        expect(computeResultDetail(tool, { path: "a.csv" }, { bytes: 7 }, log)).toBe("wrote 7 bytes");
+    });
+
+    it("caps an over-long result the same as a call detail", () => {
+        const tool = toolWithResultHook(() => "x".repeat(5000));
+
+        const detail = computeResultDetail(tool, { path: "a.csv" }, { bytes: 1 }, log)!;
+
+        expect(detail).toHaveLength(DETAIL_MAX_LENGTH);
+        expect(detail.endsWith("…")).toBe(true);
+    });
+
+    it("swallows a throwing result hook and records it at debug", () => {
+        const { logger, debugs } = recordingLogger();
+        const tool = toolWithResultHook(() => {
+            throw new Error("result hook is broken");
+        });
+
+        expect(computeResultDetail(tool, { path: "a.csv" }, { bytes: 1 }, logger)).toBeUndefined();
+        expect(debugs).toHaveLength(1);
+        expect(debugs[0]!.fields).toMatchObject({ tool: "described-result", error: "result hook is broken" });
+    });
+
+    it("ignores a hook that returns a non-string or an empty string", () => {
+        const nonString = toolWithResultHook(() => undefined as unknown as string);
+        const empty = toolWithResultHook(() => "");
+
+        expect(computeResultDetail(nonString, { path: "a.csv" }, { bytes: 1 }, log)).toBeUndefined();
+        expect(computeResultDetail(empty, { path: "a.csv" }, { bytes: 1 }, log)).toBeUndefined();
+    });
+
+    // The result satisfies no schema, thus a hook that reads a field the tool never produced sees
+    // `undefined` and the guard keeps that mistake cosmetic.
+    it("survives a hook that reads a field the result does not carry", () => {
+        const tool = toolWithResultHook((_input, result) => (result as unknown as { missing: { deep: string } }).missing.deep);
+
+        expect(computeResultDetail(tool, { path: "a.csv" }, { bytes: 1 }, createNoopLogger())).toBeUndefined();
     });
 });

--- a/harness/src/loop/tool-detail.ts
+++ b/harness/src/loop/tool-detail.ts
@@ -2,8 +2,10 @@
  * The call detail: one line naming what a tool call is doing.
  *
  * A tool states it through its own `describeCall` hook, colocated with the Zod
- * `inputSchema` the compiler checks it against. Everything else about the
- * detail happens here, once, for every tool: validate, guard, normalize.
+ * `inputSchema` the compiler checks it against, and through its optional
+ * `describeResult` hook, which names what the call produced. Everything else
+ * about the detail happens here, once, for every tool: validate, guard,
+ * normalize.
  *
  * Two rules make this the only place that matters:
  *
@@ -140,6 +142,37 @@ export function computeDetail(tool: Tool, rawInput: unknown, log: Logger): ToolC
         // `debug`, not `warn`: a broken description is a cosmetic defect in one
         // tool, and the turn it happened in succeeded.
         log.debug("describeCall failed", { tool: tool.id, ...log.errorFields(err) });
+        return undefined;
+    }
+}
+
+/**
+ * Compute a tool call's result detail, best-effort.
+ *
+ * `parsedInput` is the value the dispatch already validated, and `result` is the
+ * ok value the tool returned one line above. Thus neither is re-parsed here: a
+ * second parse of the input would repeat work the dispatch did, and the result
+ * satisfies no schema at all — the tool's own `Output` type is what the hook
+ * declares, and the tool is the author of both.
+ *
+ * The guard is the whole difference from a bare call. A hook that throws, returns
+ * a non-string, or returns nothing usable yields no result detail, and the
+ * finished event falls back on the call detail. A description must never be able
+ * to fail a call that already succeeded.
+ */
+export function computeResultDetail(tool: Tool, parsedInput: unknown, result: unknown, log: Logger): ToolCallDetail | undefined {
+    // The guard tests for a function, not for presence, for the same reason as in
+    // `computeDetail`: a packaged tool comes from an open list, thus a
+    // `describeResult` that is not callable is reachable.
+    const describeResult = tool.describeResult;
+    if (typeof describeResult !== "function") return undefined;
+
+    try {
+        return normalizeDetail(describeResult(parsedInput, result));
+    } catch (err) {
+        // `debug`, not `warn`: a broken description is a cosmetic defect in one
+        // tool, and the call it happened on succeeded.
+        log.debug("describeResult failed", { tool: tool.id, ...log.errorFields(err) });
         return undefined;
     }
 }

--- a/harness/src/tools/define-tool.test.ts
+++ b/harness/src/tools/define-tool.test.ts
@@ -181,4 +181,87 @@ describe("defineTool", () => {
             expect(tool.id).toBe("undecided");
         });
     });
+
+    describe("describeResult", () => {
+        it("carries a declared hook onto the packaged tool", () => {
+            const tool = defineTool({
+                id: "described-result",
+                description: "Renders a page.",
+                inputSchema: z.object({ path: z.string() }),
+                describeCall: (input) => input.path,
+                describeResult: (input, result) => `${input.path} -> ${result.page}`,
+                execute: async () => ok({ page: "index.html" }),
+            });
+
+            expect(tool.describeResult?.({ path: "draft" }, { page: "index.html" })).toBe("draft -> index.html");
+        });
+
+        it("packages no hook for a definition that declares none", () => {
+            const tool = defineTool({
+                id: "call-only",
+                description: "Describes its call alone.",
+                inputSchema: z.object({ path: z.string() }),
+                describeCall: (input) => input.path,
+                execute: async () => ok({}),
+            });
+
+            expect(tool.describeResult).toBeUndefined();
+            expect("describeResult" in tool).toBe(false);
+        });
+
+        // An empty-input tool cannot distinguish its calls, and it can still name what each one
+        // produced. Thus the two decisions are independent.
+        it("packages a result hook beside a declined call hook", () => {
+            const tool = defineTool({
+                id: "result-only",
+                description: "Takes no field, and names its outcome.",
+                inputSchema: z.object({}),
+                describeCall: "none",
+                describeResult: (_input, result) => result.outcome,
+                execute: async () => ok({ outcome: "rendered" }),
+            });
+
+            expect("describeCall" in tool).toBe(false);
+            expect(tool.describeResult?.({}, { outcome: "rendered" })).toBe("rendered");
+        });
+
+        it("never reaches the model — the emitted AI SDK definition is unchanged", () => {
+            const schema = z.object({ path: z.string() });
+            const withHook = defineTool({
+                id: "same-tool",
+                description: "Renders a page.",
+                inputSchema: schema,
+                describeCall: "none",
+                describeResult: (_input, result) => result.page,
+                execute: async () => ok({ page: "index.html" }),
+            });
+            const withoutHook = defineTool({
+                id: "same-tool",
+                description: "Renders a page.",
+                inputSchema: schema,
+                describeCall: "none",
+                execute: async () => ok({ page: "index.html" }),
+            });
+
+            expect(withHook.jsonSchema).toEqual(withoutHook.jsonSchema);
+            expect(JSON.stringify(createRegistry([withHook]).definitions())).toBe(JSON.stringify(createRegistry([withoutHook]).definitions()));
+            expect(JSON.stringify(createRegistry([withHook]).definitions())).not.toContain("describeResult");
+        });
+
+        it("types the hook against the tool's own output", () => {
+            // Read the CAUTION on the call hook above: the directive documents the
+            // contract, and no gate enforces it.
+            const tool = defineTool({
+                id: "typed-result-hook",
+                description: "Produces only `page`.",
+                inputSchema: z.object({ path: z.string() }),
+                describeCall: "none",
+                // @ts-expect-error -- `versionId` is absent from this tool's output.
+                describeResult: (_input, result) => result.versionId,
+                execute: async () => ok({ page: "index.html" }),
+            });
+
+            expect(tool.id).toBe("typed-result-hook");
+        });
+    });
 });

--- a/harness/src/tools/define-tool.ts
+++ b/harness/src/tools/define-tool.ts
@@ -138,6 +138,8 @@ export interface Tool<Input = unknown, Output = unknown> {
     readonly executionMode: ToolExecutionMode;
     /** See {@link ToolDefinition.describeCall}. Absent when the tool declares none. */
     describeCall?(input: Input): string;
+    /** See {@link ToolDefinition.describeResult}. Absent when the tool declares none. */
+    describeResult?(input: Input, result: Output): string;
     execute(input: Input, ctx: ToolContext): Promise<Result<Output, ToolError>>;
 }
 
@@ -179,6 +181,36 @@ export interface ToolDefinition<Schema extends z.ZodType, Output> {
      * The hook never reaches the model.
      */
     describeCall: ((input: z.infer<Schema>) => string) | "none";
+    /**
+     * One line that names what THIS call PRODUCED — the outcome-time counterpart
+     * of `describeCall`. A page path, a recorded id, and a listed count are facts
+     * of the result, thus no hook over the input can name one. The finished event
+     * carries this line, and it carries the call detail when the hook gives
+     * nothing.
+     *
+     * The decision is OPTIONAL, unlike `describeCall`. A call always has an input
+     * to describe or an input that cannot distinguish it, thus that decision is
+     * forced. A result is different: a tool whose ok value adds no fact that a
+     * reader wants leaves the call detail to stand for the whole call. Thus the
+     * absent key is the whole of "this tool describes no result", and the `"none"`
+     * sentinel has no counterpart here.
+     *
+     * The hook runs on an ok outcome only. An error outcome already names itself,
+     * and a hook over a failed call reads a shape that does not exist.
+     *
+     * A hook is synchronous and pure — no I/O, no ambient state — and a
+     * description must never fail a call: the loop guards the call and drops the
+     * detail on any failure (see the tool-call-detail capability). The result
+     * arrives as the tool produced it, thus the hook reads a value of its own
+     * declared `Output` type and no parse stands between the two.
+     *
+     * Return whatever reads best. Normalization — one line, control characters
+     * removed, secrets redacted, length capped — happens once at the emit site,
+     * never here.
+     *
+     * The hook never reaches the model.
+     */
+    readonly describeResult?: (input: z.infer<Schema>, result: Output) => string;
     execute(input: z.infer<Schema>, ctx: ToolContext): Promise<Result<Output, ToolError>>;
 }
 
@@ -216,6 +248,10 @@ export function defineTool<Schema extends z.ZodType, Output>(def: ToolDefinition
         // `typeof` is the discriminator, not equality with the sentinel, so a
         // hook that returns the string `"none"` still packages as a hook.
         ...(typeof def.describeCall === "function" ? { describeCall: def.describeCall } : {}),
+        // The same property-presence pattern as `describeCall`: a tool that
+        // declares no result hook carries no key, thus "has a hook" is one
+        // property check on either side.
+        ...(typeof def.describeResult === "function" ? { describeResult: def.describeResult } : {}),
         execute: def.execute,
     };
 }

--- a/harness/src/tools/detail-resolver.ts
+++ b/harness/src/tools/detail-resolver.ts
@@ -15,8 +15,13 @@
  *   registry construction.
  *
  * It resolves through the same `computeDetail` the loop uses, so a reloaded
- * thread cannot show a different detail from the one the live turn showed.
- * Nothing is persisted: storage stays the pure model transcript.
+ * thread shows the same CALL detail the live turn showed.
+ *
+ * The bound is the input. A reload reconstructs from the persisted call alone, and a
+ * tool that describes its own RESULT names a fact that the input cannot carry — a page
+ * path, a recorded version. That line reaches the live surface on the finished event and
+ * it does not reappear here, thus a reloaded call falls back to its call detail. Nothing
+ * is persisted: storage stays the pure model transcript.
  */
 
 import { computeDetail, type ToolCallDetail } from "../loop/tool-detail.js";

--- a/harness/src/tools/report-authoring/authoring-tools.test.ts
+++ b/harness/src/tools/report-authoring/authoring-tools.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "bun:test";
 
 import type { Scope } from "../../auth/types.js";
+import { normalizeDetail } from "../../loop/tool-detail.js";
 import type { DraftDocument } from "../../report-model/draft.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
@@ -679,5 +680,101 @@ describe("the cost of a landing", () => {
         const value = (await tools.set_title.execute({ title: "Report" }, ctxForThread("t1")))._unsafeUnwrap();
 
         expect(value).toEqual({ applied: true, changed: [] });
+    });
+});
+
+describe("the call detail", () => {
+    /** The tools of a bare gateway. Each hook is pure, thus no seeded state matters here. */
+    const tools = createReportAuthoringTools(makeFakeGateway());
+
+    /** Run a tool's call hook, asserting that the tool declares one. */
+    function detailOf(tool: { describeCall?: (input: never) => string }, input: unknown): string {
+        expect(tool.describeCall).toBeDefined();
+        return tool.describeCall!(input as never);
+    }
+
+    /** A whole-table reference onto one pinned path. */
+    function tableBinding(path: string): Record<string, unknown> {
+        return { kind: "artifact-table", path, hash: "sha256:aaa" };
+    }
+
+    it("names the kind and the title of an added section", () => {
+        expect(detailOf(tools.add_block, { block: { kind: "section", id: "s1", title: "Summary", blocks: [] } })).toBe('add section "Summary"');
+    });
+
+    it("names the file of an added table, chart, and figure", () => {
+        expect(detailOf(tools.add_block, { block: { kind: "table", id: "b1", binding: tableBinding("runs/r1/s1/output/de.csv") } })).toBe("add table de.csv");
+        expect(
+            detailOf(tools.add_block, {
+                block: { kind: "chart", id: "b2", binding: tableBinding("runs/r1/s1/output/de.csv"), chartType: "bar", encoding: { x: "gene" } },
+            }),
+        ).toBe("add chart de.csv");
+        expect(
+            detailOf(tools.add_block, {
+                block: { kind: "figure", id: "b3", binding: { kind: "artifact-file", path: "runs/r1/s1/figures/volcano.png", hash: "sha256:bbb" } },
+            }),
+        ).toBe("add figure volcano.png");
+    });
+
+    it("names the first bound file of a claim, and skips a citation that names none", () => {
+        const bindings = [
+            { kind: "citation", idKind: "pmid", id: "12345", raw: "Watson 1953" },
+            { kind: "artifact-value", path: "output/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } },
+        ];
+
+        expect(detailOf(tools.add_block, { block: { kind: "claim", id: "c1", content: { prose: "x" }, bindings } })).toBe("add claim de.csv");
+    });
+
+    it("names the file of a metric, through a direct value and through a derivation", () => {
+        const direct = { kind: "artifact-value", path: "output/counts.csv", hash: "sha256:aaa", locator: { column: "n", row: 0 } };
+        const derived = {
+            kind: "derivation",
+            op: "ratio",
+            inputs: [
+                { kind: "artifact-value", path: "output/a.csv", hash: "sha256:aaa", locator: { column: "n", row: 0 } },
+                { kind: "artifact-value", path: "output/b.csv", hash: "sha256:bbb", locator: { column: "n", row: 0 } },
+            ],
+        };
+
+        expect(detailOf(tools.add_block, { block: { kind: "metric", id: "m1", label: "count", value: direct } })).toBe("add metric counts.csv");
+        expect(detailOf(tools.add_block, { block: { kind: "metric", id: "m2", label: "ratio", value: derived } })).toBe("add metric a.csv");
+    });
+
+    it("gives the kind alone for a block that names no subject", () => {
+        expect(detailOf(tools.add_block, { block: { kind: "text", id: "t1", content: { prose: "hello" } } })).toBe("add text");
+        expect(detailOf(tools.add_block, { block: { kind: "section", id: "s1", title: "", blocks: [] } })).toBe("add section");
+        expect(detailOf(tools.add_block, { block: { kind: "claim", id: "c1", content: { prose: "x" }, bindings: [{ kind: "citation", id: "1" }] } })).toBe(
+            "add claim",
+        );
+    });
+
+    it("gives a bare line for a payload that names no kind", () => {
+        expect(detailOf(tools.add_block, { block: { id: "b1" } })).toBe("add a block");
+        expect(detailOf(tools.add_block, { block: "not a block at all" })).toBe("add a block");
+    });
+
+    // A model routinely sends a nested object as a stringified payload, and the tool decodes it before
+    // the core reads it. The detail decodes the same value, thus the two never disagree about the call.
+    it("reads a double-encoded payload the same as a plain one", () => {
+        const block = JSON.stringify({ kind: "table", id: "b1", binding: tableBinding("output/de.csv") });
+
+        expect(detailOf(tools.add_block, { block })).toBe("add table de.csv");
+    });
+
+    // The emit-site cap cuts the tail. Left to it, a long title takes the whole line and the quote that
+    // closes the mark goes with the cut. The hook bounds the title, thus the mark always closes.
+    it("bounds a long section title, so the mark always closes", () => {
+        const detail = detailOf(tools.add_block, { block: { kind: "section", id: "s1", title: "T".repeat(80), blocks: [] } });
+
+        expect(detail).toBe(`add section "${"T".repeat(31)}…"`);
+        expect(normalizeDetail(detail)).toBe(detail);
+    });
+
+    it("keeps the block id as the whole detail of each other mutation and of the read", () => {
+        expect(detailOf(tools.change_block, { targetId: "b1" })).toBe("change b1");
+        expect(detailOf(tools.move_block, { targetId: "b1", parentId: "s2" })).toBe("move b1");
+        expect(detailOf(tools.remove_block, { targetId: "b1" })).toBe("remove b1");
+        expect(detailOf(tools.read_block, { targetId: "b1" })).toBe("read b1");
+        expect(detailOf(tools.set_title, { title: "Report" })).toBe("title the report Report");
     });
 });

--- a/harness/src/tools/report-authoring/authoring-tools.ts
+++ b/harness/src/tools/report-authoring/authoring-tools.ts
@@ -18,9 +18,11 @@
  */
 
 import { err, ok, type Result } from "neverthrow";
+import { basename } from "node:path";
 import { z } from "zod";
 
 import type { Scope } from "../../auth/types.js";
+import { capCodePoints, DETAIL_NEEDLE_MAX_LENGTH } from "../../loop/tool-detail.js";
 import { isSafeId } from "../../workspace/paths.js";
 import {
     addBlock,
@@ -407,14 +409,78 @@ function readId(block: unknown): string | undefined {
     return readStringField(block, "id");
 }
 
-function readStringField(block: unknown, field: "kind" | "id"): string | undefined {
-    if (block !== null && typeof block === "object") {
-        const value = (block as Record<string, unknown>)[field];
-        if (typeof value === "string") {
-            return value;
+/** Read one field of an untyped payload, or `undefined` when the payload is not an object. */
+function fieldOf(value: unknown, field: string): unknown {
+    return value !== null && typeof value === "object" ? (value as Record<string, unknown>)[field] : undefined;
+}
+
+function readStringField(block: unknown, field: string): string | undefined {
+    const value = fieldOf(block, field);
+    return typeof value === "string" ? value : undefined;
+}
+
+/** The pinned path of an untyped reference payload, or `undefined` when it names none. */
+function referencePath(reference: unknown): string | undefined {
+    const path = readStringField(reference, "path");
+    return path === undefined || path.length === 0 ? undefined : path;
+}
+
+/**
+ * The artifact path that an untyped block payload binds, or `undefined` when the kind binds no path.
+ *
+ * Where a reference sits differs per kind, thus the walk reads the one field of each kind and never
+ * searches the payload. A claim can hold a citation first, which names no path, thus the walk takes the
+ * first binding that names one. A metric holds a scalar reference, and a derivation holds its own two
+ * inputs, thus the first input names the derived value. A text block, a citation block, and a section
+ * bind no artifact at all.
+ *
+ * The payload is model-authored and unvalidated here, thus each read is a guarded read and a wrong shape
+ * gives `undefined`.
+ */
+function boundArtifactPath(kind: string, block: unknown): string | undefined {
+    if (kind === "table" || kind === "chart" || kind === "figure") {
+        return referencePath(fieldOf(block, "binding"));
+    }
+    if (kind === "claim") {
+        const bindings = fieldOf(block, "bindings");
+        if (!Array.isArray(bindings)) {
+            return undefined;
         }
+        for (const binding of bindings) {
+            const path = referencePath(binding);
+            if (path !== undefined) {
+                return path;
+            }
+        }
+        return undefined;
+    }
+    if (kind === "metric") {
+        const value = fieldOf(block, "value");
+        const direct = referencePath(value);
+        if (direct !== undefined) {
+            return direct;
+        }
+        const inputs = fieldOf(value, "inputs");
+        return Array.isArray(inputs) ? referencePath(inputs[0]) : undefined;
     }
     return undefined;
+}
+
+/**
+ * The subject that names one added block: the title of a section in quotes, or the file name of the
+ * artifact that the block binds. A block that names neither gives no subject, and the kind stands alone.
+ *
+ * The title is model-authored text of no fixed length, thus the needle bound cuts it before the emit-site
+ * cap can cut the quote that closes it. The file name is the base name alone, because the directory
+ * segments of an analysis path repeat across every block and the file name is what tells two apart.
+ */
+function addedSubject(kind: string, block: unknown): string | undefined {
+    if (kind === "section") {
+        const title = readStringField(block, "title");
+        return title === undefined || title.length === 0 ? undefined : `"${capCodePoints(title, DETAIL_NEEDLE_MAX_LENGTH)}"`;
+    }
+    const path = boundArtifactPath(kind, block);
+    return path === undefined ? undefined : basename(path);
 }
 
 /**
@@ -517,8 +583,13 @@ export function createReportAuthoringTools(gateway: ReportSessionStateGateway): 
         inputSchema: addBlockInput,
         executionMode: AUTHORING_EXECUTION_MODE,
         describeCall: (input): string => {
-            const kind = readKind(decodeBlockPayload(input.block));
-            return kind !== undefined ? `add ${kind}` : "add a block";
+            const block = decodeBlockPayload(input.block);
+            const kind = readKind(block);
+            if (kind === undefined) {
+                return "add a block";
+            }
+            const subject = addedSubject(kind, block);
+            return subject === undefined ? `add ${kind}` : `add ${kind} ${subject}`;
         },
         execute: async (input, ctx): Promise<Result<MutationResult, ToolError>> => {
             const opened = await openThread(ctx);

--- a/harness/src/tools/report-session/examine-page.test.ts
+++ b/harness/src/tools/report-session/examine-page.test.ts
@@ -35,7 +35,7 @@ import type {
 } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import { readToolResultImage, type ToolContext } from "../define-tool.js";
-import { createExaminePageTool, type CapturePage, type PageCapture } from "./examine-page.js";
+import { createExaminePageTool, type CapturePage, type ExaminePageResult, type PageCapture } from "./examine-page.js";
 
 const DEFAULT_ANALYSIS_ID = "analysis-001";
 
@@ -552,5 +552,56 @@ describe("the transport precedence", () => {
         // The static realization gives the configured endpoint, thus the capture reaches that one.
         expect(connected).toEqual([CONFIGURED_ENDPOINT]);
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
+    });
+});
+
+describe("the result detail", () => {
+    /** Run the tool's result hook, asserting that the tool declares one. */
+    function detailOf(tool: ReturnType<typeof createExaminePageTool>, result: ExaminePageResult): string {
+        expect(tool.describeResult).toBeDefined();
+        return tool.describeResult!({}, result);
+    }
+
+    it("names the look outcome of a capture", async () => {
+        const root = await makeRoot();
+        const threadId = "t1";
+        await writePage(root, threadId);
+        const gateway = makeFakeGateway();
+        gateway.seed(threadId, "rendered-hash");
+        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: [], failedRequests: [] };
+        const capture: CapturePage = () => Promise.resolve(stub);
+        const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
+
+        const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+        expect(detailOf(tool, result)).toBe("examined");
+    });
+
+    it("names the absent page", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", null);
+        const capture: CapturePage = () => Promise.reject(new Error("the capture must not run when no page exists"));
+        const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(detailOf(tool, result)).toBe("no-page");
+    });
+
+    it("names a failed capture", async () => {
+        const root = await makeRoot();
+        const threadId = "t1";
+        await writePage(root, threadId);
+        const gateway = makeFakeGateway();
+        gateway.seed(threadId, "rendered-hash");
+        const capture: CapturePage = () => Promise.reject(new Error("the browser refused the page"));
+        const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture, logger: recordingLogger().logger });
+
+        const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("capture-failed");
+        // The cause of the fault stays in the log, thus the line never carries a browser message.
+        expect(detailOf(tool, result)).toBe("capture-failed");
     });
 });

--- a/harness/src/tools/report-session/examine-page.ts
+++ b/harness/src/tools/report-session/examine-page.ts
@@ -327,6 +327,10 @@ export function createExaminePageTool(deps: ExaminePageToolDeps): Tool<ExaminePa
         inputSchema: examinePageInput,
         executionMode: "inline",
         describeCall: "none",
+        // A look gives a picture, and a picture has no one-line form. Thus the outcome of the look is the
+        // whole line: a watcher reads that the eyes saw the page, or that the page was absent, or that the
+        // capture failed.
+        describeResult: (_input, result): string => result.outcome,
         execute: async (_input, ctx): Promise<Result<ExaminePageResult, ToolError>> => {
             // The check runs before every read, thus one clear signal replaces a capture failure for each
             // page. The arm stamps no seen hash, because no eyes saw the page. It also narrows the transport

--- a/harness/src/tools/report-session/list-artifacts.test.ts
+++ b/harness/src/tools/report-session/list-artifacts.test.ts
@@ -435,6 +435,20 @@ describe("the result detail", () => {
         expect(detailOf(tool, result)).toBe("3 artifacts");
     });
 
+    it("counts one artifact in the singular, and an empty pinned set in the plural", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("one", stagedInputs(1));
+        gateway.seed("none", stagedInputs(0));
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const one = (await tool.execute({}, ctxForThread("one")))._unsafeUnwrap();
+        const none = (await tool.execute({}, ctxForThread("none")))._unsafeUnwrap();
+
+        expect(detailOf(tool, one)).toBe("1 artifact");
+        expect(detailOf(tool, none)).toBe("0 artifacts");
+    });
+
     // A count alone reads as the whole pinned set, thus a cut listing names the total it came from.
     it("names the total beside the count of a truncated listing", async () => {
         const root = await makeRoot();

--- a/harness/src/tools/report-session/list-artifacts.test.ts
+++ b/harness/src/tools/report-session/list-artifacts.test.ts
@@ -17,7 +17,7 @@ import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
-import { createListPinnedArtifactsTool } from "./list-artifacts.js";
+import { createListPinnedArtifactsTool, type ListPinnedArtifactsResult } from "./list-artifacts.js";
 
 /** Each root that a test made. The cleanup removes them after the suite. */
 const roots: string[] = [];
@@ -405,5 +405,55 @@ describe("the session refusal", () => {
         if (result.outcome === "refused") {
             expect(result.refusal.reason).toBe("absent-state");
         }
+    });
+});
+
+describe("the result detail", () => {
+    /** Seed a snapshot of `count` staged inputs, as the cap tests do. */
+    function stagedInputs(count: number): ReportSnapshot {
+        const artifacts: ReportSnapshot["artifacts"] = {};
+        for (let index = 0; index < count; index += 1) {
+            artifacts[`data/inputs/f${String(index).padStart(3, "0")}/raw.csv`] = { hash: `sha256:${index}`, fileType: "output" };
+        }
+        return { artifacts };
+    }
+
+    /** Run the tool's result hook, asserting that the tool declares one. */
+    function detailOf(tool: ReturnType<typeof createListPinnedArtifactsTool>, result: ListPinnedArtifactsResult): string {
+        expect(tool.describeResult).toBeDefined();
+        return tool.describeResult!({}, result);
+    }
+
+    it("names the listed count of a whole listing", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", stagedInputs(3));
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(detailOf(tool, result)).toBe("3 artifacts");
+    });
+
+    // A count alone reads as the whole pinned set, thus a cut listing names the total it came from.
+    it("names the total beside the count of a truncated listing", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", stagedInputs(250));
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(detailOf(tool, result)).toBe("200 artifacts of 250");
+    });
+
+    it("names the outcome kind of a refusal", async () => {
+        const root = await makeRoot();
+        const tool = createListPinnedArtifactsTool({ gateway: makeFakeGateway(), resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("absent")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("refused");
+        expect(detailOf(tool, result)).toBe("refused");
     });
 });

--- a/harness/src/tools/report-session/list-artifacts.ts
+++ b/harness/src/tools/report-session/list-artifacts.ts
@@ -195,7 +195,8 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
             if (result.outcome !== "listed") {
                 return result.outcome;
             }
-            const listed = `${result.artifacts.length} artifacts`;
+            const count = result.artifacts.length;
+            const listed = `${count} ${count === 1 ? "artifact" : "artifacts"}`;
             return result.truncated ? `${listed} of ${result.total}` : listed;
         },
         execute: async (_input, ctx): Promise<Result<ListPinnedArtifactsResult, ToolError>> => {

--- a/harness/src/tools/report-session/list-artifacts.ts
+++ b/harness/src/tools/report-session/list-artifacts.ts
@@ -188,6 +188,16 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
         inputSchema: listPinnedArtifactsInput,
         executionMode: "inline",
         describeCall: "none",
+        // The size of the listing is what a watcher reads, and the cap makes that size differ from the
+        // pinned set. Thus a truncated listing names the total beside the count, and a whole listing names
+        // the count alone, because a total that equals the count says the same thing two times.
+        describeResult: (_input, result): string => {
+            if (result.outcome !== "listed") {
+                return result.outcome;
+            }
+            const listed = `${result.artifacts.length} artifacts`;
+            return result.truncated ? `${listed} of ${result.total}` : listed;
+        },
         execute: async (_input, ctx): Promise<Result<ListPinnedArtifactsResult, ToolError>> => {
             const opened = await openReportThread(deps.gateway, ctx.session.scope);
             if (opened.isErr()) {

--- a/harness/src/tools/report-session/preview-report.test.ts
+++ b/harness/src/tools/report-session/preview-report.test.ts
@@ -22,7 +22,7 @@ import { PAGE_ASSETS } from "../../report-render/assets.js";
 import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
-import { createPreviewReportTool } from "./preview-report.js";
+import { createPreviewReportTool, type PreviewReportResult } from "./preview-report.js";
 
 /** Each root that a test made. The cleanup removes them after the suite. */
 const roots: string[] = [];
@@ -467,5 +467,59 @@ describe("the session refusal", () => {
         }
         // The mismatch refuses before any resolution, thus no page lands.
         expect(existsSync(join(root, "report-sessions"))).toBe(false);
+    });
+});
+
+describe("the result detail", () => {
+    /** Run the tool's result hook, asserting that the tool declares one. */
+    function detailOf(tool: ReturnType<typeof createPreviewReportTool>, result: PreviewReportResult): string {
+        expect(tool.describeResult).toBeDefined();
+        return tool.describeResult!({}, result);
+    }
+
+    it("names the page path of a render", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: metricDoc(), snapshot: metricSnapshot });
+        const tool = createPreviewReportTool({
+            gateway,
+            makeResolver: () => createFixtureResolver(),
+            resolveWorkspaceRoot: () => root,
+        });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("rendered");
+        expect(detailOf(tool, result)).toBe(`page ${join(root, "report-sessions", "t1", "index.html")}`);
+    });
+
+    it("names the outcome kind of a degraded arm", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: { title: "", sections: [] }, snapshot: { artifacts: {} } });
+        const tool = createPreviewReportTool({
+            gateway,
+            makeResolver: () => createFixtureResolver(),
+            resolveWorkspaceRoot: () => root,
+        });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("gaps");
+        expect(detailOf(tool, result)).toBe("gaps");
+    });
+
+    // The page landed and the marker did not, thus the line must not read as a clean pass.
+    it("names the stamp failure, and never the page that it left on disk", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        const tool = createPreviewReportTool({
+            gateway,
+            makeResolver: () => createFixtureResolver(),
+            resolveWorkspaceRoot: () => root,
+        });
+
+        expect(detailOf(tool, { outcome: "stamp-failed", pagePath: join(root, "page.html"), detail: "the store is down" })).toBe("stamp-failed");
+        expect(detailOf(tool, { outcome: "refused", refusal: { reason: "absent-state", detail: "no session" } })).toBe("refused");
     });
 });

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -300,6 +300,11 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
         inputSchema: previewReportInput,
         executionMode: "inline",
         describeCall: "none",
+        // The page path is the one fact of a preview that a watcher wants, and it exists only in the
+        // result. Each other arm is a degraded condition whose kind already names it, thus the kind
+        // stands as the line. A stamp failure is such an arm: the page landed, but the marker did not,
+        // and a line that named the page would read as a clean pass.
+        describeResult: (_input, result): string => (result.outcome === "rendered" ? `page ${result.pagePath}` : result.outcome),
         execute: async (_input, ctx): Promise<Result<PreviewReportResult, ToolError>> => {
             const opened = await openReportThread(deps.gateway, ctx.session.scope);
             if (opened.isErr()) {

--- a/harness/src/tools/report-session/record-version.test.ts
+++ b/harness/src/tools/report-session/record-version.test.ts
@@ -25,7 +25,7 @@ import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
 import type { ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
 import { createPreviewReportTool } from "./preview-report.js";
-import { createRecordVersionTool } from "./record-version.js";
+import { createRecordVersionTool, type RecordVersionResult } from "./record-version.js";
 
 const ANALYSIS_ID = "analysis-001";
 
@@ -262,5 +262,38 @@ describe("createRecordVersionTool", () => {
             const resolved = (await resolver.resolve(block.value, metricSnapshot))._unsafeUnwrap();
             expect(resolved).toEqual({ type: "scalar", value: 42 });
         }
+    });
+
+    describe("the result detail", () => {
+        /** Run the tool's result hook, asserting that the tool declares one. */
+        function detailOf(tool: ReturnType<typeof createRecordVersionTool>, result: RecordVersionResult): string {
+            expect(tool.describeResult).toBeDefined();
+            return tool.describeResult!({}, result);
+        }
+
+        it("names the version that landed", async () => {
+            const parentId = "parent-detail";
+            const threadId = "thread-detail";
+            (await threads.createThread({ threadId: parentId, analysisId: ANALYSIS_ID }))._unsafeUnwrap();
+            (await threads.createThread({ threadId, analysisId: ANALYSIS_ID, type: "report", parentThreadId: parentId, parentSeq: 1 }))._unsafeUnwrap();
+            const doc = metricDoc();
+            const tool = makeTool(gatewayFor(threadId, doc, metricSnapshot, computeDraftHash(doc)));
+
+            const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(result.outcome).toBe("recorded");
+            if (result.outcome === "recorded") {
+                expect(detailOf(tool, result)).toBe(`version ${result.versionId}`);
+            }
+        });
+
+        it("names the outcome kind of a gate that refused", async () => {
+            const threadId = "thread-detail-never-seen";
+            const tool = makeTool(gatewayFor(threadId, metricDoc(), metricSnapshot, null));
+
+            const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(detailOf(tool, result)).toBe("never-seen");
+        });
     });
 });

--- a/harness/src/tools/report-session/record-version.ts
+++ b/harness/src/tools/report-session/record-version.ts
@@ -117,6 +117,9 @@ export function createRecordVersionTool(deps: RecordVersionToolDeps): Tool<Recor
         inputSchema: recordVersionInput,
         executionMode: "inline",
         describeCall: "none",
+        // The version id is the one durable product of the call, thus the recorded arm names it. Each
+        // other arm is a gate that refused, and the kind of the arm is what a watcher must read.
+        describeResult: (_input, result): string => (result.outcome === "recorded" ? `version ${result.versionId}` : result.outcome),
         execute: async (_input, ctx): Promise<Result<RecordVersionResult, ToolError>> => {
             const opened = await openReportThread(deps.gateway, ctx.session.scope);
             if (opened.isErr()) {


### PR DESCRIPTION
## What & why

The report-session tools showed opaque call lines, and a watcher could not tell which section the agent adds or where the page landed. The detail seam gains an optional result hook: the finished event carries a detail recomputed from the ok-channel result, and the started detail stays the fallback. The providers then name their subjects:

- `add_block` names the kind with the section title or the bound file name.
- `preview_report` names the page path on a render, and the outcome kind otherwise.
- `record_report_version` names the version, and `examine_page` names the look outcome.
- `list_pinned_artifacts` names the listed count, with the truncation.

Notes for the reviewer:

- The result hook rides the same guard and the same normalization as the call hook: synchronous, pure, one capped redacted line, and never able to fail a call. An error outcome keeps the started detail.
- The CLI part update takes a present finished detail and never blanks on an absent one, thus no CLI change.
- The tool surface is exported, thus the linked-harness cli typecheck ran clean.

Refs #378

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
