### PR TITLE
feat(harness): stage the table data as script assets

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/design.md
@@ -1,0 +1,44 @@
+# Design: stage-the-table-data-assets
+
+## Context
+
+The table view renders every resolved row into the markup, and the chart option rides as inline JSON. The preview tool stages the page, the static assets of the manifest, and the bound figures (`src/tools/report-session/preview-report.ts`). The renderer is pure: it reads no file and writes no file, and that rule stays.
+
+## Decisions
+
+### D1: The renderer returns the payloads, and the caller writes them
+
+The render result gains a `dataAssets` list beside the page string: one entry for each bound table, with the asset file name and the payload bytes. The renderer stays pure and deterministic, and the preview tool writes each entry in the figure-staging pipeline. Two previews of one document give byte-identical payloads.
+
+### D2: One payload is columnar, with a dictionary pass
+
+The payload registers under one global map, keyed by the block id: `window.__REPORT_TABLES[<blockId>] = { columns, rows, dict }`. The rows are arrays in column order. A string that occurs more than one time in a column moves into `dict`, and the row cell holds its index. A number stays a number. The decode is a few lines in the page script, and the encode is deterministic: the dictionary orders by first appearance.
+
+### D3: The asset name carries the content hash
+
+The file is `assets/t-<hash12>.data.js`, the same content-address style as a staged figure. Thus two previews of unchanged data reuse one name, a changed table gets a new name, and the authoritative sweep removes the stale one.
+
+### D4: The row bound is content on the binding
+
+`rowBound: { column, count, order }` is optional on the whole-table binding, with `desc` as the default order. The resolution applies it: the resolved table holds the bounded rows, sorted by the named column with the numeric-aware compare. Thus the asset, the render, the gate, and a chart over the same binding see one bounded set. An unknown column in the bound refuses at the structural tier, exactly as a grammar column does.
+
+### D5: The sidecar is the pinned bytes
+
+The reader download is the raw artifact, not a re-serialization. The preview copies the pinned file beside the page as `assets/<hash12>-<basename>`, and the table card links it with a `download` attribute. A relative link is not a remote reference, thus the stands-alone rule holds untouched.
+
+### D6: The sweep is authoritative over the assets directory
+
+After a preview writes the page, it removes every file in `assets/` that the new page does not reference: a stale data asset, a stale figure, and a stale sidecar alike. The manifest statics always stay. Thus a removed block leaves no orphan, and the folder is exactly the page's closure.
+
+### D7: The interim table shows the header and the download
+
+The DOM rows go now, and the grid of the next tracker change consumes the registered data. Between the two changes, the table card holds the header row, the download link, and the data asset. The round-one enhancer becomes inert on an empty body, and its removal belongs to the grid change.
+
+### D8: A chart keeps its inline option, and compression waits for its case
+
+The chart data is bounded by what a chart can show, and moving it needs an option-to-dataset surgery with no present need. A data asset past a size threshold near 10 MB takes the gzip arm with a zeroed header when such a table appears. Both are stated later arms, not silent gaps.
+
+## Risks / Trade-offs
+
+- A block id rides into a JS identifier context. The id is safe-id constrained by the contract, and the payload writes it as a JSON string key, thus no injection surface opens.
+- The interim page shows no rows in a plain browser until the grid lands. The pairing is one tracker sequence, and the delivery branch ships whole.

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: stage-the-table-data-assets
+
+## Why
+
+The session page stamps 14,201 table rows into its markup, and `index.html` weighs 7.2 MB. A `fetch` is refused on a `file://` page, thus a data file cannot load the way an image does. A classic script asset loads fine, and the page already carries ECharts that way. The decided direction: the page stays `file://`-first, with classic script assets alone.
+
+## What Changes
+
+- The renderer emits the bound table of each table block as a columnar data-script payload: a columns list, row arrays, and a dictionary pass for repeated strings. The page markup holds the table header and no data rows, and a classic `script` tag references the asset.
+- The renderer stays pure: it returns the payloads beside the page string, and the preview tool writes them, in the same pipeline that stages the figures.
+- The table binding gains an optional row bound as content: the top N rows by a named column. The bound rows are the table, thus the asset, the render, and the gate see one bounded set.
+- A raw CSV copy of each bound table stages beside the page, and the table card links it as the reader download.
+- The asset stage of the preview is authoritative: it writes what the document references, and it removes what nothing references.
+- A chart keeps its inline option, and a data asset past a compression threshold is a stated later arm.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-block-model`: the table binding carries the optional row bound.
+- `report-render`: the table renders headers over a data asset, and the renderer returns the payloads.
+- `report-session-agent`: the preview stages the data assets and the sidecars, and the stage is authoritative.
+
+## Impact
+
+- Affected code: `src/contracts/report-reference.ts`, `src/report-render/` (the table view, the render result, the assets), `src/tools/report-session/preview-report.ts`, the resolution path of the row bound, and their tests.
+- The page loses its DOM rows before the grid child lands. The interim table shows its header and the download link, and the pairing closes in the next change of the tracker.

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-block-model/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-block-model/spec.md
@@ -1,0 +1,22 @@
+# Delta: report-block-model
+
+## MODIFIED Requirements
+
+### Requirement: A table binding declares its column meanings
+
+A whole-table binding MUST also admit an optional row bound as content: the top N rows by a named column, with `desc` as the default order. The bound rows are the table: the resolution applies the bound, thus every reader of the binding sees one bounded set. A bound whose column the artifact does not hold refuses at the structural tier.
+
+#### Scenario: A bounded binding validates
+
+- **WHEN** the author binds a table with a row bound of the top 20 rows by a p-value column
+- **THEN** the block validates, and the bound rides the stored document
+
+#### Scenario: The bound applies at resolution
+
+- **WHEN** a bounded binding resolves against a table of 14,201 rows
+- **THEN** the resolved table holds the 20 bounded rows, sorted by the named column
+
+#### Scenario: A bound over an unknown column refuses
+
+- **WHEN** a row bound names a column that the artifact does not hold
+- **THEN** the structural tier refuses the block before a landing

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-render/spec.md
@@ -1,0 +1,31 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: The table data rides a data-script asset
+
+The renderer MUST emit the bound table of each table block as a columnar data-script payload: a columns list, row arrays, and a dictionary for a string that occurs more than one time. The payload registers under one global map, keyed by the block id, and a classic `script` tag references the asset. The table markup holds the header and no data rows. The renderer MUST return the payloads beside the page string, because the renderer writes no file. The payload derivation MUST be deterministic, thus two renders of one document give byte-identical payloads.
+
+The asset name MUST carry the content hash of the payload, in the content-address style of a staged figure. The table card MUST link the raw pinned bytes of its artifact as the reader download, through a relative link.
+
+The chart keeps its inline option. A data asset past a compression threshold near 10 MB is a later arm, and today every payload stages plain.
+
+#### Scenario: The page holds no data rows
+
+- **WHEN** the caller renders a document with a table of 14,201 resolved rows
+- **THEN** the markup holds the table header and zero data rows, and the payload holds the 14,201 rows
+
+#### Scenario: The payload is deterministic
+
+- **WHEN** the caller renders one document two times
+- **THEN** the two payload sets are byte-identical, and the asset names match
+
+#### Scenario: The dictionary compresses a repeated string
+
+- **WHEN** a column holds one category value across many rows
+- **THEN** the payload stores the value one time in the dictionary, and each row holds its index
+
+#### Scenario: The card links the download
+
+- **WHEN** the caller renders a table block
+- **THEN** the card holds a relative download link to the staged raw bytes of the artifact

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/specs/report-session-agent/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The render-and-preview tool
+
+The preview MUST stage each data-script payload and each table sidecar beside the page, in the pipeline that stages the figures. The stage MUST be authoritative over the assets directory: after the page lands, every file that the new page does not reference goes, and the manifest statics stay. Thus a removed block leaves no orphan, and the directory is exactly the page's closure.
+
+#### Scenario: The data asset lands beside the page
+
+- **WHEN** the preview renders a document with a bound table
+- **THEN** the data-script asset and the raw sidecar sit under `assets/`, and the page references both
+
+#### Scenario: The stage removes what nothing references
+
+- **WHEN** a block goes and the next preview runs
+- **THEN** the stale data asset and the stale sidecar are gone, and the manifest statics stay

--- a/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-stage-the-table-data-assets/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: stage-the-table-data-assets
+
+## 1. The row bound
+
+- [x] 1.1 The whole-table binding admits the optional `rowBound` in `src/contracts/report-reference.ts`, with a description that names it as the primary size control.
+- [x] 1.2 The resolution applies the bound with the numeric-aware compare, and the structural tier refuses an unknown bound column.
+
+## 2. The payload
+
+- [x] 2.1 The renderer derives one columnar payload for each bound table: columns, row arrays, and the first-appearance dictionary.
+- [x] 2.2 The render result returns the payloads with their content-hash asset names, and the table markup holds the header and no data rows.
+- [x] 2.3 The page script decodes the dictionary, and the table card holds the raw-bytes download link.
+
+## 3. The stage
+
+- [x] 3.1 The preview writes each payload and each sidecar in the figure pipeline.
+- [x] 3.2 The stage sweeps the assets directory: what the page does not reference goes, and the manifest statics stay.
+
+## 4. The proof
+
+- [x] 4.1 Tests cover the nine delta scenarios across the three deltas.
+- [x] 4.2 A document with no table stages no data asset, and its page stays byte-identical.
+- [x] 4.3 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-block-model/spec.md
+++ b/harness/openspec/specs/report-block-model/spec.md
@@ -168,6 +168,8 @@ A whole-table binding MUST admit two optional maps, keyed by the column name: a 
 
 The field descriptions MUST teach the declaration, because the authoring tools carry the schema to the agent. A key that names no column of the artifact is ignored, because absence is a normal condition.
 
+A whole-table binding MUST also admit an optional row bound as content: the top N rows by a named column, with `desc` as the default order. The bound rows are the table: the resolution applies the bound, thus every reader of the binding sees one bounded set. A bound whose column the artifact does not hold refuses at the structural tier.
+
 #### Scenario: A binding declares a meaning and a label
 
 - **WHEN** the author binds a table and declares one column as a `p-value` with a display label
@@ -177,3 +179,18 @@ The field descriptions MUST teach the declaration, because the authoring tools c
 
 - **WHEN** a declaration names a column that the artifact does not hold
 - **THEN** the render proceeds, and the stray key has no effect
+
+#### Scenario: A bounded binding validates
+
+- **WHEN** the author binds a table with a row bound of the top 20 rows by a p-value column
+- **THEN** the block validates, and the bound rides the stored document
+
+#### Scenario: The bound applies at resolution
+
+- **WHEN** a bounded binding resolves against a table of 14,201 rows
+- **THEN** the resolved table holds the 20 bounded rows, sorted by the named column
+
+#### Scenario: A bound over an unknown column refuses
+
+- **WHEN** a row bound names a column that the artifact does not hold
+- **THEN** the structural tier refuses the block before a landing

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -279,6 +279,34 @@ The renderer MUST hold one fixed derivation rule for each chart type. A chart wh
 - **WHEN** the caller renders a bar chart whose categories first appear as Day2, Day10, Day1
 - **THEN** the category axis lists Day2, Day10, Day1 in that order
 
+### Requirement: The table data rides a data-script asset
+
+The renderer MUST emit the bound table of each table block as a columnar data-script payload: a columns list, row arrays, and a dictionary for a string that occurs more than one time. The payload registers under one global map, keyed by the block id, and a classic `script` tag references the asset. The table markup holds the header and no data rows. The renderer MUST return the payloads beside the page string, because the renderer writes no file. The payload derivation MUST be deterministic, thus two renders of one document give byte-identical payloads.
+
+The asset name MUST carry the content hash of the payload, in the content-address style of a staged figure. The table card MUST link the raw pinned bytes of its artifact as the reader download, through a relative link.
+
+The chart keeps its inline option. A data asset past a compression threshold near 10 MB is a later arm, and today every payload stages plain.
+
+#### Scenario: The page holds no data rows
+
+- **WHEN** the caller renders a document with a table of 14,201 resolved rows
+- **THEN** the markup holds the table header and zero data rows, and the payload holds the 14,201 rows
+
+#### Scenario: The payload is deterministic
+
+- **WHEN** the caller renders one document two times
+- **THEN** the two payload sets are byte-identical, and the asset names match
+
+#### Scenario: The dictionary compresses a repeated string
+
+- **WHEN** a column holds one category value across many rows
+- **THEN** the payload stores the value one time in the dictionary, and each row holds its index
+
+#### Scenario: The card links the download
+
+- **WHEN** the caller renders a table block
+- **THEN** the card holds a relative download link to the staged raw bytes of the artifact
+
 ### Requirement: The horizontal bar renders with the category on y
 
 A horizontal bar MUST render the category axis on y and the value axis on x. The category axis MUST keep every label, because the long names are the reason the orientation exists. An annotation names a rendered axis, thus a zero line on the horizontal value axis is an `x` reference line. The axis titles, the declared labels, and the number rules bind to the axes wherever they render. A composition that mixes a horizontal bar with another series on one grid MUST refuse as a render problem.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -173,6 +173,8 @@ The preview tool MUST run the finish on the draft first. A gap list MUST return 
 
 The hosted view of a session page is a later capability with its own URL space, and the result carries no access grant. An unresolved reference, a resolver absence, and a failed write MUST each return a typed outcome that names the cause. The tool MUST NOT throw for any of these outcomes.
 
+The preview MUST stage each data-script payload and each table sidecar beside the page, in the pipeline that stages the figures. The stage MUST be authoritative over the assets directory: after the page lands, every file that the new page does not reference goes, and the manifest statics stay. Thus a removed block leaves no orphan, and the directory is exactly the page's closure.
+
 #### Scenario: An unfinished draft returns the gaps
 - **WHEN** the agent calls the preview on a draft with an empty section
 - **THEN** the result carries the gap list, and no page lands
@@ -188,6 +190,16 @@ The hosted view of a session page is a later capability with its own URL space, 
 #### Scenario: The stamp follows the page
 - **WHEN** the preview writes the page
 - **THEN** the session state holds the hash of the rendered document
+
+#### Scenario: The data asset lands beside the page
+
+- **WHEN** the preview renders a document with a bound table
+- **THEN** the data-script asset and the raw sidecar sit under `assets/`, and the page references both
+
+#### Scenario: The stage removes what nothing references
+
+- **WHEN** a block goes and the next preview runs
+- **THEN** the stale data asset and the stale sidecar are gone, and the manifest statics stay
 
 ### Requirement: The value bridge
 A pure module beside the renderer MUST map resolved values onto `RenderValues`: a scalar to a metric value, rows to a table, and a file echo to a figure source through a caller-supplied policy. The policy of the preview tool MUST stage the bound image into `assets/` beside the page, and the `src` is that relative path. The bridge MUST NOT read a file and MUST NOT resolve a reference itself.

--- a/harness/scripts/render-fixture.ts
+++ b/harness/scripts/render-fixture.ts
@@ -34,7 +34,12 @@ await mkdir(assetsDir, { recursive: true });
 for (const asset of PAGE_ASSETS) {
     await copyFile(moduleResolver.resolve(asset.specifier), join(assetsDir, asset.file));
 }
+// The rows of a table ride a data asset. Without the write the page opens with a failed script request,
+// and the person sees a table card with no data behind it.
+for (const asset of rendered.value.dataAssets) {
+    await writeFile(join(assetsDir, asset.name), asset.bytes, "utf8");
+}
 
 const pagePath = join(pageDir, "index.html");
-await writeFile(pagePath, rendered.value, "utf8");
+await writeFile(pagePath, rendered.value.html, "utf8");
 console.log(pagePath);

--- a/harness/src/contracts/report-reference.test.ts
+++ b/harness/src/contracts/report-reference.test.ts
@@ -173,6 +173,41 @@ describe("parseReference — error outcomes", () => {
     });
 });
 
+describe("the row bound of a table binding", () => {
+    /** One whole-table binding with the given row bound. */
+    function bounded(rowBound: unknown): Reference {
+        return { kind: "artifact-table", path: "runs/run-1/step-a/output/de.csv", hash: HASH, rowBound } as unknown as Reference;
+    }
+
+    it("round-trips a bound of the top rows by a column", () => {
+        expectRoundTrip(bounded({ column: "padj", count: 20, order: "asc" }));
+    });
+
+    it("round-trips a bound that names no order, thus the stored document keeps the short form", () => {
+        expectRoundTrip(bounded({ column: "score", count: 20 }));
+    });
+
+    it("rejects a bound of zero rows", () => {
+        expectParseError(encodeUnchecked(bounded({ column: "padj", count: 0 })), "schema-mismatch");
+    });
+
+    it("rejects a bound of a fractional count", () => {
+        expectParseError(encodeUnchecked(bounded({ column: "padj", count: 2.5 })), "schema-mismatch");
+    });
+
+    it("rejects a bound that names no column", () => {
+        expectParseError(encodeUnchecked(bounded({ column: "", count: 20 })), "schema-mismatch");
+    });
+
+    it("rejects an order outside the two directions", () => {
+        expectParseError(encodeUnchecked(bounded({ column: "padj", count: 20, order: "random" })), "schema-mismatch");
+    });
+
+    it("rejects a field that the bound grammar does not declare", () => {
+        expectParseError(encodeUnchecked(bounded({ column: "padj", count: 20, offset: 5 })), "schema-mismatch");
+    });
+});
+
 describe("parseReference — schema rejection", () => {
     it("rejects an artifact reference without a hash", () => {
         expectParseError(encodeUnchecked({ kind: "artifact-value", run: "r", path: "p", locator: { column: "c", row: 0 } }), "schema-mismatch");

--- a/harness/src/contracts/report-reference.ts
+++ b/harness/src/contracts/report-reference.ts
@@ -104,6 +104,23 @@ export const ArtifactValueReferenceSchema = z.strictObject({
 export const ColumnMeaningSchema = z.enum(["p-value", "effect", "count", "identifier", "category"]);
 
 /**
+ * The row bound of a whole-table binding: the top rows by one column.
+ *
+ * The bound is content and not presentation. The resolution applies it, thus the resolved table, the
+ * rendered card, the staged data, and the gate all read one bounded set.
+ */
+export const RowBoundSchema = z.strictObject({
+    column: z.string().min(1).describe("The column that ranks the rows. The artifact must hold it, and the bound refuses a name that it does not."),
+    count: z.number().int().positive().describe("How many rows to keep. The bound takes the first rows of the ranked order."),
+    order: z
+        .enum(["desc", "asc"])
+        .optional()
+        .describe(
+            "The rank direction. Omit it for `desc`, which keeps the largest values. Use `asc` for a column where the smallest value ranks first, such as a p-value.",
+        ),
+});
+
+/**
  * A reference to a whole table artifact. It carries no locator, because it binds every row.
  *
  * It carries no assert. A table is not one value, thus the only belief that an author can hold about it
@@ -115,6 +132,9 @@ export const ColumnMeaningSchema = z.enum(["p-value", "effect", "count", "identi
 export const ArtifactTableReferenceSchema = z.strictObject({
     kind: z.literal("artifact-table"),
     ...artifactPinShape,
+    rowBound: RowBoundSchema.optional().describe(
+        "The primary size control of a table: the top rows by one column. Bind the whole artifact and bound it here, and never bind a pre-cut copy of the file. A binding with no bound resolves every row of the artifact.",
+    ),
     columns: z.array(z.string()).optional().describe("An optional column subset to render. Omit to bind every column."),
     columnMeanings: z
         .record(z.string(), ColumnMeaningSchema)
@@ -239,6 +259,7 @@ export const UnresolvedReferenceSchema = z.strictObject({
 
 export type ArtifactValueReference = z.infer<typeof ArtifactValueReferenceSchema>;
 export type ArtifactTableReference = z.infer<typeof ArtifactTableReferenceSchema>;
+export type RowBound = z.infer<typeof RowBoundSchema>;
 export type ColumnMeaning = z.infer<typeof ColumnMeaningSchema>;
 export type ArtifactFileReference = z.infer<typeof ArtifactFileReferenceSchema>;
 export type CitationReference = z.infer<typeof CitationReferenceSchema>;

--- a/harness/src/report-model/fixture-resolver.ts
+++ b/harness/src/report-model/fixture-resolver.ts
@@ -19,6 +19,7 @@ import type {
 } from "../contracts/report-reference.js";
 import { asFiniteNumber, cellMatchesFilterValue, checkCitationAssertion, checkValueAssertion } from "./assert-rules.js";
 import {
+    applyRowBound,
     columnsHeldByNoRow,
     fileTypeHoldsNoCell,
     snapshotEntry,
@@ -107,7 +108,15 @@ function resolveArtifactTable(reference: ArtifactTableReference, snapshot: Repor
         return fail(reference, "unreadable-artifact", `the ${tableFileType} at ${reference.path} holds no cell to read`);
     }
 
-    const rows = artifact.rows ?? [];
+    // The bound ranks the rows as the artifact holds them, thus a bound over a column that the subset
+    // below leaves out still ranks them. An unknown bound column addresses nothing, exactly as an unknown
+    // subset column does.
+    const bound = reference.rowBound;
+    const allRows = artifact.rows ?? [];
+    if (bound !== undefined && columnsHeldByNoRow(allRows, [bound.column]).length > 0) {
+        return fail(reference, "locator-out-of-range", `the row bound names column ${bound.column}, which the table at ${reference.path} does not hold`);
+    }
+    const rows = bound === undefined ? allRows : applyRowBound(allRows, bound);
     const columns = reference.columns;
     if (columns === undefined) {
         return ok({ type: "table", rows });

--- a/harness/src/report-model/production-resolver.test.ts
+++ b/harness/src/report-model/production-resolver.test.ts
@@ -424,6 +424,52 @@ describe("production resolver, the row bound", () => {
         expect("a".localeCompare("A", "en")).toBeLessThan(0);
     });
 
+    test("a sentinel of a numeric column ranks last under a descending bound", async () => {
+        const hash = await writeArtifact("sentinel.csv", "gene,score\nA,0.1\nB,NA\nC,0.9\nD,NA\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("sentinel.csv", hash), rowBound: { column: "score", count: 2 } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "sentinel.csv", hash }]));
+
+        // The column is numeric, thus `NA` is the absence of a measurement. A bound of the top two rows
+        // gives the two measurements, and never the two sentinels.
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.gene)).toEqual(["C", "A"]);
+    });
+
+    test("a sentinel stays last under an ascending bound too", async () => {
+        const hash = await writeArtifact("sentinel-asc.csv", "gene,score\nA,NA\nB,0.9\nC,0.1\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("sentinel-asc.csv", hash), rowBound: { column: "score", count: 3, order: "asc" } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "sentinel-asc.csv", hash }]));
+
+        // The direction orders the measurements. It never lifts a row that holds no rank.
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.gene)).toEqual(["C", "B", "A"]);
+    });
+
+    test("a column where nothing parses ranks by its text", async () => {
+        const hash = await writeArtifact("labels.csv", "gene,label\nA,beta\nB,alpha\nC,gamma\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("labels.csv", hash), rowBound: { column: "label", count: 2, order: "asc" } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "labels.csv", hash }]));
+
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.gene)).toEqual(["B", "A"]);
+    });
+
+    test("a bound over an inherited member of a plain object refuses, and it throws nothing", async () => {
+        const hash = await writeArtifact("proto.csv", "gene,score\nA,1\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("proto.csv", hash), rowBound: { column: "constructor", count: 5 } };
+
+        // A row parses into a plain object. A membership test with `in` would find the inherited function,
+        // and the rank of it would throw inside the tool that promises no throw.
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "proto.csv", hash }]));
+
+        expect(result._unsafeUnwrapErr().reason).toBe("locator-out-of-range");
+        expect(result._unsafeUnwrapErr().detail).toContain("constructor");
+    });
+
     test("a bound over a column that the table does not hold refuses", async () => {
         const hash = await writeArtifact("nobound.csv", "gene,score\nA,1\n");
         const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });

--- a/harness/src/report-model/production-resolver.test.ts
+++ b/harness/src/report-model/production-resolver.test.ts
@@ -362,6 +362,107 @@ describe("production resolver, the table and chart values", () => {
     });
 });
 
+describe("production resolver, the row bound", () => {
+    /** A CSV of `count` rows. The score falls as the index rises, thus the top of a `desc` bound is the head. */
+    function rankedCsv(count: number): string {
+        const lines = ["gene,score"];
+        for (let index = 0; index < count; index += 1) {
+            lines.push(`G${index},${(count - index) / count}`);
+        }
+        return `${lines.join("\n")}\n`;
+    }
+
+    test("a bounded reference gives the top rows by the named column", async () => {
+        const hash = await writeArtifact("bound.csv", rankedCsv(14201));
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("bound.csv", hash), rowBound: { column: "score", count: 20 } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "bound.csv", hash }]));
+
+        const rows = (result._unsafeUnwrap() as { type: "table"; rows: Row[] }).rows;
+        // The resolved table is the bounded table. Thus the card, the data asset, and the gate read one set.
+        expect(rows.length).toBe(20);
+        expect(rows[0].gene).toBe("G0");
+        expect(rows[19].gene).toBe("G19");
+    });
+
+    test("an ascending bound reads the numeric magnitude of a text cell", async () => {
+        const hash = await writeArtifact("padj.csv", "gene,padj\nA,0.5\nB,1e-9\nC,0.02\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("padj.csv", hash), rowBound: { column: "padj", count: 2, order: "asc" } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "padj.csv", hash }]));
+
+        // A CSV holds each cell as text. A text compare would rank `0.02` before `1e-9`.
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.gene)).toEqual(["B", "C"]);
+    });
+
+    test("a tie keeps the order of the file, thus two runs give one result", async () => {
+        const hash = await writeArtifact("ties.csv", "gene,score\nA,1\nB,1\nC,1\nD,0\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("ties.csv", hash), rowBound: { column: "score", count: 3 } };
+        const snapshot = snapshotOf([{ path: "ties.csv", hash }]);
+
+        const first = await resolver.resolve(reference, snapshot);
+        const second = await resolver.resolve(reference, snapshot);
+
+        expect((first._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.gene)).toEqual(["A", "B", "C"]);
+        expect(second._unsafeUnwrap()).toEqual(first._unsafeUnwrap());
+    });
+
+    test("a text column ranks in code-unit order, and never in the collation of the host", async () => {
+        const hash = await writeArtifact("case.csv", "label,n\na,1\nB,2\nA,3\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("case.csv", hash), rowBound: { column: "label", count: 3, order: "asc" } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "case.csv", hash }]));
+
+        // The code-unit order puts each capital before each lowercase letter. An ICU collation ranks `a`
+        // before `A`, and it varies with the host. The bounded rows reach the bytes of the data asset,
+        // thus the order of the bound is part of the content address of that asset.
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows.map((row) => row.label)).toEqual(["A", "B", "a"]);
+        expect("a".localeCompare("A", "en")).toBeLessThan(0);
+    });
+
+    test("a bound over a column that the table does not hold refuses", async () => {
+        const hash = await writeArtifact("nobound.csv", "gene,score\nA,1\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("nobound.csv", hash), rowBound: { column: "padj", count: 5 } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "nobound.csv", hash }]));
+
+        expect(result._unsafeUnwrapErr().reason).toBe("locator-out-of-range");
+        expect(result._unsafeUnwrapErr().detail).toContain("padj");
+    });
+
+    test("the bound ranks before the projection, thus a subset that omits the bound column still bounds", async () => {
+        const hash = await writeArtifact("subset.csv", "gene,score\nA,0.1\nB,0.9\n");
+        const resolver = createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS });
+        const reference: ArtifactTableReference = { ...tableRef("subset.csv", hash, ["gene"]), rowBound: { column: "score", count: 1 } };
+
+        const result = await resolver.resolve(reference, snapshotOf([{ path: "subset.csv", hash }]));
+
+        expect((result._unsafeUnwrap() as { rows: Row[] }).rows).toEqual([{ gene: "B" }]);
+    });
+
+    test("the fixture realization bounds the same rows as the production one", async () => {
+        const hash = await writeArtifact("agree.csv", "gene,score\nA,0.1\nB,0.9\nC,0.5\n");
+        const rows: Row[] = [
+            { gene: "A", score: "0.1" },
+            { gene: "B", score: "0.9" },
+            { gene: "C", score: "0.5" },
+        ];
+        const snapshot = snapshotOf([{ path: "agree.csv", hash, rows }]);
+        const reference: ArtifactTableReference = { ...tableRef("agree.csv", hash), rowBound: { column: "score", count: 2 } };
+
+        const production = await createProductionResolver({ workspaceRoot: root, analysisId: ANALYSIS }).resolve(reference, snapshot);
+        const fixture = await createFixtureResolver().resolve(reference, snapshot);
+
+        // One rule of the bound serves both realizations, thus a fixture test states the production answer.
+        expect(fixture._unsafeUnwrap()).toEqual(production._unsafeUnwrap());
+    });
+});
+
 describe("production resolver, the prepare cache", () => {
     test("after a prepare, resolve answers from the cache even when the file is gone", async () => {
         const hash = await writeArtifact("cached.csv", "gene,score\nBRCA1,0.9\n");

--- a/harness/src/report-model/production-resolver.ts
+++ b/harness/src/report-model/production-resolver.ts
@@ -39,6 +39,7 @@ import { computeSha256File } from "../lib/fs-helpers.js";
 import { resolveWorkspacePath } from "../workspace/paths.js";
 import { asFiniteNumber, cellMatchesFilterValue, checkCitationAssertion, checkValueAssertion } from "./assert-rules.js";
 import {
+    applyRowBound,
     columnsHeldByNoRow,
     fileTypeHoldsNoCell,
     snapshotEntry,
@@ -805,7 +806,15 @@ export function createProductionResolver(deps: ProductionResolverDeps): Referenc
         if (gated.isErr()) {
             return err(gated.error);
         }
-        const rows = gated.value;
+        // The bound ranks the rows as the artifact holds them, thus a bound over a column that the subset
+        // below leaves out still ranks them. An unknown bound column addresses nothing, exactly as an
+        // unknown subset column does.
+        const bound = reference.rowBound;
+        const allRows = gated.value;
+        if (bound !== undefined && columnsHeldByNoRow(allRows, [bound.column]).length > 0) {
+            return fail(reference, "locator-out-of-range", `the row bound names column ${bound.column}, which the table at ${reference.path} does not hold`);
+        }
+        const rows = bound === undefined ? allRows : applyRowBound(allRows, bound);
         const columns = reference.columns;
         if (columns === undefined) {
             return ok({ type: "table", rows });

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -111,41 +111,34 @@ export function columnsHeldByNoRow(rows: Array<Record<string, string | number>>,
     if (rows.length === 0) {
         return [];
     }
-    return columns.filter((column) => !rows.some((row) => column in row));
+    // An agent authors a column name, thus the name is untrusted text. A row can be a plain object from a
+    // `JSON.parse` of a stored snapshot, and `in` finds an inherited member such as `constructor`. The name
+    // would then read as a column, and the read of the cell would give a function. The own-key test admits
+    // a real column alone.
+    return columns.filter((column) => !rows.some((row) => Object.hasOwn(row, column)));
+}
+
+/** The cell of one row under an own key, or `undefined` when the row holds no such column. */
+function cellOf(row: Record<string, string | number>, column: string): string | number | undefined {
+    return Object.hasOwn(row, column) ? row[column] : undefined;
+}
+
+/** One row of a bound, with the cell of the bound column and the number that the cell reads as. */
+interface RankedRow {
+    readonly row: Record<string, string | number>;
+    readonly index: number;
+    readonly cell: string | number | undefined;
+    readonly value: number | undefined;
 }
 
 /**
- * The rank of one cell against another, under the numeric-aware compare.
+ * The code-unit rank of the string form of two cells.
  *
- * A text-backed artifact holds every cell as a string, thus a numeric column arrives as `"0.01"`. Two
- * cells that both read as a finite number compare as numbers. Thus a p-value column ranks by magnitude,
- * and a code-unit order would put `"10"` between `"1"` and `"2"`.
- *
- * Any other pair compares by the code-unit order of the string form. The comparison never calls
- * `localeCompare`, because the ICU of a host decides that order and the bounded rows reach the bytes of
- * the data asset. Thus one table gives one payload and one asset name on every host.
- *
- * A cell that the row does not hold ranks last in either direction. Such a row carries no value for the
- * bound to rank, thus it never displaces a row that does.
+ * The comparison never calls `localeCompare`, because the ICU of a host decides that order and the bounded
+ * rows reach the bytes of the data asset. Thus one table gives one payload and one asset name on every
+ * host.
  */
-function rankCells(left: string | number | undefined, right: string | number | undefined, descending: boolean): number {
-    if (left === undefined || right === undefined) {
-        return left === right ? 0 : left === undefined ? 1 : -1;
-    }
-    const rank = rankValues(left, right);
-    if (rank === 0) {
-        return 0;
-    }
-    return descending ? -rank : rank;
-}
-
-/** The rank of two present cells: numeric when both read as a finite number, and code-unit order otherwise. */
-function rankValues(left: string | number, right: string | number): number {
-    const leftNumber = asFiniteNumber(left);
-    const rightNumber = asFiniteNumber(right);
-    if (leftNumber !== undefined && rightNumber !== undefined) {
-        return leftNumber - rightNumber;
-    }
+function rankText(left: string | number, right: string | number): number {
     const leftText = String(left);
     const rightText = String(right);
     if (leftText < rightText) return -1;
@@ -154,7 +147,38 @@ function rankValues(left: string | number, right: string | number): number {
 }
 
 /**
+ * A row that holds no rank in the column, which the bound keeps last in either direction.
+ *
+ * A row that the column does not reach carries no value to rank. In a numeric column a cell that reads as
+ * no number carries none either: a sentinel such as `NA` is the absence of a measurement, and a rank for it
+ * against a real value would be invented. Thus a descending bound of the top 20 rows gives 20 measurements,
+ * and never 20 sentinels.
+ */
+function holdsNoRank(entry: RankedRow, numeric: boolean): boolean {
+    return entry.cell === undefined || (numeric && entry.value === undefined);
+}
+
+/** One row that holds a rank in the bound column. Its cell is present, and a numeric column parsed it. */
+type RankableRow = RankedRow & { readonly cell: string | number };
+
+/**
+ * The rank of two rows that both hold one. A numeric column compares the parsed numbers, and a column
+ * where nothing parses compares the code-unit order of the text.
+ */
+function rankRankable(left: RankableRow, right: RankableRow, numeric: boolean): number {
+    if (numeric && left.value !== undefined && right.value !== undefined) {
+        return left.value - right.value;
+    }
+    return rankText(left.cell, right.cell);
+}
+
+/**
  * Apply a row bound to a table: rank the rows by the bound column, and keep the first `count` of them.
+ *
+ * The kind of the column decides one time, over the whole column, and never for one pair. A column is
+ * numeric when one cell of it reads as a finite number. A text-backed artifact holds every cell as a
+ * string, thus the parse is what tells a measurement from a label, and a code-unit order would put `"10"`
+ * between `"1"` and `"2"`. A column where nothing parses ranks by the code-unit order of its text.
  *
  * The sort is stable by construction. The walk carries the source index of each row and it breaks a tie on
  * that index, thus two rows of equal rank keep the order of the file and two runs over one table give one
@@ -166,12 +190,22 @@ function rankValues(left: string | number, right: string | number): number {
  */
 export function applyRowBound(rows: Array<Record<string, string | number>>, bound: RowBound): Array<Record<string, string | number>> {
     const descending = (bound.order ?? "desc") === "desc";
-    const ranked = rows.map((row, index) => ({ row, index }));
-    ranked.sort((left, right) => {
-        const rank = rankCells(left.row[bound.column], right.row[bound.column], descending);
-        return rank === 0 ? left.index - right.index : rank;
+    const ranked: RankedRow[] = rows.map((row, index) => {
+        const cell = cellOf(row, bound.column);
+        return { row, index, cell, value: cell === undefined ? undefined : asFiniteNumber(cell) };
     });
-    return ranked.slice(0, bound.count).map((entry) => entry.row);
+    const numeric = ranked.some((entry) => entry.value !== undefined);
+
+    // A row with no rank stays behind every ranked row, and the direction never lifts it. The two lists
+    // keep their source order, thus the tail is as stable as the head.
+    const rankable = ranked.filter((entry): entry is RankableRow => !holdsNoRank(entry, numeric));
+    const unrankable = ranked.filter((entry) => holdsNoRank(entry, numeric));
+
+    const sorted = [...rankable].sort((left, right) => {
+        const rank = rankRankable(left, right, numeric);
+        return rank === 0 ? left.index - right.index : descending ? -rank : rank;
+    });
+    return [...sorted, ...unrankable].slice(0, bound.count).map((entry) => entry.row);
 }
 
 /**

--- a/harness/src/report-model/reference-resolver.ts
+++ b/harness/src/report-model/reference-resolver.ts
@@ -8,8 +8,9 @@
 
 import type { Result } from "neverthrow";
 
-import type { Reference, UnresolvedReference } from "../contracts/report-reference.js";
+import type { Reference, RowBound, UnresolvedReference } from "../contracts/report-reference.js";
 import type { ArtifactType } from "../schemas/artifact-manifest.js";
+import { asFiniteNumber } from "./assert-rules.js";
 
 /**
  * One pinned artifact: its content hash, and its rows as plain cells.
@@ -111,6 +112,66 @@ export function columnsHeldByNoRow(rows: Array<Record<string, string | number>>,
         return [];
     }
     return columns.filter((column) => !rows.some((row) => column in row));
+}
+
+/**
+ * The rank of one cell against another, under the numeric-aware compare.
+ *
+ * A text-backed artifact holds every cell as a string, thus a numeric column arrives as `"0.01"`. Two
+ * cells that both read as a finite number compare as numbers. Thus a p-value column ranks by magnitude,
+ * and a code-unit order would put `"10"` between `"1"` and `"2"`.
+ *
+ * Any other pair compares by the code-unit order of the string form. The comparison never calls
+ * `localeCompare`, because the ICU of a host decides that order and the bounded rows reach the bytes of
+ * the data asset. Thus one table gives one payload and one asset name on every host.
+ *
+ * A cell that the row does not hold ranks last in either direction. Such a row carries no value for the
+ * bound to rank, thus it never displaces a row that does.
+ */
+function rankCells(left: string | number | undefined, right: string | number | undefined, descending: boolean): number {
+    if (left === undefined || right === undefined) {
+        return left === right ? 0 : left === undefined ? 1 : -1;
+    }
+    const rank = rankValues(left, right);
+    if (rank === 0) {
+        return 0;
+    }
+    return descending ? -rank : rank;
+}
+
+/** The rank of two present cells: numeric when both read as a finite number, and code-unit order otherwise. */
+function rankValues(left: string | number, right: string | number): number {
+    const leftNumber = asFiniteNumber(left);
+    const rightNumber = asFiniteNumber(right);
+    if (leftNumber !== undefined && rightNumber !== undefined) {
+        return leftNumber - rightNumber;
+    }
+    const leftText = String(left);
+    const rightText = String(right);
+    if (leftText < rightText) return -1;
+    if (leftText > rightText) return 1;
+    return 0;
+}
+
+/**
+ * Apply a row bound to a table: rank the rows by the bound column, and keep the first `count` of them.
+ *
+ * The sort is stable by construction. The walk carries the source index of each row and it breaks a tie on
+ * that index, thus two rows of equal rank keep the order of the file and two runs over one table give one
+ * result. `Array.prototype.sort` is specified as stable in the current language, and the explicit tiebreak
+ * states the property at the site that depends on it.
+ *
+ * The bound reads the rows as they arrive. A caller that projects onto a column subset projects after the
+ * bound, thus a bound over a column that the subset leaves out still ranks the rows.
+ */
+export function applyRowBound(rows: Array<Record<string, string | number>>, bound: RowBound): Array<Record<string, string | number>> {
+    const descending = (bound.order ?? "desc") === "desc";
+    const ranked = rows.map((row, index) => ({ row, index }));
+    ranked.sort((left, right) => {
+        const rank = rankCells(left.row[bound.column], right.row[bound.column], descending);
+        return rank === 0 ? left.index - right.index : rank;
+    });
+    return ranked.slice(0, bound.count).map((entry) => entry.row);
 }
 
 /**

--- a/harness/src/report-model/structural-validation.test.ts
+++ b/harness/src/report-model/structural-validation.test.ts
@@ -239,6 +239,26 @@ describe("validateReferenceStructure", () => {
             const failure = columnFailure(["invented"], tableReference(ROWS_PATH, WRONG_HASH));
             expect(failure?.reason).toBe("hash-mismatch");
         });
+
+        it("passes a row bound over a column of the bound table", () => {
+            const bounded = { ...tableReference(ROWS_PATH, ROWS_HASH), rowBound: { column: "padj", count: 20, order: "asc" as const } };
+            expect(failureFor(bounded, rowSnapshot)).toBeUndefined();
+        });
+
+        it("refuses a row bound over a column that the table does not hold", () => {
+            const bounded = { ...tableReference(ROWS_PATH, ROWS_HASH), rowBound: { column: "invented", count: 20 } };
+
+            // The bound decides which rows the table holds, thus an unknown bound column refuses before the
+            // block lands, exactly as an unknown grammar column does.
+            const failure = failureFor(bounded, rowSnapshot);
+            expect(failure?.reason).toBe("locator-out-of-range");
+            expect(failure?.detail).toContain("invented");
+        });
+
+        it("passes a row bound against a snapshot that pins identity and holds no row", () => {
+            const bounded = { ...tableReference(OUTPUT_PATH, OUTPUT_HASH), rowBound: { column: "invented", count: 20 } };
+            expect(failureFor(bounded, rowSnapshot)).toBeUndefined();
+        });
     });
 
     describe("the read of a file", () => {

--- a/harness/src/report-model/structural-validation.test.ts
+++ b/harness/src/report-model/structural-validation.test.ts
@@ -255,6 +255,22 @@ describe("validateReferenceStructure", () => {
             expect(failure?.detail).toContain("invented");
         });
 
+        it("refuses a row bound over an inherited member of a plain object", () => {
+            const bounded = { ...tableReference(ROWS_PATH, ROWS_HASH), rowBound: { column: "constructor", count: 20 } };
+
+            // A stored snapshot parses into a plain object. A membership test that read the prototype would
+            // admit this name as a column, and the value tier would then rank a function.
+            const failure = failureFor(bounded, rowSnapshot);
+            expect(failure?.reason).toBe("locator-out-of-range");
+            expect(failure?.detail).toContain("constructor");
+        });
+
+        it("refuses a chart column that names an inherited member of a plain object", () => {
+            const failure = columnFailure(["constructor"]);
+            expect(failure?.reason).toBe("locator-out-of-range");
+            expect(failure?.detail).toContain("constructor");
+        });
+
         it("passes a row bound against a snapshot that pins identity and holds no row", () => {
             const bounded = { ...tableReference(OUTPUT_PATH, OUTPUT_HASH), rowBound: { column: "invented", count: 20 } };
             expect(failureFor(bounded, rowSnapshot)).toBeUndefined();

--- a/harness/src/report-model/structural-validation.ts
+++ b/harness/src/report-model/structural-validation.ts
@@ -91,8 +91,20 @@ export function validateReferenceStructure(reference: Reference, snapshot: Repor
     switch (reference.kind) {
         case "artifact-table": {
             const pin = validatePin(reference, snapshot);
-            if (pin.isErr() || columns === undefined || columns.length === 0) {
+            if (pin.isErr()) {
                 return pin;
+            }
+            // The bound is content: it decides which rows the table holds. Thus a bound column that the
+            // artifact does not hold refuses here, exactly as a grammar column of a chart does.
+            const bound = reference.rowBound;
+            if (bound !== undefined) {
+                const absent = columnsHeldByNoRow(snapshotEntry(snapshot, reference.path)?.rows ?? [], [bound.column]);
+                if (absent.length > 0) {
+                    return fail(reference, "locator-out-of-range", `the row bound names column ${bound.column}, which the bound table does not hold`);
+                }
+            }
+            if (columns === undefined || columns.length === 0) {
+                return ok();
             }
             return validateColumns(reference, snapshot, columns);
         }

--- a/harness/src/report-render/assets.ts
+++ b/harness/src/report-render/assets.ts
@@ -26,6 +26,30 @@ export function assetSource(asset: PageAsset): string {
     return `${ASSETS_DIR}/${asset.file}`;
 }
 
+/** The relative source of a staged file by its name. A page reference never spells the directory itself. */
+export function stagedSource(file: string): string {
+    return `${ASSETS_DIR}/${file}`;
+}
+
+/** The count of hash characters in a staged name. A staged file carries enough of the hash to be unique. */
+const HASH_CHARS = 12;
+
+/**
+ * The staged name of the raw bytes of one table artifact: a hash head, then the basename of the path.
+ *
+ * The reader downloads the pinned file itself and never a re-serialization of it, thus the name must carry
+ * the identity of those bytes. The hash head makes two artifacts of one basename two staged files, and the
+ * basename keeps the downloaded file recognizable on the disk of the reader.
+ *
+ * The hash arrives as `algorithm:hex`, and neither the colon nor a path separator is safe in a file name.
+ * The head takes the hex alone, and the basename takes each unsafe run as one dash.
+ */
+export function tableSidecarName(hash: string, path: string): string {
+    const hex = hash.slice(hash.lastIndexOf(":") + 1).replace(/[^a-z0-9]+/gi, "");
+    const base = path.slice(path.lastIndexOf("/") + 1).replace(/[^a-z0-9._-]+/gi, "-");
+    return `${hex.slice(0, HASH_CHARS)}-${base}`;
+}
+
 /** The chart runtime. The page-side bootstrap reads the `echarts` global that this file declares. */
 export const ECHARTS_ASSET: PageAsset = {
     file: "echarts.min.js",

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -577,6 +577,28 @@ img {
   color: var(--color-primary-700);
   background: var(--color-border-subtle);
 }
+/* The footer of a table card. It holds the download of the raw bytes, thus it reads as a foot rule under
+   the table and never as a second control bar. */
+.report-table-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 16px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-alt);
+}
+.report-table-download {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary-500);
+  text-decoration: none;
+}
+.report-table-download:hover {
+  color: var(--color-primary-700);
+  text-decoration: underline;
+}
 
 /* ── Figure and citation cards ────────────────────────── */
 .report-figure {

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -598,14 +598,18 @@ export const TABLE_DATA_DECODER = `(function () {
     var decoded = [];
     for (var r = 0; r < encoded.length; r++) {
       var row = encoded[r];
-      var record = {};
+      // A column name is authored text. A plain object would read an inherited member such as
+      // "constructor" as a dictionary, and it would send a "__proto__" column to the prototype. The
+      // null-prototype record and the own-key test keep every column name an ordinary entry.
+      var record = Object.create(null);
       for (var c = 0; c < columns.length; c++) {
         var cell = row[c];
         if (cell === null || cell === undefined) {
           continue;
         }
-        var values = dict[columns[c]];
-        record[columns[c]] = values && typeof cell === "number" ? values[cell] : cell;
+        var name = columns[c];
+        var values = Object.prototype.hasOwnProperty.call(dict, name) ? dict[name] : null;
+        record[name] = values && typeof cell === "number" ? values[cell] : cell;
       }
       decoded.push(record);
     }

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -7,6 +7,7 @@
 
 import { assetSource, ECHARTS_ASSET } from "./assets.js";
 import { ECHARTS_THEME_NAME } from "./design.js";
+import { TABLE_DATA_GLOBAL } from "./table-data.js";
 import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
 
 /**
@@ -561,5 +562,54 @@ export const TABLE_ENHANCER = `(function () {
     document.addEventListener("DOMContentLoaded", start);
   } else {
     start();
+  }
+})();`;
+
+/**
+ * The decoder of the table data assets.
+ *
+ * Each data asset registers its payload under the global map, keyed by the block id. The payload is
+ * columnar: a row is an array in column order, and a number in a column that carries a dictionary is the
+ * index of its value. This script materializes the decoded rows one time, thus a reader of the data takes
+ * plain row objects and no reader repeats the decode.
+ *
+ * The decoded rows land on the payload itself, under `rows`. The encoded arrays stay under `encoded`, thus
+ * the decode runs one time even when the script runs again. A cell of `null` names a column that the row
+ * does not hold, and the decoded row omits that key. Thus a ragged row stays ragged and no key reads as an
+ * empty value.
+ *
+ * The script runs after the data assets and before the page scripts. A page with no table registers no
+ * map, and the guard leaves such a page untouched.
+ */
+export const TABLE_DATA_DECODER = `(function () {
+  var registry = window.${TABLE_DATA_GLOBAL};
+  if (!registry) {
+    return;
+  }
+  var ids = Object.keys(registry);
+  for (var i = 0; i < ids.length; i++) {
+    var payload = registry[ids[i]];
+    if (!payload || payload.encoded) {
+      continue;
+    }
+    var columns = payload.columns || [];
+    var dict = payload.dict || {};
+    var encoded = payload.rows || [];
+    var decoded = [];
+    for (var r = 0; r < encoded.length; r++) {
+      var row = encoded[r];
+      var record = {};
+      for (var c = 0; c < columns.length; c++) {
+        var cell = row[c];
+        if (cell === null || cell === undefined) {
+          continue;
+        }
+        var values = dict[columns[c]];
+        record[columns[c]] = values && typeof cell === "number" ? values[cell] : cell;
+      }
+      decoded.push(record);
+    }
+    payload.encoded = encoded;
+    payload.rows = decoded;
   }
 })();`;

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { load } from "cheerio";
 
-import type { Block, CitationBlock, MetricBlock, ReportDocument, TextBlock } from "../contracts/report-blocks.js";
-import { ASSETS_DIR, PAGE_ASSETS } from "./assets.js";
+import type { Block, CitationBlock, MetricBlock, ReportDocument, TableBlock, TextBlock } from "../contracts/report-blocks.js";
+import { ASSETS_DIR, PAGE_ASSETS, tableSidecarName } from "./assets.js";
 import { DESIGN_CSS } from "./design.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "./fixture.js";
-import { CHART_BOOTSTRAP, SECTION_SPY, TABLE_ENHANCER } from "./page.js";
+import { CHART_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER, TABLE_ENHANCER } from "./page.js";
+import { TABLE_DATA_GLOBAL } from "./table-data.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
 import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
@@ -115,17 +116,33 @@ function styleReferences(css: string): string[] {
     return references;
 }
 
+/** Each table binding of a block tree, in document order. The sidecar of a card names its pinned artifact. */
+function tableBindingsOf(blocks: readonly Block[]): TableBlock["binding"][] {
+    const bindings: TableBlock["binding"][] = [];
+    for (const block of blocks) {
+        if (block.kind === "table") {
+            bindings.push(block.binding);
+        }
+        if (block.kind === "section") {
+            bindings.push(...tableBindingsOf(block.blocks));
+        }
+    }
+    return bindings;
+}
+
 describe("renderReportPage assembly", () => {
     it("gives byte-identical output for the same document and values", () => {
         const first = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES);
         const second = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES);
         expect(first.isOk()).toBe(true);
         expect(second.isOk()).toBe(true);
-        expect(first._unsafeUnwrap()).toBe(second._unsafeUnwrap());
+        expect(first._unsafeUnwrap().html).toBe(second._unsafeUnwrap().html);
+        // The payload of a table is a pure function of its rows, thus the assets match byte for byte.
+        expect(first._unsafeUnwrap().dataAssets).toEqual(second._unsafeUnwrap().dataAssets);
     });
 
     it("renders from in-memory inputs with no directory and no file", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         expect(typeof html).toBe("string");
         expect(html.startsWith("<!doctype html>")).toBe(true);
         expect(html).toContain("The cohort holds 48 primary lung adenocarcinoma biopsies.");
@@ -137,7 +154,7 @@ describe("renderReportPage text lists", () => {
     /** One page whose section holds the given text block. */
     function pageOfText(block: TextBlock): ReturnType<typeof load> {
         const document: ReportDocument = { title: "T", sections: [{ kind: "section", id: "s", title: "S", blocks: [block] }] };
-        return load(renderReportPage(document, {})._unsafeUnwrap());
+        return load(renderReportPage(document, {})._unsafeUnwrap().html);
     }
 
     it("holds the lead paragraph and the ordered list of six items", () => {
@@ -177,6 +194,133 @@ describe("renderReportPage text lists", () => {
     });
 });
 
+describe("the table data assets", () => {
+    const TABLE_PATH = "runs/run-1/step-a/output/de.csv";
+    const TABLE_HASH = `sha256:${"a".repeat(64)}`;
+
+    /** One page of one table block over the given rows. */
+    function tableDocument(): ReportDocument {
+        return {
+            title: "T",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [{ kind: "table", id: "tbl", binding: { kind: "artifact-table", path: TABLE_PATH, hash: TABLE_HASH } }],
+                },
+            ],
+        };
+    }
+
+    /** A table value of `count` rows, with a gene name, a p-value, and one of two directions. */
+    function valuesOf(count: number): RenderValues {
+        const rows = [];
+        for (let index = 0; index < count; index += 1) {
+            rows.push({ gene: `G${index}`, padj: index / count, direction: index % 2 === 0 ? "up" : "down" });
+        }
+        return { tbl: { type: "table", columns: ["gene", "padj", "direction"], rows } };
+    }
+
+    it("holds the header and no data row, and the payload holds every row", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(14201))._unsafeUnwrap();
+        const page = load(rendered.html);
+
+        expect(page("th.data-table-sort").length).toBe(3);
+        expect(page("tbody tr").length).toBe(0);
+        expect(rendered.dataAssets.length).toBe(1);
+
+        const payload = JSON.parse(rendered.dataAssets[0].bytes.slice(rendered.dataAssets[0].bytes.indexOf("]=") + 2, -2)) as {
+            columns: string[];
+            rows: unknown[][];
+        };
+        expect(payload.columns).toEqual(["gene", "padj", "direction"]);
+        expect(payload.rows.length).toBe(14201);
+    });
+
+    it("compresses a repeated category into the dictionary of its column", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(100))._unsafeUnwrap();
+
+        // The direction column holds two values across one hundred rows, thus the payload names each one
+        // time and each row holds its index.
+        expect(rendered.dataAssets[0].bytes).toContain(`"dict":{"direction":["up","down"]}`);
+        expect(rendered.dataAssets[0].bytes.split(`"up"`).length - 1).toBe(1);
+    });
+
+    it("gives byte-identical assets and one asset name over two renders", () => {
+        const first = renderReportPage(tableDocument(), valuesOf(500))._unsafeUnwrap();
+        const second = renderReportPage(tableDocument(), valuesOf(500))._unsafeUnwrap();
+
+        expect(second.dataAssets).toEqual(first.dataAssets);
+        expect(second.html).toBe(first.html);
+    });
+
+    it("references each asset from a classic script tag, and decodes after the last of them", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(3))._unsafeUnwrap();
+        const source = `${ASSETS_DIR}/${rendered.dataAssets[0].name}`;
+
+        // A `fetch` is refused on a `file://` page. A classic script loads on any page, thus the data
+        // reaches the reader through a script tag and never through a request.
+        expect(rendered.html).toContain(`<script src="${source}"></script>`);
+        expect(rendered.html.indexOf(source)).toBeLessThan(rendered.html.indexOf(TABLE_DATA_DECODER));
+        expect(rendered.html.indexOf(TABLE_DATA_DECODER)).toBeLessThan(rendered.html.indexOf(TABLE_ENHANCER));
+    });
+
+    it("decodes the payload into plain rows, one time, in the page script", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(4))._unsafeUnwrap();
+        const window: Record<string, unknown> = {};
+
+        // The asset is browser source text. It arrives as a classic script, thus the global is the whole
+        // interface between the payload and the decoder.
+        new Function("window", rendered.dataAssets[0].bytes)(window);
+        new Function("window", TABLE_DATA_DECODER)(window);
+
+        const registry = window[TABLE_DATA_GLOBAL] as Record<string, { rows: Record<string, string | number>[] }>;
+        expect(registry["tbl"].rows.length).toBe(4);
+        expect(registry["tbl"].rows[0]).toEqual({ gene: "G0", padj: 0, direction: "up" });
+        expect(registry["tbl"].rows[1]).toEqual({ gene: "G1", padj: 0.25, direction: "down" });
+
+        // A second run finds the decoded rows and leaves them, thus a late script pays the decode one time.
+        new Function("window", TABLE_DATA_DECODER)(window);
+        expect(registry["tbl"].rows[0]).toEqual({ gene: "G0", padj: 0, direction: "up" });
+    });
+
+    it("omits a column that a ragged row does not hold, thus no key reads as an empty value", () => {
+        const document = tableDocument();
+        const values: RenderValues = { tbl: { type: "table", columns: ["gene", "padj"], rows: [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }] } };
+        const rendered = renderReportPage(document, values)._unsafeUnwrap();
+        const window: Record<string, unknown> = {};
+
+        new Function("window", rendered.dataAssets[0].bytes)(window);
+        new Function("window", TABLE_DATA_DECODER)(window);
+
+        const registry = window[TABLE_DATA_GLOBAL] as Record<string, { rows: Record<string, string | number>[] }>;
+        expect(registry["tbl"].rows[1]).toEqual({ gene: "MYC" });
+    });
+
+    it("links the staged raw bytes of the artifact as the download of the card", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(3))._unsafeUnwrap();
+        const link = load(rendered.html)("a.report-table-download");
+
+        expect(link.attr("href")).toBe(`${ASSETS_DIR}/${tableSidecarName(TABLE_HASH, TABLE_PATH)}`);
+        expect(link.attr("download")).toBe(tableSidecarName(TABLE_HASH, TABLE_PATH));
+    });
+
+    it("stages no data asset for a document with no table, and renders that page as before", () => {
+        const document: ReportDocument = {
+            title: "T",
+            sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "text", id: "t1", content: { prose: "No table here." } }] }],
+        };
+        const rendered = renderReportPage(document, {})._unsafeUnwrap();
+
+        expect(rendered.dataAssets).toEqual([]);
+        // A page with no payload registers no map and carries no decoder, thus it stays what it was.
+        expect(rendered.html).not.toContain(TABLE_DATA_GLOBAL);
+        expect(rendered.html).not.toContain(".data.js");
+        expect(rendered.html).toBe(renderReportPage(document, {})._unsafeUnwrap().html);
+    });
+});
+
 describe("the page stands alone", () => {
     /** A page whose citation card carries a pinned record, thus the body holds a PubMed navigation. */
     function pageWithACitation(): string {
@@ -191,7 +335,7 @@ describe("the page stands alone", () => {
                 },
             ],
         };
-        return renderReportPage(document, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        return renderReportPage(document, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap().html;
     }
 
     /**
@@ -205,7 +349,7 @@ describe("the page stands alone", () => {
     }
 
     it("names a remote host at a navigation anchor and at no other element", () => {
-        for (const html of [renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap(), pageWithACitation()]) {
+        for (const html of [renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html, pageWithACitation()]) {
             const references = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)];
             expect(references.length).toBeGreaterThan(0);
 
@@ -223,19 +367,20 @@ describe("the page stands alone", () => {
     });
 
     it("names the brand host one time, thus no second surface fetches it", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         expect(html.split(BRAND_LINK).length - 1).toBe(1);
     });
 
-    it("names one manifest entry for each staged asset reference", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
-        const staged = new Set(PAGE_ASSETS.map((asset) => asset.file));
+    it("names a staged file for each asset reference of the page", () => {
+        const rendered = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const sidecars = tableBindingsOf(FIXTURE_DOCUMENT.sections).map((binding) => tableSidecarName(binding.hash, binding.path));
+        const staged = new Set([...PAGE_ASSETS.map((asset) => asset.file), ...rendered.dataAssets.map((asset) => asset.name), ...sidecars]);
         const prefix = `${ASSETS_DIR}/`;
-        const stagedReferences = [...attributeReferences(html), ...styleReferences(DESIGN_CSS)].filter((value) => value.startsWith(prefix));
+        const stagedReferences = [...attributeReferences(rendered.html), ...styleReferences(DESIGN_CSS)].filter((value) => value.startsWith(prefix));
         expect(stagedReferences.length).toBeGreaterThan(0);
 
-        // A reference that names no manifest entry is a file that the caller never stages, thus the page
-        // would open with a failed request.
+        // A reference that no staged file answers is a request that fails when the page opens. The three
+        // kinds together are what the preview writes beside the page.
         const unstaged = stagedReferences.filter((value) => !staged.has(value.slice(prefix.length)));
         expect(unstaged).toEqual([]);
     });
@@ -322,18 +467,18 @@ describe("renderReportPage metric grouping", () => {
     }
 
     it("groups a run of three metrics into one grid of three cards", () => {
-        const html = renderReportPage(pageOf([metric("m1"), metric("m2"), metric("m3")]), scalars("m1", "m2", "m3"))._unsafeUnwrap();
+        const html = renderReportPage(pageOf([metric("m1"), metric("m2"), metric("m3")]), scalars("m1", "m2", "m3"))._unsafeUnwrap().html;
         expect(counts(html)).toEqual({ grids: 1, cards: 3, grouped: 3 });
     });
 
     it("leaves a lone metric between two texts as a bare card", () => {
-        const html = renderReportPage(pageOf([text("t1"), metric("m1"), text("t2")]), scalars("m1"))._unsafeUnwrap();
+        const html = renderReportPage(pageOf([text("t1"), metric("m1"), text("t2")]), scalars("m1"))._unsafeUnwrap().html;
         // One metric reads as one statistic, not as a row of statistics. Thus no grid wraps it.
         expect(counts(html)).toEqual({ grids: 0, cards: 1, grouped: 0 });
     });
 
     it("groups a run of two that ends the section", () => {
-        const html = renderReportPage(pageOf([text("t1"), metric("m1"), metric("m2")]), scalars("m1", "m2"))._unsafeUnwrap();
+        const html = renderReportPage(pageOf([text("t1"), metric("m1"), metric("m2")]), scalars("m1", "m2"))._unsafeUnwrap().html;
         expect(counts(html)).toEqual({ grids: 1, cards: 2, grouped: 2 });
     });
 
@@ -344,7 +489,7 @@ describe("renderReportPage metric grouping", () => {
             title: "Inner",
             blocks: [metric("m1"), metric("m2"), text("t1")],
         };
-        const html = renderReportPage(pageOf([text("t0"), nested]), scalars("m1", "m2"))._unsafeUnwrap();
+        const html = renderReportPage(pageOf([text("t0"), nested]), scalars("m1", "m2"))._unsafeUnwrap().html;
         expect(counts(html)).toEqual({ grids: 1, cards: 2, grouped: 2 });
     });
 
@@ -426,7 +571,7 @@ describe("renderReportPage value validation", () => {
         };
         const result = renderReportPage(document, {});
         expect(result.isOk()).toBe(true);
-        const html = result._unsafeUnwrap();
+        const html = result._unsafeUnwrap().html;
         expect(html).toContain("A claim.");
         expect(html).toContain(`href="#cite-1"`);
     });
@@ -443,7 +588,7 @@ describe("renderReportPage navigation and references", () => {
                 { kind: "section", id: "sec-3", title: "Three", blocks: [child] },
             ],
         };
-        const html = renderReportPage(document, {})._unsafeUnwrap();
+        const html = renderReportPage(document, {})._unsafeUnwrap().html;
         expect(html).toContain(`href="#sec-1"`);
         expect(html).toContain(`href="#sec-2"`);
         expect(html).toContain(`href="#sec-3"`);
@@ -465,7 +610,7 @@ describe("renderReportPage navigation and references", () => {
                 },
             ],
         };
-        const html = renderReportPage(document, {})._unsafeUnwrap();
+        const html = renderReportPage(document, {})._unsafeUnwrap().html;
         // The bibliography holds one entry.
         expect(html.split(`<li id="cite-`).length - 1).toBe(1);
         // The claim marker and the citation marker point at the same entry.
@@ -496,7 +641,7 @@ describe("renderReportPage navigation and references", () => {
                 },
             ],
         };
-        const html = renderReportPage(document, {})._unsafeUnwrap();
+        const html = renderReportPage(document, {})._unsafeUnwrap().html;
 
         // The key names the paper, and the raw text is the words of the author. Thus one paper takes one
         // number, and the two markers point at the one entry.
@@ -539,7 +684,7 @@ describe("the citation bibliography", () => {
             twoOfEach,
             {},
             { "pmid:26997480": { citation: "Hugo et al. 2016", description: "The resistance paper." } },
-        )._unsafeUnwrap();
+        )._unsafeUnwrap().html;
         const card = load(html)("div.report-citation").last();
 
         expect(card.find("span.report-cite-marker").text()).toBe("[2]");
@@ -558,14 +703,14 @@ describe("the citation bibliography", () => {
     });
 
     it("adds no description line to a record that carries none", () => {
-        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap().html;
 
         expect(load(html)("li#cite-2").text()).toContain("Hugo et al. 2016");
         expect(load(html)("li#cite-2 div.report-cite-description").length).toBe(0);
     });
 
     it("shows the key and the note alone for a key that the record map does not hold", () => {
-        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap().html;
         const card = load(html)("div.report-citation").first();
 
         expect(card.find("a.report-citation-source").length).toBe(0);
@@ -577,7 +722,7 @@ describe("the citation bibliography", () => {
     });
 
     it("counts the artifact markers and the citation markers in two ladders", () => {
-        const page = load(renderReportPage(twoOfEach, {})._unsafeUnwrap());
+        const page = load(renderReportPage(twoOfEach, {})._unsafeUnwrap().html);
 
         expect(
             page("sup.report-marker a")
@@ -595,7 +740,7 @@ describe("the citation bibliography", () => {
     });
 
     it("names PubMed as a navigation and never as a loaded resource", () => {
-        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap();
+        const html = renderReportPage(twoOfEach, {}, { "pmid:26997480": { citation: "Hugo et al. 2016" } })._unsafeUnwrap().html;
         const link = "https://pubmed.ncbi.nlm.nih.gov/26997480/";
 
         // A navigation costs no request when the page opens, thus the page still stands alone.
@@ -603,8 +748,8 @@ describe("the citation bibliography", () => {
     });
 
     it("renders a stored pin that holds no record map as it did before", () => {
-        const withNoRecords = renderReportPage(twoOfEach, {})._unsafeUnwrap();
-        const withEmptyRecords = renderReportPage(twoOfEach, {}, {})._unsafeUnwrap();
+        const withNoRecords = renderReportPage(twoOfEach, {})._unsafeUnwrap().html;
+        const withEmptyRecords = renderReportPage(twoOfEach, {}, {})._unsafeUnwrap().html;
 
         expect(withNoRecords).toBe(withEmptyRecords);
         expect(withNoRecords).not.toContain("pubmed.ncbi.nlm.nih.gov");
@@ -613,7 +758,7 @@ describe("the citation bibliography", () => {
 });
 
 describe("the page identity", () => {
-    const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+    const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
 
     it("closes the page with the Inflexa footer note", () => {
         expect(html).toContain("Powered by Inflexa");
@@ -664,7 +809,7 @@ describe("the one content column", () => {
     };
 
     it("holds the prose, the table, and the chart inside the one column", () => {
-        const page = load(renderReportPage(columnDocument, columnValues)._unsafeUnwrap());
+        const page = load(renderReportPage(columnDocument, columnValues)._unsafeUnwrap().html);
         expect(page(".report-content .report-prose").length).toBe(1);
         expect(page(".report-content .report-table").length).toBe(1);
         expect(page(".report-content .report-chart").length).toBe(1);
@@ -700,7 +845,7 @@ describe("the appendix bands", () => {
     };
 
     it("titles the provenance list Data provenance", () => {
-        const html = renderReportPage(artifactDocument, {})._unsafeUnwrap();
+        const html = renderReportPage(artifactDocument, {})._unsafeUnwrap().html;
         expect(html).toContain("Data provenance");
         // A reader expects literature under "References". This list is provenance, thus no heading of the
         // page carries that word.
@@ -711,7 +856,7 @@ describe("the appendix bands", () => {
     });
 
     it("titles the bibliography Literature, and titles no provenance band over it", () => {
-        const html = renderReportPage(citationDocument, {})._unsafeUnwrap();
+        const html = renderReportPage(citationDocument, {})._unsafeUnwrap().html;
         const titles = load(html)("h2.report-ref-title")
             .toArray()
             .map((node) => load(html)(node).text());
@@ -735,7 +880,7 @@ describe("the appendix bands", () => {
                 },
             ],
         };
-        const html = renderReportPage(both, {})._unsafeUnwrap();
+        const html = renderReportPage(both, {})._unsafeUnwrap().html;
         const titles = load(html)("h2.report-ref-title")
             .toArray()
             .map((node) => load(html)(node).text());
@@ -910,7 +1055,7 @@ describe("the section scrollspy", () => {
     });
 
     it("rides the page beside the other scripts, with its rule in the design source", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         expect(html).toContain(SECTION_SPY);
         expect(DESIGN_CSS).toContain(`.${ACTIVE_CLASS}`);
     });
@@ -943,7 +1088,7 @@ describe("the table enhancer", () => {
     }
 
     it("rides the page after the scrollspy", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         expect(html).toContain(TABLE_ENHANCER);
         expect(html.indexOf(TABLE_ENHANCER)).toBeGreaterThan(html.indexOf(SECTION_SPY));
     });
@@ -1026,20 +1171,14 @@ describe("the table enhancer", () => {
         expect(PRINT_BLOCK).toMatch(/\.report-table-live \.report-table-controls,\s*\.report-table-live \.report-table-toggle\s*\{[^}]*display:\s*none/);
     });
 
-    it("puts the sort headers, the filter, the hidden rows, and the toggle on a page over the cap", () => {
+    it("puts the sort headers on a page and no data row under them", () => {
         const over = tablePage(TABLE_ROW_CAP + 3);
-        const page = load(renderReportPage(over.document, over.values)._unsafeUnwrap());
+        const page = load(renderReportPage(over.document, over.values)._unsafeUnwrap().html);
         expect(page("th.data-table-sort").length).toBe(2);
-        expect(page(".report-table-filter").length).toBe(1);
-        expect(page("tbody tr").length).toBe(TABLE_ROW_CAP + 3);
-        expect(page("tbody tr.report-row-hidden").length).toBe(3);
-        expect(page(".report-table-toggle").text()).toBe(`Show all ${TABLE_ROW_CAP + 3}`);
-    });
-
-    it("leaves a page at the cap with no hidden row and no toggle", () => {
-        const atCap = tablePage(TABLE_ROW_CAP);
-        const page = load(renderReportPage(atCap.document, atCap.values)._unsafeUnwrap());
-        expect(page("tbody tr.report-row-hidden").length).toBe(0);
+        // The enhancer of this page finds an empty body and takes no card, thus the page carries neither
+        // the control that it drives nor a row that it hides.
+        expect(page("tbody tr").length).toBe(0);
+        expect(page(".report-table-filter").length).toBe(0);
         expect(page(".report-table-toggle").length).toBe(0);
     });
 });
@@ -1167,6 +1306,15 @@ describe("the table enhancer behavior", () => {
         };
     }
 
+    it("takes no card whose body holds no row, and it throws nothing", () => {
+        // The card of a table renders its rows from the data asset, thus the body of the markup is empty.
+        // The enhancer of this page finds nothing to drive, and it must leave the card as it is.
+        const table = mount([]);
+
+        expect(table.card.classes.has("report-table-live")).toBe(false);
+        expect(table.headers.length).toBe(0);
+    });
+
     it("sorts a numeric column that holds a sentinel by magnitude", () => {
         const table = mount([["10"], ["NA"], ["9"]]);
         table.headers[0].fire("click");
@@ -1258,7 +1406,7 @@ describe("the table enhancer behavior", () => {
 
 describe("renderReportPage readiness signal", () => {
     it("carries the theme-ready dispatch and the sentinel in the page markup", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         // The bootstrap signals readiness when it completes, thus a capture keys on a real event and returns
         // when the page is ready instead of at a timeout.
         expect(html).toContain("window.__inflexaThemeReady = true");
@@ -1324,7 +1472,7 @@ describe("renderReportPage number format", () => {
 
     it("shows a long metric value in the short form and the full digits on the title", () => {
         const document = pageOf([{ kind: "metric", id: "m1", label: "Effect size", value: scalarRef }]);
-        const html = renderReportPage(document, { m1: { type: "scalar", value: -5.7618623255 } })._unsafeUnwrap();
+        const html = renderReportPage(document, { m1: { type: "scalar", value: -5.7618623255 } })._unsafeUnwrap().html;
         const value = load(html)(".stat-card-value");
         expect(value.text()).toBe("-5.76");
         expect(value.attr("title")).toBe("-5.7618623255");
@@ -1332,13 +1480,13 @@ describe("renderReportPage number format", () => {
 
     it("gives a metric whose form hides no digit no title attribute", () => {
         const document = pageOf([{ kind: "metric", id: "m1", label: "Genes tested", value: scalarRef }]);
-        const html = renderReportPage(document, { m1: { type: "scalar", value: 18432 } })._unsafeUnwrap();
+        const html = renderReportPage(document, { m1: { type: "scalar", value: 18432 } })._unsafeUnwrap().html;
         const value = load(html)(".stat-card-value");
         expect(value.text()).toBe("18,432");
         expect(value.attr("title")).toBeUndefined();
     });
 
-    it("formats each numeric table cell by its column and passes a text cell through", () => {
+    it("carries each raw table cell into the payload and formats none of them", () => {
         const document = pageOf([{ kind: "table", id: "tbl", binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" } }]);
         const values: RenderValues = {
             tbl: {
@@ -1347,11 +1495,12 @@ describe("renderReportPage number format", () => {
                 rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109, padj: 0.0000427777663038, direction: "up" }],
             },
         };
-        const cells = load(renderReportPage(document, values)._unsafeUnwrap())(".data-table tbody td");
-        expect(cells.map((_, cell) => load(cell).text()).get()).toEqual(["TP53", "-3.09", "4.3e-5", "up"]);
-        expect(cells.eq(1).attr("title")).toBe("-3.089028528355109");
-        expect(cells.eq(2).attr("title")).toBe("0.0000427777663038");
-        expect(cells.eq(3).attr("title")).toBeUndefined();
+        const rendered = renderReportPage(document, values)._unsafeUnwrap();
+
+        // The number format is presentation, and the payload is data. A rounded value in the asset would
+        // put a shown form where a magnitude belongs.
+        expect(rendered.dataAssets[0].bytes).toContain(`["TP53",-3.089028528355109,0.0000427777663038,"up"]`);
+        expect(load(rendered.html)(".data-table tbody td").length).toBe(0);
     });
 });
 
@@ -1377,7 +1526,7 @@ describe("renderReportPage escaping", () => {
             title: "Report <script>alert(1)</script>",
             sections: [{ kind: "section", id: "s", title: "S", blocks: [{ kind: "text", id: "t", content: { prose: "x" } }] }],
         };
-        const html = renderReportPage(document, {})._unsafeUnwrap();
+        const html = renderReportPage(document, {})._unsafeUnwrap().html;
         expect(html).toContain("<title>Report &lt;script&gt;alert(1)&lt;/script&gt;</title>");
         // The heading content holds the escaped form between its open and close tags.
         expect(html).toContain(">Report &lt;script&gt;alert(1)&lt;/script&gt;<");

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -222,6 +222,22 @@ describe("the table data assets", () => {
         return { tbl: { type: "table", columns: ["gene", "padj", "direction"], rows } };
     }
 
+    /**
+     * Run one data asset as the page runs it, and give back the registered payload.
+     *
+     * The asset is browser source text, thus a read of the source string would test the serialization and
+     * not the value that a reader takes. `decode` runs the page decoder over the payload as well.
+     */
+    function registeredPayload(asset: { bytes: string }, decode = false): { columns: string[]; rows: unknown[]; dict: Record<string, string[]> } {
+        const window: Record<string, unknown> = {};
+        new Function("window", asset.bytes)(window);
+        if (decode) {
+            new Function("window", TABLE_DATA_DECODER)(window);
+        }
+        const registry = window[TABLE_DATA_GLOBAL] as Record<string, { columns: string[]; rows: unknown[]; dict: Record<string, string[]> }>;
+        return registry["tbl"];
+    }
+
     it("holds the header and no data row, and the payload holds every row", () => {
         const rendered = renderReportPage(tableDocument(), valuesOf(14201))._unsafeUnwrap();
         const page = load(rendered.html);
@@ -230,21 +246,20 @@ describe("the table data assets", () => {
         expect(page("tbody tr").length).toBe(0);
         expect(rendered.dataAssets.length).toBe(1);
 
-        const payload = JSON.parse(rendered.dataAssets[0].bytes.slice(rendered.dataAssets[0].bytes.indexOf("]=") + 2, -2)) as {
-            columns: string[];
-            rows: unknown[][];
-        };
+        const payload = registeredPayload(rendered.dataAssets[0]);
         expect(payload.columns).toEqual(["gene", "padj", "direction"]);
         expect(payload.rows.length).toBe(14201);
     });
 
     it("compresses a repeated category into the dictionary of its column", () => {
         const rendered = renderReportPage(tableDocument(), valuesOf(100))._unsafeUnwrap();
+        const payload = registeredPayload(rendered.dataAssets[0]);
 
         // The direction column holds two values across one hundred rows, thus the payload names each one
         // time and each row holds its index.
-        expect(rendered.dataAssets[0].bytes).toContain(`"dict":{"direction":["up","down"]}`);
-        expect(rendered.dataAssets[0].bytes.split(`"up"`).length - 1).toBe(1);
+        expect(payload.dict).toEqual({ direction: ["up", "down"] });
+        expect(payload.rows[0]).toEqual(["G0", 0, 0]);
+        expect(payload.rows[1]).toEqual(["G1", 0.01, 1]);
     });
 
     it("gives byte-identical assets and one asset name over two renders", () => {
@@ -283,6 +298,31 @@ describe("the table data assets", () => {
         // A second run finds the decoded rows and leaves them, thus a late script pays the decode one time.
         new Function("window", TABLE_DATA_DECODER)(window);
         expect(registry["tbl"].rows[0]).toEqual({ gene: "G0", padj: 0, direction: "up" });
+    });
+
+    it("decodes a column that names a prototype member as an ordinary column", () => {
+        const document = tableDocument();
+        // An object literal sends a `__proto__` key to the prototype. The rows arrive from a parse in the
+        // real path, thus the test builds them the same way and the column stays an own key.
+        const rows = JSON.parse('[{"constructor":"up","__proto__":"left","gene":"TP53"},{"constructor":"up","__proto__":"right","gene":"MYC"}]') as Record<
+            string,
+            string | number
+        >[];
+        const values: RenderValues = { tbl: { type: "table", columns: ["constructor", "__proto__", "gene"], rows } };
+        const rendered = renderReportPage(document, values)._unsafeUnwrap();
+        const window: Record<string, unknown> = {};
+
+        new Function("window", rendered.dataAssets[0].bytes)(window);
+        new Function("window", TABLE_DATA_DECODER)(window);
+
+        // A column name is authored text. An object literal would send `__proto__` to the prototype, and a
+        // plain record would read `constructor` off the prototype instead of the dictionary of the column.
+        const registry = window[TABLE_DATA_GLOBAL] as Record<string, { rows: Record<string, string | number>[] }>;
+        const first = registry["tbl"].rows[0];
+        expect(Object.hasOwn(first, "__proto__")).toBe(true);
+        expect(first["__proto__"]).toBe("left");
+        expect(first["constructor"]).toBe("up");
+        expect(registry["tbl"].rows[1]["constructor"]).toBe("up");
     });
 
     it("omits a column that a ragged row does not hold, thus no key reads as an empty value", () => {
@@ -1496,10 +1536,13 @@ describe("renderReportPage number format", () => {
             },
         };
         const rendered = renderReportPage(document, values)._unsafeUnwrap();
+        const window: Record<string, unknown> = {};
+        new Function("window", rendered.dataAssets[0].bytes)(window);
+        const registry = window[TABLE_DATA_GLOBAL] as Record<string, { rows: unknown[] }>;
 
         // The number format is presentation, and the payload is data. A rounded value in the asset would
         // put a shown form where a magnitude belongs.
-        expect(rendered.dataAssets[0].bytes).toContain(`["TP53",-3.089028528355109,0.0000427777663038,"up"]`);
+        expect(registry["tbl"].rows[0]).toEqual(["TP53", -3.089028528355109, 0.0000427777663038, "up"]);
         expect(load(rendered.html)(".data-table tbody td").length).toBe(0);
     });
 });

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -24,25 +24,31 @@ import { deriveChartOption } from "./chart.js";
 import { assemblePage, renderBand, renderReferenceSection } from "./views/page-view.js";
 import { renderClaim, renderNav, renderSection, renderText } from "./views/prose.js";
 import { citationKeyOf, ReferenceLedger } from "./references.js";
-import type { RenderProblem, RenderValue, RenderValues } from "./types.js";
-import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable } from "./views/values.js";
+import { encodeTablePayload, tableDataAsset, type DataAsset } from "./table-data.js";
+import type { RenderedPage, RenderProblem, RenderValue, RenderValues } from "./types.js";
+import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable, tableColumns } from "./views/values.js";
 
 /**
- * Render a report document, its value map, and the pinned citation records to one HTML string.
+ * Render a report document, its value map, and the pinned citation records to one page and its data assets.
  *
  * The walk collects every value problem. When any problem exists, the render returns the problems and no
- * HTML. When no problem exists, the render assembles the page and returns the string.
+ * page. When no problem exists, the render assembles the page and returns it beside the assets that the
+ * page references.
  *
  * The records are the bibliography of the pin, and they are optional. A caller that passes none renders
  * each citation from its key alone, thus a stored pin that holds no record map renders as it did before.
+ *
+ * The renderer writes no file. The data assets ride the result, and the caller stages them beside the page.
+ * Thus the render stays pure, and two renders of one document give byte-identical assets.
  */
-export function renderReportPage(document: ReportDocument, values: RenderValues, records?: CitationRecords): Result<string, RenderProblem[]> {
+export function renderReportPage(document: ReportDocument, values: RenderValues, records?: CitationRecords): Result<RenderedPage, RenderProblem[]> {
     const problems: RenderProblem[] = [];
     const ledger = new ReferenceLedger();
+    const dataAssets: DataAsset[] = [];
 
     const content: string[] = [];
     for (const [index, section] of document.sections.entries()) {
-        content.push(renderBand(index, renderBlock(section, values, ledger, records, 0, problems)));
+        content.push(renderBand(index, renderBlock(section, values, ledger, records, dataAssets, 0, problems)));
     }
     if (problems.length > 0) {
         return err(problems);
@@ -50,7 +56,7 @@ export function renderReportPage(document: ReportDocument, values: RenderValues,
 
     const nav = renderNav(document.sections);
     const references = renderReferenceSection(ledger, document.sections.length, records);
-    return ok(assemblePage(document.title, nav, content.join(""), references));
+    return ok({ html: assemblePage(document.title, nav, content.join(""), references, dataAssets), dataAssets });
 }
 
 /**
@@ -63,6 +69,7 @@ function renderBlock(
     values: RenderValues,
     ledger: ReferenceLedger,
     records: CitationRecords | undefined,
+    dataAssets: DataAsset[],
     depth: number,
     problems: RenderProblem[],
 ): string {
@@ -95,6 +102,10 @@ function renderBlock(
                 problems.push(wrongShape(block.id, entry.type, "table"));
                 return "";
             }
+            // The rows of the block ride a data asset, and the card holds the header alone. The payload
+            // reads the column order of the header, thus a cell of an encoded row names its column by
+            // position.
+            dataAssets.push(tableDataAsset(block.id, encodeTablePayload(tableColumns(entry), entry.rows)));
             return renderTable(block, entry);
         }
         case "figure": {
@@ -127,7 +138,7 @@ function renderBlock(
             return renderChart(block, option.value);
         }
         case "section":
-            return renderSection(block, depth, renderChildren(block.blocks, values, ledger, records, depth + 1, problems));
+            return renderSection(block, depth, renderChildren(block.blocks, values, ledger, records, dataAssets, depth + 1, problems));
     }
 }
 
@@ -142,6 +153,7 @@ function renderChildren(
     values: RenderValues,
     ledger: ReferenceLedger,
     records: CitationRecords | undefined,
+    dataAssets: DataAsset[],
     depth: number,
     problems: RenderProblem[],
 ): string {
@@ -151,7 +163,7 @@ function renderChildren(
         const run = metricRunLength(blocks, index);
         const rendered: string[] = [];
         for (let offset = 0; offset < Math.max(run, 1); offset += 1) {
-            rendered.push(renderBlock(blocks[index + offset], values, ledger, records, depth, problems));
+            rendered.push(renderBlock(blocks[index + offset], values, ledger, records, dataAssets, depth, problems));
         }
         parts.push(run > 1 ? renderMetricGrid(rendered.join("")) : rendered.join(""));
         index += Math.max(run, 1);

--- a/harness/src/report-render/table-data.test.ts
+++ b/harness/src/report-render/table-data.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "bun:test";
 
-import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL } from "./table-data.js";
+import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL, type TablePayload } from "./table-data.js";
 
 describe("encodeTablePayload", () => {
     it("writes each row as an array in column order", () => {
@@ -91,12 +91,31 @@ describe("encodeTablePayload", () => {
 describe("tableDataAsset", () => {
     const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }]);
 
+    /** Run one asset as the page runs it, and give back the registry that it wrote. */
+    function registryOf(bytes: string): Record<string, TablePayload> {
+        const window: Record<string, unknown> = {};
+        new Function("window", bytes)(window);
+        return window[TABLE_DATA_GLOBAL] as Record<string, TablePayload>;
+    }
+
     it("registers the payload under the global map, keyed by the block id", () => {
         const asset = tableDataAsset("tbl-1", payload);
 
         expect(asset.bytes).toContain(`window.${TABLE_DATA_GLOBAL}`);
         expect(asset.bytes).toContain(`[${JSON.stringify("tbl-1")}]=`);
-        expect(asset.bytes).toContain(`"columns":["gene"]`);
+        expect(registryOf(asset.bytes)["tbl-1"]).toEqual(payload);
+    });
+
+    it("parses the payload instead of writing an object literal, thus a prototype key stays a column", () => {
+        const columns = ["__proto__", "constructor"];
+        const rows = JSON.parse('[{"__proto__":"a","constructor":"b"}]') as Record<string, string | number>[];
+        const asset = tableDataAsset("tbl-1", encodeTablePayload(columns, rows));
+
+        // An object literal with a `__proto__` key sets the prototype of the object. The parse defines an
+        // own property for every key, thus the payload reaches the page with the columns that it declares.
+        const registered = registryOf(asset.bytes)["tbl-1"];
+        expect(registered.columns).toEqual(columns);
+        expect(registered.rows).toEqual([["a", "b"]]);
     });
 
     it("names the file by the content hash of its bytes", () => {

--- a/harness/src/report-render/table-data.test.ts
+++ b/harness/src/report-render/table-data.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The tests of the table data payload: the columnar encode, the dictionary pass, and the asset name.
+ *
+ * The decode of the page reads the same shape, thus a test here states what the page script consumes.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL } from "./table-data.js";
+
+describe("encodeTablePayload", () => {
+    it("writes each row as an array in column order", () => {
+        const payload = encodeTablePayload(
+            ["gene", "padj"],
+            [
+                { gene: "TP53", padj: 0.01 },
+                { gene: "MYC", padj: 0.02 },
+            ],
+        );
+
+        // No row repeats the column names, thus a table of many rows costs one column list.
+        expect(payload.columns).toEqual(["gene", "padj"]);
+        expect(payload.rows).toEqual([
+            ["TP53", 0.01],
+            ["MYC", 0.02],
+        ]);
+        expect(payload.dict).toEqual({});
+    });
+
+    it("moves a repeated string of a column into the dictionary, in first-appearance order", () => {
+        const rows = [
+            { gene: "TP53", direction: "up" },
+            { gene: "MYC", direction: "down" },
+            { gene: "EGFR", direction: "up" },
+            { gene: "KRAS", direction: "down" },
+        ];
+
+        const payload = encodeTablePayload(["gene", "direction"], rows);
+
+        // The category column holds two values across four rows, thus it costs two strings and four indexes.
+        expect(payload.dict).toEqual({ direction: ["up", "down"] });
+        expect(payload.rows).toEqual([
+            ["TP53", 0],
+            ["MYC", 1],
+            ["EGFR", 0],
+            ["KRAS", 1],
+        ]);
+    });
+
+    it("leaves a column of distinct strings raw, because a dictionary would save nothing", () => {
+        const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }, { gene: "MYC" }]);
+
+        expect(payload.dict).toEqual({});
+        expect(payload.rows).toEqual([["TP53"], ["MYC"]]);
+    });
+
+    it("leaves a column that holds a number raw, thus no cell of it reads as an index", () => {
+        const payload = encodeTablePayload(["mixed"], [{ mixed: "same" }, { mixed: "same" }, { mixed: 1 }]);
+
+        expect(payload.dict).toEqual({});
+        expect(payload.rows).toEqual([["same"], ["same"], [1]]);
+    });
+
+    it("keeps a string that occurs one time in its row, because an entry would save nothing", () => {
+        const payload = encodeTablePayload(["direction"], [{ direction: "up" }, { direction: "up" }, { direction: "sideways" }]);
+
+        // The dictionary holds the repeated value alone, and the lone value stays where it is.
+        expect(payload.dict).toEqual({ direction: ["up"] });
+        expect(payload.rows).toEqual([[0], [0], ["sideways"]]);
+    });
+
+    it("writes an absent cell as null, thus a ragged row keeps its shape", () => {
+        const payload = encodeTablePayload(["gene", "padj"], [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }]);
+
+        expect(payload.rows).toEqual([
+            ["TP53", 0.01],
+            ["MYC", null],
+        ]);
+    });
+
+    it("gives one payload for one table, thus two encodes match", () => {
+        const rows = [
+            { gene: "TP53", direction: "up" },
+            { gene: "MYC", direction: "up" },
+        ];
+
+        expect(encodeTablePayload(["gene", "direction"], rows)).toEqual(encodeTablePayload(["gene", "direction"], rows));
+    });
+});
+
+describe("tableDataAsset", () => {
+    const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }]);
+
+    it("registers the payload under the global map, keyed by the block id", () => {
+        const asset = tableDataAsset("tbl-1", payload);
+
+        expect(asset.bytes).toContain(`window.${TABLE_DATA_GLOBAL}`);
+        expect(asset.bytes).toContain(`[${JSON.stringify("tbl-1")}]=`);
+        expect(asset.bytes).toContain(`"columns":["gene"]`);
+    });
+
+    it("names the file by the content hash of its bytes", () => {
+        const asset = tableDataAsset("tbl-1", payload);
+
+        expect(asset.name).toMatch(/^t-[0-9a-f]{12}\.data\.js$/);
+        // The name is the address of the bytes, thus one payload gives one name.
+        expect(tableDataAsset("tbl-1", payload).name).toBe(asset.name);
+    });
+
+    it("gives a different name to a different payload and to a different block", () => {
+        const other = encodeTablePayload(["gene"], [{ gene: "MYC" }]);
+
+        expect(tableDataAsset("tbl-1", other).name).not.toBe(tableDataAsset("tbl-1", payload).name);
+        expect(tableDataAsset("tbl-2", payload).name).not.toBe(tableDataAsset("tbl-1", payload).name);
+    });
+
+    it("keeps a hostile block id and a hostile cell as data", () => {
+        const hostile = encodeTablePayload(["gene"], [{ gene: "</script><script>alert(1)</script>" }]);
+        const asset = tableDataAsset("</script>", hostile);
+
+        // The payload rides JSON, and the escape of the sink covers the one sequence that closes an element.
+        expect(asset.bytes).not.toContain("</script>");
+        expect(asset.bytes).toContain("\\u003c/script>");
+    });
+});

