### PR TITLE
feat(harness): polish the chart text for a reader

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/design.md
@@ -24,5 +24,5 @@ Underscores become spaces in a series name, deterministically, at derivation tim
 
 ## Risks / Trade-offs
 
-- A volcano over a non-log2 effect column would carry a wrong x title. The guide lines at `±1` already make that claim, thus the title adds no new wrongness, and the agent axes override corrects both.
+- A volcano over a non-log2 effect column would carry a wrong x title. The guide lines at `±1` already make that claim, thus the title adds no new wrongness. A declared column label on the binding corrects the title, because a preset block carries no axes field.
 - Two category values that differ only in underscores collapse to one legend text. The series stay distinct, and the case is not real data practice.

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/design.md
@@ -1,0 +1,28 @@
+# Design: polish-the-chart-text
+
+## Context
+
+The preset expansions live in `src/report-render/chart-presets.ts`. `plainTitle` titles the x axis with the raw column, and a transformed channel takes no title, thus the derived name (`neg_log10(pvalue)`) states the y quantity. The reference-line annotations carry no position, and the chart runtime prints a vertical line's value label at the top. The series names take the raw category values (`chart.ts`, the group split), and the palette assigns colors by order.
+
+## Decisions
+
+### D1: A preset states its semantic titles, under the declared label
+
+The volcano guide lines sit at `±1`, which is a log2 claim. Thus the preset honestly titles its x axis "log2 fold change" and its y axis "−log10(p)". The manhattan titles its y axis "−log10(p)", and its x keeps the position column. The `ma` and `km` presets keep the column path, because their axes carry no fixed quantity. The precedence, most specific first: an agent axes title, a declared column label, the preset title, then the raw or derived name.
+
+### D2: The null category is the literal value `ns`
+
+The volcano convention writes the insignificant category as `ns`, and the preset draws the significance split itself. A category whose value is exactly `ns` on a preset-expanded chart takes the muted chart color of the design source. A wider heuristic would guess, and a wrong guess mutes a real finding. The rule is narrow, stated, and testable.
+
+### D3: A vertical guide labels at the axis end
+
+The label of a vertical reference line takes the start position, at the axis, out of the title band. A horizontal line keeps the end position, at the right edge, where the session page already reads well.
+
+### D4: A category series name prettifies at derivation
+
+Underscores become spaces in a series name, deterministically, at derivation time. The tooltip template reads the series name, thus the two agree. No legend hover carries the raw value, because a legend formatter is a function and the option rides as inline JSON. The raw value stays in the data rows, thus the provenance loses nothing.
+
+## Risks / Trade-offs
+
+- A volcano over a non-log2 effect column would carry a wrong x title. The guide lines at `±1` already make that claim, thus the title adds no new wrongness, and the agent axes override corrects both.
+- Two category values that differ only in underscores collapse to one legend text. The series stay distinct, and the case is not real data practice.

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: polish-the-chart-text
+
+## Why
+
+The volcano chart of the session prints machine text. The y axis reads `neg_log10(pvalue)`, the legend reads `up_in_nonresponders`, and the null category shouts in full green. The value labels of the vertical guide lines print at the top of the plot, in the band of the y-axis title.
+
+## What Changes
+
+- A preset fills its own semantic axis titles, because it knows its quantities. A volcano reads "log2 fold change" and "−log10(p)", and a manhattan reads "−log10(p)" on its y axis. The precedence: an agent axes title, then a declared column label, then the preset title, then the raw or derived name.
+- The category value `ns` on a preset chart takes the muted role of the palette. The significant categories carry the color, and the null category recedes.
+- The value labels of a vertical reference line move to the axis end, out of the title band. A horizontal line keeps its label at the right edge.
+- A category series name prettifies at derivation: underscores become spaces. The tooltip reads the same name, and the raw value stays in the data. No hover carries the raw name, because a legend formatter would be a function and the option rides as inline JSON.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-render`: the chart text rules — the preset titles, the muted null category, the guide-label position, and the legend prettify.
+
+## Impact
+
+- Affected code: `src/report-render/chart-presets.ts`, `src/report-render/chart.ts`, `src/report-render/design.ts` for the muted chart color, and their tests.
+- The derivation stays deterministic, and a chart with no preset and no category changes nothing.

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/specs/report-render/spec.md
@@ -8,7 +8,7 @@ A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change"
 
 The category value `ns` on a preset-expanded chart MUST take the muted chart color of the design source. Thus the significant categories carry the color, and the null category recedes.
 
-The value label of a vertical reference line MUST sit at the axis end, out of the title band. A horizontal line keeps its label at the right edge.
+The value label of a vertical reference line MUST sit at the axis end, out of the title band. A vertical reference band labels the same way. A horizontal line keeps its label at the right edge.
 
 A category series name MUST prettify at derivation: underscores become spaces, deterministically. The tooltip reads the same name, and the raw value stays in the data rows.
 

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/specs/report-render/spec.md
@@ -1,0 +1,38 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The chart text reads for a reader
+
+A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change" and "−log10(p)", and a manhattan titles "−log10(p)" on its y axis. The precedence, most specific first: an agent axes title, a declared column label, the preset title, then the raw or derived name.
+
+The category value `ns` on a preset-expanded chart MUST take the muted chart color of the design source. Thus the significant categories carry the color, and the null category recedes.
+
+The value label of a vertical reference line MUST sit at the axis end, out of the title band. A horizontal line keeps its label at the right edge.
+
+A category series name MUST prettify at derivation: underscores become spaces, deterministically. The tooltip reads the same name, and the raw value stays in the data rows.
+
+#### Scenario: The volcano titles its axes
+
+- **WHEN** the caller derives a `volcano` chart with no axes override and no declared label
+- **THEN** the x axis reads `log2 fold change`, and the y axis reads `−log10(p)`
+
+#### Scenario: A declared label beats the preset title
+
+- **WHEN** the binding declares a label for the effect column of a `volcano`
+- **THEN** the x axis reads the declared label
+
+#### Scenario: The null category recedes
+
+- **WHEN** a `volcano` groups by a column whose values hold `ns`
+- **THEN** the `ns` series carries the muted chart color, and the other series keep the palette
+
+#### Scenario: A vertical guide labels at the axis
+
+- **WHEN** the caller derives a chart with a vertical reference line
+- **THEN** the value label of the line sits at the axis end, and the title band stays clear
+
+#### Scenario: The legend reads words
+
+- **WHEN** a chart groups by a column whose value is `up_in_nonresponders`
+- **THEN** the series name reads `up in nonresponders`, and the data rows keep the raw value

--- a/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-polish-the-chart-text/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: polish-the-chart-text
+
+## 1. The preset titles
+
+- [x] 1.1 The volcano and the manhattan expansions fill their semantic axis titles in `src/report-render/chart-presets.ts`.
+- [x] 1.2 The title precedence lands where the axis name resolves: agent axes, declared label, preset title, then the raw or derived name.
+
+## 2. The muted null category
+
+- [x] 2.1 The design source names one muted chart color.
+- [x] 2.2 A preset-expanded chart assigns it to the series whose category value is exactly `ns`.
+
+## 3. The guide labels
+
+- [x] 3.1 A vertical reference line labels at the axis end, and a horizontal line keeps the right edge.
+
+## 4. The legend words
+
+- [x] 4.1 A category series name prettifies at derivation: underscores become spaces. The tooltip reads the same name.
+
+## 5. The proof
+
+- [x] 5.1 Tests cover the five delta scenarios, in the existing chart-test style.
+- [x] 5.2 A chart with no preset and no category stays byte-identical to before.
+- [x] 5.3 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -267,6 +267,41 @@ The renderer MUST hold one fixed derivation rule for each chart type. A chart wh
 - **WHEN** the caller renders a bar chart whose categories first appear as Day2, Day10, Day1
 - **THEN** the category axis lists Day2, Day10, Day1 in that order
 
+### Requirement: The chart text reads for a reader
+
+A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change" and "−log10(p)", and a manhattan titles "−log10(p)" on its y axis. The precedence, most specific first: an agent axes title, a declared column label, the preset title, then the raw or derived name.
+
+The category value `ns` on a preset-expanded chart MUST take the muted chart color of the design source. Thus the significant categories carry the color, and the null category recedes.
+
+The value label of a vertical reference line MUST sit at the axis end, out of the title band. A horizontal line keeps its label at the right edge.
+
+A category series name MUST prettify at derivation: underscores become spaces, deterministically. The tooltip reads the same name, and the raw value stays in the data rows.
+
+#### Scenario: The volcano titles its axes
+
+- **WHEN** the caller derives a `volcano` chart with no axes override and no declared label
+- **THEN** the x axis reads `log2 fold change`, and the y axis reads `−log10(p)`
+
+#### Scenario: A declared label beats the preset title
+
+- **WHEN** the binding declares a label for the effect column of a `volcano`
+- **THEN** the x axis reads the declared label
+
+#### Scenario: The null category recedes
+
+- **WHEN** a `volcano` groups by a column whose values hold `ns`
+- **THEN** the `ns` series carries the muted chart color, and the other series keep the palette
+
+#### Scenario: A vertical guide labels at the axis
+
+- **WHEN** the caller derives a chart with a vertical reference line
+- **THEN** the value label of the line sits at the axis end, and the title band stays clear
+
+#### Scenario: The legend reads words
+
+- **WHEN** a chart groups by a column whose value is `up_in_nonresponders`
+- **THEN** the series name reads `up in nonresponders`, and the data rows keep the raw value
+
 ### Requirement: The claim evidence renders as markers and a provenance appendix
 A claim MUST render its prose with evidence markers. The references MUST list at the end of the page under the title "Data provenance", styled as a muted appendix. The literature renders from citation blocks, and it stays separate from the appendix. The markers number by first appearance. An identical reference MUST appear one time in the list. Reference identity is the full reference value after a stable serialization, thus two references are identical only when every field matches. A derivation reference MUST list as its operation with its two pinned inputs, each named by path and locator.
 

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -273,7 +273,7 @@ A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change"
 
 The category value `ns` on a preset-expanded chart MUST take the muted chart color of the design source. Thus the significant categories carry the color, and the null category recedes.
 
-The value label of a vertical reference line MUST sit at the axis end, out of the title band. A horizontal line keeps its label at the right edge.
+The value label of a vertical reference line MUST sit at the axis end, out of the title band. A vertical reference band labels the same way. A horizontal line keeps its label at the right edge.
 
 A category series name MUST prettify at derivation: underscores become spaces, deterministically. The tooltip reads the same name, and the raw value stays in the data rows.
 

--- a/harness/src/report-render/chart-presets.ts
+++ b/harness/src/report-render/chart-presets.ts
@@ -12,15 +12,7 @@
  * channel and it drops an authored transform there, and no value takes the transform two times.
  */
 
-import {
-    channelColumn,
-    channelTransform,
-    type ChartAxes,
-    type ChartChannel,
-    type ChartComposition,
-    type ChartEncoding,
-    type ChartType,
-} from "../contracts/report-blocks.js";
+import { channelColumn, channelTransform, type ChartChannel, type ChartComposition, type ChartEncoding, type ChartType } from "../contracts/report-blocks.js";
 
 /** The four chart types that expand into a composition. */
 export const PRESET_CHART_TYPES = ["volcano", "manhattan", "ma", "km"] as const;
@@ -39,6 +31,21 @@ export const MANHATTAN_P_THRESHOLD = 5e-8;
 
 /** The baseline of an MA plot. A point above it rose, and a point below it fell. */
 export const MA_BASELINE = 0;
+
+/**
+ * The x title of a volcano. The two effect guides sit at `±1`, which is a log2 claim, thus the preset states
+ * the same quantity in words.
+ */
+const LOG2_EFFECT_TITLE = "log2 fold change";
+
+/** The y title of a preset that transforms its p column. The minus sign is the character, not a hyphen. */
+const NEG_LOG10_P_TITLE = "−log10(p)";
+
+/** The semantic axis titles of one preset. A preset whose axis carries no fixed quantity states none. */
+export interface PresetAxisTitles {
+    readonly x?: string;
+    readonly y?: string;
+}
 
 /** True when the chart type expands into a composition. */
 export function isPresetChartType(chartType: ChartType): chartType is PresetChartType {
@@ -87,7 +94,6 @@ function volcano(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): Cha
             { kind: "reference-line", axis: "x", value: -VOLCANO_EFFECT_THRESHOLD },
             { kind: "reference-line", axis: "x", value: VOLCANO_EFFECT_THRESHOLD },
         ],
-        axes: plainTitle(x),
     };
 }
 
@@ -102,7 +108,6 @@ function manhattan(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): C
             },
         ],
         annotations: [{ kind: "reference-line", axis: "y", value: -Math.log10(MANHATTAN_P_THRESHOLD), label: `p ${MANHATTAN_P_THRESHOLD}` }],
-        axes: plainTitle(x),
     };
 }
 
@@ -128,15 +133,30 @@ function km(x: ChartChannel, y: ChartChannel, encoding: ChartEncoding): ChartCom
 }
 
 /**
- * The x title of a preset.
+ * The semantic axis titles that one preset states.
  *
- * A preset titles the x axis with the column that feeds it. A channel that carries a transform plots a
- * derived quantity, thus the column name would state the wrong one. Such a channel takes no title, and the
- * derived name of the renderer states the true quantity. The y axis of a preset that transforms its p
- * column takes no title for the same reason.
+ * A preset knows its own quantities, thus it names them in words. A volcano plots a log2 effect against the
+ * transformed p, and a manhattan plots a genome position against the same transformed p. The `ma` and the
+ * `km` presets name nothing, because neither axis of them carries a fixed quantity.
+ *
+ * A channel that carries an authored transform plots a derived quantity, thus the semantic title would
+ * state the wrong one. Such a channel takes no title, and the derived name of the renderer states the true
+ * quantity. The y channel of a volcano and of a manhattan takes the transform of the preset itself, thus
+ * its title is exact.
+ *
+ * The titles rank under a declared column label. Thus they ride beside the composition and never inside its
+ * `axes` field, where an agent title sits and where they would outrank the label.
  */
-function plainTitle(x: ChartChannel): ChartAxes {
-    return channelTransform(x) === undefined ? { x: { title: channelColumn(x) } } : {};
+export function presetAxisTitles(preset: PresetChartType, x: ChartChannel): PresetAxisTitles {
+    switch (preset) {
+        case "volcano":
+            return { ...(channelTransform(x) === undefined ? { x: LOG2_EFFECT_TITLE } : {}), y: NEG_LOG10_P_TITLE };
+        case "manhattan":
+            return { y: NEG_LOG10_P_TITLE };
+        case "ma":
+        case "km":
+            return {};
+    }
 }
 
 /** The two optional channels that every preset carries through from the quick-path encoding. */

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -4,7 +4,7 @@ import type { ChartBlock, ChartComposition } from "../contracts/report-blocks.js
 import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption, type ChartRow, type EchartOption } from "./chart.js";
 import { MANHATTAN_P_THRESHOLD, VOLCANO_EFFECT_THRESHOLD, VOLCANO_P_THRESHOLD } from "./chart-presets.js";
-import { DESIGN_CSS } from "./design.js";
+import { DESIGN_CSS, MUTED_CHART_COLOR } from "./design.js";
 
 type Encoding = NonNullable<ChartBlock["encoding"]>;
 type ChartType = NonNullable<ChartBlock["chartType"]>;
@@ -797,16 +797,18 @@ describe("the preset expansion", () => {
         expect(asArr(series.data)[0]).toEqual({ value: [2.94, 3], name: "CA9" });
         expect(asArr(asObj(series.markLine).data)).toEqual([
             { yAxis: -Math.log10(VOLCANO_P_THRESHOLD), label: { formatter: `p ${VOLCANO_P_THRESHOLD}` } },
-            { xAxis: -VOLCANO_EFFECT_THRESHOLD },
-            { xAxis: VOLCANO_EFFECT_THRESHOLD },
+            // A vertical guide labels at the axis end, thus its value reads clear of the y-axis title.
+            { xAxis: -VOLCANO_EFFECT_THRESHOLD, label: { position: "start" } },
+            { xAxis: VOLCANO_EFFECT_THRESHOLD, label: { position: "start" } },
         ]);
-        expect(asObj(option.xAxis).name).toBe("lfc");
-        // The y channel carries the transform, thus the derived name states the plotted quantity.
-        expect(asObj(option.yAxis).name).toBe("neg_log10(p)");
+        // The preset knows its own quantities, thus each axis reads them in words.
+        expect(asObj(option.xAxis).name).toBe("log2 fold change");
+        expect(asObj(option.yAxis).name).toBe("−log10(p)");
     });
 
-    it("gives no x title to a preset channel that carries a transform", () => {
+    it("gives no semantic x title to a preset channel that carries a transform", () => {
         const option = derive(chartBlock("volcano", { x: { column: "lfc", transform: "abs" }, y: "p" }), rows);
+        // The channel plots the absolute effect, thus the log2 title would state the wrong quantity.
         expect(asObj(option.xAxis).name).toBe("abs(lfc)");
     });
 
@@ -860,6 +862,109 @@ describe("the preset expansion", () => {
         const problem = deriveChartOption(chartBlock("volcano", { x: "lfc" }, { id: "v1" }), rows)._unsafeUnwrapErr();
         expect(problem.detail).toContain("volcano");
         expect(problem.detail).toContain("y");
+    });
+});
+
+describe("the chart text", () => {
+    const rows: ChartRow[] = [
+        { gene: "A", lfc: 2.9, p: 0.001, sig: "up_in_nonresponders" },
+        { gene: "B", lfc: -2.4, p: 0.5, sig: "ns" },
+        { gene: "C", lfc: 0.1, p: 0.9, sig: "ns" },
+    ];
+
+    it("titles the volcano axes with the quantities that the preset plots", () => {
+        const option = derive(chartBlock("volcano", { x: "lfc", y: "p" }), rows);
+        expect(asObj(option.xAxis).name).toBe("log2 fold change");
+        expect(asObj(option.yAxis).name).toBe("−log10(p)");
+    });
+
+    it("titles the manhattan y axis, and keeps the position column on its x axis", () => {
+        const positions: ChartRow[] = [
+            { position: 10, p: 0.001, chrom: "1" },
+            { position: 20, p: 0.5, chrom: "2" },
+        ];
+        const option = derive(chartBlock("manhattan", { x: "position", y: "p" }), positions);
+        expect(asObj(option.yAxis).name).toBe("−log10(p)");
+        expect(asObj(option.xAxis).name).toBe("position");
+    });
+
+    it("keeps a declared column label over the preset title", () => {
+        const option = derive(chartBlock("volcano", { x: "lfc", y: "p" }, { labels: { lfc: "Fold change (log2)" } }), rows);
+        expect(asObj(option.xAxis).name).toBe("Fold change (log2)");
+    });
+
+    it("mutes the null category of a preset, and leaves each other series on the palette", () => {
+        const series = asArr(derive(chartBlock("volcano", { x: "lfc", y: "p", group: "sig" }), rows).series);
+        expect(series.map((entry) => asObj(entry).name)).toEqual(["up in nonresponders", "ns"]);
+        expect(asObj(series[1]).itemStyle).toEqual({ color: MUTED_CHART_COLOR });
+        // The palette assigns a color by the series order, thus a series that names none keeps its place.
+        expect("itemStyle" in asObj(series[0])).toBe(false);
+    });
+
+    it("leaves the null category of an authored composition on the palette", () => {
+        const option = derive(composedBlock({ series: [{ form: "scatter", encoding: { x: "lfc", y: "p", group: "sig" } }] }), rows);
+        const series = asArr(option.series);
+        expect(asObj(series[1]).name).toBe("ns");
+        // The rule reads the significance split that a preset draws itself, thus no authored series mutes.
+        expect("itemStyle" in asObj(series[1])).toBe(false);
+    });
+
+    it("labels a vertical guide at the axis end, and keeps a horizontal guide at the right edge", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "p" } }],
+                annotations: [
+                    { kind: "reference-line", axis: "x", value: 1, label: "effect" },
+                    { kind: "reference-line", axis: "y", value: 0.05, label: "p" },
+                ],
+            }),
+            rows,
+        );
+        const marks = asArr(asObj(asObj(asArr(option.series)[0]).markLine).data);
+        expect(marks[0]).toEqual({ xAxis: 1, label: { formatter: "effect", position: "start" } });
+        expect(marks[1]).toEqual({ yAxis: 0.05, label: { formatter: "p" } });
+    });
+
+    it("reads a category series name as words, and keeps the raw value in the data rows", () => {
+        const option = derive(chartBlock("bar", { x: "gene", y: "lfc", group: "sig" }), rows);
+        const series = asArr(option.series);
+        expect(asObj(series[0]).name).toBe("up in nonresponders");
+        // The legend text is presentation. The plotted pair keeps the cells of the row.
+        expect(asObj(series[0]).data).toEqual([["A", 2.9]]);
+        expect(asObj(option.xAxis).data).toEqual(["A", "B", "C"]);
+    });
+
+    it("prettifies the category half of a named series alone", () => {
+        const option = derive(composedBlock({ series: [{ form: "line", encoding: { x: "gene", y: "lfc", group: "sig" }, name: "Effect_size" }] }), rows);
+        // The author wrote the series name, thus it reaches the legend as written.
+        expect(asObj(asArr(option.series)[0]).name).toBe("Effect_size (up in nonresponders)");
+    });
+
+    it("keeps a chart with no preset and no category byte-identical", () => {
+        const option = derive(composedBlock({ series: [{ form: "scatter", encoding: { x: "lfc", y: "p" } }] }), rows);
+        expect(JSON.stringify(option)).toBe(
+            JSON.stringify({
+                tooltip: { trigger: "item", formatter: "{a}: {c}" },
+                xAxis: { type: "value", scale: true, name: "lfc", nameLocation: "middle", nameGap: 34, axisLabel: { interval: 0 } },
+                yAxis: { type: "value", scale: true, name: "p", axisLabel: { interval: 0 } },
+                series: [
+                    {
+                        type: "scatter",
+                        name: "p",
+                        large: true,
+                        largeThreshold: 2000,
+                        data: [
+                            [2.9, 0.001],
+                            [-2.4, 0.5],
+                            [0.1, 0.9],
+                        ],
+                    },
+                ],
+                legend: { show: false },
+                grid: { top: "8%", bottom: "20%", left: "10%", right: "5%" },
+                toolbox: { right: 0, top: 0, feature: { saveAsImage: { type: "png", name: "chart" } } },
+            }),
+        );
     });
 });
 

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -660,7 +660,8 @@ describe("the composition annotations", () => {
         const series = asObj(asArr(option.series)[0]);
         expect(asObj(series.markLine).silent).toBe(true);
         expect(asArr(asObj(series.markLine).data)).toEqual([{ yAxis: 6, label: { formatter: "cut" } }]);
-        expect(asArr(asObj(series.markArea).data)).toEqual([[{ xAxis: -1 }, { xAxis: 1 }]]);
+        // A vertical band labels at its inside bottom edge, thus the text sits at the axis and not on the title.
+        expect(asArr(asObj(series.markArea).data)).toEqual([[{ xAxis: -1, label: { position: "insideBottom" } }, { xAxis: 1 }]]);
     });
 
     it("names the declared top-N subset alone, and no other point", () => {
@@ -923,6 +924,54 @@ describe("the chart text", () => {
         const marks = asArr(asObj(asObj(asArr(option.series)[0]).markLine).data);
         expect(marks[0]).toEqual({ xAxis: 1, label: { formatter: "effect", position: "start" } });
         expect(marks[1]).toEqual({ yAxis: 0.05, label: { formatter: "p" } });
+    });
+
+    it("names a group-less preset series with the preset title, thus the tooltip reads no machine text", () => {
+        const series = asArr(derive(chartBlock("volcano", { x: "lfc", y: "p" }), rows).series);
+        // The `{a}` of the tooltip template reads this name, and the y axis reads the same text.
+        expect(asObj(series[0]).name).toBe("−log10(p)");
+    });
+
+    it("keeps a declared label over the preset title in the series name too", () => {
+        const option = derive(chartBlock("ma", { x: "lfc", y: "p" }, { labels: { p: "Adjusted p-value" } }), rows);
+        expect(asObj(asArr(option.series)[0]).name).toBe("Adjusted p-value");
+        expect(asObj(option.yAxis).name).toBe("Adjusted p-value");
+    });
+
+    it("puts the guide lines on a series that no muted color paints", () => {
+        // The null category appears first, thus the carrier of the marks is not the first emitted series.
+        const nsFirst: ChartRow[] = [
+            { gene: "B", lfc: -2.4, p: 0.5, sig: "ns" },
+            { gene: "A", lfc: 2.9, p: 0.001, sig: "up_in_nonresponders" },
+        ];
+        const series = asArr(derive(chartBlock("volcano", { x: "lfc", y: "p", group: "sig" }), nsFirst).series);
+        expect(asObj(series[0]).name).toBe("ns");
+        expect(asObj(series[0]).itemStyle).toEqual({ color: MUTED_CHART_COLOR });
+        // The runtime strokes a guide in the item color of its carrier, thus a muted carrier greys each guide.
+        expect("markLine" in asObj(series[0])).toBe(false);
+        expect(asArr(asObj(asObj(series[1]).markLine).data).length).toBe(3);
+    });
+
+    it("keeps the guide lines on the first series when every series is muted", () => {
+        const allNull: ChartRow[] = [
+            { gene: "B", lfc: -2.4, p: 0.5, sig: "ns" },
+            { gene: "C", lfc: 0.1, p: 0.9, sig: "ns" },
+        ];
+        const series = asArr(derive(chartBlock("volcano", { x: "lfc", y: "p", group: "sig" }), allNull).series);
+        // No series can carry a guide clear of the muted color, thus each guide still reaches the page.
+        expect(asArr(asObj(asObj(series[0]).markLine).data).length).toBe(3);
+    });
+
+    it("keeps a horizontal band on its default label position", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "scatter", encoding: { x: "lfc", y: "p" } }],
+                annotations: [{ kind: "reference-band", axis: "y", from: 0, to: 1, label: "range" }],
+            }),
+            rows,
+        );
+        const areas = asArr(asObj(asObj(asArr(option.series)[0]).markArea).data);
+        expect(areas[0]).toEqual([{ yAxis: 0, label: { formatter: "range" } }, { yAxis: 1 }]);
     });
 
     it("reads a category series name as words, and keeps the raw value in the data rows", () => {

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -104,6 +104,15 @@ const X_AXIS_NAME_GAP = 34;
 const VERTICAL_LABEL_POSITION = "start";
 
 /**
+ * The label position of a vertical guide band.
+ *
+ * A band is a rectangle, and the chart runtime gives it the element positions and not the line positions of
+ * a guide line. The inside bottom edge of a vertical band sits at the x axis, thus it is the position that
+ * matches the start of a vertical line.
+ */
+const VERTICAL_BAND_LABEL_POSITION = "insideBottom";
+
+/**
  * The y axis of a histogram.
  *
  * The axis counts rows, thus a fractional tick names no count. `minInterval` holds each tick a whole count
@@ -660,10 +669,14 @@ interface Point {
     y0?: Cell;
 }
 
-/** One runtime series, and whether it can carry the mark members of the annotations. */
+/**
+ * One runtime series, whether it can carry the mark members of the annotations, and whether it draws in the
+ * muted color. A muted series states no finding, thus it makes a poor carrier of a guide.
+ */
 interface EmittedSeries {
     option: EchartOption;
     carriesMarks: boolean;
+    muted: boolean;
 }
 
 /**
@@ -709,15 +722,14 @@ function deriveComposition(
     const emitted: EmittedSeries[] = [];
     for (const entry of resolved) {
         for (const group of splitByChannel(rows, entry.group)) {
-            const muted = preset !== undefined && group.name === NULL_CATEGORY;
-            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length, labels, muted);
+            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length, labels, preset);
             if (built.isErr()) return err(built.error);
             emitted.push(...built.value);
         }
     }
 
     const marks = markMembers(annotations);
-    const target = emitted.findIndex((entry) => entry.carriesMarks);
+    const target = markCarrier(emitted);
     if (Object.keys(marks).length > 0 && target >= 0) {
         emitted[target] = { ...emitted[target], option: { ...emitted[target].option, ...marks } };
     }
@@ -823,9 +835,12 @@ function splitByChannel(rows: readonly ChartRow[], group: ResolvedChannel | unde
 /**
  * Build the runtime series of one declared series over one group of rows.
  *
- * `muted` states that this series carries the null category. It takes the muted chart color, thus it
- * recedes behind the categories that carry a finding. Every other series takes no color of its own, and the
- * theme palette assigns one by the series order.
+ * A series of the null category takes the muted chart color, thus it recedes behind the categories that
+ * carry a finding. Every other series takes no color of its own, and the theme palette assigns one by the
+ * series order.
+ *
+ * A band draws two stacked line series, and no preset emits a band. Thus the null-category color never
+ * reaches one, and neither half of a band reports as muted.
  */
 function buildSeries(
     blockId: string,
@@ -835,27 +850,41 @@ function buildSeries(
     dense: boolean,
     emittedCount: number,
     labels: ColumnLabels,
-    muted: boolean,
+    preset: PresetAxisTitles | undefined,
 ): Result<EmittedSeries[], RenderProblem> {
     const form = entry.declared.form;
     const points = collectPoints(entry, group.indices);
     if (SORTED_FORMS.has(form)) {
         points.sort((a, b) => compareCell(a.x, b.x));
     }
-    const name = seriesName(entry, group.name, labels);
+    const name = seriesName(entry, group.name, labels, preset?.y);
 
     if (entry.y0 !== undefined) {
         const band = bandSeries(blockId, entry, name, points, `band-${emittedCount}`);
         if (band.isErr()) return err(band.error);
         return ok([
-            { option: band.value[0], carriesMarks: false },
-            { option: band.value[1], carriesMarks: true },
+            { option: band.value[0], carriesMarks: false, muted: false },
+            { option: band.value[1], carriesMarks: true, muted: false },
         ]);
     }
 
-    const { data, itemObjects } = seriesData(entry, points, labeled);
+    const muted = preset !== undefined && group.name === NULL_CATEGORY;
     const color = muted ? { itemStyle: { color: MUTED_CHART_COLOR } } : {};
-    return ok([{ option: { type: runtimeType(form), name, ...color, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }]);
+    const { data, itemObjects } = seriesData(entry, points, labeled);
+    return ok([{ option: { type: runtimeType(form), name, ...color, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true, muted }]);
+}
+
+/**
+ * The index of the series that carries the mark members, or `-1` when no series can carry them.
+ *
+ * The chart runtime takes the stroke of a guide from the item color of its carrier, wherever the mark states
+ * no color of its own. A muted carrier would thus paint each guide in the null-category color. The first
+ * carrier that draws in a palette color takes the marks. A chart whose every carrier is muted falls back to
+ * the first one, thus each guide still reaches the page.
+ */
+function markCarrier(emitted: readonly EmittedSeries[]): number {
+    const colored = emitted.findIndex((entry) => entry.carriesMarks && !entry.muted);
+    return colored >= 0 ? colored : emitted.findIndex((entry) => entry.carriesMarks);
 }
 
 /** The points of one group. A row whose channel gives no value drops, and no substitute value appears. */
@@ -880,18 +909,19 @@ function collectPoints(entry: ResolvedSeries, indices: readonly number[]): Point
  * The name of one runtime series.
  *
  * Each series carries a name, thus the `{a}` of the tooltip template always names something. A series with
- * no declared name and no group takes the name of its y channel. That name reads the declared label of the
- * column, the same as the y axis, thus one chart names one column one way.
+ * no declared name and no group takes the name of its y channel. That name resolves the same chain as the y
+ * axis, the declared label over the preset title over the raw name, thus one chart names one column one way
+ * and the tooltip of a group-less preset reads no machine text.
  *
  * The category value of a group prettifies, and the declared name of a series and the label of a column
  * both stay as the author wrote them. The tooltip reads this same name, thus the legend and the hover agree.
  */
-function seriesName(entry: ResolvedSeries, group: Cell | undefined, labels: ColumnLabels): string {
+function seriesName(entry: ResolvedSeries, group: Cell | undefined, labels: ColumnLabels, preset: string | undefined): string {
     const declared = entry.declared.name;
     if (declared !== undefined && group !== undefined) return `${declared} (${categoryName(group)})`;
     if (declared !== undefined) return declared;
     if (group !== undefined) return categoryName(group);
-    return axisTitle(labels, entry.y.name);
+    return axisTitle(labels, entry.y.name, preset);
 }
 
 /**
@@ -1036,9 +1066,9 @@ function topRows(rows: readonly ChartRow[], column: string, order: "asc" | "desc
  * A reference line and a reference band both carry a declared constant, thus each one rides as static
  * data of a mark member and nothing here reads a cell.
  *
- * A line on the x axis runs up the plot. Its end sits at the top, inside the band of the y-axis title, thus
- * its label takes the start position at the axis. A line on the y axis runs across, and its end sits at the
- * right edge, where the label already reads clear.
+ * A guide on the x axis runs up the plot. Its end sits at the top, inside the band of the y-axis title, thus
+ * its label takes the position at the axis. A guide on the y axis runs across, and its end sits at the right
+ * edge, where the label already reads clear.
  */
 function markMembers(annotations: readonly ChartAnnotation[]): EchartOption {
     const lines: EchartOption[] = [];
@@ -1050,7 +1080,11 @@ function markMembers(annotations: readonly ChartAnnotation[]): EchartOption {
             continue;
         }
         if (annotation.kind === "reference-band") {
-            areas.push([{ [axisKey(annotation.axis)]: annotation.from, ...markLabel(annotation.label) }, { [axisKey(annotation.axis)]: annotation.to }]);
+            const position = annotation.axis === "x" ? VERTICAL_BAND_LABEL_POSITION : undefined;
+            areas.push([
+                { [axisKey(annotation.axis)]: annotation.from, ...markLabel(annotation.label, position) },
+                { [axisKey(annotation.axis)]: annotation.to },
+            ]);
         }
     }
     return {

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -40,7 +40,8 @@ import {
 } from "../contracts/report-blocks.js";
 import { declaredForColumn, type ArtifactTableReference } from "../contracts/report-reference.js";
 import { normalizeEchartSpec } from "../tools/display/normalize-echart-spec.js";
-import { expandPreset, isPresetChartType, type PresetChartType } from "./chart-presets.js";
+import { expandPreset, isPresetChartType, presetAxisTitles, type PresetAxisTitles, type PresetChartType } from "./chart-presets.js";
+import { MUTED_CHART_COLOR } from "./design.js";
 import type { RenderProblem } from "./types.js";
 
 /** One cell of a resolved row. A cell is one string or one number. */
@@ -60,6 +61,12 @@ type BaseChartType = Exclude<ChartType, PresetChartType>;
 
 /** The display labels that the bound table declares, keyed by the raw column name. */
 type ColumnLabels = ArtifactTableReference["columnLabels"];
+
+/**
+ * The category value that carries no finding. A preset draws the significance split itself, thus the
+ * convention writes the insignificant group with this one literal.
+ */
+const NULL_CATEGORY = "ns";
 
 /**
  * A quick-path block whose channels are resolved to plain column names.
@@ -89,6 +96,14 @@ const VIRIDIS = ["#440154", "#482777", "#3e4989", "#31688e", "#26828e", "#1f9e89
 const X_AXIS_NAME_GAP = 34;
 
 /**
+ * The label position of a vertical guide line.
+ *
+ * The start of such a line sits at the x axis, and its end sits at the top of the plot. The top is the band
+ * of the y-axis title, thus a label there reads over the title.
+ */
+const VERTICAL_LABEL_POSITION = "start";
+
+/**
  * The y axis of a histogram.
  *
  * The axis counts rows, thus a fractional tick names no count. `minInterval` holds each tick a whole count
@@ -108,25 +123,41 @@ function xAxisName(title: string): EchartOption {
 }
 
 /**
- * The title of the axis that reads one column: the declared label, or the raw column name when the binding
- * declares none.
+ * The title of the axis that reads one column, most specific first: the declared label of the column, the
+ * semantic title of the preset, then the raw column name.
+ *
+ * A declared label answers for this one column of this one artifact, and a preset title answers for every
+ * chart of its kind. Thus the label outranks the preset. The caller resolves an agent axes title over this
+ * whole chain, because that title names this one axis of this one block.
  *
  * A transformed channel reads a derived name such as `neg_log10(padj)`, which no declaration keys. Thus the
  * axis of a transform keeps the name that states the transform, and it never states the raw quantity.
  */
-function axisTitle(labels: ColumnLabels, column: string): string {
-    return declaredForColumn(labels, column) ?? column;
+function axisTitle(labels: ColumnLabels, column: string, preset?: string): string {
+    return declaredForColumn(labels, column) ?? preset ?? column;
+}
+
+/**
+ * The legend text of one category value: the value with each underscore as a space.
+ *
+ * An analysis column carries a machine category such as `up_in_nonresponders`, and a legend reads for a
+ * person. The replacement reads no locale, thus the same value gives the same text on every host. The raw
+ * value stays in the data rows, thus the provenance loses nothing. No hover carries the raw text, because a
+ * legend formatter is a function and the option rides as inline JSON.
+ */
+function categoryName(value: Cell): string {
+    return String(value).replaceAll("_", " ");
 }
 
 /**
  * Derive the ECharts option for a chart block, then pass it through `normalizeEchartSpec`.
  *
  * The normalizer owns the bottom legend, the save action, and the axis-label discipline. Thus the
- * derivation sets no `title`, no `legend`, no `toolbox`, and no explicit series color. The theme palette
- * assigns the series colors by their order.
+ * derivation sets no `title`, no `legend`, and no `toolbox`. The theme palette assigns the series colors by
+ * their order, and the null category of a preset is the one series that names a color of its own.
  *
- * The axis of a channel names the label that the binding declares for its column. The raw column name
- * answers for a column that declares none.
+ * The axis of a channel names the label that the binding declares for its column. The semantic title of a
+ * preset answers next, and the raw column name answers last.
  */
 export function deriveChartOption(block: ChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
     return deriveRaw(block, rows, columns).map((option) => normalizeEchartSpec(option, { title: block.title }));
@@ -195,7 +226,8 @@ function derivePreset(
     if (x.isErr()) return err(x.error);
     const y = requireChannel(blockId, preset, encoding, "y");
     if (y.isErr()) return err(y.error);
-    return deriveComposition(blockId, expandPreset(preset, x.value, y.value, encoding), rows, columns, labels);
+    const composition = expandPreset(preset, x.value, y.value, encoding);
+    return deriveComposition(blockId, composition, rows, columns, labels, presetAxisTitles(preset, x.value));
 }
 
 /** The quick-path types that map onto one series form. A point of such a chart can carry a name. */
@@ -324,7 +356,7 @@ function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
     const categories = firstAppearance(rows.map((row) => row[x]));
     const series = groupedSeries(rows, block.encoding.group, (groupRows, name) => ({
         type: "bar",
-        ...(name !== undefined ? { name: String(name) } : {}),
+        ...(name !== undefined ? { name: categoryName(name) } : {}),
         barGap: 0,
         data: groupRows.map((row) => [row[x], row[y]]),
     }));
@@ -347,7 +379,7 @@ function deriveLine(block: ResolvedChartBlock, rows: readonly ChartRow[], column
 
     const series = groupedSeries(rows, block.encoding.group, (groupRows, name) => ({
         type: "line",
-        ...(name !== undefined ? { name: String(name) } : {}),
+        ...(name !== undefined ? { name: categoryName(name) } : {}),
         showSymbol: false,
         data: sortByX(groupRows.map((row) => [row[x], row[y]])),
     }));
@@ -370,7 +402,7 @@ function deriveScatter(block: ResolvedChartBlock, rows: readonly ChartRow[], col
 
     const series = groupedSeries(rows, block.encoding.group, (groupRows, name) => ({
         type: "scatter",
-        ...(name !== undefined ? { name: String(name) } : {}),
+        ...(name !== undefined ? { name: categoryName(name) } : {}),
         large: true,
         largeThreshold: 2000,
         data: groupRows.map((row) => [row[x], row[y]]),
@@ -471,14 +503,14 @@ function deriveBox(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
 
         series.push({
             type: "boxplot",
-            ...(group.name !== undefined ? { name: String(group.name) } : {}),
+            ...(group.name !== undefined ? { name: categoryName(group.name) } : {}),
             data: boxData,
         });
         // The outlier scatter pairs with its box series, thus it only appears when an outlier exists.
         if (outliers.length > 0) {
             series.push({
                 type: "scatter",
-                ...(group.name !== undefined ? { name: String(group.name) } : {}),
+                ...(group.name !== undefined ? { name: categoryName(group.name) } : {}),
                 symbolSize: 4,
                 data: outliers,
             });
@@ -643,6 +675,10 @@ interface EmittedSeries {
  *
  * The axes come from the first declared series. A composition plots one pair of axes, thus a later series
  * shares them.
+ *
+ * `preset` is present when a preset expanded this composition. It carries the semantic axis titles, and its
+ * presence states that the null-category rule applies. Thus an authored composition keeps every series on
+ * the palette, and a `ns` group of it carries no muted color.
  */
 function deriveComposition(
     blockId: string,
@@ -650,6 +686,7 @@ function deriveComposition(
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
     labels: ColumnLabels,
+    preset?: PresetAxisTitles,
 ): Result<EchartOption, RenderProblem> {
     const resolved: ResolvedSeries[] = [];
     for (const declared of composition.series) {
@@ -672,7 +709,8 @@ function deriveComposition(
     const emitted: EmittedSeries[] = [];
     for (const entry of resolved) {
         for (const group of splitByChannel(rows, entry.group)) {
-            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length, labels);
+            const muted = preset !== undefined && group.name === NULL_CATEGORY;
+            const built = buildSeries(blockId, entry, group, labeled.value, dense, emitted.length, labels, muted);
             if (built.isErr()) return err(built.error);
             emitted.push(...built.value);
         }
@@ -688,8 +726,8 @@ function deriveComposition(
     const named = resolved.some((entry) => entry.label !== undefined) || labeled.value.size > 0;
     return ok({
         tooltip: named ? { ...NAMED_TOOLTIP } : { ...PLAIN_TOOLTIP },
-        xAxis: compositionXAxis(rows, first, composition.axes?.x, labels),
-        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y, labels),
+        xAxis: compositionXAxis(rows, first, composition.axes?.x, labels, preset?.x),
+        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y, labels, preset?.y),
         series: emitted.map((entry) => entry.option),
     });
 }
@@ -782,7 +820,13 @@ function splitByChannel(rows: readonly ChartRow[], group: ResolvedChannel | unde
     return buckets;
 }
 
-/** Build the runtime series of one declared series over one group of rows. */
+/**
+ * Build the runtime series of one declared series over one group of rows.
+ *
+ * `muted` states that this series carries the null category. It takes the muted chart color, thus it
+ * recedes behind the categories that carry a finding. Every other series takes no color of its own, and the
+ * theme palette assigns one by the series order.
+ */
 function buildSeries(
     blockId: string,
     entry: ResolvedSeries,
@@ -791,6 +835,7 @@ function buildSeries(
     dense: boolean,
     emittedCount: number,
     labels: ColumnLabels,
+    muted: boolean,
 ): Result<EmittedSeries[], RenderProblem> {
     const form = entry.declared.form;
     const points = collectPoints(entry, group.indices);
@@ -809,7 +854,8 @@ function buildSeries(
     }
 
     const { data, itemObjects } = seriesData(entry, points, labeled);
-    return ok([{ option: { type: runtimeType(form), name, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }]);
+    const color = muted ? { itemStyle: { color: MUTED_CHART_COLOR } } : {};
+    return ok([{ option: { type: runtimeType(form), name, ...color, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true }]);
 }
 
 /** The points of one group. A row whose channel gives no value drops, and no substitute value appears. */
@@ -836,12 +882,15 @@ function collectPoints(entry: ResolvedSeries, indices: readonly number[]): Point
  * Each series carries a name, thus the `{a}` of the tooltip template always names something. A series with
  * no declared name and no group takes the name of its y channel. That name reads the declared label of the
  * column, the same as the y axis, thus one chart names one column one way.
+ *
+ * The category value of a group prettifies, and the declared name of a series and the label of a column
+ * both stay as the author wrote them. The tooltip reads this same name, thus the legend and the hover agree.
  */
 function seriesName(entry: ResolvedSeries, group: Cell | undefined, labels: ColumnLabels): string {
     const declared = entry.declared.name;
-    if (declared !== undefined && group !== undefined) return `${declared} (${String(group)})`;
+    if (declared !== undefined && group !== undefined) return `${declared} (${categoryName(group)})`;
     if (declared !== undefined) return declared;
-    if (group !== undefined) return String(group);
+    if (group !== undefined) return categoryName(group);
     return axisTitle(labels, entry.y.name);
 }
 
@@ -986,13 +1035,18 @@ function topRows(rows: readonly ChartRow[], column: string, order: "asc" | "desc
  *
  * A reference line and a reference band both carry a declared constant, thus each one rides as static
  * data of a mark member and nothing here reads a cell.
+ *
+ * A line on the x axis runs up the plot. Its end sits at the top, inside the band of the y-axis title, thus
+ * its label takes the start position at the axis. A line on the y axis runs across, and its end sits at the
+ * right edge, where the label already reads clear.
  */
 function markMembers(annotations: readonly ChartAnnotation[]): EchartOption {
     const lines: EchartOption[] = [];
     const areas: EchartOption[][] = [];
     for (const annotation of annotations) {
         if (annotation.kind === "reference-line") {
-            lines.push({ [axisKey(annotation.axis)]: annotation.value, ...markLabel(annotation.label) });
+            const position = annotation.axis === "x" ? VERTICAL_LABEL_POSITION : undefined;
+            lines.push({ [axisKey(annotation.axis)]: annotation.value, ...markLabel(annotation.label, position) });
             continue;
         }
         if (annotation.kind === "reference-band") {
@@ -1005,9 +1059,18 @@ function markMembers(annotations: readonly ChartAnnotation[]): EchartOption {
     };
 }
 
-/** The label of one mark member. The text is a constant of the annotation, and never a template. */
-function markLabel(label: string | undefined): EchartOption {
-    return label !== undefined ? { label: { formatter: label } } : {};
+/**
+ * The label of one mark member. The text is a constant of the annotation, and never a template.
+ *
+ * A member that carries neither a text nor a position emits no label member. Thus the chart runtime keeps
+ * its own default, and a member of either kind that states nothing gives the same bytes as before.
+ */
+function markLabel(label: string | undefined, position?: string): EchartOption {
+    const fields = {
+        ...(label !== undefined ? { formatter: label } : {}),
+        ...(position !== undefined ? { position } : {}),
+    };
+    return Object.keys(fields).length > 0 ? { label: fields } : {};
 }
 
 /** The mark key of one axis. A mark member names `xAxis` or `yAxis`, and the constant that sits on it. */
@@ -1021,26 +1084,39 @@ function axisKey(axis: "x" | "y"): "xAxis" | "yAxis" {
  * A bar takes a category axis, and every other form takes the inferred axis. A declared scale is the one
  * exception, because the author asked for a numeric axis and a category axis has no scale.
  */
-function compositionXAxis(rows: readonly ChartRow[], first: ResolvedSeries, declared: ChartAxes["x"], labels: ColumnLabels): EchartOption {
+function compositionXAxis(
+    rows: readonly ChartRow[],
+    first: ResolvedSeries,
+    declared: ChartAxes["x"],
+    labels: ColumnLabels,
+    preset: string | undefined,
+): EchartOption {
     if (first.declared.form !== "bar" || declared?.scale !== undefined) {
-        return compositionAxis(rows, first.x, "x", declared, labels);
+        return compositionAxis(rows, first.x, "x", declared, labels, preset);
     }
     // A bar counts its categories. The base bar rule lists the x values in first-appearance order, thus a
     // bar of either path draws the same axis.
     const categories = firstAppearance(first.x.values.filter((value): value is Cell => value !== null));
-    return { type: "category", data: categories, ...xAxisName(declared?.title ?? axisTitle(labels, first.x.name)) };
+    return { type: "category", data: categories, ...xAxisName(declared?.title ?? axisTitle(labels, first.x.name, preset)) };
 }
 
 /**
  * The axis of one composition channel.
  *
  * A declared axis title wins, because it names this one axis. The declared label of the column comes next,
- * and the raw column name answers last. A declared `log` scale maps onto the logarithmic axis type. A
- * transformed channel gives a number for each point that survives it, thus its axis is a value axis and
- * the cells of the untransformed column decide nothing.
+ * then the semantic title of the preset, and the raw column name answers last. A declared `log` scale maps
+ * onto the logarithmic axis type. A transformed channel gives a number for each point that survives it,
+ * thus its axis is a value axis and the cells of the untransformed column decide nothing.
  */
-function compositionAxis(rows: readonly ChartRow[], channel: ResolvedChannel, axis: "x" | "y", declared: ChartAxes["x"], labels: ColumnLabels): EchartOption {
-    const title = declared?.title ?? axisTitle(labels, channel.name);
+function compositionAxis(
+    rows: readonly ChartRow[],
+    channel: ResolvedChannel,
+    axis: "x" | "y",
+    declared: ChartAxes["x"],
+    labels: ColumnLabels,
+    preset: string | undefined,
+): EchartOption {
+    const title = declared?.title ?? axisTitle(labels, channel.name, preset);
     const nameFields = axis === "x" ? xAxisName(title) : { name: title };
     if (declared?.scale === "log") {
         return { type: "log", ...nameFields };
@@ -1353,7 +1429,7 @@ function histogramSeries(values: readonly number[], edges: readonly number[], na
     }
     return {
         type: "bar",
-        name: String(name),
+        name: categoryName(name),
         barWidth: "99%",
         barGap: "-100%",
         itemStyle: { opacity: 0.7 },

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -873,6 +873,15 @@ a.report-citation-source:hover {
 export const ECHARTS_THEME_NAME = "inflexa";
 
 /**
+ * The muted chart color, beside the palette of the theme.
+ *
+ * A null category states no finding, thus it must recede behind the categories that do. The value is the
+ * `--color-ns` token of the tokens above. A chart option rides to the page as inline JSON, thus it reads no
+ * custom property and the color is written again here.
+ */
+export const MUTED_CHART_COLOR = "#94a3b8";
+
+/**
  * The ECharts theme as a plain object. The renderer serializes this object and registers it, thus the theme
  * never rides a JSON file and no run-time read is necessary. The palette and the axis styles mirror the
  * light design tokens above.


### PR DESCRIPTION
## What & why

The volcano of the session printed machine text on every surface. The y axis read `neg_log10(pvalue)`, and the legend read `up_in_nonresponders`. The null category held a full palette color, and the guide labels sat in the title band. A preset now fills its semantic axis titles, under the declared column label and over the raw or derived name. The literal `ns` category of a preset chart takes the muted color of the design source. A vertical reference line labels at the axis end. A category series name prettifies at derivation, and the raw value stays in the data rows.

Reviewer notes: the preset title rides beside the composition, not inside its `axes` field. That field outranks a declared label, and the precedence demands the opposite. The old `plainTitle` wrote the raw column into `axes`, and it silently outranked a declared label. Its removal repairs that, and it stays byte-identical for an undeclared chart. The `ns` rule is the narrow literal, because a wider guess could mute a real finding. No legend hover carries the raw value, because a formatter would be a function and the option rides as inline JSON.

Refs #393

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
