### PR TITLE
feat(harness): pin and render the citation bibliography

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/design.md
@@ -1,0 +1,32 @@
+# Design: pin-the-citation-bibliography
+
+## Context
+
+`collectCitationKeys` (`src/report-model/pin-snapshot.ts:166`) reads the synthesis records and keeps `pmid:` keys as `string[]`. The snapshot type carries `citations?: string[]` (`src/report-model/reference-resolver.ts:47`), and the membership check of a citation reference reads that list. `renderCitation` (`src/report-render/views/values.tsx:296`) renders the marker and the note alone, through the shared ledger. The appendix prints the bare key (`src/report-render/views/references-view.tsx:81`).
+
+## Decisions
+
+### D1: The records ride a parallel optional map, and the key list stays
+
+The snapshot gains `citationRecords?: Record<key, { citation: string; description?: string }>`. The key list keeps the membership role, thus the resolver, the gate, and every stored pin change nothing. A legacy pin has no map, and each reader falls back to the bare key. A dual-shape key list would instead thread a union through the membership checks for no gain.
+
+### D2: The collection keeps the first record for a key
+
+The synthesis `keyReferences` carry the curated descriptions, and the per-finding references name the same PMIDs again with narrower relevance text. The collection walks the key references first, thus the richer record wins, and a later duplicate never overwrites. The dedupe and the code-unit sort of the keys stay as they are.
+
+### D3: The card is the bibliography entry
+
+The citation card renders: the bracket marker of the citation ladder, the short citation, the note, and the key. A `pmid:` key also renders a PubMed link, built as `https://pubmed.ncbi.nlm.nih.gov/<id>/`. The link is deterministic, and a navigation loads nothing into the page, thus the stand-alone rule holds. A key of another identifier space renders with no link.
+
+### D4: The citation ladder splits from the artifact ladder
+
+The ledger numbers citations in their own sequence, and the marker renders in brackets, `[1]`. The artifact footnotes keep the numeric superscript ladder. Thus the prose footnotes point at the provenance appendix, and the bracket markers point at the reference list, exactly as a paper reads. The appendix keeps one citation entry for each cited key, with the short citation beside it.
+
+### D5: The listing carries the citation, not the description
+
+The listing result gives `{ key, citation? }` entries in place of the bare key strings. The description stays out, because the listing is an orientation surface and the description pads every turn. The tool description names the change of shape, and the result is never stored, thus no compatibility arm exists.
+
+## Risks / Trade-offs
+
+- A synthesis with no `citation` text gives a record-less key, and the card falls back to the bare key. That is the honest floor, and the absence rule covers it.
+- The bracket ladder changes the look of a stored document's citation markers at the next render. The change is the point of the finding, and no recorded page mutates.

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: pin-the-citation-bibliography
+
+## Why
+
+The References section of the session page holds no bibliography. The citation cards show only the agent's note, numbered in the same ladder as the artifact footnotes. The appendix prints `pmid:26997480` bare. No author, no year, no link. The identity exists at the source — the run synthesis carries `citation: "Hugo et al. 2016"` and a description beside each PMID — and the pin keeps the key alone.
+
+## What Changes
+
+- The pin stores a citation record beside each key: the short citation and the description, in an optional map keyed by the citation key. The key list stays as it is, thus the membership check and every stored pin keep working.
+- The citation card renders the short citation, the note, and a PubMed link for a `pmid:` key. The link is a navigation, not a loaded resource, thus the page still stands alone.
+- The literature numbering splits from the artifact footnotes. The citation cards number in their own bracket ladder, and the artifact footnotes keep the numeric ladder.
+- The appendix citation entries show the short citation beside the key.
+- The pinned-artifact listing tool gives the short citation beside each key, thus the agent stops the guess about which PMID is which paper.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-snapshot`: the pin collects the citation records, not the keys alone.
+- `report-render`: the citation card renders the bibliography, and the citation numbering splits from the artifact ladder.
+- `report-session-agent`: the listing gives the citation beside its key.
+
+## Impact
+
+- Affected code: `src/report-model/pin-snapshot.ts`, `src/report-model/reference-resolver.ts` (the snapshot type), `src/report-render/references.ts` and the views, `src/tools/report-session/list-artifacts.ts`, and their tests.
+- A stored pin with no record map renders as today, thus no migration exists.

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-render/spec.md
@@ -1,0 +1,43 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The citation card is a bibliography entry
+
+The citation card MUST render the short citation of its pinned record, the note of the block, and the citation key. A `pmid:` key MUST also render a PubMed link, built deterministically from the id. The link is a navigation and it loads nothing, thus the stand-alone rule holds. A key with no pinned record renders the key and the note alone, because absence is a normal condition.
+
+The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The appendix citation entry MUST show the short citation beside the key when the record exists.
+
+#### Scenario: The card renders the bibliography
+
+- **WHEN** a citation block binds `pmid:26997480` and the pinned record carries `Hugo et al. 2016`
+- **THEN** the card shows the bracket marker, the short citation, the note, and a PubMed link for the id
+
+#### Scenario: A record-less key still renders
+
+- **WHEN** a citation block binds a key that the record map does not hold
+- **THEN** the card shows the bracket marker, the key, and the note, with no link
+
+#### Scenario: The two ladders split
+
+- **WHEN** a page holds two artifact references and two citations
+- **THEN** the artifact markers read `1` and `2`, and the citation markers read `[1]` and `[2]`
+
+## MODIFIED Requirements
+
+### Requirement: The page stands alone
+The skeleton MUST inline the style rules. The page MUST reference each script and each font as a relative `assets/<name>` path, and it MUST reference no CDN host. The renderer MUST export one asset manifest, and each entry MUST name the staged file and its package source. The caller MUST stage each manifest entry beside the page, in the same pipeline that stages the figures.
+
+The front door of the package MUST re-export that manifest and its entry type. An embedder that stages the assets itself reads the manifest, and it binds the asset lookup that the preview tool accepts. The front door already carries the type of that lookup, thus the value it describes belongs beside it. A hand-kept copy of the entries in an embedder would ship a build that is short one file, with nothing to say so.
+
+#### Scenario: The page loads no remote resource
+- **WHEN** the caller renders any valid document
+- **THEN** the page holds no `src` and no stylesheet `href` with an `http` or an `https` scheme. A navigation anchor is the one admitted remote reference
+
+#### Scenario: The manifest and the page agree
+- **WHEN** the caller renders any valid document
+- **THEN** each `assets/` reference in the skeleton names one manifest entry
+
+#### Scenario: The front door carries the manifest
+- **WHEN** a consumer imports the package by its name
+- **THEN** the asset manifest and its entry type resolve from that import

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-render/spec.md
@@ -6,7 +6,7 @@
 
 The citation card MUST render the short citation of its pinned record, the note of the block, and the citation key. A `pmid:` key MUST also render a PubMed link, built deterministically from the id. The link is a navigation and it loads nothing, thus the stand-alone rule holds. A key with no pinned record renders the key and the note alone, because absence is a normal condition.
 
-The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The appendix citation entry MUST show the short citation beside the key when the record exists.
+The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The ladder MUST number by the citation key, thus two blocks over one paper share one number. The bibliography MUST list under its own heading, apart from the provenance appendix. Each entry shows the short citation, and the description when the record carries one, beside the key.
 
 #### Scenario: The card renders the bibliography
 
@@ -22,6 +22,16 @@ The citation markers MUST number in their own bracket ladder, split from the num
 
 - **WHEN** a page holds two artifact references and two citations
 - **THEN** the artifact markers read `1` and `2`, and the citation markers read `[1]` and `[2]`
+
+#### Scenario: One paper takes one number
+
+- **WHEN** a claim binding and a citation block name one `pmid:` key with different display text
+- **THEN** both markers read `[1]`, and the bibliography holds one entry for the key
+
+#### Scenario: The bibliography wears its own heading
+
+- **WHEN** the caller renders a document whose only references are citations
+- **THEN** the literature lists under its own heading, and no list titles it "Data provenance"
 
 ## MODIFIED Requirements
 

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-session-agent/spec.md
@@ -1,0 +1,12 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The read-only roster
+
+The listing MUST give each pinned citation as its key with the short citation beside it, when the pinned record carries one. Thus the agent reads which id is which paper, and it composes a citation block with no guess. A key with no record lists bare, because absence is a normal condition.
+
+#### Scenario: The listing names the paper beside the key
+
+- **WHEN** the agent calls the listing tool in a session whose pin records `Hugo et al. 2016` under `pmid:26997480`
+- **THEN** the listed citation carries the key and the short citation

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-snapshot/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/specs/report-snapshot/spec.md
@@ -1,0 +1,33 @@
+# Delta: report-snapshot
+
+## MODIFIED Requirements
+
+### Requirement: The pin collects the citation evidence
+The pin MUST collect the citation ids of each run synthesis into the snapshot citation list: the key references, and the per-finding references. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
+
+The pin MUST also store a citation record beside each key that carries one: the short citation, and the description. The records ride an optional map keyed by the citation key, and the key list keeps the membership role. The first record for a key wins, and the key references walk first, thus the curated description survives a narrower duplicate. A key with no record stays a bare key, and a stored pin with no map reads as today.
+
+#### Scenario: A synthesis PMID becomes a pinned citation key
+
+- **WHEN** the pin reads a synthesis whose key references carry PMID `12345`
+- **THEN** the stored snapshot citation list holds `pmid:12345`
+
+#### Scenario: A citation block over a pinned PMID resolves
+
+- **WHEN** a citation reference names `pmid:12345` and the snapshot citation list holds that key
+- **THEN** the reference resolves, and the gate passes it
+
+#### Scenario: The record rides beside the key
+
+- **WHEN** the pin reads a synthesis whose key reference carries PMID `12345` with the citation `Hugo et al. 2016`
+- **THEN** the stored record map holds that citation under `pmid:12345`
+
+#### Scenario: The curated record survives a duplicate
+
+- **WHEN** a key reference and a finding reference both name PMID `12345`
+- **THEN** the stored record is the key-reference one
+
+#### Scenario: A legacy pin reads as today
+
+- **WHEN** a stored pin holds the key list and no record map
+- **THEN** the snapshot loads, and each reader falls back to the bare key

--- a/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-pin-the-citation-bibliography/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: pin-the-citation-bibliography
+
+## 1. The pin
+
+- [x] 1.1 The snapshot type gains `citationRecords`, an optional map from the key to `{ citation, description? }` (`src/report-model/reference-resolver.ts`).
+- [x] 1.2 The collection stores the record beside the key, key references first, first record wins (`src/report-model/pin-snapshot.ts`).
+
+## 2. The render
+
+- [x] 2.1 The citation card renders the short citation, the note, the key, and the PubMed link of a `pmid:` key.
+- [x] 2.2 The citation markers number in their own bracket ladder, and the artifact footnotes keep the numeric ladder (`src/report-render/references.ts`).
+- [x] 2.3 The appendix citation entry shows the short citation beside the key when the record exists.
+
+## 3. The listing
+
+- [x] 3.1 The listing gives `{ key, citation? }` entries, and its description names the shape (`src/tools/report-session/list-artifacts.ts`).
+
+## 4. The proof
+
+- [x] 4.1 A pin test stores the record, keeps the first for a duplicate key, and loads a legacy pin with no map.
+- [x] 4.2 A render test covers the bibliography card, the record-less fallback, and the two split ladders.
+- [x] 4.3 A listing test covers the citation beside the key.
+- [x] 4.4 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -278,14 +278,35 @@ A claim MUST render its prose with evidence markers. The references MUST list at
 - **WHEN** the caller renders a document with a claim
 - **THEN** the list at the end of the page is titled "Data provenance", and no auto-generated surface is titled "References"
 
+### Requirement: The citation card is a bibliography entry
+
+The citation card MUST render the short citation of its pinned record, the note of the block, and the citation key. A `pmid:` key MUST also render a PubMed link, built deterministically from the id. The link is a navigation and it loads nothing, thus the stand-alone rule holds. A key with no pinned record renders the key and the note alone, because absence is a normal condition.
+
+The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The appendix citation entry MUST show the short citation beside the key when the record exists.
+
+#### Scenario: The card renders the bibliography
+
+- **WHEN** a citation block binds `pmid:26997480` and the pinned record carries `Hugo et al. 2016`
+- **THEN** the card shows the bracket marker, the short citation, the note, and a PubMed link for the id
+
+#### Scenario: A record-less key still renders
+
+- **WHEN** a citation block binds a key that the record map does not hold
+- **THEN** the card shows the bracket marker, the key, and the note, with no link
+
+#### Scenario: The two ladders split
+
+- **WHEN** a page holds two artifact references and two citations
+- **THEN** the artifact markers read `1` and `2`, and the citation markers read `[1]` and `[2]`
+
 ### Requirement: The page stands alone
 The skeleton MUST inline the style rules. The page MUST reference each script and each font as a relative `assets/<name>` path, and it MUST reference no CDN host. The renderer MUST export one asset manifest, and each entry MUST name the staged file and its package source. The caller MUST stage each manifest entry beside the page, in the same pipeline that stages the figures.
 
 The front door of the package MUST re-export that manifest and its entry type. An embedder that stages the assets itself reads the manifest, and it binds the asset lookup that the preview tool accepts. The front door already carries the type of that lookup, thus the value it describes belongs beside it. A hand-kept copy of the entries in an embedder would ship a build that is short one file, with nothing to say so.
 
-#### Scenario: The page references no remote host
+#### Scenario: The page loads no remote resource
 - **WHEN** the caller renders any valid document
-- **THEN** the page holds no `src` and no `href` with an `http` or an `https` scheme
+- **THEN** the page holds no `src` and no stylesheet `href` with an `http` or an `https` scheme. A navigation anchor is the one admitted remote reference
 
 #### Scenario: The manifest and the page agree
 - **WHEN** the caller renders any valid document

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -282,7 +282,7 @@ A claim MUST render its prose with evidence markers. The references MUST list at
 
 The citation card MUST render the short citation of its pinned record, the note of the block, and the citation key. A `pmid:` key MUST also render a PubMed link, built deterministically from the id. The link is a navigation and it loads nothing, thus the stand-alone rule holds. A key with no pinned record renders the key and the note alone, because absence is a normal condition.
 
-The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The appendix citation entry MUST show the short citation beside the key when the record exists.
+The citation markers MUST number in their own bracket ladder, split from the numeric ladder of the artifact footnotes. The ladder MUST number by the citation key, thus two blocks over one paper share one number. The bibliography MUST list under its own heading, apart from the provenance appendix. Each entry shows the short citation, and the description when the record carries one, beside the key.
 
 #### Scenario: The card renders the bibliography
 
@@ -298,6 +298,16 @@ The citation markers MUST number in their own bracket ladder, split from the num
 
 - **WHEN** a page holds two artifact references and two citations
 - **THEN** the artifact markers read `1` and `2`, and the citation markers read `[1]` and `[2]`
+
+#### Scenario: One paper takes one number
+
+- **WHEN** a claim binding and a citation block name one `pmid:` key with different display text
+- **THEN** both markers read `[1]`, and the bibliography holds one entry for the key
+
+#### Scenario: The bibliography wears its own heading
+
+- **WHEN** the caller renders a document whose only references are citations
+- **THEN** the literature lists under its own heading, and no list titles it "Data provenance"
 
 ### Requirement: The page stands alone
 The skeleton MUST inline the style rules. The page MUST reference each script and each font as a relative `assets/<name>` path, and it MUST reference no CDN host. The renderer MUST export one asset manifest, and each entry MUST name the staged file and its package source. The caller MUST stage each manifest entry beside the page, in the same pipeline that stages the figures.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -138,6 +138,8 @@ The roster of the agent MUST hold: the workspace read tools (`read_file`, `list_
 
 The listing tool MUST give the pinned artifacts in a deterministic order: the path, the hash, and the file type. It MUST also give the pinned citation ids. The listing is bounded, and a truncated listing MUST carry the total count and a truncation marker. For a `.csv` or a `.tsv` artifact it also gives the columns, from a bounded read of the header. A header that the bounded read cannot parse whole gives no columns. An unreadable header gives no columns and no error, because absence is a normal condition.
 
