### PR TITLE
feat(harness): tile tall page captures and carry multiple images in one tool result

### DIFF
--- a/harness/openspec/changes/tile-the-tall-page-capture/.openspec.yaml
+++ b/harness/openspec/changes/tile-the-tall-page-capture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/harness/openspec/changes/tile-the-tall-page-capture/design.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/design.md
@@ -1,0 +1,37 @@
+# Design: tile-the-tall-page-capture
+
+## Context
+
+`capturePage` gave one full-page shot, with one retry at the window when Chrome refused the bitmap. The provider path holds two constraints that the capture could not see: a hard cap of 8000 pixels per dimension that rejects the whole request, and a downscale to about 1568 pixels on the long side that compresses a tall legal picture past legibility. A single-shot capture of a long report page therefore either kills the turn or blinds the model. The loop carried at most one picture per tool result, thus slicing needs the encoding to generalize first.
+
+## Decisions
+
+### D1: The tile height is two window heights, and it is also the single-shot bound
+
+One constant, `TILE_HEIGHT_PX = 2 * VIEWPORT_HEIGHT` (1800). A slice of that height downscales to about 1568 pixels with the text still readable; a taller slice does not. The same number bounds the single-shot arm: a page at the bound or under survives the downscale whole, thus it costs one picture instead of two.
+
+### D2: The budget is six slices, and the truncation is honest
+
+`MAX_TILES = 6` bounds what one look costs the context — six pictures cover 10800 pixels, which holds every report page seen so far. A taller page truncates, and the coverage carries `capturedPx` against `totalPx`. The alternative — silently dropping the tail — would let the agent judge a page it did not see, and the prompt could not warn it.
+
+### D3: The coverage is a discriminated union on the capture result
+
+`{ kind: "full" }`, `{ kind: "tiled", capturedPx, totalPx }`, `{ kind: "viewport" }`. The accounting fields exist only on the arm that can truncate, thus a consumer cannot read a stale count off a full look. Each slice carries its `range` (`fromY`, `toY`), and the eyes tool mirrors those ranges as `tiles` on the JSON, in picture order.
+
+### D4: The picture convention is a list, read through one seam
+
+`readToolResultImages` returns an ordered list, and the one-image shape reads as a list of one. The single-image writer stays, thus the existing call sites and any cached values keep their meaning. The loop encodes the list on the placement it already picked; no `imagesToolResults` flag exists, because every supported wire that renders one image block in a place renders several.
+
+### D5: The Chrome-refusal arm wraps both shapes
+
+A thrown full-page shot and a thrown slice degrade the same way: one retry at the window, cause chained on a second throw. The tall page that reaches the tiled arm is exactly the page most likely to strain the compositor, thus the arm must cover it.
+
+### D6: The measure failure reads as a short page
+
+`document.documentElement.scrollHeight` is measured once after the settle. A page that refuses the measure captures as one full-page shot, thus a broken measure degrades to yesterday's behavior instead of a dead look.
+
+## Risks / Trade-offs
+
+- A truncated look does not see the tail of a page past 10800 pixels. The coverage names it, the prompt teaches it, and the agent judges only what it saw.
+- Slice seams can cut a block in half. Consecutive slices share no overlap, thus a fault on the seam line appears split across two pictures; the tiles list gives the model the rows to stitch the two views.
+- Six full-width PNG slices cost more context than one downscaled picture. That cost is the point: the model gets pixels it can read.

--- a/harness/openspec/changes/tile-the-tall-page-capture/proposal.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: tile-the-tall-page-capture
+
+## Why
+
+A long report page killed a whole chat turn in staging. The eyes tool captures with `fullPage: true`, Chrome happily rendered a bitmap past 8000 pixels, and the provider rejected the request with a 400 — "At least one of the image dimensions exceed max allowed size: 8000 pixels". The existing viewport fallback never fired, because it guards a Chrome refusal and Chrome did not refuse; the failure surfaced at the provider, where the capture code cannot see it. Scaling the picture down is not a fix either: the provider downscales every image to about 1568 pixels on the long side, thus even a legal 7000-pixel capture reaches the model compressed past legibility. The fix is slicing.
+
+## What Changes
+
+- `capturePage` (`src/lib/page-capture.ts`) measures the document height after the readiness wait. A short page keeps the one full-page shot. A taller page captures consecutive vertical slices of about two window heights each, in document order, up to a budget of six slices. A page taller than the budget covers truncates honestly: the coverage reports the captured pixels against the total. The Chrome-refusal degradation stays — a thrown capture retries once at the window, with the cause chained.
+- `PageCapture` becomes multi-shot: `screenshots: [{ base64, range? }]` plus a coverage discriminant — `{ kind: "full" }`, `{ kind: "tiled", capturedPx, totalPx }`, or `{ kind: "viewport" }`.
+- The tool-result picture convention becomes an ordered list. `withToolResultImages` attaches a list, `readToolResultImages` reads either shape as a list, and the loop encodes every image on the placement it already picked: `[text, ...files]` on the tool result, each picture into the deferred user-message collector in order, or one warn with the count on the drop. No new capability flag — a wire that declares a picture capability declares it for the list.
+- The `examined` outcome of `examine_page` gains the coverage accounting and a `tiles` list (`{ index, fromY, toY }`) that mirrors the picture order, thus the model reads which rows each picture holds. The report-session prompt teaches the slices and the honest truncation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `report-verification`: the eyes-tool requirement gains the tiled capture, the slice budget, and the honest coverage accounting.
+- `harness-agent-loop`: the tool-picture requirement generalizes to an ordered list of pictures under the same placement precedence.
+- `report-session-agent`: the prompt obligations teach the sliced look and the unseen tail.
+
+## Impact
+
+- Affected code: `src/lib/page-capture.ts`, `src/tools/define-tool.ts`, `src/loop/run-agent.ts`, `src/tools/report-session/examine-page.ts`, `src/prompts/report-session.ts`, and their tests.
+- `PageCapture` changes shape. The eyes tool is its one consumer; the old report path is gone.
+- The single-image writer `withToolResultImage` stays, and the reader tolerates both shapes, thus no other tool moves.

--- a/harness/openspec/changes/tile-the-tall-page-capture/specs/harness-agent-loop/spec.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/specs/harness-agent-loop/spec.md
@@ -1,0 +1,27 @@
+# Delta: harness-agent-loop
+
+## MODIFIED Requirements
+
+### Requirement: The loop places a tool picture by the capability precedence
+
+A tool ok value MAY carry an ordered list of pictures, and the loop MUST keep the order of the list on the wire. The one-picture convention MUST read as a list of one, thus a tool that attaches one picture and a tool that attaches a list meet the loop in the same shape. The placement precedence is unchanged, and no capability flag distinguishes the list: a wire that declares a picture capability declares it for the list.
+
+When `imageToolResults` is set, the tool result MUST carry the JSON text part and then one image block per picture, in order. When `imageToolResults` is absent and `imageUserMessages` is set, the fallback user message MUST carry each picture of the result in order, each behind a text part that names the tool call; a result with several pictures MUST number them. When both flags are absent, the loop MUST drop every picture of the result, keep the JSON text, and record one warn that carries the count.
+
+#### Scenario: A multi-picture result rides the tool result in order
+
+- **GIVEN** a provider that advertises `imageToolResults`
+- **WHEN** a tool result carries two pictures
+- **THEN** the tool result carries the JSON text part and then the two image blocks, in the order the tool gave
+
+#### Scenario: A multi-picture result rides the fallback message in order
+
+- **GIVEN** a provider that advertises `imageUserMessages` and not `imageToolResults`
+- **WHEN** a tool result carries two pictures
+- **THEN** the fallback user message carries both pictures in order, each behind a numbered text part that names the tool call
+
+#### Scenario: A wire with neither flag drops the list with one counted warn
+
+- **GIVEN** a provider that advertises neither picture flag
+- **WHEN** a tool result carries two pictures
+- **THEN** the loop drops both, keeps the JSON text, and records one warn that carries the count of two

--- a/harness/openspec/changes/tile-the-tall-page-capture/specs/report-session-agent/spec.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/specs/report-session-agent/spec.md
@@ -1,0 +1,12 @@
+# Delta: report-session-agent
+
+## MODIFIED Requirements
+
+### Requirement: The prompt obligations
+
+The prompt MUST teach the sliced look. A tall page arrives as consecutive top-to-bottom slices of the same page, in document order, and the agent reads the slices as one page. The prompt MUST state plainly that a truncated coverage — fewer captured pixels than total pixels — means the tail of the page was not seen: absent from the look, and not from the page. The prompt MUST state that only a whole look — one full shot, or slices that captured every pixel — makes an unseen section a real fault; under a partial look the agent judges what the pictures show and leaves the rest of the draft as it stands.
+
+#### Scenario: The prompt teaches the sliced look
+
+- **WHEN** a reviewer reads the prompt module
+- **THEN** the sliced look reads as one page in document order, and a truncated coverage names the unseen tail as absent from the look and not from the page

