### PR TITLE
feat(harness): chain the derivations into the provenance, and prune the unused

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/design.md
@@ -1,0 +1,32 @@
+# Design: chain-and-prune-the-derivations
+
+## Context
+
+The ledger marks a claim binding and a citation binding, and a whole-table binding never joins (`src/report-render/references.ts`). The derivation records live in the durable session state (`src/state/report-session-state.ts:64`): the output path, the output hash, the sources with hashes, the script hash, and the script text. The served snapshot merges the records, thus a derived table binds, and the appendix stays blind to the chain.
+
+## Decisions
+
+### D1: The table and the chart mark their bindings
+
+`renderTable` and the chart arm mark the block binding in the provenance ladder, and the card shows the marker beside its title. A figure marks today through its claim usage — its whole-file binding joins the same way, thus the rule reads: every evidentiary binding ledgers. The appendix entry of a whole-table binding names the path, as the artifact-table entry form already does.
+
+### D2: The derivation records ride the render call
+
+`renderReportPage` takes the derivation records beside the citation records, keyed by the output path. The appendix entry of a path that the records hold adds the chain line: each source path with its hash prefix, and the script hash prefix. The renderer stays pure, and the preview passes the records from the session state.
+
+### D3: The unused set is a set difference at finish
+
+A derivation is used when any binding of the document names its output path. The finish computes the difference over the records and the document. It lists each unused output as an advisory warning, in the existing warning channel. No file read joins, because the records and the document both sit in memory.
+
+### D4: The record prunes files, and never records
+
+After the gate passes and the version lands, the record tool removes the output file of each unused derivation under the session `derived/` directory. The records stay append-only, and the bytes are reproducible from the script and the sources. A failed removal logs and changes no outcome, exactly as the asset sweep does.
+
+### D5: The prune reaches the derived directory alone
+
+The prune resolves each unused output path, and it removes only a path under `report-sessions/{threadId}/derived`. A record whose path sits elsewhere is skipped, because the tool never deletes outside its own directory.
+
+## Risks / Trade-offs
+
+- A user can re-run a pruned derivation only through the agent, because the bytes are gone. The record keeps the script and the sources, thus the re-run is one tool call.
+- The chain line lengthens the appendix. It rides only on a derived path, and the muted appendix style bounds the noise.

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: chain-and-prune-the-derivations
+
+## Why
+
+The provenance appendix ledgers a claim value and a citation alone, thus the derived chart of the session shows no provenance line at all. The derived directory also accumulates dead files: the session holds two tables that no block references, and nothing prunes the bytes. The decided direction of the tracker: an unused derivation gets a warning and a prune, and never a hard gate.
+
+## What Changes
+
+- The whole-table binding of a table block and of a chart block joins the provenance ledger. Thus every evidentiary block carries an appendix entry.
+- The appendix entry of a derived path states its chain: the sources with their hashes, and the script hash, from the durable derivation record. The records ride the render call, exactly as the citation records do.
+- The finish lists each unused derivation as an advisory warning, beside the free-numeral warnings. A warning decides no outcome.
+- The record prunes the output files of the derivations that the recorded document does not reference. The records stay append-only, and the bytes are reproducible from them.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-render`: the whole-table bindings ledger, and the derived entry states the chain.
+- `report-authoring`: the finish warns on an unused derivation.
+- `report-verification`: the record prunes the unused derivation outputs.
+
+## Impact
+
+- Affected code: `src/report-render/references.ts` and the views, `src/report-render/render.ts`, the finish path, the record tool, `src/tools/report-session/preview-report.ts`, and their tests.
+- A document with no derivation renders as before, and a session with no unused derivation prunes nothing.

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-authoring/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-authoring/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-authoring
+
+## MODIFIED Requirements
+
+### Requirement: The finish carries the advisory warnings
+
+The finish MUST list each unused derivation as an advisory warning: a derivation record whose output path no binding of the document names. The warning names the output path, and it decides no outcome, exactly as a free-numeral warning does.
+
+#### Scenario: An unused derivation warns
+
+- **WHEN** the finish runs over a document that ignores one derivation record
+- **THEN** the finish carries a warning that names the unused output, and the outcome stays as the gaps decide
+
+#### Scenario: A used derivation warns nothing
+
+- **WHEN** every derivation output is named by a binding
+- **THEN** the finish carries no derivation warning

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-render/spec.md
@@ -1,0 +1,22 @@
+# Delta: report-render
+
+## ADDED Requirements
+
+### Requirement: Every evidentiary binding joins the provenance appendix
+
+The whole-table binding of a table block and of a chart block MUST join the provenance ledger, and the card shows the marker. The appendix entry names the path, in the artifact-table entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
+
+#### Scenario: A bound table gains its appendix entry
+
+- **WHEN** the caller renders a table block over a pinned artifact
+- **THEN** the card carries a marker, and the appendix names the path
+
+#### Scenario: A derived chart states its chain
+
+- **WHEN** the caller renders a chart over a derived path whose record names two sources and a script
+- **THEN** the appendix entry carries the two source paths with hash prefixes, and the script hash prefix
+
+#### Scenario: A document with no derivation renders as before
+
+- **WHEN** the caller renders a document whose bindings name no derived path
+- **THEN** no chain line renders, and the appendix holds the plain entries

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-render/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-render/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Every evidentiary binding joins the provenance appendix
 
-The whole-table binding of a table block and of a chart block MUST join the provenance ledger, and the card shows the marker. The appendix entry names the path, in the artifact-table entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
+The binding of each evidentiary block MUST join its ladder: the metric value, the table, the chart, and the figure beside the claim and the citation. The card shows the marker, and the appendix entry names the path in its entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
 
 #### Scenario: A bound table gains its appendix entry
 

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-verification/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/specs/report-verification/spec.md
@@ -1,0 +1,17 @@
+# Delta: report-verification
+
+## MODIFIED Requirements
+
+### Requirement: The gate runs before the store
+
+The record MUST prune the output file of each derivation that the recorded document does not reference, after the version lands. The prune reaches only a path under the session `derived/` directory. The records stay append-only, because the bytes are reproducible from the script and the sources. A failed removal logs, and it changes no outcome.
+
+#### Scenario: The record prunes the unused outputs
+
+- **WHEN** the record lands a version whose document names one of two derivation outputs
+- **THEN** the unused output file goes, the used one stays, and both records stay
+
+#### Scenario: A failed prune keeps the version
+
+- **WHEN** the removal of an unused output throws
+- **THEN** the version stands, and the log names the failed removal

--- a/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-chain-and-prune-the-derivations/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: chain-and-prune-the-derivations
+
+## 1. The appendix chain
+
+- [x] 1.1 The table and the chart mark their bindings in the provenance ledger, and the cards show the markers.
+- [x] 1.2 The derivation records ride the render call, and the appendix entry of a derived path adds the chain line.
+
+## 2. The finish warning
+
+- [x] 2.1 The finish lists each unused derivation as an advisory warning that names the output path.
+
+## 3. The record prune
+
+- [x] 3.1 The record removes the output file of each unused derivation, under the session `derived/` directory alone.
+- [x] 3.2 A failed removal logs and changes no outcome.
+
+## 4. The proof
+
+- [x] 4.1 Tests cover the seven delta scenarios across the three deltas.
+- [x] 4.2 A document with no derivation and a session with none prune nothing and warn nothing.
+- [x] 4.3 Run the targeted suites of the touched modules, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-authoring/spec.md
+++ b/harness/openspec/specs/report-authoring/spec.md
@@ -193,6 +193,8 @@ The finish operation MUST validate the whole draft against the full document sch
 
 The finish MUST also carry each advisory warning, in both outcomes. A free numeral in prose is such a warning: it needs no file, thus the finish scans for it. A warning MUST NOT decide the outcome.
 
+The finish MUST list each unused derivation as an advisory warning: a derivation record whose output path no binding of the document names. The warning names the output path, and it decides no outcome, exactly as a free-numeral warning does.
+
 #### Scenario: An empty section is a gap at the finish
 - **WHEN** the agent finishes a draft that holds one empty section
 - **THEN** the finish reports the empty section as a gap, and it gives no document
@@ -208,6 +210,16 @@ The finish MUST also carry each advisory warning, in both outcomes. A free numer
 #### Scenario: A free numeral warns
 - **WHEN** the agent finishes a draft whose prose carries a figure with no metric block behind it
 - **THEN** the finish carries a warning for that block, and the warning does not change the outcome
+
+#### Scenario: An unused derivation warns
+
+- **WHEN** the finish runs over a document that ignores one derivation record
+- **THEN** the finish carries a warning that names the unused output, and the outcome stays as the gaps decide
+
+#### Scenario: A used derivation warns nothing
+
+- **WHEN** every derivation output is named by a binding
+- **THEN** the finish carries no derivation warning
 
 ### Requirement: The authoring tool surface
 The operations MUST ship as harness tools, made with `defineTool` through one factory. The factory closes over a session-state gateway and reads no other ambient state. A tool MUST read the thread id from the scope of the call, and it MUST load the state through the gateway. A landed document MUST persist before the tool reports. A call whose scope carries no thread id MUST refuse as typed data in the ok channel.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -390,6 +390,25 @@ A claim MUST render its prose with evidence markers. The references MUST list at
 - **WHEN** the caller renders a document with a claim
 - **THEN** the list at the end of the page is titled "Data provenance", and no auto-generated surface is titled "References"
 
+### Requirement: Every evidentiary binding joins the provenance appendix
+
+The whole-table binding of a table block and of a chart block MUST join the provenance ledger, and the card shows the marker. The appendix entry names the path, in the artifact-table entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
+
+#### Scenario: A bound table gains its appendix entry
+
+- **WHEN** the caller renders a table block over a pinned artifact
+- **THEN** the card carries a marker, and the appendix names the path
+
+#### Scenario: A derived chart states its chain
+
+- **WHEN** the caller renders a chart over a derived path whose record names two sources and a script
+- **THEN** the appendix entry carries the two source paths with hash prefixes, and the script hash prefix
+
+#### Scenario: A document with no derivation renders as before
+
+- **WHEN** the caller renders a document whose bindings name no derived path
+- **THEN** no chain line renders, and the appendix holds the plain entries
+
 ### Requirement: The citation card is a bibliography entry
 
 The citation card MUST render the short citation of its pinned record, the note of the block, and the citation key. A `pmid:` key MUST also render a PubMed link, built deterministically from the id. The link is a navigation and it loads nothing, thus the stand-alone rule holds. A key with no pinned record renders the key and the note alone, because absence is a normal condition.

--- a/harness/openspec/specs/report-render/spec.md
+++ b/harness/openspec/specs/report-render/spec.md
@@ -392,7 +392,7 @@ A claim MUST render its prose with evidence markers. The references MUST list at
 
 ### Requirement: Every evidentiary binding joins the provenance appendix
 
-The whole-table binding of a table block and of a chart block MUST join the provenance ledger, and the card shows the marker. The appendix entry names the path, in the artifact-table entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
+The binding of each evidentiary block MUST join its ladder: the metric value, the table, the chart, and the figure beside the claim and the citation. The card shows the marker, and the appendix entry names the path in its entry form. The appendix entry of a derived path MUST add the chain of its record: each source path with its hash prefix, and the script hash prefix. The derivation records ride the render call, exactly as the citation records do, and the renderer stays pure.
 
 #### Scenario: A bound table gains its appendix entry
 

--- a/harness/openspec/specs/report-verification/spec.md
+++ b/harness/openspec/specs/report-verification/spec.md
@@ -17,6 +17,8 @@ visual judgment itself stays with the agent, and it stays advisory.
 ### Requirement: The gate runs before the store
 The record tool MUST run the full validation before `store.record`. The validation MUST cover the finish, the resolution of every reference, the chart-encoding match, and the assert match. Only a pass MUST reach the store. Thus a version that the gate did not accept never exists. The record MUST write the document value that the gate validated. The one-per-thread rule of the store bounds a concurrent race.
 
+The record MUST prune the output file of each derivation that the recorded document does not reference, after the version lands. The prune reaches only a path under the session `derived/` directory. The records stay append-only, because the bytes are reproducible from the script and the sources. A failed removal logs, and it changes no outcome.
+
 #### Scenario: A failed gate records nothing
 - **WHEN** one reference of the document fails its assert
 - **THEN** the record refuses, and the store holds no new row
@@ -24,6 +26,16 @@ The record tool MUST run the full validation before `store.record`. The validati
 #### Scenario: A pass records one version
 - **WHEN** the gate passes and the thread holds no version
 - **THEN** the store records the version, and the tool gives the version id
+
+#### Scenario: The record prunes the unused outputs
+
+- **WHEN** the record lands a version whose document names one of two derivation outputs
+- **THEN** the unused output file goes, the used one stays, and both records stay
+
+#### Scenario: A failed prune keeps the version
+
+- **WHEN** the removal of an unused output throws
+- **THEN** the version stands, and the log names the failed removal
 
 ### Requirement: A failure names its block
 Each gate failure MUST carry the `id` of the block that holds the failed part. Thus the agent repairs one block, and not the report at large.

--- a/harness/src/agents/report-session-agent.ts
+++ b/harness/src/agents/report-session-agent.ts
@@ -180,11 +180,13 @@ export function createReportSessionAgent(deps: ReportSessionAgentDeps): AgentDef
             ...(eyes ? { eyes } : {}),
             ...(logger ? { logger } : {}),
         }),
-        // The record tool. It gates the whole document, then records one version.
+        // The record tool. It gates the whole document, records one version, then prunes each
+        // derived table that the recorded document does not bind.
         createRecordVersionTool({
             gateway,
             store,
             threads,
+            resolveWorkspaceRoot,
             ...(makeResolver ? { makeResolver } : {}),
             ...(logger ? { logger } : {}),
         }),

--- a/harness/src/app/report-session-runtime.ts
+++ b/harness/src/app/report-session-runtime.ts
@@ -219,7 +219,9 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
      * snapshot cannot serve a tool, because the pin writes the snapshot first.
      *
      * The served snapshot is the stored pin with the derivations merged onto it, thus a
-     * tool reads one membership and it never merges again.
+     * tool reads one membership and it never merges again. The records ride the load
+     * beside the merged snapshot, because the chain of a derived path and the unused set
+     * both read the record and not the membership.
      */
     function toLoad(state: StoredSessionState): SessionStateLoad {
         if (state.snapshot === null) {
@@ -232,6 +234,7 @@ export function createReportSessionRuntime(deps: ReportSessionRuntimeDeps): Repo
             analysisId: state.analysisId,
             token: state.document,
             seenDocumentHash: state.seenDocumentHash,
+            derivations: state.derivations,
         };
     }
 

--- a/harness/src/report-model/block-walk.test.ts
+++ b/harness/src/report-model/block-walk.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Block } from "../contracts/report-blocks.js";
+import { referencedPaths, walkBlocks } from "./block-walk.js";
+
+const TABLE_PATH = "runs/run-1/step-a/output/de.csv";
+const VALUE_PATH = "runs/run-1/step-b/output/counts.csv";
+const FIGURE_PATH = "runs/run-1/step-a/figures/volcano.png";
+const CHART_PATH = "report-sessions/t1/derived/merged.csv";
+const INPUT_A_PATH = "runs/run-1/step-c/output/treated.csv";
+const INPUT_B_PATH = "runs/run-1/step-c/output/control.csv";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+
+describe("referencedPaths", () => {
+    it("names the path of each binding kind that a block carries", () => {
+        const blocks: Block[] = [
+            { kind: "metric", id: "m1", label: "Genes", value: { kind: "artifact-value", path: VALUE_PATH, hash: HASH, locator: { column: "n", row: 0 } } },
+            { kind: "table", id: "tb1", binding: { kind: "artifact-table", path: TABLE_PATH, hash: HASH } },
+            { kind: "chart", id: "ch1", binding: { kind: "artifact-table", path: CHART_PATH, hash: HASH }, chartType: "bar", encoding: { x: "a", y: "b" } },
+            { kind: "figure", id: "f1", binding: { kind: "artifact-file", path: FIGURE_PATH, hash: HASH } },
+        ];
+
+        // Each of the four evidentiary kinds names its artifact, thus a derived table that any one of them
+        // binds counts as used.
+        expect([...referencedPaths(walkBlocks(blocks).references)].sort()).toEqual([CHART_PATH, FIGURE_PATH, TABLE_PATH, VALUE_PATH].sort());
+    });
+
+    it("names the path of each input of a derivation reference", () => {
+        const blocks: Block[] = [
+            {
+                kind: "metric",
+                id: "m1",
+                label: "Ratio",
+                value: {
+                    kind: "derivation",
+                    op: "ratio",
+                    inputs: [
+                        { kind: "artifact-value", path: INPUT_A_PATH, hash: HASH, locator: { column: "n", row: 0 } },
+                        { kind: "artifact-value", path: INPUT_B_PATH, hash: HASH, locator: { column: "n", row: 0 } },
+                    ],
+                },
+            },
+        ];
+
+        // A derivation reference reads two cells and it names no file of its own, thus a derived table that
+        // feeds the arithmetic counts as used.
+        expect([...referencedPaths(walkBlocks(blocks).references)].sort()).toEqual([INPUT_A_PATH, INPUT_B_PATH].sort());
+    });
+
+    it("names no path for a citation, and reads a nested section", () => {
+        const blocks: Block[] = [
+            {
+                kind: "section",
+                id: "s1",
+                title: "Intro",
+                blocks: [
+                    { kind: "citation", id: "cit1", binding: { kind: "citation", idKind: "pmid", id: "12345", raw: "Doe 2020" } },
+                    {
+                        kind: "claim",
+                        id: "c1",
+                        content: { prose: "A claim." },
+                        bindings: [{ kind: "artifact-value", path: VALUE_PATH, hash: HASH, locator: { column: "n", row: 0 } }],
+                    },
+                ],
+            },
+        ];
+
+        // A citation names a paper and never a file of the workspace. The walk is pre-order, thus a binding
+        // under a section reaches the set.
+        expect([...referencedPaths(walkBlocks(blocks).references)]).toEqual([VALUE_PATH]);
+    });
+
+    it("gives an empty set for a tree that binds nothing", () => {
+        expect(referencedPaths(walkBlocks([{ kind: "text", id: "t1", content: { prose: "Body." } }]).references).size).toBe(0);
+    });
+});

--- a/harness/src/report-model/block-walk.ts
+++ b/harness/src/report-model/block-walk.ts
@@ -34,12 +34,24 @@ export interface CollectedReference {
     encodingColumns?: string[];
 }
 
-/** An advisory warning about the content of one block. A warning never makes a report invalid. */
-export interface ReportWarning {
+/** An advisory warning about the prose of one block. The detail is the numeral that the prose carries. */
+export interface FreeNumeralWarning {
     blockId: string;
     kind: "free-numeral";
     detail: string;
 }
+
+/**
+ * An advisory warning about one derivation that no binding of the document names. The detail is the output
+ * path of the record. The record stays, and the bytes are reproducible from the script and the sources.
+ */
+export interface UnusedDerivationWarning {
+    kind: "unused-derivation";
+    detail: string;
+}
+
+/** One advisory warning about a report. A warning never makes a report invalid. */
+export type ReportWarning = FreeNumeralWarning | UnusedDerivationWarning;
 
 /** What one walk over a block tree found. */
 export interface BlockWalk {
@@ -48,7 +60,7 @@ export interface BlockWalk {
     /** Each id that more than one block holds, named one time, in sorted order. */
     repeatedIds: string[];
     /** Each free numeral that prose carries. */
-    warnings: ReportWarning[];
+    warnings: FreeNumeralWarning[];
 }
 
 /**
@@ -66,8 +78,8 @@ export interface BlockWalk {
 const NUMERAL_PATTERN = /(?<![A-Za-z0-9])-?\d+(?:\.\d+)?%?/g;
 
 /** Warn for each free-standing numeral that the prose of one block carries. */
-export function numeralWarnings(blockId: string, prose: string): ReportWarning[] {
-    const warnings: ReportWarning[] = [];
+export function numeralWarnings(blockId: string, prose: string): FreeNumeralWarning[] {
+    const warnings: FreeNumeralWarning[] = [];
     for (const match of prose.matchAll(NUMERAL_PATTERN)) {
         warnings.push({ blockId, kind: "free-numeral", detail: match[0] });
     }
@@ -126,7 +138,7 @@ function chartColumns(block: ChartBlock): string[] {
  */
 export function walkBlocks(blocks: readonly AnyBlock[]): BlockWalk {
     const references: CollectedReference[] = [];
-    const warnings: ReportWarning[] = [];
+    const warnings: FreeNumeralWarning[] = [];
     const seenIds = new Set<string>();
     const repeated = new Set<string>();
 
@@ -175,4 +187,31 @@ export function walkBlocks(blocks: readonly AnyBlock[]): BlockWalk {
     }
 
     return { references, repeatedIds: [...repeated].sort(), warnings };
+}
+
+/**
+ * Each artifact path that a set of collected references names.
+ *
+ * An artifact binding names one path. A derivation reference computes over two inputs, thus it names the
+ * path of each input and a table that feeds a derived scalar counts as named. A citation names no path.
+ *
+ * The set answers one question: which files does this document use. The finish reads it against the
+ * derivations of the session, and the record reads it again over the recorded document.
+ */
+export function referencedPaths(references: readonly CollectedReference[]): Set<string> {
+    const paths = new Set<string>();
+    for (const entry of references) {
+        const reference = entry.reference;
+        if (reference.kind === "citation") {
+            continue;
+        }
+        if (reference.kind === "derivation") {
+            for (const input of reference.inputs) {
+                paths.add(input.path);
+            }
+            continue;
+        }
+        paths.add(reference.path);
+    }
+    return paths;
 }

--- a/harness/src/report-model/draft-finish.test.ts
+++ b/harness/src/report-model/draft-finish.test.ts
@@ -217,6 +217,32 @@ describe("the finish warnings", () => {
         expect(finishDraft(draft, derivedSnapshot(used), [{ outputPath: used }]).warnings).toEqual([]);
     });
 
+    it("counts a derivation that a chart binds", () => {
+        const used = "report-sessions/t1/derived/used.csv";
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Intro",
+                    blocks: [
+                        {
+                            kind: "chart",
+                            id: "ch1",
+                            binding: { kind: "artifact-table", path: used, hash: DERIVED_HASH },
+                            chartType: "bar",
+                            encoding: { x: "gene", y: "padj" },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // A chart plots the whole table, thus its binding names the derived path and the derivation is used.
+        expect(finishDraft(draft, derivedSnapshot(used), [{ outputPath: used }]).warnings).toEqual([]);
+    });
+
     it("counts a derivation that a claim binds through a value reference", () => {
         const used = "report-sessions/t1/derived/used.csv";
         const draft: DraftDocument = {

--- a/harness/src/report-model/draft-finish.test.ts
+++ b/harness/src/report-model/draft-finish.test.ts
@@ -16,6 +16,19 @@ const snapshot: ReportSnapshot = {
     },
 };
 
+/** The content hash that each derived table of these tests carries. */
+const DERIVED_HASH = `sha256:${"b".repeat(64)}`;
+
+/** A snapshot that holds the pinned output and one derived table, as the served membership gives it. */
+function derivedSnapshot(derived: string): ReportSnapshot {
+    return {
+        artifacts: {
+            [OUTPUT_PATH]: { hash: OUTPUT_HASH, fileType: "output" },
+            [derived]: { hash: DERIVED_HASH },
+        },
+    };
+}
+
 function valueReference(path: string = OUTPUT_PATH, hash: string = OUTPUT_HASH): ArtifactValueReference {
     return {
         kind: "artifact-value",
@@ -164,6 +177,78 @@ describe("the finish warnings", () => {
 
         expect(result.valid).toBe(false);
         expect(result.warnings).toEqual([{ blockId: "t1", kind: "free-numeral", detail: "12" }]);
+    });
+
+    it("warns about a derivation that no binding names, and the draft still finishes", () => {
+        const used = "report-sessions/t1/derived/used.csv";
+        const unused = "report-sessions/t1/derived/unused.csv";
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Intro",
+                    blocks: [{ kind: "table", id: "tb1", binding: { kind: "artifact-table", path: used, hash: DERIVED_HASH } }],
+                },
+            ],
+        };
+        const result = finishDraft(draft, derivedSnapshot(used), [{ outputPath: used }, { outputPath: unused }]);
+
+        // The used derivation warns nothing, and the unused one names its output path.
+        expect(result.warnings).toEqual([{ kind: "unused-derivation", detail: unused }]);
+        // A warning decides no outcome, thus the draft finishes.
+        expect(result.valid).toBe(true);
+    });
+
+    it("warns nothing when every derivation output is named by a binding", () => {
+        const used = "report-sessions/t1/derived/used.csv";
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Intro",
+                    blocks: [{ kind: "table", id: "tb1", binding: { kind: "artifact-table", path: used, hash: DERIVED_HASH } }],
+                },
+            ],
+        };
+        expect(finishDraft(draft, derivedSnapshot(used), [{ outputPath: used }]).warnings).toEqual([]);
+    });
+
+    it("counts a derivation that a claim binds through a value reference", () => {
+        const used = "report-sessions/t1/derived/used.csv";
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Intro",
+                    blocks: [
+                        {
+                            kind: "claim",
+                            id: "c1",
+                            content: { prose: "A claim." },
+                            bindings: [{ kind: "artifact-value", path: used, hash: DERIVED_HASH, locator: { column: "padj", row: 0 } }],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // A binding of any kind names the path, thus a cell of the derived table uses the derivation.
+        expect(finishDraft(draft, derivedSnapshot(used), [{ outputPath: used }]).warnings).toEqual([]);
+    });
+
+    it("warns nothing for a session that derived nothing", () => {
+        const draft: DraftDocument = {
+            title: "Report",
+            sections: [{ kind: "section", id: "s1", title: "Intro", blocks: [{ kind: "text", id: "t1", content: { prose: "Body." } }] }],
+        };
+        expect(finishDraft(draft, snapshot).warnings).toEqual([]);
+        expect(finishDraft(draft, snapshot, []).warnings).toEqual([]);
     });
 
     it("reports an empty title as a schema gap", () => {

--- a/harness/src/report-model/draft-finish.ts
+++ b/harness/src/report-model/draft-finish.ts
@@ -14,13 +14,17 @@
  * channel a caller could not read the one signal that catches a figure typed into prose with no metric
  * block behind it.
  *
+ * The unused-derivation scan rides the same channel. The records and the draft both sit in memory, thus the
+ * scan opens no file either. A derivation whose output path no binding names warns, and the derived bytes
+ * stay until the record prunes them.
+ *
  * The result is plain data. A gap is an expected outcome, not an error, thus the finish never throws. On
  * a pass the finish gives the valid document, and it does not change the draft.
  */
 
 import { ReportDocumentSchema, type ReportDocument } from "../contracts/report-blocks.js";
 import type { UnresolvedReference } from "../contracts/report-reference.js";
-import { walkBlocks, type ReportWarning } from "./block-walk.js";
+import { referencedPaths, walkBlocks, type CollectedReference, type ReportWarning, type UnusedDerivationWarning } from "./block-walk.js";
 import type { DraftDocument } from "./draft.js";
 import type { ReportSnapshot } from "./reference-resolver.js";
 import { validateReferenceStructure } from "./structural-validation.js";
@@ -56,10 +60,40 @@ export type FinishResult =
     { valid: true; document: ReportDocument; warnings: ReportWarning[] } | { valid: false; gaps: FinishGap[]; warnings: ReportWarning[] };
 
 /**
- * Finish a draft. The finish validates the schema, the unique ids, and the structural resolution of each
- * reference, and it reports each gap as data. It warns about each free numeral in prose.
+ * One derivation of the session, as the finish reads it. The finish needs the output path alone, because
+ * the used set is the paths that the bindings name.
  */
-export function finishDraft(draft: DraftDocument, snapshot: ReportSnapshot): FinishResult {
+export interface SessionDerivation {
+    readonly outputPath: string;
+}
+
+/**
+ * Warn for each derivation that no binding of the draft names.
+ *
+ * A derivation is used when a binding names its output path. Thus the scan is a set difference over the
+ * records and the collected references, and it reads no file. A warning names the output path, and it
+ * decides no outcome.
+ */
+function unusedDerivationWarnings(derivations: readonly SessionDerivation[], references: readonly CollectedReference[]): UnusedDerivationWarning[] {
+    if (derivations.length === 0) {
+        return [];
+    }
+    const named = referencedPaths(references);
+    const warnings: UnusedDerivationWarning[] = [];
+    for (const record of derivations) {
+        if (!named.has(record.outputPath)) {
+            warnings.push({ kind: "unused-derivation", detail: record.outputPath });
+        }
+    }
+    return warnings;
+}
+
+/**
+ * Finish a draft. The finish validates the schema, the unique ids, and the structural resolution of each
+ * reference, and it reports each gap as data. It warns about each free numeral in prose, and about each
+ * derivation of the session that no binding names.
+ */
+export function finishDraft(draft: DraftDocument, snapshot: ReportSnapshot, derivations: readonly SessionDerivation[] = []): FinishResult {
     const gaps: FinishGap[] = [];
 
     const parsed = ReportDocumentSchema.safeParse(draft);
@@ -75,7 +109,8 @@ export function finishDraft(draft: DraftDocument, snapshot: ReportSnapshot): Fin
 
     // The walk reads the draft tree, not the parse result. The draft is already typed, thus the walk stays
     // well-defined even when the schema parse fails, and a caller still gets the id and reference gaps.
-    const { references, repeatedIds, warnings } = walkBlocks(draft.sections);
+    const { references, repeatedIds, warnings: proseWarnings } = walkBlocks(draft.sections);
+    const warnings: ReportWarning[] = [...proseWarnings, ...unusedDerivationWarnings(derivations, references)];
 
     for (const id of repeatedIds) {
         gaps.push({ kind: "duplicate-id", id });

--- a/harness/src/report-render/chart.test.ts
+++ b/harness/src/report-render/chart.test.ts
@@ -5,6 +5,7 @@ import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption, type ChartRow, type EchartOption } from "./chart.js";
 import { MANHATTAN_P_THRESHOLD, VOLCANO_EFFECT_THRESHOLD, VOLCANO_P_THRESHOLD } from "./chart-presets.js";
 import { DESIGN_CSS, MUTED_CHART_COLOR } from "./design.js";
+import { ReferenceLedger } from "./references.js";
 
 type Encoding = NonNullable<ChartBlock["encoding"]>;
 type ChartType = NonNullable<ChartBlock["chartType"]>;
@@ -1275,7 +1276,7 @@ describe("renderChart", () => {
     it("places the JSON script as the immediate next sibling of the container", () => {
         const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b1" });
         const option = derive(block, [{ day: "Mon", count: 1 }]);
-        const html = renderChart(block, option);
+        const html = renderChart(block, new ReferenceLedger(), option);
         expect(html).toContain('id="chart-b1"');
         expect(html).toContain('data-echarts-id="b1"');
         expect(html).toContain('</div><script type="application/json">');
@@ -1284,7 +1285,7 @@ describe("renderChart", () => {
     it("escapes a </script> sequence inside a string cell", () => {
         const block = chartBlock("bar", { x: "k", y: "v" }, { id: "b2" });
         const rows: ChartRow[] = [{ k: "a</script>b", v: 1 }];
-        const html = renderChart(block, derive(block, rows));
+        const html = renderChart(block, new ReferenceLedger(), derive(block, rows));
         // The hostile close sequence never reaches the page as raw markup.
         expect(html).not.toContain("a</script>b");
         expect(html).toContain("a\\u003c/script>b");
@@ -1292,7 +1293,7 @@ describe("renderChart", () => {
 
     it("puts the sized container class on the element that carries the option id", () => {
         const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b3" });
-        const html = renderChart(block, derive(block, [{ day: "Mon", count: 1 }]));
+        const html = renderChart(block, new ReferenceLedger(), derive(block, [{ day: "Mon", count: 1 }]));
         // The bootstrap finds the container by `data-echarts-id`, and the style sheet sizes it by the
         // `chart-container` class. The two must sit on one element. A class on a different element, or no
         // class at all, gives the chart runtime a box of zero height and the chart draws into nothing.
@@ -1301,14 +1302,16 @@ describe("renderChart", () => {
 
     it("wraps the chart in the corner-accent card under the mono title line", () => {
         const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b4", title: "Panel title" });
-        const html = renderChart(block, derive(block, [{ day: "Mon", count: 1 }]));
-        expect(html).toContain(`<div class="report-chart-title">Panel title</div>`);
+        const html = renderChart(block, new ReferenceLedger(), derive(block, [{ day: "Mon", count: 1 }]));
+        // The title line carries the marker of the whole-table binding, thus the card names its appendix
+        // entry beside its title.
+        expect(html).toContain(`<div class="report-chart-title">Panel title<sup class="report-marker"><a href="#ref-1">1</a></sup></div>`);
         expect(html).toContain(`class="report-chart-card corner-accents"`);
     });
 
     it("wears no window costume", () => {
         const block = chartBlock("bar", { x: "day", y: "count" }, { id: "b5", title: "Panel title" });
-        const html = renderChart(block, derive(block, [{ day: "Mon", count: 1 }]));
+        const html = renderChart(block, new ReferenceLedger(), derive(block, [{ day: "Mon", count: 1 }]));
         // A report is a document. The dots, the badge, and the chrome bar make a data card read as an
         // application window, thus the card carries none of them.
         expect(html).not.toContain("window-chrome");

--- a/harness/src/report-render/design.ts
+++ b/harness/src/report-render/design.ts
@@ -638,6 +638,19 @@ a.report-citation-source:hover {
 .report-ref-detail {
   color: var(--color-text-muted);
 }
+/* The chain of a derived path reads under its entry, thus the entry line keeps the form of a pinned
+   artifact and the sources sit on a line of their own. */
+.report-ref-chain {
+  margin-top: 2px;
+  color: var(--color-text-muted);
+}
+/* The head of a content hash. It reads smaller than a path, because it identifies bytes and a reader
+   compares it against a staged file name instead of reading it. */
+.report-ref-hash {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
 /* The bibliography holds its own bracket number, thus the list shows no decimal marker of its own. */
 .report-citations {
   padding-left: 0;

--- a/harness/src/report-render/references.test.ts
+++ b/harness/src/report-render/references.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import type { Reference } from "../contracts/report-reference.js";
 import { renderBibliography, renderReferenceList } from "./views/references-view.js";
-import { ReferenceLedger } from "./references.js";
+import { derivationChains, ReferenceLedger, type DerivationChain } from "./references.js";
 
 describe("ReferenceLedger.mark", () => {
     it("numbers references by first appearance", () => {
@@ -103,6 +103,61 @@ describe("renderReferenceList", () => {
         // A citation belongs to the bibliography, thus the provenance list of such a page renders not at
         // all and its band carries no title.
         expect(renderReferenceList(ledger)).toBe("");
+    });
+});
+
+describe("the chain line of a derived path", () => {
+    const DERIVED = "report-sessions/t1/derived/merged.csv";
+
+    /** One chain over two sources and one script. Each hash carries a long hex tail. */
+    const chain: DerivationChain = {
+        outputPath: DERIVED,
+        sources: [
+            { path: "runs/r1/de.csv", hash: `sha256:${"a".repeat(64)}` },
+            { path: "runs/r1/counts.csv", hash: `sha256:${"b".repeat(64)}` },
+        ],
+        scriptHash: `sha256:${"c".repeat(64)}`,
+    };
+
+    /** A ledger that holds one whole-table binding over the derived path. */
+    function ledgerOverDerived(): ReferenceLedger {
+        const ledger = new ReferenceLedger();
+        ledger.mark({ kind: "artifact-table", path: DERIVED, hash: `sha256:${"d".repeat(64)}` });
+        return ledger;
+    }
+
+    it("names each source with its hash head, and the script hash head", () => {
+        const list = renderReferenceList(ledgerOverDerived(), derivationChains([chain]));
+
+        expect(list).toContain("runs/r1/de.csv");
+        expect(list).toContain("runs/r1/counts.csv");
+        expect(list).toContain(`<code class="report-ref-hash">${"a".repeat(12)}</code>`);
+        expect(list).toContain(`<code class="report-ref-hash">${"b".repeat(12)}</code>`);
+        expect(list).toContain(`<code class="report-ref-hash">${"c".repeat(12)}</code>`);
+        // The head identifies the bytes. A whole hash reads as noise, thus no 64-character run reaches the
+        // page and the algorithm name stays off the line.
+        expect(list).not.toContain("a".repeat(13));
+        expect(list).not.toContain(`sha256:${"a".repeat(12)}`);
+    });
+
+    it("keeps the artifact-table entry form over the chain line", () => {
+        const list = renderReferenceList(ledgerOverDerived(), derivationChains([chain]));
+
+        // A whole-table binding of a derived path reads as an artifact table, and the chain adds one line
+        // under it.
+        expect(list).toContain("Artifact table");
+        expect(list).toContain(DERIVED);
+        expect(list).toContain(`<div class="report-ref-chain">`);
+    });
+
+    it("renders no chain line for a path that the records do not hold", () => {
+        const pinned = new ReferenceLedger();
+        pinned.mark({ kind: "artifact-table", path: "runs/r1/de.csv", hash: `sha256:${"a".repeat(64)}` });
+
+        // The chains hold one derived path, and this entry names another. Thus the entry reads exactly as
+        // it does with no chains at all.
+        expect(renderReferenceList(pinned, derivationChains([chain]))).toBe(renderReferenceList(pinned));
+        expect(renderReferenceList(pinned)).not.toContain("report-ref-chain");
     });
 });
 

--- a/harness/src/report-render/references.ts
+++ b/harness/src/report-render/references.ts
@@ -26,6 +26,45 @@ export function citationKeyOf(reference: CitationReference): string {
 /** The two ladders of a page: the numeric footnote ladder, and the bracket ladder of the literature. */
 export type ReferenceLadder = "provenance" | "citation";
 
+/** One source of a derivation: the pinned path that the script read, and the content hash of those bytes. */
+export interface DerivationChainSource {
+    readonly path: string;
+    readonly hash: string;
+}
+
+/**
+ * The chain of one derived path: the sources that the script read, and the hash of the script itself.
+ *
+ * The renderer declares the shape that the appendix reads, and never the durable record that carries it.
+ * Thus a caller passes the stored records straight through, and the render stays a pure function of plain
+ * data.
+ */
+export interface DerivationChain {
+    readonly outputPath: string;
+    readonly sources: readonly DerivationChainSource[];
+    readonly scriptHash: string;
+}
+
+/** The chain of each derived path of one render, keyed by the output path that the bindings name. */
+export type DerivationChains = ReadonlyMap<string, DerivationChain>;
+
+/**
+ * Key each chain by its output path.
+ *
+ * The appendix reads one chain for one path, thus the map is the read form of the list. A repeated output
+ * path keeps the first record, because the durable list refuses a repeated path and a second one carries no
+ * new meaning.
+ */
+export function derivationChains(records: readonly DerivationChain[] | undefined): DerivationChains {
+    const chains = new Map<string, DerivationChain>();
+    for (const record of records ?? []) {
+        if (!chains.has(record.outputPath)) {
+            chains.set(record.outputPath, record);
+        }
+    }
+    return chains;
+}
+
 /** Each reference kind that the provenance ladder holds, which is every kind except a citation. */
 export type ProvenanceReference = Exclude<Reference, CitationReference>;
 

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -962,6 +962,94 @@ describe("the appendix bands", () => {
     });
 });
 
+describe("the whole-table bindings in the appendix", () => {
+    const PINNED = "runs/run-1/step-a/output/de.csv";
+    const DERIVED = "report-sessions/t1/derived/merged.csv";
+    const PINNED_HASH = `sha256:${"a".repeat(64)}`;
+    const DERIVED_HASH = `sha256:${"d".repeat(64)}`;
+
+    /** The chain of the derived path: two sources with their hashes, and the script that made the table. */
+    const chain = {
+        outputPath: DERIVED,
+        sources: [
+            { path: "runs/run-1/step-a/output/de.csv", hash: `sha256:${"a".repeat(64)}` },
+            { path: "runs/run-1/step-b/output/counts.csv", hash: `sha256:${"b".repeat(64)}` },
+        ],
+        scriptHash: `sha256:${"c".repeat(64)}`,
+    };
+
+    /** One page whose section holds the given blocks. */
+    function pageOf(blocks: Block[], values: RenderValues, derivations?: readonly (typeof chain)[]): string {
+        const document: ReportDocument = { title: "T", sections: [{ kind: "section", id: "s", title: "S", blocks }] };
+        return renderReportPage(document, values, undefined, derivations)._unsafeUnwrap().html;
+    }
+
+    /** One table block over the given path, and one chart block over it. */
+    function tableBlock(path: string, hash: string): Block {
+        return { kind: "table", id: "tbl", binding: { kind: "artifact-table", path, hash } };
+    }
+
+    function chartBlock(path: string, hash: string): Block {
+        return { kind: "chart", id: "cht", binding: { kind: "artifact-table", path, hash }, chartType: "bar", encoding: { x: "day", y: "count" } };
+    }
+
+    const oneRow: RenderValues = {
+        tbl: { type: "table", rows: [{ day: "Mon", count: 1 }] },
+        cht: { type: "table", rows: [{ day: "Mon", count: 1 }] },
+    };
+
+    it("gives a bound table its marker and its appendix entry", () => {
+        const html = pageOf([tableBlock(PINNED, PINNED_HASH)], oneRow);
+        const page = load(html);
+
+        // Every evidentiary block ledgers, thus the card carries a marker and the appendix names the path.
+        expect(page(".report-table-title .report-marker a").attr("href")).toBe("#ref-1");
+        expect(page("li#ref-1").text()).toContain(PINNED);
+        expect(page("li#ref-1").text()).toContain("Artifact table");
+    });
+
+    it("gives a bound chart its marker and its appendix entry", () => {
+        const html = pageOf([chartBlock(PINNED, PINNED_HASH)], oneRow);
+        const page = load(html);
+
+        expect(page(".report-chart-title .report-marker a").attr("href")).toBe("#ref-1");
+        expect(page("li#ref-1").text()).toContain(PINNED);
+    });
+
+    it("gives one number to a table and a chart over one artifact", () => {
+        const html = pageOf([tableBlock(PINNED, PINNED_HASH), chartBlock(PINNED, PINNED_HASH)], oneRow);
+        const page = load(html);
+
+        // The two blocks bind one reference. The ledger keeps one identity, thus the appendix holds one
+        // entry and both markers point at it.
+        expect(page("ol.report-references li").length).toBe(1);
+        expect(page('.report-marker a[href="#ref-1"]').length).toBe(2);
+    });
+
+    it("states the chain of a derived chart in its appendix entry", () => {
+        const html = pageOf([chartBlock(DERIVED, DERIVED_HASH)], oneRow, [chain]);
+        const entry = load(html)("li#ref-1").text();
+
+        // The entry carries each source with the head of its hash, and the head of the script hash.
+        expect(entry).toContain("runs/run-1/step-a/output/de.csv");
+        expect(entry).toContain("runs/run-1/step-b/output/counts.csv");
+        expect(entry).toContain("a".repeat(12));
+        expect(entry).toContain("b".repeat(12));
+        expect(entry).toContain("c".repeat(12));
+        // A whole hash never reaches the page.
+        expect(html).not.toContain("a".repeat(13));
+    });
+
+    it("renders a document with no derived path byte-identically with the records and without them", () => {
+        const blocks = [tableBlock(PINNED, PINNED_HASH), chartBlock(PINNED, PINNED_HASH)];
+
+        // The chain names a path that no binding of this document holds. Thus the page is a pure function
+        // of the document and the values, exactly as it was before the records rode the call.
+        expect(pageOf(blocks, oneRow, [chain])).toBe(pageOf(blocks, oneRow));
+        expect(load(pageOf(blocks, oneRow))(".report-ref-chain").length).toBe(0);
+    });
+});
+
 describe("the section scrollspy", () => {
     /** The class that the spy writes. The design source holds the matching rule under the same name. */
     const ACTIVE_CLASS = "report-nav-link-active";

--- a/harness/src/report-render/render.test.ts
+++ b/harness/src/report-render/render.test.ts
@@ -962,7 +962,7 @@ describe("the appendix bands", () => {
     });
 });
 
-describe("the whole-table bindings in the appendix", () => {
+describe("the evidentiary bindings in the appendix", () => {
     const PINNED = "runs/run-1/step-a/output/de.csv";
     const DERIVED = "report-sessions/t1/derived/merged.csv";
     const PINNED_HASH = `sha256:${"a".repeat(64)}`;
@@ -984,7 +984,7 @@ describe("the whole-table bindings in the appendix", () => {
         return renderReportPage(document, values, undefined, derivations)._unsafeUnwrap().html;
     }
 
-    /** One table block over the given path, and one chart block over it. */
+    /** One block of each evidentiary kind over the given artifact. Each one binds through its own kind. */
     function tableBlock(path: string, hash: string): Block {
         return { kind: "table", id: "tbl", binding: { kind: "artifact-table", path, hash } };
     }
@@ -993,9 +993,19 @@ describe("the whole-table bindings in the appendix", () => {
         return { kind: "chart", id: "cht", binding: { kind: "artifact-table", path, hash }, chartType: "bar", encoding: { x: "day", y: "count" } };
     }
 
+    function metricBlock(path: string, hash: string): Block {
+        return { kind: "metric", id: "mtr", label: "Genes tested", value: { kind: "artifact-value", path, hash, locator: { column: "count", row: 0 } } };
+    }
+
+    function figureBlock(path: string, hash: string): Block {
+        return { kind: "figure", id: "fig", binding: { kind: "artifact-file", path, hash } };
+    }
+
     const oneRow: RenderValues = {
         tbl: { type: "table", rows: [{ day: "Mon", count: 1 }] },
         cht: { type: "table", rows: [{ day: "Mon", count: 1 }] },
+        mtr: { type: "scalar", value: 1 },
+        fig: { type: "figure", src: "assets/plot.png" },
     };
 
     it("gives a bound table its marker and its appendix entry", () => {
@@ -1024,6 +1034,33 @@ describe("the whole-table bindings in the appendix", () => {
         // entry and both markers point at it.
         expect(page("ol.report-references li").length).toBe(1);
         expect(page('.report-marker a[href="#ref-1"]').length).toBe(2);
+    });
+
+    it("gives a marker and a chain entry to each evidentiary kind over one derived path", () => {
+        const blocks = [
+            metricBlock(DERIVED, DERIVED_HASH),
+            tableBlock(DERIVED, DERIVED_HASH),
+            chartBlock(DERIVED, DERIVED_HASH),
+            figureBlock(DERIVED, DERIVED_HASH),
+        ];
+        const page = load(pageOf(blocks, oneRow, [chain]));
+
+        // Each of the four cards carries its marker, each on the line that names the card.
+        expect(page(".stat-card-label .report-marker").length).toBe(1);
+        expect(page(".report-table-title .report-marker").length).toBe(1);
+        expect(page(".report-chart-title .report-marker").length).toBe(1);
+        expect(page(".report-figure .report-caption .report-marker").length).toBe(1);
+
+        // Each marker points at an entry that exists. The table and the chart bind one whole-table
+        // reference, thus three entries serve the four cards.
+        const targets = page(".report-marker a")
+            .toArray()
+            .map((node) => page(node).attr("href"));
+        expect(targets.length).toBe(4);
+        expect(targets.filter((target) => page(`li${target}`).length === 1).length).toBe(4);
+        expect(page("ol.report-references li").length).toBe(3);
+        // Every entry names the derived path, thus every entry states the chain of that path.
+        expect(page("ol.report-references li .report-ref-chain").length).toBe(3);
     });
 
     it("states the chain of a derived chart in its appendix entry", () => {

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -99,7 +99,7 @@ function renderBlock(
                 problems.push(wrongShape(block.id, entry.type, "scalar"));
                 return "";
             }
-            return renderMetric(block, entry);
+            return renderMetric(block, ledger, entry);
         }
         case "table": {
             const entry = values[block.id];
@@ -128,7 +128,7 @@ function renderBlock(
                 problems.push(wrongShape(block.id, entry.type, "figure"));
                 return "";
             }
-            return renderFigure(block, entry);
+            return renderFigure(block, ledger, entry);
         }
         case "chart": {
             const entry = values[block.id];

--- a/harness/src/report-render/render.ts
+++ b/harness/src/report-render/render.ts
@@ -23,7 +23,7 @@ import { renderChart } from "./views/chart-view.js";
 import { deriveChartOption } from "./chart.js";
 import { assemblePage, renderBand, renderReferenceSection } from "./views/page-view.js";
 import { renderClaim, renderNav, renderSection, renderText } from "./views/prose.js";
-import { citationKeyOf, ReferenceLedger } from "./references.js";
+import { citationKeyOf, derivationChains, ReferenceLedger, type DerivationChain } from "./references.js";
 import { encodeTablePayload, tableDataAsset, type DataAsset } from "./table-data.js";
 import type { RenderedPage, RenderProblem, RenderValue, RenderValues } from "./types.js";
 import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTable, tableColumns, tableDisplay } from "./views/values.js";
@@ -38,10 +38,19 @@ import { renderCitation, renderFigure, renderMetric, renderMetricGrid, renderTab
  * The records are the bibliography of the pin, and they are optional. A caller that passes none renders
  * each citation from its key alone, thus a stored pin that holds no record map renders as it did before.
  *
+ * The derivations are the chains of the session, and they are optional too. An appendix entry whose path a
+ * chain names states its sources and its script. A document that binds no derived path renders
+ * byte-identically with the chains and without them.
+ *
  * The renderer writes no file. The data assets ride the result, and the caller stages them beside the page.
  * Thus the render stays pure, and two renders of one document give byte-identical assets.
  */
-export function renderReportPage(document: ReportDocument, values: RenderValues, records?: CitationRecords): Result<RenderedPage, RenderProblem[]> {
+export function renderReportPage(
+    document: ReportDocument,
+    values: RenderValues,
+    records?: CitationRecords,
+    derivations?: readonly DerivationChain[],
+): Result<RenderedPage, RenderProblem[]> {
     const problems: RenderProblem[] = [];
     const ledger = new ReferenceLedger();
     const dataAssets: DataAsset[] = [];
@@ -55,7 +64,7 @@ export function renderReportPage(document: ReportDocument, values: RenderValues,
     }
 
     const nav = renderNav(document.sections);
-    const references = renderReferenceSection(ledger, document.sections.length, records);
+    const references = renderReferenceSection(ledger, document.sections.length, records, derivationChains(derivations));
     return ok({ html: assemblePage(document.title, nav, content.join(""), references, dataAssets), dataAssets });
 }
 
@@ -107,7 +116,7 @@ function renderBlock(
             // display entry of that column sits at the same index.
             const columns = tableColumns(entry);
             dataAssets.push(tableDataAsset(block.id, encodeTablePayload(columns, entry.rows, tableDisplay(block, entry, columns))));
-            return renderTable(block, entry.rows.length);
+            return renderTable(block, ledger, entry.rows.length);
         }
         case "figure": {
             const entry = values[block.id];
@@ -136,7 +145,7 @@ function renderBlock(
                 problems.push(option.error);
                 return "";
             }
-            return renderChart(block, option.value);
+            return renderChart(block, ledger, option.value);
         }
         case "section":
             return renderSection(block, depth, renderChildren(block.blocks, values, ledger, records, dataAssets, depth + 1, problems));

--- a/harness/src/report-render/views/chart-view.tsx
+++ b/harness/src/report-render/views/chart-view.tsx
@@ -13,10 +13,19 @@ import { raw } from "hono/html";
 
 import type { ChartBlock } from "../../contracts/report-blocks.js";
 import type { EchartOption } from "../chart.js";
+import type { ReferenceLedger } from "../references.js";
+import { LadderMarker } from "./references-view.js";
 import { scriptJson } from "../script-json.js";
 
-/** Render the card markup for a chart. */
-export function renderChart(block: ChartBlock, option: EchartOption): string {
+/**
+ * Render the card markup for a chart.
+ *
+ * The whole-table binding joins the provenance ladder, thus the title line carries the marker and the
+ * appendix names the artifact that the chart plots. A chart with no title still shows its marker on the
+ * same line.
+ */
+export function renderChart(block: ChartBlock, ledger: ReferenceLedger, option: EchartOption): string {
+    const mark = ledger.mark(block.binding);
     const containerId = chartContainerId(block.id);
     // The JSON goes to the page through `raw()`, thus `scriptJson` is the sole guard of this sink. It
     // replaces every `<` with `\u003c`, thus a `</script` sequence in a string cell cannot close the
@@ -24,7 +33,10 @@ export function renderChart(block: ChartBlock, option: EchartOption): string {
     const json = scriptJson(option);
     return String(
         <div class="report-chart">
-            {block.title !== undefined ? <div class="report-chart-title">{block.title}</div> : null}
+            <div class="report-chart-title">
+                {block.title}
+                <LadderMarker mark={mark} />
+            </div>
             <div class="report-chart-card corner-accents">
                 <div id={containerId} data-echarts-id={block.id} class="chart-container"></div>
                 <script type="application/json">{raw(json)}</script>

--- a/harness/src/report-render/views/page-view.tsx
+++ b/harness/src/report-render/views/page-view.tsx
@@ -24,7 +24,7 @@ import { stagedSource } from "../assets.js";
 import { DESIGN_CSS, ECHARTS_THEME, ECHARTS_THEME_NAME } from "../design.js";
 import type { DataAsset } from "../table-data.js";
 import type { CitationRecords } from "../../report-model/reference-resolver.js";
-import type { ReferenceLedger } from "../references.js";
+import type { DerivationChains, ReferenceLedger } from "../references.js";
 import { renderBibliography, renderReferenceList } from "./references-view.js";
 import { scriptJson } from "../script-json.js";
 
@@ -87,10 +87,11 @@ function appendixHeading(title: string): string {
  * An empty ladder renders no band, thus a report with citations alone shows the literature title alone.
  * The index continues the band alternation of the sections, and a band that renders takes the next one.
  * The records carry the bibliography of each cited key, and a ledger with no citation reads none of them.
+ * The chains carry the derivation of each derived path, and a provenance entry of such a path states it.
  */
-export function renderReferenceSection(ledger: ReferenceLedger, index: number, records?: CitationRecords): string {
+export function renderReferenceSection(ledger: ReferenceLedger, index: number, records?: CitationRecords, chains?: DerivationChains): string {
     const bands: string[] = [];
-    const provenance = renderReferenceList(ledger);
+    const provenance = renderReferenceList(ledger, chains);
     if (provenance !== "") {
         bands.push(renderBand(index, appendixHeading(PROVENANCE_TITLE) + provenance));
     }

--- a/harness/src/report-render/views/references-view.tsx
+++ b/harness/src/report-render/views/references-view.tsx
@@ -13,7 +13,14 @@ import type { PropsWithChildren } from "hono/jsx";
 
 import { citationRecordOf, type CitationRecords } from "../../report-model/reference-resolver.js";
 import type { ArtifactValueReference, CitationReference } from "../../contracts/report-reference.js";
-import { citationKeyOf, type ProvenanceReference, type ReferenceLedger, type ReferenceMark } from "../references.js";
+import {
+    citationKeyOf,
+    type DerivationChain,
+    type DerivationChains,
+    type ProvenanceReference,
+    type ReferenceLedger,
+    type ReferenceMark,
+} from "../references.js";
 
 /**
  * One provenance marker as a superscript that links to the list entry. The number comes from the ledger as
@@ -59,6 +66,57 @@ function Detail({ children }: PropsWithChildren) {
     return <span class="report-ref-detail">{children}</span>;
 }
 
+/** The head of a content hash in a monospace span. */
+function HashCode({ children }: PropsWithChildren) {
+    return <code class="report-ref-hash">{children}</code>;
+}
+
+/**
+ * The count of hash characters that a chain line shows.
+ *
+ * A content hash is 64 hex characters, and a line that carries three whole ones reads as noise. The head
+ * identifies the bytes, and it matches the count that a staged file name carries. Thus a reader compares the
+ * two by sight.
+ */
+const CHAIN_HASH_CHARS = 12;
+
+/** The head of one content hash: the hex after the algorithm name, cut to the shown length. */
+function hashHead(hash: string): string {
+    return hash.slice(hash.lastIndexOf(":") + 1).slice(0, CHAIN_HASH_CHARS);
+}
+
+/**
+ * The chain of one derived path: each source with the head of its hash, then the head of the script hash.
+ *
+ * The line rides under the entry of the path, thus the entry itself keeps the form of a pinned artifact and
+ * the chain adds one quiet line under it. A reader mounts the same sources, runs the same script, and gets
+ * the same bytes.
+ */
+function ChainLine({ chain }: { chain: DerivationChain }) {
+    return (
+        <div class="report-ref-chain">
+            <RefKind>Derived from</RefKind>{" "}
+            {chain.sources.map((source, index) => (
+                <>
+                    {index > 0 ? " and " : ""}
+                    <PathCode>{source.path}</PathCode> <HashCode>{hashHead(source.hash)}</HashCode>
+                </>
+            ))}{" "}
+            <Detail>by script</Detail> <HashCode>{hashHead(chain.scriptHash)}</HashCode>
+        </div>
+    );
+}
+
+/**
+ * The one path that a provenance reference names, or `undefined` for a kind that names no single file.
+ *
+ * A derivation reference computes over two inputs, thus it names no output file of its own and no chain
+ * belongs to it.
+ */
+function pathOf(reference: ProvenanceReference): string | undefined {
+    return reference.kind === "derivation" ? undefined : reference.path;
+}
+
 /**
  * Describe a locator as plain text: the column and the one row selector. The refine of the schema admits
  * exactly one of `row` or `rowFilter`, thus the two branches cover a valid locator.
@@ -79,7 +137,7 @@ function describeLocator(locator: ArtifactValueReference["locator"]): string {
  * the reference pins one cell. A derivation entry names its operation and its two inputs, each by path and
  * locator.
  */
-function ReferenceEntry({ reference }: { reference: ProvenanceReference }) {
+function ReferenceBody({ reference }: { reference: ProvenanceReference }) {
     switch (reference.kind) {
         case "artifact-value":
             return (
@@ -115,6 +173,23 @@ function ReferenceEntry({ reference }: { reference: ProvenanceReference }) {
 }
 
 /**
+ * One provenance entry: the body of its kind, and the chain of its path where the records hold one.
+ *
+ * A path that no record names renders the body alone, thus a page over pinned artifacts alone reads exactly
+ * as it did before the chains existed.
+ */
+function ReferenceEntry({ reference, chains }: { reference: ProvenanceReference; chains: DerivationChains | undefined }) {
+    const path = pathOf(reference);
+    const chain = path === undefined ? undefined : chains?.get(path);
+    return (
+        <>
+            <ReferenceBody reference={reference} />
+            {chain !== undefined ? <ChainLine chain={chain} /> : null}
+        </>
+    );
+}
+
+/**
  * The inner markup of one bibliography entry: the short citation of the pinned record, the key, and the
  * description of the record on a line of its own. A key that the record map does not hold shows the key
  * alone, because absence is a normal condition.
@@ -144,8 +219,11 @@ function CitationEntry({ reference, records }: { reference: CitationReference; r
  * order of the provenance ladder. The list is an appendix: a reader consults one entry from a marker, thus
  * the design keeps it quieter than the body. A ledger with no provenance entry gives an empty string, thus
  * the page shows no empty list.
+ *
+ * The chains are the derivations of the session, keyed by the output path. An entry whose path the chains
+ * hold carries the chain line, and each other entry carries none.
  */
-export function renderReferenceList(ledger: ReferenceLedger): string {
+export function renderReferenceList(ledger: ReferenceLedger, chains?: DerivationChains): string {
     const entries = ledger.provenanceEntries();
     if (entries.length === 0) {
         return "";
@@ -154,7 +232,7 @@ export function renderReferenceList(ledger: ReferenceLedger): string {
         <ol class="report-references">
             {entries.map((reference, index) => (
                 <li id={`ref-${index + 1}`} class="report-ref-item">
-                    <ReferenceEntry reference={reference} />
+                    <ReferenceEntry reference={reference} chains={chains} />
                 </li>
             ))}
         </ol>,

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -176,7 +176,7 @@ describe("renderTable", () => {
     const block: TableBlock = { kind: "table", id: "tb1", binding: tableBinding };
 
     it("renders one empty grid mount that names its block, and no row", () => {
-        const html = renderTable(block, 3);
+        const html = renderTable(block, new ReferenceLedger(), 3);
 
         expect(html).toContain(`<div class="report-grid" ${GRID_MOUNT_ATTRIBUTE}="tb1"></div>`);
         // The rows and the header ride the data asset, thus the markup carries no copy of either.
@@ -186,14 +186,26 @@ describe("renderTable", () => {
     });
 
     it("renders the title of the card and the caption under it", () => {
-        const html = renderTable({ ...block, title: "Top genes", caption: "The hypoxic group." }, 3);
+        const html = renderTable({ ...block, title: "Top genes", caption: "The hypoxic group." }, new ReferenceLedger(), 3);
 
-        expect(html).toContain(`<div class="report-table-title">Top genes</div>`);
+        // The title line carries the marker of the whole-table binding, thus the card names its appendix
+        // entry beside its title.
+        expect(html).toContain(`<div class="report-table-title">Top genes<sup class="report-marker"><a href="#ref-1">1</a></sup></div>`);
         expect(html).toContain(`<p class="report-caption">The hypoxic group.</p>`);
     });
 
+    it("marks the whole-table binding in the provenance ladder, and shows the marker with no title", () => {
+        const ledger = new ReferenceLedger();
+        const html = renderTable(block, ledger, 3);
+
+        // Every evidentiary binding ledgers, thus the appendix names the artifact of a card that carries no
+        // title of its own.
+        expect(html).toContain(`<div class="report-table-title"><sup class="report-marker"><a href="#ref-1">1</a></sup></div>`);
+        expect(ledger.provenanceEntries()).toEqual([tableBinding]);
+    });
+
     it("states the row count of the table in the status line, grouped", () => {
-        const html = renderTable(block, 14201);
+        const html = renderTable(block, new ReferenceLedger(), 14201);
 
         // The count reads as the number format of the page reads a count, thus the card and a cell agree.
         expect(html).toContain(`<span class="${GRID_COUNT_CLASS}">14,201 ${GRID_ROWS_WORD}</span>`);
@@ -202,10 +214,10 @@ describe("renderTable", () => {
     it("names the row bound of the binding beside the count, and nothing where the binding carries none", () => {
         const bounded: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "padj", count: 20, order: "asc" } } };
         // An ascending bound keeps the smallest values, thus the status names that end of the ranked order.
-        expect(renderTable(bounded, 20)).toContain(`<span class="report-table-bound">lowest 20 by padj</span>`);
+        expect(renderTable(bounded, new ReferenceLedger(), 20)).toContain(`<span class="report-table-bound">lowest 20 by padj</span>`);
 
         const top: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "nes", count: 20 } } };
-        expect(renderTable(top, 20)).toContain(`<span class="report-table-bound">top 20 by nes</span>`);
+        expect(renderTable(top, new ReferenceLedger(), 20)).toContain(`<span class="report-table-bound">top 20 by nes</span>`);
 
         // The declared label of the column names the bound, the same as it names the header.
         const labeled: TableBlock = {
@@ -213,16 +225,16 @@ describe("renderTable", () => {
             id: "tb1",
             binding: { ...tableBinding, rowBound: { column: "padj", count: 6 }, columnLabels: { padj: "Adjusted p-value" } },
         };
-        expect(renderTable(labeled, 6)).toContain("top 6 by Adjusted p-value");
+        expect(renderTable(labeled, new ReferenceLedger(), 6)).toContain("top 6 by Adjusted p-value");
 
         // A large bound groups its digits, the same as the count beside it.
         const wide: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, rowBound: { column: "nes", count: 5000 } } };
-        expect(renderTable(wide, 5000)).toContain("top 5,000 by nes");
-        expect(renderTable(block, 6)).not.toContain("report-table-bound");
+        expect(renderTable(wide, new ReferenceLedger(), 5000)).toContain("top 5,000 by nes");
+        expect(renderTable(block, new ReferenceLedger(), 6)).not.toContain("report-table-bound");
     });
 
     it("renders the download as a button of the card footer, named for the format of the file", () => {
-        const html = renderTable(block, 2);
+        const html = renderTable(block, new ReferenceLedger(), 2);
         const name = tableSidecarName(tableBinding.hash, tableBinding.path);
 
         // The link is relative, thus the page fetches no host when it opens. The attribute makes the
@@ -236,14 +248,14 @@ describe("renderTable", () => {
 
     it("names the format of another file, and it names none where the path carries no extension", () => {
         const parquet: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, path: "runs/r1/de.parquet" } };
-        expect(renderTable(parquet, 2)).toContain(">Download PARQUET</a>");
+        expect(renderTable(parquet, new ReferenceLedger(), 2)).toContain(">Download PARQUET</a>");
 
         const bare: TableBlock = { kind: "table", id: "tb1", binding: { ...tableBinding, path: "runs/r1/table" } };
-        expect(renderTable(bare, 2)).toContain(">Download</a>");
+        expect(renderTable(bare, new ReferenceLedger(), 2)).toContain(">Download</a>");
     });
 
     it("carries no filter, no toggle, and no capped row, because the grid owns the table", () => {
-        const html = renderTable(block, 25);
+        const html = renderTable(block, new ReferenceLedger(), 25);
 
         for (const retired of ["report-table-filter", "report-table-toggle", "report-row", "data-table"]) {
             expect(html).not.toContain(retired);

--- a/harness/src/report-render/views/values.test.ts
+++ b/harness/src/report-render/views/values.test.ts
@@ -27,43 +27,52 @@ describe("renderMetric", () => {
     }
 
     it("shows the label and the scalar value", () => {
-        const html = renderMetric(metric("Adjusted p-value"), { type: "scalar", value: 0.0123 });
+        const html = renderMetric(metric("Adjusted p-value"), new ReferenceLedger(), { type: "scalar", value: 0.0123 });
         expect(html).toContain("Adjusted p-value");
         // A p-value from one hundredth up reads better as a plain decimal than as an exponent.
         expect(html).toContain(">0.0123<");
     });
 
     it("puts the full digits in the title attribute of the value", () => {
-        const html = renderMetric(metric("Effect size"), { type: "scalar", value: -5.7618623255 });
+        const html = renderMetric(metric("Effect size"), new ReferenceLedger(), { type: "scalar", value: -5.7618623255 });
         expect(html).toContain(`<div class="stat-card-value" title="-5.7618623255">-5.76</div>`);
     });
 
     it("shows a p-value label in the scientific form with the full digits on the title", () => {
-        const html = renderMetric(metric("padj"), { type: "scalar", value: 0.0000427777663038 });
+        const html = renderMetric(metric("padj"), new ReferenceLedger(), { type: "scalar", value: 0.0000427777663038 });
         expect(html).toContain(`title="0.0000427777663038"`);
         expect(html).toContain(">4.3e-5<");
     });
 
     it("groups a count and carries no title, because the grouping hides no digit", () => {
-        const html = renderMetric(metric("Genes tested"), { type: "scalar", value: 18432 });
+        const html = renderMetric(metric("Genes tested"), new ReferenceLedger(), { type: "scalar", value: 18432 });
         expect(html).toContain(`<div class="stat-card-value">18,432</div>`);
         expect(html).not.toContain("title=");
     });
 
     it("passes a non-numeric value through with no title", () => {
-        const html = renderMetric(metric("Sequencing depth"), { type: "scalar", value: "42.6M" });
+        const html = renderMetric(metric("Sequencing depth"), new ReferenceLedger(), { type: "scalar", value: "42.6M" });
         expect(html).toContain(`<div class="stat-card-value">42.6M</div>`);
         expect(html).not.toContain("title=");
     });
 
     it("shows the near-zero form for a zero p-value, because a metric has no column to bound it", () => {
-        const html = renderMetric(metric("padj"), { type: "scalar", value: 0 });
+        const html = renderMetric(metric("padj"), new ReferenceLedger(), { type: "scalar", value: 0 });
         expect(html).toContain(`<div class="stat-card-value" title="0">≈0</div>`);
     });
 
     it("keeps a zero that names no p-value", () => {
-        const html = renderMetric(metric("Genes tested"), { type: "scalar", value: 0 });
+        const html = renderMetric(metric("Genes tested"), new ReferenceLedger(), { type: "scalar", value: 0 });
         expect(html).toContain(`<div class="stat-card-value">0</div>`);
+    });
+
+    it("marks the value binding in the provenance ladder, and shows the marker on the label", () => {
+        const ledger = new ReferenceLedger();
+        const html = renderMetric(metric("Genes tested"), ledger, { type: "scalar", value: 18432 });
+
+        // The marker sits on the label line, thus the value line stays the one figure of the card.
+        expect(html).toContain(`<div class="stat-card-label">Genes tested<sup class="report-marker"><a href="#ref-1">1</a></sup></div>`);
+        expect(ledger.provenanceEntries()).toEqual([scalarBinding]);
     });
 });
 
@@ -266,14 +275,14 @@ describe("renderTable", () => {
 describe("renderFigure", () => {
     it("puts the source in the src attribute and the caption below", () => {
         const block: FigureBlock = { kind: "figure", id: "f1", binding: figureBinding, caption: "Volcano plot" };
-        const html = renderFigure(block, { type: "figure", src: "data:image/png;base64,AAAA" });
+        const html = renderFigure(block, new ReferenceLedger(), { type: "figure", src: "data:image/png;base64,AAAA" });
         expect(html).toContain(`src="data:image/png;base64,AAAA"`);
         expect(html).toContain("Volcano plot");
     });
 
     it("keeps a quote in the caption as text and inside the alt attribute", () => {
         const block: FigureBlock = { kind: "figure", id: "f2", binding: figureBinding, caption: 'a "quoted" caption' };
-        const html = renderFigure(block, { type: "figure", src: "plot.png" });
+        const html = renderFigure(block, new ReferenceLedger(), { type: "figure", src: "plot.png" });
         // The runtime escapes each child, thus the figcaption content holds the escaped quote.
         expect(html).toContain("a &quot;quoted&quot; caption");
         // The alt attribute escapes the quote, thus the quote cannot break the attribute.
@@ -282,10 +291,22 @@ describe("renderFigure", () => {
 
     it("keeps a quote in the source inside the src attribute", () => {
         const block: FigureBlock = { kind: "figure", id: "f3", binding: figureBinding, caption: "c" };
-        const html = renderFigure(block, { type: "figure", src: 'x" onerror="alert(1)' });
+        const html = renderFigure(block, new ReferenceLedger(), { type: "figure", src: 'x" onerror="alert(1)' });
         expect(html).toContain(`src="x&quot; onerror=&quot;alert(1)"`);
         // The broken-out form with raw quotes is absent.
         expect(html).not.toContain(`onerror="alert(1)"`);
+    });
+
+    it("marks the file binding in the provenance ladder, and shows the marker with no caption", () => {
+        const ledger = new ReferenceLedger();
+        const block: FigureBlock = { kind: "figure", id: "f4", binding: figureBinding };
+        const html = renderFigure(block, ledger, { type: "figure", src: "plot.png" });
+
+        // A figure with no caption still ledgers, thus the appendix names the image that the page shows.
+        expect(html).toContain(`<figcaption class="report-caption"><sup class="report-marker"><a href="#ref-1">1</a></sup></figcaption>`);
+        // The alt text stays the picture, thus the marker never reaches a screen reader as caption text.
+        expect(html).toContain(`alt=""`);
+        expect(ledger.provenanceEntries()).toEqual([figureBinding]);
     });
 });
 

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -17,6 +17,9 @@
  * each column ride a data asset beside the page, and the page script builds the grid over them. Thus the
  * markup carries no row, and `tableDisplay` gives the page what the server resolved for each column.
  *
+ * Each card marks its binding in the shared ledger, thus every evidentiary block carries a marker and an
+ * appendix entry. A reference that two blocks share keeps one number and one entry.
+ *
  * Each data card carries the `corner-accents` class. Thus the card keeps square corners with the L-shaped
  * accents, which is the geometric identity of the report.
  */
@@ -80,15 +83,23 @@ type FigureValue = Extract<RenderValue, { type: "figure" }>;
  *
  * A metric reads one cell and it has no column, thus no neighbor bounds a zero here. A zero under a
  * p-value label reads as the near-zero form.
+ *
+ * The value binding joins the provenance ladder, thus the label line carries the marker and the appendix
+ * names the cell. The marker sits on the label and never on the value, because the value line is the one
+ * figure that a reader takes from the card.
  */
-export function renderMetric(block: MetricBlock, value: ScalarValue): string {
+export function renderMetric(block: MetricBlock, ledger: ReferenceLedger, value: ScalarValue): string {
+    const mark = ledger.mark(block.value);
     const shown = formatNumberCell(value.value, selectNumberKind(block.label, value.value));
     return String(
         <div class="stat-card corner-accents">
             <div class="stat-card-value" title={shown.full}>
                 {shown.text}
             </div>
-            <div class="stat-card-label">{block.label}</div>
+            <div class="stat-card-label">
+                {block.label}
+                <LadderMarker mark={mark} />
+            </div>
         </div>,
     );
 }
@@ -251,13 +262,21 @@ export function renderTable(block: TableBlock, ledger: ReferenceLedger, rowCount
  * Render a figure block as a corner-accent card. The source rides the `src` attribute, and the caption
  * renders below the image. The caption also fills the `alt` attribute, thus the escape keeps a hostile
  * source and a hostile caption inside their slots.
+ *
+ * The whole-file binding joins the provenance ladder, thus the caption line carries the marker and the
+ * appendix names the image. A figure with no caption still shows its marker on that line. The marker stays
+ * out of the `alt` text, because a screen reader reads the alt as the picture and not as a footnote.
  */
-export function renderFigure(block: FigureBlock, value: FigureValue): string {
+export function renderFigure(block: FigureBlock, ledger: ReferenceLedger, value: FigureValue): string {
+    const mark = ledger.mark(block.binding);
     const caption = block.caption;
     return String(
         <figure class="report-figure corner-accents">
             <img src={value.src} alt={caption !== undefined ? caption : ""} class="report-figure-image" />
-            {caption !== undefined ? <figcaption class="report-caption">{caption}</figcaption> : null}
+            <figcaption class="report-caption">
+                {caption}
+                <LadderMarker mark={mark} />
+            </figcaption>
         </figure>,
     );
 }

--- a/harness/src/report-render/views/values.tsx
+++ b/harness/src/report-render/views/values.tsx
@@ -211,14 +211,22 @@ function boundText(binding: TableBlock["binding"]): string | undefined {
  *
  * The download names the staged copy of the pinned artifact. The link is relative and the browser saves
  * the file, thus the page fetches nothing when it opens and the reader still gets the whole table.
+ *
+ * The whole-table binding joins the provenance ladder, thus the title line carries the marker and the
+ * appendix names the artifact. Every evidentiary block ledgers this way, and a card with no title still
+ * shows its marker on the same line.
  */
-export function renderTable(block: TableBlock, rowCount: number): string {
+export function renderTable(block: TableBlock, ledger: ReferenceLedger, rowCount: number): string {
     const binding = block.binding;
+    const mark = ledger.mark(binding);
     const download = tableSidecarName(binding.hash, binding.path);
     const bound = boundText(binding);
     return String(
         <div class="report-table">
-            {block.title !== undefined ? <div class="report-table-title">{block.title}</div> : null}
+            <div class="report-table-title">
+                {block.title}
+                <LadderMarker mark={mark} />
+            </div>
             <div class="corner-accents">
                 <div class="report-grid" {...{ [GRID_MOUNT_ATTRIBUTE]: block.id }}></div>
                 <div class="report-table-footer">

--- a/harness/src/runtime/assemble.test.ts
+++ b/harness/src/runtime/assemble.test.ts
@@ -197,7 +197,8 @@ async function makeEyesRoot(threadId: string): Promise<string> {
 function eyesGateway(): ReportSessionStateGateway {
     const state: ReportSessionState = { document: { title: "", sections: [] }, snapshot: { artifacts: {} } };
     return {
-        load: (): Promise<SessionStateLoad> => Promise.resolve({ outcome: "found", state, analysisId: EYES_ANALYSIS_ID, token: null, seenDocumentHash: null }),
+        load: (): Promise<SessionStateLoad> =>
+            Promise.resolve({ outcome: "found", state, analysisId: EYES_ANALYSIS_ID, token: null, seenDocumentHash: null, derivations: [] }),
         persist: () => Promise.resolve({ outcome: "persisted" }),
         stampRendered: () => Promise.resolve({ outcome: "stamped" }),
         stampSeen: () => Promise.resolve({ outcome: "stamped" }),

--- a/harness/src/tools/report-authoring/authoring-tools.test.ts
+++ b/harness/src/tools/report-authoring/authoring-tools.test.ts
@@ -86,7 +86,7 @@ function makeFakeGateway(): FakeGateway {
                 return Promise.resolve({ outcome: "absent" });
             }
             const state = structuredClone(row.state);
-            return Promise.resolve({ outcome: "found", state, analysisId: row.analysisId, token: state.document, seenDocumentHash: null });
+            return Promise.resolve({ outcome: "found", state, analysisId: row.analysisId, token: state.document, seenDocumentHash: null, derivations: [] });
         },
         ...stampStubs,
         persist(threadId, document): Promise<SessionStatePersist> {
@@ -394,6 +394,7 @@ describe("the tool-layer refusal", () => {
                     analysisId: "analysis-001",
                     token: null,
                     seenDocumentHash: null,
+                    derivations: [],
                 }),
             persist: () => Promise.resolve({ outcome: "conflict" }),
             ...stampStubs,

--- a/harness/src/tools/report-authoring/authoring-tools.ts
+++ b/harness/src/tools/report-authoring/authoring-tools.ts
@@ -40,6 +40,7 @@ import { buildOutline, childOutline, readBlock, type OutlineEntry, type Readable
 import { finishDraft, type FinishResult } from "../../report-model/draft-finish.js";
 import { DraftBlockSchema, type DraftDocument } from "../../report-model/draft.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
+import type { DerivationRecord } from "../../state/report-session-state.js";
 import { defineTool, type Tool, type ToolContext, type ToolError } from "../define-tool.js";
 
 /**
@@ -192,15 +193,27 @@ export type SessionStateToken = DraftDocument | null;
 
 /**
  * The outcome of a gateway load. `found` carries the state, the analysis that owns the thread, the
- * concurrency token, and the seen-document hash of the look-before-record rule. `absent` and `wrong-type`
- * are permanent conditions, and `failed` is a transient fault that names its cause.
+ * concurrency token, the seen-document hash of the look-before-record rule, and the derivations of the
+ * session. `absent` and `wrong-type` are permanent conditions, and `failed` is a transient fault that names
+ * its cause.
  *
  * `seenDocumentHash` is the hash that the last eyes capture saw, or `null` before the first look. The record
  * tool compares it against the hash of the current draft, thus a never-seen page and a stale look each
  * refuse.
+ *
+ * `derivations` is the ledger of the session, in the order that the records landed. The snapshot already
+ * carries each derived path as a member, thus a tool that binds reads the snapshot. The records themselves
+ * carry the chain, and the finish, the appendix, and the prune each read them.
  */
 export type SessionStateLoad =
-    | { outcome: "found"; state: ReportSessionState; analysisId: string; token: SessionStateToken; seenDocumentHash: string | null }
+    | {
+          outcome: "found";
+          state: ReportSessionState;
+          analysisId: string;
+          token: SessionStateToken;
+          seenDocumentHash: string | null;
+          derivations: readonly DerivationRecord[];
+      }
     | { outcome: "absent" }
     | { outcome: "wrong-type"; detail: string }
     | { outcome: "failed"; detail: string };
@@ -249,7 +262,7 @@ export interface ReportSessionStateGateway {
 
 /**
  * The thread of a call, its analysis, the loaded state, the concurrency token that the persist compares
- * against, and the seen-document hash of the look-before-record rule.
+ * against, the seen-document hash of the look-before-record rule, and the derivations of the session.
  */
 export interface OpenedThread {
     readonly threadId: string;
@@ -258,6 +271,8 @@ export interface OpenedThread {
     readonly token: SessionStateToken;
     /** The hash that the last eyes capture saw, or `null` before the first look. */
     readonly seenDocumentHash: string | null;
+    /** The derivations of the session, in the order that the records landed. */
+    readonly derivations: readonly DerivationRecord[];
 }
 
 /**
@@ -296,7 +311,14 @@ export async function openReportThread(gateway: ReportSessionStateGateway, scope
             detail: `the scope names the analysis ${analysisId}, but the thread ${threadId} belongs to the analysis ${loaded.analysisId}`,
         });
     }
-    return ok({ threadId, analysisId, state: loaded.state, token: loaded.token, seenDocumentHash: loaded.seenDocumentHash });
+    return ok({
+        threadId,
+        analysisId,
+        state: loaded.state,
+        token: loaded.token,
+        seenDocumentHash: loaded.seenDocumentHash,
+        derivations: loaded.derivations,
+    });
 }
 
 /** The eight authoring tools. */
@@ -763,7 +785,7 @@ export function createReportAuthoringTools(gateway: ReportSessionStateGateway): 
             if (opened.isErr()) {
                 return ok({ refused: opened.error });
             }
-            return ok(finishDraft(opened.value.state.document, opened.value.state.snapshot));
+            return ok(finishDraft(opened.value.state.document, opened.value.state.snapshot, opened.value.derivations));
         },
     });
 

--- a/harness/src/tools/report-session/derive-table.test.ts
+++ b/harness/src/tools/report-session/derive-table.test.ts
@@ -87,7 +87,14 @@ function makeFakeGateway(): FakeGateway {
                 return Promise.resolve({ outcome: "absent" });
             }
             const copy = structuredClone(state);
-            return Promise.resolve({ outcome: "found", state: copy, analysisId: DEFAULT_ANALYSIS_ID, token: copy.document, seenDocumentHash: null });
+            return Promise.resolve({
+                outcome: "found",
+                state: copy,
+                analysisId: DEFAULT_ANALYSIS_ID,
+                token: copy.document,
+                seenDocumentHash: null,
+                derivations: [],
+            });
         },
         persist(): Promise<SessionStatePersist> {
             return Promise.resolve({ outcome: "persisted" });

--- a/harness/src/tools/report-session/derive-table.ts
+++ b/harness/src/tools/report-session/derive-table.ts
@@ -51,7 +51,7 @@ import { generateExecutionId } from "../../sandbox/execution-id.js";
 import { mintSandboxIdentity } from "../../sandbox/identity.js";
 import type { ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
 import type { DerivationRecord, DerivationSource, ReportSessionStateStore } from "../../state/report-session-state.js";
-import { isSafeId, reportSessionDir, toSandboxPath, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
+import { isSafeId, reportSessionDerivedDir, toSandboxPath, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
 import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
 import { readHeaderColumns } from "./list-artifacts.js";
@@ -125,9 +125,6 @@ const SCRIPT_CAP_BYTES = 64 * 1024;
 
 /** The cap of the declared inputs. One derivation reads the evidence of a few artifacts, and never a tree. */
 const INPUT_CAP = 20;
-
-/** The directory of the derived tables of a session, under the directory of that session. */
-const DERIVED_DIR = "derived";
 
 /** The environment variable that carries the declared inputs into the container. */
 export const DERIVE_INPUT_ENV = "DERIVE_INPUTS";
@@ -365,7 +362,7 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
 
             // The write tail is the one writable mount of the container, and the output sits inside it. Both
             // compose from the session-directory builder, thus the layout has one owner.
-            const writableTail = `${reportSessionDir(threadId)}/${DERIVED_DIR}`;
+            const writableTail = reportSessionDerivedDir(threadId);
             const outputPath = `${writableTail}/${input.output}`;
             // The served membership carries each derivation of the session, thus this one test refuses a
             // repeated name and a collision with a pinned artifact alike.

--- a/harness/src/tools/report-session/examine-page.test.ts
+++ b/harness/src/tools/report-session/examine-page.test.ts
@@ -89,7 +89,14 @@ function makeFakeGateway(): FakeGateway {
             if (row === undefined) {
                 return Promise.resolve({ outcome: "absent" });
             }
-            return Promise.resolve({ outcome: "found", state: row.state, analysisId: row.analysisId, token: null, seenDocumentHash: row.seen });
+            return Promise.resolve({
+                outcome: "found",
+                state: row.state,
+                analysisId: row.analysisId,
+                token: null,
+                seenDocumentHash: row.seen,
+                derivations: [],
+            });
         },
         persist(): Promise<SessionStatePersist> {
             return Promise.resolve({ outcome: "persisted" });

--- a/harness/src/tools/report-session/list-artifacts.test.ts
+++ b/harness/src/tools/report-session/list-artifacts.test.ts
@@ -65,7 +65,7 @@ function makeFakeGateway(): FakeGateway {
                 return Promise.resolve({ outcome: "absent" });
             }
             const state = structuredClone(row.state);
-            return Promise.resolve({ outcome: "found", state, analysisId: row.analysisId, token: state.document, seenDocumentHash: null });
+            return Promise.resolve({ outcome: "found", state, analysisId: row.analysisId, token: state.document, seenDocumentHash: null, derivations: [] });
         },
         persist(): Promise<SessionStatePersist> {
             return Promise.resolve({ outcome: "persisted" });

--- a/harness/src/tools/report-session/preview-report.test.ts
+++ b/harness/src/tools/report-session/preview-report.test.ts
@@ -19,6 +19,7 @@ import { computeDraftHash } from "../../report-model/draft-hash.js";
 import { createFixtureResolver } from "../../report-model/fixture-resolver.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import { PAGE_ASSETS, tableSidecarName } from "../../report-render/assets.js";
+import type { DerivationRecord } from "../../state/report-session-state.js";
 import type { ReportSessionState, ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
@@ -50,6 +51,8 @@ const DEFAULT_ANALYSIS_ID = "analysis-001";
  */
 interface FakeGateway extends ReportSessionStateGateway {
     seed(threadId: string, state: ReportSessionState, analysisId?: string): void;
+    /** Seed the derivation ledger of a thread. A thread with no seed carries an empty ledger. */
+    seedDerivations(threadId: string, derivations: readonly DerivationRecord[]): void;
     setFault(fault: boolean): void;
     /** The hash that the last `stampRendered` wrote for the thread, or `null` when no stamp landed. */
     renderedHash(threadId: string): string | null;
@@ -60,6 +63,7 @@ interface FakeRow {
     analysisId: string;
     rendered: string | null;
     seen: string | null;
+    derivations: readonly DerivationRecord[];
 }
 
 function makeFakeGateway(): FakeGateway {
@@ -67,7 +71,13 @@ function makeFakeGateway(): FakeGateway {
     let fault = false;
     return {
         seed(threadId, state, analysisId = DEFAULT_ANALYSIS_ID): void {
-            rows.set(threadId, { state: structuredClone(state), analysisId, rendered: null, seen: null });
+            rows.set(threadId, { state: structuredClone(state), analysisId, rendered: null, seen: null, derivations: [] });
+        },
+        seedDerivations(threadId, derivations): void {
+            const row = rows.get(threadId);
+            if (row !== undefined) {
+                rows.set(threadId, { ...row, derivations });
+            }
         },
         setFault(value): void {
             fault = value;
@@ -84,7 +94,14 @@ function makeFakeGateway(): FakeGateway {
                 return Promise.resolve({ outcome: "absent" });
             }
             const state = structuredClone(row.state);
-            return Promise.resolve({ outcome: "found", state, analysisId: row.analysisId, token: state.document, seenDocumentHash: row.seen });
+            return Promise.resolve({
+                outcome: "found",
+                state,
+                analysisId: row.analysisId,
+                token: state.document,
+                seenDocumentHash: row.seen,
+                derivations: row.derivations,
+            });
         },
         persist(threadId, document): Promise<SessionStatePersist> {
             const existing = rows.get(threadId);
@@ -95,6 +112,7 @@ function makeFakeGateway(): FakeGateway {
                 analysisId,
                 rendered: existing?.rendered ?? null,
                 seen: existing?.seen ?? null,
+                derivations: existing?.derivations ?? [],
             });
             return Promise.resolve({ outcome: "persisted" });
         },
@@ -243,6 +261,84 @@ describe("the pass path", () => {
         const assetsDir = join(root, "report-sessions", "t1", "assets");
         const staged = await Promise.all(PAGE_ASSETS.map((asset) => readFile(join(assetsDir, asset.file), "utf8")));
         expect(staged).toEqual(PAGE_ASSETS.map(() => "PACKED-ASSET-BYTES"));
+    });
+});
+
+describe("the derivation records of the session", () => {
+    const DERIVED = "report-sessions/t1/derived/merged.csv";
+    const DERIVED_HASH = `sha256:${"d".repeat(64)}`;
+
+    /** One derivation record of the session, over two sources and one script. */
+    const record: DerivationRecord = {
+        outputPath: DERIVED,
+        outputHash: DERIVED_HASH,
+        sources: [
+            { path: "data/x.csv", hash: `sha256:${"a".repeat(64)}` },
+            { path: "data/y.csv", hash: `sha256:${"b".repeat(64)}` },
+        ],
+        scriptHash: `sha256:${"c".repeat(64)}`,
+        script: "import pandas",
+    };
+
+    /** A draft whose one table block binds the derived path. */
+    function derivedDoc(): DraftDocument {
+        return {
+            title: "Report",
+            sections: [
+                {
+                    kind: "section",
+                    id: "s1",
+                    title: "Intro",
+                    blocks: [{ kind: "table", id: "tb1", binding: { kind: "artifact-table", path: DERIVED, hash: DERIVED_HASH } }],
+                },
+            ],
+        };
+    }
+
+    /** The served membership: the pinned artifacts, with the derived table as one more entry. */
+    const derivedSnapshot: ReportSnapshot = {
+        artifacts: {
+            "data/x.csv": { hash: "sha256:aaa", rows: [{ n: 42 }] },
+            [DERIVED]: { hash: DERIVED_HASH, rows: [{ gene: "TP53", padj: 0.004 }] },
+        },
+    };
+
+    it("states the chain of the derived path in the appendix of the page", async () => {
+        const root = await makeRoot();
+        // The card of a table offers its pinned bytes as a download, thus the stage copies the derived file.
+        await mkdir(join(root, "report-sessions", "t1", "derived"), { recursive: true });
+        await writeFile(join(root, DERIVED), "gene,padj\nTP53,0.004\n", "utf8");
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: derivedDoc(), snapshot: derivedSnapshot });
+        gateway.seedDerivations("t1", [record]);
+        const tool = createPreviewReportTool({ gateway, makeResolver: () => createFixtureResolver(), resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("rendered");
+        if (result.outcome === "rendered") {
+            const page = await readFile(result.pagePath, "utf8");
+            // The tool passes the records of the session state to the render, thus the appendix entry of the
+            // derived path names its sources and its script.
+            expect(page).toContain(`<div class="report-ref-chain">`);
+            expect(page).toContain("data/y.csv");
+            expect(page).toContain(`<code class="report-ref-hash">${"c".repeat(12)}</code>`);
+        }
+    });
+
+    it("renders no chain line for a session that derived nothing", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: metricDoc(), snapshot: metricSnapshot });
+        const tool = createPreviewReportTool({ gateway, makeResolver: () => createFixtureResolver(), resolveWorkspaceRoot: () => root });
+
+        const result = (await tool.execute({}, ctxForThread("t1")))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("rendered");
+        if (result.outcome === "rendered") {
+            const page = await readFile(result.pagePath, "utf8");
+            expect(page).not.toContain(`<div class="report-ref-chain">`);
+        }
     });
 });
 

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -403,10 +403,10 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
             if (opened.isErr()) {
                 return ok({ outcome: "refused", refusal: opened.error });
             }
-            const { threadId, analysisId, state } = opened.value;
+            const { threadId, analysisId, state, derivations } = opened.value;
             const { document: draft, snapshot } = state;
 
-            const finished = finishDraft(draft, snapshot);
+            const finished = finishDraft(draft, snapshot, derivations);
             if (!finished.valid) {
                 return ok({ outcome: "gaps", gaps: finished.gaps });
             }
@@ -436,9 +436,10 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
                 return ok({ outcome: "bridge-mismatch", mismatches: bridged.error });
             }
 
-            // The records are the bibliography of the pin. They ride the render call and never the value
-            // map, because the appendix reads them beside the cards and the value map is keyed by block.
-            const rendered = renderReportPage(document, bridged.value, snapshot.citationRecords);
+            // The citation records are the bibliography of the pin, and the derivation records are the chain
+            // of each derived path. Both ride the render call and never the value map, because the appendix
+            // reads them beside the cards and the value map is keyed by block.
+            const rendered = renderReportPage(document, bridged.value, snapshot.citationRecords, derivations);
             if (rendered.isErr()) {
                 return ok({ outcome: "render-problems", problems: rendered.error });
             }

--- a/harness/src/tools/report-session/record-version.test.ts
+++ b/harness/src/tools/report-session/record-version.test.ts
@@ -110,6 +110,19 @@ function docWithTable(path: string): DraftDocument {
     return draft;
 }
 
+/** A valid draft with the metric of `metricDoc` and one chart that binds the given derived path. */
+function docWithChart(path: string): DraftDocument {
+    const draft = metricDoc();
+    draft.sections[0].blocks.push({
+        kind: "chart",
+        id: "ch1",
+        binding: { kind: "artifact-table", path, hash: DERIVED_HASH },
+        chartType: "bar",
+        encoding: { x: "gene", y: "padj" },
+    });
+    return draft;
+}
+
 /** Write one file under a workspace root, and make each directory over it. */
 async function stageFile(root: string, path: string): Promise<string> {
     const absolute = join(root, path);
@@ -335,6 +348,25 @@ describe("createRecordVersionTool", () => {
             // The records are append-only. The bytes are reproducible from the script and the sources, thus
             // the prune touches no record.
             expect(records.map((record) => record.outputPath)).toEqual([used, unused]);
+        });
+
+        it("keeps the output that a chart block binds", async () => {
+            const threadId = "thread-prune-chart";
+            await anchorThread(threadId, "parent-prune-chart");
+            const root = await makeRoot("record-prune-chart-");
+
+            const plotted = derivedPath(threadId, "plotted.csv");
+            const plottedFile = await stageFile(root, plotted);
+
+            const doc = docWithChart(plotted);
+            const gateway = gatewayFor(threadId, doc, snapshotWithDerived([plotted]), computeDraftHash(doc), [derivation(plotted)]);
+
+            const result = (await makeTool(gateway, root).execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(result.outcome).toBe("recorded");
+            // A chart holds no card of its own rows, and it still names its artifact. Thus the whole-table
+            // binding of a chart uses the derivation and the prune removes nothing.
+            expect(existsSync(plottedFile)).toBe(true);
         });
 
         it("keeps the version and logs when a removal fails", async () => {

--- a/harness/src/tools/report-session/record-version.test.ts
+++ b/harness/src/tools/report-session/record-version.test.ts
@@ -7,12 +7,15 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Pool } from "pg";
 
 import type { Scope } from "../../auth/types.js";
+import { createNoopLogger } from "../../lib/console-logger.js";
+import type { Logger } from "../../lib/logger.js";
 import { createThreadStore, type ThreadStore } from "../../memory/thread-store.js";
 import type { DraftDocument } from "../../report-model/draft.js";
 import { computeDraftHash } from "../../report-model/draft-hash.js";
@@ -20,7 +23,9 @@ import { createFixtureResolver } from "../../report-model/fixture-resolver.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import { withSchema } from "../../__tests__/setup/postgres.js";
 import { upsertAnalysis } from "../../state/analyses.js";
+import type { DerivationRecord } from "../../state/report-session-state.js";
 import { createReportVersionStore, type ReportVersionStore } from "../../state/report-versions.js";
+import { reportSessionDerivedDir } from "../../workspace/paths.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
 import type { ReportSessionStateGateway, SessionStateLoad, SessionStatePersist, StampResult } from "../report-authoring/authoring-tools.js";
@@ -31,6 +36,13 @@ const ANALYSIS_ID = "analysis-001";
 
 /** Each workspace root that a test made. The cleanup removes them after the suite. */
 const createdRoots: string[] = [];
+
+/** Make one temp directory as a workspace root, and register it for the cleanup. */
+async function makeRoot(prefix: string): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), prefix));
+    createdRoots.push(root);
+    return root;
+}
 
 /** A snapshot with one readable artifact that the metric binds to. */
 const metricSnapshot: ReportSnapshot = { artifacts: { "data/x.csv": { hash: "sha256:aaa", rows: [{ n: 42 }] } } };
@@ -63,14 +75,77 @@ function metricDoc(assertValue?: number): DraftDocument {
     };
 }
 
-/** A gateway whose load gives the one thread its state and the seen hash that a test decides. */
-function gatewayFor(threadId: string, document: DraftDocument, snapshot: ReportSnapshot, seen: string | null): ReportSessionStateGateway {
+/** The content hash that every derived table of these tests carries. */
+const DERIVED_HASH = `sha256:${"b".repeat(64)}`;
+
+/** One derivation record of a session. The output path is the workspace-relative path that the record holds. */
+function derivation(outputPath: string): DerivationRecord {
+    return {
+        outputPath,
+        outputHash: DERIVED_HASH,
+        sources: [{ path: "data/x.csv", hash: "sha256:aaa" }],
+        scriptHash: `sha256:${"c".repeat(64)}`,
+        script: "import pandas",
+    };
+}
+
+/** The path of one derived table of a thread, under the derived directory of its session. */
+function derivedPath(threadId: string, name: string): string {
+    return `${reportSessionDerivedDir(threadId)}/${name}`;
+}
+
+/** A snapshot that holds the metric artifact and each named derived table. */
+function snapshotWithDerived(paths: readonly string[]): ReportSnapshot {
+    const artifacts: ReportSnapshot["artifacts"] = { ...metricSnapshot.artifacts };
+    for (const path of paths) {
+        artifacts[path] = { hash: DERIVED_HASH, rows: [{ gene: "TP53", padj: 0.004 }] };
+    }
+    return { artifacts };
+}
+
+/** A valid draft with the metric of `metricDoc` and one table that binds the given derived path. */
+function docWithTable(path: string): DraftDocument {
+    const draft = metricDoc();
+    draft.sections[0].blocks.push({ kind: "table", id: "tb1", binding: { kind: "artifact-table", path, hash: DERIVED_HASH } });
+    return draft;
+}
+
+/** Write one file under a workspace root, and make each directory over it. */
+async function stageFile(root: string, path: string): Promise<string> {
+    const absolute = join(root, path);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await writeFile(absolute, "gene,padj\nTP53,0.004\n", "utf8");
+    return absolute;
+}
+
+/** A logger that keeps each warn message, thus a test reads the one record of a failed prune. */
+function recordingLogger(): { logger: Logger; warns: string[] } {
+    const warns: string[] = [];
+    const logger: Logger = {
+        ...createNoopLogger(),
+        warn: (msg) => {
+            warns.push(msg);
+        },
+        with: () => logger,
+        named: () => logger,
+    };
+    return { logger, warns };
+}
+
+/** A gateway whose load gives the one thread its state, the seen hash, and the derivations that a test decides. */
+function gatewayFor(
+    threadId: string,
+    document: DraftDocument,
+    snapshot: ReportSnapshot,
+    seen: string | null,
+    derivations: readonly DerivationRecord[] = [],
+): ReportSessionStateGateway {
     const stamped = (): Promise<StampResult> => Promise.resolve({ outcome: "stamped" });
     return {
         load: (t): Promise<SessionStateLoad> =>
             Promise.resolve(
                 t === threadId
-                    ? { outcome: "found", state: { document, snapshot }, analysisId: ANALYSIS_ID, token: null, seenDocumentHash: seen }
+                    ? { outcome: "found", state: { document, snapshot }, analysisId: ANALYSIS_ID, token: null, seenDocumentHash: seen, derivations }
                     : { outcome: "absent" },
             ),
         persist: (): Promise<SessionStatePersist> => Promise.resolve({ outcome: "persisted" }),
@@ -91,6 +166,8 @@ describe("createRecordVersionTool", () => {
     let drop: () => Promise<void>;
     let store: ReportVersionStore;
     let threads: ThreadStore;
+    /** The workspace root of the suite. The prune resolves the derived directory of a session under it. */
+    let suiteRoot: string;
 
     beforeAll(async () => {
         const ctx = await withSchema("record_report_version");
@@ -99,6 +176,7 @@ describe("createRecordVersionTool", () => {
         store = createReportVersionStore({ pool });
         threads = createThreadStore(pool);
         (await upsertAnalysis(pool, ANALYSIS_ID, null))._unsafeUnwrap();
+        suiteRoot = await makeRoot("record-suite-");
     });
 
     afterAll(async () => {
@@ -108,8 +186,15 @@ describe("createRecordVersionTool", () => {
         await drop();
     });
 
-    function makeTool(gateway: ReportSessionStateGateway) {
-        return createRecordVersionTool({ gateway, store, threads, makeResolver: () => createFixtureResolver() });
+    function makeTool(gateway: ReportSessionStateGateway, root?: string, logger?: Logger) {
+        return createRecordVersionTool({
+            gateway,
+            store,
+            threads,
+            resolveWorkspaceRoot: () => root ?? suiteRoot,
+            makeResolver: () => createFixtureResolver(),
+            ...(logger ? { logger } : {}),
+        });
     }
 
     it("records nothing and names the block when an assert fails", async () => {
@@ -157,7 +242,7 @@ describe("createRecordVersionTool", () => {
             constructions += 1;
             return createFixtureResolver();
         };
-        const tool = createRecordVersionTool({ gateway, store, threads, makeResolver });
+        const tool = createRecordVersionTool({ gateway, store, threads, resolveWorkspaceRoot: () => suiteRoot, makeResolver });
 
         const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
 
@@ -177,6 +262,7 @@ describe("createRecordVersionTool", () => {
             gateway,
             store,
             threads,
+            resolveWorkspaceRoot: () => suiteRoot,
             makeResolver: () => {
                 throw new Error("the workspace root did not resolve");
             },
@@ -218,6 +304,106 @@ describe("createRecordVersionTool", () => {
         expect(stored!.document.title).toBe("Report");
     });
 
+    describe("the derivation prune", () => {
+        /** Anchor one report thread and its parent conversation, thus the record reaches the store. */
+        async function anchorThread(threadId: string, parentId: string): Promise<void> {
+            (await threads.createThread({ threadId: parentId, analysisId: ANALYSIS_ID }))._unsafeUnwrap();
+            (await threads.createThread({ threadId, analysisId: ANALYSIS_ID, type: "report", parentThreadId: parentId, parentSeq: 1 }))._unsafeUnwrap();
+        }
+
+        it("removes the unused output, keeps the used one, and keeps both records", async () => {
+            const threadId = "thread-prune";
+            await anchorThread(threadId, "parent-prune");
+            const root = await makeRoot("record-prune-");
+
+            const used = derivedPath(threadId, "used.csv");
+            const unused = derivedPath(threadId, "unused.csv");
+            const usedFile = await stageFile(root, used);
+            const unusedFile = await stageFile(root, unused);
+
+            const doc = docWithTable(used);
+            const records = [derivation(used), derivation(unused)];
+            const gateway = gatewayFor(threadId, doc, snapshotWithDerived([used, unused]), computeDraftHash(doc), records);
+
+            const result = (await makeTool(gateway, root).execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(result.outcome).toBe("recorded");
+            // A binding names the used path, thus its bytes stay. No binding names the other, thus its file
+            // goes and the disk of the session holds the closure of the recorded report.
+            expect(existsSync(usedFile)).toBe(true);
+            expect(existsSync(unusedFile)).toBe(false);
+            // The records are append-only. The bytes are reproducible from the script and the sources, thus
+            // the prune touches no record.
+            expect(records.map((record) => record.outputPath)).toEqual([used, unused]);
+        });
+
+        it("keeps the version and logs when a removal fails", async () => {
+            const threadId = "thread-prune-fault";
+            await anchorThread(threadId, "parent-prune-fault");
+            const root = await makeRoot("record-prune-fault-");
+
+            const unused = derivedPath(threadId, "unused.csv");
+            // A directory at the output name refuses a plain file removal, thus the removal throws and the
+            // prune reports one failure.
+            await mkdir(join(root, unused, "inner"), { recursive: true });
+
+            const doc = metricDoc();
+            const { logger, warns } = recordingLogger();
+            const gateway = gatewayFor(threadId, doc, metricSnapshot, computeDraftHash(doc), [derivation(unused)]);
+
+            const result = (await makeTool(gateway, root, logger).execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            // The prune runs after the version lands, thus a failed removal costs the cleanup alone.
+            expect(result.outcome).toBe("recorded");
+            expect((await store.getThreadVersion(threadId))._unsafeUnwrap()).not.toBeNull();
+            expect(warns).toContain("an unused derivation did not go");
+        });
+
+        it("removes no file that sits outside the derived directory of the session", async () => {
+            const threadId = "thread-prune-escape";
+            await anchorThread(threadId, "parent-prune-escape");
+            const parent = await makeRoot("record-prune-escape-");
+            const root = join(parent, "workspace");
+            await mkdir(root, { recursive: true });
+
+            // One record names a run output inside the tree, and one climbs out of the tree. The prune owns
+            // the derived directory alone, thus it removes neither.
+            const inTree = "runs/r1/output/stray.csv";
+            const outOfTree = "../escape.csv";
+            const inTreeFile = await stageFile(root, inTree);
+            const outOfTreeFile = await stageFile(parent, "escape.csv");
+
+            const doc = metricDoc();
+            const { logger, warns } = recordingLogger();
+            const gateway = gatewayFor(threadId, doc, metricSnapshot, computeDraftHash(doc), [derivation(inTree), derivation(outOfTree)]);
+
+            const result = (await makeTool(gateway, root, logger).execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(result.outcome).toBe("recorded");
+            expect(existsSync(inTreeFile)).toBe(true);
+            expect(existsSync(outOfTreeFile)).toBe(true);
+            expect(warns.filter((line) => line === "an unused derivation sits outside the derived directory of the session").length).toBe(2);
+        });
+
+        it("prunes nothing for a session that derived nothing", async () => {
+            const threadId = "thread-prune-none";
+            await anchorThread(threadId, "parent-prune-none");
+            const root = await makeRoot("record-prune-none-");
+
+            // A file under the derived directory that no record names stays, because the prune reads the
+            // records and never the directory.
+            const stray = await stageFile(root, derivedPath(threadId, "stray.csv"));
+
+            const doc = metricDoc();
+            const gateway = gatewayFor(threadId, doc, metricSnapshot, computeDraftHash(doc));
+
+            const result = (await makeTool(gateway, root).execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+            expect(result.outcome).toBe("recorded");
+            expect(existsSync(stray)).toBe(true);
+        });
+    });
+
     it("serves the preview and the record gate through one resolver factory on the same reference", async () => {
         const parentId = "parent-shared";
         const threadId = "thread-shared";
@@ -236,14 +422,13 @@ describe("createRecordVersionTool", () => {
             return resolver;
         };
 
-        const root = await mkdtemp(join(tmpdir(), "record-shared-"));
-        createdRoots.push(root);
+        const root = await makeRoot("record-shared-");
 
         const previewTool = createPreviewReportTool({ gateway, makeResolver, resolveWorkspaceRoot: () => root });
         const preview = (await previewTool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
         expect(preview.outcome).toBe("rendered");
 
-        const recordTool = createRecordVersionTool({ gateway, store, threads, makeResolver });
+        const recordTool = createRecordVersionTool({ gateway, store, threads, resolveWorkspaceRoot: () => root, makeResolver });
         const record = (await recordTool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
         expect(record.outcome).toBe("recorded");
 

--- a/harness/src/tools/report-session/record-version.ts
+++ b/harness/src/tools/report-session/record-version.ts
@@ -37,7 +37,7 @@ import type { ReportDocument } from "../../contracts/report-blocks.js";
 import { createNoopLogger } from "../../lib/console-logger.js";
 import { describeDbError } from "../../lib/db-result.js";
 import { describeFsError, tryFsWrite } from "../../lib/fs-result.js";
-import { defaultErrorFields, type Logger } from "../../lib/logger.js";
+import type { Logger } from "../../lib/logger.js";
 import type { ThreadStore } from "../../memory/thread-store.js";
 import { referencedPaths, walkBlocks } from "../../report-model/block-walk.js";
 import { finishDraft, type FinishGap, type SessionDerivation } from "../../report-model/draft-finish.js";
@@ -126,7 +126,8 @@ function describeRecordFailure(error: RecordVersionError): string {
  *
  * The version already stands at this point. Thus each failure costs the cleanup alone: an unresolvable root,
  * a path that escapes, and a failed removal each log and change no outcome. The records stay, and the bytes
- * are reproducible from the script and the sources.
+ * are reproducible from the script and the sources. The scope of the prune resolves inside the same guard as
+ * the root, because both builders throw and a throw here would read as a failure of a call that succeeded.
  */
 async function pruneUnusedDerivations(args: {
     readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
@@ -146,17 +147,18 @@ async function pruneUnusedDerivations(args: {
     }
 
     let root: string;
+    let derivedDir: string;
     try {
         root = args.resolveWorkspaceRoot(args.analysisId);
+        derivedDir = resolvePath(root, reportSessionDerivedDir(args.threadId));
     } catch (cause) {
         args.logger.warn("the unused derivations did not prune", {
             threadId: args.threadId,
             analysisId: args.analysisId,
-            ...defaultErrorFields(cause),
+            ...args.logger.errorFields(cause),
         });
         return;
     }
-    const derivedDir = resolvePath(root, reportSessionDerivedDir(args.threadId));
 
     for (const record of unused) {
         const resolved = resolveWorkspacePath({ workspaceRoot: root, analysisId: args.analysisId, path: record.outputPath });

--- a/harness/src/tools/report-session/record-version.ts
+++ b/harness/src/tools/report-session/record-version.ts
@@ -20,21 +20,32 @@
  * On a pass the store records the document that the gate validated, the pinned snapshot, and the anchor from
  * the thread row. The one-per-thread rule of the store bounds a concurrent race, and that refusal returns as
  * data. The outcome of a pass carries the version id.
+ *
+ * The prune runs after the version lands. It removes the output file of each derivation that the recorded
+ * document does not reference, under the `derived/` directory of the session alone. The records stay
+ * append-only, because the bytes are reproducible from the script and the sources. A failed removal logs and
+ * changes no outcome.
  */
 
 import { ok, type Result } from "neverthrow";
+import { rm } from "node:fs/promises";
+import { resolve as resolvePath, sep } from "node:path";
 import { z } from "zod";
 
 import type { AuthContext } from "../../auth/types.js";
+import type { ReportDocument } from "../../contracts/report-blocks.js";
 import { createNoopLogger } from "../../lib/console-logger.js";
 import { describeDbError } from "../../lib/db-result.js";
-import type { Logger } from "../../lib/logger.js";
+import { describeFsError, tryFsWrite } from "../../lib/fs-result.js";
+import { defaultErrorFields, type Logger } from "../../lib/logger.js";
 import type { ThreadStore } from "../../memory/thread-store.js";
-import { finishDraft, type FinishGap } from "../../report-model/draft-finish.js";
+import { referencedPaths, walkBlocks } from "../../report-model/block-walk.js";
+import { finishDraft, type FinishGap, type SessionDerivation } from "../../report-model/draft-finish.js";
 import { computeDraftHash } from "../../report-model/draft-hash.js";
 import type { ReferenceResolver } from "../../report-model/reference-resolver.js";
 import { validateReport, type ResolutionFailure, type SchemaIssue } from "../../report-model/validate.js";
 import type { RecordVersionError, ReportVersionStore } from "../../state/report-versions.js";
+import { reportSessionDerivedDir, resolveWorkspacePath, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
 import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
 
@@ -72,11 +83,16 @@ export type RecordVersionResult =
  * version carries the parent conversation and the transcript position. `makeResolver` is optional, because a
  * resolver realization can be absent, and the gate needs one. It binds one analysis, thus the tool makes the
  * resolver over the scope of the call.
+ *
+ * `resolveWorkspaceRoot` maps the analysis of the call onto its workspace root. The prune reaches the
+ * derived directory of the session under that root, thus the seam is mandatory: a composition that bound
+ * none would record a version and leave every unused derivation on disk.
  */
 export interface RecordVersionToolDeps {
     readonly gateway: ReportSessionStateGateway;
     readonly store: ReportVersionStore;
     readonly threads: Pick<ThreadStore, "getThread">;
+    readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
     readonly makeResolver?: (scope: { analysisId: string; auth: AuthContext }) => ReferenceResolver;
     readonly logger?: Logger;
 }
@@ -98,6 +114,69 @@ function describeRecordFailure(error: RecordVersionError): string {
 }
 
 /**
+ * Remove the output file of each derivation that the recorded document does not reference.
+ *
+ * The unused set is a set difference: a derivation is used when a binding of the recorded document names its
+ * output path. The document is the one that the gate validated, thus the prune reads what the version holds
+ * and never the draft.
+ *
+ * The prune reaches the `derived/` directory of the session alone. A record whose path resolves outside that
+ * directory is skipped, because this tool never removes a file that it does not own. A stale record from an
+ * earlier layout and a crafted path both land in that arm.
+ *
+ * The version already stands at this point. Thus each failure costs the cleanup alone: an unresolvable root,
+ * a path that escapes, and a failed removal each log and change no outcome. The records stay, and the bytes
+ * are reproducible from the script and the sources.
+ */
+async function pruneUnusedDerivations(args: {
+    readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
+    readonly analysisId: string;
+    readonly threadId: string;
+    readonly document: ReportDocument;
+    readonly derivations: readonly SessionDerivation[];
+    readonly logger: Logger;
+}): Promise<void> {
+    if (args.derivations.length === 0) {
+        return;
+    }
+    const named = referencedPaths(walkBlocks(args.document.sections).references);
+    const unused = args.derivations.filter((record) => !named.has(record.outputPath));
+    if (unused.length === 0) {
+        return;
+    }
+
+    let root: string;
+    try {
+        root = args.resolveWorkspaceRoot(args.analysisId);
+    } catch (cause) {
+        args.logger.warn("the unused derivations did not prune", {
+            threadId: args.threadId,
+            analysisId: args.analysisId,
+            ...defaultErrorFields(cause),
+        });
+        return;
+    }
+    const derivedDir = resolvePath(root, reportSessionDerivedDir(args.threadId));
+
+    for (const record of unused) {
+        const resolved = resolveWorkspacePath({ workspaceRoot: root, analysisId: args.analysisId, path: record.outputPath });
+        if (resolved.kind !== "ok" || !resolved.absolute.startsWith(derivedDir + sep)) {
+            args.logger.warn("an unused derivation sits outside the derived directory of the session", {
+                threadId: args.threadId,
+                analysisId: args.analysisId,
+                path: record.outputPath,
+            });
+            continue;
+        }
+        // An absent file is the normal condition of a prune that ran before, thus `force` treats it as done.
+        const removed = await tryFsWrite("record.rm", () => rm(resolved.absolute, { force: true }), { path: resolved.absolute });
+        if (removed.isErr()) {
+            args.logger.warn("an unused derivation did not go", { path: resolved.absolute, detail: describeFsError(removed.error) });
+        }
+    }
+}
+
+/**
  * Make the record tool over the session-state gateway, the version store, the thread store, and the
  * resolver.
  *
@@ -113,7 +192,8 @@ export function createRecordVersionTool(deps: RecordVersionToolDeps): Tool<Recor
             "Record the current draft as one report version. The tool runs the whole gate first: it finishes the draft, " +
             "resolves each reference, matches each chart encoding, and matches each assert. An incomplete draft gives back the gap list, " +
             "and a failed reference gives back the block that broke. The tool records a version only after the eyes look at the current page. " +
-            "A thread holds one version, thus a second record gives back that the thread already holds one.",
+            "A thread holds one version, thus a second record gives back that the thread already holds one. " +
+            "After the version lands, the tool removes the file of each derived table that no block of the recorded report binds.",
         inputSchema: recordVersionInput,
         executionMode: "inline",
         describeCall: "none",
@@ -125,10 +205,10 @@ export function createRecordVersionTool(deps: RecordVersionToolDeps): Tool<Recor
             if (opened.isErr()) {
                 return ok({ outcome: "refused", refusal: opened.error });
             }
-            const { threadId, analysisId, state, seenDocumentHash } = opened.value;
+            const { threadId, analysisId, state, seenDocumentHash, derivations } = opened.value;
             const { document: draft, snapshot } = state;
 
-            const finished = finishDraft(draft, snapshot);
+            const finished = finishDraft(draft, snapshot, derivations);
             if (!finished.valid) {
                 return ok({ outcome: "gaps", gaps: finished.gaps });
             }
@@ -187,6 +267,18 @@ export function createRecordVersionTool(deps: RecordVersionToolDeps): Tool<Recor
                 parentThreadId: thread.value.parentThreadId,
                 parentSeq: thread.value.parentSeq,
             });
+            if (recorded.isOk()) {
+                // The version stands from here. The prune reclaims the bytes of each derivation that the
+                // recorded document ignores, and it decides nothing about the outcome.
+                await pruneUnusedDerivations({
+                    resolveWorkspaceRoot: deps.resolveWorkspaceRoot,
+                    analysisId,
+                    threadId,
+                    document: finished.document,
+                    derivations,
+                    logger,
+                });
+            }
             return recorded.match(
                 (ref): Result<RecordVersionResult, ToolError> => ok({ outcome: "recorded", versionId: ref.versionId }),
                 (error): Result<RecordVersionResult, ToolError> => {

--- a/harness/src/workspace/paths.ts
+++ b/harness/src/workspace/paths.ts
@@ -271,6 +271,17 @@ export function reportSessionDir(threadId: string): string {
 }
 
 /**
+ * Directory of the derived tables of one report session, workspace-root-relative.
+ *
+ * The derivation writes its output here, and the record prunes an output that the recorded document does
+ * not name. Both spell the segment through this helper, thus the write mount and the prune scope cannot
+ * disagree.
+ */
+export function reportSessionDerivedDir(threadId: string): string {
+    return `${reportSessionDir(threadId)}/derived`;
+}
+
+/**
  * For an analysis-rooted input (`/{analysisId}/...`), strip the leading
  * `/{analysisId}/` segment so it can be resolved relative to the analysis
  * root. Returns `null` if the first segment does not match `analysisId` —


### PR DESCRIPTION
## What & why

The provenance appendix ledgered a claim value and a citation alone, thus the derived volcano of the session showed no provenance line. The derived directory also kept dead files that no block references. Every evidentiary binding now joins the appendix, and the card shows its marker. A derived path adds its chain from the durable record: the source paths with hash prefixes, and the script hash prefix. The finish lists each unused derivation as an advisory warning, beside the free-numeral warnings. The record prunes the unused output files after the version lands, under the session derived directory alone. The records stay append-only, because the bytes are reproducible from the script and the sources.

Reviewer notes: the derivation records ride the gateway load beside the seen hash, and the pure modules declare their own narrow shapes over them. The workspace-root seam is a required dep of the record tool, because an optional seam would skip the prune in silence forever. The derived-directory helper now spells both the write tail of the derivation tool and the prune scope, thus the two cannot disagree. A failed removal logs and changes no outcome, as the asset sweep does.

Refs #400

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
