### PR TITLE
feat(harness): orient the bar horizontal

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/design.md
@@ -1,0 +1,31 @@
+# Design: orient-the-bar-horizontal
+
+## Context
+
+`ChartTypeSchema` (`src/contracts/report-blocks.ts:30`) names the quick-path types, and the composition series form sits at line 77. `deriveBar` (`src/report-render/chart.ts:357`) renders the category on x and the value on y, with no other arrangement. The GSEA NES chart wants the category on y, because a gene-set name is long and a slanted x label is unreadable.
+
+## Decisions
+
+### D1: The orientation is a field, not a new type
+
+A `horizontal-bar` chart type would double the bar rules and split the tests. The orientation is one optional enum field, `vertical` by default. The quick path carries it beside `chartType`, and the composition carries it on the bar series form. An absent field keeps every stored document byte-identical.
+
+### D2: The channels keep their data meaning
+
+`x` names the category column and `y` names the value column, in both orientations. The horizontal orientation renders the category axis on y and the value axis on x. One encoding thus serves both orientations, and the author flips one field instead of rewriting the channels.
+
+### D3: A non-bar quick path refuses the orientation
+
+An orientation beside `line` or `pie` is a stated authoring fault, and the render problem names it. A silent ignore would teach the author a field that does nothing.
+
+### D4: Annotations and text rules bind to rendered axes
+
+An annotation names a rendered axis, exactly as today, thus a zero line on a horizontal value axis is an `x` reference line. The axis titles, the declared labels, and the number formatting bind to the axes wherever they render. The category axis of a horizontal bar keeps every label, because the long names are the reason the orientation exists.
+
+### D5: The mixed-form guard covers the orientation
+
+A composition that mixes a horizontal bar with another series on one grid has no honest shared axis pair. The derivation refuses the mix as a render problem, exactly as the grammar refuses a form pair that shares no axis semantics today. One series per orientation keeps the rule simple, and the GSEA case wants one series alone.
+
+## Risks / Trade-offs
+
+- A horizontal bar with many categories grows tall inside a fixed container. The container height is a design-source concern, and the row bound of the binding is the size control.

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: orient-the-bar-horizontal
+
+## Why
+
+The enrichment section of the session still shows a matplotlib PNG. The chart-first rule could not fire. The GSEA NES chart needs the category on the y axis, because the set names are long. But the grammar has no orientation on a bar. With the orientation, the figure becomes a chart block over the GSEA summary table, and the design system styles it.
+
+## What Changes
+
+- The bar gains an optional orientation: `vertical`, the default, and `horizontal`. The quick path carries it beside the chart type, and the composition carries it on the bar series form.
+- An orientation on a quick-path type that is not a bar refuses as a render problem, because a stated fault beats a silent ignore.
+- The encoding channels keep their data meaning: `x` names the category column, and `y` names the value column. The horizontal orientation renders the category axis on y and the value axis on x.
+- An annotation names a rendered axis, exactly as today. Thus a zero line on a horizontal value axis is an `x` reference line.
+- The axis titles, the declared labels, and the number formatting follow the axes wherever they render.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-block-model`: the chart grammar admits the bar orientation on the quick path and on the bar series form.
+- `report-render`: the derivation renders a horizontal bar, and the text rules follow the axes.
+
+## Impact
+
+- Affected code: `src/contracts/report-blocks.ts`, `src/report-render/chart.ts`, and their tests.
+- A bar with no orientation stays byte-identical, thus every stored document renders as before.

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-block-model/spec.md
@@ -11,10 +11,6 @@ The bar MUST admit an optional orientation: `vertical`, the default, and `horizo
 - **WHEN** the author binds a quick-path `bar` with the `horizontal` orientation
 - **THEN** the block validates, and the orientation rides the stored document
 
-#### Scenario: An orientation on a non-bar refuses
-
-- **WHEN** the author states an orientation beside the `line` chart type
-- **THEN** the render refuses with a problem that names the fault
 
 #### Scenario: An absent orientation stays vertical
 

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-block-model/spec.md
@@ -1,0 +1,22 @@
+# Delta: report-block-model
+
+## MODIFIED Requirements
+
+### Requirement: The chart grammar
+
+The bar MUST admit an optional orientation: `vertical`, the default, and `horizontal`. The quick path carries the orientation beside the chart type, and the composition carries it on the bar series form. The channels keep their data meaning in both orientations: `x` names the category column, and `y` names the value column. An orientation beside a quick-path type that is not a bar is an authoring fault.
+
+#### Scenario: A horizontal bar validates
+
+- **WHEN** the author binds a quick-path `bar` with the `horizontal` orientation
+- **THEN** the block validates, and the orientation rides the stored document
+
+#### Scenario: An orientation on a non-bar refuses
+
+- **WHEN** the author states an orientation beside the `line` chart type
+- **THEN** the render refuses with a problem that names the fault
+
+#### Scenario: An absent orientation stays vertical
+
+- **WHEN** a stored bar block carries no orientation
+- **THEN** the block validates, and the chart renders exactly as before

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-render/spec.md
@@ -20,3 +20,8 @@ A horizontal bar MUST render the category axis on y and the value axis on x. The
 
 - **WHEN** a composition holds a horizontal bar series and a scatter series
 - **THEN** the derivation refuses with a problem that names the mix
+
+#### Scenario: An orientation on a non-bar refuses
+
+- **WHEN** the author states an orientation beside the `line` chart type
+- **THEN** the render refuses with a problem that names the fault

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/specs/report-render/spec.md
@@ -1,0 +1,22 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The horizontal bar renders with the category on y
+
+A horizontal bar MUST render the category axis on y and the value axis on x. The category axis MUST keep every label, because the long names are the reason the orientation exists. An annotation names a rendered axis, thus a zero line on the horizontal value axis is an `x` reference line. The axis titles, the declared labels, and the number rules bind to the axes wherever they render. A composition that mixes a horizontal bar with another series on one grid MUST refuse as a render problem.
+
+#### Scenario: The NES chart renders horizontal with a zero line
+
+- **WHEN** the caller derives a horizontal bar over a set-name column and an NES column, with an `x` reference line at zero
+- **THEN** the category axis sits on y with every label, and the zero line stands on the value axis
+
+#### Scenario: A vertical bar stays as it is
+
+- **WHEN** the caller derives a bar with no orientation
+- **THEN** the option is byte-identical to the option before the orientation existed
+
+#### Scenario: A mixed grid refuses
+
+- **WHEN** a composition holds a horizontal bar series and a scatter series
+- **THEN** the derivation refuses with a problem that names the mix

