### PR TITLE
feat: surface a model refusal as a typed turn outcome

### DIFF
--- a/cli/src/modules/harness/dev/chat.ts
+++ b/cli/src/modules/harness/dev/chat.ts
@@ -289,6 +289,11 @@ async function runTurn(
                 reportAppendError(outcome.appendError);
                 printer.finishTurn();
                 break;
+            case "filtered":
+                sink.errLine("The model declined this request and stopped the turn (content filter). Switch the chat model, then send the message again.");
+                reportAppendError(outcome.appendError);
+                printer.finishTurn(outcome.fallbackText);
+                break;
             case "failed":
                 sink.errLine(`The turn failed: ${describeCause(outcome.cause)}`);
                 reportAppendError(outcome.appendError);

--- a/cli/src/modules/harness/turn.test.ts
+++ b/cli/src/modules/harness/turn.test.ts
@@ -43,6 +43,12 @@ const prepareNotFound: ChatTurnSeams["prepare"] = () => Promise.resolve({ kind: 
 /** A `run` seam that finishes cleanly, appending one assistant message to the loop. */
 const runOk: ChatTurnSeams["run"] = (_agent, initial) =>
     Promise.resolve({ messages: [...initial, assistantMessage], finish: { reason: "stop", cappedOut: false, truncationRecoveries: 0 } });
+/** A `run` seam that resolves a `content-filter` finish — the model declined and stopped. */
+const runFiltered: ChatTurnSeams["run"] = (_agent, initial) =>
+    Promise.resolve({
+        messages: [...initial, assistantMessage],
+        finish: { reason: "content-filter", rawFinishReason: "refusal", cappedOut: false, truncationRecoveries: 0 },
+    });
 /**
  * A `run` seam that RESOLVES an interrupted turn: the streaming wrapper surfaces the abort as a
  * resolved "aborted" finish carrying the partial loop output (here one partial assistant message).
@@ -197,6 +203,20 @@ describe("runChatTurn", () => {
         // A turn that reported nothing carries no `turnUsage` KEY, not one holding `undefined` — the
         // engine spreads it conditionally so absence has one representation all the way to storage.
         expect(appended[0]?.turn && "turnUsage" in appended[0].turn).toBe(false);
+    });
+
+    test("a content-filter finish persists like ok and returns filtered with the endpoint's word", async () => {
+        const { history, appended } = recordingHistory();
+        const outcome = await runWith({ prepare: prepareOk, run: runFiltered, history, signal: new AbortController().signal });
+        expect(outcome.kind).toBe("filtered");
+        if (outcome.kind === "filtered") {
+            expect(outcome.fallbackText).toBe("the answer");
+            expect(outcome.rawFinishReason).toBe("refusal");
+            expect(outcome.appendError).toBeUndefined();
+        }
+        // The refusal keeps the ok path's persistence: the reply and its display projection land.
+        expect(appended[0]?.turn.modelMessages).toEqual([userMessage, assistantMessage]);
+        expect(appended[0]?.turn.displayMessages.map((message) => message.role)).toEqual(["user", "assistant"]);
     });
 
     test("a resolved aborted finish persists [userMessage, ...partial] and returns aborted", async () => {

--- a/cli/src/modules/harness/turn.ts
+++ b/cli/src/modules/harness/turn.ts
@@ -56,15 +56,15 @@ import { enterChatTurn } from "./agent_switch.ts";
 export type TurnUsage = Readonly<NonNullable<AgentFinish["turnUsage"]>>;
 
 /**
- * The result of running one chat turn. The three `runAgent`-reaching kinds
- * (`ok`/`aborted`/`failed`) each carry an optional {@link TurnOutcome.appendError}
+ * The result of running one chat turn. The four `runAgent`-reaching kinds
+ * (`ok`/`filtered`/`aborted`/`failed`) each carry an optional {@link TurnOutcome.appendError}
  * because `appendTurn` runs unconditionally on all of them (the partial turn
  * must survive an abort/throw), so its persistence fault is surfaced ORTHOGONALLY
  * to the turn's own fate rather than collapsing two independent failures into
  * one. `prepare_failed`/`thread_gone`/`agent_unresolved` bail BEFORE `runAgent`,
  * so they never append and never carry an append error.
  *
- * Those same three kinds also carry an optional {@link TurnUsage}. It rides here rather
+ * Those same four kinds also carry an optional {@link TurnUsage}. It rides here rather
  * than being read back out of the usage ledger because the ledger structurally cannot
  * answer "what did THIS turn cost": a chat-path usage record is attributed to a thread,
  * never to a turn. The run's finish already holds the whole-turn total, so reading it
@@ -75,6 +75,9 @@ export type TurnUsage = Readonly<NonNullable<AgentFinish["turnUsage"]>>;
  * - `ok` — the loop finished; `fallbackText` is `finalText(result.messages)`,
  *   the turn's final assistant text (a streamed surface suppresses it as a
  *   duplicate; a delta-less surface renders it).
+ * - `filtered` — the model's safety classifier declined and stopped the turn (an
+ *   Anthropic `refusal`, normalized to `content-filter`). A completed reply, not a
+ *   fault: it keeps the ok path's persistence, `fallbackText`, and cost.
  * - `aborted` — the turn-scoped signal fired mid-run; the run resolves with an
  *   "aborted" finish carrying its partial transcript, so the engine persists
  *   `[userMessage, ...partial]` (an empty partial degenerates to `[userMessage]`).
@@ -91,6 +94,13 @@ export type TurnUsage = Readonly<NonNullable<AgentFinish["turnUsage"]>>;
  */
 export type TurnOutcome =
     | { readonly kind: "ok"; readonly fallbackText: string; readonly turnUsage?: TurnUsage; readonly appendError?: DbError }
+    | {
+          readonly kind: "filtered";
+          readonly fallbackText: string;
+          readonly rawFinishReason?: string;
+          readonly turnUsage?: TurnUsage;
+          readonly appendError?: DbError;
+      }
     | { readonly kind: "aborted"; readonly turnUsage?: TurnUsage; readonly appendError?: DbError }
     | { readonly kind: "failed"; readonly cause: unknown; readonly turnUsage?: TurnUsage; readonly appendError?: DbError }
     | { readonly kind: "prepare_failed"; readonly cause: unknown }
@@ -211,6 +221,13 @@ export function buildChatSession(agentId: string, analysisId: string, threadId: 
  */
 type RunPhase =
     | { readonly kind: "ok"; readonly fallbackText: string; readonly turnUsage?: TurnUsage; readonly durationMs?: number }
+    | {
+          readonly kind: "filtered";
+          readonly fallbackText: string;
+          readonly rawFinishReason?: string;
+          readonly turnUsage?: TurnUsage;
+          readonly durationMs?: number;
+      }
     | { readonly kind: "aborted"; readonly turnUsage?: TurnUsage; readonly durationMs?: number }
     | { readonly kind: "failed"; readonly cause: unknown; readonly turnUsage?: TurnUsage; readonly durationMs?: number };
 
@@ -328,9 +345,23 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
                 // The two spans come from one `Date.now` pair in one process. The gap is milliseconds, thus
                 // the printed figures differ only on a short turn or on a rounding step.
                 const durationMs = Date.now() - turnStartedAt;
-                return result.finish.reason === "aborted"
-                    ? { phase: { kind: "aborted", durationMs, ...(turnUsage ? { turnUsage } : {}) }, toPersist }
-                    : { phase: { kind: "ok", fallbackText: finalText(result.messages), durationMs, ...(turnUsage ? { turnUsage } : {}) }, toPersist };
+                const spend = turnUsage ? { turnUsage } : {};
+                if (result.finish.reason === "aborted") return { phase: { kind: "aborted", durationMs, ...spend }, toPersist };
+                // A `content-filter` finish is a refusal: a completed reply, not a fault. It
+                // keeps the ok path's persistence and cost; only the kind differs.
+                if (result.finish.reason === "content-filter") {
+                    return {
+                        phase: {
+                            kind: "filtered",
+                            fallbackText: finalText(result.messages),
+                            ...(result.finish.rawFinishReason !== undefined ? { rawFinishReason: result.finish.rawFinishReason } : {}),
+                            durationMs,
+                            ...spend,
+                        },
+                        toPersist,
+                    };
+                }
+                return { phase: { kind: "ok", fallbackText: finalText(result.messages), durationMs, ...spend }, toPersist };
             },
             // `runAgent` threw rather than resolving. For an abort this is the DEFENSIVE path — one that
             // never reached the streaming wrapper (e.g. the signal fired before the first model call), so
@@ -370,7 +401,7 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
         // shown nothing. `finish` is therefore called before the append, not inside the `ok` branch —
         // an aborted turn displayed real work, and its projection is what the retract window renders.
         const displayMessages = display.finish({
-            ...(run.phase.kind === "ok" ? { fallbackText: run.phase.fallbackText } : {}),
+            ...(run.phase.kind === "ok" || run.phase.kind === "filtered" ? { fallbackText: run.phase.fallbackText } : {}),
             ...(run.phase.kind === "aborted" ? { interrupted: true } : {}),
         });
         const appendError = (
@@ -395,6 +426,16 @@ export async function runChatTurn(args: RunChatTurnArgs, seams: ChatTurnSeams = 
         switch (run.phase.kind) {
             case "ok":
                 return { kind: "ok", fallbackText: run.phase.fallbackText, ...spend, appendError };
+            case "filtered":
+                // The one place the endpoint's own word survives — the banner shows only the generic line.
+                getLogger("harness").warn({ rawFinishReason: run.phase.rawFinishReason }, "chat turn stopped by the model content filter");
+                return {
+                    kind: "filtered",
+                    fallbackText: run.phase.fallbackText,
+                    ...(run.phase.rawFinishReason !== undefined ? { rawFinishReason: run.phase.rawFinishReason } : {}),
+                    ...spend,
+                    appendError,
+                };
             case "aborted":
                 return { kind: "aborted", ...spend, appendError };
             case "failed":

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -898,9 +898,9 @@ export function turnFailureMessage(cause: unknown): string {
  * flush the streamed text (or the engine's `fallbackText` on a delta-less turn), close any open tool
  * chip, stamp what the turn cost (its duration and, when the run reported one, its token rollup),
  * surface an append fault non-fatally, and set the coarse status.
- * `failed`/`prepare_failed`/`thread_gone`/`agent_unresolved` also raise the error banner with an
- * actionable line; `aborted` returns to idle with no error (the user cancelled), having flushed what
- * streamed. `prepare_failed`/`thread_gone`/`agent_unresolved` bail before the loop, so they pop the
+ * `filtered`/`failed`/`prepare_failed`/`thread_gone`/`agent_unresolved` also raise the error banner
+ * with an actionable line; `aborted` returns to idle with no error (the user cancelled), having flushed
+ * what streamed. `prepare_failed`/`thread_gone`/`agent_unresolved` bail before the loop, so they pop the
  * empty assistant bubble instead.
  */
 function finishTurn(outcome: TurnOutcome, assistantId: string, startedAt: number): void {
@@ -930,6 +930,30 @@ function finishTurn(outcome: TurnOutcome, assistantId: string, startedAt: number
             stampTurnCost(assistantId, startedAt, outcome.turnUsage);
             reportAppendError(outcome.appendError);
             setChatStatus("idle");
+            return;
+        case "filtered":
+            // A refusal flushes what it carried the way `ok` does (the reply may hold partial
+            // prose), then raises the banner: the turn ended without an answer, and only a
+            // model change can unblock it, so the user must see why it stopped.
+            if (streamText().length === 0 && outcome.fallbackText.trim().length > 0) {
+                if (streamPartId() === null) beginStreamSegment();
+                setStreamText(outcome.fallbackText);
+            }
+            commitStream();
+            drainOpenTools();
+            stampTurnCost(assistantId, startedAt, outcome.turnUsage);
+            // No raw cause rides on `filtered`; keep a structured stand-in so the details
+            // dialog shows the endpoint's word rather than an empty view.
+            setLastTurnFailure({
+                type: "content_filter",
+                ...(outcome.rawFinishReason !== undefined ? { rawFinishReason: outcome.rawFinishReason } : {}),
+                message: "The model declined this request and stopped the turn.",
+            });
+            setErrorMsg(
+                `The model declined this request and stopped the turn (content filter). Switch the chat model ("Switch chat model" in the command palette), then send the message again. — ${detailsHint()}`,
+            );
+            reportAppendError(outcome.appendError);
+            setChatStatus("error");
             return;
         case "aborted":
             // An aborted turn that produced nothing leaves NO empty assistant shell — the user message
@@ -1561,7 +1585,7 @@ function closeTurnState(): void {
 
 /**
  * Whether the aborted turn actually LANDED an orphan turn on the thread — the precondition for running
- * the durable retract. `ok`/`aborted`/`failed` reach `runAgent` and append unconditionally, so their
+ * the durable retract. `ok`/`filtered`/`aborted`/`failed` reach `runAgent` and append unconditionally, so their
  * orphan is on the tail iff the append did not fault; `prepare_failed`/`thread_gone`/`agent_unresolved`
  * bail BEFORE `appendTurn`, so no orphan exists. Removing the tail when none of this turn's rows are
  * there would delete an EARLIER turn's real history — hence the gate.
@@ -1569,6 +1593,7 @@ function closeTurnState(): void {
 function turnAppendLanded(outcome: TurnOutcome): boolean {
     switch (outcome.kind) {
         case "ok":
+        case "filtered":
         case "aborted":
         case "failed":
             return outcome.appendError === undefined;

--- a/harness/src/loop/__fixtures__/scripted-provider.ts
+++ b/harness/src/loop/__fixtures__/scripted-provider.ts
@@ -28,9 +28,11 @@ export function makeMessage(
     finishReason: ChatResponse["finishReason"] | "tool_use" | "end_turn" | "max_tokens" | "refusal",
     usage?: ChatUsage,
 ): ChatResponse {
+    const mapped = mapFinishReason(finishReason);
     return {
         message: { role: "assistant", content },
-        finishReason: mapFinishReason(finishReason),
+        finishReason: mapped,
+        ...(mapped === finishReason ? {} : { rawFinishReason: finishReason }),
         usage,
     };
 }

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -870,6 +870,7 @@ describe("runAgent — undispatched tool calls at a terminal finish", () => {
         const { messages, finish } = await runAgent(agentDef([tool]), GO, makeSession(), opts(provider, { logger }));
 
         expect(finish.reason).toBe("content-filter");
+        expect(finish.rawFinishReason).toBe("refusal");
         expect(wasExecuted()).toBe(false);
         expect(toolCallIdsOf(messages)).toEqual([]);
         const last = messages.at(-1)!;
@@ -949,6 +950,7 @@ describe("runAgent — finish signal", () => {
 
         expect(finish).toEqual({
             reason: "stop",
+            rawFinishReason: "end_turn",
             cappedOut: false,
             truncationRecoveries: 0,
         });

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -35,6 +35,11 @@ import type { AgentDefinition, EmitFn, EventSource, LoopMessage, RunStep } from 
 
 export interface AgentFinish {
     readonly reason: FinishReason | "aborted" | "max_iterations" | "denied";
+    /**
+     * The endpoint's own word for the stop, when the provider captured one —
+     * `reason` normalizes it (an Anthropic `refusal` becomes `content-filter`).
+     */
+    readonly rawFinishReason?: string;
     readonly cappedOut: boolean;
     readonly truncationRecoveries: number;
     /**
@@ -460,7 +465,16 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             await emit({ type: "iteration", source, index: i, final: true });
             recordAgentRun({ agentId: agent.id, iterations, cappedOut: false, usage });
             logFinish("info", reply.finishReason, false);
-            return { messages, finish: { reason: reply.finishReason, cappedOut: false, truncationRecoveries, ...finishUsage() } };
+            return {
+                messages,
+                finish: {
+                    reason: reply.finishReason,
+                    ...(reply.rawFinishReason === undefined ? {} : { rawFinishReason: reply.rawFinishReason }),
+                    cappedOut: false,
+                    truncationRecoveries,
+                    ...finishUsage(),
+                },
+            };
         }
 
         await emit({ type: "iteration", source, index: i, final: false });


### PR DESCRIPTION
## What & why

A refusal from the model ends a turn as a normal reply with the stop reason "refusal", normalized to "content-filter". The loop treated it as a plain terminal, and the CLI mapped every non-aborted finish to "ok". Thus the conversation stopped in silence, and the user saw a turn that looked complete. This change types the outcome, and the harness finish carries the endpoint's raw word. The engine maps a content-filter finish to a "filtered" outcome. Both surfaces name the content filter, and they point the user to the model picker.

Notes for the reviewer:

- The refusal stays on the ok channel, because it is a completed reply. The error channel would drop the transcript and the cost.
- A filtered turn persists the same way an ok turn does, and the retract gate counts it as appended.
- The full CLI suite has one failure in `src/modules/embedding/local-provider.test.ts` on my machine. The file is untouched, and it also fails alone on a clean tree.

## Type of change

- [x] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
