### PR TITLE
feat(harness): report-session data parts — emit data-report-rendered, generalize the spawn part

### DIFF
--- a/cli/src/modules/harness/chat_printer.ts
+++ b/cli/src/modules/harness/chat_printer.ts
@@ -138,16 +138,19 @@ export function readRunCard(data: unknown): { runId: string; title: string; step
 }
 
 /**
- * Read a report-session spawn's thread id off the `unknown` `data` payload (the harness's
- * `ReportSessionStartedPart`: `{threadId, parentThreadId}`). Narrows defensively and copies the one
- * field it keeps — no reference to `data` survives the call. The parent thread id is not read: the
+ * Read a child-session spawn's fields off the `unknown` `data` payload (the harness's
+ * `ChildSessionStartedPart`: `{threadId, parentThreadId, threadType}`). Narrows defensively and copies
+ * the fields it keeps — no reference to `data` survives the call. The parent thread id is not read: the
  * part rides the parent's own transcript, thus the position already states the parent. Exported
  * alongside {@link readPlanCard} so the TUI adapter shares the reader.
  */
-export function readReportSessionStarted(data: unknown): { threadId: string } {
-    // `data` is external/loop-owned; cast to a loose record and read-and-coerce the field.
+export function readChildSessionStarted(data: unknown): { threadId: string; threadType: string } {
+    // `data` is external/loop-owned; cast to a loose record and read-and-coerce the fields.
     const d = (data ?? {}) as Record<string, unknown>;
-    return { threadId: typeof d.threadId === "string" ? d.threadId : "" };
+    return {
+        threadId: typeof d.threadId === "string" ? d.threadId : "",
+        threadType: typeof d.threadType === "string" ? d.threadType : "",
+    };
 }
 
 /** The recognized ask statuses, as a runtime set for the reader's narrow. Typed `AskCardStatus[]` so an entry can only be a valid status. */

--- a/cli/src/tui/components/chat_report_entry.render.test.tsx
+++ b/cli/src/tui/components/chat_report_entry.render.test.tsx
@@ -16,7 +16,7 @@ import type { Analysis } from "../../types/analysis.ts";
 // assertion proves that a mapping ran, not that the entry landed where the reader expects it. Thus this
 // drives the real `Chat` over the real stores, and reads the order off one frame.
 //
-// The position comes from the persisted `data-report-session-started` part inside the turn that
+// The position comes from the persisted `data-child-session-started` part inside the turn that
 // spawned the session. The listing stays the authority for the row: the title and the activity stamp
 // come from it, and a part whose row the listing does not hold paints nothing. A child that no mounted
 // part claims paints at the tail.
@@ -55,7 +55,7 @@ const ws = {
 type FixtureRow = {
     seq: number;
     role: "user" | "assistant";
-    /** The thread ids of the `data-report-session-started` parts that this row carries. */
+    /** The thread ids of the `data-child-session-started` parts that this row carries. */
     spawns?: string[];
 };
 
@@ -88,7 +88,7 @@ function transcriptSeams(rows: FixtureRow[]): LoadSeams {
                 role: r.role,
                 parts: [
                     { type: "text", text: `${r.role} ${r.seq}` },
-                    ...(r.spawns ?? []).map((threadId) => ({ type: "data-report-session-started", threadId, parentThreadId: SID })),
+                    ...(r.spawns ?? []).map((threadId) => ({ type: "data-child-session-started", threadId, parentThreadId: SID, threadType: "report" })),
                 ],
             })) as unknown as CortexMsg[],
     };

