### PR TITLE
docs(harness): propose the citation-grounding ledger

### DIFF
--- a/harness/openspec/changes/citation-grounding-ledger/.openspec.yaml
+++ b/harness/openspec/changes/citation-grounding-ledger/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/harness/openspec/changes/citation-grounding-ledger/design.md
+++ b/harness/openspec/changes/citation-grounding-ledger/design.md
@@ -1,0 +1,61 @@
+# Design: citation-grounding-ledger
+
+## Context
+
+The run synthesizer emits `findings[].references[].pmid` through its `submit_synthesis` terminal tool (`src/execution/run-synthesis.ts:357`). The semantic validation tests only the numeric format (`run-synthesis.ts:184`). The prompt rule says that each PMID must come from a `literature_reviewer` response (`src/prompts/synthesis-agent.ts:148`). No code enforces that rule.
+
+The reviewer tool runs an inner agent loop and returns its final text (`src/tools/research/literature-reviewer.ts:115`). The inner transcript holds the tool results of the reviewer, and those results carry the PMIDs from the bibliographic authorities. The transcript is in scope inside the tool `execute`, and the loop stores a tool result as a typed `tool-result` part (`src/loop/run-agent.ts:446`).
+
+The analogical reasoner (`src/tools/research/generate-analogy-report.ts:194`) and the target-assessment critique (`src/workflows/execute-target-assessment.ts:537`) cite literature with no verification tool.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A model-written PMID in a synthesis finding is grounded in a tool result, and the gate is mechanical.
+- The analogical reasoner and the target-assessment critique can call `resolve_citation`.
+
+**Non-Goals:**
+
+- No authority resolution inside the gate. The ledger entries already come from an authority.
+- No gate on the prose report of the reviewer, on a step summary, or on a chat reply.
+- No DOI or arXiv entries in the ledger. The synthesis references hold PMIDs only.
+- No change to the sandbox agent metas.
+
+## Decisions
+
+### 1. A transcript ledger, not authority resolution, blocks at the gate
+
+The gate accepts a PMID only when a prior tool result carried it. This is deterministic, synchronous, and free of network failure modes. The alternative was `resolveMany` at submit time. That proves existence, but it adds latency, rate limits, and an outage policy to a validation path. The ledger chain ends at PubMed itself, thus resolution adds no new proof.
+
+### 2. The ledger collects from the inner tool results of the reviewer
+
+`createLiteratureReviewerTool` gains an optional `citationLedger` dependency. After the inner `runAgent` returns, the tool extracts the PMIDs from the `tool-result` parts of the inner transcript. It records them into the ledger. The prose report is not a source, because the report is model text. A PMID that the reviewer invents thus stays out of the ledger, and the gate downstream rejects it.
+
+### 3. Extraction is field-aware, with a contextual text pattern as the second source
+
+The extractor walks a parsed tool-result value. It collects a value whose key is `pmid` (case-insensitive) and whose text fits the PMID format. In a plain string it collects only a `PMID: <digits>` contextual match, never a bare number. A bare-number rule would collect years and counts, and an over-full ledger weakens the gate. A missed identifier causes a rejection, and the loop recovers through re-delegation to the reviewer. The helper lives in `src/citations/ledger.ts` with the ledger factory.
+
+### 4. The gate is a pure semantic check over closure state
+
+`InnerToolContext` (`run-synthesis.ts:92`) gains the ledger. Two new checks join `semanticCheck`: one over `findings[].references[].pmid`, one over `keyReferences[].pmid`. A rejection names each ungrounded PMID and points the model at `literature_reviewer`. The checks stay synchronous, and the validate and submit tools keep their shape.
+
+### 5. The reasoner and the critique get the voluntary tool, not a gate
+
+Their outputs are prose and supplied-evidence citations, and the target-assessment validator already tests dossier self-consistency. A gate there is a larger design with its own submit protocol. This change adds `resolve_citation` to `reasonerTools` and to `critiqueTools`, plus the prompt teaching.
+
+### 6. Wiring follows the existing dependency pattern
+
+- `createGenerateAnalogyReportTool` gains `citationResolver` in its deps. The conversation agent has the resolver in scope (`src/agents/conversation-agent.ts:216`).
+- `ExecuteTargetAssessmentDeps` gains `citationResolver`. `assembleCoreRuntime` passes the resolver that it already builds (`src/runtime/assemble.ts:283`), in the same way as `usageRecorder` (`assemble.ts:293`).
+
+## Risks / Trade-offs
+
+- [Under-extraction causes a spurious rejection] → The contextual pattern plus the field walk covers the pubmed and reviewer result shapes. The rejection message gives the recovery path, and the loop is re-callable.
+- [A step-summary PMID is now rejected] → This is deliberate. The prompt already forbids it, and the reviewer path confirms such a PMID in one delegation.
+- [The ledger trusts tool results] → An entry comes from an authority response, not from model text. `resolve_citation` stays available for a caller-supplied citation.
+- [A larger synthesis prompt] → The synthesis prompt is a static constant, thus the prompt-cache prefix changes one time and stays stable.
+
+## Migration Plan
+
+No persisted shape changes. The change is additive, and a revert restores the old gate.