--- a/harness/openspec/changes/tile-the-tall-page-capture/specs/report-verification/spec.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/specs/report-verification/spec.md
@@ -1,0 +1,36 @@
+# Delta: report-verification
+
+## MODIFIED Requirements
+
+### Requirement: The eyes tool
+
+The capture MUST measure the document height after the settle. A page at the single-shot bound or under MUST capture as one full-page shot. A taller page MUST capture as consecutive vertical slices in document order, each about two reader-window heights, because the provider path rejects a picture past its dimension cap and downscales a tall legal picture past legibility. A slice budget MUST bound the count, and a page taller than the budget covers MUST truncate honestly: the coverage carries the captured pixels against the total, and nothing pretends the look was whole.
+
+The result MUST name the coverage of the pictures as a discriminant: the whole page in one shot, the tiled slices with the captured and the total pixels, or the viewport alone. Each slice MUST carry its document range, and the look result MUST mirror those ranges in picture order, thus the agent reads which rows each picture holds. The slices MUST ride the image path of the tool result in document order.
+
+The capture MUST retry one time at the reader viewport when a screenshot throws, for the full-page shot and for a slice alike. A partial look — the viewport alone, or slices that the budget truncated — MUST still stamp the seen hash, because the agent saw the current document. Thus an oversized page degrades a look, and it never blocks the record path.
+
+#### Scenario: A tall page arrives as slices
+
+- **WHEN** the document height passes the single-shot bound
+- **THEN** the result carries consecutive slices in document order, each with its document range, and the coverage carries the captured and the total pixels
+
+#### Scenario: A short page keeps the one shot
+
+- **WHEN** the document height sits at the single-shot bound or under
+- **THEN** the result carries one full-page picture, and the coverage names the whole page
+
+#### Scenario: A page past the budget truncates honestly
+
+- **WHEN** the document height passes what the slice budget covers
+- **THEN** the slices stop at the budget, and the coverage reports fewer captured pixels than total pixels
+
+#### Scenario: A failed slice capture degrades to the viewport
+
+- **WHEN** a slice screenshot throws and the viewport screenshot passes
+- **THEN** the result carries the viewport picture, the coverage names the viewport, and the seen stamp lands
+
+#### Scenario: A truncated look still stamps
+
+- **WHEN** a tiled look reports fewer captured pixels than total pixels
+- **THEN** the seen stamp lands, and the coverage is what tells the agent what it saw

--- a/harness/openspec/changes/tile-the-tall-page-capture/tasks.md
+++ b/harness/openspec/changes/tile-the-tall-page-capture/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: tile-the-tall-page-capture
+
+## 1. The list convention of the tool pictures
+
+- [x] 1.1 Add `withToolResultImages` and `readToolResultImages` to `src/tools/define-tool.ts`; the reader tolerates the one-image shape and gives an ordered list.
+- [x] 1.2 Generalize the three placement arms in `src/loop/run-agent.ts`: `[text, ...files]` on the tool result, each picture into the deferred collector in order with a numbered label, one warn with the count on the drop.
+- [x] 1.3 Tests: the multi-picture tool result, the multi-picture fallback message, and the counted drop warn.
+
+## 2. The tiled capture
+
+- [x] 2.1 Measure the document height after the settle in `src/lib/page-capture.ts`; a failed measure reads as a short page.
+- [x] 2.2 Slice a page past `TILE_HEIGHT_PX` into consecutive clips of that height, up to `MAX_TILES`, in document order; a short page keeps the one full-page shot.
+- [x] 2.3 Reshape `PageCapture`: `screenshots` with per-slice ranges, and the coverage discriminant with the honest `capturedPx` / `totalPx` accounting.
+- [x] 2.4 Keep the Chrome-refusal degradation around both shapes: one retry at the window, cause chained on a second throw.
+- [x] 2.5 Tests: the short page, the tile count and the ranges of a tall page, the truncation accounting past the budget, and the refusal arm.
+
+## 3. The eyes tool and the prompt
+
+- [x] 3.1 Carry the coverage discriminant and the `tiles` ranges on the `examined` outcome of `src/tools/report-session/examine-page.ts`, and attach the slices in document order through `withToolResultImages`.
+- [x] 3.2 Teach the sliced look and the unseen tail in `src/prompts/report-session.ts`: the slices read as one page, and a truncated coverage means the tail was not seen.
+- [x] 3.3 Tests: the tiled outcome shape, with the ranges on the JSON and the slices on the image path.
+
+## 4. The proof
+
+- [x] 4.1 Run the touched suites, the whole `src/loop/` suite, `bun run typecheck`, and `bun run lint`.

--- a/harness/src/app/spawn-report-session.test.ts
+++ b/harness/src/app/spawn-report-session.test.ts
@@ -202,7 +202,7 @@ describe("the eyes rule", () => {
         expect(
             compositionHasEyes({
                 chrome: {},
-                capture: () => Promise.resolve({ screenshotBase64: "", coverage: "full", consoleErrors: [], failedRequests: [] }),
+                capture: () => Promise.resolve({ screenshots: [], coverage: { kind: "full" as const }, consoleErrors: [], failedRequests: [] }),
             }),
         ).toBe(true);
         // A config that names a browser is the route of a standing sidecar.
@@ -232,7 +232,7 @@ describe("spawnReportSession refusals", () => {
         const seamed = createReportSessionSpawn({
             pool,
             chrome: {},
-            capture: () => Promise.resolve({ screenshotBase64: "", coverage: "full", consoleErrors: [], failedRequests: [] }),
+            capture: () => Promise.resolve({ screenshots: [], coverage: { kind: "full" as const }, consoleErrors: [], failedRequests: [] }),
         });
 
         const child = (await seamed.spawnReportSession("p1", BRIEF))._unsafeUnwrap();

--- a/harness/src/lib/page-capture.test.ts
+++ b/harness/src/lib/page-capture.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the settle and the frame of the capture.
+ * Unit tests for the settle, the frame, and the slicing of the capture.
  *
  * The connector seam of the chrome module hands the capture a page that no browser backs. Thus the order of
  * the steps and the arguments of each setter are observable with no sidecar at all.
@@ -25,14 +25,17 @@ function makeRecorder(): Recorder {
 }
 
 /**
- * How the page answers each screenshot call.
+ * How the page answers the height measure and each screenshot call.
  *
- * A refusal names the cause that the call raises. Absent, the call gives its picture. The two arms carry a
- * different picture, thus a test reads which of the two calls the result came from.
+ * `scrollHeight` is what the measure gives; absent, the measure gives no number and the page reads as short.
+ * A refusal names the cause that a call raises. Absent, the call gives its picture. Each arm carries a
+ * different picture, thus a test reads which call the result came from.
  */
 interface ShotPlan {
+    readonly scrollHeight?: number;
     readonly failFullPage?: Error;
     readonly failViewport?: Error;
+    readonly failTile?: Error;
 }
 
 /** The picture of the full-page call, and the picture of the viewport call. */
@@ -53,12 +56,19 @@ function makeFakeBrowser(recorder: Recorder, plan: ShotPlan = {}): Browser {
         goto: async () => {
             recorder.steps.push("goto");
         },
-        evaluate: async () => {
-            recorder.steps.push("evaluate");
+        // The readiness wait carries arguments, and the height measure carries none. Thus the fake reads the
+        // arity, and each of the two evaluations gets its own step name and answer.
+        evaluate: async (_body: unknown, ...args: unknown[]) => {
+            recorder.steps.push(args.length === 0 ? "measure" : "evaluate");
+            return args.length === 0 ? plan.scrollHeight : undefined;
         },
         screenshot: async (options: ScreenshotOptions) => {
             recorder.steps.push("screenshot");
             recorder.shots.push(options);
+            if (options.clip !== undefined) {
+                if (plan.failTile !== undefined) throw plan.failTile;
+                return `TILE-${options.clip.y}`;
+            }
             const refusal = options.fullPage === true ? plan.failFullPage : plan.failViewport;
             if (refusal !== undefined) throw refusal;
             return options.fullPage === true ? FULL_PAGE_SHOT : VIEWPORT_SHOT;
@@ -73,9 +83,9 @@ function makeFakeBrowser(recorder: Recorder, plan: ShotPlan = {}): Browser {
             close: async () => {},
         }),
     };
-    // The capture reads six members of a page, and the connection cache reads four members of a browser. The
-    // fake carries those members, thus no call of the capture reaches the gap between the fake and the class
-    // of puppeteer.
+    // The capture reads seven members of a page, and the connection cache reads four members of a browser.
+    // The fake carries those members, thus no call of the capture reaches the gap between the fake and the
+    // class of puppeteer.
     return fake as unknown as Browser;
 }
 
@@ -95,11 +105,11 @@ describe("the settled capture", () => {
 
         // The size and the emulation both precede the navigation. Thus the layout resolves at the width of a
         // reader, and the page reveals its sections with each transition already collapsed.
-        expect(recorder.steps).toEqual(["viewport", "emulate", "goto", "evaluate", "screenshot"]);
+        expect(recorder.steps).toEqual(["viewport", "emulate", "goto", "evaluate", "measure", "screenshot"]);
         expect(recorder.features).toEqual([[{ name: "prefers-reduced-motion", value: "reduce" }]]);
-        expect(capture.screenshotBase64).toBe(FULL_PAGE_SHOT);
-        // The full-page call passed, thus the picture holds the whole document.
-        expect(capture.coverage).toBe("full");
+        expect(capture.screenshots).toEqual([{ base64: FULL_PAGE_SHOT }]);
+        // The full-page call passed, thus the one picture holds the whole document.
+        expect(capture.coverage).toEqual({ kind: "full" });
     });
 });
 
@@ -118,6 +128,69 @@ describe("the framed capture", () => {
     });
 });
 