--- a/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-orient-the-bar-horizontal/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: orient-the-bar-horizontal
+
+## 1. The contract
+
+- [x] 1.1 The quick path admits the optional orientation beside `chartType`, and the bar series form admits it, in `src/contracts/report-blocks.ts`. The field descriptions teach when the horizontal form serves.
+
+## 2. The derivation
+
+- [x] 2.1 `deriveBar` renders the horizontal arrangement: the category axis on y with every label, and the value axis on x.
+- [x] 2.2 An orientation beside a non-bar quick path refuses as a render problem.
+- [x] 2.3 A composition that mixes a horizontal bar with another series refuses as a render problem.
+- [x] 2.4 The axis titles, the declared labels, and the number rules bind to the axes wherever they render.
+
+## 3. The proof
+
+- [x] 3.1 Tests cover the six delta scenarios, and the vertical byte-identity pins against the stored option shape.
+- [x] 3.2 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -94,6 +94,8 @@ A chart block MUST carry either the quick path or the composition, and never bot
 
 The annotations are typed members. A reference line names an axis and a constant. A reference band names an axis and two constants. Point labels name a rank rule over a named column, with a bounded count. The chart type enum holds the seven base types and the presets `volcano`, `manhattan`, `ma`, and `km`.
 
+The bar MUST admit an optional orientation: `vertical`, the default, and `horizontal`. The quick path carries the orientation beside the chart type, and the composition carries it on the bar series form. The channels keep their data meaning in both orientations: `x` names the category column, and `y` names the value column. An orientation beside a quick-path type that is not a bar is an authoring fault.
+
 The grammar MUST keep the fabrication holes unrepresentable. No member carries a data literal, and no member carries script text. The structural tier MUST refuse a grammar column that the bound table does not hold.
 
 #### Scenario: The quick path and the composition exclude each other
@@ -115,6 +117,18 @@ The grammar MUST keep the fabrication holes unrepresentable. No member carries a
 #### Scenario: A preset parses on the quick path
 - **WHEN** a chart block carries the `volcano` type with an effect column, a p column, and a label column
 - **THEN** the block parses on the quick path
+
+#### Scenario: A horizontal bar validates
+- **WHEN** the author binds a quick-path `bar` with the `horizontal` orientation
+- **THEN** the block validates, and the orientation rides the stored document
+
+#### Scenario: An orientation on a non-bar refuses
+- **WHEN** the author states an orientation beside the `line` chart type
+- **THEN** the render refuses with a problem that names the fault
+
+#### Scenario: An absent orientation stays vertical
+- **WHEN** a stored bar block carries no orientation
+- **THEN** the block validates, and the chart renders exactly as before
 
 ### Requirement: Each evidentiary kind carries a binding field
 

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -122,9 +122,6 @@ The grammar MUST keep the fabrication holes unrepresentable. No member carries a
 - **WHEN** the author binds a quick-path `bar` with the `horizontal` orientation
 - **THEN** the block validates, and the orientation rides the stored document
 
-#### Scenario: An orientation on a non-bar refuses
-- **WHEN** the author states an orientation beside the `line` chart type
-- **THEN** the render refuses with a problem that names the fault
 
 #### Scenario: An absent orientation stays vertical
 - **WHEN** a stored bar block carries no orientation

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -286,6 +286,11 @@ A horizontal bar MUST render the category axis on y and the value axis on x. The
 - **WHEN** a composition holds a horizontal bar series and a scatter series
 - **THEN** the derivation refuses with a problem that names the mix
 
+#### Scenario: An orientation on a non-bar refuses
+
+- **WHEN** the author states an orientation beside the `line` chart type
+- **THEN** the render refuses with a problem that names the fault
+
 ### Requirement: The chart text reads for a reader
 
 A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change" and "−log10(p)", and a manhattan titles "−log10(p)" on its y axis. The precedence, most specific first: an agent axes title, a declared column label, the preset title, then the raw or derived name.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -267,6 +267,25 @@ The renderer MUST hold one fixed derivation rule for each chart type. A chart wh
 - **WHEN** the caller renders a bar chart whose categories first appear as Day2, Day10, Day1
 - **THEN** the category axis lists Day2, Day10, Day1 in that order
 
+### Requirement: The horizontal bar renders with the category on y
+
+A horizontal bar MUST render the category axis on y and the value axis on x. The category axis MUST keep every label, because the long names are the reason the orientation exists. An annotation names a rendered axis, thus a zero line on the horizontal value axis is an `x` reference line. The axis titles, the declared labels, and the number rules bind to the axes wherever they render. A composition that mixes a horizontal bar with another series on one grid MUST refuse as a render problem.
+
+#### Scenario: The NES chart renders horizontal with a zero line
+
+- **WHEN** the caller derives a horizontal bar over a set-name column and an NES column, with an `x` reference line at zero
+- **THEN** the category axis sits on y with every label, and the zero line stands on the value axis
+
+#### Scenario: A vertical bar stays as it is
+
+- **WHEN** the caller derives a bar with no orientation
+- **THEN** the option is byte-identical to the option before the orientation existed
+
+#### Scenario: A mixed grid refuses
+
+- **WHEN** a composition holds a horizontal bar series and a scatter series
+- **THEN** the derivation refuses with a problem that names the mix
+
 ### Requirement: The chart text reads for a reader
 
 A preset MUST fill its semantic axis titles. A volcano titles "log2 fold change" and "−log10(p)", and a manhattan titles "−log10(p)" on its y axis. The precedence, most specific first: an agent axes title, a declared column label, the preset title, then the raw or derived name.

--- a/harness/src/contracts/report-blocks.test.ts
+++ b/harness/src/contracts/report-blocks.test.ts
@@ -70,6 +70,47 @@ describe("the quick path", () => {
     });
 });
 
