### PR TITLE
feat(harness): render the tables with AG Grid Community

### DIFF
--- a/harness/bun.lock
+++ b/harness/bun.lock
@@ -24,6 +24,7 @@
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@opentelemetry/sdk-trace-node": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.43.0",
+        "ag-grid-community": "36.1.0",
         "ai": "^7.0.61",
         "cheerio": "^1.2.0",
         "dockerode": "^4.0.12",
@@ -288,6 +289,12 @@
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ag-charts-types": ["ag-charts-types@14.1.0", "", {}, "sha512-mmzkng88c0l+Z9PvCMowMilhVeNgDU/iMuMemcOQD4BG/qO4vbkxWvyQO0iqju8Dx7YOY81PNzC/RmElQNiVkA=="],
+
+    "ag-grid-community": ["ag-grid-community@36.1.0", "", { "dependencies": { "ag-charts-types": "14.1.0", "ag-stack": "36.1.0" } }, "sha512-WnvSQ4csRs8gv/b1B0lPHykQXvUJVgi2u5mpY0Aa6dv3pvhDVVqCT8dwUyOeCog4JNPptaXGrOrZ8qP2XoJzVA=="],
+
+    "ag-stack": ["ag-stack@36.1.0", "", {}, "sha512-Kmkf5iRZmyduNx2KtW450j6GbCdJ4ejacSpb1AWl0yrdquRmScLRc1SlLolx6lyCbTBSJGo4tRraKbBzre+GlQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/design.md
@@ -1,0 +1,40 @@
+# Design: render-the-tables-with-the-grid
+
+## Context
+
+The data assets register each table's rows on the page, decoded, under the block id. The table card shows the header and the download link, and the round-one enhancer is inert over the empty body. The asset manifest (`src/report-render/assets.ts`) stages the ECharts bundle from its package. The page references it as a classic script, the one mechanism that a `file://` page admits.
+
+## Decisions
+
+### D1: The bundle ships exactly as ECharts does
+
+`ag-grid-community` joins `dependencies`, pinned exact. The manifest gains one entry over `ag-grid-community/dist/ag-grid-community.min.js`, and the preview stages it beside the page. The vanilla `createGrid` global serves, and no framework wrapper joins — the locked decision of the tracker.
+
+### D2: The server resolves, and the page formats
+
+The payload gains a `display` member: the resolved header label of each column, the resolved number kind, and the below-resolution bound where one exists. The kind resolution — the declaration, the token guess, the magnitude arms, the zero rule — stays server-side, where it is tested. The page script holds one small formatter over the shipped kinds. A shared test vector pins the client twin against the server helper, thus the two cannot drift in silence.
+
+### D3: The theme interpolates the design tokens at build
+
+The grid theme builds with `themeQuartz.withParams`, and the parameter values interpolate from the design-source token constants into the page script. One source styles the page and the grid, and no CSS custom property crosses into the grid parameters, because the theming API takes values.
+
+### D4: The grid boots after the payloads, from the registry
+
+The boot script walks the grid mounts and reads the decoded rows of each block id. It builds the column definitions from the display member, and it calls `createGrid`. The page script is design-source code, thus a real function formatter is admitted there. The inline-JSON constraint binds the chart option, and never the page script.
+
+### D5: The filter surface is the grid's own
+
+The per-column filters and the header sort ship enabled, and no quick-filter input renders. A second input would rebuild what the grid gives, and the review of the mechanism demo already rejected one.
+
+### D6: The enhancer retires whole
+
+The enhancer script, its marker, the filter input, the cap constant, the hidden-row classes, and their styles go. The grid owns the table presentation, thus the page keeps one table mechanism. The print form takes the grid's print layout, thus every bounded row prints. The row bound of the binding keeps the print sane, and that pairing is the decided size control.
+
+### D7: A missing payload leaves the card honest
+
+A grid mount whose block id the registry does not hold renders the header-only card with the download link, and the boot skips it. Absence is a normal condition, and the page never throws over it.
+
+## Risks / Trade-offs
+
+- The bundle is about two times the ECharts weight. The cost is one static asset beside the page, and the decided direction accepts it.
+- The grid markup is div-based, not a semantic table. The trade came with the decision, and the data rides the download for any reader that wants the raw form.

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: render-the-tables-with-the-grid
+
+## Why
+
+The round-one enhancer re-implements sort, filter, and a row cap by hand. The data assets of the previous change emptied the DOM it works on. The decided direction of the tracker: the tables render through AG Grid Community, vanilla `createGrid`, pinned as a page asset beside ECharts. A working demo beside the session page proves the fit on `file://`.
+
+## What Changes
+
+- The harness gains one dependency, `ag-grid-community`, pinned. Its bundle joins the asset manifest exactly as the ECharts bundle does, and the page references it as a classic script.
+- The table card renders a grid mount, and the page script boots one grid for each table block from the registered data. The client-side row model virtualizes the DOM.
+- The payload gains a display member: the resolved header labels, the resolved number kind of each column, and the below-resolution bounds. The server resolves, and the page formats. Thus the format rules stay in one place, and the client half is a thin twin over the shipped kinds.
+- The grid theme maps the design tokens: the palette, the typography, and the header treatment. The token values interpolate from the design source at build, thus one source styles the page and the grid.
+- No separate filter row ships. The per-column filters and the header sort are the one filter surface.
+- The vanilla enhancer retires: the script, the marker, the filter input, and the cap styles go. The print form shows the grid viewport, and the row bound of the binding is the size control.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-render`: the enhancer requirement goes, and the grid requirement takes its place.
+
+## Impact
+
+- Affected code: `harness/package.json`, `src/report-render/assets.ts`, `src/report-render/table-data.ts` (the display member), the table view, `src/report-render/page.ts` (the boot script), `src/report-render/design.ts` (the theme), and their tests.
+- The eyes checklist and the capture stay unchanged, and the page still stands alone.

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/specs/report-render/spec.md
@@ -14,7 +14,7 @@ The payload MUST carry a display member: the resolved header label of each colum
 
 The grid theme MUST build from the design tokens, thus the grid reads as the page does. The per-column filters and the header sort are the one filter surface, and no separate filter input renders. The full raw value of a formatted cell rides the cell tooltip, exactly as the `title` attribute carried it.
 
-The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, thus every bounded row prints, and the row bound keeps the print sane. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
+The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, up to a stated print cap. A larger table prints its first rows, and a printed line names the truncation and the download. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
 
 #### Scenario: The grid renders the bounded table
 
@@ -31,10 +31,15 @@ The renderer MUST trim a percent-delimited display name to its first segment, wi
 - **WHEN** the page renders any table block
 - **THEN** no standalone filter input sits above the grid, and the column filters serve
 
-#### Scenario: The print shows every bounded row
+#### Scenario: The print shows the bounded rows
 
-- **WHEN** the page prints a table block
-- **THEN** the print form holds every bounded row, and no scroll viewport clips one
+- **WHEN** the page prints a table block at or under the print cap
+- **THEN** the print form holds every row, and no scroll viewport clips one
+
+#### Scenario: A giant table prints with a stated truncation
+
+- **WHEN** the page prints a table block over the print cap
+- **THEN** the print holds the first rows, and a printed line names the truncation and the download
 
 #### Scenario: A missing payload keeps the card honest
 

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/specs/report-render/spec.md
@@ -1,0 +1,56 @@
+# Delta: report-render
+
+## REMOVED Requirements
+
+### Requirement: The table enhancer
+
+## ADDED Requirements
+
+### Requirement: The table grid
+
+The page MUST render each table block through the pinned grid bundle, booted by the page script from the registered data of the block. The bundle joins the asset manifest, and the page references it as a classic script. The client-side row model virtualizes the DOM, thus the page holds the visible slice alone.
+
+The payload MUST carry a display member: the resolved header label of each column, the resolved number kind, and the below-resolution bound where one exists. The server resolves, and the page formats over the shipped kinds. A shared test vector MUST pin the client formatter against the server helper.
+
+The grid theme MUST build from the design tokens, thus the grid reads as the page does. The per-column filters and the header sort are the one filter surface, and no separate filter input renders. The full raw value of a formatted cell rides the cell tooltip, exactly as the `title` attribute carried it.
+
+The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, thus every bounded row prints, and the row bound keeps the print sane. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
+
+#### Scenario: The grid renders the bounded table
+
+- **WHEN** the page loads with a table block of 14,201 registered rows
+- **THEN** the grid shows the rows with sort and per-column filters, and the DOM holds the visible slice alone
+
+#### Scenario: The client formats as the server does
+
+- **WHEN** the shared vector runs through the server helper and the client formatter
+- **THEN** the two give identical text for every entry
+
+#### Scenario: No filter row renders
+
+- **WHEN** the page renders any table block
+- **THEN** no standalone filter input sits above the grid, and the column filters serve
+
+#### Scenario: The print shows every bounded row
+
+- **WHEN** the page prints a table block
+- **THEN** the print form holds every bounded row, and no scroll viewport clips one
+
+#### Scenario: A missing payload keeps the card honest
+
+- **WHEN** a grid mount finds no registered data under its block id
+- **THEN** the header card and the download link stay, and the page throws nothing
+
+## MODIFIED Requirements
+
+### Requirement: A rendered form for each block kind
+
+The table block MUST render through the grid over its payload, and the payload holds the rows in place of the markup.
+
+#### Scenario: A table shows every resolved row through the grid
+- **WHEN** the caller renders a table block whose value entry holds three rows
+- **THEN** the payload holds the three rows, the grid shows them, and no sample note renders
+
+#### Scenario: An empty table keeps its card
+- **WHEN** the caller renders a table block whose value entry holds zero rows and named columns
+- **THEN** the card holds the title and the download link, and the payload holds the columns with no row

--- a/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-render-the-tables-with-the-grid/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: render-the-tables-with-the-grid
+
+## 1. The bundle
+
+- [x] 1.1 `ag-grid-community` joins the harness dependencies, pinned exact, and its bundle joins the asset manifest.
+
+## 2. The payload display member
+
+- [x] 2.1 The table payload gains `display`: the header labels, the number kinds, and the below-resolution bounds, resolved server-side.
+- [x] 2.2 A shared test vector pins the client formatter against the server helper.
+
+## 3. The page
+
+- [x] 3.1 The table card renders a grid mount, and the boot script builds one grid for each registered block.
+- [x] 3.2 The grid theme builds from the design-token values, interpolated at build.
+- [x] 3.3 The full raw value rides the cell tooltip, and the percent-delimited trim keeps its behavior on the grid.
+- [x] 3.4 A missing payload keeps the header card and the download link, and the boot skips it.
+
+## 4. The retirement
+
+- [x] 4.1 The enhancer script, its marker, the filter input, the cap constant, and their styles go.
+
+## 5. The proof
+
+- [x] 5.1 Tests cover the four delta scenarios, and the retired surfaces appear nowhere on the page.
+- [x] 5.2 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -175,7 +175,7 @@ The payload MUST carry a display member: the resolved header label of each colum
 
 The grid theme MUST build from the design tokens, thus the grid reads as the page does. The per-column filters and the header sort are the one filter surface, and no separate filter input renders. The full raw value of a formatted cell rides the cell tooltip, exactly as the `title` attribute carried it.
 
-The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, thus every bounded row prints, and the row bound keeps the print sane. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
+The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, up to a stated print cap. A larger table prints its first rows, and a printed line names the truncation and the download. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
 
 #### Scenario: The grid renders the bounded table
 
@@ -192,10 +192,15 @@ The renderer MUST trim a percent-delimited display name to its first segment, wi
 - **WHEN** the page renders any table block
 - **THEN** no standalone filter input sits above the grid, and the column filters serve
 
-#### Scenario: The print shows every bounded row
+#### Scenario: The print shows the bounded rows
 
-- **WHEN** the page prints a table block
-- **THEN** the print form holds every bounded row, and no scroll viewport clips one
+- **WHEN** the page prints a table block at or under the print cap
+- **THEN** the print form holds every row, and no scroll viewport clips one
+
+#### Scenario: A giant table prints with a stated truncation
+
+- **WHEN** the page prints a table block over the print cap
+- **THEN** the print holds the first rows, and a printed line names the truncation and the download
 
 #### Scenario: A missing payload keeps the card honest
 

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -52,6 +52,8 @@ The renderer MUST give each of the eight block kinds a rendered form. The render
 
 A text block with a list MUST render the list after its prose paragraphs, as ordered or unordered list markup by the flag. Each item escapes exactly as a paragraph does, and the list fills the content column. A text block with a list and an empty prose renders the list alone.
 
+The table block MUST render through the grid over its payload, and the payload holds the rows in place of the markup.
+
 #### Scenario: A section renders as a heading by depth
 - **WHEN** the caller renders a section with a nested child section
 - **THEN** the outer title renders as a higher heading level than the inner title
@@ -60,17 +62,17 @@ A text block with a list MUST render the list after its prose paragraphs, as ord
 - **WHEN** the caller renders a metric block with a scalar value entry
 - **THEN** the page shows the label and the scalar value together
 
-#### Scenario: A table renders every resolved row
+#### Scenario: A table shows every resolved row through the grid
 - **WHEN** the caller renders a table block whose value entry holds three rows
-- **THEN** the page holds an HTML table with the three rows, and no sample note
+- **THEN** the payload holds the three rows, the grid shows them, and no sample note renders
 
 #### Scenario: A figure renders from the supplied source
 - **WHEN** the caller renders a figure block with a figure source string and a caption
 - **THEN** the page holds an image with that source, and the caption below it
 
-#### Scenario: An empty table renders its header alone
+#### Scenario: An empty table keeps its card
 - **WHEN** the caller renders a table block whose value entry holds zero rows and named columns
-- **THEN** the page holds the table with its header, and no data row
+- **THEN** the card holds the title and the download link, and the payload holds the columns with no row
 
 #### Scenario: An empty chart still renders its container
 - **WHEN** the caller renders a chart block whose value entry holds zero rows
@@ -165,34 +167,40 @@ The table header MUST show the declared label of a column, with the raw column n
 - **WHEN** the table view renders the column `gene_symbol` with no declared label
 - **THEN** the header shows `gene symbol`, and the `title` attribute of the header holds the raw name
 
-### Requirement: The table enhancer
-The page MUST enhance each rendered table with a header sort, one filter input, and a row cap, through a page script with no dependency. The DOM MUST hold every resolved row, and the enhancer hides a row with a class and never removes one. The sort MUST read a raw value attribute that the view emits, thus the formatted text stays presentation. A numeric column sorts numerically, and every other column sorts in code-unit order. The cap is a renderer constant, and a table over the cap MUST carry a toggle that names the total row count. The print form MUST show every row. A browser without script keeps the complete plain table.
+### Requirement: The table grid
 
-The renderer MUST trim a percent-delimited display name to its first segment. The full text rides the `title` attribute.
+The page MUST render each table block through the pinned grid bundle, booted by the page script from the registered data of the block. The bundle joins the asset manifest, and the page references it as a classic script. The client-side row model virtualizes the DOM, thus the page holds the visible slice alone.
 
-#### Scenario: The rows stay in the DOM under the cap
-- **WHEN** the caller renders a table with more rows than the cap
-- **THEN** the markup holds every row, the rows past the cap carry the hidden class, and the toggle names the total
+The payload MUST carry a display member: the resolved header label of each column, the resolved number kind, and the below-resolution bound where one exists. The server resolves, and the page formats over the shipped kinds. A shared test vector MUST pin the client formatter against the server helper.
 
-#### Scenario: A sort reads the raw value
-- **WHEN** the view renders a numeric cell with a formatted text
-- **THEN** the cell carries the raw value in a data attribute, and the enhancer sorts by that value
+The grid theme MUST build from the design tokens, thus the grid reads as the page does. The per-column filters and the header sort are the one filter surface, and no separate filter input renders. The full raw value of a formatted cell rides the cell tooltip, exactly as the `title` attribute carried it.
 
-#### Scenario: A small table carries no toggle
-- **WHEN** the caller renders a table at or under the cap
-- **THEN** no row carries the hidden class, and no toggle renders
+The renderer MUST trim a percent-delimited display name to its first segment, with the full text on the cell tooltip. The print form MUST take the grid's print layout, thus every bounded row prints, and the row bound keeps the print sane. A grid mount whose payload the registry does not hold keeps the header card and the download link, and the boot skips it.
 
-#### Scenario: A noisy name trims with the full text on hover
-- **WHEN** a cell holds a percent-delimited set name
-- **THEN** the cell shows the first segment, and the `title` attribute holds the full text
+#### Scenario: The grid renders the bounded table
 
-#### Scenario: The print form shows every row
-- **WHEN** the reader prints a page with a capped table
-- **THEN** the print rules reveal each hidden row
+- **WHEN** the page loads with a table block of 14,201 registered rows
+- **THEN** the grid shows the rows with sort and per-column filters, and the DOM holds the visible slice alone
 
-#### Scenario: A scriptless browser sees the whole plain table
-- **WHEN** the page loads with scripting disabled
-- **THEN** every row paints, and no inert control shows, because the sheet hides and shows only under the live marker
+#### Scenario: The client formats as the server does
+
+- **WHEN** the shared vector runs through the server helper and the client formatter
+- **THEN** the two give identical text for every entry
+
+#### Scenario: No filter row renders
+
+- **WHEN** the page renders any table block
+- **THEN** no standalone filter input sits above the grid, and the column filters serve
+
+#### Scenario: The print shows every bounded row
+
+- **WHEN** the page prints a table block
+- **THEN** the print form holds every bounded row, and no scroll viewport clips one
+
+#### Scenario: A missing payload keeps the card honest
+
+- **WHEN** a grid mount finds no registered data under its block id
+- **THEN** the header card and the download link stay, and the page throws nothing
 
 ### Requirement: The page navigation
 The page MUST hold a left-side navigation with one anchor for each top-level section. Each anchor MUST target its section by the section block id.

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@inflexa-ai/harness",
     "version": "0.20.0",
-    "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
+    "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",
     "main": "dist/index.js",

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@inflexa-ai/harness",
     "version": "0.20.0",
-    "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
+    "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",
     "main": "dist/index.js",
@@ -64,6 +64,7 @@
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@opentelemetry/sdk-trace-node": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.43.0",
+        "ag-grid-community": "36.1.0",
         "ai": "^7.0.61",
         "cheerio": "^1.2.0",
         "dockerode": "^4.0.12",

--- a/harness/scripts/render-fixture.ts
+++ b/harness/scripts/render-fixture.ts
@@ -12,16 +12,13 @@
  */
 
 import { copyFile, mkdir, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { ASSETS_DIR, PAGE_ASSETS } from "../src/report-render/assets.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "../src/report-render/fixture.js";
 import { renderReportPage } from "../src/report-render/render.js";
-
-/** The resolver of a package source. Each manifest entry names a module specifier of the installation. */
-const moduleResolver = createRequire(import.meta.url);
+import { resolvePageAssetFromInstallation } from "../src/tools/report-session/preview-report.js";
 
 const rendered = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES);
 if (rendered.isErr()) {
@@ -31,8 +28,10 @@ if (rendered.isErr()) {
 const pageDir = join(tmpdir(), "inflexa-report-fixture");
 const assetsDir = join(pageDir, ASSETS_DIR);
 await mkdir(assetsDir, { recursive: true });
+// The fixture stages what the preview stages. Thus one lookup answers for both, and a manifest entry that
+// the preview resolves cannot be an entry that the fixture page misses.
 for (const asset of PAGE_ASSETS) {
-    await copyFile(moduleResolver.resolve(asset.specifier), join(assetsDir, asset.file));
+    await copyFile(resolvePageAssetFromInstallation(asset.specifier), join(assetsDir, asset.file));
 }
 // The rows of a table ride a data asset. Without the write the page opens with a failed script request,
 // and the person sees a table card with no data behind it.

--- a/harness/scripts/render-fixture.ts
+++ b/harness/scripts/render-fixture.ts
@@ -18,7 +18,7 @@ import { join } from "node:path";
 import { ASSETS_DIR, PAGE_ASSETS } from "../src/report-render/assets.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "../src/report-render/fixture.js";
 import { renderReportPage } from "../src/report-render/render.js";
-import { resolvePageAssetFromInstallation } from "../src/tools/report-session/preview-report.js";
+import { resolvePageAssetFromInstallation } from "../src/report-render/asset-lookup.js";
 
 const rendered = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES);
 if (rendered.isErr()) {
@@ -28,8 +28,8 @@ if (rendered.isErr()) {
 const pageDir = join(tmpdir(), "inflexa-report-fixture");
 const assetsDir = join(pageDir, ASSETS_DIR);
 await mkdir(assetsDir, { recursive: true });
-// The fixture stages what the preview stages. Thus one lookup answers for both, and a manifest entry that
-// the preview resolves cannot be an entry that the fixture page misses.
+// The fixture stages what the preview stages, because one lookup answers for both. Thus a manifest entry
+// that the preview resolves cannot be an entry that the fixture page misses.
 for (const asset of PAGE_ASSETS) {
     await copyFile(resolvePageAssetFromInstallation(asset.specifier), join(assetsDir, asset.file));
 }

--- a/harness/src/report-render/asset-lookup.ts
+++ b/harness/src/report-render/asset-lookup.ts
@@ -1,0 +1,39 @@
+/**
+ * The lookup of the source file of one staged page asset.
+ *
+ * A manifest entry (`assets.ts`) names a module specifier, and a caller that stages the assets beside a page
+ * needs the file on disk. The resolution reads the installation of the harness, thus the staged bytes are
+ * the bytes of the pinned version.
+ *
+ * The module sits beside the manifest, thus the preview tool and the fixture script read one lookup and
+ * neither one carries the module graph of the other.
+ */
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+/** The resolver of a package source. It reads the installation that holds this module. */
+const moduleResolver = createRequire(import.meta.url);
+
+/**
+ * The absolute path of the source file of one manifest specifier.
+ *
+ * A package that publishes an `exports` map refuses a subpath that the map does not name, and a browser
+ * bundle beside the module entry is such a subpath. The fallback then reads the specifier as a path under
+ * each candidate `node_modules` directory of the resolution. Thus a bundle that the map hides still stages,
+ * and a specifier that names no file still fails with the resolution error of the package.
+ */
+export function resolvePageAssetFromInstallation(specifier: string): string {
+    try {
+        return moduleResolver.resolve(specifier);
+    } catch (cause) {
+        for (const directory of moduleResolver.resolve.paths(specifier) ?? []) {
+            const candidate = join(directory, specifier);
+            if (existsSync(candidate)) {
+                return candidate;
+            }
+        }
+        throw cause;
+    }
+}

--- a/harness/src/report-render/assets.ts
+++ b/harness/src/report-render/assets.ts
@@ -56,6 +56,17 @@ export const ECHARTS_ASSET: PageAsset = {
     specifier: "echarts/dist/echarts.min.js",
 };
 
+/**
+ * The grid runtime. The page-side bootstrap reads the `agGrid` global that this file declares.
+ *
+ * The entry names the browser bundle of the package. The package `exports` map publishes the module
+ * entries alone, thus this specifier resolves as a path under the installed package directory.
+ */
+export const AG_GRID_ASSET: PageAsset = {
+    file: "ag-grid-community.min.js",
+    specifier: "ag-grid-community/dist/ag-grid-community.min.js",
+};
+
 /** The sans font. The file is the latin subset of the variable font, thus one file carries each weight. */
 export const SANS_FONT_ASSET: PageAsset = {
     file: "space-grotesk-latin-wght-normal.woff2",
@@ -95,6 +106,7 @@ export const MONO_FONT_700_ASSET: PageAsset = {
 /** Each asset that the caller stages beside the page. */
 export const PAGE_ASSETS: readonly PageAsset[] = [
     ECHARTS_ASSET,
+    AG_GRID_ASSET,
     SANS_FONT_ASSET,
     MONO_FONT_400_ASSET,
     MONO_FONT_500_ASSET,

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -478,16 +478,39 @@ img {
 .report-grid {
   width: 100%;
 }
-/* The footer of a table card. It holds the download of the raw bytes, thus it reads as a foot rule under
-   the table and never as a second control bar. */
+/* The footer of a table card: the status of the table on the left, the download button on the right, and
+   the print note under both. The three read as one surface under the grid. */
 .report-table-footer {
-  display: flex;
-  justify-content: flex-end;
   padding: 8px 16px;
   border-top: 1px solid var(--color-border);
   background: var(--color-bg-alt);
 }
+.report-table-footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+/* The status of the table: the row count, and the row bound of the binding beside it. */
+.report-table-status {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+}
+.report-table-bound {
+  color: var(--color-text-muted);
+}
+/* The bound reads as a second clause of the status line, thus a separator divides the two. The dot is a
+   literal character, because a hex escape eats the space that follows it and the two clauses would touch. */
+.report-table-bound::before {
+  content: " · ";
+}
+/* The download of the raw bytes. It reads as a button, because it is the one action of a table card. */
 .report-table-download {
+  display: inline-block;
+  flex-shrink: 0;
+  padding: 6px 12px;
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
@@ -495,10 +518,25 @@ img {
   text-transform: uppercase;
   color: var(--color-primary-500);
   text-decoration: none;
+  background: var(--color-card);
+  border: 1px solid var(--color-primary-200);
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
 }
 .report-table-download:hover {
   color: var(--color-primary-700);
-  text-decoration: underline;
+  background: var(--color-primary-50);
+  border-color: var(--color-primary-500);
+}
+/* The print note of a table card. The page script writes the bound of a truncated print form into it at
+   print time, and it clears the text after. An empty note takes no space, thus the screen shows none. */
+.report-grid-note {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+.report-grid-note:empty {
+  display: none;
 }
 
 /* ── Figure and citation cards ────────────────────────── */
@@ -821,6 +859,15 @@ export const GRID_MIN_COLUMN_WIDTH_PX = 120;
 
 /** The delay before a cell tooltip shows, in milliseconds. */
 export const GRID_TOOLTIP_DELAY_MS = 200;
+
+/**
+ * The count of rows that a print form holds.
+ *
+ * The print layout lays every row out at once, and a table with no row bound would take hundreds of pages.
+ * The print stops at this count, the note of the card states the truncation, and the download carries the
+ * whole table. A table under the count prints whole.
+ */
+export const GRID_PRINT_ROW_CAP = 1000;
 
 /**
  * The theme parameters of a grid. The page script passes them to `themeQuartz.withParams`.

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -60,6 +60,28 @@ const FONT_FACES = `@font-face {
   font-display: swap;
 }`;
 
+/**
+ * The token values that the page and the grid share.
+ *
+ * The grid takes its theme through a parameter object, and that API takes values. A CSS custom property
+ * would arrive at the grid as text that it cannot read. Thus the shared tokens are constants here, the
+ * `:root` block below interpolates them, and `GRID_THEME_PARAMS` reads the same names. One source then
+ * styles the page and the grid.
+ */
+const TOKEN = {
+    primary500: "#576dea",
+    heading: "#0f172a",
+    textStrong: "#334155",
+    textSecondary: "#64748b",
+    textMuted: "#94a3b8",
+    card: "#ffffff",
+    bgAlt: "#f8fafc",
+    borderSubtle: "#f1f5f9",
+    border: "#e2e8f0",
+    fontSans: `"Space Grotesk Variable", system-ui, sans-serif`,
+    fontMono: `"IBM Plex Mono", ui-monospace, monospace`,
+} as const;
+
 /** The style rules of the page. The renderer inlines them in one `<style>` block. */
 export const DESIGN_CSS = `${FONT_FACES}
 
@@ -71,23 +93,23 @@ export const DESIGN_CSS = `${FONT_FACES}
   --color-primary-200: #bcc2f9;
   --color-primary-300: #9ba5f5;
   --color-primary-400: #7987f0;
-  --color-primary-500: #576dea;
+  --color-primary-500: ${TOKEN.primary500};
   --color-primary-600: #4458d4;
   --color-primary-700: #3545b0;
 
   /* Text */
-  --color-heading:        #0f172a;
-  --color-text-strong:    #334155;
+  --color-heading:        ${TOKEN.heading};
+  --color-text-strong:    ${TOKEN.textStrong};
   --color-text:           #475569;
-  --color-text-secondary: #64748b;
-  --color-text-muted:     #94a3b8;
+  --color-text-secondary: ${TOKEN.textSecondary};
+  --color-text-muted:     ${TOKEN.textMuted};
 
   /* Surface */
   --color-bg:             #ffffff;
-  --color-bg-alt:         #f8fafc;
-  --color-card:           #ffffff;
-  --color-border-subtle:  #f1f5f9;
-  --color-border:         #e2e8f0;
+  --color-bg-alt:         ${TOKEN.bgAlt};
+  --color-card:           ${TOKEN.card};
+  --color-border-subtle:  ${TOKEN.borderSubtle};
+  --color-border:         ${TOKEN.border};
   --color-border-hover:   #cbd5e1;
   --color-surface-dark:   #0f172a;
 
@@ -112,8 +134,8 @@ export const DESIGN_CSS = `${FONT_FACES}
   --color-stat-amber:   #f59e0b;
 
   /* Typography and layout */
-  --font-sans: "Space Grotesk Variable", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --font-sans: ${TOKEN.fontSans};
+  --font-mono: ${TOKEN.fontMono};
   --layout-max: 1600px;
   --content-max: 1100px;
   --nav-width: 15rem;
@@ -450,132 +472,11 @@ img {
   text-transform: uppercase;
   color: var(--color-primary-500);
 }
-/* The control strip of a table card. It holds the filter input of the page enhancer.
-
-   The strip shows under the live marker alone. The page script writes that marker on each card that it
-   enhances, thus a browser with no script sees no input that it cannot drive. */
-.report-table-controls {
-  display: none;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-card);
-}
-.report-table-live .report-table-controls {
-  display: block;
-}
-.report-table-filter {
+/* The mount of one grid. The page script sizes it from the row count, thus the box fits a short table and
+   a long table scrolls inside its own viewport. A mount whose payload the page does not hold takes no size,
+   thus the card shows its title and its download alone. */
+.report-grid {
   width: 100%;
-  max-width: 320px;
-  padding: 7px 10px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--color-text-strong);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-}
-.report-table-filter:focus {
-  outline: none;
-  border-color: var(--color-primary-500);
-}
-.report-table-filter::placeholder {
-  color: var(--color-text-muted);
-}
-.data-table-scroll {
-  overflow-x: auto;
-}
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
-}
-.data-table th {
-  padding: 12px 16px;
-  text-align: left;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-  background-color: var(--color-bg-alt);
-  border-bottom: 1px solid var(--color-border);
-}
-.data-table td {
-  padding: 10px 16px;
-  color: var(--color-text-strong);
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-/* A sortable header. The page script adds one of the two mark classes to the header that orders the table,
-   and it holds that class on one header at a time.
-
-   The affordance shows under the live marker alone. A zero-row table never takes the marker, thus its
-   headers stay plain and no pointer promises a sort that does nothing. */
-.report-table-live .data-table-sort {
-  cursor: pointer;
-  -webkit-user-select: none;
-  user-select: none;
-}
-.report-table-live .data-table-sort:hover {
-  color: var(--color-heading);
-}
-.data-table-sort-asc::after,
-.data-table-sort-desc::after {
-  padding-left: 4px;
-  color: var(--color-primary-500);
-}
-.data-table-sort-asc::after {
-  content: "\\2191";
-}
-.data-table-sort-desc::after {
-  content: "\\2193";
-}
-.report-row {
-  transition: background-color 0.15s ease;
-}
-.report-row:hover {
-  background-color: var(--color-bg-alt);
-}
-.report-row:last-child td {
-  border-bottom: 0;
-}
-/* The cap hides each row past it, and the toggle and the filter both write this class. The row stays in the
-   document, thus the page keeps every resolved value and no data moves.
-
-   The rule takes effect under the live marker alone. The page script writes that marker on each card that it
-   enhances. Thus a browser with no script shows the complete plain table, and no row hides behind a toggle
-   that cannot open. */
-.report-table-live .report-row-hidden {
-  display: none;
-}
-/* The toggle of the row cap. It sits under the table, and it names the total row count. It shows under the
-   live marker alone, thus a browser with no script sees no button that it cannot drive. */
-.report-table-toggle {
-  display: none;
-  width: 100%;
-  padding: 10px 16px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-align: center;
-  color: var(--color-primary-500);
-  background: var(--color-bg-alt);
-  border: 0;
-  border-top: 1px solid var(--color-border);
-  cursor: pointer;
-}
-.report-table-live .report-table-toggle {
-  display: block;
-}
-/* The filter can keep the cap or less. No row then waits behind the toggle, thus the script hides it. The
-   rule comes after the rule that shows the toggle, thus it wins on the same specificity. */
-.report-table-live .report-table-toggle-off {
-  display: none;
-}
-.report-table-toggle:hover {
-  color: var(--color-primary-700);
-  background: var(--color-border-subtle);
 }
 /* The footer of a table card. It holds the download of the raw bytes, thus it reads as a foot rule under
    the table and never as a second control bar. */
@@ -882,15 +783,6 @@ a.report-citation-source:hover {
   .texture-noise::after {
     display: none;
   }
-  /* Paper carries no filter and no toggle. Thus the controls drop out, and each hidden row prints. Each
-     selector matches its live rule above, thus print wins on the same specificity and by its position. */
-  .report-table-live .report-table-controls,
-  .report-table-live .report-table-toggle {
-    display: none;
-  }
-  .report-table-live .report-row-hidden {
-    display: table-row;
-  }
   .report-footer {
     background: var(--color-bg);
   }
@@ -899,6 +791,71 @@ a.report-citation-source:hover {
     color: var(--color-text-strong);
   }
 }`;
+
+/**
+ * The row height and the header height of a grid, in pixels.
+ *
+ * The theme takes both, and the page script measures the mount with the same two numbers. Thus the box of
+ * the mount and the rows inside it agree, and no row half shows at the bottom edge.
+ */
+export const GRID_ROW_HEIGHT_PX = 36;
+export const GRID_HEADER_HEIGHT_PX = 40;
+
+/**
+ * The bottom border of the header row, in pixels.
+ *
+ * The grid draws that border under the header, thus the box of the mount holds the header, this border, and
+ * the rows. Without it the last row sits one pixel past the box, and the grid paints a scrollbar over a
+ * table that fits.
+ */
+export const GRID_HEADER_BORDER_PX = 1;
+
+/**
+ * The count of rows that a grid shows before it scrolls, and the smallest width of a column.
+ *
+ * A card of a fixed height would leave a short table half empty. The page script takes the smaller of this
+ * count and the row count, thus a table of three rows takes the height of three rows.
+ */
+export const GRID_VISIBLE_ROWS = 12;
+export const GRID_MIN_COLUMN_WIDTH_PX = 120;
+
+/** The delay before a cell tooltip shows, in milliseconds. */
+export const GRID_TOOLTIP_DELAY_MS = 200;
+
+/**
+ * The theme parameters of a grid. The page script passes them to `themeQuartz.withParams`.
+ *
+ * The values read the shared tokens above. Thus the palette, the two font families, and the header
+ * treatment of the grid are the palette, the families, and the treatment of the page.
+ *
+ * `browserColorScheme` pins the light scheme. The page carries one palette, thus a browser in the dark
+ * scheme must not invert the grid under it.
+ */
+export const GRID_THEME_PARAMS = {
+    accentColor: TOKEN.primary500,
+    backgroundColor: TOKEN.card,
+    foregroundColor: TOKEN.textStrong,
+    borderColor: TOKEN.border,
+    browserColorScheme: "light",
+    fontFamily: TOKEN.fontSans,
+    fontSize: 14,
+    headerBackgroundColor: TOKEN.bgAlt,
+    headerFontFamily: TOKEN.fontMono,
+    headerFontSize: 11,
+    headerFontWeight: 600,
+    headerTextColor: TOKEN.textSecondary,
+    headerHeight: GRID_HEADER_HEIGHT_PX,
+    iconColor: TOKEN.textMuted,
+    oddRowBackgroundColor: TOKEN.card,
+    rowHeight: GRID_ROW_HEIGHT_PX,
+    rowHoverColor: TOKEN.bgAlt,
+    subtleTextColor: TOKEN.textMuted,
+    // The corner-accent card around the mount carries the border and the square corners of the identity.
+    // A second border on the wrapper would double the rule at each edge of the card.
+    wrapperBorder: false,
+    wrapperBorderRadius: 0,
+    borderRadius: 0,
+};
 
 /**
  * The registered name of the ECharts theme. The registration script writes this name, and the bootstrap

--- a/harness/src/report-render/number-format.test.ts
+++ b/harness/src/report-render/number-format.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
 
-import { formatNumberCell, holdsAPValue, selectNumberKind, smallestPositiveValue } from "./number-format.js";
+import {
+    formatNumberCell,
+    formatTableCell,
+    holdsAPValue,
+    selectColumnKind,
+    selectNumberKind,
+    smallestPositiveValue,
+    type NumberKind,
+} from "./number-format.js";
+import { TABLE_CELL_FORMATTER } from "./page.js";
 
 describe("formatNumberCell scientific", () => {
     it("gives a coefficient of two significant digits and an exponent", () => {
@@ -330,5 +339,103 @@ describe("holdsAPValue", () => {
         expect(holdsAPValue("significance", "p-value")).toBe(true);
         // A declaration replaces the name, thus a p-value name under a different meaning answers false.
         expect(holdsAPValue("padj", "count")).toBe(false);
+    });
+});
+
+describe("selectColumnKind", () => {
+    it("gives the identifier kind to a column of names", () => {
+        expect(selectColumnKind("pmid")).toBe("identifier");
+        expect(selectColumnKind("cluster", "identifier")).toBe("identifier");
+        // A category reads as a name too, thus the cluster `01` keeps its own text.
+        expect(selectColumnKind("cluster", "category")).toBe("identifier");
+    });
+
+    it("gives the scientific kind to a probability column, by the name and by the declaration alike", () => {
+        expect(selectColumnKind("padj")).toBe("scientific");
+        expect(selectColumnKind("significance", "p-value")).toBe("scientific");
+        // A declaration replaces the name, thus a p-value name under a different meaning reads as a magnitude.
+        expect(selectColumnKind("padj", "count")).toBe("compact-scientific");
+    });
+
+    it("gives the rounded kind to every other column", () => {
+        expect(selectColumnKind("log2FoldChange")).toBe("compact-scientific");
+        expect(selectColumnKind("reads")).toBe("compact-scientific");
+        expect(selectColumnKind("effect", "effect")).toBe("compact-scientific");
+    });
+});
+
+/**
+ * The shared vector of the table cell format.
+ *
+ * The server resolves the kind of a column, and the page formats each cell under it. Thus one function has
+ * two realizations: `formatTableCell` here, and the `formatCell` fragment that the grid boot inlines. Each
+ * entry runs through both, and the two must give one text.
+ */
+describe("the table cell format", () => {
+    /** One entry of the vector: the cell, the kind of its column, the bound of the column, and the text. */
+    interface Entry {
+        readonly cell: string | number;
+        readonly kind: NumberKind;
+        readonly bound?: number;
+        readonly expected: string;
+    }
+
+    const VECTOR: readonly Entry[] = [
+        // The identifier kind gives the source text, with no grouping and no rounding.
+        { cell: "31978945", kind: "identifier", expected: "31978945" },
+        { cell: " 007 ", kind: "identifier", expected: "007" },
+        { cell: 12, kind: "identifier", expected: "12" },
+        // A probability column: the bound of a stored zero, the exponent under one hundredth, the decimal above it.
+        { cell: 0, kind: "scientific", bound: 0.00036, expected: "<4e-4" },
+        { cell: "0", kind: "scientific", bound: 0.02, expected: "<0.02" },
+        { cell: 0, kind: "scientific", bound: 9.6e-8, expected: "<1e-7" },
+        { cell: 0, kind: "scientific", expected: "≈0" },
+        { cell: 0.0000427777663038, kind: "scientific", expected: "4.3e-5" },
+        { cell: 2.7e-10, kind: "scientific", expected: "2.7e-10" },
+        { cell: 0.536, kind: "scientific", expected: "0.536" },
+        { cell: 0.05, kind: "scientific", expected: "0.05" },
+        { cell: 1, kind: "scientific", expected: "1" },
+        // A magnitude column: the grouped whole number, the rounded float, the exponent under one thousandth.
+        { cell: 14201, kind: "compact-scientific", expected: "14,201" },
+        { cell: -1234567, kind: "compact-scientific", expected: "-1,234,567" },
+        { cell: 15234.7, kind: "compact-scientific", expected: "15,235" },
+        { cell: -3.089028528355109, kind: "compact-scientific", expected: "-3.09" },
+        { cell: 0.00025, kind: "compact-scientific", expected: "2.5e-4" },
+        { cell: 0, kind: "compact-scientific", expected: "0" },
+        { cell: 1e16, kind: "compact-scientific", expected: "1e16" },
+        { cell: "1.50", kind: "compact-scientific", expected: "1.5" },
+        // A cell that holds no finite number passes through, thus a sentinel keeps its own text.
+        { cell: "NA", kind: "compact-scientific", expected: "NA" },
+        { cell: "up", kind: "compact-scientific", expected: "up" },
+        { cell: "", kind: "compact-scientific", expected: "" },
+        // The trim of a delimited name, and each text that carries a percent sign and stays whole.
+        { cell: "HALLMARK_HYPOXIA%MSigDB%M5891", kind: "compact-scientific", expected: "HALLMARK_HYPOXIA" },
+        { cell: "95%", kind: "compact-scientific", expected: "95%" },
+        { cell: "KEGG%hsa04110", kind: "compact-scientific", expected: "KEGG%hsa04110" },
+        { cell: "up 20% vs control%cohort", kind: "compact-scientific", expected: "up 20% vs control%cohort" },
+        { cell: "GO_APOPTOSIS%GO%GO:0006915", kind: "identifier", expected: "GO_APOPTOSIS" },
+    ];
+
+    /**
+     * The client formatter, as the page runs it.
+     *
+     * The fragment is browser source text. A read of that text would state the serialization and not the
+     * text that a reader sees, thus the test runs the fragment and calls its one entry point.
+     */
+    const formatOnThePage = new Function(`${TABLE_CELL_FORMATTER}\nreturn formatCell;`)() as (
+        cell: string | number,
+        kind: NumberKind,
+        bound?: number,
+    ) => string;
+
+    it("gives the stated text on the server", () => {
+        const actual = VECTOR.map((entry) => formatTableCell(entry.cell, entry.kind, entry.bound));
+        expect(actual).toEqual(VECTOR.map((entry) => entry.expected));
+    });
+
+    it("gives the same text on the page as on the server, for every entry", () => {
+        const server = VECTOR.map((entry) => formatTableCell(entry.cell, entry.kind, entry.bound));
+        const page = VECTOR.map((entry) => formatOnThePage(entry.cell, entry.kind, entry.bound));
+        expect(page).toEqual(server);
     });
 });

--- a/harness/src/report-render/number-format.test.ts
+++ b/harness/src/report-render/number-format.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import {
-    formatNumberCell,
-    formatTableCell,
-    holdsAPValue,
-    selectColumnKind,
-    selectNumberKind,
-    smallestPositiveValue,
-    type NumberKind,
-} from "./number-format.js";
+import { formatNumberCell, formatTableCell, selectColumnKind, selectNumberKind, smallestPositiveValue, type NumberKind } from "./number-format.js";
 import { TABLE_CELL_FORMATTER } from "./page.js";
 
 describe("formatNumberCell scientific", () => {
@@ -329,16 +321,6 @@ describe("selectNumberKind of a zero", () => {
         expect(selectNumberKind("significance", 0, "effect")).toBe("compact");
         // A zero count and a zero effect are real values, thus each one keeps its own text.
         expect(formatNumberCell(0, selectNumberKind("genes", 0))).toEqual({ text: "0" });
-    });
-});
-
-describe("holdsAPValue", () => {
-    it("answers for a token-matched name and for a declaration alike", () => {
-        expect(holdsAPValue("fdr")).toBe(true);
-        expect(holdsAPValue("significance")).toBe(false);
-        expect(holdsAPValue("significance", "p-value")).toBe(true);
-        // A declaration replaces the name, thus a p-value name under a different meaning answers false.
-        expect(holdsAPValue("padj", "count")).toBe(false);
     });
 });
 

--- a/harness/src/report-render/number-format.ts
+++ b/harness/src/report-render/number-format.ts
@@ -18,6 +18,10 @@
  *
  * The column meaning that a binding declares replaces the name of the column in the kind decision. The
  * magnitude of the cell decides after it, the same for a declared column and for an undeclared one.
+ *
+ * A table resolves one kind for each whole column with `selectColumnKind`, and the data asset ships that
+ * kind. `formatTableCell` then reads the cell under it. The page script holds a twin of that one function,
+ * and a shared test vector pins the two together.
  */
 
 import type { ColumnMeaning } from "../contracts/report-reference.js";
@@ -86,6 +90,15 @@ const GROUP_COMMAS = /,/g;
  * because the column gives nothing better.
  */
 const NEAR_ZERO_FORM = "≈0";
+
+/** The delimiter of an encoded set name, for example `HALLMARK_HYPOXIA%MSigDB%M5891`. */
+const NAME_DELIMITER = "%";
+
+/** The count of segments that an encoded set name holds: the name, the collection, and the accession. */
+const NAME_SEGMENTS = 3;
+
+/** One whitespace character. A segment of an encoded name holds none. */
+const WHITESPACE = /\s/;
 
 /**
  * Format one cell in one kind.
@@ -163,6 +176,92 @@ export function selectNumberKind(column: string, cell: string | number, meaning?
 }
 
 /**
+ * The number kind of one whole column.
+ *
+ * A column carries one kind, and the cell decides the arms under it. `identifier` names a column of names.
+ * `scientific` names a column of probabilities, where a small value reads as an exponent and a stored zero
+ * reads as a bound. `compact-scientific` names every other column, where a whole number groups and a float
+ * rounds.
+ *
+ * The renderer ships this kind with the table data, and the page formats each cell under it. Thus the
+ * declaration and the token guess stay here, on the server, where a test reads them.
+ */
+export function selectColumnKind(column: string, meaning?: ColumnMeaning): NumberKind {
+    if (holdsAName(column, meaning)) {
+        return "identifier";
+    }
+    return holdsAPValue(column, meaning) ? "scientific" : "compact-scientific";
+}
+
+/**
+ * The shown text of one table cell, under the kind of its column.
+ *
+ * The page script holds a twin of this function, because the rows reach the reader through the data asset
+ * and the page formats them there. A shared test vector runs both over the same entries, thus the two
+ * cannot give different text in silence.
+ *
+ * `bound` is the smallest positive value of the column. A stored zero of a probability column reads as a
+ * bound under it, thus the page never prints a probability of zero.
+ *
+ * A delimited name shows its first segment. Such a name holds no finite number, thus the number format
+ * passes it through and this trim reads the text that the format gave.
+ */
+export function formatTableCell(cell: string | number, kind: NumberKind, bound?: number): string {
+    const shown = formatNumberCell(cell, cellKind(cell, kind), bound).text;
+    return firstNameSegment(shown) ?? shown;
+}
+
+/**
+ * The kind of one cell under the kind of its column.
+ *
+ * A column of names gives one kind to each of its cells. A column of magnitudes reads the cell: a zero of a
+ * probability column takes the bound, a small probability takes the exponent, a safe integer takes the
+ * grouped form, and every other value takes the rounded form. A cell that holds no finite number takes the
+ * rounded form too, because the format passes such a cell through unchanged.
+ */
+function cellKind(cell: string | number, column: NumberKind): NumberKind {
+    if (column === "identifier") {
+        return "identifier";
+    }
+    const value = finiteValue(cell);
+    if (value === null) {
+        return "compact-scientific";
+    }
+    if (column === "scientific") {
+        // A stored zero in a probability column claims no zero probability. It states that the estimator
+        // bottomed out, thus the page shows a bound and a bare `0` would read as a result.
+        if (value === 0) {
+            return "below-resolution";
+        }
+        // From one hundredth up, the plain decimal is as short as the exponent and it is easier to read.
+        if (value > 0 && value < SCIENTIFIC_FLOOR) {
+            return "scientific";
+        }
+    }
+    // An integer above the safe range is no longer exact, thus it reads as a general float and not as a count.
+    return Number.isSafeInteger(value) ? "compact" : "compact-scientific";
+}
+
+/**
+ * The first segment of a delimited name, or `undefined` when the text carries no delimited name.
+ *
+ * An enrichment tool joins the name of a set, its collection, and its accession with a percent sign. The
+ * name alone identifies the row, thus the rest is noise inside a narrow column.
+ *
+ * Such a name holds three or more segments, each segment holds a character, and no segment holds a
+ * whitespace character. Every other text keeps its whole form. Thus `95%` stays whole, and a sentence such
+ * as `up 20% vs control` stays whole.
+ */
+function firstNameSegment(text: string): string | undefined {
+    const segments = text.split(NAME_DELIMITER);
+    if (segments.length < NAME_SEGMENTS) {
+        return undefined;
+    }
+    const encoded = segments.every((segment) => segment.length > 0 && !WHITESPACE.test(segment));
+    return encoded ? segments[0] : undefined;
+}
+
+/**
  * True when the column holds a name and not a magnitude.
  *
  * A declared `identifier` and a declared `category` both hold one. The identifier kind is the one kind that
@@ -183,7 +282,8 @@ function holdsAName(column: string, meaning: ColumnMeaning | undefined): boolean
  * below this test. An effect is a float, and it reads there in the compact-scientific kind. A count is a
  * whole number, and it reads there in the compact kind.
  *
- * The caller of a table reads this to find the columns whose zeros need a bound.
+ * The kind of a whole column reads this, thus a probability column takes the scientific kind and the zeros
+ * of that column take a bound.
  */
 export function holdsAPValue(column: string, meaning?: ColumnMeaning): boolean {
     return meaning !== undefined ? meaning === "p-value" : isPValueColumn(column);

--- a/harness/src/report-render/number-format.ts
+++ b/harness/src/report-render/number-format.ts
@@ -282,11 +282,27 @@ function holdsAName(column: string, meaning: ColumnMeaning | undefined): boolean
  * below this test. An effect is a float, and it reads there in the compact-scientific kind. A count is a
  * whole number, and it reads there in the compact kind.
  *
- * The kind of a whole column reads this, thus a probability column takes the scientific kind and the zeros
- * of that column take a bound.
+ * The kind of a cell and the kind of a whole column both read this, thus a probability column takes the
+ * scientific kind and the zeros of that column take a bound.
  */
-export function holdsAPValue(column: string, meaning?: ColumnMeaning): boolean {
+function holdsAPValue(column: string, meaning?: ColumnMeaning): boolean {
     return meaning !== undefined ? meaning === "p-value" : isPValueColumn(column);
+}
+
+/**
+ * True when one cell of a column parses as a finite number.
+ *
+ * The filter of a column reads this. One value that parses keeps the column numeric, thus a sentinel such
+ * as `NA` beside the numbers cannot drop the column to the text filter. A column where no cell parses holds
+ * names, and a name filters as text.
+ */
+export function holdsANumber(cells: readonly (string | number | undefined)[]): boolean {
+    for (const cell of cells) {
+        if (cell !== undefined && finiteValue(cell) !== null) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -1,21 +1,35 @@
 /**
- * The page constants: the head references, the readiness names, and the four page-side scripts.
+ * The page constants: the head references, the readiness names, and the page-side scripts.
  *
  * A script here is browser source text, not module code. Thus it reads no module binding, and each value
- * that it needs is interpolated at build time. The style rules and the ECharts theme live in `design.ts`.
+ * that it needs is interpolated at build time. The style rules, the ECharts theme, and the grid theme
+ * parameters live in `design.ts`.
  */
 
-import { assetSource, ECHARTS_ASSET } from "./assets.js";
-import { ECHARTS_THEME_NAME } from "./design.js";
+import { AG_GRID_ASSET, assetSource, ECHARTS_ASSET } from "./assets.js";
+import {
+    ECHARTS_THEME_NAME,
+    GRID_HEADER_BORDER_PX,
+    GRID_HEADER_HEIGHT_PX,
+    GRID_MIN_COLUMN_WIDTH_PX,
+    GRID_ROW_HEIGHT_PX,
+    GRID_THEME_PARAMS,
+    GRID_TOOLTIP_DELAY_MS,
+    GRID_VISIBLE_ROWS,
+} from "./design.js";
+import { scriptJson } from "./script-json.js";
 import { TABLE_DATA_GLOBAL } from "./table-data.js";
-import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
+import { GRID_MOUNT_ATTRIBUTE } from "./views/values.js";
 
 /**
- * The head references of the staged assets. The page loads the chart runtime from the sibling assets
- * directory, thus the head names no remote host. The manifest gives the staged name, thus the tag and the
- * stage step of the caller cannot disagree.
+ * The head references of the staged assets. The page loads the chart runtime and the grid runtime from the
+ * sibling assets directory, thus the head names no remote host. The manifest gives each staged name, thus
+ * the tag and the stage step of the caller cannot disagree.
+ *
+ * Each of the two is a classic script. A `file://` page refuses a module request, thus a classic script is
+ * the one form that loads beside the page.
  */
-export const ASSET_HEAD = `<script src="${assetSource(ECHARTS_ASSET)}"></script>`;
+export const ASSET_HEAD = `<script src="${assetSource(ECHARTS_ASSET)}"></script><script src="${assetSource(AG_GRID_ASSET)}"></script>`;
 
 /**
  * The name of the readiness event, and the name of the window sentinel that guards a late listener. The
@@ -63,42 +77,6 @@ const REVEAL_SETTLE_TIMEOUT_MS = 2_000;
  */
 const NAV_ACTIVE_CLASS = "report-nav-link-active";
 const SPY_BOTTOM_MARGIN_PERCENT = 70;
-
-/**
- * The class that hides one table row, and the two classes that mark the sorted header.
- *
- * The table view emits the hidden class on each row past the cap, and the enhancer below writes the same
- * class as the filter and the toggle change what shows. The design sheet holds the matching rule of each of
- * the three names.
- */
-const ROW_HIDDEN_CLASS = "report-row-hidden";
-const SORT_ASCENDING_CLASS = "data-table-sort-asc";
-const SORT_DESCENDING_CLASS = "data-table-sort-desc";
-
-/**
- * The marker class of a card that the enhancer took.
- *
- * The rule that hides a row takes effect under this marker alone. The script writes the marker when it binds
- * a card, thus a browser with no script shows the complete plain table and no row hides behind a toggle that
- * cannot open.
- */
-const TABLE_LIVE_CLASS = "report-table-live";
-
-/**
- * The class that hides the toggle of the row cap.
- *
- * A filter that keeps the cap or less leaves no row behind the toggle. The script writes this class at that
- * time, thus the reader sees a control only while the control does something.
- */
-const TOGGLE_HIDDEN_CLASS = "report-table-toggle-off";
-
-/**
- * The label of the toggle while every row that the filter keeps shows.
- *
- * The view composes the collapsed label, because the view holds the total row count. Thus the enhancer keeps
- * the label that it finds and it restores that text, and the two sites cannot disagree over the count.
- */
-const SHOW_FEWER_LABEL = "Show fewer";
 
 /**
  * The page-side script that wires each chart. It finds every chart container, reads the option JSON from
@@ -356,216 +334,6 @@ export const SECTION_SPY = `(function () {
 })();`;
 
 /**
- * The page-side script that gives each table its sort, its filter, and its row cap.
- *
- * The enhancer is presentation over a complete DOM. Every resolved row is already in the markup, thus the
- * script moves a row and hides a row, and it never adds one and never removes one.
- *
- * The script marks each card that it takes. The rule that hides a row reads that marker, thus a browser with
- * no script keeps the plain table with every row, and the cap costs the reader nothing there.
- *
- * A click on a header cycles the column: ascending, then descending, then the document order. The Enter key
- * and the Space key give the same cycle, thus a reader sorts from the keyboard. The script records the
- * initial index of each row at start, thus the document order is always recoverable.
- *
- * The sort reads the `data-value` attribute of a cell, thus a rounded number still orders by its full
- * magnitude. A column sorts numerically when one non-empty value of it parses as a number, thus a sentinel
- * such as `NA` cannot drop the column to text order and rank `10` before `9`. A value that holds no rank,
- * which is an empty cell and a cell that the numeric column cannot parse, stays at the end under both
- * directions. Two equal cells keep the document order, thus one sort gives one order and not the order of
- * the engine.
- *
- * The filter reads the `data-value` attributes of a row, and never the shown text. Thus a reader finds the
- * accession that the trim hides, and a match cannot form across two cells. The comparison lowercases both
- * texts with `toLowerCase`. That method reads no locale, and it is exact over the ASCII range of a gene name
- * and an accession.
- *
- * The cap composes with both. After each change the first rows that the filter keeps show, up to the cap,
- * and the rest hide. The toggle opens the table, and each row that the filter keeps then shows. The label of
- * the toggle flips between the collapsed label and the label above, and the collapsed label counts the rows
- * that the filter keeps. A filter that keeps the cap or less hides the toggle, because nothing then waits
- * behind it.
- *
- * The script registers no reveal work. It touches neither the reveal gate nor the readiness sentinel, thus a
- * capture of the page still signals at the same point.
- */
-export const TABLE_ENHANCER = `(function () {
-  var CAP = ${TABLE_ROW_CAP};
-  var HIDDEN = ${JSON.stringify(ROW_HIDDEN_CLASS)};
-  var ASCENDING = ${JSON.stringify(SORT_ASCENDING_CLASS)};
-  var DESCENDING = ${JSON.stringify(SORT_DESCENDING_CLASS)};
-  var LIVE = ${JSON.stringify(TABLE_LIVE_CLASS)};
-  var TOGGLE_OFF = ${JSON.stringify(TOGGLE_HIDDEN_CLASS)};
-  var FEWER = ${JSON.stringify(SHOW_FEWER_LABEL)};
-  var ALL = ${JSON.stringify(SHOW_ALL_PREFIX)};
-  function rawValue(row, index) {
-    var cell = row.cells[index];
-    return cell ? cell.getAttribute("data-value") || "" : "";
-  }
-  function rowValues(row) {
-    var joined = "";
-    for (var c = 0; c < row.cells.length; c++) {
-      joined += (row.cells[c].getAttribute("data-value") || "") + "\\n";
-    }
-    return joined.toLowerCase();
-  }
-  function numericColumn(rows, index) {
-    for (var i = 0; i < rows.length; i++) {
-      var value = rawValue(rows[i], index);
-      if (value !== "" && !isNaN(Number(value))) {
-        return true;
-      }
-    }
-    return false;
-  }
-  function rankless(value, numeric) {
-    return value === "" || (numeric && isNaN(Number(value)));
-  }
-  function enhance(card) {
-    var table = card.querySelector("table.data-table");
-    var body = table ? table.querySelector("tbody") : null;
-    if (!body || body.rows.length === 0) {
-      return;
-    }
-    var rows = [];
-    var order = [];
-    var values = [];
-    for (var r = 0; r < body.rows.length; r++) {
-      rows.push(body.rows[r]);
-      order.push(r);
-      values.push(rowValues(body.rows[r]));
-    }
-    var headers = table.querySelectorAll("th[data-sort-index]");
-    var filter = card.querySelector(".report-table-filter");
-    var toggle = card.querySelector(".report-table-toggle");
-    var query = "";
-    var open = false;
-    var sorted = null;
-    var descending = false;
-    function paint() {
-      var kept = 0;
-      for (var i = 0; i < order.length; i++) {
-        var index = order[i];
-        var row = rows[index];
-        if (query !== "" && values[index].indexOf(query) < 0) {
-          row.classList.add(HIDDEN);
-          continue;
-        }
-        kept += 1;
-        if (open || kept <= CAP) {
-          row.classList.remove(HIDDEN);
-        } else {
-          row.classList.add(HIDDEN);
-        }
-      }
-      if (toggle) {
-        toggle.textContent = open ? FEWER : ALL + kept;
-        if (kept > CAP) {
-          toggle.classList.remove(TOGGLE_OFF);
-        } else {
-          toggle.classList.add(TOGGLE_OFF);
-        }
-      }
-      for (var h = 0; h < headers.length; h++) {
-        headers[h].classList.remove(ASCENDING);
-        headers[h].classList.remove(DESCENDING);
-        headers[h].setAttribute("aria-sort", "none");
-      }
-      if (sorted) {
-        sorted.classList.add(descending ? DESCENDING : ASCENDING);
-        sorted.setAttribute("aria-sort", descending ? "descending" : "ascending");
-      }
-    }
-    function place() {
-      for (var p = 0; p < order.length; p++) {
-        body.appendChild(rows[order[p]]);
-      }
-    }
-    function sort(index) {
-      var numeric = numericColumn(rows, index);
-      var direction = descending ? -1 : 1;
-      order.sort(function (left, right) {
-        var a = rawValue(rows[left], index);
-        var b = rawValue(rows[right], index);
-        var aOut = rankless(a, numeric);
-        var bOut = rankless(b, numeric);
-        if (aOut || bOut) {
-          return aOut === bOut ? left - right : aOut ? 1 : -1;
-        }
-        var rank = numeric ? Number(a) - Number(b) : a < b ? -1 : a > b ? 1 : 0;
-        return rank === 0 ? left - right : rank * direction;
-      });
-      place();
-    }
-    function reset() {
-      order.sort(function (left, right) {
-        return left - right;
-      });
-      place();
-    }
-    function cycle(header, index) {
-      if (sorted !== header) {
-        sorted = header;
-        descending = false;
-        sort(index);
-      } else if (!descending) {
-        descending = true;
-        sort(index);
-      } else {
-        sorted = null;
-        descending = false;
-        reset();
-      }
-      paint();
-    }
-    function bind(header, index) {
-      header.addEventListener("click", function () {
-        cycle(header, index);
-      });
-      header.addEventListener("keydown", function (event) {
-        if (event.key !== "Enter" && event.key !== " ") {
-          return;
-        }
-        // The Space key scrolls the page by default. The header takes the key instead, thus the keyboard
-        // gives the same cycle as the pointer.
-        event.preventDefault();
-        cycle(header, index);
-      });
-    }
-    for (var k = 0; k < headers.length; k++) {
-      bind(headers[k], parseInt(headers[k].getAttribute("data-sort-index") || "0", 10) || 0);
-    }
-    if (filter) {
-      filter.addEventListener("input", function () {
-        query = (filter.value || "").toLowerCase();
-        paint();
-      });
-    }
-    if (toggle) {
-      toggle.addEventListener("click", function () {
-        open = !open;
-        paint();
-      });
-    }
-    card.classList.add(LIVE);
-  }
-  function start() {
-    if (!document.querySelectorAll || typeof document.documentElement.classList === "undefined") {
-      return;
-    }
-    var cards = document.querySelectorAll(".report-table");
-    for (var c = 0; c < cards.length; c++) {
-      enhance(cards[c]);
-    }
-  }
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", start);
-  } else {
-    start();
-  }
-})();`;
-
-/**
  * The decoder of the table data assets.
  *
  * Each data asset registers its payload under the global map, keyed by the block id. The payload is
@@ -615,5 +383,236 @@ export const TABLE_DATA_DECODER = `(function () {
     }
     payload.encoded = encoded;
     payload.rows = decoded;
+  }
+})();`;
+
+/**
+ * The client twin of `formatTableCell`, as browser source text.
+ *
+ * The rows of a table reach the reader through the data asset, thus the page formats each cell. The server
+ * ships the kind of each column, and this fragment reads the cell under that kind: the identifier text, the
+ * bound of a stored zero, the exponent of a small probability, the grouped whole number, the rounded float,
+ * and the trim of a delimited name.
+ *
+ * The fragment writes its own constants, because a page script reads no module binding. A shared test vector
+ * runs the server helper and this twin over the same entries, thus the two cannot give different text in
+ * silence. `formatCell` is the one entry point, and the grid boot below inlines the whole fragment.
+ */
+export const TABLE_CELL_FORMATTER = `function formatCell(cell, kind, bound) {
+  var text = cellText(cell, kind, bound);
+  var segments = text.split("%");
+  if (segments.length < 3) {
+    return text;
+  }
+  for (var s = 0; s < segments.length; s++) {
+    if (segments[s].length === 0 || /\\s/.test(segments[s])) {
+      return text;
+    }
+  }
+  return segments[0];
+}
+function cellText(cell, kind, bound) {
+  if (kind === "identifier") {
+    return String(cell).trim();
+  }
+  var value = finiteValue(cell);
+  if (value === null) {
+    return String(cell);
+  }
+  if (kind === "scientific") {
+    if (value === 0) {
+      return bound !== undefined && bound !== null && bound > 0 ? "<" + boundForm(bound) : "≈" + "0";
+    }
+    if (value > 0 && value < 1e-2) {
+      return scientificForm(value);
+    }
+  }
+  if (Number.isSafeInteger(value)) {
+    return compactForm(value);
+  }
+  var magnitude = Math.abs(value);
+  if (value !== 0 && magnitude < 1e-3) {
+    return scientificForm(value);
+  }
+  var rounded = Math.round(magnitude);
+  if (rounded >= 1e3 && rounded < 1e15) {
+    return compactForm(value);
+  }
+  return tidy(value.toPrecision(3));
+}
+function finiteValue(cell) {
+  if (typeof cell === "number") {
+    return isFinite(cell) ? cell : null;
+  }
+  var trimmed = String(cell).trim();
+  if (trimmed === "") {
+    return null;
+  }
+  var parsed = Number(trimmed);
+  return isFinite(parsed) ? parsed : null;
+}
+function boundForm(bound) {
+  var parts = bound.toExponential().split("e");
+  var digits = parts[0].replace(".", "");
+  var raised = Number(digits.charAt(0)) + (digits.length > 1 ? 1 : 0);
+  var carries = raised === 10;
+  var digit = carries ? 1 : raised;
+  var power = Number(parts[1]) + (carries ? 1 : 0);
+  if (power < -2) {
+    return digit + "e" + power;
+  }
+  return power >= 0 ? String(digit) + zeros(power) : "0." + zeros(-power - 1) + digit;
+}
+function zeros(count) {
+  var text = "";
+  for (var z = 0; z < count; z++) {
+    text += "0";
+  }
+  return text;
+}
+function scientificForm(value) {
+  return tidy(value.toExponential(1));
+}
+function compactForm(value) {
+  return (value < 0 ? "-" : "") + groupDigits(Math.abs(value).toFixed(0));
+}
+function groupDigits(digits) {
+  if (!/^[0-9]+$/.test(digits)) {
+    return digits;
+  }
+  var grouped = "";
+  for (var d = 0; d < digits.length; d++) {
+    if (d > 0 && (digits.length - d) % 3 === 0) {
+      grouped += ",";
+    }
+    grouped += digits.charAt(d);
+  }
+  return grouped;
+}
+function tidy(text) {
+  var marker = text.indexOf("e");
+  if (marker < 0) {
+    return trimZeros(text);
+  }
+  return trimZeros(text.slice(0, marker)) + "e" + text.slice(marker + 1).replace("+", "");
+}
+function trimZeros(text) {
+  if (text.indexOf(".") < 0) {
+    return text;
+  }
+  var end = text.length;
+  while (end > 0 && text.charAt(end - 1) === "0") {
+    end -= 1;
+  }
+  if (text.charAt(end - 1) === ".") {
+    end -= 1;
+  }
+  return text.slice(0, end);
+}`;
+
+/**
+ * The page-side script that builds one grid for each table block.
+ *
+ * The script walks the grid mounts. Each mount names its block, and the registry holds the decoded rows and
+ * the column display of that block. Thus the boot reads what the server resolved, and it resolves nothing
+ * again. A mount whose block the registry does not hold keeps its empty card, and the walk continues.
+ *
+ * The column definition takes the label, the filter, and the two readings of a cell. The formatter gives the
+ * shown text under the kind of the column, and the tooltip gives the raw cell where the shown text differs
+ * from it. A value getter reads the own key of the row, because the field of a column reads a point as a
+ * path and a column name can hold one.
+ *
+ * The row model is the client-side model. It renders the visible slice alone, thus a table of many thousands
+ * of rows costs the DOM a screen of rows. The mount takes the height of its rows, up to the visible count,
+ * thus a short table leaves no empty box under it.
+ *
+ * The print hooks switch the grid to its print layout. That layout lays every row out at once and it holds
+ * no scroll viewport, thus each bounded row reaches the paper. The row bound of the binding is what keeps
+ * that page count sane.
+ *
+ * One grid builds inside a guard. A malformed payload is exactly the fault that a look must diagnose, thus
+ * it must never stop a sibling grid and it must never throw out of the page.
+ */
+export const GRID_BOOTSTRAP = `(function () {
+  ${TABLE_CELL_FORMATTER}
+  var registry = window.${TABLE_DATA_GLOBAL};
+  var mounts = document.querySelectorAll("[${GRID_MOUNT_ATTRIBUTE}]");
+  if (!registry || typeof agGrid === "undefined" || mounts.length === 0) {
+    return;
+  }
+  if (agGrid.ModuleRegistry && agGrid.AllCommunityModule) {
+    agGrid.ModuleRegistry.registerModules([agGrid.AllCommunityModule]);
+  }
+  var theme = agGrid.themeQuartz.withParams(${scriptJson(GRID_THEME_PARAMS)});
+  function columnOf(name, display) {
+    var kind = display.kind;
+    var bound = display.bound;
+    var label = display.label || name;
+    var column = {
+      colId: name,
+      headerName: label,
+      valueGetter: function (params) {
+        return params.data ? params.data[name] : undefined;
+      },
+      valueFormatter: function (params) {
+        return params.value === undefined || params.value === null ? "" : formatCell(params.value, kind, bound);
+      },
+      tooltipValueGetter: function (params) {
+        if (params.value === undefined || params.value === null) {
+          return "";
+        }
+        var raw = String(params.value);
+        return raw === formatCell(params.value, kind, bound) ? "" : raw;
+      },
+      filter: kind === "identifier" ? "agTextColumnFilter" : "agNumberColumnFilter"
+    };
+    if (label !== name) {
+      column.headerTooltip = name;
+    }
+    return column;
+  }
+  function bindPrint(api, mount, height) {
+    window.addEventListener("beforeprint", function () {
+      mount.style.height = "auto";
+      api.setGridOption("domLayout", "print");
+    });
+    window.addEventListener("afterprint", function () {
+      api.setGridOption("domLayout", "normal");
+      mount.style.height = height;
+    });
+  }
+  for (var i = 0; i < mounts.length; i++) {
+    var mount = mounts[i];
+    var id = mount.getAttribute("${GRID_MOUNT_ATTRIBUTE}") || "";
+    var payload = Object.prototype.hasOwnProperty.call(registry, id) ? registry[id] : null;
+    if (!payload || !payload.columns || !payload.display) {
+      continue;
+    }
+    try {
+      var columns = [];
+      for (var c = 0; c < payload.columns.length; c++) {
+        columns.push(columnOf(payload.columns[c], payload.display[c] || {}));
+      }
+      var rows = payload.rows || [];
+      var shown = rows.length < ${GRID_VISIBLE_ROWS} ? rows.length : ${GRID_VISIBLE_ROWS};
+      var height = ${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX} + shown * ${GRID_ROW_HEIGHT_PX} + "px";
+      mount.style.height = height;
+      bindPrint(
+        agGrid.createGrid(mount, {
+          theme: theme,
+          columnDefs: columns,
+          rowData: rows,
+          defaultColDef: { sortable: true, resizable: true, flex: 1, minWidth: ${GRID_MIN_COLUMN_WIDTH_PX} },
+          suppressCellFocus: true,
+          // The tooltip carries the raw value of a shown cell. A reader hovers to read that value, thus the
+          // delay is short and the value arrives while the pointer is still on the cell.
+          tooltipShowDelay: ${GRID_TOOLTIP_DELAY_MS}
+        }),
+        mount,
+        height
+      );
+    } catch (cause) {
+      console.error("grid boot failed for " + id + ": " + (cause && cause.message ? cause.message : cause));
+    }
   }
 })();`;

--- a/harness/src/report-render/page.ts
+++ b/harness/src/report-render/page.ts
@@ -12,6 +12,7 @@ import {
     GRID_HEADER_BORDER_PX,
     GRID_HEADER_HEIGHT_PX,
     GRID_MIN_COLUMN_WIDTH_PX,
+    GRID_PRINT_ROW_CAP,
     GRID_ROW_HEIGHT_PX,
     GRID_THEME_PARAMS,
     GRID_TOOLTIP_DELAY_MS,
@@ -19,17 +20,26 @@ import {
 } from "./design.js";
 import { scriptJson } from "./script-json.js";
 import { TABLE_DATA_GLOBAL } from "./table-data.js";
-import { GRID_MOUNT_ATTRIBUTE } from "./views/values.js";
+import { GRID_COUNT_CLASS, GRID_MOUNT_ATTRIBUTE, GRID_NOTE_CLASS, GRID_ROWS_WORD } from "./views/values.js";
 
 /**
- * The head references of the staged assets. The page loads the chart runtime and the grid runtime from the
- * sibling assets directory, thus the head names no remote host. The manifest gives each staged name, thus
- * the tag and the stage step of the caller cannot disagree.
+ * The head reference of the chart runtime. The page loads it from the sibling assets directory, thus the
+ * head names no remote host. The manifest gives the staged name, thus the tag and the stage step of the
+ * caller cannot disagree.
  *
- * Each of the two is a classic script. A `file://` page refuses a module request, thus a classic script is
- * the one form that loads beside the page.
+ * The tag is a classic script. A `file://` page refuses a module request, thus a classic script is the one
+ * form that loads beside the page.
  */
-export const ASSET_HEAD = `<script src="${assetSource(ECHARTS_ASSET)}"></script><script src="${assetSource(AG_GRID_ASSET)}"></script>`;
+export const ASSET_HEAD = `<script src="${assetSource(ECHARTS_ASSET)}"></script>`;
+
+/**
+ * The head reference of the grid runtime.
+ *
+ * The bundle weighs about two megabytes, and a page with no table has nothing to build. Thus the skeleton
+ * writes this tag only for a page that carries table data, and the manifest still stages the file for the
+ * whole directory.
+ */
+export const GRID_ASSET_HEAD = `<script src="${assetSource(AG_GRID_ASSET)}"></script>`;
 
 /**
  * The name of the readiness event, and the name of the window sentinel that guards a late listener. The
@@ -520,15 +530,20 @@ function trimZeros(text) {
  * The column definition takes the label, the filter, and the two readings of a cell. The formatter gives the
  * shown text under the kind of the column, and the tooltip gives the raw cell where the shown text differs
  * from it. A value getter reads the own key of the row, because the field of a column reads a point as a
- * path and a column name can hold one.
+ * path and a column name can hold one. A number column also parses the cell for its filter, thus a column
+ * of numeric text compares as a number and a sentinel matches nothing.
  *
  * The row model is the client-side model. It renders the visible slice alone, thus a table of many thousands
  * of rows costs the DOM a screen of rows. The mount takes the height of its rows, up to the visible count,
- * thus a short table leaves no empty box under it.
+ * thus a short table leaves no empty box under it. A wide table adds the horizontal scroll bar that the
+ * host paints, measured at the first data render, thus the bar covers no row.
+ *
+ * The status of the card reads the model of the grid. The grid gives a model event after each filter and
+ * each sort, thus the count states what the reader sees against what the table holds.
  *
  * The print hooks switch the grid to its print layout. That layout lays every row out at once and it holds
- * no scroll viewport, thus each bounded row reaches the paper. The row bound of the binding is what keeps
- * that page count sane.
+ * no scroll viewport, thus each row of the print form reaches the paper. The print stops at the print bound,
+ * and the note of the card then states what the paper shows and where the whole table is.
  *
  * One grid builds inside a guard. A malformed payload is exactly the fault that a look must diagnose, thus
  * it must never stop a sibling grid and it must never throw out of the page.
@@ -564,20 +579,88 @@ export const GRID_BOOTSTRAP = `(function () {
         var raw = String(params.value);
         return raw === formatCell(params.value, kind, bound) ? "" : raw;
       },
-      filter: kind === "identifier" ? "agTextColumnFilter" : "agNumberColumnFilter"
+      filter: display.filter === "number" ? "agNumberColumnFilter" : "agTextColumnFilter"
     };
+    if (display.filter === "number") {
+      // The number filter compares numbers. A cell of numeric text would compare as text under it, thus the
+      // filter reads the parsed value and a cell that parses to nothing matches no comparison.
+      column.filterValueGetter = function (params) {
+        var cell = params.data ? params.data[name] : undefined;
+        var parsed = cell === undefined || cell === null || cell === "" ? NaN : Number(cell);
+        return isFinite(parsed) ? parsed : null;
+      };
+    }
     if (label !== name) {
       column.headerTooltip = name;
     }
     return column;
   }
-  function bindPrint(api, mount, height) {
+  function scrollBarHeight(mount) {
+    // The grid lays its horizontal bar in a strip of its own under the rows, and that strip takes its space
+    // from the box of the mount. Thus the height of the strip is what the last row loses, and an overlay bar
+    // leaves the strip at zero. A grid that names the strip differently gives none, and the box then holds
+    // the rows alone.
+    var strip = mount.querySelector(".ag-body-horizontal-scroll");
+    return strip ? strip.offsetHeight : 0;
+  }
+  function fitToScrollBar(mount, rowSpace) {
+    var height = rowSpace + scrollBarHeight(mount) + "px";
+    if (mount.style.height !== height) {
+      mount.style.height = height;
+    }
+  }
+  function onFirstRender(mount, rowSpace) {
+    // The grid lays its columns out with the first data render. A measure before that render finds no
+    // viewport and no bar, thus the fit waits for the grid to say that the rows are on the page.
+    return function () {
+      fitToScrollBar(mount, rowSpace);
+    };
+  }
+  function statusText(shown, total) {
+    var whole = formatCell(total, "compact-scientific") + " ${GRID_ROWS_WORD}";
+    return shown === total ? whole : formatCell(shown, "compact-scientific") + " of " + whole;
+  }
+  function onModelUpdate(count, total) {
+    // The grid gives this event after each filter and each sort, thus the status states what the reader
+    // sees against what the table holds.
+    return function (params) {
+      if (count) {
+        count.textContent = statusText(params.api.getDisplayedRowCount(), total);
+      }
+    };
+  }
+  function printNote(total) {
+    return (
+      "The print shows the first " +
+      formatCell(${GRID_PRINT_ROW_CAP}, "compact-scientific") +
+      " of " +
+      formatCell(total, "compact-scientific") +
+      " ${GRID_ROWS_WORD}. The full table rides the download."
+    );
+  }
+  function bindPrint(api, mount, note, rows) {
+    var capped = rows.length > ${GRID_PRINT_ROW_CAP};
+    var height = "";
     window.addEventListener("beforeprint", function () {
+      // The height of the screen form is whatever the fit left, thus the restore reads it at print time.
+      height = mount.style.height;
       mount.style.height = "auto";
+      if (capped) {
+        api.setGridOption("rowData", rows.slice(0, ${GRID_PRINT_ROW_CAP}));
+        if (note) {
+          note.textContent = printNote(rows.length);
+        }
+      }
       api.setGridOption("domLayout", "print");
     });
     window.addEventListener("afterprint", function () {
       api.setGridOption("domLayout", "normal");
+      if (capped) {
+        api.setGridOption("rowData", rows);
+        if (note) {
+          note.textContent = "";
+        }
+      }
       mount.style.height = height;
     });
   }
@@ -588,6 +671,9 @@ export const GRID_BOOTSTRAP = `(function () {
     if (!payload || !payload.columns || !payload.display) {
       continue;
     }
+    var card = mount.parentNode;
+    var note = card ? card.querySelector(".${GRID_NOTE_CLASS}") : null;
+    var count = card ? card.querySelector(".${GRID_COUNT_CLASS}") : null;
     try {
       var columns = [];
       for (var c = 0; c < payload.columns.length; c++) {
@@ -595,22 +681,21 @@ export const GRID_BOOTSTRAP = `(function () {
       }
       var rows = payload.rows || [];
       var shown = rows.length < ${GRID_VISIBLE_ROWS} ? rows.length : ${GRID_VISIBLE_ROWS};
-      var height = ${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX} + shown * ${GRID_ROW_HEIGHT_PX} + "px";
-      mount.style.height = height;
-      bindPrint(
-        agGrid.createGrid(mount, {
-          theme: theme,
-          columnDefs: columns,
-          rowData: rows,
-          defaultColDef: { sortable: true, resizable: true, flex: 1, minWidth: ${GRID_MIN_COLUMN_WIDTH_PX} },
-          suppressCellFocus: true,
-          // The tooltip carries the raw value of a shown cell. A reader hovers to read that value, thus the
-          // delay is short and the value arrives while the pointer is still on the cell.
-          tooltipShowDelay: ${GRID_TOOLTIP_DELAY_MS}
-        }),
-        mount,
-        height
-      );
+      var rowSpace = ${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX} + shown * ${GRID_ROW_HEIGHT_PX};
+      mount.style.height = rowSpace + "px";
+      var api = agGrid.createGrid(mount, {
+        theme: theme,
+        columnDefs: columns,
+        rowData: rows,
+        defaultColDef: { sortable: true, resizable: true, flex: 1, minWidth: ${GRID_MIN_COLUMN_WIDTH_PX} },
+        suppressCellFocus: true,
+        // The tooltip carries the raw value of a shown cell. A reader hovers to read that value, thus the
+        // delay is short and the value arrives while the pointer is still on the cell.
+        tooltipShowDelay: ${GRID_TOOLTIP_DELAY_MS},
+        onFirstDataRendered: onFirstRender(mount, rowSpace),
+        onModelUpdated: onModelUpdate(count, rows.length)
+      });
+      bindPrint(api, mount, note, rows);
     } catch (cause) {
       console.error("grid boot failed for " + id + ": " + (cause && cause.message ? cause.message : cause));
     }

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -2,14 +2,23 @@ import { describe, expect, it } from "bun:test";
 import { load } from "cheerio";
 
 import type { Block, CitationBlock, MetricBlock, ReportDocument, TableBlock, TextBlock } from "../contracts/report-blocks.js";
-import { ASSETS_DIR, PAGE_ASSETS, tableSidecarName } from "./assets.js";
-import { DESIGN_CSS } from "./design.js";
+import { AG_GRID_ASSET, ASSETS_DIR, PAGE_ASSETS, tableSidecarName } from "./assets.js";
+import {
+    DESIGN_CSS,
+    GRID_HEADER_BORDER_PX,
+    GRID_HEADER_HEIGHT_PX,
+    GRID_MIN_COLUMN_WIDTH_PX,
+    GRID_ROW_HEIGHT_PX,
+    GRID_THEME_PARAMS,
+    GRID_VISIBLE_ROWS,
+} from "./design.js";
 import { FIXTURE_DOCUMENT, FIXTURE_VALUES } from "./fixture.js";
-import { CHART_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER, TABLE_ENHANCER } from "./page.js";
+import { CHART_BOOTSTRAP, GRID_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER } from "./page.js";
+import { formatTableCell } from "./number-format.js";
 import { TABLE_DATA_GLOBAL } from "./table-data.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
-import { SHOW_ALL_PREFIX, TABLE_ROW_CAP } from "./views/values.js";
+import { GRID_MOUNT_ATTRIBUTE } from "./views/values.js";
 
 /**
  * The site of the navigation brand. It is the one reference of the page that names a remote host.
@@ -238,17 +247,28 @@ describe("the table data assets", () => {
         return registry["tbl"];
     }
 
-    it("holds the header and no data row, and the payload holds every row", () => {
+    it("holds one empty grid mount, and the payload holds every row", () => {
         const rendered = renderReportPage(tableDocument(), valuesOf(14201))._unsafeUnwrap();
         const page = load(rendered.html);
 
-        expect(page("th.data-table-sort").length).toBe(3);
-        expect(page("tbody tr").length).toBe(0);
+        expect(page(`[${GRID_MOUNT_ATTRIBUTE}="tbl"]`).length).toBe(1);
+        expect(page(`[${GRID_MOUNT_ATTRIBUTE}]`).text()).toBe("");
         expect(rendered.dataAssets.length).toBe(1);
 
         const payload = registeredPayload(rendered.dataAssets[0]);
         expect(payload.columns).toEqual(["gene", "padj", "direction"]);
         expect(payload.rows.length).toBe(14201);
+    });
+
+    it("carries the display of each column beside the rows", () => {
+        const rendered = renderReportPage(tableDocument(), valuesOf(3))._unsafeUnwrap();
+        const payload = registeredPayload(rendered.dataAssets[0]) as unknown as { display: { label: string; kind: string; bound?: number }[] };
+
+        // The server resolves the label, the kind, and the bound one time for each column. Thus the page
+        // formats each cell with no read of a declaration.
+        expect(payload.display.map((entry) => entry.kind)).toEqual(["compact-scientific", "scientific", "compact-scientific"]);
+        expect(payload.display.map((entry) => entry.label)).toEqual(["gene", "padj", "direction"]);
+        expect(payload.display[1].bound).toBe(1 / 3);
     });
 
     it("compresses a repeated category into the dictionary of its column", () => {
@@ -278,7 +298,7 @@ describe("the table data assets", () => {
         // reaches the reader through a script tag and never through a request.
         expect(rendered.html).toContain(`<script src="${source}"></script>`);
         expect(rendered.html.indexOf(source)).toBeLessThan(rendered.html.indexOf(TABLE_DATA_DECODER));
-        expect(rendered.html.indexOf(TABLE_DATA_DECODER)).toBeLessThan(rendered.html.indexOf(TABLE_ENHANCER));
+        expect(rendered.html.indexOf(TABLE_DATA_DECODER)).toBeLessThan(rendered.html.indexOf(GRID_BOOTSTRAP));
     });
 
     it("decodes the payload into plain rows, one time, in the page script", () => {
@@ -354,8 +374,10 @@ describe("the table data assets", () => {
         const rendered = renderReportPage(document, {})._unsafeUnwrap();
 
         expect(rendered.dataAssets).toEqual([]);
-        // A page with no payload registers no map and carries no decoder, thus it stays what it was.
+        // A page with no payload registers no map, and it carries neither the decoder nor the grid boot,
+        // thus it stays what it was.
         expect(rendered.html).not.toContain(TABLE_DATA_GLOBAL);
+        expect(rendered.html).not.toContain(GRID_BOOTSTRAP);
         expect(rendered.html).not.toContain(".data.js");
         expect(rendered.html).toBe(renderReportPage(document, {})._unsafeUnwrap().html);
     });
@@ -1101,10 +1123,7 @@ describe("the section scrollspy", () => {
     });
 });
 
-describe("the table enhancer", () => {
-    /** The print block of the sheet. It is the last block, thus the tail from its opening is its body. */
-    const PRINT_BLOCK = DESIGN_CSS.slice(DESIGN_CSS.indexOf("@media print"));
-
+describe("the table grid", () => {
     /** A page with one table of `count` rows and two columns. */
     function tablePage(count: number): { document: ReportDocument; values: RenderValues } {
         const rows = [];
@@ -1127,320 +1146,325 @@ describe("the table enhancer", () => {
         };
     }
 
-    it("rides the page after the scrollspy", () => {
+    it("references the grid bundle as a classic script from the staged assets", () => {
         const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
-        expect(html).toContain(TABLE_ENHANCER);
-        expect(html.indexOf(TABLE_ENHANCER)).toBeGreaterThan(html.indexOf(SECTION_SPY));
+
+        // A `file://` page refuses a module request, thus the runtime loads as a classic script. The
+        // manifest carries the entry, thus the stage step of the caller writes the file that the tag names.
+        expect(html).toContain(`<script src="${ASSETS_DIR}/${AG_GRID_ASSET.file}"></script>`);
+        expect(PAGE_ASSETS).toContain(AG_GRID_ASSET);
     });
 
-    it("bounds the markup and the script at one cap", () => {
-        // The view hides the rows past the cap, and the script applies the same cap again after each sort
-        // and each filter. Two numbers here would show one count and then show a different one.
-        expect(TABLE_ENHANCER).toContain(`var CAP = ${TABLE_ROW_CAP};`);
+    it("boots after the decode and before the readiness signal", () => {
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
+
+        // The boot reads the decoded rows, thus it runs after the decoder. It runs before the chart
+        // bootstrap, which signals readiness, thus a capture of the page shows a page whose grids stand.
+        expect(html.indexOf(TABLE_DATA_DECODER)).toBeLessThan(html.indexOf(GRID_BOOTSTRAP));
+        expect(html.indexOf(GRID_BOOTSTRAP)).toBeLessThan(html.indexOf(CHART_BOOTSTRAP));
     });
 
-    it("writes the classes that the view emits and that the design source styles", () => {
-        expect(TABLE_ENHANCER).toContain(`"report-row-hidden"`);
-        expect(TABLE_ENHANCER).toContain(`"data-table-sort-asc"`);
-        expect(TABLE_ENHANCER).toContain(`"data-table-sort-desc"`);
-        expect(DESIGN_CSS).toContain(".report-row-hidden");
-        expect(DESIGN_CSS).toContain(".data-table-sort-asc");
-        expect(DESIGN_CSS).toContain(".data-table-sort-desc");
-    });
-
-    it("reads no locale in the filter comparison and no locale in the sort", () => {
-        // `toLowerCase` is exact over the ASCII range of a gene name. A locale method gives different text
-        // and a different order on a different host, thus the page would stop being deterministic.
-        expect(TABLE_ENHANCER).toContain("toLowerCase()");
-        expect(TABLE_ENHANCER).not.toContain("localeCompare");
-        expect(TABLE_ENHANCER).not.toContain("toLocale");
-    });
-
-    it("touches neither the reveal gate nor the readiness sentinel", () => {
-        // The enhancer registers no reveal work. A page that waited on the enhancer would signal late.
-        expect(TABLE_ENHANCER).not.toContain("__inflexa");
-    });
-
-    it("hides a row under the live marker alone, thus a browser with no script shows every row", () => {
-        // The script writes the marker on each card that it takes. Without the marker no rule hides a row,
-        // thus the plain table stays complete and no row hides behind a toggle that cannot open.
-        const selectors = [...DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(/[^{}]*\.report-row-hidden[^{}]*\{/g)].map((match) => match[0]);
-        expect(selectors.length).toBeGreaterThan(0);
-        for (const selector of selectors) {
-            expect(selector).toContain(".report-table-live");
-        }
-        expect(TABLE_ENHANCER).toContain(`var LIVE = "report-table-live";`);
-        expect(TABLE_ENHANCER).toContain("card.classList.add(LIVE);");
-    });
-
-    it("shows a control under the live marker alone", () => {
-        const css = DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
-        for (const control of ["report-table-controls", "report-table-toggle"]) {
-            const rules = [...css.matchAll(new RegExp(`([^{}]*\\.${control}[^{}]*)\\{([^}]*)\\}`, "g"))];
-            const withDisplay = rules.filter((rule) => /display:\s*[a-z-]+/.test(rule[2]));
-            expect(withDisplay.length).toBeGreaterThan(0);
-            for (const rule of withDisplay) {
-                if (/display:\s*none/.test(rule[2])) {
-                    continue;
-                }
-                // A rule that shows the control must name the marker. Without it a browser with no script
-                // paints an input and a button that nothing drives.
-                expect(rule[1]).toContain(".report-table-live");
-            }
-            // The default is hidden, thus the control appears only after the script takes the card.
-            const hiddenByDefault = withDisplay.some((rule) => !rule[1].includes(".report-table-live") && /display:\s*none/.test(rule[2]));
-            expect(hiddenByDefault).toBe(true);
-        }
-    });
-
-    it("gives the sort affordance under the live marker alone", () => {
-        const css = DESIGN_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
-        const rules = [...css.matchAll(/([^{}]*\.data-table-sort[^{}]*)\{([^}]*)\}/g)];
-        const affordance = rules.filter((rule) => /cursor:/.test(rule[2]) || /:hover/.test(rule[1]));
-        expect(affordance.length).toBeGreaterThan(0);
-        for (const rule of affordance) {
-            // A zero-row table never takes the marker. Its headers must then promise no sort.
-            expect(rule[1]).toContain(".report-table-live");
-        }
-    });
-
-    it("shows every row in the print form and drops the controls", () => {
-        // The base rule hides a capped row. The print rule comes after it, thus it wins on paper.
-        expect(DESIGN_CSS.indexOf(".report-row-hidden")).toBeLessThan(DESIGN_CSS.indexOf("@media print"));
-        expect(PRINT_BLOCK).toMatch(/\.report-row-hidden\s*\{[^}]*display:\s*table-row/);
-        expect(PRINT_BLOCK).toMatch(/\.report-table-live \.report-table-controls,\s*\.report-table-live \.report-table-toggle\s*\{[^}]*display:\s*none/);
-    });
-
-    it("puts the sort headers on a page and no data row under them", () => {
-        const over = tablePage(TABLE_ROW_CAP + 3);
+    it("puts one mount and no row on a page of many rows", () => {
+        const over = tablePage(14_201);
         const page = load(renderReportPage(over.document, over.values)._unsafeUnwrap().html);
-        expect(page("th.data-table-sort").length).toBe(2);
-        // The enhancer of this page finds an empty body and takes no card, thus the page carries neither
-        // the control that it drives nor a row that it hides.
-        expect(page("tbody tr").length).toBe(0);
-        expect(page(".report-table-filter").length).toBe(0);
-        expect(page(".report-table-toggle").length).toBe(0);
+
+        expect(page(`[${GRID_MOUNT_ATTRIBUTE}]`).length).toBe(1);
+        expect(page("tr").length).toBe(0);
+        // The card keeps its download, thus the reader takes the raw bytes whatever the script does.
+        expect(page("a.report-table-download").length).toBe(1);
     });
 });
 
-describe("the table enhancer behavior", () => {
-    /** The event that a header handler reads. The key selects the branch, and the guard stops the scroll. */
-    interface FakeEvent {
-        key?: string;
-        preventDefault: () => void;
+describe("the grid boot", () => {
+    /** One column definition, in the shape that the boot builds. */
+    interface FakeColumn {
+        colId: string;
+        headerName: string;
+        headerTooltip?: string;
+        filter: string;
+        valueGetter: (params: { data?: Record<string, string | number> }) => string | number | undefined;
+        valueFormatter: (params: { value: unknown }) => string;
+        tooltipValueGetter: (params: { value: unknown }) => string;
     }
 
-    /** One element in the shape that the script reads: a class set, an attribute map, and its handlers. */
-    interface FakeNode {
-        classes: Set<string>;
-        attributes: Record<string, string>;
-        classList: { add: (name: string) => void; remove: (name: string) => void };
-        addEventListener: (name: string, handler: (event: FakeEvent) => void) => void;
-        setAttribute: (name: string, value: string) => void;
+    /** The grid options that the boot passes to `createGrid`. */
+    interface FakeOptions {
+        theme: unknown;
+        columnDefs: FakeColumn[];
+        rowData: Record<string, string | number>[];
+        defaultColDef: Record<string, unknown>;
+        rowModelType?: string;
+    }
+
+    /** One mount, in the shape that the boot reads: the block attribute and the inline style. */
+    interface FakeMount {
+        style: { height: string };
         getAttribute: (name: string) => string | null;
-        fire: (name: string, key?: string) => void;
     }
 
-    type FakeRow = FakeNode & { cells: { getAttribute: (name: string) => string | null }[] };
-    type FakeFilter = FakeNode & { value: string };
-    type FakeToggle = FakeNode & { textContent: string };
-    type FakeCard = FakeNode & { querySelector: (selector: string) => unknown };
-
-    /** The handles of one mounted table: the elements, the painted order, and the two readings of it. */
-    interface Mounted {
-        card: FakeNode;
-        headers: FakeNode[];
-        filter: FakeFilter;
-        toggle: FakeToggle;
-        column: (index: number) => string[];
-        visible: () => string[];
-    }
-
-    function fakeNode(initial: string[] = []): FakeNode {
-        const classes = new Set(initial);
-        const attributes: Record<string, string> = {};
-        const handlers: Record<string, ((event: FakeEvent) => void)[]> = {};
-        return {
-            classes,
-            attributes,
-            classList: {
-                add: (name) => {
-                    classes.add(name);
-                },
-                remove: (name) => {
-                    classes.delete(name);
-                },
-            },
-            addEventListener: (name, handler) => {
-                handlers[name] = [...(handlers[name] ?? []), handler];
-            },
-            setAttribute: (name, value) => {
-                attributes[name] = value;
-            },
-            getAttribute: (name) => attributes[name] ?? null,
-            fire: (name, key) => {
-                for (const handler of handlers[name] ?? []) {
-                    handler({ key, preventDefault: () => undefined });
-                }
-            },
-        };
+    /** One payload, in the shape that the decoder leaves under the block id. */
+    function payloadOf(columns: string[], display: unknown[], rows: Record<string, string | number>[]) {
+        return { columns, display, rows, dict: {} };
     }
 
     /**
-     * Mount one table of raw cell values and run the emitted enhancer over it.
+     * Run the emitted boot over the given payloads, and give back what it built.
      *
      * The script is browser source text. Each global arrives as a parameter, thus these fakes are the whole
-     * DOM that it drives and no real browser is necessary. `appendChild` moves a row to the end, as the
-     * browser method does, thus the painted order is the order that a reader sees.
+     * environment that it drives and no real browser and no real grid are necessary.
      */
-    function mount(cells: string[][], withToggle = false): Mounted {
-        const rows: FakeRow[] = cells.map((values) => ({
-            ...fakeNode(["report-row"]),
-            cells: values.map((value) => ({ getAttribute: (name: string) => (name === "data-value" ? value : null) })),
+    function boot(payloads: Record<string, unknown>, mountIds?: string[], breakOn?: string) {
+        const created: { id: string; options: FakeOptions }[] = [];
+        const registered: unknown[][] = [];
+        const applied: { option: string; value: unknown }[] = [];
+        const listeners: Record<string, (() => void)[]> = {};
+        const errors: string[] = [];
+        const themeParams: unknown[] = [];
+        const mounts: FakeMount[] = (mountIds ?? Object.keys(payloads)).map((id) => ({
+            style: { height: "" },
+            getAttribute: (name: string) => (name === GRID_MOUNT_ATTRIBUTE ? id : null),
         }));
-        const headers = (cells[0] ?? []).map((_, index) => {
-            const header = fakeNode(["data-table-sort"]);
-            header.attributes["data-sort-index"] = String(index);
-            return header;
-        });
-        const filter: FakeFilter = { ...fakeNode(), value: "" };
-        const toggle: FakeToggle = { ...fakeNode(["report-table-toggle"]), textContent: `${SHOW_ALL_PREFIX}${rows.length}` };
-        const painted = [...rows];
-        const body = {
-            rows,
-            appendChild: (node: FakeRow) => {
-                const at = painted.indexOf(node);
-                if (at >= 0) {
-                    painted.splice(at, 1);
+        const agGrid = {
+            ModuleRegistry: {
+                registerModules: (modules: unknown[]) => {
+                    registered.push(modules);
+                },
+            },
+            AllCommunityModule: { moduleName: "community" },
+            themeQuartz: {
+                withParams: (given: unknown) => {
+                    themeParams.push(given);
+                    return { params: given };
+                },
+            },
+            createGrid: (mount: FakeMount, options: FakeOptions) => {
+                const id = mount.getAttribute(GRID_MOUNT_ATTRIBUTE) ?? "";
+                if (id === breakOn) {
+                    throw new Error("the grid refused the payload");
                 }
-                painted.push(node);
+                created.push({ id, options });
+                return {
+                    setGridOption: (option: string, value: unknown) => {
+                        applied.push({ option, value });
+                    },
+                };
             },
         };
-        const table = { querySelector: () => body, querySelectorAll: () => headers };
-        const card: FakeCard = {
-            ...fakeNode(["report-table"]),
-            querySelector: (selector: string): unknown => {
-                if (selector === "table.data-table") {
-                    return table;
-                }
-                if (selector === ".report-table-filter") {
-                    return filter;
-                }
-                return withToggle ? toggle : null;
+        const registry = Object.create(null) as Record<string, unknown>;
+        for (const [id, payload] of Object.entries(payloads)) {
+            registry[id] = payload;
+        }
+        const window = {
+            [TABLE_DATA_GLOBAL]: registry,
+            addEventListener: (name: string, handler: () => void) => {
+                listeners[name] = [...(listeners[name] ?? []), handler];
             },
         };
-        const doc = {
-            readyState: "complete",
-            documentElement: { classList: { add: () => undefined } },
-            querySelectorAll: () => [card],
-            addEventListener: () => undefined,
+        const document = { querySelectorAll: () => mounts };
+        const console = {
+            error: (message: string) => {
+                errors.push(message);
+            },
         };
-        new Function("document", TABLE_ENHANCER)(doc);
+        new Function("window", "document", "agGrid", "console", GRID_BOOTSTRAP)(window, document, agGrid, console);
         return {
-            card,
-            headers,
-            filter,
-            toggle,
-            column: (index) => painted.map((row) => row.cells[index].getAttribute("data-value") ?? ""),
-            visible: () => painted.filter((row) => !row.classes.has("report-row-hidden")).map((row) => row.cells[0].getAttribute("data-value") ?? ""),
+            created,
+            registered,
+            applied,
+            errors,
+            mounts,
+            themeParams,
+            fire: (name: string) => {
+                for (const handler of listeners[name] ?? []) {
+                    handler();
+                }
+            },
         };
     }
 
-    it("takes no card whose body holds no row, and it throws nothing", () => {
-        // The card of a table renders its rows from the data asset, thus the body of the markup is empty.
-        // The enhancer of this page finds nothing to drive, and it must leave the card as it is.
-        const table = mount([]);
-
-        expect(table.card.classes.has("report-table-live")).toBe(false);
-        expect(table.headers.length).toBe(0);
-    });
-
-    it("sorts a numeric column that holds a sentinel by magnitude", () => {
-        const table = mount([["10"], ["NA"], ["9"]]);
-        table.headers[0].fire("click");
-        // One value that parses keeps the column numeric. Under a text order `10` would rank before `9`.
-        expect(table.column(0)).toEqual(["9", "10", "NA"]);
-        table.headers[0].fire("click");
-        // The sentinel holds no rank, thus it stays at the end under both directions.
-        expect(table.column(0)).toEqual(["10", "9", "NA"]);
-        table.headers[0].fire("click");
-        expect(table.column(0)).toEqual(["10", "NA", "9"]);
-    });
-
-    it("sorts a text column in code-unit order", () => {
-        const table = mount([["b"], ["A"], ["a"]]);
-        table.headers[0].fire("click");
-        expect(table.column(0)).toEqual(["A", "a", "b"]);
-    });
-
-    it("cycles from the keyboard and writes the sort state of each header", () => {
-        const table = mount([
-            ["2", "x"],
-            ["1", "y"],
-        ]);
-        table.headers[0].fire("keydown", "Enter");
-        expect(table.column(0)).toEqual(["1", "2"]);
-        expect(table.headers[0].attributes["aria-sort"]).toBe("ascending");
-        expect(table.headers[1].attributes["aria-sort"]).toBe("none");
-        table.headers[0].fire("keydown", " ");
-        expect(table.headers[0].attributes["aria-sort"]).toBe("descending");
-        // A key that names no action leaves the order and the state as they are.
-        table.headers[0].fire("keydown", "a");
-        expect(table.headers[0].attributes["aria-sort"]).toBe("descending");
-    });
-
-    it("filters on the raw values of a row and forms no match across two cells", () => {
-        const table = mount([
-            ["AB", "CD"],
-            ["ZZ", "YY"],
-        ]);
-        table.filter.value = "bc";
-        table.filter.fire("input");
-        expect(table.visible()).toEqual([]);
-        table.filter.value = "cd";
-        table.filter.fire("input");
-        expect(table.visible()).toEqual(["AB"]);
-    });
-
-    it("finds the text that the trim hides, because the filter reads the raw value", () => {
-        const table = mount([["HALLMARK_HYPOXIA%MSigDB%M5891"], ["TP53"]]);
-        table.filter.value = "m5891";
-        table.filter.fire("input");
-        expect(table.visible()).toEqual(["HALLMARK_HYPOXIA%MSigDB%M5891"]);
-    });
-
-    it("counts the kept rows on the toggle and hides the toggle at the cap", () => {
-        const cells: string[][] = [];
-        for (let index = 0; index < TABLE_ROW_CAP + 5; index += 1) {
-            cells.push([`G${index}`]);
+    /** One table of two columns: a gene name and an adjusted p-value. */
+    function genePayload(rowCount = 3) {
+        const rows = [];
+        for (let index = 0; index < rowCount; index += 1) {
+            rows.push({ gene: `G${index}`, padj: 0.0001 });
         }
-        const table = mount(cells, true);
-        table.filter.fire("input");
-        expect(table.visible().length).toBe(TABLE_ROW_CAP);
-        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}${TABLE_ROW_CAP + 5}`);
-        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(false);
+        return payloadOf(
+            ["gene", "padj"],
+            [
+                { label: "gene", kind: "compact-scientific" },
+                { label: "Adjusted p-value", kind: "scientific", bound: 0.0001 },
+            ],
+            rows,
+        );
+    }
 
-        table.toggle.fire("click");
-        expect(table.visible().length).toBe(TABLE_ROW_CAP + 5);
-        expect(table.toggle.textContent).toBe("Show fewer");
-        table.toggle.fire("click");
+    it("builds one grid for each mount, over the decoded rows of its block", () => {
+        const run = boot({ one: genePayload(2), two: genePayload(5) });
 
-        // The filter keeps 11 rows: `G1` and `G10` through `G19`. Nothing then waits behind the toggle.
-        table.filter.value = "g1";
-        table.filter.fire("input");
-        expect(table.visible().length).toBe(11);
-        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}11`);
-        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(true);
-
-        table.filter.value = "";
-        table.filter.fire("input");
-        expect(table.toggle.textContent).toBe(`${SHOW_ALL_PREFIX}${TABLE_ROW_CAP + 5}`);
-        expect(table.toggle.classes.has("report-table-toggle-off")).toBe(false);
+        expect(run.created.map((grid) => grid.id)).toEqual(["one", "two"]);
+        expect(run.created[1].options.rowData.length).toBe(5);
+        // The client-side row model is the default, and it renders the visible slice alone. A page that
+        // named another model would ask the page for rows that no page can give.
+        expect(run.created[0].options.rowModelType).toBeUndefined();
     });
 
-    it("marks a card that it takes and leaves a zero-row card unmarked", () => {
-        expect(mount([["a"]]).card.classes.has("report-table-live")).toBe(true);
-        expect(mount([]).card.classes.has("report-table-live")).toBe(false);
+    it("registers the community modules before it builds a grid", () => {
+        const run = boot({ one: genePayload() });
+
+        expect(run.registered.length).toBe(1);
+        expect(run.registered[0].length).toBe(1);
+    });
+
+    it("names each column from the display and reads the own key of the row", () => {
+        const payload = payloadOf(["p.value"], [{ label: "p value", kind: "scientific" }], [{ "p.value": 0.5 }]);
+        const column = boot({ one: payload }).created[0].options.columnDefs[0];
+
+        expect(column.colId).toBe("p.value");
+        expect(column.headerName).toBe("p value");
+        // A field reads a point as a path into the row. The getter reads the key itself, thus a column
+        // such as `p.value` reaches its own cells.
+        expect(column.valueGetter({ data: { "p.value": 0.5 } })).toBe(0.5);
+        expect(column.valueGetter({})).toBeUndefined();
+    });
+
+    it("puts the raw column name on the header hover where the label differs from it", () => {
+        const columns = boot({ one: genePayload() }).created[0].options.columnDefs;
+
+        expect(columns[1].headerTooltip).toBe("padj");
+        // A hover that repeats the header text tells a reader nothing, thus a plain header carries none.
+        expect(columns[0].headerTooltip).toBeUndefined();
+    });
+
+    it("formats each cell under the kind of its column, as the server does", () => {
+        const columns = boot({ one: genePayload() }).created[0].options.columnDefs;
+
+        expect(columns[1].valueFormatter({ value: 0.0000427777663038 })).toBe(formatTableCell(0.0000427777663038, "scientific"));
+        expect(columns[1].valueFormatter({ value: 0.0000427777663038 })).toBe("4.3e-5");
+        // The bound of the column rides the display, thus a stored zero reads as a bound and never as a result.
+        expect(columns[1].valueFormatter({ value: 0 })).toBe("<1e-4");
+        expect(columns[0].valueFormatter({ value: 14201 })).toBe("14,201");
+        expect(columns[0].valueFormatter({ value: undefined })).toBe("");
+    });
+
+    it("puts the raw value on the tooltip of a cell that the format changed", () => {
+        const columns = boot({ one: genePayload() }).created[0].options.columnDefs;
+
+        expect(columns[1].tooltipValueGetter({ value: 0.0000427777663038 })).toBe("0.0000427777663038");
+        expect(columns[1].tooltipValueGetter({ value: 0 })).toBe("0");
+        // A cell whose shown text is its own raw text carries no tooltip.
+        expect(columns[0].tooltipValueGetter({ value: "up" })).toBe("");
+        expect(columns[0].tooltipValueGetter({ value: undefined })).toBe("");
+    });
+
+    it("trims a delimited name in the cell and keeps the whole name on the tooltip", () => {
+        const name = "HALLMARK_HYPOXIA%MSigDB%M5891";
+        const payload = payloadOf(["set"], [{ label: "set", kind: "compact-scientific" }], [{ set: name }]);
+        const column = boot({ one: payload }).created[0].options.columnDefs[0];
+
+        expect(column.valueFormatter({ value: name })).toBe("HALLMARK_HYPOXIA");
+        expect(column.tooltipValueGetter({ value: name })).toBe(name);
+    });
+
+    it("gives a number filter to a magnitude column and a text filter to a column of names", () => {
+        const payload = payloadOf(
+            ["pmid", "reads"],
+            [
+                { label: "pmid", kind: "identifier" },
+                { label: "reads", kind: "compact-scientific" },
+            ],
+            [{ pmid: "31978945", reads: 12 }],
+        );
+        const columns = boot({ one: payload }).created[0].options.columnDefs;
+
+        expect(columns[0].filter).toBe("agTextColumnFilter");
+        expect(columns[1].filter).toBe("agNumberColumnFilter");
+    });
+
+    it("sorts from the header and fits each column to the width of the grid", () => {
+        const defaults = boot({ one: genePayload() }).created[0].options.defaultColDef;
+
+        // The per-column filters and the header sort are the one filter surface of a table.
+        expect(defaults.sortable).toBe(true);
+        expect(defaults.flex).toBe(1);
+        expect(defaults.minWidth).toBe(GRID_MIN_COLUMN_WIDTH_PX);
+    });
+
+    it("builds the theme from the design tokens", () => {
+        const run = boot({ one: genePayload() });
+
+        expect(run.themeParams).toEqual([GRID_THEME_PARAMS]);
+        expect(run.created[0].options.theme).toEqual({ params: GRID_THEME_PARAMS });
+    });
+
+    it("sizes the mount from the row count, up to the visible bound", () => {
+        const short = boot({ one: genePayload(3) });
+        expect(short.mounts[0].style.height).toBe(`${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX + 3 * GRID_ROW_HEIGHT_PX}px`);
+
+        const long = boot({ one: genePayload(GRID_VISIBLE_ROWS + 40) });
+        // A long table scrolls inside its own viewport, thus the card never grows with the row count.
+        expect(long.mounts[0].style.height).toBe(`${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX + GRID_VISIBLE_ROWS * GRID_ROW_HEIGHT_PX}px`);
+    });
+
+    it("takes the print layout of the grid on a print and gives it back after one", () => {
+        const run = boot({ one: genePayload(3) });
+        const height = run.mounts[0].style.height;
+
+        run.fire("beforeprint");
+        // The print layout lays every row out at once and it holds no scroll viewport, thus each bounded
+        // row reaches the paper.
+        expect(run.applied).toEqual([{ option: "domLayout", value: "print" }]);
+        expect(run.mounts[0].style.height).toBe("auto");
+
+        run.fire("afterprint");
+        expect(run.applied[1]).toEqual({ option: "domLayout", value: "normal" });
+        expect(run.mounts[0].style.height).toBe(height);
+    });
+
+    it("skips a mount whose block the registry does not hold, and it throws nothing", () => {
+        const run = boot({ one: genePayload() }, ["one", "absent"]);
+
+        expect(run.created.map((grid) => grid.id)).toEqual(["one"]);
+        expect(run.errors).toEqual([]);
+        // The mount of the absent block takes no height, thus its card shows its title and its download alone.
+        expect(run.mounts[1].style.height).toBe("");
+    });
+
+    it("skips a payload that carries no display, and it throws nothing", () => {
+        const run = boot({ one: { columns: ["gene"], rows: [{ gene: "TP53" }], dict: {} } });
+
+        expect(run.created).toEqual([]);
+        expect(run.errors).toEqual([]);
+    });
+
+    it("keeps a sibling grid when one grid refuses its payload", () => {
+        const run = boot({ bad: genePayload(), good: genePayload() }, ["bad", "good"], "bad");
+
+        // A malformed payload is the fault that a look must diagnose. It must never stop a sibling grid.
+        expect(run.created.map((grid) => grid.id)).toEqual(["good"]);
+        expect(run.errors.length).toBe(1);
+        expect(run.errors[0]).toContain("bad");
+    });
+});
+
+describe("the retired table enhancer", () => {
+    it("carries no marker, no filter input, and no cap class on a rendered page", () => {
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
+
+        // The grid owns the table presentation, thus the page holds one table mechanism and no second one.
+        for (const retired of ["report-table-live", "report-table-filter", "report-table-controls", "report-table-toggle", "report-row-hidden"]) {
+            expect(html).not.toContain(retired);
+        }
+    });
+
+    it("holds no rule and no markup of the plain table", () => {
+        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
+
+        for (const retired of ["data-table", "data-sort-index", "<tbody", "<thead"]) {
+            expect(html).not.toContain(retired);
+        }
+        for (const rule of [".report-table-live", ".report-table-filter", ".report-table-toggle", ".report-row", ".data-table"]) {
+            expect(DESIGN_CSS).not.toContain(rule);
+        }
     });
 });
 

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -8,6 +8,7 @@ import {
     GRID_HEADER_BORDER_PX,
     GRID_HEADER_HEIGHT_PX,
     GRID_MIN_COLUMN_WIDTH_PX,
+    GRID_PRINT_ROW_CAP,
     GRID_ROW_HEIGHT_PX,
     GRID_THEME_PARAMS,
     GRID_VISIBLE_ROWS,
@@ -18,7 +19,7 @@ import { formatTableCell } from "./number-format.js";
 import { TABLE_DATA_GLOBAL } from "./table-data.js";
 import { renderReportPage } from "./render.js";
 import type { RenderValues } from "./types.js";
-import { GRID_MOUNT_ATTRIBUTE } from "./views/values.js";
+import { GRID_COUNT_CLASS, GRID_MOUNT_ATTRIBUTE, GRID_NOTE_CLASS } from "./views/values.js";
 
 /**
  * The site of the navigation brand. It is the one reference of the page that names a remote host.
@@ -1155,6 +1156,35 @@ describe("the table grid", () => {
         expect(PAGE_ASSETS).toContain(AG_GRID_ASSET);
     });
 
+    it("skips the grid runtime and the boot on a page with no table", () => {
+        const document: ReportDocument = {
+            title: "T",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s",
+                    title: "S",
+                    blocks: [
+                        {
+                            kind: "chart",
+                            id: "cht",
+                            binding: { kind: "artifact-table", path: "t.csv", hash: "sha256:aaa" },
+                            chartType: "bar",
+                            encoding: { x: "label", y: "count" },
+                        },
+                    ],
+                },
+            ],
+        };
+        const html = renderReportPage(document, { cht: { type: "table", rows: [{ label: "a", count: 5 }] } })._unsafeUnwrap().html;
+
+        // The bundle weighs about two megabytes, and this page builds no grid. Thus it names neither the
+        // runtime nor the boot, and the chart runtime stays.
+        expect(html).not.toContain(AG_GRID_ASSET.file);
+        expect(html).not.toContain(GRID_BOOTSTRAP);
+        expect(html).toContain(`${ASSETS_DIR}/echarts.min.js`);
+    });
+
     it("boots after the decode and before the readiness signal", () => {
         const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
 
@@ -1183,6 +1213,7 @@ describe("the grid boot", () => {
         headerTooltip?: string;
         filter: string;
         valueGetter: (params: { data?: Record<string, string | number> }) => string | number | undefined;
+        filterValueGetter?: (params: { data?: Record<string, string | number> }) => number | null;
         valueFormatter: (params: { value: unknown }) => string;
         tooltipValueGetter: (params: { value: unknown }) => string;
     }
@@ -1194,12 +1225,29 @@ describe("the grid boot", () => {
         rowData: Record<string, string | number>[];
         defaultColDef: Record<string, unknown>;
         rowModelType?: string;
+        onFirstDataRendered?: () => void;
+        onModelUpdated?: (params: { api: { getDisplayedRowCount: () => number } }) => void;
     }
 
-    /** One mount, in the shape that the boot reads: the block attribute and the inline style. */
+    /** One element of the card that the boot writes into: the print note, and the row count of the status. */
+    interface FakeText {
+        textContent: string;
+    }
+
+    /**
+     * One mount, in the shape that the boot reads: the block attribute, the inline style, the note beside it,
+     * and the descendants that it measures for a scroll bar.
+     */
     interface FakeMount {
         style: { height: string };
         getAttribute: (name: string) => string | null;
+        querySelector: (selector: string) => FakeStrip | null;
+        parentNode: { querySelector: (selector: string) => FakeText | null };
+    }
+
+    /** The strip that the grid lays its horizontal bar in, in the shape that the fit reads. */
+    interface FakeStrip {
+        offsetHeight: number;
     }
 
     /** One payload, in the shape that the decoder leaves under the block id. */
@@ -1213,17 +1261,29 @@ describe("the grid boot", () => {
      * The script is browser source text. Each global arrives as a parameter, thus these fakes are the whole
      * environment that it drives and no real browser and no real grid are necessary.
      */
-    function boot(payloads: Record<string, unknown>, mountIds?: string[], breakOn?: string) {
+    function boot(payloads: Record<string, unknown>, mountIds?: string[], breakOn?: string, strip?: FakeStrip) {
         const created: { id: string; options: FakeOptions }[] = [];
+        const grids: { narrowTo: (count: number) => void }[] = [];
         const registered: unknown[][] = [];
         const applied: { option: string; value: unknown }[] = [];
         const listeners: Record<string, (() => void)[]> = {};
         const errors: string[] = [];
         const themeParams: unknown[] = [];
-        const mounts: FakeMount[] = (mountIds ?? Object.keys(payloads)).map((id) => ({
-            style: { height: "" },
-            getAttribute: (name: string) => (name === GRID_MOUNT_ATTRIBUTE ? id : null),
-        }));
+        const notes: FakeText[] = [];
+        const counts: FakeText[] = [];
+        const mounts: FakeMount[] = (mountIds ?? Object.keys(payloads)).map((id) => {
+            const note: FakeText = { textContent: "" };
+            const count: FakeText = { textContent: "" };
+            notes.push(note);
+            counts.push(count);
+            const inCard: Record<string, FakeText> = { [`.${GRID_NOTE_CLASS}`]: note, [`.${GRID_COUNT_CLASS}`]: count };
+            return {
+                style: { height: "" },
+                getAttribute: (name: string) => (name === GRID_MOUNT_ATTRIBUTE ? id : null),
+                querySelector: (selector: string) => (selector === ".ag-body-horizontal-scroll" ? (strip ?? null) : null),
+                parentNode: { querySelector: (selector: string) => inCard[selector] ?? null },
+            };
+        });
         const agGrid = {
             ModuleRegistry: {
                 registerModules: (modules: unknown[]) => {
@@ -1243,11 +1303,25 @@ describe("the grid boot", () => {
                     throw new Error("the grid refused the payload");
                 }
                 created.push({ id, options });
-                return {
+                // The grid renders its rows after it builds, and it gives the model event with them. The fit
+                // of the mount and the status of the card hang on the two calls, thus the fake makes both as
+                // the grid does.
+                let displayed = options.rowData.length;
+                const api = { getDisplayedRowCount: () => displayed };
+                options.onFirstDataRendered?.();
+                options.onModelUpdated?.({ api });
+                const handle = {
                     setGridOption: (option: string, value: unknown) => {
                         applied.push({ option, value });
                     },
+                    // The fake stands in for a filter: it narrows the model, then it gives the event again.
+                    narrowTo: (count: number) => {
+                        displayed = count;
+                        options.onModelUpdated?.({ api });
+                    },
                 };
+                grids.push(handle);
+                return handle;
             },
         };
         const registry = Object.create(null) as Record<string, unknown>;
@@ -1269,10 +1343,13 @@ describe("the grid boot", () => {
         new Function("window", "document", "agGrid", "console", GRID_BOOTSTRAP)(window, document, agGrid, console);
         return {
             created,
+            grids,
             registered,
             applied,
             errors,
             mounts,
+            notes,
+            counts,
             themeParams,
             fire: (name: string) => {
                 for (const handler of listeners[name] ?? []) {
@@ -1291,8 +1368,8 @@ describe("the grid boot", () => {
         return payloadOf(
             ["gene", "padj"],
             [
-                { label: "gene", kind: "compact-scientific" },
-                { label: "Adjusted p-value", kind: "scientific", bound: 0.0001 },
+                { label: "gene", kind: "compact-scientific", filter: "text" },
+                { label: "Adjusted p-value", kind: "scientific", filter: "number", bound: 0.0001 },
             ],
             rows,
         );
@@ -1316,7 +1393,7 @@ describe("the grid boot", () => {
     });
 
     it("names each column from the display and reads the own key of the row", () => {
-        const payload = payloadOf(["p.value"], [{ label: "p value", kind: "scientific" }], [{ "p.value": 0.5 }]);
+        const payload = payloadOf(["p.value"], [{ label: "p value", kind: "scientific", filter: "number" }], [{ "p.value": 0.5 }]);
         const column = boot({ one: payload }).created[0].options.columnDefs[0];
 
         expect(column.colId).toBe("p.value");
@@ -1358,26 +1435,39 @@ describe("the grid boot", () => {
 
     it("trims a delimited name in the cell and keeps the whole name on the tooltip", () => {
         const name = "HALLMARK_HYPOXIA%MSigDB%M5891";
-        const payload = payloadOf(["set"], [{ label: "set", kind: "compact-scientific" }], [{ set: name }]);
+        const payload = payloadOf(["set"], [{ label: "set", kind: "compact-scientific", filter: "text" }], [{ set: name }]);
         const column = boot({ one: payload }).created[0].options.columnDefs[0];
 
         expect(column.valueFormatter({ value: name })).toBe("HALLMARK_HYPOXIA");
         expect(column.tooltipValueGetter({ value: name })).toBe(name);
     });
 
-    it("gives a number filter to a magnitude column and a text filter to a column of names", () => {
+    it("takes the filter of each column from the display", () => {
+        const columns = boot({ one: genePayload() }).created[0].options.columnDefs;
+
+        // A gene column holds names. A reader filters it by name, thus the number filter would leave the
+        // column unfilterable.
+        expect(columns[0].filter).toBe("agTextColumnFilter");
+        expect(columns[1].filter).toBe("agNumberColumnFilter");
+    });
+
+    it("parses the cell for a number filter, thus a column of numeric text compares as a number", () => {
         const payload = payloadOf(
-            ["pmid", "reads"],
+            ["pmid", "gene"],
             [
-                { label: "pmid", kind: "identifier" },
-                { label: "reads", kind: "compact-scientific" },
+                { label: "pmid", kind: "identifier", filter: "number" },
+                { label: "gene", kind: "compact-scientific", filter: "text" },
             ],
-            [{ pmid: "31978945", reads: 12 }],
+            [{ pmid: "31978945", gene: "TP53" }],
         );
         const columns = boot({ one: payload }).created[0].options.columnDefs;
 
-        expect(columns[0].filter).toBe("agTextColumnFilter");
-        expect(columns[1].filter).toBe("agNumberColumnFilter");
+        expect(columns[0].filterValueGetter?.({ data: { pmid: "31978945" } })).toBe(31978945);
+        // A cell that parses to no number matches no comparison of the filter.
+        expect(columns[0].filterValueGetter?.({ data: { pmid: "NA" } })).toBeNull();
+        expect(columns[0].filterValueGetter?.({})).toBeNull();
+        // A text column filters on the value itself, thus it carries no parse.
+        expect(columns[1].filterValueGetter).toBeUndefined();
     });
 
     it("sorts from the header and fits each column to the width of the grid", () => {
@@ -1405,19 +1495,69 @@ describe("the grid boot", () => {
         expect(long.mounts[0].style.height).toBe(`${GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX + GRID_VISIBLE_ROWS * GRID_ROW_HEIGHT_PX}px`);
     });
 
+    it("adds the horizontal scroll bar of a wide table to the mount, thus the bar covers no row", () => {
+        const rowSpace = GRID_HEADER_HEIGHT_PX + GRID_HEADER_BORDER_PX + 3 * GRID_ROW_HEIGHT_PX;
+
+        // A wide table scrolls sideways, and the grid takes the height of that bar out of the row space.
+        const wide = boot({ one: genePayload(3) }, undefined, undefined, { offsetHeight: 15 });
+        expect(wide.mounts[0].style.height).toBe(`${rowSpace + 15}px`);
+
+        // An overlay bar lies over the rows and leaves the strip at zero, thus the mount keeps its height.
+        const overlay = boot({ one: genePayload(3) }, undefined, undefined, { offsetHeight: 0 });
+        expect(overlay.mounts[0].style.height).toBe(`${rowSpace}px`);
+
+        // A table that fits carries no strip at all.
+        expect(boot({ one: genePayload(3) }).mounts[0].style.height).toBe(`${rowSpace}px`);
+    });
+
     it("takes the print layout of the grid on a print and gives it back after one", () => {
         const run = boot({ one: genePayload(3) });
         const height = run.mounts[0].style.height;
 
         run.fire("beforeprint");
-        // The print layout lays every row out at once and it holds no scroll viewport, thus each bounded
-        // row reaches the paper.
+        // The print layout lays every row out at once and it holds no scroll viewport, thus each row of the
+        // print form reaches the paper. A table under the print bound prints whole and carries no note.
         expect(run.applied).toEqual([{ option: "domLayout", value: "print" }]);
         expect(run.mounts[0].style.height).toBe("auto");
+        expect(run.notes[0].textContent).toBe("");
 
         run.fire("afterprint");
         expect(run.applied[1]).toEqual({ option: "domLayout", value: "normal" });
         expect(run.mounts[0].style.height).toBe(height);
+    });
+
+    it("bounds the print form of a long table and states the truncation on the card", () => {
+        const total = GRID_PRINT_ROW_CAP + 201;
+        const run = boot({ one: genePayload(total) });
+
+        run.fire("beforeprint");
+        const printed = run.applied[0] as { option: string; value: Record<string, string | number>[] };
+        // The print layout builds every row that it holds. An unbounded table would take hundreds of pages,
+        // thus the print stops at the bound and the note names what the paper leaves out.
+        expect(printed.option).toBe("rowData");
+        expect(printed.value.length).toBe(GRID_PRINT_ROW_CAP);
+        expect(run.applied[1]).toEqual({ option: "domLayout", value: "print" });
+        expect(run.notes[0].textContent).toBe("The print shows the first 1,000 of 1,201 rows. The full table rides the download.");
+
+        run.fire("afterprint");
+        expect(run.applied[2]).toEqual({ option: "domLayout", value: "normal" });
+        expect((run.applied[3] as { option: string; value: unknown[] }).value.length).toBe(total);
+        // The screen shows no note, thus the line lives for the print alone.
+        expect(run.notes[0].textContent).toBe("");
+    });
+
+    it("states the row count of the table on the card, and the shown count under a filter", () => {
+        const run = boot({ one: genePayload(1201) });
+
+        // The model event arrives with the rows, thus the card states the whole count before any filter.
+        expect(run.counts[0].textContent).toBe("1,201 rows");
+
+        run.grids[0].narrowTo(132);
+        // A filter narrows the model. The status then reads what the grid shows against what it holds.
+        expect(run.counts[0].textContent).toBe("132 of 1,201 rows");
+
+        run.grids[0].narrowTo(1201);
+        expect(run.counts[0].textContent).toBe("1,201 rows");
     });
 
     it("skips a mount whose block the registry does not hold, and it throws nothing", () => {
@@ -1457,12 +1597,14 @@ describe("the retired table enhancer", () => {
     });
 
     it("holds no rule and no markup of the plain table", () => {
-        const html = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap().html;
+        const rendered = renderReportPage(FIXTURE_DOCUMENT, FIXTURE_VALUES)._unsafeUnwrap();
+        const page = load(rendered.html);
 
-        for (const retired of ["data-table", "data-sort-index", "<tbody", "<thead"]) {
-            expect(html).not.toContain(retired);
-        }
-        for (const rule of [".report-table-live", ".report-table-filter", ".report-table-toggle", ".report-row", ".data-table"]) {
+        // The grid renders each cell, thus the page carries one mount for each table and no table markup.
+        expect(page(`[${GRID_MOUNT_ATTRIBUTE}]`).length).toBeGreaterThan(0);
+        expect(page("td").length).toBe(0);
+        expect(page("table").length).toBe(0);
+        for (const rule of [".report-table-live", ".report-table-filter", ".report-table-toggle", ".report-row", ".data-table-sort"]) {
             expect(DESIGN_CSS).not.toContain(rule);
         }
     });

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -26,7 +26,7 @@ import { renderClaim, renderNav, renderSection, renderText } from "./views/prose
 import { citationKeyOf, ReferenceLedger } from "./references.js";
 import { encodeTablePayload, tableDataAsset, type DataAsset } from "./table-data.js";
 import type { RenderedPage, RenderProblem, RenderValue, RenderValues } from "./types.js";
-import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable, tableColumns } from "./views/values.js";
+import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable, tableColumns, tableDisplay } from "./views/values.js";
 
 /**
  * Render a report document, its value map, and the pinned citation records to one page and its data assets.
@@ -102,11 +102,12 @@ function renderBlock(
                 problems.push(wrongShape(block.id, entry.type, "table"));
                 return "";
             }
-            // The rows of the block ride a data asset, and the card holds the header alone. The payload
-            // reads the column order of the header, thus a cell of an encoded row names its column by
-            // position.
-            dataAssets.push(tableDataAsset(block.id, encodeTablePayload(tableColumns(entry), entry.rows)));
-            return renderTable(block, entry);
+            // The rows of the block ride a data asset, and the card holds one empty mount. The payload
+            // carries the column order, thus a cell of an encoded row names its column by position and the
+            // display entry of that column sits at the same index.
+            const columns = tableColumns(entry);
+            dataAssets.push(tableDataAsset(block.id, encodeTablePayload(columns, entry.rows, tableDisplay(block, entry, columns))));
+            return renderTable(block);
         }
         case "figure": {
             const entry = values[block.id];

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -107,7 +107,7 @@ function renderBlock(
             // display entry of that column sits at the same index.
             const columns = tableColumns(entry);
             dataAssets.push(tableDataAsset(block.id, encodeTablePayload(columns, entry.rows, tableDisplay(block, entry, columns))));
-            return renderTable(block);
+            return renderTable(block, entry.rows.length);
         }
         case "figure": {
             const entry = values[block.id];

--- a/harness/src/report-render/table-data.test.ts
+++ b/harness/src/report-render/table-data.test.ts
@@ -6,7 +6,15 @@
 
 import { describe, expect, it } from "bun:test";
 
-import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL, type TablePayload } from "./table-data.js";
+import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL, type ColumnDisplay, type TablePayload } from "./table-data.js";
+
+/**
+ * The display of a plain column list. The encode never reads a display entry, thus a test that states
+ * something else about the payload takes this one and says nothing about the format.
+ */
+function displayOf(columns: readonly string[]): ColumnDisplay[] {
+    return columns.map((label) => ({ label, kind: "compact-scientific" }));
+}
 
 describe("encodeTablePayload", () => {
     it("writes each row as an array in column order", () => {
@@ -16,6 +24,7 @@ describe("encodeTablePayload", () => {
                 { gene: "TP53", padj: 0.01 },
                 { gene: "MYC", padj: 0.02 },
             ],
+            displayOf(["gene", "padj"]),
         );
 
         // No row repeats the column names, thus a table of many rows costs one column list.
@@ -35,7 +44,7 @@ describe("encodeTablePayload", () => {
             { gene: "KRAS", direction: "down" },
         ];
 
-        const payload = encodeTablePayload(["gene", "direction"], rows);
+        const payload = encodeTablePayload(["gene", "direction"], rows, displayOf(["gene", "direction"]));
 
         // The category column holds two values across four rows, thus it costs two strings and four indexes.
         expect(payload.dict).toEqual({ direction: ["up", "down"] });
@@ -48,21 +57,21 @@ describe("encodeTablePayload", () => {
     });
 
     it("leaves a column of distinct strings raw, because a dictionary would save nothing", () => {
-        const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }, { gene: "MYC" }]);
+        const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }, { gene: "MYC" }], displayOf(["gene"]));
 
         expect(payload.dict).toEqual({});
         expect(payload.rows).toEqual([["TP53"], ["MYC"]]);
     });
 
     it("leaves a column that holds a number raw, thus no cell of it reads as an index", () => {
-        const payload = encodeTablePayload(["mixed"], [{ mixed: "same" }, { mixed: "same" }, { mixed: 1 }]);
+        const payload = encodeTablePayload(["mixed"], [{ mixed: "same" }, { mixed: "same" }, { mixed: 1 }], displayOf(["mixed"]));
 
         expect(payload.dict).toEqual({});
         expect(payload.rows).toEqual([["same"], ["same"], [1]]);
     });
 
     it("keeps a string that occurs one time in its row, because an entry would save nothing", () => {
-        const payload = encodeTablePayload(["direction"], [{ direction: "up" }, { direction: "up" }, { direction: "sideways" }]);
+        const payload = encodeTablePayload(["direction"], [{ direction: "up" }, { direction: "up" }, { direction: "sideways" }], displayOf(["direction"]));
 
         // The dictionary holds the repeated value alone, and the lone value stays where it is.
         expect(payload.dict).toEqual({ direction: ["up"] });
@@ -70,12 +79,24 @@ describe("encodeTablePayload", () => {
     });
 
     it("writes an absent cell as null, thus a ragged row keeps its shape", () => {
-        const payload = encodeTablePayload(["gene", "padj"], [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }]);
+        const payload = encodeTablePayload(["gene", "padj"], [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }], displayOf(["gene", "padj"]));
 
         expect(payload.rows).toEqual([
             ["TP53", 0.01],
             ["MYC", null],
         ]);
+    });
+
+    it("carries one display entry for each column, at the index of that column", () => {
+        const display: ColumnDisplay[] = [
+            { label: "Gene", kind: "identifier" },
+            { label: "Adjusted p-value", kind: "scientific", bound: 0.00036 },
+        ];
+        const payload = encodeTablePayload(["gene", "padj"], [{ gene: "TP53", padj: 0 }], display);
+
+        // The page reads the entry of a column at the index of its name, thus a list needs no key guard.
+        expect(payload.display).toEqual(display);
+        expect(payload.display.length).toBe(payload.columns.length);
     });
 
     it("gives one payload for one table, thus two encodes match", () => {
@@ -84,12 +105,14 @@ describe("encodeTablePayload", () => {
             { gene: "MYC", direction: "up" },
         ];
 
-        expect(encodeTablePayload(["gene", "direction"], rows)).toEqual(encodeTablePayload(["gene", "direction"], rows));
+        expect(encodeTablePayload(["gene", "direction"], rows, displayOf(["gene", "direction"]))).toEqual(
+            encodeTablePayload(["gene", "direction"], rows, displayOf(["gene", "direction"])),
+        );
     });
 });
 
 describe("tableDataAsset", () => {
-    const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }]);
+    const payload = encodeTablePayload(["gene"], [{ gene: "TP53" }], displayOf(["gene"]));
 
     /** Run one asset as the page runs it, and give back the registry that it wrote. */
     function registryOf(bytes: string): Record<string, TablePayload> {
@@ -109,7 +132,7 @@ describe("tableDataAsset", () => {
     it("parses the payload instead of writing an object literal, thus a prototype key stays a column", () => {
         const columns = ["__proto__", "constructor"];
         const rows = JSON.parse('[{"__proto__":"a","constructor":"b"}]') as Record<string, string | number>[];
-        const asset = tableDataAsset("tbl-1", encodeTablePayload(columns, rows));
+        const asset = tableDataAsset("tbl-1", encodeTablePayload(columns, rows, displayOf(columns)));
 
         // An object literal with a `__proto__` key sets the prototype of the object. The parse defines an
         // own property for every key, thus the payload reaches the page with the columns that it declares.
@@ -127,14 +150,14 @@ describe("tableDataAsset", () => {
     });
 
     it("gives a different name to a different payload and to a different block", () => {
-        const other = encodeTablePayload(["gene"], [{ gene: "MYC" }]);
+        const other = encodeTablePayload(["gene"], [{ gene: "MYC" }], displayOf(["gene"]));
 
         expect(tableDataAsset("tbl-1", other).name).not.toBe(tableDataAsset("tbl-1", payload).name);
         expect(tableDataAsset("tbl-2", payload).name).not.toBe(tableDataAsset("tbl-1", payload).name);
     });
 
     it("keeps a hostile block id and a hostile cell as data", () => {
-        const hostile = encodeTablePayload(["gene"], [{ gene: "</script><script>alert(1)</script>" }]);
+        const hostile = encodeTablePayload(["gene"], [{ gene: "</script><script>alert(1)</script>" }], displayOf(["gene"]));
         const asset = tableDataAsset("</script>", hostile);
 
         // The payload rides JSON, and the escape of the sink covers the one sequence that closes an element.

--- a/harness/src/report-render/table-data.test.ts
+++ b/harness/src/report-render/table-data.test.ts
@@ -13,7 +13,7 @@ import { encodeTablePayload, tableDataAsset, TABLE_DATA_GLOBAL, type ColumnDispl
  * something else about the payload takes this one and says nothing about the format.
  */
 function displayOf(columns: readonly string[]): ColumnDisplay[] {
-    return columns.map((label) => ({ label, kind: "compact-scientific" }));
+    return columns.map((label) => ({ label, kind: "compact-scientific", filter: "number" }));
 }
 
 describe("encodeTablePayload", () => {
@@ -89,8 +89,8 @@ describe("encodeTablePayload", () => {
 
     it("carries one display entry for each column, at the index of that column", () => {
         const display: ColumnDisplay[] = [
-            { label: "Gene", kind: "identifier" },
-            { label: "Adjusted p-value", kind: "scientific", bound: 0.00036 },
+            { label: "Gene", kind: "identifier", filter: "text" },
+            { label: "Adjusted p-value", kind: "scientific", filter: "number", bound: 0.00036 },
         ];
         const payload = encodeTablePayload(["gene", "padj"], [{ gene: "TP53", padj: 0 }], display);
 

--- a/harness/src/report-render/table-data.ts
+++ b/harness/src/report-render/table-data.ts
@@ -31,16 +31,20 @@ export const TABLE_DATA_GLOBAL = "__REPORT_TABLES";
 /** One cell of an encoded row: a raw value, a dictionary index, or `null` for a cell that the row lacks. */
 export type EncodedCell = string | number | null;
 
+/** The filter that a column takes on the page: the number filter of a magnitude, or the text filter of a name. */
+export type ColumnFilter = "number" | "text";
+
 /**
- * How one column shows on the page: the header label, the number kind of the column, and the bound of a
- * stored zero where the column holds one.
+ * How one column shows on the page: the header label, the number kind of the column, the filter of the
+ * column, and the bound of a stored zero where the column holds one.
  *
- * The server resolves each of the three, and the page reads them. Thus the declaration, the token guess,
- * and the read of a whole column stay on the server, and the page formats alone.
+ * The server resolves each of the four, and the page reads them. Thus the declaration, the token guess, and
+ * the read of a whole column stay on the server, and the page formats and filters alone.
  */
 export interface ColumnDisplay {
     label: string;
     kind: NumberKind;
+    filter: ColumnFilter;
     bound?: number;
 }
 

--- a/harness/src/report-render/table-data.ts
+++ b/harness/src/report-render/table-data.ts
@@ -10,11 +10,15 @@
  * cell that holds it becomes its index. A category column of one thousand rows and four values then costs
  * four strings and one thousand small integers.
  *
+ * The payload also carries the display of each column: the header label, the number kind, and the bound of
+ * a stored zero. The server resolves the three, and the page formats each cell under them.
+ *
  * The module is pure, and it reads no file. The renderer derives a payload, and the caller writes it.
  */
 
 import { createHash } from "node:crypto";
 
+import type { NumberKind } from "./number-format.js";
 import { scriptJson } from "./script-json.js";
 
 /**
@@ -28,16 +32,33 @@ export const TABLE_DATA_GLOBAL = "__REPORT_TABLES";
 export type EncodedCell = string | number | null;
 
 /**
+ * How one column shows on the page: the header label, the number kind of the column, and the bound of a
+ * stored zero where the column holds one.
+ *
+ * The server resolves each of the three, and the page reads them. Thus the declaration, the token guess,
+ * and the read of a whole column stay on the server, and the page formats alone.
+ */
+export interface ColumnDisplay {
+    label: string;
+    kind: NumberKind;
+    bound?: number;
+}
+
+/**
  * One encoded table.
  *
  * `columns` is the column order, and each row of `rows` holds one cell for each column in that order.
  * `dict` holds the repeated values of a column, keyed by the column name. A cell of such a column is a
  * number when it names an entry of that list, and the value itself at every other time.
+ *
+ * `display` holds one entry for each column, in the same order. A list and not a map, thus a column named
+ * `__proto__` needs no guard on the page and the entry of a column sits at the index of its name.
  */
 export interface TablePayload {
     columns: string[];
     rows: EncodedCell[][];
     dict: Record<string, string[]>;
+    display: ColumnDisplay[];
 }
 
 /** One data asset that the caller writes beside the page: the staged file name, and the source text of it. */
@@ -86,8 +107,14 @@ function columnDictionary(rows: ReadonlyArray<Record<string, string | number>>, 
  *
  * A cell that a row does not hold rides as `null`. A table tolerates a ragged row, thus the payload states
  * the absence in place and never shifts the rest of the row.
+ *
+ * `display` arrives in the column order, thus the entry of a column sits at the index of its name.
  */
-export function encodeTablePayload(columns: readonly string[], rows: ReadonlyArray<Record<string, string | number>>): TablePayload {
+export function encodeTablePayload(
+    columns: readonly string[],
+    rows: ReadonlyArray<Record<string, string | number>>,
+    display: readonly ColumnDisplay[],
+): TablePayload {
     const dict: Record<string, string[]> = {};
     const indexes = new Map<string, Map<string, number>>();
     for (const column of columns) {
@@ -110,7 +137,7 @@ export function encodeTablePayload(columns: readonly string[], rows: ReadonlyArr
             return index === undefined ? cell : index;
         }),
     );
-    return { columns: [...columns], rows: encodedRows, dict };
+    return { columns: [...columns], rows: encodedRows, dict, display: [...display] };
 }
 
 /**

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -19,7 +19,7 @@
 
 import { raw } from "hono/html";
 
-import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, GRID_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER } from "../page.js";
+import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, GRID_ASSET_HEAD, GRID_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER } from "../page.js";
 import { stagedSource } from "../assets.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { DataAsset } from "../table-data.js";
@@ -108,7 +108,7 @@ export function renderReferenceSection(ledger: ReferenceLedger, index: number, r
  *
  * Each data asset rides a classic `script` tag at the end of the body, and the decoder runs after the last
  * of them. Thus every payload is registered before any reader looks. A table block always gives one data
- * asset, thus a page with no asset carries no tag, no decoder, and no grid boot.
+ * asset, thus a page with no asset carries no tag, no decoder, no grid runtime, and no grid boot.
  */
 export function assemblePage(title: string, nav: string, content: string, references: string, dataAssets: readonly DataAsset[] = []): string {
     return (
@@ -120,6 +120,7 @@ export function assemblePage(title: string, nav: string, content: string, refere
                     <meta name="viewport" content="width=device-width, initial-scale=1" />
                     <title>{title}</title>
                     {raw(ASSET_HEAD)}
+                    {dataAssets.length > 0 ? raw(GRID_ASSET_HEAD) : null}
                     <style>{raw(DESIGN_CSS)}</style>
                 </head>
                 <body>

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -1,13 +1,13 @@
 /**
  * The page assembly: the hero, the bands, the appendix bands, and the footer.
  *
- * The skeleton inlines the style rules in the head, and it puts the five scripts at the end of the body.
- * The order of the first three scripts is a contract. The theme registration runs before the chart
- * bootstrap, thus each chart finds its theme. The fade-in observer also runs before the chart bootstrap,
- * thus the bootstrap finds the reveal gate and it signals readiness after the first reveal pass. The
- * scrollspy reads the sections alone, and the table enhancer reads the tables alone, thus the position of
- * each of the two is free. The navigation, the main content, and the reference frame arrive as
- * already-escaped markup strings, thus `raw()` inserts them byte for byte.
+ * The skeleton inlines the style rules in the head, and it puts the page scripts at the end of the body.
+ * The script order is a contract. The theme registration runs before the chart bootstrap, thus each chart
+ * finds its theme. The fade-in observer also runs before the chart bootstrap, thus the bootstrap finds the
+ * reveal gate and it signals readiness after the first reveal pass. The grid boot runs before the chart
+ * bootstrap too, thus every grid stands before the page signals that it is ready. The scrollspy reads the
+ * sections alone, thus its position is free. The navigation, the main content, and the reference frame
+ * arrive as already-escaped markup strings, thus `raw()` inserts them byte for byte.
  *
  * One band holds one top-level section. The band index drives the alternation of the background and of the
  * texture, thus a caller that adds a band passes the next index.
@@ -19,7 +19,7 @@
 
 import { raw } from "hono/html";
 
-import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, SECTION_SPY, TABLE_DATA_DECODER, TABLE_ENHANCER } from "../page.js";
+import { ASSET_HEAD, CHART_BOOTSTRAP, FADE_IN_OBSERVER, GRID_BOOTSTRAP, SECTION_SPY, TABLE_DATA_DECODER } from "../page.js";
 import { stagedSource } from "../assets.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { DataAsset } from "../table-data.js";
@@ -107,8 +107,8 @@ export function renderReferenceSection(ledger: ReferenceLedger, index: number, r
  * optional, thus an empty frame adds no markup.
  *
  * Each data asset rides a classic `script` tag at the end of the body, and the decoder runs after the last
- * of them. Thus every payload is registered before any reader looks, and a page with no table carries
- * neither a tag nor the decoder.
+ * of them. Thus every payload is registered before any reader looks. A table block always gives one data
+ * asset, thus a page with no asset carries no tag, no decoder, and no grid boot.
  */
 export function assemblePage(title: string, nav: string, content: string, references: string, dataAssets: readonly DataAsset[] = []): string {
     return (
@@ -150,9 +150,9 @@ export function assemblePage(title: string, nav: string, content: string, refere
                     {dataAssets.length > 0 ? <script>{raw(TABLE_DATA_DECODER)}</script> : null}
                     <script>{raw(THEME_REGISTRATION)}</script>
                     <script>{raw(FADE_IN_OBSERVER)}</script>
+                    {dataAssets.length > 0 ? <script>{raw(GRID_BOOTSTRAP)}</script> : null}
                     <script>{raw(CHART_BOOTSTRAP)}</script>
                     <script>{raw(SECTION_SPY)}</script>
-                    <script>{raw(TABLE_ENHANCER)}</script>
                 </body>
             </html>,
         )

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -3,7 +3,17 @@ import { describe, expect, it } from "bun:test";
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import type { ScalarReference } from "../../contracts/report-reference.js";
 import { tableSidecarName } from "../assets.js";
-import { GRID_MOUNT_ATTRIBUTE, renderCitation, renderFigure, renderMetric, renderTable, tableDisplay } from "./values.js";
+import {
+    GRID_COUNT_CLASS,
+    GRID_MOUNT_ATTRIBUTE,
+    GRID_NOTE_CLASS,
+    GRID_ROWS_WORD,
+    renderCitation,
+    renderFigure,
+    renderMetric,
+    renderTable,
+    tableDisplay,
+} from "./values.js";
 import { ReferenceLedger } from "../references.js";
 
 const scalarBinding: ScalarReference = { kind: "artifact-value", path: "runs/r1/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
@@ -88,6 +98,28 @@ describe("tableDisplay", () => {
         expect(display[0].label).toBe("gene symbol");
     });
 
+    it("takes the filter of a column from its cells and not from its kind", () => {
+        const display = displayOf(block, ["gene", "padj"], [{ gene: "TP53", padj: 0.01 }]);
+
+        // A gene column holds names, thus a reader filters it by name. A p-value column holds magnitudes.
+        expect(display[0].filter).toBe("text");
+        expect(display[1].filter).toBe("number");
+    });
+
+    it("keeps the number filter of a column that holds a sentinel beside its numbers", () => {
+        const rows = [{ reads: "NA" }, { reads: 14201 }];
+        expect(displayOf(block, ["reads"], rows)[0].filter).toBe("number");
+        // A column where no cell parses holds names, thus it filters as text.
+        expect(displayOf(block, ["direction"], [{ direction: "up" }, { direction: "down" }])[0].filter).toBe("text");
+    });
+
+    it("gives the number filter to an identifier column that holds numeric text", () => {
+        // The kind keeps the source text of the identifier, and the filter reads what the cells hold.
+        const display = displayOf(block, ["pmid"], [{ pmid: "31978945" }]);
+        expect(display[0].kind).toBe("identifier");
+        expect(display[0].filter).toBe("number");
+    });
+
     it("reads a p-value column as the scientific kind and every other column as the rounded kind", () => {
         const display = displayOf(block, ["gene", "padj", "reads"], [{ gene: "TP53", padj: 0.01, reads: 14201 }]);
 
@@ -144,7 +176,7 @@ describe("renderTable", () => {
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
 
     it("renders one empty grid mount that names its block, and no row", () => {
-        const html = renderTable(block);
+        const html = renderTable(block, 3);
 
         expect(html).toContain(`<div class="report-grid" ${GRID_MOUNT_ATTRIBUTE}="tb1"></div>`);
         // The rows and the header ride the data asset, thus the markup carries no copy of either.
@@ -154,25 +186,64 @@ describe("renderTable", () => {
     });
 
     it("renders the title of the card and the caption under it", () => {
-        const html = renderTable({ ...block, title: "Top genes", caption: "The hypoxic group." });
+        const html = renderTable({ ...block, title: "Top genes", caption: "The hypoxic group." }, 3);
 
         expect(html).toContain(`<div class="report-table-title">Top genes</div>`);
         expect(html).toContain(`<p class="report-caption">The hypoxic group.</p>`);
     });
 
-    it("links the staged raw bytes of the pinned artifact as the download", () => {
-        const html = renderTable(block);
+    it("states the row count of the table in the status line, grouped", () => {
+        const html = renderTable(block, 14201);
+
+        // The count reads as the number format of the page reads a count, thus the card and a cell agree.
+        expect(html).toContain(`<span class="${GRID_COUNT_CLASS}">14,201 ${GRID_ROWS_WORD}</span>`);
+    });
+
+    it("names the row bound of the binding beside the count, and nothing where the binding carries none", () => {
+        const bounded: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "padj", count: 20, order: "asc" } } };
+        // An ascending bound keeps the smallest values, thus the status names that end of the ranked order.
+        expect(renderTable(bounded, 20)).toContain(`<span class="report-table-bound">lowest 20 by padj</span>`);
+
+        const top: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "nes", count: 20 } } };
+        expect(renderTable(top, 20)).toContain(`<span class="report-table-bound">top 20 by nes</span>`);
+
+        // The declared label of the column names the bound, the same as it names the header.
+        const labeled: TableBlock = {
+            kind: "table",
+            id: "tb1",
+            binding: { ...tableBinding, rowBound: { column: "padj", count: 6 }, columnLabels: { padj: "Adjusted p-value" } },
+        };
+        expect(renderTable(labeled, 6)).toContain("top 6 by Adjusted p-value");
+
+        // A large bound groups its digits, the same as the count beside it.
+        const wide: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "nes", count: 5000 } } };
+        expect(renderTable(wide, 5000)).toContain("top 5,000 by nes");
+        expect(renderTable(block, 6)).not.toContain("report-table-bound");
+    });
+
+    it("renders the download as a button of the card footer, named for the format of the file", () => {
+        const html = renderTable(block, 2);
         const name = tableSidecarName(tableBinding.hash, tableBinding.path);
 
         // The link is relative, thus the page fetches no host when it opens. The attribute makes the
         // browser save the file instead of navigating to it.
-        expect(html).toContain(`href="assets/${name}"`);
-        expect(html).toContain(`download="${name}"`);
+        expect(html).toContain(`<a class="report-table-download" href="assets/${name}" download="${name}">Download CSV</a>`);
         expect(name.endsWith("de.csv")).toBe(true);
+        // The status and the button sit in one row of the footer, and the print note sits under them.
+        expect(html).toContain(`<div class="report-table-footer"><div class="report-table-footer-row">`);
+        expect(html).toContain(`<div class="${GRID_NOTE_CLASS}"></div></div>`);
+    });
+
+    it("names the format of another file, and it names none where the path carries no extension", () => {
+        const parquet: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, path: "runs/r1/de.parquet" } };
+        expect(renderTable(parquet, 2)).toContain(">Download PARQUET</a>");
+
+        const bare: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, path: "runs/r1/table" } };
+        expect(renderTable(bare, 2)).toContain(">Download</a>");
     });
 
     it("carries no filter, no toggle, and no capped row, because the grid owns the table", () => {
-        const html = renderTable(block);
+        const html = renderTable(block, 25);
 
         for (const retired of ["report-table-filter", "report-table-toggle", "report-row", "data-table"]) {
             expect(html).not.toContain(retired);

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
 import type { ScalarReference } from "../../contracts/report-reference.js";
 import { tableSidecarName } from "../assets.js";
-import { renderCitation, renderFigure, renderMetric, renderTable, renderTableRows, TABLE_ROW_CAP } from "./values.js";
+import { GRID_MOUNT_ATTRIBUTE, renderCitation, renderFigure, renderMetric, renderTable, tableDisplay } from "./values.js";
 import { ReferenceLedger } from "../references.js";
 
 const scalarBinding: ScalarReference = { kind: "artifact-value", path: "runs/r1/de.csv", hash: "sha256:aaa", locator: { column: "padj", row: 0 } };
@@ -57,210 +57,85 @@ describe("renderMetric", () => {
     });
 });
 
-describe("renderTableRows", () => {
+describe("tableDisplay", () => {
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
-
-    /** One table value of `count` rows. The gene column numbers each row, thus a sorted order is readable. */
-    function rowsOf(count: number) {
-        const rows = [];
-        for (let index = 0; index < count; index += 1) {
-            rows.push({ gene: `G${index}`, padj: 0.01 });
-        }
-        return { type: "table", rows } as const;
-    }
-
-    it("renders one row for each resolved row", () => {
-        const html = renderTableRows(block, {
-            type: "table",
-            rows: [
-                { gene: "TP53", padj: 0.01 },
-                { gene: "MYC", padj: 0.02 },
-                { gene: "EGFR", padj: 0.03 },
-            ],
-        });
-        expect(html.split(`<tr class="report-row`).length - 1).toBe(3);
-        expect(html).toContain("TP53");
-    });
-
-    it("renders nothing for a zero-row table", () => {
-        expect(renderTableRows(block, { type: "table", rows: [], columns: ["gene", "padj"] })).toBe("");
-    });
-
-    it("renders an absent cell as an empty cell", () => {
-        const html = renderTableRows(block, {
-            type: "table",
-            rows: [{ gene: "TP53", padj: 0.01 }, { gene: "MYC" }],
-            columns: ["gene", "padj"],
-        });
-        expect(html).toContain(`<td data-value=""></td>`);
-        expect(html).not.toContain("undefined");
-    });
-
-    it("shows a p-value column in the scientific form with the full digits on the title", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", padj: 0.0000427777663038 }] });
-        expect(html).toContain(`<td data-value="0.0000427777663038" title="0.0000427777663038">4.3e-5</td>`);
-    });
-
-    it("rounds a long float to three significant digits and keeps the full digits on the title", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: -3.089028528355109 }] });
-        expect(html).toContain(`<td data-value="-3.089028528355109" title="-3.089028528355109">-3.09</td>`);
-    });
-
-    it("groups a count and gives it no title, because the grouping hides no digit", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", reads: 14201 }] });
-        expect(html).toContain(`<td data-value="14201">14,201</td>`);
-    });
-
-    it("keeps an identifier column whole, with no grouping and no title", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", pmid: "31978945" }] });
-        expect(html).toContain(`<td data-value="31978945">31978945</td>`);
-        expect(html).not.toContain("31,978,945");
-        expect(html).not.toContain("title=");
-    });
-
-    it("gives a grouped whole number to a large float and keeps the full digits on the title", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
-        expect(html).toContain(`<td data-value="15234.7" title="15234.7">15,235</td>`);
-    });
-
-    it("passes a non-numeric cell through unchanged and gives it no title", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", direction: "up" }] });
-        expect(html).toContain(`<td data-value="up">up</td>`);
-        expect(html).not.toContain("title=");
-    });
-
-    it("carries the raw value of a shortened cell, thus the sort reads the full magnitude", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", baseMean: 15234.7 }] });
-        // The shown text is a rounded form. A sort over the shown text would order `15,235` as a string.
-        expect(html).toContain(`data-value="15234.7"`);
-    });
-
-    it("marks each row past the cap as hidden", () => {
-        const total = TABLE_ROW_CAP + 5;
-        const html = renderTableRows(block, rowsOf(total));
-        expect(html.split(`<tr class="report-row`).length - 1).toBe(total);
-        expect(html.split(`<tr class="report-row report-row-hidden">`).length - 1).toBe(5);
-    });
-
-    it("marks no row of a table at the cap as hidden", () => {
-        const html = renderTableRows(block, rowsOf(TABLE_ROW_CAP));
-        expect(html.split(`<tr class="report-row">`).length - 1).toBe(TABLE_ROW_CAP);
-        expect(html).not.toContain("report-row-hidden");
-    });
-
-    it("shows the first segment of a delimited name and keeps the whole name on the title", () => {
-        const name = "HALLMARK_HYPOXIA%MSigDB%M5891";
-        const html = renderTableRows(block, { type: "table", rows: [{ set: name, padj: 0.01 }] });
-        expect(html).toContain(`<td data-value="${name}" title="${name}">HALLMARK_HYPOXIA</td>`);
-    });
-
-    it("keeps a text whose last segment is empty, thus a percentage stays whole", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", coverage: "95%" }] });
-        expect(html).toContain(`<td data-value="95%">95%</td>`);
-    });
-
-    it("keeps a text of two segments whole, because an encoded name holds three", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", note: "KEGG%hsa04110" }] });
-        expect(html).toContain(`<td data-value="KEGG%hsa04110">KEGG%hsa04110</td>`);
-    });
-
-    it("keeps a sentence with a percentage whole, because a segment of an encoded name holds no space", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", change: "up 20% vs control%cohort" }] });
-        expect(html).toContain(`<td data-value="up 20% vs control%cohort">up 20% vs control%cohort</td>`);
-    });
 
     /** One table block whose binding carries the declarations that a test states. */
     function declared(declaration: Pick<TableBlock["binding"], "columnMeanings" | "columnLabels">): TableBlock {
         return { kind: "table", id: "tb1", binding: { ...tableBinding, ...declaration } };
     }
 
-    it("reads a declared p-value column in the scientific form, although its name matches no token", () => {
-        const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.00427777663038 }] } as const;
-        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
-        expect(html).toContain(`<td data-value="0.00427777663038" title="0.00427777663038">4.3e-3</td>`);
-        // The same cell with no declaration keeps the guess, thus the declaration is what moved the kind.
-        expect(renderTableRows(block, rows)).toContain(`>0.00428</td>`);
+    /** The display of the named columns over the given rows, in the column order. */
+    function displayOf(table: TableBlock, columns: string[], rows: Record<string, string | number>[]) {
+        return tableDisplay(table, { type: "table", rows }, columns);
+    }
+
+    it("gives one entry for each column, in the column order", () => {
+        const display = displayOf(block, ["gene", "padj"], [{ gene: "TP53", padj: 0.01 }]);
+
+        expect(display.length).toBe(2);
+        expect(display[0].label).toBe("gene");
+        expect(display[1].label).toBe("padj");
     });
 
-    it("keeps a declared p-value from one hundredth up as a plain decimal with no full form", () => {
-        const rows = { type: "table", rows: [{ gene: "TP53", significance: 0.536 }] } as const;
-        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
-        expect(html).toContain(`<td data-value="0.536">0.536</td>`);
-        expect(html).not.toContain("5.4e-1");
+    it("shows the declared label of a column", () => {
+        const display = displayOf(declared({ columnLabels: { padj: "Adjusted p-value" } }), ["padj"], [{ padj: 0.01 }]);
+        expect(display[0].label).toBe("Adjusted p-value");
     });
 
-    it("bounds a zero FDR by the smallest positive value of its own column", () => {
-        const html = renderTableRows(block, {
-            type: "table",
-            rows: [
-                { gene: "TP53", fdr: 0 },
-                { gene: "MYC", fdr: 0.00036 },
-                { gene: "EGFR", fdr: 0.02 },
-            ],
-        });
-        // The runtime escapes the `<` of the bound, thus the comparison reaches the page as text.
-        expect(html).toContain(`<td data-value="0" title="0">&lt;4e-4</td>`);
-        expect(html).not.toContain(`>0</td>`);
+    it("prettifies the label of an undeclared column", () => {
+        const display = displayOf(block, ["gene_symbol"], [{ gene_symbol: "TP53" }]);
+        expect(display[0].label).toBe("gene symbol");
     });
 
-    it("bounds a zero of a declared p-value column, the same as a token-matched one", () => {
-        const rows = {
-            type: "table",
-            rows: [
-                { gene: "TP53", significance: 0 },
-                { gene: "MYC", significance: 0.00036 },
-            ],
-        } as const;
-        const html = renderTableRows(declared({ columnMeanings: { significance: "p-value" } }), rows);
-        expect(html).toContain(`<td data-value="0" title="0">&lt;4e-4</td>`);
-        // With no declaration the name matches no token, thus the zero stays a count-like zero.
-        expect(renderTableRows(block, rows)).toContain(`<td data-value="0">0</td>`);
+    it("reads a p-value column as the scientific kind and every other column as the rounded kind", () => {
+        const display = displayOf(block, ["gene", "padj", "reads"], [{ gene: "TP53", padj: 0.01, reads: 14201 }]);
+
+        expect(display[0].kind).toBe("compact-scientific");
+        expect(display[1].kind).toBe("scientific");
+        expect(display[2].kind).toBe("compact-scientific");
     });
 
-    it("shows the near-zero form for a p-value column that holds no positive value", () => {
-        const html = renderTableRows(block, {
-            type: "table",
-            rows: [
-                { gene: "TP53", padj: 0 },
-                { gene: "MYC", padj: 0 },
-            ],
-        });
-        expect(html).toContain(`<td data-value="0" title="0">≈0</td>`);
+    it("reads a declared p-value column as the scientific kind, although its name matches no token", () => {
+        const table = declared({ columnMeanings: { significance: "p-value" } });
+        expect(displayOf(table, ["significance"], [{ significance: 0.004 }])[0].kind).toBe("scientific");
+        // The same column with no declaration matches no token, thus it keeps the rounded kind.
+        expect(displayOf(block, ["significance"], [{ significance: 0.004 }])[0].kind).toBe("compact-scientific");
     });
 
-    it("reads each p-value column on its own, thus a neighbor of one column bounds no other", () => {
-        const html = renderTableRows(block, {
-            type: "table",
-            rows: [
-                { pvalue: 0, padj: 0.00036 },
-                { pvalue: 0.0002, padj: 0 },
-            ],
-        });
-        expect(html).toContain(`>&lt;2e-4</td>`);
-        expect(html).toContain(`>&lt;4e-4</td>`);
+    it("reads an identifier column and a declared category column as the identifier kind", () => {
+        expect(displayOf(block, ["pmid"], [{ pmid: "31978945" }])[0].kind).toBe("identifier");
+        const table = declared({ columnMeanings: { cluster: "category" } });
+        expect(displayOf(table, ["cluster"], [{ cluster: "01" }])[0].kind).toBe("identifier");
     });
 
-    it("keeps the zero of a declared count column", () => {
-        const html = renderTableRows(declared({ columnMeanings: { hits: "count" } }), { type: "table", rows: [{ gene: "TP53", hits: 0 }] });
-        expect(html).toContain(`<td data-value="0">0</td>`);
-        expect(html).not.toContain("≈0");
+    it("bounds a p-value column by the smallest positive value of its own rows", () => {
+        const rows = [
+            { fdr: 0, pvalue: 0.0002 },
+            { fdr: 0.00036, pvalue: 0 },
+            { fdr: 0.02, pvalue: 0.5 },
+        ];
+        const display = displayOf(block, ["fdr", "pvalue"], rows);
+
+        // Each column reads on its own, thus the neighbor of one column bounds no other.
+        expect(display[0].bound).toBe(0.00036);
+        expect(display[1].bound).toBe(0.0002);
     });
 
-    it("keeps the zero of an undeclared column of a different nature", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "TP53", log2FoldChange: 0, reads: 0 }] });
-        expect(html.split(`<td data-value="0">0</td>`).length - 1).toBe(2);
+    it("gives no bound to a p-value column that holds no positive value", () => {
+        const display = displayOf(block, ["padj"], [{ padj: 0 }, { padj: 0 }]);
+        expect(display[0].bound).toBeUndefined();
+    });
+
+    it("gives no bound to a column of another nature, because no zero of it reads as a bound", () => {
+        const display = displayOf(block, ["reads"], [{ reads: 0 }, { reads: 14201 }]);
+        expect(display[0].bound).toBeUndefined();
     });
 
     it("ignores a declaration that names no column of the table", () => {
-        const rows = { type: "table", rows: [{ gene: "TP53", padj: 0.00427777663038 }] } as const;
         const stray = declared({ columnMeanings: { absent: "identifier" }, columnLabels: { absent: "Absent column" } });
-        expect(renderTableRows(stray, rows)).toBe(renderTableRows(block, rows));
-    });
-
-    it("keeps a hostile cell as text after the format passes it through", () => {
-        const html = renderTableRows(block, { type: "table", rows: [{ gene: "<script>alert(1)</script>", padj: 0.01 }] });
-        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
-        expect(html).not.toContain("<script>alert(1)");
+        const rows = [{ gene: "TP53", padj: 0.004 }];
+        expect(displayOf(stray, ["gene", "padj"], rows)).toEqual(displayOf(block, ["gene", "padj"], rows));
     });
 });
 
@@ -268,63 +143,25 @@ describe("renderTable", () => {
     /** The block that every card test renders. Its binding names the pinned artifact of the download. */
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
 
-    /** One table block whose binding carries the declarations that a test states. */
-    function declared(declaration: Pick<TableBlock["binding"], "columnMeanings" | "columnLabels">): TableBlock {
-        return { kind: "table", id: "tb1", binding: { ...tableBinding, ...declaration } };
-    }
+    it("renders one empty grid mount that names its block, and no row", () => {
+        const html = renderTable(block);
 
-    /** One table value of `count` rows. The card renders none of them, thus the count states the input alone. */
-    function rowsOf(count: number) {
-        const rows = [];
-        for (let index = 0; index < count; index += 1) {
-            rows.push({ gene: `G${index}`, padj: 0.01 });
-        }
-        return { type: "table", rows } as const;
-    }
-
-    it("renders one header cell for each column and no data row", () => {
-        const html = renderTable(block, rowsOf(3));
-
-        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
-        // The rows ride the data asset, thus the markup carries no copy of them.
-        expect(html).toContain("<tbody></tbody>");
+        expect(html).toContain(`<div class="report-grid" ${GRID_MOUNT_ATTRIBUTE}="tb1"></div>`);
+        // The rows and the header ride the data asset, thus the markup carries no copy of either.
+        expect(html).not.toContain("<table");
+        expect(html).not.toContain("<th");
         expect(html).not.toContain("<td");
-        expect(html).not.toContain("G0");
     });
 
-    it("renders the header of a zero-row table with named columns", () => {
-        const html = renderTable(block, { type: "table", rows: [], columns: ["gene", "padj"] });
-        expect(html.split(`<th class="data-table-sort"`).length - 1).toBe(2);
-    });
+    it("renders the title of the card and the caption under it", () => {
+        const html = renderTable({ ...block, title: "Top genes", caption: "The hypoxic group." });
 
-    it("keeps the body empty however many rows resolve", () => {
-        expect(renderTable(block, rowsOf(TABLE_ROW_CAP + 5))).toContain("<tbody></tbody>");
-        expect(renderTable(block, rowsOf(TABLE_ROW_CAP + 5))).not.toContain("report-row");
-    });
-
-    it("gives each sortable header the tab order, thus the keyboard reaches the sort", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
-        expect(html.split(`<th class="data-table-sort" data-sort-index="`).length - 1).toBe(2);
-        expect(html.split(`tabindex="0"`).length - 1).toBe(2);
-    });
-
-    it("shows the declared label of a column and keeps the raw name on hover", () => {
-        const html = renderTable(declared({ columnLabels: { padj: "Adjusted p-value" } }), { type: "table", rows: [{ gene: "TP53", padj: 0.01 }] });
-        expect(html).toContain(`tabindex="0" title="padj">Adjusted p-value</th>`);
-    });
-
-    it("prettifies an undeclared header and keeps the raw name on hover", () => {
-        const html = renderTable(block, { type: "table", rows: [{ gene_symbol: "TP53" }] });
-        expect(html).toContain(`tabindex="0" title="gene_symbol">gene symbol</th>`);
-    });
-
-    it("gives no title to a header whose shown text is its raw name", () => {
-        const html = renderTable(declared({ columnLabels: { gene: "gene" } }), { type: "table", rows: [{ gene: "TP53" }] });
-        expect(html).toContain(`tabindex="0">gene</th>`);
+        expect(html).toContain(`<div class="report-table-title">Top genes</div>`);
+        expect(html).toContain(`<p class="report-caption">The hypoxic group.</p>`);
     });
 
     it("links the staged raw bytes of the pinned artifact as the download", () => {
-        const html = renderTable(block, rowsOf(2));
+        const html = renderTable(block);
         const name = tableSidecarName(tableBinding.hash, tableBinding.path);
 
         // The link is relative, thus the page fetches no host when it opens. The attribute makes the
@@ -334,10 +171,12 @@ describe("renderTable", () => {
         expect(name.endsWith("de.csv")).toBe(true);
     });
 
-    it("carries no filter and no toggle, because the enhancer drives neither over an empty body", () => {
-        const html = renderTable(block, rowsOf(TABLE_ROW_CAP + 5));
-        expect(html).not.toContain("report-table-filter");
-        expect(html).not.toContain("report-table-toggle");
+    it("carries no filter, no toggle, and no capped row, because the grid owns the table", () => {
+        const html = renderTable(block);
+
+        for (const retired of ["report-table-filter", "report-table-toggle", "report-row", "data-table"]) {
+            expect(html).not.toContain(retired);
+        }
     });
 });
 

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -13,9 +13,9 @@
  * declares for its column, and the column name answers for a column that declares none. A metric takes its
  * label, because a value locator declares no column-wide meaning.
  *
- * A table card carries the header of its table, an empty body, and the download of the raw pinned bytes.
- * The rows ride a data asset beside the page, thus the markup carries no copy of them. `renderTableRows`
- * holds the presentation of a cell, and it stays beside the card that owns that presentation.
+ * A table card carries the grid mount and the download of the raw pinned bytes. The rows and the display of
+ * each column ride a data asset beside the page, and the page script builds the grid over them. Thus the
+ * markup carries no row, and `tableDisplay` gives the page what the server resolved for each column.
  *
  * Each data card carries the `corner-accents` class. Thus the card keeps square corners with the L-shaped
  * accents, which is the geometric identity of the report.
@@ -24,39 +24,21 @@
 import { raw } from "hono/html";
 
 import type { CitationBlock, FigureBlock, MetricBlock, TableBlock } from "../../contracts/report-blocks.js";
-import { declaredForColumn, type ColumnMeaning } from "../../contracts/report-reference.js";
+import { declaredForColumn } from "../../contracts/report-reference.js";
 import type { CitationRecord } from "../../report-model/reference-resolver.js";
 import { stagedSource, tableSidecarName } from "../assets.js";
 import { LadderMarker } from "./references-view.js";
-import { formatNumberCell, holdsAPValue, selectNumberKind, smallestPositiveValue } from "../number-format.js";
+import { formatNumberCell, selectColumnKind, selectNumberKind, smallestPositiveValue } from "../number-format.js";
 import { citationKeyOf, type ReferenceLedger } from "../references.js";
+import type { ColumnDisplay } from "../table-data.js";
 import type { RenderValue } from "../types.js";
 
 /**
- * The count of table rows that the page shows before the toggle.
+ * The attribute that marks the grid mount of a table card, and that names the block of its data.
  *
- * The cap is a renderer constant, thus a block carries no field for it and the column subset stays the one
- * content-level choice. The page enhancer reads the same constant, thus the markup and the script bound the
- * table at one number.
+ * The page script reads the same attribute, thus the card and the boot cannot disagree over a rename.
  */
-export const TABLE_ROW_CAP = 20;
-
-/** The delimiter of an encoded set name, for example `HALLMARK_HYPOXIA%MSigDB%M5891`. */
-const NAME_DELIMITER = "%";
-
-/** The count of segments that an encoded set name holds: the name, the collection, and the accession. */
-const NAME_SEGMENTS = 3;
-
-/** One whitespace character. A segment of an encoded name holds none. */
-const WHITESPACE = /\s/;
-
-/**
- * The collapsed label of the row-cap toggle.
- *
- * The view composes the label at render, and the enhancer composes it again from the count that the filter
- * keeps. Both read this one prefix, thus the two labels cannot drift apart.
- */
-export const SHOW_ALL_PREFIX = "Show all ";
+export const GRID_MOUNT_ATTRIBUTE = "data-report-grid";
 
 /** The label of the download link of a table card. It names what the reader gets, which is the whole table. */
 const DOWNLOAD_LABEL = "Download the full table";
@@ -120,174 +102,61 @@ export function tableColumns(value: TableValue): string[] {
 }
 
 /**
- * The first segment of a delimited name, or `undefined` when the text carries no delimited name.
- *
- * An enrichment tool joins the name of a set, its collection, and its accession with a percent sign. The
- * name alone identifies the row, thus the rest is noise inside a narrow column.
- *
- * Such a name holds three or more segments, each segment holds a character, and no segment holds a
- * whitespace character. Every other text keeps its whole form. Thus `95%` stays whole, and a sentence such
- * as `up 20% vs control` stays whole.
- */
-function firstNameSegment(text: string): string | undefined {
-    const segments = text.split(NAME_DELIMITER);
-    if (segments.length < NAME_SEGMENTS) {
-        return undefined;
-    }
-    const encoded = segments.every((segment) => segment.length > 0 && !WHITESPACE.test(segment));
-    return encoded ? segments[0] : undefined;
-}
-
-/**
- * The heading of one column: the text on the page, and the raw name for the `title` attribute.
+ * The header label of one column.
  *
  * A declared label names what the column measures. A column with no label prettifies, thus an underscore
- * reads as a space. The raw name rides the hover only when the shown text differs from it, because a title
- * that repeats the text tells a reader nothing.
+ * reads as a space. The page compares the label against the raw name, and it puts the raw name on the
+ * header hover where the two differ.
  */
-function columnHeading(column: string, labels: TableBlock["binding"]["columnLabels"]): { text: string; title?: string } {
-    const label = declaredForColumn(labels, column);
-    const text = label ?? column.replaceAll("_", " ");
-    return text === column ? { text } : { text, title: column };
+function columnLabel(column: string, labels: TableBlock["binding"]["columnLabels"]): string {
+    return declaredForColumn(labels, column) ?? column.replaceAll("_", " ");
 }
 
 /**
- * The smallest positive value of each p-value column, keyed by the column name.
+ * The display of each column of a table, in the column order of the header.
  *
- * A stored zero in such a column renders as a bound under its smallest positive neighbor. The view reads
- * each p-value column one time here, thus the cell format stays column-blind and a wide table reads no
- * column twice. A column with no positive value takes no entry, and its zero then renders as the near-zero
- * form.
+ * The renderer resolves the label, the number kind, and the bound of a stored zero one time for each
+ * column, and the data asset ships them. Thus the page formats a cell with no read of a declaration and no
+ * second pass over a column.
+ *
+ * A probability column carries the smallest positive value of its own rows as the bound. The read runs one
+ * time for each such column, thus a wide table reads no column twice. A column with no positive value takes
+ * no bound, and its zero then reads as the near-zero form.
  */
-function pValueBounds(columns: readonly string[], value: TableValue, meanings: TableBlock["binding"]["columnMeanings"]): Map<string, number> {
-    const bounds = new Map<string, number>();
-    for (const column of columns) {
-        if (!holdsAPValue(column, declaredForColumn(meanings, column))) {
-            continue;
+export function tableDisplay(block: TableBlock, value: TableValue, columns: readonly string[]): ColumnDisplay[] {
+    const binding = block.binding;
+    return columns.map((column) => {
+        const kind = selectColumnKind(column, declaredForColumn(binding.columnMeanings, column));
+        const label = columnLabel(column, binding.columnLabels);
+        if (kind !== "scientific") {
+            return { label, kind };
         }
         const bound = smallestPositiveValue(value.rows.map((row) => row[column]));
-        if (bound !== undefined) {
-            bounds.set(column, bound);
-        }
-    }
-    return bounds;
+        return bound === undefined ? { label, kind } : { label, kind, bound };
+    });
 }
 
 /**
- * One body cell of a table.
- *
- * The declared meaning selects the number kind, and the column name selects it for a column that declares
- * none. Thus a p-value column reads in the scientific form. The full digits ride the `title` attribute when
- * the shown form hides one. An absent cell renders as an empty cell, thus a ragged row keeps its shape.
- *
- * `bound` is the smallest positive value of the column. A stored zero of a p-value column reads as a bound
- * under it, thus the page never prints a p-value of zero.
- *
- * Each cell carries its raw value in the `data-value` attribute. The page enhancer sorts on that value, thus
- * the shown text stays presentation and a rounded number still sorts by its full magnitude.
- *
- * A delimited name shows its first segment, and the whole name rides the `title` attribute. Such a name
- * holds no finite number, thus the number format passed it through and this trim reads the text that the
- * format gave.
- */
-function Cell({
-    column,
-    cell,
-    meaning,
-    bound,
-}: {
-    column: string;
-    cell: string | number | undefined;
-    meaning: ColumnMeaning | undefined;
-    bound: number | undefined;
-}) {
-    if (cell === undefined) {
-        return <td data-value=""></td>;
-    }
-    const shown = formatNumberCell(cell, selectNumberKind(column, cell, meaning), bound);
-    const segment = firstNameSegment(shown.text);
-    if (segment !== undefined) {
-        return (
-            <td data-value={String(cell)} title={shown.text}>
-                {segment}
-            </td>
-        );
-    }
-    return (
-        <td data-value={String(cell)} title={shown.full}>
-            {shown.text}
-        </td>
-    );
-}
-
-/**
- * Render the body rows of a table as markup: one row for each resolved row, each cell under the format of
- * its column.
- *
- * The card renders no body row today, because the rows of a table ride a data asset and the page reads
- * them from there. This function is the one home of the cell presentation: the declared meaning, the
- * number format, the p-value bound of a column, and the trim of a delimited name. It stays beside the card
- * that it belongs to, thus the presentation of a cell has one definition.
- *
- * A row past the cap carries the hidden class, and the enhancer hides it under its live marker alone.
- */
-export function renderTableRows(block: TableBlock, value: TableValue): string {
-    const columns = tableColumns(value);
-    const binding = block.binding;
-    const bounds = pValueBounds(columns, value, binding.columnMeanings);
-    return String(
-        <>
-            {value.rows.map((row, index) => (
-                <tr class={index < TABLE_ROW_CAP ? "report-row" : "report-row report-row-hidden"}>
-                    {columns.map((column) => (
-                        <Cell column={column} cell={row[column]} meaning={declaredForColumn(binding.columnMeanings, column)} bound={bounds.get(column)} />
-                    ))}
-                </tr>
-            ))}
-        </>,
-    );
-}
-
-/**
- * Render a table block as the header of its table, the download of its raw bytes, and an empty body.
+ * Render a table block as the grid mount and the download of its raw bytes.
  *
  * The rows ride a data asset beside the page. A page that stamped 14,201 rows into its markup weighed
- * megabytes, and each row was a copy of the column names. Thus the markup holds the header alone, and the
- * page reads the rows from the payload that registers under the block id.
+ * megabytes, and each row was a copy of the column names. Thus the markup holds one empty mount, and the
+ * page script builds the grid over the payload that registers under the block id.
  *
- * Each header cell stays a plain `th`. It carries the sort class and the index of its column, thus the
- * enhancer reads the column of a click and a browser with no script keeps a plain header. The header also
- * takes the tab order, thus a reader sorts the table from the keyboard. The header shows the declared label
- * of the column, and the raw name rides the `title` attribute.
+ * The mount names its block in the mount attribute. A mount whose block the registry does not hold stays
+ * empty, thus the card keeps its title and its download and the page throws nothing.
  *
  * The download names the staged copy of the pinned artifact. The link is relative and the browser saves
  * the file, thus the page fetches nothing when it opens and the reader still gets the whole table.
  */
-export function renderTable(block: TableBlock, value: TableValue): string {
-    const columns = tableColumns(value);
+export function renderTable(block: TableBlock): string {
     const binding = block.binding;
     const download = tableSidecarName(binding.hash, binding.path);
     return String(
         <div class="report-table">
             {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
             <div class="corner-accents">
-                <div class="data-table-scroll">
-                    <table class="data-table">
-                        <thead>
-                            <tr>
-                                {columns.map((column, index) => {
-                                    const heading = columnHeading(column, binding.columnLabels);
-                                    return (
-                                        <th class="data-table-sort" data-sort-index={String(index)} tabindex={0} title={heading.title}>
-                                            {heading.text}
-                                        </th>
-                                    );
-                                })}
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
+                <div class="report-grid" {...{ [GRID_MOUNT_ATTRIBUTE]: block.id }}></div>
                 <div class="report-table-footer">
                     <a class="report-table-download" href={stagedSource(download)} download={download}>
                         {DOWNLOAD_LABEL}

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -28,9 +28,9 @@ import { declaredForColumn } from "../../contracts/report-reference.js";
 import type { CitationRecord } from "../../report-model/reference-resolver.js";
 import { stagedSource, tableSidecarName } from "../assets.js";
 import { LadderMarker } from "./references-view.js";
-import { formatNumberCell, selectColumnKind, selectNumberKind, smallestPositiveValue } from "../number-format.js";
+import { formatNumberCell, formatTableCell, holdsANumber, selectColumnKind, selectNumberKind, smallestPositiveValue } from "../number-format.js";
 import { citationKeyOf, type ReferenceLedger } from "../references.js";
-import type { ColumnDisplay } from "../table-data.js";
+import type { ColumnDisplay, ColumnFilter } from "../table-data.js";
 import type { RenderValue } from "../types.js";
 
 /**
@@ -40,8 +40,28 @@ import type { RenderValue } from "../types.js";
  */
 export const GRID_MOUNT_ATTRIBUTE = "data-report-grid";
 
-/** The label of the download link of a table card. It names what the reader gets, which is the whole table. */
-const DOWNLOAD_LABEL = "Download the full table";
+/**
+ * The class of the print note of a table card.
+ *
+ * The note is empty on the screen. The page script writes the bound of a truncated print form into it at
+ * print time, and it clears the text after. The page script reads the same class, thus the card and the
+ * boot cannot disagree over a rename.
+ */
+export const GRID_NOTE_CLASS = "report-grid-note";
+
+/**
+ * The class of the row count of a table card.
+ *
+ * The renderer writes the count of the resolved rows, and the page script writes it again after each filter.
+ * The page script reads the same class, thus the card and the boot cannot disagree over a rename.
+ */
+export const GRID_COUNT_CLASS = "report-table-count";
+
+/** The word that follows a row count, in the status line of the card and in the print note alike. */
+export const GRID_ROWS_WORD = "rows";
+
+/** The label of the download button of a table card, without the format of the file. */
+const DOWNLOAD_LABEL = "Download";
 
 /** The scalar value that a metric renders from. */
 type ScalarValue = Extract<RenderValue, { type: "scalar" }>;
@@ -115,25 +135,61 @@ function columnLabel(column: string, labels: TableBlock["binding"]["columnLabels
 /**
  * The display of each column of a table, in the column order of the header.
  *
- * The renderer resolves the label, the number kind, and the bound of a stored zero one time for each
- * column, and the data asset ships them. Thus the page formats a cell with no read of a declaration and no
- * second pass over a column.
+ * The renderer resolves the label, the number kind, the filter, and the bound of a stored zero one time for
+ * each column, and the data asset ships them. Thus the page formats a cell with no read of a declaration
+ * and no second pass over a column.
  *
- * A probability column carries the smallest positive value of its own rows as the bound. The read runs one
- * time for each such column, thus a wide table reads no column twice. A column with no positive value takes
- * no bound, and its zero then reads as the near-zero form.
+ * The filter reads the cells and not the kind. A column of gene names carries no number, thus it takes the
+ * text filter and a reader finds a gene by its name. A column where one cell parses takes the number filter.
+ *
+ * A probability column carries the smallest positive value of its own rows as the bound. A column with no
+ * positive value takes no bound, and its zero then reads as the near-zero form.
  */
 export function tableDisplay(block: TableBlock, value: TableValue, columns: readonly string[]): ColumnDisplay[] {
     const binding = block.binding;
     return columns.map((column) => {
+        // One pass over the column serves the filter and the bound alike, thus a wide table reads no column
+        // twice.
+        const cells = value.rows.map((row) => row[column]);
         const kind = selectColumnKind(column, declaredForColumn(binding.columnMeanings, column));
         const label = columnLabel(column, binding.columnLabels);
+        const filter: ColumnFilter = holdsANumber(cells) ? "number" : "text";
         if (kind !== "scientific") {
-            return { label, kind };
+            return { label, kind, filter };
         }
-        const bound = smallestPositiveValue(value.rows.map((row) => row[column]));
-        return bound === undefined ? { label, kind } : { label, kind, bound };
+        const bound = smallestPositiveValue(cells);
+        return bound === undefined ? { label, kind, filter } : { label, kind, filter, bound };
     });
+}
+
+/**
+ * The label of the download button: the word and the format of the pinned file, for example `Download CSV`.
+ *
+ * The extension of the path names the format, thus the label states what the reader gets. A path with no
+ * extension gives the word alone, because a made-up format would be a claim about bytes that nobody read.
+ */
+function downloadLabel(path: string): string {
+    const base = path.slice(path.lastIndexOf("/") + 1);
+    const dot = base.lastIndexOf(".");
+    const format = dot > 0 ? base.slice(dot + 1).toUpperCase() : "";
+    return format === "" ? DOWNLOAD_LABEL : `${DOWNLOAD_LABEL} ${format}`;
+}
+
+/**
+ * The row bound of a binding as text, for example `top 20 by padj`, or `undefined` where the binding carries
+ * none.
+ *
+ * The bound is what the resolution kept, thus the status line states it beside the count and a reader never
+ * reads a cut table as the whole artifact. The rank direction names the end that the bound kept.
+ */
+function boundText(binding: TableBlock["binding"]): string | undefined {
+    const bound = binding.rowBound;
+    if (bound === undefined) {
+        return undefined;
+    }
+    const end = bound.order === "asc" ? "lowest" : "top";
+    const count = formatTableCell(bound.count, "compact-scientific");
+    return `${end} ${count} by ${columnLabel(bound.column, binding.columnLabels)}`;
 }
 
 /**
@@ -144,23 +200,38 @@ export function tableDisplay(block: TableBlock, value: TableValue, columns: read
  * page script builds the grid over the payload that registers under the block id.
  *
  * The mount names its block in the mount attribute. A mount whose block the registry does not hold stays
- * empty, thus the card keeps its title and its download and the page throws nothing.
+ * empty, thus the card keeps its title, its status, and its download, and the page throws nothing.
+ *
+ * The footer holds one status line and the download button. The status states the count of the resolved
+ * rows, and the row bound of the binding beside it. The page script writes the count again after each
+ * filter, thus a reader of a narrowed table sees what the grid shows and what the table holds.
+ *
+ * The note under the status stays empty on the screen. A print of a table that passes the print bound writes
+ * the bound into it, thus the paper states what it shows and what it leaves out.
  *
  * The download names the staged copy of the pinned artifact. The link is relative and the browser saves
  * the file, thus the page fetches nothing when it opens and the reader still gets the whole table.
  */
-export function renderTable(block: TableBlock): string {
+export function renderTable(block: TableBlock, rowCount: number): string {
     const binding = block.binding;
     const download = tableSidecarName(binding.hash, binding.path);
+    const bound = boundText(binding);
     return String(
         <div class="report-table">
             {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
             <div class="corner-accents">
                 <div class="report-grid" {...{ [GRID_MOUNT_ATTRIBUTE]: block.id }}></div>
                 <div class="report-table-footer">
-                    <a class="report-table-download" href={stagedSource(download)} download={download}>
-                        {DOWNLOAD_LABEL}
-                    </a>
+                    <div class="report-table-footer-row">
+                        <span class="report-table-status">
+                            <span class={GRID_COUNT_CLASS}>{`${formatTableCell(rowCount, "compact-scientific")} ${GRID_ROWS_WORD}`}</span>
+                            {bound !== undefined ? <span class="report-table-bound">{bound}</span> : null}
+                        </span>
+                        <a class="report-table-download" href={stagedSource(download)} download={download}>
+                            {downloadLabel(binding.path)}
+                        </a>
+                    </div>
+                    <div class={GRID_NOTE_CLASS}></div>
                 </div>
             </div>
             {block.caption !== undefined ? <p class="report-caption">{block.caption}</p> : null}

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -30,9 +30,7 @@
  */
 
 import { err, ok, type Result } from "neverthrow";
-import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, rm, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { extname, join } from "node:path";
 import { z } from "zod";
 
@@ -47,6 +45,7 @@ import { finishDraft, type FinishGap } from "../../report-model/draft-finish.js"
 import type { ReferenceResolver, ReportSnapshot, ResolvedValue } from "../../report-model/reference-resolver.js";
 import { resolveDocumentReferences, type ResolutionFailure } from "../../report-model/validate.js";
 import { bridgeValues, type BlockResolution, type BridgeMismatch, type ResolvedFile } from "../../report-render/value-bridge.js";
+import { resolvePageAssetFromInstallation } from "../../report-render/asset-lookup.js";
 import { ASSETS_DIR, PAGE_ASSETS, tableSidecarName } from "../../report-render/assets.js";
 import { renderReportPage } from "../../report-render/render.js";
 import type { DataAsset } from "../../report-render/table-data.js";
@@ -118,34 +117,6 @@ function assetFileName(file: ResolvedFile): string {
 function figureSourcePolicy(file: ResolvedFile): string {
     return `assets/${assetFileName(file)}`;
 }
-
-/**
- * The resolver of a package source. A manifest entry names a module specifier, and the resolution reads
- * the installation of the harness. Thus the staged bytes are the bytes of the pinned version.
- */
-const moduleResolver = createRequire(import.meta.url);
-
-/**
- * The default asset lookup: the module resolution of the installation of the harness.
- *
- * A package that publishes an `exports` map refuses a subpath that the map does not name, and a browser
- * bundle beside the module entry is such a subpath. The fallback reads the specifier as a path under each
- * candidate `node_modules` directory of the resolution. Thus a bundle that the map hides still stages, and
- * a specifier that names no file still fails with the resolution error of the package.
- */
-export const resolvePageAssetFromInstallation: ResolvePageAsset = (specifier) => {
-    try {
-        return moduleResolver.resolve(specifier);
-    } catch (cause) {
-        for (const directory of moduleResolver.resolve.paths(specifier) ?? []) {
-            const candidate = join(directory, specifier);
-            if (existsSync(candidate)) {
-                return candidate;
-            }
-        }
-        throw cause;
-    }
-};
 
 /**
  * Pair each block with the resolved value of its binding, in document order.

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -30,6 +30,7 @@
  */
 
 import { err, ok, type Result } from "neverthrow";
+import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { extname, join } from "node:path";
@@ -124,8 +125,27 @@ function figureSourcePolicy(file: ResolvedFile): string {
  */
 const moduleResolver = createRequire(import.meta.url);
 
-/** The default asset lookup: the module resolution of the installation of the harness. */
-const resolvePageAssetFromInstallation: ResolvePageAsset = (specifier) => moduleResolver.resolve(specifier);
+/**
+ * The default asset lookup: the module resolution of the installation of the harness.
+ *
+ * A package that publishes an `exports` map refuses a subpath that the map does not name, and a browser
+ * bundle beside the module entry is such a subpath. The fallback reads the specifier as a path under each
+ * candidate `node_modules` directory of the resolution. Thus a bundle that the map hides still stages, and
+ * a specifier that names no file still fails with the resolution error of the package.
+ */
+export const resolvePageAssetFromInstallation: ResolvePageAsset = (specifier) => {
+    try {
+        return moduleResolver.resolve(specifier);
+    } catch (cause) {
+        for (const directory of moduleResolver.resolve.paths(specifier) ?? []) {
+            const candidate = join(directory, specifier);
+            if (existsSync(candidate)) {
+                return candidate;
+            }
+        }
+        throw cause;
+    }
+};
 
 /**
  * Pair each block with the resolved value of its binding, in document order.


### PR DESCRIPTION
## What & why

The round-one enhancer rebuilt sort and filter by hand, and the data assets of the previous change emptied the DOM it read. Each table block now renders through AG Grid Community, booted by the page script from the registered data. The bundle is pinned exact and staged as a page asset, exactly as the ECharts bundle is. The server resolves the header labels, the number kinds, and the below-resolution bounds into a display member of the payload. The page formats over the shipped kinds, and a shared test vector pins the client formatter against the server helper byte for byte. The theme builds from the design tokens, no separate filter row ships, the print form takes the grid's print layout, and the enhancer retires whole.

Reviewer notes: the change is proven in a real browser on `file://`. A 14,201-row page holds 23 rows in the DOM, and the filters and the sort work. The print hook flips the layout and restores it. The bundle does not resolve through the package exports map, thus the installation lookup falls back to the path form, shared with the fixture script. Column access rides value getters, because the grid reads a point in a field name as a path. A missing payload keeps the header card and the download link, and the boot skips it.

Refs #399

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
