### PR TITLE
feat(cli): give the eyes enough shared memory for the capture

### DIFF
--- a/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/design.md
+++ b/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/design.md
@@ -1,0 +1,25 @@
+# Design: give-the-eyes-shared-memory
+
+## Context
+
+The eyes realization starts one container for one look (`src/modules/harness/eyes.ts:168-222`). The run args carry the port publication, the mount, the lifetime entrypoint, and the image. No `--shm-size` is present, thus the runtime default applies. Under podman that default is 64 MiB.
+
+Chrome composes a full-page capture in shared memory. A 1440 px wide capture of an 11,189 px page is a ~64 MB RGBA bitmap, at the ceiling. The capture then fails with `Protocol error (Page.captureScreenshot): Unable to capture screenshot`, and the look reports `capture-failed`.
+
+## Decisions
+
+### D1: One gigabyte, as a constant beside the lifetime
+
+The size rides as a module constant, beside `DEFAULT_LIFETIME_SECONDS`. One gigabyte holds a page an order of magnitude taller than the observed one, and the memory is only committed while a look runs. A smaller bound would invite the same fault on a longer report. The value is not configurable, because no user-facing knob exists for the eyes, and a knob without a consumer is surface without a need.
+
+### D2: The flag lands in the `run` args, not in the image
+
+`--shm-size` is a runtime allocation flag, and the pinned image cannot carry it. The arg joins the array between the detach flags and the port publication, thus the arg-order assertions of the tests stay readable.
+
+### D3: The proof is an arg assertion, not a container run
+
+The failure only shows under the default `/dev/shm` of a real container runtime. A test that started a real container would be slow and environment-bound. The durable proof asserts the argument in the composed run args, through the injected `run` seam that the existing tests already use.
+
+## Risks / Trade-offs
+
+- A machine with less than 1 GiB free swaps during a look. The lifetime bound caps the exposure, and the gate bounds two browsers at one time.

--- a/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/proposal.md
+++ b/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: give-the-eyes-shared-memory
+
+## Why
+
+Seven looks of the second real report session failed with `Protocol error (Page.captureScreenshot): Unable to capture screenshot`. The record gate then refused with `never-seen`, thus the session ended with no recorded version.
+
+A live A/B run pins the root cause. The eyes container starts with no `--shm-size`, and the podman default gives it a 64 MiB `/dev/shm`. The capture asks for the full page, and the bitmap of the 11,189 px session page is about 64 MB. The same container command with `--shm-size=1g` captures the same page cleanly.
+
+## What Changes
+
+- The ephemeral eyes realization (`src/modules/harness/eyes.ts`, `createEphemeralEyes`) adds `--shm-size=1g` to the container run args.
+- A test pins the shm argument in the run args, beside the existing arg assertions.
+- Nothing else about the eyes changes: the lifetime entrypoint, the count gate, the readiness probe, the mount, and the release stay as they are.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `harness-runtime`: the eyes-realization requirement gains the shared-memory allowance, because the capture bitmap of a tall page does not fit the runtime default.
+
+## Impact
+
+- Affected code: `src/modules/harness/eyes.ts`, `src/modules/harness/eyes.test.ts`.
+- No contract change, no new dependency, no behavior change outside the container args.
+- The harness-side capture fallback is a separate harness change, not this one.

--- a/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/specs/harness-runtime/spec.md
+++ b/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/specs/harness-runtime/spec.md
@@ -1,0 +1,12 @@
+# Delta: harness-runtime
+
+## MODIFIED Requirements
+
+### Requirement: The CLI realizes the eyes of a report session
+
+The container MUST carry a shared-memory allowance that holds a full-page capture bitmap. The runtime default of 64 MiB refuses the capture of a tall page. The look then fails with a protocol error, although the page itself is sound.
+
+#### Scenario: The shared-memory allowance rides the run args
+
+- **WHEN** the seam starts the container of one look
+- **THEN** the run args carry the shared-memory size, and the size holds a full-page capture of a tall report page

--- a/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/tasks.md
+++ b/cli/openspec/changes/archive/2026-08-16-give-the-eyes-shared-memory/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: give-the-eyes-shared-memory
+
+## 1. The shared-memory allowance
+
+- [x] 1.1 Add a shared-memory size constant beside `DEFAULT_LIFETIME_SECONDS` in `src/modules/harness/eyes.ts`, with a comment that states why the runtime default loses a full-page capture.
+- [x] 1.2 Add `--shm-size` with that constant to the `run` args of the acquire, between the detach flags and the port publication.
+
+## 2. The proof
+
+- [x] 2.1 Extend the run-args assertions in `src/modules/harness/eyes.test.ts`: the composed args carry the shared-memory size.
+- [x] 2.2 Run the targeted suite `bun run test src/modules/harness/eyes.test.ts`, and `bun run typecheck`.