+describe("the bar orientation", () => {
+    it("takes a horizontal bar, and the orientation rides the parsed block", () => {
+        const parsed = ChartBlockSchema.safeParse(chart({ chartType: "bar", encoding: { x: "pathway", y: "nes" }, orientation: "horizontal" }));
+        expect(parsed.success).toBe(true);
+        expect(parsed.success && parsed.data.orientation).toBe("horizontal");
+    });
+
+    it("takes a bar with no orientation, thus a stored block keeps parsing", () => {
+        const parsed = ChartBlockSchema.safeParse(chart({ chartType: "bar", encoding: { x: "pathway", y: "nes" } }));
+        expect(parsed.success).toBe(true);
+        expect(parsed.success && parsed.data.orientation).toBeUndefined();
+    });
+
+    it("takes an orientation beside a type that is not a bar, because the render states that fault", () => {
+        // The grammar admits it. A silent ignore is what the rule forbids, and the derivation refuses it.
+        expect(parses({ chartType: "line", encoding: { x: "time", y: "survival" }, orientation: "horizontal" })).toBe(true);
+    });
+
+    it("refuses an orientation outside the two arrangements", () => {
+        expect(parses({ chartType: "bar", encoding: { x: "pathway", y: "nes" }, orientation: "sideways" })).toBe(false);
+    });
+
+    it("takes the orientation on a bar series of a composition", () => {
+        expect(parses({ composition: { series: [{ form: "bar", orientation: "horizontal", encoding: { x: "pathway", y: "nes" } }] } })).toBe(true);
+    });
+
+    it("refuses the orientation on a series form that draws no bar", () => {
+        for (const form of ["line", "scatter", "area", "step"]) {
+            expect(parses({ composition: { series: [{ form, orientation: "horizontal", encoding: { x: "time", y: "survival" } }] } })).toBe(false);
+        }
+    });
+
+    it("refuses a block-level orientation beside a composition, because the series states the arrangement", () => {
+        expect(parses({ composition: scatterComposition(), orientation: "horizontal" })).toBe(false);
+    });
+
+    it("refuses an orientation that stands alone, with no chart type and no composition", () => {
+        expect(parses({ orientation: "horizontal" })).toBe(false);
+    });
+});
+
 describe("the composition", () => {
     it("takes one series of each form", () => {
         for (const form of ["line", "scatter", "bar", "area", "step"]) {

--- a/harness/src/contracts/report-blocks.ts
+++ b/harness/src/contracts/report-blocks.ts
@@ -33,6 +33,16 @@ const ChartTypeSchema = z.enum(["bar", "line", "scatter", "histogram", "box", "h
 const ChartTransformSchema = z.enum(["log10", "neg_log10", "abs", "rank"]);
 
 /**
+ * The arrangement of a bar. The channels keep their data meaning under both values, thus one encoding
+ * serves both and the author flips this one field.
+ */
+const ChartOrientationSchema = z.enum(["vertical", "horizontal"]);
+
+/** The teaching text of the orientation. The quick path and the bar series form both carry it. */
+const ORIENTATION_DESCRIPTION =
+    "The arrangement of the bars. `vertical` is the default, and it draws the categories along the bottom. `horizontal` draws them up the left side, and it is the form to reach for when a category name is long, for example a gene-set name: a long name reads on the y axis, and it is unreadable slanted under a vertical bar. The channels do not move with the orientation. `x` names the category column and `y` names the value column in both.";
+
+/**
  * One visual channel: a column name, or a column with a per-row transform.
  *
  * The object form carries a column and a transform, and it carries no value. Thus a channel can never
@@ -70,17 +80,23 @@ const ChartSeriesEncodingSchema = z.strictObject({
  * One series of a composition: a plot form, its own channels, and an optional legend name.
  *
  * A `step` series is a line with the step flag. An `area` series can name a `y0` lower bound, thus a band
- * between two columns of one row is expressible. The refine holds `y0` to the one form that draws a band.
+ * between two columns of one row is expressible. The refine holds `y0` to the one form that draws a band,
+ * and the second refine holds the orientation to the one form that carries an arrangement.
  */
 export const ChartSeriesSchema = z
     .strictObject({
         form: z.enum(["line", "scatter", "bar", "area", "step"]).describe("The plot form of the series."),
         encoding: ChartSeriesEncodingSchema.describe("The columns that feed the series."),
         name: z.string().optional().describe("The legend name of the series."),
+        orientation: ChartOrientationSchema.optional().describe(ORIENTATION_DESCRIPTION),
     })
     .refine((series) => series.form === "area" || series.encoding.y0 === undefined, {
         message: "`y0` is legal on an `area` series only.",
         path: ["encoding", "y0"],
+    })
+    .refine((series) => series.form === "bar" || series.orientation === undefined, {
+        message: "`orientation` is legal on a `bar` series only.",
+        path: ["orientation"],
     });
 
 /** A guide line at one constant on one axis. */
@@ -187,16 +203,21 @@ export const ChartBlockSchema = z
             "The quick path. Give `encoding` with it, and omit `composition`. A preset (`volcano`, `manhattan`, `ma`, `km`) reads the same channels, and it applies its own transform and its own guide lines.",
         ),
         encoding: ChartEncodingSchema.optional().describe("The channels of the quick path."),
+        orientation: ChartOrientationSchema.optional().describe(
+            `${ORIENTATION_DESCRIPTION} The field belongs to the \`bar\` chart type, and every other type refuses it.`,
+        ),
         composition: ChartCompositionSchema.optional().describe("The full grammar. Omit `chartType` and `encoding` with it."),
         caption: z.string().optional(),
     })
     .refine(
         (block) => {
             const quickPath = block.chartType !== undefined && block.encoding !== undefined;
-            const partialQuickPath = block.chartType !== undefined || block.encoding !== undefined;
+            // The orientation is a quick-path field. A composition states the arrangement on its own bar
+            // series, thus a block-level orientation beside one names an arrangement that nothing reads.
+            const partialQuickPath = block.chartType !== undefined || block.encoding !== undefined || block.orientation !== undefined;
             return block.composition !== undefined ? !partialQuickPath : quickPath;
         },
-        { message: "A chart carries either `chartType` with `encoding`, or `composition`." },
+        { message: "A chart carries either `chartType` with `encoding`, or `composition`. The `orientation` belongs to the quick path." },
     );
 
 /** A static image artifact. An image has no per-cell address, thus it is pinned whole-file. */

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -139,6 +139,24 @@ describe("the bar orientation", () => {
         expect(asObj(yAxis.axisLabel).interval).toBe(0);
         // The rotation is an x-axis rule, thus a name up the y axis reads level.
         expect("rotate" in asObj(yAxis.axisLabel)).toBe(false);
+        // The runtime draws the first category at the origin, thus the axis inverts to read top-down.
+        expect(yAxis.inverse).toBe(true);
+    });
+
+    it("holds the category labels inside the grid, thus a long name draws whole", () => {
+        const quick = derive(chartBlock("bar", { x: "set", y: "nes" }, { orientation: "horizontal" }), nesRows);
+        const composed = derive(composedBlock({ series: [{ form: "bar", orientation: "horizontal", encoding: { x: "set", y: "nes" } }] }), nesRows);
+        for (const option of [quick, composed]) {
+            expect(asObj(option.grid).containLabel).toBe(true);
+            // The normalizer fills only an unset key, thus the margins land beside the contained labels.
+            expect(asObj(option.grid).left).toBe("10%");
+        }
+    });
+
+    it("leaves the grid of a vertical bar to the normalizer alone", () => {
+        const option = derive(chartBlock("bar", { x: "set", y: "nes" }), nesRows);
+        expect("containLabel" in asObj(option.grid)).toBe(false);
+        expect("inverse" in asObj(option.xAxis)).toBe(false);
     });
 
     it("leads each pair with the value, because the runtime reads the first member on x", () => {
@@ -212,8 +230,11 @@ describe("the bar orientation", () => {
         );
         const yAxis = asObj(option.yAxis);
         expect(yAxis.type).toBe("category");
+        // The rows arrive strongest-first, thus the inverted axis reads them down from the top.
         expect(yAxis.data).toEqual(["HALLMARK_HYPOXIA", "HALLMARK_G2M_CHECKPOINT", "HALLMARK_GLYCOLYSIS"]);
+        expect(yAxis.inverse).toBe(true);
         expect(asObj(yAxis.axisLabel).interval).toBe(0);
+        expect(asObj(option.grid).containLabel).toBe(true);
         expect(asObj(option.xAxis).type).toBe("value");
         // An annotation names a rendered axis, thus the zero of a horizontal bar stands on `x`.
         const marks = asArr(asObj(asObj(asArr(option.series)[0]).markLine).data);
@@ -261,6 +282,22 @@ describe("the bar orientation", () => {
         expect(problem.blockId).toBe("m1");
         expect(problem.detail).toContain("horizontal bar");
         expect(problem.detail).toContain("y axis");
+    });
+
+    it("refuses a block that carries an orientation beside a composition", () => {
+        // The grammar refuses the pair. A block that reaches the renderer without a parse would otherwise
+        // dispatch the composition and drop the orientation in silence.
+        const block: ChartBlock = {
+            kind: "chart",
+            id: "b1",
+            binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00" },
+            composition: { series: [{ form: "bar", encoding: { x: "set", y: "nes" } }] },
+            orientation: "horizontal",
+        };
+        const problem = deriveChartOption(block, nesRows)._unsafeUnwrapErr();
+        expect(problem.blockId).toBe("b1");
+        expect(problem.detail).toContain("orientation");
+        expect(problem.detail).toContain("composition");
     });
 
     it("carries the orientation through the quick path that names its points", () => {

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -12,14 +12,22 @@ type ChartType = NonNullable<ChartBlock["chartType"]>;
 /** The declared display labels of a binding, keyed by the raw column name. */
 type Labels = ChartBlock["binding"]["columnLabels"];
 
+/** The arrangement of a bar, as the quick path states it. */
+type Orientation = ChartBlock["orientation"];
+
 /** Build a chart block. The binding declares a label only where a test states one. */
-function chartBlock(chartType: ChartType, encoding: Encoding, extra: { id?: string; title?: string; caption?: string; labels?: Labels } = {}): ChartBlock {
+function chartBlock(
+    chartType: ChartType,
+    encoding: Encoding,
+    extra: { id?: string; title?: string; caption?: string; labels?: Labels; orientation?: Orientation } = {},
+): ChartBlock {
     return {
         kind: "chart",
         id: extra.id ?? "c1",
         binding: { kind: "artifact-table", path: "table.csv", hash: "sha256:00", ...(extra.labels !== undefined ? { columnLabels: extra.labels } : {}) },
         chartType,
         encoding,
+        ...(extra.orientation !== undefined ? { orientation: extra.orientation } : {}),
         ...(extra.title !== undefined ? { title: extra.title } : {}),
         ...(extra.caption !== undefined ? { caption: extra.caption } : {}),
     };
@@ -109,6 +117,170 @@ describe("deriveChartOption bar", () => {
         const second = derive(block, rows);
         expect(first).toEqual(second);
         expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    });
+});
+
+describe("the bar orientation", () => {
+    /** The GSEA summary of the session: a long set name, and the enrichment score beside it. */
+    const nesRows: ChartRow[] = [
+        { set: "HALLMARK_HYPOXIA", nes: 2.41 },
+        { set: "HALLMARK_G2M_CHECKPOINT", nes: -1.74 },
+        { set: "HALLMARK_GLYCOLYSIS", nes: 2.18 },
+    ];
+
+    it("renders the category on y and the value on x, with every label", () => {
+        const option = derive(chartBlock("bar", { x: "set", y: "nes" }, { orientation: "horizontal" }), nesRows);
+        const xAxis = asObj(option.xAxis);
+        const yAxis = asObj(option.yAxis);
+        expect(yAxis.type).toBe("category");
+        expect(yAxis.data).toEqual(["HALLMARK_HYPOXIA", "HALLMARK_G2M_CHECKPOINT", "HALLMARK_GLYCOLYSIS"]);
+        expect(xAxis.type).toBe("value");
+        // The long names are the reason for the arrangement, thus no label of the category axis drops.
+        expect(asObj(yAxis.axisLabel).interval).toBe(0);
+        // The rotation is an x-axis rule, thus a name up the y axis reads level.
+        expect("rotate" in asObj(yAxis.axisLabel)).toBe(false);
+    });
+
+    it("leads each pair with the value, because the runtime reads the first member on x", () => {
+        const option = derive(chartBlock("bar", { x: "set", y: "nes" }, { orientation: "horizontal" }), nesRows);
+        expect(asObj(asArr(option.series)[0]).data).toEqual([
+            [2.41, "HALLMARK_HYPOXIA"],
+            [-1.74, "HALLMARK_G2M_CHECKPOINT"],
+            [2.18, "HALLMARK_GLYCOLYSIS"],
+        ]);
+    });
+
+    it("lands the title of each column on the axis that draws it", () => {
+        const option = derive(
+            chartBlock("bar", { x: "set", y: "nes" }, { orientation: "horizontal", labels: { set: "Gene set", nes: "Normalized enrichment score" } }),
+            nesRows,
+        );
+        expect(asObj(option.xAxis).name).toBe("Normalized enrichment score");
+        expect(asObj(option.yAxis).name).toBe("Gene set");
+        // An x axis takes the centered name, thus the value title clears the right margin of the grid.
+        expect(asObj(option.xAxis).nameLocation).toBe("middle");
+    });
+
+    it("states the fault of an orientation beside a type that is not a bar", () => {
+        for (const chartType of ["line", "pie", "volcano"] as const) {
+            const block = chartBlock(chartType, { x: "set", y: "nes", value: "nes", group: "set" }, { id: "o1", orientation: "horizontal" });
+            const problem = deriveChartOption(block, nesRows)._unsafeUnwrapErr();
+            expect(problem.blockId).toBe("o1");
+            expect(problem.detail).toContain(chartType);
+            expect(problem.detail).toContain("orientation");
+        }
+    });
+
+    it("keeps the vertical arrangement of a bar that states no orientation", () => {
+        const option = derive(chartBlock("bar", { x: "set", y: "nes" }), nesRows);
+        expect(JSON.stringify(option)).toBe(
+            JSON.stringify({
+                xAxis: {
+                    type: "category",
+                    data: ["HALLMARK_HYPOXIA", "HALLMARK_G2M_CHECKPOINT", "HALLMARK_GLYCOLYSIS"],
+                    name: "set",
+                    nameLocation: "middle",
+                    nameGap: 34,
+                    axisLabel: { interval: 0 },
+                },
+                yAxis: { type: "value", name: "nes", axisLabel: { interval: 0 } },
+                series: [
+                    {
+                        type: "bar",
+                        barGap: 0,
+                        data: [
+                            ["HALLMARK_HYPOXIA", 2.41],
+                            ["HALLMARK_G2M_CHECKPOINT", -1.74],
+                            ["HALLMARK_GLYCOLYSIS", 2.18],
+                        ],
+                    },
+                ],
+                legend: { show: false },
+                grid: { top: "8%", bottom: "20%", left: "10%", right: "5%" },
+                toolbox: { right: 0, top: 0, feature: { saveAsImage: { type: "png", name: "chart" } } },
+            }),
+        );
+    });
+
+    it("renders the NES chart horizontal, with the zero line on the value axis", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "bar", orientation: "horizontal", encoding: { x: "set", y: "nes" } }],
+                annotations: [{ kind: "reference-line", axis: "x", value: 0 }],
+            }),
+            nesRows,
+        );
+        const yAxis = asObj(option.yAxis);
+        expect(yAxis.type).toBe("category");
+        expect(yAxis.data).toEqual(["HALLMARK_HYPOXIA", "HALLMARK_G2M_CHECKPOINT", "HALLMARK_GLYCOLYSIS"]);
+        expect(asObj(yAxis.axisLabel).interval).toBe(0);
+        expect(asObj(option.xAxis).type).toBe("value");
+        // An annotation names a rendered axis, thus the zero of a horizontal bar stands on `x`.
+        const marks = asArr(asObj(asObj(asArr(option.series)[0]).markLine).data);
+        expect(marks).toEqual([{ xAxis: 0, label: { position: "start" } }]);
+    });
+
+    it("swaps the pairs of a composition bar too, and keeps the category name on a named point", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "bar", orientation: "horizontal", encoding: { x: "set", y: "nes" } }],
+                annotations: [{ kind: "point-labels", column: "nes", order: "desc", n: 1 }],
+            }),
+            nesRows,
+        );
+        const data = asArr(asObj(asArr(option.series)[0]).data);
+        expect(data[1]).toEqual([-1.74, "HALLMARK_G2M_CHECKPOINT"]);
+        // The name of a bar is what it counts, thus the marked point still reads the category cell.
+        expect(asObj(data[0]).name).toBe("HALLMARK_HYPOXIA");
+        expect(asObj(data[0]).value).toEqual([2.41, "HALLMARK_HYPOXIA"]);
+    });
+
+    it("titles the rendered axes of a composition, thus a declared axes title names the axis it sits on", () => {
+        const option = derive(
+            composedBlock({
+                series: [{ form: "bar", orientation: "horizontal", encoding: { x: "set", y: "nes" } }],
+                axes: { x: { title: "Enrichment" }, y: { title: "Pathway" } },
+            }),
+            nesRows,
+        );
+        expect(asObj(option.xAxis).name).toBe("Enrichment");
+        expect(asObj(option.yAxis).name).toBe("Pathway");
+    });
+
+    it("refuses a grid that mixes a horizontal bar with another series", () => {
+        const block = composedBlock(
+            {
+                series: [
+                    { form: "bar", orientation: "horizontal", encoding: { x: "set", y: "nes" } },
+                    { form: "scatter", encoding: { x: "set", y: "nes" } },
+                ],
+            },
+            { id: "m1" },
+        );
+        const problem = deriveChartOption(block, nesRows)._unsafeUnwrapErr();
+        expect(problem.blockId).toBe("m1");
+        expect(problem.detail).toContain("horizontal bar");
+        expect(problem.detail).toContain("y axis");
+    });
+
+    it("carries the orientation through the quick path that names its points", () => {
+        // A `label` channel routes the quick path through a composition, and the arrangement crosses with it.
+        const option = derive(chartBlock("bar", { x: "set", y: "nes", label: "set" }, { orientation: "horizontal" }), nesRows);
+        expect(asObj(option.yAxis).type).toBe("category");
+        expect(asObj(asArr(asObj(asArr(option.series)[0]).data)[0]).value).toEqual([2.41, "HALLMARK_HYPOXIA"]);
+    });
+
+    it("keeps a vertical bar beside another series, because the two share an axis pair", () => {
+        const option = derive(
+            composedBlock({
+                series: [
+                    { form: "bar", encoding: { x: "set", y: "nes" } },
+                    { form: "scatter", encoding: { x: "set", y: "nes" } },
+                ],
+            }),
+            nesRows,
+        );
+        expect(asArr(option.series).length).toBe(2);
     });
 });
 

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -127,6 +127,25 @@ const VERTICAL_LABEL_POSITION = "start";
 const VERTICAL_BAND_LABEL_POSITION = "insideBottom";
 
 /**
+ * The type fields of a category axis that renders on y.
+ *
+ * The chart runtime draws the first category of a y axis at the origin, thus it stacks the rows upward and
+ * a table that is sorted strongest-first reads weakest-on-top. The inverted axis puts the first row at the
+ * top, and the page then reads down in the order that the rows hold. The data order itself never moves.
+ */
+const HORIZONTAL_CATEGORY_AXIS: EchartOption = { type: "category", inverse: true };
+
+/**
+ * The grid of a chart whose category names render as axis labels.
+ *
+ * The theme pins `containLabel: false`, and the normalizer fills a left margin of 10 percent. A long
+ * category name then draws past the edge of the canvas. `containLabel` gives the measurement to the chart
+ * runtime, which is the one part that can measure the text. A fixed band of pixels would guess a width
+ * here, and a guess clips a longer name and wastes the room of a shorter one.
+ */
+const LABEL_CONTAINING_GRID: EchartOption = { containLabel: true };
+
+/**
  * The y axis of a histogram.
  *
  * The axis counts rows, thus a fractional tick names no count. `minInterval` holds each tick a whole count
@@ -195,6 +214,13 @@ export function deriveChartOption(block: ChartBlock, rows: readonly ChartRow[], 
  */
 function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: readonly string[]): Result<EchartOption, RenderProblem> {
     const labels = block.binding.columnLabels;
+    const orientation = block.orientation;
+    if (orientation !== undefined && block.composition !== undefined) {
+        // The schema refine already makes this pair unrepresentable. The guard states the same rule for a
+        // value that reaches the renderer without a parse, because a composition states the arrangement on
+        // its own bar series and this one would otherwise drop in silence.
+        return err(problem(block.id, "A composition states the arrangement on its own bar series, thus the chart carries no orientation beside it."));
+    }
     if (block.composition !== undefined) {
         return deriveComposition(block.id, block.composition, rows, columns, labels);
     }
@@ -205,7 +231,6 @@ function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: reado
         // value that reaches the renderer without a parse.
         return err(problem(block.id, "The chart carries neither a chart type with an encoding, nor a composition."));
     }
