### PR TITLE
feat(harness): type the chart grammar

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/design.md
@@ -1,0 +1,34 @@
+## Context
+
+`ChartBlockSchema` carries one type enum and a four-channel encoding (`contracts/report-blocks.ts`). The derivation holds one fixed rule for each type, computes no aggregate, and stays deterministic (`report-render/chart.ts`). The option rides as inline JSON, thus no function can ride it. A string template of the chart runtime is static text, and it can name a point.
+
+## Goals / Non-Goals
+
+- Goal: a composition that expresses real scientific charts, with every value from the pinned artifact.
+- Goal: the quick path stays one field, and a preset expands into the composition inside the renderer.
+- Non-goal: a raw option surface. Series data literals and function formatters stay unrepresentable.
+- Non-goal: a second binding. A chart composes over its one bound table.
+- Non-goal: a statistical estimator in the renderer. The `km` preset renders precomputed survival columns, and it estimates nothing.
+
+## Decisions
+
+- **A channel is a column name, or a column with a transform.** The channel schema is a union of a plain string and `{ column, transform }`. The transform enum is `log10`, `neg_log10`, `abs`, and `rank`. The first three are per-row pure. `rank` is a deterministic derivation over the column: competition ranking over ascending numeric order, and a tie shares its rank. Each derived value traces to one cell, thus the no-aggregate rule holds.
+- **The encoding gains `label`.** The label column names a point. The derivation puts it on the data item as its name, and a static template formatter shows the name with the values. A template is static text, thus the script hole stays closed.
+- **A series is a form with its own encoding.** The forms are `line`, `scatter`, `bar`, `area`, and `step`. A `step` series is a line with the step flag. An `area` series takes an optional `y0` lower-bound column, thus a per-row band between two columns is expressible. Each series reads the one bound table.
+- **Annotations are three typed members.** A reference line names an axis and a constant value. A reference band names an axis and two constants. Point labels name a rank rule: a column, an order, and an `n` bounded at 20. An annotation constant is a declared guide, and never a plotted data value.
+- **The composition is exclusive with the quick path.** The block carries either `chartType` with `encoding`, or `composition`. A refine makes the exactly-one rule a parse failure. The seven current types stay, and `volcano`, `manhattan`, and `ma`, and `km` join the enum as presets.
+- **A preset expands inside the renderer.** The expansion is a pure function from the preset and its encoding onto a composition. The volcano takes the effect column on x and the p column on y through `neg_log10`, with the declared guide lines. The `km` preset takes precomputed survival columns as grouped step series. Thus the derivation has one grammar path, and a preset is sugar.
+- **Axes carry titles and scales.** A scale is `linear` or `log`, mapped onto the static axis type. A title replaces the raw column name where the author gives one.
+- **The structural tier walks every named column.** The walk covers each series channel, each transform column, the label, the rank column, and `y0`. A name that the bound table does not hold refuses before a landing.
+- **The dense scatter takes a larger hit radius.** A row count over a threshold raises the symbol size one step, as a static field.
+- **A transform over an unusable cell drops the point.** `log10` and `neg_log10` over a non-positive value give null, and the point drops, the same as a non-numeric cell today. The drop is deterministic, and no substitute value appears.
+
+## Risks / Trade-offs
+
+- [The grammar grows the published block schema] → the schema is the one place the model learns the shape, thus the growth is the point. The descriptions stay short.
+- [A preset default hides a judgment] → each preset default is a declared constant in one expansion module. The caption still belongs to the author.
+- [Two representations of one chart] → the expansion runs before the derivation, thus the derivation reads one shape and the two paths cannot drift.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The chart encoding holds four column names, and no more. In the first real session the tooltip showed nothing, and the axis read a raw column name. Every point shared one color, and a faithful volcano was impossible. The failure is a typed surface that is too poor, not missing power.
+
+## What Changes
+
+- The chart block gains a typed composition: one or more series, each with a form (`line`, `scatter`, `bar`, `area`, `step`) and its own column encoding.
+- Annotations are typed members: a reference line, a reference band, and point labels for a declared top-N subset.
+- A channel accepts a per-row pure transform: `log10`, `neg_log10`, `abs`, or `rank`. Each derived value traces to one cell.
+- Axes carry titles and scales, and the number helper bounds what the static option admits.
+- The encoding gains a `label` channel, thus a tooltip names its point. A dense scatter takes a larger hit radius.
+- The current chart types stay as the quick path, and the genomics presets (`volcano`, `manhattan`, `ma`, `km`) join them. A preset expands into the composition inside the renderer.
+- The structural tier covers every column that the grammar names.
+
+## The boundary that stands
+
+The agent authors no raw echarts option. The encoding carries column names, and the resolver supplies every value from the hash-pinned artifact. Series data literals and function formatters stay unrepresentable.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-block-model`: a new requirement gives the chart grammar: the composition, the annotations, the transforms, the presets, and the unrepresentable holes.
+- `report-render`: the derivation grows the composition, the preset expansion, the annotations, the tooltip, and the hit radius.
+
+## Impact
+
+- `harness/src/contracts/report-blocks.ts` — the grammar schema.
+- `harness/src/report-render/chart.ts` — the expansion and the derivation.
+- `harness/src/report-model/` — the structural walk over the new members.
+- The contract is exported, thus the linked-harness cli typecheck gates the change.

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-block-model/spec.md
@@ -1,0 +1,30 @@
+# Delta: report-block-model
+
+## ADDED Requirements
+
+### Requirement: The chart grammar
+A chart block MUST carry either the quick path or the composition, and never both. The quick path is one chart type with one encoding. The composition holds one or more series, optional annotations, and optional axes. A series has a form (`line`, `scatter`, `bar`, `area`, `step`) and its own column encoding. An `area` series can name a `y0` lower-bound column. A channel is a column name, or a column with a per-row transform (`log10`, `neg_log10`, `abs`, `rank`). The encoding can name a `label` column for the identity of a point.
+
+The annotations are typed members. A reference line names an axis and a constant. A reference band names an axis and two constants. Point labels name a rank rule over a named column, with a bounded count. The chart type enum holds the seven base types and the presets `volcano`, `manhattan`, `ma`, and `km`.
+
+The grammar MUST keep the fabrication holes unrepresentable. No member carries a data literal, and no member carries script text. The structural tier MUST refuse a grammar column that the bound table does not hold.
+
+#### Scenario: The quick path and the composition exclude each other
+- **WHEN** a chart block carries a chart type and a composition together
+- **THEN** the parse fails
+
+#### Scenario: A transform channel parses
+- **WHEN** a chart series maps y onto a p-value column through `neg_log10`
+- **THEN** the block parses, and the channel carries the column with the transform
+
+#### Scenario: A data literal is unrepresentable
+- **WHEN** a composition member carries an array of numbers as series data
+- **THEN** the parse fails, because no member admits a data literal
+
+#### Scenario: A grammar column outside the table refuses
+- **WHEN** a series channel names a column that the bound table does not hold
+- **THEN** the structural tier refuses the block before a landing
+
+#### Scenario: A preset parses on the quick path
+- **WHEN** a chart block carries the `volcano` type with an effect column, a p column, and a label column
+- **THEN** the block parses on the quick path

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-render/spec.md
@@ -1,0 +1,28 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The composition derivation
+The renderer MUST derive one option from a chart composition: one runtime series for each declared series, over the resolved rows of the one bound table. A transform applies per row, and `rank` ranks the column deterministically with shared ranks on ties. The label column rides each data item, and a static template formatter shows the name with the values. A reference line and a reference band derive as static mark members. Point labels show on the declared top-N subset alone. An axis title replaces the raw column name where the author gives one, and a `log` scale maps onto the static axis type.
+
+A preset MUST expand into a composition through one pure expansion, before the derivation. The `km` preset renders precomputed survival columns as grouped step series, and the renderer estimates nothing. A dense scatter over a row-count threshold takes a larger symbol size. The derivation MUST stay deterministic, and it MUST compute no aggregate.
+
+#### Scenario: A volcano derives from the preset
+- **WHEN** the caller renders a `volcano` chart over an effect column and a p column
+- **THEN** the option holds a scatter over the effect and the transformed p, with the declared guide lines
+
+#### Scenario: The tooltip names the point
+- **WHEN** the caller renders a scatter with a label column
+- **THEN** each data item carries the label as its name, and the option holds a static template formatter
+
+#### Scenario: A rank transform is deterministic
+- **WHEN** the caller derives one composition over the same rows two times
+- **THEN** the two options are byte-identical, and a tied value shares its rank
+
+#### Scenario: An area band derives from two columns
+- **WHEN** a composition holds an `area` series with `y` and `y0` columns
+- **THEN** the option holds the per-row band between the two columns
+
+#### Scenario: The annotations are static members
+- **WHEN** a composition holds a reference line and point labels for a top-N subset
+- **THEN** the option holds static mark data and per-item label flags, and no function rides the option

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/specs/report-render/spec.md
@@ -7,6 +7,8 @@ The renderer MUST derive one option from a chart composition: one runtime series
 
 A preset MUST expand into a composition through one pure expansion, before the derivation. The `km` preset renders precomputed survival columns as grouped step series, and the renderer estimates nothing. A dense scatter over a row-count threshold takes a larger symbol size. The derivation MUST stay deterministic, and it MUST compute no aggregate.
 
+Two authoring faults MUST refuse as render problems. A band whose lower bound sits above its upper bound refuses, and the problem names the block. A quick-path transform whose derived name collides with a real table column refuses, and the problem names the collision.
+
 #### Scenario: A volcano derives from the preset
 - **WHEN** the caller renders a `volcano` chart over an effect column and a p column
 - **THEN** the option holds a scatter over the effect and the transformed p, with the declared guide lines

--- a/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-type-the-chart-grammar/tasks.md
@@ -1,0 +1,23 @@
+## 1. The contract
+
+- [x] 1.1 The channel schema, the series schema, the annotations, the axes, and the composition in `src/contracts/report-blocks.ts`. The exactly-one refine between the quick path and the composition.
+- [x] 1.2 The `label` channel on the encoding, and the preset members on the type enum.
+- [x] 1.3 Contract tests: each new member, the exclusivity, and the unrepresentable holes.
+
+## 2. The structural walk
+
+- [x] 2.1 Extend the column coverage of the structural tier over every grammar name: the series channels, the transform columns, the label, the rank column, and `y0`.
+- [x] 2.2 Tests: a grammar column outside the table refuses, and a valid composition lands.
+
+## 3. The renderer
+
+- [x] 3.1 The preset expansion module: one pure function from a preset onto a composition, with the declared guide constants.
+- [x] 3.2 The composition derivation in `src/report-render/chart.ts`: the series, the transforms, the rank, the annotations, the axes, the tooltip template, and the hit radius.
+- [x] 3.3 Renderer tests: the volcano, the tooltip name, the rank determinism, the area band, the static annotations, and the base types unchanged.
+
+## 4. The gates
+
+- [x] 4.1 Run the targeted contract, report-model, and report-render suites only.
+- [x] 4.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.
+- [x] 4.3 The contract is exported, thus run `bun run harness:local` from `cli/` and the cli typecheck.
+- [x] 4.4 Render a composition proof page to the scratchpad, and confirm the tooltip template and the annotations in the emitted option.

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -89,6 +89,33 @@ block.
 - **WHEN** a `section` holds no block
 - **THEN** validation rejects the section
 
+### Requirement: The chart grammar
+A chart block MUST carry either the quick path or the composition, and never both. The quick path is one chart type with one encoding. The composition holds one or more series, optional annotations, and optional axes. A series has a form (`line`, `scatter`, `bar`, `area`, `step`) and its own column encoding. An `area` series can name a `y0` lower-bound column. A channel is a column name, or a column with a per-row transform (`log10`, `neg_log10`, `abs`, `rank`). The encoding can name a `label` column for the identity of a point.
+
+The annotations are typed members. A reference line names an axis and a constant. A reference band names an axis and two constants. Point labels name a rank rule over a named column, with a bounded count. The chart type enum holds the seven base types and the presets `volcano`, `manhattan`, `ma`, and `km`.
+
+The grammar MUST keep the fabrication holes unrepresentable. No member carries a data literal, and no member carries script text. The structural tier MUST refuse a grammar column that the bound table does not hold.
+
+#### Scenario: The quick path and the composition exclude each other
+- **WHEN** a chart block carries a chart type and a composition together
+- **THEN** the parse fails
+
+#### Scenario: A transform channel parses
+- **WHEN** a chart series maps y onto a p-value column through `neg_log10`
+- **THEN** the block parses, and the channel carries the column with the transform
+
+#### Scenario: A data literal is unrepresentable
+- **WHEN** a composition member carries an array of numbers as series data
+- **THEN** the parse fails, because no member admits a data literal
+
+#### Scenario: A grammar column outside the table refuses
+- **WHEN** a series channel names a column that the bound table does not hold
+- **THEN** the structural tier refuses the block before a landing
+
+#### Scenario: A preset parses on the quick path
+- **WHEN** a chart block carries the `volcano` type with an effect column, a p column, and a label column
+- **THEN** the block parses on the quick path
+
 ### Requirement: Each evidentiary kind carries a binding field
 
 A `claim`, a `metric`, a `table`, a `chart`, a `figure`, and a `citation` MUST each

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -169,6 +169,31 @@ The renderer MUST derive the ECharts option object from the chart type, the enco
 - **WHEN** the caller renders a chart block
 - **THEN** the inline option carries the normalized layout, and it carries no in-spec title
 
+### Requirement: The composition derivation
+The renderer MUST derive one option from a chart composition: one runtime series for each declared series, over the resolved rows of the one bound table. A transform applies per row, and `rank` ranks the column deterministically with shared ranks on ties. The label column rides each data item, and a static template formatter shows the name with the values. A reference line and a reference band derive as static mark members. Point labels show on the declared top-N subset alone. An axis title replaces the raw column name where the author gives one, and a `log` scale maps onto the static axis type.
+
+A preset MUST expand into a composition through one pure expansion, before the derivation. The `km` preset renders precomputed survival columns as grouped step series, and the renderer estimates nothing. A dense scatter over a row-count threshold takes a larger symbol size. The derivation MUST stay deterministic, and it MUST compute no aggregate.
+
+#### Scenario: A volcano derives from the preset
+- **WHEN** the caller renders a `volcano` chart over an effect column and a p column
+- **THEN** the option holds a scatter over the effect and the transformed p, with the declared guide lines
+
+#### Scenario: The tooltip names the point
+- **WHEN** the caller renders a scatter with a label column
+- **THEN** each data item carries the label as its name, and the option holds a static template formatter
+
+#### Scenario: A rank transform is deterministic
+- **WHEN** the caller derives one composition over the same rows two times
+- **THEN** the two options are byte-identical, and a tied value shares its rank
+
+#### Scenario: An area band derives from two columns
+- **WHEN** a composition holds an `area` series with `y` and `y0` columns
+- **THEN** the option holds the per-row band between the two columns
+
+#### Scenario: The annotations are static members
+- **WHEN** a composition holds a reference line and point labels for a top-N subset
+- **THEN** the option holds static mark data and per-item label flags, and no function rides the option
+
 ### Requirement: The per-type derivation rules
 The renderer MUST hold one fixed derivation rule for each chart type. A chart whose encoding lacks a column that its type demands MUST give a `RenderProblem`. The renderer MUST compute no aggregate, and a pie or heatmap entry with a repeated category MUST give a `RenderProblem`. The histogram MUST bin with the auto rule: the larger of the Sturges count and the Freedman-Diaconis count. The box MUST compute type-7 quantiles with Tukey fences at 1.5 IQR. Category order and group order MUST follow the first appearance in the rows.
 

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -174,6 +174,8 @@ The renderer MUST derive one option from a chart composition: one runtime series
 
 A preset MUST expand into a composition through one pure expansion, before the derivation. The `km` preset renders precomputed survival columns as grouped step series, and the renderer estimates nothing. A dense scatter over a row-count threshold takes a larger symbol size. The derivation MUST stay deterministic, and it MUST compute no aggregate.
 
+Two authoring faults MUST refuse as render problems. A band whose lower bound sits above its upper bound refuses, and the problem names the block. A quick-path transform whose derived name collides with a real table column refuses, and the problem names the collision.
+
 #### Scenario: A volcano derives from the preset
 - **WHEN** the caller renders a `volcano` chart over an effect column and a p column
 - **THEN** the option holds a scatter over the effect and the transformed p, with the declared guide lines

--- a/harness/src/contracts/report-blocks.test.ts
+++ b/harness/src/contracts/report-blocks.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+
+import { ChartBlockSchema, channelColumn, channelTransform, type ChartComposition } from "./report-blocks.js";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+
+/** The binding of every chart under test. The grammar rules never read the binding. */
+const BINDING = { kind: "artifact-table", run: "run-1", path: "runs/run-1/step-a/output/de.csv", hash: HASH };
+
+/** A chart block that carries the given grammar fields. The extra fields ride unchecked, thus a hole is testable. */
+function chart(fields: Record<string, unknown>): Record<string, unknown> {
+    return { kind: "chart", id: "chart-1", binding: BINDING, ...fields };
+}
+
+/** True when the chart block parses. */
+function parses(fields: Record<string, unknown>): boolean {
+    return ChartBlockSchema.safeParse(chart(fields)).success;
+}
+
+/** One composition of one plain scatter series. */
+function scatterComposition(): ChartComposition {
+    return { series: [{ form: "scatter", encoding: { x: "log2FoldChange", y: "padj" } }] };
+}
+
+describe("the chart channel", () => {
+    it("takes a plain column name", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "log2FoldChange", y: "padj" } })).toBe(true);
+    });
+
+    it("takes a column with a per-row transform", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "log2FoldChange", y: { column: "padj", transform: "neg_log10" } } })).toBe(true);
+    });
+
+    it("takes each of the four transforms", () => {
+        for (const transform of ["log10", "neg_log10", "abs", "rank"]) {
+            expect(parses({ chartType: "scatter", encoding: { x: "gene", y: { column: "padj", transform } } })).toBe(true);
+        }
+    });
+
+    it("refuses a transform outside the four", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "gene", y: { column: "padj", transform: "sqrt" } } })).toBe(false);
+    });
+
+    it("refuses a channel that carries a value beside its column", () => {
+        // A channel names a column and a transform, and nothing else. Thus a value can never ride a channel.
+        expect(parses({ chartType: "scatter", encoding: { x: "gene", y: { column: "padj", transform: "abs", values: [1, 2, 3] } } })).toBe(false);
+    });
+
+    it("gives the column and the transform of either channel form", () => {
+        expect(channelColumn("padj")).toBe("padj");
+        expect(channelTransform("padj")).toBeUndefined();
+        expect(channelColumn({ column: "padj", transform: "neg_log10" })).toBe("padj");
+        expect(channelTransform({ column: "padj", transform: "neg_log10" })).toBe("neg_log10");
+    });
+});
+
+describe("the quick path", () => {
+    it("takes a label column", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "log2FoldChange", y: "padj", label: "gene" } })).toBe(true);
+    });
+
+    it("takes each preset with the same channels as a base type", () => {
+        for (const preset of ["volcano", "manhattan", "ma", "km"]) {
+            expect(parses({ chartType: preset, encoding: { x: "log2FoldChange", y: "padj", label: "gene" } })).toBe(true);
+        }
+    });
+
+    it("refuses a channel that the encoding does not declare", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "gene", y: "padj", size: "baseMean" } })).toBe(false);
+    });
+});
+
+describe("the composition", () => {
+    it("takes one series of each form", () => {
+        for (const form of ["line", "scatter", "bar", "area", "step"]) {
+            expect(parses({ composition: { series: [{ form, encoding: { x: "time", y: "survival" } }] } })).toBe(true);
+        }
+    });
+
+    it("refuses a series list that holds no series", () => {
+        expect(parses({ composition: { series: [] } })).toBe(false);
+    });
+
+    it("refuses a series that names no y channel", () => {
+        expect(parses({ composition: { series: [{ form: "line", encoding: { x: "time" } }] } })).toBe(false);
+    });
+
+    it("takes a `y0` lower bound on an area series", () => {
+        expect(parses({ composition: { series: [{ form: "area", encoding: { x: "time", y: "upper", y0: "lower" } }] } })).toBe(true);
+    });
+
+    it("refuses a `y0` lower bound on any other form", () => {
+        for (const form of ["line", "scatter", "bar", "step"]) {
+            expect(parses({ composition: { series: [{ form, encoding: { x: "time", y: "upper", y0: "lower" } }] } })).toBe(false);
+        }
+    });
+
+    it("takes a series name and a group channel", () => {
+        expect(parses({ composition: { series: [{ form: "step", encoding: { x: "time", y: "survival", group: "arm" }, name: "Overall" }] } })).toBe(true);
+    });
+
+    it("takes the three annotation kinds", () => {
+        const annotations = [
+            { kind: "reference-line", axis: "y", value: 1.3, label: "p 0.05" },
+            { kind: "reference-band", axis: "x", from: -1, to: 1, label: "no effect" },
+            { kind: "point-labels", column: "padj", order: "asc", n: 10 },
+        ];
+        expect(parses({ composition: { ...scatterComposition(), annotations } })).toBe(true);
+    });
+
+    it("refuses an annotation kind outside the three", () => {
+        expect(parses({ composition: { ...scatterComposition(), annotations: [{ kind: "trend-line", axis: "y" }] } })).toBe(false);
+    });
+
+    it("bounds the point-label count at 20", () => {
+        const withCount = (n: number): boolean =>
+            parses({ composition: { ...scatterComposition(), annotations: [{ kind: "point-labels", column: "padj", order: "desc", n }] } });
+        expect(withCount(20)).toBe(true);
+        expect(withCount(21)).toBe(false);
+        expect(withCount(0)).toBe(false);
+        expect(withCount(2.5)).toBe(false);
+    });
+
+    it("takes an axis title and an axis scale", () => {
+        expect(parses({ composition: { ...scatterComposition(), axes: { x: { title: "Fold change" }, y: { title: "-log10 p", scale: "log" } } } })).toBe(true);
+    });
+
+    it("refuses an axis scale outside the two", () => {
+        expect(parses({ composition: { ...scatterComposition(), axes: { y: { scale: "sqrt" } } } })).toBe(false);
+    });
+});
+
+describe("the unrepresentable holes", () => {
+    it("refuses a series that carries a data literal", () => {
+        expect(parses({ composition: { series: [{ form: "line", encoding: { x: "time", y: "survival" }, data: [1, 2, 3] }] } })).toBe(false);
+    });
+
+    it("refuses a composition that carries a data literal beside its series", () => {
+        expect(parses({ composition: { ...scatterComposition(), dataset: { source: [[1, 2]] } } })).toBe(false);
+    });
+
+    it("refuses a block that carries a raw option", () => {
+        expect(parses({ chartType: "scatter", encoding: { x: "gene", y: "padj" }, option: { series: [] } })).toBe(false);
+    });
+
+    it("refuses a series that carries script text", () => {
+        expect(
+            parses({ composition: { series: [{ form: "line", encoding: { x: "time", y: "survival" }, formatter: "function (p) { return p.name; }" }] } }),
+        ).toBe(false);
+    });
+
+    it("refuses an annotation that carries script text", () => {
+        expect(
+            parses({ composition: { ...scatterComposition(), annotations: [{ kind: "reference-line", axis: "y", value: 1, formatter: "(v) => v" }] } }),
+        ).toBe(false);
+    });
+});
+
+describe("the exclusivity of the two paths", () => {
+    it("takes the quick path alone", () => {
+        expect(parses({ chartType: "bar", encoding: { x: "pathway", y: "nes" } })).toBe(true);
+    });
+
+    it("takes the composition alone", () => {
+        expect(parses({ composition: scatterComposition() })).toBe(true);
+    });
+
+    it("refuses a chart type with an encoding and a composition together", () => {
+        expect(parses({ chartType: "bar", encoding: { x: "pathway", y: "nes" }, composition: scatterComposition() })).toBe(false);
+    });
+
+    it("refuses a chart type and a composition together, with no encoding", () => {
+        expect(parses({ chartType: "bar", composition: scatterComposition() })).toBe(false);
+    });
+
+    it("refuses an encoding and a composition together, with no chart type", () => {
+        expect(parses({ encoding: { x: "pathway", y: "nes" }, composition: scatterComposition() })).toBe(false);
+    });
+
+    it("refuses a chart type with no encoding", () => {
+        expect(parses({ chartType: "bar" })).toBe(false);
+    });
+
+    it("refuses an encoding with no chart type", () => {
+        expect(parses({ encoding: { x: "pathway", y: "nes" } })).toBe(false);
+    });
+
+    it("refuses a block that carries neither path", () => {
+        expect(parses({})).toBe(false);
+    });
+});

--- a/harness/src/contracts/report-blocks.ts
+++ b/harness/src/contracts/report-blocks.ts
@@ -23,15 +23,116 @@ import {
     ScalarReferenceSchema,
 } from "./report-reference.js";
 
-/** The chart vocabulary. Each value names one plot form. */
-const ChartTypeSchema = z.enum(["bar", "line", "scatter", "histogram", "box", "heatmap", "pie"]);
+/**
+ * The chart vocabulary. The first seven values name one plot form each. The last four are presets of a
+ * scientific plot, and the renderer expands a preset into a composition.
+ */
+const ChartTypeSchema = z.enum(["bar", "line", "scatter", "histogram", "box", "heatmap", "pie", "volcano", "manhattan", "ma", "km"]);
+
+/** The per-row transforms of a channel. Each derived value comes from one cell. */
+const ChartTransformSchema = z.enum(["log10", "neg_log10", "abs", "rank"]);
+
+/**
+ * One visual channel: a column name, or a column with a per-row transform.
+ *
+ * The object form carries a column and a transform, and it carries no value. Thus a channel can never
+ * bring a data literal into the chart option.
+ */
+export const ChartChannelSchema = z.union([
+    z.string().describe("The column that feeds the channel."),
+    z.strictObject({
+        column: z.string().describe("The column that feeds the channel."),
+        transform: ChartTransformSchema.describe(
+            "The per-row transform. `log10` and `neg_log10` drop a cell that is not positive. `rank` gives the place of the cell in the ascending order of the column, and a tie shares its place.",
+        ),
+    }),
+]);
 
 /** The mapping from a data column to a visual channel. Each channel is optional. */
 const ChartEncodingSchema = z.strictObject({
-    x: z.string().optional().describe("The column on the x axis."),
-    y: z.string().optional().describe("The column on the y axis."),
-    group: z.string().optional().describe("The column that splits and colors the series."),
-    value: z.string().optional().describe("The value column for a pie or heatmap."),
+    x: ChartChannelSchema.optional().describe("The channel on the x axis."),
+    y: ChartChannelSchema.optional().describe("The channel on the y axis."),
+    group: ChartChannelSchema.optional().describe("The column that splits and colors the series."),
+    value: ChartChannelSchema.optional().describe("The value column for a pie or heatmap."),
+    label: z.string().optional().describe("The column that names each point. The name rides the tooltip of a bar, a line, and a scatter."),
+});
+
+/** The channels of one series. A series plots two channels, thus `x` and `y` are both present. */
+const ChartSeriesEncodingSchema = z.strictObject({
+    x: ChartChannelSchema.describe("The channel on the x axis."),
+    y: ChartChannelSchema.describe("The channel on the y axis."),
+    y0: ChartChannelSchema.optional().describe("The lower bound of a band. It is legal on an `area` series only."),
+    group: ChartChannelSchema.optional().describe("The column that splits the series, one series for each value."),
+    label: z.string().optional().describe("The column that names each point of the series."),
+});
+
+/**
+ * One series of a composition: a plot form, its own channels, and an optional legend name.
+ *
+ * A `step` series is a line with the step flag. An `area` series can name a `y0` lower bound, thus a band
+ * between two columns of one row is expressible. The refine holds `y0` to the one form that draws a band.
+ */
+export const ChartSeriesSchema = z
+    .strictObject({
+        form: z.enum(["line", "scatter", "bar", "area", "step"]).describe("The plot form of the series."),
+        encoding: ChartSeriesEncodingSchema.describe("The columns that feed the series."),
+        name: z.string().optional().describe("The legend name of the series."),
+    })
+    .refine((series) => series.form === "area" || series.encoding.y0 === undefined, {
+        message: "`y0` is legal on an `area` series only.",
+        path: ["encoding", "y0"],
+    });
+
+/** A guide line at one constant on one axis. */
+const ReferenceLineAnnotationSchema = z.strictObject({
+    kind: z.literal("reference-line"),
+    axis: z.enum(["x", "y"]).describe("The axis that the constant sits on."),
+    value: z.number().describe("The constant of the guide line."),
+    label: z.string().optional().describe("The text beside the line."),
+});
+
+/** A guide band between two constants on one axis. */
+const ReferenceBandAnnotationSchema = z.strictObject({
+    kind: z.literal("reference-band"),
+    axis: z.enum(["x", "y"]).describe("The axis that the two constants sit on."),
+    from: z.number().describe("The lower bound of the band."),
+    to: z.number().describe("The upper bound of the band."),
+    label: z.string().optional().describe("The text on the band."),
+});
+
+/** A name beside each point of a declared top-N subset. The subset comes from a rank over one column. */
+const PointLabelsAnnotationSchema = z.strictObject({
+    kind: z.literal("point-labels"),
+    column: z.string().describe("The column that ranks the rows."),
+    order: z.enum(["asc", "desc"]).describe("The direction of the rank."),
+    n: z.number().int().min(1).max(20).describe("How many points carry a name. The maximum is 20."),
+});
+
+/**
+ * One annotation of a composition.
+ *
+ * A reference line and a reference band both carry a declared constant. Such a constant is a guide, and it
+ * is never a plotted value.
+ */
+export const ChartAnnotationSchema = z.discriminatedUnion("kind", [ReferenceLineAnnotationSchema, ReferenceBandAnnotationSchema, PointLabelsAnnotationSchema]);
+
+/** The title and the scale of one axis. */
+const ChartAxisSchema = z.strictObject({
+    title: z.string().optional().describe("The axis title. It replaces the column name."),
+    scale: z.enum(["linear", "log"]).optional().describe("The axis scale."),
+});
+
+/** The two axes of a composition. */
+export const ChartAxesSchema = z.strictObject({
+    x: ChartAxisSchema.optional().describe("The x axis."),
+    y: ChartAxisSchema.optional().describe("The y axis."),
+});
+
+/** The full chart grammar: the series, the annotations, and the axes. Each series reads the one bound table. */
+export const ChartCompositionSchema = z.strictObject({
+    series: z.array(ChartSeriesSchema).min(1).describe("One series at least. Each one reads the bound table."),
+    annotations: z.array(ChartAnnotationSchema).optional().describe("The guide lines, the guide bands, and the point names."),
+    axes: ChartAxesSchema.optional().describe("The axis titles and the axis scales."),
 });
 
 /** Prose with no binding. The absence of a binding field is the rule for this kind. */
@@ -66,16 +167,37 @@ export const TableBlockSchema = z.strictObject({
     caption: z.string().optional(),
 });
 
-/** A whole-table artifact rendered as a chart, with the plot form and the channel mapping. */
-export const ChartBlockSchema = z.strictObject({
-    kind: z.literal("chart"),
-    id: z.string().min(1).describe("The stable identity of the block."),
-    title: z.string().optional(),
-    binding: ArtifactTableReferenceSchema.describe("The whole-table artifact to plot."),
-    chartType: ChartTypeSchema,
-    encoding: ChartEncodingSchema,
-    caption: z.string().optional(),
-});
+/**
+ * A whole-table artifact rendered as a chart.
+ *
+ * The block carries the quick path or the composition, and never both. The quick path is one chart type
+ * with one encoding. The composition holds the series, the annotations, and the axes. The refine makes the
+ * exactly-one rule a parse failure.
+ *
+ * No member of either path carries a data literal, and no member carries script text. Thus every plotted
+ * value comes from the resolved rows of the bound table.
+ */
+export const ChartBlockSchema = z
+    .strictObject({
+        kind: z.literal("chart"),
+        id: z.string().min(1).describe("The stable identity of the block."),
+        title: z.string().optional(),
+        binding: ArtifactTableReferenceSchema.describe("The whole-table artifact to plot."),
+        chartType: ChartTypeSchema.optional().describe(
+            "The quick path. Give `encoding` with it, and omit `composition`. A preset (`volcano`, `manhattan`, `ma`, `km`) reads the same channels, and it applies its own transform and its own guide lines.",
+        ),
+        encoding: ChartEncodingSchema.optional().describe("The channels of the quick path."),
+        composition: ChartCompositionSchema.optional().describe("The full grammar. Omit `chartType` and `encoding` with it."),
+        caption: z.string().optional(),
+    })
+    .refine(
+        (block) => {
+            const quickPath = block.chartType !== undefined && block.encoding !== undefined;
+            const partialQuickPath = block.chartType !== undefined || block.encoding !== undefined;
+            return block.composition !== undefined ? !partialQuickPath : quickPath;
+        },
+        { message: "A chart carries either `chartType` with `encoding`, or `composition`." },
+    );
 
 /** A static image artifact. An image has no per-cell address, thus it is pinned whole-file. */
 export const FigureBlockSchema = z.strictObject({
@@ -153,6 +275,30 @@ export const ReportDocumentSchema = z.strictObject({
     sections: z.array(SectionBlockSchema).min(1).describe("The top-level sections, each with at least one block."),
 });
 
+/**
+ * The column that one channel names.
+ *
+ * A transform rides beside the column and never in place of it, thus the two channel forms name their
+ * column the same way. The walk, the preset expansion, and the derivation all read the name through this
+ * one function.
+ */
+export function channelColumn(channel: ChartChannel): string {
+    return typeof channel === "string" ? channel : channel.column;
+}
+
+/** The transform of one channel, or `undefined` when the channel names a plain column. */
+export function channelTransform(channel: ChartChannel): ChartTransform | undefined {
+    return typeof channel === "string" ? undefined : channel.transform;
+}
+
+export type ChartChannel = z.infer<typeof ChartChannelSchema>;
+export type ChartTransform = z.infer<typeof ChartTransformSchema>;
+export type ChartEncoding = z.infer<typeof ChartEncodingSchema>;
+export type ChartSeries = z.infer<typeof ChartSeriesSchema>;
+export type ChartAnnotation = z.infer<typeof ChartAnnotationSchema>;
+export type ChartAxes = z.infer<typeof ChartAxesSchema>;
+export type ChartComposition = z.infer<typeof ChartCompositionSchema>;
+export type ChartType = z.infer<typeof ChartTypeSchema>;
 export type TextBlock = z.infer<typeof TextBlockSchema>;
 export type ClaimBlock = z.infer<typeof ClaimBlockSchema>;
 export type MetricBlock = z.infer<typeof MetricBlockSchema>;

--- a/harness/src/report-model/block-walk.ts
+++ b/harness/src/report-model/block-walk.ts
@@ -13,7 +13,7 @@
  * which part it needs.
  */
 
-import type { Block } from "../contracts/report-blocks.js";
+import { channelColumn, type Block, type ChartBlock, type ChartChannel } from "../contracts/report-blocks.js";
 import type { Reference } from "../contracts/report-reference.js";
 import type { DraftBlock } from "./draft.js";
 
@@ -23,10 +23,10 @@ export type AnyBlock = Block | DraftBlock;
 /**
  * One reference that the walk met, tied to the block that carries it.
  *
- * `encodingColumns` is present for a `chart` only. A chart names its axes as free strings, thus the names
- * must be matched against the table that the binding resolves to. Nothing else can catch a chart that
- * plots a column which does not exist. The match needs the resolved rows, thus only a value-tier consumer
- * reads this field.
+ * `encodingColumns` is present for a `chart` only. A chart names its columns as free strings, thus the
+ * names must be matched against the table that the binding resolves to. Nothing else can catch a chart
+ * that plots a column which does not exist. The field carries every column that the chart grammar names,
+ * thus the structural tier and the value tier match the same set.
  */
 export interface CollectedReference {
     blockId: string;
@@ -75,6 +75,50 @@ export function numeralWarnings(blockId: string, prose: string): ReportWarning[]
 }
 
 /**
+ * Each column that the grammar of one chart names.
+ *
+ * The quick path names its four channels and its label. A composition names the channels of each series,
+ * the lower bound of a band, the label of each series, and the column of each rank rule. A transform rides
+ * beside its column, thus a transformed channel names the same column as a plain one.
+ *
+ * A name comes back one time, in the order that the grammar states it. Thus a refusal names each absent
+ * column one time.
+ */
+function chartColumns(block: ChartBlock): string[] {
+    const columns: string[] = [];
+    const add = (column: string | undefined): void => {
+        if (column !== undefined && !columns.includes(column)) columns.push(column);
+    };
+    const addChannel = (channel: ChartChannel | undefined): void => {
+        if (channel !== undefined) add(channelColumn(channel));
+    };
+
+    const encoding = block.encoding;
+    if (encoding !== undefined) {
+        addChannel(encoding.x);
+        addChannel(encoding.y);
+        addChannel(encoding.group);
+        addChannel(encoding.value);
+        add(encoding.label);
+    }
+
+    const composition = block.composition;
+    if (composition !== undefined) {
+        for (const series of composition.series) {
+            addChannel(series.encoding.x);
+            addChannel(series.encoding.y);
+            addChannel(series.encoding.y0);
+            addChannel(series.encoding.group);
+            add(series.encoding.label);
+        }
+        for (const annotation of composition.annotations ?? []) {
+            if (annotation.kind === "point-labels") add(annotation.column);
+        }
+    }
+    return columns;
+}
+
+/**
  * Walk a block tree, and report each reference, each repeated id, and each free numeral.
  *
  * An id is what makes a block addressable, thus an amend by id is well defined only while each id belongs
@@ -110,12 +154,9 @@ export function walkBlocks(blocks: readonly AnyBlock[]): BlockWalk {
             case "metric":
                 references.push({ blockId: block.id, reference: block.value });
                 return;
-            case "chart": {
-                const encoding = block.encoding;
-                const encodingColumns = [encoding.x, encoding.y, encoding.group, encoding.value].filter((column) => column !== undefined);
-                references.push({ blockId: block.id, reference: block.binding, encodingColumns });
+            case "chart":
+                references.push({ blockId: block.id, reference: block.binding, encodingColumns: chartColumns(block) });
                 return;
-            }
             case "table":
             case "figure":
             case "citation":

--- a/harness/src/report-model/draft-finish.ts
+++ b/harness/src/report-model/draft-finish.ts
@@ -5,8 +5,9 @@
  * draft one time: the full document schema, the unique ids, and the structural tier over every reference.
  *
  * The finish opens no file, and it reads the snapshot alone. Thus it runs the structural tier only, and
- * the value tier stays in the gate of the report pipeline. The chart encoding-column match needs the rows
- * behind a binding, thus it stays with the value tier.
+ * the value tier stays in the gate of the report pipeline. The structural tier matches the columns of a
+ * chart wherever the snapshot can answer, and the value tier matches them again over the rows that it
+ * reads.
  *
  * The free-numeral scan needs no file, thus the finish runs it and reports each hit as a warning. A
  * warning never makes a draft invalid, and it rides beside the outcome in either case. Without the
@@ -81,7 +82,7 @@ export function finishDraft(draft: DraftDocument, snapshot: ReportSnapshot): Fin
     }
 
     for (const entry of references) {
-        const result = validateReferenceStructure(entry.reference, snapshot);
+        const result = validateReferenceStructure(entry.reference, snapshot, entry.encodingColumns);
         if (result.isErr()) {
             gaps.push({ kind: "unresolved-reference", blockId: entry.blockId, failure: result.error });
         }

--- a/harness/src/report-model/draft-operations.test.ts
+++ b/harness/src/report-model/draft-operations.test.ts
@@ -292,6 +292,40 @@ describe("addBlock", () => {
         expect(draft).toEqual(before);
     });
 
+    // A fixture snapshot carries the rows of its artifacts, thus the structural tier can match a chart
+    // column before the block lands.
+    const rowSnapshot: ReportSnapshot = { artifacts: { [OUTPUT_PATH]: { hash: OUTPUT_HASH, fileType: "output", rows: [{ gene: "TP53", padj: 0.001 }] } } };
+
+    /** A chart block that plots one composition over the rows of the snapshot. */
+    function composedChart(id: string, yColumn: string): DraftBlock {
+        return {
+            kind: "chart",
+            id,
+            binding: tableReference(),
+            composition: { series: [{ form: "scatter", encoding: { x: "gene", y: { column: yColumn, transform: "neg_log10" }, label: "gene" } }] },
+        };
+    }
+
+    it("lands a composition whose every column is a column of the bound table", () => {
+        const draft = baseDraft();
+        const landed = addBlock(draft, { block: composedChart("chart-ok", "padj"), destination: { parentId: "sec-2" } }, rowSnapshot)._unsafeUnwrap();
+
+        expect(landed.sections[1].blocks.map((block) => block.id)).toEqual(["chart-ok"]);
+    });
+
+    it("refuses a composition whose series channel names a column outside the bound table", () => {
+        const draft = baseDraft();
+        const before = structuredClone(draft);
+        const failure = addBlock(draft, { block: composedChart("chart-bad", "invented"), destination: { parentId: "sec-2" } }, rowSnapshot)._unsafeUnwrapErr();
+
+        expect(failure.reason).toBe("unresolved-reference");
+        if (failure.reason === "unresolved-reference") {
+            expect(failure.unresolved[0].reason).toBe("locator-out-of-range");
+            expect(failure.unresolved[0].detail).toContain("invented");
+        }
+        expect(draft).toEqual(before);
+    });
+
     it("lands a reference that names the path alone, and stamps the snapshot hash", () => {
         const draft = baseDraft();
         const landed = addBlock(

--- a/harness/src/report-model/draft-operations.ts
+++ b/harness/src/report-model/draft-operations.ts
@@ -314,7 +314,7 @@ function commit(candidate: DraftDocument, added: DraftBlock | undefined, snapsho
 
     const unresolved: UnresolvedReference[] = [];
     for (const entry of walkBlocks([added]).references) {
-        validateReferenceStructure(entry.reference, snapshot).match(
+        validateReferenceStructure(entry.reference, snapshot, entry.encodingColumns).match(
             () => {},
             (failure) => {
                 unresolved.push(failure);

--- a/harness/src/report-model/structural-validation.test.ts
+++ b/harness/src/report-model/structural-validation.test.ts
@@ -192,6 +192,55 @@ describe("validateReferenceStructure", () => {
         });
     });
 
+    describe("the columns of a chart grammar", () => {
+        // A fixture snapshot carries the rows of its artifacts, thus the tier can answer a column match
+        // from the snapshot alone.
+        const ROWS_PATH = "runs/run-1/step-c/output/de-rows.csv";
+        const ROWS_HASH = `sha256:${"7".repeat(64)}`;
+        const rowSnapshot: ReportSnapshot = {
+            artifacts: {
+                ...snapshot.artifacts,
+                [ROWS_PATH]: { hash: ROWS_HASH, fileType: "output", rows: [{ gene: "TP53", log2FoldChange: 6, padj: 0.001 }] },
+            },
+        };
+
+        /** Validate one chart binding against the named grammar columns. */
+        function columnFailure(columns: string[], reference = tableReference(ROWS_PATH, ROWS_HASH)): UnresolvedReference | undefined {
+            return validateReferenceStructure(reference, rowSnapshot, columns).match(
+                () => undefined,
+                (failure) => failure,
+            );
+        }
+
+        it("passes a composition whose every column is a column of the bound table", () => {
+            expect(columnFailure(["gene", "log2FoldChange", "padj"])).toBeUndefined();
+        });
+
+        it("refuses a column that the bound table does not hold", () => {
+            const failure = columnFailure(["log2FoldChange", "invented"]);
+            expect(failure?.reason).toBe("locator-out-of-range");
+            expect(failure?.detail).toContain("invented");
+        });
+
+        it("refuses a column that the declared column subset leaves out", () => {
+            const projection = { ...tableReference(ROWS_PATH, ROWS_HASH), columns: ["gene"] };
+            const failure = columnFailure(["gene", "padj"], projection);
+            expect(failure?.reason).toBe("locator-out-of-range");
+            expect(failure?.detail).toContain("padj");
+        });
+
+        it("passes each column against a snapshot that pins identity and holds no row", () => {
+            // A production snapshot carries no row. It contradicts no name, thus the value tier settles the
+            // match over the artifact that it reads.
+            expect(columnFailure(["invented"], tableReference(OUTPUT_PATH, OUTPUT_HASH))).toBeUndefined();
+        });
+
+        it("refuses a bad pin before it looks at one column", () => {
+            const failure = columnFailure(["invented"], tableReference(ROWS_PATH, WRONG_HASH));
+            expect(failure?.reason).toBe("hash-mismatch");
+        });
+    });
+
     describe("the read of a file", () => {
         it("passes a sound reference whose path holds no file on disk", () => {
             // The path is under a run directory that nothing ever made, thus a read of it must fail. The

--- a/harness/src/report-model/structural-validation.ts
+++ b/harness/src/report-model/structural-validation.ts
@@ -18,7 +18,7 @@ import type {
     UnresolvedReason,
     UnresolvedReference,
 } from "../contracts/report-reference.js";
-import { fileTypeHoldsNoCell, snapshotEntry, type ReportSnapshot } from "./reference-resolver.js";
+import { columnsHeldByNoRow, fileTypeHoldsNoCell, snapshotEntry, type ReportSnapshot } from "./reference-resolver.js";
 
 /** The three reference kinds that name one artifact directly. Each one carries the artifact pin fields. */
 type PinnedReference = ArtifactValueReference | ArtifactTableReference | ArtifactFileReference;
@@ -51,18 +51,52 @@ function validatePin(reference: PinnedReference, snapshot: ReportSnapshot): Resu
 }
 
 /**
+ * Match each column that a chart grammar names against the table that the block binds.
+ *
+ * The tier reads the snapshot alone, thus it answers from the two things that the snapshot holds. A table
+ * reference that declares a column subset answers on its own terms, because a name outside the subset
+ * addresses nothing. A snapshot entry that carries rows answers from those rows.
+ *
+ * A snapshot that pins identity alone holds no rows. Such a snapshot contradicts no name, thus the tier
+ * passes and the value tier settles the match over the artifact that it reads.
+ */
+function validateColumns(reference: ArtifactTableReference, snapshot: ReportSnapshot, columns: readonly string[]): Result<void, UnresolvedReference> {
+    const subset = reference.columns;
+    if (subset !== undefined) {
+        const outside = columns.filter((column) => !subset.includes(column));
+        if (outside.length > 0) {
+            return fail(reference, "locator-out-of-range", `the chart names column ${outside.join(", ")}, which the bound column subset leaves out`);
+        }
+    }
+    const absent = columnsHeldByNoRow(snapshotEntry(snapshot, reference.path)?.rows ?? [], columns);
+    if (absent.length > 0) {
+        return fail(reference, "locator-out-of-range", `the chart names column ${absent.join(", ")}, which the bound table does not hold`);
+    }
+    return ok();
+}
+
+/**
  * Validate one reference against the snapshot.
  *
  * The `Ok` channel carries no value. The tier answers membership, identity, and the file type, and a
  * value comes from a read of the artifact. An `assert` is the authored belief about that value, thus this
  * tier matches no assertion and a reference that carries one passes on its pin alone.
  *
+ * `columns` carries each column that the grammar of a chart block names. The walk collects them, thus a
+ * chart that plots an invented column refuses before it lands, wherever the snapshot can answer.
+ *
  * The answer is synchronous, because the snapshot is already in memory.
  */
-export function validateReferenceStructure(reference: Reference, snapshot: ReportSnapshot): Result<void, UnresolvedReference> {
+export function validateReferenceStructure(reference: Reference, snapshot: ReportSnapshot, columns?: readonly string[]): Result<void, UnresolvedReference> {
     switch (reference.kind) {
+        case "artifact-table": {
+            const pin = validatePin(reference, snapshot);
+            if (pin.isErr() || columns === undefined || columns.length === 0) {
+                return pin;
+            }
+            return validateColumns(reference, snapshot, columns);
+        }
         case "artifact-value":
-        case "artifact-table":
         case "artifact-file":
             return validatePin(reference, snapshot);
         case "derivation": {

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import type { Block, ReportDocument } from "../contracts/report-blocks.js";
+import type { Block, ChartComposition, ReportDocument } from "../contracts/report-blocks.js";
 import { parseReference, serializeReference, type Reference } from "../contracts/report-reference.js";
 import { valuesMatch } from "./assert-rules.js";
 import { createFixtureResolver } from "./fixture-resolver.js";
@@ -807,6 +807,53 @@ describe("validateReport — a chart encoding", () => {
 
     it("validates an encoding with no channel at all", async () => {
         expectValid(await validateReport(reportWith(chartWith("chart-bare", {})), snapshot, resolver));
+    });
+});
+
+describe("validateReport — a chart composition", () => {
+    /** Bind a composition to table B, whose rows hold `sample` and `value`. */
+    function compositionChart(id: string, composition: ChartComposition): Block {
+        return { kind: "chart", id, binding: { kind: "artifact-table", run: "run-1", path: TABLE_B_PATH, hash: TABLE_B_HASH }, composition };
+    }
+
+    it("validates a composition whose every column is a real column", async () => {
+        const result = await validateReport(
+            reportWith(
+                compositionChart("chart-composed", {
+                    series: [
+                        { form: "line", encoding: { x: "sample", y: "value", label: "sample" } },
+                        { form: "area", encoding: { x: "sample", y: "value", y0: "value", group: "sample" } },
+                    ],
+                    annotations: [{ kind: "point-labels", column: "value", order: "desc", n: 3 }],
+                }),
+            ),
+            snapshot,
+            resolver,
+        );
+        expectValid(result);
+    });
+
+    it("names an invented column in a series channel, in a transform, in `y0`, in a label, and in a rank rule", async () => {
+        const invalid = expectInvalid(
+            await validateReport(
+                reportWith(
+                    compositionChart("chart-invented-grammar", {
+                        series: [
+                            { form: "scatter", encoding: { x: "nope-x", y: { column: "nope-transform", transform: "neg_log10" }, label: "nope-label" } },
+                            { form: "area", encoding: { x: "sample", y: "value", y0: "nope-y0" } },
+                        ],
+                        annotations: [{ kind: "point-labels", column: "nope-rank", order: "asc", n: 5 }],
+                    }),
+                ),
+                snapshot,
+                resolver,
+            ),
+        );
+        const detail = (invalid.resolutionFailures ?? [])[0].failure.detail ?? "";
+        expect((invalid.resolutionFailures ?? [])[0].failure.reason).toBe("locator-out-of-range");
+        for (const name of ["nope-x", "nope-transform", "nope-label", "nope-y0", "nope-rank"]) {
+            expect(detail).toContain(name);
+        }
     });
 });
 

--- a/harness/src/report-render/chart-presets.ts
+++ b/harness/src/report-render/chart-presets.ts
@@ -12,7 +12,15 @@
  * channel and it drops an authored transform there, and no value takes the transform two times.
  */
 
-import { channelColumn, type ChartChannel, type ChartComposition, type ChartEncoding, type ChartType } from "../contracts/report-blocks.js";
+import {
+    channelColumn,
+    channelTransform,
+    type ChartAxes,
+    type ChartChannel,
+    type ChartComposition,
+    type ChartEncoding,
+    type ChartType,
+} from "../contracts/report-blocks.js";
 
 /** The four chart types that expand into a composition. */
 export const PRESET_CHART_TYPES = ["volcano", "manhattan", "ma", "km"] as const;
@@ -79,7 +87,7 @@ function volcano(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): Cha
             { kind: "reference-line", axis: "x", value: -VOLCANO_EFFECT_THRESHOLD },
             { kind: "reference-line", axis: "x", value: VOLCANO_EFFECT_THRESHOLD },
         ],
-        axes: { x: { title: channelColumn(x) }, y: { title: `-log10 ${pColumn}` } },
+        axes: plainTitle(x),
     };
 }
 
@@ -94,7 +102,7 @@ function manhattan(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): C
             },
         ],
         annotations: [{ kind: "reference-line", axis: "y", value: -Math.log10(MANHATTAN_P_THRESHOLD), label: `p ${MANHATTAN_P_THRESHOLD}` }],
-        axes: { x: { title: channelColumn(x) }, y: { title: `-log10 ${pColumn}` } },
+        axes: plainTitle(x),
     };
 }
 
@@ -117,6 +125,18 @@ function km(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartCom
     return {
         series: [{ form: "step", encoding: { x, y, ...optionalChannels(encoding) } }],
     };
+}
+
+/**
+ * The x title of a preset.
+ *
+ * A preset titles the x axis with the column that feeds it. A channel that carries a transform plots a
+ * derived quantity, thus the column name would state the wrong one. Such a channel takes no title, and the
+ * derived name of the renderer states the true quantity. The y axis of a preset that transforms its p
+ * column takes no title for the same reason.
+ */
+function plainTitle(x: ChartChannel): ChartAxes {
+    return channelTransform(x) === undefined ? { x: { title: channelColumn(x) } } : {};
 }
 
 /** The two optional channels that every preset carries through from the quick-path encoding. */

--- a/harness/src/report-render/chart-presets.ts
+++ b/harness/src/report-render/chart-presets.ts
@@ -1,0 +1,128 @@
+/**
+ * The preset expansion of the chart grammar.
+ *
+ * A preset is sugar over the composition. `expandPreset` gives the composition of one preset, thus the
+ * derivation reads one shape and the two paths cannot drift.
+ *
+ * Each default of a preset is a declared constant of this module. A guide line carries such a constant,
+ * and a guide is never a plotted value. The expansion estimates nothing: the `km` preset plots the
+ * precomputed survival columns as they are, and it fits no survival curve.
+ *
+ * A preset declares its own transform on the channel that it transforms. Thus it reads the column of that
+ * channel and it drops an authored transform there, and no value takes the transform two times.
+ */
+
+import { channelColumn, type ChartChannel, type ChartComposition, type ChartEncoding, type ChartType } from "../contracts/report-blocks.js";
+
+/** The four chart types that expand into a composition. */
+export const PRESET_CHART_TYPES = ["volcano", "manhattan", "ma", "km"] as const;
+
+/** One chart type that expands into a composition. */
+export type PresetChartType = (typeof PRESET_CHART_TYPES)[number];
+
+/** The p-value threshold of a volcano. The guide line sits at the transformed value of it. */
+export const VOLCANO_P_THRESHOLD = 0.05;
+
+/** The effect threshold of a volcano. One guide line sits at each side of zero. */
+export const VOLCANO_EFFECT_THRESHOLD = 1;
+
+/** The genome-wide significance threshold of a Manhattan plot. */
+export const MANHATTAN_P_THRESHOLD = 5e-8;
+
+/** The baseline of an MA plot. A point above it rose, and a point below it fell. */
+export const MA_BASELINE = 0;
+
+/** True when the chart type expands into a composition. */
+export function isPresetChartType(chartType: ChartType): chartType is PresetChartType {
+    // The array holds the four preset members, thus the test never reads a base type as a preset.
+    return (PRESET_CHART_TYPES as readonly string[]).includes(chartType);
+}
+
+/**
+ * Expand one preset into a composition.
+ *
+ * `x` and `y` are the two channels that every preset demands. The caller resolves them from the encoding
+ * and refuses an absent one, thus this function is total and it needs no failure channel. `encoding`
+ * supplies the optional `group` and `label` channels.
+ */
+export function expandPreset(preset: PresetChartType, x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartComposition {
+    switch (preset) {
+        case "volcano":
+            return volcano(x, y, encoding);
+        case "manhattan":
+            return manhattan(x, y, encoding);
+        case "ma":
+            return ma(x, y, encoding);
+        case "km":
+            return km(x, y, encoding);
+    }
+}
+
+/**
+ * The effect on x, the transformed p-value on y, and three guide lines.
+ *
+ * The two effect guides sit at each side of zero, and the p guide sits at the transformed threshold. The
+ * expression of the guide is the expression of the `neg_log10` transform, thus the guide and the points
+ * share one scale.
+ */
+function volcano(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartComposition {
+    const pColumn = channelColumn(y);
+    return {
+        series: [
+            {
+                form: "scatter",
+                encoding: { x, y: { column: pColumn, transform: "neg_log10" }, ...optionalChannels(encoding) },
+            },
+        ],
+        annotations: [
+            { kind: "reference-line", axis: "y", value: -Math.log10(VOLCANO_P_THRESHOLD), label: `p ${VOLCANO_P_THRESHOLD}` },
+            { kind: "reference-line", axis: "x", value: -VOLCANO_EFFECT_THRESHOLD },
+            { kind: "reference-line", axis: "x", value: VOLCANO_EFFECT_THRESHOLD },
+        ],
+        axes: { x: { title: channelColumn(x) }, y: { title: `-log10 ${pColumn}` } },
+    };
+}
+
+/** The genome position on x, the transformed p-value on y, and the genome-wide guide line. */
+function manhattan(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartComposition {
+    const pColumn = channelColumn(y);
+    return {
+        series: [
+            {
+                form: "scatter",
+                encoding: { x, y: { column: pColumn, transform: "neg_log10" }, ...optionalChannels(encoding) },
+            },
+        ],
+        annotations: [{ kind: "reference-line", axis: "y", value: -Math.log10(MANHATTAN_P_THRESHOLD), label: `p ${MANHATTAN_P_THRESHOLD}` }],
+        axes: { x: { title: channelColumn(x) }, y: { title: `-log10 ${pColumn}` } },
+    };
+}
+
+/** The mean level on x, the effect on y, and the baseline guide line. */
+function ma(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartComposition {
+    return {
+        series: [{ form: "scatter", encoding: { x, y, ...optionalChannels(encoding) } }],
+        annotations: [{ kind: "reference-line", axis: "y", value: MA_BASELINE }],
+    };
+}
+
+/**
+ * The time on x and the precomputed survival on y, as one step series for each arm.
+ *
+ * A survival curve holds its value between two events, thus the step form is the honest one. The quick
+ * path carries two channels for the two axes and no channel for a confidence bound. Thus a band around a
+ * curve is a composition, where an `area` series names the upper bound on `y` and the lower bound on `y0`.
+ */
+function km(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartComposition {
+    return {
+        series: [{ form: "step", encoding: { x, y, ...optionalChannels(encoding) } }],
+    };
+}
+
+/** The two optional channels that every preset carries through from the quick-path encoding. */
+function optionalChannels(encoding: ChartEncoding): { group?: ChartChannel; label?: string } {
+    return {
+        ...(encoding.group !== undefined ? { group: encoding.group } : {}),
+        ...(encoding.label !== undefined ? { label: encoding.label } : {}),
+    };
+}

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -543,6 +543,17 @@ describe("the composition tooltip and the point names", () => {
         expect(asObj(option.tooltip).formatter).toBe("{b}<br/>{a}: {c}");
     });
 
+    it("draws a labeled bar on the axis and the gap of the base bar rule", () => {
+        const barRows: ChartRow[] = [
+            { day: "Mon", count: 5 },
+            { day: "Tue", count: 7 },
+        ];
+        const base = derive(chartBlock("bar", { x: "day", y: "count" }), barRows);
+        const labeled = derive(chartBlock("bar", { x: "day", y: "count", label: "day" }), barRows);
+        expect(labeled.xAxis).toEqual(base.xAxis);
+        expect(asObj(asArr(labeled.series)[0]).barGap).toBe(asObj(asArr(base.series)[0]).barGap);
+    });
+
     it("refuses a label on a chart that draws no point for one row", () => {
         const problem = deriveChartOption(chartBlock("histogram", { x: "lfc", label: "gene" }, { id: "h1" }), rows)._unsafeUnwrapErr();
         expect(problem.detail).toContain("label");
@@ -617,6 +628,26 @@ describe("the composition annotations", () => {
         expect(json).not.toContain("=>");
     });
 
+    it("marks the smallest cell of a text p-value column", () => {
+        const textRows: ChartRow[] = [
+            { gene: "A", lfc: 1, p: "1e-3" },
+            { gene: "B", lfc: 2, p: "9e-9" },
+            { gene: "C", lfc: 3, p: "2e-4" },
+        ];
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "lfc", label: "gene" } }],
+                annotations: [{ kind: "point-labels", column: "p", order: "asc", n: 1 }],
+            }),
+            textRows,
+        );
+        // A code-unit order would put "1e-3" first, which is the largest of the three p-values.
+        const data = asArr(asObj(asArr(option.series)[0]).data);
+        expect(asObj(data[1]).label).toEqual({ show: true, formatter: "{b}" });
+        expect("label" in asObj(data[0])).toBe(false);
+        expect("label" in asObj(data[2])).toBe(false);
+    });
+
     it("refuses a rank column that no row holds", () => {
         const block = composedBlock(
             {
@@ -653,6 +684,19 @@ describe("the area band", () => {
         expect(asObj(asObj(series[1]).areaStyle).opacity).toBe(0.25);
     });
 
+    it("refuses a band whose lower bound is over its upper bound", () => {
+        const inverted: ChartRow[] = [
+            { t: 1, lo: 2, hi: 5 },
+            { t: 2, lo: 7, hi: 3 },
+        ];
+        const block = composedBlock({ series: [{ form: "area", encoding: { x: "t", y: "hi", y0: "lo" } }] }, { id: "cb" });
+        const problem = deriveChartOption(block, inverted)._unsafeUnwrapErr();
+        expect(problem.kind).toBe("invalid-chart-input");
+        expect(problem.blockId).toBe("cb");
+        expect(problem.detail).toContain("hi");
+        expect(problem.detail).toContain("lo");
+    });
+
     it("draws a plain filled line for an area series with no lower bound", () => {
         const option = derive(composedBlock({ series: [{ form: "area", encoding: { x: "t", y: "hi" } }] }), rows);
         const series = asArr(option.series);
@@ -678,7 +722,30 @@ describe("the preset expansion", () => {
             { xAxis: VOLCANO_EFFECT_THRESHOLD },
         ]);
         expect(asObj(option.xAxis).name).toBe("lfc");
-        expect(asObj(option.yAxis).name).toBe("-log10 p");
+        // The y channel carries the transform, thus the derived name states the plotted quantity.
+        expect(asObj(option.yAxis).name).toBe("neg_log10(p)");
+    });
+
+    it("gives no x title to a preset channel that carries a transform", () => {
+        const option = derive(chartBlock("volcano", { x: { column: "lfc", transform: "abs" }, y: "p" }), rows);
+        expect(asObj(option.xAxis).name).toBe("abs(lfc)");
+    });
+
+    it("orders the survival steps by the number of a text time column", () => {
+        const timeRows: ChartRow[] = [
+            { time: "2", survival: "0.8" },
+            { time: "10", survival: "0.5" },
+            { time: "1", survival: "0.9" },
+            { time: "11", survival: "0.4" },
+        ];
+        const option = derive(chartBlock("km", { x: "time", y: "survival" }), timeRows);
+        // A CSV gives each cell as text. A code-unit order would put "10" between "1" and "2".
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            ["1", "0.9"],
+            ["2", "0.8"],
+            ["10", "0.5"],
+            ["11", "0.4"],
+        ]);
     });
 
     it("derives a manhattan with the genome-wide guide line and one series per chromosome", () => {
@@ -738,6 +805,27 @@ describe("the quick-path transform", () => {
         const rows: ChartRow[] = [{ g: "A", v: 100 }];
         const problem = deriveChartOption(chartBlock("bar", { x: "g", y: { column: "invented", transform: "log10" } }, { id: "q1" }), rows)._unsafeUnwrapErr();
         expect(problem.detail).toContain("invented");
+    });
+
+    it("refuses a derived name that the bound table already holds", () => {
+        // The derived column goes into a copy of each row. A write over a real column of the table would
+        // plot the wrong cells under the right name.
+        const rows: ChartRow[] = [{ g: "A", v: 100, "log10(v)": 7 }];
+        const problem = deriveChartOption(chartBlock("bar", { x: "g", y: { column: "v", transform: "log10" } }, { id: "q2" }), rows)._unsafeUnwrapErr();
+        expect(problem.kind).toBe("invalid-chart-input");
+        expect(problem.detail).toContain("log10(v)");
+    });
+});
+
+describe("the composition guards", () => {
+    it("refuses a composition that carries no series", () => {
+        // The schema holds a composition to one series at least, thus the cast is the only way to reach the
+        // guard that protects the axes of the derivation.
+        const empty = { series: [] } as unknown as ChartComposition;
+        const problem = deriveChartOption(composedBlock(empty, { id: "ce" }), [{ t: 1 }])._unsafeUnwrapErr();
+        expect(problem.kind).toBe("invalid-chart-input");
+        expect(problem.blockId).toBe("ce");
+        expect(problem.detail).toContain("no series");
     });
 });
 

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "bun:test";
 
-import type { ChartBlock } from "../contracts/report-blocks.js";
+import type { ChartBlock, ChartComposition } from "../contracts/report-blocks.js";
 import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption, type ChartRow, type EchartOption } from "./chart.js";
+import { MANHATTAN_P_THRESHOLD, VOLCANO_EFFECT_THRESHOLD, VOLCANO_P_THRESHOLD } from "./chart-presets.js";
 import { DESIGN_CSS } from "./design.js";
 
-type Encoding = ChartBlock["encoding"];
-type ChartType = ChartBlock["chartType"];
+type Encoding = NonNullable<ChartBlock["encoding"]>;
+type ChartType = NonNullable<ChartBlock["chartType"]>;
 
 /** Build a chart block with a placeholder binding. The renderer never reads the binding. */
 function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: string; title?: string; caption?: string } = {}): ChartBlock {
@@ -18,6 +19,17 @@ function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: stri
         encoding,
         ...(extra.title !== undefined ? { title: extra.title } : {}),
         ...(extra.caption !== undefined ? { caption: extra.caption } : {}),
+    };
+}
+
+/** Build a chart block that carries one composition. The renderer never reads the binding. */
+function composedBlock(composition: ChartComposition, extra: { id?: string; title?: string } = {}): ChartBlock {
+    return {
+        kind: "chart",
+        id: extra.id ?? "c1",
+        binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00" },
+        composition,
+        ...(extra.title !== undefined ? { title: extra.title } : {}),
     };
 }
 
@@ -344,6 +356,388 @@ describe("the axis name placement", () => {
         const xAxis = asObj(derive(chartBlock("histogram", { x: "n" }), [{ n: 1 }, { n: 2 }]).xAxis);
         expect("name" in xAxis).toBe(false);
         expect("nameLocation" in xAxis).toBe(false);
+    });
+});
+
+describe("the composition derivation", () => {
+    const rows: ChartRow[] = [
+        { t: 1, hi: 5, lo: 2, arm: "A", gene: "CA9" },
+        { t: 2, hi: 7, lo: 3, arm: "A", gene: "TP53" },
+        { t: 1, hi: 4, lo: 1, arm: "B", gene: "VEGFA" },
+    ];
+
+    it("gives one runtime series for each declared series", () => {
+        const option = derive(
+            composedBlock({
+                series: [
+                    { form: "line", encoding: { x: "t", y: "hi" }, name: "Upper" },
+                    { form: "bar", encoding: { x: "t", y: "lo" }, name: "Lower" },
+                ],
+            }),
+            rows,
+        );
+        const series = asArr(option.series);
+        expect(series.length).toBe(2);
+        expect(asObj(series[0]).type).toBe("line");
+        expect(asObj(series[0]).name).toBe("Upper");
+        expect(asObj(series[1]).type).toBe("bar");
+        expect(asObj(series[1]).name).toBe("Lower");
+    });
+
+    it("gives one runtime series for each group value, in first-appearance order", () => {
+        const option = derive(composedBlock({ series: [{ form: "step", encoding: { x: "t", y: "hi", group: "arm" } }] }), rows);
+        const series = asArr(option.series);
+        expect(series.map((entry) => asObj(entry).name)).toEqual(["A", "B"]);
+        expect(asObj(series[0]).data).toEqual([
+            [1, 5],
+            [2, 7],
+        ]);
+    });
+
+    it("emits the step flag for a step series", () => {
+        const series = asObj(asArr(derive(composedBlock({ series: [{ form: "step", encoding: { x: "t", y: "hi" } }] }), rows).series)[0]);
+        expect(series.type).toBe("line");
+        expect(series.step).toBe("end");
+    });
+
+    it("sorts a line by x, and keeps the row order of a bar", () => {
+        const unsorted: ChartRow[] = [
+            { t: 3, v: 30 },
+            { t: 1, v: 10 },
+            { t: 2, v: 20 },
+        ];
+        const line = derive(composedBlock({ series: [{ form: "line", encoding: { x: "t", y: "v" } }] }), unsorted);
+        const bar = derive(composedBlock({ series: [{ form: "bar", encoding: { x: "t", y: "v" } }] }), unsorted);
+        expect(asObj(asArr(line.series)[0]).data).toEqual([
+            [1, 10],
+            [2, 20],
+            [3, 30],
+        ]);
+        expect(asObj(asArr(bar.series)[0]).data).toEqual([
+            [3, 30],
+            [1, 10],
+            [2, 20],
+        ]);
+    });
+
+    it("names the axes from the channels, and takes a declared title and scale", () => {
+        const bare = derive(composedBlock({ series: [{ form: "line", encoding: { x: "t", y: "hi" } }] }), rows);
+        expect(asObj(bare.xAxis).name).toBe("t");
+        expect(asObj(bare.yAxis).name).toBe("hi");
+
+        const titled = derive(
+            composedBlock({
+                series: [{ form: "line", encoding: { x: "t", y: "hi" } }],
+                axes: { x: { title: "Months" }, y: { title: "Level", scale: "log" } },
+            }),
+            rows,
+        );
+        expect(asObj(titled.xAxis).name).toBe("Months");
+        expect(asObj(titled.yAxis).name).toBe("Level");
+        expect(asObj(titled.yAxis).type).toBe("log");
+    });
+
+    it("refuses a series channel that names a column no row holds", () => {
+        const block = composedBlock({ series: [{ form: "line", encoding: { x: "t", y: "invented" } }] }, { id: "cx" });
+        const problem = deriveChartOption(block, rows)._unsafeUnwrapErr();
+        expect(problem.kind).toBe("invalid-chart-input");
+        expect(problem.blockId).toBe("cx");
+        expect(problem.detail).toContain("invented");
+    });
+
+    it("gives the larger hit radius to a dense scatter", () => {
+        const sparse: ChartRow[] = Array.from({ length: 10 }, (_entry, index) => ({ t: index, v: index }));
+        const dense: ChartRow[] = Array.from({ length: 2001 }, (_entry, index) => ({ t: index, v: index }));
+        const block = composedBlock({ series: [{ form: "scatter", encoding: { x: "t", y: "v" } }] });
+        expect("symbolSize" in asObj(asArr(derive(block, sparse).series)[0])).toBe(false);
+        expect(asObj(asArr(derive(block, dense).series)[0]).symbolSize).toBe(12);
+    });
+});
+
+describe("the composition transforms", () => {
+    it("transforms each row, and drops the point that the transform cannot take", () => {
+        const rows: ChartRow[] = [
+            { gene: "A", p: 0.01 },
+            { gene: "B", p: 0 },
+            { gene: "C", p: -1 },
+            { gene: "D", p: "not a number" },
+        ];
+        const option = derive(composedBlock({ series: [{ form: "scatter", encoding: { x: "gene", y: { column: "p", transform: "neg_log10" } } }] }), rows);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([["A", 2]]);
+        // The axis carries the transform, thus it never names the untransformed column.
+        expect(asObj(option.yAxis).name).toBe("neg_log10(p)");
+    });
+
+    it("takes the absolute value of each cell", () => {
+        const rows: ChartRow[] = [
+            { g: "A", v: -3 },
+            { g: "B", v: 4 },
+        ];
+        const option = derive(composedBlock({ series: [{ form: "bar", encoding: { x: "g", y: { column: "v", transform: "abs" } } }] }), rows);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            ["A", 3],
+            ["B", 4],
+        ]);
+    });
+
+    it("ranks a column upward, and a tie shares its place", () => {
+        const rows: ChartRow[] = [
+            { g: "a", v: 30 },
+            { g: "b", v: 10 },
+            { g: "c", v: 20 },
+            { g: "d", v: 20 },
+        ];
+        const option = derive(composedBlock({ series: [{ form: "bar", encoding: { x: "g", y: { column: "v", transform: "rank" } } }] }), rows);
+        // The two ties both take the place 2, thus the next value takes the place 4.
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            ["a", 4],
+            ["b", 1],
+            ["c", 2],
+            ["d", 2],
+        ]);
+    });
+
+    it("derives the same bytes two times over the same rows", () => {
+        const rows: ChartRow[] = [
+            { g: "a", v: 20 },
+            { g: "b", v: 20 },
+            { g: "c", v: 5 },
+        ];
+        const block = composedBlock({
+            series: [{ form: "scatter", encoding: { x: { column: "v", transform: "rank" }, y: { column: "v", transform: "log10" }, label: "g" } }],
+            annotations: [{ kind: "point-labels", column: "v", order: "desc", n: 2 }],
+        });
+        expect(JSON.stringify(derive(block, rows))).toBe(JSON.stringify(derive(block, rows)));
+    });
+});
+
+describe("the composition tooltip and the point names", () => {
+    const rows: ChartRow[] = [
+        { gene: "CA9", lfc: 2.94, padj: 0.001 },
+        { gene: "TP53", lfc: -2.41, padj: 0.02 },
+    ];
+
+    it("puts the label on each data item, and gives a static template formatter", () => {
+        const option = derive(composedBlock({ series: [{ form: "scatter", encoding: { x: "lfc", y: "padj", label: "gene" } }] }), rows);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            { value: [2.94, 0.001], name: "CA9" },
+            { value: [-2.41, 0.02], name: "TP53" },
+        ]);
+        const tooltip = asObj(option.tooltip);
+        expect(tooltip.trigger).toBe("item");
+        expect(typeof tooltip.formatter).toBe("string");
+        expect(tooltip.formatter).toBe("{b}<br/>{a}: {c}");
+    });
+
+    it("gives the plain template when no point carries a name", () => {
+        const option = derive(composedBlock({ series: [{ form: "scatter", encoding: { x: "lfc", y: "padj" } }] }), rows);
+        expect(asObj(option.tooltip).formatter).toBe("{a}: {c}");
+    });
+
+    it("routes a quick-path scatter with a label through the composition", () => {
+        const option = derive(chartBlock("scatter", { x: "lfc", y: "padj", label: "gene" }), rows);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            { value: [2.94, 0.001], name: "CA9" },
+            { value: [-2.41, 0.02], name: "TP53" },
+        ]);
+        expect(asObj(option.tooltip).formatter).toBe("{b}<br/>{a}: {c}");
+    });
+
+    it("refuses a label on a chart that draws no point for one row", () => {
+        const problem = deriveChartOption(chartBlock("histogram", { x: "lfc", label: "gene" }, { id: "h1" }), rows)._unsafeUnwrapErr();
+        expect(problem.detail).toContain("label");
+    });
+});
+
+describe("the composition annotations", () => {
+    const rows: ChartRow[] = [
+        { gene: "CA9", lfc: 2.94, score: 9 },
+        { gene: "TP53", lfc: -2.41, score: 5 },
+        { gene: "VEGFA", lfc: 1.1, score: 7 },
+    ];
+
+    it("puts a reference line and a reference band on the first series as static mark data", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "score" } }],
+                annotations: [
+                    { kind: "reference-line", axis: "y", value: 6, label: "cut" },
+                    { kind: "reference-band", axis: "x", from: -1, to: 1 },
+                ],
+            }),
+            rows,
+        );
+        const series = asObj(asArr(option.series)[0]);
+        expect(asObj(series.markLine).silent).toBe(true);
+        expect(asArr(asObj(series.markLine).data)).toEqual([{ yAxis: 6, label: { formatter: "cut" } }]);
+        expect(asArr(asObj(series.markArea).data)).toEqual([[{ xAxis: -1 }, { xAxis: 1 }]]);
+    });
+
+    it("names the declared top-N subset alone, and no other point", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "score", label: "gene" } }],
+                annotations: [{ kind: "point-labels", column: "score", order: "desc", n: 1 }],
+            }),
+            rows,
+        );
+        const data = asArr(asObj(asArr(option.series)[0]).data);
+        expect(data[0]).toEqual({ value: [2.94, 9], name: "CA9", label: { show: true, formatter: "{b}" } });
+        expect(data[1]).toEqual({ value: [-2.41, 5], name: "TP53" });
+        expect(data[2]).toEqual({ value: [1.1, 7], name: "VEGFA" });
+    });
+
+    it("names a marked point after the x cell when the series carries no label channel", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "gene", y: "score" } }],
+                annotations: [{ kind: "point-labels", column: "score", order: "asc", n: 1 }],
+            }),
+            rows,
+        );
+        const data = asArr(asObj(asArr(option.series)[0]).data);
+        expect(data[1]).toEqual({ value: ["TP53", 5], name: "TP53", label: { show: true, formatter: "{b}" } });
+        expect(data[0]).toEqual(["CA9", 9]);
+    });
+
+    it("carries no function text into the option", () => {
+        const json = JSON.stringify(
+            derive(
+                composedBlock({
+                    series: [{ form: "scatter", encoding: { x: "lfc", y: "score", label: "gene" } }],
+                    annotations: [
+                        { kind: "reference-line", axis: "y", value: 6 },
+                        { kind: "point-labels", column: "score", order: "asc", n: 2 },
+                    ],
+                }),
+                rows,
+            ),
+        );
+        expect(json).not.toContain("function");
+        expect(json).not.toContain("=>");
+    });
+
+    it("refuses a rank column that no row holds", () => {
+        const block = composedBlock(
+            {
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "score" } }],
+                annotations: [{ kind: "point-labels", column: "invented", order: "asc", n: 2 }],
+            },
+            { id: "cp" },
+        );
+        expect(deriveChartOption(block, rows)._unsafeUnwrapErr().detail).toContain("invented");
+    });
+});
+
+describe("the area band", () => {
+    const rows: ChartRow[] = [
+        { t: 1, lo: 2, hi: 5 },
+        { t: 2, lo: 3, hi: 7 },
+    ];
+
+    it("gives the two stacked series that draw the band between the two columns", () => {
+        const option = derive(composedBlock({ series: [{ form: "area", encoding: { x: "t", y: "hi", y0: "lo" } }] }), rows);
+        const series = asArr(option.series);
+        expect(series.length).toBe(2);
+        // The runtime stacks the band. Thus the lower series carries the `y0` column, and the sum of the
+        // two series at each x is the `y` column.
+        expect(asObj(series[0]).data).toEqual([
+            [1, 2],
+            [2, 3],
+        ]);
+        expect(asObj(series[1]).data).toEqual([
+            [1, 3],
+            [2, 4],
+        ]);
+        expect(asObj(series[0]).stack).toBe(asObj(series[1]).stack);
+        expect(asObj(asObj(series[1]).areaStyle).opacity).toBe(0.25);
+    });
+
+    it("draws a plain filled line for an area series with no lower bound", () => {
+        const option = derive(composedBlock({ series: [{ form: "area", encoding: { x: "t", y: "hi" } }] }), rows);
+        const series = asArr(option.series);
+        expect(series.length).toBe(1);
+        expect(asObj(series[0]).areaStyle).toEqual({});
+    });
+});
+
+describe("the preset expansion", () => {
+    const rows: ChartRow[] = [
+        { gene: "CA9", lfc: 2.94, p: 0.001, position: 10, chrom: "1", mean: 40, time: 1, survival: 0.9, arm: "A" },
+        { gene: "TP53", lfc: -2.41, p: 0.5, position: 20, chrom: "2", mean: 60, time: 2, survival: 0.7, arm: "B" },
+    ];
+
+    it("derives a volcano as a scatter over the effect and the transformed p, with the guide lines", () => {
+        const option = derive(chartBlock("volcano", { x: "lfc", y: "p", label: "gene" }), rows);
+        const series = asObj(asArr(option.series)[0]);
+        expect(series.type).toBe("scatter");
+        expect(asArr(series.data)[0]).toEqual({ value: [2.94, 3], name: "CA9" });
+        expect(asArr(asObj(series.markLine).data)).toEqual([
+            { yAxis: -Math.log10(VOLCANO_P_THRESHOLD), label: { formatter: `p ${VOLCANO_P_THRESHOLD}` } },
+            { xAxis: -VOLCANO_EFFECT_THRESHOLD },
+            { xAxis: VOLCANO_EFFECT_THRESHOLD },
+        ]);
+        expect(asObj(option.xAxis).name).toBe("lfc");
+        expect(asObj(option.yAxis).name).toBe("-log10 p");
+    });
+
+    it("derives a manhattan with the genome-wide guide line and one series per chromosome", () => {
+        const option = derive(chartBlock("manhattan", { x: "position", y: "p", group: "chrom" }), rows);
+        const series = asArr(option.series);
+        expect(series.map((entry) => asObj(entry).name)).toEqual(["1", "2"]);
+        expect(asArr(asObj(asObj(series[0]).markLine).data)).toEqual([
+            { yAxis: -Math.log10(MANHATTAN_P_THRESHOLD), label: { formatter: `p ${MANHATTAN_P_THRESHOLD}` } },
+        ]);
+    });
+
+    it("derives an MA plot with the baseline guide line", () => {
+        const option = derive(chartBlock("ma", { x: "mean", y: "lfc" }), rows);
+        const series = asObj(asArr(option.series)[0]);
+        expect(series.type).toBe("scatter");
+        expect(asArr(series.data)).toEqual([
+            [40, 2.94],
+            [60, -2.41],
+        ]);
+        expect(asArr(asObj(series.markLine).data)).toEqual([{ yAxis: 0 }]);
+    });
+
+    it("derives a survival plot as one step series for each arm, and it estimates nothing", () => {
+        const option = derive(chartBlock("km", { x: "time", y: "survival", group: "arm" }), rows);
+        const series = asArr(option.series);
+        expect(series.map((entry) => asObj(entry).name)).toEqual(["A", "B"]);
+        expect(asObj(series[0]).step).toBe("end");
+        expect(asObj(series[0]).data).toEqual([[1, 0.9]]);
+        expect("markLine" in asObj(series[0])).toBe(false);
+    });
+
+    it("names the missing demanded channel of a preset", () => {
+        const problem = deriveChartOption(chartBlock("volcano", { x: "lfc" }, { id: "v1" }), rows)._unsafeUnwrapErr();
+        expect(problem.detail).toContain("volcano");
+        expect(problem.detail).toContain("y");
+    });
+});
+
+describe("the quick-path transform", () => {
+    it("derives the transformed column, and names the axis after it", () => {
+        const rows: ChartRow[] = [
+            { g: "A", v: 100 },
+            { g: "B", v: 0 },
+            { g: "C", v: 1000 },
+        ];
+        const option = derive(chartBlock("bar", { x: "g", y: { column: "v", transform: "log10" } }), rows);
+        expect(asObj(option.yAxis).name).toBe("log10(v)");
+        // The zero cell takes no logarithm, thus its row drops and no substitute value appears.
+        expect(asObj(option.xAxis).data).toEqual(["A", "C"]);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            ["A", 2],
+            ["C", 3],
+        ]);
+    });
+
+    it("refuses a transform over a column that no row holds", () => {
+        const rows: ChartRow[] = [{ g: "A", v: 100 }];
+        const problem = deriveChartOption(chartBlock("bar", { x: "g", y: { column: "invented", transform: "log10" } }, { id: "q1" }), rows)._unsafeUnwrapErr();
+        expect(problem.detail).toContain("invented");
     });
 });
 

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -1,28 +1,45 @@
 /**
  * The chart derivation of the report page.
  *
- * A chart block binds one whole-table artifact and a channel mapping. `deriveChartOption` turns the
- * chart type, the encoding, and the resolved rows into one ECharts option object. The chart container
- * markup lives beside this file, and it wraps the option that this derivation gives.
+ * A chart block binds one whole-table artifact, and it carries the quick path or the composition.
+ * `deriveChartOption` turns that grammar and the resolved rows into one ECharts option object. The chart
+ * container markup lives beside this file, and it wraps the option that this derivation gives.
+ *
+ * The derivation reads one shape. A preset expands into a composition before the derivation
+ * (`chart-presets.ts`), and each base chart type keeps its own fixed rule. Thus the two paths cannot
+ * drift.
  *
  * The renderer computes no aggregate. Each plotted number stays traceable to one cell of the evidence
- * artifact. A pie or a heatmap arrives one row per category or per cell, thus a repeated category or a
- * repeated pair is a refusal and not a silent sum.
+ * artifact, or to a per-row transform of one cell. A pie or a heatmap arrives one row per category or per
+ * cell, thus a repeated category or a repeated pair is a refusal and not a silent sum.
  *
  * The derivation is deterministic. Every object builds in one fixed key order, and the code reads no
  * clock, no random value, and no locale. A string comparison uses the code-unit order (`<`) and never
  * `localeCompare`, thus the same rows give the same bytes on every host.
  *
- * The option rides to the page as inline JSON. Thus no axis label can carry a function formatter, and a
- * string `axisLabel.formatter` substitutes the value without a round. As a result the derivation bounds the
- * tick precision of the one axis whose unit it declares itself, and every other value axis keeps the tick
- * values that ECharts computes.
+ * The option rides to the page as inline JSON. Thus no axis label and no tooltip can carry a function
+ * formatter, and every formatter here is a static template of the chart runtime. As a result the
+ * derivation bounds the tick precision of the one axis whose unit it declares itself, and every other
+ * value axis keeps the tick values that ECharts computes.
  */
 
 import { err, ok, type Result } from "neverthrow";
 
-import type { ChartBlock } from "../contracts/report-blocks.js";
+import {
+    channelColumn,
+    channelTransform,
+    type ChartAnnotation,
+    type ChartAxes,
+    type ChartBlock,
+    type ChartChannel,
+    type ChartComposition,
+    type ChartEncoding,
+    type ChartSeries,
+    type ChartTransform,
+    type ChartType,
+} from "../contracts/report-blocks.js";
 import { normalizeEchartSpec } from "../tools/display/normalize-echart-spec.js";
+import { expandPreset, isPresetChartType, type PresetChartType } from "./chart-presets.js";
 import type { RenderProblem } from "./types.js";
 
 /** One cell of a resolved row. A cell is one string or one number. */
@@ -36,6 +53,21 @@ export type EchartOption = Record<string, unknown>;
 
 /** The four channels of a chart encoding. Each type demands a subset of them. */
 type Channel = "x" | "y" | "group" | "value";
+
+/** One chart type that carries its own fixed rule. A preset carries no rule, because it expands first. */
+type BaseChartType = Exclude<ChartType, PresetChartType>;
+
+/**
+ * A quick-path block whose channels are resolved to plain column names.
+ *
+ * A transform channel derives its own column into the rows under a name that carries the transform. Thus
+ * each base rule reads one plain column name, and no base rule knows about a transform.
+ */
+interface ResolvedChartBlock {
+    id: string;
+    chartType: BaseChartType;
+    encoding: Partial<Record<Channel, string>>;
+}
 
 /**
  * The ten-stop viridis ramp for a heatmap `visualMap`. The stops run dark to light, thus a continuous
@@ -81,8 +113,37 @@ export function deriveChartOption(block: ChartBlock, rows: readonly ChartRow[], 
     return deriveRaw(block, rows, columns).map((option) => normalizeEchartSpec(option, { title: block.title }));
 }
 
-/** Dispatch to the per-type derivation. Each type holds one fixed rule. */
+/**
+ * Dispatch the grammar of one chart block.
+ *
+ * A composition derives directly. A preset expands into a composition first. A quick path that names a
+ * point routes through a one-series composition, because a base rule builds a bare pair and only a
+ * composition item carries a name. Every other quick path reaches the fixed rule of its base type.
+ */
 function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
+    if (block.composition !== undefined) {
+        return deriveComposition(block.id, block.composition, rows, columns);
+    }
+    const chartType = block.chartType;
+    const encoding = block.encoding;
+    if (chartType === undefined || encoding === undefined) {
+        // The schema refine already makes this shape unrepresentable. The guard states the same rule for a
+        // value that reaches the renderer without a parse.
+        return err(problem(block.id, "The chart carries neither a chart type with an encoding, nor a composition."));
+    }
+    if (isPresetChartType(chartType)) {
+        return derivePreset(block.id, chartType, encoding, rows, columns);
+    }
+    if (encoding.label !== undefined) {
+        return deriveLabeled(block.id, chartType, encoding, rows, columns);
+    }
+    const quick = resolveQuickPath(block.id, chartType, encoding, rows, columns);
+    if (quick.isErr()) return err(quick.error);
+    return deriveBase(quick.value.block, quick.value.rows, columns);
+}
+
+/** Dispatch to the per-type derivation. Each type holds one fixed rule. */
+function deriveBase(block: ResolvedChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
     switch (block.chartType) {
         case "bar":
             return deriveBar(block, rows, columns);
@@ -101,10 +162,130 @@ function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: reado
     }
 }
 
+/** Expand one preset over its two demanded channels, then derive the composition that it gives. */
+function derivePreset(
+    blockId: string,
+    preset: PresetChartType,
+    encoding: ChartEncoding,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<EchartOption, RenderProblem> {
+    const x = requireChannel(blockId, preset, encoding, "x");
+    if (x.isErr()) return err(x.error);
+    const y = requireChannel(blockId, preset, encoding, "y");
+    if (y.isErr()) return err(y.error);
+    return deriveComposition(blockId, expandPreset(preset, x.value, y.value, encoding), rows, columns);
+}
+
+/** The quick-path types that map onto one series form. A point of such a chart can carry a name. */
+const LABELED_FORMS: Partial<Record<BaseChartType, ChartSeries["form"]>> = { bar: "bar", line: "line", scatter: "scatter" };
+
+/**
+ * Derive a quick path that names its points, as a composition of one series.
+ *
+ * A histogram bins its rows, a box summarizes them, and a heatmap and a pie both address a pair or a
+ * category. None of the four draws one point for one row, thus none of them can carry a per-row name.
+ */
+function deriveLabeled(
+    blockId: string,
+    chartType: BaseChartType,
+    encoding: ChartEncoding,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<EchartOption, RenderProblem> {
+    const form = LABELED_FORMS[chartType];
+    if (form === undefined) {
+        return err(problem(blockId, `The ${chartType} chart draws no point for one row, thus it takes no "label" channel.`));
+    }
+    const x = requireChannel(blockId, chartType, encoding, "x");
+    if (x.isErr()) return err(x.error);
+    const y = requireChannel(blockId, chartType, encoding, "y");
+    if (y.isErr()) return err(y.error);
+    const composition: ChartComposition = {
+        series: [
+            {
+                form,
+                encoding: {
+                    x: x.value,
+                    y: y.value,
+                    ...(encoding.group !== undefined ? { group: encoding.group } : {}),
+                    ...(encoding.label !== undefined ? { label: encoding.label } : {}),
+                },
+            },
+        ],
+    };
+    return deriveComposition(blockId, composition, rows, columns);
+}
+
+/**
+ * Resolve the quick path of a base chart type: the plain column of each channel, and the rows that the
+ * base rules read.
+ *
+ * A channel with no transform passes through, and the rows pass through by reference. Thus a chart with
+ * no transform derives the same bytes as before the grammar grew. A channel with a transform derives one
+ * column into a copy of each row, under a name that carries the transform. Thus an axis never names the
+ * untransformed column. A row whose transform gives no value drops, the same as a non-numeric cell.
+ */
+function resolveQuickPath(
+    blockId: string,
+    chartType: BaseChartType,
+    encoding: ChartEncoding,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<{ block: ResolvedChartBlock; rows: readonly ChartRow[] }, RenderProblem> {
+    const resolved: Partial<Record<Channel, string>> = {};
+    const derived: Array<{ column: string; name: string; transform: ChartTransform }> = [];
+    for (const channel of CHANNELS) {
+        const declared = encoding[channel];
+        if (declared === undefined) continue;
+        const column = channelColumn(declared);
+        const transform = channelTransform(declared);
+        if (transform === undefined) {
+            resolved[channel] = column;
+            continue;
+        }
+        if (rows.length > 0 && !columnPresent(column, rows, columns)) {
+            return err(problem(blockId, `The column "${column}" is absent from every row.`));
+        }
+        const name = transformedName(transform, column);
+        resolved[channel] = name;
+        derived.push({ column, name, transform });
+    }
+
+    const block: ResolvedChartBlock = { id: blockId, chartType, encoding: resolved };
+    return ok({ block, rows: derived.length === 0 ? rows : deriveTransformedRows(rows, derived) });
+}
+
+/** The four channels of the quick path, in one fixed order. */
+const CHANNELS: readonly Channel[] = ["x", "y", "group", "value"];
+
+/**
+ * Copy each row with its derived columns beside the source columns. A row that one transform leaves
+ * without a value drops, thus no substitute value ever appears.
+ */
+function deriveTransformedRows(rows: readonly ChartRow[], derived: ReadonlyArray<{ column: string; name: string; transform: ChartTransform }>): ChartRow[] {
+    const values = derived.map((entry) => transformColumn(rows, entry.column, entry.transform));
+    const out: ChartRow[] = [];
+    for (let index = 0; index < rows.length; index += 1) {
+        const next: ChartRow = { ...rows[index] };
+        let complete = true;
+        for (let slot = 0; slot < derived.length; slot += 1) {
+            const value = values[slot][index];
+            if (value === null) {
+                complete = false;
+                break;
+            }
+            next[derived[slot].name] = value;
+        }
+        if (complete) out.push(next);
+    }
+    return out;
+}
+
 // ── The per-type derivations ────────────────────────────────────────────────
 
 /** A category x axis, a value y axis, and one bar series per group with the `[x, y]` pairs. */
-function deriveBar(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const yResult = requireColumn(block, rows, columns, "y");
@@ -128,7 +309,7 @@ function deriveBar(block: ChartBlock, rows: readonly ChartRow[], columns: readon
 }
 
 /** Per-column axis inference, and one line series per group whose data sorts by x. */
-function deriveLine(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveLine(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const yResult = requireColumn(block, rows, columns, "y");
@@ -151,7 +332,7 @@ function deriveLine(block: ChartBlock, rows: readonly ChartRow[], columns: reado
 }
 
 /** The same axis inference as a line chart, with no sort and the large-render flags. */
-function deriveScatter(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveScatter(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const yResult = requireColumn(block, rows, columns, "y");
@@ -175,7 +356,7 @@ function deriveScatter(block: ChartBlock, rows: readonly ChartRow[], columns: re
 }
 
 /** Equal-width bins over the global range. Each group shares the same edges. */
-function deriveHistogram(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveHistogram(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const x = xResult.value;
@@ -217,7 +398,7 @@ function deriveHistogram(block: ChartBlock, rows: readonly ChartRow[], columns: 
 }
 
 /** A five-number summary per category, plus a paired scatter series for the outliers. */
-function deriveBox(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveBox(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const yResult = requireColumn(block, rows, columns, "y");
@@ -273,7 +454,7 @@ function deriveBox(block: ChartBlock, rows: readonly ChartRow[], columns: readon
 }
 
 /** A dense grid over every pair of x and y categories, with a viridis `visualMap`. */
-function deriveHeatmap(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function deriveHeatmap(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
     const yResult = requireColumn(block, rows, columns, "y");
@@ -327,7 +508,7 @@ function deriveHeatmap(block: ChartBlock, rows: readonly ChartRow[], columns: re
 }
 
 /** One slice per group category, in first-appearance order. A repeated category refuses. */
-function derivePie(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
+function derivePie(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const groupResult = requireColumn(block, rows, columns, "group");
     if (groupResult.isErr()) return err(groupResult.error);
     const valueResult = requireColumn(block, rows, columns, "value");
@@ -352,6 +533,441 @@ function derivePie(block: ChartBlock, rows: readonly ChartRow[], columns: readon
     });
 }
 
+// ── The composition derivation ──────────────────────────────────────────────
+
+/** The row count from which a scatter takes the larger hit radius. */
+const DENSE_SCATTER_ROWS = 2000;
+
+/** The symbol size of a dense scatter. The ECharts default is 10, thus a dense point takes one step up. */
+const DENSE_SCATTER_SYMBOL_SIZE = 12;
+
+/** The point count from which the scatter renderer takes its large path. */
+const LARGE_SCATTER_THRESHOLD = 2000;
+
+/** The opacity of the band that an `area` series draws between its two bounds. */
+const BAND_OPACITY = 0.25;
+
+/** The forms whose data runs along the x axis. A line that zigzags states an order that no column holds. */
+const SORTED_FORMS: ReadonlySet<ChartSeries["form"]> = new Set(["line", "area", "step"]);
+
+/**
+ * The tooltip of a composition whose points carry no name.
+ *
+ * `{a}` is the series name, and `{c}` is the value of the item. The text is a static template of the
+ * chart runtime, thus the option carries no function and the inline JSON stays a pure value.
+ */
+const PLAIN_TOOLTIP: EchartOption = { trigger: "item", formatter: "{a}: {c}" };
+
+/** The tooltip of a composition whose points carry a name. `{b}` is the name of the item. */
+const NAMED_TOOLTIP: EchartOption = { trigger: "item", formatter: "{b}<br/>{a}: {c}" };
+
+/** The label of one named point. `{b}` is the name of the item, thus the label needs no function. */
+const POINT_LABEL: EchartOption = { show: true, formatter: "{b}" };
+
+/** One resolved channel: the name that an axis reads, and the value that each row gives. */
+interface ResolvedChannel {
+    name: string;
+    values: readonly (Cell | null)[];
+    transformed: boolean;
+}
+
+/** One resolved series: the declared series, and the channels that it reads. */
+interface ResolvedSeries {
+    declared: ChartSeries;
+    x: ResolvedChannel;
+    y: ResolvedChannel;
+    y0?: ResolvedChannel;
+    group?: ResolvedChannel;
+    label?: readonly (Cell | null)[];
+}
+
+/** One plotted point. `index` names the row that it came from, thus a rank rule can find it again. */
+interface Point {
+    index: number;
+    x: Cell;
+    y: Cell;
+    y0?: Cell;
+}
+
+/** One runtime series, and whether it can carry the mark members of the annotations. */
+interface EmittedSeries {
+    option: EchartOption;
+    carriesMarks: boolean;
+}
+
+/**
+ * Derive one option from a composition.
+ *
+ * Each declared series gives one runtime series for each value of its group column, over the resolved
+ * rows of the one bound table. The annotations ride the first series that draws a column of the table,
+ * because a mark member belongs to a series and one carrier states each guide one time.
+ *
+ * The axes come from the first declared series. A composition plots one pair of axes, thus a later series
+ * shares them.
+ */
+function deriveComposition(
+    blockId: string,
+    composition: ChartComposition,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<EchartOption, RenderProblem> {
+    const resolved: ResolvedSeries[] = [];
+    for (const declared of composition.series) {
+        const series = resolveSeries(blockId, declared, rows, columns);
+        if (series.isErr()) return err(series.error);
+        resolved.push(series.value);
+    }
+
+    const annotations = composition.annotations ?? [];
+    const labeled = pointLabelRows(blockId, annotations, rows, columns);
+    if (labeled.isErr()) return err(labeled.error);
+
+    const dense = rows.length > DENSE_SCATTER_ROWS;
+    const emitted: EmittedSeries[] = [];
+    for (const entry of resolved) {
+        for (const group of splitByChannel(rows, entry.group)) {
+            emitted.push(...buildSeries(entry, group, labeled.value, dense, emitted.length));
+        }
+    }
+
+    const marks = markMembers(annotations);
+    const target = emitted.findIndex((entry) => entry.carriesMarks);
+    if (Object.keys(marks).length > 0 && target >= 0) {
+        emitted[target] = { ...emitted[target], option: { ...emitted[target].option, ...marks } };
+    }
+
+    const first = resolved[0];
+    const named = resolved.some((entry) => entry.label !== undefined) || labeled.value.size > 0;
+    return ok({
+        tooltip: named ? { ...NAMED_TOOLTIP } : { ...PLAIN_TOOLTIP },
+        xAxis: compositionAxis(rows, first.x, "x", composition.axes?.x),
+        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y),
+        series: emitted.map((entry) => entry.option),
+    });
+}
+
+/** Resolve each channel of one declared series against the rows. An absent column is a refusal. */
+function resolveSeries(
+    blockId: string,
+    declared: ChartSeries,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<ResolvedSeries, RenderProblem> {
+    const x = resolveChannel(blockId, declared.encoding.x, rows, columns);
+    if (x.isErr()) return err(x.error);
+    const y = resolveChannel(blockId, declared.encoding.y, rows, columns);
+    if (y.isErr()) return err(y.error);
+    const resolved: ResolvedSeries = { declared, x: x.value, y: y.value };
+
+    const declaredY0 = declared.encoding.y0;
+    if (declaredY0 !== undefined) {
+        const y0 = resolveChannel(blockId, declaredY0, rows, columns);
+        if (y0.isErr()) return err(y0.error);
+        resolved.y0 = y0.value;
+    }
+    const declaredGroup = declared.encoding.group;
+    if (declaredGroup !== undefined) {
+        const group = resolveChannel(blockId, declaredGroup, rows, columns);
+        if (group.isErr()) return err(group.error);
+        resolved.group = group.value;
+    }
+    const labelColumn = declared.encoding.label;
+    if (labelColumn !== undefined) {
+        const absent = requirePresent(blockId, labelColumn, rows, columns);
+        if (absent !== undefined) return err(absent);
+        resolved.label = rows.map((row) => row[labelColumn] ?? null);
+    }
+    return ok(resolved);
+}
+
+/** Resolve one channel: its effective name, and the value that each row gives for it. */
+function resolveChannel(
+    blockId: string,
+    channel: ChartChannel,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<ResolvedChannel, RenderProblem> {
+    const column = channelColumn(channel);
+    const absent = requirePresent(blockId, column, rows, columns);
+    if (absent !== undefined) return err(absent);
+
+    const transform = channelTransform(channel);
+    if (transform === undefined) {
+        return ok({ name: column, values: rows.map((row) => row[column] ?? null), transformed: false });
+    }
+    return ok({ name: transformedName(transform, column), values: transformColumn(rows, column, transform), transformed: true });
+}
+
+/** The refusal for a column that no row holds, or `undefined` when the column is present. */
+function requirePresent(blockId: string, column: string, rows: readonly ChartRow[], columns: readonly string[] | undefined): RenderProblem | undefined {
+    if (rows.length > 0 && !columnPresent(column, rows, columns)) {
+        return problem(blockId, `The column "${column}" is absent from every row.`);
+    }
+    return undefined;
+}
+
+/**
+ * Split the row indices by the group channel, in first-appearance order.
+ *
+ * A row whose group cell gives no value belongs to no series, thus it drops. A series with no group
+ * channel takes every row.
+ */
+function splitByChannel(rows: readonly ChartRow[], group: ResolvedChannel | undefined): Array<{ name: Cell | undefined; indices: readonly number[] }> {
+    if (group === undefined) {
+        return [{ name: undefined, indices: rows.map((_row, index) => index) }];
+    }
+    const buckets: Array<{ name: Cell; indices: number[] }> = [];
+    const byKey = new Map<string, { name: Cell; indices: number[] }>();
+    for (let index = 0; index < rows.length; index += 1) {
+        const value = group.values[index];
+        if (value === null) continue;
+        // The key carries the type of the cell, thus the number `1` and the string `"1"` are two groups.
+        const key = `${typeof value}:${String(value)}`;
+        let bucket = byKey.get(key);
+        if (bucket === undefined) {
+            bucket = { name: value, indices: [] };
+            byKey.set(key, bucket);
+            buckets.push(bucket);
+        }
+        bucket.indices.push(index);
+    }
+    return buckets;
+}
+
+/** Build the runtime series of one declared series over one group of rows. */
+function buildSeries(
+    entry: ResolvedSeries,
+    group: { name: Cell | undefined; indices: readonly number[] },
+    labeled: ReadonlySet<number>,
+    dense: boolean,
+    emittedCount: number,
+): EmittedSeries[] {
+    const form = entry.declared.form;
+    const points = collectPoints(entry, group.indices);
+    if (SORTED_FORMS.has(form)) {
+        points.sort((a, b) => compareCell(a.x, b.x));
+    }
+    const name = seriesName(entry, group.name);
+
+    if (entry.y0 !== undefined) {
+        const [lower, upper] = bandSeries(name, points, `band-${emittedCount}`);
+        return [
+            { option: lower, carriesMarks: false },
+            { option: upper, carriesMarks: true },
+        ];
+    }
+
+    const { data, itemObjects } = seriesData(entry, points, labeled);
+    return [{ option: { type: runtimeType(form), name, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }];
+}
+
+/** The points of one group. A row whose channel gives no value drops, and no substitute value appears. */
+function collectPoints(entry: ResolvedSeries, indices: readonly number[]): Point[] {
+    const points: Point[] = [];
+    for (const index of indices) {
+        const x = entry.x.values[index];
+        const y = entry.y.values[index];
+        if (x === null || y === null) continue;
+        if (entry.y0 === undefined) {
+            points.push({ index, x, y });
+            continue;
+        }
+        const y0 = entry.y0.values[index];
+        if (y0 === null) continue;
+        points.push({ index, x, y, y0 });
+    }
+    return points;
+}
+
+/**
+ * The name of one runtime series.
+ *
+ * Each series carries a name, thus the `{a}` of the tooltip template always names something. A series with
+ * no declared name and no group takes the name of its y channel.
+ */
+function seriesName(entry: ResolvedSeries, group: Cell | undefined): string {
+    const declared = entry.declared.name;
+    if (declared !== undefined && group !== undefined) return `${declared} (${String(group)})`;
+    if (declared !== undefined) return declared;
+    if (group !== undefined) return String(group);
+    return entry.y.name;
+}
+
+/**
+ * The data of one runtime series.
+ *
+ * A bare pair is the smallest item that states one point. A point that carries a name, or that the rank
+ * rule marks, takes the object form, because only an object item holds a name and a label.
+ */
+function seriesData(entry: ResolvedSeries, points: readonly Point[], labeled: ReadonlySet<number>): { data: unknown[]; itemObjects: boolean } {
+    const data: unknown[] = [];
+    let itemObjects = false;
+    for (const point of points) {
+        const label = entry.label?.[point.index];
+        const named = label !== undefined && label !== null;
+        const marked = labeled.has(point.index);
+        if (!named && !marked) {
+            data.push([point.x, point.y]);
+            continue;
+        }
+        itemObjects = true;
+        data.push({
+            value: [point.x, point.y],
+            // A marked point of a series with no label channel takes the x cell as its name. Thus the
+            // `{b}` of the label template and of the tooltip names a cell of the row, and never nothing.
+            name: named ? String(label) : String(point.x),
+            ...(marked ? { label: { ...POINT_LABEL } } : {}),
+        });
+    }
+    return { data, itemObjects };
+}
+
+/**
+ * The two runtime series of a band.
+ *
+ * The chart runtime stacks a band. Thus the lower series carries the `y0` column, the upper series carries
+ * the difference between the two columns, and the stack puts the upper line back on the `y` column. The
+ * two series show no tooltip, because the difference is no cell of the table.
+ */
+function bandSeries(name: string, points: readonly Point[], stack: string): EchartOption[] {
+    const lower: unknown[] = [];
+    const upper: unknown[] = [];
+    for (const point of points) {
+        const base = toNumber(point.y0);
+        const top = toNumber(point.y);
+        if (base === null || top === null) continue;
+        lower.push([point.x, base]);
+        upper.push([point.x, top - base]);
+    }
+    return [
+        { type: "line", name, stack, showSymbol: false, silent: true, lineStyle: { opacity: 0 }, tooltip: { show: false }, data: lower },
+        { type: "line", name, stack, showSymbol: false, areaStyle: { opacity: BAND_OPACITY }, tooltip: { show: false }, data: upper },
+    ];
+}
+
+/** The runtime type of one form. A step and an area are both a line with one more field. */
+function runtimeType(form: ChartSeries["form"]): string {
+    switch (form) {
+        case "bar":
+            return "bar";
+        case "scatter":
+            return "scatter";
+        case "line":
+        case "area":
+        case "step":
+            return "line";
+    }
+}
+
+/** The fields that one form adds to its runtime series. */
+function formOptions(form: ChartSeries["form"], dense: boolean, itemObjects: boolean): EchartOption {
+    switch (form) {
+        case "bar":
+            return {};
+        case "line":
+            return { showSymbol: false };
+        case "step":
+            return { step: "end", showSymbol: false };
+        case "area":
+            return { showSymbol: false, areaStyle: {} };
+        case "scatter":
+            return {
+                ...(dense ? { symbolSize: DENSE_SCATTER_SYMBOL_SIZE } : {}),
+                // The large path draws a simplified point, and it drops a per-item style. Thus a series
+                // whose items carry a name or a label keeps the normal path.
+                ...(itemObjects ? {} : { large: true, largeThreshold: LARGE_SCATTER_THRESHOLD }),
+            };
+    }
+}
+
+/** The row indices that the point-label annotations mark. An absent rank column is a refusal. */
+function pointLabelRows(
+    blockId: string,
+    annotations: readonly ChartAnnotation[],
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+): Result<ReadonlySet<number>, RenderProblem> {
+    const marked = new Set<number>();
+    for (const annotation of annotations) {
+        if (annotation.kind !== "point-labels") continue;
+        const absent = requirePresent(blockId, annotation.column, rows, columns);
+        if (absent !== undefined) return err(absent);
+        for (const index of topRows(rows, annotation.column, annotation.order, annotation.n)) {
+            marked.add(index);
+        }
+    }
+    return ok(marked);
+}
+
+/**
+ * The indices of the first `n` rows under the order of one column.
+ *
+ * A row whose cell is absent takes no place. The sort is stable, thus two equal cells keep the row order
+ * and the subset is the same on every host.
+ */
+function topRows(rows: readonly ChartRow[], column: string, order: "asc" | "desc", n: number): number[] {
+    const ranked: number[] = [];
+    for (let index = 0; index < rows.length; index += 1) {
+        if (rows[index][column] !== undefined) ranked.push(index);
+    }
+    ranked.sort((a, b) => {
+        const compared = compareCell(rows[a][column], rows[b][column]);
+        return order === "asc" ? compared : -compared;
+    });
+    return ranked.slice(0, n);
+}
+
+/**
+ * The mark members of the annotations.
+ *
+ * A reference line and a reference band both carry a declared constant, thus each one rides as static
+ * data of a mark member and nothing here reads a cell.
+ */
+function markMembers(annotations: readonly ChartAnnotation[]): EchartOption {
+    const lines: EchartOption[] = [];
+    const areas: EchartOption[][] = [];
+    for (const annotation of annotations) {
+        if (annotation.kind === "reference-line") {
+            lines.push({ [axisKey(annotation.axis)]: annotation.value, ...markLabel(annotation.label) });
+            continue;
+        }
+        if (annotation.kind === "reference-band") {
+            areas.push([{ [axisKey(annotation.axis)]: annotation.from, ...markLabel(annotation.label) }, { [axisKey(annotation.axis)]: annotation.to }]);
+        }
+    }
+    return {
+        ...(lines.length > 0 ? { markLine: { silent: true, symbol: "none", data: lines } } : {}),
+        ...(areas.length > 0 ? { markArea: { silent: true, data: areas } } : {}),
+    };
+}
+
+/** The label of one mark member. The text is a constant of the annotation, and never a template. */
+function markLabel(label: string | undefined): EchartOption {
+    return label !== undefined ? { label: { formatter: label } } : {};
+}
+
+/** The mark key of one axis. A mark member names `xAxis` or `yAxis`, and the constant that sits on it. */
+function axisKey(axis: "x" | "y"): "xAxis" | "yAxis" {
+    return axis === "x" ? "xAxis" : "yAxis";
+}
+
+/**
+ * The axis of one composition channel.
+ *
+ * A declared title replaces the column name. A declared `log` scale maps onto the logarithmic axis type. A
+ * transformed channel gives a number for each point that survives it, thus its axis is a value axis and
+ * the cells of the untransformed column decide nothing.
+ */
+function compositionAxis(rows: readonly ChartRow[], channel: ResolvedChannel, axis: "x" | "y", declared: ChartAxes["x"]): EchartOption {
+    const title = declared?.title ?? channel.name;
+    const nameFields = axis === "x" ? xAxisName(title) : { name: title };
+    if (declared?.scale === "log") {
+        return { type: "log", ...nameFields };
+    }
+    const base = channel.transformed ? { type: "value", scale: true } : inferAxis(rows, channel.name, axis);
+    return { ...base, ...nameFields };
+}
+
 // ── The shared building blocks ──────────────────────────────────────────────
 
 /** A typed `invalid-chart-input` problem that names the block and the cause. */
@@ -365,7 +981,12 @@ function problem(blockId: string, detail: string): RenderProblem {
  * A channel that the encoding omits is a refusal. A named column that no row holds is a refusal too.
  * A zero-row chart skips the row check, thus it renders an empty container.
  */
-function requireColumn(block: ChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined, channel: Channel): Result<string, RenderProblem> {
+function requireColumn(
+    block: ResolvedChartBlock,
+    rows: readonly ChartRow[],
+    columns: readonly string[] | undefined,
+    channel: Channel,
+): Result<string, RenderProblem> {
     const column = block.encoding[channel];
     if (column === undefined) {
         return err(problem(block.id, `The ${block.chartType} chart needs a column for the "${channel}" channel.`));
@@ -374,6 +995,78 @@ function requireColumn(block: ChartBlock, rows: readonly ChartRow[], columns: re
         return err(problem(block.id, `The column "${column}" is absent from every row.`));
     }
     return ok(column);
+}
+
+/**
+ * Resolve one demanded channel of a quick-path encoding to the channel itself.
+ *
+ * The composition derivation matches the column against the rows, thus this check answers for the
+ * presence of the channel alone and it names the channel that the chart type demands.
+ */
+function requireChannel(blockId: string, chartType: ChartType, encoding: ChartEncoding, channel: Channel): Result<ChartChannel, RenderProblem> {
+    const declared = encoding[channel];
+    if (declared === undefined) {
+        return err(problem(blockId, `The ${chartType} chart needs a column for the "${channel}" channel.`));
+    }
+    return ok(declared);
+}
+
+/**
+ * The name of a derived column, for example `neg_log10(padj)`.
+ *
+ * The name carries the transform, thus an axis that takes its name from the column never states the
+ * untransformed quantity.
+ */
+function transformedName(transform: ChartTransform, column: string): string {
+    return `${transform}(${column})`;
+}
+
+/** The transformed value of one column, one entry for each row. A row with no usable cell gives `null`. */
+function transformColumn(rows: readonly ChartRow[], column: string, transform: ChartTransform): (number | null)[] {
+    if (transform === "rank") {
+        return rankColumn(rows, column);
+    }
+    return rows.map((row) => applyTransform(toNumber(row[column]), transform));
+}
+
+/**
+ * One per-row transform.
+ *
+ * `log10` and `neg_log10` give no value for a cell that is not positive, thus the point drops. No
+ * substitute value ever appears in its place.
+ */
+function applyTransform(value: number | null, transform: Exclude<ChartTransform, "rank">): number | null {
+    if (value === null) return null;
+    switch (transform) {
+        case "log10":
+            return value > 0 ? Math.log10(value) : null;
+        case "neg_log10":
+            return value > 0 ? -Math.log10(value) : null;
+        case "abs":
+            return Math.abs(value);
+    }
+}
+
+/**
+ * The competition rank of each cell of one column, over the ascending order of the column.
+ *
+ * The smallest value takes the place 1, and a tie shares its place. Thus the place after a tie of two
+ * skips one number, which is what a competition rank states. A cell with no number takes no place, and
+ * its point drops. The rank reads the column alone, thus the same rows give the same places.
+ */
+function rankColumn(rows: readonly ChartRow[], column: string): (number | null)[] {
+    const values = rows.map((row) => toNumber(row[column]));
+    const counts = new Map<number, number>();
+    for (const value of values) {
+        if (value !== null) counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    const places = new Map<number, number>();
+    let place = 1;
+    for (const value of [...counts.keys()].sort((a, b) => a - b)) {
+        places.set(value, place);
+        place += counts.get(value) ?? 0;
+    }
+    return values.map((value) => (value === null ? null : (places.get(value) ?? null)));
 }
 
 /** True when the column exists in the declared header, or in one row at least. */

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -248,6 +248,11 @@ function resolveQuickPath(
             return err(problem(blockId, `The column "${column}" is absent from every row.`));
         }
         const name = transformedName(transform, column);
+        if (columnPresent(name, rows, columns)) {
+            // The derived column goes into a copy of each row. A table that already holds that name would
+            // lose its own column under the derived one, and the chart would plot the wrong cells.
+            return err(problem(blockId, `The transform of "${column}" derives the column "${name}", which the bound table already holds.`));
+        }
         resolved[channel] = name;
         derived.push({ column, name, transform });
     }
@@ -618,6 +623,12 @@ function deriveComposition(
         resolved.push(series.value);
     }
 
+    if (resolved.length === 0) {
+        // The schema holds a composition to one series at least. The guard states the same rule for a
+        // value that reaches the renderer without a parse, because the axes come from the first series.
+        return err(problem(blockId, "The composition carries no series."));
+    }
+
     const annotations = composition.annotations ?? [];
     const labeled = pointLabelRows(blockId, annotations, rows, columns);
     if (labeled.isErr()) return err(labeled.error);
@@ -626,7 +637,9 @@ function deriveComposition(
     const emitted: EmittedSeries[] = [];
     for (const entry of resolved) {
         for (const group of splitByChannel(rows, entry.group)) {
-            emitted.push(...buildSeries(entry, group, labeled.value, dense, emitted.length));
+            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length);
+            if (built.isErr()) return err(built.error);
+            emitted.push(...built.value);
         }
     }
 
@@ -640,7 +653,7 @@ function deriveComposition(
     const named = resolved.some((entry) => entry.label !== undefined) || labeled.value.size > 0;
     return ok({
         tooltip: named ? { ...NAMED_TOOLTIP } : { ...PLAIN_TOOLTIP },
-        xAxis: compositionAxis(rows, first.x, "x", composition.axes?.x),
+        xAxis: compositionXAxis(rows, first, composition.axes?.x),
         yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y),
         series: emitted.map((entry) => entry.option),
     });
@@ -736,12 +749,13 @@ function splitByChannel(rows: readonly ChartRow[], group: ResolvedChannel | unde
 
 /** Build the runtime series of one declared series over one group of rows. */
 function buildSeries(
+    blockId: string,
     entry: ResolvedSeries,
     group: { name: Cell | undefined; indices: readonly number[] },
     labeled: ReadonlySet<number>,
     dense: boolean,
     emittedCount: number,
-): EmittedSeries[] {
+): Result<EmittedSeries[], RenderProblem> {
     const form = entry.declared.form;
     const points = collectPoints(entry, group.indices);
     if (SORTED_FORMS.has(form)) {
@@ -750,15 +764,16 @@ function buildSeries(
     const name = seriesName(entry, group.name);
 
     if (entry.y0 !== undefined) {
-        const [lower, upper] = bandSeries(name, points, `band-${emittedCount}`);
-        return [
-            { option: lower, carriesMarks: false },
-            { option: upper, carriesMarks: true },
-        ];
+        const band = bandSeries(blockId, entry, name, points, `band-${emittedCount}`);
+        if (band.isErr()) return err(band.error);
+        return ok([
+            { option: band.value[0], carriesMarks: false },
+            { option: band.value[1], carriesMarks: true },
+        ]);
     }
 
     const { data, itemObjects } = seriesData(entry, points, labeled);
-    return [{ option: { type: runtimeType(form), name, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }];
+    return ok([{ option: { type: runtimeType(form), name, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }]);
 }
 
 /** The points of one group. A row whose channel gives no value drops, and no substitute value appears. */
@@ -828,21 +843,31 @@ function seriesData(entry: ResolvedSeries, points: readonly Point[], labeled: Re
  * The chart runtime stacks a band. Thus the lower series carries the `y0` column, the upper series carries
  * the difference between the two columns, and the stack puts the upper line back on the `y` column. The
  * two series show no tooltip, because the difference is no cell of the table.
+ *
+ * A stack takes a difference that is not negative. A row where `y` is under `y0` names the lower bound as
+ * the upper one, thus the band would draw from the axis and state a bound that no cell holds. The two
+ * columns are in the wrong order, and the refusal names the row.
  */
-function bandSeries(name: string, points: readonly Point[], stack: string): EchartOption[] {
+function bandSeries(blockId: string, entry: ResolvedSeries, name: string, points: readonly Point[], stack: string): Result<EchartOption[], RenderProblem> {
     const lower: unknown[] = [];
     const upper: unknown[] = [];
     for (const point of points) {
         const base = toNumber(point.y0);
         const top = toNumber(point.y);
         if (base === null || top === null) continue;
+        if (top < base) {
+            const detail =
+                `The band of the series "${name}" holds a row where the "${entry.y.name}" value ${top} ` +
+                `is under the "${entry.y0?.name ?? ""}" value ${base}. The upper bound belongs on "y".`;
+            return err(problem(blockId, detail));
+        }
         lower.push([point.x, base]);
         upper.push([point.x, top - base]);
     }
-    return [
+    return ok([
         { type: "line", name, stack, showSymbol: false, silent: true, lineStyle: { opacity: 0 }, tooltip: { show: false }, data: lower },
         { type: "line", name, stack, showSymbol: false, areaStyle: { opacity: BAND_OPACITY }, tooltip: { show: false }, data: upper },
-    ];
+    ]);
 }
 
 /** The runtime type of one form. A step and an area are both a line with one more field. */
@@ -863,7 +888,9 @@ function runtimeType(form: ChartSeries["form"]): string {
 function formOptions(form: ChartSeries["form"], dense: boolean, itemObjects: boolean): EchartOption {
     switch (form) {
         case "bar":
-            return {};
+            // The base bar rule puts the bars of one category side by side with no gap between them. A bar
+            // of either path then reads the same.
+            return { barGap: 0 };
         case "line":
             return { showSymbol: false };
         case "step":
@@ -949,6 +976,22 @@ function markLabel(label: string | undefined): EchartOption {
 /** The mark key of one axis. A mark member names `xAxis` or `yAxis`, and the constant that sits on it. */
 function axisKey(axis: "x" | "y"): "xAxis" | "yAxis" {
     return axis === "x" ? "xAxis" : "yAxis";
+}
+
+/**
+ * The x axis of a composition.
+ *
+ * A bar takes a category axis, and every other form takes the inferred axis. A declared scale is the one
+ * exception, because the author asked for a numeric axis and a category axis has no scale.
+ */
+function compositionXAxis(rows: readonly ChartRow[], first: ResolvedSeries, declared: ChartAxes["x"]): EchartOption {
+    if (first.declared.form !== "bar" || declared?.scale !== undefined) {
+        return compositionAxis(rows, first.x, "x", declared);
+    }
+    // A bar counts its categories. The base bar rule lists the x values in first-appearance order, thus a
+    // bar of either path draws the same axis.
+    const categories = firstAppearance(first.x.values.filter((value): value is Cell => value !== null));
+    return { type: "category", data: categories, ...xAxisName(declared?.title ?? first.x.name) };
 }
 
 /**
@@ -1174,13 +1217,19 @@ function sortByX(pairs: Cell[][]): Cell[][] {
 }
 
 /**
- * Compare two cells for a sort by x. Two numbers compare by their difference. Any other pair compares
- * by the code-unit order of the string form. The comparison never calls `localeCompare`, thus the order
- * stays the same on every host.
+ * Compare two cells for a sort by x, and for a rank rule.
+ *
+ * A pair that both hold a finite number compares by that number. A text-backed table gives each cell as a
+ * string, thus a code-unit order would put `"10"` between `"1"` and `"2"` and a time axis would run out of
+ * order. Any other pair compares by the code-unit order of the string form.
+ *
+ * The comparison never calls `localeCompare`, thus the order stays the same on every host.
  */
 function compareCell(a: Cell, b: Cell): number {
-    if (typeof a === "number" && typeof b === "number") {
-        return a - b;
+    const leftNumber = toNumber(a);
+    const rightNumber = toNumber(b);
+    if (leftNumber !== null && rightNumber !== null) {
+        return leftNumber - rightNumber;
     }
     const left = String(a);
     const right = String(b);


### PR DESCRIPTION
## What & why

The chart encoding held four column names, and no more. On the first real report the tooltip showed nothing, the axis read a raw column name, and a faithful volcano was impossible. The decided direction: stop enumerating chart types, and type a chart grammar.

- A chart block now carries either the quick path (one type, one encoding) or a composition: series with forms (`line`, `scatter`, `bar`, `area`, `step`), typed annotations, and axes with titles and scales.
- A channel accepts a per-row transform (`log10`, `neg_log10`, `abs`, `rank`), thus a volcano renders from a p-value column. Each derived value traces to one cell.
- The encoding gains a `label` column: the point name rides each data item, and a static template formatter shows it. No function rides the option.
- The genomics presets (`volcano`, `manhattan`, `ma`, `km`) expand into the composition inside the renderer. The `km` preset renders precomputed survival columns, and it estimates nothing.
- The boundary stands: no raw echarts option, no series data literal, one bound table, and the structural tier refuses a grammar column that the table does not hold.

Notes for the reviewer:

- The area band rides the stack mechanism of the runtime, because no static member draws a band between two absolute columns. The per-row difference of two cells of one row stays per-row.
- The seven base derivations kept their bodies byte-identical, and their tests did not change.
- A composition proof page confirms the template, the mark members, and the absence of any function text.

Refs #372. Refs #329.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
