### PR TITLE
feat(harness): extend the prompt obligations of the Report Builder

### DIFF
--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/.openspec.yaml
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/design.md
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/design.md
@@ -1,0 +1,27 @@
+# Design: extend-the-prompt-obligations
+
+## Context
+
+The prompt module composes the conversational part of the Report Builder (`src/prompts/report-session.ts`). It carries the loop order, the fault checklist, the narrative spine, the chart-first rule, the headline obligations, and the "Do NOT" list. The prompt names tools and mechanisms, and it never names a dataset, a path, or a format.
+
+## Decisions
+
+### D1: Each obligation rides the section that owns its moment
+
+The zero-p rule and the notation agreement join the grounding prose, beside the transcribe-from-memory ban. The reader-words rule joins the narrative section. The derive-and-chart rule extends the chart-first paragraph, because it is the same preference one step deeper. The headline derivation joins the headline obligations. The declaration and the row bound join the tool paragraphs of the binding. A new section would fragment the prompt, and the existing sections carry the voice.
+
+### D2: The named cases stay mechanism-level
+
+The KM and the GSEA cases name the preset and the orientation, and never a dataset or a column. "A survival figure derives its step table and binds the `km` preset" teaches the mechanism, and the environment supplies the specifics.
+
+### D3: The "Do NOT" list grows by two
+
+The zero-p transcription and the raw-token prose join the list, in the existing entry style: the fault, and the honest alternative in one breath.
+
+### D4: The probes end through two sentences, not a checklist
+
+"A metric binds a numeric cell" and "check the add arguments before the call" cover the observed probe waste. A longer procedure would pad the prompt for a marginal return.
+
+## Risks / Trade-offs
+
+- The prompt grows by roughly a paragraph across sections. The cache pays one write, and every session reads the same constant after it.