--- a/harness/openspec/changes/citation-grounding-ledger/proposal.md
+++ b/harness/openspec/changes/citation-grounding-ledger/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: citation-grounding-ledger
+
+## Why
+
+The run synthesizer writes `findings[].references[].pmid` into durable, indexed findings. The only guard on those identifiers is a prompt rule plus a format validation (`src/execution/run-synthesis.ts:184`). Thus a model-invented PMID that fits the format persists as evidence. The analogical reasoner and the target-assessment critique also write citations with no verification tool at all.
+
+## What Changes
+
+- Add a citation ledger: a loop-scoped record of each bibliographic identifier that a tool result carried.
+- The literature-reviewer tool records the identifiers from its inner tool results into the ledger of its caller. Its prose report is not a ledger source, thus an identifier that the reviewer invents does not enter the ledger.
+- The `validate_synthesis` and `submit_synthesis` tools reject a finding reference or a key reference whose PMID is not in the ledger. The rejection names each ungrounded PMID, and the loop continues.
+- Add the `resolve_citation` tool to the analogical reasoner and to the target-assessment critique agent. Plumb the `CitationResolver` into the target-assessment workflow dependencies for this.
+- Extend the synthesis-agent prompt and the critique prompt with the new mechanism.
+
+The gate is deterministic and local. It makes no network call, because each ledger entry already comes from a bibliographic authority through a tool result.
+
+## Capabilities
+
+### New Capabilities
+
+- `citation-grounding`: the ledger primitive, its extraction rules, and the grounding gate of the run synthesizer. It also gives `resolve_citation` to the analogical reasoner and to the target-assessment critique.
+
+### Modified Capabilities
+
+- `literature-reviewer`: the semantic validation of `submit_synthesis` gains a grounding rejection, and the reviewer tool contract gains the ledger contribution from its inner transcript.
+
+## Impact
+
+- `src/execution/run-synthesis.ts`: the ledger closure state and the new semantic checks.
+- `src/tools/research/literature-reviewer.ts`: the ledger contribution from the inner transcript.
+- `src/citations/`: the identifier extraction helper.
+- `src/tools/research/generate-analogy-report.ts`: `resolve_citation` in the reasoner tool set.
+- `src/workflows/execute-target-assessment.ts` and `src/workflows/target-assessment/investigation/index.ts`: the resolver dependency and the critique tool set.
+- `src/prompts/synthesis-agent.ts`, `src/prompts/analogical-reasoner.ts`, and the critique prompt: teach the mechanism.
+- No breaking change to a public export. The `literature-reviewer` tool signature gains an optional ledger dependency.

