### PR TITLE
fix(sandbox): stop losing the owner workflow id in length-capped namespaces

### DIFF
--- a/harness/openspec/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/specs/docker-sandbox-provider/spec.md
@@ -270,11 +270,27 @@ returning each one's `sandboxId`, `ownerWorkflowId`, and creation time, so the
 scheduled reaper (`registerSandboxReaper`) can map a machine back to its owning
 workflow and tear down orphans.
 
+`ownerWorkflowId` is a DBOS lookup key, so every backend SHALL record it verbatim
+and SHALL report whether the value it returns is verbatim (`ownerIsVerbatim`).
+Docker label values are unconstrained, so this backend stores and returns the id
+as given. A backend whose metadata namespace cannot hold the id unaltered — see
+the K8s label cap in the harness-sandbox-exec spec — SHALL record it somewhere
+that can, and SHALL NOT report a rewritten value as verbatim: a lookup that fails
+against a lossy id proves nothing about the owning workflow.
+
 #### Scenario: Managed containers are enumerable for the reaper
 
 - **GIVEN** two running sandbox containers labeled `app.kubernetes.io/managed-by=cortex`
 - **WHEN** `listManagedSandboxes()` is called
 - **THEN** it returns both, each carrying its `sandboxId` and `ownerWorkflowId` label values
+
+#### Scenario: An owner id no label namespace could hold still round-trips
+
+- **GIVEN** a sandbox created with a `childWorkflowId` that exceeds the K8s label
+  value cap and carries characters illegal in one
+- **WHEN** `listManagedSandboxes()` is called
+- **THEN** the reported `ownerWorkflowId` SHALL equal the `childWorkflowId` byte for byte
+- **AND** `ownerIsVerbatim` SHALL be true
 
 #### Scenario: Reaper tears down an orphaned machine
 

--- a/harness/openspec/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/specs/docker-sandbox-provider/spec.md
@@ -270,13 +270,13 @@ returning each one's `sandboxId`, `ownerWorkflowId`, and creation time, so the
 scheduled reaper (`registerSandboxReaper`) can map a machine back to its owning
 workflow and tear down orphans.
 
-`ownerWorkflowId` is a DBOS lookup key, so every backend SHALL record it verbatim
-and SHALL report whether the value it returns is verbatim (`ownerIsVerbatim`).
-Docker label values are unconstrained, so this backend stores and returns the id
-as given. A backend whose metadata namespace cannot hold the id unaltered — see
-the K8s label cap in the harness-sandbox-exec spec — SHALL record it somewhere
-that can, and SHALL NOT report a rewritten value as verbatim: a lookup that fails
-against a lossy id proves nothing about the owning workflow.
+`ownerWorkflowId` is a DBOS lookup key, so every backend SHALL record and return
+it verbatim, and SHALL report `null` rather than a rewritten value when it holds
+no verbatim id: a lookup that fails against a lossy id proves nothing about the
+owning workflow, so a lossy id is worse than none. Docker label values are
+unconstrained, so this backend stores the id as given. A backend whose chosen
+metadata namespace cannot hold the id unaltered — see the K8s label cap in the
+harness-sandbox-exec spec — SHALL record it in one that can.
 
 #### Scenario: Managed containers are enumerable for the reaper
 
@@ -290,7 +290,12 @@ against a lossy id proves nothing about the owning workflow.
   value cap and carries characters illegal in one
 - **WHEN** `listManagedSandboxes()` is called
 - **THEN** the reported `ownerWorkflowId` SHALL equal the `childWorkflowId` byte for byte
-- **AND** `ownerIsVerbatim` SHALL be true
+
+#### Scenario: A machine recording no owner reports none
+
+- **GIVEN** a managed machine carrying no owner workflow id
+- **WHEN** `listManagedSandboxes()` is called
+- **THEN** the reported `ownerWorkflowId` SHALL be `null`
 
 #### Scenario: Reaper tears down an orphaned machine
 

--- a/harness/openspec/specs/exec-provenance-lineage/spec.md
+++ b/harness/openspec/specs/exec-provenance-lineage/spec.md
@@ -62,7 +62,10 @@ the mount root prepended: reconcile drops both a foreign path and a missing in-t
 verbatim name says which of the two happened, and the drop record is the only account a reader gets of a
 hook-filter leak. Read hashes SHALL be left unset at track time and filled from disk by
 `reconcileManifestWithDisk` before registration. When the frame is absent or `disabled`, `feedExecFrame`
-SHALL record the command with no inputs and no writes rather than throw.
+SHALL record the command with no inputs and no writes rather than throw. A `disabled` frame SHALL
+additionally be logged: it means the sandbox tracker never started, so the record is empty rather than
+complete, and nothing downstream distinguishes the two. Left unlogged, a total capture failure is
+indistinguishable from a command that touched no files.
 
 #### Scenario: Command reading an input and writing an output produces a lineage edge
 
@@ -105,6 +108,13 @@ SHALL record the command with no inputs and no writes rather than throw.
 - **GIVEN** an `ExecResult` whose `provenance` is absent or has `disabled: true`
 - **WHEN** the tool feeds it via `feedExecFrame`
 - **THEN** the command is recorded with an empty `inputs` array and no error is thrown
+
+#### Scenario: A disabled frame is reported, not silently emptied
+
+- **GIVEN** an `ExecResult` whose `provenance` has `disabled: true`
+- **WHEN** the tool feeds it via `feedExecFrame`
+- **THEN** a warning naming the command SHALL be logged, so a total capture failure is
+  distinguishable from a command that genuinely touched no files
 
 ### Requirement: Post-step registration consumes runtime-derived lineage
 

--- a/harness/openspec/specs/harness-sandbox-exec/spec.md
+++ b/harness/openspec/specs/harness-sandbox-exec/spec.md
@@ -642,6 +642,8 @@ be idempotent: "already gone" is a successful teardown and SHALL NOT throw.
 `teardownById(sandboxId)` SHALL delete a machine by id alone — the reaper path,
 which holds a `sandboxId` but no full `SandboxRef` — and SHALL NOT touch the
 registry (the reaper reconciles the row itself). It too SHALL be idempotent.
+`isAliveById(sandboxId)` SHALL answer liveness on the same id-only terms, with
+the semantics and throwing contract of `isAlive`, which SHALL delegate to it.
 
 #### Scenario: Teardown removes the machine and clears the row
 
@@ -767,10 +769,19 @@ orphaned sandbox machines and stale registry rows. One sweep SHALL run as a
 single DBOS step: `listManagedSandboxes`, then for each machine read its
 owner-workflow status. A machine whose owner is in `{PENDING, ENQUEUED, RUNNING}`
 SHALL be left alone; one whose owner is terminal (`SUCCESS`/`ERROR`/`CANCELLED`)
-or missing SHALL be reaped via `teardownById`, and the stuck step row SHALL be
-reconciled to the workflow's terminal status. A label-less/legacy machine SHALL
-be reaped only past a creation-time grace (~10 minutes) so a partially-created
-in-flight machine is never caught.
+SHALL be reaped via `teardownById`, and the stuck step row SHALL be reconciled to
+the workflow's terminal status.
+
+A machine whose owner does **not** resolve to a workflow at all — it records no
+owner, or the id it records names no `dbos.workflow_status` row — SHALL NOT be
+reaped on age alone. Age cannot distinguish a genuine orphan from a live machine
+whose owner id failed to resolve, and DBOS records the owner's status at enqueue,
+*before* the machine exists, so a missing status is never evidence that the work
+has finished. Past a creation-time grace (~10 minutes) the sweep SHALL instead
+probe `isAliveById` and reap only an observably dead machine. A machine still
+alive SHALL be left standing and counted in the sweep summary, so an
+unattributable machine is a reported leak rather than a silent teardown of live
+work. A probe that throws SHALL leave the machine for the next sweep.
 
 #### Scenario: Terminal-owner machine is reaped and its row reconciled
 
@@ -785,11 +796,24 @@ in-flight machine is never caught.
 - **WHEN** the reaper sweep runs
 - **THEN** the machine SHALL NOT be torn down
 
-#### Scenario: Label-less machine reaped only past the grace
+#### Scenario: Unresolvable-owner machine is left alone within the grace
 
-- **GIVEN** a managed machine with no owner-workflow label
+- **GIVEN** a managed machine whose owner does not resolve to a workflow
 - **WHEN** the reaper sweep runs before the creation-time grace elapses
-- **THEN** the machine SHALL be left alone
+- **THEN** the machine SHALL be left alone, and SHALL NOT be probed
+
+#### Scenario: Unresolvable-owner machine past the grace is reaped only when dead
+
+- **GIVEN** a managed machine past the grace whose owner does not resolve to a workflow
+- **WHEN** the reaper sweep runs and `isAliveById` reports the machine dead
+- **THEN** `teardownById` SHALL delete the machine
+
+#### Scenario: A live machine is never reaped for being unattributable
+
+- **GIVEN** a managed machine past the grace whose owner does not resolve to a workflow
+- **WHEN** the reaper sweep runs and `isAliveById` reports the machine alive
+- **THEN** the machine SHALL NOT be torn down
+- **AND** the sweep summary SHALL count it as live-unattributed
 
 ### Requirement: Notification-cleanup sweep clears unconsumed DBOS sends
 

--- a/harness/openspec/specs/sandbox-provenance-tracking/spec.md
+++ b/harness/openspec/specs/sandbox-provenance-tracking/spec.md
@@ -275,6 +275,15 @@ The sandbox-server SHALL create a fresh Unix domain socket (`SOCK_DGRAM`) at a u
 
 The server SHALL read all pending datagrams from the socket after the child process exits, with a configurable drain timeout (default 100ms) to allow for late-arriving messages.
 