--- a/harness/src/report-render/table-data.ts
+++ b/harness/src/report-render/table-data.ts
@@ -1,0 +1,139 @@
+/**
+ * The data-script payload of one table block.
+ *
+ * A table of many thousands of rows stamped into the markup makes a page of many megabytes. A `fetch` is
+ * refused on a `file://` page, thus a data file cannot load the way an image does. A classic script asset
+ * loads on any page, and the payload registers itself under one global map when the browser runs it.
+ *
+ * The encode is columnar. The rows are arrays in column order, thus no row repeats the column names. A
+ * string that occurs more than one time in a column moves into the dictionary of that column, and each
+ * cell that holds it becomes its index. A category column of one thousand rows and four values then costs
+ * four strings and one thousand small integers.
+ *
+ * The module is pure, and it reads no file. The renderer derives a payload, and the caller writes it.
+ */
+
+import { createHash } from "node:crypto";
+
+import { scriptJson } from "./script-json.js";
+
+/**
+ * The global map that each payload registers under, keyed by the block id.
+ *
+ * The page script reads the same name, thus the payload and the reader cannot disagree over a rename.
+ */
+export const TABLE_DATA_GLOBAL = "__REPORT_TABLES";
+
+/** One cell of an encoded row: a raw value, a dictionary index, or `null` for a cell that the row lacks. */
+export type EncodedCell = string | number | null;
+
+/**
+ * One encoded table.
+ *
+ * `columns` is the column order, and each row of `rows` holds one cell for each column in that order.
+ * `dict` holds the repeated values of a column, keyed by the column name. A cell of such a column is a
+ * number when it names an entry of that list, and the value itself at every other time.
+ */
+export interface TablePayload {
+    columns: string[];
+    rows: EncodedCell[][];
+    dict: Record<string, string[]>;
+}
+
+/** One data asset that the caller writes beside the page: the staged file name, and the source text of it. */
+export interface DataAsset {
+    name: string;
+    bytes: string;
+}
+
+/** The count of hash characters in an asset name. It matches the sidecar of an artifact, thus one form reads across the directory. */
+const HASH_CHARS = 12;
+
+/**
+ * The dictionary of one column, or `undefined` when the column takes none.
+ *
+ * A column takes a dictionary when every cell of it is a string. The condition keeps the decode
+ * unambiguous: a number in such a column can only be an index, and a string can only be a value. A column
+ * that holds one number rides raw, thus no reader must tell an index from a measurement.
+ *
+ * The dictionary holds each string that occurs more than one time, in first-appearance order. A string
+ * that occurs one time saves nothing as an entry, thus it stays in its row. The order is a function of the
+ * rows alone, thus one table gives one dictionary and two encodes of it match.
+ */
+function columnDictionary(rows: ReadonlyArray<Record<string, string | number>>, column: string): string[] | undefined {
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+        const cell = row[column];
+        if (typeof cell !== "string") {
+            return undefined;
+        }
+        counts.set(cell, (counts.get(cell) ?? 0) + 1);
+    }
+    const repeated: string[] = [];
+    for (const [value, count] of counts) {
+        if (count > 1) {
+            repeated.push(value);
+        }
+    }
+    return repeated.length > 0 ? repeated : undefined;
+}
+
+/**
+ * Encode a resolved table into its payload.
+ *
+ * The caller gives the column order, and the header of the card reads that same order. Thus the position
+ * of a cell in a row names its column.
+ *
+ * A cell that a row does not hold rides as `null`. A table tolerates a ragged row, thus the payload states
+ * the absence in place and never shifts the rest of the row.
+ */
+export function encodeTablePayload(columns: readonly string[], rows: ReadonlyArray<Record<string, string | number>>): TablePayload {
+    const dict: Record<string, string[]> = {};
+    const indexes = new Map<string, Map<string, number>>();
+    for (const column of columns) {
+        const values = columnDictionary(rows, column);
+        if (values === undefined) {
+            continue;
+        }
+        dict[column] = values;
+        indexes.set(column, new Map(values.map((value, index) => [value, index])));
+    }
+
+    const encodedRows = rows.map((row) =>
+        columns.map((column): EncodedCell => {
+            const cell = row[column];
+            if (cell === undefined) {
+                return null;
+            }
+            // A dictionary column holds strings alone, thus a cell of another type never carries an index.
+            const index = typeof cell === "string" ? indexes.get(column)?.get(cell) : undefined;
+            return index === undefined ? cell : index;
+        }),
+    );
+    return { columns: [...columns], rows: encodedRows, dict };
+}
+
+/**
+ * The source text of one payload asset.
+ *
+ * The text assigns into the global map under the block id. The map takes the null-prototype form, thus a
+ * block id such as `constructor` stays an ordinary entry. The block id and each cell ride as JSON, thus
+ * hostile text is data and never source.
+ */
+function payloadSource(blockId: string, payload: TablePayload): string {
+    const registry = `window.${TABLE_DATA_GLOBAL}`;
+    return `${registry}=${registry}||Object.create(null);${registry}[${scriptJson(blockId)}]=${scriptJson(payload)};\n`;
+}
+
+/**
+ * The data asset of one table block: the content-addressed file name, and the source text.
+ *
+ * The name carries the hash of the bytes, in the content-address style of a staged figure. Thus two
+ * previews of unchanged data give one name, a changed table gives a new name, and the sweep of the stage
+ * removes the name that nothing references any more.
+ */
+export function tableDataAsset(blockId: string, payload: TablePayload): DataAsset {
+    const bytes = payloadSource(blockId, payload);
+    const hash = createHash("sha256").update(bytes).digest("hex").slice(0, HASH_CHARS);
+    return { name: `t-${hash}.data.js`, bytes };
+}