--- a/cli/src/tui/hooks/conversation.test.ts
+++ b/cli/src/tui/hooks/conversation.test.ts
@@ -1623,15 +1623,15 @@ describe("display-card parts map identically live and on reload", () => {
     });
 
     test("a report-session spawn maps to the same report-session part in both paths", async () => {
-        const data = { threadId: "child-1", parentThreadId: SID };
+        const data = { threadId: "child-1", parentThreadId: SID, threadType: "report" };
         await send(
             { sessionId: SID, analysisId: AID, userText: "?" },
-            fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => void emit({ type: "data-report-session-started", source: TOP, data })),
+            fakeSeams({ kind: "ok", fallbackText: "" }, (emit) => void emit({ type: "data-child-session-started", source: TOP, data })),
         );
         const live = messages[1]?.parts.find((p) => p.type === "report-session");
 
         const reloaded = cortexToUiMessage(
-            { id: "m1", role: "assistant", parts: [{ type: "data-report-session-started", ...data }] } as unknown as CortexMsg,
+            { id: "m1", role: "assistant", parts: [{ type: "data-child-session-started", ...data }] } as unknown as CortexMsg,
             SID,
             AID,
         );

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -22,7 +22,7 @@ import {
     isSubAgentEvent,
     readAskPart,
     readPlanCard,
-    readReportSessionStarted,
+    readChildSessionStarted,
     readRunCard,
     subAgentActivityLabel,
 } from "../../modules/harness/chat_printer.ts";
@@ -498,8 +498,9 @@ type EmitEventArg = Parameters<EmitFn>[0];
  *   - `tool-started`/`tool-finished` become one live tool part paired by tool-use id, with a
  *     duration and error outcome on finish;
  *   - `data-plan`/`data-run-card` become card parts via the shared readers;
- *   - `data-report-session-started` becomes a report-session part at its position, and it pokes the
- *     report-children listing so the entry paints inside the turn;
+ *   - `data-child-session-started` with threadType `report` becomes a report-session part at its
+ *     position, and it pokes the report-children listing so the entry paints inside the turn; any
+ *     other threadType renders the tagged mention;
  *   - any other `data-*` part renders a visible tagged mention (observed, not swallowed);
  *   - `iteration`/`done` are dropped.
  *
@@ -615,8 +616,10 @@ function renderDataPart(type: `data-${string}`, data: unknown): void {
         case "data-file-reference":
             appendPart(fileReferencePart(data, currentAnalysisId ?? ""));
             return;
-        case "data-report-session-started": {
-            appendPart({ id: randomUUIDv7(), type: "report-session", threadId: readReportSessionStarted(data).threadId });
+        case "data-child-session-started": {
+            const started = readChildSessionStarted(data);
+            if (started.threadType !== "report") break;
+            appendPart({ id: randomUUIDv7(), type: "report-session", threadId: started.threadId });
             // The spawn wrote its thread row BEFORE it emitted this part, thus a read now finds the
             // row and the entry paints inside the turn. The settle-edge read of `watchReportChildren`
             // stays the authority for the title, which pg seeds after the child's first message.
@@ -1033,8 +1036,8 @@ function replayedToolStatus(outcome: ToolCallOutcome | undefined): ToolCallPart[
 /**
  * Map a reconstructed {@link CortexMsg} to a {@link UIMessage}: text → text part; a replayed
  * tool-call → a finished tool part; recognized cards (`data-plan`/`data-run-card`) → card parts via
- * the SAME readers the live adapter uses; a `data-report-session-started` → a report-session part at
- * its stored position; anything else the harness resolver kept → a visible tagged mention. The harness resolver already dropped what the UI does not render (reasoning, tool
+ * the SAME readers the live adapter uses; a `data-child-session-started` with threadType `report` → a
+ * report-session part at its stored position; anything else the harness resolver kept → a visible tagged mention. The harness resolver already dropped what the UI does not render (reasoning, tool
  * results). Card parts are FLAT on the reconstructed part, and the readers narrow off any object, so
  * the part is passed straight through. A persisted `interrupted` marker re-derives the same live flag
  * so a reloaded transcript renders exactly what the live abort showed.
@@ -1083,9 +1086,15 @@ export function cortexToUiMessage(m: CortexMsg, sessionId: string, analysisId = 
             case "data-file-reference":
                 parts.push(fileReferencePart(part, analysisId));
                 break;
-            case "data-report-session-started":
-                parts.push({ id: randomUUIDv7(), type: "report-session", threadId: readReportSessionStarted(part).threadId });
+            case "data-child-session-started": {
+                const started = readChildSessionStarted(part);
+                if (started.threadType !== "report") {
+                    parts.push({ id: randomUUIDv7(), sessionId, messageId: m.id, type: "text", text: `[part:${part.type}]`, createdAt: 0 });
+                    break;
+                }
+                parts.push({ id: randomUUIDv7(), type: "report-session", threadId: started.threadId });
                 break;
+            }
             default:
                 // Observe a reconstructed part the UI has no first-class renderer for as a one-line tagged
                 // mention — never swallowed. (The recognized display cards are handled in the cases above.)

--- a/cli/src/types/session.ts
+++ b/cli/src/types/session.ts
@@ -203,7 +203,7 @@ export type OpenableCardPart = {
 
 /**
  * The record that a turn started a report session, from the harness
- * `data-report-session-started` part. It carries the thread id alone: the part is a
+ * `data-child-session-started` part (threadType `report`). It carries the thread id alone: the part is a
  * placement record, and the thread store is the authority for the session — its
  * existence, its title, and its archived state. The renderer joins the live
  * report-children listing by this id, and it renders nothing when the row is absent.

--- a/harness/openspec/changes/emit-report-rendered-part/design.md
+++ b/harness/openspec/changes/emit-report-rendered-part/design.md
@@ -1,0 +1,13 @@
+# Design
+
+## The registry classification
+
+The part is `emitter: conversation`, `consumer: conversation`, not transient, and not reconciling. The classification is the whole persistence mechanism: the conversation display recorder keeps each durable conversation part in the position of its emission, thus the part needs no storage code of its own. Each render is its own event, thus the part does not reconcile and each emission mints a fresh `id`.
+
+## The payload is minimal
+
+The part carries `id`, `renderedAt`, and `title` only. No path, no format field, no version internals, and no minted URL ride it: each of those goes stale or names a lifetime the part cannot own. The version store and the session-page mint stay the authority for what is viewable, thus the part places and signals, and a consumer reads the viewable state from those surfaces. The `title` rides because the finished document holds it on the success arm; it is display sugar, never authority.
+
+## The rendered arm only
+
+Each degraded arm — a refusal, a gap list, a resolver absence, an unresolvable root, an unresolved reference, a bridge mismatch, a render problem, an out-of-scope figure, a failed write, and a failed stamp — shows no fresh page, thus it emits nothing. The stamp-failed arm has a page on disk, but the tool tells the agent to preview again, and that pass emits.

--- a/harness/openspec/changes/emit-report-rendered-part/design.md
+++ b/harness/openspec/changes/emit-report-rendered-part/design.md
@@ -2,12 +2,20 @@
 
 ## The registry classification
 
-The part is `emitter: conversation`, `consumer: conversation`, not transient, and not reconciling. The classification is the whole persistence mechanism: the conversation display recorder keeps each durable conversation part in the position of its emission, thus the part needs no storage code of its own. Each render is its own event, thus the part does not reconcile and each emission mints a fresh `id`.
+The rendered part is `emitter: conversation`, `consumer: conversation`, not transient, and not reconciling. The classification is the whole persistence mechanism: the conversation display recorder keeps each durable conversation part in the position of its emission, thus the part needs no storage code of its own. Each render is its own event, thus the part does not reconcile and each emission mints a fresh `id`.
 
 ## The payload is minimal
 
-The part carries `id`, `renderedAt`, and `title` only. No path, no format field, no version internals, and no minted URL ride it: each of those goes stale or names a lifetime the part cannot own. The version store and the session-page mint stay the authority for what is viewable, thus the part places and signals, and a consumer reads the viewable state from those surfaces. The `title` rides because the finished document holds it on the success arm; it is display sugar, never authority.
+The rendered part carries `id`, `renderedAt`, and `title` only. No path, no format field, no version internals, and no minted URL ride it: each of those goes stale or names a lifetime the part cannot own. The version store and the session-page mint stay the authority for what is viewable, thus the part places and signals, and a consumer reads the viewable state from those surfaces. The `title` rides because the finished document holds it on the success arm; it is display sugar, never authority.
 
 ## The rendered arm only
 
 Each degraded arm — a refusal, a gap list, a resolver absence, an unresolvable root, an unresolved reference, a bridge mismatch, a render problem, an out-of-scope figure, a failed write, and a failed stamp — shows no fresh page, thus it emits nothing. The stamp-failed arm has a page on disk, but the tool tells the agent to preview again, and that pass emits.
+
+## The spawn part generalizes
+
+The spawn mechanic is parent→child, and the report session is one child type. The part name and the contract type name the mechanic, not the type, and `threadType` names the type as data. The field is a plain string and deliberately not an enum: a future session type must ride through an older consumer without failing validation. The known vocabulary lives in the doc comment, and the thread store owns it.
+
+## No migration for the old key
+
+Nothing is deployed. A display row persisted under `report-session-started` in a staging database fails the stored-envelope validation and renders nothing, and that loss is accepted. A dual-read would carry a dead key forever for data that no one needs.

--- a/harness/openspec/changes/emit-report-rendered-part/proposal.md
+++ b/harness/openspec/changes/emit-report-rendered-part/proposal.md
@@ -1,0 +1,29 @@
+# Emit a chat part when a report preview renders
+
+## Why
+
+The report-session path emits no chat data part. A web client that watches the chat stream cannot see that a preview rendered a fresh page mid-turn: it learns of the render only when the turn settles and it reads the version surfaces again. The transcript of the child thread has the same gap on reload — nothing places a "report updated" entry inside the turn, at the point where the render ran.
+
+One persisted chat part repairs both. A part in the stream tells the client that a fresh page exists, at the moment it lands. The same part persists into the display projection of the turn, thus a reload shows the entry at the position of the render.
+
+## What Changes
+
+- `preview_report` emits a `data-report-rendered` part through the emit sink of its tool context. The part carries an `id` unique to the emission, the `renderedAt` ISO timestamp of the render, and the `title` of the rendered document. It rides the `rendered` arm only. Every degraded arm emits nothing.
+- The part joins the chat-part vocabulary: the contract interface, the Zod schema, the part registry, and the durable display projection. Its registry entry is `conversation` / `conversation` / not transient / not reconciling, thus the conversation display recorder persists it in position.
+- The part is a placement record and a freshness signal only. The version store and the session-page mint stay the authority for what is viewable: the part carries no path, no format field, no version internals, and no minted URL.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `report-session-agent`: the preview announces a rendered page as one durable chat part.
+
+## Impact
+
+Harness source:
+
+- `src/contracts/chat-parts.ts`, `src/contracts/schemas/chat-parts.ts`, `src/contracts/part-registry.ts`, `src/contracts/index.ts` — the part vocabulary.
+- `src/memory/conversation-display-storage.ts` — the durable display key for the part.
+- `src/tools/report-session/preview-report.ts` — the emission on the rendered arm.
+
+Consumers: the change is additive. A host adopts the part for mid-turn freshness and for the inline entry; a host that ignores it loses nothing.

--- a/harness/openspec/changes/emit-report-rendered-part/proposal.md
+++ b/harness/openspec/changes/emit-report-rendered-part/proposal.md
@@ -1,4 +1,4 @@
-# Emit a chat part when a report preview renders
+# Emit a chat part when a report preview renders, and generalize the spawn part
 
 ## Why
 
@@ -6,24 +6,29 @@ The report-session path emits no chat data part. A web client that watches the c
 
 One persisted chat part repairs both. A part in the stream tells the client that a fresh page exists, at the moment it lands. The same part persists into the display projection of the turn, thus a reload shows the entry at the position of the render.
 
+The spawn part has a naming problem of its own. `data-report-session-started` binds the parent→child session mechanic to one thread type, and the mechanic is reusable: a report session is the first child-session type, not the only one. Nothing is deployed, thus the rename costs nothing now and a lock-in later.
+
 ## What Changes
 
 - `preview_report` emits a `data-report-rendered` part through the emit sink of its tool context. The part carries an `id` unique to the emission, the `renderedAt` ISO timestamp of the render, and the `title` of the rendered document. It rides the `rendered` arm only. Every degraded arm emits nothing.
 - The part joins the chat-part vocabulary: the contract interface, the Zod schema, the part registry, and the durable display projection. Its registry entry is `conversation` / `conversation` / not transient / not reconciling, thus the conversation display recorder persists it in position.
 - The part is a placement record and a freshness signal only. The version store and the session-page mint stay the authority for what is viewable: the part carries no path, no format field, no version internals, and no minted URL.
+- `data-report-session-started` renames to `data-child-session-started`, and the payload gains `threadType` — the type of the child thread in the thread store's vocabulary (`"report"` today). The contract type renames to `ChildSessionStartedPart`, the durable display key to `child-session-started`, and `start_report_session` emits the new type with `threadType: "report"`. The authority rule stays: the part places and signals, and the thread store decides what exists.
 
 ## Capabilities
 
 ### Modified Capabilities
 
 - `report-session-agent`: the preview announces a rendered page as one durable chat part.
+- `report-session-spawn`: the spawn announcement generalizes to the child-session vocabulary.
 
 ## Impact
 
 Harness source:
 
-- `src/contracts/chat-parts.ts`, `src/contracts/schemas/chat-parts.ts`, `src/contracts/part-registry.ts`, `src/contracts/index.ts` — the part vocabulary.
-- `src/memory/conversation-display-storage.ts` — the durable display key for the part.
+- `src/contracts/chat-parts.ts`, `src/contracts/schemas/chat-parts.ts`, `src/contracts/part-registry.ts`, `src/contracts/index.ts`, `src/contracts/message.ts` — the part vocabulary.
+- `src/memory/conversation-display-storage.ts` — the durable display keys for both parts.
 - `src/tools/report-session/preview-report.ts` — the emission on the rendered arm.
+- `src/tools/start-report-session.ts` — the spawn emission under the new type.
 
-Consumers: the change is additive. A host adopts the part for mid-turn freshness and for the inline entry; a host that ignores it loses nothing.
+Consumers: the rendered part is additive; a host that ignores it loses nothing. The rename ships before any deployment, thus no reader holds the old literal in durable state that matters — a stored `report-session-started` display key renders nothing, and that loss is accepted. The CLI compiles against the published 0.23.0 and keeps the old literal until it adopts the 0.24.0 release.

--- a/harness/openspec/changes/emit-report-rendered-part/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/emit-report-rendered-part/specs/report-session-agent/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The preview announces a rendered page as one durable chat part
+
+When the page lands and the stamp passes, `preview_report` SHALL emit one `data-report-rendered` part through the emit sink of its tool context. The part SHALL carry an `id` unique to the emission, the `renderedAt` ISO timestamp of the render, and the `title` of the rendered document. The tool SHALL NOT emit the part on any degraded arm, because a degraded arm shows no fresh page.
+
+The part SHALL be a durable conversation part in the part registry, thus the display projection of the turn persists it in the position of its emission. A reload then shows the entry where the render ran.
+
+The part is a placement record and a freshness signal only. The part SHALL carry no page path, no format field, no version internals, and no minted URL. The version store and the session-page mint SHALL stay the authority for what is viewable.
+
+#### Scenario: A rendered page emits one part
+
+- **WHEN** the agent calls `preview_report` and the page lands
+- **THEN** the tool emits exactly one `data-report-rendered` part, with a per-emission id, the ISO timestamp of the render, and the title of the document
+
+#### Scenario: A degraded arm emits nothing
+
+- **WHEN** the tool returns any arm other than `rendered`
+- **THEN** the tool emits no part
+
+#### Scenario: The part persists into the display projection
+
+- **GIVEN** a turn whose loop records the conversation display
+- **WHEN** the tool emits the part between two text runs
+- **THEN** the persisted display of the turn holds the part between the two text runs

--- a/harness/openspec/changes/emit-report-rendered-part/specs/report-session-spawn/spec.md
+++ b/harness/openspec/changes/emit-report-rendered-part/specs/report-session-spawn/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: The tool announces a started session as one durable chat part
+
+When the spawn succeeds, `start_report_session` SHALL emit one `data-child-session-started` part through the emit sink of its tool context. The part SHALL carry the `threadId` of the child, the `parentThreadId` of the conversation, and the `threadType` of the child in the thread store's vocabulary (`"report"` for a report session). The `threadType` field SHALL be a plain string and not an enum, thus a future session type does not fail validation in an older consumer. The tool SHALL NOT emit the part on the existing-session arm or on a refusal, because those arms start no session.
+
+The part SHALL be a durable conversation part in the part registry, thus the display projection of the turn persists it in the position of its emission. A reload then shows the entry at the spawn point, and no message `seq` rides the wire.
+
+The part is a placement record and a freshness signal only. The thread store SHALL stay the authority for the session: its existence, its title, and its archived state. A consumer whose part names an archived or absent thread SHALL render nothing for it.
+
+#### Scenario: A started session emits one part
+
+- **WHEN** the agent calls `start_report_session` and the spawn succeeds
+- **THEN** the tool emits exactly one `data-child-session-started` part, and the part carries the thread id of the child, the thread id of the parent conversation, and the thread type `"report"`
+
+#### Scenario: The existing-session arm emits nothing
+
+- **GIVEN** a parent whose newest report child sits at or past the last user turn
+- **WHEN** the agent calls the tool and the advice names that child
+- **THEN** the tool emits no part
+
+#### Scenario: A refusal emits nothing
+
+- **WHEN** the tool refuses a call, for any refusal arm
+- **THEN** the tool emits no part
+
+#### Scenario: The part persists into the display projection
+
+- **GIVEN** a turn whose loop records the conversation display
+- **WHEN** the tool emits the part between two text runs
+- **THEN** the persisted display of the turn holds the part between the two text runs

--- a/harness/openspec/changes/emit-report-rendered-part/tasks.md
+++ b/harness/openspec/changes/emit-report-rendered-part/tasks.md
@@ -16,3 +16,10 @@
 
 - [x] 3.1 Emit the part in `src/tools/report-session/preview-report.ts` on the rendered arm, with a per-emission `id`, `renderedAt`, and the document `title`.
 - [x] 3.2 Test the arms: the rendered arm emits one well-formed part, and a degraded arm emits nothing.
+
+## 4. The spawn-part rename
+
+- [x] 4.1 Rename `ReportSessionStartedPart` to `ChildSessionStartedPart` (`data-child-session-started`) and add `threadType`, across the contract, the schema, the registry, and the index barrel.
+- [x] 4.2 Rename the durable display key to `child-session-started` in `src/memory/conversation-display-storage.ts`. No dual-read of the old key.
+- [x] 4.3 Emit the new type with `threadType: "report"` in `src/tools/start-report-session.ts`.
+- [x] 4.4 Sweep each harness reference to the old literal and type name. The CLI keeps the old literal until it adopts the 0.24.0 release.

--- a/harness/openspec/changes/emit-report-rendered-part/tasks.md
+++ b/harness/openspec/changes/emit-report-rendered-part/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## 1. The part vocabulary
+
+- [x] 1.1 Add `ReportRenderedPart` to `src/contracts/chat-parts.ts` and to the `CortexChatPart` union, with the authority rule in its doc comment.
+- [x] 1.2 Add `ReportRenderedPartSchema` to `src/contracts/schemas/chat-parts.ts` and to `CortexChatPartSchema`.
+- [x] 1.3 Add the `data-report-rendered` entry to `PART_REGISTRY`: `conversation` / `conversation` / not transient / not reconciling.
+- [x] 1.4 Export the type from `src/contracts/index.ts`.
+
+## 2. The durable display projection
+
+- [x] 2.1 Add the `report-rendered` key to `ConversationUIData` and to the stored-envelope `dataSchemas` in `src/memory/conversation-display-storage.ts`.
+- [x] 2.2 Test that the recorder keeps the part in the position of its emission.
+
+## 3. The emission
+
+- [x] 3.1 Emit the part in `src/tools/report-session/preview-report.ts` on the rendered arm, with a per-emission `id`, `renderedAt`, and the document `title`.
+- [x] 3.2 Test the arms: the rendered arm emits one well-formed part, and a degraded arm emits nothing.

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/contracts/chat-parts.ts
+++ b/harness/src/contracts/chat-parts.ts
@@ -406,6 +406,28 @@ export interface ReportSessionStartedPart {
     parentThreadId: string;
 }
 
+// ── Report Rendered (report session preview) ───────────────────────
+
+/**
+ * The record that a report-session preview rendered the page. It rides the
+ * chat stream live, and it persists into the turn at the position of the
+ * render.
+ *
+ * The part is a placement record and a freshness signal only. The version
+ * store and the session-page mint stay the authority for what is viewable:
+ * the part carries no path, no format, and no URL. A consumer that wants the
+ * page reads those surfaces.
+ */
+export interface ReportRenderedPart {
+    type: "data-report-rendered";
+    /** Unique per emission. */
+    id: string;
+    /** The ISO timestamp of the successful render. */
+    renderedAt: string;
+    /** The title of the rendered document. */
+    title?: string;
+}
+
 // ── Union ───────────────────────────────────────────────────────────
 
 export type CortexChatPart =
@@ -426,4 +448,5 @@ export type CortexChatPart =
     | SynthesisProgressPart
     | RunCompletedPart
     | RunFailedPart
-    | ReportSessionStartedPart;
+    | ReportSessionStartedPart
+    | ReportRenderedPart;

--- a/harness/src/contracts/chat-parts.ts
+++ b/harness/src/contracts/chat-parts.ts
@@ -387,10 +387,10 @@ export interface RunFailedPart {
     reason?: string;
 }
 
-// ── Report Session Started (report session spawn) ──────────────────
+// ── Child Session Started (parent→child session spawn) ─────────────
 
 /**
- * The record that a turn started a report session. It rides the chat stream
+ * The record that a turn started a child session. It rides the chat stream
  * live, and it persists into the turn at the position of the spawn.
  *
  * The part is a placement record and a freshness signal only. The thread
@@ -398,12 +398,17 @@ export interface RunFailedPart {
  * archived state. When the thread of the part is archived or absent, a
  * consumer renders nothing for it.
  */
-export interface ReportSessionStartedPart {
-    type: "data-report-session-started";
-    /** The id of the report thread that the spawn made. */
+export interface ChildSessionStartedPart {
+    type: "data-child-session-started";
+    /** The id of the child thread that the spawn made. */
     threadId: string;
     /** The id of the conversation thread that spawned it. */
     parentThreadId: string;
+    /**
+     * The type of the child thread, in the thread store's vocabulary.
+     * Known values today: `"report"`.
+     */
+    threadType: string;
 }
 
 // ── Report Rendered (report session preview) ───────────────────────
@@ -448,5 +453,5 @@ export type CortexChatPart =
     | SynthesisProgressPart
     | RunCompletedPart
     | RunFailedPart
-    | ReportSessionStartedPart
+    | ChildSessionStartedPart
     | ReportRenderedPart;

--- a/harness/src/contracts/index.ts
+++ b/harness/src/contracts/index.ts
@@ -34,6 +34,7 @@ export type {
     RunCompletedPart,
     RunFailedPart,
     ReportSessionStartedPart,
+    ReportRenderedPart,
     CortexChatPart,
 } from "./chat-parts.js";
 

--- a/harness/src/contracts/index.ts
+++ b/harness/src/contracts/index.ts
@@ -33,7 +33,7 @@ export type {
     RunCompletedFinding,
     RunCompletedPart,
     RunFailedPart,
-    ReportSessionStartedPart,
+    ChildSessionStartedPart,
     ReportRenderedPart,
     CortexChatPart,
 } from "./chat-parts.js";

--- a/harness/src/contracts/message.ts
+++ b/harness/src/contracts/message.ts
@@ -3,7 +3,7 @@
  * and the public API for everything the chat path exchanges.
  *
  * No AI SDK types appear here or anywhere else in the package. The
- * discriminant is `type`, so `switch (part.type) { case "data-report-session-started": ... }`
+ * discriminant is `type`, so `switch (part.type) { case "data-child-session-started": ... }`
  * narrows the union member without any `as` cast.
  */
 

--- a/harness/src/contracts/part-registry.ts
+++ b/harness/src/contracts/part-registry.ts
@@ -35,6 +35,7 @@ export const PART_REGISTRY: Record<CortexChatPartType, PartDescriptor> = {
     "data-run-completed": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: false },
     "data-run-failed": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: false },
     "data-report-session-started": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
+    "data-report-rendered": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
 };
 
 export function isTransient(type: CortexChatPartType): boolean {

--- a/harness/src/contracts/part-registry.ts
+++ b/harness/src/contracts/part-registry.ts
@@ -34,7 +34,7 @@ export const PART_REGISTRY: Record<CortexChatPartType, PartDescriptor> = {
     "data-synthesis-progress": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: true },
     "data-run-completed": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: false },
     "data-run-failed": { emitter: "workflow", consumer: "sidebar", transient: false, reconciling: false },
-    "data-report-session-started": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
+    "data-child-session-started": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
     "data-report-rendered": { emitter: "conversation", consumer: "conversation", transient: false, reconciling: false },
 };
 

--- a/harness/src/contracts/schemas/chat-parts.ts
+++ b/harness/src/contracts/schemas/chat-parts.ts
@@ -334,6 +334,15 @@ export const ReportSessionStartedPartSchema = z.object({
     parentThreadId: z.string(),
 });
 
+// ── Report Rendered ────────────────────────────────────────────────
+
+export const ReportRenderedPartSchema = z.object({
+    type: z.literal("data-report-rendered"),
+    id: z.string(),
+    renderedAt: z.string(),
+    title: z.string().optional(),
+});
+
 // ── Union ───────────────────────────────────────────────────────────
 
 export const CortexChatPartSchema = z.discriminatedUnion("type", [
@@ -355,4 +364,5 @@ export const CortexChatPartSchema = z.discriminatedUnion("type", [
     RunCompletedPartSchema,
     RunFailedPartSchema,
     ReportSessionStartedPartSchema,
+    ReportRenderedPartSchema,
 ]);

--- a/harness/src/contracts/schemas/chat-parts.ts
+++ b/harness/src/contracts/schemas/chat-parts.ts
@@ -326,12 +326,15 @@ export const RunFailedPartSchema = z.object({
     reason: z.string().optional(),
 });
 
-// ── Report Session Started ─────────────────────────────────────────
+// ── Child Session Started ──────────────────────────────────────────
 
-export const ReportSessionStartedPartSchema = z.object({
-    type: z.literal("data-report-session-started"),
+export const ChildSessionStartedPartSchema = z.object({
+    type: z.literal("data-child-session-started"),
     threadId: z.string(),
     parentThreadId: z.string(),
+    // A plain string, deliberately not an enum: a future session type must
+    // not fail validation in an older consumer.
+    threadType: z.string(),
 });
 
 // ── Report Rendered ────────────────────────────────────────────────
@@ -363,6 +366,6 @@ export const CortexChatPartSchema = z.discriminatedUnion("type", [
     SynthesisProgressPartSchema,
     RunCompletedPartSchema,
     RunFailedPartSchema,
-    ReportSessionStartedPartSchema,
+    ChildSessionStartedPartSchema,
     ReportRenderedPartSchema,
 ]);

--- a/harness/src/memory/conversation-display-recorder.test.ts
+++ b/harness/src/memory/conversation-display-recorder.test.ts
@@ -76,6 +76,26 @@ describe("conversation display recorder", () => {
         ]);
     });
 
+    it("records a report-rendered part in the position of its emission", async () => {
+        const { recorder } = harness();
+        await recorder.emit({ type: "text-delta", text: "rendering" });
+        await recorder.emit({
+            type: "data-report-rendered",
+            source: TOP,
+            data: { id: "rr1", renderedAt: "2026-08-18T00:00:00.000Z", title: "Report" },
+        });
+        await recorder.emit({ type: "text-delta", text: "done" });
+
+        // The part is durable conversation display, thus the recorder keeps it
+        // between the two text runs and a reload shows it where the render ran.
+        const display = recorder.finish();
+        expect(display[1]!.parts).toEqual([
+            { type: "text", text: "rendering", state: "done" },
+            { type: "data-report-rendered", id: "rr1", data: { id: "rr1", renderedAt: "2026-08-18T00:00:00.000Z", title: "Report" } },
+            { type: "text", text: "done", state: "done" },
+        ]);
+    });
+
     it("records each call's outcome and detail as shown, denial distinct from failure", async () => {
         const { recorder } = harness();
         await recorder.emit({ type: "tool-started", source: TOP, toolUseId: "r", name: "read_file", input: {}, detail: "scripts/run.py" });

--- a/harness/src/memory/conversation-display-recorder.test.ts
+++ b/harness/src/memory/conversation-display-recorder.test.ts
@@ -60,10 +60,10 @@ describe("conversation display recorder", () => {
         expect(recorder.finish()[1]!.parts.map((part) => ("id" in part ? part.id : part.type))).toEqual(["a", "b", "from-b", "from-a"]);
     });
 
-    it("records a report-session-started part in the position of its emission", async () => {
+    it("records a child-session-started part in the position of its emission", async () => {
         const { recorder } = harness();
         await recorder.emit({ type: "text-delta", text: "starting" });
-        await recorder.emit({ type: "data-report-session-started", source: TOP, data: { threadId: "r1", parentThreadId: "p1" } });
+        await recorder.emit({ type: "data-child-session-started", source: TOP, data: { threadId: "r1", parentThreadId: "p1", threadType: "report" } });
         await recorder.emit({ type: "text-delta", text: "done" });
 
         // The part is durable conversation display, thus the recorder keeps it
@@ -71,7 +71,7 @@ describe("conversation display recorder", () => {
         const display = recorder.finish();
         expect(display[1]!.parts).toEqual([
             { type: "text", text: "starting", state: "done" },
-            { type: "data-report-session-started", data: { threadId: "r1", parentThreadId: "p1" } },
+            { type: "data-child-session-started", data: { threadId: "r1", parentThreadId: "p1", threadType: "report" } },
             { type: "text", text: "done", state: "done" },
         ]);
     });

--- a/harness/src/memory/conversation-display-storage.ts
+++ b/harness/src/memory/conversation-display-storage.ts
@@ -18,14 +18,14 @@
 import { validateUIMessages, type DataUIPart, type UIMessage, type UIMessagePart } from "ai";
 import { z } from "zod";
 
-import type { AskPart, FileReferencePart, PlanPart, PresentationPart, ReportRenderedPart, ReportSessionStartedPart, RunCardPart } from "../contracts/chat-parts.js";
+import type { AskPart, ChildSessionStartedPart, FileReferencePart, PlanPart, PresentationPart, ReportRenderedPart, RunCardPart } from "../contracts/chat-parts.js";
 import {
     AskPartSchema,
+    ChildSessionStartedPartSchema,
     FileReferencePartSchema,
     PlanPartSchema,
     PresentationPartSchema,
     ReportRenderedPartSchema,
-    ReportSessionStartedPartSchema,
     RunCardPartSchema,
 } from "../contracts/schemas/chat-parts.js";
 import { ToolCallOutcomeSchema } from "../contracts/schemas/chat-events.js";
@@ -50,7 +50,7 @@ export type ConversationUIData = {
     "run-card": Payload<RunCardPart>;
     "file-reference": Payload<FileReferencePart>;
     ask: Payload<AskPart>;
-    "report-session-started": Payload<ReportSessionStartedPart>;
+    "child-session-started": Payload<ChildSessionStartedPart>;
     "report-rendered": Payload<ReportRenderedPart>;
 };
 
@@ -97,7 +97,7 @@ const dataSchemas = {
     "run-card": RunCardPartSchema.omit({ type: true }).strict(),
     "file-reference": FileReferencePartSchema.omit({ type: true }).strict(),
     ask: AskPartSchema.omit({ type: true }).strict(),
-    "report-session-started": ReportSessionStartedPartSchema.omit({ type: true }).strict(),
+    "child-session-started": ChildSessionStartedPartSchema.omit({ type: true }).strict(),
     "report-rendered": ReportRenderedPartSchema.omit({ type: true }).strict(),
 };
 

--- a/harness/src/memory/conversation-display-storage.ts
+++ b/harness/src/memory/conversation-display-storage.ts
@@ -18,12 +18,13 @@
 import { validateUIMessages, type DataUIPart, type UIMessage, type UIMessagePart } from "ai";
 import { z } from "zod";
 
-import type { AskPart, FileReferencePart, PlanPart, PresentationPart, ReportSessionStartedPart, RunCardPart } from "../contracts/chat-parts.js";
+import type { AskPart, FileReferencePart, PlanPart, PresentationPart, ReportRenderedPart, ReportSessionStartedPart, RunCardPart } from "../contracts/chat-parts.js";
 import {
     AskPartSchema,
     FileReferencePartSchema,
     PlanPartSchema,
     PresentationPartSchema,
+    ReportRenderedPartSchema,
     ReportSessionStartedPartSchema,
     RunCardPartSchema,
 } from "../contracts/schemas/chat-parts.js";
@@ -50,6 +51,7 @@ export type ConversationUIData = {
     "file-reference": Payload<FileReferencePart>;
     ask: Payload<AskPart>;
     "report-session-started": Payload<ReportSessionStartedPart>;
+    "report-rendered": Payload<ReportRenderedPart>;
 };
 
 export interface ConversationDisplayMetadata {
@@ -96,6 +98,7 @@ const dataSchemas = {
     "file-reference": FileReferencePartSchema.omit({ type: true }).strict(),
     ask: AskPartSchema.omit({ type: true }).strict(),
     "report-session-started": ReportSessionStartedPartSchema.omit({ type: true }).strict(),
+    "report-rendered": ReportRenderedPartSchema.omit({ type: true }).strict(),
 };
 
 export interface StoredDisplayEnvelope {

--- a/harness/src/tools/report-session/preview-report.test.ts
+++ b/harness/src/tools/report-session/preview-report.test.ts
@@ -136,11 +136,16 @@ function makeFakeGateway(): FakeGateway {
     };
 }
 
+/** A tool context whose scope names a report thread, beside the events that its emit recorded. */
+function ctxWithEmitted(threadId: string): { ctx: ToolContext; emitted: unknown[] } {
+    const { ctx, emitted } = makeToolContext();
+    const scope: Scope = { kind: "analysis", analysisId: DEFAULT_ANALYSIS_ID, threadId };
+    return { ctx: { ...ctx, session: { ...ctx.session, scope } }, emitted };
+}
+
 /** A tool context whose scope names a report thread. */
 function ctxForThread(threadId: string): ToolContext {
-    const { ctx } = makeToolContext();
-    const scope: Scope = { kind: "analysis", analysisId: DEFAULT_ANALYSIS_ID, threadId };
-    return { ...ctx, session: { ...ctx.session, scope } };
+    return ctxWithEmitted(threadId).ctx;
 }
 
 /** A snapshot with one readable artifact that a metric binds to. */
@@ -283,6 +288,46 @@ describe("the pass path", () => {
         const assetsDir = join(root, "report-sessions", "t1", "assets");
         const staged = await Promise.all(PAGE_ASSETS.map((asset) => readFile(join(assetsDir, asset.file), "utf8")));
         expect(staged).toEqual(PAGE_ASSETS.map(() => "PACKED-ASSET-BYTES"));
+    });
+
+    it("emits one data-report-rendered part when the page lands", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: metricDoc(), snapshot: metricSnapshot });
+        const tool = createPreviewReportTool({
+            gateway,
+            makeResolver: () => createFixtureResolver(),
+            resolveWorkspaceRoot: () => root,
+        });
+        const { ctx, emitted } = ctxWithEmitted("t1");
+
+        const result = (await tool.execute({}, ctx))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("rendered");
+        expect(emitted).toHaveLength(1);
+        const part = emitted[0] as { type: string; data: { id: string; renderedAt: string; title: string } };
+        expect(part.type).toBe("data-report-rendered");
+        expect(part.data.title).toBe("Report");
+        // The id is one UUID per emission, and the timestamp is a valid ISO instant.
+        expect(part.data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        expect(new Date(part.data.renderedAt).toISOString()).toBe(part.data.renderedAt);
+    });
+
+    it("emits nothing on the gap arm", async () => {
+        const root = await makeRoot();
+        const gateway = makeFakeGateway();
+        gateway.seed("t1", { document: { title: "", sections: [] }, snapshot: { artifacts: {} } });
+        const tool = createPreviewReportTool({
+            gateway,
+            makeResolver: () => createFixtureResolver(),
+            resolveWorkspaceRoot: () => root,
+        });
+        const { ctx, emitted } = ctxWithEmitted("t1");
+
+        const result = (await tool.execute({}, ctx))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("gaps");
+        expect(emitted).toEqual([]);
     });
 });
 

--- a/harness/src/tools/report-session/preview-report.ts
+++ b/harness/src/tools/report-session/preview-report.ts
@@ -28,13 +28,15 @@
  * render problem, a figure that escapes the workspace root, a write failure, and a stamp failure. The tool
  * never throws for one of them. When the page
  * lands, the tool stamps the hash of the rendered draft on the session state, thus the eyes and the record
- * know which draft the page shows. The filesystem speaks the
+ * know which draft the page shows. It then emits one durable `data-report-rendered` part, thus the
+ * transcript places the render and a live client learns that a fresh page exists. The filesystem speaks the
  * throw protocol, and the workspace-root seam signals an unresolvable resource the same way. Thus the
  * write runs through the `tryFs` glue, which turns a genuine fault into the ok-channel outcome and lets a
  * control-flow exception propagate.
  */
 
 import { err, ok, type Result } from "neverthrow";
+import { randomUUID } from "node:crypto";
 import { copyFile, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { extname, join } from "node:path";
 import { relative as relativePosix } from "node:path/posix";
@@ -610,6 +612,13 @@ export function createPreviewReportTool(deps: PreviewReportToolDeps): Tool<Previ
                 logger.warn("the rendered hash did not stamp", { threadId, analysisId, detail });
                 return ok({ outcome: "stamp-failed", pagePath: written.value, detail });
             }
+
+            // The part rides the rendered arm only. Each degraded arm shows no
+            // fresh page, thus it emits nothing.
+            await ctx.emit({
+                type: "data-report-rendered",
+                data: { id: randomUUID(), renderedAt: new Date().toISOString(), title: document.title },
+            });
 
             const access = await mintAccess(deps.makeSessionPages, analysisId, threadId, ctx.session.auth, logger);
             return ok({ outcome: "rendered", pagePath: written.value, ...(access !== undefined ? { access } : {}) });

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -153,7 +153,7 @@ describe("the started part", () => {
         return { ctx: { ...ctx, session: { ...ctx.session, scope } }, emitted };
     }
 
-    it("emits one data-report-session-started part on the started arm", async () => {
+    it("emits one data-child-session-started part on the started arm", async () => {
         await seedConversation("p1", "Parent");
         const { ctx, emitted } = watchedCtxForThread("p1");
 
@@ -161,7 +161,7 @@ describe("the started part", () => {
 
         expect(result.outcome).toBe("started");
         if (result.outcome !== "started") return;
-        expect(emitted).toEqual([{ type: "data-report-session-started", data: { threadId: result.threadId, parentThreadId: "p1" } }]);
+        expect(emitted).toEqual([{ type: "data-child-session-started", data: { threadId: result.threadId, parentThreadId: "p1", threadType: "report" } }]);
     });
 
     it("emits nothing on the existing-session arm", async () => {

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -247,8 +247,8 @@ export function createStartReportSessionTool(deps: StartReportSessionToolDeps): 
                 // names a session that an earlier turn announced, thus a second
                 // part would put a second entry into the transcript.
                 await ctx.emit({
-                    type: "data-report-session-started",
-                    data: { threadId: child.threadId, parentThreadId },
+                    type: "data-child-session-started",
+                    data: { threadId: child.threadId, parentThreadId, threadType: "report" },
                 });
                 return ok({ outcome: "started", threadId: child.threadId, title: child.title });
             }


### PR DESCRIPTION
Stacked on #420 (`remove-old-report-path`). Merge that first; this PR targets its branch.

Two chat-part changes to the report-session path, decided before anything deploys: a new durable `data-report-rendered` part emitted on preview success, and a generalization of the spawn part `data-report-session-started` → `data-child-session-started`.

## 1. New part: `data-report-rendered`

```ts
export interface ReportRenderedPart {
    type: "data-report-rendered";
    /** Unique per emission. */
    id: string;
    /** The ISO timestamp of the successful render. */
    renderedAt: string;
    /** The title of the rendered document. */
    title?: string;
}
```

**Authority rule** (stated in the contract doc comment, mirroring the spawn part): the part is a placement record and a freshness signal only. The version store and the session-page mint stay the authority for what is viewable — the part carries no path, no format field, no version internals, and no minted URL. That is what makes it evolution-proof: nothing in it can go stale or name a lifetime it cannot own. `title` rides only because the finished `ReportDocument` holds it in hand on the success arm.

**Emission point:** `src/tools/report-session/preview-report.ts`, on the `rendered` arm only — after the page landed and the rendered-hash stamp passed, via `ctx.emit` with a `randomUUID()` id. Every degraded arm (`refused`, `gaps`, `resolver-unavailable`, `root-unresolvable`, `unresolved-references`, `bridge-mismatch`, `render-problems`, `figure-out-of-scope`, `write-failed`, `stamp-failed`) emits nothing; a stamp-failed pass re-previews and that pass emits.

**Registry:** `{ emitter: "conversation", consumer: "conversation", transient: false, reconciling: false }` — non-transient, so the conversation display recorder persists it positionally. No per-type recorder wiring beyond the registry entry plus the display-storage vocabulary key.

## 2. Generalized spawn part: `data-child-session-started`

The parent→child session mechanic is reusable; report sessions are just the first type. `ReportSessionStartedPart` → `ChildSessionStartedPart`, payload now `{ threadId, parentThreadId, threadType }`. `threadType` matches the thread store's vocabulary (`"report"` today) and is deliberately `z.string()`, NOT an enum, so a future session type does not fail validation in older consumers. The authority rule is unchanged: thread store authoritative; absent/archived thread → render nothing.

Swept across contract, schema, registry, index barrel, `contracts/message.ts` doc, display-storage key (`report-session-started` → `child-session-started`), the `start_report_session` emit site (`threadType: "report"`), and tests. **No dual-read/migration** — nothing is deployed; staging rows under the old key render nothing (accepted). **`cli/` untouched** — it compiles against published 0.23.0 and keeps the old literal until a follow-up after 0.24.0 publishes.

## Included

- Contract interfaces + unions, Zod schemas, registry entries, `contracts/index.ts` exports, display-storage keys.
- OpenSpec change `openspec/changes/emit-report-rendered-part/` covering both: proposal, design, tasks, `report-session-agent` spec delta (new rendered-part requirement) and `report-session-spawn` spec delta (MODIFIED spawn-part requirement on top of #418's pending change).
- Tests: preview success arm emits exactly one well-formed part (UUID id, valid ISO `renderedAt`, document title); gap arm emits nothing; recorder keeps both parts in the position of their emission; spawn-tool tests updated to the new literal + `threadType`.
- Final commit bumps the harness to `0.24.0` (`Release harness`).

## Validation

`bun run typecheck`, `bun run lint`, `bun test` on the touched files plus the full `src/memory/` suite — all green.

## CLI
`refactor(cli): follow the child-session-started rename` — the reader becomes `readChildSessionStarted` (copies `threadId` + `threadType`), both adapter arms handle `data-child-session-started` and render the report-session entry only for `threadType: "report"` (other types fall to the tagged-mention default). PR checks validate against the linked working-copy harness; after merge the `lint (cli)` job on main runs against the 0.23.0 pin and stays red until the post-publish pin bump to 0.24.0 (conventional follow-up).