### PR TITLE
fix: settle undispatched tool calls so a cut reply cannot wedge a thread

### DIFF
--- a/cli/src/modules/harness/turn.ts
+++ b/cli/src/modules/harness/turn.ts
@@ -241,7 +241,13 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
     // store a figure that reads shorter than the one the user watched.
     const turnStartedAt = Date.now();
     try {
-        const prepared = await ResultAsync.fromPromise(seams.prepare({ pool }, { analysisId, threadId, userInput }), (e): unknown => e).match(
+        // The logger rides into preparation so the history-repair warning of the
+        // message assembly reaches the file log — without it, a repaired thread
+        // heals silently and the writer defect it covers stays invisible.
+        const prepared = await ResultAsync.fromPromise(
+            seams.prepare({ pool, logger: harnessLogger("harness") }, { analysisId, threadId, userInput }),
+            (e): unknown => e,
+        ).match(
             (r) => r,
             (cause): { readonly kind: "prepare_failed"; readonly cause: unknown } => ({ kind: "prepare_failed", cause }),
         );

--- a/harness/src/app/chat-turn.ts
+++ b/harness/src/app/chat-turn.ts
@@ -102,6 +102,7 @@ export async function prepareChatTurn(deps: PrepareChatTurnDeps, params: Prepare
         runActivityContext,
         history,
         workingMemory: createWorkingMemory(pool),
+        ...(deps.logger ? { logger: deps.logger } : {}),
     });
 
     return { kind: "ok", threadType, messages, userMessage };

--- a/harness/src/app/message-assembly.test.ts
+++ b/harness/src/app/message-assembly.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
+import type { ModelMessage } from "ai";
 import { okAsync } from "neverthrow";
 
 import { assembleMessages } from "./message-assembly.js";
+import { createCapturingLogger } from "../__tests__/setup/logger.js";
 import type { ThreadHistory } from "../memory/thread-history.js";
 import type { WorkingMemoryStore } from "../memory/working-memory.js";
 import { emptyWorkingMemory } from "../memory/working-memory.js";
@@ -220,5 +222,69 @@ describe("assembleMessages", () => {
         expect(contentText(messages[0]!)).toContain(secret);
         // Analysis context message is passed through verbatim.
         expect(contentText(messages[1]!)).toContain(secret);
+    });
+
+    /** {@link stubHistory} typed over the AI SDK shape, for a window that carries tool parts. */
+    function modelHistory(window: ModelMessage[]): ThreadHistory {
+        return {
+            ...stubHistory([]),
+            loadRecent: () => okAsync(window),
+        };
+    }
+
+    test("repairs a stored dangling tool call and logs the strip", async () => {
+        const logger = createCapturingLogger();
+        const window: ModelMessage[] = [
+            { role: "user", content: "earlier question" },
+            {
+                role: "assistant",
+                content: [
+                    { type: "text", text: "on it" },
+                    { type: "tool-call", toolCallId: "tu-x", toolName: "update_working_memory", input: {} },
+                ],
+            },
+        ];
+
+        const { messages } = await assembleMessages({
+            threadId: "thread-1",
+            threadType: "conversation",
+            analysisId: "analysis-1",
+            userInput: "what happened?",
+            analysisContext: null,
+            runActivityContext: RUN_ACTIVITY,
+            history: modelHistory(window),
+            workingMemory: stubWorkingMemory(),
+            logger,
+        });
+
+        // The unanswered call is gone; the prose of the turn survives.
+        expect(messages[1]).toEqual({ role: "assistant", content: [{ type: "text", text: "on it" }] });
+        const warn = logger.records.find((r) => r.level === "warn");
+        expect(warn?.msg).toContain("unanswered tool calls stripped from thread history");
+        expect(warn?.fields).toMatchObject({ threadId: "thread-1", toolCallIds: ["tu-x"], tools: ["update_working_memory"] });
+    });
+
+    test("keeps an answered tool call untouched and logs nothing", async () => {
+        const logger = createCapturingLogger();
+        const window: ModelMessage[] = [
+            { role: "user", content: "earlier question" },
+            { role: "assistant", content: [{ type: "tool-call", toolCallId: "tu-1", toolName: "read_file", input: {} }] },
+            { role: "tool", content: [{ type: "tool-result", toolCallId: "tu-1", toolName: "read_file", output: { type: "json", value: {} } }] },
+        ];
+
+        const { messages } = await assembleMessages({
+            threadId: "thread-1",
+            threadType: "conversation",
+            analysisId: "analysis-1",
+            userInput: "continue",
+            analysisContext: null,
+            runActivityContext: RUN_ACTIVITY,
+            history: modelHistory(window),
+            workingMemory: stubWorkingMemory(),
+            logger,
+        });
+
+        expect(messages.slice(0, 3)).toEqual(window);
+        expect(logger.records).toEqual([]);
     });
 });