--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/proposal.md
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/proposal.md
@@ -1,0 +1,33 @@
+# Proposal: extend-the-prompt-obligations
+
+## Why
+
+The second real session shows six agent habits that the tools now outgrow. The prose said "FDR 0.000" and pasted raw set tokens. The KM figures stayed matplotlib although the `km` preset and the derivation exist. The headline fired its absence branch although a cohort summary is derivable. The notation drifted from the page, and the first turn spent blocks on probes. Each cure landed in the ten merged changes, and the prompt still teaches none of them.
+
+## What Changes
+
+One pass over the Report Builder prompt (`src/prompts/report-session.ts`):
+
+- Never transcribe a zero p. Write "below the resolution of the test" and continue — the page renders the honest bound itself.
+- Name a gene set in reader words. The raw token belongs to the table and the appendix.
+- Derive and chart: when a figure PNG shows what a derivable table can carry, derive the table and bind the chart. The KM curves and the GSEA bars are the named cases, over the `km` preset and the horizontal bar.
+- When the headline scalars sit in no artifact, derive the headline table first.
+- Quote a number as the page prints it, and the look confirms the agreement.
+- A metric binds a numeric cell. An enumeration of three or more parallel points composes as the typed list.
+- Declare the column meanings and the display labels on a table binding, and set the row bound on a large table.
+- A model table reads best with a composed display column, for example the ratio with its interval — a small derivation the agent can offer.
+- The "Do NOT" list gains the zero-p transcription and the raw-token prose.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-session-agent`: the prompt-obligations requirement gains the new obligations and their scenarios.
+
+## Impact
+
+- Affected code: `src/prompts/report-session.ts` and its prompt test. No tool changes.

--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/specs/report-session-agent/spec.md
@@ -1,0 +1,37 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The prompt obligations
+
+The prompt MUST carry the second-session obligations:
+
+- The agent never transcribes a zero p-value into a sentence. It writes that the value sits below the resolution of the test, and the page renders the honest bound.
+- The agent names a gene set in reader words, and the raw token stays in the table and the appendix.
+- The derive-and-chart rule extends the chart-first rule: when a figure image shows what a derivable table can carry, the agent derives the table and binds the chart. A survival figure derives its step table for the `km` preset, and a ranked-set figure derives for the horizontal bar.
+- When the headline scalars sit in no artifact, the agent derives the headline table first.
+- The agent quotes a number as the page prints it, and the look confirms the agreement.
+- A metric binds a numeric cell, and an enumeration of three or more parallel points composes as the typed list.
+- The agent declares the column meanings and the display labels on a table binding, and it sets the row bound on a large table.
+
+The "Do NOT" list MUST name the zero-p transcription and the raw-token prose.
+
+#### Scenario: The prompt teaches the zero-p rule
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the zero-p transcription is a named fault, with the below-resolution phrasing as the alternative
+
+#### Scenario: The prompt teaches derive-and-chart
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the derive-and-chart rule is present, with the survival and the ranked-set cases named at the mechanism level
+
+#### Scenario: The prompt teaches the declaration and the bound
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the column-meaning declaration, the display labels, and the row bound are named obligations
+
+#### Scenario: The prompt stays free of environment detail
+
+- **WHEN** a reviewer reads the new obligations
+- **THEN** no dataset name, no path, and no format promise is present

--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/specs/report-session-agent/spec.md
@@ -13,8 +13,10 @@ The prompt MUST carry the second-session obligations:
 - The agent quotes a number as the page prints it, and the look confirms the agreement.
 - A metric binds a numeric cell, and an enumeration of three or more parallel points composes as the typed list.
 - The agent declares the column meanings and the display labels on a table binding, and it sets the row bound on a large table.
+- A model table reads best with a composed display column, and the agent can offer that small derivation.
+- The agent settles the add arguments before the call, thus no block lands as a probe.
 
-The "Do NOT" list MUST name the zero-p transcription and the raw-token prose.
+The "Do NOT" list MUST name the zero-p transcription and the raw-token prose. The look checklist gains the printed zero probability as a named fault.
 
 #### Scenario: The prompt teaches the zero-p rule
 

--- a/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/tasks.md
+++ b/harness/openspec/changes/archive/2026-08-16-extend-the-prompt-obligations/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: extend-the-prompt-obligations
+
+## 1. The prompt pass
+
+- [x] 1.1 The obligations land in their owning sections of `src/prompts/report-session.ts`, per the design.
+- [x] 1.2 The "Do NOT" list gains the zero-p transcription and the raw-token prose, in the existing entry style.
+
+## 2. The proof
+
+- [x] 2.1 The prompt test pins the new obligations by substring, and the no-environment-detail assertions stay green.
+- [x] 2.2 Run the prompt and agent suites, and `tsc -p tsconfig.json`.

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -238,6 +238,33 @@ The prompt MUST carry the chart-first rule: prefer a chart block when a table ar
 
 The prompt MUST carry the headline obligations. The headline row leads with the cohort and the yield. When the pinned evidence gives no cohort value, the headline leads with what the evidence gives, and the agent says so. A caveated value is not a headline. The card set carries its own contrast, and the prose rounds to the short form that the look confirms.
 
+The prompt MUST carry the second-session obligations:
+
+- The agent never transcribes a zero p-value into a sentence. It writes that the value sits below the resolution of the test, and the page renders the honest bound.
+- The agent names a gene set in reader words, and the raw token stays in the table and the appendix.
+- The derive-and-chart rule extends the chart-first rule: when a figure image shows what a derivable table can carry, the agent derives the table and binds the chart. A survival figure derives its step table for the `km` preset, and a ranked-set figure derives for the horizontal bar.
+- When the headline scalars sit in no artifact, the agent derives the headline table first.
+- The agent quotes a number as the page prints it, and the look confirms the agreement.
+- A metric binds a numeric cell, and an enumeration of three or more parallel points composes as the typed list.
+- The agent declares the column meanings and the display labels on a table binding, and it sets the row bound on a large table.
+
+The "Do NOT" list MUST name the zero-p transcription and the raw-token prose.
+
+#### Scenario: The prompt teaches the zero-p rule
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the zero-p transcription is a named fault, with the below-resolution phrasing as the alternative
+
+#### Scenario: The prompt teaches derive-and-chart
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the derive-and-chart rule is present, with the survival and the ranked-set cases named at the mechanism level
+
+#### Scenario: The prompt teaches the declaration and the bound
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the column-meaning declaration, the display labels, and the row bound are named obligations
+
 #### Scenario: The prompt stays free of environment detail
 - **WHEN** a reviewer reads the prompt module
 - **THEN** no dataset name, no path, and no format promise is present

--- a/harness/openspec/specs/report-session-agent/spec.md
+++ b/harness/openspec/specs/report-session-agent/spec.md
@@ -225,6 +225,7 @@ The look step MUST carry the fault checklist. The agent examines the picture for
 - an unreadable precision
 - content that stayed invisible
 - a number in the prose that disagrees with its card
+- a printed zero probability
 
 A found fault is a repair, and never a note.
 
@@ -247,6 +248,8 @@ The prompt MUST carry the second-session obligations:
 - The agent quotes a number as the page prints it, and the look confirms the agreement.
 - A metric binds a numeric cell, and an enumeration of three or more parallel points composes as the typed list.
 - The agent declares the column meanings and the display labels on a table binding, and it sets the row bound on a large table.
+- A model table reads best with a composed display column, and the agent can offer that small derivation.
+- The agent settles the add arguments before the call, thus no block lands as a probe.
 
 The "Do NOT" list MUST name the zero-p transcription and the raw-token prose.
 

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -134,6 +134,61 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("never from memory");
     });
 
+    test("the prompt teaches the zero-p rule and the notation agreement", () => {
+        // The fault, its honest phrasing, and the page that renders the bound are
+        // stable substrings, thus the assertion does not couple to the full prose.
+        expect(reportSessionPrompt).toContain("Never write a zero p-value into a sentence");
+        expect(reportSessionPrompt).toContain("below the resolution of the test");
+        expect(reportSessionPrompt).toContain("The page renders the honest bound itself");
+        // The prose reads the printed form, and the look settles the agreement.
+        expect(reportSessionPrompt).toContain("Quote a number as the page prints it");
+        expect(reportSessionPrompt).toContain("the sentence and the card agree");
+        // The anti-pattern entry names the zero-p transcription.
+        expect(reportSessionPrompt).toContain("Transcribe a zero p-value");
+    });
+
+    test("the prompt teaches the reader words of a gene set", () => {
+        // The rule and its home for the raw token are stable substrings.
+        expect(reportSessionPrompt).toContain("Name a gene set in reader words");
+        expect(reportSessionPrompt).toContain("belongs to the table and to the appendix");
+        // The anti-pattern entry names the raw token in the prose.
+        expect(reportSessionPrompt).toContain("Write a raw token into the prose");
+    });
+
+    test("the prompt teaches derive-and-chart with the two named cases", () => {
+        // The rule and its two cases stay at the mechanism level, thus the assertion
+        // pins the preset and the orientation and never a dataset or a column.
+        expect(reportSessionPrompt).toContain("Derive that table and");
+        expect(reportSessionPrompt).toContain("A survival figure derives its step table");
+        expect(reportSessionPrompt).toContain("`km`");
+        expect(reportSessionPrompt).toContain("A ranked-set figure derives its ranked table");
+        expect(reportSessionPrompt).toContain("horizontal");
+    });
+
+    test("the prompt teaches the headline derivation", () => {
+        // The derivation comes first, and the absence branch is the last resort.
+        expect(reportSessionPrompt).toContain("derive the headline table first");
+        expect(reportSessionPrompt).toContain("Report an absent value only when the derivation cannot give it");
+    });
+
+    test("the prompt teaches the declarations, the row bound, and the composed column", () => {
+        // The two declaration maps and the bound are stable substrings, thus a
+        // binding that ships raw column names cannot pass as guidance.
+        expect(reportSessionPrompt).toContain("Declare the column meanings and");
+        expect(reportSessionPrompt).toContain("the display labels on it");
+        expect(reportSessionPrompt).toContain("Set the row bound on a large table");
+        // The composed display column is an offer, thus the agent proposes it.
+        expect(reportSessionPrompt).toContain("composed display column");
+    });
+
+    test("the prompt ends the probes at the block call", () => {
+        // A metric binds a number, an enumeration composes as the list, and the
+        // arguments are settled before the call.
+        expect(reportSessionPrompt).toContain("A metric binds a numeric cell");
+        expect(reportSessionPrompt).toContain("composes as the typed list");
+        expect(reportSessionPrompt).toContain("before you make the call");
+    });
+
     test("the prompt teaches the verification loop and names the visual spiral", () => {
         // The loop order and the two verification tools are stable substrings, thus
         // the assertion does not couple to the full prose.

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -139,7 +139,10 @@ describe("createReportSessionAgent", () => {
         // stable substrings, thus the assertion does not couple to the full prose.
         expect(reportSessionPrompt).toContain("Never write a zero p-value into a sentence");
         expect(reportSessionPrompt).toContain("below the resolution of the test");
-        expect(reportSessionPrompt).toContain("The page renders the honest bound itself");
+        // A column bounds the zero, thus the promise names the two blocks that carry
+        // one. A metric card holds one cell, thus the look catches its printed value.
+        expect(reportSessionPrompt).toContain("A table and a chart render the honest bound");
+        expect(reportSessionPrompt).toContain("A metric card reads one cell");
         // The prose reads the printed form, and the look settles the agreement.
         expect(reportSessionPrompt).toContain("Quote a number as the page prints it");
         expect(reportSessionPrompt).toContain("the sentence and the card agree");
@@ -150,7 +153,10 @@ describe("createReportSessionAgent", () => {
     test("the prompt teaches the reader words of a gene set", () => {
         // The rule and its home for the raw token are stable substrings.
         expect(reportSessionPrompt).toContain("Name a gene set in reader words");
-        expect(reportSessionPrompt).toContain("belongs to the table and to the appendix");
+        // The token stays where the evidence puts it, and the appendix is a region
+        // that the renderer writes and never a place that the agent authors into.
+        expect(reportSessionPrompt).toContain("it stays in the table cell that holds it");
+        expect(reportSessionPrompt).toContain("The renderer writes the");
         // The anti-pattern entry names the raw token in the prose.
         expect(reportSessionPrompt).toContain("Write a raw token into the prose");
     });
@@ -159,9 +165,13 @@ describe("createReportSessionAgent", () => {
         // The rule and its two cases stay at the mechanism level, thus the assertion
         // pins the preset and the orientation and never a dataset or a column.
         expect(reportSessionPrompt).toContain("Derive that table and");
-        expect(reportSessionPrompt).toContain("A survival figure derives its step table");
+        // The derivation reads the evidence and never the image, thus the wording
+        // names the evidence that the figure plots. The two substrings sit on two
+        // lines of the prompt, thus neither one crosses the wrap between them.
+        expect(reportSessionPrompt).toContain("For a survival figure, derive the step table from the");
+        expect(reportSessionPrompt).toContain("evidence that the figure plots");
         expect(reportSessionPrompt).toContain("`km`");
-        expect(reportSessionPrompt).toContain("A ranked-set figure derives its ranked table");
+        expect(reportSessionPrompt).toContain("derive the ranked table the same way");
         expect(reportSessionPrompt).toContain("horizontal");
     });
 
@@ -211,6 +221,9 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("an overflowing card");
         expect(reportSessionPrompt).toContain("a raw column name on an axis");
         expect(reportSessionPrompt).toContain("an unreadable precision");
+        // A metric card carries no column to bound a zero, thus the look is where a
+        // printed zero probability gets caught.
+        expect(reportSessionPrompt).toContain("a printed zero probability");
         expect(reportSessionPrompt).toContain("a number that disagrees");
         expect(reportSessionPrompt).toContain("content that stayed invisible");
         // A found fault ends in a repair, thus the agent never reports one instead.
@@ -269,7 +282,12 @@ describe("createReportSessionAgent", () => {
         // substrings, thus the assertion does not couple to the full prose.
         expect(reportSessionPrompt).toContain("derive_table");
         expect(reportSessionPrompt).toContain("a pivot, and an aggregate are such reshaping");
-        expect(reportSessionPrompt).toContain("transform is not: a chart block reads the column that it needs");
+        // The exclusion is chart-scoped. A table carries no knob, thus its composed
+        // display column derives and the two paragraphs agree. Each substring sits on
+        // one line of the prompt, thus a line wrap cuts none of them.
+        expect(reportSessionPrompt).toContain("transform of a chart is not: a chart block reads the column that it needs");
+        expect(reportSessionPrompt).toContain("A table carries no such knob");
+        expect(reportSessionPrompt).toContain("column of a table derives");
         // A derived table is evidence of the session, thus it binds like a pinned one.
         expect(reportSessionPrompt).toContain("binds like any pinned artifact");
     });
@@ -280,8 +298,10 @@ describe("createReportSessionAgent", () => {
         expect(reportSessionPrompt).toContain("Prefer a chart block when a table artifact holds the data");
         expect(reportSessionPrompt).toContain("a figure image only when no table carries the data");
         expect(reportSessionPrompt).toContain("this rule is about the report page alone");
-        // The anti-pattern entry names the figure that stands where a table serves.
+        // The anti-pattern entry names the figure that stands where a table serves,
+        // and the derivation widens what a table can serve.
         expect(reportSessionPrompt).toContain("Reach for a figure where a table serves");
+        expect(reportSessionPrompt).toContain("that no derivation can give");
     });
 
     test("the prompt carries the headline obligations", () => {

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -43,6 +43,9 @@ Each section opens with its topic sentence, and it closes toward the next sectio
 No table and no chart appears before the sentence that tells the reader what to see
 in it. The evidence illustrates the prose, thus it never replaces the prose.
 
+Name a gene set in reader words. A raw set token is the name that the evidence
+carries, thus it belongs to the table and to the appendix, and never to a sentence.
+
 The summary is the argument spine again, in short form.
 The angle of the brief decides the order of the findings, thus the finding that
 the user asked about leads.
@@ -63,10 +66,20 @@ A report is a tree of typed blocks, and you build it with the authoring tools:
 Build the report as a shape first, then fill each section. Keep the outline as your
 map, and read one block only when the label does not tell you enough.
 
+A metric binds a numeric cell, and never a text one. An enumeration of three or more
+parallel points composes as the typed list of a text block. Make sure of the
+arguments of an \`add_block\` call before you make the call, because a refused call
+costs a turn and teaches you nothing.
+
 Prefer a chart block when a table artifact holds the data. \`list_pinned_artifacts\`
 names each table artifact and its columns, thus it shows what a chart can plot.
 Reach for a figure image only when no table carries the data. The run phase keeps
 its own plots, and this rule is about the report page alone.
+
+A figure image often shows what a derivable table can carry. Derive that table and
+bind the chart when it does. A survival figure derives its step table and binds the
+\`km\` preset. A ranked-set figure derives its ranked table and binds the horizontal
+bar.
 
 A run writes statistical tables, and not plot-ready ones. When a real reshaping
 stands between the evidence and the block, \`derive_table\` runs your Python script
@@ -82,6 +95,10 @@ An unshrunken effect size that shrinkage collapses is such a value, thus it read
 the body under its caveat. When the pinned evidence holds no cohort value, the
 headline leads with what the evidence gives. Tell the user which value is absent.
 
+When the headline scalars sit in no artifact, derive the headline table first, and
+bind each card to that table. A cohort summary is one aggregate over the pinned
+evidence. Report an absent value only when the derivation cannot give it.
+
 The card set carries its own contrast, thus a value reads against its neighbor and
 the label does not do all the work. Round a number in the prose to the short form.
 The look then shows a number that does not agree with its card.
@@ -93,6 +110,14 @@ reference points at the pinned evidence of this session. The evidence is frozen 
 the start of the session, thus a later run does not change what a reference
 resolves to. Bind every value. Never transcribe a number that you remember.
 
+Never write a zero p-value into a sentence. A test reports zero when the value falls
+under what its arithmetic holds, thus the honest sentence says that the value sits
+below the resolution of the test. The page renders the honest bound itself.
+
+Quote a number as the page prints it. The page owns the notation of a value, thus a
+sentence carries the printed form and never a second notation of your own. The look
+then confirms that the sentence and the card agree.
+
 \`list_pinned_artifacts\` is the orientation source for that evidence. It lists a
 pinned artifact with its path, its content hash, its file type, and the columns of a
 tabular artifact. The listing is capped: it gives the total of the pinned set and a
@@ -102,6 +127,15 @@ block, and take the path and the column name from what it gives.
 A reference names the path alone, and the session stamps the hash from the pinned
 evidence when the block lands. A path that the pinned evidence does not hold comes
 back as an unresolved reference, and you repair that path.
+
+A whole-table binding carries its own declarations. Declare the column meanings and
+the display labels on it, thus the header, the axis title, and the number format each
+read what the column measures. Set the row bound on a large table, thus the card
+shows the ranked rows that carry the point.
+
+A model table reads best with a composed display column, for example the ratio
+beside its interval in one cell. Such a column is a small derivation, and you offer
+it to the user.
 
 The literature of the report composes as citation blocks, and each one binds to a
 citation of the pinned evidence. \`list_pinned_artifacts\` names the pinned
@@ -178,6 +212,9 @@ failed. When the page reads clean, record.
 
 - **Transcribe a number from memory.** Every metric, every table cell, and every
   figure binds to a reference that resolves against the pinned evidence.
+- **Transcribe a zero p-value.** A test reports zero when the value falls under what
+  its arithmetic holds. Write that the value sits below the resolution of the test,
+  and let the page render the honest bound.
 - **Start a run, or change the analysis.** You read the analysis; you never run it
   and never write to it. You hold no tool that does either, and that is by design.
 - **Invent a path.** Name a file by what a search or a run gave you. Never guess a
@@ -193,6 +230,8 @@ failed. When the page reads clean, record.
 - **Show evidence before its sentence.** A table and a chart land after the sentence
   that tells the reader what to see in it. The evidence illustrates the prose, and
   it never carries the point alone.
+- **Write a raw token into the prose.** A gene set reads in reader words. The raw
+  token that the evidence carries belongs to the table and to the appendix.
 - **Reach for a figure where a table serves.** When a table artifact holds the data,
   compose a chart block. A figure image is for the data that no table carries.
 - **Lead with a caveated value.** A headline states the cohort and the yield. A value

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -44,7 +44,8 @@ No table and no chart appears before the sentence that tells the reader what to 
 in it. The evidence illustrates the prose, thus it never replaces the prose.
 
 Name a gene set in reader words. A raw set token is the name that the evidence
-carries, thus it belongs to the table and to the appendix, and never to a sentence.
+carries, thus it stays in the table cell that holds it. The renderer writes the
+provenance appendix of the page, and a sentence never carries the raw token.
 
 The summary is the argument spine again, in short form.
 The angle of the brief decides the order of the findings, thus the finding that
@@ -77,17 +78,18 @@ Reach for a figure image only when no table carries the data. The run phase keep
 its own plots, and this rule is about the report page alone.
 
 A figure image often shows what a derivable table can carry. Derive that table and
-bind the chart when it does. A survival figure derives its step table and binds the
-\`km\` preset. A ranked-set figure derives its ranked table and binds the horizontal
-bar.
+bind the chart when it does. For a survival figure, derive the step table from the
+evidence that the figure plots, and bind the \`km\` preset. For a ranked-set figure,
+derive the ranked table the same way, and bind the horizontal bar.
 
 A run writes statistical tables, and not plot-ready ones. When a real reshaping
 stands between the evidence and the block, \`derive_table\` runs your Python script
 over the pinned inputs that you declare, and it pins the result to this session. A
 join of two tables, a pivot, and an aggregate are such reshaping. A per-row
-transform is not: a chart block reads the column that it needs. The derived table
-binds like any pinned artifact, and its record holds your script, the sources, and
-the hashes.
+transform of a chart is not: a chart block reads the column that it needs, thus a
+knob of the chart serves it. A table carries no such knob, thus a composed display
+column of a table derives. The derived table binds like any pinned artifact, and its
+record holds your script, the sources, and the hashes.
 
 The headline row leads with the cohort and the yield: the n, the group split, the
 yield count, and the event count. A value that carries a caveat is not a headline.
@@ -112,7 +114,9 @@ resolves to. Bind every value. Never transcribe a number that you remember.
 
 Never write a zero p-value into a sentence. A test reports zero when the value falls
 under what its arithmetic holds, thus the honest sentence says that the value sits
-below the resolution of the test. The page renders the honest bound itself.
+below the resolution of the test. A table and a chart render the honest bound from
+the column that holds the zero. A metric card reads one cell and it has no such
+column, thus you read the printed value at the look.
 
 Quote a number as the page prints it. The page owns the notation of a value, thus a
 sentence carries the printed form and never a second notation of your own. The look
@@ -191,6 +195,8 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
     a written label, not the name that the evidence carries.
   - an unreadable precision: a number with too many digits to read, or a rounding
     that hides the result.
+  - a printed zero probability: a p-value that a card, a cell, or an axis shows as a
+    plain zero. A probability that the test could not resolve is never zero.
   - a number that disagrees: a value in the prose that is not the value on the
     card beside it.
   - content that stayed invisible: an empty band, a blank card, or a section that
@@ -214,7 +220,7 @@ failed. When the page reads clean, record.
   figure binds to a reference that resolves against the pinned evidence.
 - **Transcribe a zero p-value.** A test reports zero when the value falls under what
   its arithmetic holds. Write that the value sits below the resolution of the test,
-  and let the page render the honest bound.
+  and let the table or the chart render the honest bound.
 - **Start a run, or change the analysis.** You read the analysis; you never run it
   and never write to it. You hold no tool that does either, and that is by design.
 - **Invent a path.** Name a file by what a search or a run gave you. Never guess a
@@ -231,9 +237,11 @@ failed. When the page reads clean, record.
   that tells the reader what to see in it. The evidence illustrates the prose, and
   it never carries the point alone.
 - **Write a raw token into the prose.** A gene set reads in reader words. The raw
-  token that the evidence carries belongs to the table and to the appendix.
+  token stays in the table cell that holds it, and the renderer writes the
+  provenance appendix of the page.
 - **Reach for a figure where a table serves.** When a table artifact holds the data,
-  compose a chart block. A figure image is for the data that no table carries.
+  compose a chart block. A figure image is for the data that no table carries and
+  that no derivation can give.
 - **Lead with a caveated value.** A headline states the cohort and the yield. A value
   that a caveat qualifies reads in the body, under that caveat.
 - **Rebuild when one amend serves.** One feedback is one block change. Change, move,


### PR DESCRIPTION
## What & why

The second real session showed six agent habits that the merged changes now outgrow, and the prompt taught none of the cures. One pass lands each obligation in the section that owns its moment. The grounding prose gains the zero-p rule and the notation agreement. The narrative gains the reader-words rule for a gene set. The chart-first paragraph extends one step: derive and chart, with the survival and the ranked-set cases named at the mechanism level. The headline obligations gain the derivation route for missing scalars. The binding paragraphs gain the meaning declarations, the display labels, the row bound, and the composed display column offer. Two probe-ending sentences close the first-turn waste, and the "Do NOT" list gains the zero-p transcription and the raw-token prose.

Reviewer notes: the prompt names tools and mechanisms only — the `km` preset and the horizontal orientation ride as bare identifiers, and no dataset, path, or format joins. The no-environment-detail assertions stay green, and six substring pins cover the new obligation families.

Refs #401

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
