### PR TITLE
feat(harness): derive a table inside the report session

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/design.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The value tier already runs a fixed extraction script in an ephemeral sandbox (`tasks/extract-values.ts`): the `SandboxClient` submit and await, the sandbox identity, the run authorizer on every terminal path, and no ledger entry. The session state is one durable row for each thread (`state/report-session-state.ts`), and the gateway serves the stored snapshot to every tool (`app/report-session-runtime.ts`). The snapshot is the membership boundary of a session.
+
+## Goals / Non-Goals
+
+- Goal: the agent reshapes pinned evidence into a table that a block can bind, with a recorded provenance chain.
+- Goal: the derivation is repeatable: the record pins the script hash, the source hashes, and the output hash.
+- Non-goal: an analysis run. No run id, no `cortex_runs` row, no `cortex_artifacts` row, and no write outside the session directory.
+- Non-goal: a network. The sandbox rails give none, and the derivation keeps that.
+- Non-goal: a change to the run agents or to the sandbox standards.
+
+## Decisions
+
+- **The tool is `derive_table`, on the report roster.** The input: a Python script, the declared pinned input paths, and one output file name. The output lands under the session `derived/` directory, named by the tool from the declared name.
+- **The rails are the extraction rails, generalized to an agent-authored script.** The tool draws the same seams as the value tier: the sandbox client, the identity mint, and the authorizer on every terminal path. The container is ephemeral, and it goes away with the work.
+- **The mounts are the difference.** The analysis tree mounts read-only, the shape that the substrate gives every sandbox. One write mount covers the session `derived/` tail alone, thus no write can reach the workspace tree. The script output lands in the write mount directly, thus a large table makes no roundtrip.
+- **The mount plan gains one declared write tail.** `CreateSandboxMeta` takes an optional workspace-relative `writableTail`, and the plan uses it in place of the step tail, with no step subdirs. Each tail segment passes the safe-id discipline of the step builder. An absent field keeps the plan of today, thus the run path stays byte-identical.
+- **The inputs are declared, and the record pins them.** Each input path must sit in the served membership, and its hash comes from there. The declaration is the provenance contract. The read reach equals the read-only roster reach, and the declared-input wall is a later hardening of the mount plan.
+- **The record lives in the session state.** The row gains a derivation list. One record holds the output path, the output hash, the source paths with their hashes, the script hash, and the script text. The script text rides the record, thus the verifier re-runs it without a second store.
+- **The served membership merges the records.** The gateway load extends the served snapshot artifacts with each derivation output, keyed by its session-relative workspace path. The stored pin never changes, thus the anchor stays honest and the merge is recomputable.
+- **The structural tier and the resolvers stay unchanged.** They read the served snapshot, thus a derived table binds, resolves, and validates the same way as a pinned one.
+- **The purge covers `derived/`.** The session page disposal removes the session directory whole, and the tests state that `derived/` goes with it.
+- **The bounds.** One derivation runs at a time for a thread. The script caps at 64 KiB, the declared inputs at 20, and the output at one file. The exec budget matches the extraction budget.
+
+## Risks / Trade-offs
+
+- [An agent-authored script fabricates a table] → the record chains the output to the pinned sources and the script. The verifier can run the script again, thus fabrication leaves a reproducible trail.
+- [A script writes junk beside the output] → the write mount is one directory, and the tool records and serves the declared output alone. A stray file dies with the purge.
+- [Two turns derive one name] → the tool refuses a name that a record already holds. A record is immutable, and a rerun takes a new name.
+
+## Open Questions
+
+None.

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The runs write statistical tables, and not plot-ready ones. In the first real session the agent could not reshape a table, and the rejected alternative was a display-CSV rule on every run agent. A per-row transform now lives in the renderer, thus the derivation serves real reshaping: a join, a pivot, an aggregate.
+
+## What Changes
+
+- A session-scoped derivation tool joins the Report Builder roster. The agent derives a table from the pinned evidence.
+- The derivation runs on the sandbox substrate that exists: the container rails, the resource policy, no network, and the signed exec protocol.
+- The mounts differ from a run: the declared pinned inputs read-only, and one write mount under the session `derived/` directory.
+- No run id, no ledger entry, and no workspace-tree write. The record lives in the session state: the source hashes, the script hash, the output path, and the output hash.
+- The served snapshot merges the derivation records, thus a derived table is bindable and the stored pin stays untouched.
+- The purge of a session covers `derived/`.
+
+## The rule that survives
+
+The read-only roster rule stands: no tool starts an analysis run, and no tool changes the analysis. A session derivation does neither. It mints no run id, it registers no artifact, and it writes under the session directory alone.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-session-agent`: the roster gains the derivation tool with the carve-out sentence, and the durable session state gains the derivation record.
+- `report-verification`: the derivation is repeatable, because the record pins the script and the sources.
+
+## Impact
+
+- `harness/src/tools/report-session/` — the derivation tool.
+- `harness/src/state/report-session-state.ts` — the record.
+- `harness/src/app/report-session-runtime.ts` — the merged membership at the load.
+- The sandbox rails of `harness/src/tasks/extract-values.ts` are the pattern, and they do not change.

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-session-agent/spec.md
@@ -1,0 +1,57 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The read-only roster
+The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_files`, `file_stat`, and `grep`), the workspace search, `inspect_run`, `inspect_data_profile`, the authoring tools, the pinned-artifact listing tool, the derivation tool, and the render-and-preview tool. The roster MUST NOT hold a planner, a run launcher, a working-memory write, or a sandbox mutate surface. Thus no tool starts a run, and no tool changes an analysis. A session derivation is a sandbox exec inside the session: it mints no run id, it registers no artifact, and it writes under the session directory alone.
+
+The listing tool MUST give the pinned artifacts in a deterministic order: the path, the hash, and the file type. It MUST also give the pinned citation ids. The listing is bounded, and a truncated listing MUST carry the total count and a truncation marker. For a `.csv` or a `.tsv` artifact it also gives the columns, from a bounded read of the header. A header that the bounded read cannot parse whole gives no columns. An unreadable header gives no columns and no error, because absence is a normal condition.
+
+#### Scenario: The roster holds no run starter
+- **WHEN** the assembled agent lists its tools
+- **THEN** no tool id of the run-starter set or the mutate set is present
+
+#### Scenario: The analysis read surface is present
+- **WHEN** the assembled agent lists its tools
+- **THEN** the workspace read tools, the search, the run inspection, and the data-profile inspection are present
+
+#### Scenario: The listing gives the pinned set with columns
+- **WHEN** the agent calls the listing tool in a session whose snapshot pins a CSV artifact
+- **THEN** the result carries the path, the hash, the file type, and the header columns of that artifact
+
+#### Scenario: An unreadable artifact still lists
+- **WHEN** the snapshot pins a path whose bytes are absent from the disk
+- **THEN** the result carries the path and the hash, with no columns and no error
+
+#### Scenario: A large pinned set truncates with a marker
+- **WHEN** the snapshot pins more artifacts than the listing bound
+- **THEN** the result carries the bounded listing, the total count, and the truncation marker
+
+#### Scenario: A derivation starts no run
+- **WHEN** the agent derives a table in a session
+- **THEN** no run row and no artifact row lands, and the output sits under the session directory
+
+## ADDED Requirements
+
+### Requirement: The session derivation
+The derivation tool MUST run an agent-authored script on the sandbox substrate: the container rails, the resource policy, no network, and the signed exec protocol. The analysis tree mounts read-only, and one write mount covers the session `derived/` directory alone. The script writes its output into that mount directly. Each declared input MUST sit in the served membership, and its hash comes from there. The record lands in the durable session state: the output path, the output hash, the source paths with their hashes, the script hash, and the script text. The served snapshot MUST merge the derivation records, thus a derived table binds the same way as a pinned one. The stored pin never changes. The tool MUST refuse an output name that a record already holds.
+
+#### Scenario: A derived table becomes bindable
+- **WHEN** a derivation lands and the agent adds a table block over the derived path
+- **THEN** the block lands, and the reference resolves against the derived output
+
+#### Scenario: The record chains the provenance
+- **WHEN** a derivation lands
+- **THEN** the session state holds the output hash, the source hashes, the script hash, and the script text
+
+#### Scenario: A write outside the derived directory fails
+- **WHEN** the script writes a path outside the `derived/` mount
+- **THEN** the write fails inside the container, because the one write mount covers `derived/` alone
+
+#### Scenario: A repeated output name refuses
+- **WHEN** the agent derives onto a name that a record already holds
+- **THEN** the tool refuses as typed data, and the record stays as it is
+
+#### Scenario: The purge covers the derived directory
+- **WHEN** the session pages dispose
+- **THEN** the `derived/` directory goes with the session directory

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-verification/spec.md
@@ -1,0 +1,10 @@
+# Delta: report-verification
+
+## ADDED Requirements
+
+### Requirement: A derivation is repeatable
+The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can mount the same pinned inputs, run the recorded script, and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+
+#### Scenario: The record admits a re-run
+- **WHEN** a verifier reads a derivation record
+- **THEN** the record names the script, the sources with their hashes, and the expected output hash

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/workspace-layout/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/workspace-layout/spec.md
@@ -1,0 +1,27 @@
+# Delta: workspace-layout
+
+## MODIFIED Requirements
+
+### Requirement: Per-analysis workspace tree
+
+
+Each analysis SHALL have a workspace tree rooted at the embedder-resolved workspace root (`resolveWorkspaceRoot(resourceId)` — see the workspace-root-resolution capability) containing `data/` for immutable input files (per-file directories under `data/inputs/`, staged by the embedder before any run), `runs/` for workflow-run artifacts, `reports/` for flat report output, `previews/` for versioned report previews, and `report-sessions/` for the page of a report session. Host paths carry no `{resourceId}` segment — the resolved root already identifies the resource. The `data/` tree SHALL be treated as read-only by every surface; only a step's own run directory, or one declared session write tail, is writable.
+
+A sandbox write tail is a workspace-relative path that a sandbox creation declares in place of the step directory. Each segment passes the safe-id discipline of the step builder. The session derivation declares `report-sessions/{threadId}/derived`, and the run path declares none, thus the run mounts stay as they are.
+
+#### Scenario: New analysis workspace structure
+
+- **WHEN** an analysis workspace is initialized
+- **THEN** the `data/` directory holds the immutable inputs and `runs/` is
+  created on demand when the first workflow run starts
+
+#### Scenario: Input files are immutable
+
+- **WHEN** any mutate surface resolves a write whose path falls under
+  the workspace root's `data/`
+- **THEN** the write SHALL be rejected (it is outside the step's writable
+  working directory) and the input bytes SHALL remain unchanged
+
+#### Scenario: A declared write tail is the one writable mount
+- **WHEN** a sandbox creation declares a write tail
+- **THEN** the container holds the tree read-only and that tail read-write, and no step directory mounts

--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/tasks.md
@@ -1,0 +1,35 @@
+## 1. The record
+
+- [x] 1.1 The derivation record on `src/state/report-session-state.ts`: the list on the row, the append operation, and the name-uniqueness rule.
+- [x] 1.2 Store tests: the append, the read-back, the refusal of a repeated name, and the parse of a legacy row with no list.
+
+## 1b. The write tail
+
+- [x] 1b.1 `CreateSandboxMeta` gains the optional workspace-relative `writableTail`, with per-segment safe-id validation in the mount plan.
+- [x] 1b.2 `buildMountPlan` and `buildSessionSubPaths` use the tail in place of the step tail, with no step subdirs. An absent field keeps the plan of today.
+- [x] 1b.3 The host-side preparation generalizes: the host makes the tail directory, with the world-writable arm where the engine preserves host ownership.
+- [x] 1b.4 Both backends translate the plan unchanged in form. The mount-plan, preparation, and backend tests cover the tail, and the run-path shapes stay byte-identical.
+
+## 2. The tool
+
+- [x] 2.1 The `derive_table` tool in `src/tools/report-session/`, on the extraction rails: the sandbox client, the identity, and the authorizer on every terminal path.
+- [x] 2.2 The mounts: the tree read-only, and the declared write tail over `derived/`. The script writes the output directly, and stdout carries logs alone. The bounds: the script cap, the input cap, and one output.
+- [x] 2.3 The record lands after the exec: the output hash from the disk, the source hashes from the served membership, and the script hash.
+- [x] 2.4 The roster wiring, the tool description, and the call details for the started and the finished lines.
+- [x] 2.5 Tool tests with a stubbed sandbox client: the happy path, the undeclared input, the repeated name, the over-cap script, and the failed exec.
+
+## 3. The membership
+
+- [x] 3.1 The gateway load merges the derivation records into the served snapshot in `src/app/report-session-runtime.ts`.
+- [x] 3.2 Tests: a derived path binds through the authoring tools, and the stored pin stays unchanged.
+
+## 4. The teaching and the purge
+
+- [x] 4.1 The prompt names the derivation: real reshaping through the tool, and a per-row transform through the chart grammar.
+- [x] 4.2 The purge tests state that `derived/` goes with the session directory.
+
+## 5. The gates
+
+- [x] 5.1 Run the targeted suites of the touched modules only, with the podman Postgres for the store suites.
+- [x] 5.2 Run `bun run format:file` on the touched `src/` files, then `tsc -p tsconfig.json`.
+- [x] 5.3 The state and tool surfaces are exported, thus run `bun run harness:local` from `cli/` and the cli typecheck.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -95,6 +95,29 @@ The in-progress document and the pinned snapshot of a thread MUST live in one du
 - **WHEN** one process lands an add, and a different process serves the next turn
 - **THEN** the outline of the next turn holds the added block
 
+### Requirement: The session derivation
+The derivation tool MUST run an agent-authored script on the sandbox substrate: the container rails, the resource policy, no network, and the signed exec protocol. The analysis tree mounts read-only, and one write mount covers the session `derived/` directory alone. The script writes its output into that mount directly. Each declared input MUST sit in the served membership, and its hash comes from there. The record lands in the durable session state: the output path, the output hash, the source paths with their hashes, the script hash, and the script text. The served snapshot MUST merge the derivation records, thus a derived table binds the same way as a pinned one. The stored pin never changes. The tool MUST refuse an output name that a record already holds.
+
+#### Scenario: A derived table becomes bindable
+- **WHEN** a derivation lands and the agent adds a table block over the derived path
+- **THEN** the block lands, and the reference resolves against the derived output
+
+#### Scenario: The record chains the provenance
+- **WHEN** a derivation lands
+- **THEN** the session state holds the output hash, the source hashes, the script hash, and the script text
+
+#### Scenario: A write outside the derived directory fails
+- **WHEN** the script writes a path outside the `derived/` mount
+- **THEN** the write fails inside the container, because the one write mount covers `derived/` alone
+
+#### Scenario: A repeated output name refuses
+- **WHEN** the agent derives onto a name that a record already holds
+- **THEN** the tool refuses as typed data, and the record stays as it is
+
+#### Scenario: The purge covers the derived directory
+- **WHEN** the session pages dispose
+- **THEN** the `derived/` directory goes with the session directory
+
 ### Requirement: The session tools name their calls
 The report tools MUST give a call detail that names their subject. `add_block` names the kind, with the title of a section or the file name of a bound artifact. `change_block`, `move_block`, and `remove_block` name the block id. On an ok outcome, `preview_report` names the page path, and `record_report_version` names the version. `examine_page` names the look outcome, and the listing tool names the listed count with the truncation.
 
@@ -111,7 +134,7 @@ The report tools MUST give a call detail that names their subject. `add_block` n
 - **THEN** the finished line names the page path
 
 ### Requirement: The read-only roster
-The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_files`, `file_stat`, and `grep`), the workspace search, `inspect_run`, `inspect_data_profile`, the authoring tools, the pinned-artifact listing tool, and the render-and-preview tool. The roster MUST NOT hold a planner, a run launcher, a working-memory write, or a sandbox mutate surface. Thus no tool starts a run, and no tool changes an analysis.
+The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_files`, `file_stat`, and `grep`), the workspace search, `inspect_run`, `inspect_data_profile`, the authoring tools, the pinned-artifact listing tool, the derivation tool, and the render-and-preview tool. The roster MUST NOT hold a planner, a run launcher, a working-memory write, or a sandbox mutate surface. Thus no tool starts a run, and no tool changes an analysis. A session derivation is a sandbox exec inside the session: it mints no run id, it registers no artifact, and it writes under the session directory alone.
 
 The listing tool MUST give the pinned artifacts in a deterministic order: the path, the hash, and the file type. It MUST also give the pinned citation ids. The listing is bounded, and a truncated listing MUST carry the total count and a truncation marker. For a `.csv` or a `.tsv` artifact it also gives the columns, from a bounded read of the header. A header that the bounded read cannot parse whole gives no columns. An unreadable header gives no columns and no error, because absence is a normal condition.
 
@@ -134,6 +157,10 @@ The listing tool MUST give the pinned artifacts in a deterministic order: the pa
 #### Scenario: A large pinned set truncates with a marker
 - **WHEN** the snapshot pins more artifacts than the listing bound
 - **THEN** the result carries the bounded listing, the total count, and the truncation marker
+
+#### Scenario: A derivation starts no run
+- **WHEN** the agent derives a table in a session
+- **THEN** no run row and no artifact row lands, and the output sits under the session directory
 
 ### Requirement: The render-and-preview tool
 The preview tool MUST run the finish on the draft first. A gap list MUST return as data, and no render runs. On a pass, the tool MUST resolve each reference through the injected `ReferenceResolver`, bridge the values, and render with `renderReportPage`. The page and its staged assets MUST land in the session directory `report-sessions/{threadId}/` under the workspace root. The result MUST carry the page path as data. When the page lands, the tool MUST stamp the hash of the rendered document on the session state.

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -43,6 +43,13 @@ The record MUST refuse until the eyes ran against the current document state. Th
 - **WHEN** the eyes ran, and the agent then changed a block
 - **THEN** the record refuses until a new preview and a new look run
 
+### Requirement: A derivation is repeatable
+The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can mount the same pinned inputs, run the recorded script, and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+
+#### Scenario: The record admits a re-run
+- **WHEN** a verifier reads a derivation record
+- **THEN** the record names the script, the sources with their hashes, and the expected output hash
+
 ### Requirement: The eyes seam
 The composition MUST give the eyes through one provisioning seam. The acquire operation takes a scope and returns a lease. The scope carries the analysis id and the workspace root, thus a realization can mount the root for a `file://` navigation. The lease carries a browser endpoint and a release operation.
 

--- a/harness/openspec/specs/workspace-layout/spec.md
+++ b/harness/openspec/specs/workspace-layout/spec.md
@@ -25,7 +25,9 @@ host that serves previews maps onto the workspace-root storage itself.
 ### Requirement: Per-analysis workspace tree
 
 
-Each analysis SHALL have a workspace tree rooted at the embedder-resolved workspace root (`resolveWorkspaceRoot(resourceId)` — see the workspace-root-resolution capability) containing `data/` for immutable input files (per-file directories under `data/inputs/`, staged by the embedder before any run), `runs/` for workflow-run artifacts, `reports/` for flat report output, `previews/` for versioned report previews, and `report-sessions/` for the page of a report session. Host paths carry no `{resourceId}` segment — the resolved root already identifies the resource. The `data/` tree SHALL be treated as read-only by every surface; only a step's own run directory is writable.
+Each analysis SHALL have a workspace tree rooted at the embedder-resolved workspace root (`resolveWorkspaceRoot(resourceId)` — see the workspace-root-resolution capability) containing `data/` for immutable input files (per-file directories under `data/inputs/`, staged by the embedder before any run), `runs/` for workflow-run artifacts, `reports/` for flat report output, `previews/` for versioned report previews, and `report-sessions/` for the page of a report session. Host paths carry no `{resourceId}` segment — the resolved root already identifies the resource. The `data/` tree SHALL be treated as read-only by every surface; only a step's own run directory, or one declared session write tail, is writable.
+
+A sandbox write tail is a workspace-relative path that a sandbox creation declares in place of the step directory. Each segment passes the safe-id discipline of the step builder. The session derivation declares `report-sessions/{threadId}/derived`, and the run path declares none, thus the run mounts stay as they are.
 
 #### Scenario: New analysis workspace structure
 