-    const orientation = block.orientation;
     if (orientation !== undefined && chartType !== "bar") {
         // A silent ignore would teach the author a field that does nothing, thus the fault is stated.
         return err(problem(block.id, `The ${chartType} chart takes no orientation. An orientation is a rule of the bar alone.`));
@@ -387,7 +412,8 @@ function deriveTransformedRows(rows: readonly ChartRow[], derived: ReadonlyArray
  *
  * The category axis of the horizontal arrangement keeps every label. `normalizeEchartSpec` pins the label
  * interval of each axis, and it turns an x label alone, thus a long name on y reads level and none of them
- * drops.
+ * drops. The same arrangement inverts that axis and contains its labels, for the reasons that
+ * `HORIZONTAL_CATEGORY_AXIS` and `LABEL_CONTAINING_GRID` give.
  */
 function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
@@ -409,8 +435,9 @@ function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
     if (horizontal) {
         return ok({
             xAxis: { type: "value", ...xAxisName(axisTitle(block.labels, y)) },
-            yAxis: { type: "category", data: categories, name: axisTitle(block.labels, x) },
+            yAxis: { ...HORIZONTAL_CATEGORY_AXIS, data: categories, name: axisTitle(block.labels, x) },
             series,
+            grid: { ...LABEL_CONTAINING_GRID },
         });
     }
     return ok({
@@ -791,6 +818,8 @@ function deriveComposition(
         xAxis: axes.xAxis,
         yAxis: axes.yAxis,
         series: emitted.map((entry) => entry.option),
+        // A horizontal bar draws its category names as y labels, thus the grid must hold them.
+        ...(isHorizontalBar(first.declared) ? { grid: { ...LABEL_CONTAINING_GRID } } : {}),
     });
 }
 
@@ -1226,6 +1255,8 @@ function compositionXAxis(
  * A bar counts its categories. The base bar rule lists the values of the category channel in
  * first-appearance order, thus a bar of either path draws the same axis. A declared scale asks for a
  * numeric axis, and a category axis has no scale, thus such an axis falls to the inferred one.
+ *
+ * A category axis on y inverts, thus the first row of the table reads at the top of the plot.
  */
 function barCategoryAxis(
     rows: readonly ChartRow[],
@@ -1240,8 +1271,9 @@ function barCategoryAxis(
     }
     const categories = firstAppearance(channel.values.filter((value): value is Cell => value !== null));
     const title = declared?.title ?? axisTitle(labels, channel.name, preset);
+    const typeFields = axis === "x" ? { type: "category" } : { ...HORIZONTAL_CATEGORY_AXIS };
     const nameFields = axis === "x" ? xAxisName(title) : { name: title };
-    return { type: "category", data: categories, ...nameFields };
+    return { ...typeFields, data: categories, ...nameFields };
 }
 
 /**

--- a/harness/src/report-render/chart.ts
+++ b/harness/src/report-render/chart.ts
@@ -62,11 +62,24 @@ type BaseChartType = Exclude<ChartType, PresetChartType>;
 /** The display labels that the bound table declares, keyed by the raw column name. */
 type ColumnLabels = ArtifactTableReference["columnLabels"];
 
+/** The arrangement of a bar. An absent value is the vertical arrangement. */
+type ChartOrientation = ChartSeries["orientation"];
+
 /**
  * The category value that carries no finding. A preset draws the significance split itself, thus the
  * convention writes the insignificant group with this one literal.
  */
 const NULL_CATEGORY = "ns";
+
+/**
+ * True when one declared series draws its bars across the plot.
+ *
+ * The category channel then renders on the y axis and the value channel renders on the x axis. Every other
+ * form and every other orientation gives false, thus one test answers for the whole composition path.
+ */
+function isHorizontalBar(series: ChartSeries): boolean {
+    return series.form === "bar" && series.orientation === "horizontal";
+}
 
 /**
  * A quick-path block whose channels are resolved to plain column names.
@@ -79,6 +92,7 @@ interface ResolvedChartBlock {
     chartType: BaseChartType;
     encoding: Partial<Record<Channel, string>>;
     labels: ColumnLabels;
+    orientation: ChartOrientation;
 }
 
 /**
@@ -191,13 +205,18 @@ function deriveRaw(block: ChartBlock, rows: readonly ChartRow[], columns?: reado
         // value that reaches the renderer without a parse.
         return err(problem(block.id, "The chart carries neither a chart type with an encoding, nor a composition."));
     }
+    const orientation = block.orientation;
+    if (orientation !== undefined && chartType !== "bar") {
+        // A silent ignore would teach the author a field that does nothing, thus the fault is stated.
+        return err(problem(block.id, `The ${chartType} chart takes no orientation. An orientation is a rule of the bar alone.`));
+    }
     if (isPresetChartType(chartType)) {
         return derivePreset(block.id, chartType, encoding, rows, columns, labels);
     }
     if (encoding.label !== undefined) {
-        return deriveLabeled(block.id, chartType, encoding, rows, columns, labels);
+        return deriveLabeled(block.id, chartType, encoding, rows, columns, labels, orientation);
     }
-    const quick = resolveQuickPath(block.id, chartType, encoding, rows, columns, labels);
+    const quick = resolveQuickPath(block.id, chartType, encoding, rows, columns, labels, orientation);
     if (quick.isErr()) return err(quick.error);
     return deriveBase(quick.value.block, quick.value.rows, columns);
 }
@@ -255,6 +274,7 @@ function deriveLabeled(
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
     labels: ColumnLabels,
+    orientation: ChartOrientation,
 ): Result<EchartOption, RenderProblem> {
     const form = LABELED_FORMS[chartType];
     if (form === undefined) {
@@ -274,6 +294,9 @@ function deriveLabeled(
                     ...(encoding.group !== undefined ? { group: encoding.group } : {}),
                     ...(encoding.label !== undefined ? { label: encoding.label } : {}),
                 },
+                // The caller refused an orientation on every type but the bar, thus the form here is a bar
+                // wherever one arrives. The arrangement crosses onto the series, and no name channel loses it.
+                ...(orientation !== undefined ? { orientation } : {}),
             },
         ],
     };
@@ -296,6 +319,7 @@ function resolveQuickPath(
     rows: readonly ChartRow[],
     columns: readonly string[] | undefined,
     labels: ColumnLabels,
+    orientation: ChartOrientation,
 ): Result<{ block: ResolvedChartBlock; rows: readonly ChartRow[] }, RenderProblem> {
     const resolved: Partial<Record<Channel, string>> = {};
     const derived: Array<{ column: string; name: string; transform: ChartTransform }> = [];
@@ -321,7 +345,7 @@ function resolveQuickPath(
         derived.push({ column, name, transform });
     }
 
-    const block: ResolvedChartBlock = { id: blockId, chartType, encoding: resolved, labels };
+    const block: ResolvedChartBlock = { id: blockId, chartType, encoding: resolved, labels, orientation };
     return ok({ block, rows: derived.length === 0 ? rows : deriveTransformedRows(rows, derived) });
 }
 
@@ -353,7 +377,18 @@ function deriveTransformedRows(rows: readonly ChartRow[], derived: ReadonlyArray
 
 // ── The per-type derivations ────────────────────────────────────────────────
 
-/** A category x axis, a value y axis, and one bar series per group with the `[x, y]` pairs. */
+/**
+ * A category axis, a value axis, and one bar series per group with the pairs of the two channels.
+ *
+ * The vertical arrangement counts the categories along x and measures up y. The horizontal arrangement
+ * swaps the two axes, and the pair of each point swaps with them: the chart runtime reads the first member
+ * of a pair on x, thus the value leads there. The channels themselves do not move, and `x` names the
+ * category column under both arrangements.
+ *
+ * The category axis of the horizontal arrangement keeps every label. `normalizeEchartSpec` pins the label
+ * interval of each axis, and it turns an x label alone, thus a long name on y reads level and none of them
+ * drops.
+ */
 function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns: readonly string[] | undefined): Result<EchartOption, RenderProblem> {
     const xResult = requireColumn(block, rows, columns, "x");
     if (xResult.isErr()) return err(xResult.error);
@@ -362,14 +397,22 @@ function deriveBar(block: ResolvedChartBlock, rows: readonly ChartRow[], columns
     const x = xResult.value;
     const y = yResult.value;
 
+    const horizontal = block.orientation === "horizontal";
     const categories = firstAppearance(rows.map((row) => row[x]));
     const series = groupedSeries(rows, block.encoding.group, (groupRows, name) => ({
         type: "bar",
         ...(name !== undefined ? { name: categoryName(name) } : {}),
         barGap: 0,
-        data: groupRows.map((row) => [row[x], row[y]]),
+        data: groupRows.map((row) => (horizontal ? [row[y], row[x]] : [row[x], row[y]])),
     }));
 
+    if (horizontal) {
+        return ok({
+            xAxis: { type: "value", ...xAxisName(axisTitle(block.labels, y)) },
+            yAxis: { type: "category", data: categories, name: axisTitle(block.labels, x) },
+            series,
+        });
+    }
     return ok({
         xAxis: { type: "category", data: categories, ...xAxisName(axisTitle(block.labels, x)) },
         yAxis: { type: "value", name: axisTitle(block.labels, y) },
@@ -701,6 +744,12 @@ function deriveComposition(
     labels: ColumnLabels,
     preset?: PresetAxisTitles,
 ): Result<EchartOption, RenderProblem> {
+    if (composition.series.length > 1 && composition.series.some(isHorizontalBar)) {
+        // A horizontal bar reads its categories up the y axis, and every other form reads a value there.
+        // The two share no honest axis pair on one grid, thus the mix refuses instead of plotting a lie.
+        return err(problem(blockId, "A horizontal bar plots its categories on the y axis, thus it shares no axis pair with another series."));
+    }
+
     const resolved: ResolvedSeries[] = [];
     for (const declared of composition.series) {
         const series = resolveSeries(blockId, declared, rows, columns);
@@ -736,10 +785,11 @@ function deriveComposition(
 
     const first = resolved[0];
     const named = resolved.some((entry) => entry.label !== undefined) || labeled.value.size > 0;
+    const axes = compositionAxes(rows, first, composition.axes, labels, preset);
     return ok({
         tooltip: named ? { ...NAMED_TOOLTIP } : { ...PLAIN_TOOLTIP },
-        xAxis: compositionXAxis(rows, first, composition.axes?.x, labels, preset?.x),
-        yAxis: compositionAxis(rows, first.y, "y", composition.axes?.y, labels, preset?.y),
+        xAxis: axes.xAxis,
+        yAxis: axes.yAxis,
         series: emitted.map((entry) => entry.option),
     });
 }
@@ -870,7 +920,7 @@ function buildSeries(
 
     const muted = preset !== undefined && group.name === NULL_CATEGORY;
     const color = muted ? { itemStyle: { color: MUTED_CHART_COLOR } } : {};
-    const { data, itemObjects } = seriesData(entry, points, labeled);
+    const { data, itemObjects } = seriesData(entry, points, labeled, isHorizontalBar(entry.declared));
     return ok([{ option: { type: runtimeType(form), name, ...color, ...formOptions(form, dense, itemObjects), data }, carriesMarks: true, muted }]);
 }
 
@@ -929,21 +979,31 @@ function seriesName(entry: ResolvedSeries, group: Cell | undefined, labels: Colu
  *
  * A bare pair is the smallest item that states one point. A point that carries a name, or that the rank
  * rule marks, takes the object form, because only an object item holds a name and a label.
+ *
+ * The chart runtime reads the first member of a pair on the x axis. Thus a horizontal bar leads with its
+ * value, and the category follows. The name of a point still reads the category channel, because the name
+ * of a bar is what it counts and not how much it counts.
  */
-function seriesData(entry: ResolvedSeries, points: readonly Point[], labeled: ReadonlySet<number>): { data: unknown[]; itemObjects: boolean } {
+function seriesData(
+    entry: ResolvedSeries,
+    points: readonly Point[],
+    labeled: ReadonlySet<number>,
+    horizontal: boolean,
+): { data: unknown[]; itemObjects: boolean } {
     const data: unknown[] = [];
     let itemObjects = false;
     for (const point of points) {
+        const pair = horizontal ? [point.y, point.x] : [point.x, point.y];
         const label = entry.label?.[point.index];
         const named = label !== undefined && label !== null;
         const marked = labeled.has(point.index);
         if (!named && !marked) {
-            data.push([point.x, point.y]);
+            data.push(pair);
             continue;
         }
         itemObjects = true;
         data.push({
-            value: [point.x, point.y],
+            value: pair,
             // A marked point of a series with no label channel takes the x cell as its name. Thus the
             // `{b}` of the label template and of the tooltip names a cell of the row, and never nothing.
             name: named ? String(label) : String(point.x),
@@ -1113,7 +1173,36 @@ function axisKey(axis: "x" | "y"): "xAxis" | "yAxis" {
 }
 
 /**
- * The x axis of a composition.
+ * The two axes of a composition.
+ *
+ * A vertical bar counts its categories on x, and every other form reads the inferred axis there. A
+ * horizontal bar swaps the two: the category channel renders on y, and the value channel renders on x.
+ *
+ * A declared axis names the axis that it renders on, exactly as an annotation does. Thus `axes.x` titles
+ * the value axis of a horizontal bar. A declared column label and a preset title both follow their own
+ * column, thus each one lands on whichever axis draws that column.
+ */
+function compositionAxes(
+    rows: readonly ChartRow[],
+    first: ResolvedSeries,
+    axes: ChartComposition["axes"],
+    labels: ColumnLabels,
+    preset: PresetAxisTitles | undefined,
+): { xAxis: EchartOption; yAxis: EchartOption } {
+    if (isHorizontalBar(first.declared)) {
+        return {
+            xAxis: compositionAxis(rows, first.y, "x", axes?.x, labels, preset?.y),
+            yAxis: barCategoryAxis(rows, first.x, "y", axes?.y, labels, preset?.x),
+        };
+    }
+    return {
+        xAxis: compositionXAxis(rows, first, axes?.x, labels, preset?.x),
+        yAxis: compositionAxis(rows, first.y, "y", axes?.y, labels, preset?.y),
+    };
+}
+
+/**
+ * The x axis of a composition whose bars stand up, or of any other form.
  *
  * A bar takes a category axis, and every other form takes the inferred axis. A declared scale is the one
  * exception, because the author asked for a numeric axis and a category axis has no scale.
@@ -1128,10 +1217,31 @@ function compositionXAxis(
     if (first.declared.form !== "bar" || declared?.scale !== undefined) {
         return compositionAxis(rows, first.x, "x", declared, labels, preset);
     }
-    // A bar counts its categories. The base bar rule lists the x values in first-appearance order, thus a
-    // bar of either path draws the same axis.
-    const categories = firstAppearance(first.x.values.filter((value): value is Cell => value !== null));
-    return { type: "category", data: categories, ...xAxisName(declared?.title ?? axisTitle(labels, first.x.name, preset)) };
+    return barCategoryAxis(rows, first.x, "x", declared, labels, preset);
+}
+
+/**
+ * The category axis of a composition bar, on whichever axis it renders.
+ *
+ * A bar counts its categories. The base bar rule lists the values of the category channel in
+ * first-appearance order, thus a bar of either path draws the same axis. A declared scale asks for a
+ * numeric axis, and a category axis has no scale, thus such an axis falls to the inferred one.
+ */
+function barCategoryAxis(
+    rows: readonly ChartRow[],
+    channel: ResolvedChannel,
+    axis: "x" | "y",
+    declared: ChartAxes["x"],
+    labels: ColumnLabels,
+    preset: string | undefined,
+): EchartOption {
+    if (declared?.scale !== undefined) {
+        return compositionAxis(rows, channel, axis, declared, labels, preset);
+    }
+    const categories = firstAppearance(channel.values.filter((value): value is Cell => value !== null));
+    const title = declared?.title ?? axisTitle(labels, channel.name, preset);
+    const nameFields = axis === "x" ? xAxisName(title) : { name: title };
+    return { type: "category", data: categories, ...nameFields };
 }
 
 /**


### PR DESCRIPTION
## What & why

The enrichment section of the session still shows a matplotlib PNG. The grammar had no horizontal bar, and the long set names demand the category on y. The bar now admits an optional orientation, on the quick path beside the chart type and on the bar series form of the composition. The channels keep their data meaning: `x` names the category column, and `y` names the value column. The horizontal arrangement renders the category axis on y with every label, and the value axis on x. A zero line for an NES chart stands on the value axis as an `x` reference line.

Reviewer notes: an absent orientation derives byte-identically, and a test pins the whole stored option shape. An orientation beside a non-bar quick path refuses as a render problem, and the series-form refine mirrors the sibling `y0`-on-`area` rule. A mixed horizontal grid refuses, because no honest shared axis pair exists. The label-interval discipline stays with the normalizer, which already owns it, and the test proves the requirement at the option level.

Refs #396

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