+The listing MUST give each pinned citation as its key with the short citation beside it, when the pinned record carries one. Thus the agent reads which id is which paper, and it composes a citation block with no guess. A key with no record lists bare, because absence is a normal condition.
+
 #### Scenario: The roster holds no run starter
 - **WHEN** the assembled agent lists its tools
 - **THEN** no tool id of the run-starter set or the mutate set is present
@@ -157,6 +159,10 @@ The listing tool MUST give the pinned artifacts in a deterministic order: the pa
 #### Scenario: A large pinned set truncates with a marker
 - **WHEN** the snapshot pins more artifacts than the listing bound
 - **THEN** the result carries the bounded listing, the total count, and the truncation marker
+
+#### Scenario: The listing names the paper beside the key
+- **WHEN** the agent calls the listing tool in a session whose pin records `Hugo et al. 2016` under `pmid:26997480`
+- **THEN** the listed citation carries the key and the short citation
 
 #### Scenario: A derivation starts no run
 - **WHEN** the agent derives a table in a session

--- a/harness/openspec/specs/report-snapshot/spec.md
+++ b/harness/openspec/specs/report-snapshot/spec.md
@@ -82,6 +82,8 @@ necessary.
 ### Requirement: The pin collects the citation evidence
 The pin MUST collect the citation ids of each run synthesis into the snapshot citation list: the key references, and the per-finding references. Each PMID becomes the key `pmid:<id>`, and the keys dedupe and sort in code-unit order. The collection reads the synthesis record of each run of the analysis. An absent synthesis, an unreadable one, and a malformed one each give no keys and no error, because absence is a normal condition. A composition that gives no workspace-root seam pins no citations, and the pin still lands. A failed run listing MUST fail the pin, because a store fault is not absence.
 
+The pin MUST also store a citation record beside each key that carries one: the short citation, and the description. The records ride an optional map keyed by the citation key, and the key list keeps the membership role. The first record for a key wins, and the key references walk first, thus the curated description survives a narrower duplicate. A key with no record stays a bare key, and a stored pin with no map reads as today.
+
 #### Scenario: A synthesis PMID becomes a pinned citation key
 - **WHEN** the pin runs for an analysis whose run synthesis carries the key reference PMID `12345`
 - **THEN** the stored snapshot citation list holds `pmid:12345`
@@ -101,6 +103,18 @@ The pin MUST collect the citation ids of each run synthesis into the snapshot ci
 #### Scenario: Two runs that cite one paper pin one key
 - **WHEN** two run syntheses carry one PMID
 - **THEN** the citation list holds the key one time