--- a/cli/openspec/specs/harness-runtime/spec.md
+++ b/cli/openspec/specs/harness-runtime/spec.md
@@ -445,6 +445,8 @@ The mount MUST repeat the workspace root of the scope on both sides. The browser
 
 The container MUST publish its devtools port on the loopback interface alone. The browser reads the workspace of the user, and a port on every interface would serve that tree to the network.
 
+The container MUST carry a shared-memory allowance that holds a full-page capture bitmap. The runtime default of 64 MiB refuses the capture of a tall page. The look then fails with a protocol error, although the page itself is sound.
+
 The container MUST carry its own deadline, and that deadline MUST NOT depend on this process. A process can die between the acquire and the release, thus no release of a caller is the guarantee.
 
 The realization MUST bound how many browsers run at one time. The page gate of the harness bounds one endpoint, and each look here names a new endpoint.
@@ -479,3 +481,8 @@ The realization MUST run on the container runtime that the boot pinned already. 
 
 - **WHEN** the container starts and the endpoint never answers
 - **THEN** the acquire removes the container, it gives its slot back, and it throws
+
+#### Scenario: The shared-memory allowance rides the run args
+
+- **WHEN** the seam starts the container of one look
+- **THEN** the run args carry the shared-memory size, and the size holds a full-page capture of a tall report page