+The path SHALL be of a fixed length that fits `sun_path`, which caps a pathname `AF_UNIX` address at 107 bytes (`struct sockaddr_un`; Go rejects an over-long name client-side as a bare `EINVAL`, so the bind never reaches the kernel and the error never names its cause). The path SHALL therefore derive from a hash of the execution id rather than embedding it: that id carries a DBOS workflow id and a plan-authored step slug, neither of which sandbox-server can bound or even see the bound of. Nothing parses the filename — it reaches children only through the environment variable — so it need carry no identifying content; the tracker SHALL instead log the execution id beside the hashed path once at start, so the two remain correlatable.
+
+#### Scenario: An execution id too long to embed still binds
+
+- **GIVEN** an execution id whose literal embedding would exceed the `sun_path` cap
+- **WHEN** the tracker is constructed and started
+- **THEN** the socket path SHALL be within the cap and the socket SHALL bind
+- **AND** distinct execution ids SHALL still yield distinct socket paths
+
 #### Scenario: Socket created before command and cleaned up after
 
 - **WHEN** `POST /exec` is called with a command

--- a/harness/src/agents/sandbox/__fixtures__/deps.ts
+++ b/harness/src/agents/sandbox/__fixtures__/deps.ts
@@ -40,6 +40,9 @@ export function makeFakeSandboxClient(): SandboxClient {
         async isAlive() {
             return { alive: true, oomKilled: false };
         },
+        async isAliveById() {
+            return { alive: true, oomKilled: false };
+        },
         async teardown() {},
         async teardownById() {},
         async listManagedSandboxes() {

--- a/harness/src/provenance/exec-frame.test.ts
+++ b/harness/src/provenance/exec-frame.test.ts
@@ -151,6 +151,31 @@ describe("feedExecFrame", () => {
         });
         expect(collector.getDataInputs()).toHaveLength(0);
     });
+
+    test("a disabled frame is reported, not silently emptied", () => {
+        // The record it produces is indistinguishable from a command that touched
+        // nothing, so the log line is the only account of a total capture failure.
+        const collector = new ProvenanceCollector({ stepId: "s", runId: "r" });
+        const { logger, warnings } = recordingLogger();
+        feedExecFrame({
+            collector,
+            mountRoot: "/a1",
+            command: ["python3", "scripts/x.py"],
+            exitCode: 0,
+            durationMs: 10,
+            provenance: { disabled: true, reads: [], writes: [], deletes: [] },
+            logger,
+        });
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]!.fields).toMatchObject({ command: "python3" });
+    });
+
+    test("an absent frame is not reported — nothing claims to have captured anything", () => {
+        const collector = new ProvenanceCollector({ stepId: "s", runId: "r" });
+        const { logger, warnings } = recordingLogger();
+        feedExecFrame({ collector, mountRoot: "/a1", command: ["ls"], exitCode: 0, durationMs: 1, logger });
+        expect(warnings).toHaveLength(0);
+    });
 });
 
 /** Captures the refusal records so the drop can be asserted as observable. */