--- a/harness/openspec/changes/citation-grounding-ledger/specs/citation-grounding/spec.md
+++ b/harness/openspec/changes/citation-grounding-ledger/specs/citation-grounding/spec.md
@@ -1,0 +1,70 @@
+# citation-grounding Specification
+
+## ADDED Requirements
+
+### Requirement: The citation ledger records identifiers from tool results
+
+The harness MUST give a citation ledger factory, `createCitationLedger()`, in `harness/src/citations/ledger.ts`. A ledger MUST expose `add(pmids)` and `has(pmid)`. The module MUST also give an extraction helper that walks a tool-result value. The helper MUST collect a value whose key is `pmid` (case-insensitive) and whose text fits the PMID format. Inside a plain string, the helper MUST collect only a `PMID: <digits>` contextual match. The helper MUST NOT collect a bare number, because years and counts would then enter the ledger.
+
+#### Scenario: Field-aware extraction
+
+- **WHEN** the extractor walks a tool result that holds `{ "pmid": "12345678" }` at any depth
+- **THEN** the extraction result contains `12345678`
+
+#### Scenario: Contextual extraction from text
+
+- **WHEN** the extractor walks a string value that contains `PMID: 23456789`
+- **THEN** the extraction result contains `23456789`
+
+#### Scenario: A bare number is not collected
+
+- **WHEN** the extractor walks a string value that contains `2023` or `n=1500` with no `pmid` key and no `PMID:` prefix
+- **THEN** the extraction result contains neither number
+
+### Requirement: The run-synthesizer gate accepts only a grounded PMID
+
+The run-synthesizer loop MUST hold one citation ledger per `generateRunSynthesis` call. The embedded `literature_reviewer` tool MUST record into that ledger. The semantic validation of `validate_synthesis` and `submit_synthesis` MUST reject a `findings[].references[].pmid` or a `keyReferences[].pmid` that the ledger does not hold. The rejection issue MUST name each ungrounded PMID, and its hint MUST point the agent at `literature_reviewer`. The synthesis-agent prompt MUST state that this gate is mechanical.
+
+#### Scenario: An invented PMID is rejected
+
+- **WHEN** the synthesizer submits a finding reference with a PMID that no tool result of the loop carried
+- **THEN** `submit_synthesis` returns `{ accepted: false, issues }` and one issue names that PMID as ungrounded
+
+#### Scenario: A PMID copied from a step summary is rejected
+
+- **WHEN** a step summary in the loop input carries a PMID and the synthesizer cites it without a `literature_reviewer` delegation
+- **THEN** the submission is rejected, and the hint tells the agent to confirm the PMID through `literature_reviewer`
+
+#### Scenario: A grounded PMID is accepted
+
+- **WHEN** the synthesizer cites a PMID that a `literature_reviewer` call surfaced from its inner tool results
+- **AND** the payload passes each other validation
+- **THEN** `submit_synthesis` returns `{ accepted: true }`
+
+### Requirement: The analogical reasoner can resolve a citation
+
+`createGenerateAnalogyReportTool` MUST take a `citationResolver` dependency, and `reasonerTools` MUST include the `resolve_citation` tool. The analogical-reasoner prompt MUST name the tool for the verification of a citation identity, not for topical discovery.
+
+#### Scenario: Tool inventory of the reasoner
+
+- **WHEN** the analogical-reasoner agent definition is inspected
+- **THEN** its tool array contains `resolve_citation` next to the cross-domain search tools
+
+#### Scenario: The conversation agent wires the resolver
+
+- **WHEN** `createConversationAgent` builds the analogy-report tool
+- **THEN** it passes the same `CitationResolver` that its own `resolve_citation` tool uses
+
+### Requirement: The target-assessment critique can resolve a citation
+
+`ExecuteTargetAssessmentDeps` MUST carry a `citationResolver`, and the critique tool set MUST include the `resolve_citation` tool next to the PubMed tool. `assembleCoreRuntime` MUST pass the resolver that it builds, in the same way as `usageRecorder`. The critique prompt MUST name the tool as the way to confirm a cited reference.
+
+#### Scenario: Tool inventory of the critique
+
+- **WHEN** the critique agent loop is built inside the target-assessment investigation
+- **THEN** its tool array contains `resolve_citation` and the PubMed tool
+
+#### Scenario: The composition root wires the resolver
+
+- **WHEN** `assembleCoreRuntime` registers the target-assessment workflow
+- **THEN** the workflow deps carry the `CitationResolver` that the runtime built