--- a/cli/src/modules/harness/eyes.test.ts
+++ b/cli/src/modules/harness/eyes.test.ts
@@ -41,8 +41,13 @@ describe("createEphemeralEyes", () => {
         // The endpoint is the published host port, and the browser is reachable from this host alone.
         expect(lease.browserUrl).toBe("http://127.0.0.1:45678");
         expect(t.calls).toHaveLength(1);
-        expect(t.argsOf("run")).toContain("-d");
-        expect(t.argsOf("run")).toContain(EYES_IMAGE);
+        const args = t.argsOf("run");
+        expect(args).toContain("-d");
+        expect(args).toContain(EYES_IMAGE);
+        // Chrome composes a full-page capture bitmap in /dev/shm, and the runtime default is too small for a
+        // tall report page. Without this argument the look fails with a protocol error.
+        expect(args).toContain("--shm-size");
+        expect(args[args.indexOf("--shm-size") + 1]).toBe("1g");
     });
 
     test("the mount repeats the workspace root on both sides", async () => {

--- a/cli/src/modules/harness/eyes.ts
+++ b/cli/src/modules/harness/eyes.ts
@@ -45,6 +45,16 @@ const IMAGE_RUN_SCRIPT = "/headless-shell/run.sh";
 const DEFAULT_LIFETIME_SECONDS = 180;
 
 /**
+ * How much shared memory one container gets.
+ *
+ * Chrome composes a full-page capture bitmap in `/dev/shm`. The podman default of 64 MiB is smaller than that
+ * bitmap for a tall report page, thus the capture fails with a protocol error although the page itself is
+ * sound. One gigabyte holds a page an order of magnitude taller than the observed 11,189 px case, and the
+ * memory is only committed while a look runs.
+ */
+const SHM_SIZE = "1g";
+
+/**
  * How many browsers run at one time.
  *
  * The page gate of the harness bounds one endpoint, and each look here names a new endpoint. Thus the count
@@ -174,6 +184,8 @@ export function createEphemeralEyes(deps: EphemeralEyesDeps): AcquireEyes {
                 "run",
                 "-d",
                 "--rm",
+                "--shm-size",
+                SHM_SIZE,
                 "-p",
                 `127.0.0.1:${port}:${CONTAINER_DEVTOOLS_PORT}`,
                 "-v",

--- a/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/design.md
@@ -1,0 +1,27 @@
+# Design: retry-the-capture-at-the-viewport
+
+## Context
+
+`capturePage` (`src/lib/page-capture.ts:102-149`) navigates, settles, and screenshots with `fullPage: true`. The screenshot call throws a protocol error when the compositor cannot hold the full-page bitmap. Today that throw ends the capture, the eyes tool maps it onto `capture-failed`, and no seen stamp lands. The record then refuses with `never-seen` forever on that environment.
+
+## Decisions
+
+### D1: The retry sits inside `capturePage`, not in the eyes tool
+
+The capture module owns the screenshot mechanics, and both capture callers get the same degradation. The eyes tool keeps its one job: map the capture onto the typed look result.
+
+### D2: One retry, viewport alone, same page instance
+
+The page already navigated and settled, thus the retry reuses it and costs one screenshot call. The retry drops `fullPage` and captures the window: 1440 by 900, the reader viewport. A second failure propagates as today, because a viewport bitmap that also fails names a broken browser and not a tall page.
+
+### D3: `coverage` is a required field with two values
+
+`PageCapture.coverage` is `"full" | "viewport"`. Required, because an optional flag invites a caller that forgets the partial case. The two capture callers compile against the new field, and the change is internal to the package, thus no consumer migration exists.
+
+### D4: A viewport look counts as a look
+
+The look-before-record rule asks that the agent saw the current document. A viewport picture is a true picture of that document, thus the seen stamp lands. The tool result names the coverage, and the agent judges what it saw. The alternative — refusing the stamp — would rebuild the exact deadlock that this change removes.
+
+## Risks / Trade-offs
+
+- A viewport look shows the top window alone, thus a below-fold defect can pass the look. The coverage marker makes that visible to the agent, and the environment fix of the embedder makes the case rare.

--- a/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: retry-the-capture-at-the-viewport
+
+## Why
+
+The full-page screenshot of a tall report page can exceed what the browser environment can rasterize. In the second real session, seven looks failed with one protocol error, and the record gate then refused every version. The environment fix lands in the embedder. The harness still owes a degraded look, thus one oversized page never blocks the record path again.
+
+## What Changes
+
+- `capturePage` (`src/lib/page-capture.ts`) retries one time at the viewport alone when the full-page screenshot throws. The result then carries the coverage of the picture.
+- `PageCapture` gains a `coverage` field: `"full"` or `"viewport"`. The full arm stays the default shape of every passing capture.
+- The eyes tool (`src/tools/report-session/examine-page.ts`) passes the coverage through to the agent, thus the agent knows that the picture shows the window alone.
+- A viewport look still stamps the seen hash, because the agent saw the current page. The record path stays open.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-verification`: the eyes-tool requirement gains the viewport fallback and the coverage marker.
+
+## Impact
+
+- Affected code: `src/lib/page-capture.ts`, `src/tools/report-session/examine-page.ts`, and their tests.
+- The added field is additive, thus the preview-snapshot caller of the old path keeps its shape.
+- The embedder half — the shared-memory allowance of the eyes container — is a separate cli change.

--- a/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/specs/report-verification/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-verification
+
+## MODIFIED Requirements
+
+### Requirement: The eyes tool
+
+The capture MUST retry one time at the reader viewport when the full-page screenshot throws. The result MUST name the coverage of the picture: the whole page, or the viewport alone. A viewport look MUST still stamp the seen hash, because the agent saw the current document. Thus an oversized page degrades a look, and it never blocks the record path.
+
+#### Scenario: A failed full-page capture degrades to the viewport
+
+- **WHEN** the full-page screenshot throws and the viewport screenshot passes
+- **THEN** the result carries the viewport picture, the coverage names the viewport, and the seen stamp lands
+
+#### Scenario: A failed viewport retry stays a failed capture
+
+- **WHEN** the full-page screenshot throws and the viewport retry also throws
+- **THEN** the result carries the typed capture failure, exactly as before

--- a/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-retry-the-capture-at-the-viewport/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: retry-the-capture-at-the-viewport
+
+## 1. The capture fallback
+
+- [x] 1.1 Add `coverage: "full" | "viewport"` to `PageCapture` in `src/lib/page-capture.ts`, with a JSDoc that states when the viewport arm appears.
+- [x] 1.2 Wrap the full-page screenshot: on a throw, screenshot the viewport on the same page, and set the coverage. A second throw propagates.
+
+## 2. The eyes tool passes the coverage through
+
+- [x] 2.1 Carry the coverage onto the look result of `src/tools/report-session/examine-page.ts`, thus the agent reads what the picture shows.
+- [x] 2.2 Make sure that a viewport look stamps the seen hash, exactly as a full look does.
+
+## 3. The proof
+
+- [x] 3.1 A test drives the fallback: the first screenshot call throws, the second passes, and the result names the viewport coverage.
+- [x] 3.2 A test drives the double failure: both calls throw, and the typed capture failure stays.
+- [x] 3.3 Run the targeted suites of the two modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -93,6 +93,8 @@ The eyes tool MUST open the session page through a `file://` navigation of headl
 
 The capture MUST settle the page before the screenshot, through reduced-motion emulation. The design source collapses each transition under that preference, thus the picture shows the final state and no mid-fade content. The capture MUST show the whole page at a reader viewport, thus a defect below the fold is visible and the checklist is answerable.
 
+The capture MUST retry one time at the reader viewport when the full-page screenshot throws. The result MUST name the coverage of the picture: the whole page, or the viewport alone. A viewport look MUST still stamp the seen hash, because the agent saw the current document. Thus an oversized page degrades a look, and it never blocks the record path.
+
 The tool MUST reach the browser through the eyes seam of the composition. One look MUST acquire one lease, and the tool MUST release the lease after the look. The release runs on a pass and on a failed capture alike.
 
 A failed release MUST NOT change the outcome of the look, and the log names the failed release. A failed acquire MUST be a typed outcome, and nothing throws.
@@ -110,6 +112,16 @@ An injected capture seam MUST win over the eyes seam, because it replaces the wh
 #### Scenario: No page is a typed outcome
 - **WHEN** the eyes run before any preview
 - **THEN** the result says that no page exists, and nothing throws
+
+#### Scenario: A failed full-page capture degrades to the viewport
+
+- **WHEN** the full-page screenshot throws and the viewport screenshot passes
+- **THEN** the result carries the viewport picture, the coverage names the viewport, and the seen stamp lands
+
+#### Scenario: A failed viewport retry stays a failed capture
+
+- **WHEN** the full-page screenshot throws and the viewport retry also throws
+- **THEN** the result carries the typed capture failure, exactly as before
 
 #### Scenario: One look releases its lease
 

--- a/harness/src/app/spawn-report-session.test.ts
+++ b/harness/src/app/spawn-report-session.test.ts
@@ -199,7 +199,12 @@ describe("the eyes rule", () => {
             true,
         );
         // A capture seam replaces the transport of the look.
-        expect(compositionHasEyes({ chrome: {}, capture: () => Promise.resolve({ screenshotBase64: "", consoleErrors: [], failedRequests: [] }) })).toBe(true);
+        expect(
+            compositionHasEyes({
+                chrome: {},
+                capture: () => Promise.resolve({ screenshotBase64: "", coverage: "full", consoleErrors: [], failedRequests: [] }),
+            }),
+        ).toBe(true);
         // A config that names a browser is the route of a standing sidecar.
         expect(compositionHasEyes({ chrome: WITH_BROWSER })).toBe(true);
     });
@@ -227,7 +232,7 @@ describe("spawnReportSession refusals", () => {
         const seamed = createReportSessionSpawn({
             pool,
             chrome: {},
-            capture: () => Promise.resolve({ screenshotBase64: "", consoleErrors: [], failedRequests: [] }),
+            capture: () => Promise.resolve({ screenshotBase64: "", coverage: "full", consoleErrors: [], failedRequests: [] }),
         });
 
         const child = (await seamed.spawnReportSession("p1", BRIEF))._unsafeUnwrap();

--- a/harness/src/lib/page-capture.test.ts
+++ b/harness/src/lib/page-capture.test.ts
@@ -136,14 +136,18 @@ describe("the degraded capture", () => {
 
     it("propagates the fault when the window bitmap also fails", async () => {
         const recorder = makeRecorder();
+        const refusedFullPage = new Error("the compositor refused the bitmap");
         restoreConnector = setBrowserConnector(async () =>
-            makeFakeBrowser(recorder, { failFullPage: new Error("the compositor refused the bitmap"), failViewport: new Error("the browser is broken") }),
+            makeFakeBrowser(recorder, { failFullPage: refusedFullPage, failViewport: new Error("the browser is broken") }),
         );
 
         const capture = capturePage({ browserUrl: "http://capture-broken.test:9222" }, "http://page.test/report");
 
         // A window bitmap that also fails names a broken browser, thus the capture keeps its throw protocol.
         await expect(capture).rejects.toThrow("the browser is broken");
+        // The report of a dead look names the second refusal, thus the first one rides on it as the cause.
+        const thrown = await capture.catch((cause: unknown) => cause);
+        expect((thrown as Error).cause).toBe(refusedFullPage);
         expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }, { encoding: "base64" }]);
     });
 });

--- a/harness/src/lib/page-capture.test.ts
+++ b/harness/src/lib/page-capture.test.ts
@@ -24,7 +24,22 @@ function makeRecorder(): Recorder {
     return { steps: [], features: [], viewports: [], shots: [] };
 }
 
-function makeFakeBrowser(recorder: Recorder): Browser {
+/**
+ * How the page answers each screenshot call.
+ *
+ * A refusal names the cause that the call raises. Absent, the call gives its picture. The two arms carry a
+ * different picture, thus a test reads which of the two calls the result came from.
+ */
+interface ShotPlan {
+    readonly failFullPage?: Error;
+    readonly failViewport?: Error;
+}
+
+/** The picture of the full-page call, and the picture of the viewport call. */
+const FULL_PAGE_SHOT = "c2hvdA==";
+const VIEWPORT_SHOT = "dmlld3BvcnQ=";
+
+function makeFakeBrowser(recorder: Recorder, plan: ShotPlan = {}): Browser {
     const page = {
         on: () => {},
         setViewport: async (viewport: Viewport) => {
@@ -44,7 +59,9 @@ function makeFakeBrowser(recorder: Recorder): Browser {
         screenshot: async (options: ScreenshotOptions) => {
             recorder.steps.push("screenshot");
             recorder.shots.push(options);
-            return "c2hvdA==";
+            const refusal = options.fullPage === true ? plan.failFullPage : plan.failViewport;
+            if (refusal !== undefined) throw refusal;
+            return options.fullPage === true ? FULL_PAGE_SHOT : VIEWPORT_SHOT;
         },
     };
     const fake = {
@@ -80,7 +97,9 @@ describe("the settled capture", () => {
         // reader, and the page reveals its sections with each transition already collapsed.
         expect(recorder.steps).toEqual(["viewport", "emulate", "goto", "evaluate", "screenshot"]);
         expect(recorder.features).toEqual([[{ name: "prefers-reduced-motion", value: "reduce" }]]);
-        expect(capture.screenshotBase64).toBe("c2hvdA==");
+        expect(capture.screenshotBase64).toBe(FULL_PAGE_SHOT);
+        // The full-page call passed, thus the picture holds the whole document.
+        expect(capture.coverage).toBe("full");
     });
 });
 
@@ -96,5 +115,35 @@ describe("the framed capture", () => {
         // below the fold. Thus the two values together make the look checklist answerable.
         expect(recorder.viewports).toEqual([{ width: 1440, height: 900 }]);
         expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }]);
+    });
+});
+
+describe("the degraded capture", () => {
+    it("retries at the window when the full-page bitmap fails, and names the viewport coverage", async () => {
+        const recorder = makeRecorder();
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder, { failFullPage: new Error("the compositor refused the bitmap") }));
+
+        const capture = await capturePage({ browserUrl: "http://capture-degrade.test:9222" }, "http://page.test/report");
+
+        // The retry drops the full-page flag, and it runs on the page that already navigated. Thus one
+        // oversized page costs one more screenshot call and no second load.
+        expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }, { encoding: "base64" }]);
+        expect(recorder.steps.filter((step) => step === "goto")).toEqual(["goto"]);
+        // The picture came from the retry, and the coverage names what it holds.
+        expect(capture.screenshotBase64).toBe(VIEWPORT_SHOT);
+        expect(capture.coverage).toBe("viewport");
+    });
+
+    it("propagates the fault when the window bitmap also fails", async () => {
+        const recorder = makeRecorder();
+        restoreConnector = setBrowserConnector(async () =>
+            makeFakeBrowser(recorder, { failFullPage: new Error("the compositor refused the bitmap"), failViewport: new Error("the browser is broken") }),
+        );
+
+        const capture = capturePage({ browserUrl: "http://capture-broken.test:9222" }, "http://page.test/report");
+
+        // A window bitmap that also fails names a broken browser, thus the capture keeps its throw protocol.
+        await expect(capture).rejects.toThrow("the browser is broken");
+        expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }, { encoding: "base64" }]);
     });
 });