--- a/harness/src/provenance/exec-frame.ts
+++ b/harness/src/provenance/exec-frame.ts
@@ -67,14 +67,19 @@ export function feedExecFrame(args: FeedExecFrameArgs): void {
     const code = exitCode ?? -1;
     const duration = durationMs ?? 0;
 
-    if (!provenance || provenance.disabled) {
-        collector.recordCommandExecution(cmd, [...cmdArgs], code, duration, [], undefined, []);
-        return;
-    }
-
     // Resolved once so the read loop logs unconditionally instead of threading
     // `?.` through every diagnostic.
     const logger = (args.logger ?? createNoopLogger()).named("exec-frame");
+
+    if (!provenance || provenance.disabled) {
+        // The sandbox failed to start its tracker, so this command's file
+        // operations were never captured. The record below is empty rather than
+        // complete, and downstream nothing distinguishes the two — say so here or
+        // the gap ships looking like a command that touched no files.
+        if (provenance?.disabled) logger.warn("sandbox reported provenance disabled — no file operations captured for this command", { command: cmd });
+        collector.recordCommandExecution(cmd, [...cmdArgs], code, duration, [], undefined, []);
+        return;
+    }
 
     const commandReads: InputRef[] = [];
     for (const read of provenance.reads) {

--- a/harness/src/sandbox/client.ts
+++ b/harness/src/sandbox/client.ts
@@ -86,6 +86,14 @@ export interface SandboxClient {
     isAlive(ref: SandboxRef): Promise<SandboxLiveness>;
 
     /**
+     * Liveness by id alone — the reaper path (see the harness-sandbox-exec spec),
+     * which holds a `sandboxId` from the cluster sweep but no full `SandboxRef`.
+     * Same semantics and the same throwing contract as {@link SandboxClient.isAlive},
+     * which delegates to it.
+     */
+    isAliveById(sandboxId: string): Promise<SandboxLiveness>;
+
+    /**
      * DBOS step (`sandbox.teardown`). Deletes the K8s Job / removes the
      * Docker container, clears the active-sandbox registry. Idempotent —
      * "already gone" is a successful teardown.

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -171,7 +171,7 @@ describe("createSandboxClient — engine connection threading", () => {
 
             const managed = await client.listManagedSandboxes();
 
-            expect(managed).toEqual([{ sandboxId: "sentinel-sbx", ownerWorkflowId: "wf-x", createdAtMs: 1700000 }]);
+            expect(managed).toEqual([{ sandboxId: "sentinel-sbx", ownerWorkflowId: "wf-x", ownerIsVerbatim: true, createdAtMs: 1700000 }]);
         } finally {
             await new Promise<void>((resolve) => server.close(() => resolve()));
             await rm(dir, { recursive: true, force: true });

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -171,7 +171,7 @@ describe("createSandboxClient — engine connection threading", () => {
 
             const managed = await client.listManagedSandboxes();
 
-            expect(managed).toEqual([{ sandboxId: "sentinel-sbx", ownerWorkflowId: "wf-x", ownerIsVerbatim: true, createdAtMs: 1700000 }]);
+            expect(managed).toEqual([{ sandboxId: "sentinel-sbx", ownerWorkflowId: "wf-x", createdAtMs: 1700000 }]);
         } finally {
             await new Promise<void>((resolve) => server.close(() => resolve()));
             await rm(dir, { recursive: true, force: true });

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -268,6 +268,7 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
         submitExec: async (ref, body) => submitExec(ref, body, config.submitDeps),
         awaitExec: (ref, execId, emit, deadline) => awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),
         isAlive,
+        isAliveById: async (sandboxId) => unwrapOrThrow(await ops.isAliveById(sandboxId)),
         teardown,
         teardownById: async (sandboxId) => unwrapOrThrow(await ops.teardownById(sandboxId)),
         listManagedSandboxes: async () => unwrapOrThrow(await ops.listManagedSandboxes()),

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -261,6 +261,7 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
     teardown(ref: SandboxRef): ResultAsync<void, SandboxError>;
     teardownById(sandboxId: string): ResultAsync<void, SandboxError>;
     isAlive(ref: SandboxRef): ResultAsync<SandboxLiveness, SandboxError>;
+    isAliveById(sandboxId: string): ResultAsync<SandboxLiveness, SandboxError>;
     listManagedSandboxes(): ResultAsync<ManagedSandbox[], SandboxError>;
 } {
     // The injected test instance wins; otherwise a configured socket dials that
@@ -443,6 +444,8 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                         return {
                             sandboxId: labels["cortex/sandbox-id"] ?? "",
                             ownerWorkflowId: labels[OWNER_WORKFLOW_LABEL] ?? null,
+                            // Docker label values are unconstrained, so the id is stored verbatim.
+                            ownerIsVerbatim: true,
                             // Docker reports `Created` as unix seconds.
                             createdAtMs: typeof c.Created === "number" ? c.Created * 1000 : null,
                         };
@@ -452,25 +455,31 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
         },
 
         isAlive(ref) {
-            return trySandbox(
-                async () => {
-                    const info = await docker.getContainer(ref.sandboxId).inspect();
-                    const oomKilled = info.State.OOMKilled === true;
-                    // A running container is a reachable sandbox: the host dials its
-                    // published loopback port directly.
-                    return { alive: info.State.Running === true, oomKilled };
-                },
-                (status, cause) => ({
-                    type: "liveness_failed",
-                    op: "docker.isAlive",
-                    sandboxId: ref.sandboxId,
-                    status,
-                    cause,
-                }),
-            ).orElse((e) =>
-                // dockerode throws 404 for a missing container — observably dead.
-                statusOf(e) === 404 ? ok({ alive: false, oomKilled: false }) : err(e),
-            );
+            return isAliveById(ref.sandboxId);
         },
+
+        isAliveById,
     };
+
+    function isAliveById(sandboxId: string): ResultAsync<SandboxLiveness, SandboxError> {
+        return trySandbox(
+            async () => {
+                const info = await docker.getContainer(sandboxId).inspect();
+                const oomKilled = info.State.OOMKilled === true;
+                // A running container is a reachable sandbox: the host dials its
+                // published loopback port directly.
+                return { alive: info.State.Running === true, oomKilled };
+            },
+            (status, cause) => ({
+                type: "liveness_failed",
+                op: "docker.isAlive",
+                sandboxId,
+                status,
+                cause,
+            }),
+        ).orElse((e) =>
+            // dockerode throws 404 for a missing container — observably dead.
+            statusOf(e) === 404 ? ok({ alive: false, oomKilled: false }) : err(e),
+        );
+    }
 }

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -443,9 +443,8 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                         const labels = c.Labels ?? {};
                         return {
                             sandboxId: labels["cortex/sandbox-id"] ?? "",
-                            ownerWorkflowId: labels[OWNER_WORKFLOW_LABEL] ?? null,
                             // Docker label values are unconstrained, so the id is stored verbatim.
-                            ownerIsVerbatim: true,
+                            ownerWorkflowId: labels[OWNER_WORKFLOW_LABEL] ?? null,
                             // Docker reports `Created` as unix seconds.
                             createdAtMs: typeof c.Created === "number" ? c.Created * 1000 : null,
                         };

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -15,7 +15,7 @@ import { mintSandboxIdentity } from "./identity.js";
 const SESSION_PVC_ROOT = "/sessions";
 const resolveWorkspaceRoot = (analysisId: string) => `${SESSION_PVC_ROOT}/${analysisId}`;
 
-function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string } = {}) {
+function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string; existingOwnerAsLegacyLabel?: boolean } = {}) {
     const createdJobs: V1Job[] = [];
     const deletedJobs: string[] = [];
     let podIdx = 0;
@@ -43,19 +43,25 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
             deletedJobs.push(name);
         },
         // Used by the spawn step's owner-guard (returns the pre-existing Job with
-        // its owner label) and then by `waitForJobGone` after a delete (404).
+        // its recorded owner) and then by `waitForJobGone` after a delete (404).
+        // `existingOwnerAsLegacyLabel` models a Job written by the release before
+        // the owner id moved to an annotation: label only, and sanitized.
+        listNamespacedJob: async (_args: { namespace: string; labelSelector?: string }) => ({ items: createdJobs }),
         readNamespacedJob: async ({ name }: { namespace: string; name: string }) => {
             if (existingDeleted) {
                 const err = new Error("not found") as Error & { code: number };
                 err.code = 404;
                 throw err;
             }
-            return {
-                metadata: {
-                    name,
-                    labels: { "cortex/owner-workflow-id": existingOwner },
-                },
-            };
+            return opts.existingOwnerAsLegacyLabel
+                ? { metadata: { name, labels: { "cortex/owner-workflow-id": sanitizeLabelValue(existingOwner) } } }
+                : {
+                      metadata: {
+                          name,
+                          annotations: { "cortex/owner-workflow-id": existingOwner },
+                          labels: { "cortex/owner-workflow-id": sanitizeLabelValue(existingOwner) },
+                      },
+                  };
         },
     } as unknown as BatchV1Api;
 
@@ -697,14 +703,21 @@ describe("k8s job ownership labels", () => {
             )
         )._unsafeUnwrap();
 
-        const labels = stub.createdJobs[0]!.metadata!.labels!;
-        expect(labels["app.kubernetes.io/managed-by"]).toBe("cortex");
-        expect(labels["cortex/owner-workflow-id"]).toBe("run-1-0");
-        expect(labels["cortex/run-id"]).toBe("run-1");
-        expect(labels["cortex/step-id"]).toBe("step-a");
+        const meta = stub.createdJobs[0]!.metadata!;
+        expect(meta.labels!["app.kubernetes.io/managed-by"]).toBe("cortex");
+        expect(meta.annotations!["cortex/owner-workflow-id"]).toBe("run-1-0");
+        expect(meta.labels!["cortex/run-id"]).toBe("run-1");
+        expect(meta.labels!["cortex/step-id"]).toBe("step-a");
     });
 
-    test("sanitizes a colon-bearing workflow id into a valid label value", async () => {
+    test("an owner id that no label could hold round-trips through listManagedSandboxes", async () => {
+        // The production data-profile id: `dataprofile:{analysisUUID}:{nonceUUID}`,
+        // 85 bytes with colons — over the 63-byte label cap and outside the label
+        // charset twice over. It is a real DBOS workflow id, so what comes back out
+        // has to be usable as a `getWorkflowStatus` key, byte for byte.
+        const childWorkflowId = "dataprofile:01a01372-a1bd-73d6-8dd2-9dc7cb84aa2e:0f3c1d2e-4b5a-6c7d-8e9f-a0b1c2d3e4f5";
+        expect(childWorkflowId.length).toBeGreaterThan(63);
+
         const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "p" } }]);
         const ops = createK8sSandboxOps({
             image: "sandbox-base:latest",
@@ -720,21 +733,75 @@ describe("k8s job ownership labels", () => {
 
         (
             await ops.createSandbox(
-                {
-                    runId: "data-profile",
-                    stepId: "profile",
-                    analysisId: "an-1",
-                    childWorkflowId: "data-profile:data-profiler-g3u48je4",
-                    resources: { cpu: 2, memoryGb: 4 },
-                },
+                { runId: "data-profile", stepId: "profile", analysisId: "an-1", childWorkflowId, resources: { cpu: 2, memoryGb: 4 } },
                 mintSandboxIdentity("data-profile"),
             )
         )._unsafeUnwrap();
 
-        const owner = stub.createdJobs[0]!.metadata!.labels!["cortex/owner-workflow-id"]!;
-        expect(owner).toBe("data-profile-data-profiler-g3u48je4");
-        expect(owner).toMatch(/^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/);
-        expect(owner.length).toBeLessThanOrEqual(63);
+        const managed = (await ops.listManagedSandboxes())._unsafeUnwrap();
+        expect(managed[0]!.ownerWorkflowId).toBe(childWorkflowId);
+        expect(managed[0]!.ownerIsVerbatim).toBe(true);
+
+        // The label mirror still has to be admissible, or the API server rejects the
+        // whole Job — it just is not what anyone looks the workflow up by.
+        const label = stub.createdJobs[0]!.metadata!.labels!["cortex/owner-workflow-id"]!;
+        expect(label).toMatch(/^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/);
+        expect(label.length).toBeLessThanOrEqual(63);
+    });
+
+    test("a Job carrying only the legacy label is still attributable, and marked non-verbatim", async () => {
+        // Written by the previous release, still standing mid-rollout. The id it
+        // records is the lossy one, so a failed lookup against it proves nothing —
+        // which is what `ownerIsVerbatim: false` tells the reaper.
+        const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "p" } }]);
+        stub.createdJobs.push({
+            metadata: {
+                name: "sbx-legacy",
+                labels: { "cortex/sandbox-id": "sbx-legacy", "cortex/owner-workflow-id": "run-9-0" },
+                creationTimestamp: new Date(1_700_000_000_000),
+            },
+        } as V1Job);
+
+        const ops = createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+
+        const managed = (await ops.listManagedSandboxes())._unsafeUnwrap();
+        expect(managed).toEqual([{ sandboxId: "sbx-legacy", ownerWorkflowId: "run-9-0", ownerIsVerbatim: false, createdAtMs: 1_700_000_000_000 }]);
+    });
+
+    test("adoption accepts a Job that records its owner only in the legacy label", async () => {
+        const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "p" } }], {
+            create409Times: 1,
+            existingOwner: "run-1-0",
+            existingOwnerAsLegacyLabel: true,
+        });
+        const ops = createK8sSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            namespace: "sandbox",
+            sessionPvcRoot: SESSION_PVC_ROOT,
+            resolveWorkspaceRoot,
+            sessionPvc: "cortex-sessions",
+            batchApi: stub.batchApi,
+            coreApi: stub.coreApi,
+            registerSandbox: async () => {},
+        });
+
+        const result = await ops.createSandbox(
+            { runId: "run-1", stepId: "step-a", analysisId: "an-1", childWorkflowId: "run-1-0", resources: { cpu: 2, memoryGb: 4 } },
+            mintSandboxIdentity("run-1"),
+        );
+
+        expect(result.isOk()).toBe(true);
     });
 });
 

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -15,7 +15,7 @@ import { mintSandboxIdentity } from "./identity.js";
 const SESSION_PVC_ROOT = "/sessions";
 const resolveWorkspaceRoot = (analysisId: string) => `${SESSION_PVC_ROOT}/${analysisId}`;
 
-function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string; existingOwnerAsLegacyLabel?: boolean } = {}) {
+function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string } = {}) {
     const createdJobs: V1Job[] = [];
     const deletedJobs: string[] = [];
     let podIdx = 0;
@@ -44,8 +44,6 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
         },
         // Used by the spawn step's owner-guard (returns the pre-existing Job with
         // its recorded owner) and then by `waitForJobGone` after a delete (404).
-        // `existingOwnerAsLegacyLabel` models a Job written by the release before
-        // the owner id moved to an annotation: label only, and sanitized.
         listNamespacedJob: async (_args: { namespace: string; labelSelector?: string }) => ({ items: createdJobs }),
         readNamespacedJob: async ({ name }: { namespace: string; name: string }) => {
             if (existingDeleted) {
@@ -53,15 +51,7 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
                 err.code = 404;
                 throw err;
             }
-            return opts.existingOwnerAsLegacyLabel
-                ? { metadata: { name, labels: { "cortex/owner-workflow-id": sanitizeLabelValue(existingOwner) } } }
-                : {
-                      metadata: {
-                          name,
-                          annotations: { "cortex/owner-workflow-id": existingOwner },
-                          labels: { "cortex/owner-workflow-id": sanitizeLabelValue(existingOwner) },
-                      },
-                  };
+            return { metadata: { name, annotations: { "cortex/owner-workflow-id": existingOwner } } };
         },
     } as unknown as BatchV1Api;
 
@@ -740,24 +730,22 @@ describe("k8s job ownership labels", () => {
 
         const managed = (await ops.listManagedSandboxes())._unsafeUnwrap();
         expect(managed[0]!.ownerWorkflowId).toBe(childWorkflowId);
-        expect(managed[0]!.ownerIsVerbatim).toBe(true);
 
-        // The label mirror still has to be admissible, or the API server rejects the
-        // whole Job — it just is not what anyone looks the workflow up by.
-        const label = stub.createdJobs[0]!.metadata!.labels!["cortex/owner-workflow-id"]!;
-        expect(label).toMatch(/^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/);
-        expect(label.length).toBeLessThanOrEqual(63);
+        // The id lives in the annotation precisely because no label could hold it:
+        // every label value on the Job still has to be admissible or the API server
+        // rejects the whole thing.
+        for (const value of Object.values(stub.createdJobs[0]!.metadata!.labels!)) {
+            expect(value).toMatch(/^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/);
+            expect(value.length).toBeLessThanOrEqual(63);
+        }
     });
 
-    test("a Job carrying only the legacy label is still attributable, and marked non-verbatim", async () => {
-        // Written by the previous release, still standing mid-rollout. The id it
-        // records is the lossy one, so a failed lookup against it proves nothing —
-        // which is what `ownerIsVerbatim: false` tells the reaper.
+    test("a Job recording no owner reports none rather than guessing", async () => {
         const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "p" } }]);
         stub.createdJobs.push({
             metadata: {
-                name: "sbx-legacy",
-                labels: { "cortex/sandbox-id": "sbx-legacy", "cortex/owner-workflow-id": "run-9-0" },
+                name: "sbx-ownerless",
+                labels: { "cortex/sandbox-id": "sbx-ownerless" },
                 creationTimestamp: new Date(1_700_000_000_000),
             },
         } as V1Job);
@@ -775,33 +763,7 @@ describe("k8s job ownership labels", () => {
         });
 
         const managed = (await ops.listManagedSandboxes())._unsafeUnwrap();
-        expect(managed).toEqual([{ sandboxId: "sbx-legacy", ownerWorkflowId: "run-9-0", ownerIsVerbatim: false, createdAtMs: 1_700_000_000_000 }]);
-    });
-
-    test("adoption accepts a Job that records its owner only in the legacy label", async () => {
-        const stub = stubApis([{ status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "p" } }], {
-            create409Times: 1,
-            existingOwner: "run-1-0",
-            existingOwnerAsLegacyLabel: true,
-        });
-        const ops = createK8sSandboxOps({
-            image: "sandbox-base:latest",
-            cortexBaseUrl: "https://x",
-            namespace: "sandbox",
-            sessionPvcRoot: SESSION_PVC_ROOT,
-            resolveWorkspaceRoot,
-            sessionPvc: "cortex-sessions",
-            batchApi: stub.batchApi,
-            coreApi: stub.coreApi,
-            registerSandbox: async () => {},
-        });
-
-        const result = await ops.createSandbox(
-            { runId: "run-1", stepId: "step-a", analysisId: "an-1", childWorkflowId: "run-1-0", resources: { cpu: 2, memoryGb: 4 } },
-            mintSandboxIdentity("run-1"),
-        );
-
-        expect(result.isOk()).toBe(true);
+        expect(managed).toEqual([{ sandboxId: "sbx-ownerless", ownerWorkflowId: null, createdAtMs: 1_700_000_000_000 }]);
     });
 });
 

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -50,13 +50,12 @@ const POD_POLL_INTERVAL_MS = 1_000;
 const MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
 const MANAGED_BY_VALUE = "cortex";
 /**
- * Key of the owning DBOS workflow id. Written as an **annotation**, whose value
- * has neither a length cap nor a charset restriction, so the id round-trips
- * verbatim and can be handed back to `DBOS.getWorkflowStatus`. Also written as
- * a label under the same key for one release, so a replica still running the
- * previous version can attribute this Job mid-rollout; nothing selects on it.
+ * Annotation key of the owning DBOS workflow id. An annotation value has neither
+ * a length cap nor a charset restriction, so the id round-trips verbatim and can
+ * be handed back to `DBOS.getWorkflowStatus`. Deliberately not a label: nothing
+ * selects on it, and a label value could not hold it (see {@link sanitizeLabelValue}).
  */
-const OWNER_WORKFLOW_KEY = "cortex/owner-workflow-id";
+const OWNER_WORKFLOW_ANNOTATION = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
 const ANALYSIS_ID_LABEL = "cortex/analysis-id";
@@ -68,7 +67,7 @@ const ANALYSIS_ID_LABEL = "cortex/analysis-id";
  *
  * Lossy by construction: `:` becomes `-` and anything past 63 chars is dropped,
  * neither of which is recoverable. No label value may therefore be used as a
- * lookup key — see {@link OWNER_WORKFLOW_KEY}.
+ * lookup key — see {@link OWNER_WORKFLOW_ANNOTATION}.
  */
 export function sanitizeLabelValue(value: string): string {
     return value
@@ -78,16 +77,9 @@ export function sanitizeLabelValue(value: string): string {
         .replace(/[^A-Za-z0-9]+$/, "");
 }
 
-/**
- * The owner workflow id recorded on a Job. `verbatim` distinguishes the
- * annotation (exact) from the legacy label mirror (sanitized), which decides
- * what an equality check may compare against.
- */
-function readOwnerWorkflowId(metadata: V1ObjectMeta | undefined): { value: string; verbatim: boolean } | null {
-    const annotated = metadata?.annotations?.[OWNER_WORKFLOW_KEY];
-    if (annotated !== undefined) return { value: annotated, verbatim: true };
-    const labelled = metadata?.labels?.[OWNER_WORKFLOW_KEY];
-    return labelled === undefined ? null : { value: labelled, verbatim: false };
+/** The owner workflow id recorded on a Job, or null if it records none. */
+function readOwnerWorkflowId(metadata: V1ObjectMeta | undefined): string | null {
+    return metadata?.annotations?.[OWNER_WORKFLOW_ANNOTATION] ?? null;
 }
 
 export interface K8sClientConfig {
@@ -323,13 +315,12 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
             name: sandboxId,
             namespace: config.namespace,
             annotations: {
-                [OWNER_WORKFLOW_KEY]: meta.childWorkflowId,
+                [OWNER_WORKFLOW_ANNOTATION]: meta.childWorkflowId,
             },
             labels: {
                 [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
                 role: "sandbox",
                 "cortex/sandbox-id": sandboxId,
-                [OWNER_WORKFLOW_KEY]: sanitizeLabelValue(meta.childWorkflowId),
                 [STEP_ID_LABEL]: sanitizeLabelValue(meta.stepId),
                 ...attributionLabels,
             },
@@ -491,16 +482,13 @@ function createOrAdoptJob(
 
             const existingRead = await trySandbox(() => batchApi.readNamespacedJob({ namespace, name: sandboxId }), createFailed);
             if (existingRead.isErr()) return err(existingRead.error);
-            // A Job from the previous release carries only the sanitized label, so the
-            // comparison has to meet it in the same lossy space it was written in.
             const owner = readOwnerWorkflowId(existingRead.value.metadata);
-            const expected = owner?.verbatim === false ? sanitizeLabelValue(ownerWorkflowId) : ownerWorkflowId;
-            if (owner === null || owner.value !== expected) {
+            if (owner !== ownerWorkflowId) {
                 return err({
                     type: "name_conflict",
                     op: "k8s.createSandbox",
                     sandboxId,
-                    owner: owner?.value ?? null,
+                    owner,
                 });
             }
 
@@ -602,11 +590,9 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                     .map((j) => {
                         const labels = j.metadata?.labels ?? {};
                         const ts = j.metadata?.creationTimestamp;
-                        const owner = readOwnerWorkflowId(j.metadata);
                         return {
                             sandboxId: labels["cortex/sandbox-id"] ?? j.metadata?.name ?? "",
-                            ownerWorkflowId: owner?.value ?? null,
-                            ownerIsVerbatim: owner?.verbatim ?? false,
+                            ownerWorkflowId: readOwnerWorkflowId(j.metadata),
                             createdAtMs: ts ? new Date(ts).getTime() : null,
                         };
                     })

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -14,7 +14,17 @@
 
 import { relative as relativePath, sep } from "node:path";
 
-import { BatchV1Api, CoreV1Api, KubeConfig, type V1Job, type V1PodSpec, type V1Toleration, type V1Volume, type V1VolumeMount } from "@kubernetes/client-node";
+import {
+    BatchV1Api,
+    CoreV1Api,
+    KubeConfig,
+    type V1Job,
+    type V1ObjectMeta,
+    type V1PodSpec,
+    type V1Toleration,
+    type V1Volume,
+    type V1VolumeMount,
+} from "@kubernetes/client-node";
 import { ResultAsync, err, ok } from "neverthrow";
 
 import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
@@ -39,7 +49,14 @@ const POD_POLL_INTERVAL_MS = 1_000;
 
 const MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
 const MANAGED_BY_VALUE = "cortex";
-const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
+/**
+ * Key of the owning DBOS workflow id. Written as an **annotation**, whose value
+ * has neither a length cap nor a charset restriction, so the id round-trips
+ * verbatim and can be handed back to `DBOS.getWorkflowStatus`. Also written as
+ * a label under the same key for one release, so a replica still running the
+ * previous version can attribute this Job mid-rollout; nothing selects on it.
+ */
+const OWNER_WORKFLOW_KEY = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
 const ANALYSIS_ID_LABEL = "cortex/analysis-id";
@@ -47,11 +64,11 @@ const ANALYSIS_ID_LABEL = "cortex/analysis-id";
 /**
  * Coerce an arbitrary identifier into a valid K8s label value:
  * ≤63 chars, `[A-Za-z0-9._-]` only, starting and ending alphanumeric.
- * Workflow ids legitimately contain `:` (exec-id routing packs
- * `workflowId:stepId:fnId`), which is illegal in a label — without this an
- * otherwise-valid Job is rejected with a 422 at admission. Sanitization is a
- * no-op for already-valid ids, so DBOS-keyed lookups (adoption, reaper) match
- * unchanged; only the synthetic, non-DBOS data-profile id is rewritten.
+ * Without it one malformed value gets the whole Job rejected at admission.
+ *
+ * Lossy by construction: `:` becomes `-` and anything past 63 chars is dropped,
+ * neither of which is recoverable. No label value may therefore be used as a
+ * lookup key — see {@link OWNER_WORKFLOW_KEY}.
  */
 export function sanitizeLabelValue(value: string): string {
     return value
@@ -59,6 +76,18 @@ export function sanitizeLabelValue(value: string): string {
         .replace(/^[^A-Za-z0-9]+/, "")
         .slice(0, 63)
         .replace(/[^A-Za-z0-9]+$/, "");
+}
+
+/**
+ * The owner workflow id recorded on a Job. `verbatim` distinguishes the
+ * annotation (exact) from the legacy label mirror (sanitized), which decides
+ * what an equality check may compare against.
+ */
+function readOwnerWorkflowId(metadata: V1ObjectMeta | undefined): { value: string; verbatim: boolean } | null {
+    const annotated = metadata?.annotations?.[OWNER_WORKFLOW_KEY];
+    if (annotated !== undefined) return { value: annotated, verbatim: true };
+    const labelled = metadata?.labels?.[OWNER_WORKFLOW_KEY];
+    return labelled === undefined ? null : { value: labelled, verbatim: false };
 }
 
 export interface K8sClientConfig {
@@ -293,11 +322,14 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
         metadata: {
             name: sandboxId,
             namespace: config.namespace,
+            annotations: {
+                [OWNER_WORKFLOW_KEY]: meta.childWorkflowId,
+            },
             labels: {
                 [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
                 role: "sandbox",
                 "cortex/sandbox-id": sandboxId,
-                [OWNER_WORKFLOW_LABEL]: sanitizeLabelValue(meta.childWorkflowId),
+                [OWNER_WORKFLOW_KEY]: sanitizeLabelValue(meta.childWorkflowId),
                 [STEP_ID_LABEL]: sanitizeLabelValue(meta.stepId),
                 ...attributionLabels,
             },
@@ -429,8 +461,8 @@ function waitForJobGone(batchApi: BatchV1Api, namespace: string, name: string): 
  * dead prior attempt under the same checkpointed name: delete it, wait for the
  * name to free, and recreate fresh.
  *
- * Adoption (and deletion) is **owner-guarded**: the existing Job's
- * `cortex/owner-workflow-id` label must match this step's `ownerWorkflowId`.
+ * Adoption (and deletion) is **owner-guarded**: the existing Job's recorded
+ * owner workflow id must match this step's `ownerWorkflowId`.
  * Only a recovery re-run carries the same checkpointed identity, so a mismatch
  * means an (astronomically rare) name collision with a *different* step —
  * adopting its pod would HMAC-fail every callback, and deleting its Job would
@@ -459,13 +491,16 @@ function createOrAdoptJob(
 
             const existingRead = await trySandbox(() => batchApi.readNamespacedJob({ namespace, name: sandboxId }), createFailed);
             if (existingRead.isErr()) return err(existingRead.error);
-            const owner = existingRead.value.metadata?.labels?.[OWNER_WORKFLOW_LABEL];
-            if (owner !== ownerWorkflowId) {
+            // A Job from the previous release carries only the sanitized label, so the
+            // comparison has to meet it in the same lossy space it was written in.
+            const owner = readOwnerWorkflowId(existingRead.value.metadata);
+            const expected = owner?.verbatim === false ? sanitizeLabelValue(ownerWorkflowId) : ownerWorkflowId;
+            if (owner === null || owner.value !== expected) {
                 return err({
                     type: "name_conflict",
                     op: "k8s.createSandbox",
                     sandboxId,
-                    owner: owner ?? null,
+                    owner: owner?.value ?? null,
                 });
             }
 
@@ -489,6 +524,7 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
     teardown(ref: SandboxRef): ResultAsync<void, SandboxError>;
     teardownById(sandboxId: string): ResultAsync<void, SandboxError>;
     isAlive(ref: SandboxRef): ResultAsync<SandboxLiveness, SandboxError>;
+    isAliveById(sandboxId: string): ResultAsync<SandboxLiveness, SandboxError>;
     listManagedSandboxes(): ResultAsync<ManagedSandbox[], SandboxError>;
 } {
     const { batchApi, coreApi } = config.batchApi && config.coreApi ? { batchApi: config.batchApi, coreApi: config.coreApi } : buildKubeApi();
@@ -500,7 +536,7 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                     const { sandboxId } = identity;
                     const job = buildJobSpec(meta, config, identity);
 
-                    const adopted = await createOrAdoptJob(batchApi, coreApi, config.namespace, sandboxId, sanitizeLabelValue(meta.childWorkflowId), job);
+                    const adopted = await createOrAdoptJob(batchApi, coreApi, config.namespace, sandboxId, meta.childWorkflowId, job);
                     if (adopted.isErr()) return err(adopted.error);
 
                     // A Job whose pod never schedules (quota rejection, no nodes, spot
@@ -566,9 +602,11 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                     .map((j) => {
                         const labels = j.metadata?.labels ?? {};
                         const ts = j.metadata?.creationTimestamp;
+                        const owner = readOwnerWorkflowId(j.metadata);
                         return {
                             sandboxId: labels["cortex/sandbox-id"] ?? j.metadata?.name ?? "",
-                            ownerWorkflowId: labels[OWNER_WORKFLOW_LABEL] ?? null,
+                            ownerWorkflowId: owner?.value ?? null,
+                            ownerIsVerbatim: owner?.verbatim ?? false,
                             createdAtMs: ts ? new Date(ts).getTime() : null,
                         };
                     })
@@ -577,40 +615,46 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
         },
 
         isAlive(ref) {
-            return trySandbox(
-                () =>
-                    coreApi.listNamespacedPod({
-                        namespace: config.namespace,
-                        labelSelector: `cortex/sandbox-id=${ref.sandboxId}`,
-                    }),
-                (status, cause) => ({
-                    type: "liveness_failed",
-                    op: "k8s.isAlive",
-                    sandboxId: ref.sandboxId,
-                    status,
-                    cause,
-                }),
-            )
-                .map((pods) => {
-                    const pod = pods.items[0];
-                    if (!pod) return { alive: false, oomKilled: false };
-                    const phase = pod.status?.phase;
-                    // `Pending` and `Running` are alive; `Succeeded`, `Failed`,
-                    // `Unknown` are dead. `Pending` covers startup.
-                    const alive = phase === "Pending" || phase === "Running";
-                    const oomKilled =
-                        !alive &&
-                        (pod.status?.containerStatuses ?? []).some(
-                            (cs) => cs.state?.terminated?.reason === "OOMKilled" || cs.lastState?.terminated?.reason === "OOMKilled",
-                        );
-                    return { alive, oomKilled };
-                })
-                .orElse((e) =>
-                    // A 404 means the pod is gone — observably dead.
-                    statusOf(e) === 404 ? ok({ alive: false, oomKilled: false }) : err(e),
-                );
+            return isAliveById(ref.sandboxId);
         },
+
+        isAliveById,
     };
+
+    function isAliveById(sandboxId: string): ResultAsync<SandboxLiveness, SandboxError> {
+        return trySandbox(
+            () =>
+                coreApi.listNamespacedPod({
+                    namespace: config.namespace,
+                    labelSelector: `cortex/sandbox-id=${sandboxId}`,
+                }),
+            (status, cause) => ({
+                type: "liveness_failed",
+                op: "k8s.isAlive",
+                sandboxId,
+                status,
+                cause,
+            }),
+        )
+            .map((pods) => {
+                const pod = pods.items[0];
+                if (!pod) return { alive: false, oomKilled: false };
+                const phase = pod.status?.phase;
+                // `Pending` and `Running` are alive; `Succeeded`, `Failed`,
+                // `Unknown` are dead. `Pending` covers startup.
+                const alive = phase === "Pending" || phase === "Running";
+                const oomKilled =
+                    !alive &&
+                    (pod.status?.containerStatuses ?? []).some(
+                        (cs) => cs.state?.terminated?.reason === "OOMKilled" || cs.lastState?.terminated?.reason === "OOMKilled",
+                    );
+                return { alive, oomKilled };
+            })
+            .orElse((e) =>
+                // A 404 means the pod is gone — observably dead.
+                statusOf(e) === 404 ? ok({ alive: false, oomKilled: false }) : err(e),
+            );
+    }
 }
 
 /**

--- a/harness/src/sandbox/reaper.test.ts
+++ b/harness/src/sandbox/reaper.test.ts
@@ -1,24 +1,28 @@
 /**
  * Reaper pure-logic tests. Covers:
- *  - classifyManaged: in-flight workflow → leave; terminal/missing → reap;
- *    creation-time grace for label-less / status-less machines
+ *  - classifyManaged: in-flight workflow → leave; terminal → reap; unresolvable
+ *    owner → grace-gated deferral to a liveness probe
  *  - terminalStepStatus mapping
  *  - reapOnce: tears down + reconciles reapable machines, leaves in-flight
- *    ones, and survives a teardown failure on one machine
+ *    ones, never tears down a machine that is still alive, and survives a
+ *    teardown failure on one machine
  */
 
 import { describe, expect, test } from "bun:test";
 import type { Pool } from "pg";
 
 import { classifyManaged, reapOnce, terminalStepStatus } from "./reaper.js";
-import type { ManagedSandbox } from "./types.js";
+import type { ManagedSandbox, SandboxLiveness } from "./types.js";
 
 const GRACE = 10 * 60_000;
 const NOW = 1_000_000_000;
 
 function managed(sandboxId: string, ownerWorkflowId: string | null, createdAtMs: number | null = NOW): ManagedSandbox {
-    return { sandboxId, ownerWorkflowId, createdAtMs };
+    return { sandboxId, ownerWorkflowId, ownerIsVerbatim: ownerWorkflowId !== null, createdAtMs };
 }
+
+const DEAD: SandboxLiveness = { alive: false, oomKilled: false };
+const ALIVE: SandboxLiveness = { alive: true, oomKilled: false };
 
 describe("classifyManaged", () => {
     test("leaves a machine whose workflow is still in flight", () => {
@@ -35,15 +39,21 @@ describe("classifyManaged", () => {
         }
     });
 
-    test("status-less (gone workflow / no label): grace-gated", () => {
+    test("status-less (gone workflow / no owner): grace-gated, then liveness-gated", () => {
         // Fresh → within grace → leave (guards the create race).
         expect(classifyManaged(managed("s", null, NOW - 1000), null, NOW, GRACE)).toBe("leave");
-        // Old → past grace → reap.
-        expect(classifyManaged(managed("s", null, NOW - GRACE - 1), null, NOW, GRACE)).toBe("reap");
+        // Old → past grace → still not reaped on age alone.
+        expect(classifyManaged(managed("s", null, NOW - GRACE - 1), null, NOW, GRACE)).toBe("reap-if-dead");
     });
 
-    test("unknown creation time is treated as past grace (reap)", () => {
-        expect(classifyManaged(managed("s", null, null), null, NOW, GRACE)).toBe("reap");
+    test("a recorded owner that does not resolve never reaps on age alone", () => {
+        // The prod failure this guards: an owner id that cannot be looked up is not
+        // evidence the machine is finished, however old the machine is.
+        expect(classifyManaged(managed("s", "wf-unresolvable", NOW - GRACE * 10), null, NOW, GRACE)).toBe("reap-if-dead");
+    });
+
+    test("unknown creation time is past grace, but still liveness-gated", () => {
+        expect(classifyManaged(managed("s", null, null), null, NOW, GRACE)).toBe("reap-if-dead");
     });
 });
 
@@ -92,6 +102,7 @@ describe("reapOnce", () => {
             pool,
             sandboxClient: {
                 listManagedSandboxes: async () => managedList,
+                isAliveById: async () => DEAD,
                 teardownById: async (id) => {
                     tornDown.push(id);
                 },
@@ -108,7 +119,61 @@ describe("reapOnce", () => {
             reapedCount: 2,
             rowsReconciled: 2,
             leftCount: 2,
+            liveUnattributed: 0,
         });
+    });
+
+    test("never tears down a machine that is still alive, however old and unattributable", async () => {
+        // The prod incident in one case: a live data-profile sandbox whose owner id
+        // did not round-trip through its K8s label, reaped purely for being past the
+        // grace while its workflow was mid-run.
+        const tornDown: string[] = [];
+        const { pool, reconciled } = fakePool();
+
+        const summary = await reapOnce({
+            pool,
+            sandboxClient: {
+                listManagedSandboxes: async () => [managed("sbx-live-orphan", "wf-unresolvable", NOW - GRACE * 10)],
+                isAliveById: async () => ALIVE,
+                teardownById: async (id) => {
+                    tornDown.push(id);
+                },
+            },
+            getStatus: async () => null,
+            graceMs: GRACE,
+            nowMs: () => NOW,
+        });
+
+        expect(tornDown).toEqual([]);
+        expect(reconciled).toEqual([]);
+        expect(summary.reapedCount).toBe(0);
+        expect(summary.leftCount).toBe(1);
+        expect(summary.liveUnattributed).toBe(1);
+    });
+
+    test("a liveness probe that throws leaves the machine for the next sweep", async () => {
+        const tornDown: string[] = [];
+        const { pool } = fakePool();
+
+        const summary = await reapOnce({
+            pool,
+            sandboxClient: {
+                listManagedSandboxes: async () => [managed("sbx-unknown", null, NOW - GRACE - 1)],
+                isAliveById: async () => {
+                    throw new Error("API server unreachable");
+                },
+                teardownById: async (id) => {
+                    tornDown.push(id);
+                },
+            },
+            getStatus: async () => null,
+            graceMs: GRACE,
+            nowMs: () => NOW,
+        });
+
+        expect(tornDown).toEqual([]);
+        expect(summary.reapedCount).toBe(0);
+        expect(summary.leftCount).toBe(1);
     });
 
     test("a teardown failure on one machine does not abort the sweep", async () => {
@@ -120,6 +185,7 @@ describe("reapOnce", () => {
             pool,
             sandboxClient: {
                 listManagedSandboxes: async () => managedList,
+                isAliveById: async () => DEAD,
                 teardownById: async (id) => {
                     if (id === "sbx-a") throw new Error("delete failed");
                     tornDown.push(id);

--- a/harness/src/sandbox/reaper.test.ts
+++ b/harness/src/sandbox/reaper.test.ts
@@ -18,7 +18,7 @@ const GRACE = 10 * 60_000;
 const NOW = 1_000_000_000;
 
 function managed(sandboxId: string, ownerWorkflowId: string | null, createdAtMs: number | null = NOW): ManagedSandbox {
-    return { sandboxId, ownerWorkflowId, ownerIsVerbatim: ownerWorkflowId !== null, createdAtMs };
+    return { sandboxId, ownerWorkflowId, createdAtMs };
 }
 
 const DEAD: SandboxLiveness = { alive: false, oomKilled: false };

--- a/harness/src/sandbox/reaper.ts
+++ b/harness/src/sandbox/reaper.ts
@@ -5,9 +5,10 @@
  * Distinct from the liveness watchdog (`sandbox/watchdog.ts`): the watchdog
  * sweeps registry→cluster and unblocks stuck recvs; the reaper sweeps
  * cluster→registry and garbage-collects. It lists every Cortex-managed sandbox
- * machine in the configured namespace, reads each machine's owner-workflow-id
- * label, and reaps any whose owning workflow is terminal/missing — tearing the
- * machine down and reconciling its step row.
+ * machine in the configured namespace, resolves each machine's recorded owner
+ * workflow, and reaps the ones whose owner is terminal — tearing the machine
+ * down and reconciling its step row. A machine whose owner does not resolve at
+ * all is torn down only once a liveness probe says it is dead.
  *
  * Why a sweep and not teardown-on-cancel: DBOS forbids running a step in a
  * cancelled workflow, so the body cannot tear down on the cancel path; and only
@@ -41,21 +42,24 @@ const DEFAULT_GRACE_MS = 10 * 60_000;
  */
 const ACTIVE_WORKFLOW_STATUSES = new Set(["PENDING", "ENQUEUED", "RUNNING"]);
 
-export type ReapDecision = "leave" | "reap";
+export type ReapDecision = "leave" | "reap" | "reap-if-dead";
 
 /**
- * Decide whether a managed machine is reapable. The owning workflow's status
- * is authoritative — DBOS writes it at enqueue, *before* the machine exists, so
- * a just-spawned machine is always observably in-flight and never mistaken for
- * an orphan. Only the no-status case (no owner label, or the workflow is gone)
- * falls back to a creation-time grace, the one window the status signal can't
- * cover.
+ * Decide whether a managed machine is reapable. A resolved owner status is
+ * authoritative in both directions — DBOS records it at enqueue, *before* the
+ * machine exists, so an in-flight workflow's machine is always observably
+ * in-flight and a terminal one's is always reapable.
+ *
+ * A missing status is authoritative for neither. It means the machine records
+ * no owner, or the id it records did not resolve, or DBOS pruned the row —
+ * and age cannot separate those from a genuine orphan. So the decision defers
+ * to a liveness probe: only an observably dead machine is torn down. Reaping a
+ * live machine on age alone is what this branch exists to prevent.
  */
 export function classifyManaged(sb: ManagedSandbox, status: { status: string } | null, nowMs: number, graceMs: number): ReapDecision {
-    if (status && ACTIVE_WORKFLOW_STATUSES.has(status.status)) return "leave";
-    if (status) return "reap";
+    if (status) return ACTIVE_WORKFLOW_STATUSES.has(status.status) ? "leave" : "reap";
     const ageMs = sb.createdAtMs == null ? Number.POSITIVE_INFINITY : nowMs - sb.createdAtMs;
-    return ageMs >= graceMs ? "reap" : "leave";
+    return ageMs >= graceMs ? "reap-if-dead" : "leave";
 }
 
 /** Map the owning workflow's terminal status to the step row's terminal status. */
@@ -73,9 +77,9 @@ export function terminalStepStatus(workflowStatus: string | null): "canceled" | 
 
 export interface ReaperDeps {
     pool: Pool;
-    sandboxClient: Pick<SandboxClient, "listManagedSandboxes" | "teardownById">;
+    sandboxClient: Pick<SandboxClient, "listManagedSandboxes" | "teardownById" | "isAliveById">;
     getStatus: (workflowId: string) => Promise<{ status: string } | null>;
-    /** Creation-time grace for label-less / orphaned machines. */
+    /** Creation-time grace before an unattributable machine is even probed. */
     graceMs?: number;
     /** Wall-clock ms; injected for tests. */
     nowMs?: () => number;
@@ -87,6 +91,12 @@ export interface ReapSummary {
     reapedCount: number;
     rowsReconciled: number;
     leftCount: number;
+    /**
+     * Machines past the grace whose owner did not resolve but which are still
+     * alive, so they were left standing. A non-zero value is a standing leak
+     * *and* a bug signal — it means owner ids are not round-tripping.
+     */
+    liveUnattributed: number;
 }
 
 /**
@@ -103,13 +113,45 @@ export async function reapOnce(deps: ReaperDeps): Promise<ReapSummary> {
     let reapedCount = 0;
     let rowsReconciled = 0;
     let leftCount = 0;
+    let liveUnattributed = 0;
 
     for (const sb of managed) {
         const status = sb.ownerWorkflowId ? await deps.getStatus(sb.ownerWorkflowId) : null;
+        const decision = classifyManaged(sb, status, nowMs, graceMs);
 
-        if (classifyManaged(sb, status, nowMs, graceMs) === "leave") {
+        if (decision === "leave") {
             leftCount++;
             continue;
+        }
+
+        if (decision === "reap-if-dead") {
+            // A verbatim id that resolves to nothing is an anomaly worth naming: either
+            // DBOS pruned the row or the id never reached the machine intact.
+            if (sb.ownerWorkflowId && sb.ownerIsVerbatim) {
+                logger.warn("owner workflow id resolved to no workflow", { sandboxId: sb.sandboxId, ownerWorkflowId: sb.ownerWorkflowId });
+            }
+
+            let liveness;
+            try {
+                liveness = await deps.sandboxClient.isAliveById(sb.sandboxId);
+            } catch (err) {
+                // A probe that cannot answer is not a dead machine. Leave it; the next
+                // sweep re-probes.
+                logger.warn("liveness probe threw — leaving this machine", { sandboxId: sb.sandboxId, ...logger.errorFields(err) });
+                leftCount++;
+                continue;
+            }
+
+            if (liveness.alive) {
+                logger.warn("machine has no resolvable owner but is still alive — left standing", {
+                    sandboxId: sb.sandboxId,
+                    ownerWorkflowId: sb.ownerWorkflowId,
+                    ownerIsVerbatim: sb.ownerIsVerbatim,
+                });
+                leftCount++;
+                liveUnattributed++;
+                continue;
+            }
         }
 
         try {
@@ -130,6 +172,7 @@ export async function reapOnce(deps: ReaperDeps): Promise<ReapSummary> {
         reapedCount,
         rowsReconciled,
         leftCount,
+        liveUnattributed,
     };
     // Spread: an interface has no implicit index signature, so it needs widening to `LogFields`.
     logger.info("sweep completed", { ...summary });
@@ -138,7 +181,7 @@ export async function reapOnce(deps: ReaperDeps): Promise<ReapSummary> {
 
 export interface RegisterReaperDeps {
     pool: Pool;
-    sandboxClient: Pick<SandboxClient, "listManagedSandboxes" | "teardownById">;
+    sandboxClient: Pick<SandboxClient, "listManagedSandboxes" | "teardownById" | "isAliveById">;
     graceMs?: number;
     logger?: Logger;
 }

--- a/harness/src/sandbox/reaper.ts
+++ b/harness/src/sandbox/reaper.ts
@@ -125,9 +125,9 @@ export async function reapOnce(deps: ReaperDeps): Promise<ReapSummary> {
         }
 
         if (decision === "reap-if-dead") {
-            // A verbatim id that resolves to nothing is an anomaly worth naming: either
+            // A recorded id that resolves to nothing is an anomaly worth naming: either
             // DBOS pruned the row or the id never reached the machine intact.
-            if (sb.ownerWorkflowId && sb.ownerIsVerbatim) {
+            if (sb.ownerWorkflowId) {
                 logger.warn("owner workflow id resolved to no workflow", { sandboxId: sb.sandboxId, ownerWorkflowId: sb.ownerWorkflowId });
             }
 
@@ -146,7 +146,6 @@ export async function reapOnce(deps: ReaperDeps): Promise<ReapSummary> {
                 logger.warn("machine has no resolvable owner but is still alive — left standing", {
                     sandboxId: sb.sandboxId,
                     ownerWorkflowId: sb.ownerWorkflowId,
-                    ownerIsVerbatim: sb.ownerIsVerbatim,
                 });
                 leftCount++;
                 liveUnattributed++;

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -267,18 +267,13 @@ export interface SandboxIdentity {
  * A sandbox machine the backend is running that Cortex *manages*
  * (`app.kubernetes.io/managed-by=cortex`), enumerated by the reaper for the
  * cluster→registry sweep (see the harness-sandbox-exec spec). `ownerWorkflowId`
- * is null for machines that record no owner at all, which are only reaped past
- * a creation-time grace and only when observably dead.
+ * is the id as minted, so it is usable as a DBOS lookup key; null means the
+ * machine records no owner, and such a machine is reaped only past a
+ * creation-time grace and only when observably dead.
  */
 export interface ManagedSandbox {
     sandboxId: string;
     ownerWorkflowId: string | null;
-    /**
-     * Whether `ownerWorkflowId` is the id as minted, and so usable as a DBOS
-     * lookup key. False when it was recovered from a lossy encoding — a K8s
-     * label written by a prior release — where a failed lookup proves nothing.
-     */
-    ownerIsVerbatim: boolean;
     createdAtMs: number | null;
 }
 

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -223,8 +223,8 @@ export interface CreateSandboxMeta {
     /** The first `execId` that will fire against this sandbox; nullable for
      *  early-create flows where the workflow mints the first execId later. */
     execId?: string | null;
-    /** Owning DBOS child workflow id (`"${parentRunId}-${N}"`). Stamped onto the
-     *  sandbox machine as the `cortex/owner-workflow-id` label so the reaper can
+    /** Owning DBOS child workflow id (`"${parentRunId}-${N}"`). Recorded verbatim
+     *  on the sandbox machine under `cortex/owner-workflow-id` so the reaper can
      *  map a cluster-side machine back to its workflow and check liveness. */
     childWorkflowId: string;
     /** Backend-specific extras carried through to the per-backend impl. */
@@ -266,13 +266,19 @@ export interface SandboxIdentity {
 /**
  * A sandbox machine the backend is running that Cortex *manages*
  * (`app.kubernetes.io/managed-by=cortex`), enumerated by the reaper for the
- * cluster→registry sweep (see the harness-sandbox-exec spec). The `ownerWorkflowId` comes from the
- * `cortex/owner-workflow-id` label and may be null for legacy/label-less
- * machines, which are only reaped past a creation-time grace.
+ * cluster→registry sweep (see the harness-sandbox-exec spec). `ownerWorkflowId`
+ * is null for machines that record no owner at all, which are only reaped past
+ * a creation-time grace and only when observably dead.
  */
 export interface ManagedSandbox {
     sandboxId: string;
     ownerWorkflowId: string | null;
+    /**
+     * Whether `ownerWorkflowId` is the id as minted, and so usable as a DBOS
+     * lookup key. False when it was recovered from a lossy encoding — a K8s
+     * label written by a prior release — where a failed lookup proves nothing.
+     */
+    ownerIsVerbatim: boolean;
     createdAtMs: number | null;
 }
 

--- a/images/sandbox-base/server/provenance.go
+++ b/images/sandbox-base/server/provenance.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -51,6 +52,9 @@ type ProvenanceEntry struct {
 // ProvenanceTracker collects file-read provenance from interpreter hooks,
 // LD_PRELOAD, and inotify during a single command execution.
 type ProvenanceTracker struct {
+	// Retained only to correlate the hashed socket filename back to the exec
+	// it belongs to in the logs.
+	id         string
 	socketPath string
 	rlogPath   string
 	watchDirs  []string
@@ -75,9 +79,19 @@ type ProvenanceTracker struct {
 // ── Constructor / lifecycle ────────────────────────────────────
 
 // NewProvenanceTracker creates a tracker with a unique socket path.
+//
+// The path is derived from a hash of id rather than id itself, so it is a fixed
+// 31 bytes whatever the caller passes. A pathname AF_UNIX socket is capped at
+// 107 bytes by sun_path (`struct sockaddr_un`; Go rejects an over-long name
+// client-side, before the bind syscall, as a bare EINVAL), and id embeds a DBOS
+// workflow id whose length nothing on this side can see or bound. Nothing reads
+// the filename — children receive the path only through PROVENANCE_SOCKET — so
+// making it opaque costs nothing.
 func NewProvenanceTracker(id string, watchDirs []string) *ProvenanceTracker {
-	socketPath := fmt.Sprintf("/tmp/prov-%s.sock", id)
+	sum := sha256.Sum256([]byte(id))
+	socketPath := fmt.Sprintf("/tmp/prov-%x.sock", sum[:8])
 	pt := &ProvenanceTracker{
+		id:         id,
 		socketPath: socketPath,
 		rlogPath:   socketPath + ".rlog",
 		watchDirs:  watchDirs,
@@ -105,6 +119,7 @@ func (pt *ProvenanceTracker) Start() error {
 		return fmt.Errorf("provenance socket: %w", err)
 	}
 	pt.listener = conn
+	log.Printf("[provenance] tracker started: socket=%s id=%s", pt.socketPath, pt.id)
 
 	// Start socket reader goroutine
 	pt.wg.Add(1)

--- a/images/sandbox-base/server/provenance_socketpath_test.go
+++ b/images/sandbox-base/server/provenance_socketpath_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+// sunPathMax is the size of sun_path in struct sockaddr_un (include/uapi/linux/un.h).
+// A pathname socket needs room for the terminating NUL, so the usable ceiling is
+// one less. Go enforces this client-side and returns a bare EINVAL, so an
+// over-long path never reaches the kernel and never names itself in the error.
+const sunPathMax = 108
+
+// The id the production data profiler passes: sanitizeForFilename over the exec
+// id `dataprofile:{analysisUUID}:{nonceUUID}:profile:{fnId}`, plus the "-" and
+// 19-digit nanosecond stamp executor.go appends. 118 bytes.
+const realDataProfileID = "dataprofile_01a01372-a1bd-73d6-8dd2-9dc7cb84aa2e_0f3c1d2e-4b5a-6c7d-8e9f-a0b1c2d3e4f5_profile_fn-t-1787044333668000000"
+
+func TestNewProvenanceTrackerSocketPathFitsSunPath(t *testing.T) {
+	// A step id is a plan-authored slug and an analysis id is a UUID: neither is
+	// bounded on this side, so the constructor may not pass either through into
+	// the path. Includes the id that broke production.
+	for name, id := range map[string]string{
+		"production data profile": realDataProfileID,
+		"analysis step":           "019efa6f-1234-7abc-8def-0123456789ab-3_differential-expression-analysis_fn-t-1787044333668000000",
+		"pathological":            strings.Repeat("x", 4096),
+		"empty":                   "",
+	} {
+		pt := NewProvenanceTracker(id, nil)
+		if len(pt.socketPath) >= sunPathMax {
+			t.Errorf("%s: socket path is %d bytes, sun_path holds %d: %s", name, len(pt.socketPath), sunPathMax-1, pt.socketPath)
+		}
+		// The rlog sits beside it and is a regular file, but keep it inside the
+		// same ceiling so neither can be the thing that overflows.
+		if len(pt.rlogPath) >= sunPathMax {
+			t.Errorf("%s: rlog path is %d bytes: %s", name, len(pt.rlogPath), pt.rlogPath)
+		}
+	}
+}
+
+func TestNewProvenanceTrackerSocketPathIsDistinctPerID(t *testing.T) {
+	a := NewProvenanceTracker(realDataProfileID, nil)
+	b := NewProvenanceTracker(realDataProfileID+"1", nil)
+	if a.socketPath == b.socketPath {
+		t.Fatalf("distinct ids collided on %s", a.socketPath)
+	}
+	if NewProvenanceTracker(realDataProfileID, nil).socketPath != a.socketPath {
+		t.Fatal("same id produced two different socket paths")
+	}
+}
+
+// The constructor's whole job is producing a path that binds. Asserting the
+// length alone would still pass if the path were malformed some other way.
+func TestNewProvenanceTrackerSocketPathBinds(t *testing.T) {
+	pt := NewProvenanceTracker(realDataProfileID, nil)
+	if err := pt.Start(); err != nil {
+		t.Fatalf("Start() on a production-shaped id: %v", err)
+	}
+	defer func() {
+		pt.Stop()
+		os.Remove(pt.socketPath)
+	}()
+
+	conn, err := net.Dial("unixgram", pt.socketPath)
+	if err != nil {
+		t.Fatalf("dial %s: %v", pt.socketPath, err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte(fmt.Sprintf(`{"t":1,"p":"/x","pid":1,"layer":"test","op":"read"}`))); err != nil {
+		t.Fatalf("write to %s: %v", pt.socketPath, err)
+	}
+}


### PR DESCRIPTION
## What

The data-profile DBOS workflow id is `dataprofile:{analysisUUID}:{nonceUUID}` — 85 bytes, colons included. Two independent consumers embed it into a namespace with a hard limit that neither they nor the minter can see, and both fail open.

|Consumer|Limit|Failure|
|-|-|-|
|K8s Job label `cortex/owner-workflow-id`|63 bytes, `[A-Za-z0-9._-]`|`sanitizeLabelValue` maps `:`→`-` and truncates → the reaper's `getWorkflowStatus` never matches → live sandboxes reaped on the 10-minute grace|
|AF_UNIX `sun_path` via `execId`|107 bytes|`bind: invalid argument` → provenance fails open, no file operations captured|

Observed in production on analysis `01a01372-a1bd-73d6-8dd2-9dc7cb84aa2e`: a data-profile sandbox torn down 13 minutes in while its workflow was mid-run, after which the profiler spent another 10 minutes issuing LLM calls against a sandbox that no longer existed. Analysis-step sandboxes were unaffected by the label bug (`{runId}-{idx}` sanitizes to itself), which is why it stayed hidden.

## Changes

**Owner id moves to a Job annotation.** Annotations have neither a length cap nor a charset rule, so the id round-trips verbatim and remains usable as a `getWorkflowStatus` key. Nothing selects on the label — every `labelSelector` in `k8s-client.ts` is on `cortex/sandbox-id` or `managed-by` — and the owner label was Job-metadata only, never on the pod template, so the OpenCost / `kube_pod_labels` billing surface is untouched. `platform-charts` and `platform-infra` reference no `cortex/*` sandbox labels at all.

No compatibility layer: nothing is running against the previous release, so the Job carries the annotation alone. A machine either reports an id usable as a DBOS key or reports `null` — a lossy id is worse than none, because a lookup that fails against one proves nothing about the owning workflow.

**Reaper no longer reaps on age alone.** The no-status branch was the only decision made without consulting the shared authority. Since DBOS records a workflow's status at enqueue — before the machine exists — a missing status never means the work finished; it means the pointer is broken or the row was pruned. `classifyManaged` now returns a third decision, `reap-if-dead`, and the sweep defers to `isAliveById`, tearing down only an observably dead machine. Live-but-unattributable machines are left standing and counted as `liveUnattributed` in the sweep summary, so the leak is reported rather than paid for in destroyed work. A probe that throws leaves the machine for the next sweep.

This is the part that would have prevented the outage on its own, independent of the id encoding.

**`isAliveById(sandboxId)`** added to `SandboxClient`, following the existing `teardownById` precedent ("the reaper holds a `sandboxId` but no full `SandboxRef`"). `isAlive(ref)` delegates to it. Both backends already derived liveness from `sandboxId` alone; this makes that explicit in the type rather than implicit.

**Provenance socket path is hashed** — `/tmp/prov-{sha256[:8]}.sock`, a fixed 31 bytes whatever the caller passes. Nothing parses the filename (it reaches children only via `PROVENANCE_SOCKET`), and `Start()` now logs the id beside the hashed path so the correlation survives.

**`disabled` frames are now reported.** `feedExecFrame` consumed the flag by silently recording an empty frame, indistinguishable from a command that genuinely touched no files. Fail-open in Go composed with fail-silent in TypeScript is what let this run unnoticed for as long as it did.

## Not only data-profile

The new Go test shows the analysis-step shape is over the `sun_path` cap too:

```
{runId 36} + {-idx 2} + : + {stepId} + : + fn-t  ≤ 72  →  stepId ≤ 28
```

A plan-authored slug longer than ~28 characters — `differential-expression-analysis` is 31 — breaks provenance identically. Shortening the data-profile id would not have covered that; hashing the path does.

## Tests

Both regression tests were confirmed to fail against the prior code and pass here:

- `k8s-client.test.ts` round-trips a real 85-byte production id through `listManagedSandboxes`. Pre-fix it returns the 62-byte mangled label.
- `provenance_socketpath_test.go` reproduces the exact production error, `bind: invalid argument` on a 133-byte path, and asserts the socket actually binds.

Two tests were replaced because they encoded the bug as intended behaviour:

- `"sanitizes a colon-bearing workflow id into a valid label value"` asserted the value was a valid *label* and never that it was a usable *workflow id*. Its fixture (`data-profile:data-profiler-{slug}`) was not the production shape either.
- `NewProvenanceTracker` had no coverage at all — every provenance test builds `&ProvenanceTracker{...}` as a struct literal, bypassing the constructor whose only real caller is `executor.go:163`, in production.

`typecheck`, `lint`, `prettier`, `go vet`, `go test` clean. Harness suite 3435 pass / 19 fail; those 19 are report-render and report-session tests that fail identically on a pristine `main` checkout.

## Specs

Updated in place — `harness-sandbox-exec`, `docker-sandbox-provider`, `sandbox-provenance-tracking`, `exec-provenance-lineage`. The reaper requirement now states the liveness gate; the provider requirement now states that `ownerWorkflowId` is a DBOS lookup key every backend records verbatim, reporting `null` rather than a rewritten value.

## Release ordering

The harness change ships on the normal path. The sandbox image is a slower path — manual "Build Sandbox Images" dispatch, then a `sandbox.image.tag` bump per environment — so provenance stays broken until that lands. The two halves are independent; neither depends on the other.

## Deliberately out of scope

Dropping the redundant `:{stepId}` segment from `execId`. It carries no identity the workflow id does not already have, but it is a durable correlation key (`submitExec` idempotency, the `exec-event:${execId}` recv topic, `cortex_step_executions.exec_id`, `workflowIdFromExec`), and old 3-segment and new 2-segment ids would coexist across a rollout with no reliable way to tell them apart. Worth doing alone, with a migration plan, and unnecessary for correctness once the socket path is hashed.