### PR TITLE
fix(harness): raise the report-session cap and push batched reads

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "private": true,
     "type": "module",
     "scripts": {
@@ -22,7 +22,7 @@
     "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.21",
+        "@inflexa-ai/harness": "0.21.1",
         "@inflexa-ai/prov-kernel": "^0.5.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "description": "Host-agnostic bioinformatics agent harness \u2014 hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -72,9 +72,9 @@ describe("createReportSessionAgent", () => {
         expect(agent.id).toBe(REPORT_SESSION_AGENT_ID);
         expect(agent.id).toBe("report-session");
         expect(agent.model).toBe("anthropic/claude-opus-4-8");
-        // The report turn drives many small tool calls, the same headroom the
-        // conversation agent uses.
-        expect(agent.maxIterations).toBe(50);
+        // A full session drives more small tool calls than a conversation turn,
+        // thus the cap matches the report runner (REPORT_AGENT_MAX_STEPS).
+        expect(agent.maxIterations).toBe(75);
     });
 
     test("holds the analysis read surface", () => {

--- a/harness/src/agents/report-session-agent.ts
+++ b/harness/src/agents/report-session-agent.ts
@@ -59,10 +59,11 @@ import { composeSystemPrompt } from "./system-prompt.js";
 export const REPORT_SESSION_AGENT_ID = "report-session" as const;
 
 /**
- * Runaway guard. A report turn drives many small tool calls, thus it needs the
- * same headroom as the conversation agent.
+ * Runaway guard. A full session — orient, derive, compose each section, preview,
+ * look, record — drives more small tool calls than a conversation turn, thus it
+ * gets the headroom of the report runner (REPORT_AGENT_MAX_STEPS).
  */
-const REPORT_SESSION_MAX_ITERATIONS = 50;
+const REPORT_SESSION_MAX_ITERATIONS = 75;
 
 /**
  * The shared dependencies of the report agent. The gateway binds the per-session

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -23,6 +23,11 @@ tool only where the context is thin, and reach in a targeted way:
 Do not orient again when a prior turn already read what you need — its results are
 still in your context. To reach further is targeted, not a fresh sweep.
 
+When you need more than one independent read, make the calls together in one
+reply. A batch runs in parallel and spends one step. A chain of single calls
+spends one step for each read, and the turn can run out of steps before the
+report is complete.
+
 ## Compose the Argument Spine
 
 Before the first block, compose the argument spine. The argument spine is the

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -23,10 +23,12 @@ tool only where the context is thin, and reach in a targeted way:
 Do not orient again when a prior turn already read what you need — its results are
 still in your context. To reach further is targeted, not a fresh sweep.
 
-When you need more than one independent read, make the calls together in one
-reply. A batch runs in parallel and spends one step. A chain of single calls
-spends one step for each read, and the turn can run out of steps before the
-report is complete.
+When your next calls do not depend on the result of one another, make them
+together in one reply. The rule is the same for a read and for an edit: a reply
+of many calls spends one step. A chain of single calls spends one step for each
+call, and the turn can then reach its step cap before the report is complete.
+The loop runs the calls of one reply in order, thus a batch of edits lands in
+your order.
 
 ## Compose the Argument Spine
 


### PR DESCRIPTION
## What & why

A full report session drives about 65 loop iterations. The old cap of 50 stopped the turn in the middle of the composition. This change raises `REPORT_SESSION_MAX_ITERATIONS` to 75, which is the cap that the report runner permits. The prompt of the report-session agent now tells the agent to make independent reads together in one reply, because a batch spends one iteration.

Notes for the reviewer:

- The PR releases the harness as 0.21.1, and it sets the CLI pin to 0.21.1 with a CLI release as 0.13.1.
- `cli/bun.lock` keeps the 0.21.0 entry, because the registry holds no 0.21.1 before the harness publish.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`). Lint and the build pass. 13 report-session tests fail in this environment, on this branch and on main alike.
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
