### PR TITLE
feat(harness): emit data-report-session-started part from start_report_session

### DIFF
--- a/harness/openspec/changes/emit-report-session-started-part/design.md
+++ b/harness/openspec/changes/emit-report-session-started-part/design.md
@@ -1,0 +1,13 @@
+# Design
+
+## The registry classification
+
+The part is `emitter: conversation`, `consumer: conversation`, not transient, and not reconciling. The classification is the whole persistence mechanism: the conversation display recorder keeps each durable conversation part in the position of its emission, thus the part needs no storage code of its own. One spawn makes one part, thus the part does not reconcile and it carries no `id`.
+
+## The payload is minimal
+
+The part carries `threadId` and `parentThreadId` only. The title of a session is seeded after the spawn, and the store can archive the session later. A snapshot of either in the part would go stale in the transcript. Thus the part names the thread, and a consumer reads the live state from the thread listing. This is the one authority rule of the change: the part places and signals, and the store decides what exists.
+
+## The started arm only
+
+The existing-session arm names a session that an earlier turn announced, and that turn already holds the part. A second part would put a second entry into the transcript for one session. A refusal starts nothing, thus it emits nothing.

--- a/harness/openspec/changes/emit-report-session-started-part/proposal.md
+++ b/harness/openspec/changes/emit-report-session-started-part/proposal.md
@@ -1,0 +1,31 @@
+# Emit a chat part when a report session starts
+
+## Why
+
+A web client reads the chat stream and the thread listing over HTTP. It does not see a tool result, thus it cannot see that a turn spawned a report session. Today such a client infers the spawn from the lifecycle of the turn: when a turn settles, it reads the thread listing again. That inference is fragile. A turn that fails before its first token settles on a path that the client does not watch, and the spawned session stays invisible until the next reload.
+
+The transcript has the same gap on reload. A message on the wire carries no store `seq`, thus a remote client cannot place a session entry at its spawn point. The CLI joins `Thread.parentSeq` against the store rows in process, and a remote client has no such join.
+
+One persisted chat part repairs both. A part in the stream tells the client that a session started, at the moment it started. The same part persists into the display projection of the turn, thus a reload shows the entry at the position of the spawn with no `seq` on the wire.
+
+## What Changes
+
+- `start_report_session` emits a `data-report-session-started` part through the emit sink of its tool context. The part carries `threadId` and `parentThreadId`. It rides the started arm only. The existing-session arm and each refusal emit nothing.
+- The part joins the chat-part vocabulary: the contract interface, the Zod schema, the part registry, and the durable display projection. Its registry entry is `conversation` / `conversation` / not transient / not reconciling, thus the conversation display recorder persists it in position.
+- The part is a placement record and a freshness signal only. The thread store is the authority for the session: its existence, its title, and its archived state. A consumer whose part names an archived or absent thread renders nothing for it.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `report-session-spawn`: the tool announces a started session as one durable chat part.
+
+## Impact
+
+Harness source:
+
+- `src/contracts/chat-parts.ts`, `src/contracts/schemas/chat-parts.ts`, `src/contracts/part-registry.ts`, `src/contracts/index.ts` — the part vocabulary.
+- `src/memory/conversation-display-storage.ts` — the durable display key for the part.
+- `src/tools/start-report-session.ts` — the emission on the started arm.
+
+Consumers: the change is additive. The CLI stays unchanged, because its store-driven listing already covers the two edges in process. A reloaded transcript in the CLI shows the part as a tagged mention until the CLI adopts a renderer for it. A web host can adopt the part to replace its settle-edge inference.

--- a/harness/openspec/changes/emit-report-session-started-part/specs/report-session-spawn/spec.md
+++ b/harness/openspec/changes/emit-report-session-started-part/specs/report-session-spawn/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: The tool announces a started session as one durable chat part
+
+When the spawn succeeds, `start_report_session` SHALL emit one `data-report-session-started` part through the emit sink of its tool context. The part SHALL carry the `threadId` of the child and the `parentThreadId` of the conversation. The tool SHALL NOT emit the part on the existing-session arm or on a refusal, because those arms start no session.
+
+The part SHALL be a durable conversation part in the part registry, thus the display projection of the turn persists it in the position of its emission. A reload then shows the entry at the spawn point, and no message `seq` rides the wire.
+
+The part is a placement record and a freshness signal only. The thread store SHALL stay the authority for the session: its existence, its title, and its archived state. A consumer whose part names an archived or absent thread SHALL render nothing for it.
+
+#### Scenario: A started session emits one part
+
+- **WHEN** the agent calls `start_report_session` and the spawn succeeds
+- **THEN** the tool emits exactly one `data-report-session-started` part, and the part carries the thread id of the child and the thread id of the parent conversation
+
+#### Scenario: The existing-session arm emits nothing
+
+- **GIVEN** a parent whose newest report child sits at or past the last user turn
+- **WHEN** the agent calls the tool and the advice names that child
+- **THEN** the tool emits no part
+
+#### Scenario: A refusal emits nothing
+
+- **WHEN** the tool refuses a call, for any refusal arm
+- **THEN** the tool emits no part
+
+#### Scenario: The part persists into the display projection
+
+- **GIVEN** a turn whose loop records the conversation display
+- **WHEN** the tool emits the part between two text runs
+- **THEN** the persisted display of the turn holds the part between the two text runs