+
+#### Scenario: The record rides beside the key
+- **WHEN** the pin reads a synthesis whose key reference carries PMID `12345` with the citation `Hugo et al. 2016`
+- **THEN** the stored record map holds that citation under `pmid:12345`
+
+#### Scenario: The curated record survives a duplicate
+- **WHEN** a key reference and a finding reference both name PMID `12345`
+- **THEN** the stored record is the key-reference one
+
+#### Scenario: A legacy pin reads as today
+- **WHEN** a stored pin holds the key list and no record map
+- **THEN** the snapshot loads, and each reader falls back to the bare key
 
 ### Requirement: The snapshot is the membership boundary of a session
 

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -178,12 +178,14 @@ describe("createReportSessionAgent", () => {
         // The citation rule and its anti-pattern are stable substrings, thus the
         // assertion does not couple to the full prose.
         expect(reportSessionPrompt).toContain("citation blocks");
-        expect(reportSessionPrompt).toContain("citation id of the pinned evidence");
+        expect(reportSessionPrompt).toContain("citation of the pinned evidence");
         expect(reportSessionPrompt).toContain("does not resolve");
         expect(reportSessionPrompt).toContain("Inline a citation that does not resolve");
-        // The listing tool is the route to a pinned id, thus the agent never learns one from a refusal.
+        // The listing tool is the route to a pinned citation, thus the agent never learns one from a
+        // refusal. The shape of the field rides the description of the tool, thus the prompt names none.
         expect(reportSessionPrompt).toContain("`citations` field");
-        expect(reportSessionPrompt).toContain("never take an id out of a refusal");
+        expect(reportSessionPrompt).toContain("never take a citation out");
+        expect(reportSessionPrompt).not.toContain("idKind");
     });
 
     test("the prompt carries the argument spine", () => {

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -104,10 +104,10 @@ evidence when the block lands. A path that the pinned evidence does not hold com
 back as an unresolved reference, and you repair that path.
 
 The literature of the report composes as citation blocks, and each one binds to a
-citation id of the pinned evidence. \`list_pinned_artifacts\` names those ids in its
-\`citations\` field: read them there, and never take an id out of a refusal. A
-citation that the pinned evidence does not hold does not resolve. Report such a
-citation to the user, and never write it into the prose instead.
+citation of the pinned evidence. \`list_pinned_artifacts\` names the pinned
+literature in its \`citations\` field: read it there, and never take a citation out
+of a refusal. A citation that the pinned evidence does not hold does not resolve.
+Report such a citation to the user, and never write it into the prose instead.
 
 \`finish_draft\` checks the whole draft against the schema, the id rule, and the
 structural tier. It returns each completeness gap, or the finished document. Read

--- a/harness/src/report-model/pin-snapshot.test.ts
+++ b/harness/src/report-model/pin-snapshot.test.ts
@@ -10,6 +10,7 @@ import { upsertArtifact, upsertArtifacts, type RegisterArtifactInput } from "../
 import { insertRun } from "../state/runs.js";
 import { createFixtureResolver } from "./fixture-resolver.js";
 import { pinReportSnapshot } from "./pin-snapshot.js";
+import type { CitationRecords } from "./reference-resolver.js";
 
 const ANALYSIS = "analysis-pin";
 
@@ -152,6 +153,11 @@ describe("the citation evidence of the pin", () => {
         return snapshot.citations;
     }
 
+    async function pinCitationRecords(): Promise<CitationRecords | undefined> {
+        const snapshot = (await pinReportSnapshot(pool, ANALYSIS, { resolveWorkspaceRoot: resolveRoot }))._unsafeUnwrap();
+        return snapshot.citationRecords;
+    }
+
     it("gives one `pmid:` key for each key reference of a run synthesis", async () => {
         await seedRun("run-1");
         await writeSynthesis(
@@ -276,6 +282,66 @@ describe("the citation evidence of the pin", () => {
         // The pin writes the key, and the resolver reads it. One test over the two sides locks the shape
         // of the key, thus a change on one side alone fails here and not at a session of a user.
         expect(resolved._unsafeUnwrap()).toEqual({ type: "citation", id: "pmid:31234" });
+    });
+
+    it("stores the citation and the description of a key reference beside its key", async () => {
+        await seedRun("run-record");
+        await writeSynthesis(
+            "run-record",
+            JSON.stringify({
+                keyReferences: [
+                    { pmid: "26997480", citation: " Hugo et al. 2016 ", description: "The resistance paper." },
+                    { pmid: "999", citation: "Roe 2021" },
+                ],
+            }),
+        );
+
+        // The trim of the citation proves that the record carries the text alone. A reference with no
+        // description stores the citation on its own.
+        expect(await pinCitationRecords()).toEqual({
+            "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." },
+            "pmid:999": { citation: "Roe 2021" },
+        });
+    });
+
+    it("keeps the record of the key reference when a finding names the same paper", async () => {
+        await seedRun("run-duplicate");
+        // The finding reference carries the narrower relevance text, and the key reference carries the
+        // curated description. The key references walk first, thus the curated record survives.
+        await writeSynthesis(
+            "run-duplicate",
+            JSON.stringify({
+                findings: [{ references: [{ pmid: "12345", citation: "Smith 2020 (finding)", relevance: "It supports the finding." }] }],
+                keyReferences: [{ pmid: "12345", citation: "Smith 2020", description: "The primary paper." }],
+            }),
+        );
+
+        expect(await pinCitationRecords()).toEqual({ "pmid:12345": { citation: "Smith 2020", description: "The primary paper." } });
+    });
+
+    it("stores the citation of a finding reference that no key reference names", async () => {
+        await seedRun("run-finding-record");
+        await writeSynthesis(
+            "run-finding-record",
+            JSON.stringify({
+                findings: [{ references: [{ pmid: "31234", citation: "Doe 2019", relevance: "It contextualizes the finding." }] }],
+                keyReferences: [],
+            }),
+        );
+
+        // The relevance text is not the description of the paper, thus the record carries the citation
+        // alone.
+        expect(await pinCitationRecords()).toEqual({ "pmid:31234": { citation: "Doe 2019" } });
+    });
+
+    it("stores no map when no reference carries a citation text", async () => {
+        await seedRun("run-bare-keys");
+        await writeSynthesis("run-bare-keys", JSON.stringify({ keyReferences: [{ pmid: "12345" }, { pmid: "999", citation: "   " }] }));
+
+        // The keys still pin, thus a citation block over either one resolves. A stored pin with no map
+        // reads the same as a pin that predates the map.
+        expect(await pinCitations()).toEqual(["pmid:12345", "pmid:999"]);
+        expect(await pinCitationRecords()).toBeUndefined();
     });
 
     it("fails the pin when the run listing fails", async () => {

--- a/harness/src/report-model/pin-snapshot.ts
+++ b/harness/src/report-model/pin-snapshot.ts
@@ -12,6 +12,9 @@
  * that the synthesis engaged, and two fields of a run synthesis carry it: the key references and the
  * references of each finding. The records live in the run tree on disk. Thus the pin reads that tree
  * through the workspace-root seam of the caller.
+ *
+ * A reference that carries a short citation also pins a bibliography record beside its key. The key list
+ * keeps the membership role, thus the record map is optional and it changes no resolution.
  */
 
 import { err, ok, type Result } from "neverthrow";
@@ -23,7 +26,7 @@ import { queryAnalysisArtifacts, type AnalysisArtifactRef } from "../state/artif
 import type { Querier } from "../state/db.js";
 import { queryRunsByAnalysis } from "../state/runs.js";
 import { isSafeId, runDir, type ResolveWorkspaceRoot } from "../workspace/paths.js";
-import type { ArtifactSnapshot, ReportSnapshot } from "./reference-resolver.js";
+import type { ArtifactSnapshot, CitationRecord, ReportSnapshot } from "./reference-resolver.js";
 
 /**
  * The reason that the pin gave no snapshot. The ledger read and the run listing are the two operations
@@ -94,13 +97,44 @@ async function readSynthesisText(absolute: string): Promise<string | undefined> 
     ).unwrapOr(undefined);
 }
 
+/** One citation of a synthesis record: the key, and the bibliography record when the entry carries one. */
+interface CitationEntry {
+    readonly key: string;
+    readonly record?: CitationRecord;
+}
+
+/** The trimmed text of a field, or `undefined` when the field is not a non-empty string. */
+function trimmedText(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+        return undefined;
+    }
+    const text = value.trim();
+    return text.length > 0 ? text : undefined;
+}
+
 /**
- * Take one `pmid:` key from each entry of one reference list, and add it to `keys`.
+ * The bibliography record of one reference entry, or `undefined` when the entry carries no citation text.
+ *
+ * A key reference carries `citation` and `description`. A reference of a finding carries `citation` and a
+ * narrower `relevance`, thus it gives the short citation alone. A record without a citation would state
+ * nothing, thus such an entry gives a bare key.
+ */
+function recordOf(reference: { citation?: unknown; description?: unknown }): CitationRecord | undefined {
+    const citation = trimmedText(reference.citation);
+    if (citation === undefined) {
+        return undefined;
+    }
+    const description = trimmedText(reference.description);
+    return description === undefined ? { citation } : { citation, description };
+}
+
+/**
+ * Take one `pmid:` citation from each entry of one reference list, and add it to `entries`.
  *
  * The walk is lenient: a value that is not a list, an entry that is not an object, and a PMID that is
- * not a non-empty string each give no key.
+ * not a non-empty string each give no citation.
  */
-function pushPmidKeys(list: unknown, keys: string[]): void {
+function pushPmidCitations(list: unknown, entries: CitationEntry[]): void {
     if (!Array.isArray(list)) {
         return;
     }
@@ -114,21 +148,25 @@ function pushPmidKeys(list: unknown, keys: string[]): void {
         }
         const id = pmid.trim();
         if (id.length > 0) {
-            keys.push(`pmid:${id}`);
+            const record = recordOf(reference as { citation?: unknown; description?: unknown });
+            entries.push(record === undefined ? { key: `pmid:${id}` } : { key: `pmid:${id}`, record });
         }
     }
 }
 
 /**
- * The citation keys of one synthesis text.
+ * The citations of one synthesis text, in the order that the record carries them.
  *
  * The extraction is lenient: it parses the JSON, and it takes each PMID of `keyReferences` and of the
  * references of each finding. The key references are the papers that the synthesis names as primary, and
  * the references of the findings are the superset. Thus a citation over either one resolves. A
  * whole-schema parse would empty the citation list of the whole analysis for one record that a different
- * schema version wrote. Malformed JSON gives no key.
+ * schema version wrote. Malformed JSON gives no citation.
+ *
+ * The key references come first, because the caller keeps the first record of a key and the curated
+ * description sits there.
  */
-function citationKeysOf(text: string): string[] {
+function citationsOf(text: string): CitationEntry[] {
     let parsed: unknown;
     try {
         parsed = JSON.parse(text);
@@ -138,18 +176,24 @@ function citationKeysOf(text: string): string[] {
     if (typeof parsed !== "object" || parsed === null) {
         return [];
     }
-    const keys: string[] = [];
-    pushPmidKeys((parsed as { keyReferences?: unknown }).keyReferences, keys);
+    const entries: CitationEntry[] = [];
+    pushPmidCitations((parsed as { keyReferences?: unknown }).keyReferences, entries);
     const findings = (parsed as { findings?: unknown }).findings;
     if (Array.isArray(findings)) {
         for (const finding of findings) {
             if (typeof finding !== "object" || finding === null) {
                 continue;
             }
-            pushPmidKeys((finding as { references?: unknown }).references, keys);
+            pushPmidCitations((finding as { references?: unknown }).references, entries);
         }
     }
-    return keys;
+    return entries;
+}
+
+/** The citation evidence of one analysis: the sorted key list, and the record of each key that carries one. */
+interface CollectedCitations {
+    readonly keys: string[];
+    readonly records: Map<string, CitationRecord>;
 }
 
 /**
@@ -159,21 +203,29 @@ function citationKeysOf(text: string): string[] {
  * key references and the references of each finding. The keys dedupe, and they sort in code-unit order.
  * Thus one disk state gives one list, and a second pin over that state gives the same list.
  *
+ * The first record of a key wins. The key references of a record walk before its findings, thus the
+ * curated description survives a duplicate that names the same paper with a narrower text.
+ *
  * A run listing that fails fails the collection, because a store fault is not absence. Each other fault
  * is a normal condition: an unresolvable workspace root, an absent record, an unreadable record, and a
  * malformed record each give no key and no error.
  */
-async function collectCitationKeys(pool: Querier, resolveWorkspaceRoot: ResolveWorkspaceRoot, analysisId: string): Promise<Result<string[], PinSnapshotError>> {
+async function collectCitations(
+    pool: Querier,
+    resolveWorkspaceRoot: ResolveWorkspaceRoot,
+    analysisId: string,
+): Promise<Result<CollectedCitations, PinSnapshotError>> {
     let root: string;
     try {
         root = resolveWorkspaceRoot(analysisId);
     } catch {
         // The seam signals an unresolvable resource by a throw. The artifact map still states the
         // membership of the session, thus the fault costs the citation list alone.
-        return ok([]);
+        return ok({ keys: [], records: new Map() });
     }
 
     const keys = new Set<string>();
+    const records = new Map<string, CitationRecord>();
     for (let offset = 0; ; offset += RUN_PAGE_SIZE) {
         const page = await queryRunsByAnalysis(pool, analysisId, { limit: RUN_PAGE_SIZE, offset });
         if (page.isErr()) {
@@ -189,12 +241,15 @@ async function collectCitationKeys(pool: Querier, resolveWorkspaceRoot: ResolveW
             if (text === undefined) {
                 continue;
             }
-            for (const key of citationKeysOf(text)) {
-                keys.add(key);
+            for (const entry of citationsOf(text)) {
+                keys.add(entry.key);
+                if (entry.record !== undefined && !records.has(entry.key)) {
+                    records.set(entry.key, entry.record);
+                }
             }
         }
         if (page.value.length < RUN_PAGE_SIZE) {
-            return ok([...keys].sort());
+            return ok({ keys: [...keys].sort(), records });
         }
     }
 }
@@ -233,6 +288,10 @@ export async function pinReportSnapshot(
     if (options.resolveWorkspaceRoot === undefined) {
         return ok({ artifacts, citations: [] });
     }
-    const citations = await collectCitationKeys(pool, options.resolveWorkspaceRoot, analysisId);
-    return citations.map((keys) => ({ artifacts, citations: keys }));
+    const citations = await collectCitations(pool, options.resolveWorkspaceRoot, analysisId);
+    // A collection that recorded nothing stores no map. Thus the snapshot of an analysis whose synthesis
+    // carries no citation text reads the same as a pin that predates the map.
+    return citations.map(({ keys, records }) =>
+        records.size === 0 ? { artifacts, citations: keys } : { artifacts, citations: keys, citationRecords: Object.fromEntries(records) },
+    );
 }

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -37,14 +37,31 @@ export interface ArtifactSnapshot {
 }
 
 /**
+ * One pinned citation record: the short citation of the paper, and the description that the synthesis
+ * gave. The record is the bibliography of a citation key, and the key alone states the membership.
+ */
+export interface CitationRecord {
+    citation: string;
+    description?: string;
+}
+
+/** The pinned citation records, keyed by the citation key, for example `pmid:12345`. */
+export type CitationRecords = Record<string, CitationRecord>;
+
+/**
  * The pinned evidence that a resolver reads. The `artifacts` map is keyed by the analysis-relative path,
  * the same path that an artifact reference names and the same key as `cortex_artifacts.path`. That path
  * is unique across the analysis, thus one map holds the artifacts of every run without a collision.
  * `citations` holds each known external id as an `idKind:id` string, for example `pmid:12345`.
+ *
+ * `citationRecords` carries the bibliography of a key that the synthesis described. The key list keeps the
+ * membership role, thus a key with no record is a pinned citation and a stored pin with no map reads the
+ * same as one that predates the map.
  */
 export interface ReportSnapshot {
     artifacts: Record<string, ArtifactSnapshot>;
     citations?: string[];
+    citationRecords?: CitationRecords;
 }
 
 /**
@@ -134,4 +151,19 @@ export function fileTypeHoldsNoCell(fileType: string | null | undefined): boolea
  */
 export function snapshotEntry(snapshot: ReportSnapshot, path: string): ArtifactSnapshot | undefined {
     return Object.hasOwn(snapshot.artifacts, path) ? snapshot.artifacts[path] : undefined;
+}
+
+/**
+ * Give back the citation record at `key`, or `undefined` when the map holds no such own key.
+ *
+ * An agent authors the citation key of a block, thus the key is untrusted text. The map can be a plain
+ * object from a `JSON.parse` of a stored snapshot, and a bracket lookup with a key such as `constructor`
+ * finds an inherited member. The `Object.hasOwn` guard admits an own key only, thus an inherited member
+ * reads as absent.
+ *
+ * The card and the appendix both read this one lookup. Thus the two surfaces can never disagree about the
+ * bibliography of one key.
+ */
+export function citationRecordOf(records: CitationRecords | undefined, key: string): CitationRecord | undefined {
+    return records !== undefined && Object.hasOwn(records, key) ? records[key] : undefined;
 }

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -581,8 +581,37 @@ img {
   font-size: 14px;
   color: var(--color-text-secondary);
 }
+/* The bracket marker of the literature ladder. It reads beside the text and not above it, thus it stays a
+   span and never a superscript. */
+.report-cite-marker {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.report-cite-marker a {
+  color: var(--color-primary-500);
+  text-decoration: none;
+}
+.report-cite-marker a:hover {
+  text-decoration: underline;
+}
+/* The short citation is the name of the paper, thus it carries the weight of the card. */
+.report-citation-source {
+  font-weight: 600;
+  color: var(--color-text);
+}
+a.report-citation-source {
+  text-decoration: none;
+}
+a.report-citation-source:hover {
+  text-decoration: underline;
+}
 .report-citation-note {
   color: var(--color-text);
+}
+.report-citation-key {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-muted);
 }
 .report-caption {
   margin-top: 8px;
@@ -635,6 +664,20 @@ img {
 }
 .report-ref-detail {
   color: var(--color-text-muted);
+}
+/* The bibliography holds its own bracket number, thus the list shows no decimal marker of its own. */
+.report-citations {
+  padding-left: 0;
+  list-style: none;
+  color: var(--color-text-muted);
+}
+.report-cite-index {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+.report-cite-source {
+  color: var(--color-text-secondary);
 }
 
 /* ── Section textures ─────────────────────────────────── */

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -679,6 +679,11 @@ a.report-citation-source:hover {
 .report-cite-source {
   color: var(--color-text-secondary);
 }
+/* The description of the paper reads under its citation, thus it takes a line of its own. */
+.report-cite-description {
+  margin-top: 2px;
+  color: var(--color-text-muted);
+}
 
 /* ── Section textures ─────────────────────────────────── */
 /* A texture is felt, not seen: a low opacity and a faded edge. */

--- a/harness/src/report-render/references.test.ts
+++ b/harness/src/report-render/references.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import type { Reference } from "../contracts/report-reference.js";
-import { renderReferenceList } from "./views/references-view.js";
+import { renderBibliography, renderReferenceList } from "./views/references-view.js";
 import { ReferenceLedger } from "./references.js";
 
 describe("ReferenceLedger.mark", () => {
@@ -48,6 +48,28 @@ describe("ReferenceLedger.mark", () => {
         expect(ledger.provenanceEntries().length).toBe(1);
         expect(ledger.citationEntries().length).toBe(2);
     });
+
+    it("gives one number to one paper that two references name with different display text", () => {
+        const first: Reference = { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al. Science. 2016." };
+        const second: Reference = { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo 2016" };
+        const ledger = new ReferenceLedger();
+
+        // The key names the paper, thus the identity of the citation ladder reads the key and never the
+        // serialization. A serialization identity would give one paper two numbers here.
+        expect(ledger.mark(first)).toEqual({ ladder: "citation", n: 1 });
+        expect(ledger.mark(second)).toEqual({ ladder: "citation", n: 1 });
+        expect(ledger.citationEntries().length).toBe(1);
+    });
+
+    it("keeps two locators of one artifact apart", () => {
+        const first: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
+        const second: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 1 } };
+        const ledger = new ReferenceLedger();
+
+        // The provenance ladder keeps the whole serialization, because one file holds many cells.
+        expect(ledger.mark(first).n).toBe(1);
+        expect(ledger.mark(second).n).toBe(2);
+    });
 });
 
 describe("renderReferenceList", () => {
@@ -74,17 +96,29 @@ describe("renderReferenceList", () => {
         expect(renderReferenceList(new ReferenceLedger())).toBe("");
     });
 
-    it("names the paper beside the key of a citation that the pin recorded", () => {
+    it("gives an empty string for a ledger that holds citations alone", () => {
+        const ledger = new ReferenceLedger();
+        ledger.mark({ kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" });
+
+        // A citation belongs to the bibliography, thus the provenance list of such a page renders not at
+        // all and its band carries no title.
+        expect(renderReferenceList(ledger)).toBe("");
+    });
+});
+
+describe("renderBibliography", () => {
+    it("names the paper, the key, and the description of a citation that the pin recorded", () => {
         const paper: Reference = { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al." };
         const ledger = new ReferenceLedger();
         ledger.mark(paper);
 
-        const list = renderReferenceList(ledger, { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } });
+        const list = renderBibliography(ledger, { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } });
 
         expect(list).toContain(`id="cite-1"`);
         expect(list).toContain("[1]");
         expect(list).toContain("Hugo et al. 2016");
         expect(list).toContain("pmid:26997480");
+        expect(list).toContain(`<div class="report-cite-description">The resistance paper.</div>`);
     });
 
     it("names the key alone for a citation that the record map does not hold", () => {
@@ -92,10 +126,18 @@ describe("renderReferenceList", () => {
         const ledger = new ReferenceLedger();
         ledger.mark(paper);
 
-        const list = renderReferenceList(ledger, {});
+        const list = renderBibliography(ledger, {});
 
         expect(list).toContain(`id="cite-1"`);
         expect(list).toContain("doi:10.1000/xyz");
         expect(list).not.toContain("report-cite-source");
+        expect(list).not.toContain("report-cite-description");
+    });
+
+    it("gives an empty string for a ledger that holds no citation", () => {
+        const ledger = new ReferenceLedger();
+        ledger.mark({ kind: "artifact-table", path: "runs/r1/de.csv", hash: "sha256:aaa" });
+
+        expect(renderBibliography(ledger)).toBe("");
     });
 });

--- a/harness/src/report-render/references.test.ts
+++ b/harness/src/report-render/references.test.ts
@@ -9,11 +9,11 @@ describe("ReferenceLedger.mark", () => {
         const first: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
         const second: Reference = { kind: "artifact-value", path: "runs/r1/b.csv", hash: "sha256:bbb", locator: { column: "padj", row: 1 } };
         const ledger = new ReferenceLedger();
-        expect(ledger.mark(first)).toBe(1);
-        expect(ledger.mark(second)).toBe(2);
+        expect(ledger.mark(first)).toEqual({ ladder: "provenance", n: 1 });
+        expect(ledger.mark(second)).toEqual({ ladder: "provenance", n: 2 });
         // The first reference keeps its number, thus a second appearance adds no entry.
-        expect(ledger.mark(first)).toBe(1);
-        expect(ledger.entries().length).toBe(2);
+        expect(ledger.mark(first)).toEqual({ ladder: "provenance", n: 1 });
+        expect(ledger.provenanceEntries().length).toBe(2);
     });
 
     it("dedupes two field-identical references built with different key orders", () => {
@@ -21,17 +21,32 @@ describe("ReferenceLedger.mark", () => {
         // The same fields as `first`, with a different key order at the top level and inside the locator.
         const second: Reference = { hash: "sha256:aaa", locator: { row: 3, column: "padj" }, path: "runs/r1/a.csv", kind: "artifact-value" };
         const ledger = new ReferenceLedger();
-        expect(ledger.mark(first)).toBe(1);
-        expect(ledger.mark(second)).toBe(1);
-        expect(ledger.entries().length).toBe(1);
+        expect(ledger.mark(first).n).toBe(1);
+        expect(ledger.mark(second).n).toBe(1);
+        expect(ledger.provenanceEntries().length).toBe(1);
     });
 
     it("distinguishes two references that differ in one field", () => {
         const first: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 3 } };
         const second: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 4 } };
         const ledger = new ReferenceLedger();
-        expect(ledger.mark(first)).toBe(1);
-        expect(ledger.mark(second)).toBe(2);
+        expect(ledger.mark(first).n).toBe(1);
+        expect(ledger.mark(second).n).toBe(2);
+    });
+
+    it("counts a citation in its own ladder", () => {
+        const artifact: Reference = { kind: "artifact-value", path: "runs/r1/a.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
+        const paper: Reference = { kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" };
+        const secondPaper: Reference = { kind: "citation", idKind: "pmid", id: "999", raw: "Roe 2021" };
+        const ledger = new ReferenceLedger();
+
+        // The artifact takes the first number of the provenance ladder, and the paper takes the first
+        // number of the citation ladder. Thus one page carries the two sequences apart.
+        expect(ledger.mark(artifact)).toEqual({ ladder: "provenance", n: 1 });
+        expect(ledger.mark(paper)).toEqual({ ladder: "citation", n: 1 });
+        expect(ledger.mark(secondPaper)).toEqual({ ladder: "citation", n: 2 });
+        expect(ledger.provenanceEntries().length).toBe(1);
+        expect(ledger.citationEntries().length).toBe(2);
     });
 });
 
@@ -57,5 +72,30 @@ describe("renderReferenceList", () => {
 
     it("gives an empty string for an empty ledger", () => {
         expect(renderReferenceList(new ReferenceLedger())).toBe("");
+    });
+
+    it("names the paper beside the key of a citation that the pin recorded", () => {
+        const paper: Reference = { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al." };
+        const ledger = new ReferenceLedger();
+        ledger.mark(paper);
+
+        const list = renderReferenceList(ledger, { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } });
+
+        expect(list).toContain(`id="cite-1"`);
+        expect(list).toContain("[1]");
+        expect(list).toContain("Hugo et al. 2016");
+        expect(list).toContain("pmid:26997480");
+    });
+
+    it("names the key alone for a citation that the record map does not hold", () => {
+        const paper: Reference = { kind: "citation", idKind: "doi", id: "10.1000/xyz", raw: "Roe 2021" };
+        const ledger = new ReferenceLedger();
+        ledger.mark(paper);
+
+        const list = renderReferenceList(ledger, {});
+
+        expect(list).toContain(`id="cite-1"`);
+        expect(list).toContain("doi:10.1000/xyz");
+        expect(list).not.toContain("report-cite-source");
     });
 });

--- a/harness/src/report-render/references.ts
+++ b/harness/src/report-render/references.ts
@@ -6,43 +6,68 @@
  * marker and a citation marker read from the same ledger, thus one reference that two blocks share gets
  * one number and one list entry.
  *
+ * The ledger holds two ladders. A citation reference numbers in the citation ladder, and every other
+ * reference numbers in the provenance ladder. Thus the prose footnotes point at the provenance appendix,
+ * the bracket markers point at the bibliography, and a page reads the way that a paper reads.
+ *
  * Identity is the canonical serialization of the reference. `serializeReference` sorts the keys at every
  * depth, thus two references match only when every field matches. The key order of the source object does
  * not change the identity.
  */
 
-import { serializeReference, type Reference } from "../contracts/report-reference.js";
+import { serializeReference, type CitationReference, type Reference } from "../contracts/report-reference.js";
+
+/** The two ladders of a page: the numeric footnote ladder, and the bracket ladder of the literature. */
+export type ReferenceLadder = "provenance" | "citation";
+
+/** Each reference kind that the provenance ladder holds, which is every kind except a citation. */
+export type ProvenanceReference = Exclude<Reference, CitationReference>;
+
+/** One marked reference: the ladder that holds it, and its number inside that ladder. */
+export interface ReferenceMark {
+    ladder: ReferenceLadder;
+    n: number;
+}
 
 /**
  * The mutable ledger of references.
  *
  * The page walk makes one ledger, and it threads the ledger through each claim and each citation. The
- * order of the entries is the order of the first mark, thus the marker numbers count up by first
- * appearance.
+ * order of the entries of a ladder is the order of the first mark, thus the marker numbers count up by
+ * first appearance inside that ladder.
  */
 export class ReferenceLedger {
-    private readonly order: Reference[] = [];
-    private readonly markers = new Map<string, number>();
+    private readonly provenance: ProvenanceReference[] = [];
+    private readonly citations: CitationReference[] = [];
+    private readonly marks = new Map<string, ReferenceMark>();
 
     /**
-     * Give the marker number of a reference. A new reference gets the next number, and it joins the
-     * order. A reference that matches an earlier one gives the earlier number, thus the list holds it one
-     * time.
+     * Give the mark of a reference. A new reference gets the next number of its ladder, and it joins the
+     * order of that ladder. A reference that matches an earlier one gives the earlier mark, thus the list
+     * holds it one time.
      */
-    mark(reference: Reference): number {
+    mark(reference: Reference): ReferenceMark {
         const key = serializeReference(reference);
-        const seen = this.markers.get(key);
+        const seen = this.marks.get(key);
         if (seen !== undefined) {
             return seen;
         }
-        const marker = this.order.length + 1;
-        this.markers.set(key, marker);
-        this.order.push(reference);
-        return marker;
+        // `push` gives back the new length of the array, which is the number of the entry that it added.
+        const mark: ReferenceMark =
+            reference.kind === "citation"
+                ? { ladder: "citation", n: this.citations.push(reference) }
+                : { ladder: "provenance", n: this.provenance.push(reference) };
+        this.marks.set(key, mark);
+        return mark;
     }
 
-    /** The references in first-appearance order. The marker of an entry is its position plus one. */
-    entries(): readonly Reference[] {
-        return this.order;
+    /** The provenance references in first-appearance order. The marker of an entry is its position plus one. */
+    provenanceEntries(): readonly ProvenanceReference[] {
+        return this.provenance;
+    }
+
+    /** The citation references in first-appearance order. The marker of an entry is its position plus one. */
+    citationEntries(): readonly CitationReference[] {
+        return this.citations;
     }
 }

--- a/harness/src/report-render/references.ts
+++ b/harness/src/report-render/references.ts
@@ -10,12 +10,18 @@
  * reference numbers in the provenance ladder. Thus the prose footnotes point at the provenance appendix,
  * the bracket markers point at the bibliography, and a page reads the way that a paper reads.
  *
- * Identity is the canonical serialization of the reference. `serializeReference` sorts the keys at every
- * depth, thus two references match only when every field matches. The key order of the source object does
- * not change the identity.
+ * Each ladder holds its own identity. A provenance identity is the canonical serialization of the
+ * reference: `serializeReference` sorts the keys at every depth, thus two references match only when every
+ * field matches, and two locators of one file stay apart. A citation identity is the citation key alone,
+ * because the key names the paper and the display text is authored beside it.
  */
 
 import { serializeReference, type CitationReference, type Reference } from "../contracts/report-reference.js";
+
+/** The citation key of one citation reference, in the prefixed `idKind:id` form. */
+export function citationKeyOf(reference: CitationReference): string {
+    return `${reference.idKind}:${reference.id}`;
+}
 
 /** The two ladders of a page: the numeric footnote ladder, and the bracket ladder of the literature. */
 export type ReferenceLadder = "provenance" | "citation";
@@ -39,25 +45,37 @@ export interface ReferenceMark {
 export class ReferenceLedger {
     private readonly provenance: ProvenanceReference[] = [];
     private readonly citations: CitationReference[] = [];
-    private readonly marks = new Map<string, ReferenceMark>();
+    private readonly provenanceMarks = new Map<string, ReferenceMark>();
+    private readonly citationMarks = new Map<string, ReferenceMark>();
 
     /**
      * Give the mark of a reference. A new reference gets the next number of its ladder, and it joins the
      * order of that ladder. A reference that matches an earlier one gives the earlier mark, thus the list
      * holds it one time.
+     *
+     * A citation matches on its key alone. The `raw` text and the display fields of a citation are the
+     * words of the author, and two blocks over one paper carry different words. The key names the paper,
+     * thus one paper takes one number and the bibliography holds it one time.
      */
     mark(reference: Reference): ReferenceMark {
+        // `push` gives back the new length of the array, which is the number of the entry that it added.
+        if (reference.kind === "citation") {
+            const key = citationKeyOf(reference);
+            const seen = this.citationMarks.get(key);
+            if (seen !== undefined) {
+                return seen;
+            }
+            const mark: ReferenceMark = { ladder: "citation", n: this.citations.push(reference) };
+            this.citationMarks.set(key, mark);
+            return mark;
+        }
         const key = serializeReference(reference);
-        const seen = this.marks.get(key);
+        const seen = this.provenanceMarks.get(key);
         if (seen !== undefined) {
             return seen;
         }
-        // `push` gives back the new length of the array, which is the number of the entry that it added.
-        const mark: ReferenceMark =
-            reference.kind === "citation"
-                ? { ladder: "citation", n: this.citations.push(reference) }
-                : { ladder: "provenance", n: this.provenance.push(reference) };
-        this.marks.set(key, mark);
+        const mark: ReferenceMark = { ladder: "provenance", n: this.provenance.push(reference) };
+        this.provenanceMarks.set(key, mark);
         return mark;
     }
 

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -134,27 +134,52 @@ describe("renderReportPage assembly", () => {
 });
 
 describe("the page stands alone", () => {
-    it("holds no attribute reference and no style reference with a remote scheme", () => {
+    /** A page whose citation card carries a pinned record, thus the body holds a PubMed navigation. */
+    function pageWithACitation(): string {
+        const document: ReportDocument = {
+            title: "T",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [{ kind: "citation", id: "cit1", binding: { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al." } }],
+                },
+            ],
+        };
+        return renderReportPage(document, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+    }
+
+    /**
+     * The rule reads the element and never the value. A navigation costs no request when the page opens,
+     * thus an anchor admits a remote host. A `src`, a `srcset`, and a stylesheet source each fetch on
+     * open, thus none of them admits one.
+     */
+    function remoteSitesOf(html: string): string[] {
+        const remote = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)].filter((value) => /^https?:/i.test(value));
+        return [...new Set(remote.flatMap((value) => referenceSites(html, value)))];
+    }
+
+    it("names a remote host at a navigation anchor and at no other element", () => {
+        for (const html of [renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap(), pageWithACitation()]) {
+            const references = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)];
+            expect(references.length).toBeGreaterThan(0);
+
+            // A remote value of the style sheet reaches no element of the page, thus it gives no site and
+            // the empty list fails this equality.
+            expect(remoteSitesOf(html)).toEqual(["a[href]"]);
+
+            // Each other reference resolves inside the page directory: a staged asset, an inline data URI,
+            // or an anchor of the page itself. The scheme test reads the start of the value, thus a
+            // namespace URI inside a data URI never reads as a host.
+            const local = (value: string) =>
+                value.startsWith(`${ASSETS_DIR}/`) || value.startsWith("data:") || value.startsWith("#") || /^https?:/i.test(value);
+            expect(references.filter((value) => !local(value))).toEqual([]);
+        }
+    });
+
+    it("names the brand host one time, thus no second surface fetches it", () => {
         const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
-        const references = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)];
-        expect(references.length).toBeGreaterThan(0);
-
-        // The brand value reaches the page as a navigation and as nothing else. A `src` that names the same
-        // host fetches on open, thus the exemption below binds to the anchor and not to the value.
-        expect(referenceSites(html, BRAND_LINK)).toEqual(["a[href]"]);
-
-        // The scheme test reads the start of the value. A namespace URI inside a data URI names no host to
-        // fetch, thus the test must not read a scheme out of the middle of a value.
-        const remote = references.filter((value) => /^https?:/i.test(value) && value !== BRAND_LINK);
-        expect(remote).toEqual([]);
-
-        // Each reference resolves inside the page directory: a staged asset, an inline data URI, or an
-        // anchor of the page itself. The brand link is the one exception, and it fetches nothing.
-        const local = (value: string) => value.startsWith(`${ASSETS_DIR}/`) || value.startsWith("data:") || value.startsWith("#") || value === BRAND_LINK;
-        const foreign = references.filter((value) => !local(value));
-        expect(foreign).toEqual([]);
-
-        // The one remote value reaches the page one time, thus no second surface names a host.
         expect(html.split(BRAND_LINK).length - 1).toBe(1);
     });
 
@@ -402,6 +427,38 @@ describe("renderReportPage navigation and references", () => {
         // The claim marker and the citation marker point at the same entry.
         expect(html.split(`href="#cite-1"`).length - 1).toBe(2);
     });
+
+    it("lists one entry for one paper that two blocks name with different display text", () => {
+        const document: ReportDocument = {
+            title: "T",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "claim",
+                            id: "c1",
+                            content: { prose: "A claim." },
+                            bindings: [{ kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al. Science. 2016." }],
+                        },
+                        {
+                            kind: "citation",
+                            id: "cit1",
+                            binding: { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo 2016" },
+                        },
+                    ],
+                },
+            ],
+        };
+        const html = renderReportPage(document, {})._unsafeUnwrap();
+
+        // The key names the paper, and the raw text is the words of the author. Thus one paper takes one
+        // number, and the two markers point at the one entry.
+        expect(html.split(`<li id="cite-`).length - 1).toBe(1);
+        expect(html.split(`href="#cite-1"`).length - 1).toBe(2);
+    });
 });
 
 describe("the citation bibliography", () => {
@@ -446,10 +503,21 @@ describe("the citation bibliography", () => {
         expect(card.find("a.report-citation-source").attr("href")).toBe("https://pubmed.ncbi.nlm.nih.gov/26997480/");
         expect(card.find("span.report-citation-note").text()).toBe("the second paper");
         expect(card.find("span.report-citation-key").text()).toBe("pmid:26997480");
-        // The appendix entry names the paper beside the key.
+        // The card sits in the body, thus it carries the short citation and never the description.
+        expect(card.text()).not.toContain("The resistance paper.");
+
+        // The appendix entry names the paper beside the key, and it carries the description under them.
         const entry = load(html)("li#cite-2");
         expect(entry.text()).toContain("Hugo et al. 2016");
         expect(entry.text()).toContain("pmid:26997480");
+        expect(entry.find("div.report-cite-description").text()).toBe("The resistance paper.");
+    });
+
+    it("adds no description line to a record that carries none", () => {
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+
+        expect(load(html)("li#cite-2").text()).toContain("Hugo et al. 2016");
+        expect(load(html)("li#cite-2 div.report-cite-description").length).toBe(0);
     });
 
     it("shows the key and the note alone for a key that the record map does not hold", () => {
@@ -574,20 +642,62 @@ describe("the one content column", () => {
     });
 });
 
-describe("the provenance appendix", () => {
-    /** A document with one claim. The ledger then holds one entry, thus the appendix renders. */
-    const claimDocument: ReportDocument = {
+describe("the appendix bands", () => {
+    /** A document whose one claim binds an artifact, thus the provenance ladder holds one entry. */
+    const artifactDocument: ReportDocument = {
+        title: "T",
+        sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "claim", id: "c1", content: { prose: "A claim." }, bindings: [scalarRef] }] }],
+    };
+
+    /** A document whose one claim binds a paper, thus the citation ladder holds the only entry. */
+    const citationDocument: ReportDocument = {
         title: "T",
         sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "claim", id: "c1", content: { prose: "A claim." }, bindings: [citation] }] }],
     };
 