@@ -39,6 +41,10 @@ Each analysis SHALL have a workspace tree rooted at the embedder-resolved worksp
   the workspace root's `data/`
 - **THEN** the write SHALL be rejected (it is outside the step's writable
   working directory) and the input bytes SHALL remain unchanged
+
+#### Scenario: A declared write tail is the one writable mount
+- **WHEN** a sandbox creation declares a write tail
+- **THEN** the container holds the tree read-only and that tail read-write, and no step directory mounts
 
 ### Requirement: Run and step directory structure
 

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -8,6 +8,7 @@ import { createRegistry } from "../tools/registry.js";
 import type { EmbeddingProvider } from "../providers/types.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
 import type { ThreadStore } from "../memory/thread-store.js";
+import type { ReportSessionStateStore } from "../state/report-session-state.js";
 import type { ReportVersionStore } from "../state/report-versions.js";
 import type { ReportSessionStateGateway } from "../tools/report-authoring/authoring-tools.js";
 
@@ -25,6 +26,7 @@ function buildAgent() {
         store: {} as ReportVersionStore,
         threads: {} as Pick<ThreadStore, "getThread">,
         chrome: {},
+        derivations: {} as Pick<ReportSessionStateStore, "appendDerivation">,
     });
 }
 
@@ -32,8 +34,8 @@ function buildAgent() {
 const READ_SURFACE = ["read_file", "list_files", "file_stat", "grep", "workspace_search", "inspect_run", "inspect_data_profile"] as const;
 
 // The composition surface: the eight authoring tools, the pinned-artifact listing
-// tool, the render-and-preview tool, the eyes tool, and the record tool. These
-// twelve ids are what makes the report path a report path.
+// tool, the derivation tool, the render-and-preview tool, the eyes tool, and the
+// record tool. These thirteen ids are what makes the report path a report path.
 const COMPOSITION_SURFACE = [
     "add_block",
     "change_block",
@@ -44,6 +46,7 @@ const COMPOSITION_SURFACE = [
     "read_block",
     "finish_draft",
     "list_pinned_artifacts",
+    "derive_table",
     "preview_report",
     "examine_page",
     "record_report_version",
@@ -81,7 +84,7 @@ describe("createReportSessionAgent", () => {
         }
     });
 
-    test("holds the twelve composition tools", () => {
+    test("holds the thirteen composition tools", () => {
         const ids = new Set(buildAgent().tools.map((tool) => tool.id));
         for (const expected of COMPOSITION_SURFACE) {
             expect(ids.has(expected)).toBe(true);
@@ -202,6 +205,16 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("The angle of the brief decides the order of the findings");
         // The anti-pattern entry names evidence that precedes its sentence.
         expect(reportSessionPrompt).toContain("Show evidence before its sentence");
+    });
+
+    test("the prompt divides a derivation from a chart knob", () => {
+        // The tool name, the three reshaping cases, and the per-row bound are stable
+        // substrings, thus the assertion does not couple to the full prose.
+        expect(reportSessionPrompt).toContain("derive_table");
+        expect(reportSessionPrompt).toContain("a pivot, and an aggregate are such reshaping");
+        expect(reportSessionPrompt).toContain("transform is not: a chart block reads the column that it needs");
+        // A derived table is evidence of the session, thus it binds like a pinned one.
+        expect(reportSessionPrompt).toContain("binds like any pinned artifact");
     });
 
     test("the prompt carries the chart-first rule", () => {

--- a/harness/src/agents/report-session-agent.ts
+++ b/harness/src/agents/report-session-agent.ts
@@ -13,6 +13,10 @@
  * mutate surface. Thus no tool starts a run, and no tool changes an analysis. The
  * roster omits those tools, and no runtime guard blocks them.
  *
+ * The derivation tool is the one tool that runs a container, and it changes no
+ * analysis either. It mints no run id, it registers no artifact, and it writes under
+ * the directory of the session alone.
+ *
  * The definition carries no per-session value. The system prompt composes through
  * `composeSystemPrompt` with the identity part and the conversational part, the
  * same composition as the conversation agent. Thus the prompt prefix stays constant
@@ -22,7 +26,10 @@
 import type { Pool } from "pg";
 
 import type { AuthContext } from "../auth/types.js";
+import type { RunAuthorizer } from "../execution/run-authorizer.js";
 import type { AgentDefinition } from "../loop/types.js";
+import type { SandboxClient } from "../sandbox/client.js";
+import type { ReportSessionStateStore } from "../state/report-session-state.js";
 import type { Tool } from "../tools/define-tool.js";
 import type { EmbeddingProvider } from "../providers/types.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
@@ -36,6 +43,7 @@ import type { ReportVersionStore } from "../state/report-versions.js";
 import type { ReportSessionStateGateway } from "../tools/report-authoring/authoring-tools.js";
 import { createReportAuthoringTools } from "../tools/report-authoring/authoring-tools.js";
 import {
+    createDeriveTableTool,
     createExaminePageTool,
     createListPinnedArtifactsTool,
     createPreviewReportTool,
@@ -77,6 +85,18 @@ export interface ReportSessionAgentDeps {
     readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
     /** Append-only version store -- the record tool gates the whole document first, then records one version. */
     readonly store: ReportVersionStore;
+    /** Derivation ledger -- the derivation tool appends one record for each derived table. */
+    readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
+    /**
+     * Sandbox seam -- the derivation tool runs one ephemeral container for each derived table. Omitted, the
+     * tool reports that the composition gives no sandbox, and it derives nothing.
+     */
+    readonly sandboxClient?: SandboxClient;
+    /**
+     * Run-authorization seam -- the derivation tool authorizes the exec and revokes on every terminal path.
+     * Omitted, the tool derives nothing, the same as an absent sandbox client.
+     */
+    readonly runAuthorizer?: RunAuthorizer;
     /** Thread reader -- the record tool reads the anchor of the report thread. */
     readonly threads: Pick<ThreadStore, "getThread">;
     /** Headless-Chrome config -- the eyes tool opens the rendered page. */
@@ -105,6 +125,7 @@ export interface ReportSessionAgentDeps {
 /** Build the report `AgentDefinition` with every tool bound to its deps. */
 export function createReportSessionAgent(deps: ReportSessionAgentDeps): AgentDefinition {
     const { model, pool, embedding, workspaceFs, gateway, resolveWorkspaceRoot, store, threads, chrome, eyes, makeResolver, resolvePageAsset, logger } = deps;
+    const { derivations, sandboxClient, runAuthorizer } = deps;
     const authoring = createReportAuthoringTools(gateway);
 
     const tools: Tool[] = [
@@ -131,6 +152,16 @@ export function createReportSessionAgent(deps: ReportSessionAgentDeps): AgentDef
         createListPinnedArtifactsTool({
             gateway,
             resolveWorkspaceRoot,
+            ...(logger ? { logger } : {}),
+        }),
+        // The derivation tool. It reshapes the pinned evidence into one table under the
+        // session directory, on the sandbox rails of the value tier.
+        createDeriveTableTool({
+            gateway,
+            resolveWorkspaceRoot,
+            derivations,
+            ...(sandboxClient ? { sandboxClient } : {}),
+            ...(runAuthorizer ? { runAuthorizer } : {}),
             ...(logger ? { logger } : {}),
         }),
         // The render-and-preview tool. It resolves the page root per call.

--- a/harness/src/app/report-session-runtime.test.ts
+++ b/harness/src/app/report-session-runtime.test.ts
@@ -15,11 +15,15 @@ import { join } from "node:path";
 import type { Pool } from "pg";
 
 import { withSchema } from "../__tests__/setup/postgres.js";
+import type { Scope } from "../auth/types.js";
 import { createThreadStore } from "../memory/thread-store.js";
 import type { DraftDocument } from "../report-model/draft.js";
 import { upsertAnalysis } from "../state/analyses.js";
 import { upsertArtifact, type RegisterArtifactInput } from "../state/artifacts.js";
+import type { DerivationRecord } from "../state/report-session-state.js";
 import { insertRun } from "../state/runs.js";
+import { makeToolContext } from "../tools/__fixtures__/tool-context.js";
+import { createReportAuthoringTools } from "../tools/report-authoring/authoring-tools.js";
 import { createReportSessionRuntime } from "./report-session-runtime.js";
 
 const DOC_ONE: DraftDocument = {
@@ -222,6 +226,99 @@ describe("createReportSessionRuntime", () => {
         } finally {
             await rm(root, { recursive: true, force: true });
         }
+    });
+
+    /**
+     * One derivation record over a source of the pinned set. The hashes are well-formed `algorithm:hex`
+     * values, because the grammar of a reference refuses any other shape.
+     */
+    function derivation(threadId: string, output: string, sourcePath: string, sourceHash: string): DerivationRecord {
+        return {
+            outputPath: `report-sessions/${threadId}/derived/${output}`,
+            outputHash: "sha256:dddddd",
+            sources: [{ path: sourcePath, hash: sourceHash }],
+            scriptHash: "sha256:eeeeee",
+            script: "import pandas\n",
+        };
+    }
+
+    it("serves each derivation as a member, and the stored pin stays as it was written", async () => {
+        const analysisId = "analysis-derived-membership";
+        const threadId = "thread-derived-membership";
+        await seedAnalysis(analysisId);
+        await seedThread(threadId, analysisId);
+        const pinnedPath = "runs/r1/output/de.csv";
+        await upsertArtifact(pool, artifact(analysisId, pinnedPath, "sha256:aaa"));
+
+        const runtime = createReportSessionRuntime({ pool });
+        const pinned = await runtime.gateway.load(threadId);
+        expect(pinned.outcome).toBe("found");
+        if (pinned.outcome !== "found") throw new Error("expected found");
+        expect(Object.keys(pinned.state.snapshot.artifacts)).toEqual([pinnedPath]);
+        // The stored pin, as the row holds it before any derivation lands.
+        const { rows: before } = await pool.query<{ snapshot: unknown }>({
+            text: "SELECT snapshot FROM cortex_report_session_state WHERE thread_id = $1",
+            values: [threadId],
+        });
+
+        const record = derivation(threadId, "yield.csv", pinnedPath, "sha256:aaa");
+        expect((await runtime.derivations.appendDerivation(threadId, record))._unsafeUnwrap()).toBe("appended");
+
+        // A fresh runtime reads the row, thus the merge runs on the durable state and not on a value that
+        // the append held.
+        const served = await createReportSessionRuntime({ pool }).gateway.load(threadId);
+        expect(served.outcome).toBe("found");
+        if (served.outcome !== "found") throw new Error("expected found");
+        expect(Object.keys(served.state.snapshot.artifacts).sort()).toEqual([record.outputPath, pinnedPath].sort());
+        // The served entry carries the output hash of the record.
+        expect(served.state.snapshot.artifacts[record.outputPath]).toEqual({ hash: record.outputHash });
+        // The pinned entry is untouched by the merge.
+        expect(served.state.snapshot.artifacts[pinnedPath]!.hash).toBe("sha256:aaa");
+
+        // The stored snapshot column holds the pin alone, thus the anchor stays honest.
+        const { rows: after } = await pool.query<{ snapshot: unknown }>({
+            text: "SELECT snapshot FROM cortex_report_session_state WHERE thread_id = $1",
+            values: [threadId],
+        });
+        expect(after[0]!.snapshot).toEqual(before[0]!.snapshot);
+        expect(Object.keys(after[0]!.snapshot as Record<string, unknown>)).not.toContain(record.outputPath);
+    });
+
+    it("binds a derived path through the authoring tools, and the stamp fills its hash", async () => {
+        const analysisId = "analysis-derived-binding";
+        const threadId = "thread-derived-binding";
+        await seedAnalysis(analysisId);
+        await seedThread(threadId, analysisId);
+        await upsertArtifact(pool, artifact(analysisId, "runs/r1/output/de.csv", "sha256:aaa"));
+
+        const runtime = createReportSessionRuntime({ pool });
+        await runtime.gateway.load(threadId);
+        const record = derivation(threadId, "yield.csv", "runs/r1/output/de.csv", "sha256:aaa");
+        expect((await runtime.derivations.appendDerivation(threadId, record))._unsafeUnwrap()).toBe("appended");
+
+        const tools = createReportAuthoringTools(runtime.gateway);
+        const { ctx } = makeToolContext();
+        const scope: Scope = { kind: "analysis", analysisId, threadId };
+        const call = { ...ctx, session: { ...ctx.session, scope } };
+
+        expect((await tools.add_block.execute({ block: { kind: "section", id: "s1", title: "Findings", blocks: [] } }, call))._unsafeUnwrap().applied).toBe(
+            true,
+        );
+        // The reference names the derived path alone. The stamp fills the hash from the served membership,
+        // thus a derived table binds the same way as a pinned artifact.
+        const added = (
+            await tools.add_block.execute(
+                { block: { kind: "table", id: "t1", binding: { kind: "artifact-table", path: record.outputPath } }, parentId: "s1", place: "end" },
+                call,
+            )
+        )._unsafeUnwrap();
+        expect(added.applied).toBe(true);
+
+        const loaded = await runtime.gateway.load(threadId);
+        if (loaded.outcome !== "found") throw new Error("expected found");
+        const section = loaded.state.document.sections[0]!;
+        const table = section.blocks[0]!;
+        expect(table).toMatchObject({ kind: "table", id: "t1", binding: { path: record.outputPath, hash: record.outputHash } });
     });
 
     it("lands the pin with no citation when the deps bind no workspace root", async () => {

--- a/harness/src/app/report-session-runtime.ts
+++ b/harness/src/app/report-session-runtime.ts
@@ -113,6 +113,10 @@ export interface ReportSessionRuntime {
  * A derived entry carries the output hash alone. A file type states a role of the run ledger, and a
  * derivation holds none. The map takes a null prototype, the same as the stored parse, thus a path such as
  * `__proto__` stays an ordinary entry.
+ *
+ * The derivations land last, thus a record whose output path equals a pinned path would shadow the pin. No
+ * such record exists: the derivation tool refuses an output name that the served membership already holds,
+ * and the output path of a derivation sits under the session directory, which the pin never reaches.
  */
 function serveMembership(snapshot: ReportSnapshot, derivations: readonly DerivationRecord[]): ReportSnapshot {
     if (derivations.length === 0) {

--- a/harness/src/app/report-session-runtime.ts
+++ b/harness/src/app/report-session-runtime.ts
@@ -26,6 +26,11 @@
  * thread and a wrong thread type are permanent, and a store or pin fault is
  * transient. The persist is a compare-and-swap against the prior document that the
  * load read, thus two concurrent turns cannot both land.
+ *
+ * The load serves the stored pin with the derivations of the session merged onto it.
+ * Thus a derived table binds, resolves, and validates the same way as a pinned one.
+ * The stored pin never changes, thus the anchor stays honest and the merge is
+ * recomputable from the row.
  */
 
 import type { Pool } from "pg";
@@ -36,7 +41,14 @@ import type { Logger } from "../lib/logger.js";
 import { createThreadStore } from "../memory/thread-store.js";
 import type { DraftDocument } from "../report-model/draft.js";
 import { pinReportSnapshot } from "../report-model/pin-snapshot.js";
-import { createReportSessionStateStore, type ReportSessionState as StoredSessionState, type SessionStateReadError } from "../state/report-session-state.js";
+import type { ArtifactSnapshot, ReportSnapshot } from "../report-model/reference-resolver.js";
+import {
+    createReportSessionStateStore,
+    type DerivationRecord,
+    type ReportSessionState as StoredSessionState,
+    type ReportSessionStateStore,
+    type SessionStateReadError,
+} from "../state/report-session-state.js";
 import type {
     ReportSessionStateGateway,
     SeenStampResult,
@@ -83,7 +95,37 @@ export interface ReportSessionRuntimeDeps {
  */
 export interface ReportSessionRuntime {
     readonly gateway: ReportSessionStateGateway;
+    /**
+     * The derivation ledger of the session state. The derivation tool appends one record for each
+     * derivation, and the gateway load serves each record as a member of the snapshot.
+     */
+    readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
     ensureSessionState(threadId: string): Promise<EnsureSessionStateResult>;
+}
+
+/**
+ * The served membership: the stored pin, with one entry for each derivation of the session.
+ *
+ * The tools read the served snapshot, thus a derived table binds the same way as a pinned one. The stored
+ * pin stays untouched, thus the merge runs again on each load and the row keeps the evidence of the pin
+ * alone.
+ *
+ * A derived entry carries the output hash alone. A file type states a role of the run ledger, and a
+ * derivation holds none. The map takes a null prototype, the same as the stored parse, thus a path such as
+ * `__proto__` stays an ordinary entry.
+ */
+function serveMembership(snapshot: ReportSnapshot, derivations: readonly DerivationRecord[]): ReportSnapshot {
+    if (derivations.length === 0) {
+        return snapshot;
+    }
+    const artifacts: Record<string, ArtifactSnapshot> = Object.create(null);
+    for (const [path, entry] of Object.entries(snapshot.artifacts)) {
+        artifacts[path] = entry;
+    }
+    for (const record of derivations) {
+        artifacts[record.outputPath] = { hash: record.outputHash };
+    }
+    return { ...snapshot, artifacts };
 }
 
 /**
@@ -171,6 +213,9 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
      * no document, thus the load gives the empty draft. The found load carries the
      * stored analysis and the prior document as the concurrency token. A row with no
      * snapshot cannot serve a tool, because the pin writes the snapshot first.
+     *
+     * The served snapshot is the stored pin with the derivations merged onto it, thus a
+     * tool reads one membership and it never merges again.
      */
     function toLoad(state: StoredSessionState): SessionStateLoad {
         if (state.snapshot === null) {
@@ -179,7 +224,7 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
         }
         return {
             outcome: "found",
-            state: { document: state.document ?? EMPTY_DRAFT, snapshot: state.snapshot },
+            state: { document: state.document ?? EMPTY_DRAFT, snapshot: serveMembership(state.snapshot, state.derivations) },
             analysisId: state.analysisId,
             token: state.document,
             seenDocumentHash: state.seenDocumentHash,
@@ -257,5 +302,5 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
         },
     };
 
-    return { gateway, ensureSessionState };
+    return { gateway, derivations: store, ensureSessionState };
 }

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -68,6 +68,14 @@ names each table artifact and its columns, thus it shows what a chart can plot.
 Reach for a figure image only when no table carries the data. The run phase keeps
 its own plots, and this rule is about the report page alone.
 
+A run writes statistical tables, and not plot-ready ones. When a real reshaping
+stands between the evidence and the block, \`derive_table\` runs your Python script
+over the pinned inputs that you declare, and it pins the result to this session. A
+join of two tables, a pivot, and an aggregate are such reshaping. A per-row
+transform is not: a chart block reads the column that it needs. The derived table
+binds like any pinned artifact, and its record holds your script, the sources, and
+the hashes.
+
 The headline row leads with the cohort and the yield: the n, the group split, the
 yield count, and the event count. A value that carries a caveat is not a headline.
 An unshrunken effect size that shrinkage collapses is such a value, thus it reads in

--- a/harness/src/runtime/assemble.test.ts
+++ b/harness/src/runtime/assemble.test.ts
@@ -21,6 +21,7 @@ import { createThreadHistory } from "../memory/thread-history.js";
 import { createThreadStore } from "../memory/thread-store.js";
 import type { ChatProvider, EmbeddingProvider } from "../providers/types.js";
 import { upsertAnalysis } from "../state/analyses.js";
+import type { ReportSessionStateStore } from "../state/report-session-state.js";
 import type { ReportVersionStore } from "../state/report-versions.js";
 import { makeToolContext } from "../tools/__fixtures__/tool-context.js";
 import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad } from "../tools/report-authoring/authoring-tools.js";
@@ -252,6 +253,7 @@ function reportAgentOver(eyes: AcquireEyes | undefined, chrome: ChromeConfig, ro
         store: {} as ReportVersionStore,
         threads: {} as Pick<ThreadStore, "getThread">,
         chrome,
+        derivations: {} as Pick<ReportSessionStateStore, "appendDerivation">,
         ...(eyes ? { eyes } : {}),
     });
 }

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -353,6 +353,12 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
         store: reportVersionStore,
         threads: reportThreads,
         chrome: conversation.chrome,
+        // The derivation tool draws the rails of the value tier: the same sandbox client
+        // and the same run authorizer. Thus a session derivation and an extraction run on
+        // one substrate, and neither one mints a run of the analysis.
+        derivations: reportSession.derivations,
+        sandboxClient: wf.dataProfile.sandboxClient,
+        runAuthorizer: conversation.runAuthorizer,
         makeResolver: makeReportResolver,
         ...(eyes ? { eyes } : {}),
         ...(deps.resolveReportPageAsset ? { resolvePageAsset: deps.resolveReportPageAsset } : {}),

--- a/harness/src/sandbox/client.ts
+++ b/harness/src/sandbox/client.ts
@@ -21,9 +21,29 @@
  * `DBOS.recv` and `DBOS.writeStream` are body-only.
  */
 
-import type { CreateSandboxMeta, ExecEmit, ExecResult, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SubmitExecBody } from "./types.js";
+import type {
+    CreateSandboxMeta,
+    ExecEmit,
+    ExecResult,
+    ManagedSandbox,
+    SandboxIdentity,
+    SandboxLiveness,
+    SandboxRef,
+    SandboxTransport,
+    SubmitExecBody,
+} from "./types.js";
 
 export interface SandboxClient {
+    /**
+     * The result transport this client awaits under, fixed at construction. A caller that runs outside a
+     * workflow body reads it: `callback` awaits through `DBOS.recv`, which is body-only, thus such a caller
+     * must refuse before it starts a container it can never await.
+     *
+     * Optional, because a hand-written realization states nothing here. Absent means unknown, and a caller
+     * treats it as the poll default rather than refusing every composition that omits it.
+     */
+    readonly transport?: SandboxTransport;
+
     /**
      * DBOS step (`sandbox.create`) — the spawn half of the two-step create
      * (see the harness-sandbox-exec spec). Launches the sandbox-base container/Job under the

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -113,6 +113,36 @@ describe("precreateStepTree — step-tree access mode", () => {
         // The read-only path returns before creating or chmodding any step tree.
         await expect(stat(stepDir())).rejects.toThrow();
     });
+
+    /** A declared write tail, in the shape the session derivation gives. */
+    const TAIL = "report-sessions/thread-1/derived";
+    const tailDir = () => join(root, "report-sessions", "thread-1", "derived");
+
+    test("a declared tail makes that one directory, and no step tree", async () => {
+        await precreateStepTree(deps(undefined), { ...meta, writableTail: TAIL });
+
+        expect((await stat(tailDir())).isDirectory()).toBe(true);
+        // A declared tail is one directory, thus no artifact subdirectory lands under it.
+        for (const sub of STEP_SUBDIRS) {
+            await expect(stat(join(tailDir(), sub))).rejects.toThrow();
+        }
+        // The step tree of the coordinates is never made, because the tail took its place.
+        await expect(stat(stepDir())).rejects.toThrow();
+    });
+
+    test("world-writable: a declared tail ends world-writable", async () => {
+        await precreateStepTree(deps("world-writable"), { ...meta, writableTail: TAIL });
+
+        expect(await modeOf(tailDir())).toBe(0o777);
+        // The loosening is scoped to the tail — its ancestors keep default modes.
+        expect(await modeOf(join(root, "report-sessions"))).not.toBe(0o777);
+    });
+
+    test("a crafted tail escapes nothing, because the builder refuses it first", async () => {
+        await expect(precreateStepTree(deps(undefined), { ...meta, writableTail: "../escape" })).rejects.toThrow(/Invalid writableTail/);
+        await expect(precreateStepTree(deps(undefined), { ...meta, writableTail: TAIL, readOnly: true })).rejects.toThrow(/read-only sandbox cannot/);
+        await expect(stat(join(root, "..", "escape"))).rejects.toThrow();
+    });
 });
 
 describe("createSandboxClient — engine connection threading", () => {

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -243,6 +243,7 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
     const isAlive = async (ref: SandboxRef) => unwrapOrThrow(await ops.isAlive(ref));
 
     return {
+        transport,
         createSandbox: async (meta, identity) => {
             // The config states an engine fact (binds preserve host ownership);
             // which remediation that fact demands — today, a world-writable step

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -20,7 +20,7 @@ import type { Pool } from "pg";
 
 import type { Logger } from "../lib/logger.js";
 import { clampResources, type ResourceLimits } from "../config/resource-limits.js";
-import { stepWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
+import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { tryMutation } from "../lib/db-result.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { clearSandboxRef, setSandboxRef } from "../state/index.js";
@@ -28,7 +28,7 @@ import { awaitExec, type AwaitExecOptions } from "./await-exec.js";
 import type { SandboxClient } from "./client.js";
 import { createDockerSandboxOps } from "./docker-client.js";
 import { createK8sSandboxOps } from "./k8s-client.js";
-import { STEP_SUBDIRS } from "./mount-plan.js";
+import { sandboxWriteTail } from "./mount-plan.js";
 import { submitExec, type SubmitExecDeps } from "./submit-exec.js";
 import { toPersistedRef, type CreateSandboxMeta, type SandboxRef, type SandboxTransport } from "./types.js";
 
@@ -140,35 +140,40 @@ export function composeAwaitOptions(
 }
 
 /**
- * Backend-agnostic pre-creation of the writable step tree under the analysis's
+ * Backend-agnostic pre-creation of the writable tree under the analysis's
  * resolved workspace root. On Docker that root is the host dir the container
  * binds; on K8s it lives under the session PVC the sandbox pod mounts via
  * subPath. `mkdir(recursive)` is idempotent, so an existing tree (replay, retry)
- * is not an error. A read-only sandbox has no writable step mount, so there is
+ * is not an error. A read-only sandbox has no writable mount, so there is
  * nothing to pre-create.
  *
- * `stepTreeAccess: "world-writable"` chmods the step dir and each subdir so the
+ * The writable tree is the step directory with its five artifact subdirs, or the
+ * declared write tail as one directory. `sandboxWriteTail` decides which, so the
+ * directory the host makes and the directory the sandbox mounts are the same one,
+ * and the run path keeps the tree it always had.
+ *
+ * `stepTreeAccess: "world-writable"` chmods the directory and each subdir so the
  * uid-1000 sandbox workload can write them through engines that honor host bind
  * ownership. The chmod is explicit, not `mkdir`'s `mode` option: the process
  * umask masks `mkdir`'s mode, and on replay the dirs already exist so `mkdir`
- * would not touch them either way. Scoped to the step write tree — the
+ * would not touch them either way. Scoped to the write tree — the
  * read-only mount sources are never re-moded. Exported for tests.
  */
 export async function precreateStepTree(
     deps: { resolveWorkspaceRoot: ResolveWorkspaceRoot; stepTreeAccess?: "world-writable" },
     meta: CreateSandboxMeta,
 ): Promise<void> {
-    if (meta.readOnly) return;
-    const stepDir = stepWritePrefix({
-        workspaceRoot: deps.resolveWorkspaceRoot(meta.analysisId),
-        runId: meta.runId,
-        stepId: meta.stepId,
-    });
-    await mkdir(stepDir, { recursive: true });
-    await Promise.all(STEP_SUBDIRS.map((sub) => mkdir(join(stepDir, sub), { recursive: true })));
+    const write = sandboxWriteTail(meta);
+    if (write === undefined) return;
+    // `tailWritePrefix` (not a raw `join`) so every segment runs through the same
+    // id validation the mount builders apply — a crafted tail cannot escape the
+    // resolved root.
+    const writeDir = tailWritePrefix({ workspaceRoot: deps.resolveWorkspaceRoot(meta.analysisId), tail: write.tail });
+    await mkdir(writeDir, { recursive: true });
+    await Promise.all(write.subdirs.map((sub) => mkdir(join(writeDir, sub), { recursive: true })));
     if (deps.stepTreeAccess === "world-writable") {
-        await chmod(stepDir, 0o777);
-        await Promise.all(STEP_SUBDIRS.map((sub) => chmod(join(stepDir, sub), 0o777)));
+        await chmod(writeDir, 0o777);
+        await Promise.all(write.subdirs.map((sub) => chmod(join(writeDir, sub), 0o777)));
     }
 }
 

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -418,6 +418,52 @@ describe("docker createSandbox — mounts and platform", () => {
         expect(sandboxOf(created)!.workingDir).toBe("/an-1");
     });
 
+    test("binds a declared write tail in place of the step directory", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox(
+                { ...META, runId: "derive-table", stepId: "derive", writableTail: "report-sessions/thread-1/derived" },
+                mintSandboxIdentity("derive-table"),
+            )
+        )._unsafeUnwrap();
+
+        const sandbox = sandboxOf(created)!;
+        // The tree stays read-only, and the one read-write bind covers the declared tail alone.
+        expect(sandbox.binds).toEqual(["/sessions/an-1:/an-1:ro", "/sessions/an-1/report-sessions/thread-1/derived:/an-1/report-sessions/thread-1/derived:rw"]);
+        // No step directory of the coordinates reaches a bind.
+        expect(sandbox.binds.some((b) => b.includes("runs/derive-table"))).toBe(false);
+        expect(sandbox.workingDir).toBe("/an-1/report-sessions/thread-1/derived");
+    });
+
+    test("refuses a crafted write tail before any container is created", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        // The mount builders validate each segment, thus a traversal never becomes a bind source. The
+        // refusal is a throw at the builder, and the `ResultAsync` carries it as a rejection.
+        const attempt = async (): Promise<void> => {
+            (await ops.createSandbox({ ...META, writableTail: "../escape" }, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+        };
+        await expect(attempt()).rejects.toThrow(/Invalid writableTail/);
+        expect(created).toHaveLength(0);
+    });
+
     test("skips the /mnt/libs mount when the store's current pointer has vanished since boot", async () => {
         const { docker, created } = stubDocker();
         await rm(join(libRoot, "current"), { force: true });

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -36,9 +36,9 @@ import { ResultAsync, err, ok, type Result } from "neverthrow";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
-import { stepWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
+import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
-import { buildMountPlan } from "./mount-plan.js";
+import { buildMountPlan, sandboxWriteTail } from "./mount-plan.js";
 
 /** Read the originating HTTP status off any `SandboxError` variant that carries one. */
 function statusOf(e: SandboxError): number | undefined {
@@ -304,13 +304,16 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                     });
 
                     const hostTreePath = config.resolveWorkspaceRoot(meta.analysisId);
-                    // `stepWritePrefix` (not a raw `join`) so the RW bind source runs through
-                    // the same id validation as the pre-created step tree — a crafted stepId
-                    // cannot escape the resolved root into the container.
-                    const hostStepPath = stepWritePrefix({ workspaceRoot: hostTreePath, runId: meta.runId, stepId: meta.stepId });
+                    // `tailWritePrefix` (not a raw `join`) so the RW bind source runs through
+                    // the same validation as the pre-created write tree — a crafted stepId or
+                    // a crafted tail cannot escape the resolved root into the container. The
+                    // tail is the step directory, or the one the caller declared.
+                    const write = sandboxWriteTail(meta);
                     const binds = [
                         `${hostTreePath}:${plan.readonlyTreePath}:ro`,
-                        ...(plan.writableStepPath ? [`${hostStepPath}:${plan.writableStepPath}:rw`] : []),
+                        ...(write && plan.writableStepPath
+                            ? [`${tailWritePrefix({ workspaceRoot: hostTreePath, tail: write.tail })}:${plan.writableStepPath}:rw`]
+                            : []),
                         ...(libsMounted && config.libStorePath ? [`${config.libStorePath}:${plan.libsPath}:ro`] : []),
                         ...(refsMounted && config.refStorePath ? [`${config.refStorePath}:${plan.refsPath}:ro`] : []),
                     ];

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -194,6 +194,49 @@ describe("k8s createSandbox", () => {
         expect(mounts.find((m) => m.name === "session" && m.mountPath === "/an-1/runs/run-1/step-a")!.subPath).toBe("tenants/acme/an-1/runs/run-1/step-a");
     });
 
+    test("mounts a declared write tail in place of the step directory", async () => {
+        const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.7" }, metadata: { name: "sbx-tail" } }]);
+
+        const ops = createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot: (id) => `${SESSION_PVC_ROOT}/${id}`,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox(
+                {
+                    runId: "derive-table",
+                    stepId: "derive",
+                    analysisId: "an-1",
+                    childWorkflowId: "derive-table:x",
+                    resources: { cpu: 1, memoryGb: 1 },
+                    writableTail: "report-sessions/thread-1/derived",
+                },
+                mintSandboxIdentity("derive-table"),
+            )
+        )._unsafeUnwrap();
+
+        const container = stub.createdJobs[0]!.spec!.template.spec!.containers[0]!;
+        const mounts = container.volumeMounts!.filter((m) => m.name === "session");
+
+        expect(container.workingDir).toBe("/an-1/report-sessions/thread-1/derived");
+        // The tree stays read-only, and the one read-write mount covers the declared tail alone.
+        expect(mounts.find((m) => m.mountPath === "/an-1")!.readOnly).toBe(true);
+        const rw = mounts.find((m) => m.mountPath === "/an-1/report-sessions/thread-1/derived")!;
+        expect(rw.subPath).toBe("an-1/report-sessions/thread-1/derived");
+        expect(rw.readOnly).toBe(false);
+        // No step directory of the coordinates reaches a mount.
+        expect(mounts.some((m) => m.mountPath.includes("runs/derive-table"))).toBe(false);
+        expect(mounts).toHaveLength(2);
+    });
+
     test("a workspace root outside sessionPvcRoot is a loud failure, not a silently wrong mount", async () => {
         const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.9" }, metadata: { name: "sbx-escape" } }]);
 

--- a/harness/src/sandbox/mount-plan.test.ts
+++ b/harness/src/sandbox/mount-plan.test.ts
@@ -6,9 +6,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { buildMountPlan, buildSessionSubPaths, STEP_SUBDIRS } from "./mount-plan.js";
+import { buildMountPlan, buildSessionSubPaths, sandboxWriteTail, STEP_SUBDIRS } from "./mount-plan.js";
 
 const COORDS = { analysisId: "an-1", runId: "run-1", stepId: "step-a" };
+
+/** A declared write tail, in the shape the session derivation gives. */
+const TAIL = "report-sessions/thread-1/derived";
 
 describe("buildMountPlan", () => {
     test("computes container paths from coordinates", () => {
@@ -113,5 +116,83 @@ describe("buildMountPlan id validation", () => {
         expect(() => buildMountPlan({ ...COORDS, analysisId: ".." }, { libs: false, refs: false })).toThrow(/Invalid analysisId/);
         expect(() => buildMountPlan({ ...COORDS, stepId: ".." }, { libs: false, refs: false })).toThrow(/Invalid stepId/);
         expect(() => buildMountPlan({ ...COORDS, runId: ".." }, { libs: false, refs: false })).toThrow(/Invalid runId/);
+    });
+});
+
+describe("the declared write tail", () => {
+    test("takes the place of the step tail as the one writable mount", () => {
+        const plan = buildMountPlan({ ...COORDS, writableTail: TAIL }, { libs: true, refs: true });
+        expect(plan.writableStepPath).toBe(`/an-1/${TAIL}`);
+        // The working directory is the write mount, thus a script writes beside where it stands.
+        expect(plan.workingDir).toBe(`/an-1/${TAIL}`);
+        // A declared tail is one directory, thus the host pre-creates no artifact subdirectory under it.
+        expect(plan.stepSubdirs).toEqual([]);
+        // The read-only tree and the two stores are untouched by the tail.
+        expect(plan.readonlyTreePath).toBe("/an-1");
+        expect(plan.libsPath).toBe("/mnt/libs");
+        expect(plan.refsPath).toBe("/mnt/refs");
+        expect(plan.env.PROVENANCE_WATCH_DIRS).toBe("/an-1");
+        // The step tail of the coordinates reaches no mount.
+        expect(plan.writableStepPath).not.toContain("runs/run-1/step-a");
+    });
+
+    test("nests under the workspace subPath on the PVC side", () => {
+        const subPaths = buildSessionSubPaths({ ...COORDS, writableTail: TAIL }, "tenants/acme/an-1");
+        expect(subPaths.ro).toBe("tenants/acme/an-1");
+        expect(subPaths.rw).toBe(`tenants/acme/an-1/${TAIL}`);
+        // The RW subPath matches the container RW mount path sans leading slash — the two sides of the
+        // same directory.
+        expect(`/an-1/${subPaths.rw!.slice("tenants/acme/an-1/".length)}`).toBe(
+            buildMountPlan({ ...COORDS, writableTail: TAIL }, { libs: false, refs: false }).writableStepPath,
+        );
+    });
+
+    test("refuses a tail beside read-only, because the two state opposite things", () => {
+        expect(() => buildMountPlan({ ...COORDS, writableTail: TAIL, readOnly: true }, { libs: false, refs: false })).toThrow(/read-only sandbox cannot/);
+        expect(() => buildSessionSubPaths({ ...COORDS, writableTail: TAIL, readOnly: true }, "an-1")).toThrow(/read-only sandbox cannot/);
+        expect(() => sandboxWriteTail({ ...COORDS, writableTail: TAIL, readOnly: true })).toThrow(/read-only sandbox cannot/);
+    });
+
+    test("refuses an empty, absolute, or traversing tail", () => {
+        for (const tail of ["", "/abs/derived", "../escape", "report-sessions/../../etc", "report-sessions//derived", "derived/"]) {
+            expect(() => buildMountPlan({ ...COORDS, writableTail: tail }, { libs: false, refs: false })).toThrow(/Invalid writableTail/);
+        }
+    });
+
+    test("refuses a tail segment that carries a shell-hostile character", () => {
+        expect(() => buildMountPlan({ ...COORDS, writableTail: "report-sessions/thread 1/derived" }, { libs: false, refs: false })).toThrow(
+            /Invalid writableTail/,
+        );
+        expect(() => buildMountPlan({ ...COORDS, writableTail: "report-sessions/a\0b/derived" }, { libs: false, refs: false })).toThrow(/Invalid writableTail/);
+    });
+
+    test("keeps the run plan byte-identical when no tail is declared", () => {
+        // The run path is the whole reason the field is optional: an absent tail must give exactly the plan
+        // of a step, field for field.
+        const stepPlan = buildMountPlan(COORDS, { libs: true, refs: true });
+        expect(stepPlan).toEqual({
+            readonlyTreePath: "/an-1",
+            writableStepPath: "/an-1/runs/run-1/step-a",
+            workingDir: "/an-1/runs/run-1/step-a",
+            libsPath: "/mnt/libs",
+            refsPath: "/mnt/refs",
+            stepSubdirs: STEP_SUBDIRS,
+            env: stepPlan.env,
+        });
+        expect(buildSessionSubPaths(COORDS, "an-1")).toEqual({ ro: "an-1", rw: "an-1/runs/run-1/step-a" });
+    });
+});
+
+describe("sandboxWriteTail", () => {
+    test("gives the step tail with its five subdirectories when no tail is declared", () => {
+        expect(sandboxWriteTail(COORDS)).toEqual({ tail: "runs/run-1/step-a", subdirs: STEP_SUBDIRS });
+    });
+
+    test("gives the declared tail with no subdirectory", () => {
+        expect(sandboxWriteTail({ ...COORDS, writableTail: TAIL })).toEqual({ tail: TAIL, subdirs: [] });
+    });
+
+    test("gives nothing for a read-only sandbox", () => {
+        expect(sandboxWriteTail({ ...COORDS, readOnly: true })).toBeUndefined();
     });
 });

--- a/harness/src/sandbox/mount-plan.test.ts
+++ b/harness/src/sandbox/mount-plan.test.ts
@@ -153,6 +153,15 @@ describe("the declared write tail", () => {
         expect(() => sandboxWriteTail({ ...COORDS, writableTail: TAIL, readOnly: true })).toThrow(/read-only sandbox cannot/);
     });
 
+    test("validates the two ids even where the tail replaces the step directory", () => {
+        // The ids reach the sandbox name, the ownership labels, and the registry row on every path, thus a
+        // declared tail is no reason to skip their validation.
+        expect(() => buildMountPlan({ ...COORDS, runId: "..", writableTail: TAIL }, { libs: false, refs: false })).toThrow(/Invalid runId/);
+        expect(() => buildMountPlan({ ...COORDS, stepId: "a/b", writableTail: TAIL }, { libs: false, refs: false })).toThrow(/Invalid stepId/);
+        expect(() => sandboxWriteTail({ ...COORDS, stepId: "..", readOnly: true })).toThrow(/Invalid stepId/);
+        expect(() => buildSessionSubPaths({ ...COORDS, runId: "..", writableTail: TAIL }, "an-1")).toThrow(/Invalid runId/);
+    });
+
     test("refuses an empty, absolute, or traversing tail", () => {
         for (const tail of ["", "/abs/derived", "../escape", "report-sessions/../../etc", "report-sessions//derived", "derived/"]) {
             expect(() => buildMountPlan({ ...COORDS, writableTail: tail }, { libs: false, refs: false })).toThrow(/Invalid writableTail/);

--- a/harness/src/sandbox/mount-plan.ts
+++ b/harness/src/sandbox/mount-plan.ts
@@ -10,6 +10,17 @@
  * artifacts, lib store read-only at `/mnt/libs`, ref store read-only at
  * `/mnt/refs`.
  *
+ * A caller can declare its own `writableTail` in place of the step tail — a
+ * workspace-relative path that becomes the one read-write mount, with no step
+ * subdirectories under it. The session derivation declares one; the run path
+ * declares none and keeps the step tail. Thus a sandbox writes into the step
+ * directory or into the one declared tail, and nowhere else.
+ *
+ * The precedence is a refusal, not an order: `readOnly` and `writableTail` state
+ * opposite things about the same mount, thus a coordinate set that carries both
+ * throws here — the same as a crafted id. No caller can hold both and get a
+ * silently chosen winner.
+ *
  * Container paths are a function of `resourceId` alone — they never carry the
  * host location of the tree. Where that tree physically lives is the embedder's
  * (`resolveWorkspaceRoot`); the two are reconciled per backend: Docker binds the
@@ -17,7 +28,7 @@
  * (see {@link buildSessionSubPaths}).
  */
 
-import { assertSafeId } from "../workspace/paths.js";
+import { assertSafeId, assertSafeTail } from "../workspace/paths.js";
 
 export const STEP_SUBDIRS = ["output", "scripts", "figures", "logs", "notebooks"] as const;
 
@@ -39,6 +50,14 @@ export interface MountPlanCoords {
      * a generic read-only agent that must not mutate analysis files.
      */
     readOnly?: boolean;
+    /**
+     * The declared write tail: a workspace-relative path that takes the place of the
+     * step tail as the one read-write mount, with no step subdirectories under it.
+     * Each segment passes the safe-id discipline of the step builder. Absent keeps
+     * the step tail, thus the run path is unchanged. A tail beside `readOnly` is a
+     * contradiction, and the builders refuse it.
+     */
+    writableTail?: string;
 }
 
 export interface MountPlanStores {
@@ -52,20 +71,21 @@ export interface MountPlan {
     /** Flat read-only mount of the whole analysis tree. */
     readonlyTreePath: string;
     /**
-     * Nested read-write mount for this step's artifacts, also the WorkingDir.
-     * Undefined for a read-only sandbox — no writable mount exists; the
-     * WorkingDir falls back to the read-only tree root.
+     * Nested read-write mount, also the WorkingDir: the step's artifact directory,
+     * or the declared write tail in its place. Undefined for a read-only sandbox —
+     * no writable mount exists; the WorkingDir falls back to the read-only tree
+     * root.
      */
     writableStepPath?: string;
-    /** Container WorkingDir: the writable step path, or the RO tree root in
+    /** Container WorkingDir: the writable mount, or the RO tree root in
      *  read-only mode. */
     workingDir: string;
     /** Container path of the lib store, present only when `libs`. */
     libsPath?: string;
     /** Container path of the ref store, present only when `refs`. */
     refsPath?: string;
-    /** Pre-created subdirectories under the writable step path. Empty when
-     *  read-only (nothing to pre-create). */
+    /** Pre-created subdirectories under the writable mount. Empty when read-only
+     *  (nothing to pre-create) and when a declared tail replaces the step tail. */
     stepSubdirs: readonly string[];
     /** Env merged into the sandbox container: provenance + lib-store vars. */
     env: Record<string, string>;
@@ -75,7 +95,7 @@ export interface MountPlan {
 export interface SessionSubPaths {
     /** Read-only mount of the whole analysis tree. */
     readonly ro: string;
-    /** Read-write mount of the step's artifact dir; absent when read-only. */
+    /** Read-write mount of the step's artifact dir, or of the declared tail; absent when read-only. */
     readonly rw?: string;
 }
 
@@ -90,6 +110,35 @@ function stepTail(runId: string, stepId: string): string {
     assertSafeId(runId, "runId");
     assertSafeId(stepId, "stepId");
     return `runs/${runId}/${stepId}`;
+}
+
+/** The one writable mount of a sandbox: its workspace-relative tail, and what the host pre-makes under it. */
+export interface SandboxWriteTail {
+    /** The tail beneath the workspace root, in both container and PVC-relative space. */
+    readonly tail: string;
+    /** The subdirectories the host pre-creates under the tail. A declared tail is one directory, thus none. */
+    readonly subdirs: readonly string[];
+}
+
+/**
+ * The write tail of a sandbox, or `undefined` when the sandbox holds no write mount.
+ *
+ * The one owner of the rule, read by the container path, the PVC subPath, and the
+ * host-side preparation alike. Thus the directory the harness makes and the
+ * directory the sandbox mounts are provably the same one.
+ *
+ * `readOnly` beside a declared tail states two opposite things about one mount, thus
+ * it throws rather than picking a winner.
+ */
+export function sandboxWriteTail(coords: MountPlanCoords): SandboxWriteTail | undefined {
+    if (coords.writableTail === undefined) {
+        return coords.readOnly ? undefined : { tail: stepTail(coords.runId, coords.stepId), subdirs: STEP_SUBDIRS };
+    }
+    if (coords.readOnly) {
+        throw new Error(`sandbox mount: a read-only sandbox cannot declare a write tail (got ${coords.writableTail})`);
+    }
+    // The segments come back validated, thus the join below re-splits nothing.
+    return { tail: assertSafeTail(coords.writableTail).join("/"), subdirs: [] };
 }
 
 /**
@@ -108,9 +157,10 @@ export function buildSessionSubPaths(coords: MountPlanCoords, workspaceSubPath: 
             `buildSessionSubPaths: workspaceSubPath must be a non-empty PVC-root-relative path without '..' (got ${JSON.stringify(workspaceSubPath)})`,
         );
     }
+    const write = sandboxWriteTail(coords);
     return {
         ro: workspaceSubPath,
-        rw: coords.readOnly ? undefined : `${workspaceSubPath}/${stepTail(coords.runId, coords.stepId)}`,
+        ...(write === undefined ? {} : { rw: `${workspaceSubPath}/${write.tail}` }),
     };
 }
 
@@ -127,12 +177,13 @@ function libStoreEnv(): Record<string, string> {
 }
 
 export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores): MountPlan {
-    const { analysisId, runId, stepId, readOnly } = coords;
+    const { analysisId } = coords;
     // `analysisId` becomes the RO mount point `/{analysisId}` even in read-only
     // mode (where `stepTail` — which validates runId/stepId — is not reached).
     assertSafeId(analysisId, "analysisId");
     const readonlyTreePath = `/${analysisId}`;
-    const writableStepPath = readOnly ? undefined : `${readonlyTreePath}/${stepTail(runId, stepId)}`;
+    const write = sandboxWriteTail(coords);
+    const writableStepPath = write === undefined ? undefined : `${readonlyTreePath}/${write.tail}`;
 
     return {
         readonlyTreePath,
@@ -140,7 +191,7 @@ export function buildMountPlan(coords: MountPlanCoords, stores: MountPlanStores)
         workingDir: writableStepPath ?? readonlyTreePath,
         libsPath: stores.libs ? LIBS_CONTAINER_PATH : undefined,
         refsPath: stores.refs ? REFS_CONTAINER_PATH : undefined,
-        stepSubdirs: readOnly ? [] : STEP_SUBDIRS,
+        stepSubdirs: write?.subdirs ?? [],
         env: {
             PROVENANCE_WATCH_DIRS: readonlyTreePath,
             ...(stores.libs ? libStoreEnv() : {}),

--- a/harness/src/sandbox/mount-plan.ts
+++ b/harness/src/sandbox/mount-plan.ts
@@ -131,6 +131,11 @@ export interface SandboxWriteTail {
  * it throws rather than picking a winner.
  */
 export function sandboxWriteTail(coords: MountPlanCoords): SandboxWriteTail | undefined {
+    // The two ids reach the sandbox name, the ownership labels, and the registry row on every path, not the
+    // step tail alone. Thus they take their validation before any branch, and a crafted id is refused even
+    // where no step directory is built.
+    assertSafeId(coords.runId, "runId");
+    assertSafeId(coords.stepId, "stepId");
     if (coords.writableTail === undefined) {
         return coords.readOnly ? undefined : { tail: stepTail(coords.runId, coords.stepId), subdirs: STEP_SUBDIRS };
     }

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -237,6 +237,12 @@ export interface CreateSandboxMeta {
     /** Enforced read-only: provision with no read-write step mount, only the
      *  read-only analysis tree for generic read-only agents. */
     readOnly?: boolean;
+    /** Workspace-relative path that becomes the one read-write mount, in place of
+     *  the step directory and with no step subdirectories under it. Each segment
+     *  passes the safe-id discipline of the step builder. Absent keeps the step
+     *  mount, thus a run provisions exactly as before. A tail beside `readOnly` is
+     *  a contradiction, and the mount builders refuse it. */
+    writableTail?: string;
     /** Billing attribution stamped as pod labels for OpenCost compute metering.
      *  Absent ⇒ the pod is invisible to the metering reconciler (filter-level). */
     billing?: { billingContextId: string; userId: string };

--- a/harness/src/state/init.ts
+++ b/harness/src/state/init.ts
@@ -180,6 +180,13 @@ CREATE INDEX IF NOT EXISTS idx_cortex_report_versions_analysis
 -- holds the hash that the last eyes capture saw, copied from the rendered hash.
 -- Each is nullable, because a fresh session has run no preview and no eyes. The
 -- record refuses unless the seen hash equals the hash of the current draft.
+--
+-- The derivations column holds the derivation list of the session. One record
+-- carries the derived output path, the output hash, the source paths with their
+-- hashes, the script hash, and the script text. The column is nullable, because a
+-- session that derived nothing holds no list, and the read gives an empty list for
+-- such a row. The served membership merges the records onto the pin, and the pin
+-- itself never changes.
 CREATE TABLE IF NOT EXISTS cortex_report_session_state (
   thread_id              TEXT PRIMARY KEY,
   analysis_id            TEXT NOT NULL
@@ -187,6 +194,7 @@ CREATE TABLE IF NOT EXISTS cortex_report_session_state (
                            ON DELETE CASCADE,
   document               JSONB,
   snapshot               JSONB,
+  derivations            JSONB,
   rendered_document_hash TEXT,
   seen_document_hash     TEXT,
   created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -578,6 +586,10 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                 // which is the honest state, thus an existing row reads back as never-seen.
                 "ALTER TABLE cortex_report_session_state ADD COLUMN IF NOT EXISTS rendered_document_hash TEXT",
                 "ALTER TABLE cortex_report_session_state ADD COLUMN IF NOT EXISTS seen_document_hash TEXT",
+                // The derivation list of a report session. Nullable and unbackfilled: a
+                // session that derived nothing holds no list, and the read gives an empty
+                // list for such a row.
+                "ALTER TABLE cortex_report_session_state ADD COLUMN IF NOT EXISTS derivations JSONB",
                 // Databases created before `data_profile_status` became nullable still
                 // carry the NOT NULL floor, which would reject a clear. Idempotent:
                 // dropping an absent NOT NULL no-ops, so this is a no-op on fresh DBs.

--- a/harness/src/state/report-session-state.test.ts
+++ b/harness/src/state/report-session-state.test.ts
@@ -13,7 +13,7 @@ import { withSchema } from "../__tests__/setup/postgres.js";
 import type { DraftDocument } from "../report-model/draft.js";
 import type { ReportSnapshot } from "../report-model/reference-resolver.js";
 import { upsertAnalysis } from "./analyses.js";
-import { createReportSessionStateStore, type ReportSessionStateStore } from "./report-session-state.js";
+import { createReportSessionStateStore, type DerivationRecord, type ReportSessionStateStore } from "./report-session-state.js";
 
 const validDraft: DraftDocument = {
     title: "A report",
@@ -199,10 +199,19 @@ describe("createReportSessionStateStore", () => {
         const threadId = "thread-purge-cascade";
 
         (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+        (
+            await store.appendDerivation(threadId, {
+                outputPath: `report-sessions/${threadId}/derived/a.csv`,
+                outputHash: "sha256:aaaaaa",
+                sources: [{ path: "runs/r1/output/de.csv", hash: "abc123" }],
+                scriptHash: "sha256:bbbbbb",
+                script: "import pandas\n",
+            })
+        )._unsafeUnwrap();
         expect((await store.readState(threadId))._unsafeUnwrap()).not.toBeNull();
 
         // The analysis_id foreign key cascades. A purge removes the analysis-state row,
-        // thus the session-state row goes with it.
+        // thus the session-state row and the derivations that it holds go with it.
         await pool.query({ text: "DELETE FROM cortex_analysis_state WHERE analysis_id = $1", values: [analysisId] });
 
         expect((await store.readState(threadId))._unsafeUnwrap()).toBeNull();
@@ -248,5 +257,93 @@ describe("createReportSessionStateStore", () => {
     it("gives an absence for a stamp against a thread with no row", async () => {
         expect((await store.stampRendered("thread-stamp-absent", "h"))._unsafeUnwrap()).toBe("absent");
         expect((await store.stampSeen("thread-stamp-absent"))._unsafeUnwrap()).toBe("absent");
+    });
+
+    /** One derivation record. Each test names its own output path, thus the name rule reads one case. */
+    function derivation(output: string, sourcePath = "runs/r1/output/de.csv"): DerivationRecord {
+        return {
+            outputPath: `report-sessions/thread-x/derived/${output}`,
+            outputHash: `sha256:${output}`,
+            sources: [{ path: sourcePath, hash: "abc123" }],
+            scriptHash: "sha256:script",
+            script: "import pandas\n",
+        };
+    }
+
+    it("appends each derivation, and the read gives them in the order that they landed", async () => {
+        const analysisId = "analysis-derivations";
+        await seedAnalysis(analysisId);
+        const threadId = "thread-derivations";
+        (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+
+        // A fresh row holds no list at all, thus the read gives an empty list.
+        expect((await store.readState(threadId))._unsafeUnwrap()!.derivations).toEqual([]);
+
+        const first = derivation("a.csv");
+        const second = derivation("b.csv", "runs/r1/output/counts.csv");
+        expect((await store.appendDerivation(threadId, first))._unsafeUnwrap()).toBe("appended");
+        expect((await store.appendDerivation(threadId, second))._unsafeUnwrap()).toBe("appended");
+
+        // A second store instance reads the same durable list, with each record whole.
+        const read = (await createReportSessionStateStore({ pool }).readState(threadId))._unsafeUnwrap();
+        expect(read!.derivations).toEqual([first, second]);
+        // The record carries what a second run needs: the script, the sources, and the output hash.
+        expect(read!.derivations[0]!.script).toBe("import pandas\n");
+        expect(read!.derivations[0]!.sources).toEqual([{ path: "runs/r1/output/de.csv", hash: "abc123" }]);
+    });
+
+    it("refuses a second record that holds an output path of the list", async () => {
+        const analysisId = "analysis-derivation-name";
+        await seedAnalysis(analysisId);
+        const threadId = "thread-derivation-name";
+        (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+
+        const landed = derivation("yield.csv");
+        expect((await store.appendDerivation(threadId, landed))._unsafeUnwrap()).toBe("appended");
+
+        // The output path is unique across the list, thus a second record of that path refuses.
+        const repeated: DerivationRecord = { ...landed, outputHash: "sha256:different", script: "import numpy\n" };
+        expect((await store.appendDerivation(threadId, repeated))._unsafeUnwrap()).toBe("duplicate");
+
+        // The stored list keeps the first record, thus the refusal changed nothing.
+        const read = (await store.readState(threadId))._unsafeUnwrap();
+        expect(read!.derivations).toEqual([landed]);
+    });
+
+    it("gives an absence for an append against a thread with no row", async () => {
+        expect((await store.appendDerivation("thread-derivation-absent", derivation("a.csv")))._unsafeUnwrap()).toBe("absent");
+    });
+
+    it("reads a row whose list predates the column as an empty list", async () => {
+        const analysisId = "analysis-derivation-legacy";
+        await seedAnalysis(analysisId);
+        const threadId = "thread-derivation-legacy";
+        (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+
+        // A row written before the column existed carries SQL NULL. The read gives an empty list, and it
+        // gives no error, because a session that derived nothing holds none.
+        await pool.query({ text: "UPDATE cortex_report_session_state SET derivations = NULL WHERE thread_id = $1", values: [threadId] });
+        const read = (await store.readState(threadId))._unsafeUnwrap();
+        expect(read!.derivations).toEqual([]);
+        expect(read!.snapshot).toEqual(snapshot);
+    });
+
+    it("reads a corrupted derivation list as a typed error", async () => {
+        const analysisId = "analysis-derivation-corrupt";
+        await seedAnalysis(analysisId);
+        const threadId = "thread-derivation-corrupt";
+        (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+
+        await pool.query({
+            text: `UPDATE cortex_report_session_state SET derivations = '[{"outputPath":1}]'::jsonb WHERE thread_id = $1`,
+            values: [threadId],
+        });
+
+        const failure = (await store.readState(threadId))._unsafeUnwrapErr();
+        expect(failure.type).toBe("corrupt_session_state");
+        if (failure.type === "corrupt_session_state") {
+            expect(failure.part).toBe("derivations");
+            expect(failure.issues.length).toBeGreaterThan(0);
+        }
     });
 });

--- a/harness/src/state/report-session-state.test.ts
+++ b/harness/src/state/report-session-state.test.ts
@@ -310,6 +310,63 @@ describe("createReportSessionStateStore", () => {
         expect(read!.derivations).toEqual([landed]);
     });
 
+    /**
+     * Wait until a backend blocks on a lock over the session-state table.
+     *
+     * The concurrency case must know that the second append reached the row lock before the first one
+     * commits. A `pg_stat_activity` read is that signal, thus the case drives a real wait and never a sleep
+     * that a slow machine turns into a pass.
+     */
+    async function waitForBlockedAppend(): Promise<void> {
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+            const { rows } = await pool.query<{ waiting: number }>({
+                text: `SELECT COUNT(*)::int AS waiting FROM pg_stat_activity
+                        WHERE datname = current_database() AND wait_event_type = 'Lock'
+                          AND query LIKE '%cortex_report_session_state%'`,
+            });
+            if ((rows[0]?.waiting ?? 0) > 0) return;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        throw new Error("the second append never blocked on the row lock");
+    }
+
+    it("lands one of two concurrent appends of the same output path", async () => {
+        const analysisId = "analysis-derivation-race";
+        await seedAnalysis(analysisId);
+        const threadId = "thread-derivation-race";
+        (await store.writeSnapshot({ threadId, analysisId, snapshot }))._unsafeUnwrap();
+
+        // Two sessions, each on its own connection and inside its own transaction. The first append holds
+        // the row lock while the second one runs, thus the second one must re-read the list of the first
+        // before it decides. A name rule that read a snapshot of the list would let both records land.
+        const first = await pool.connect();
+        const second = await pool.connect();
+        try {
+            // The store calls `query` alone, thus a pooled client stands in for the pool here.
+            const firstStore = createReportSessionStateStore({ pool: first as unknown as Pool });
+            const secondStore = createReportSessionStateStore({ pool: second as unknown as Pool });
+            const record = derivation("race.csv");
+
+            await first.query("BEGIN");
+            await second.query("BEGIN");
+
+            expect((await firstStore.appendDerivation(threadId, record))._unsafeUnwrap()).toBe("appended");
+            // The second append blocks on the row that the first one holds. It settles after the commit.
+            const blocked = secondStore.appendDerivation(threadId, { ...record, outputHash: "sha256:second" });
+            await waitForBlockedAppend();
+            await first.query("COMMIT");
+            expect((await blocked)._unsafeUnwrap()).toBe("duplicate");
+            await second.query("COMMIT");
+        } finally {
+            first.release();
+            second.release();
+        }
+
+        // The thread holds the record of the winner, and it holds it one time.
+        const read = (await store.readState(threadId))._unsafeUnwrap();
+        expect(read!.derivations).toEqual([derivation("race.csv")]);
+    });
+
     it("gives an absence for an append against a thread with no row", async () => {
         expect((await store.appendDerivation("thread-derivation-absent", derivation("a.csv")))._unsafeUnwrap()).toBe("absent");
     });

--- a/harness/src/state/report-session-state.ts
+++ b/harness/src/state/report-session-state.ts
@@ -21,6 +21,12 @@
  * document can be incomplete. A column that fails a parse reads as a typed error, and
  * it does not crash. An absent row reads as a normal absence.
  *
+ * The row also holds the derivation list of the session. One record chains a derived
+ * table to the evidence that made it: the output path, the output hash, the source
+ * paths with their hashes, the script hash, and the script text. A record is
+ * immutable, and the append refuses a repeated output path. A row that holds no list
+ * reads as an empty list.
+ *
  * A persist is a compare-and-swap. The load reads the prior document, and the persist
  * lands only when the row still holds it. Thus two concurrent turns cannot both land,
  * and the loser reads the state again.
@@ -30,6 +36,7 @@
 
 import { type Result, type ResultAsync, err, ok } from "neverthrow";
 import type { Pool } from "pg";
+import { z } from "zod";
 
 import { type DbError, tryMutation, tryQuery } from "../lib/db-result.js";
 import type { Logger } from "../lib/logger.js";
@@ -37,6 +44,48 @@ import type { DomainError } from "../lib/result.js";
 import { DraftDocumentSchema, type DraftDocument } from "../report-model/draft.js";
 import type { ReportSnapshot } from "../report-model/reference-resolver.js";
 import { parseSnapshot, reduceIssues, type SchemaIssue } from "./snapshot-parse.js";
+
+/** One source of a derivation: the pinned path that the script read, and the hash of that path. */
+export interface DerivationSource {
+    readonly path: string;
+    readonly hash: string;
+}
+
+/**
+ * One derivation of a session.
+ *
+ * The record chains the derived table to the evidence that made it, thus a verifier mounts the same
+ * sources, runs the same script, and compares the output hash. The script text rides the record, thus the
+ * verifier needs no second store.
+ *
+ * `outputPath` is the workspace-root-relative path of the derived file, and it is the key that the served
+ * membership holds. A record is immutable, thus a new derivation takes a new output path.
+ */
+export interface DerivationRecord {
+    readonly outputPath: string;
+    readonly outputHash: string;
+    readonly sources: readonly DerivationSource[];
+    readonly scriptHash: string;
+    readonly script: string;
+}
+
+const DerivationSourceSchema = z.object({ path: z.string(), hash: z.string() });
+
+const DerivationRecordSchema = z.object({
+    outputPath: z.string(),
+    outputHash: z.string(),
+    sources: z.array(DerivationSourceSchema),
+    scriptHash: z.string(),
+    script: z.string(),
+});
+
+const DerivationListSchema = z.array(DerivationRecordSchema);
+
+/**
+ * The outcome of an append. `appended` landed the record. `duplicate` means that a record already holds the
+ * output path, thus the list stays as it is. `absent` means that no row holds the thread.
+ */
+export type AppendDerivationOutcome = "appended" | "duplicate" | "absent";
 
 /** The state of one report session, as the store gives it back. */
 export interface ReportSessionState {
@@ -46,6 +95,8 @@ export interface ReportSessionState {
     readonly document: DraftDocument | null;
     /** The pinned snapshot, or `null` before the pin writes it. */
     readonly snapshot: ReportSnapshot | null;
+    /** The derivations of the session, in the order that they landed. A row with no list reads as empty. */
+    readonly derivations: readonly DerivationRecord[];
     /** The hash of the draft that the last preview rendered, or `null` before the first preview. */
     readonly renderedDocumentHash: string | null;
     /** The hash that the last eyes capture saw, or `null` before the first look. */
@@ -102,7 +153,7 @@ export type SessionStateReadError = {
     readonly type: "corrupt_session_state";
     readonly op: string;
     readonly threadId: string;
-    readonly part: "document" | "snapshot";
+    readonly part: "document" | "snapshot" | "derivations";
     readonly issues: readonly SchemaIssue[];
 };
 
@@ -143,6 +194,12 @@ export interface ReportSessionStateStore {
      * one. `absent` means that no row holds the thread.
      */
     stampSeen(threadId: string): ResultAsync<SeenStampOutcome, DbError>;
+    /**
+     * Append one derivation record to the list of a thread. The output path is unique across the list,
+     * thus a repeated path refuses with `duplicate` and the stored list stays as it is. `absent` means
+     * that no row holds the thread.
+     */
+    appendDerivation(threadId: string, record: DerivationRecord): ResultAsync<AppendDerivationOutcome, DbError>;
 }
 
 export interface ReportSessionStateStoreDeps {
@@ -151,13 +208,14 @@ export interface ReportSessionStateStoreDeps {
 }
 
 /** The full row projection every read shares. */
-const STATE_COLUMNS = "thread_id, analysis_id, document, snapshot, rendered_document_hash, seen_document_hash, created_at";
+const STATE_COLUMNS = "thread_id, analysis_id, document, snapshot, derivations, rendered_document_hash, seen_document_hash, created_at";
 
 interface SessionStateRow {
     readonly thread_id: string;
     readonly analysis_id: string;
     readonly document: unknown;
     readonly snapshot: unknown;
+    readonly derivations: unknown;
     readonly rendered_document_hash: string | null;
     readonly seen_document_hash: string | null;
     readonly created_at: Date;
@@ -202,11 +260,28 @@ function rowToState(row: SessionStateRow): Result<ReportSessionState, SessionSta
         }
         snapshot = parsed.value;
     }
+    // A row that predates the list carries SQL NULL, and a session that derived nothing carries none
+    // either. Both read as an empty list, because a session with no derivation has none.
+    let derivations: readonly DerivationRecord[] = [];
+    if (row.derivations !== null && row.derivations !== undefined) {
+        const parsed = DerivationListSchema.safeParse(row.derivations);
+        if (!parsed.success) {
+            return err({
+                type: "corrupt_session_state",
+                op: "report-session-state.read",
+                threadId: row.thread_id,
+                part: "derivations",
+                issues: reduceIssues(parsed.error),
+            });
+        }
+        derivations = parsed.data;
+    }
     return ok({
         threadId: row.thread_id,
         analysisId: row.analysis_id,
         document,
         snapshot,
+        derivations,
         renderedDocumentHash: row.rendered_document_hash,
         seenDocumentHash: row.seen_document_hash,
         createdAt: row.created_at,
@@ -309,5 +384,36 @@ export function createReportSessionStateStore({ pool }: ReportSessionStateStoreD
         });
     }
 
-    return { readState, writeSnapshot, persistDocument, stampRendered, stampSeen };
+    function appendDerivation(threadId: string, record: DerivationRecord): ResultAsync<AppendDerivationOutcome, DbError> {
+        return tryMutation("report-session-state.appendDerivation", async () => {
+            // One statement tells a duplicate from an absence, the same way the persist does. `existed`
+            // counts the row, and `appended` counts the update. The name rule reads the stored list inside
+            // the statement, thus two concurrent appends of one name cannot both land.
+            const { rows } = await pool.query<{ existed: number; appended: number }>({
+                text: `WITH target AS (
+    SELECT thread_id, COALESCE(derivations, '[]'::jsonb) AS list
+      FROM cortex_report_session_state
+     WHERE thread_id = $1
+  ), appended AS (
+    UPDATE cortex_report_session_state AS s
+       SET derivations = COALESCE(s.derivations, '[]'::jsonb) || $2::jsonb
+      FROM target AS t
+     WHERE s.thread_id = t.thread_id
+       AND NOT EXISTS (
+         SELECT 1 FROM jsonb_array_elements(t.list) AS held WHERE held->>'outputPath' = $3
+       )
+    RETURNING 1
+  )
+  SELECT (SELECT COUNT(*) FROM target)::int AS existed, (SELECT COUNT(*) FROM appended)::int AS appended`,
+                // The record rides as a one-element array, thus the `||` operator appends one element and
+                // never merges the fields of an object into the list.
+                values: [threadId, JSON.stringify([record]), record.outputPath],
+            });
+            const row = rows[0];
+            if (row === undefined || row.existed === 0) return "absent";
+            return row.appended > 0 ? "appended" : "duplicate";
+        });
+    }
+
+    return { readState, writeSnapshot, persistDocument, stampRendered, stampSeen, appendDerivation };
 }

--- a/harness/src/state/report-session-state.ts
+++ b/harness/src/state/report-session-state.ts
@@ -387,20 +387,24 @@ export function createReportSessionStateStore({ pool }: ReportSessionStateStoreD
     function appendDerivation(threadId: string, record: DerivationRecord): ResultAsync<AppendDerivationOutcome, DbError> {
         return tryMutation("report-session-state.appendDerivation", async () => {
             // One statement tells a duplicate from an absence, the same way the persist does. `existed`
-            // counts the row, and `appended` counts the update. The name rule reads the stored list inside
-            // the statement, thus two concurrent appends of one name cannot both land.
+            // counts the row, and `appended` counts the update.
+            //
+            // The name rule sits in the qualification of the UPDATE, over the row that the statement locks.
+            // A read of the CTE would test the list as it stood at the start of the statement: two
+            // concurrent appends of one name would each pass that test, and both would land. Postgres
+            // re-evaluates the qualification of an UPDATE against the row that it waited for, thus the
+            // loser of the race sees the list of the winner and it appends nothing.
             const { rows } = await pool.query<{ existed: number; appended: number }>({
                 text: `WITH target AS (
-    SELECT thread_id, COALESCE(derivations, '[]'::jsonb) AS list
+    SELECT thread_id
       FROM cortex_report_session_state
      WHERE thread_id = $1
   ), appended AS (
     UPDATE cortex_report_session_state AS s
        SET derivations = COALESCE(s.derivations, '[]'::jsonb) || $2::jsonb
-      FROM target AS t
-     WHERE s.thread_id = t.thread_id
+     WHERE s.thread_id = $1
        AND NOT EXISTS (
-         SELECT 1 FROM jsonb_array_elements(t.list) AS held WHERE held->>'outputPath' = $3
+         SELECT 1 FROM jsonb_array_elements(COALESCE(s.derivations, '[]'::jsonb)) AS held WHERE held->>'outputPath' = $3
        )
     RETURNING 1
   )

--- a/harness/src/tools/report-session/derive-table.test.ts
+++ b/harness/src/tools/report-session/derive-table.test.ts
@@ -25,7 +25,7 @@ import type { DbError } from "../../lib/db-result.js";
 import { computeSha256 } from "../../lib/fs-helpers.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import type { SandboxClient } from "../../sandbox/client.js";
-import type { CreateSandboxMeta, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import type { CreateSandboxMeta, ExecResult, SandboxRef, SandboxTransport, SubmitExecBody } from "../../sandbox/types.js";
 import type { AppendDerivationOutcome, DerivationRecord } from "../../state/report-session-state.js";
 import { reportSessionDir } from "../../workspace/paths.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
@@ -154,6 +154,7 @@ function makeSandbox(args: {
     readonly root: string;
     readonly reply?: ExecResult;
     readonly throws?: boolean;
+    readonly transport?: SandboxTransport;
     readonly write?: (outputHostPath: string) => Promise<void>;
 }): FakeSandbox {
     const creates: CreateSandboxMeta[] = [];
@@ -161,6 +162,7 @@ function makeSandbox(args: {
     const teardowns: string[] = [];
     const ref: SandboxRef = { sandboxId: "sbx-derive-1", host: "127.0.0.1", port: 8765, backend: "docker", callbackSecret: "base64:secret" };
     const client = {
+        ...(args.transport === undefined ? {} : { transport: args.transport }),
         createSandbox(meta: CreateSandboxMeta): Promise<SandboxRef> {
             creates.push(meta);
             return Promise.resolve(ref);
@@ -482,6 +484,23 @@ describe("a derivation that gives no table", () => {
         expect(auth.revoked).toEqual(["derive-table-failed"]);
     });
 
+    it("clears the output path first, thus a stale file is never adopted as the new table", async () => {
+        const root = await makeRoot();
+        const stale = join(root, reportSessionDir("t1"), "derived", "yield.csv");
+        await mkdir(dirname(stale), { recursive: true });
+        await writeFile(stale, "stale,bytes\n1,2\n", "utf8");
+        // The script exits clean and it writes no file. The bytes of the failed attempt before it must not
+        // become the table of this one.
+        const sandbox = makeSandbox({ root, reply: execResult({ stdout: "a log line\n" }) });
+        const { tool, ledger } = makeTool({ root, sandbox });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("no-output");
+        expect(ledger.records).toHaveLength(0);
+        expect(existsSync(stale)).toBe(false);
+    });
+
     it("refuses an output that resolves outside the workspace tree", async () => {
         const root = await makeRoot();
         const outside = join(await makeRoot(), "secret.csv");
@@ -518,6 +537,22 @@ describe("a derivation that gives no table", () => {
         expect(auth.revoked).toEqual(["derive-table-failed"]);
     });
 
+    it("revokes the authorization when the work throws", async () => {
+        const root = await makeRoot();
+        // A stored path is untrusted text. One that escapes the tree makes the host-to-container mapper
+        // throw, and the authorization must not stand behind that throw.
+        const hostile = "../../etc/passwd";
+        const { tool, auth, sandbox } = makeTool({ root, snapshot: { artifacts: { [hostile]: { hash: PINNED_HASH } } } });
+
+        const attempt = async (): Promise<void> => {
+            (await tool.execute({ script: SCRIPT, inputs: [hostile], output: "yield.csv" }, ctxForThread("t1")))._unsafeUnwrap();
+        };
+
+        await expect(attempt()).rejects.toThrow(/escapes the workspace root/);
+        expect(auth.revoked).toEqual(["derive-table-failed"]);
+        expect(sandbox.creates).toHaveLength(0);
+    });
+
     it("reports a ledger fault as a failed derivation", async () => {
         const root = await makeRoot();
         const fault: DbError = { type: "mutation_failed", op: "append", cause: new Error("the pool is down") };
@@ -540,6 +575,33 @@ describe("a composition with no sandbox", () => {
         const result = (await tool.execute({ script: SCRIPT, inputs: [PINNED_PATH], output: "yield.csv" }, ctxForThread("t1")))._unsafeUnwrap();
 
         expect(result.outcome).toBe("unavailable");
+    });
+
+    it("refuses under a callback transport, because a turn cannot await one", async () => {
+        const root = await makeRoot();
+        // The callback await is a workflow-body call, and a report turn is not one. The refusal comes before
+        // any container starts, thus nothing is left running that nothing can await.
+        const sandbox = makeSandbox({ root, transport: "callback", write: writesTable() });
+        const { tool, ledger } = makeTool({ root, sandbox });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("unavailable");
+        if (result.outcome === "unavailable") {
+            expect(result.detail).toContain("callbacks");
+        }
+        expect(sandbox.creates).toHaveLength(0);
+        expect(ledger.records).toHaveLength(0);
+    });
+
+    it("derives under the poll transport, and under a client that states none", async () => {
+        const root = await makeRoot();
+        const polling = makeTool({ root, sandbox: makeSandbox({ root, transport: "poll", write: writesTable() }) });
+        expect((await derive(polling.tool, {})).outcome).toBe("derived");
+
+        // An absent field states nothing, thus it reads as the poll default and it refuses nothing.
+        const silent = makeTool({ root: await makeRoot() });
+        expect((await derive(silent.tool, {})).outcome).toBe("derived");
     });
 
     it("refuses a call whose scope names no report thread", async () => {

--- a/harness/src/tools/report-session/derive-table.test.ts
+++ b/harness/src/tools/report-session/derive-table.test.ts
@@ -1,0 +1,594 @@
+/**
+ * The tests of the derivation tool.
+ *
+ * Each test drives the tool through `execute` with a temp directory as the workspace root, an in-memory
+ * gateway, an in-memory derivation ledger, and a stubbed sandbox client. The stub gives back the exec result
+ * that the case names, and it writes into the host side of the write mount the way a script would. Thus no
+ * container runs and each arm of the tool is decidable here.
+ *
+ * The cases cover the happy path, the declared write tail, the undeclared input, the repeated name, the
+ * over-cap script, the input cap, the unsafe name, the failed exec, the green exec that wrote no file, the
+ * output that resolves outside the tree, and the composition that binds no sandbox.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { errAsync, okAsync, type ResultAsync } from "neverthrow";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { Scope } from "../../auth/types.js";
+import { createLocalRunAuthorizer } from "../../auth/local-run-authorizer.js";
+import type { RunAuthorization, RunAuthorizer } from "../../execution/run-authorizer.js";
+import type { DbError } from "../../lib/db-result.js";
+import { computeSha256 } from "../../lib/fs-helpers.js";
+import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
+import type { SandboxClient } from "../../sandbox/client.js";
+import type { CreateSandboxMeta, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import type { AppendDerivationOutcome, DerivationRecord } from "../../state/report-session-state.js";
+import { reportSessionDir } from "../../workspace/paths.js";
+import { makeToolContext } from "../__fixtures__/tool-context.js";
+import type { ToolContext } from "../define-tool.js";
+import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
+import {
+    buildDerivationExec,
+    createDeriveTableTool,
+    describeExecFailure,
+    DERIVE_INPUT_ENV,
+    DERIVE_OUTPUT_ENV,
+    type DeriveTableResult,
+} from "./derive-table.js";
+
+/** Each root that a test made. The cleanup removes them after the suite. */
+const roots: string[] = [];
+
+afterAll(async () => {
+    for (const root of roots) {
+        await rm(root, { recursive: true, force: true });
+    }
+});
+
+async function makeRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "derive-table-"));
+    roots.push(root);
+    return root;
+}
+
+/** The default analysis of a seeded thread. It matches the scope of `ctxForThread`, thus a call resolves. */
+const DEFAULT_ANALYSIS_ID = "analysis-001";
+
+/** The pinned path that most cases declare, and its pinned hash. */
+const PINNED_PATH = "runs/r1/output/de.csv";
+const PINNED_HASH = "sha256:aaa111";
+
+/** A short reshaping script. The stub never runs it, thus its body only has to be a plausible one. */
+const SCRIPT = 'import os, pandas as pd\npd.read_csv("de.csv").to_csv(os.environ["DERIVE_OUTPUT"], index=False)\n';
+
+/** The table that the stub writes into the write mount for a green exec. */
+const TABLE = "group,yield\na,3\nb,5\n";
+
+const emptyDraft = { title: "", sections: [] };
+
+/** An in-memory gateway. It holds one state and one analysis for each thread. */
+interface FakeGateway extends ReportSessionStateGateway {
+    seed(threadId: string, snapshot: ReportSnapshot): void;
+}
+
+function makeFakeGateway(): FakeGateway {
+    const rows = new Map<string, ReportSessionState>();
+    return {
+        seed(threadId, snapshot): void {
+            rows.set(threadId, { document: structuredClone(emptyDraft), snapshot: structuredClone(snapshot) });
+        },
+        load(threadId): Promise<SessionStateLoad> {
+            const state = rows.get(threadId);
+            if (state === undefined) {
+                return Promise.resolve({ outcome: "absent" });
+            }
+            const copy = structuredClone(state);
+            return Promise.resolve({ outcome: "found", state: copy, analysisId: DEFAULT_ANALYSIS_ID, token: copy.document, seenDocumentHash: null });
+        },
+        persist(): Promise<SessionStatePersist> {
+            return Promise.resolve({ outcome: "persisted" });
+        },
+        stampRendered(): Promise<StampResult> {
+            return Promise.resolve({ outcome: "stamped" });
+        },
+        stampSeen(): Promise<StampResult> {
+            return Promise.resolve({ outcome: "stamped" });
+        },
+    };
+}
+
+/** An in-memory derivation ledger with the name rule of the store. */
+interface FakeLedger {
+    appendDerivation(threadId: string, record: DerivationRecord): ResultAsync<AppendDerivationOutcome, DbError>;
+    readonly records: DerivationRecord[];
+}
+
+function makeLedger(outcome?: AppendDerivationOutcome, fault?: DbError): FakeLedger {
+    const records: DerivationRecord[] = [];
+    return {
+        records,
+        appendDerivation(_threadId, record): ResultAsync<AppendDerivationOutcome, DbError> {
+            if (fault !== undefined) {
+                return errAsync(fault);
+            }
+            if (outcome !== undefined) {
+                return okAsync(outcome);
+            }
+            if (records.some((held) => held.outputPath === record.outputPath)) {
+                return okAsync("duplicate");
+            }
+            records.push(record);
+            return okAsync("appended");
+        },
+    };
+}
+
+/** A stubbed sandbox client. It records what the tool asked for, and it gives back one exec result. */
+interface FakeSandbox {
+    readonly client: SandboxClient;
+    readonly creates: CreateSandboxMeta[];
+    readonly submits: SubmitExecBody[];
+    readonly teardowns: string[];
+}
+
+/**
+ * The host side of a container path. The tree mounts at `/{analysisId}`, thus the stub strips that mount
+ * point and joins the tail onto the root. The stub writes where the container would write, and the tool then
+ * reads the file exactly as it reads a real one.
+ */
+function hostSideOf(root: string, containerPath: string): string {
+    return join(root, containerPath.slice(`/${DEFAULT_ANALYSIS_ID}/`.length));
+}
+
+/**
+ * A stubbed sandbox client.
+ *
+ * `write` stands for the script: it runs at the moment the exec settles, and it gets the host side of the
+ * output path that the submit body declared. A case that gives none models a script that wrote no file.
+ */
+function makeSandbox(args: {
+    readonly root: string;
+    readonly reply?: ExecResult;
+    readonly throws?: boolean;
+    readonly write?: (outputHostPath: string) => Promise<void>;
+}): FakeSandbox {
+    const creates: CreateSandboxMeta[] = [];
+    const submits: SubmitExecBody[] = [];
+    const teardowns: string[] = [];
+    const ref: SandboxRef = { sandboxId: "sbx-derive-1", host: "127.0.0.1", port: 8765, backend: "docker", callbackSecret: "base64:secret" };
+    const client = {
+        createSandbox(meta: CreateSandboxMeta): Promise<SandboxRef> {
+            creates.push(meta);
+            return Promise.resolve(ref);
+        },
+        submitExec(_ref: SandboxRef, body: SubmitExecBody): Promise<void> {
+            submits.push(body);
+            return Promise.resolve();
+        },
+        async awaitExec(): Promise<ExecResult> {
+            if (args.throws === true) {
+                throw new Error("the poll loop broke");
+            }
+            const body = submits[submits.length - 1];
+            if (args.write !== undefined && body !== undefined) {
+                await args.write(hostSideOf(args.root, body.env![DERIVE_OUTPUT_ENV]));
+            }
+            return args.reply ?? execResult({});
+        },
+        teardown(handle: SandboxRef): Promise<void> {
+            teardowns.push(handle.sandboxId);
+            return Promise.resolve();
+        },
+        isAlive: () => Promise.resolve({ alive: true, oomKilled: false }),
+        teardownById: () => Promise.resolve(),
+        listManagedSandboxes: () => Promise.resolve([]),
+    } satisfies SandboxClient;
+    return { client, creates, submits, teardowns };
+}
+
+/** The write of a script that lands the table at the declared output path. */
+function writesTable(table = TABLE): (outputHostPath: string) => Promise<void> {
+    return async (outputHostPath) => {
+        await mkdir(dirname(outputHostPath), { recursive: true });
+        await writeFile(outputHostPath, table, "utf8");
+    };
+}
+
+/** A run authorizer over the local realization, with the revoke reasons recorded. */
+interface FakeAuthorizer {
+    readonly authorizer: RunAuthorizer;
+    readonly frames: string[];
+    readonly revoked: string[];
+}
+
+function makeAuthorizer(): FakeAuthorizer {
+    const local = createLocalRunAuthorizer();
+    const frames: string[] = [];
+    const revoked: string[] = [];
+    const authorizer: RunAuthorizer = {
+        async authorize(input): Promise<RunAuthorization> {
+            frames.push(`${input.frame.runId}/${input.frame.stepId}/${input.provenance.agentId}`);
+            return local.authorize(input);
+        },
+        async revoke(_authorization, reason): Promise<void> {
+            revoked.push(reason);
+        },
+        async revokeByJti(): Promise<void> {},
+    };
+    return { authorizer, frames, revoked };
+}
+
+/** A complete exec result. Each case overrides only the fields that it asserts. */
+function execResult(over: Partial<ExecResult>): ExecResult {
+    return { execId: "exec-1", exitCode: 0, stdout: TABLE, stderr: "", durationMs: 12, timedOut: false, ...over };
+}
+
+/** A tool context whose scope names a report thread. */
+function ctxForThread(threadId: string): ToolContext {
+    const { ctx } = makeToolContext();
+    const scope: Scope = { kind: "analysis", analysisId: DEFAULT_ANALYSIS_ID, threadId };
+    return { ...ctx, session: { ...ctx.session, scope } };
+}
+
+/** The snapshot that pins one tabular output. */
+function pinnedSnapshot(): ReportSnapshot {
+    return { artifacts: { [PINNED_PATH]: { hash: PINNED_HASH, fileType: "output" } } };
+}
+
+/** One assembled tool over the four seams, with each recording part handed back. */
+function makeTool(args: { root: string; snapshot?: ReportSnapshot; result?: ExecResult; ledger?: FakeLedger; sandbox?: FakeSandbox }) {
+    const gateway = makeFakeGateway();
+    gateway.seed("t1", args.snapshot ?? pinnedSnapshot());
+    // The default stub is a script that lands the table where the submit body declared it.
+    const sandbox = args.sandbox ?? makeSandbox({ root: args.root, ...(args.result ? { reply: args.result } : {}), write: writesTable() });
+    const ledger = args.ledger ?? makeLedger();
+    const auth = makeAuthorizer();
+    const tool = createDeriveTableTool({
+        gateway,
+        resolveWorkspaceRoot: () => args.root,
+        derivations: ledger,
+        sandboxClient: sandbox.client,
+        runAuthorizer: auth.authorizer,
+    });
+    return { tool, gateway, sandbox, ledger, auth };
+}
+
+/** Run the tool over one thread, and give back the ok value. */
+async function derive(tool: ReturnType<typeof makeTool>["tool"], input: { script?: string; inputs?: string[]; output?: string }): Promise<DeriveTableResult> {
+    return (
+        await tool.execute({ script: input.script ?? SCRIPT, inputs: input.inputs ?? [PINNED_PATH], output: input.output ?? "yield.csv" }, ctxForThread("t1"))
+    )._unsafeUnwrap();
+}
+
+describe("the derived table", () => {
+    it("lands under the derived directory of the session, and the record pins the chain", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox, ledger, auth } = makeTool({ root });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("derived");
+        if (result.outcome !== "derived") throw new Error("expected a derived table");
+        // The derived path sits under the directory of the session, thus the disposal of that directory
+        // removes the derived table with it.
+        expect(result.path).toBe(`${reportSessionDir("t1")}/derived/yield.csv`);
+        expect(result.path.startsWith(`${reportSessionDir("t1")}/`)).toBe(true);
+        // The bytes that the script wrote into the mount are the bytes of the derived table.
+        expect(await readFile(join(root, result.path), "utf8")).toBe(TABLE);
+        // The hash comes off the disk, thus it is the hash that a verifier reads.
+        expect(result.hash).toBe(computeSha256(Buffer.from(TABLE, "utf8")));
+        expect(result.scriptHash).toBe(computeSha256(Buffer.from(SCRIPT, "utf8")));
+        // The columns describe the derived table, the same way the listing describes a pinned one.
+        expect(result.columns).toEqual(["group", "yield"]);
+        // The source carries the hash of the served membership, and never a hash of the call.
+        expect(result.sources).toEqual([{ path: PINNED_PATH, hash: PINNED_HASH }]);
+
+        // The record holds what a second run needs: the script, the sources, and the output hash.
+        expect(ledger.records).toHaveLength(1);
+        expect(ledger.records[0]).toEqual({
+            outputPath: result.path,
+            outputHash: result.hash,
+            sources: [{ path: PINNED_PATH, hash: PINNED_HASH }],
+            scriptHash: result.scriptHash,
+            script: SCRIPT,
+        });
+
+        // The container is ephemeral, thus it goes away with the work.
+        expect(sandbox.teardowns).toEqual(["sbx-derive-1"]);
+        // The authorization revokes on the terminal path.
+        expect(auth.revoked).toEqual(["derive-table-completed"]);
+    });
+
+    it("declares the derived directory as the one write mount of the container", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox, auth } = makeTool({ root });
+
+        await derive(tool, {});
+
+        expect(sandbox.creates).toHaveLength(1);
+        const meta = sandbox.creates[0]!;
+        // The one writable mount of the container is the derived directory of this session. The tree stays
+        // read-only under it, thus no write of the script can reach the analysis.
+        expect(meta.writableTail).toBe(`${reportSessionDir("t1")}/derived`);
+        // A read-only container could write nothing at all, thus the two are never declared together.
+        expect(meta.readOnly).toBeUndefined();
+        expect(meta.analysisId).toBe(DEFAULT_ANALYSIS_ID);
+        // The run id and the step id are constants of the derivation. Neither one names a run of the
+        // analysis, thus the pass mints no run.
+        expect(meta.runId).toBe("derive-table");
+        expect(meta.stepId).toBe("derive");
+        expect(meta.resources).toEqual({ cpu: 2, memoryGb: 8 });
+        // The frame of the authorization names the same synthetic run.
+        expect(auth.frames).toEqual(["derive-table/derive/table-deriver"]);
+    });
+
+    it("submits the script with the mounted inputs and the mounted output path", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox } = makeTool({ root });
+
+        await derive(tool, {});
+
+        expect(sandbox.submits).toHaveLength(1);
+        const body = sandbox.submits[0]!;
+        expect(body.command).toEqual(["python3", "-c", SCRIPT]);
+        // The working directory is the write mount, thus the script writes beside where it stands.
+        expect(body.cwd).toBe(`/${DEFAULT_ANALYSIS_ID}/${reportSessionDir("t1")}/derived`);
+        // Each declared input rides as the path that the container reads, with the hash of the membership.
+        expect(JSON.parse(body.env![DERIVE_INPUT_ENV])).toEqual([{ path: `/${DEFAULT_ANALYSIS_ID}/${PINNED_PATH}`, hash: PINNED_HASH }]);
+        // The output path rides too, thus the script names no directory of its own.
+        expect(body.env![DERIVE_OUTPUT_ENV]).toBe(`/${DEFAULT_ANALYSIS_ID}/${reportSessionDir("t1")}/derived/yield.csv`);
+    });
+
+    it("gives the derived path as the result line, and the output name as the call line", async () => {
+        const root = await makeRoot();
+        const { tool } = makeTool({ root });
+        const input = { script: SCRIPT, inputs: [PINNED_PATH], output: "yield.csv" };
+
+        expect(tool.describeCall!(input)).toBe("derive yield.csv");
+        const result = await derive(tool, {});
+        expect(tool.describeResult!(input, result)).toBe(`${reportSessionDir("t1")}/derived/yield.csv`);
+    });
+});
+
+describe("the bounds of a derivation", () => {
+    it("refuses an input that the pinned evidence does not hold, and it starts no container", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox } = makeTool({ root });
+
+        const result = await derive(tool, { inputs: [PINNED_PATH, "runs/r9/output/absent.csv"] });
+
+        expect(result.outcome).toBe("absent-input");
+        if (result.outcome === "absent-input") {
+            expect(result.path).toBe("runs/r9/output/absent.csv");
+        }
+        // The refusal reads the membership alone, thus no container starts.
+        expect(sandbox.creates).toHaveLength(0);
+    });
+
+    it("refuses a name that the membership already holds", async () => {
+        const root = await makeRoot();
+        const held = `${reportSessionDir("t1")}/derived/yield.csv`;
+        const snapshot: ReportSnapshot = { artifacts: { [PINNED_PATH]: { hash: PINNED_HASH }, [held]: { hash: "sha256:bbb222" } } };
+        const { tool, sandbox } = makeTool({ root, snapshot });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("repeated-name");
+        if (result.outcome === "repeated-name") {
+            expect(result.outputPath).toBe(held);
+        }
+        expect(sandbox.creates).toHaveLength(0);
+    });
+
+    it("refuses a record that another turn landed first", async () => {
+        const root = await makeRoot();
+        const { tool } = makeTool({ root, ledger: makeLedger("duplicate") });
+
+        // The membership held no such name at the load, thus the name rule of the store is the last word.
+        const result = await derive(tool, {});
+        expect(result.outcome).toBe("repeated-name");
+    });
+
+    it("refuses a script that is over the cap", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox } = makeTool({ root });
+
+        const result = await derive(tool, { script: "#".repeat(64 * 1024 + 1) });
+
+        expect(result.outcome).toBe("script-too-large");
+        if (result.outcome === "script-too-large") {
+            expect(result.cap).toBe(64 * 1024);
+            expect(result.bytes).toBe(64 * 1024 + 1);
+        }
+        expect(sandbox.creates).toHaveLength(0);
+    });
+
+    it("refuses more inputs than the cap, and it counts a repeated path one time", async () => {
+        const root = await makeRoot();
+        const artifacts: ReportSnapshot["artifacts"] = {};
+        for (let index = 0; index < 21; index += 1) {
+            artifacts[`runs/r1/output/f${String(index)}.csv`] = { hash: `sha256:${String(index)}` };
+        }
+        const { tool } = makeTool({ root, snapshot: { artifacts } });
+
+        const many = Object.keys(artifacts);
+        const result = await derive(tool, { inputs: many });
+        expect(result.outcome).toBe("too-many-inputs");
+        if (result.outcome === "too-many-inputs") {
+            expect(result.count).toBe(21);
+            expect(result.cap).toBe(20);
+        }
+
+        // A repeated path names one source, thus a list of one path repeated is inside the cap.
+        const repeated = await derive(tool, { inputs: new Array<string>(30).fill(many[0]!), output: "one.csv" });
+        expect(repeated.outcome).toBe("derived");
+    });
+
+    it("refuses an output name that names a directory or a traversal", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox } = makeTool({ root });
+
+        for (const name of ["../escape.csv", "sub/dir.csv", "..", "with space.csv"]) {
+            const result = await derive(tool, { output: name });
+            expect(result.outcome).toBe("unsafe-name");
+        }
+        expect(sandbox.creates).toHaveLength(0);
+    });
+});
+
+describe("a derivation that gives no table", () => {
+    it("gives the sandbox detail of a failed script, and it revokes", async () => {
+        const root = await makeRoot();
+        const { tool, sandbox, ledger, auth } = makeTool({
+            root,
+            result: execResult({ exitCode: 1, stdout: "", stderr: "Traceback: KeyError: 'gene'" }),
+        });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("exec-failed");
+        if (result.outcome === "exec-failed") {
+            expect(result.detail).toContain("KeyError");
+        }
+        // No table means no record, and the container still goes away.
+        expect(ledger.records).toHaveLength(0);
+        expect(sandbox.teardowns).toEqual(["sbx-derive-1"]);
+        expect(auth.revoked).toEqual(["derive-table-failed"]);
+    });
+
+    it("gives a timeout and a dead sandbox as a failed exec", async () => {
+        expect(describeExecFailure(execResult({ timedOut: true }))).toContain("deadline");
+        expect(describeExecFailure(execResult({ syntheticFailure: { reason: "sandbox-dead" } }))).toContain("sandbox-dead");
+        expect(describeExecFailure(execResult({}))).toBeUndefined();
+    });
+
+    it("gives no-output for a green script that wrote no file", async () => {
+        const root = await makeRoot();
+        // The script exits clean and it writes nothing into the mount, thus the output path holds no file.
+        const sandbox = makeSandbox({ root, reply: execResult({ stdout: "a log line\n" }) });
+        const { tool, ledger, auth } = makeTool({ root, sandbox });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("no-output");
+        if (result.outcome === "no-output") {
+            expect(result.detail).toContain("yield.csv");
+        }
+        expect(ledger.records).toHaveLength(0);
+        expect(auth.revoked).toEqual(["derive-table-failed"]);
+    });
+
+    it("refuses an output that resolves outside the workspace tree", async () => {
+        const root = await makeRoot();
+        const outside = join(await makeRoot(), "secret.csv");
+        await writeFile(outside, "user,secret\n", "utf8");
+        // A script can leave a symbolic link at the output name. The host classifies the file before it
+        // hashes one byte, thus the bytes of a host file never become evidence of the session.
+        const sandbox = makeSandbox({
+            root,
+            write: async (outputHostPath) => {
+                await mkdir(dirname(outputHostPath), { recursive: true });
+                await symlink(outside, outputHostPath);
+            },
+        });
+        const { tool, ledger } = makeTool({ root, sandbox });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("exec-failed");
+        if (result.outcome === "exec-failed") {
+            expect(result.detail).toContain("outside the workspace tree");
+        }
+        expect(ledger.records).toHaveLength(0);
+    });
+
+    it("tears the container down when the exec throws", async () => {
+        const root = await makeRoot();
+        const sandbox = makeSandbox({ root, throws: true });
+        const { tool, auth } = makeTool({ root, sandbox });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("exec-failed");
+        expect(sandbox.teardowns).toEqual(["sbx-derive-1"]);
+        expect(auth.revoked).toEqual(["derive-table-failed"]);
+    });
+
+    it("reports a ledger fault as a failed derivation", async () => {
+        const root = await makeRoot();
+        const fault: DbError = { type: "mutation_failed", op: "append", cause: new Error("the pool is down") };
+        const { tool, auth } = makeTool({ root, ledger: makeLedger(undefined, fault) });
+
+        const result = await derive(tool, {});
+
+        expect(result.outcome).toBe("exec-failed");
+        expect(auth.revoked).toEqual(["derive-table-failed"]);
+    });
+});
+
+describe("a composition with no sandbox", () => {
+    it("reports that it cannot derive, and it reads no state", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", pinnedSnapshot());
+        const tool = createDeriveTableTool({ gateway, resolveWorkspaceRoot: () => root, derivations: makeLedger() });
+
+        const result = (await tool.execute({ script: SCRIPT, inputs: [PINNED_PATH], output: "yield.csv" }, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("unavailable");
+    });
+
+    it("refuses a call whose scope names no report thread", async () => {
+        const root = await makeRoot();
+        const { tool } = makeTool({ root });
+        const { ctx } = makeToolContext();
+
+        const result = (await tool.execute({ script: SCRIPT, inputs: [PINNED_PATH], output: "yield.csv" }, ctx))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("refused");
+        if (result.outcome === "refused") {
+            expect(result.refusal.reason).toBe("no-thread-scope");
+        }
+    });
+});
+
+describe("the disposal of a session", () => {
+    it("puts the derived table inside the directory that the disposal removes", async () => {
+        const root = await makeRoot();
+        const { tool } = makeTool({ root });
+
+        const result = await derive(tool, {});
+        if (result.outcome !== "derived") throw new Error("expected a derived table");
+
+        const sessionDir = join(root, reportSessionDir("t1"));
+        expect(existsSync(join(root, result.path))).toBe(true);
+        // A host removes the whole directory of a session when its pages dispose. The derived table sits
+        // under that one directory, thus it goes with the disposal and no second sweep names it.
+        await rm(sessionDir, { recursive: true, force: true });
+        expect(existsSync(join(root, result.path))).toBe(false);
+        expect(existsSync(sessionDir)).toBe(false);
+    });
+});
+
+describe("buildDerivationExec", () => {
+    it("runs the script through python -c inside the write mount", () => {
+        const body = buildDerivationExec({
+            script: "print(1)",
+            execId: "exec-9",
+            workingDir: "/an-1/report-sessions/t1/derived",
+            inputs: [{ path: "/an-1/data/x.csv", hash: "sha256:h1" }],
+            output: "/an-1/report-sessions/t1/derived/y.csv",
+        });
+
+        expect(body.command).toEqual(["python3", "-c", "print(1)"]);
+        expect(body.execId).toBe("exec-9");
+        expect(body.cwd).toBe("/an-1/report-sessions/t1/derived");
+        expect(body.timeoutSeconds).toBe(300);
+        expect(JSON.parse(body.env![DERIVE_INPUT_ENV])).toEqual([{ path: "/an-1/data/x.csv", hash: "sha256:h1" }]);
+        expect(body.env![DERIVE_OUTPUT_ENV]).toBe("/an-1/report-sessions/t1/derived/y.csv");
+    });
+});

--- a/harness/src/tools/report-session/derive-table.ts
+++ b/harness/src/tools/report-session/derive-table.ts
@@ -1,0 +1,536 @@
+/**
+ * The derivation tool of a report session.
+ *
+ * A run writes statistical tables, and not plot-ready ones. This tool reshapes the pinned evidence into one
+ * table that a block can bind: a join, a pivot, or an aggregate. The agent writes the script, and the record
+ * chains the derived table back to the evidence that made it.
+ *
+ * A session derivation is not an analysis run. It mints no run id, it registers no artifact, and it writes
+ * under the session directory alone. The rails are the rails of the value tier (`tasks/extract-values.ts`):
+ * the sandbox client, the identity mint, and the authorizer on every terminal path. The container is
+ * ephemeral, and it goes away with the work.
+ *
+ * The container mounts the analysis tree read-only, and one write mount covers the `derived/` directory of
+ * the session alone. The script writes its table into that mount directly, thus a large table makes no
+ * roundtrip and no write of the script can reach the workspace tree. The working directory of the exec is
+ * that same mount, and the standard output carries the logs of the script alone.
+ *
+ * The host then reads the file that the container wrote. A path inside the mount is still untrusted bytes: a
+ * script can leave a symbolic link in place of its output. Thus the host classifies the file against the
+ * workspace root before it hashes one byte, and an escape refuses as typed data.
+ *
+ * Each declared input must sit in the served membership, and its hash comes from there. The declaration is
+ * what the record pins, thus a derived cell traces to a pinned artifact and to the script that read it.
+ *
+ * The tool refuses an output name that the membership already holds. A record is immutable, and a second
+ * derivation of one table takes a new name.
+ *
+ * A composition with no sandbox client and no run authorizer cannot derive at all. The tool reports that
+ * condition one time, up front, the same discipline as the eyes. A per-attempt failure would instead read as
+ * a transient fault, and it would invite a repeat of a call that can never pass.
+ */
+
+import { err, ok, type Result } from "neverthrow";
+import { join } from "node:path";
+import { z } from "zod";
+
+import type { RunAuthorization, RunAuthorizer } from "../../execution/run-authorizer.js";
+import { createNoopLogger } from "../../lib/console-logger.js";
+import { classifyWithinRoot, computeSha256, computeSha256File } from "../../lib/fs-helpers.js";
+import { defaultErrorFields, type Logger } from "../../lib/logger.js";
+import type { ResourceSpec } from "../../config/resource-limits.js";
+import { snapshotEntry } from "../../report-model/reference-resolver.js";
+import type { SandboxClient } from "../../sandbox/client.js";
+import { generateExecutionId } from "../../sandbox/execution-id.js";
+import { mintSandboxIdentity } from "../../sandbox/identity.js";
+import type { ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import type { DerivationRecord, DerivationSource, ReportSessionStateStore } from "../../state/report-session-state.js";
+import { isSafeId, reportSessionDir, toSandboxPath, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
+import { defineTool, type Tool, type ToolError } from "../define-tool.js";
+import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
+import { readHeaderColumns } from "./list-artifacts.js";
+
+/** The input of one derivation: the script, the declared pinned inputs, and the name of the output file. */
+const deriveTableInput = z.object({
+    script: z.string().min(1),
+    inputs: z.array(z.string()).min(1),
+    output: z.string().min(1),
+});
+
+export type DeriveTableInput = z.infer<typeof deriveTableInput>;
+
+/**
+ * The typed outcome of the derivation tool. Each arm is ok-channel data, thus the tool never throws for one
+ * of them.
+ *
+ * `derived` carries the workspace-relative path of the derived table, its content hash, the hash of the
+ * script, the sources that the record pins, and the header columns of the output. Each other arm names a
+ * condition that the agent repairs: a call that is out of bounds, an input that the membership does not
+ * hold, a name that a record already holds, a script that failed in the container, and a green script that
+ * left no file at the output name.
+ */
+export type DeriveTableResult =
+    | { outcome: "refused"; refusal: SessionRefusal }
+    | { outcome: "unavailable"; detail: string }
+    | { outcome: "script-too-large"; bytes: number; cap: number; detail: string }
+    | { outcome: "too-many-inputs"; count: number; cap: number; detail: string }
+    | { outcome: "unsafe-name"; detail: string }
+    | { outcome: "absent-input"; path: string; detail: string }
+    | { outcome: "repeated-name"; outputPath: string; detail: string }
+    | { outcome: "exec-failed"; detail: string }
+    | { outcome: "no-output"; detail: string }
+    | { outcome: "derived"; path: string; hash: string; scriptHash: string; sources: DerivationSource[]; columns?: string[] };
+
+/**
+ * The construction deps of the derivation tool.
+ *
+ * `derivations` is the append side of the durable session state, thus the record lands beside the document
+ * and the pin. `sandboxClient` and `runAuthorizer` are the two rails of the exec, and a composition that
+ * binds neither leaves the session with no derivation at all. `resolveWorkspaceRoot` maps the analysis of
+ * the call onto its workspace root, thus one singleton tool serves every analysis.
+ */
+export interface DeriveTableToolDeps {
+    readonly gateway: ReportSessionStateGateway;
+    readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
+    readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
+    readonly sandboxClient?: SandboxClient;
+    readonly runAuthorizer?: RunAuthorizer;
+    readonly logger?: Logger;
+}
+
+/** The synthetic run id and step id of one derivation. Both are constants, and neither names a run row. */
+const DERIVE_RUN_LITERAL = "derive-table" as const;
+const DERIVE_STEP_LITERAL = "derive" as const;
+
+/** The provenance agent id. No agent loop runs in the container, thus this names the derivation pass. */
+const DERIVE_AGENT_ID = "table-deriver" as const;
+
+/** The exec budget of one derivation. It matches the budget of the value tier. */
+const DERIVATION_DEADLINE_MS = 300_000;
+
+/**
+ * The container size of one derivation. A join or a pivot loads each declared input into pandas at one
+ * time, thus the container needs the headroom of the value tier.
+ */
+const DERIVATION_RESOURCES: ResourceSpec = { cpu: 2, memoryGb: 8 };
+
+/** The cap of the script, in bytes. A reshaping script sits far under it, and the command line carries it. */
+const SCRIPT_CAP_BYTES = 64 * 1024;
+
+/** The cap of the declared inputs. One derivation reads the evidence of a few artifacts, and never a tree. */
+const INPUT_CAP = 20;
+
+/** The directory of the derived tables of a session, under the directory of that session. */
+const DERIVED_DIR = "derived";
+
+/** The environment variable that carries the declared inputs into the container. */
+export const DERIVE_INPUT_ENV = "DERIVE_INPUTS";
+
+/** The environment variable that carries the container path of the output file into the container. */
+export const DERIVE_OUTPUT_ENV = "DERIVE_OUTPUT";
+
+/** The cap of the failure detail that the tool copies out of the standard error of the script. */
+const STDERR_TAIL_CAP = 2_000;
+
+/** The awaitExec callback. A derivation reports no live activity, thus the callback drops each event. */
+const noopEmit: ExecEmit = () => {};
+
+/** The line that the agent reads when the composition binds no sandbox rails. */
+const NO_SANDBOX_DETAIL = "the composition gives no sandbox, thus this session cannot derive a table";
+
+/** One declared input, as the container reads it: the mounted path of the file, and its pinned hash. */
+export interface DerivationInputMount {
+    readonly path: string;
+    readonly hash: string;
+}
+
+/**
+ * Build the sandbox exec of one derivation. The command runs the script of the agent through `python3 -c`.
+ *
+ * The working directory is the write mount, thus the script writes its table beside where it stands. Each
+ * declared input rides as its mounted path, thus the script opens the file wherever it works from. The
+ * output path rides too, thus the script names no directory of its own.
+ *
+ * The function is pure, thus a test asserts the command shape without a sandbox.
+ */
+export function buildDerivationExec(args: {
+    readonly script: string;
+    readonly execId: string;
+    readonly workingDir: string;
+    readonly inputs: readonly DerivationInputMount[];
+    readonly output: string;
+}): SubmitExecBody {
+    return {
+        command: ["python3", "-c", args.script],
+        execId: args.execId,
+        cwd: args.workingDir,
+        env: {
+            [DERIVE_INPUT_ENV]: JSON.stringify(args.inputs.map((input) => ({ path: input.path, hash: input.hash }))),
+            [DERIVE_OUTPUT_ENV]: args.output,
+        },
+        timeoutSeconds: Math.floor(DERIVATION_DEADLINE_MS / 1000),
+    };
+}
+
+/**
+ * Give the failure of an exec result, or `undefined` when the script ran to a clean exit.
+ *
+ * A synthetic failure, a timeout, and a non-zero exit each mean that no table came back. The detail of a
+ * non-zero exit carries the tail of the standard error, thus the agent repairs the script from what the
+ * container reported.
+ *
+ * The function is pure, thus a test asserts the mapping without a sandbox.
+ */
+export function describeExecFailure(result: ExecResult): string | undefined {
+    if (result.syntheticFailure !== undefined) {
+        return `the derivation sandbox failed: ${result.syntheticFailure.reason}`;
+    }
+    if (result.timedOut) {
+        return "the derivation reached the deadline";
+    }
+    if (result.exitCode !== 0) {
+        const tail = result.stderr.slice(-STDERR_TAIL_CAP).trim();
+        const exit = `the script exited with code ${String(result.exitCode)}`;
+        return tail.length === 0 ? exit : `${exit}: ${tail}`;
+    }
+    return undefined;
+}
+
+/**
+ * Run one derivation in an ephemeral container, and give the exec result back.
+ *
+ * The container mounts the analysis tree read-only, and the declared write tail is its one writable mount.
+ * Thus the script reads the evidence and it writes into the `derived/` directory of the session and nowhere
+ * else. The teardown runs on both paths, thus no machine outlives the call. A teardown fault reaches the log
+ * alone, because the work is done.
+ *
+ * Each seam call is guarded, thus a fault of the sandbox becomes a short detail and the tool keeps its
+ * no-throw contract.
+ */
+async function runDerivationExec(args: {
+    readonly client: SandboxClient;
+    readonly analysisId: string;
+    readonly executionId: string;
+    readonly script: string;
+    readonly writableTail: string;
+    readonly workingDir: string;
+    readonly inputs: readonly DerivationInputMount[];
+    readonly output: string;
+    readonly logger: Logger;
+}): Promise<Result<ExecResult, string>> {
+    let sandbox: SandboxRef;
+    try {
+        sandbox = await args.client.createSandbox(
+            {
+                runId: DERIVE_RUN_LITERAL,
+                stepId: DERIVE_STEP_LITERAL,
+                analysisId: args.analysisId,
+                childWorkflowId: `${DERIVE_RUN_LITERAL}:${args.executionId}`,
+                resources: DERIVATION_RESOURCES,
+                writableTail: args.writableTail,
+            },
+            mintSandboxIdentity(DERIVE_RUN_LITERAL),
+        );
+    } catch (cause) {
+        args.logger.error("the derivation sandbox did not start", args.logger.errorFields(cause));
+        return err("the derivation sandbox did not start");
+    }
+
+    try {
+        // The tool runs inside one live turn and it never replays, thus the wall clock is the deadline.
+        const deadline = Date.now() + DERIVATION_DEADLINE_MS;
+        await args.client.submitExec(
+            sandbox,
+            buildDerivationExec({
+                script: args.script,
+                execId: args.executionId,
+                workingDir: args.workingDir,
+                inputs: args.inputs,
+                output: args.output,
+            }),
+        );
+        return ok(await args.client.awaitExec(sandbox, args.executionId, noopEmit, deadline));
+    } catch (cause) {
+        args.logger.error("the derivation exec did not complete", args.logger.errorFields(cause));
+        return err("the derivation exec did not complete");
+    } finally {
+        try {
+            await args.client.teardown(sandbox);
+        } catch (cause) {
+            args.logger.warn("the derivation sandbox did not tear down", args.logger.errorFields(cause));
+        }
+    }
+}
+
+/**
+ * Make the derivation tool over the session-state gateway, the derivation ledger, and the sandbox rails.
+ *
+ * The tool reads the thread id from the scope of the call, and it loads the membership through the gateway.
+ * Thus one factory serves every thread, and the tool holds no per-session value.
+ */
+export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTableInput, DeriveTableResult> {
+    const logger = (deps.logger ?? createNoopLogger()).named("derive-table");
+    const { sandboxClient, runAuthorizer } = deps;
+
+    return defineTool({
+        id: "derive_table",
+        description:
+            "Derive one table from the pinned evidence with a Python script, and pin the result to this session. " +
+            "Reach for it when a real reshaping stands between the evidence and the block: a join of two tables, a pivot, or an aggregate. " +
+            "A per-row transform is not a derivation, because a chart block reads the column that it needs. " +
+            "Name each pinned path that the script reads in `inputs`: each one must sit in the pinned evidence, and the record pins its hash. " +
+            'Give the file name of the result in "output": one name, with no directory and no separator, for example "yield_by_group.csv". ' +
+            `The script reads the ${DERIVE_INPUT_ENV} environment variable for its inputs: a JSON list that gives the mounted path and the hash of each declared one. ` +
+            `It writes the whole table as CSV to the path in the ${DERIVE_OUTPUT_ENV} environment variable, which sits in the working directory of the script. ` +
+            "That directory is the one place that the script can write: the analysis mounts read-only, and the container has no network. " +
+            "The standard output carries the logs of the script alone, thus a table that it prints there reaches nobody. " +
+            "The derived table joins the pinned evidence of this session, thus a block binds its path the same way as a pinned artifact. " +
+            "A name that this session already derived is refused, thus a second derivation of one table takes a new name.",
+        inputSchema: deriveTableInput,
+        executionMode: "inline",
+        describeCall: (input): string => `derive ${input.output}`,
+        // The derived path is the one durable product of the call, thus the derived arm names it. Each other
+        // arm is a condition that refused, and the kind of the arm is what a watcher must read.
+        describeResult: (_input, result): string => (result.outcome === "derived" ? result.path : result.outcome),
+        execute: async (input, ctx): Promise<Result<DeriveTableResult, ToolError>> => {
+            // The check runs before every read, thus one clear signal replaces a failure for each attempt.
+            // It also narrows the two rails below, thus the exec needs no assertion.
+            if (sandboxClient === undefined || runAuthorizer === undefined) {
+                logger.warn("the composition gives no sandbox, thus no derivation can run");
+                return ok({ outcome: "unavailable", detail: NO_SANDBOX_DETAIL });
+            }
+
+            const opened = await openReportThread(deps.gateway, ctx.session.scope);
+            if (opened.isErr()) {
+                return ok({ outcome: "refused", refusal: opened.error });
+            }
+            const { threadId, analysisId, state } = opened.value;
+
+            const bytes = Buffer.byteLength(input.script, "utf8");
+            if (bytes > SCRIPT_CAP_BYTES) {
+                return ok({
+                    outcome: "script-too-large",
+                    bytes,
+                    cap: SCRIPT_CAP_BYTES,
+                    detail: `the script is ${String(bytes)} bytes, and the cap is ${String(SCRIPT_CAP_BYTES)} bytes`,
+                });
+            }
+            // A repeated path names one source, thus the list keeps the first occurrence and the record pins
+            // each source one time.
+            const declared = [...new Set(input.inputs)];
+            if (declared.length > INPUT_CAP) {
+                return ok({
+                    outcome: "too-many-inputs",
+                    count: declared.length,
+                    cap: INPUT_CAP,
+                    detail: `the call declares ${String(declared.length)} inputs, and the cap is ${String(INPUT_CAP)}`,
+                });
+            }
+            if (!isSafeId(input.output)) {
+                return ok({
+                    outcome: "unsafe-name",
+                    detail: "the output names one file, with no directory, no separator, and no traversal",
+                });
+            }
+
+            // Each declared input takes its hash from the served membership. A path that the membership does
+            // not hold has no pinned hash, thus the record could chain nothing to it.
+            const sources: DerivationSource[] = [];
+            for (const path of declared) {
+                const entry = snapshotEntry(state.snapshot, path);
+                if (entry === undefined) {
+                    return ok({
+                        outcome: "absent-input",
+                        path,
+                        detail: `the pinned evidence of this session holds no artifact at ${path}`,
+                    });
+                }
+                sources.push({ path, hash: entry.hash });
+            }
+
+            // The write tail is the one writable mount of the container, and the output sits inside it. Both
+            // compose from the session-directory builder, thus the layout has one owner.
+            const writableTail = `${reportSessionDir(threadId)}/${DERIVED_DIR}`;
+            const outputPath = `${writableTail}/${input.output}`;
+            // The served membership carries each derivation of the session, thus this one test refuses a
+            // repeated name and a collision with a pinned artifact alike.
+            if (snapshotEntry(state.snapshot, outputPath) !== undefined) {
+                return ok({
+                    outcome: "repeated-name",
+                    outputPath,
+                    detail: `the evidence of this session already holds ${outputPath}, thus this derivation takes a new name`,
+                });
+            }
+
+            let root: string;
+            try {
+                root = deps.resolveWorkspaceRoot(analysisId);
+            } catch (cause) {
+                logger.warn("the workspace root did not resolve", { threadId, analysisId, ...defaultErrorFields(cause) });
+                return ok({ outcome: "unavailable", detail: "the workspace root did not resolve, thus the derived table has no place to land" });
+            }
+
+            let authorization: RunAuthorization;
+            try {
+                authorization = await runAuthorizer.authorize({
+                    auth: ctx.session.auth,
+                    scope: { kind: "analysis", analysisId },
+                    provenance: { agentId: DERIVE_AGENT_ID, callPath: [DERIVE_AGENT_ID] },
+                    frame: { runId: DERIVE_RUN_LITERAL, stepId: DERIVE_STEP_LITERAL },
+                });
+            } catch (cause) {
+                logger.error("the derivation was not authorized", { threadId, analysisId, ...defaultErrorFields(cause) });
+                return ok({ outcome: "unavailable", detail: "the derivation was not authorized" });
+            }
+
+            const result = await derive({
+                client: sandboxClient,
+                derivations: deps.derivations,
+                root,
+                threadId,
+                analysisId,
+                script: input.script,
+                sources,
+                writableTail,
+                outputPath,
+                outputName: input.output,
+                logger,
+            });
+
+            // The authorization revokes on every terminal path. A revoke fault changes no outcome of the
+            // call, thus it reaches the log alone.
+            try {
+                await runAuthorizer.revoke(authorization, result.outcome === "derived" ? "derive-table-completed" : "derive-table-failed");
+            } catch (cause) {
+                logger.warn("the derivation authorization did not revoke", { threadId, analysisId, ...defaultErrorFields(cause) });
+            }
+            return ok(result);
+        },
+    });
+}
+
+/**
+ * Run one derivation and record what the script wrote.
+ *
+ * The order is the order of the evidence. The script writes into the write mount, the host classifies the
+ * file, the hash comes off the disk, and the record lands last. Thus the recorded hash is the hash of the
+ * file that a verifier reads.
+ *
+ * The classification is the guard of the read. A script can leave a symbolic link at the output name, and a
+ * link that resolves outside the tree would otherwise carry a host file into the evidence of the session.
+ */
+async function derive(args: {
+    readonly client: SandboxClient;
+    readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
+    readonly root: string;
+    readonly threadId: string;
+    readonly analysisId: string;
+    readonly script: string;
+    readonly sources: readonly DerivationSource[];
+    readonly writableTail: string;
+    readonly outputPath: string;
+    readonly outputName: string;
+    readonly logger: Logger;
+}): Promise<DeriveTableResult> {
+    const executionId = generateExecutionId(DERIVE_AGENT_ID);
+    const absolute = join(args.root, args.outputPath);
+    // The container sees the tree at its own mount point, thus each path that the script reads maps through
+    // the one host-to-container mapper and never through a formula here.
+    const workingDir = toSandboxPath(args.root, args.analysisId, join(args.root, args.writableTail));
+    const executed = await runDerivationExec({
+        client: args.client,
+        analysisId: args.analysisId,
+        executionId,
+        script: args.script,
+        writableTail: args.writableTail,
+        workingDir,
+        inputs: args.sources.map((source) => ({ path: toSandboxPath(args.root, args.analysisId, join(args.root, source.path)), hash: source.hash })),
+        output: toSandboxPath(args.root, args.analysisId, absolute),
+        logger: args.logger,
+    });
+    if (executed.isErr()) {
+        return { outcome: "exec-failed", detail: executed.error };
+    }
+    const failure = describeExecFailure(executed.value);
+    if (failure !== undefined) {
+        return { outcome: "exec-failed", detail: failure };
+    }
+
+    const verdict = await classifyWithinRoot(args.root, absolute).catch((cause: unknown) => {
+        args.logger.error("the derived table did not classify", { threadId: args.threadId, ...defaultErrorFields(cause) });
+        return "escaped" as const;
+    });
+    if (verdict === "absent") {
+        // A clean exit with no file at the output path means that the script wrote nothing, or that it wrote
+        // under a different name inside the mount. Either way this derivation has no table.
+        return {
+            outcome: "no-output",
+            detail: `the script ran to a clean exit and it wrote no file at ${args.outputName}`,
+        };
+    }
+    if (verdict === "escaped") {
+        args.logger.error("the derived table resolves outside the workspace root", { threadId: args.threadId, path: args.outputPath });
+        return { outcome: "exec-failed", detail: `${args.outputName} resolves outside the workspace tree, thus it is not evidence of this session` };
+    }
+
+    let outputHash: string;
+    try {
+        outputHash = await computeSha256File(absolute);
+    } catch (cause) {
+        args.logger.error("the derived table did not hash", { threadId: args.threadId, ...defaultErrorFields(cause) });
+        return { outcome: "exec-failed", detail: "the derived table did not hash" };
+    }
+
+    const record: DerivationRecord = {
+        outputPath: args.outputPath,
+        outputHash,
+        sources: [...args.sources],
+        scriptHash: computeSha256(Buffer.from(args.script, "utf8")),
+        script: args.script,
+    };
+    const appended = await args.derivations.appendDerivation(args.threadId, record);
+    if (appended.isErr()) {
+        args.logger.error("the derivation record did not land", { threadId: args.threadId, ...args.logger.errorFields(appended.error.cause) });
+        return { outcome: "exec-failed", detail: "the derivation record did not land, thus the table is not evidence of this session" };
+    }
+    if (appended.value === "duplicate") {
+        // The membership test above already refused a repeated name. A duplicate here means that another
+        // turn landed the same name inside this call, thus the name rule of the store is the last word.
+        return {
+            outcome: "repeated-name",
+            outputPath: args.outputPath,
+            detail: `another turn recorded ${args.outputPath} first, thus this derivation takes a new name`,
+        };
+    }
+    if (appended.value === "absent") {
+        args.logger.error("the derivation record matched no session row", { threadId: args.threadId });
+        return { outcome: "exec-failed", detail: "no report session state row exists to hold the derivation" };
+    }
+
+    // The columns describe the derived table the same way as the listing describes a pinned one. A file that
+    // gives no header gives no columns, and absence is a normal condition here.
+    const columns = await readColumnsQuietly(args.outputPath, absolute, args.logger);
+    return {
+        outcome: "derived",
+        path: args.outputPath,
+        hash: outputHash,
+        scriptHash: record.scriptHash,
+        sources: [...args.sources],
+        ...(columns === undefined ? {} : { columns }),
+    };
+}
+
+/**
+ * The header columns of the derived table, or `undefined` when the read gives none.
+ *
+ * The derivation already landed at this point, thus a read fault costs the columns alone. The read never
+ * throws for an absent file, and this guard covers a genuine fault of the disk.
+ */
+async function readColumnsQuietly(path: string, absolute: string, logger: Logger): Promise<string[] | undefined> {
+    try {
+        return await readHeaderColumns(path, absolute);
+    } catch (cause) {
+        logger.warn("the derived table gave no columns", { path, ...defaultErrorFields(cause) });
+        return undefined;
+    }
+}

--- a/harness/src/tools/report-session/derive-table.ts
+++ b/harness/src/tools/report-session/derive-table.ts
@@ -28,9 +28,15 @@
  * A composition with no sandbox client and no run authorizer cannot derive at all. The tool reports that
  * condition one time, up front, the same discipline as the eyes. A per-attempt failure would instead read as
  * a transient fault, and it would invite a repeat of a call that can never pass.
+ *
+ * The transport of the client is the second such bound. A derivation runs inside one live turn and not
+ * inside a workflow body. The poll transport awaits with plain steps and a plain sleep, thus it settles
+ * there. The callback transport awaits through `DBOS.recv`, which a workflow body alone can call, thus this
+ * tool refuses up front under it rather than start a container that nothing can await.
  */
 
 import { err, ok, type Result } from "neverthrow";
+import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 
@@ -137,6 +143,9 @@ const noopEmit: ExecEmit = () => {};
 
 /** The line that the agent reads when the composition binds no sandbox rails. */
 const NO_SANDBOX_DETAIL = "the composition gives no sandbox, thus this session cannot derive a table";
+
+/** The line that the agent reads when the sandbox client awaits under a transport that a turn cannot drive. */
+const CALLBACK_TRANSPORT_DETAIL = "the sandbox of this composition reports through callbacks, which a report turn cannot await, thus it derives no table";
 
 /** One declared input, as the container reads it: the mounted path of the file, and its pinned hash. */
 export interface DerivationInputMount {
@@ -299,6 +308,12 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
                 logger.warn("the composition gives no sandbox, thus no derivation can run");
                 return ok({ outcome: "unavailable", detail: NO_SANDBOX_DETAIL });
             }
+            // The await of the callback transport is a workflow-body call, and a report turn is not one. An
+            // absent field states nothing, thus it reads as the poll default and it refuses nothing.
+            if (sandboxClient.transport === "callback") {
+                logger.warn("the sandbox client awaits through callbacks, thus no derivation can run in a turn");
+                return ok({ outcome: "unavailable", detail: CALLBACK_TRANSPORT_DETAIL });
+            }
 
             const opened = await openReportThread(deps.gateway, ctx.session.scope);
             if (opened.isErr()) {
@@ -383,28 +398,34 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
                 return ok({ outcome: "unavailable", detail: "the derivation was not authorized" });
             }
 
-            const result = await derive({
-                client: sandboxClient,
-                derivations: deps.derivations,
-                root,
-                threadId,
-                analysisId,
-                script: input.script,
-                sources,
-                writableTail,
-                outputPath,
-                outputName: input.output,
-                logger,
-            });
-
-            // The authorization revokes on every terminal path. A revoke fault changes no outcome of the
-            // call, thus it reaches the log alone.
+            // The work sits inside the `try`, and the revoke sits in the `finally`. Thus the authorization
+            // revokes on every terminal path, the thrown one included: a path builder refuses a hostile
+            // stored path with a throw, and that throw must not leave an authorization standing.
+            let result: DeriveTableResult | undefined;
             try {
-                await runAuthorizer.revoke(authorization, result.outcome === "derived" ? "derive-table-completed" : "derive-table-failed");
-            } catch (cause) {
-                logger.warn("the derivation authorization did not revoke", { threadId, analysisId, ...defaultErrorFields(cause) });
+                result = await derive({
+                    client: sandboxClient,
+                    derivations: deps.derivations,
+                    root,
+                    threadId,
+                    analysisId,
+                    script: input.script,
+                    sources,
+                    writableTail,
+                    outputPath,
+                    outputName: input.output,
+                    logger,
+                });
+                return ok(result);
+            } finally {
+                // A revoke fault changes no outcome of the call, thus it reaches the log alone. An absent
+                // result means that the work threw, and a throw is a failed derivation.
+                try {
+                    await runAuthorizer.revoke(authorization, result?.outcome === "derived" ? "derive-table-completed" : "derive-table-failed");
+                } catch (cause) {
+                    logger.warn("the derivation authorization did not revoke", { threadId, analysisId, ...defaultErrorFields(cause) });
+                }
             }
-            return ok(result);
         },
     });
 }
@@ -418,6 +439,11 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
  *
  * The classification is the guard of the read. A script can leave a symbolic link at the output name, and a
  * link that resolves outside the tree would otherwise carry a host file into the evidence of the session.
+ *
+ * The output path clears before the exec. The host owns the `derived/` directory, and a failed attempt can
+ * leave a file at the name that this attempt declares. Without the clearance a script that writes nothing
+ * would adopt those bytes as its own table, and the record would chain a script to a file that it never
+ * wrote. A clearance fault refuses the derivation, because the same doubt stands.
  */
 async function derive(args: {
     readonly client: SandboxClient;
@@ -437,6 +463,18 @@ async function derive(args: {
     // The container sees the tree at its own mount point, thus each path that the script reads maps through
     // the one host-to-container mapper and never through a formula here.
     const workingDir = toSandboxPath(args.root, args.analysisId, join(args.root, args.writableTail));
+
+    // `unlink` removes a symbolic link as the link, and never the file that it names. An absent path is the
+    // normal condition, thus it is not a fault.
+    try {
+        await unlink(absolute);
+    } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code !== "ENOENT") {
+            args.logger.error("the output path did not clear before the derivation", { threadId: args.threadId, ...defaultErrorFields(cause) });
+            return { outcome: "exec-failed", detail: `${args.outputName} already holds a file that did not clear, thus this derivation takes a new name` };
+        }
+    }
+
     const executed = await runDerivationExec({
         client: args.client,
         analysisId: args.analysisId,

--- a/harness/src/tools/report-session/index.ts
+++ b/harness/src/tools/report-session/index.ts
@@ -23,6 +23,7 @@ export {
     type PageCapture,
 } from "./examine-page.js";
 export { createRecordVersionTool, type RecordVersionInput, type RecordVersionResult, type RecordVersionToolDeps } from "./record-version.js";
+export { createDeriveTableTool, type DeriveTableInput, type DeriveTableResult, type DeriveTableToolDeps } from "./derive-table.js";
 export {
     createListPinnedArtifactsTool,
     type ListPinnedArtifactsInput,

--- a/harness/src/tools/report-session/list-artifacts.ts
+++ b/harness/src/tools/report-session/list-artifacts.ts
@@ -164,6 +164,22 @@ function columnsOf(read: HeaderRead, delimiter: string): string[] | undefined {
 }
 
 /**
+ * The header columns of a file on disk, or `undefined` when the file gives none.
+ *
+ * `path` decides whether the file carries a header at all, and `absolute` is where the bytes sit. The
+ * derivation tool reads the columns of its own output the same way, thus the two surfaces describe a table
+ * with one rule.
+ */
+export async function readHeaderColumns(path: string, absolute: string): Promise<string[] | undefined> {
+    const delimiter = delimiterOf(path);
+    if (delimiter === undefined) {
+        return undefined;
+    }
+    const read = await readHeaderLine(absolute);
+    return read === undefined ? undefined : columnsOf(read, delimiter);
+}
+
+/**
  * Make the pinned-artifact listing tool over the session-state gateway.
  *
  * The tool reads the thread id from the scope of the call, and it loads the snapshot through the gateway.
@@ -224,12 +240,10 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
                 const entry = state.snapshot.artifacts[path];
                 const fileType = entry.fileType;
                 const artifact: PinnedArtifact = { path, hash: entry.hash, ...(typeof fileType === "string" ? { fileType } : {}) };
-                const delimiter = delimiterOf(path);
-                if (root !== undefined && delimiter !== undefined && !fileTypeHoldsNoCell(fileType)) {
+                if (root !== undefined && !fileTypeHoldsNoCell(fileType)) {
                     const resolved = resolveWorkspacePath({ workspaceRoot: root, analysisId, path });
                     if (resolved.kind === "ok") {
-                        const read = await readHeaderLine(resolved.absolute);
-                        const columns = read === undefined ? undefined : columnsOf(read, delimiter);
+                        const columns = await readHeaderColumns(path, resolved.absolute);
                         if (columns !== undefined) {
                             artifact.columns = columns;
                         }

--- a/harness/src/workspace/paths.test.ts
+++ b/harness/src/workspace/paths.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import { resolve as resolvePath, sep } from "node:path";
 
-import { assertSafeId, previewDir, reportSessionDir, resolveForWrite, resolveWorkspacePath, stepWritePrefix, toSandboxPath } from "./paths.js";
+import {
+    assertSafeId,
+    assertSafeTail,
+    previewDir,
+    reportSessionDir,
+    resolveForWrite,
+    resolveWorkspacePath,
+    stepWritePrefix,
+    tailWritePrefix,
+    toSandboxPath,
+} from "./paths.js";
 
 const SESSIONS = "/var/sessions";
 const ANALYSIS = "analysis-001";
@@ -246,6 +256,42 @@ describe("reportSessionDir", () => {
         expect(() => reportSessionDir("..")).toThrow(/Invalid threadId/);
         expect(() => reportSessionDir("a/b")).toThrow(/Invalid threadId/);
         expect(() => reportSessionDir("a\0b")).toThrow(/Invalid threadId/);
+    });
+});
+
+describe("assertSafeTail", () => {
+    it("gives the segments of a workspace-relative tail", () => {
+        expect(assertSafeTail("report-sessions/thread-a/derived")).toEqual(["report-sessions", "thread-a", "derived"]);
+        expect(assertSafeTail("derived")).toEqual(["derived"]);
+    });
+
+    it("rejects an empty, an absolute, and a traversing tail", () => {
+        expect(() => assertSafeTail("")).toThrow(/Invalid writableTail/);
+        expect(() => assertSafeTail("/abs/derived")).toThrow(/Invalid writableTail/);
+        expect(() => assertSafeTail("../escape")).toThrow(/Invalid writableTail/);
+        expect(() => assertSafeTail("a/../../etc")).toThrow(/Invalid writableTail/);
+        // An empty segment reaches the same refusal, thus a doubled or a trailing separator is out.
+        expect(() => assertSafeTail("a//b")).toThrow(/Invalid writableTail/);
+        expect(() => assertSafeTail("a/")).toThrow(/Invalid writableTail/);
+    });
+
+    it("rejects a segment that carries a NUL or a space, and it names the label", () => {
+        expect(() => assertSafeTail("a\0b/c")).toThrow(/Invalid writableTail/);
+        expect(() => assertSafeTail("a b/c", "tail")).toThrow(/Invalid tail/);
+    });
+});
+
+describe("tailWritePrefix", () => {
+    it("joins the validated segments under the workspace root", () => {
+        expect(tailWritePrefix({ workspaceRoot: ROOT, tail: "report-sessions/thread-a/derived" })).toBe(
+            resolvePath(ROOT, "report-sessions", "thread-a", "derived"),
+        );
+        // The step tail gives the same path as the step builder, thus one preparation serves both.
+        expect(tailWritePrefix({ workspaceRoot: ROOT, tail: "runs/run-abc/step-1" })).toBe(STEP_DIR);
+    });
+
+    it("refuses a crafted tail instead of resolving outside the root", () => {
+        expect(() => tailWritePrefix({ workspaceRoot: ROOT, tail: "../../etc" })).toThrow(/Invalid writableTail/);
     });
 });
 

--- a/harness/src/workspace/paths.ts
+++ b/harness/src/workspace/paths.ts
@@ -154,6 +154,44 @@ export function stepWritePrefix(args: { readonly workspaceRoot: string; readonly
 }
 
 /**
+ * Split a declared sandbox write tail into its segments, and refuse a tail that is
+ * not one workspace-relative path.
+ *
+ * A tail names the one writable mount of a sandbox in place of the step directory.
+ * It reaches the mount builders from a caller, thus it takes the same discipline as
+ * a `stepId`: each segment passes {@link assertSafeId}, which refuses a separator,
+ * a NUL, a shell-hostile char, and a pure-dot segment. An empty tail names the
+ * workspace root itself, and an absolute tail names a host location. Both are
+ * refused, because a write mount must be a directory inside the tree.
+ *
+ * The segments come back so a host-path builder joins the validated parts, and it
+ * never re-splits the raw text.
+ */
+export function assertSafeTail(tail: string, label = "writableTail"): string[] {
+    if (tail.length === 0 || tail.startsWith("/")) {
+        throw new Error(`Invalid ${label}: ${tail}`);
+    }
+    const segments = tail.split("/");
+    for (const segment of segments) {
+        assertSafeId(segment, label);
+    }
+    return segments;
+}
+
+/**
+ * Derive the host path of a declared write tail under a workspace root.
+ *
+ * The counterpart of {@link stepWritePrefix} for a sandbox that declares its own
+ * write tail. The tail passes the same validation before it becomes a host
+ * directory path, thus a crafted segment cannot widen or escape the mount. This is
+ * the one builder of that path: the host makes the directory with it, and the
+ * Docker bind source comes from it.
+ */
+export function tailWritePrefix(args: { readonly workspaceRoot: string; readonly tail: string }): string {
+    return resolvePath(args.workspaceRoot, ...assertSafeTail(args.tail));
+}
+
+/**
  * Map a host-side absolute path within an analysis's workspace tree to its
  * in-sandbox absolute path. The tree is bind-mounted at `/{resourceId}`, so
  * the sandbox path is the resource id plus the root-relative tail — the host


### PR DESCRIPTION
## What & why

The runs write statistical tables, and not plot-ready ones. In the first real session the agent could not reshape a table. The `derive_table` tool now runs an agent-authored Python script on the sandbox rails: the container resource policy, no network, the signed exec protocol, and the authorizer on every terminal path. A per-row transform stays a chart knob, thus the derivation serves real reshaping: a join, a pivot, an aggregate.

The mount plan gains one declared write tail. `CreateSandboxMeta` takes an optional workspace-relative `writableTail`, validated segment by segment through the step-builder discipline. The tree mounts read-only, the one write mount covers `report-sessions/{threadId}/derived`, and the script writes its output directly. An absent tail keeps the run-path plan byte-identical, and a tail beside `readOnly` refuses at the builder.

The boundary stands: a derivation is not an analysis run. No run id, no ledger row, and no write outside `derived/`. The record lands in the session state: the output hash, the source hashes, the script hash, and the script text. Thus a verifier can run the script again. The served snapshot merges the records, and a derived table binds like a pinned one.

Notes for the reviewer:

- The K8s client took no edit: the plan already carries what it translates, and a new test pins the tail flow.
- The host classifies the output before it hashes it, thus a planted symbolic link cannot pull a host file into the evidence.
- The purge is embedder-owned, and the derived directory rides inside the session directory that the disposal removes.

Refs #373

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved, with one named loosening: the write confinement widens from the step directory alone to the step directory or one declared, segment-validated write tail. Everything else stands: unprivileged uid-1000 workload, no network egress in poll mode, signature-authenticated exec endpoints, read-only analysis tree, resource limits, and no host credentials in spawned commands.
- [x] **Provenance:** prior analyses remain reproducible. A derivation records its declared sources, its script, and its output hash. Two stated bounds remain: the script read reach is the whole read-only tree, and the record pins no image reference. The declared-input wall and the image pin are later hardenings.