--- a/harness/openspec/changes/emit-report-session-started-part/tasks.md
+++ b/harness/openspec/changes/emit-report-session-started-part/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## 1. The part vocabulary
+
+- [x] 1.1 Add `ReportSessionStartedPart` to `src/contracts/chat-parts.ts` and to the `CortexChatPart` union, with the authority rule in its doc comment.
+- [x] 1.2 Add `ReportSessionStartedPartSchema` to `src/contracts/schemas/chat-parts.ts` and to `CortexChatPartSchema`.
+- [x] 1.3 Add the `data-report-session-started` entry to `PART_REGISTRY`: `conversation` / `conversation` / not transient / not reconciling.
+- [x] 1.4 Export the type from `src/contracts/index.ts`.
+
+## 2. The durable display projection
+
+- [x] 2.1 Add the `report-session-started` key to `ConversationUIData` and to the stored-envelope `dataSchemas` in `src/memory/conversation-display-storage.ts`.
+- [x] 2.2 Test that the recorder keeps the part in the position of its emission.
+
+## 3. The emission
+
+- [x] 3.1 Emit the part in `src/tools/start-report-session.ts` on the started arm, with `threadId` and `parentThreadId`.
+- [x] 3.2 Test the three arms: started emits one part, existing-session emits nothing, and a refusal emits nothing.

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.22.1",
+    "version": "0.23.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/contracts/chat-parts.ts
+++ b/harness/src/contracts/chat-parts.ts
@@ -421,6 +421,25 @@ export interface DataPreviewFailedPart {
     errorKind?: "render" | "submit" | "build" | "timeout" | "internal";
 }
 
+// ── Report Session Started (report session spawn) ──────────────────
+
+/**
+ * The record that a turn started a report session. It rides the chat stream
+ * live, and it persists into the turn at the position of the spawn.
+ *
+ * The part is a placement record and a freshness signal only. The thread
+ * store is the authority for the session: its existence, its title, and its
+ * archived state. When the thread of the part is archived or absent, a
+ * consumer renders nothing for it.
+ */
+export interface ReportSessionStartedPart {
+    type: "data-report-session-started";
+    /** The id of the report thread that the spawn made. */
+    threadId: string;
+    /** The id of the conversation thread that spawned it. */
+    parentThreadId: string;
+}
+
 // ── Union ───────────────────────────────────────────────────────────
 
 export type CortexChatPart =
@@ -442,4 +461,5 @@ export type CortexChatPart =
     | RunCompletedPart
     | RunFailedPart
     | PreviewPart
-    | DataPreviewFailedPart;
+    | DataPreviewFailedPart
+    | ReportSessionStartedPart;

--- a/harness/src/contracts/index.ts
+++ b/harness/src/contracts/index.ts
@@ -35,6 +35,7 @@ export type {
     RunFailedPart,
     PreviewPart,
     DataPreviewFailedPart,
+    ReportSessionStartedPart,
     CortexChatPart,
 } from "./chat-parts.js";
 

--- a/harness/src/contracts/part-registry.ts
+++ b/harness/src/contracts/part-registry.ts
@@ -36,6 +36,7 @@ export const PART_REGISTRY: Record<CortexChatPartType, PartDescriptor> = {
     "data-run-failed": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: false },
     "data-report-preview": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
     "data-report-preview-failed": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