--- a/harness/openspec/changes/citation-grounding-ledger/specs/literature-reviewer/spec.md
+++ b/harness/openspec/changes/citation-grounding-ledger/specs/literature-reviewer/spec.md
@@ -1,0 +1,71 @@
+# literature-reviewer Delta
+
+## MODIFIED Requirements
+
+### Requirement: Sub-agent packaged as a tool
+
+The harness MUST expose the `literature-reviewer` as a sub-agent in the shape of a tool. Its `execute` MUST call `runAgent` with a focused agent definition. The child `Session` MUST come from `forSubAgent(parentSession, "literature-reviewer")`.
+
+The factory `createLiteratureReviewerTool(deps)` lives at `harness/src/tools/research/literature-reviewer.ts`. It captures its `ChatProvider`, model id, and `bioKeys` dependencies. The child loop uses `passthroughStep`, because the tool call of the parent is the durable step. The tool MUST return `ok({ report })`, where `report` is the final text of the child transcript.
+
+The factory MUST also accept an optional `citationLedger` dependency. When the ledger is present, the tool MUST extract the PMIDs from the `tool-result` parts of the inner transcript. This extraction runs after the child loop returns, and the tool MUST record the PMIDs into the ledger. The prose report MUST NOT be a ledger source, because the report is model text.
+
+#### Scenario: Tool creation
+
+- **WHEN** `createLiteratureReviewerTool(deps)` runs
+- **THEN** the returned `Tool` has the on-wire id `literature_reviewer`
+- **AND** `execute(input, ctx)` runs `runAgent` over the sub-agent definition, with a session from `forSubAgent`
+
+#### Scenario: Child transcript is ephemeral
+
+- **WHEN** the literature-reviewer tool completes
+- **THEN** no store persists the working message array of the child (the sub-agent delegation rule of the harness-agent-loop spec)
+- **AND** the parent loop sees only the `ok({ report })` return value of the tool
+
+#### Scenario: Ledger contribution from the inner transcript
+
+- **WHEN** the tool runs with a `citationLedger` and an inner tool result carries a PMID
+- **THEN** the ledger holds that PMID after the tool returns
+
+#### Scenario: A report-only PMID stays out of the ledger
+
+- **WHEN** the final report of the child names a PMID that no inner tool result carried
+- **THEN** the ledger does not hold that PMID
+
+### Requirement: submit_synthesis validates and is re-callable; no-terminal throws
+
+`submit_synthesis` MUST validate the submitted payload again, against `RunSynthesisSchema` plus the semantic validations. The semantic validations are:
+
+- the runId match
+- the stepId references
+- the theme-to-finding references
+- the keyReferences citation rule
+- the numeric PMID format
+- the citation-ledger grounding, per the `citation-grounding` spec
+
+On success the tool returns `{ accepted: true }`. On rejection it returns `{ accepted: false, issues }`, and the agent can correct the cited issue paths and call again.
+
+When the loop ends without a terminal tool call, `runToTerminal` MUST grant one salvage continuation. The tools of that continuation are only the terminal tools. If the continuation also ends without a terminal tool call, `generateRunSynthesis` MUST throw.
+
+A genuine synthesis failure MUST re-throw out of `synthesizeRun`, after a `failed` progress phase. Thus the run fails loudly. Only the honest non-fatal outcomes return empty findings after a `skipped` phase. Those outcomes are the no-step-summaries condition and a `report_blocker` call.
+
+#### Scenario: Rejected submission is fixed and resubmitted
+
+- **WHEN** `submit_synthesis` returns `{ accepted: false, issues }`
+- **THEN** the agent corrects the fields at the cited issue paths and calls `submit_synthesis` again
+
+#### Scenario: An ungrounded PMID is a rejection
+
+- **WHEN** the payload cites a PMID that the citation ledger does not hold
+- **THEN** `submit_synthesis` returns `{ accepted: false, issues }` and one issue names that PMID
+
+#### Scenario: Blocker is a non-fatal skip
+
+- **WHEN** the synthesizer calls `report_blocker`
+- **THEN** `synthesizeRun` reports a `skipped` phase with the blocker reason and returns empty findings
+
+#### Scenario: No terminal call fails the run
+
+- **WHEN** the loop and its salvage continuation both end without a terminal tool call
+- **THEN** `generateRunSynthesis` throws
+- **AND** `synthesizeRun` re-throws, and the run fails loudly