--- a/harness/src/report-render/table-data.ts
+++ b/harness/src/report-render/table-data.ts
@@ -117,12 +117,18 @@ export function encodeTablePayload(columns: readonly string[], rows: ReadonlyArr
  * The source text of one payload asset.
  *
  * The text assigns into the global map under the block id. The map takes the null-prototype form, thus a
- * block id such as `constructor` stays an ordinary entry. The block id and each cell ride as JSON, thus
- * hostile text is data and never source.
+ * block id such as `constructor` stays an ordinary entry. The block id rides as JSON, thus hostile text is
+ * data and never source.
+ *
+ * The payload itself rides through `JSON.parse` and never as an object literal. An object literal with a
+ * `__proto__` key sets the prototype of the object instead of an own entry, thus a column of that name
+ * would arrive as a mangled object with no such column. `JSON.parse` defines an own property for every
+ * key, thus each column name reaches the page as a column name.
  */
 function payloadSource(blockId: string, payload: TablePayload): string {
     const registry = `window.${TABLE_DATA_GLOBAL}`;
-    return `${registry}=${registry}||Object.create(null);${registry}[${scriptJson(blockId)}]=${scriptJson(payload)};\n`;
+    const json = scriptJson(JSON.stringify(payload));
+    return `${registry}=${registry}||Object.create(null);${registry}[${scriptJson(blockId)}]=JSON.parse(${json});\n`;
 }
 
 /**

--- a/harness/src/report-render/types.ts
+++ b/harness/src/report-render/types.ts
@@ -8,6 +8,8 @@
  * image bytes.
  */
 
+import type { DataAsset } from "./table-data.js";
+
 /**
  * The value that one block resolves to, as a closed union. A `scalar` gives one number or one string. A
  * `table` gives the rows and the optional column order. A `figure` gives a ready source string. A
@@ -31,3 +33,14 @@ export interface RenderProblem {
 
 /** The value map that the renderer takes, keyed by block id. */
 export type RenderValues = Record<string, RenderValue>;
+
+/**
+ * One rendered page: the HTML string, and each data asset that the page references.
+ *
+ * The renderer writes no file. Thus it gives the asset bytes back to the caller, and the caller stages
+ * them beside the page. A document with no table gives an empty list, and its page references none.
+ */
+export interface RenderedPage {
+    html: string;
+    dataAssets: DataAsset[];
+}

--- a/harness/src/report-render/validity.test.ts
+++ b/harness/src/report-render/validity.test.ts
@@ -51,7 +51,7 @@ const htmlValidate = new HtmlValidate({
 
 describe("the rendered page validates as HTML and CSS", () => {
     it("passes the offline HTML validation with the recommended preset", async () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
         const report = await htmlValidate.validateString(html);
         // A finding names the rule and the element, thus a failure reads as its own cause.
         const findings = report.results.flatMap((result) =>
@@ -107,7 +107,7 @@ describe("a raw script sink stays hardened", () => {
     };
 
     it("keeps the hostile cell escaped in the inline JSON and the page whole", () => {
-        const html = renderReportPage(hostileDocument, hostileValues)._unsafeUnwrap();
+        const html = renderReportPage(hostileDocument, hostileValues)._unsafeUnwrap().html;
 
         // The `<` of the hostile cell reaches the inline JSON as the `\u003c` sequence.
         expect(html).toContain("\\u003c/script>\\u003cscript>alert(1)\\u003c/script>");

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -19,8 +19,10 @@
 
 import { raw } from "hono/html";
 
-import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_ENHANCER } from "../page.js";
+import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_DATA_DECODER, TABLE_ENHANCER } from "../page.js";
+import { stagedSource } from "../assets.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
+import type { DataAsset } from "../table-data.js";
 import type { CitationRecords } from "../../report-model/reference-resolver.js";
 import type { ReferenceLedger } from "../references.js";
 import { renderBibliography, renderReferenceList } from "./references-view.js";
@@ -100,11 +102,15 @@ export function renderReferenceSection(ledger: ReferenceLedger, index: number, r
 }
 
 /**
- * Assemble the page from the title, the navigation, the main content, and the reference frame. The title
- * passes through the runtime as text, and the runtime escapes it. The reference frame is optional, thus
- * an empty frame adds no markup.
+ * Assemble the page from the title, the navigation, the main content, the reference frame, and the data
+ * assets. The title passes through the runtime as text, and the runtime escapes it. The reference frame is
+ * optional, thus an empty frame adds no markup.
+ *
+ * Each data asset rides a classic `script` tag at the end of the body, and the decoder runs after the last
+ * of them. Thus every payload is registered before any reader looks, and a page with no table carries
+ * neither a tag nor the decoder.
  */
-export function assemblePage(title: string, nav: string, content: string, references: string): string {
+export function assemblePage(title: string, nav: string, content: string, references: string, dataAssets: readonly DataAsset[] = []): string {
     return (
         "<!doctype html>" +
         String(
@@ -138,6 +144,10 @@ export function assemblePage(title: string, nav: string, content: string, refere
                             </div>
                         </div>
                     </footer>
+                    {dataAssets.map((asset) => (
+                        <script src={stagedSource(asset.name)}></script>
+                    ))}
+                    {dataAssets.length > 0 ? <script>{raw(TABLE_DATA_DECODER)}</script> : null}
                     <script>{raw(THEME_REGISTRATION)}</script>
                     <script>{raw(FADE_IN_OBSERVER)}</script>
                     <script>{raw(CHART_BOOTSTRAP)}</script>

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import type { ScalarReference } from "../../contracts/report-reference.js";
-import { renderCitation, renderFigure, renderMetric, renderTable, TABLE_ROW_CAP } from "./values.js";
+import { tableSidecarName } from "../assets.js";
+import { renderCitation, renderFigure, renderMetric, renderTable, renderTableRows, TABLE_ROW_CAP } from "./values.js";
 import { ReferenceLedger } from "../references.js";
 
 const scalarBinding: ScalarReference = { kind: "artifact-value", path: "runs/r1/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
@@ -56,7 +57,7 @@ describe("renderMetric", () => {
     });
 });
 
-describe("renderTable", () => {
+describe("renderTableRows", () => {
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
 
     /** One table value of `count` rows. The gene column numbers each row, thus a sorted order is readable. */
@@ -68,8 +69,8 @@ describe("renderTable", () => {
         return { type: "table", rows } as const;
     }
 
-    it("renders one header cell for each column and one row for each resolved row", () => {
-        const html = renderTable(block, {
+    it("renders one row for each resolved row", () => {
+        const html = renderTableRows(block, {
             type: "table",
             rows: [
                 { gene: "TP53", padj: 0.01 },
@@ -77,19 +78,16 @@ describe("renderTable", () => {
                 { gene: "EGFR", padj: 0.03 },
             ],
         });
-        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
         expect(html.split(`<tr class="report-row`).length - 1).toBe(3);
         expect(html).toContain("TP53");
     });
 
-    it("renders the header alone for a zero-row table with named columns", () => {
-        const html = renderTable(block, { type: "table", rows: [], columns: ["gene", "padj"] });
-        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
-        expect(html).not.toContain(`<tr class="report-row`);
+    it("renders nothing for a zero-row table", () => {
+        expect(renderTableRows(block, { type: "table", rows: [], columns: ["gene", "padj"] })).toBe("");
     });
 
     it("renders an absent cell as an empty cell", () => {
-        const html = renderTable(block, {
+        const html = renderTableRows(block, {
             type: "table",
             rows: [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }],
             columns: ["gene", "padj"],
@@ -99,89 +97,76 @@ describe("renderTable", () => {
     });
 
     it("shows a p-value column in the scientific form with the full digits on the title", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.0000427777663038 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", padj: 0.0000427777663038 }] });
         expect(html).toContain(`<td data-value="0.0000427777663038" title="0.0000427777663038">4.3e-5</td>`);
     });
 
     it("rounds a long float to three significant digits and keeps the full digits on the title", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109 }] });
         expect(html).toContain(`<td data-value="-3.089028528355109" title="-3.089028528355109">-3.09</td>`);
     });
 
     it("groups a count and gives it no title, because the grouping hides no digit", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
         expect(html).toContain(`<td data-value="14201">14,201</td>`);
     });
 
     it("keeps an identifier column whole, with no grouping and no title", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", pmid: "31978945" }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", pmid: "31978945" }] });
         expect(html).toContain(`<td data-value="31978945">31978945</td>`);
         expect(html).not.toContain("31,978,945");
         expect(html).not.toContain("title=");
     });
 
     it("gives a grouped whole number to a large float and keeps the full digits on the title", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
         expect(html).toContain(`<td data-value="15234.7" title="15234.7">15,235</td>`);
     });
 
     it("passes a non-numeric cell through unchanged and gives it no title", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", direction: "up" }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", direction: "up" }] });
         expect(html).toContain(`<td data-value="up">up</td>`);
         expect(html).not.toContain("title=");
     });
 
     it("carries the raw value of a shortened cell, thus the sort reads the full magnitude", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
         // The shown text is a rounded form. A sort over the shown text would order `15,235` as a string.
         expect(html).toContain(`data-value="15234.7"`);
     });
 
-    it("hides each row past the cap and names the total on the toggle", () => {
+    it("marks each row past the cap as hidden", () => {
         const total = TABLE_ROW_CAP + 5;
-        const html = renderTable(block, rowsOf(total));
+        const html = renderTableRows(block, rowsOf(total));
         expect(html.split(`<tr class="report-row`).length - 1).toBe(total);
         expect(html.split(`<tr class="report-row report-row-hidden">`).length - 1).toBe(5);
-        expect(html).toContain(`<button type="button" class="report-table-toggle">Show all ${total}</button>`);
     });
 
-    it("leaves a table at the cap with no hidden row and no toggle", () => {
-        const html = renderTable(block, rowsOf(TABLE_ROW_CAP));
+    it("marks no row of a table at the cap as hidden", () => {
+        const html = renderTableRows(block, rowsOf(TABLE_ROW_CAP));
         expect(html.split(`<tr class="report-row">`).length - 1).toBe(TABLE_ROW_CAP);
         expect(html).not.toContain("report-row-hidden");
-        expect(html).not.toContain("report-table-toggle");
-    });
-
-    it("carries one filter input for each table card", () => {
-        const html = renderTable(block, rowsOf(3));
-        expect(html.split(`class="report-table-filter"`).length - 1).toBe(1);
     });
 
     it("shows the first segment of a delimited name and keeps the whole name on the title", () => {
         const name = "HALLMARK_HYPOXIA%MSigDB%M5891";
-        const html = renderTable(block, { type: "table", rows: [{ set: name, padj: 0.01 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ set: name, padj: 0.01 }] });
         expect(html).toContain(`<td data-value="${name}" title="${name}">HALLMARK_HYPOXIA</td>`);
     });
 
     it("keeps a text whose last segment is empty, thus a percentage stays whole", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", coverage: "95%" }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", coverage: "95%" }] });
         expect(html).toContain(`<td data-value="95%">95%</td>`);
     });
 
     it("keeps a text of two segments whole, because an encoded name holds three", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", note: "KEGG%hsa04110" }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", note: "KEGG%hsa04110" }] });
         expect(html).toContain(`<td data-value="KEGG%hsa04110">KEGG%hsa04110</td>`);
     });
 
     it("keeps a sentence with a percentage whole, because a segment of an encoded name holds no space", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", change: "up 20% vs control%cohort" }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", change: "up 20% vs control%cohort" }] });
         expect(html).toContain(`<td data-value="up 20% vs control%cohort">up 20% vs control%cohort</td>`);
-    });
-
-    it("gives each sortable header the tab order, thus the keyboard reaches the sort", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
-        expect(html.split(`<th class="data-table-sort" data-sort-index="`).length - 1).toBe(2);
-        expect(html.split(`tabindex="0"`).length - 1).toBe(2);
     });
 
     /** One table block whose binding carries the declarations that a test states. */
