### PR TITLE
fix(harness): measure an over-long tool argument, and widen the audience bound

### DIFF
--- a/harness/src/lib/zod-issues.test.ts
+++ b/harness/src/lib/zod-issues.test.ts
@@ -26,6 +26,36 @@ const NestedSchema = z.object({
 });
 
 describe("hintForZodIssue", () => {
+    test("measures a string that went past its maximum length", () => {
+        const schema = z.object({ audience: z.string().max(400) });
+        const input = { audience: "x".repeat(463) };
+
+        const [issue] = issuesFor(schema, input);
+        const hint = hintForZodIssue(issue!, input);
+
+        expect(hint).toBeDefined();
+        expect(hint).toContain("463 characters");
+        expect(hint).toContain("63 characters");
+    });
+
+    test("stays silent for a string that is too short", () => {
+        const schema = z.object({ audience: z.string().min(4) });
+        const input = { audience: "ab" };
+
+        const [issue] = issuesFor(schema, input);
+
+        expect(hintForZodIssue(issue!, input)).toBeUndefined();
+    });
+
+    test("stays silent when a maximum applies to an array, not to a string", () => {
+        const schema = z.object({ steps: z.array(z.string()).max(1) });
+        const input = { steps: ["a", "b"] };
+
+        const [issue] = issuesFor(schema, input);
+
+        expect(hintForZodIssue(issue!, input)).toBeUndefined();
+    });
+
     test("hints when an object field arrived as a JSON-encoded string", () => {
         const schema = z.object({ synthesis: z.object({ runId: z.string() }) });
         const input = { synthesis: JSON.stringify({ runId: "run-1" }) };

--- a/harness/src/lib/zod-issues.ts
+++ b/harness/src/lib/zod-issues.ts
@@ -21,7 +21,9 @@
  *    caller's data; it distinguishes the two modes so the message the model
  *    reads matches the mistake it actually made. When neither mode explains the
  *    string it stays silent, because speculative advice to a model that is
- *    already misdiagnosing is worse than no advice at all.
+ *    already misdiagnosing is worse than no advice at all. It also measures a
+ *    string that broke a maximum length, because the Zod message gives the
+ *    bound and never the length that arrived.
  *  - `repairToolInput` — an **issue-guided** repair: only a path where the
  *    schema wanted an `object` or `array` and found a string is even considered,
  *    so a tool that legitimately declares a `z.string()` field is never touched.
@@ -61,9 +63,12 @@ const TRAILING_CALL_TAGS = /<\/parameter>\s*(?:<\/invoke>\s*)?$/;
  * said. `input` is the raw value that failed validation — the same value handed
  * to `safeParse` — because the issue alone does not carry the offending value.
  *
- * Fires only for an `invalid_type` issue wanting an `object` or an `array` whose
- * path resolves to a string, and only when that string demonstrably *is* the
- * expected value:
+ * Fires for a `too_big` issue on a string, which yields the length that arrived
+ * and the count to remove.
+ *
+ * Fires otherwise only for an `invalid_type` issue wanting an `object` or an
+ * `array` whose path resolves to a string, and only when that string
+ * demonstrably *is* the expected value:
  *
  *  1. it parses in full as JSON of the expected type → double encoding, and
  *  2. it parses only once a wrapper artifact is stripped → the value is intact
@@ -76,6 +81,9 @@ const TRAILING_CALL_TAGS = /<\/parameter>\s*(?:<\/invoke>\s*)?$/;
  * `undefined` rather than throwing.
  */
 export function hintForZodIssue(issue: z.core.$ZodIssue, input: unknown): string | undefined {
+    const overLength = hintForOverLongString(issue, input);
+    if (overLength !== undefined) return overLength;
+
     const expected = repairableExpectation(issue);
     if (expected === undefined) return undefined;
 
@@ -132,6 +140,30 @@ export function repairToolInput(input: unknown, error: z.ZodError): unknown | un
     } catch {
         return undefined;
     }
+}
+
+/**
+ * The measurement of a string that broke its maximum length, or `undefined` for
+ * any other issue.
+ *
+ * A Zod `too_big` message names the bound and stops there. A model reasons in
+ * tokens, thus it cannot count the characters that it sent, and it cuts by
+ * guess. Each guess costs one rejected call. The hint gives the two numbers
+ * that end the guess: the length that arrived, and the count to remove.
+ */
+function hintForOverLongString(issue: z.core.$ZodIssue, input: unknown): string | undefined {
+    if (issue.code !== "too_big" || issue.origin !== "string") return undefined;
+
+    const value = resolvePath(input, issue.path);
+    if (typeof value !== "string") return undefined;
+
+    const maximum = Number(issue.maximum);
+    if (!Number.isFinite(maximum)) return undefined;
+
+    const excess = value.length - maximum;
+    if (excess <= 0) return undefined;
+
+    return `This argument arrived with ${value.length} characters. Remove at least ${excess} characters, and send it again.`;
 }
 
 /** The `object`/`array` expectation of an `invalid_type` issue, if it has one. */

--- a/harness/src/tools/start-report-session.test.ts
+++ b/harness/src/tools/start-report-session.test.ts
@@ -394,8 +394,8 @@ describe("the bounds of the brief", () => {
     it("refuses a field past its bound, and accepts the same field at the bound", async () => {
         // The bound of `audience` is the smallest of the five, thus one long value
         // shows the rule with no dependence on the number itself.
-        const atBound = { ...INPUT, audience: "x".repeat(200) };
-        const pastBound = { ...INPUT, audience: "x".repeat(201) };
+        const atBound = { ...INPUT, audience: "x".repeat(400) };
+        const pastBound = { ...INPUT, audience: "x".repeat(401) };
 
         expect(tool.inputSchema.safeParse(atBound).success).toBe(true);
         expect(tool.inputSchema.safeParse(pastBound).success).toBe(false);

--- a/harness/src/tools/start-report-session.ts
+++ b/harness/src/tools/start-report-session.ts
@@ -36,16 +36,20 @@ import { defineTool, type Tool, type ToolError } from "./define-tool.js";
  * message row, thus the schema holds no unbounded string out of the store.
  *
  * The description caps the brief at approximately 2000 tokens, and a token is
- * about four characters. Thus the five bounds sum to 8000 characters, and the
+ * about four characters. Thus the five bounds sum to 8200 characters, and the
  * widest brief that the schema admits still meets the cap that the agent reads.
  *
  * The share of each field follows its role. `audience` names one reader, thus a
  * phrase is enough. `objective` and `angle` carry a sentence or two. Each
  * optional field carries a list of items, thus it takes the largest share.
+ *
+ * The bound of `audience` holds 400 characters, not the 200 that the phrase
+ * alone needs. A model counts tokens, not characters, thus a tight bound gives
+ * a rejected call and a retry.
  */
 const BRIEF_MAX = {
     objective: 1500,
-    audience: 200,
+    audience: 400,
     angle: 1500,
     exclusions: 2400,
     openQuestions: 2400,


### PR DESCRIPTION
## What & why

A `start_report_session` call in production sent an `audience` string past its 200-character bound. The loop rejected it four times before the model cut enough, because the message named the bound and never the length that arrived. A model reasons in tokens, thus it cannot count characters, and each retry was a guess.

`hintForZodIssue` now measures a `too_big` string, and it gives the length that arrived with the count to remove. The bound of `audience` goes to 400.

## Notes for a reviewer

- The measurement reaches the two other model-facing validation sites too, `execution/run-synthesis.ts` and `tools/research/generate-plan.ts`. Both already read the same hint.
- The five brief bounds now sum to 8200 characters. The description still caps the whole brief at approximately 2000 tokens, and 8200 characters sits inside that.
- The bound already reached the model as `maxLength` in the tool JSON Schema. The model ignored it, thus the hint is the part that changes the outcome.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