-    it("titles the auto-generated list Data provenance", () => {
-        const html = renderReportPage(claimDocument, {})._unsafeUnwrap();
+    it("titles the provenance list Data provenance", () => {
+        const html = renderReportPage(artifactDocument, {})._unsafeUnwrap();
         expect(html).toContain("Data provenance");
-        // A reader expects literature under "References". The auto-generated list is provenance, thus no
-        // heading of the page carries that word.
+        // A reader expects literature under "References". This list is provenance, thus no heading of the
+        // page carries that word.
         expect(html).not.toContain(">References<");
         expect(load(html)("h2.report-ref-title").length).toBe(1);
+        // The page cites no paper, thus it carries no bibliography band.
+        expect(html).not.toContain("Literature");
+    });
+
+    it("titles the bibliography Literature, and titles no provenance band over it", () => {
+        const html = renderReportPage(citationDocument, {})._unsafeUnwrap();
+        const titles = load(html)("h2.report-ref-title")
+            .toArray()
+            .map((node) => load(html)(node).text());
+
+        // The one appendix of the page holds papers, thus it wears the literature title alone. A reader
+        // never reads a paper under the provenance heading.
+        expect(titles).toEqual(["Literature"]);
+        expect(html).toContain(`<ol class="report-citations">`);
+        expect(html).not.toContain(`<ol class="report-references">`);
+    });
+
+    it("titles the two bands apart when the page holds both kinds of reference", () => {
+        const both: ReportDocument = {
+            title: "T",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [{ kind: "claim", id: "c1", content: { prose: "A claim." }, bindings: [scalarRef, citation] }],
+                },
+            ],
+        };
+        const html = renderReportPage(both, {})._unsafeUnwrap();
+        const titles = load(html)("h2.report-ref-title")
+            .toArray()
+            .map((node) => load(html)(node).text());
+
+        // The provenance band comes first, and the literature band continues the band alternation.
+        expect(titles).toEqual(["Data provenance", "Literature"]);
     });
 
     it("reads quieter than the body of the report", () => {

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -359,7 +359,7 @@ describe("renderReportPage value validation", () => {
         expect(result.isOk()).toBe(true);
         const html = result._unsafeUnwrap();
         expect(html).toContain("A claim.");
-        expect(html).toContain(`href="#ref-1"`);
+        expect(html).toContain(`href="#cite-1"`);
     });
 });
 