@@ -191,21 +176,21 @@ describe("renderTable", () => {
 
     it("reads a declared p-value column in the scientific form, although its name matches no token", () => {
         const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.00427777663038 }] } as const;
-        const html = renderTable(declared({ columnMeanings: { significance: "p-value" } }), rows);
+        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
         expect(html).toContain(`<td data-value="0.00427777663038" title="0.00427777663038">4.3e-3</td>`);
         // The same cell with no declaration keeps the guess, thus the declaration is what moved the kind.
-        expect(renderTable(block, rows)).toContain(`>0.00428</td>`);
+        expect(renderTableRows(block, rows)).toContain(`>0.00428</td>`);
     });
 
     it("keeps a declared p-value from one hundredth up as a plain decimal with no full form", () => {
         const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.536 }] } as const;
-        const html = renderTable(declared({ columnMeanings: { significance: "p-value" } }), rows);
+        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
         expect(html).toContain(`<td data-value="0.536">0.536</td>`);
         expect(html).not.toContain("5.4e-1");
     });
 
     it("bounds a zero FDR by the smallest positive value of its own column", () => {
-        const html = renderTable(block, {
+        const html = renderTableRows(block, {
             type: "table",
             rows: [
                 { gene: "TP53", fdr: 0 },
@@ -226,14 +211,14 @@ describe("renderTable", () => {
                 { gene: "MYC", significance: 0.00036 },
             ],
         } as const;
-        const html = renderTable(declared({ columnMeanings: { significance: "p-value" } }), rows);
+        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
         expect(html).toContain(`<td data-value="0" title="0">&lt;4e-4</td>`);
         // With no declaration the name matches no token, thus the zero stays a count-like zero.
-        expect(renderTable(block, rows)).toContain(`<td data-value="0">0</td>`);
+        expect(renderTableRows(block, rows)).toContain(`<td data-value="0">0</td>`);
     });
 
     it("shows the near-zero form for a p-value column that holds no positive value", () => {
-        const html = renderTable(block, {
+        const html = renderTableRows(block, {
             type: "table",
             rows: [
                 { gene: "TP53", padj: 0 },
@@ -244,7 +229,7 @@ describe("renderTable", () => {
     });
 
     it("reads each p-value column on its own, thus a neighbor of one column bounds no other", () => {
-        const html = renderTable(block, {
+        const html = renderTableRows(block, {
             type: "table",
             rows: [
                 { pvalue: 0, padj: 0.00036 },
@@ -256,14 +241,71 @@ describe("renderTable", () => {
     });
 
     it("keeps the zero of a declared count column", () => {
-        const html = renderTable(declared({ columnMeanings: { hits: "count" } }), { type: "table", rows: [{ gene: "TP53", hits: 0 }] });
+        const html = renderTableRows(declared({ columnMeanings: { hits: "count" } }), { type: "table", rows: [{ gene: "TP53", hits: 0 }] });
         expect(html).toContain(`<td data-value="0">0</td>`);
         expect(html).not.toContain("≈0");
     });
 
     it("keeps the zero of an undeclared column of a different nature", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: 0, reads: 0 }] });
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: 0, reads: 0 }] });
         expect(html.split(`<td data-value="0">0</td>`).length - 1).toBe(2);
+    });
+
+    it("ignores a declaration that names no column of the table", () => {
+        const rows = { type: "table", rows: [{ gene: "TP53", padj: 0.00427777663038 }] } as const;
+        const stray = declared({ columnMeanings: { absent: "identifier" }, columnLabels: { absent: "Absent column" } });
+        expect(renderTableRows(stray, rows)).toBe(renderTableRows(block, rows));
+    });
+
+    it("keeps a hostile cell as text after the format passes it through", () => {
+        const html = renderTableRows(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
+        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(html).not.toContain("<script>alert(1)");
+    });
+});
+
+describe("renderTable", () => {
+    /** The block that every card test renders. Its binding names the pinned artifact of the download. */
+    const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
+
+    /** One table block whose binding carries the declarations that a test states. */
+    function declared(declaration: Pick<TableBlock["binding"], "columnMeanings" | "columnLabels">): TableBlock {
+        return { kind: "table", id: "tb1", binding: { ...tableBinding, ...declaration } };
+    }
+
+    /** One table value of `count` rows. The card renders none of them, thus the count states the input alone. */
+    function rowsOf(count: number) {
+        const rows = [];
+        for (let index = 0; index < count; index += 1) {
+            rows.push({ gene: `G${index}`, padj: 0.01 });
+        }
+        return { type: "table", rows } as const;
+    }
+
+    it("renders one header cell for each column and no data row", () => {
+        const html = renderTable(block, rowsOf(3));
+
+        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
+        // The rows ride the data asset, thus the markup carries no copy of them.
+        expect(html).toContain("<tbody></tbody>");
+        expect(html).not.toContain("<td");
+        expect(html).not.toContain("G0");
+    });
+
+    it("renders the header of a zero-row table with named columns", () => {
+        const html = renderTable(block, { type: "table", rows: [], columns: ["gene", "padj"] });
+        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
+    });
+
+    it("keeps the body empty however many rows resolve", () => {
+        expect(renderTable(block, rowsOf(TABLE_ROW_CAP + 5))).toContain("<tbody></tbody>");
+        expect(renderTable(block, rowsOf(TABLE_ROW_CAP + 5))).not.toContain("report-row");
+    });
+
+    it("gives each sortable header the tab order, thus the keyboard reaches the sort", () => {
+        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
+        expect(html.split(`<th class="data-table-sort" data-sort-index="`).length - 1).toBe(2);
+        expect(html.split(`tabindex="0"`).length - 1).toBe(2);
     });
 
     it("shows the declared label of a column and keeps the raw name on hover", () => {
@@ -281,16 +323,21 @@ describe("renderTable", () => {
         expect(html).toContain(`tabindex="0">gene</th>`);
     });
 
-    it("ignores a declaration that names no column of the table", () => {
-        const rows = { type: "table", rows: [{ gene: "TP53", padj: 0.00427777663038 }] } as const;
-        const stray = declared({ columnMeanings: { absent: "identifier" }, columnLabels: { absent: "Absent column" } });
-        expect(renderTable(stray, rows)).toBe(renderTable(block, rows));
+    it("links the staged raw bytes of the pinned artifact as the download", () => {
+        const html = renderTable(block, rowsOf(2));
+        const name = tableSidecarName(tableBinding.hash, tableBinding.path);
+
+        // The link is relative, thus the page fetches no host when it opens. The attribute makes the
+        // browser save the file instead of navigating to it.
+        expect(html).toContain(`href="assets/${name}"`);
+        expect(html).toContain(`download="${name}"`);
+        expect(name.endsWith("de.csv")).toBe(true);
     });
 
-    it("keeps a hostile cell as text after the format passes it through", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
-        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
-        expect(html).not.toContain("<script>alert(1)");
+    it("carries no filter and no toggle, because the enhancer drives neither over an empty body", () => {
+        const html = renderTable(block, rowsOf(TABLE_ROW_CAP + 5));
+        expect(html).not.toContain("report-table-filter");
+        expect(html).not.toContain("report-table-toggle");
     });
 });
 

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -13,9 +13,9 @@
  * declares for its column, and the column name answers for a column that declares none. A metric takes its
  * label, because a value locator declares no column-wide meaning.
  *
- * A table card also carries the markup of the page enhancer: the raw value of each cell, the sortable
- * header, the filter input, and the row cap with its toggle. The markup alone is a complete plain table,
- * thus the enhancer adds behavior over it and it never supplies a value.
+ * A table card carries the header of its table, an empty body, and the download of the raw pinned bytes.
+ * The rows ride a data asset beside the page, thus the markup carries no copy of them. `renderTableRows`
+ * holds the presentation of a cell, and it stays beside the card that owns that presentation.
  *
  * Each data card carries the `corner-accents` class. Thus the card keeps square corners with the L-shaped
  * accents, which is the geometric identity of the report.
@@ -26,6 +26,7 @@ import { raw } from "hono/html";
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import { declaredForColumn, type ColumnMeaning } from "../../contracts/report-reference.js";
 import type { CitationRecord } from "../../report-model/reference-resolver.js";
+import { stagedSource, tableSidecarName } from "../assets.js";
 import { LadderMarker } from "./references-view.js";
 import { formatNumberCell, holdsAPValue, selectNumberKind, smallestPositiveValue } from "../number-format.js";
 import { citationKeyOf, type ReferenceLedger } from "../references.js";
@@ -56,6 +57,9 @@ const WHITESPACE = /\s/;
  * keeps. Both read this one prefix, thus the two labels cannot drift apart.
  */
 export const SHOW_ALL_PREFIX = "Show all ";
+
+/** The label of the download link of a table card. It names what the reader gets, which is the whole table. */
+const DOWNLOAD_LABEL = "Download the full table";
 
 /** The scalar value that a metric renders from. */
 type ScalarValue = Extract<RenderValue, { type: "scalar" }>;
@@ -103,8 +107,11 @@ export function renderMetricGrid(cardsHtml: string): string {
 /**
  * The column order of a table. The value columns win when they are present. The keys of the first row
  * give the order otherwise, in first-appearance order.
+ *
+ * The header of the card and the payload of the data asset both read this order. Thus the position of a
+ * cell in an encoded row names the column of its header.
  */
-function tableColumns(value: TableValue): string[] {
+export function tableColumns(value: TableValue): string[] {
     if (value.columns !== undefined) {
         return value.columns;
     }
@@ -214,33 +221,56 @@ function Cell({
 }
 
 /**
- * Render a table block. The header holds one cell for each column, and the body holds one row for each
- * resolved row. A zero-row table renders the header alone. The title and the caption render only when the
- * block carries one.
+ * Render the body rows of a table as markup: one row for each resolved row, each cell under the format of
+ * its column.
+ *
+ * The card renders no body row today, because the rows of a table ride a data asset and the page reads
+ * them from there. This function is the one home of the cell presentation: the declared meaning, the
+ * number format, the p-value bound of a column, and the trim of a delimited name. It stays beside the card
+ * that it belongs to, thus the presentation of a cell has one definition.
+ *
+ * A row past the cap carries the hidden class, and the enhancer hides it under its live marker alone.
+ */
+export function renderTableRows(block: TableBlock, value: TableValue): string {
+    const columns = tableColumns(value);
+    const binding = block.binding;
+    const bounds = pValueBounds(columns, value, binding.columnMeanings);
+    return String(
+        <>
+            {value.rows.map((row, index) => (
+                <tr class={index < TABLE_ROW_CAP ? "report-row" : "report-row report-row-hidden"}>
+                    {columns.map((column) => (
+                        <Cell column={column} cell={row[column]} meaning={declaredForColumn(binding.columnMeanings, column)} bound={bounds.get(column)} />
+                    ))}
+                </tr>
+            ))}
+        </>,
+    );
+}
+
+/**
+ * Render a table block as the header of its table, the download of its raw bytes, and an empty body.
+ *
+ * The rows ride a data asset beside the page. A page that stamped 14,201 rows into its markup weighed
+ * megabytes, and each row was a copy of the column names. Thus the markup holds the header alone, and the
+ * page reads the rows from the payload that registers under the block id.
  *
  * Each header cell stays a plain `th`. It carries the sort class and the index of its column, thus the
  * enhancer reads the column of a click and a browser with no script keeps a plain header. The header also
  * takes the tab order, thus a reader sorts the table from the keyboard. The header shows the declared label
  * of the column, and the raw name rides the `title` attribute.
  *
- * The body holds every resolved row. A row past the cap carries the hidden class, and the card then carries
- * the toggle that names the total count. A table at the cap or under it carries no hidden row and no toggle.
- * The hidden class hides a row under the live marker of the enhancer alone, thus a browser with no script
- * shows every row. The label of the toggle names the total, and the enhancer composes the same label again
- * from the count that the filter keeps.
+ * The download names the staged copy of the pinned artifact. The link is relative and the browser saves
+ * the file, thus the page fetches nothing when it opens and the reader still gets the whole table.
  */
 export function renderTable(block: TableBlock, value: TableValue): string {
     const columns = tableColumns(value);
-    const total = value.rows.length;
     const binding = block.binding;
-    const bounds = pValueBounds(columns, value, binding.columnMeanings);
+    const download = tableSidecarName(binding.hash, binding.path);
     return String(
         <div class="report-table">
             {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
             <div class="corner-accents">
-                <div class="report-table-controls">
-                    <input class="report-table-filter" type="text" placeholder="Filter rows" aria-label="Filter rows" />
-                </div>
                 <div class="data-table-scroll">
                     <table class="data-table">
                         <thead>
@@ -255,23 +285,14 @@ export function renderTable(block: TableBlock, value: TableValue): string {
                                 })}
                             </tr>
                         </thead>
-                        <tbody>
-                            {value.rows.map((row, index) => (
-                                <tr class={index < TABLE_ROW_CAP ? "report-row" : "report-row report-row-hidden"}>
-                                    {columns.map((column) => (
-                                        <Cell
-                                            column={column}
-                                            cell={row[column]}
-                                            meaning={declaredForColumn(binding.columnMeanings, column)}
-                                            bound={bounds.get(column)}
-                                        />
-                                    ))}
-                                </tr>
-                            ))}
-                        </tbody>
+                        <tbody></tbody>
                     </table>
                 </div>
-                {total > TABLE_ROW_CAP ? <button type="button" class="report-table-toggle">{`${SHOW_ALL_PREFIX}${total}`}</button> : null}
+                <div class="report-table-footer">
+                    <a class="report-table-download" href={stagedSource(download)} download={download}>
+                        {DOWNLOAD_LABEL}
+                    </a>
+                </div>
             </div>
             {block.caption !== undefined ? <p class="report-caption">{block.caption}</p> : null}
         </div>,

--- a/harness/src/tools/report-session/preview-report.test.ts
+++ b/harness/src/tools/report-session/preview-report.test.ts
@@ -9,7 +9,7 @@
 
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,7 +18,7 @@ import type { DraftDocument } from "../../report-model/draft.js";
 import { computeDraftHash } from "../../report-model/draft-hash.js";
 import { createFixtureResolver } from "../../report-model/fixture-resolver.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
-import { PAGE_ASSETS } from "../../report-render/assets.js";
+import { PAGE_ASSETS, tableSidecarName } from "../../report-render/assets.js";
 import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
@@ -308,6 +308,121 @@ describe("the staged asset", () => {
             expect(content).toContain("assets/sha256-bbb.png");
         }
         assertNoLegacyDirs(root);
+    });
+});
+
+describe("the staged table data", () => {
+    const TABLE_PATH = "runs/r1/output/de.csv";
+    const TABLE_HASH = "sha256:ccc";
+    const TABLE_CSV = "gene,direction\nTP53,up\nMYC,down\nEGFR,up\n";
+
+    /** A snapshot whose one artifact is the table that the card binds. The fixture reads its rows. */
+    function tableSnapshot(): ReportSnapshot {
+        return {
+            artifacts: {
+                [TABLE_PATH]: {
+                    hash: TABLE_HASH,
+                    fileType: "output",
+                    rows: [
+                        { gene: "TP53", direction: "up" },
+                        { gene: "MYC", direction: "down" },
+                        { gene: "EGFR", direction: "up" },
+                    ],
+                },
+            },
+        };
+    }
+
+    /** A draft of one table block, with an optional second block that a later preview drops. */
+    function tableDoc(extra?: DraftDocument["sections"][number]["blocks"][number]): DraftDocument {
+        return {
+            title: "Tables",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Results",
+                    blocks: [
+                        { kind: "table", id: "tbl", binding: { kind: "artifact-table", path: TABLE_PATH, hash: TABLE_HASH } },
+                        ...(extra === undefined ? [] : [extra]),
+                    ],
+                },
+            ],
+        };
+    }
+
+    /** Write the artifact that the sidecar copies, under the workspace root. */
+    async function seedTable(root: string): Promise<void> {
+        await mkdir(join(root, "runs/r1/output"), { recursive: true });
+        await writeFile(join(root, TABLE_PATH), TABLE_CSV);
+    }
+
+    it("stages the data asset and the raw sidecar, and the page references both", async () => {
+        const root = await makeRoot();
+        await seedTable(root);
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: tableDoc(), snapshot: tableSnapshot() });
+        const tool = createPreviewReportTool({ gateway, makeResolver: () => createFixtureResolver(), resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("rendered");
+        if (result.outcome === "rendered") {
+            const assetsDir = join(root, "report-sessions", "t1", "assets");
+            const staged = await readdir(assetsDir);
+            const dataAsset = staged.find((name) => name.endsWith(".data.js"));
+            const sidecar = tableSidecarName(TABLE_HASH, TABLE_PATH);
+
+            expect(dataAsset).toBeDefined();
+            // The sidecar is the pinned bytes themselves, thus the reader downloads the file and never a
+            // re-serialization of it.
+            expect(await readFile(join(assetsDir, sidecar), "utf8")).toBe(TABLE_CSV);
+            expect(await readFile(join(assetsDir, dataAsset!), "utf8")).toContain("TP53");
+
+            const page = await readFile(result.pagePath, "utf8");
+            expect(page).toContain(`assets/${dataAsset!}`);
+            expect(page).toContain(`assets/${sidecar}`);
+        }
+        assertNoLegacyDirs(root);
+    });
+
+    it("removes what the new page does not reference, and keeps each manifest static", async () => {
+        const root = await makeRoot();
+        await seedTable(root);
+        await mkdir(join(root, "runs/r1/figures"), { recursive: true });
+        await writeFile(join(root, "runs/r1/figures/plot.png"), "PNGDATA");
+        const snapshot = tableSnapshot();
+        snapshot.artifacts["runs/r1/figures/plot.png"] = { hash: "sha256:bbb", fileType: "figure" };
+        const gateway = makeFakeGateway();
+        const figure = {
+            kind: "figure" as const,
+            id: "f1",
+            binding: { kind: "artifact-file" as const, path: "runs/r1/figures/plot.png", hash: "sha256:bbb" },
+            caption: "A plot",
+        };
+        gateway.seed("t1", { document: tableDoc(figure), snapshot });
+        const tool = createPreviewReportTool({ gateway, makeResolver: () => createFixtureResolver(), resolveWorkspaceRoot: () => root });
+        const assetsDir = join(root, "report-sessions", "t1", "assets");
+
+        const first = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+        expect(first.outcome).toBe("rendered");
+        const afterFirst = await readdir(assetsDir);
+        expect(afterFirst).toContain("sha256-bbb.png");
+
+        // A stale file of an earlier preview, and the block that produced the figure, both go.
+        await writeFile(join(assetsDir, "t-000000000000.data.js"), "stale");
+        gateway.seed("t1", { document: tableDoc(), snapshot });
+        const second = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+        expect(second.outcome).toBe("rendered");
+
+        const afterSecond = await readdir(assetsDir);
+        expect(afterSecond).not.toContain("sha256-bbb.png");
+        expect(afterSecond).not.toContain("t-000000000000.data.js");
+        expect(afterSecond.filter((name) => name.endsWith(".data.js")).length).toBe(1);
+        expect(afterSecond).toContain(tableSidecarName(TABLE_HASH, TABLE_PATH));
+        for (const asset of PAGE_ASSETS) {
+            expect(afterSecond).toContain(asset.file);
+        }
     });
 });
 

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -6,6 +6,10 @@
  * resolves each reference through the injected resolver, bridges the resolved values into the render model,
  * and renders the page.
  *
+ * The renderer writes no file. It gives the page and the data asset of each table, and this tool stages
+ * them beside the figures. The stage is authoritative over the assets directory: what this preview wrote
+ * stays, and each other file goes.
+ *
  * The page and its staged assets land in `report-sessions/{threadId}/` under the workspace root. That
  * namespace belongs to this path alone, thus the tool never writes under the old `previews/` or `reports/`
  * trees. The result carries the absolute page path, thus a local host shows the page with no seam.
@@ -26,7 +30,7 @@
  */
 
 import { err, ok, type Result } from "neverthrow";
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { extname, join } from "node:path";
 import { z } from "zod";
@@ -42,8 +46,9 @@ import { finishDraft, type FinishGap } from "../../report-model/draft-finish.js"
 import type { ReferenceResolver, ReportSnapshot, ResolvedValue } from "../../report-model/reference-resolver.js";
 import { resolveDocumentReferences, type ResolutionFailure } from "../../report-model/validate.js";
 import { bridgeValues, type BlockResolution, type BridgeMismatch, type ResolvedFile } from "../../report-render/value-bridge.js";
-import { ASSETS_DIR, PAGE_ASSETS } from "../../report-render/assets.js";
+import { ASSETS_DIR, PAGE_ASSETS, tableSidecarName } from "../../report-render/assets.js";
 import { renderReportPage } from "../../report-render/render.js";
+import type { DataAsset } from "../../report-render/table-data.js";
 import type { RenderProblem } from "../../report-render/types.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
 import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
@@ -169,6 +174,44 @@ function collectResolutions(blocks: readonly Block[], resolvedByBlock: ReadonlyM
 }
 
 /**
+ * One staged copy of the raw bytes of a table: the staged name, the analysis-relative path of the pinned
+ * artifact, and the block whose card links it.
+ */
+interface TableSidecar {
+    readonly blockId: string;
+    readonly name: string;
+    readonly path: string;
+}
+
+/**
+ * The sidecar of each table block of the document, in document order.
+ *
+ * A table card offers the whole table as a download, and the download is the pinned file itself and never a
+ * re-serialization of it. The card spells the staged name through `tableSidecarName`, thus the stage reads
+ * that same function and the link and the file cannot disagree.
+ *
+ * A chart binds a table too, and it holds no card. Thus the walk reads the table blocks alone.
+ */
+function collectTableSidecars(blocks: readonly Block[]): TableSidecar[] {
+    const sidecars: TableSidecar[] = [];
+    const visit = (block: Block): void => {
+        if (block.kind === "section") {
+            for (const child of block.blocks) {
+                visit(child);
+            }
+            return;
+        }
+        if (block.kind === "table") {
+            sidecars.push({ blockId: block.id, name: tableSidecarName(block.binding.hash, block.binding.path), path: block.binding.path });
+        }
+    };
+    for (const block of blocks) {
+        visit(block);
+    }
+    return sidecars;
+}
+
+/**
  * Resolve each reference of the document, and split the resolutions from the unresolved references.
  *
  * The shared `resolveDocumentReferences` walks the tree, resolves each reference under the concurrency
@@ -206,8 +249,11 @@ type PreviewWriteFailure = { kind: "fs"; error: FsError } | { kind: "figure-out-
  * outside the root refuses and names the block, and no copy runs.
  *
  * The page references the chart runtime and the fonts under the same `assets/` directory, thus one copy
- * loop stages the figures and the manifest entries together. The manifest is never empty, thus the assets
- * directory exists beside every page.
+ * loop stages the figures, the table sidecars, and the manifest entries together. The manifest is never
+ * empty, thus the assets directory exists beside every page.
+ *
+ * The data assets are the one part that the renderer produces rather than the disk. They write after the
+ * copies and before the page. The sweep then runs, and the directory holds the closure of this page alone.
  */
 async function renderToWorkspace(args: {
     resolveWorkspaceRoot: ResolveWorkspaceRoot;
@@ -215,7 +261,10 @@ async function renderToWorkspace(args: {
     analysisId: string;
     threadId: string;
     resolutions: readonly BlockResolution[];
+    sidecars: readonly TableSidecar[];
+    dataAssets: readonly DataAsset[];
     page: string;
+    logger: Logger;
 }): Promise<Result<string, PreviewWriteFailure>> {
     let root: string;
     try {
@@ -248,6 +297,19 @@ async function renderToWorkspace(args: {
         sources.set(name, resolved.absolute);
     }
 
+    // Each table sidecar: the pinned bytes themselves, under the name that the download link of the card
+    // spells. The path of a snapshot entry is untrusted, thus the containment test runs here too.
+    for (const sidecar of args.sidecars) {
+        if (sources.has(sidecar.name)) {
+            continue;
+        }
+        const resolved = resolveWorkspacePath({ workspaceRoot: root, analysisId: args.analysisId, path: sidecar.path });
+        if (resolved.kind !== "ok") {
+            return err({ kind: "figure-out-of-scope", blockId: sidecar.blockId, path: sidecar.path });
+        }
+        sources.set(sidecar.name, resolved.absolute);
+    }
+
     // Each manifest entry, mapped from its staged name to the file that the asset lookup gives. A specifier
     // that does not resolve is a fault of the installation, thus it rides the `fs` kind.
     for (const asset of PAGE_ASSETS) {
@@ -272,11 +334,51 @@ async function renderToWorkspace(args: {
             return err({ kind: "fs", error: copied.error });
         }
     }
+    // Each data asset is source text that the renderer derived, thus it writes and never copies.
+    for (const asset of args.dataAssets) {
+        const assetPath = join(assetsDir, asset.name);
+        const wroteAsset = await tryFsWrite("preview.writeFile", () => writeFile(assetPath, asset.bytes, "utf8"), { path: assetPath });
+        if (wroteAsset.isErr()) {
+            return err({ kind: "fs", error: wroteAsset.error });
+        }
+    }
     const wrote = await tryFsWrite("preview.writeFile", () => writeFile(pagePath, args.page, "utf8"), { path: pagePath });
     if (wrote.isErr()) {
         return err({ kind: "fs", error: wrote.error });
     }
+
+    const staged = new Set<string>([...sources.keys(), ...args.dataAssets.map((asset) => asset.name)]);
+    await sweepAssets(assetsDir, staged, args.logger);
     return ok(pagePath);
+}
+
+/**
+ * Remove each file of the assets directory that this preview did not stage.
+ *
+ * The stage is authoritative: the directory holds the closure of the page and nothing else. A block that
+ * goes leaves a stale data asset, a stale sidecar, and a stale figure behind, and each one costs disk and
+ * misleads a reader who opens the directory. The staged set is what this run wrote, thus the sweep needs no
+ * read of the page.
+ *
+ * A sweep fault costs the cleanup alone. The page and its assets are on disk and complete, thus a failed
+ * listing and a failed removal each log and the preview still reports the page.
+ */
+async function sweepAssets(assetsDir: string, staged: ReadonlySet<string>, logger: Logger): Promise<void> {
+    const listed = await tryFsWrite("preview.readdir", () => readdir(assetsDir), { path: assetsDir });
+    if (listed.isErr()) {
+        logger.warn("the assets directory did not list", { path: assetsDir, detail: describeFsError(listed.error) });
+        return;
+    }
+    for (const entry of listed.value) {
+        if (staged.has(entry)) {
+            continue;
+        }
+        const stale = join(assetsDir, entry);
+        const removed = await tryFsWrite("preview.rm", () => rm(stale, { force: true, recursive: true }), { path: stale });
+        if (removed.isErr()) {
+            logger.warn("a stale asset did not go", { path: stale, detail: describeFsError(removed.error) });
+        }
+    }
 }
 
 /**
@@ -356,7 +458,10 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
                 analysisId,
                 threadId,
                 resolutions,
-                page: rendered.value,
+                sidecars: collectTableSidecars(document.sections),
+                dataAssets: rendered.value.dataAssets,
+                page: rendered.value.html,
+                logger,
             });
             if (written.isErr()) {
                 const failure = written.error;


### PR DESCRIPTION
## What & why

The session page stamps 14,201 table rows into its markup, and `index.html` weighs 7.2 MB. A `fetch` is refused on a `file://` page, thus the data rides the one mechanism that works there: a classic script asset, exactly as ECharts does. The renderer now emits each table block as a columnar payload with a first-appearance dictionary, and the markup holds the header alone. The render result returns the payloads, and the preview writes them beside the page, with the raw artifact bytes as the reader download. The binding gains an optional row bound as content, applied at resolution with a stable code-unit rank. The asset stage is authoritative: what the page does not reference goes, and the manifest statics stay.

Reviewer notes: the renderer stays pure — it returns payloads and writes nothing. The bound ranks before the column projection, thus a bound over an omitted display column works. `renderTableRows` keeps its export with no page caller, because the grid change of the next iteration consumes the cell presentation. The interim page shows the header and the download until that grid lands, and the pairing closes on this delivery branch. The compression arm past 10 MB and the chart's inline option are stated later arms.

Refs #398

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
