### PR TITLE
feat(harness): declare the column meaning on a table binding

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/design.md
@@ -1,0 +1,34 @@
+# Design: declare-the-column-meaning
+
+## Context
+
+`selectNumberKind(column, cell)` (`src/report-render/number-format.ts:102`) picks the kind from the column name and the magnitude. The name half tokenizes the column and matches `P_VALUE_TOKENS`. The chart derivation names an axis with the raw column (`src/report-render/chart.ts:102`), and the table header prints the raw name. Nothing lets the author state what a column is or how it reads.
+
+## Decisions
+
+### D1: The declaration rides the whole-table binding
+
+`ArtifactTableReferenceSchema` gains `columnMeanings` and `columnLabels`, both optional records keyed by the column name. The table block and the chart block bind through this one schema, thus one declaration serves both. A value locator declares nothing, because one cell has no column-wide meaning to state.
+
+### D2: The meanings are a closed enum of five
+
+`p-value`, `effect`, `count`, `identifier`, `category`. A declared meaning routes the column onto the same resolution arm that the name guess selects, and the magnitude arms stay. Thus a declared column renders byte-identically to a name-matched column of the same nature. A `category` passes through as text, and it is the one meaning with no name-guess counterpart. The routing lives beside the number helper, thus a block still carries no format field and the round-one layer decision stands.
+
+### D3: The declaration wins, the guess falls back
+
+The kind resolution takes an optional declared meaning beside the column name. A declared meaning replaces the name guess alone, and the magnitude arms stay. Thus a declared `p-value` column renders byte-identically to a token-matched one, and `0.536` stays `0.536` under both. An undeclared column keeps the token-and-magnitude guess, thus every stored document renders as before. The token set stays as code, and its comment names its demoted role.
+
+### D4: A label is display text with the raw name on hover
+
+A declared label replaces the column name in the table header and in the axis title of a chart channel that reads the column. The raw name rides in the `title` attribute of the header, and the axis keeps its deterministic derivation.
+
+An undeclared column header prettifies as the fallback: underscores become spaces, and the raw name rides on hover when the two differ. The prettification is a display rule of the design source, thus no block carries it. The axis title of an undeclared column stays the raw name, because the preset-title work of a sibling change owns the chart text.
+
+### D5: An unknown key is ignored
+
+A meaning or a label whose key names no column in the artifact simply never matches. No validation error, because absence is a normal condition, and a stale declaration after a re-derivation must not kill the render.
+
+## Risks / Trade-offs
+
+- An author can declare a wrong meaning, and the page then formats a column wrongly. The declaration is content, thus the review of the draft is the check, exactly as for a caption.
+- Two optional records widen the authoring schema. The field descriptions carry the teaching, thus the prompt stays unchanged.

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: declare-the-column-meaning
+
+## Why
+
+The renderer guesses what a column means from its name. `P_VALUE_TOKENS` (`src/report-render/number-format.ts:50`) matches name tokens, and the guess is fragile. A name outside the list misses, for example `significance`. A `q` column that is not a probability hits. The agent read the artifact, and it knows which column holds a p-value. The system asks the name instead of the author.
+
+## What Changes
+
+- The whole-table binding (`ArtifactTableReferenceSchema`, `src/contracts/report-reference.ts:104`) gains two optional maps: `columnMeanings` (column name to a meaning) and `columnLabels` (column name to a display label).
+- The meanings are a closed set: `p-value`, `effect`, `count`, `identifier`, `category`. A meaning is content — what the column is — and it is not a format.
+- The design source keeps the one rule for how each meaning renders. The number-kind resolution reads a declared meaning first, and the name-token guess demotes to the fallback.
+- A declared display label names the column on the page: the table header, and the axis title of a chart bound to the table. The raw name rides on hover.
+- The field descriptions teach the declaration, thus the authoring tools carry it to the agent with no prompt change.
+- A key that names no real column is ignored, because absence is a normal condition.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-block-model`: the table binding carries the two optional declaration maps.
+- `report-render`: the number-kind resolution reads the declaration first, and a declared label names the header and the axis.
+
+## Impact
+
+- Affected code: `src/contracts/report-reference.ts`, `src/report-render/number-format.ts`, the table view, the chart derivation, and their tests.
+- Both fields are optional, thus every stored document keeps rendering, and the token fallback keeps the old behavior.

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-block-model/spec.md
@@ -1,0 +1,19 @@
+# Delta: report-block-model
+
+## ADDED Requirements
+
+### Requirement: A table binding declares its column meanings
+
+A whole-table binding MUST admit two optional maps, keyed by the column name: a meaning, and a display label. The meanings are a closed set: `p-value`, `effect`, `count`, `identifier`, and `category`. A meaning states what the column is, and it is not a format. No block carries a format field.
+
+The field descriptions MUST teach the declaration, because the authoring tools carry the schema to the agent. A key that names no column of the artifact is ignored, because absence is a normal condition.
+
+#### Scenario: A binding declares a meaning and a label
+
+- **WHEN** the author binds a table and declares one column as a `p-value` with a display label
+- **THEN** the block validates, and the declaration rides the stored document
+
+#### Scenario: An unknown key changes nothing
+
+- **WHEN** a declaration names a column that the artifact does not hold
+- **THEN** the render proceeds, and the stray key has no effect

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-render/spec.md
@@ -3,8 +3,37 @@
 ## MODIFIED Requirements
 
 ### Requirement: The number format of a resolved value
+The renderer MUST format each numeric value that it shows, through one number helper with three kinds: `scientific`, `compact`, and `compact-scientific`. The helper applies to the metric value and to each numeric table cell. The renderer picks the kind by magnitude and by column meaning, and no block carries a format field.
+
+The chart option rides as inline JSON, thus no function can format an axis tick. The derivation MUST bound an axis only where a static option field can state the bound. The count axis of a histogram holds whole ticks. Every other axis keeps the tick algorithm of the chart runtime.
+
+When the shown form hides digits, the element MUST carry the full digits in its `title` attribute. When the shown form hides no digit, the element carries no `title` attribute. The helper MUST be deterministic: it reads no locale, thus the same value gives the same text on every host.
 
 The kind resolution MUST read a declared column meaning first, and the name guess is the fallback for an undeclared column. A declared meaning replaces the name test alone, and the magnitude arms stay. Thus a declared column renders byte-identically to a name-matched column of the same nature.
+
+#### Scenario: A p-value renders in the scientific kind
+- **WHEN** the caller renders a metric whose value resolves to `0.0000427777663038`
+- **THEN** the card shows a scientific form such as `4.3e-5`, and the `title` attribute holds the full digits
+
+#### Scenario: A long float renders with few significant digits
+- **WHEN** the caller renders a table cell that holds `-3.089028528355109`
+- **THEN** the cell shows a short form such as `-3.09`, and the `title` attribute holds the full digits
+
+#### Scenario: A count renders in the compact kind
+- **WHEN** the caller renders a value that is a large integer count such as `14201`
+- **THEN** the text shows the grouped form `14,201`, and the `title` attribute holds the full digits only when the shown form hides a digit
+
+#### Scenario: A short value carries no tooltip
+- **WHEN** the caller renders a value whose full form already shows every digit, such as `42`
+- **THEN** the text shows `42`, and the element carries no `title` attribute
+
+#### Scenario: A non-numeric cell passes through
+- **WHEN** the caller renders a table cell that holds the text `up`
+- **THEN** the cell shows `up` unchanged
+
+#### Scenario: A count axis holds whole ticks
+- **WHEN** the caller derives a histogram option
+- **THEN** the count axis carries a whole-tick bound, thus no count tick shows a fraction
 
 #### Scenario: A declared meaning beats the name guess
 

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/specs/report-render/spec.md
@@ -1,0 +1,38 @@
+# Delta: report-render
+
+## MODIFIED Requirements
+
+### Requirement: The number format of a resolved value
+
+The kind resolution MUST read a declared column meaning first, and the name guess is the fallback for an undeclared column. A declared meaning replaces the name test alone, and the magnitude arms stay. Thus a declared column renders byte-identically to a name-matched column of the same nature.
+
+#### Scenario: A declared meaning beats the name guess
+
+- **WHEN** the caller renders a small numeric cell of a column declared `p-value`, whose name matches no token
+- **THEN** the cell renders in the scientific kind, and the `title` attribute holds the full digits
+
+#### Scenario: The magnitude arms survive a declaration
+
+- **WHEN** the caller renders `0.536` in a column declared `p-value`
+- **THEN** the cell shows `0.536`, exactly as a token-matched p-value column shows it
+
+## ADDED Requirements
+
+### Requirement: A declared display label names the column
+
+The table header MUST show the declared label of a column, with the raw column name in the `title` attribute of the header. An axis whose channel reads a labeled column MUST carry the label as its axis title. An undeclared header MUST prettify as the fallback: underscores become spaces, with the raw name on hover when the two differ. An undeclared axis keeps the raw name.
+
+#### Scenario: The header shows the label with the raw name on hover
+
+- **WHEN** the table view renders a column declared with a display label
+- **THEN** the header shows the label, and the `title` attribute of the header holds the raw name
+
+#### Scenario: The axis carries the label
+
+- **WHEN** the chart derivation names an axis for a channel whose column carries a declared label
+- **THEN** the axis title is the label, and the derivation stays deterministic
+
+#### Scenario: An undeclared header prettifies
+
+- **WHEN** the table view renders the column `gene_symbol` with no declared label
+- **THEN** the header shows `gene symbol`, and the `title` attribute of the header holds the raw name

--- a/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-declare-the-column-meaning/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: declare-the-column-meaning
+
+## 1. The contract
+
+- [x] 1.1 Add `columnMeanings` and `columnLabels` to `ArtifactTableReferenceSchema` in `src/contracts/report-reference.ts`, both optional records, with field descriptions that teach the declaration.
+- [x] 1.2 Export the meaning enum as a named schema, thus the renderer reads one closed set.
+
+## 2. The kind resolution
+
+- [x] 2.1 Add the meaning-to-kind map beside the number helper in `src/report-render/number-format.ts`, with the demoted-guess comment on the token set.
+- [x] 2.2 Thread the declared meaning into the kind resolution where a table binding is in scope: the table view and the chart derivation. A metric keeps the guess, because a value locator declares nothing.
+
+## 3. The display label
+
+- [x] 3.1 The table header shows the declared label, with the raw column name in the `title` attribute of the header. An undeclared header prettifies: underscores become spaces, with the raw name on hover when the two differ.
+- [x] 3.2 The chart axis title reads the declared label of the channel column, and the derivation stays deterministic.
+
+## 4. The proof
+
+- [x] 4.1 A test renders a declared `p-value` column whose name matches no token, and the cell is scientific.
+- [x] 4.2 A test renders a labeled header with the raw name on hover, and a labeled axis title.
+- [x] 4.3 A test renders a stray declaration key, and nothing changes.
+- [x] 4.4 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -138,3 +138,19 @@ capability.
 
 - **WHEN** a `metric` block carries two bindings
 - **THEN** validation rejects the block, because a metric carries exactly one scalar binding
+
+### Requirement: A table binding declares its column meanings
+
+A whole-table binding MUST admit two optional maps, keyed by the column name: a meaning, and a display label. The meanings are a closed set: `p-value`, `effect`, `count`, `identifier`, and `category`. A meaning states what the column is, and it is not a format. No block carries a format field.
+
+The field descriptions MUST teach the declaration, because the authoring tools carry the schema to the agent. A key that names no column of the artifact is ignored, because absence is a normal condition.
+
+#### Scenario: A binding declares a meaning and a label
+
+- **WHEN** the author binds a table and declares one column as a `p-value` with a display label
+- **THEN** the block validates, and the declaration rides the stored document
+
+#### Scenario: An unknown key changes nothing
+
+- **WHEN** a declaration names a column that the artifact does not hold
+- **THEN** the render proceeds, and the stray key has no effect

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -81,6 +81,8 @@ The chart option rides as inline JSON, thus no function can format an axis tick.
 
 When the shown form hides digits, the element MUST carry the full digits in its `title` attribute. When the shown form hides no digit, the element carries no `title` attribute. The helper MUST be deterministic: it reads no locale, thus the same value gives the same text on every host.
 
+The kind resolution MUST read a declared column meaning first, and the name guess is the fallback for an undeclared column. A declared meaning replaces the name test alone, and the magnitude arms stay. Thus a declared column renders byte-identically to a name-matched column of the same nature.
+
 #### Scenario: A p-value renders in the scientific kind
 - **WHEN** the caller renders a metric whose value resolves to `0.0000427777663038`
 - **THEN** the card shows a scientific form such as `4.3e-5`, and the `title` attribute holds the full digits
@@ -104,6 +106,35 @@ When the shown form hides digits, the element MUST carry the full digits in its 
 #### Scenario: A count axis holds whole ticks
 - **WHEN** the caller derives a histogram option
 - **THEN** the count axis carries a whole-tick bound, thus no count tick shows a fraction
+
+#### Scenario: A declared meaning beats the name guess
+
+- **WHEN** the caller renders a small numeric cell of a column declared `p-value`, whose name matches no token
+- **THEN** the cell renders in the scientific kind, and the `title` attribute holds the full digits
+
+#### Scenario: The magnitude arms survive a declaration
+
+- **WHEN** the caller renders `0.536` in a column declared `p-value`
+- **THEN** the cell shows `0.536`, exactly as a token-matched p-value column shows it
+
+### Requirement: A declared display label names the column
+
+The table header MUST show the declared label of a column, with the raw column name in the `title` attribute of the header. An axis whose channel reads a labeled column MUST carry the label as its axis title. An undeclared header MUST prettify as the fallback: underscores become spaces, with the raw name on hover when the two differ. An undeclared axis keeps the raw name.
+
+#### Scenario: The header shows the label with the raw name on hover
+
+- **WHEN** the table view renders a column declared with a display label
+- **THEN** the header shows the label, and the `title` attribute of the header holds the raw name
+
+#### Scenario: The axis carries the label
+
+- **WHEN** the chart derivation names an axis for a channel whose column carries a declared label
+- **THEN** the axis title is the label, and the derivation stays deterministic
+
+#### Scenario: An undeclared header prettifies
+
+- **WHEN** the table view renders the column `gene_symbol` with no declared label
+- **THEN** the header shows `gene symbol`, and the `title` attribute of the header holds the raw name
 
 ### Requirement: The table enhancer
 The page MUST enhance each rendered table with a header sort, one filter input, and a row cap, through a page script with no dependency. The DOM MUST hold every resolved row, and the enhancer hides a row with a class and never removes one. The sort MUST read a raw value attribute that the view emits, thus the formatted text stays presentation. A numeric column sorts numerically, and every other column sorts in code-unit order. The cap is a renderer constant, and a table over the cap MUST carry a toggle that names the total row count. The print form MUST show every row. A browser without script keeps the complete plain table.

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -55,6 +55,30 @@ describe("serializeReference/parseReference — round trip", () => {
         expectRoundTrip(reference);
     });
 
+    it("round-trips an artifact-table that declares a column meaning and a column label", () => {
+        const reference: Reference = {
+            kind: "artifact-table",
+            run: "run-1",
+            path: "runs/run-1/step-a/output/de.csv",
+            hash: HASH,
+            columnMeanings: { significance: "p-value", log2FoldChange: "effect" },
+            columnLabels: { significance: "Adjusted p-value" },
+        };
+        expectRoundTrip(reference);
+    });
+
+    it("round-trips a declaration whose key names no column, because a stale key is a normal condition", () => {
+        const reference: Reference = {
+            kind: "artifact-table",
+            path: "runs/run-1/step-a/output/de.csv",
+            hash: HASH,
+            columns: ["gene"],
+            columnMeanings: { absent: "count" },
+            columnLabels: { absent: "Absent column" },
+        };
+        expectRoundTrip(reference);
+    });
+
     it("round-trips a derivation with two inputs and an assert", () => {
         const reference: Reference = {
             kind: "derivation",
@@ -270,6 +294,14 @@ describe("parseReference — the per-kind assert shape", () => {
             encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", hash: HASH, locator: { column: "c", row: 0 }, assert: { hash: HASH } }),
             "schema-mismatch",
         );
+    });
+
+    it("rejects a column meaning outside the closed set of five", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-table", path: "t.csv", hash: HASH, columnMeanings: { padj: "probability" } }), "schema-mismatch");
+    });
+
+    it("rejects a column label that is not text", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-table", path: "t.csv", hash: HASH, columnLabels: { padj: 7 } }), "schema-mismatch");
     });
 
     it("rejects any assert on an artifact-table", () => {

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -304,6 +304,10 @@ describe("parseReference — the per-kind assert shape", () => {
         expectParseError(encodeUnchecked({ kind: "artifact-table", path: "t.csv", hash: HASH, columnLabels: { padj: 7 } }), "schema-mismatch");
     });
 
+    it("rejects an empty column label, which would blank the header and the axis", () => {
+        expectParseError(encodeUnchecked({ kind: "artifact-table", path: "t.csv", hash: HASH, columnLabels: { padj: "" } }), "schema-mismatch");
+    });
+
     it("rejects any assert on an artifact-table", () => {
         expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { hash: HASH } }), "schema-mismatch");
         expectParseError(encodeUnchecked({ kind: "artifact-table", run: "r", path: "p", hash: HASH, assert: { value: 5 } }), "schema-mismatch");

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -123,7 +123,9 @@ export const ArtifactTableReferenceSchema = z.strictObject({
             "What each column holds, keyed by the raw column name. A meaning is the content of the column, and it is not a format: `p-value` is a probability, `effect` is a signed magnitude such as a fold change, `count` is a whole tally, `identifier` is a name that is written with digits, and `category` is a label. You read the artifact, thus you know which column is which. Declare the columns that you know, and omit the rest. A key that names no column of the artifact has no effect.",
         ),
     columnLabels: z
-        .record(z.string(), z.string())
+        // A label replaces the column name on the page. Empty text names nothing, thus it would blank the
+        // header and the axis title. Omit the key instead, which is the way to declare no label.
+        .record(z.string(), z.string().min(1))
         .optional()
         .describe(
             "The display name of each column, keyed by the raw column name. A label names what the column measures, for example `Adjusted p-value` for `padj`. The page shows the label in the table header and in the axis title, and the raw name stays on hover. A key that names no column of the artifact has no effect.",

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -96,15 +96,38 @@ export const ArtifactValueReferenceSchema = z.strictObject({
 });
 
 /**
+ * What one column of a table holds, as a closed set of five.
+ *
+ * A meaning states the content of the column. It is not a format: the design source keeps the one rule for
+ * how each meaning reads on the page, thus no block carries a format field.
+ */
+export const ColumnMeaningSchema = z.enum(["p-value", "effect", "count", "identifier", "category"]);
+
+/**
  * A reference to a whole table artifact. It carries no locator, because it binds every row.
  *
  * It carries no assert. A table is not one value, thus the only belief that an author can hold about it
  * is its bytes, and the pinned `hash` already carries that belief.
+ *
+ * The two declaration maps state what the columns are and what to call them. They ride the whole-table
+ * binding, thus one declaration serves the table block and the chart block alike.
  */
 export const ArtifactTableReferenceSchema = z.strictObject({
     kind: z.literal("artifact-table"),
     ...artifactPinShape,
     columns: z.array(z.string()).optional().describe("An optional column subset to render. Omit to bind every column."),
+    columnMeanings: z
+        .record(z.string(), ColumnMeaningSchema)
+        .optional()
+        .describe(
+            "What each column holds, keyed by the raw column name. A meaning is the content of the column, and it is not a format: `p-value` is a probability, `effect` is a signed magnitude such as a fold change, `count` is a whole tally, `identifier` is a name that is written with digits, and `category` is a label. You read the artifact, thus you know which column is which. Declare the columns that you know, and omit the rest. A key that names no column of the artifact has no effect.",
+        ),
+    columnLabels: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+            "The display name of each column, keyed by the raw column name. A label names what the column measures, for example `Adjusted p-value` for `padj`. The page shows the label in the table header and in the axis title, and the raw name stays on hover. A key that names no column of the artifact has no effect.",
+        ),
     ...displayShape,
 });
 
@@ -214,6 +237,7 @@ export const UnresolvedReferenceSchema = z.strictObject({
 
 export type ArtifactValueReference = z.infer<typeof ArtifactValueReferenceSchema>;
 export type ArtifactTableReference = z.infer<typeof ArtifactTableReferenceSchema>;
+export type ColumnMeaning = z.infer<typeof ColumnMeaningSchema>;
 export type ArtifactFileReference = z.infer<typeof ArtifactFileReferenceSchema>;
 export type CitationReference = z.infer<typeof CitationReferenceSchema>;
 export type DerivationInputReference = z.infer<typeof DerivationInputReferenceSchema>;
@@ -222,6 +246,20 @@ export type Reference = z.infer<typeof ReferenceSchema>;
 export type ScalarReference = z.infer<typeof ScalarReferenceSchema>;
 export type UnresolvedReason = z.infer<typeof UnresolvedReasonSchema>;
 export type UnresolvedReference = z.infer<typeof UnresolvedReferenceSchema>;
+
+/**
+ * The declaration that a binding holds for one column, or `undefined` when it holds none.
+ *
+ * A key that names no column of the artifact never reaches this reader, thus a stale declaration after a
+ * re-derivation has no effect. The reader takes an own key alone. Thus a column that carries the name of a
+ * member of the object prototype gives no value, and the declared type stays true at runtime.
+ */
+export function declaredForColumn<T>(declarations: Record<string, T> | undefined, column: string): T | undefined {
+    if (declarations === undefined || !Object.prototype.hasOwnProperty.call(declarations, column)) {
+        return undefined;
+    }
+    return declarations[column];
+}
 
 /** The URI scheme and version for a serialized reference. The payload after it is opaque. */
 const REFERENCE_URI_PREFIX = "inflexa-ref:v1:";

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -427,6 +427,8 @@ describe("the composition derivation", () => {
         const bare = derive(composedBlock({ series: [{ form: "line", encoding: { x: "t", y: "hi" } }] }), rows);
         expect(asObj(bare.xAxis).name).toBe("t");
         expect(asObj(bare.yAxis).name).toBe("hi");
+        // A series with no declared name and no group falls back to its y channel, thus it agrees with the axis.
+        expect(asObj(asArr(bare.series)[0]).name).toBe("hi");
 
         const titled = derive(
             composedBlock({
@@ -557,6 +559,28 @@ describe("the declared column labels", () => {
         );
         // The axis states the plotted quantity, and the plotted quantity is the transform of the column.
         expect(asObj(derive(block, transformed).yAxis).name).toBe("neg_log10(p)");
+    });
+
+    it("names the series fallback with the declared label, thus the series and the axis agree", () => {
+        const block = composedBlock({ series: [{ form: "line", encoding: { x: "day", y: "count" } }] }, { labels: { count: "Cells counted" } });
+        const option = derive(block, rows);
+        expect(asObj(asArr(option.series)[0]).name).toBe("Cells counted");
+        expect(asObj(option.yAxis).name).toBe("Cells counted");
+    });
+
+    it("names the histogram axis with the declared label of its column", () => {
+        const counts: ChartRow[] = [{ n: 1 }, { n: 2 }, { n: 3 }, { n: 4 }];
+        const xAxis = asObj(derive(chartBlock("histogram", { x: "n" }, { labels: { n: "Reads per cell" } }), counts).xAxis);
+        expect(xAxis.name).toBe("Reads per cell");
+        expect(xAxis.nameLocation).toBe("middle");
+    });
+
+    it("keeps the bare histogram axis of a column that declares no label", () => {
+        const counts: ChartRow[] = [{ n: 1 }, { n: 2 }, { n: 3 }, { n: 4 }];
+        const bare = { type: "value", scale: true, axisLabel: { interval: 0 } };
+        expect(JSON.stringify(derive(chartBlock("histogram", { x: "n" }), counts).xAxis)).toBe(JSON.stringify(bare));
+        // A zero-row histogram takes the same axis, thus the empty container states the same quantity.
+        expect(JSON.stringify(derive(chartBlock("histogram", { x: "n" }), []).xAxis)).toBe(JSON.stringify(bare));
     });
 
     it("ignores a label that names no column, thus the derivation gives the same bytes", () => {

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -9,12 +9,15 @@ import { DESIGN_CSS } from "./design.js";
 type Encoding = NonNullable<ChartBlock["encoding"]>;
 type ChartType = NonNullable<ChartBlock["chartType"]>;
 
-/** Build a chart block with a placeholder binding. The renderer never reads the binding. */
-function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: string; title?: string; caption?: string } = {}): ChartBlock {
+/** The declared display labels of a binding, keyed by the raw column name. */
+type Labels = ChartBlock["binding"]["columnLabels"];
+
+/** Build a chart block. The binding declares a label only where a test states one. */
+function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: string; title?: string; caption?: string; labels?: Labels } = {}): ChartBlock {
     return {
         kind: "chart",
         id: extra.id ?? "c1",
-        binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00" },
+        binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00", ...(extra.labels !== undefined ? { columnLabels: extra.labels } : {}) },
         chartType,
         encoding,
         ...(extra.title !== undefined ? { title: extra.title } : {}),
@@ -22,12 +25,12 @@ function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: stri
     };
 }
 
-/** Build a chart block that carries one composition. The renderer never reads the binding. */
-function composedBlock(composition: ChartComposition, extra: { id?: string; title?: string } = {}): ChartBlock {
+/** Build a chart block that carries one composition. The binding declares a label only where a test states one. */
+function composedBlock(composition: ChartComposition, extra: { id?: string; title?: string; labels?: Labels } = {}): ChartBlock {
     return {
         kind: "chart",
         id: extra.id ?? "c1",
-        binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00" },
+        binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00", ...(extra.labels !== undefined ? { columnLabels: extra.labels } : {}) },
         composition,
         ...(extra.title !== undefined ? { title: extra.title } : {}),
     };
@@ -508,6 +511,58 @@ describe("the composition transforms", () => {
             annotations: [{ kind: "point-labels", column: "v", order: "desc", n: 2 }],
         });
         expect(JSON.stringify(derive(block, rows))).toBe(JSON.stringify(derive(block, rows)));
+    });
+});
+
+describe("the declared column labels", () => {
+    const rows: ChartRow[] = [
+        { day: "Mon", count: 5 },
+        { day: "Tue", count: 7 },
+    ];
+
+    it("names each axis of a quick path with the declared label of its column", () => {
+        const block = chartBlock("bar", { x: "day", y: "count" }, { labels: { day: "Day of the week", count: "Cells counted" } });
+        const option = derive(block, rows);
+        expect(asObj(option.xAxis).name).toBe("Day of the week");
+        expect(asObj(option.yAxis).name).toBe("Cells counted");
+    });
+
+    it("keeps the raw column name on an axis whose column declares no label", () => {
+        const option = derive(chartBlock("scatter", { x: "day", y: "count" }, { labels: { count: "Cells counted" } }), rows);
+        expect(asObj(option.xAxis).name).toBe("day");
+        expect(asObj(option.yAxis).name).toBe("Cells counted");
+    });
+
+    it("names a composition axis with the declared label", () => {
+        const block = composedBlock({ series: [{ form: "line", encoding: { x: "day", y: "count" } }] }, { labels: { count: "Cells counted" } });
+        expect(asObj(derive(block, rows).yAxis).name).toBe("Cells counted");
+    });
+
+    it("keeps the declared axis title over the declared label, because the title names this one axis", () => {
+        const block = composedBlock(
+            { series: [{ form: "line", encoding: { x: "day", y: "count" } }], axes: { y: { title: "Cells per well" } } },
+            { labels: { count: "Cells counted" } },
+        );
+        expect(asObj(derive(block, rows).yAxis).name).toBe("Cells per well");
+    });
+
+    it("keeps the transformed name on an axis whose source column declares a label", () => {
+        const transformed: ChartRow[] = [
+            { gene: "A", p: 0.01 },
+            { gene: "B", p: 0.1 },
+        ];
+        const block = composedBlock(
+            { series: [{ form: "scatter", encoding: { x: "gene", y: { column: "p", transform: "neg_log10" } } }] },
+            { labels: { p: "Adjusted p-value" } },
+        );
+        // The axis states the plotted quantity, and the plotted quantity is the transform of the column.
+        expect(asObj(derive(block, transformed).yAxis).name).toBe("neg_log10(p)");
+    });
+
+    it("ignores a label that names no column, thus the derivation gives the same bytes", () => {
+        const plain = derive(chartBlock("bar", { x: "day", y: "count" }), rows);
+        const stray = derive(chartBlock("bar", { x: "day", y: "count" }, { labels: { absent: "Absent column" } }), rows);
+        expect(JSON.stringify(stray)).toBe(JSON.stringify(plain));
     });
 });
 

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -38,6 +38,7 @@ import {
     type ChartTransform,
     type ChartType,
 } from "../contracts/report-blocks.js";
+import { declaredForColumn, type ArtifactTableReference } from "../contracts/report-reference.js";
 import { normalizeEchartSpec } from "../tools/display/normalize-echart-spec.js";
 import { expandPreset, isPresetChartType, type PresetChartType } from "./chart-presets.js";
 import type { RenderProblem } from "./types.js";
@@ -57,6 +58,9 @@ type Channel = "x" | "y" | "group" | "value";
 /** One chart type that carries its own fixed rule. A preset carries no rule, because it expands first. */
 type BaseChartType = Exclude<ChartType, PresetChartType>;
 
+/** The display labels that the bound table declares, keyed by the raw column name. */
+type ColumnLabels = ArtifactTableReference["columnLabels"];
+
 /**
  * A quick-path block whose channels are resolved to plain column names.
  *
@@ -67,6 +71,7 @@ interface ResolvedChartBlock {
     id: string;
     chartType: BaseChartType;
     encoding: Partial<Record<Channel, string>>;
+    labels: ColumnLabels;
 }
 
 /**
@@ -98,8 +103,19 @@ const COUNT_AXIS: EchartOption = { type: "value", name: "Count", minInterval: 1 
  * of `"end"` puts the name at the right end of the axis, thus the name runs past that margin and the panel
  * clips it. A centered name sits under the middle of the axis, and no margin can cut it.
  */
-function xAxisName(column: string): EchartOption {
-    return { name: column, nameLocation: "middle", nameGap: X_AXIS_NAME_GAP };
+function xAxisName(title: string): EchartOption {
+    return { name: title, nameLocation: "middle", nameGap: X_AXIS_NAME_GAP };
+}
+
+/**
+ * The title of the axis that reads one column: the declared label, or the raw column name when the binding
+ * declares none.
+ *
+ * A transformed channel reads a derived name such as `neg_log10(padj)`, which no declaration keys. Thus the
+ * axis of a transform keeps the name that states the transform, and it never states the raw quantity.
+ */
+function axisTitle(labels: ColumnLabels, column: string): string {
+    return declaredForColumn(labels, column) ?? column;
 }
 
 /**
@@ -108,6 +124,9 @@ function xAxisName(column: string): EchartOption {
  * The normalizer owns the bottom legend, the save action, and the axis-label discipline. Thus the
  * derivation sets no `title`, no `legend`, no `toolbox`, and no explicit series color. The theme palette
  * assigns the series colors by their order.
+ *
+ * The axis of a channel names the label that the binding declares for its column. The raw column name
+ * answers for a column that declares none.
  */
 export function deriveChartOption(block: ChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
     return deriveRaw(block, rows, columns).map((option) => normalizeEchartSpec(option, { title: block.title }));
@@ -121,8 +140,9 @@ export function deriveChartOption(block: ChartBlock, rows: readonly ChartRow[], 
  * composition item carries a name. Every other quick path reaches the fixed rule of its base type.
  */
 function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
+    const labels = block.binding.columnLabels;
     if (block.composition !== undefined) {
-        return deriveComposition(block.id, block.composition, rows, columns);
+        return deriveComposition(block.id, block.composition, rows, columns, labels);
     }
     const chartType = block.chartType;
     const encoding = block.encoding;
@@ -132,12 +152,12 @@ function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: reado
         return err(problem(block.id, "The chart carries neither a chart type with an encoding, nor a composition."));
     }
     if (isPresetChartType(chartType)) {
-        return derivePreset(block.id, chartType, encoding, rows, columns);
+        return derivePreset(block.id, chartType, encoding, rows, columns, labels);
     }
     if (encoding.label !== undefined) {
-        return deriveLabeled(block.id, chartType, encoding, rows, columns);
+        return deriveLabeled(block.id, chartType, encoding, rows, columns, labels);
     }
-    const quick = resolveQuickPath(block.id, chartType, encoding, rows, columns);
+    const quick = resolveQuickPath(block.id, chartType, encoding, rows, columns, labels);
     if (quick.isErr()) return err(quick.error);
     return deriveBase(quick.value.block, quick.value.rows, columns);
 }
@@ -169,12 +189,13 @@ function derivePreset(
     encoding: ChartEncoding,
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
+    labels: ColumnLabels,
 ): Result<EchartOption, RenderProblem> {
     const x = requireChannel(blockId, preset, encoding, "x");
     if (x.isErr()) return err(x.error);
     const y = requireChannel(blockId, preset, encoding, "y");
     if (y.isErr()) return err(y.error);
-    return deriveComposition(blockId, expandPreset(preset, x.value, y.value, encoding), rows, columns);
+    return deriveComposition(blockId, expandPreset(preset, x.value, y.value, encoding), rows, columns, labels);
 }
 
 /** The quick-path types that map onto one series form. A point of such a chart can carry a name. */
@@ -192,6 +213,7 @@ function deriveLabeled(
     encoding: ChartEncoding,
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
+    labels: ColumnLabels,
 ): Result<EchartOption, RenderProblem> {
     const form = LABELED_FORMS[chartType];
     if (form === undefined) {
@@ -214,7 +236,7 @@ function deriveLabeled(
             },
         ],
     };
-    return deriveComposition(blockId, composition, rows, columns);
+    return deriveComposition(blockId, composition, rows, columns, labels);
 }
 
 /**
@@ -232,6 +254,7 @@ function resolveQuickPath(
     encoding: ChartEncoding,
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
+    labels: ColumnLabels,
 ): Result<{ block: ResolvedChartBlock; rows: readonly ChartRow[] }, RenderProblem> {
     const resolved: Partial<Record<Channel, string>> = {};
     const derived: Array<{ column: string; name: string; transform: ChartTransform }> = [];
@@ -257,7 +280,7 @@ function resolveQuickPath(
         derived.push({ column, name, transform });
     }
 
-    const block: ResolvedChartBlock = { id: blockId, chartType, encoding: resolved };
+    const block: ResolvedChartBlock = { id: blockId, chartType, encoding: resolved, labels };
     return ok({ block, rows: derived.length === 0 ? rows : deriveTransformedRows(rows, derived) });
 }
 
@@ -307,8 +330,8 @@ function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
     }));
 
     return ok({
-        xAxis: { type: "category", data: categories, ...xAxisName(x) },
-        yAxis: { type: "value", name: y },
+        xAxis: { type: "category", data: categories, ...xAxisName(axisTitle(block.labels, x)) },
+        yAxis: { type: "value", name: axisTitle(block.labels, y) },
         series,
     });
 }
@@ -330,8 +353,8 @@ function deriveLine(block: ResolvedChartBlock, rows: readonly ChartRow[], column
     }));
 
     return ok({
-        xAxis: inferAxis(rows, x, "x"),
-        yAxis: inferAxis(rows, y, "y"),
+        xAxis: inferAxis(rows, x, "x", axisTitle(block.labels, x)),
+        yAxis: inferAxis(rows, y, "y", axisTitle(block.labels, y)),
         series,
     });
 }
@@ -354,8 +377,8 @@ function deriveScatter(block: ResolvedChartBlock, rows: readonly ChartRow[], col
     }));
 
     return ok({
-        xAxis: inferAxis(rows, x, "x"),
-        yAxis: inferAxis(rows, y, "y"),
+        xAxis: inferAxis(rows, x, "x", axisTitle(block.labels, x)),
+        yAxis: inferAxis(rows, y, "y", axisTitle(block.labels, y)),
         series,
     });
 }
@@ -452,8 +475,8 @@ function deriveBox(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
     }
 
     return ok({
-        xAxis: { type: "category", data: categories, ...xAxisName(x) },
-        yAxis: { type: "value", name: y },
+        xAxis: { type: "category", data: categories, ...xAxisName(axisTitle(block.labels, x)) },
+        yAxis: { type: "value", name: axisTitle(block.labels, y) },
         series,
     });
 }
@@ -496,8 +519,8 @@ function deriveHeatmap(block: ResolvedChartBlock, rows: readonly ChartRow[], col
     const max = finite.length > 0 ? Math.max(...finite) : 1;
 
     return ok({
-        xAxis: { type: "category", data: xCategories.map(String), ...xAxisName(x), splitArea: { show: true } },
-        yAxis: { type: "category", data: yCategories.map(String), name: y, splitArea: { show: true } },
+        xAxis: { type: "category", data: xCategories.map(String), ...xAxisName(axisTitle(block.labels, x)), splitArea: { show: true } },
+        yAxis: { type: "category", data: yCategories.map(String), name: axisTitle(block.labels, y), splitArea: { show: true } },
         visualMap: {
             type: "continuous",
             min,
@@ -615,6 +638,7 @@ function deriveComposition(
     composition: ChartComposition,
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
+    labels: ColumnLabels,
 ): Result<EchartOption, RenderProblem> {
     const resolved: ResolvedSeries[] = [];
     for (const declared of composition.series) {
@@ -653,8 +677,8 @@ function deriveComposition(
     const named = resolved.some((entry) => entry.label !== undefined) || labeled.value.size > 0;
     return ok({
         tooltip: named ? { ...NAMED_TOOLTIP } : { ...PLAIN_TOOLTIP },
-        xAxis: compositionXAxis(rows, first, composition.axes?.x),
-        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y),
+        xAxis: compositionXAxis(rows, first, composition.axes?.x, labels),
+        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y, labels),
         series: emitted.map((entry) => entry.option),
     });
 }
@@ -984,30 +1008,31 @@ function axisKey(axis: "x" | "y"): "xAxis" | "yAxis" {
  * A bar takes a category axis, and every other form takes the inferred axis. A declared scale is the one
  * exception, because the author asked for a numeric axis and a category axis has no scale.
  */
-function compositionXAxis(rows: readonly ChartRow[], first: ResolvedSeries, declared: ChartAxes["x"]): EchartOption {
+function compositionXAxis(rows: readonly ChartRow[], first: ResolvedSeries, declared: ChartAxes["x"], labels: ColumnLabels): EchartOption {
     if (first.declared.form !== "bar" || declared?.scale !== undefined) {
-        return compositionAxis(rows, first.x, "x", declared);
+        return compositionAxis(rows, first.x, "x", declared, labels);
     }
     // A bar counts its categories. The base bar rule lists the x values in first-appearance order, thus a
     // bar of either path draws the same axis.
     const categories = firstAppearance(first.x.values.filter((value): value is Cell => value !== null));
-    return { type: "category", data: categories, ...xAxisName(declared?.title ?? first.x.name) };
+    return { type: "category", data: categories, ...xAxisName(declared?.title ?? axisTitle(labels, first.x.name)) };
 }
 
 /**
  * The axis of one composition channel.
  *
- * A declared title replaces the column name. A declared `log` scale maps onto the logarithmic axis type. A
+ * A declared axis title wins, because it names this one axis. The declared label of the column comes next,
+ * and the raw column name answers last. A declared `log` scale maps onto the logarithmic axis type. A
  * transformed channel gives a number for each point that survives it, thus its axis is a value axis and
  * the cells of the untransformed column decide nothing.
  */
-function compositionAxis(rows: readonly ChartRow[], channel: ResolvedChannel, axis: "x" | "y", declared: ChartAxes["x"]): EchartOption {
-    const title = declared?.title ?? channel.name;
+function compositionAxis(rows: readonly ChartRow[], channel: ResolvedChannel, axis: "x" | "y", declared: ChartAxes["x"], labels: ColumnLabels): EchartOption {
+    const title = declared?.title ?? axisTitle(labels, channel.name);
     const nameFields = axis === "x" ? xAxisName(title) : { name: title };
     if (declared?.scale === "log") {
         return { type: "log", ...nameFields };
     }
-    const base = channel.transformed ? { type: "value", scale: true } : inferAxis(rows, channel.name, axis);
+    const base = channel.transformed ? { type: "value", scale: true } : inferAxis(rows, channel.name, axis, title);
     return { ...base, ...nameFields };
 }
 
@@ -1166,10 +1191,11 @@ function numericColumn(rows: readonly ChartRow[], column: string): number[] {
  * with its distinct values as strings. Any other column is a value axis with `scale: true`.
  *
  * The `axis` argument names the channel that the column feeds. An x column takes the centered name, and a
- * y column keeps the default name placement.
+ * y column keeps the default name placement. The `title` argument names the axis, thus the column decides
+ * the axis type and the title decides the text.
  */
-function inferAxis(rows: readonly ChartRow[], column: string, axis: "x" | "y"): EchartOption {
-    const nameFields = axis === "x" ? xAxisName(column) : { name: column };
+function inferAxis(rows: readonly ChartRow[], column: string, axis: "x" | "y", title: string): EchartOption {
+    const nameFields = axis === "x" ? xAxisName(title) : { name: title };
     if (rows.some((row) => isNonNumericString(row[column]))) {
         return { type: "category", data: firstAppearance(rows.map((row) => row[column])).map(String), ...nameFields };
     }

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -383,6 +383,17 @@ function deriveScatter(block: ResolvedChartBlock, rows: readonly ChartRow[], col
     });
 }
 
+/**
+ * The x axis of a histogram.
+ *
+ * The axis carries a bin range and not the cells of the column, thus it stays bare where the author names
+ * nothing. A declared label names the quantity that the bins measure, and the axis then carries it.
+ */
+function histogramXAxis(labels: ColumnLabels, column: string): EchartOption {
+    const label = declaredForColumn(labels, column);
+    return { type: "value", scale: true, ...(label !== undefined ? xAxisName(label) : {}) };
+}
+
 /** Equal-width bins over the global range. Each group shares the same edges. */
 function deriveHistogram(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
@@ -392,7 +403,7 @@ function deriveHistogram(block: ResolvedChartBlock, rows: readonly ChartRow[], c
 
     if (rows.length === 0) {
         return ok({
-            xAxis: { type: "value", scale: true },
+            xAxis: histogramXAxis(block.labels, x),
             yAxis: { ...COUNT_AXIS },
             series: [{ type: "bar", barWidth: "99%", data: [] }],
         });
@@ -419,7 +430,7 @@ function deriveHistogram(block: ResolvedChartBlock, rows: readonly ChartRow[], c
     }
 
     return ok({
-        xAxis: { type: "value", scale: true },
+        xAxis: histogramXAxis(block.labels, x),
         yAxis: { ...COUNT_AXIS },
         series,
     });
@@ -661,7 +672,7 @@ function deriveComposition(
     const emitted: EmittedSeries[] = [];
     for (const entry of resolved) {
         for (const group of splitByChannel(rows, entry.group)) {
-            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length);
+            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length, labels);
             if (built.isErr()) return err(built.error);
             emitted.push(...built.value);
         }
@@ -779,13 +790,14 @@ function buildSeries(
     labeled: ReadonlySet<number>,
     dense: boolean,
     emittedCount: number,
+    labels: ColumnLabels,
 ): Result<EmittedSeries[], RenderProblem> {
     const form = entry.declared.form;
     const points = collectPoints(entry, group.indices);
     if (SORTED_FORMS.has(form)) {
         points.sort((a, b) => compareCell(a.x, b.x));
     }
-    const name = seriesName(entry, group.name);
+    const name = seriesName(entry, group.name, labels);
 
     if (entry.y0 !== undefined) {
         const band = bandSeries(blockId, entry, name, points, `band-${emittedCount}`);
@@ -822,14 +834,15 @@ function collectPoints(entry: ResolvedSeries, indices: readonly number[]): Point
  * The name of one runtime series.
  *
  * Each series carries a name, thus the `{a}` of the tooltip template always names something. A series with
- * no declared name and no group takes the name of its y channel.
+ * no declared name and no group takes the name of its y channel. That name reads the declared label of the
+ * column, the same as the y axis, thus one chart names one column one way.
  */
-function seriesName(entry: ResolvedSeries, group: Cell | undefined): string {
+function seriesName(entry: ResolvedSeries, group: Cell | undefined, labels: ColumnLabels): string {
     const declared = entry.declared.name;
     if (declared !== undefined && group !== undefined) return `${declared} (${String(group)})`;
     if (declared !== undefined) return declared;
     if (group !== undefined) return String(group);
-    return entry.y.name;
+    return axisTitle(labels, entry.y.name);
 }
 
 /**

--- a/harness/src/report-render/number-format.test.ts
+++ b/harness/src/report-render/number-format.test.ts
@@ -212,3 +212,51 @@ describe("selectNumberKind", () => {
         expect(selectNumberKind("padj", "")).toBe("compact-scientific");
     });
 });
+
+describe("selectNumberKind with a declared meaning", () => {
+    it("gives the scientific kind to a declared p-value under one hundredth, although its name matches no token", () => {
+        expect(selectNumberKind("significance", 0.004, "p-value")).toBe("scientific");
+        expect(formatNumberCell(0.00427777663038, selectNumberKind("significance", 0.00427777663038, "p-value"))).toEqual({
+            text: "4.3e-3",
+            full: "0.00427777663038",
+        });
+    });
+
+    it("keeps a declared p-value from one hundredth up as a plain decimal", () => {
+        expect(selectNumberKind("significance", 0.536, "p-value")).toBe("compact-scientific");
+        expect(formatNumberCell(0.536, selectNumberKind("significance", 0.536, "p-value"))).toEqual({ text: "0.536" });
+    });
+
+    it("gives the same bytes as a token match, thus the declaration replaces the name alone", () => {
+        for (const cell of [0.00000038, 0.0099, 0.01, 0.05, 0.536, 1, 0]) {
+            const declared = formatNumberCell(cell, selectNumberKind("significance", cell, "p-value"));
+            const guessed = formatNumberCell(cell, selectNumberKind("padj", cell));
+            expect(declared).toEqual(guessed);
+        }
+    });
+
+    it("gives each of the other four meanings the kind of its own nature", () => {
+        expect(selectNumberKind("significance", 2.5, "effect")).toBe("compact-scientific");
+        expect(selectNumberKind("significance", 14201, "count")).toBe("compact");
+        expect(selectNumberKind("significance", 31978945, "identifier")).toBe("identifier");
+        expect(selectNumberKind("significance", "01", "category")).toBe("identifier");
+    });
+
+    it("keeps a category cell that reads as a number as its own text", () => {
+        expect(formatNumberCell("01", selectNumberKind("cluster", "01", "category"))).toEqual({ text: "01" });
+    });
+
+    it("replaces the name guess, thus a name of a different nature decides nothing", () => {
+        // The name names an identifier, and the declaration names a count.
+        expect(selectNumberKind("pmid", 31978945, "count")).toBe("compact");
+        // The name names a p-value, and the declaration names an effect.
+        expect(selectNumberKind("padj", 0.0001, "effect")).toBe("compact-scientific");
+    });
+
+    it("keeps the magnitude arms under a declared magnitude, the same as an undeclared column", () => {
+        // A count above the safe range is no longer exact, thus it reads as a general float.
+        expect(selectNumberKind("total", 1e21, "count")).toBe(selectNumberKind("genes", 1e21));
+        // A whole-number effect takes the compact kind, the same as any other whole number.
+        expect(selectNumberKind("shift", 3, "effect")).toBe(selectNumberKind("log2FoldChange", 3));
+    });
+});

--- a/harness/src/report-render/number-format.ts
+++ b/harness/src/report-render/number-format.ts
@@ -14,7 +14,12 @@
  * A shown form hides digits when it no longer parses back to the value, or when it no longer matches the
  * source text of a string cell. The caller puts the full digits in the `title` attribute at that time, and
  * it emits no attribute at any other time.
+ *
+ * The column meaning that a binding declares replaces the name of the column in the kind decision. The
+ * magnitude of the cell decides after it, the same for a declared column and for an undeclared one.
  */
+
+import type { ColumnMeaning } from "../contracts/report-reference.js";
 
 /** The four number kinds that the renderer shows. */
 export type NumberKind = "scientific" | "compact" | "compact-scientific" | "identifier";
@@ -46,7 +51,12 @@ const GROUPED_CEILING = 1e15;
 /** The size of one grouped digit run, for example the three digits of `14,201`. */
 const GROUP_SIZE = 3;
 
-/** The whole tokens of a column name that name a p-value. Such a value reads better in the scientific form. */
+/**
+ * The whole tokens of a column name that name a p-value. Such a value reads better in the scientific form.
+ *
+ * The tokens are the fallback for a column that declares no meaning. A declaration states what the column
+ * is, and a name only suggests it. Thus a token match answers where the author declared nothing.
+ */
 const P_VALUE_TOKENS = new Set(["p", "pval", "pvalue", "padj", "fdr", "q", "qval"]);
 
 /** The whole tokens of a column name that name an identifier. Such a value is a name, not a magnitude. */
@@ -94,13 +104,17 @@ export function formatNumberCell(cell: string | number, kind: NumberKind): Forma
 /**
  * Select the number kind for one cell of one column.
  *
- * An identifier column selects the identifier kind. A p-value column selects the scientific kind for a value
- * between zero and one hundredth. A safe integer selects the compact kind. Every other finite number selects
- * the compact-scientific kind. A cell that holds no finite number selects the compact-scientific kind too,
- * because the format passes such a cell through unchanged.
+ * A declaration replaces the name of the column, and the magnitude decides after it exactly as it does for
+ * a name match. Thus a declared p-value column gives the same bytes as a p-value column that the tokens
+ * match: `3.8e-7` takes the scientific form, and `0.536` stays `0.536`.
+ *
+ * An identifier column selects the identifier kind. A p-value column selects the scientific kind for a
+ * value between zero and one hundredth. A safe integer selects the compact kind. Every other finite number
+ * selects the compact-scientific kind. A cell that holds no finite number selects the compact-scientific
+ * kind too, because the format passes such a cell through unchanged.
  */
-export function selectNumberKind(column: string, cell: string | number): NumberKind {
-    if (isIdentifierColumn(column)) {
+export function selectNumberKind(column: string, cell: string | number, meaning?: ColumnMeaning): NumberKind {
+    if (holdsAName(column, meaning)) {
         return "identifier";
     }
     const value = finiteValue(cell);
@@ -109,7 +123,7 @@ export function selectNumberKind(column: string, cell: string | number): NumberK
     }
     // From one hundredth up, the plain decimal is as short as the exponent and it is easier to read. Thus
     // `0.05` stays `0.05` and it does not become `5e-2`.
-    if (value > 0 && value < SCIENTIFIC_FLOOR && isPValueColumn(column)) {
+    if (value > 0 && value < SCIENTIFIC_FLOOR && holdsAPValue(column, meaning)) {
         return "scientific";
     }
     // An integer above the safe range is no longer exact, thus it reads as a general float and not as a count.
@@ -117,6 +131,31 @@ export function selectNumberKind(column: string, cell: string | number): NumberK
         return "compact";
     }
     return "compact-scientific";
+}
+
+/**
+ * True when the column holds a name and not a magnitude.
+ *
+ * A declared `identifier` and a declared `category` both hold one. The identifier kind is the one kind that
+ * gives the source text unchanged, thus a category that reads as a number keeps its own text, for example
+ * the cluster `01`. A column that declares no meaning falls to the name tokens.
+ */
+function holdsAName(column: string, meaning: ColumnMeaning | undefined): boolean {
+    if (meaning !== undefined) {
+        return meaning === "identifier" || meaning === "category";
+    }
+    return isIdentifierColumn(column);
+}
+
+/**
+ * True when the column holds a probability. A column that declares no meaning falls to the name tokens.
+ *
+ * A declared `effect` and a declared `count` both hold a magnitude, thus each one takes the magnitude arms
+ * below this test. An effect is a float, and it reads there in the compact-scientific kind. A count is a
+ * whole number, and it reads there in the compact kind.
+ */
+function holdsAPValue(column: string, meaning: ColumnMeaning | undefined): boolean {
+    return meaning !== undefined ? meaning === "p-value" : isPValueColumn(column);
 }
 
 /** The finite number of one cell, or `null` when the cell holds no finite number. */

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -174,6 +174,47 @@ describe("renderTable", () => {
         expect(html.split(`tabindex="0"`).length - 1).toBe(2);
     });
 
+    /** One table block whose binding carries the declarations that a test states. */
+    function declared(declaration: Pick<TableBlock["binding"], "columnMeanings" | "columnLabels">): TableBlock {
+        return { kind: "table", id: "tb1", binding: { ...tableBinding, ...declaration } };
+    }
+
+    it("reads a declared p-value column in the scientific form, although its name matches no token", () => {
+        const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.00427777663038 }] } as const;
+        const html = renderTable(declared({ columnMeanings: { significance: "p-value" } }), rows);
+        expect(html).toContain(`<td data-value="0.00427777663038" title="0.00427777663038">4.3e-3</td>`);
+        // The same cell with no declaration keeps the guess, thus the declaration is what moved the kind.
+        expect(renderTable(block, rows)).toContain(`>0.00428</td>`);
+    });
+
+    it("keeps a declared p-value from one hundredth up as a plain decimal with no full form", () => {
+        const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.536 }] } as const;
+        const html = renderTable(declared({ columnMeanings: { significance: "p-value" } }), rows);
+        expect(html).toContain(`<td data-value="0.536">0.536</td>`);
+        expect(html).not.toContain("5.4e-1");
+    });
+
+    it("shows the declared label of a column and keeps the raw name on hover", () => {
+        const html = renderTable(declared({ columnLabels: { padj: "Adjusted p-value" } }), { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
+        expect(html).toContain(`tabindex="0" title="padj">Adjusted p-value</th>`);
+    });
+
+    it("prettifies an undeclared header and keeps the raw name on hover", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene_symbol: "TP53" }] });
+        expect(html).toContain(`tabindex="0" title="gene_symbol">gene symbol</th>`);
+    });
+
+    it("gives no title to a header whose shown text is its raw name", () => {
+        const html = renderTable(declared({ columnLabels: { gene: "gene" } }), { type: "table", rows: [{ gene: "TP53" }] });
+        expect(html).toContain(`tabindex="0">gene</th>`);
+    });
+
+    it("ignores a declaration that names no column of the table", () => {
+        const rows = { type: "table", rows: [{ gene: "TP53", padj: 0.00427777663038 }] } as const;
+        const stray = declared({ columnMeanings: { absent: "identifier" }, columnLabels: { absent: "Absent column" } });
+        expect(renderTable(stray, rows)).toBe(renderTable(block, rows));
+    });
+
     it("keeps a hostile cell as text after the format passes it through", () => {
         const html = renderTable(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
         expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -6,8 +6,9 @@
  * hostile source reaches the page as text. The `title` attribute takes the same escape as every other
  * attribute value, thus the full digits cannot break out of their slot.
  *
- * A number reaches the page through the number format. The name that stands over the number selects the
- * kind: the label of a metric, and the column name of a table cell.
+ * A number reaches the page through the number format. A table cell takes the meaning that the binding
+ * declares for its column, and the column name answers for a column that declares none. A metric takes its
+ * label, because a value locator declares no column-wide meaning.
  *
  * A table card also carries the markup of the page enhancer: the raw value of each cell, the sortable
  * header, the filter input, and the row cap with its toggle. The markup alone is a complete plain table,
@@ -20,6 +21,7 @@
 import { raw } from "hono/html";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
+import { declaredForColumn, type ColumnMeaning } from "../../contracts/report-reference.js";
 import { Marker } from "./references-view.js";
 import { formatNumberCell, selectNumberKind } from "../number-format.js";
 import type { ReferenceLedger } from "../references.js";
@@ -123,11 +125,24 @@ function firstNameSegment(text: string): string | undefined {
 }
 
 /**
+ * The heading of one column: the text on the page, and the raw name for the `title` attribute.
+ *
+ * A declared label names what the column measures. A column with no label prettifies, thus an underscore
+ * reads as a space. The raw name rides the hover only when the shown text differs from it, because a title
+ * that repeats the text tells a reader nothing.
+ */
+function columnHeading(column: string, labels: TableBlock["binding"]["columnLabels"]): { text: string; title?: string } {
+    const label = declaredForColumn(labels, column);
+    const text = label ?? column.replaceAll("_", " ");
+    return text === column ? { text } : { text, title: column };
+}
+
+/**
  * One body cell of a table.
  *
- * The column name selects the number kind, thus a p-value column reads in the scientific form. The full
- * digits ride the `title` attribute when the shown form hides one. An absent cell renders as an empty
- * cell, thus a ragged row keeps its shape.
+ * The declared meaning selects the number kind, and the column name selects it for a column that declares
+ * none. Thus a p-value column reads in the scientific form. The full digits ride the `title` attribute when
+ * the shown form hides one. An absent cell renders as an empty cell, thus a ragged row keeps its shape.
  *
  * Each cell carries its raw value in the `data-value` attribute. The page enhancer sorts on that value, thus
  * the shown text stays presentation and a rounded number still sorts by its full magnitude.
@@ -136,11 +151,11 @@ function firstNameSegment(text: string): string | undefined {
  * holds no finite number, thus the number format passed it through and this trim reads the text that the
  * format gave.
  */
-function Cell({ column, cell }: { column: string; cell: string | number | undefined }) {
+function Cell({ column, cell, meaning }: { column: string; cell: string | number | undefined; meaning: ColumnMeaning | undefined }) {
     if (cell === undefined) {
         return <td data-value=""></td>;
     }
-    const shown = formatNumberCell(cell, selectNumberKind(column, cell));
+    const shown = formatNumberCell(cell, selectNumberKind(column, cell, meaning));
     const segment = firstNameSegment(shown.text);
     if (segment !== undefined) {
         return (
@@ -163,7 +178,8 @@ function Cell({ column, cell }: { column: string; cell: string | number | undefi
  *
  * Each header cell stays a plain `th`. It carries the sort class and the index of its column, thus the
  * enhancer reads the column of a click and a browser with no script keeps a plain header. The header also
- * takes the tab order, thus a reader sorts the table from the keyboard.
+ * takes the tab order, thus a reader sorts the table from the keyboard. The header shows the declared label
+ * of the column, and the raw name rides the `title` attribute.
  *
  * The body holds every resolved row. A row past the cap carries the hidden class, and the card then carries
  * the toggle that names the total count. A table at the cap or under it carries no hidden row and no toggle.
@@ -174,6 +190,7 @@ function Cell({ column, cell }: { column: string; cell: string | number | undefi
 export function renderTable(block: TableBlock, value: TableValue): string {
     const columns = tableColumns(value);
     const total = value.rows.length;
+    const binding = block.binding;
     return String(
         <div class="report-table">
             {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
@@ -185,18 +202,21 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                     <table class="data-table">
                         <thead>
                             <tr>
-                                {columns.map((column, index) => (
-                                    <th class="data-table-sort" data-sort-index={String(index)} tabindex={0}>
-                                        {column}
-                                    </th>
-                                ))}
+                                {columns.map((column, index) => {
+                                    const heading = columnHeading(column, binding.columnLabels);
+                                    return (
+                                        <th class="data-table-sort" data-sort-index={String(index)} tabindex={0} title={heading.title}>
+                                            {heading.text}
+                                        </th>
+                                    );
+                                })}
                             </tr>
                         </thead>
                         <tbody>
                             {value.rows.map((row, index) => (
                                 <tr class={index < TABLE_ROW_CAP ? "report-row" : "report-row report-row-hidden"}>
                                     {columns.map((column) => (
-                                        <Cell column={column} cell={row[column]} />
+                                        <Cell column={column} cell={row[column]} meaning={declaredForColumn(binding.columnMeanings, column)} />
                                     ))}
                                 </tr>
                             ))}


### PR DESCRIPTION
## What & why

The renderer guessed what a column means from its name token, and the guess misfires both ways. A name outside the list misses, and a `q` that is not a probability hits. The whole-table binding now carries two optional maps as content: `columnMeanings` (a closed set of five) and `columnLabels`. A declared meaning replaces the name test alone, and the magnitude arms stay. Thus a declared column renders byte-identically to a name-matched column of the same nature. The table header shows the declared label with the raw name on hover, and an undeclared header prettifies. A chart axis reads the declared label of its channel column.

Reviewer notes: the declaration reader takes own keys alone, thus a column named after a prototype member declares nothing. `category` maps onto the identifier kind, because that kind alone passes the source text through. A transformed channel keeps its derived name, because the transform states the plotted quantity. The two fields change nothing on a stored document. The header prettify is the one visible change to a stored page: an underscore header now reads with spaces, with the raw name on hover.

Refs #392

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