@@ -397,10 +397,106 @@ describe("renderReportPage navigation and references", () => {
             ],
         };
         const html = renderReportPage(document, {})._unsafeUnwrap();
-        // The reference list holds one entry.
-        expect(html.split(`<li id="ref-`).length - 1).toBe(1);
+        // The bibliography holds one entry.
+        expect(html.split(`<li id="cite-`).length - 1).toBe(1);
         // The claim marker and the citation marker point at the same entry.
-        expect(html.split(`href="#ref-1"`).length - 1).toBe(2);
+        expect(html.split(`href="#cite-1"`).length - 1).toBe(2);
+    });
+});
+
+describe("the citation bibliography", () => {
+    /** One page whose section holds two artifact claims and two citation blocks. */
+    const twoOfEach: ReportDocument = {
+        title: "T",
+        sections: [
+            {
+                kind: "section",
+                id: "s",
+                title: "S",
+                blocks: [
+                    { kind: "claim", id: "c1", content: { prose: "The first claim." }, bindings: [scalarRef] },
+                    {
+                        kind: "claim",
+                        id: "c2",
+                        content: { prose: "The second claim." },
+                        bindings: [{ kind: "artifact-table", path: "runs/r1/de.csv", hash: "sha256:bbb" }],
+                    },
+                    { kind: "citation", id: "cit1", binding: citation, note: "the first paper" },
+                    {
+                        kind: "citation",
+                        id: "cit2",
+                        binding: { kind: "citation", idKind: "pmid", id: "26997480", raw: "Hugo W, et al." },
+                        note: "the second paper",
+                    },
+                ],
+            },
+        ],
+    };
+
+    it("shows the marker, the short citation, the note, and the PubMed link of a recorded key", () => {
+        const html = renderReportPage(
+            twoOfEach,
+            {},
+            { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } },
+        )._unsafeUnwrap();
+        const card = load(html)("div.report-citation").last();
+
+        expect(card.find("span.report-cite-marker").text()).toBe("[2]");
+        expect(card.find("a.report-citation-source").text()).toBe("Hugo et al. 2016");
+        expect(card.find("a.report-citation-source").attr("href")).toBe("https://pubmed.ncbi.nlm.nih.gov/26997480/");
+        expect(card.find("span.report-citation-note").text()).toBe("the second paper");
+        expect(card.find("span.report-citation-key").text()).toBe("pmid:26997480");
+        // The appendix entry names the paper beside the key.
+        const entry = load(html)("li#cite-2");
+        expect(entry.text()).toContain("Hugo et al. 2016");
+        expect(entry.text()).toContain("pmid:26997480");
+    });
+
+    it("shows the key and the note alone for a key that the record map does not hold", () => {
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        const card = load(html)("div.report-citation").first();
+
+        expect(card.find("a.report-citation-source").length).toBe(0);
+        expect(card.find("span.report-citation-key").text()).toBe("pmid:12345");
+        expect(card.find("span.report-citation-note").text()).toBe("the first paper");
+        // The bibliography entry of a record-less key names the key alone.
+        expect(load(html)("li#cite-1").text()).toContain("pmid:12345");
+        expect(load(html)("li#cite-1 span.report-cite-source").length).toBe(0);
+    });
+
+    it("counts the artifact markers and the citation markers in two ladders", () => {
+        const page = load(renderReportPage(twoOfEach, {})._unsafeUnwrap());
+
+        expect(
+            page("sup.report-marker a")
+                .toArray()
+                .map((node) => page(node).text()),
+        ).toEqual(["1", "2"]);
+        expect(
+            page("span.report-cite-marker a")
+                .toArray()
+                .map((node) => page(node).text()),
+        ).toEqual(["[1]", "[2]"]);
+        // The two appendix lists each hold two entries, thus no marker points across the ladders.
+        expect(page("ol.report-references li").length).toBe(2);
+        expect(page("ol.report-citations li").length).toBe(2);
+    });
+
+    it("names PubMed as a navigation and never as a loaded resource", () => {
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        const link = "https://pubmed.ncbi.nlm.nih.gov/26997480/";
+
+        // A navigation costs no request when the page opens, thus the page still stands alone.
+        expect(referenceSites(html, link)).toEqual(["a[href]"]);
+    });
+
+    it("renders a stored pin that holds no record map as it did before", () => {
+        const withNoRecords = renderReportPage(twoOfEach, {})._unsafeUnwrap();
+        const withEmptyRecords = renderReportPage(twoOfEach, {}, {})._unsafeUnwrap();
+
+        expect(withNoRecords).toBe(withEmptyRecords);
+        expect(withNoRecords).not.toContain("pubmed.ncbi.nlm.nih.gov");
+        expect(withNoRecords).toContain("pmid:12345");
     });
 });
 

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -22,9 +22,8 @@ import { citationRecordOf, type CitationRecords } from "../report-model/referenc
 import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption } from "./chart.js";
 import { assemblePage, renderBand, renderReferenceSection } from "./views/page-view.js";
-import { citationKeyOf } from "./views/references-view.js";
 import { renderClaim, renderNav, renderSection, renderText } from "./views/prose.js";
-import { ReferenceLedger } from "./references.js";
+import { citationKeyOf, ReferenceLedger } from "./references.js";
 import type { RenderProblem, RenderValue, RenderValues } from "./types.js";
 import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable } from "./views/values.js";
 

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -8,7 +8,8 @@
  *
  * One shared `ReferenceLedger` threads through the whole walk. Thus a claim marker and a citation marker
  * count by first appearance across the page, and a reference that two blocks share keeps one number and one
- * list entry.
+ * list entry. The ledger holds one ladder for the artifact footnotes and one ladder for the literature,
+ * thus the two marker sequences count apart.
  *
  * The output is a pure function of the two inputs. The renderer reads no clock, no random value, and no
  * locale. Thus the same document and the same values give the same bytes.
@@ -17,34 +18,39 @@
 import { err, ok, type Result } from "neverthrow";
 
 import type { Block, ReportDocument } from "../contracts/report-blocks.js";
+import { citationRecordOf, type CitationRecords } from "../report-model/reference-resolver.js";
 import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption } from "./chart.js";
 import { assemblePage, renderBand, renderReferenceSection } from "./views/page-view.js";
+import { citationKeyOf } from "./views/references-view.js";
 import { renderClaim, renderNav, renderSection, renderText } from "./views/prose.js";
 import { ReferenceLedger } from "./references.js";
 import type { RenderProblem, RenderValue, RenderValues } from "./types.js";
 import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable } from "./views/values.js";
 
 /**
- * Render a report document and its value map to one HTML string.
+ * Render a report document, its value map, and the pinned citation records to one HTML string.
  *
  * The walk collects every value problem. When any problem exists, the render returns the problems and no
  * HTML. When no problem exists, the render assembles the page and returns the string.
+ *
+ * The records are the bibliography of the pin, and they are optional. A caller that passes none renders
+ * each citation from its key alone, thus a stored pin that holds no record map renders as it did before.
  */