--- a/harness/src/app/message-assembly.ts
+++ b/harness/src/app/message-assembly.ts
@@ -37,10 +37,13 @@
 
 import type { ModelMessage } from "ai";
 
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { Logger } from "../lib/logger.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import type { LoopMessage } from "../loop/types.js";
 import type { ThreadHistory } from "../memory/thread-history.js";
 import type { ThreadType } from "../memory/thread-store.js";
+import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
 import type { WorkingMemoryStore } from "../memory/working-memory.js";
 import { normalizeUnicode, redactSecrets } from "../input-sanitization.js";
 
@@ -70,6 +73,8 @@ export interface AssembleMessagesArgs {
     readonly workingMemory: WorkingMemoryStore;
     /** History-window token budget. Defaults to {@link DEFAULT_HISTORY_TOKEN_BUDGET}. */
     readonly tokenBudget?: number;
+    /** Diagnostic seam for the history repair record; omitted falls back to no-op. */
+    readonly logger?: Logger;
 }
 
 export interface AssembledMessages {
@@ -91,6 +96,22 @@ export async function assembleMessages(args: AssembleMessagesArgs): Promise<Asse
     const budget = args.tokenBudget ?? DEFAULT_HISTORY_TOKEN_BUDGET;
 
     const history = unwrapOrThrow(await args.history.loadRecent(args.threadId, budget, { keepFirstTurn: args.threadType === "report" }));
+
+    // Read-side safety net for the wire contract: every tool call carries a
+    // result. The loop upholds it at every exit, but the store outlives any one
+    // writer — a row an older build wrote, or a hand-edited database, can carry
+    // an unanswered call, and the provider boundary then refuses the WHOLE
+    // transcript on every turn: the thread is wedged forever. Stripping the
+    // orphan here degrades one message instead. The warning is the only account
+    // a reader gets that the stored thread and the assembled one differ.
+    const repaired = stripUnansweredToolCalls(history);
+    if (repaired.length > 0) {
+        (args.logger ?? createNoopLogger()).named("assembly").warn("unanswered tool calls stripped from thread history", {
+            threadId: args.threadId,
+            toolCallIds: repaired.map((d) => d.toolCallId),
+            tools: repaired.map((d) => d.toolName),
+        });
+    }
 
     // Sanitization — applied once, here, to the new user input only.
     const userMessage: ModelMessage = {

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -837,6 +837,94 @@ describe("runAgent — aborted wrap-up path", () => {
     });
 });
 