+describe("the tiled capture", () => {
+    it("keeps the one full-page shot for a page at the single-shot bound", async () => {
+        const recorder = makeRecorder();
+        // Two window heights is the bound. A page at the bound survives the provider downscale in one shot.
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder, { scrollHeight: 1800 }));
+
+        const capture = await capturePage({ browserUrl: "http://capture-bound.test:9222" }, "http://page.test/report");
+
+        expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }]);
+        expect(capture.coverage).toEqual({ kind: "full" });
+        expect(capture.screenshots).toEqual([{ base64: FULL_PAGE_SHOT }]);
+    });
+
+    it("slices a tall page into consecutive tiles in document order", async () => {
+        const recorder = makeRecorder();
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder, { scrollHeight: 5000 }));
+
+        const capture = await capturePage({ browserUrl: "http://capture-tall.test:9222" }, "http://page.test/report");
+
+        // Each slice clips two window heights at the reader width, and the last slice ends at the document.
+        expect(recorder.shots).toEqual([
+            { encoding: "base64", clip: { x: 0, y: 0, width: 1440, height: 1800 } },
+            { encoding: "base64", clip: { x: 0, y: 1800, width: 1440, height: 1800 } },
+            { encoding: "base64", clip: { x: 0, y: 3600, width: 1440, height: 1400 } },
+        ]);
+        expect(capture.screenshots).toEqual([
+            { base64: "TILE-0", range: { fromY: 0, toY: 1800 } },
+            { base64: "TILE-1800", range: { fromY: 1800, toY: 3600 } },
+            { base64: "TILE-3600", range: { fromY: 3600, toY: 5000 } },
+        ]);
+        // Every pixel is captured, and the coverage says so.
+        expect(capture.coverage).toEqual({ kind: "tiled", capturedPx: 5000, totalPx: 5000 });
+    });
+
+    it("truncates at the tile budget and reports the captured and the total pixels", async () => {
+        const recorder = makeRecorder();
+        restoreConnector = setBrowserConnector(async () => makeFakeBrowser(recorder, { scrollHeight: 20000 }));
+
+        const capture = await capturePage({ browserUrl: "http://capture-budget.test:9222" }, "http://page.test/report");
+
+        // Six slices is the budget. The pictures end at the budget, and the coverage carries the honest
+        // account: the captured pixels against the total, thus no reader mistakes the look for a whole one.
+        expect(capture.screenshots).toHaveLength(6);
+        expect(capture.screenshots[5]!.range).toEqual({ fromY: 9000, toY: 10800 });
+        expect(capture.coverage).toEqual({ kind: "tiled", capturedPx: 10800, totalPx: 20000 });
+    });
+
+    it("retries at the window when a tile bitmap fails, and names the viewport coverage", async () => {
+        const recorder = makeRecorder();
+        restoreConnector = setBrowserConnector(async () =>
+            makeFakeBrowser(recorder, { scrollHeight: 5000, failTile: new Error("the compositor refused the bitmap") }),
+        );
+
+        const capture = await capturePage({ browserUrl: "http://capture-tile-fail.test:9222" }, "http://page.test/report");
+
+        // The retry drops the clip, and it runs on the page that already navigated. Thus one refused slice
+        // costs one more screenshot call and no second load.
+        expect(recorder.shots).toEqual([{ encoding: "base64", clip: { x: 0, y: 0, width: 1440, height: 1800 } }, { encoding: "base64" }]);
+        expect(capture.screenshots).toEqual([{ base64: VIEWPORT_SHOT }]);
+        expect(capture.coverage).toEqual({ kind: "viewport" });
+    });
+});
+
 describe("the degraded capture", () => {
     it("retries at the window when the full-page bitmap fails, and names the viewport coverage", async () => {
         const recorder = makeRecorder();
@@ -130,8 +203,8 @@ describe("the degraded capture", () => {
         expect(recorder.shots).toEqual([{ encoding: "base64", fullPage: true }, { encoding: "base64" }]);
         expect(recorder.steps.filter((step) => step === "goto")).toEqual(["goto"]);
         // The picture came from the retry, and the coverage names what it holds.
-        expect(capture.screenshotBase64).toBe(VIEWPORT_SHOT);
-        expect(capture.coverage).toBe("viewport");
+        expect(capture.screenshots).toEqual([{ base64: VIEWPORT_SHOT }]);
+        expect(capture.coverage).toEqual({ kind: "viewport" });
     });
 
     it("propagates the fault when the window bitmap also fails", async () => {

--- a/harness/src/lib/page-capture.ts
+++ b/harness/src/lib/page-capture.ts
@@ -2,8 +2,15 @@
  * The one page capture over the Chrome sidecar.
  *
  * A capture navigates to a page URL, collects the console errors and the failed requests, waits for the
- * readiness signal of the page, and gives back a base64 screenshot. Two tools capture a report page: the
- * preview snapshot of the old report path and the eyes tool of a report session. Both read this module.
+ * readiness signal of the page, and gives back base64 screenshots. The eyes tool of a report session reads
+ * this module.
+ *
+ * A short page captures as one full-page shot. A tall page captures as consecutive vertical slices, because
+ * one tall picture dies twice on the provider path: a picture past the hard dimension cap rejects the whole
+ * request, and a legal tall picture downscales to about 1568 pixels on the long side, which compresses the
+ * text past legibility. A slice of about two window heights survives both. The slice budget bounds what one
+ * look costs, and a page past the budget truncates with the captured and the total pixels on the coverage,
+ * thus the truncation is never silent.
  *
  * The readiness contract is the reason for one shared body. The renderer emits the event name and the
  * sentinel name, and `report-render/page.ts` owns both constants together with the two budgets. This module
@@ -29,21 +36,36 @@ export interface FailedRequest {
     reason: string;
 }
 
-/** The picture and the faults of one page capture. */
+/** One picture of a capture: the base64 bytes, and the document rows that a slice holds. */
+export interface CapturedShot {
+    readonly base64: string;
+    /** The vertical document range of a slice, in CSS pixels. Absent on a whole-document or window picture. */
+    readonly range?: { readonly fromY: number; readonly toY: number };
+}
+
+/**
+ * What the pictures hold together. `full` is one shot of the whole document. `tiled` is consecutive vertical
+ * slices in document order; `capturedPx` is the height the slices cover and `totalPx` is the document height,
+ * thus `capturedPx < totalPx` says that the slice budget ran out and the tail of the page is absent. `viewport`
+ * appears when a screenshot threw and the retry at the window passed, thus the one picture shows the top
+ * window alone and a section below the fold is absent from it.
+ */
+export type CaptureCoverage =
+    | { readonly kind: "full" }
+    | { readonly kind: "tiled"; readonly capturedPx: number; readonly totalPx: number }
+    | { readonly kind: "viewport" };
+
+/** The pictures and the faults of one page capture. */
 export interface PageCapture {
-    screenshotBase64: string;
-    /**
-     * What the picture holds. `full` is the whole document, and it is the shape of a capture that passed at
-     * the first attempt. `viewport` appears when the full-page screenshot threw and the retry at the window
-     * passed, thus the picture shows the top window alone and a section below the fold is absent from it.
-     */
-    coverage: "full" | "viewport";
+    /** The pictures in document order: one shot under `full` and `viewport`, the slices under `tiled`. */
+    screenshots: CapturedShot[];
+    coverage: CaptureCoverage;
     consoleErrors: string[];
     failedRequests: FailedRequest[];
 }
 
 /**
- * The capture seam. It navigates to a page URL, and it gives back the screenshot and the faults. The seam
+ * The capture seam. It navigates to a page URL, and it gives back the screenshots and the faults. The seam
  * speaks the throw protocol, because the chrome connection does. A test injects a seam that reads no
  * browser, thus a tool orchestration runs with no chrome sidecar.
  */
@@ -68,6 +90,25 @@ const SELECTOR_TIMEOUT_MS = 5_000;
  */
 const VIEWPORT_WIDTH = 1440;
 const VIEWPORT_HEIGHT = 900;
+
+/**
+ * The height of one capture slice, in CSS pixels, and the bound of a single-shot page.
+ *
+ * The provider downscales every picture to about 1568 pixels on the long side before the model reads it. Two
+ * window heights survive that downscale with readable text, and a taller picture reaches the model compressed
+ * past that. Thus a page at this height or under captures as one full-page shot, and a taller page captures
+ * as slices of this height.
+ */
+const TILE_HEIGHT_PX = VIEWPORT_HEIGHT * 2;
+
+/**
+ * The most slices of one capture.
+ *
+ * Each slice is one picture on the tool result, and the budget bounds what one look costs the context. A page
+ * taller than the budget covers truncates, and the coverage carries the captured and the total pixels, thus
+ * the truncation is never silent.
+ */
+const MAX_TILES = 6;
 
 /**
  * The body of the readiness wait, in the browser context. The sentinel arm resolves a page that dispatched
@@ -98,32 +139,68 @@ function waitForThemeReady(sentinel: string, event: string, timeout: number): Pr
     });
 }
 
-/** The picture of one screenshot call: the base64 bytes, and what the picture holds. */
-type Shot = Pick<PageCapture, "screenshotBase64" | "coverage">;
+/** The pictures of one capture pass: the shots in document order, and what they hold together. */
+type Shots = Pick<PageCapture, "screenshots" | "coverage">;
 
 /** The connection gives base64 text or raw bytes, and a caller of the capture reads base64 text alone. */
 function toBase64(shot: string | Uint8Array): string {
     return typeof shot === "string" ? shot : Buffer.from(shot).toString("base64");
 }
 
+/** The body of the height measure, in the browser context. */
+function measureScrollHeight(): number {
+    return document.documentElement.scrollHeight;
+}
+
 /**
- * Take the picture of one settled page, at the whole document or at the window alone.
- *
- * The compositor can refuse a full-page bitmap of a tall page while the bitmap of the window is fine. A
- * degraded picture beats a dead look, thus a refused full page retries one time at the window. A second throw
- * names a broken browser and not a tall page, thus it propagates to the caller.
+ * Measure the document height, in CSS pixels. A page that refuses the measure reads as a short one, thus the
+ * capture takes the one full-page shot and the refusal costs no look.
  */
-async function captureShot(page: Page): Promise<Shot> {
+async function measureTotalHeight(page: Page): Promise<number> {
+    const measured = await page.evaluate(measureScrollHeight).catch(() => undefined);
+    return typeof measured === "number" && Number.isFinite(measured) ? measured : 0;
+}
+
+/**
+ * Capture the slices of one tall page, in document order. Each slice clips {@link TILE_HEIGHT_PX} rows at the
+ * reader width, and the last slice ends at the document height or at the budget, whichever comes first.
+ */
+async function captureTiles(page: Page, totalPx: number): Promise<Shots> {
+    const tileCount = Math.min(Math.ceil(totalPx / TILE_HEIGHT_PX), MAX_TILES);
+    const screenshots: CapturedShot[] = [];
+    for (let index = 0; index < tileCount; index++) {
+        const fromY = index * TILE_HEIGHT_PX;
+        const toY = Math.min(fromY + TILE_HEIGHT_PX, totalPx);
+        const clip = { x: 0, y: fromY, width: VIEWPORT_WIDTH, height: toY - fromY };
+        screenshots.push({ base64: toBase64(await page.screenshot({ encoding: "base64", clip })), range: { fromY, toY } });
+    }
+    const capturedPx = Math.min(tileCount * TILE_HEIGHT_PX, totalPx);
+    return { screenshots, coverage: { kind: "tiled", capturedPx, totalPx } };
+}
+
+/**
+ * Take the pictures of one settled page.
+ *
+ * A page at the single-shot bound or under gives one full-page shot. A taller page gives consecutive slices,
+ * because the provider path compresses or rejects one tall picture; the module comment carries the account.
+ *
+ * The compositor can refuse a bitmap of either shape while the bitmap of the window is fine. A degraded
+ * picture beats a dead look, thus a refusal retries one time at the window. A second throw names a broken
+ * browser and not a tall page, thus it propagates to the caller.
+ */
+async function captureShots(page: Page): Promise<Shots> {
+    const totalPx = await measureTotalHeight(page);
     try {
-        return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64", fullPage: true })), coverage: "full" };
-    } catch (refusedFullPage) {
+        if (totalPx > TILE_HEIGHT_PX) return await captureTiles(page, totalPx);
+        return { screenshots: [{ base64: toBase64(await page.screenshot({ encoding: "base64", fullPage: true })) }], coverage: { kind: "full" } };
+    } catch (refused) {
         try {
-            return { screenshotBase64: toBase64(await page.screenshot({ encoding: "base64" })), coverage: "viewport" };
+            return { screenshots: [{ base64: toBase64(await page.screenshot({ encoding: "base64" })) }], coverage: { kind: "viewport" } };
         } catch (refusedViewport) {
             // The two refusals together are the account of a dead look, and the caller reports the second one
             // alone. Thus the first one rides as the cause, and no reader of that report loses half of it.
             if (refusedViewport instanceof Error && refusedViewport.cause === undefined) {
-                refusedViewport.cause = refusedFullPage;
+                refusedViewport.cause = refused;
             }
             throw refusedViewport;
         }
@@ -131,11 +208,12 @@ async function captureShot(page: Page): Promise<Shot> {
 }
 
 /**
- * Capture one page: the screenshot, the console errors, and the failed requests.
+ * Capture one page: the screenshots, the console errors, and the failed requests.
  *
- * The picture holds the whole document, and not the window alone. Thus a caller can judge a section that a
- * reader reaches by a scroll. A refused full-page bitmap degrades to the window, and the coverage of the
- * result names which of the two pictures arrived.
+ * The pictures hold the document, and not the window alone. Thus a caller can judge a section that a reader
+ * reaches by a scroll. A short page arrives as one full-page shot, and a tall page arrives as consecutive
+ * slices in document order. A refused bitmap degrades to the window, and the coverage of the result names
+ * what the pictures hold.
  *
  * The readiness wait is best-effort. A page that never signals still captures at the readiness budget, thus
  * a broken page gives a picture that shows what broke.
@@ -178,12 +256,12 @@ export function capturePage(chrome: ChromeConfig, url: string, options: CaptureO
             await new Promise((resolve) => setTimeout(resolve, settle));
         }
 
-        // The picture must show the whole document at the layout that a reader gets. Thus a defect below the
+        // The pictures must show the whole document at the layout that a reader gets. Thus a defect below the
         // fold is visible, and a question about content that never appeared has an answer.
-        const shot = await captureShot(page);
+        const shots = await captureShots(page);
         return {
-            screenshotBase64: shot.screenshotBase64,
-            coverage: shot.coverage,
+            screenshots: shots.screenshots,
+            coverage: shots.coverage,
             consoleErrors,
             failedRequests,
         };

--- a/harness/src/loop/run-agent.test.ts
+++ b/harness/src/loop/run-agent.test.ts
@@ -8,7 +8,7 @@ import { isInterruptedMessage, isSyntheticUserMessage } from "../memory/ai-sdk-m
 import { makeSession } from "../providers/__fixtures__/session.js";
 import type { ChatResponse } from "../providers/types.js";
 import { AskRejectedError } from "../tools/approval/contract.js";
-import { defineTool, withToolResultImage, type Tool } from "../tools/define-tool.js";
+import { defineTool, withToolResultImage, withToolResultImages, type Tool } from "../tools/define-tool.js";
 import { makeMessage, scriptedProvider, type ScriptedProvider, textBlock, thinkingBlock, toolUseBlock } from "./__fixtures__/scripted-provider.js";
 import { runAgent, type RunAgentOptions } from "./run-agent.js";
 import { passthroughStep } from "./run-step.js";
@@ -445,6 +445,23 @@ function eyesTool(): Tool {
     });
 }
 
+/** An `eyes` tool that returns two slices beside its JSON faults, in document order. */
+function slicingEyesTool(): Tool {
+    return defineTool({
+        id: "eyes",
+        description: "Look at a tall page and give its slices in document order.",
+        inputSchema: z.object({}),
+        describeCall: "none",
+        execute: async () =>
+            ok(
+                withToolResultImages({ faults: ["boom"] }, [
+                    { base64: "TILE-ONE", mediaType: "image/png" },
+                    { base64: "TILE-TWO", mediaType: "image/png" },
+                ]),
+            ),
+    });
+}
+
 describe("runAgent — a picture on a tool result", () => {
     it("splits a picture-bearing result into a JSON text part and an image part when the wire carries a picture", async () => {
         const provider = imagingProvider([makeMessage([toolUseBlock("tu-1", "eyes", {})], "tool_use"), makeMessage([textBlock("done")], "end_turn")]);
@@ -464,6 +481,22 @@ describe("runAgent — a picture on a tool result", () => {
         expect(filePart.data).toEqual({ type: "data", data: "PNGBYTES" });
     });
 
+    it("carries every slice of a multi-picture result on the tool result, in document order", async () => {
+        const provider = imagingProvider([makeMessage([toolUseBlock("tu-1", "eyes", {})], "tool_use"), makeMessage([textBlock("done")], "end_turn")]);
+
+        const { messages } = await runAgent(agentDef([slicingEyesTool()]), GO, makeSession(), opts(provider));
+
+        const result = toolResultParts(messages[2])[0]!;
+        expect(result.output).toEqual({
+            type: "content",
+            value: [
+                { type: "text", text: JSON.stringify({ faults: ["boom"] }) },
+                { type: "file", mediaType: "image/png", data: { type: "data", data: "TILE-ONE" } },
+                { type: "file", mediaType: "image/png", data: { type: "data", data: "TILE-TWO" } },
+            ],
+        });
+    });
+
     it("drops the picture and keeps the JSON text when the wire carries none, and records the drop", async () => {
         const logger = createCapturingLogger();
         // The default scripted provider states no picture capability, thus the wire carries none.
@@ -480,6 +513,22 @@ describe("runAgent — a picture on a tool result", () => {
         expect(messages.filter((m) => m.role === "user")).toEqual([...GO]);
         // The drop rides the log, thus an operator sees that the picture did not reach the model.
         expect(logger.records.some((r) => r.level === "warn" && r.msg.includes("carries no picture"))).toBe(true);
+    });
+
+    it("drops every slice of a multi-picture result with one warn that carries the count", async () => {
+        const logger = createCapturingLogger();
+        // The default scripted provider states no picture capability, thus the wire carries none.
+        const provider = scriptedProvider([makeMessage([toolUseBlock("tu-1", "eyes", {})], "tool_use"), makeMessage([textBlock("done")], "end_turn")]);
+
+        const { messages } = await runAgent(agentDef([slicingEyesTool()]), GO, makeSession(), opts(provider, { logger }));
+
+        const result = toolResultParts(messages[2])[0]!;
+        expect(result.output).toEqual({ type: "json", value: { faults: ["boom"] } });
+        expect(JSON.stringify(messages)).not.toContain("TILE-ONE");
+        // One warn accounts for the whole result, and the count says how many pictures the model lost.
+        const warns = logger.records.filter((r) => r.level === "warn" && r.msg.includes("carries no picture"));
+        expect(warns).toHaveLength(1);
+        expect(warns[0]!.fields["imageCount"]).toBe(2);
     });
 
     it("encodes a payload-free result as a plain JSON part, byte-identical to today", async () => {
@@ -543,6 +592,24 @@ describe("runAgent — a picture on a user message", () => {
         expect(userParts(messages[3])).toEqual([
             { type: "text", text: "The picture of the tool result tu-1 of eyes." },
             { type: "file", mediaType: "image/png", data: { type: "data", data: "PNGBYTES" } },
+        ]);
+    });
+
+    it("carries every slice of a multi-picture result in the fallback message, with a numbered label on each", async () => {
+        const provider = fallbackImagingProvider([makeMessage([toolUseBlock("tu-1", "eyes", {})], "tool_use"), makeMessage([textBlock("done")], "end_turn")]);
+
+        const { messages } = await runAgent(agentDef([slicingEyesTool()]), GO, makeSession(), opts(provider));
+
+        // [user, assistant(tool-call), tool(result), user(2 pictures), assistant(text)]
+        expect(messages).toHaveLength(5);
+        const result = toolResultParts(messages[2])[0]!;
+        expect(result.output).toEqual({ type: "json", value: { faults: ["boom"] } });
+        // The labels number the slices, thus the model reads which slice each picture is.
+        expect(userParts(messages[3])).toEqual([
+            { type: "text", text: "The picture 1 of 2 of the tool result tu-1 of eyes." },
+            { type: "file", mediaType: "image/png", data: { type: "data", data: "TILE-ONE" } },
+            { type: "text", text: "The picture 2 of 2 of the tool result tu-1 of eyes." },
+            { type: "file", mediaType: "image/png", data: { type: "data", data: "TILE-TWO" } },
         ]);
     });
 

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -27,7 +27,7 @@ import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/p
 import { resultStep } from "./run-step.js";
 import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderCapabilities } from "../providers/types.js";
 import { AskRejectedError, UnavailableAsk, type AskApproval, type AskRequest } from "../tools/approval/contract.js";
-import { isToolError, readToolResultImage, type Tool, type ToolContext, type ToolResultImage } from "../tools/define-tool.js";
+import { isToolError, readToolResultImages, type Tool, type ToolContext, type ToolResultImage } from "../tools/define-tool.js";
 import { addChatUsage, hasReportedUsage, recordAgentRun, type AgentRunUsage } from "./metrics.js";
 import { computeDetail, computeResultDetail, type ToolCallDetail } from "./tool-detail.js";
 import { toolOutcomeForOutputType, type ToolOutcome } from "./tool-outcome.js";
@@ -631,18 +631,18 @@ function imagePlacementFor(capabilities: ProviderCapabilities): ImagePlacement {
     return "drop";
 }
 
-/** A picture that a tool result cannot carry, with the tool call that produced it. */
-interface DeferredImage {
+/** The pictures that a tool result cannot carry, with the tool call that produced them. */
+interface DeferredImages {
     readonly toolCallId: string;
     readonly toolName: string;
-    readonly image: ToolResultImage;
+    readonly images: readonly ToolResultImage[];
 }
 
 /**
  * How a completed tool result is encoded onto the provider message. `placement`
- * says where the picture of a tool result goes, and `log` is the diagnostic sink
+ * says where the pictures of a tool result go, and `log` is the diagnostic sink
  * of one dispatch: the record of a dropped picture, and the record of a result
- * description that failed. `deferredImages` collects the picture of each tool
+ * description that failed. `deferredImages` collects the pictures of each tool
  * result of the round under the user-message placement, and the round assembly
  * empties it.
  *
@@ -659,7 +659,18 @@ interface DeferredImage {
 interface ResultEncoding {
     readonly placement: ImagePlacement;
     readonly log: Logger;
-    readonly deferredImages: DeferredImage[];
+    readonly deferredImages: DeferredImages[];
+}
+
+/**
+ * The text part that names one deferred picture. The wire holds no structural
+ * link between a user message and a tool call, thus the line names the call. A
+ * result with several pictures numbers each one, thus the model reads which
+ * slice it looks at.
+ */
+function deferredImageLabel(deferred: DeferredImages, index: number): string {
+    const call = `the tool result ${deferred.toolCallId} of ${deferred.toolName}`;
+    return deferred.images.length === 1 ? `The picture of ${call}.` : `The picture ${index + 1} of ${deferred.images.length} of ${call}.`;
 }
 
 /**
@@ -669,24 +680,27 @@ interface ResultEncoding {
  * The tool message must come directly after the assistant message with the
  * tool calls. Thus a picture rides a separate message after the whole tool
  * message, and one message batches the round. The parts obey the order of
- * `results`, which is the order of the tool calls. Each deferred picture has a
- * result of this round, because the collector fills during the dispatch and it
- * empties here. A text part names the tool call of each picture, because the wire
- * holds no structural link between a user message and a tool call.
+ * `results`, which is the order of the tool calls, and the pictures of one
+ * result keep the order that the tool gave. Each deferred picture has a result
+ * of this round, because the collector fills during the dispatch and it empties
+ * here. A text part names the tool call of each picture, because the wire holds
+ * no structural link between a user message and a tool call.
  *
  * The message carries the synthetic marker, because a `user` message opens a
  * conversation turn. An unmarked one is loop machinery that reads as a turn
  * boundary, and it splits one stored turn in two.
  */
-function appendDeferredImages(messages: LoopMessage[], results: readonly ToolResultPart[], deferredImages: DeferredImage[]): void {
+function appendDeferredImages(messages: LoopMessage[], results: readonly ToolResultPart[], deferredImages: DeferredImages[]): void {
     if (deferredImages.length === 0) return;
     const byToolCallId = new Map(deferredImages.map((deferred) => [deferred.toolCallId, deferred]));
     const content: (TextPart | FilePart)[] = [];
     for (const result of results) {
         const deferred = byToolCallId.get(result.toolCallId);
         if (deferred === undefined) continue;
-        content.push({ type: "text", text: `The picture of the tool result ${deferred.toolCallId} of ${deferred.toolName}.` });
-        content.push({ type: "file", mediaType: deferred.image.mediaType, data: { type: "data", data: deferred.image.base64 } });
+        for (const [index, image] of deferred.images.entries()) {
+            content.push({ type: "text", text: deferredImageLabel(deferred, index) });
+            content.push({ type: "file", mediaType: image.mediaType, data: { type: "data", data: image.base64 } });
+        }
     }
     messages.push(syntheticUserMessage(content));
     deferredImages.length = 0;
@@ -859,15 +873,16 @@ function jsonValue(value: unknown) {
  * Encode a tool ok value onto a tool-result message. A value with no picture
  * stays a plain JSON result, byte-identical to a value that never carried one.
  *
- * A value that carries a picture splits: the JSON data goes to a text part, and
- * the bytes ride as an image content block. Thus the model sees the picture, and
- * the JSON text holds no bytes. When the wire carries no picture, the block drops
- * and the text stays, because base64 text floods the context and the model cannot
- * see it. The drop rides the log, thus an operator sees that the picture did not
- * reach the model.
+ * A value that carries pictures splits: the JSON data goes to a text part, and
+ * the bytes ride as image content blocks after it, in the order that the tool
+ * gave. Thus the model sees each picture, and the JSON text holds no bytes. When
+ * the wire carries no picture, the blocks drop and the text stays, because
+ * base64 text floods the context and the model cannot see it. One warn with the
+ * count rides the log, thus an operator sees how many pictures did not reach the
+ * model.
  *
  * A wire that renders a picture on a user message only gets the fallback: the
- * result keeps its JSON text, and the picture goes to the collector of the round.
+ * result keeps its JSON text, and the pictures go to the collector of the round.
  * The round then sends the bytes after the tool message.
  */
 function successResult(toolCall: ToolCallPart, value: unknown, encoding: ResultEncoding): ToolResultPart {
@@ -878,14 +893,17 @@ function successResult(toolCall: ToolCallPart, value: unknown, encoding: ResultE
         toolName: toolCall.toolName,
         output: { type: "json", value: jsonData },
     };
-    const image = readToolResultImage(value);
-    if (image === undefined) return jsonOnly;
+    const images = readToolResultImages(value);
+    if (images.length === 0) return jsonOnly;
     if (encoding.placement === "drop") {
-        encoding.log.warn("the wired provider carries no picture in a tool result, thus the picture is dropped", { toolName: toolCall.toolName });
+        encoding.log.warn("the wired provider carries no picture in a tool result, thus the pictures are dropped", {
+            toolName: toolCall.toolName,
+            imageCount: images.length,
+        });
         return jsonOnly;
     }
     if (encoding.placement === "user-message") {
-        encoding.deferredImages.push({ toolCallId: toolCall.toolCallId, toolName: toolCall.toolName, image });
+        encoding.deferredImages.push({ toolCallId: toolCall.toolCallId, toolName: toolCall.toolName, images });
         return jsonOnly;
     }
     return {
@@ -896,7 +914,7 @@ function successResult(toolCall: ToolCallPart, value: unknown, encoding: ResultE
             type: "content",
             value: [
                 { type: "text", text: JSON.stringify(jsonData) },
-                { type: "file", mediaType: image.mediaType, data: { type: "data", data: image.base64 } },
+                ...images.map((image) => ({ type: "file" as const, mediaType: image.mediaType, data: { type: "data" as const, data: image.base64 } })),
             ],
         },
     };

--- a/harness/src/prompts/report-session.ts
+++ b/harness/src/prompts/report-session.ts
@@ -198,15 +198,22 @@ The loop that ends a report is preview, look, repair, and record. Run it in orde
 
 - \`preview_report\` renders the current draft to a page. The Preview section above
   gives its rules.
-- \`examine_page\` opens the rendered page in a real browser. It gives back a
-  screenshot, the coverage of that screenshot, the console errors, and the failed
-  requests. The coverage names what the picture holds. When it names \`full\`, the
-  picture holds the whole page, from the title to the last block, at the width that
-  a reader gets. Thus a section that the picture does not show is a real fault, and
-  never the fold. When it names \`viewport\`, the browser refused the bitmap of the
-  whole page, and the picture holds the top window alone. A section under the fold
-  is then absent from the picture, and not from the page. Judge what the picture
-  shows. Look at the page, and examine the picture for each of these faults:
+- \`examine_page\` opens the rendered page in a real browser. It gives back one or
+  more screenshots, the coverage of the look, the console errors, and the failed
+  requests. The coverage names what the pictures hold. When its kind names \`full\`,
+  one picture holds the whole page, from the title to the last block, at the width
+  that a reader gets. When it names \`tiled\`, the page was tall, and the pictures
+  are consecutive top-to-bottom slices of the same page, in document order; the
+  \`tiles\` list names the pixel rows of each slice. Read the slices as one page.
+  When a tiled coverage reports fewer \`capturedPx\` than \`totalPx\`, the slice
+  budget ran out and the tail of the page was not seen: the pictures end where the
+  captured pixels end, and the rest is absent from the look, not from the page.
+  When the kind names \`viewport\`, the browser refused the bitmap of the whole
+  page, and the picture holds the top window alone. When the look saw the whole
+  page — \`full\`, or \`tiled\` with every pixel captured — a section that the
+  pictures do not show is a real fault, and never the fold. Judge what the
+  pictures show. Look at the page, and examine the pictures for each of these
+  faults:
   - clipped text: a word, a label, or a line that a box cuts short.
   - a truncated number: a value that its card, its cell, or its label cuts short.
   - an overflowing card: content that runs past its frame, or past its neighbor.
@@ -280,10 +287,12 @@ page that the user reads.
   or remove that block by its id, and do not re-author the report.
 - **Leave a gap unread.** When \`finish_draft\` or \`preview_report\` reports a gap or
   an unresolved reference, repair it. Do not present a report that does not finish.
-- **Repair a block that the picture could not show.** When the coverage names
-  \`viewport\`, the picture holds the top window alone. A section under the fold is
-  absent from that picture, and not from the page. Judge what you saw, and leave
-  the rest of the draft as it stands.
+- **Repair a block that the pictures could not show.** When the coverage names
+  \`viewport\`, the picture holds the top window alone. When a tiled coverage
+  reports fewer captured pixels than total pixels, the tail of the page past the
+  captured pixels was not seen. A section outside what the pictures hold is absent
+  from the look, and not from the page. Judge what you saw, and leave the rest of
+  the draft as it stands.
 - **Spiral on a cosmetic doubt.** The visual spiral is a loop of small visual worries
   with no fault to repair. Look one time, then repair a real fault: a fault that the
   look checklist names, an absent chart, or a failed request. A named fault is real

--- a/harness/src/tools/define-tool.ts
+++ b/harness/src/tools/define-tool.ts
@@ -48,9 +48,9 @@ export function isToolError(value: unknown): value is ToolError {
 }
 
 /**
- * The picture that a tool ok value carries beside its JSON data. `base64` holds
+ * One picture that a tool ok value carries beside its JSON data. `base64` holds
  * the bytes, and `mediaType` names the IANA type, for example "image/png". The
- * loop splits the picture out of the JSON text, and it rides the tool result as
+ * loop splits each picture out of the JSON text, and it rides the tool result as
  * an image content block. Thus the model sees the picture, and the JSON text
  * holds no bytes.
  */
@@ -60,17 +60,17 @@ export interface ToolResultImage {
 }
 
 /**
- * The reserved key that carries a picture on a tool ok value. It is a symbol,
+ * The reserved key that carries the pictures on a tool ok value. It is a symbol,
  * thus it never collides with a data field. `JSON.stringify` also omits a symbol
  * key, thus the bytes never reach the JSON text by accident.
  */
 export const toolResultImageKey: unique symbol = Symbol("toolResultImage");
 
-/** A tool ok value that can carry a picture under the reserved key. */
-export type WithToolResultImage<T> = T & { readonly [toolResultImageKey]?: ToolResultImage };
+/** A tool ok value that can carry one picture or an ordered list of them under the reserved key. */
+export type WithToolResultImage<T> = T & { readonly [toolResultImageKey]?: ToolResultImage | readonly ToolResultImage[] };
 
 /**
- * Attach a picture to a tool ok value. The value keeps its own fields, and the
+ * Attach one picture to a tool ok value. The value keeps its own fields, and the
  * picture rides under the reserved key. The loop reads the key, and it moves the
  * bytes into an image content block on the tool result.
  */
@@ -78,14 +78,33 @@ export function withToolResultImage<T extends object>(value: T, image: ToolResul
     return { ...value, [toolResultImageKey]: image };
 }
 
-/** Read the picture that a tool ok value carries, or undefined when it carries none. */
-export function readToolResultImage(value: unknown): ToolResultImage | undefined {
-    if (typeof value !== "object" || value === null) return undefined;
-    const image = (value as { [toolResultImageKey]?: unknown })[toolResultImageKey];
-    if (typeof image !== "object" || image === null) return undefined;
-    const { base64, mediaType } = image as Partial<ToolResultImage>;
-    if (typeof base64 !== "string" || typeof mediaType !== "string") return undefined;
-    return { base64, mediaType };
+/**
+ * Attach an ordered list of pictures to a tool ok value. The order is the order
+ * that the model reads, and the loop keeps it on the wire. A tool that slices a
+ * page attaches the slices in document order.
+ */
+export function withToolResultImages<T extends object>(value: T, images: readonly ToolResultImage[]): WithToolResultImage<T> {
+    return { ...value, [toolResultImageKey]: images };
+}
+
+/** Does one entry under the reserved key carry the picture shape? */
+function isToolResultImage(entry: unknown): entry is ToolResultImage {
+    if (typeof entry !== "object" || entry === null) return false;
+    const { base64, mediaType } = entry as Partial<ToolResultImage>;
+    return typeof base64 === "string" && typeof mediaType === "string";
+}
+
+/**
+ * Read the pictures that a tool ok value carries, in order. A value with none
+ * gives the empty list. The one-picture shape reads as a list of one, thus a
+ * tool that attaches one picture and a tool that attaches a list meet the loop
+ * in the same shape.
+ */
+export function readToolResultImages(value: unknown): ToolResultImage[] {
+    if (typeof value !== "object" || value === null) return [];
+    const carried = (value as { [toolResultImageKey]?: unknown })[toolResultImageKey];
+    const entries = Array.isArray(carried) ? carried : [carried];
+    return entries.filter(isToolResultImage);
 }
 
 /**

--- a/harness/src/tools/report-session/examine-page.test.ts
+++ b/harness/src/tools/report-session/examine-page.test.ts
@@ -34,7 +34,7 @@ import type {
     StampResult,
 } from "../report-authoring/authoring-tools.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
-import { readToolResultImage, type ToolContext } from "../define-tool.js";
+import { readToolResultImages, type ToolContext } from "../define-tool.js";
 import { createExaminePageTool, type CapturePage, type ExaminePageResult, type PageCapture } from "./examine-page.js";
 
 const DEFAULT_ANALYSIS_ID = "analysis-001";
@@ -281,7 +281,7 @@ describe("the no-browser outcome", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "BASE64PNG" }], coverage: { kind: "full" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: { browserUrl: "http://localhost:9222" }, capture });
 
@@ -315,7 +315,7 @@ describe("the missed stamp", () => {
         const gateway = makeFakeGateway();
         // The preview stamped no rendered hash, thus the seen stamp finds none to copy.
         gateway.seed(threadId, null);
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "BASE64PNG" }], coverage: { kind: "full" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
 
@@ -337,8 +337,8 @@ describe("the seen-stamp copy", () => {
 
         let capturedUrl: string | undefined;
         const stub: PageCapture = {
-            screenshotBase64: "BASE64PNG",
-            coverage: "full",
+            screenshots: [{ base64: "BASE64PNG" }],
+            coverage: { kind: "full" },
             consoleErrors: ["boom"],
             failedRequests: [{ url: "assets/x.png", reason: "net" }],
         };
@@ -352,13 +352,15 @@ describe("the seen-stamp copy", () => {
 
         expect(result.outcome).toBe("examined");
         if (result.outcome === "examined") {
-            expect(result.coverage).toBe("full");
+            expect(result.coverage).toEqual({ kind: "full" });
+            // One whole-document shot slices nothing, thus no tiles list rides the JSON.
+            expect(result.tiles).toBeUndefined();
             expect(result.consoleErrors).toEqual(["boom"]);
             expect(result.failedRequests).toEqual([{ url: "assets/x.png", reason: "net" }]);
             expect(result.pagePath).toBe(join("report-sessions", threadId, "index.html"));
         }
         // The screenshot rides the image path, thus the model sees the picture.
-        expect(readToolResultImage(result)).toEqual({ base64: "BASE64PNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "BASE64PNG", mediaType: "image/png" }]);
         // The JSON text holds no bytes, thus the picture never reaches the JSON by accident.
         expect(JSON.stringify(result)).not.toContain("BASE64PNG");
         // The tool navigates to the page file through a file URL.
@@ -376,7 +378,7 @@ describe("the seen-stamp copy", () => {
         gateway.seed(threadId, "rendered-hash");
 
         // The browser refused the full-page bitmap, thus the capture gives the window alone.
-        const stub: PageCapture = { screenshotBase64: "VIEWPORTPNG", coverage: "viewport", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "VIEWPORTPNG" }], coverage: { kind: "viewport" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
 
@@ -385,10 +387,52 @@ describe("the seen-stamp copy", () => {
         expect(result.outcome).toBe("examined");
         if (result.outcome === "examined") {
             // The coverage rides the JSON, thus the agent reads that the picture shows the window alone.
-            expect(result.coverage).toBe("viewport");
+            expect(result.coverage).toEqual({ kind: "viewport" });
         }
-        expect(readToolResultImage(result)).toEqual({ base64: "VIEWPORTPNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "VIEWPORTPNG", mediaType: "image/png" }]);
         // The agent saw the current document, thus the degraded look counts and the record path stays open.
+        expect(gateway.seenOf(threadId)).toBe("rendered-hash");
+    });
+
+    it("carries the slices of a tiled look in document order, with the ranges on the JSON and the honest coverage", async () => {
+        const root = await makeRoot();
+        const threadId = "t1";
+        await writePage(root, threadId);
+        const gateway = makeFakeGateway();
+        gateway.seed(threadId, "rendered-hash");
+
+        // The page was tall, and the budget covered half of it. The capture reports what it saw.
+        const stub: PageCapture = {
+            screenshots: [
+                { base64: "TILEONE", range: { fromY: 0, toY: 1800 } },
+                { base64: "TILETWO", range: { fromY: 1800, toY: 3600 } },
+            ],
+            coverage: { kind: "tiled", capturedPx: 3600, totalPx: 7200 },
+            consoleErrors: [],
+            failedRequests: [],
+        };
+        const capture: CapturePage = () => Promise.resolve(stub);
+        const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
+
+        const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
+
+        expect(result.outcome).toBe("examined");
+        if (result.outcome === "examined") {
+            // The coverage carries the captured and the total pixels, thus a truncated look is never silent.
+            expect(result.coverage).toEqual({ kind: "tiled", capturedPx: 3600, totalPx: 7200 });
+            // The tiles list mirrors the picture order, thus the model reads which rows each picture holds.
+            expect(result.tiles).toEqual([
+                { index: 0, fromY: 0, toY: 1800 },
+                { index: 1, fromY: 1800, toY: 3600 },
+            ]);
+        }
+        // The slices ride the image path in document order, and the JSON text holds no bytes.
+        expect(readToolResultImages(result)).toEqual([
+            { base64: "TILEONE", mediaType: "image/png" },
+            { base64: "TILETWO", mediaType: "image/png" },
+        ]);
+        expect(JSON.stringify(result)).not.toContain("TILEONE");
+        // A truncated look is a true look at the current document, thus it stamps the seen hash the same.
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
     });
 });
@@ -411,7 +455,7 @@ describe("the lease of one look", () => {
         const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
 
         expect(result.outcome).toBe("examined");
-        expect(readToolResultImage(result)).toEqual({ base64: "LEASEPNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "LEASEPNG", mediaType: "image/png" }]);
         // The scope carries the analysis and the root of this call, thus a realization mounts the same tree.
         expect(eyes.acquired).toEqual([{ analysisId: DEFAULT_ANALYSIS_ID, workspaceRoot: root }]);
         // The capture reached the endpoint of the lease, and not the endpoint of the chrome config.
@@ -457,7 +501,7 @@ describe("the lease of one look", () => {
 
         // The capture already passed, thus the failed release changes no outcome of the look.
         expect(result.outcome).toBe("examined");
-        expect(readToolResultImage(result)).toEqual({ base64: "KEPTPNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "KEPTPNG", mediaType: "image/png" }]);
         expect(eyes.released).toEqual([RELEASE_FAULT_ENDPOINT]);
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
         // The log is the whole record of a failed release, thus the tool names it there.
@@ -535,7 +579,7 @@ describe("the lease of one look", () => {
 
         // The capture already passed, thus the release that never settles changes no outcome of the look.
         expect(result.outcome).toBe("examined");
-        expect(readToolResultImage(result)).toEqual({ base64: "HUNGPNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "HUNGPNG", mediaType: "image/png" }]);
         expect(eyes.released).toEqual([RELEASE_HANG_ENDPOINT]);
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
         // An expired release reads the same as a thrown release, thus the log is its whole record.
@@ -550,7 +594,7 @@ describe("the transport precedence", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "BASE64PNG" }], coverage: { kind: "full" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const eyes = makeFakeEyes({ browserUrl: "http://examine-unused.test:9222" });
         const tool = createExaminePageTool({
@@ -585,7 +629,7 @@ describe("the transport precedence", () => {
         const result = (await tool.execute({}, ctxForThread(threadId)))._unsafeUnwrap();
 
         expect(result.outcome).toBe("examined");
-        expect(readToolResultImage(result)).toEqual({ base64: "STATICPNG", mediaType: "image/png" });
+        expect(readToolResultImages(result)).toEqual([{ base64: "STATICPNG", mediaType: "image/png" }]);
         // The static realization gives the configured endpoint, thus the capture reaches that one.
         expect(connected).toEqual([CONFIGURED_ENDPOINT]);
         expect(gateway.seenOf(threadId)).toBe("rendered-hash");
@@ -605,7 +649,7 @@ describe("the result detail", () => {
         await writePage(root, threadId);
         const gateway = makeFakeGateway();
         gateway.seed(threadId, "rendered-hash");
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "BASE64PNG" }], coverage: { kind: "full" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = () => Promise.resolve(stub);
         const tool = createExaminePageTool({ gateway, resolveWorkspaceRoot: () => root, chrome: {}, capture });
 
@@ -652,7 +696,7 @@ describe("the URL seam", () => {
         gateway.seed(threadId, "rendered-hash");
         let capturedUrl: string | undefined;
         let resolvedArgs: { pagePath: string; analysisId: string; threadId: string; auth: AuthContext } | undefined;
-        const stub: PageCapture = { screenshotBase64: "BASE64PNG", coverage: "full", consoleErrors: [], failedRequests: [] };
+        const stub: PageCapture = { screenshots: [{ base64: "BASE64PNG" }], coverage: { kind: "full" }, consoleErrors: [], failedRequests: [] };
         const capture: CapturePage = (url) => {
             capturedUrl = url;
             return Promise.resolve(stub);

--- a/harness/src/tools/report-session/examine-page.ts
+++ b/harness/src/tools/report-session/examine-page.ts
@@ -29,9 +29,9 @@
  *
  * On a capture the tool copies the rendered hash onto the seen hash through the gateway. Thus the look
  * counts, and the record tool lets the current draft record. The copy takes the rendered hash and never the
- * current one, thus a later edit makes the look stale and the record refuses. A picture of the window alone
- * is a true picture of the current document, thus it stamps the same and the coverage of the result is what
- * tells the agent what it saw.
+ * current one, thus a later edit makes the look stale and the record refuses. A partial look — the window
+ * alone, or slices that a budget truncated — is a true look at the current document, thus it stamps the same
+ * and the coverage of the result is what tells the agent what it saw.
  *
  * The gateway reports whether a rendered hash existed to copy. When the row holds none, no preview stamped
  * one and the look cannot count. The tool then gives a missed-stamp outcome that directs a new preview,
@@ -56,14 +56,14 @@ import { hasBrowserUrl, type ChromeConfig } from "../../lib/chrome.js";
 import { createNoopLogger } from "../../lib/console-logger.js";
 import { createStaticEyes, type AcquireEyes, type EyesLease, type EyesScope } from "../../lib/eyes.js";
 import { defaultErrorFields, type Logger } from "../../lib/logger.js";
-import { capturePage, type CapturePage, type FailedRequest, type PageCapture } from "../../lib/page-capture.js";
+import { capturePage, type CaptureCoverage, type CapturePage, type FailedRequest, type PageCapture } from "../../lib/page-capture.js";
 import { reportSessionDir, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
-import { defineTool, withToolResultImage, type Tool, type ToolError } from "../define-tool.js";
+import { defineTool, withToolResultImages, type Tool, type ToolError } from "../define-tool.js";
 import { openReportThread, type ReportSessionStateGateway, type SessionRefusal } from "../report-authoring/authoring-tools.js";
 
-// The capture shapes live beside the chrome connection, because two tools capture the same page. The tool
-// keeps them on its own surface, thus a consumer of the tool imports one module.
-export type { CapturePage, FailedRequest, PageCapture };
+// The capture shapes live beside the chrome connection. The tool keeps them on its own surface, thus a
+// consumer of the tool imports one module.
+export type { CaptureCoverage, CapturePage, FailedRequest, PageCapture };
 
 /**
  * The URL formation of one look. It maps the page of the thread onto the URL that the browser opens.
@@ -78,15 +78,24 @@ const examinePageInput = z.object({});
 
 export type ExaminePageInput = z.infer<typeof examinePageInput>;
 
+/** The document range of one slice of a tiled look, in the order that the pictures ride. */
+export interface ExaminedTile {
+    index: number;
+    fromY: number;
+    toY: number;
+}
+
 /**
  * The typed outcome of the eyes tool. Each arm is ok-channel data, thus the tool never throws for a
- * degraded condition. `examined` carries the coverage of the picture, the console errors, the failed
- * requests, and the page path. The coverage names what the agent saw: the whole document, or the window
- * alone when the browser refused a full-page bitmap. The screenshot does not ride the JSON. It rides the
- * image path of the tool result, thus the model sees the picture and the JSON text holds no bytes.
- * `missed-stamp` means that the row holds no rendered hash, thus no preview stamped one and the agent must
- * run a new preview before the next look. `no-browser` means that the composition gives no browser, thus no
- * look is possible at all and a repeat gives the same answer.
+ * degraded condition. `examined` carries the coverage of the look, the console errors, the failed
+ * requests, and the page path. The coverage names what the agent saw: the whole document in one shot,
+ * consecutive slices with the captured and the total pixels, or the window alone when the browser refused
+ * the bitmap. A tiled look carries `tiles` — the document range of each slice, in the order of the
+ * pictures — thus the model reads which rows each picture holds. The screenshots do not ride the JSON.
+ * They ride the image path of the tool result in document order, thus the model sees the pictures and the
+ * JSON text holds no bytes. `missed-stamp` means that the row holds no rendered hash, thus no preview
+ * stamped one and the agent must run a new preview before the next look. `no-browser` means that the
+ * composition gives no browser, thus no look is possible at all and a repeat gives the same answer.
  */
 export type ExaminePageResult =
     | { outcome: "refused"; refusal: SessionRefusal }
@@ -94,7 +103,14 @@ export type ExaminePageResult =
     | { outcome: "no-page" }
     | { outcome: "missed-stamp" }
     | { outcome: "capture-failed"; detail: string }
-    | { outcome: "examined"; coverage: PageCapture["coverage"]; consoleErrors: string[]; failedRequests: FailedRequest[]; pagePath: string };
+    | {
+          outcome: "examined";
+          coverage: CaptureCoverage;
+          tiles?: ExaminedTile[];
+          consoleErrors: string[];
+          failedRequests: FailedRequest[];
+          pagePath: string;
+      };
 
 /**
  * The construction deps of the eyes tool.
@@ -337,8 +353,9 @@ export function createExaminePageTool(deps: ExaminePageToolDeps): Tool<ExaminePa
         id: "examine_page",
         description:
             "Open the rendered report page in a real headless browser, and report what you see. " +
-            "Give back a screenshot, the coverage of that screenshot, the console errors, and the failed requests. " +
-            "The coverage says whether the picture holds the whole page, or the top window alone. " +
+            "Give back one or more screenshots, the coverage of the look, the console errors, and the failed requests. " +
+            "A tall page arrives as consecutive top-to-bottom slices in document order, and the tiles list names the rows of each slice. " +
+            "The coverage says whether the pictures hold the whole page, a truncated top portion of it, or the top window alone. " +
             "Run it after the preview to look at the current page, and to confirm that the layout and the charts read clean. " +
             "The report tool records a version only after you look at the current page. " +
             "If the page has no confirmed render, run the preview again first.",
@@ -432,18 +449,24 @@ export function createExaminePageTool(deps: ExaminePageToolDeps): Tool<ExaminePa
                 logger.warn("the seen hash did not stamp", { threadId, analysisId, detail });
             }
 
-            // The screenshot rides the image path of the tool result, thus the model sees the picture. The
-            // JSON keeps the faults and the page path only, thus the JSON text holds no bytes.
+            // The screenshots ride the image path of the tool result in document order, thus the model sees
+            // the pictures. The JSON keeps the faults, the tile ranges, and the page path only, thus the
+            // JSON text holds no bytes. The tiles list mirrors the picture order, thus the model reads which
+            // rows each picture holds.
+            const tiles: ExaminedTile[] = captured.screenshots.flatMap((shot, index) =>
+                shot.range === undefined ? [] : [{ index, fromY: shot.range.fromY, toY: shot.range.toY }],
+            );
             return ok(
-                withToolResultImage(
+                withToolResultImages(
                     {
                         outcome: "examined" as const,
                         coverage: captured.coverage,
+                        ...(tiles.length === 0 ? {} : { tiles }),
                         consoleErrors: captured.consoleErrors,
                         failedRequests: captured.failedRequests,
                         pagePath: relativePagePath,
                     },
-                    { base64: captured.screenshotBase64, mediaType: SCREENSHOT_MEDIA_TYPE },
+                    captured.screenshots.map((shot) => ({ base64: shot.base64, mediaType: SCREENSHOT_MEDIA_TYPE })),
                 ),
             );
         },

--- a/harness/src/tools/report-session/index.ts
+++ b/harness/src/tools/report-session/index.ts
@@ -16,7 +16,9 @@ export {
 } from "./preview-report.js";
 export {
     createExaminePageTool,
+    type CaptureCoverage,
     type CapturePage,
+    type ExaminedTile,
     type ExaminePageInput,
     type ExaminePageResult,
     type ExaminePageToolDeps,


### PR DESCRIPTION
## Why

A production report session died in staging on 2026-08-18: `examine_page` captured a long report page with `page.screenshot({fullPage: true})`, Chrome rendered a ~12000px bitmap without complaint, and Anthropic rejected the whole request with HTTP 400 `invalid_request_error` — "At least one of the image dimensions exceed max allowed size: 8000 pixels" — killing the entire chat turn. The existing viewport fallback in `captureShot` never fired, because it guards a Chrome refusal and the failure surfaced at the provider, where capture code cannot see it.

Scaling loses to tiling: the provider downscales every image to ~1568px on the long side before the model reads it, so even a legal 7000px-tall single capture reaches the model compressed past legibility. Slices are the only shape that both survives the cap and stays readable.

## What

### Tiled capture (`src/lib/page-capture.ts`)

- After the readiness wait the capture measures `document.documentElement.scrollHeight`. A page at `TILE_HEIGHT_PX` (2 × viewport height = 1800px) or under keeps today's single full-page shot — it survives the downscale whole.
- A taller page captures consecutive vertical clips of 1800px at the 1440px reader width, in document order, up to `MAX_TILES = 6` (10800px of coverage).
- A page taller than the budget covers truncates **honestly**: the coverage reports `capturedPx` vs `totalPx`. No silent truncation.
- The Chrome-refusal degradation stays around both shapes: a thrown capture retries once at the window (`viewport` coverage), cause-chaining preserved.
- New contract: `PageCapture.screenshots: [{ base64, range?: { fromY, toY } }]` plus a coverage discriminant — `{ kind: "full" }` | `{ kind: "tiled", capturedPx, totalPx }` | `{ kind: "viewport" }`. `examine_page` is the sole consumer (the old report path is gone).

### Multi-image tool results (`src/loop/run-agent.ts`, `src/tools/define-tool.ts`)

- The tool-result value convention becomes an ordered list: `withToolResultImages` attaches a list, `readToolResultImages` reads either shape (single image tolerated) as a list.
- All three placement arms generalize: the `tool-result` arm encodes `[text, ...files]` in order; the `user-message` arm defers each picture into the round collector, order preserved, with numbered labels; the `drop` arm records one warn carrying the count.
- **No new capability flag**: `imageToolResults` / `imageUserMessages` gate as before — every supported wire that accepts one image block accepts several, so a config that declares the capability declares it for the list.

### Eyes tool + prompt

- The `examined` outcome gains the coverage discriminant and a `tiles: [{ index, fromY, toY }]` list mirroring the picture order, so the model knows which rows each image holds. Slices ride the image path of the tool result in document order.
- The report-session prompt teaches the sliced look: slices read as one page top-to-bottom, and truncated coverage means the tail of the page was not seen — absent from the look, not from the page.

### OpenSpec

`openspec/changes/tile-the-tall-page-capture/` (proposal, design, tasks) with deltas to `report-verification`, `harness-agent-loop`, and `report-session-agent`. Validates `--strict`.

### Release

Deferred — no version bump in this PR; the harness releases after further changes land.

## Validation

- `bun run typecheck`, `bun run lint` — clean.
- `bun test` on `src/loop/` (full), `src/lib/page-capture.test.ts`, `src/tools/report-session/examine-page.test.ts`, `src/app/spawn-report-session.test.ts`, `src/prompts/` — 260 pass, 0 fail.