--- a/harness/src/lib/page-capture.ts
+++ b/harness/src/lib/page-capture.ts
@@ -18,6 +18,8 @@
  * outcome guards the call.
  */
 
+import type { Page } from "puppeteer-core";
+
 import { withPage, type ChromeConfig } from "./chrome.js";
 import { PAGE_NAV_TIMEOUT_MS, PAGE_READY_TIMEOUT_MS, THEME_READY_EVENT, THEME_READY_SENTINEL } from "../report-render/page.js";
 
@@ -30,6 +32,12 @@ export interface FailedRequest {
 /** The picture and the faults of one page capture. */
 export interface PageCapture {
     screenshotBase64: string;
+    /**
+     * What the picture holds. `full` is the whole document, and it is the shape of a capture that passed at
+     * the first attempt. `viewport` appears when the full-page screenshot threw and the retry at the window
+     * passed, thus the picture shows the top window alone and a section below the fold is absent from it.
+     */
+    coverage: "full" | "viewport";
     consoleErrors: string[];
     failedRequests: FailedRequest[];
 }
@@ -90,11 +98,35 @@ function waitForThemeReady(sentinel: string, event: string, timeout: number): Pr
     });
 }
 
+/** The picture of one screenshot call: the base64 bytes, and what the picture holds. */
+type Shot = Pick<PageCapture, "screenshotBase64" | "coverage">;
+
+/** The connection gives base64 text or raw bytes, and a caller of the capture reads base64 text alone. */
+function toBase64(shot: string | Uint8Array): string {
+    return typeof shot === "string" ? shot : Buffer.from(shot).toString("base64");
+}
+
+/**
+ * Take the picture of one settled page, at the whole document or at the window alone.
+ *
+ * The compositor can refuse a full-page bitmap of a tall page while the bitmap of the window is fine. A
+ * degraded picture beats a dead look, thus a refused full page retries one time at the window. A second throw
+ * names a broken browser and not a tall page, thus it propagates to the caller.
+ */
+async function captureShot(page: Page): Promise<Shot> {
+    try {
+        return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64", fullPage: true })), coverage: "full" };
+    } catch {
+        return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64" })), coverage: "viewport" };
+    }
+}
+
 /**
  * Capture one page: the screenshot, the console errors, and the failed requests.
  *
  * The picture holds the whole document, and not the window alone. Thus a caller can judge a section that a
- * reader reaches by a scroll.
+ * reader reaches by a scroll. A refused full-page bitmap degrades to the window, and the coverage of the
+ * result names which of the two pictures arrived.
  *
  * The readiness wait is best-effort. A page that never signals still captures at the readiness budget, thus
  * a broken page gives a picture that shows what broke.
@@ -139,9 +171,10 @@ export function capturePage(chrome: ChromeConfig, url: string, options: CaptureO
 
         // The picture must show the whole document at the layout that a reader gets. Thus a defect below the
         // fold is visible, and a question about content that never appeared has an answer.
-        const screenshot = await page.screenshot({ encoding: "base64", fullPage: true });
+        const shot = await captureShot(page);
         return {
-            screenshotBase64: typeof screenshot === "string" ? screenshot : Buffer.from(screenshot).toString("base64"),
+            screenshotBase64: shot.screenshotBase64,
+            coverage: shot.coverage,
             consoleErrors,
             failedRequests,
         };

--- a/harness/src/lib/page-capture.ts
+++ b/harness/src/lib/page-capture.ts
@@ -116,8 +116,17 @@ function toBase64(shot: string | Uint8Array): string {
 async function captureShot(page: Page): Promise<Shot> {
     try {
         return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64", fullPage: true })), coverage: "full" };
-    } catch {
-        return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64" })), coverage: "viewport" };
+    } catch (refusedFullPage) {
+        try {
+            return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64" })), coverage: "viewport" };
+        } catch (refusedViewport) {
+            // The two refusals together are the account of a dead look, and the caller reports the second one
+            // alone. Thus the first one rides as the cause, and no reader of that report loses half of it.
+            if (refusedViewport instanceof Error && refusedViewport.cause === undefined) {
+                refusedViewport.cause = refusedFullPage;
+            }
+            throw refusedViewport;
+        }
     }
 }
 

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -142,10 +142,14 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
 - \`preview_report\` renders the current draft to a page. The Preview section above
   gives its rules.
 - \`examine_page\` opens the rendered page in a real browser. It gives back a
-  screenshot, the console errors, and the failed requests. The picture holds the
-  whole page, from the title to the last block, at the width that a reader gets.
-  Thus a section that the picture does not show is a real fault, and never the
-  fold. Look at the page, and examine the picture for each of these faults:
+  screenshot, the coverage of that screenshot, the console errors, and the failed
+  requests. The coverage names what the picture holds. When it names \`full\`, the
+  picture holds the whole page, from the title to the last block, at the width that
+  a reader gets. Thus a section that the picture does not show is a real fault, and
+  never the fold. When it names \`viewport\`, the browser refused the bitmap of the
+  whole page, and the picture holds the top window alone. A section under the fold
+  is then absent from the picture, and not from the page. Judge what the picture
+  shows. Look at the page, and examine the picture for each of these faults:
   - clipped text: a word, a label, or a line that a box cuts short.
   - a truncated number: a value that its card, its cell, or its label cuts short.
   - an overflowing card: content that runs past its frame, or past its neighbor.
@@ -197,6 +201,10 @@ failed. When the page reads clean, record.
   or remove that block by its id, and do not re-author the report.
 - **Leave a gap unread.** When \`finish_draft\` or \`preview_report\` reports a gap or
   an unresolved reference, repair it. Do not present a report that does not finish.
+- **Repair a block that the picture could not show.** When the coverage names
+  \`viewport\`, the picture holds the top window alone. A section under the fold is
+  absent from that picture, and not from the page. Judge what you saw, and leave
+  the rest of the draft as it stands.
 - **Spiral on a cosmetic doubt.** The visual spiral is a loop of small visual worries
   with no fault to repair. Look one time, then repair a real fault: a fault that the
   look checklist names, an absent chart, or a failed request. A named fault is real

--- a/harness/src/tools/report-session/examine-page.test.ts
+++ b/harness/src/tools/report-session/examine-page.test.ts
@@ -274,7 +274,7 @@ describe("the no-browser outcome", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: { browserUrl: "http://localhost:9222" }, capture });
 
@@ -308,7 +308,7 @@ describe("the missed stamp", () => {
         const gateway = makeFakeGateway();
         // The preview stamped no rendered hash, thus the seen stamp finds none to copy.
         gateway.seed(threadId, null);
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
 
@@ -329,7 +329,12 @@ describe("the seen-stamp copy", () => {
         gateway.seed(threadId, "rendered-hash");
 
         let capturedUrl: string | undefined;
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: ["boom"], failedRequests: [{ url: "assets/x.png", reason: "net" }] };
+        const stub: PageCapture = {
+            screenshotBase64: "BASE64PNG",
+            coverage: "full",
+            consoleErrors: ["boom"],
+            failedRequests: [{ url: "assets/x.png", reason: "net" }],
+        };
         const capture: CapturePage = (url) => {
             capturedUrl = url;
             return Promise.resolve(stub);
@@ -340,6 +345,7 @@ describe("the seen-stamp copy", () => {
 
         expect(result.outcome).toBe("examined");
         if (result.outcome === "examined") {
+            expect(result.coverage).toBe("full");
             expect(result.consoleErrors).toEqual(["boom"]);
             expect(result.failedRequests).toEqual([{ url: "assets/x.png", reason: "net" }]);
             expect(result.pagePath).toBe(join("report-sessions", threadId, "index.html"));
@@ -352,6 +358,30 @@ describe("the seen-stamp copy", () => {
         expect(capturedUrl).toBeDefined();
         expect(fileURLToPath(capturedUrl!)).toBe(join(root, "report-sessions", threadId, "index.html"));
         // The look copies the rendered hash onto the seen hash, thus the record lets the current draft record.
+        expect(gateway.seenOf(threadId)).toBe("rendered-hash");
+    });
+
+    it("carries the viewport coverage of a degraded picture, and stamps the seen hash as a full look does", async () => {
+        const root = await makeRoot();
+        const threadId = "t1";
+        await writePage(root, threadId);
+        const gateway = makeFakeGateway();
+        gateway.seed(threadId, "rendered-hash");
+
+        // The browser refused the full-page bitmap, thus the capture gives the window alone.
+        const stub: PageCapture = { screenshotBase64: "VIEWPORTPNG", coverage: "viewport", consoleErrors: [], failedRequests: [] };
+        const capture: CapturePage = () => Promise.resolve(stub);
+        const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
+
+        const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("examined");
+        if (result.outcome === "examined") {
+            // The coverage rides the JSON, thus the agent reads that the picture shows the window alone.
+            expect(result.coverage).toBe("viewport");
+        }
+        expect(readToolResultImage(result)).toEqual({ base64: "VIEWPORTPNG", mediaType: "image/png" });
+        // The agent saw the current document, thus the degraded look counts and the record path stays open.
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
     });
 });
@@ -513,7 +543,7 @@ describe("the transport precedence", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const eyes = makeFakeEyes({ browserUrl: "http://examine-unused.test:9222" });
         const tool = createExaminePageTool({
@@ -568,7 +598,7 @@ describe("the result detail", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
 

--- a/harness/src/tools/report-session/examine-page.ts
+++ b/harness/src/tools/report-session/examine-page.ts
@@ -27,7 +27,9 @@
  *
  * On a capture the tool copies the rendered hash onto the seen hash through the gateway. Thus the look
  * counts, and the record tool lets the current draft record. The copy takes the rendered hash and never the
- * current one, thus a later edit makes the look stale and the record refuses.
+ * current one, thus a later edit makes the look stale and the record refuses. A picture of the window alone
+ * is a true picture of the current document, thus it stamps the same and the coverage of the result is what
+ * tells the agent what it saw.
  *
  * The gateway reports whether a rendered hash existed to copy. When the row holds none, no preview stamped
  * one and the look cannot count. The tool then gives a missed-stamp outcome that directs a new preview,
@@ -67,11 +69,13 @@ export type ExaminePageInput = z.infer<typeof examinePageInput>;
 
 /**
  * The typed outcome of the eyes tool. Each arm is ok-channel data, thus the tool never throws for a
- * degraded condition. `examined` carries the console errors, the failed requests, and the page path. The
- * screenshot does not ride the JSON. It rides the image path of the tool result, thus the model sees the
- * picture and the JSON text holds no bytes. `missed-stamp` means that the row holds no rendered hash, thus
- * no preview stamped one and the agent must run a new preview before the next look. `no-browser` means that
- * the composition gives no browser, thus no look is possible at all and a repeat gives the same answer.
+ * degraded condition. `examined` carries the coverage of the picture, the console errors, the failed
+ * requests, and the page path. The coverage names what the agent saw: the whole document, or the window
+ * alone when the browser refused a full-page bitmap. The screenshot does not ride the JSON. It rides the
+ * image path of the tool result, thus the model sees the picture and the JSON text holds no bytes.
+ * `missed-stamp` means that the row holds no rendered hash, thus no preview stamped one and the agent must
+ * run a new preview before the next look. `no-browser` means that the composition gives no browser, thus no
+ * look is possible at all and a repeat gives the same answer.
  */
 export type ExaminePageResult =
     | { outcome: "refused"; refusal: SessionRefusal }
