### PR TITLE
feat(harness): type the text list

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/design.md
@@ -1,0 +1,27 @@
+# Design: type-the-text-list
+
+## Context
+
+`TextBlockSchema` carries `content: { prose }` (`src/contracts/report-blocks.ts:155-159`), and the prose admits an empty string today. The prose view splits on blank lines and emits paragraphs (`src/report-render/views/prose.tsx:25-34`). No block form renders a list, thus an enumeration lands inline in one paragraph.
+
+## Decisions
+
+### D1: The list is typed content, not markdown
+
+`content.list` is an optional strict object: `ordered: boolean`, and `items: string[]`, each item non-empty, at least one item. A markdown engine would admit links, emphasis, and nesting, and each one is a review surface that the block model closed on purpose. One flat list of inline lines covers the enumeration case that the page shows.
+
+### D2: The list renders after the prose
+
+The lead sentences introduce the enumeration, and the items follow. The renderer emits `ol` or `ul` by the flag, one `li` for each item, escaped exactly as a paragraph. The list fills the content column, as every block does.
+
+### D3: No new emptiness rule
+
+An empty prose parses today, and the list changes nothing about that. A text block with a list and an empty prose renders the list alone. The gap check of the finish reads sections, and a text block with a list is content in the same way as one with prose.
+
+### D4: The free-numeral advisory walks the items
+
+The advisory reads the prose of a text block today. A numeral in a list item is the same honesty concern, thus the walk covers the items beside the prose.
+
+## Risks / Trade-offs
+
+- A very long item wraps as a paragraph would, and no sub-list exists. The flat form is the point, and a deeper structure is a section with blocks.