+// ── undispatched tool calls at a terminal finish ────────────────────
+
+describe("runAgent — undispatched tool calls at a terminal finish", () => {
+    /** A tool that records whether the loop ever executed it. */
+    function probeTool(): { tool: Tool; wasExecuted: () => boolean } {
+        let executed = false;
+        const tool = defineTool({
+            id: "probe",
+            description: "Record that the loop executed this call.",
+            inputSchema: z.object({}),
+            describeCall: "none",
+            execute: async () => {
+                executed = true;
+                return ok({});
+            },
+        });
+        return { tool, wasExecuted: () => executed };
+    }
+
+    function toolCallIdsOf(messages: readonly ModelMessage[]): string[] {
+        return messages.flatMap((m) =>
+            m.role === "assistant" && typeof m.content !== "string" ? m.content.filter((p) => p.type === "tool-call").map((p) => p.toolCallId) : [],
+        );
+    }
+
+    it("strips the call a content-filter finish carried, keeps the prose, and never executes it", async () => {
+        const { tool, wasExecuted } = probeTool();
+        const provider = scriptedProvider([makeMessage([textBlock("I cannot continue with this."), toolUseBlock("tu-x", "probe", {})], "refusal")]);
+        const logger = createCapturingLogger();
+
+        const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider, { logger }));
+
+        expect(finish.reason).toBe("content-filter");
+        expect(wasExecuted()).toBe(false);
+        expect(toolCallIdsOf(messages)).toEqual([]);
+        const last = messages.at(-1)!;
+        expect(last.role).toBe("assistant");
+        expect(last.content).toEqual([{ type: "text", text: "I cannot continue with this." }]);
+        const warn = logger.records.find((r) => r.level === "warn" && r.msg.includes("undispatched tool calls stripped"));
+        expect(warn?.fields).toMatchObject({ toolCallIds: ["tu-x"], tools: ["probe"] });
+    });
+
+    it("keeps the earlier, dispatched round intact and removes only the trailing call-only reply", async () => {
+        const { tool, wasExecuted } = probeTool();
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "probe", {})], "tool_use"),
+            makeMessage([toolUseBlock("tu-2", "probe", {})], "refusal"),
+        ]);
+
+        const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider));
+
+        expect(finish.reason).toBe("content-filter");
+        expect(wasExecuted()).toBe(true);
+        // [user, assistant(tu-1), tool(result tu-1)] — the call-only filtered reply is gone whole.
+        expect(messages).toHaveLength(3);
+        expect(toolCallIdsOf(messages)).toEqual(["tu-1"]);
+        expect(toolResultParts(messages[2]).map((r) => r.toolCallId)).toEqual(["tu-1"]);
+    });
+
+    it("settles a call that rides a plain stop finish", async () => {
+        const { tool, wasExecuted } = probeTool();
+        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-x", "probe", {})], "end_turn")]);
+
+        const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider));
+
+        expect(finish.reason).toBe("stop");
+        expect(wasExecuted()).toBe(false);
+        expect(messages).toEqual([...GO]);
+    });
+
+    it("re-marks the surviving step when the strip removes a call-only aborted partial", async () => {
+        const { tool } = probeTool();
+        const provider = scriptedProvider([
+            makeMessage([toolUseBlock("tu-1", "probe", {})], "tool_use"),
+            makeMessage([toolUseBlock("tu-2", "probe", {})], "aborted"),
+        ]);
+
+        const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider));
+
+        expect(finish.reason).toBe("aborted");
+        // [user, assistant(tu-1), tool(result)] — the aborted call-only partial is gone.
+        expect(messages).toHaveLength(3);
+        expect(toolCallIdsOf(messages)).toEqual(["tu-1"]);
+        // The interruption marker rides the last assistant that survived the strip.
+        expect(isInterruptedMessage(messages[1]!)).toBe(true);
+    });
+});
+
 // ── finish signal on a clean stop ───────────────────────────────────
 
 describe("runAgent — finish signal", () => {

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -896,13 +896,27 @@ describe("runAgent — undispatched tool calls at a terminal finish", () => {
         expect(toolResultParts(messages[2]).map((r) => r.toolCallId)).toEqual(["tu-1"]);
     });
 
-    it("settles a call that rides a plain stop finish", async () => {
+    it("dispatches a call that rides a stop finish, because a local model labels its tool replies stop", async () => {
         const { tool, wasExecuted } = probeTool();
-        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-x", "probe", {})], "end_turn")]);
+        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-x", "probe", {})], "end_turn"), makeMessage([textBlock("done")], "end_turn")]);
 
         const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider));
 
         expect(finish.reason).toBe("stop");
+        expect(wasExecuted()).toBe(true);
+        // [user, assistant(tu-x), tool(result), assistant("done")] — the round ran and the loop continued.
+        expect(messages).toHaveLength(4);
+        expect(toolResultParts(messages[2]).map((r) => r.toolCallId)).toEqual(["tu-x"]);
+        expect(messages.at(-1)!.content).toEqual([{ type: "text", text: "done" }]);
+    });
+
+    it("settles a call that rides an unknown finish", async () => {
+        const { tool, wasExecuted } = probeTool();
+        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-x", "probe", {})], "unknown")]);
+
+        const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider));
+
+        expect(finish.reason).toBe("unknown");
         expect(wasExecuted()).toBe(false);
         expect(messages).toEqual([...GO]);
     });

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -229,8 +229,9 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     /**
      * Settle the transcript on the way out — called at every return. A reply can
      * carry a complete tool call beside ANY finish reason, because the call
-     * streams before the stop reason arrives, and only the `tool-calls` and
-     * `length` branches dispatch. A call this run never dispatched is stripped
+     * streams before the stop reason arrives, and only the dispatching branches
+     * (`tool-calls`, a call-carrying `stop`, and `length`) run one. A call this
+     * run never dispatched is stripped
      * rather than executed (a filtered or aborted reply must not act) or answered
      * with an invented result (the model would read a fabrication as ground
      * truth). Without the strip, the unanswered call violates the wire contract —
@@ -444,7 +445,13 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             continue;
         }
 
-        if (reply.finishReason !== "tool-calls") {
+        // A local model behind an OpenAI-compatible server routinely labels a
+        // tool-calling reply `stop`. The calls are complete and the model waits
+        // on their results, thus the mislabeled round dispatches like a
+        // `tool-calls` one. Every other terminal keeps the strip: a filtered or
+        // aborted reply must not act.
+        const dispatchesRound = reply.finishReason === "tool-calls" || (reply.finishReason === "stop" && toolCalls.length > 0);
+        if (!dispatchesRound) {
             settleTranscript();
             // The settle can remove a call-only aborted partial whole; the
             // interruption marker then rides the last assistant that survived,

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -21,6 +21,7 @@ import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { hintForZodIssue, repairToolInput } from "../lib/zod-issues.js";
 import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-message-storage.js";
+import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
 import { classifyProviderError } from "../providers/errors.js";
 import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/prompt-cache.js";
 import { resultStep } from "./run-step.js";
@@ -225,6 +226,27 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         log[level]("run finished", { iterations, reason, cappedOut, truncationRecoveries, toolCalls: toolCallCount, toolErrors: toolErrorCount, usage });
     };
 
+    /**
+     * Settle the transcript on the way out — called at every return. A reply can
+     * carry a complete tool call beside ANY finish reason, because the call
+     * streams before the stop reason arrives, and only the `tool-calls` and
+     * `length` branches dispatch. A call this run never dispatched is stripped
+     * rather than executed (a filtered or aborted reply must not act) or answered
+     * with an invented result (the model would read a fabrication as ground
+     * truth). Without the strip, the unanswered call violates the wire contract —
+     * every tool call carries a result — and the provider boundary then refuses
+     * the whole transcript on every later turn of the thread. Scoped past
+     * `initial`: the caller's prefix is not this run's to repair.
+     */
+    const settleTranscript = (): void => {
+        const droppedCalls = stripUnansweredToolCalls(messages, initial.length);
+        if (droppedCalls.length === 0) return;
+        log.warn("undispatched tool calls stripped at run exit", {
+            toolCallIds: droppedCalls.map((d) => d.toolCallId),
+            tools: droppedCalls.map((d) => d.toolName),
+        });
+    };
+
     const usageRecorder = opts.usageRecorder ?? createNoopUsageRecorder();
 
     /**
@@ -272,6 +294,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // lands in a dispatch round — after the concurrent siblings in that same round
     // have completed and been appended. Mirrors the clean-stop terminal path.
     const stopOnDenial = async (i: number): Promise<RunAgentResult> => {
+        settleTranscript();
         await emit({ type: "iteration", source, index: i, final: true });
         recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
         logFinish("warn", "denied", false);
@@ -341,6 +364,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     };
 
     const stopOnResolved = async (i: number): Promise<RunAgentResult> => {
+        settleTranscript();
         await emit({ type: "iteration", source, index: i, final: true });
         recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
         return { messages, finish: { reason: "stop", cappedOut: false, truncationRecoveries } };
@@ -421,6 +445,11 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         }
 
         if (reply.finishReason !== "tool-calls") {
+            settleTranscript();
+            // The settle can remove a call-only aborted partial whole; the
+            // interruption marker then rides the last assistant that survived,
+            // matching the no-output abort contract above.
+            if (reply.finishReason === "aborted") markLastLoopAssistant(messages, initial.length);
             await emit({ type: "iteration", source, index: i, final: true });
             recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
             logFinish("info", reply.finishReason, false);
@@ -470,6 +499,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         // from every downstream reader; `cappedOut` stays true because the loop genuinely
         // exhausted its iterations, while the reason carries the abort.
         if (assistantHasContent(wrapUp.message)) messages.push(wrapUp.message);
+        settleTranscript();
         markLastLoopAssistant(messages, initial.length);
         await emit({ type: "iteration", source, index: agent.maxIterations, final: true });
         recordAgentRun({ agentId: agent.id, iterations, cappedOut: true, usage });
@@ -478,6 +508,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     }
 
     messages.push(wrapUp.message);
+    settleTranscript();
     await emit({ type: "iteration", source, index: agent.maxIterations, final: true });
     recordAgentRun({ agentId: agent.id, iterations, cappedOut: true, usage });
     logFinish("warn", "max_iterations", true);

--- a/harness/src/memory/tool-call-integrity.test.ts
+++ b/harness/src/memory/tool-call-integrity.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantModelMessage, ModelMessage } from "ai";
+
+import { stripUnansweredToolCalls } from "./tool-call-integrity.js";
+
+function toolCall(toolCallId: string, toolName = "echo"): { type: "tool-call"; toolCallId: string; toolName: string; input: unknown } {
+    return { type: "tool-call", toolCallId, toolName, input: {} };
+}
+
+function toolResult(toolCallId: string, toolName = "echo"): ModelMessage {
+    return {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId, toolName, output: { type: "json", value: { ok: true } } }],
+    };
+}
+
+function assistantContent(message: ModelMessage | undefined): AssistantModelMessage["content"] {
+    expect(message).toBeDefined();
+    expect(message!.role).toBe("assistant");
+    // Safe: the role assertion above fails the test before this cast can lie.
+    return message!.content as AssistantModelMessage["content"];
+}
+
+describe("stripUnansweredToolCalls", () => {
+    it("keeps an answered call and reports nothing", () => {
+        const messages: ModelMessage[] = [{ role: "user", content: "go" }, { role: "assistant", content: [toolCall("tu-1")] }, toolResult("tu-1")];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped).toEqual([]);
+        expect(messages.length).toBe(3);
+        expect(assistantContent(messages[1])).toEqual([toolCall("tu-1")]);
+    });
+
+    it("strips an unanswered call and keeps the text beside it", () => {
+        const messages: ModelMessage[] = [
+            { role: "user", content: "go" },
+            { role: "assistant", content: [{ type: "text", text: "I cannot continue." }, toolCall("tu-x", "update_working_memory")] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped).toEqual([{ toolCallId: "tu-x", toolName: "update_working_memory" }]);
+        expect(messages.length).toBe(2);
+        expect(assistantContent(messages[1])).toEqual([{ type: "text", text: "I cannot continue." }]);
+    });
+
+    it("removes a call-only message whole", () => {
+        const messages: ModelMessage[] = [
+            { role: "user", content: "go" },
+            { role: "assistant", content: [toolCall("tu-x")] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped).toEqual([{ toolCallId: "tu-x", toolName: "echo" }]);
+        expect(messages).toEqual([{ role: "user", content: "go" }]);
+    });
+
+    it("removes a message whose remainder is reasoning only", () => {
+        const messages: ModelMessage[] = [
+            { role: "user", content: "go" },
+            { role: "assistant", content: [{ type: "reasoning", text: "thinking" }, toolCall("tu-x")] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped.length).toBe(1);
+        expect(messages).toEqual([{ role: "user", content: "go" }]);
+    });
+
+    it("repairs a dangling call in the middle of a transcript", () => {
+        const messages: ModelMessage[] = [
+            { role: "user", content: "go" },
+            { role: "assistant", content: [toolCall("tu-1"), toolCall("tu-2")] },
+            toolResult("tu-1"),
+            { role: "user", content: "next turn" },
+            { role: "assistant", content: [{ type: "text", text: "done" }] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped).toEqual([{ toolCallId: "tu-2", toolName: "echo" }]);
+        expect(assistantContent(messages[1])).toEqual([toolCall("tu-1")]);
+        expect(messages.length).toBe(5);
+    });
+
+    it("does not repair before fromIndex, and still scans the whole array for results", () => {
+        const messages: ModelMessage[] = [
+            { role: "assistant", content: [toolCall("tu-prefix")] },
+            { role: "assistant", content: [toolCall("tu-loop")] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages, 1);
+
+        // The prefix message is not this caller's to repair; the in-range call goes.
+        expect(dropped).toEqual([{ toolCallId: "tu-loop", toolName: "echo" }]);
+        expect(messages.length).toBe(1);
+        expect(assistantContent(messages[0])).toEqual([toolCall("tu-prefix")]);
+    });
+
+    it("skips a provider-executed call whose result rides the same message", () => {
+        const messages: ModelMessage[] = [
+            {
+                role: "assistant",
+                content: [
+                    { ...toolCall("tu-server", "web_search"), providerExecuted: true },
+                    { type: "tool-result", toolCallId: "tu-server", toolName: "web_search", output: { type: "json", value: {} } },
+                ],
+            },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped).toEqual([]);
+        expect(messages.length).toBe(1);
+    });
+
+    it("reports removals across messages in transcript order", () => {
+        const messages: ModelMessage[] = [
+            { role: "assistant", content: [{ type: "text", text: "a" }, toolCall("tu-1"), toolCall("tu-2")] },
+            { role: "assistant", content: [{ type: "text", text: "b" }, toolCall("tu-3")] },
+        ];
+
+        const dropped = stripUnansweredToolCalls(messages);
+
+        expect(dropped.map((d) => d.toolCallId)).toEqual(["tu-1", "tu-2", "tu-3"]);
+    });
+});

--- a/harness/src/memory/tool-call-integrity.ts
+++ b/harness/src/memory/tool-call-integrity.ts
@@ -1,0 +1,98 @@
+/**
+ * Transcript integrity for tool calls.
+ *
+ * The wire contract of every provider is that each tool call in an assistant
+ * message has a matching tool result. A transcript that violates it is refused
+ * WHOLE — the AI SDK throws at prompt conversion, and the Anthropic API answers
+ * 400 — so a single unanswered call makes a thread unable to take any further
+ * turn. An unanswered call is a reachable state, not a hypothetical: a reply
+ * can carry a complete tool call beside ANY finish reason, because the call
+ * streams before the stop reason arrives, and only a `tool-calls` (and, for its
+ * leading calls, a `length`) finish dispatches it.
+ *
+ * The repair is a STRIP, never an invented result. A call that was not
+ * dispatched did not happen, and a fabricated result would record an execution
+ * that did not occur — the model would read it as ground truth on the next
+ * turn. The prose of the message survives the strip; a message left with
+ * nothing the wire can render disappears entirely.
+ */
+
+import type { ModelMessage, ToolCallPart } from "ai";
+
+/** One tool call removed by {@link stripUnansweredToolCalls}, identified for the caller's diagnostic record. */
+export interface DroppedToolCall {
+    readonly toolCallId: string;
+    readonly toolName: string;
+}
+
+/**
+ * Whether this tool call needs a client-supplied result. A provider-executed
+ * call is answered by the provider inside the same assistant message, so the
+ * wire contract makes no demand on the client for it — the AI SDK's own
+ * missing-result validation skips these, and so does the strip.
+ */
+function needsClientResult(part: ToolCallPart): boolean {
+    return part.providerExecuted !== true;
+}
+
+/**
+ * Remove, in place, every tool-call part at or past `fromIndex` that has no
+ * matching tool result anywhere in `messages`. Returns the removed calls in
+ * transcript order — empty on the healthy path — so the caller can log what
+ * a reader of the stored thread would otherwise never learn.
+ *
+ * Results are matched by id across the whole array, not by adjacency: the loop
+ * appends a round's results directly after its assistant message, but a
+ * deferred-image user message can ride between rounds, and the stored shape is
+ * not this function's to assume.
+ *
+ * A message that keeps a text or file part survives the strip — refusal prose
+ * is the one account the reader has of a filtered reply. A message left with
+ * no such part (a call-only message, or reasoning beside the removed call) is
+ * removed whole: reasoning without the output it preceded is not replayable,
+ * and an empty assistant message is itself a wire violation.
+ *
+ * `fromIndex` bounds the REPAIR, not the result scan. The loop passes its
+ * `initial.length` so it never rewrites the caller's prefix; the assembly
+ * repair passes nothing and covers the whole stored window.
+ */
+export function stripUnansweredToolCalls(messages: ModelMessage[], fromIndex = 0): DroppedToolCall[] {
+    const resultIds = new Set<string>();
+    for (const message of messages) {
+        if (message.role === "tool") {
+            for (const part of message.content) {
+                if (part.type === "tool-result") resultIds.add(part.toolCallId);
+            }
+        } else if (message.role === "assistant" && typeof message.content !== "string") {
+            for (const part of message.content) {
+                if (part.type === "tool-result") resultIds.add(part.toolCallId);
+            }
+        }
+    }
+
+    type AssistantPart = Exclude<Extract<ModelMessage, { role: "assistant" }>["content"], string>[number];
+
+    const dropped: DroppedToolCall[] = [];
+    // Backward, so a whole-message removal cannot shift an index this loop has
+    // yet to visit.
+    for (let idx = messages.length - 1; idx >= fromIndex; idx--) {
+        const message = messages[idx]!;
+        if (message.role !== "assistant" || typeof message.content === "string") continue;
+        const removed: ToolCallPart[] = [];
+        for (const part of message.content) {
+            if (part.type === "tool-call" && needsClientResult(part) && !resultIds.has(part.toolCallId)) removed.push(part);
+        }
+        if (removed.length === 0) continue;
+        // Prepended as a batch: the walk visits messages tail-first, but the
+        // caller's record reads in transcript order.
+        dropped.unshift(...removed.map((part) => ({ toolCallId: part.toolCallId, toolName: part.toolName })));
+        const removedParts = new Set<AssistantPart>(removed);
+        const kept = message.content.filter((part) => !removedParts.has(part));
+        if (kept.some((part) => part.type === "text" || part.type === "file" || part.type === "tool-call" || part.type === "tool-result")) {
+            messages[idx] = { ...message, content: kept };
+        } else {
+            messages.splice(idx, 1);
+        }
+    }
+    return dropped;
+}