-export function renderReportPage(document: ReportDocument, values: RenderValues): Result<string, RenderProblem[]> {
+export function renderReportPage(document: ReportDocument, values: RenderValues, records?: CitationRecords): Result<string, RenderProblem[]> {
     const problems: RenderProblem[] = [];
     const ledger = new ReferenceLedger();
 
     const content: string[] = [];
     for (const [index, section] of document.sections.entries()) {
-        content.push(renderBand(index, renderBlock(section, values, ledger, 0, problems)));
+        content.push(renderBand(index, renderBlock(section, values, ledger, records, 0, problems)));
     }
     if (problems.length > 0) {
         return err(problems);
     }
 
     const nav = renderNav(document.sections);
-    const references = renderReferenceSection(ledger, document.sections.length);
+    const references = renderReferenceSection(ledger, document.sections.length, records);
     return ok(assemblePage(document.title, nav, content.join(""), references));
 }
 
@@ -53,14 +59,21 @@ export function renderReportPage(document: ReportDocument, values: RenderValues)
  * or of the wrong shape adds one problem and renders nothing. The empty result drops out, because the whole
  * render fails when any problem exists.
  */
-function renderBlock(block: Block, values: RenderValues, ledger: ReferenceLedger, depth: number, problems: RenderProblem[]): string {
+function renderBlock(
+    block: Block,
+    values: RenderValues,
+    ledger: ReferenceLedger,
+    records: CitationRecords | undefined,
+    depth: number,
+    problems: RenderProblem[],
+): string {
     switch (block.kind) {
         case "text":
             return renderText(block);
         case "claim":
             return renderClaim(block, ledger);
         case "citation":
-            return renderCitation(block, ledger);
+            return renderCitation(block, ledger, citationRecordOf(records, citationKeyOf(block.binding)));
         case "metric": {
             const entry = values[block.id];
             if (entry === undefined) {
@@ -115,7 +128,7 @@ function renderBlock(block: Block, values: RenderValues, ledger: ReferenceLedger
             return renderChart(block, option.value);
         }
         case "section":
-            return renderSection(block, depth, renderChildren(block.blocks, values, ledger, depth + 1, problems));
+            return renderSection(block, depth, renderChildren(block.blocks, values, ledger, records, depth + 1, problems));
     }
 }
 
@@ -125,14 +138,21 @@ function renderBlock(block: Block, values: RenderValues, ledger: ReferenceLedger
  * A run of two or more metric blocks reads as one row of statistics, thus the grid holds the whole run. A
  * lone metric stays one card, and no grid wraps it. A block of a different kind ends the run.
  */
-function renderChildren(blocks: Block[], values: RenderValues, ledger: ReferenceLedger, depth: number, problems: RenderProblem[]): string {
+function renderChildren(
+    blocks: Block[],
+    values: RenderValues,
+    ledger: ReferenceLedger,
+    records: CitationRecords | undefined,
+    depth: number,
+    problems: RenderProblem[],
+): string {
     const parts: string[] = [];
     let index = 0;
     while (index < blocks.length) {
         const run = metricRunLength(blocks, index);
         const rendered: string[] = [];
         for (let offset = 0; offset < Math.max(run, 1); offset += 1) {
-            rendered.push(renderBlock(blocks[index + offset], values, ledger, depth, problems));
+            rendered.push(renderBlock(blocks[index + offset], values, ledger, records, depth, problems));
         }
         parts.push(run > 1 ? renderMetricGrid(rendered.join("")) : rendered.join(""));
         index += Math.max(run, 1);

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -21,6 +21,7 @@ import { raw } from "hono/html";
 
 import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_ENHANCER } from "../page.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
+import type { CitationRecords } from "../../report-model/reference-resolver.js";
 import type { ReferenceLedger } from "../references.js";
 import { renderReferenceList } from "./references-view.js";
 import { scriptJson } from "../script-json.js";
@@ -69,11 +70,12 @@ export function renderBand(index: number, inner: string): string {
 }
 
 /**
- * Wrap the reference list in the final band. An empty ledger gives an empty string, thus the page shows no
- * empty reference band. The index continues the band alternation of the sections.
+ * Wrap the appendix lists in the final band. An empty ledger gives an empty string, thus the page shows no
+ * empty reference band. The index continues the band alternation of the sections. The records carry the
+ * bibliography of each cited key, and a ledger with no citation reads none of them.
  */
-export function renderReferenceSection(ledger: ReferenceLedger, index: number): string {
-    const list = renderReferenceList(ledger);
+export function renderReferenceSection(ledger: ReferenceLedger, index: number, records?: CitationRecords): string {
+    const list = renderReferenceList(ledger, records);
     if (list === "") {
         return "";
     }

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -1,5 +1,5 @@
 /**
- * The page assembly: the hero, the bands, the reference band, and the footer.
+ * The page assembly: the hero, the bands, the appendix bands, and the footer.
  *
  * The skeleton inlines the style rules in the head, and it puts the five scripts at the end of the body.
  * The order of the first three scripts is a contract. The theme registration runs before the chart
@@ -23,7 +23,7 @@ import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_ENHAN
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { CitationRecords } from "../../report-model/reference-resolver.js";
 import type { ReferenceLedger } from "../references.js";
-import { renderReferenceList } from "./references-view.js";
+import { renderBibliography, renderReferenceList } from "./references-view.js";
 import { scriptJson } from "../script-json.js";
 
 /** The constant eyebrow of the hero. The render reads no clock, thus the hero carries no date. */
@@ -32,8 +32,11 @@ const HERO_EYEBROW = "INFLEXA · ANALYSIS REPORT";
 /** The constant note of the footer. */
 const FOOTER_NOTE = "Powered by Inflexa";
 
-/** The title of the auto-generated appendix. The literature stays in the citation blocks of the sections. */
+/** The title of the provenance appendix. It holds where each value of the report came from. */
 const PROVENANCE_TITLE = "Data provenance";
+
+/** The title of the bibliography. It holds each paper that a citation of the report names. */
+const LITERATURE_TITLE = "Literature";
 
 /**
  * The theme object as script-safe JSON. `scriptJson` replaces every `<` with `\u003c`, thus a later edit
@@ -69,18 +72,31 @@ export function renderBand(index: number, inner: string): string {
     );
 }
 
+/** The heading of one appendix band. The two appendices read alike, thus one heading form serves both. */
+function appendixHeading(title: string): string {
+    return String(<h2 class="report-heading report-heading-3 report-ref-title">{title}</h2>);
+}
+
 /**
- * Wrap the appendix lists in the final band. An empty ledger gives an empty string, thus the page shows no
- * empty reference band. The index continues the band alternation of the sections. The records carry the
- * bibliography of each cited key, and a ledger with no citation reads none of them.
+ * Wrap each appendix in a band of its own: the provenance of the values, then the literature. The two
+ * answer different questions, thus each one wears its own title and a reader never reads a paper under
+ * the provenance heading.
+ *
+ * An empty ladder renders no band, thus a report with citations alone shows the literature title alone.
+ * The index continues the band alternation of the sections, and a band that renders takes the next one.
+ * The records carry the bibliography of each cited key, and a ledger with no citation reads none of them.
  */
 export function renderReferenceSection(ledger: ReferenceLedger, index: number, records?: CitationRecords): string {
-    const list = renderReferenceList(ledger, records);
-    if (list === "") {
-        return "";
+    const bands: string[] = [];
+    const provenance = renderReferenceList(ledger);
+    if (provenance !== "") {
+        bands.push(renderBand(index, appendixHeading(PROVENANCE_TITLE) + provenance));
     }
-    const heading = String(<h2 class="report-heading report-heading-3 report-ref-title">{PROVENANCE_TITLE}</h2>);
-    return renderBand(index, heading + list);
+    const literature = renderBibliography(ledger, records);
+    if (literature !== "") {
+        bands.push(renderBand(index + bands.length, appendixHeading(LITERATURE_TITLE) + literature));
+    }
+    return bands.join("");
 }
 
 /**

--- a/harness/src/report-render/views/prose.test.ts
+++ b/harness/src/report-render/views/prose.test.ts
@@ -23,10 +23,24 @@ describe("renderClaim", () => {
         const ledger = new ReferenceLedger();
         const htmlA = renderClaim(claimA, ledger);
         const htmlB = renderClaim(claimB, ledger);
-        expect(htmlA).toContain(`href="#ref-1"`);
-        expect(htmlB).toContain(`href="#ref-1"`);
+        // A citation binding marks in the bracket ladder, thus the two claims point at the bibliography.
+        expect(htmlA).toContain(`href="#cite-1"`);
+        expect(htmlB).toContain(`href="#cite-1"`);
         // The shared reference holds one entry, thus the ledger counts it one time.
-        expect(ledger.entries().length).toBe(1);
+        expect(ledger.citationEntries().length).toBe(1);
+    });
+
+    it("gives an artifact binding a superscript and a citation binding a bracket", () => {
+        const artifact: Reference = { kind: "artifact-value", path: "runs/r1/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
+        const paper: Reference = { kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" };
+        const claim: ClaimBlock = { kind: "claim", id: "c4", content: { prose: "A claim." }, bindings: [artifact, paper] };
+
+        const html = renderClaim(claim, new ReferenceLedger());
+
+        // The two ladders each start at one, thus the form of the marker states which list it points at.
+        expect(html).toContain(`href="#ref-1"`);
+        expect(html).toContain(`href="#cite-1"`);
+        expect(html).toContain("[1]");
     });
 
     it("keeps a script tag in the prose as text", () => {

--- a/harness/src/report-render/views/prose.tsx
+++ b/harness/src/report-render/views/prose.tsx
@@ -10,7 +10,7 @@ import { raw } from "hono/html";
 
 import type { ClaimBlock, SectionBlock, TextBlock } from "../../contracts/report-blocks.js";
 import type { ReferenceLedger } from "../references.js";
-import { Marker } from "./references-view.js";
+import { LadderMarker } from "./references-view.js";
 
 /** The paragraph class of a text block and a claim block. The paragraph fills the content column. */
 const PARAGRAPH_CLASS = "report-prose";
@@ -49,11 +49,12 @@ export function renderText(block: TextBlock): string {
 /**
  * Render a claim block as escaped paragraphs plus evidence markers. The markers attach to the last
  * paragraph, thus they sit at the end of the claim text. The ledger marks each binding, thus a shared
- * reference keeps one number across the page.
+ * reference keeps one number across the page. A binding of an artifact gives a superscript, and a binding
+ * of a citation gives a bracket, because the two ladders count apart.
  */
 export function renderClaim(block: ClaimBlock, ledger: ReferenceLedger): string {
-    const markerNumbers = block.bindings.map((reference) => ledger.mark(reference));
-    const markers = markerNumbers.map((n) => <Marker n={n} />);
+    const marks = block.bindings.map((reference) => ledger.mark(reference));
+    const markers = marks.map((mark) => <LadderMarker mark={mark} />);
     const paragraphs = splitParagraphs(block.content.prose);
     if (paragraphs.length === 0) {
         return String(<p class={PARAGRAPH_CLASS}>{markers}</p>);

--- a/harness/src/report-render/views/references-view.tsx
+++ b/harness/src/report-render/views/references-view.tsx
@@ -4,18 +4,16 @@
  * The runtime escapes each child and each attribute value, thus a hostile path, a hostile id, or a
  * hostile operation reaches the page as text. Each list keeps the first-appearance order of its ladder,
  * thus the ordinal of each item matches its marker.
+ *
+ * The two lists render apart, because each one answers a different question and each one wears its own
+ * heading. A page with one empty ladder renders that list not at all.
  */
 
 import type { PropsWithChildren } from "hono/jsx";
 
 import { citationRecordOf, type CitationRecords } from "../../report-model/reference-resolver.js";
 import type { ArtifactValueReference, CitationReference } from "../../contracts/report-reference.js";
-import type { ProvenanceReference, ReferenceLedger, ReferenceMark } from "../references.js";
-
-/** The citation key of one citation reference, in the prefixed `idKind:id` form. */
-export function citationKeyOf(reference: CitationReference): string {
-    return `${reference.idKind}:${reference.id}`;
-}
+import { citationKeyOf, type ProvenanceReference, type ReferenceLedger, type ReferenceMark } from "../references.js";
 
 /**
  * One provenance marker as a superscript that links to the list entry. The number comes from the ledger as
@@ -117,12 +115,17 @@ function ReferenceEntry({ reference }: { reference: ProvenanceReference }) {
 }
 
 /**
- * The inner markup of one bibliography entry: the short citation of the pinned record, and the key. A key
- * that the record map does not hold shows the key alone, because absence is a normal condition.
+ * The inner markup of one bibliography entry: the short citation of the pinned record, the key, and the
+ * description of the record on a line of its own. A key that the record map does not hold shows the key
+ * alone, because absence is a normal condition.
+ *
+ * The description sits in the appendix and never on the card. The card sits in the body of the report,
+ * where a paragraph about the paper competes with the prose around it.
  */
 function CitationEntry({ reference, records }: { reference: CitationReference; records: CitationRecords | undefined }) {
     const key = citationKeyOf(reference);
     const record = citationRecordOf(records, key);
+    const description = record?.description;
     return (
         <>
             {record !== undefined ? (
@@ -131,44 +134,50 @@ function CitationEntry({ reference, records }: { reference: CitationReference; r
                 </>
             ) : null}
             <Detail>{key}</Detail>
+            {description !== undefined ? <div class="report-cite-description">{description}</div> : null}
         </>
     );
 }
 
 /**
- * The two appendix lists for the end of the page: the provenance of the values, and the literature. Each
- * list is an appendix: a reader consults one entry from a marker, thus the design keeps both quieter than
- * the body. A ladder with no entry renders no list, and an empty ledger gives an empty string.
- *
- * The bibliography holds one entry for each cited key, in the order of the citation ladder. Thus the
- * bracket marker of a card names the position of its entry.
+ * The provenance list of the appendix: one entry for each artifact reference and each derivation, in the
+ * order of the provenance ladder. The list is an appendix: a reader consults one entry from a marker, thus
+ * the design keeps it quieter than the body. A ledger with no provenance entry gives an empty string, thus
+ * the page shows no empty list.
  */
-export function renderReferenceList(ledger: ReferenceLedger, records?: CitationRecords): string {
-    const provenance = ledger.provenanceEntries();
-    const citations = ledger.citationEntries();
-    if (provenance.length === 0 && citations.length === 0) {
+export function renderReferenceList(ledger: ReferenceLedger): string {
+    const entries = ledger.provenanceEntries();
+    if (entries.length === 0) {
         return "";
     }
     return String(
-        <>
-            {provenance.length > 0 ? (
-                <ol class="report-references">
-                    {provenance.map((reference, index) => (
-                        <li id={`ref-${index + 1}`} class="report-ref-item">
-                            <ReferenceEntry reference={reference} />
-                        </li>
-                    ))}
-                </ol>
-            ) : null}
-            {citations.length > 0 ? (
-                <ol class="report-citations">
-                    {citations.map((reference, index) => (
-                        <li id={`cite-${index + 1}`} class="report-ref-item">
-                            <span class="report-cite-index">{`[${index + 1}]`}</span> <CitationEntry reference={reference} records={records} />
-                        </li>
-                    ))}
-                </ol>
-            ) : null}
-        </>,
+        <ol class="report-references">
+            {entries.map((reference, index) => (
+                <li id={`ref-${index + 1}`} class="report-ref-item">
+                    <ReferenceEntry reference={reference} />
+                </li>
+            ))}
+        </ol>,
+    );
+}
+
+/**
+ * The bibliography of the appendix: one entry for each cited key, in the order of the citation ladder.
+ * Thus the bracket marker of a card names the position of its entry. A ledger with no citation gives an
+ * empty string.
+ */
+export function renderBibliography(ledger: ReferenceLedger, records?: CitationRecords): string {
+    const entries = ledger.citationEntries();
+    if (entries.length === 0) {
+        return "";
+    }
+    return String(
+        <ol class="report-citations">
+            {entries.map((reference, index) => (
+                <li id={`cite-${index + 1}`} class="report-ref-item">
+                    <span class="report-cite-index">{`[${index + 1}]`}</span> <CitationEntry reference={reference} records={records} />
+                </li>
+            ))}
+        </ol>,
     );
 }

--- a/harness/src/report-render/views/references-view.tsx
+++ b/harness/src/report-render/views/references-view.tsx
@@ -1,18 +1,24 @@
 /**
- * The reference markup: the evidence marker and the ordered provenance list.
+ * The reference markup: the two evidence markers, the ordered provenance list, and the bibliography.
  *
  * The runtime escapes each child and each attribute value, thus a hostile path, a hostile id, or a
- * hostile operation reaches the page as text. The list keeps the first-appearance order of the ledger,
+ * hostile operation reaches the page as text. Each list keeps the first-appearance order of its ladder,
  * thus the ordinal of each item matches its marker.
  */
 
 import type { PropsWithChildren } from "hono/jsx";
 
-import type { ArtifactValueReference, Reference } from "../../contracts/report-reference.js";
-import type { ReferenceLedger } from "../references.js";
+import { citationRecordOf, type CitationRecords } from "../../report-model/reference-resolver.js";
+import type { ArtifactValueReference, CitationReference } from "../../contracts/report-reference.js";
+import type { ProvenanceReference, ReferenceLedger, ReferenceMark } from "../references.js";
+
+/** The citation key of one citation reference, in the prefixed `idKind:id` form. */
+export function citationKeyOf(reference: CitationReference): string {
+    return `${reference.idKind}:${reference.id}`;
+}
 
 /**
- * One evidence marker as a superscript that links to the list entry. The number comes from the ledger as
+ * One provenance marker as a superscript that links to the list entry. The number comes from the ledger as
  * an integer.
  */
 export function Marker({ n }: { n: number }) {
@@ -21,6 +27,23 @@ export function Marker({ n }: { n: number }) {
             <a href={`#ref-${n}`}>{n}</a>
         </sup>
     );
+}
+
+/**
+ * One citation marker as a bracket number that links to the bibliography entry. A reader of a paper reads
+ * a bracket as literature, thus the two ladders stay apart on sight.
+ */
+export function CitationMarker({ n }: { n: number }) {
+    return (
+        <span class="report-cite-marker">
+            <a href={`#cite-${n}`}>{`[${n}]`}</a>
+        </span>
+    );
+}
+
+/** The marker of one mark. The ladder of the mark selects the form, thus a marker and its anchor agree. */
+export function LadderMarker({ mark }: { mark: ReferenceMark }) {
+    return mark.ladder === "citation" ? <CitationMarker n={mark.n} /> : <Marker n={mark.n} />;
 }
 
 /** The kind label of one reference entry. */
@@ -54,11 +77,11 @@ function describeLocator(locator: ArtifactValueReference["locator"]): string {
 }
 
 /**
- * The inner markup of one list entry. An artifact entry names its path, and it adds the locator when the
- * reference pins one cell. A citation entry names its identifier space and its id. A derivation entry
- * names its operation and its two inputs, each by path and locator.
+ * The inner markup of one provenance entry. An artifact entry names its path, and it adds the locator when
+ * the reference pins one cell. A derivation entry names its operation and its two inputs, each by path and
+ * locator.
  */
-function ReferenceEntry({ reference }: { reference: Reference }) {
+function ReferenceEntry({ reference }: { reference: ProvenanceReference }) {
     switch (reference.kind) {
         case "artifact-value":
             return (
@@ -78,12 +101,6 @@ function ReferenceEntry({ reference }: { reference: Reference }) {
                     <RefKind>Artifact file</RefKind> <PathCode>{reference.path}</PathCode>
                 </>
             );
-        case "citation":
-            return (
-                <>
-                    <RefKind>Citation</RefKind> <Detail>{`${reference.idKind}:${reference.id}`}</Detail>
-                </>
-            );
         case "derivation":
             return (
                 <>
@@ -100,22 +117,58 @@ function ReferenceEntry({ reference }: { reference: Reference }) {
 }
 
 /**
- * The ordered provenance list for the end of the page. The list is an appendix: a reader consults one entry
- * from a marker, thus the design keeps it quieter than the body. An empty ledger gives an empty string, thus
- * the page shows no empty list.
+ * The inner markup of one bibliography entry: the short citation of the pinned record, and the key. A key
+ * that the record map does not hold shows the key alone, because absence is a normal condition.
  */
-export function renderReferenceList(ledger: ReferenceLedger): string {
-    const entries = ledger.entries();
-    if (entries.length === 0) {
+function CitationEntry({ reference, records }: { reference: CitationReference; records: CitationRecords | undefined }) {
+    const key = citationKeyOf(reference);
+    const record = citationRecordOf(records, key);
+    return (
+        <>
+            {record !== undefined ? (
+                <>
+                    <span class="report-cite-source">{record.citation}</span>{" "}
+                </>
+            ) : null}
+            <Detail>{key}</Detail>
+        </>
+    );
+}
+
+/**
+ * The two appendix lists for the end of the page: the provenance of the values, and the literature. Each
+ * list is an appendix: a reader consults one entry from a marker, thus the design keeps both quieter than
+ * the body. A ladder with no entry renders no list, and an empty ledger gives an empty string.
+ *
+ * The bibliography holds one entry for each cited key, in the order of the citation ladder. Thus the
+ * bracket marker of a card names the position of its entry.
+ */
+export function renderReferenceList(ledger: ReferenceLedger, records?: CitationRecords): string {
+    const provenance = ledger.provenanceEntries();
+    const citations = ledger.citationEntries();
+    if (provenance.length === 0 && citations.length === 0) {
         return "";
     }
     return String(
-        <ol class="report-references">
-            {entries.map((reference, index) => (
-                <li id={`ref-${index + 1}`} class="report-ref-item">
-                    <ReferenceEntry reference={reference} />
-                </li>
-            ))}
-        </ol>,
+        <>
+            {provenance.length > 0 ? (
+                <ol class="report-references">
+                    {provenance.map((reference, index) => (
+                        <li id={`ref-${index + 1}`} class="report-ref-item">
+                            <ReferenceEntry reference={reference} />
+                        </li>
+                    ))}
+                </ol>
+            ) : null}
+            {citations.length > 0 ? (
+                <ol class="report-citations">
+                    {citations.map((reference, index) => (
+                        <li id={`cite-${index + 1}`} class="report-ref-item">
+                            <span class="report-cite-index">{`[${index + 1}]`}</span> <CitationEntry reference={reference} records={records} />
+                        </li>
+                    ))}
+                </ol>
+            ) : null}
+        </>,
     );
 }

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -321,15 +321,53 @@ describe("renderFigure", () => {
 });
 
 describe("renderCitation", () => {
-    it("renders the marker and the optional note", () => {
-        const block: CitationBlock = {
-            kind: "citation",
-            id: "cit1",
-            binding: { kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" },
-            note: "see figure 2",
-        };
-        const html = renderCitation(block, new ReferenceLedger());
-        expect(html).toContain(`href="#ref-1"`);
+    /** One citation block over the given key, with a note. */
+    function citationBlock(idKind: "pmid" | "doi", id: string): CitationBlock {
+        return { kind: "citation", id: "cit1", binding: { kind: "citation", idKind, id, raw: "Doe 2020" }, note: "see figure 2" };
+    }
+
+    it("renders the bracket marker, the key, and the optional note", () => {
+        const html = renderCitation(citationBlock("pmid", "12345"), new ReferenceLedger());
+        expect(html).toContain(`href="#cite-1"`);
+        expect(html).toContain("[1]");
+        expect(html).toContain("pmid:12345");
         expect(html).toContain("see figure 2");
+    });
+
+    it("renders the short citation of a pmid record as a PubMed link", () => {
+        const html = renderCitation(citationBlock("pmid", "26997480"), new ReferenceLedger(), {
+            citation: "Hugo et al. 2016",
+            description: "The resistance paper.",
+        });
+
+        expect(html).toContain("Hugo et al. 2016");
+        expect(html).toContain(`href="https://pubmed.ncbi.nlm.nih.gov/26997480/"`);
+        // The card is the bibliography entry, thus it names the key beside the paper.
+        expect(html).toContain("pmid:26997480");
+        expect(html).toContain("see figure 2");
+    });
+
+    it("renders a record of another identifier space with no link", () => {
+        const html = renderCitation(citationBlock("doi", "10.1000/xyz"), new ReferenceLedger(), { citation: "Roe et al. 2021" });
+
+        expect(html).toContain("Roe et al. 2021");
+        expect(html).toContain("doi:10.1000/xyz");
+        expect(html).not.toContain("pubmed.ncbi.nlm.nih.gov");
+    });
+
+    it("renders a key that the record map does not hold with no citation and no link", () => {
+        const html = renderCitation(citationBlock("pmid", "12345"), new ReferenceLedger());
+
+        expect(html).not.toContain("report-citation-source");
+        expect(html).not.toContain("pubmed.ncbi.nlm.nih.gov");
+        expect(html).toContain("pmid:12345");
+    });
+
+    it("keeps a hostile id inside the link and inside the key", () => {
+        const html = renderCitation(citationBlock("pmid", '1" onclick="alert(1)'), new ReferenceLedger(), { citation: "Doe 2020" });
+
+        // The escape of the attribute holds the quote, and the encode of the id holds the space.
+        expect(html).not.toContain(`onclick="alert(1)"`);
+        expect(html).toContain("https://pubmed.ncbi.nlm.nih.gov/1%22%20onclick%3D%22alert(1)/");
     });
 });

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -1,5 +1,8 @@
 /**
- * The value markup: the metric card, the data table, the figure, and the inline citation.
+ * The value markup: the metric card, the data table, the figure, and the citation card.
+ *
+ * The citation card is the bibliography entry of its source. It carries the one link of the page body,
+ * which is a navigation to PubMed, thus the page loads nothing from a remote host.
  *
  * The caller resolves each value, and it narrows the value to the shape that the block needs. The runtime
  * escapes every interpolated string, thus a hostile label, a hostile cell, a hostile caption, or a
@@ -22,7 +25,8 @@ import { raw } from "hono/html";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import { declaredForColumn, type ColumnMeaning } from "../../contracts/report-reference.js";
-import { Marker } from "./references-view.js";
+import type { CitationRecord } from "../../report-model/reference-resolver.js";
+import { citationKeyOf, LadderMarker } from "./references-view.js";
 import { formatNumberCell, holdsAPValue, selectNumberKind, smallestPositiveValue } from "../number-format.js";
 import type { ReferenceLedger } from "../references.js";
 import type { RenderValue } from "../types.js";
@@ -290,20 +294,46 @@ export function renderFigure(block: FigureBlock, value: FigureValue): string {
 }
 
 /**
- * Render a citation block as a card in the reference form. The binding joins the ledger like a claim
- * binding, thus one shared source keeps one number. The optional note renders after the marker.
+ * The PubMed address of one identifier. The address is deterministic, and an anchor loads nothing, thus a
+ * page with such a link still stands alone.
  */
-export function renderCitation(block: CitationBlock, ledger: ReferenceLedger): string {
-    const n = ledger.mark(block.binding);
+const PUBMED_BASE = "https://pubmed.ncbi.nlm.nih.gov/";
+
+/**
+ * Render a citation block as a bibliography card. The binding joins the citation ladder like a claim
+ * binding, thus one shared source keeps one bracket number. The card shows the marker, the short citation
+ * of the pinned record, the optional note, and the citation key.
+ *
+ * The short citation of a `pmid:` record carries the PubMed link of its identifier. A key of another
+ * identifier space shows the citation as text. A key with no pinned record shows the key and the note
+ * alone, because absence is a normal condition and no text stands in for the paper.
+ */
+export function renderCitation(block: CitationBlock, ledger: ReferenceLedger, record?: CitationRecord): string {
+    const mark = ledger.mark(block.binding);
+    const binding = block.binding;
+    const key = citationKeyOf(binding);
     return String(
         <div class="report-citation corner-accents">
-            <Marker n={n} />
+            <LadderMarker mark={mark} />
+            {record !== undefined ? (
+                <>
+                    {" "}
+                    {binding.idKind === "pmid" ? (
+                        <a class="report-citation-source" href={`${PUBMED_BASE}${encodeURIComponent(binding.id)}/`}>
+                            {record.citation}
+                        </a>
+                    ) : (
+                        <span class="report-citation-source">{record.citation}</span>
+                    )}
+                </>
+            ) : null}
             {block.note !== undefined ? (
                 <>
                     {" "}
                     <span class="report-citation-note">{block.note}</span>
                 </>
-            ) : null}
+            ) : null}{" "}
+            <span class="report-citation-key">{key}</span>
         </div>,
     );
 }

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -26,9 +26,9 @@ import { raw } from "hono/html";
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import { declaredForColumn, type ColumnMeaning } from "../../contracts/report-reference.js";
 import type { CitationRecord } from "../../report-model/reference-resolver.js";
-import { citationKeyOf, LadderMarker } from "./references-view.js";
+import { LadderMarker } from "./references-view.js";
 import { formatNumberCell, holdsAPValue, selectNumberKind, smallestPositiveValue } from "../number-format.js";
-import type { ReferenceLedger } from "../references.js";
+import { citationKeyOf, type ReferenceLedger } from "../references.js";
 import type { RenderValue } from "../types.js";
 
 /**

--- a/harness/src/state/report-session-state.test.ts
+++ b/harness/src/state/report-session-state.test.ts
@@ -79,6 +79,33 @@ describe("createReportSessionStateStore", () => {
         expect(state!.snapshot).toEqual(snapshot);
     });
 
+    it("keeps the citation records of a pin, and reads a pin with no record map as it stands", async () => {
+        const analysisId = "analysis-citation-records";
+        await seedAnalysis(analysisId);
+        const withRecords = "thread-citation-records";
+        const legacy = "thread-citation-legacy";
+
+        const pinned: ReportSnapshot = {
+            ...snapshot,
+            citationRecords: { "pmid:12345": { citation: "Smith 2020", description: "The primary paper." } },
+        };
+        (await store.writeSnapshot({ threadId: withRecords, analysisId, snapshot: pinned }))._unsafeUnwrap();
+        const read = (await store.readState(withRecords))._unsafeUnwrap();
+        expect(read!.snapshot).toEqual(pinned);
+
+        // A stored pin that predates the map carries the key list alone. It loads with no map, thus each
+        // reader falls back to the bare key.
+        (await store.writeSnapshot({ threadId: legacy, analysisId, snapshot }))._unsafeUnwrap();
+        await pool.query({
+            text: `UPDATE cortex_report_session_state SET snapshot = $2::jsonb WHERE thread_id = $1`,
+            values: [legacy, JSON.stringify({ artifacts: snapshot.artifacts, citations: ["pmid:12345"] })],
+        });
+
+        const legacySnapshot = (await store.readState(legacy))._unsafeUnwrap()!.snapshot!;
+        expect(legacySnapshot.citations).toEqual(["pmid:12345"]);
+        expect(legacySnapshot.citationRecords).toBeUndefined();
+    });
+
     it("keeps the first row when a second write runs on the same thread", async () => {
         const analysisId = "analysis-insert-if-absent";
         await seedAnalysis(analysisId);

--- a/harness/src/state/snapshot-parse.ts
+++ b/harness/src/state/snapshot-parse.ts
@@ -35,6 +35,12 @@ const ArtifactSnapshotSchema = z.object({
 /** The citation list of a stored snapshot. A snapshot with no list reads as an absent field. */
 const CitationsSchema = z.array(z.string()).optional();
 
+/**
+ * The citation records of a stored snapshot, keyed by the citation key. A snapshot with no map reads as
+ * an absent field, thus a pin that predates the map loads the same as it did before.
+ */
+const CitationRecordsSchema = z.record(z.string(), z.object({ citation: z.string(), description: z.string().optional() })).optional();
+
 /** Reduce a zod error to the dotted path and the message of each issue. */
 export function reduceIssues(error: z.ZodError): SchemaIssue[] {
     return error.issues.map((issue) => ({
@@ -78,6 +84,10 @@ export function parseSnapshot(stored: unknown): Result<ReportSnapshot, SchemaIss
     if (!citations.success) {
         return err(prefixIssues("citations", reduceIssues(citations.error)));
     }
+    const citationRecords = CitationRecordsSchema.safeParse(stored.citationRecords);
+    if (!citationRecords.success) {
+        return err(prefixIssues("citationRecords", reduceIssues(citationRecords.error)));
+    }
     // The map takes a null prototype, the same as the pin, thus a path such as
     // `__proto__` stays an ordinary entry and never reaches a prototype slot.
     const artifacts: Record<string, ArtifactSnapshot> = Object.create(null);
@@ -93,5 +103,11 @@ export function parseSnapshot(stored: unknown): Result<ReportSnapshot, SchemaIss
     if (issues.length > 0) {
         return err(issues);
     }
-    return citations.data === undefined ? ok({ artifacts }) : ok({ artifacts, citations: citations.data });
+    // An absent part stays absent in the parsed value. Thus a reload gives the same shape that the pin
+    // wrote, and an equality test over a stored snapshot holds across the round trip.
+    return ok({
+        artifacts,
+        ...(citations.data === undefined ? {} : { citations: citations.data }),
+        ...(citationRecords.data === undefined ? {} : { citationRecords: citationRecords.data }),
+    });
 }

--- a/harness/src/tools/report-session/index.ts
+++ b/harness/src/tools/report-session/index.ts
@@ -30,4 +30,5 @@ export {
     type ListPinnedArtifactsResult,
     type ListPinnedArtifactsToolDeps,
     type PinnedArtifact,
+    type PinnedCitation,
 } from "./list-artifacts.js";

--- a/harness/src/tools/report-session/list-artifacts.test.ts
+++ b/harness/src/tools/report-session/list-artifacts.test.ts
@@ -359,9 +359,29 @@ describe("the pinned citations", () => {
 
         expect(result.outcome).toBe("listed");
         if (result.outcome === "listed") {
-            // The agent binds a citation block to one of these ids, thus the listing is the route to an
-            // id and a refusal never has to teach one.
-            expect(result.citations).toEqual(["pmid:12345", "pmid:42", "pmid:999"]);
+            // The agent binds a citation block to one of these keys, thus the listing is the route to a
+            // key and a refusal never has to teach one.
+            expect(result.citations).toEqual([{ key: "pmid:12345" }, { key: "pmid:42" }, { key: "pmid:999" }]);
+        }
+    });
+
+    it("names the paper beside the key that the pin recorded", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", {
+            artifacts: { "runs/r1/step-a/output/de.csv": { hash: "sha256:aaa", fileType: "output" } },
+            citations: ["pmid:26997480", "pmid:999"],
+            citationRecords: { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } },
+        });
+        const tool = createListPinnedArtifactsTool({ gateway, resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("listed");
+        if (result.outcome === "listed") {
+            // The description stays out, because the listing is an orientation surface. A key with no
+            // record lists bare.
+            expect(result.citations).toEqual([{ key: "pmid:26997480", citation: "Hugo et al. 2016" }, { key: "pmid:999" }]);
         }
     });
 

--- a/harness/src/tools/report-session/list-artifacts.ts
+++ b/harness/src/tools/report-session/list-artifacts.ts
@@ -2,8 +2,9 @@
  * The pinned-artifact listing tool of a report session.
  *
  * The tool reads the frozen snapshot of the thread, and it gives the pinned set: the path, the content
- * hash, the file type, and the header columns of a tabular artifact, plus the pinned citation ids. Thus
- * one call orients the agent, and a reference binds to a path or to a citation id of that set.
+ * hash, the file type, and the header columns of a tabular artifact, plus the pinned citations with the
+ * short citation of each. Thus one call orients the agent, and a reference binds to a path or to a
+ * citation key of that set.
  *
  * The order is the code-unit order of the path. Two calls over one snapshot give one listing, thus the
  * agent reads a stable set. A snapshot can pin many thousands of staged inputs, thus the listing stops at
@@ -26,7 +27,7 @@ import { resolveWorkspacePath, type ResolveWorkspaceRoot } from "../../workspace
 import { createNoopLogger } from "../../lib/console-logger.js";
 import { tryFs } from "../../lib/fs-result.js";
 import { defaultErrorFields, type Logger } from "../../lib/logger.js";
-import { fileTypeHoldsNoCell } from "../../report-model/reference-resolver.js";
+import { citationRecordOf, fileTypeHoldsNoCell } from "../../report-model/reference-resolver.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
 import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
 
@@ -49,18 +50,30 @@ export interface PinnedArtifact {
 }
 
 /**
+ * One pinned citation of the listing: the key, and the short citation of its pinned record.
+ *
+ * `citation` names which paper the key is, thus the agent binds a citation block with no guess. A key that
+ * the pin recorded no citation for carries none, because absence is a normal condition. The description of
+ * the record stays out, because the listing is an orientation surface.
+ */
+export interface PinnedCitation {
+    key: string;
+    citation?: string;
+}
+
+/**
  * The typed outcome of the listing tool. Each arm is ok-channel data, thus the tool never throws for one
  * of them.
  *
  * `total` counts the whole pinned set, and `truncated` says that the set holds more entries than
  * `artifacts` names. Thus the agent reads a partial listing as a partial listing.
  *
- * `citations` gives the pinned citation ids in the code-unit order that the pin stored. A citation
- * reference binds to one of them, thus the agent reads an id here and never out of a refusal.
+ * `citations` gives the pinned citations in the code-unit order of the keys that the pin stored. A citation
+ * reference binds to one of those keys, thus the agent reads a key here and never out of a refusal.
  */
 export type ListPinnedArtifactsResult =
     | { outcome: "refused"; refusal: SessionRefusal }
-    | { outcome: "listed"; artifacts: PinnedArtifact[]; total: number; truncated: boolean; citations: string[] };
+    | { outcome: "listed"; artifacts: PinnedArtifact[]; total: number; truncated: boolean; citations: PinnedCitation[] };
 
 /**
  * The construction deps of the listing tool.
@@ -196,8 +209,9 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
             "file whose bytes do not read each give no columns. " +
             `The listing gives a maximum of ${LISTING_CAP} entries: "total" gives the size of the pinned set, and "truncated" says that the ` +
             "set holds more artifacts than this listing names. " +
-            '"citations" gives the pinned citation ids of this session, each in the "idKind:id" form. A citation block binds to one of ' +
-            "them, thus take an id from this list and never from a refusal. " +
+            '"citations" gives the pinned literature of this session. Each entry carries "key", the citation id in the "idKind:id" form, and ' +
+            '"citation", the short citation of the paper. A key that the pin recorded no citation for carries no "citation". A citation block ' +
+            "binds to a key of this list, thus take a key from here and never from a refusal. " +
             "The pin freezes at the start of the session, thus a reference binds to an artifact of this pinned set. " +
             "Read it to orient before you bind a block, and to choose the column that a locator names. " +
             "A reference names the path alone: the session stamps the hash from this evidence.",
@@ -251,9 +265,13 @@ export function createListPinnedArtifactsTool(deps: ListPinnedArtifactsToolDeps)
                 }
                 artifacts.push(artifact);
             }
-            // The pin stores the citation keys sorted, thus the listing passes them through. A snapshot
-            // that pinned no citation gives an empty list, and an empty list is a complete answer.
-            const citations = state.snapshot.citations ?? [];
+            // The pin stores the citation keys sorted, thus the listing keeps that order. A snapshot that
+            // pinned no citation gives an empty list, and an empty list is a complete answer. A key with no
+            // pinned record lists bare, thus a stored pin that holds no record map still orients the agent.
+            const citations: PinnedCitation[] = (state.snapshot.citations ?? []).map((key) => {
+                const record = citationRecordOf(state.snapshot.citationRecords, key);
+                return record === undefined ? { key } : { key, citation: record.citation };
+            });
             return ok({ outcome: "listed", artifacts, total: paths.length, truncated: paths.length > listed.length, citations });
         },
     });

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -343,7 +343,9 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
                 return ok({ outcome: "bridge-mismatch", mismatches: bridged.error });
             }
 
-            const rendered = renderReportPage(document, bridged.value);
+            // The records are the bibliography of the pin. They ride the render call and never the value
+            // map, because the appendix reads them beside the cards and the value map is keyed by block.
+            const rendered = renderReportPage(document, bridged.value, snapshot.citationRecords);
             if (rendered.isErr()) {
                 return ok({ outcome: "render-problems", problems: rendered.error });
             }


### PR DESCRIPTION
## What & why

The References section of the session page held no bibliography. The pin kept the bare `pmid:` keys, although the run synthesis carries the short citation and a description beside each id. The pin now stores a record beside each key, in an optional map, and the key list keeps the membership role. The citation card renders the short citation, the note, the key, and a PubMed link for a `pmid:` key. The citation markers number in their own bracket ladder, split from the artifact footnotes, and the appendix gains the bibliography list. The listing tool names the paper beside each key, thus the agent binds a citation with no guess.

Reviewer notes: the records ride the render call and never the value map, because the appendix reads them beside the cards. The resolver membership logic is untouched, and a stored pin with no map reads as before — a state parse addition makes that round-trip real. The stands-alone rule narrows honestly: the page loads no remote resource, and a navigation anchor is the one admitted remote reference. The record lookup admits own keys alone, thus a hostile key finds no inherited member.

Refs #395

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