--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: type-the-text-list
+
+## Why
+
+The Limitations section of the session page is one twelve-line paragraph with "(1) … (6)" inline. The renderer splits prose on blank lines alone, and it knows no list. Thus the agent had no better form to reach for, and an enumeration reads as a wall.
+
+## What Changes
+
+- The text block gains an optional typed list beside `prose`: an items array and an ordered flag. Each item is one line of inline text.
+- The renderer emits the list markup after the prose paragraphs, and the runtime escape covers each item. No markdown engine joins.
+- A text block can carry a list with an empty prose. An empty prose with no list stays as it parses today.
+- The free-numeral advisory of the finish covers a list item exactly as it covers a paragraph.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-block-model`: the text block admits the typed list.
+- `report-render`: the list renders as list markup in the content column.
+
+## Impact
+
+- Affected code: `src/contracts/report-blocks.ts`, `src/report-render/views/prose.tsx`, the free-numeral walk, and their tests.
+- The field is optional, thus every stored document parses and renders as before.
+- The prompt obligation — an enumeration composes as a list — rides the prompt child of the tracker.

--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/specs/report-block-model/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-block-model
+
+## MODIFIED Requirements
+
+### Requirement: A content grammar constrains nesting
+
+The text block MUST admit an optional typed list beside its prose: an ordered flag, and an items array of non-empty inline lines, with at least one item. The list is content, not markup, and no markdown joins. A text block with a list and an empty prose is valid content.
+
+#### Scenario: A text block carries a list
+
+- **WHEN** a text block carries six ordered limitation items beside a lead sentence
+- **THEN** the block validates, and the list rides the stored document
+
+#### Scenario: An empty list refuses
+
+- **WHEN** a text block carries a list with zero items
+- **THEN** the parse fails

--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/specs/report-render/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-render
+
+## MODIFIED Requirements
+
+### Requirement: A rendered form for each block kind
+
+A text block with a list MUST render the list after its prose paragraphs, as ordered or unordered list markup by the flag. Each item escapes exactly as a paragraph does, and the list fills the content column. A text block with a list and an empty prose renders the list alone.
+
+#### Scenario: An enumeration renders as a list
+
+- **WHEN** the caller renders a text block with a lead sentence and six ordered items
+- **THEN** the page holds the paragraph and an ordered list with the six items
+
+#### Scenario: A list stands alone
+
+- **WHEN** the caller renders a text block with an empty prose and three unordered items
+- **THEN** the page holds the unordered list, and no empty paragraph

--- a/harness/openspec/changes/archive/2026-08-16-type-the-text-list/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-type-the-text-list/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: type-the-text-list
+
+## 1. The contract
+
+- [x] 1.1 `TextBlockSchema.content` gains the optional `list`: the ordered flag, and the non-empty items, in `src/contracts/report-blocks.ts`. The field description teaches the enumeration case.
+
+## 2. The render
+
+- [x] 2.1 The text view renders the list after the prose paragraphs, `ol` or `ul` by the flag, escaped as a paragraph.
+- [x] 2.2 The list styles fill the content column in the design source.
+
+## 3. The advisory
+
+- [x] 3.1 The free-numeral walk covers the list items beside the prose.
+
+## 4. The proof
+
+- [x] 4.1 Tests cover the four delta scenarios, and a block with no list renders byte-identically.
+- [x] 4.2 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -69,6 +69,8 @@ kind. A `text` block and a `claim` block MUST be leaves that hold inline text on
 The root MUST hold at least one section, and a `section` MUST hold at least one
 block.
 
+The text block MUST admit an optional typed list beside its prose: an ordered flag, and an items array of non-empty inline lines, with at least one item. The list is content, not markup, and no markdown joins. A text block with a list and an empty prose is valid content.
+
 #### Scenario: A chart inside a metric is rejected
 
 - **WHEN** a `metric` block holds a `chart` block as a child
@@ -88,6 +90,16 @@ block.
 
 - **WHEN** a `section` holds no block
 - **THEN** validation rejects the section
+
+#### Scenario: A text block carries a list
+
+- **WHEN** a text block carries six ordered limitation items beside a lead sentence
+- **THEN** the block validates, and the list rides the stored document
+
+#### Scenario: An empty list refuses
+
+- **WHEN** a text block carries a list with zero items
+- **THEN** the parse fails
 
 ### Requirement: The chart grammar
 A chart block MUST carry either the quick path or the composition, and never both. The quick path is one chart type with one encoding. The composition holds one or more series, optional annotations, and optional axes. A series has a form (`line`, `scatter`, `bar`, `area`, `step`) and its own column encoding. An `area` series can name a `y0` lower-bound column. A channel is a column name, or a column with a per-row transform (`log10`, `neg_log10`, `abs`, `rank`). The encoding can name a `label` column for the identity of a point.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -50,6 +50,8 @@ The renderer MUST take the values keyed by block id, as a closed union: a scalar
 ### Requirement: A rendered form for each block kind
 The renderer MUST give each of the eight block kinds a rendered form. The renderer makes each layout decision, and no markup comes from the document.
 
+A text block with a list MUST render the list after its prose paragraphs, as ordered or unordered list markup by the flag. Each item escapes exactly as a paragraph does, and the list fills the content column. A text block with a list and an empty prose renders the list alone.
+
 #### Scenario: A section renders as a heading by depth
 - **WHEN** the caller renders a section with a nested child section
 - **THEN** the outer title renders as a higher heading level than the inner title
@@ -73,6 +75,16 @@ The renderer MUST give each of the eight block kinds a rendered form. The render
 #### Scenario: An empty chart still renders its container
 - **WHEN** the caller renders a chart block whose value entry holds zero rows
 - **THEN** the page holds the chart container, and the inline option holds an empty data list
+
+#### Scenario: An enumeration renders as a list
+
+- **WHEN** the caller renders a text block with a lead sentence and six ordered items
+- **THEN** the page holds the paragraph and an ordered list with the six items
+
+#### Scenario: A list stands alone
+
+- **WHEN** the caller renders a text block with an empty prose and three unordered items
+- **THEN** the page holds the unordered list, and no empty paragraph
 
 ### Requirement: The number format of a resolved value
 The renderer MUST format each numeric value that it shows, through one number helper and its closed set of kinds. The kinds are `scientific`, `compact`, `compact-scientific`, `identifier`, and `below-resolution`. The helper applies to the metric value and to each numeric table cell. The renderer picks the kind by magnitude and by column meaning, and no block carries a format field.

--- a/harness/src/contracts/report-blocks.test.ts
+++ b/harness/src/contracts/report-blocks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { ChartBlockSchema, channelColumn, channelTransform, type ChartComposition } from "./report-blocks.js";
+import { ChartBlockSchema, ClaimBlockSchema, TextBlockSchema, channelColumn, channelTransform, type ChartComposition } from "./report-blocks.js";
 
 const HASH = `sha256:${"a".repeat(64)}`;
 
@@ -228,5 +228,73 @@ describe("the exclusivity of the two paths", () => {
 
     it("refuses a block that carries neither path", () => {
         expect(parses({})).toBe(false);
+    });
+});
+
+describe("the text list", () => {
+    /** A text block that carries the given content. The extra fields ride unchecked, thus a hole is testable. */
+    function text(content: Record<string, unknown>): Record<string, unknown> {
+        return { kind: "text", id: "text-1", content };
+    }
+
+    /** The six limitation items of the case that the list serves. */
+    const LIMITATIONS = [
+        "The cohort holds 48 biopsies, thus a subgroup is small.",
+        "The batch and the tissue site are confounded.",
+        "No independent cohort validates the signature.",
+        "The bulk profile hides the cell of origin.",
+        "The survival follow-up is short.",
+        "The pathway result rests on one database.",
+    ];
+
+    it("takes a lead sentence with six ordered items", () => {
+        const parsed = TextBlockSchema.safeParse(text({ prose: "Six limits bound the reading.", list: { ordered: true, items: LIMITATIONS } }));
+
+        expect(parsed.success).toBe(true);
+        if (parsed.success) {
+            // The list rides the parsed block, thus the stored document keeps each item.
+            expect(parsed.data.content.list?.items).toEqual(LIMITATIONS);
+            expect(parsed.data.content.list?.ordered).toBe(true);
+        }
+    });
+
+    it("takes a list with an empty prose, because the lead sentences are optional", () => {
+        expect(TextBlockSchema.safeParse(text({ prose: "", list: { ordered: false, items: ["One point."] } })).success).toBe(true);
+    });
+
+    it("takes a block with no list, thus a stored block keeps parsing", () => {
+        const parsed = TextBlockSchema.safeParse(text({ prose: "Body text." }));
+
+        expect(parsed.success).toBe(true);
+        if (parsed.success) {
+            expect(parsed.data.content.list).toBeUndefined();
+        }
+    });
+
+    it("refuses a list that holds no item", () => {
+        expect(TextBlockSchema.safeParse(text({ prose: "Lead.", list: { ordered: true, items: [] } })).success).toBe(false);
+    });
+
+    it("refuses an item that holds no text", () => {
+        expect(TextBlockSchema.safeParse(text({ prose: "Lead.", list: { ordered: true, items: ["One point.", ""] } })).success).toBe(false);
+    });
+
+    it("refuses a list that names no form", () => {
+        expect(TextBlockSchema.safeParse(text({ prose: "Lead.", list: { items: ["One point."] } })).success).toBe(false);
+    });
+
+    it("refuses a field that the list grammar does not declare", () => {
+        expect(TextBlockSchema.safeParse(text({ prose: "Lead.", list: { ordered: true, items: ["One point."], nested: [] } })).success).toBe(false);
+    });
+
+    it("refuses a list on a claim block, because the enumeration is a text block", () => {
+        const claim = {
+            kind: "claim",
+            id: "claim-1",
+            content: { prose: "A claim.", list: { ordered: true, items: ["One point."] } },
+            bindings: [{ kind: "artifact-table", path: "runs/run-1/step-a/output/de.csv", hash: HASH }],
+        };
+
+        expect(ClaimBlockSchema.safeParse(claim).success).toBe(false);
     });
 });

--- a/harness/src/contracts/report-blocks.ts
+++ b/harness/src/contracts/report-blocks.ts
@@ -151,11 +151,31 @@ export const ChartCompositionSchema = z.strictObject({
     axes: ChartAxesSchema.optional().describe("The axis titles and the axis scales."),
 });
 
+/**
+ * One typed list of a text block: the flag that selects the form, and the items.
+ *
+ * An item is one inline line, and the renderer escapes it as it escapes a paragraph. No item carries
+ * markup, and no item carries a list of its own. A deeper structure composes as a section with blocks.
+ */
+export const TextListSchema = z.strictObject({
+    ordered: z.boolean().describe("True for a numbered list, for example a ranked set or a sequence of steps. False for a bulleted list of parallel points."),
+    items: z
+        .array(z.string().min(1).describe("One item as one inline line. It carries no markup and no list of its own."))
+        .min(1)
+        .describe("One item at least. Each item is one point."),
+});
+
 /** Prose with no binding. The absence of a binding field is the rule for this kind. */
 export const TextBlockSchema = z.strictObject({
     kind: z.literal("text"),
     id: z.string().min(1).describe("The stable identity of the block."),
-    content: z.strictObject({ prose: z.string() }),
+    content: z.strictObject({
+        prose: z.string(),
+        list: TextListSchema.optional().describe(
+            "The enumeration of the block, as a list. Three or more parallel points compose here, and never inline in the prose as " +
+                '"(1) ... (6)". The prose above the list carries the lead sentences that introduce it, and it can be empty.',
+        ),
+    }),
 });
 
 /** Prose with at least one reference that justifies it. */
@@ -320,6 +340,7 @@ export type ChartAnnotation = z.infer<typeof ChartAnnotationSchema>;
 export type ChartAxes = z.infer<typeof ChartAxesSchema>;
 export type ChartComposition = z.infer<typeof ChartCompositionSchema>;
 export type ChartType = z.infer<typeof ChartTypeSchema>;
+export type TextList = z.infer<typeof TextListSchema>;
 export type TextBlock = z.infer<typeof TextBlockSchema>;
 export type ClaimBlock = z.infer<typeof ClaimBlockSchema>;
 export type MetricBlock = z.infer<typeof MetricBlockSchema>;

--- a/harness/src/report-model/block-walk.ts
+++ b/harness/src/report-model/block-walk.ts
@@ -1,7 +1,7 @@
 /**
  * The one walk over a block tree.
  *
- * A block kind decides where a reference sits, which prose carries a free numeral, and whether the block
+ * A block kind decides where a reference sits, which text carries a free numeral, and whether the block
  * holds children. Three consumers need that same knowledge: the mechanical validator, the draft finish,
  * and the draft operations. A switch for each consumer is a switch that a ninth block kind can miss in
  * silence, because each arm returns and none of them fails to build. Thus the walk lives here one time.
@@ -144,6 +144,11 @@ export function walkBlocks(blocks: readonly AnyBlock[]): BlockWalk {
                 return;
             case "text":
                 warnings.push(...numeralWarnings(block.id, block.content.prose));
+                // An item of a list states a point, the same as a sentence of the prose. Thus a free
+                // figure inside an item carries the same honesty concern, and the walk reads both.
+                for (const item of block.content.list?.items ?? []) {
+                    warnings.push(...numeralWarnings(block.id, item));
+                }
                 return;
             case "claim":
                 warnings.push(...numeralWarnings(block.id, block.content.prose));

--- a/harness/src/report-model/draft-read.test.ts
+++ b/harness/src/report-model/draft-read.test.ts
@@ -170,6 +170,45 @@ describe("buildOutline", () => {
         expect(buildOutline(draft).find((entry) => entry.id === "t1")?.label).toBe("Two limits bound the reading.");
     });
 
+    it("skips a first item that holds no text, thus the label names something", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Limits",
+                    blocks: [
+                        {
+                            kind: "text",
+                            id: "t1",
+                            content: { prose: "", list: { ordered: false, items: [" ", "The cohort is small."] } },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // The grammar admits an item of one space, thus the first item can name nothing.
+        expect(buildOutline(draft).find((entry) => entry.id === "t1")?.label).toBe("The cohort is small.");
+    });
+
+    it("labels a list of blank items with an empty label, the same as an absent field", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Limits",
+                    blocks: [{ kind: "text", id: "t1", content: { prose: "", list: { ordered: false, items: [" ", "\t"] } } }],
+                },
+            ],
+        };
+
+        expect(buildOutline(draft).find((entry) => entry.id === "t1")?.label).toBe("");
+    });
+
     it("clips a long first item of a list-only text block", () => {
         const draft: DraftDocument = {
             title: "Report",

--- a/harness/src/report-model/draft-read.test.ts
+++ b/harness/src/report-model/draft-read.test.ts
@@ -124,6 +124,71 @@ describe("buildOutline", () => {
         expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(label)).toBe(false);
     });
 
+    it("labels a list-only text block with its first item", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Limits",
+                    blocks: [
+                        {
+                            kind: "text",
+                            id: "t1",
+                            content: { prose: "", list: { ordered: true, items: ["The cohort is small.", "The batch confounds."] } },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // The lead sentences are optional, thus an outline of such a block would name nothing without
+        // the fallback.
+        expect(buildOutline(draft).find((entry) => entry.id === "t1")?.label).toBe("The cohort is small.");
+    });
+
+    it("keeps the lead sentence as the label when a text block carries both", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Limits",
+                    blocks: [
+                        {
+                            kind: "text",
+                            id: "t1",
+                            content: { prose: "Two limits bound the reading.", list: { ordered: true, items: ["The cohort is small."] } },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(buildOutline(draft).find((entry) => entry.id === "t1")?.label).toBe("Two limits bound the reading.");
+    });
+
+    it("clips a long first item of a list-only text block", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Limits",
+                    blocks: [{ kind: "text", id: "t1", content: { prose: "   ", list: { ordered: false, items: ["x".repeat(120)] } } }],
+                },
+            ],
+        };
+
+        // A prose of whitespace alone names nothing either, thus the item stands in and it clips as prose.
+        const label = buildOutline(draft).find((entry) => entry.id === "t1")?.label ?? "";
+        expect([...label].length).toBe(80);
+        expect(label.endsWith("…")).toBe(true);
+    });
+
     it("keeps a label that is exactly the clip length whole, with no marker", () => {
         const draft: DraftDocument = {
             title: "Report",

--- a/harness/src/report-model/draft-read.ts
+++ b/harness/src/report-model/draft-read.ts
@@ -96,7 +96,12 @@ function labelOf(block: DraftBlock): string {
             return clip(block.note ?? "");
         case "text": {
             const prose = block.content.prose;
-            return clip(prose.trim().length > 0 ? prose : (block.content.list?.items[0] ?? ""));
+            if (prose.trim().length > 0) {
+                return clip(prose);
+            }
+            // An item passes the grammar with one space in it, thus the first item can name nothing. The
+            // walk takes the first item that holds text, and a list of blank items gives an empty label.
+            return clip(block.content.list?.items.find((item) => item.trim().length > 0) ?? "");
         }
         case "claim":
             return clip(block.content.prose);

--- a/harness/src/report-model/draft-read.ts
+++ b/harness/src/report-model/draft-read.ts
@@ -75,6 +75,9 @@ function clip(text: string): string {
  * a note. A text and a claim carry prose. Every one of them clips: a caption, a note, and a title are free
  * prose too, thus an unclipped arm would put a paragraph into each outline that names the block.
  *
+ * A text block carries its enumeration in the list, and the lead sentences above it can be empty. Such a
+ * block gives the first item, thus the outline names it and the agent reads which block it is.
+ *
  * A block with an absent optional field gives an empty label.
  */
 function labelOf(block: DraftBlock): string {
@@ -91,8 +94,10 @@ function labelOf(block: DraftBlock): string {
             return clip(block.caption ?? "");
         case "citation":
             return clip(block.note ?? "");
-        case "text":
-            return clip(block.content.prose);
+        case "text": {
+            const prose = block.content.prose;
+            return clip(prose.trim().length > 0 ? prose : (block.content.list?.items[0] ?? ""));
+        }
         case "claim":
             return clip(block.content.prose);
     }

--- a/harness/src/report-model/validate.test.ts
+++ b/harness/src/report-model/validate.test.ts
@@ -888,6 +888,35 @@ describe("validateReport — free-numeral warnings", () => {
         expect(valid.warnings).toEqual([]);
     });
 
+    it("warns on a numeral inside a list item, the same as on one in prose", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "text",
+                id: "text-list-numeral",
+                content: { prose: "Two limits bound the reading.", list: { ordered: true, items: ["The cohort holds 48 biopsies.", "The batch confounds."] } },
+            }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        // An item states a point, thus a free figure inside it warns and the report stays valid.
+        expect(valid.warnings).toEqual([{ blockId: "text-list-numeral", kind: "free-numeral", detail: "48" }]);
+    });
+
+    it("gives no warning for a clean list", async () => {
+        const result = await validateReport(
+            reportWith({
+                kind: "text",
+                id: "text-list-clean",
+                content: { prose: "", list: { ordered: false, items: ["The cohort is small.", "TP53 rose."] } },
+            }),
+            snapshot,
+            resolver,
+        );
+        const valid = expectValid(result);
+        expect(valid.warnings).toEqual([]);
+    });
+
     it("still warns on a free figure that sits beside a symbol", async () => {
         const result = await validateReport(
             reportWith({ kind: "text", id: "text-mixed", content: { prose: "TP53 rose 42% across 3 cohorts." } }),

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -333,6 +333,18 @@ img {
   line-height: 1.7;
   color: var(--color-text);
 }
+/* A list reads as prose that carries markers, thus it takes the type scale of the paragraph. The margin
+   is explicit on each side, because the base rule zeroes an ordered list and a browser still spaces an
+   unordered one. The left padding holds the markers, thus each item aligns inside the content column. */
+.report-list {
+  margin: 0 0 16px;
+  padding-left: 24px;
+  line-height: 1.7;
+  color: var(--color-text);
+}
+.report-list-item {
+  margin-bottom: 6px;
+}
 .report-marker {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/harness/src/report-render/fixture.test.ts
+++ b/harness/src/report-render/fixture.test.ts
@@ -63,6 +63,14 @@ describe("the design fixture", () => {
         expect(covered).toEqual(declared);
     });
 
+    it("holds a text block that carries a list", () => {
+        const withAList = everyBlock(FIXTURE_DOCUMENT.sections).filter((block) => block.kind === "text" && block.content.list !== undefined);
+        // The list is a content form of the text block, and it renders markup of its own. The page shows
+        // only what the fixture holds, thus a fixture with no list keeps the list markup out of the design
+        // review and out of the HTML validation alike.
+        expect(withAList.length).toBeGreaterThan(0);
+    });
+
     it("holds a metric run that the grid groups and a lone metric that it does not", () => {
         const runs = metricRuns(FIXTURE_DOCUMENT.sections);
         // The renderer groups a run of two or more into one grid, and it leaves a lone metric as one card.

--- a/harness/src/report-render/fixture.ts
+++ b/harness/src/report-render/fixture.ts
@@ -2,9 +2,10 @@
  * The design fixture: one report document that covers every block kind, with its value map.
  *
  * A person edits `design.ts` and the views, then examines this page. Thus the fixture holds each of the
- * eight kinds, a run of metric siblings, a lone metric between two text blocks, a titled table, a titled
- * chart, a figure, a citation, and a section tree of three depths. Three top-level sections show the band
- * alternation, and the reference band holds an artifact reference beside a citation that two claims share.
+ * eight kinds, a run of metric siblings, a lone metric between two text blocks, a text block with a list,
+ * a titled table, a titled chart, a figure, a citation, and a section tree of three depths. Three
+ * top-level sections show the band alternation, and the reference band holds an artifact reference beside
+ * a citation that two claims share.
  *
  * Each value is a literal, and the figure source is an inline data URI. Thus the page is a pure function of
  * this module, and the fixture reads no file.
@@ -160,9 +161,15 @@ export const FIXTURE_DOCUMENT: ReportDocument = {
                     kind: "text",
                     id: "cohort-quality",
                     content: {
-                        prose:
-                            "Every library passed the quality gate. The duplicate rate stayed under 18 percent, and the ribosomal " +
-                            "fraction stayed under 4 percent. No biopsy dropped out of the comparison.",
+                        prose: "Every library passed the quality gate on three measures.",
+                        list: {
+                            ordered: false,
+                            items: [
+                                "The duplicate rate stayed under 18 percent.",
+                                "The ribosomal fraction stayed under 4 percent.",
+                                "No biopsy dropped out of the comparison.",
+                            ],
+                        },
                     },
                 },
             ],

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -133,6 +133,58 @@ describe("renderReportPage assembly", () => {
     });
 });
 
+describe("renderReportPage text lists", () => {
+    /** One page whose section holds the given text block. */
+    function pageOfText(block: TextBlock): ReturnType<typeof load> {
+        const document: ReportDocument = { title: "T", sections: [{ kind: "section", id: "s", title: "S", blocks: [block] }] };
+        return load(renderReportPage(document, {})._unsafeUnwrap());
+    }
+
+    it("holds the lead paragraph and the ordered list of six items", () => {
+        const items = [
+            "The cohort is small.",
+            "The batch confounds.",
+            "No cohort validates.",
+            "The profile is bulk.",
+            "The follow-up is short.",
+            "One database.",
+        ];
+        const page = pageOfText({ kind: "text", id: "t1", content: { prose: "Six limits bound the reading.", list: { ordered: true, items } } });
+
+        expect(page("p.report-prose").text()).toBe("Six limits bound the reading.");
+        expect(page("ol.report-list li").length).toBe(6);
+        expect(
+            page("ol.report-list li")
+                .toArray()
+                .map((node) => page(node).text()),
+        ).toEqual(items);
+    });
+
+    it("holds the unordered list alone for a block with an empty prose", () => {
+        const page = pageOfText({ kind: "text", id: "t2", content: { prose: "", list: { ordered: false, items: ["One.", "Two.", "Three."] } } });
+
+        expect(page("ul.report-list li").length).toBe(3);
+        // An empty prose gives no paragraph, thus the band holds the list alone.
+        expect(page("p.report-prose").length).toBe(0);
+    });
+
+    it("carries a list on the design fixture, thus the validity gate reads the markup", () => {
+        const page = load(renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap());
+
+        // The fixture is the page that the HTML validation and the design review both read. A fixture
+        // with no list would drop the new markup out of each of them in silence.
+        expect(page("ul.report-list li").length).toBeGreaterThan(0);
+    });
+
+    it("fills the content column with the list, the same as with a paragraph", () => {
+        const listRules = [...DESIGN_CSS.matchAll(/\.report-list\s*\{([^}]*)\}/g)].map((match) => match[1]);
+        expect(listRules.length).toBe(1);
+        // A list reads at the measure of the prose around it, thus no inner width caps it.
+        expect(listRules[0]).not.toContain("max-width");
+        expect(listRules[0]).toContain("line-height: 1.7");
+    });
+});
+
 describe("the page stands alone", () => {
     /** A page whose citation card carries a pinned record, thus the body holds a PubMed navigation. */
     function pageWithACitation(): string {

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -168,14 +168,6 @@ describe("renderReportPage text lists", () => {
         expect(page("p.report-prose").length).toBe(0);
     });
 
-    it("carries a list on the design fixture, thus the validity gate reads the markup", () => {
-        const page = load(renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap());
-
-        // The fixture is the page that the HTML validation and the design review both read. A fixture
-        // with no list would drop the new markup out of each of them in silence.
-        expect(page("ul.report-list li").length).toBeGreaterThan(0);
-    });
-
     it("fills the content column with the list, the same as with a paragraph", () => {
         const listRules = [...DESIGN_CSS.matchAll(/\.report-list\s*\{([^}]*)\}/g)].map((match) => match[1]);
         expect(listRules.length).toBe(1);

--- a/harness/src/report-render/views/prose.test.ts
+++ b/harness/src/report-render/views/prose.test.ts
@@ -13,6 +13,56 @@ describe("renderText", () => {
         expect(html).toContain("First paragraph.");
         expect(html).toContain("Second paragraph.");
     });
+
+    it("renders the ordered list of six items after the lead paragraph", () => {
+        const items = [
+            "The cohort is small.",
+            "The batch confounds.",
+            "No cohort validates.",
+            "The profile is bulk.",
+            "The follow-up is short.",
+            "One database.",
+        ];
+        const block: TextBlock = { kind: "text", id: "t2", content: { prose: "Six limits bound the reading.", list: { ordered: true, items } } };
+
+        const html = renderText(block);
+
+        // The lead sentence introduces the enumeration, thus the list comes after the paragraph.
+        expect(html.indexOf("<p ")).toBeLessThan(html.indexOf("<ol "));
+        expect(html).toContain("Six limits bound the reading.");
+        expect(html.split("<li ").length - 1).toBe(6);
+        for (const item of items) {
+            expect(html).toContain(item);
+        }
+        expect(html).not.toContain("<ul ");
+    });
+
+    it("renders an unordered list alone when the prose is empty", () => {
+        const block: TextBlock = { kind: "text", id: "t3", content: { prose: "", list: { ordered: false, items: ["One.", "Two.", "Three."] } } };
+
+        const html = renderText(block);
+
+        expect(html).toContain("<ul ");
+        expect(html.split("<li ").length - 1).toBe(3);
+        // An empty prose gives no paragraph, thus the page carries no empty line over the list.
+        expect(html).not.toContain("<p ");
+    });
+
+    it("renders a block with no list exactly as it renders one that never had the field", () => {
+        const block: TextBlock = { kind: "text", id: "t4", content: { prose: "First paragraph.\n\nSecond paragraph." } };
+
+        expect(renderText(block)).toBe(`<p class="report-prose">First paragraph.</p><p class="report-prose">Second paragraph.</p>`);
+    });
+
+    it("keeps a script tag in an item as text", () => {
+        const block: TextBlock = { kind: "text", id: "t5", content: { prose: "", list: { ordered: true, items: ["<script>alert(1)</script> is a risk."] } } };
+
+        const html = renderText(block);
+
+        // An item takes the escape of a paragraph, thus no item reaches the page as markup.
+        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(html).not.toContain("<script>");
+    });
 });
 
 describe("renderClaim", () => {

--- a/harness/src/report-render/views/prose.tsx
+++ b/harness/src/report-render/views/prose.tsx
@@ -4,16 +4,22 @@
  * The runtime escapes every interpolated string, thus hostile prose reaches the page as text. A text
  * block and a claim block split the prose on a blank line, and each part becomes one paragraph. A claim
  * adds one marker for each binding, and the markers number through the shared ledger.
+ *
+ * A text block also carries a typed list, and the list renders as list markup after the paragraphs. Each
+ * item takes the same escape as a paragraph, thus no item reaches the page as markup.
  */
 
 import { raw } from "hono/html";
 
-import type { ClaimBlock, SectionBlock, TextBlock } from "../../contracts/report-blocks.js";
+import type { ClaimBlock, SectionBlock, TextBlock, TextList } from "../../contracts/report-blocks.js";
 import type { ReferenceLedger } from "../references.js";
 import { LadderMarker } from "./references-view.js";
 
 /** The paragraph class of a text block and a claim block. The paragraph fills the content column. */
 const PARAGRAPH_CLASS = "report-prose";
+
+/** The class of a rendered list. The list fills the content column, the same as a paragraph. */
+const LIST_CLASS = "report-list";
 
 /** The site that the navigation brand links to. It is the one reference of the page that leaves the page. */
 const BRAND_HREF = "https://inflexa.ai/";
@@ -34,14 +40,31 @@ function splitParagraphs(prose: string): string[] {
     return paragraphs;
 }
 
-/** Render a text block as escaped paragraphs. */
+/**
+ * One typed list as list markup. The flag selects the element: an ordered list numbers its items, and an
+ * unordered one bullets them. Each item is one inline line, thus no item holds a list of its own.
+ */
+function TextListView({ list }: { list: TextList }) {
+    const items = list.items.map((item) => <li class="report-list-item">{item}</li>);
+    return list.ordered ? <ol class={LIST_CLASS}>{items}</ol> : <ul class={LIST_CLASS}>{items}</ul>;
+}
+
+/**
+ * Render a text block as escaped paragraphs, and then its list.
+ *
+ * The lead sentences introduce the enumeration, thus the list comes after them. An empty prose gives no
+ * paragraph, and a block with a list alone renders the list alone. A block with no list renders the
+ * paragraphs alone, exactly as it did before the field existed.
+ */
 export function renderText(block: TextBlock): string {
     const paragraphs = splitParagraphs(block.content.prose);
+    const list = block.content.list;
     return String(
         <>
             {paragraphs.map((paragraph) => (
                 <p class={PARAGRAPH_CLASS}>{paragraph}</p>
             ))}
+            {list !== undefined ? <TextListView list={list} /> : null}
         </>,
     );
 }

--- a/harness/src/tools/report-authoring/authoring-tools.test.ts
+++ b/harness/src/tools/report-authoring/authoring-tools.test.ts
@@ -201,6 +201,33 @@ describe("add_block", () => {
         expect(gateway.peek("t1")!.document.sections[0]!.blocks.map((block) => block.id)).toEqual(["t1"]);
     });
 
+    it("lands a text block that carries a typed list, and the gateway holds each item", async () => {
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: oneSectionDraft(), snapshot });
+        const tools = createReportAuthoringTools(gateway);
+        const block = { kind: "text", id: "t1", content: { prose: "Two limits bound the reading.", list: { ordered: true, items: ["One.", "Two."] } } };
+
+        const value = (await tools.add_block.execute({ block, parentId: "s1" }, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(value.applied).toBe(true);
+        // The draft grammar composes from the contract atoms, thus the field reaches the tool with no
+        // payload of its own and the stored draft keeps it.
+        const landed = gateway.peek("t1")!.document.sections[0]!.blocks[0]!;
+        expect(landed.kind === "text" ? landed.content.list : undefined).toEqual({ ordered: true, items: ["One.", "Two."] });
+    });
+
+    it("refuses a text block whose list holds no item", async () => {
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: oneSectionDraft(), snapshot });
+        const tools = createReportAuthoringTools(gateway);
+        const block = { kind: "text", id: "t1", content: { prose: "Lead.", list: { ordered: true, items: [] } } };
+
+        const value = (await tools.add_block.execute({ block, parentId: "s1" }, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(value.applied).toBe(false);
+        expect(gateway.peek("t1")!.document.sections[0]!.blocks).toEqual([]);
+    });
+
     it("accepts an explicit null in each destination field that the call does not use", async () => {
         const gateway = makeFakeGateway();
         gateway.seed("t1", { document: oneSectionDraft(), snapshot });


### PR DESCRIPTION
## What & why

The Limitations section of the session page is one twelve-line paragraph with "(1) … (6)" inline. The renderer split prose on blank lines alone, and it knew no list, thus the agent had no better form. The text block now carries an optional typed list beside its prose: an ordered flag, and items of non-empty inline lines. The items render as list markup after the paragraphs, escaped exactly as a paragraph. No markdown engine joins. The free-numeral advisory walks the items, and the outline labels a list-only block with its first item.

Reviewer notes: the authoring tools needed no code, because the draft schema spreads the atom schemas — two tests prove the admit and the refuse at the tool. A claim keeps its prose-only content, and a list on a claim refuses. The design fixture gained a short list, thus the markup validity gate sees the new form.

Refs #397

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