--- a/harness/openspec/changes/citation-grounding-ledger/tasks.md
+++ b/harness/openspec/changes/citation-grounding-ledger/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: citation-grounding-ledger
+
+## 1. The ledger primitive
+
+- [ ] 1.1 Make `src/citations/ledger.ts` with `createCitationLedger()`, `add(pmids)`, and `has(pmid)`
+- [ ] 1.2 Add the extraction helper: the `pmid` key walk and the `PMID: <digits>` contextual match
+- [ ] 1.3 Write the unit tests for the three extraction scenarios of the `citation-grounding` spec
+
+## 2. The reviewer ledger contribution
+
+- [ ] 2.1 Add the optional `citationLedger` dependency to `createLiteratureReviewerTool`
+- [ ] 2.2 After the child loop returns, extract the PMIDs from the inner `tool-result` parts and record them
+- [ ] 2.3 Write the tests: an inner tool-result PMID enters the ledger, and a report-only PMID does not
+
+## 3. The synthesizer gate
+
+- [ ] 3.1 Add the ledger to `InnerToolContext`, and make one ledger per `generateRunSynthesis` call
+- [ ] 3.2 Pass the ledger into the embedded reviewer tool of the loop
+- [ ] 3.3 Add the grounding validation of `findings[].references[].pmid` and `keyReferences[].pmid` to `semanticCheck` and to `salvagedSemanticCheck`
+- [ ] 3.4 Shape the rejection issue: name each ungrounded PMID, and point the hint at `literature_reviewer`
+- [ ] 3.5 Extend `__buildInnerToolsForTest` with the ledger argument
+- [ ] 3.6 Update `src/prompts/synthesis-agent.ts`: state that the gate is mechanical
+- [ ] 3.7 Write the tests for the three gate scenarios of the `citation-grounding` spec
+
+## 4. The analogical reasoner tool
+
+- [ ] 4.1 Add `citationResolver` to `GenerateAnalogyReportDeps`, and add `resolve_citation` to `reasonerTools`
+- [ ] 4.2 Pass the resolver at the conversation-agent call site of `createGenerateAnalogyReportTool`
+- [ ] 4.3 Update `src/prompts/analogical-reasoner.ts`: name the tool for citation-identity verification
+
+## 5. The target-assessment critique tool
+
+- [ ] 5.1 Add `citationResolver` to `ExecuteTargetAssessmentDeps`
+- [ ] 5.2 Add `resolve_citation` to the critique tool set at the `critiqueTools` build site
+- [ ] 5.3 Pass the resolver in `assembleCoreRuntime`, in the same way as `usageRecorder`
+- [ ] 5.4 Update the critique prompt: name the tool as the way to confirm a cited reference
+
+## 6. Verification
+
+- [ ] 6.1 Run `tsc -p tsconfig.json` in `harness/`
+- [ ] 6.2 Run `bun test` in `harness/`
+- [ ] 6.3 Run `bun run format:file` on each changed source file


### PR DESCRIPTION
## What & why

This pull request adds the OpenSpec change `citation-grounding-ledger`, documents only. The run synthesizer writes model-generated PMIDs into durable findings. The only guard is a prompt rule plus a format validation (`harness/src/execution/run-synthesis.ts:184`). The change proposes a citation ledger: the literature-reviewer tool records each PMID that its inner tool results carried, and `submit_synthesis` rejects a PMID outside the ledger.

The gate is deterministic, and it makes no network call. The change also gives the voluntary `resolve_citation` tool to the analogical reasoner and to the target-assessment critique.

Notes for the reviewer:

- The ledger source is the inner tool results of the reviewer, not its prose report. Thus a PMID that the reviewer invents stays out of the ledger.
- The gate rejects a PMID that only a step summary carries, and this is deliberate. The synthesis prompt already forbids that path, and the gate now enforces it.
- The sandbox agent metas and the report session stay out of scope. The report session already binds each citation to pinned evidence.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [x] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
