### PR TITLE
docs(harness): state the repeatability bounds of a derivation

### DIFF
--- a/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-15-derive-in-the-report-session/specs/report-verification/spec.md
@@ -3,7 +3,9 @@
 ## ADDED Requirements
 
 ### Requirement: A derivation is repeatable
-The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can mount the same pinned inputs, run the recorded script, and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can run the recorded script over the analysis tree and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+
+The record states two bounds honestly. The record pins the declared sources, and the read reach of the script is the whole tree. The record pins no image reference, thus a different sandbox image can give a different hash. The declared-input wall and the image pin are later hardenings.
 
 #### Scenario: The record admits a re-run
 - **WHEN** a verifier reads a derivation record

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -44,7 +44,9 @@ The record MUST refuse until the eyes ran against the current document state. Th
 - **THEN** the record refuses until a new preview and a new look run
 
 ### Requirement: A derivation is repeatable
-The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can mount the same pinned inputs, run the recorded script, and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+The derivation record MUST hold what a second run needs: the script text, the script hash, the source paths with their hashes, and the output hash. A verifier can run the recorded script over the analysis tree and compare the output hash. The record is immutable, thus the chain from a derived cell to the pinned evidence stays whole.
+
+The record states two bounds honestly. The record pins the declared sources, and the read reach of the script is the whole tree. The record pins no image reference, thus a different sandbox image can give a different hash. The declared-input wall and the image pin are later hardenings.
 
 #### Scenario: The record admits a re-run
 - **WHEN** a verifier reads a derivation record


### PR DESCRIPTION
## What & why

Two spec sentences missed the derivation merge. The verification spec now states the repeatability bounds of a derivation record: the record pins the declared sources while the script read reach is the whole tree, and the record pins no image reference. The two hardenings are later work. No code changes.

Refs #373

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [x] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