+    "data-report-session-started": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
 };
 
 export function isTransient(type: CortexChatPartType): boolean {

--- a/harness/src/contracts/schemas/chat-parts.ts
+++ b/harness/src/contracts/schemas/chat-parts.ts
@@ -349,6 +349,14 @@ export const DataPreviewFailedPartSchema = z.object({
     errorKind: z.enum(["render", "submit", "build", "timeout", "internal"]).optional(),
 });
 
+// ── Report Session Started ─────────────────────────────────────────
+
+export const ReportSessionStartedPartSchema = z.object({
+    type: z.literal("data-report-session-started"),
+    threadId: z.string(),
+    parentThreadId: z.string(),
+});
+
 // ── Union ───────────────────────────────────────────────────────────
 
 export const CortexChatPartSchema = z.discriminatedUnion("type", [
@@ -371,4 +379,5 @@ export const CortexChatPartSchema = z.discriminatedUnion("type", [
     RunFailedPartSchema,
     PreviewPartSchema,
     DataPreviewFailedPartSchema,
+    ReportSessionStartedPartSchema,
 ]);

--- a/harness/src/memory/conversation-display-recorder.test.ts
+++ b/harness/src/memory/conversation-display-recorder.test.ts
@@ -57,11 +57,22 @@ describe("conversation display recorder", () => {
         await recorder.emit({ type: "tool-finished", source: TOP, toolUseId: "b", name: "tool_b", outcome: "ok" });
         await recorder.emit({ type: "tool-finished", source: TOP, toolUseId: "a", name: "tool_a", outcome: "ok" });
 
-        expect(recorder.finish()[1]!.parts.map((part) => ("id" in part ? part.id : part.type))).toEqual([
-            "a",
-            "b",
-            "from-b",
-            "from-a",
+        expect(recorder.finish()[1]!.parts.map((part) => ("id" in part ? part.id : part.type))).toEqual(["a", "b", "from-b", "from-a"]);
+    });
+
+    it("records a report-session-started part in the position of its emission", async () => {
+        const { recorder } = harness();
+        await recorder.emit({ type: "text-delta", text: "starting" });
+        await recorder.emit({ type: "data-report-session-started", source: TOP, data: { threadId: "r1", parentThreadId: "p1" } });
+        await recorder.emit({ type: "text-delta", text: "done" });
+
+        // The part is durable conversation display, thus the recorder keeps it
+        // between the two text runs and a reload shows it where the spawn ran.
+        const display = recorder.finish();
+        expect(display[1]!.parts).toEqual([
+            { type: "text", text: "starting", state: "done" },
+            { type: "data-report-session-started", data: { threadId: "r1", parentThreadId: "p1" } },
+            { type: "text", text: "done", state: "done" },
         ]);
     });
 

--- a/harness/src/memory/conversation-display-storage.ts
+++ b/harness/src/memory/conversation-display-storage.ts
@@ -18,7 +18,16 @@
 import { validateUIMessages, type DataUIPart, type UIMessage, type UIMessagePart } from "ai";
 import { z } from "zod";
 
-import type { AskPart, FileReferencePart, PlanPart, PresentationPart, PreviewPart, DataPreviewFailedPart, RunCardPart } from "../contracts/chat-parts.js";
+import type {
+    AskPart,
+    FileReferencePart,
+    PlanPart,
+    PresentationPart,
+    PreviewPart,
+    DataPreviewFailedPart,
+    ReportSessionStartedPart,
+    RunCardPart,
+} from "../contracts/chat-parts.js";
 import {
     AskPartSchema,
     DataPreviewFailedPartSchema,
@@ -26,6 +35,7 @@ import {
     PlanPartSchema,
     PresentationPartSchema,
     PreviewPartSchema,
+    ReportSessionStartedPartSchema,
     RunCardPartSchema,
 } from "../contracts/schemas/chat-parts.js";
 import { ToolCallOutcomeSchema } from "../contracts/schemas/chat-events.js";
@@ -52,6 +62,7 @@ export type ConversationUIData = {
     ask: Payload<AskPart>;
     "report-preview": Payload<PreviewPart>;
     "report-preview-failed": Payload<DataPreviewFailedPart>;
+    "report-session-started": Payload<ReportSessionStartedPart>;
 };
 
 export interface ConversationDisplayMetadata {
@@ -99,6 +110,7 @@ const dataSchemas = {
     ask: AskPartSchema.omit({ type: true }).strict(),
     "report-preview": PreviewPartSchema.omit({ type: true }).strict(),
     "report-preview-failed": DataPreviewFailedPartSchema.omit({ type: true }).strict(),
+    "report-session-started": ReportSessionStartedPartSchema.omit({ type: true }).strict(),
 };
 
 export interface StoredDisplayEnvelope {

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -145,6 +145,48 @@ describe("the started arm", () => {
     });
 });
 
+describe("the started part", () => {
+    /** A tool context for one conversation thread, plus the record of its emitted events. */
+    function watchedCtxForThread(threadId: string): { ctx: ToolContext; emitted: unknown[] } {
+        const { ctx, emitted } = makeToolContext();
+        const scope: Scope = { kind: "analysis", analysisId: ANALYSIS, threadId };
+        return { ctx: { ...ctx, session: { ...ctx.session, scope } }, emitted };
+    }
+
+    it("emits one data-report-session-started part on the started arm", async () => {
+        await seedConversation("p1", "Parent");
+        const { ctx, emitted } = watchedCtxForThread("p1");
+
+        const result = (await tool.execute(INPUT, ctx))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("started");
+        if (result.outcome !== "started") return;
+        expect(emitted).toEqual([{ type: "data-report-session-started", data: { threadId: result.threadId, parentThreadId: "p1" } }]);
+    });
+
+    it("emits nothing on the existing-session arm", async () => {
+        await seedConversation("p1", "Parent");
+        expect((await run(INPUT, ctxForThread("p1"))).outcome).toBe("started");
+        const { ctx, emitted } = watchedCtxForThread("p1");
+
+        const result = (await tool.execute(INPUT, ctx))._unsafeUnwrap();
+
+        // The arm names a session that an earlier turn announced, thus a second
+        // part would put a second entry into the transcript.
+        expect(result.outcome).toBe("existing-session");
+        expect(emitted).toEqual([]);
+    });
+
+    it("emits nothing on a refusal", async () => {
+        const { ctx, emitted } = watchedCtxForThread("ghost");
+
+        const result = (await tool.execute(INPUT, ctx))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("parent_not_found");
+        expect(emitted).toEqual([]);
+    });
+});
+
 describe("the refused arm", () => {
     it("refuses a scope that carries no thread id, and writes no row", async () => {
         await seedConversation("p1", "Parent");

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -241,18 +241,23 @@ export function createStartReportSessionTool(deps: StartReportSessionToolDeps): 
             }
 
             const spawned = await spawn.spawnReportSession(parentThreadId, brief);
-            return ok(
-                spawned.match(
-                    (child): StartReportSessionResult => ({ outcome: "started", threadId: child.threadId, title: child.title }),
-                    (fault): StartReportSessionResult => {
-                        const outcome = toOutcome(fault);
-                        if (outcome.outcome === "failed") {
-                            logger.warn("the report session did not start", { parentThreadId, reason: fault.type, ...logger.errorFields(causeOf(fault)) });
-                        }
-                        return outcome;
-                    },
-                ),
-            );
+            if (spawned.isOk()) {
+                const child = spawned.value;
+                // The part rides the started arm only. The existing-session arm
+                // names a session that an earlier turn announced, thus a second
+                // part would put a second entry into the transcript.
+                await ctx.emit({
+                    type: "data-report-session-started",
+                    data: { threadId: child.threadId, parentThreadId },
+                });
+                return ok({ outcome: "started", threadId: child.threadId, title: child.title });
+            }
+            const fault = spawned.error;
+            const outcome = toOutcome(fault);
+            if (outcome.outcome === "failed") {
+                logger.warn("the report session did not start", { parentThreadId, reason: fault.type, ...logger.errorFields(causeOf(fault)) });
+            }
+            return ok(outcome);
         },
     });
 }


### PR DESCRIPTION
## What changed, and why

A web client reads the chat stream and the thread listing over HTTP, and a tool result does not reach it. Thus it cannot see that a turn spawned a report session, and it infers the spawn from the lifecycle of the turn. That inference is fragile: a turn that fails before its first token settles on a path the client does not watch, and the session stays invisible until a reload. `start_report_session` now emits one `data-report-session-started` part on the started arm, with `threadId` and `parentThreadId`. The part is a durable conversation part, thus the display projection persists it at the position of the spawn, and a reload places the entry with no message `seq` on the wire.

## Notes for the reviewer

- The part is a placement record and a freshness signal only. The thread store stays the authority for the session: its existence, its title, and its archived state. A consumer whose part names an archived or absent thread renders nothing for it. The payload stays minimal for the same reason: a title snapshot would go stale in the transcript.
- The existing-session arm and each refusal emit nothing. The existing-session arm names a session that an earlier turn announced, and that turn already holds the part.
- The CLI is intentionally unchanged. Its store-driven listing covers the scope-bind edge and the turn-settlement edge in process. A reloaded CLI transcript shows the part as a tagged mention until the CLI adopts a renderer.
- The OpenSpec change is `emit-report-session-started-part`, with one ADDED requirement on `report-session-spawn`.