@@ -79,7 +83,7 @@ export type ExaminePageResult =
     | { outcome: "no-page" }
     | { outcome: "missed-stamp" }
     | { outcome: "capture-failed"; detail: string }
-    | { outcome: "examined"; consoleErrors: string[]; failedRequests: FailedRequest[]; pagePath: string };
+    | { outcome: "examined"; coverage: PageCapture["coverage"]; consoleErrors: string[]; failedRequests: FailedRequest[]; pagePath: string };
 
 /**
  * The construction deps of the eyes tool.
@@ -407,6 +411,7 @@ export function createExaminePageTool(deps: ExaminePageToolDeps): Tool<ExaminePa
                 withToolResultImage(
                     {
                         outcome: "examined" as const,
+                        coverage: captured.coverage,
                         consoleErrors: captured.consoleErrors,
                         failedRequests: captured.failedRequests,
                         pagePath: relativePagePath,

--- a/harness/src/tools/report-session/examine-page.ts
+++ b/harness/src/tools/report-session/examine-page.ts
@@ -324,7 +324,8 @@ export function createExaminePageTool(deps: ExaminePageToolDeps): Tool<ExaminePa
         id: "examine_page",
         description:
             "Open the rendered report page in a real headless browser, and report what you see. " +
-            "Give back a screenshot, the console errors, and the failed requests. " +
+            "Give back a screenshot, the coverage of that screenshot, the console errors, and the failed requests. " +
+            "The coverage says whether the picture holds the whole page, or the top window alone. " +
             "Run it after the preview to look at the current page, and to confirm that the layout and the charts read clean. " +
             "The report tool records a version only after you look at the current page. " +
             "If the page has no confirmed render, run the preview again first.",

--- a/harness/src/tools/report/preview-snapshot.ts
+++ b/harness/src/tools/report/preview-snapshot.ts
@@ -38,6 +38,8 @@ type PreviewSnapshotOutput =
     | {
           ok: true;
           screenshotBase64: string;
+          /** What the screenshot holds: the whole page, or the top window alone when the full page failed. */
+          coverage: "full" | "viewport";
           consoleErrors: string[];
           failedRequests: Array<{ url: string; reason: string }>;
       };
@@ -118,6 +120,7 @@ export function createPreviewSnapshotTool(state: PreviewSnapshotToolState): Tool
                 return ok({
                     ok: true as const,
                     screenshotBase64: captured.screenshotBase64,
+                    coverage: captured.coverage,
                     consoleErrors: captured.consoleErrors,
                     failedRequests: captured.failedRequests,
                 });


### PR DESCRIPTION
## What & why

Seven looks of the second real report session failed with one screenshot protocol error, and the record gate then refused every version. A live A/B run in the issue pins the cause: the eyes container starts with the 64 MiB `/dev/shm` default of podman, and the full-page capture bitmap of a tall page does not fit. The cli half adds the shared-memory allowance to the container run args. The harness half hardens the capture: a refused full-page bitmap retries one time at the viewport, the result names the coverage, and a viewport look still stamps the seen hash. Thus an oversized page degrades a look, and it never blocks the record path again.

Reviewer notes: the arg assertion is the durable proof of the cli half, because the failure only shows under a real container default. The new `coverage` field of `PageCapture` is required, and every construction site in the package sets it. The one other capture caller reads the screenshot alone, thus it keeps its shape.

Refs #391

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