### PR DESCRIPTION
## What & why

A reply can carry a complete tool call beside any finish reason, because the call streams before the stop reason arrives. The loop dispatched calls only on a `tool-calls` or `length` finish. Thus a terminal finish, for example `content-filter`, left an unanswered call in the transcript. The host persisted it, and the AI SDK then refused the whole thread on each later turn with `AI_MissingToolResultsError`. The thread was dead permanently.

The fix has two layers. The loop now settles the transcript at every exit: it strips each call that it did not dispatch, and it logs the strip. The message assembly repairs a stored transcript at read time with the same strip, and it logs the thread id. The read-side repair also heals a thread that is wedged today, on its next turn.

Notes for the reviewer:

- The repair strips. It does not invent a tool result, because a call that did not run must not read as one that did. Anthropic's guidance for a refusal is the same: do not execute.
- The strip keeps the text and file parts, so refusal prose survives. A message left with only reasoning is removed whole, because reasoning without its output is not replayable.
- `stripUnansweredToolCalls` skips a provider-executed call, which mirrors the AI SDK's own missing-result validation.
- The cli commit passes the logger into chat-turn preparation, so the read-time repair reaches the file log. It is compatible with the pinned harness, because the deps bag accepts `logger` already.
- A `stop` finish that carries complete calls dispatches like `tool-calls`. A local model behind an OpenAI-compatible server labels its tool replies `stop`, and a strip would discard that work.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
