### PR TITLE
fix(harness): run a session derivation in a workflow, not in the turn

### DIFF
--- a/cli/src/modules/harness/runtime.test.ts
+++ b/cli/src/modules/harness/runtime.test.ts
@@ -205,6 +205,14 @@ function recordingSeams(calls: string[]): BootSeams {
                         executeTargetAssessment: async () => ({ assessmentId: "", status: "completed", bytes: 0 }),
                         dataProfile: async () => {},
                         extractValues: async () => ({}),
+                        deriveTableExec: async () => ({
+                            execId: "",
+                            exitCode: 0,
+                            stdout: "",
+                            stderr: "",
+                            durationMs: 0,
+                            timedOut: false,
+                        }),
                     },
                     // `CoreRuntime` requires the resolver `assembleCoreRuntime` builds; the
                     // real (pure, network-lazy) constructor stands in here, matching how this

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/agents/report-session-agent.ts
+++ b/harness/src/agents/report-session-agent.ts
@@ -28,7 +28,7 @@ import type { Pool } from "pg";
 import type { AuthContext } from "../auth/types.js";
 import type { RunAuthorizer } from "../execution/run-authorizer.js";
 import type { AgentDefinition } from "../loop/types.js";
-import type { SandboxClient } from "../sandbox/client.js";
+import type { DeriveTableRunner } from "../tools/report-session/derive-table.js";
 import type { ReportSessionStateStore } from "../state/report-session-state.js";
 import type { Tool } from "../tools/define-tool.js";
 import type { EmbeddingProvider } from "../providers/types.js";
@@ -91,10 +91,11 @@ export interface ReportSessionAgentDeps {
     /** Derivation ledger -- the derivation tool appends one record for each derived table. */
     readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
     /**
-     * Sandbox seam -- the derivation tool runs one ephemeral container for each derived table. Omitted, the
-     * tool reports that the composition gives no sandbox, and it derives nothing.
+     * Derivation-exec seam -- the derivation tool runs one ephemeral container for each derived table, and
+     * the composition realizes this seam over a registered workflow. Omitted, the tool reports that the
+     * composition gives no sandbox, and it derives nothing.
      */
-    readonly sandboxClient?: SandboxClient;
+    readonly runDerivation?: DeriveTableRunner;
     /**
      * Run-authorization seam -- the derivation tool authorizes the exec and revokes on every terminal path.
      * Omitted, the tool derives nothing, the same as an absent sandbox client.
@@ -143,7 +144,7 @@ export interface ReportSessionAgentDeps {
 /** Build the report `AgentDefinition` with every tool bound to its deps. */
 export function createReportSessionAgent(deps: ReportSessionAgentDeps): AgentDefinition {
     const { model, pool, embedding, workspaceFs, gateway, resolveWorkspaceRoot, store, threads, chrome, eyes, makeResolver, resolvePageAsset, logger } = deps;
-    const { derivations, sandboxClient, runAuthorizer, makeSessionPages, resolvePageUrl } = deps;
+    const { derivations, runDerivation, runAuthorizer, makeSessionPages, resolvePageUrl } = deps;
     const authoring = createReportAuthoringTools(gateway);
 
     const tools: Tool[] = [
@@ -178,7 +179,7 @@ export function createReportSessionAgent(deps: ReportSessionAgentDeps): AgentDef
             gateway,
             resolveWorkspaceRoot,
             derivations,
-            ...(sandboxClient ? { sandboxClient } : {}),
+            ...(runDerivation ? { runDerivation } : {}),
             ...(runAuthorizer ? { runAuthorizer } : {}),
             ...(logger ? { logger } : {}),
         }),

--- a/harness/src/runtime/assemble.ts
+++ b/harness/src/runtime/assemble.ts
@@ -44,6 +44,9 @@ import {
     type ExtractValuesResult,
     type ExtractValuesWorkflowInput,
 } from "../tasks/extract-values.js";
+import { registerDeriveTableExecWorkflow, triggerDeriveTableExec } from "../tasks/derive-table-exec.js";
+import type { DeriveTableExecInput } from "../tools/report-session/derive-table.js";
+import type { ExecResult } from "../sandbox/types.js";
 import { createCitationResolver, type CitationResolverConfig } from "../citations/resolve.js";
 import type { CitationResolver } from "../citations/types.js";
 import type { AuthContext } from "../auth/types.js";
@@ -83,6 +86,7 @@ export interface RegisteredWorkflows {
     readonly executeTargetAssessment: (input: ExecuteTargetAssessmentInput) => Promise<ExecuteTargetAssessmentResult>;
     readonly dataProfile: (input: DataProfileWorkflowInput) => Promise<void>;
     readonly extractValues: (input: ExtractValuesWorkflowInput) => Promise<ExtractValuesResult>;
+    readonly deriveTableExec: (input: DeriveTableExecInput) => Promise<ExecResult>;
 }
 
 /**
@@ -300,6 +304,12 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
         runAuthorizer: wf.dataProfile.runAuthorizer,
         ...(wf.dataProfile.logger ? { logger: wf.dataProfile.logger } : {}),
     });
+    // A session derivation runs its container here and not in the turn. The await of an exec is a
+    // workflow-body call under the callback transport, thus the tool starts this workflow and awaits it.
+    const deriveTableExec = registerDeriveTableExecWorkflow({
+        sandboxClient: wf.dataProfile.sandboxClient,
+        ...(wf.dataProfile.logger ? { logger: wf.dataProfile.logger } : {}),
+    });
 
     // The session runtime binds the per-session state to the thread behind the
     // tool boundary, thus one instance serves every report thread. It comes before
@@ -373,7 +383,7 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
         // and the same run authorizer. Thus a session derivation and an extraction run on
         // one substrate, and neither one mints a run of the analysis.
         derivations: reportSession.derivations,
-        sandboxClient: wf.dataProfile.sandboxClient,
+        runDerivation: (input) => triggerDeriveTableExec(deriveTableExec, input),
         runAuthorizer: conversation.runAuthorizer,
         makeResolver: makeReportResolver,
         ...(eyes ? { eyes } : {}),
@@ -404,6 +414,7 @@ export function assembleCoreRuntime(deps: CoreRuntimeDeps): CoreRuntime {
             executeTargetAssessment,
             dataProfile,
             extractValues,
+            deriveTableExec,
         },
         citationResolver,
     };

--- a/harness/src/sandbox/client.ts
+++ b/harness/src/sandbox/client.ts
@@ -1,5 +1,5 @@
 /**
- * `SandboxClient` — the five-method seam every sandbox-backed module in
+ * `SandboxClient` — the seam every sandbox-backed module in
  * the harness sits on. Implementations are backend-selected
  * (`docker`/`k8s`) by `createSandboxClient()` in `create-sandbox.ts` and
  * injected at the composition root as a construction-time dependency
@@ -17,33 +17,18 @@
  *   Many execs may fire against the same machine.
  * - The **exec** lifetime is one `submitExec → awaitExec`.
  *
- * `awaitExec` runs in the workflow body (not as a DBOS step) because
- * `DBOS.recv` and `DBOS.writeStream` are body-only.
+ * **Every caller of `awaitExec` runs inside a DBOS workflow body.** `DBOS.recv`
+ * and `DBOS.writeStream` are body-only, thus the callback transport cannot
+ * settle anywhere else, and the poll transport reaches for `DBOS.runStep` and
+ * `DBOS.sleepms` defaults. A caller that starts from a live chat turn registers
+ * its own workflow and starts it: `tasks/extract-values.ts` and
+ * `tasks/derive-table-exec.ts` are the two worked examples. No type carries this
+ * rule yet, thus a new caller must read this paragraph.
  */
 
-import type {
-    CreateSandboxMeta,
-    ExecEmit,
-    ExecResult,
-    ManagedSandbox,
-    SandboxIdentity,
-    SandboxLiveness,
-    SandboxRef,
-    SandboxTransport,
-    SubmitExecBody,
-} from "./types.js";
+import type { CreateSandboxMeta, ExecEmit, ExecResult, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SubmitExecBody } from "./types.js";
 
 export interface SandboxClient {
-    /**
-     * The result transport this client awaits under, fixed at construction. A caller that runs outside a
-     * workflow body reads it: `callback` awaits through `DBOS.recv`, which is body-only, thus such a caller
-     * must refuse before it starts a container it can never await.
-     *
-     * Optional, because a hand-written realization states nothing here. Absent means unknown, and a caller
-     * treats it as the poll default rather than refusing every composition that omits it.
-     */
-    readonly transport?: SandboxTransport;
-
     /**
      * DBOS step (`sandbox.create`) — the spawn half of the two-step create
      * (see the harness-sandbox-exec spec). Launches the sandbox-base container/Job under the

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -243,7 +243,6 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
     const isAlive = async (ref: SandboxRef) => unwrapOrThrow(await ops.isAlive(ref));
 
     return {
-        transport,
         createSandbox: async (meta, identity) => {
             // The config states an engine fact (binds preserve host ownership);
             // which remediation that fact demands — today, a world-writable step

--- a/harness/src/tasks/derive-table-exec.ts
+++ b/harness/src/tasks/derive-table-exec.ts
@@ -1,0 +1,118 @@
+/**
+ * The container of one report-session derivation, as a registered DBOS workflow.
+ *
+ * The `derive_table` tool runs inside one live chat turn, and a chat turn is not a workflow body. An await
+ * of an exec under the callback transport calls `DBOS.recv`, which a workflow body alone can call. Thus the
+ * container lives here, behind a registered workflow, and the tool starts it and awaits the handle.
+ *
+ * The shape is the shape of `tasks/extract-values.ts`: a body that a test drives directly, a registration
+ * that closes over the construction-time deps, and a trigger that starts the workflow and gives the result
+ * back. The tool holds the trigger as a plain function, thus no module under `tools/` imports DBOS.
+ *
+ * The body owns the whole machine lifetime. It creates the container, submits one exec, awaits the terminal
+ * result, and tears the container down on both paths. A teardown fault reaches the log alone, because the
+ * work is done by then.
+ */
+
+import { DBOS, type WorkflowHandle } from "@dbos-inc/dbos-sdk";
+import { randomUUID } from "node:crypto";
+
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { Logger } from "../lib/logger.js";
+import type { SandboxClient } from "../sandbox/client.js";
+import { mintSandboxIdentity } from "../sandbox/identity.js";
+import type { ExecEmit, ExecResult } from "../sandbox/types.js";
+import {
+    buildDerivationExec,
+    DERIVATION_DEADLINE_MS,
+    DERIVATION_RESOURCES,
+    DERIVE_RUN_LITERAL,
+    DERIVE_STEP_LITERAL,
+    type DeriveTableExecInput,
+} from "../tools/report-session/derive-table.js";
+
+/** The awaitExec callback. A derivation reports no live activity, thus the callback drops each event. */
+const noopEmit: ExecEmit = () => {};
+
+/** The construction-time deps of the body. The registration closes over them, thus the trigger holds none. */
+export interface DeriveTableExecDeps {
+    readonly sandboxClient: SandboxClient;
+    /**
+     * The checkpointed clock of the deadline. It defaults to `DBOS.now()`, which a replay reads again from
+     * the checkpoint. A test injects a fixed clock, thus it drives this body with no launched runtime.
+     */
+    readonly now?: () => Promise<number>;
+    readonly logger?: Logger;
+}
+
+/**
+ * The body, exported so a test drives it without a registered workflow.
+ *
+ * A fault of any seam call throws. The tool reads a rejection as one short detail, thus the caller needs no
+ * result type here.
+ */
+export async function runDeriveTableExecBody(input: DeriveTableExecInput, deps: DeriveTableExecDeps): Promise<ExecResult> {
+    const logger = (deps.logger ?? createNoopLogger()).named("derive-table-exec").with({ analysisId: input.analysisId });
+    const workflowId = DBOS.workflowID ?? `${DERIVE_RUN_LITERAL}:${input.executionId}`;
+
+    const sandbox = await deps.sandboxClient.createSandbox(
+        {
+            runId: DERIVE_RUN_LITERAL,
+            stepId: DERIVE_STEP_LITERAL,
+            analysisId: input.analysisId,
+            childWorkflowId: workflowId,
+            resources: DERIVATION_RESOURCES,
+            writableTail: input.writableTail,
+        },
+        mintSandboxIdentity(DERIVE_RUN_LITERAL),
+    );
+
+    try {
+        // A checkpointed clock, not `Date.now()`: the await gates on this absolute deadline, and a
+        // wall-clock deadline that grew on replay would shift which loop iteration crosses it.
+        const deadline = (await (deps.now ?? (() => DBOS.now()))()) + DERIVATION_DEADLINE_MS;
+        await deps.sandboxClient.submitExec(
+            sandbox,
+            buildDerivationExec({
+                script: input.script,
+                execId: input.executionId,
+                workingDir: input.workingDir,
+                inputs: input.inputs,
+                output: input.output,
+            }),
+        );
+        return await deps.sandboxClient.awaitExec(sandbox, input.executionId, noopEmit, deadline);
+    } finally {
+        try {
+            await deps.sandboxClient.teardown(sandbox);
+        } catch (cause) {
+            logger.warn("the derivation sandbox did not tear down", logger.errorFields(cause));
+        }
+    }
+}
+
+/**
+ * Register the derivation workflow with DBOS. It gives back the registered callable, thus a trigger
+ * dispatches with `DBOS.startWorkflow`.
+ */
+export function registerDeriveTableExecWorkflow(deps: DeriveTableExecDeps): (input: DeriveTableExecInput) => Promise<ExecResult> {
+    return DBOS.registerWorkflow((input: DeriveTableExecInput) => runDeriveTableExecBody(input, deps), { name: "derive-table-exec" });
+}
+
+/** The per-attempt workflow id. The execution id is unique already, and the nonce keeps a retry distinct. */
+export function deriveTableExecWorkflowId(executionId: string, nonce: string): string {
+    return `${DERIVE_RUN_LITERAL}:${executionId}:${nonce}`;
+}
+
+/**
+ * The async edge. It starts the registered workflow and it awaits the terminal result.
+ *
+ * The tool authorizes the derivation before this call and it revokes after, thus this edge holds no
+ * lifecycle of its own. A workflow fault rejects the returned promise.
+ */
+export async function triggerDeriveTableExec(workflow: (input: DeriveTableExecInput) => Promise<ExecResult>, input: DeriveTableExecInput): Promise<ExecResult> {
+    const handle = (await DBOS.startWorkflow(workflow, {
+        workflowID: deriveTableExecWorkflowId(input.executionId, randomUUID()),
+    })(input)) as WorkflowHandle<ExecResult>;
+    return handle.getResult();
+}

--- a/harness/src/tools/report-session/derive-table.test.ts
+++ b/harness/src/tools/report-session/derive-table.test.ts
@@ -25,7 +25,8 @@ import type { DbError } from "../../lib/db-result.js";
 import { computeSha256 } from "../../lib/fs-helpers.js";
 import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import type { SandboxClient } from "../../sandbox/client.js";
-import type { CreateSandboxMeta, ExecResult, SandboxRef, SandboxTransport, SubmitExecBody } from "../../sandbox/types.js";
+import type { CreateSandboxMeta, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import { runDeriveTableExecBody } from "../../tasks/derive-table-exec.js";
 import type { AppendDerivationOutcome, DerivationRecord } from "../../state/report-session-state.js";
 import { reportSessionDir } from "../../workspace/paths.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
@@ -161,7 +162,6 @@ function makeSandbox(args: {
     readonly root: string;
     readonly reply?: ExecResult;
     readonly throws?: boolean;
-    readonly transport?: SandboxTransport;
     readonly write?: (outputHostPath: string) => Promise<void>;
 }): FakeSandbox {
     const creates: CreateSandboxMeta[] = [];
@@ -169,7 +169,6 @@ function makeSandbox(args: {
     const teardowns: string[] = [];
     const ref: SandboxRef = { sandboxId: "sbx-derive-1", host: "127.0.0.1", port: 8765, backend: "docker", callbackSecret: "base64:secret" };
     const client = {
-        ...(args.transport === undefined ? {} : { transport: args.transport }),
         createSandbox(meta: CreateSandboxMeta): Promise<SandboxRef> {
             creates.push(meta);
             return Promise.resolve(ref);
@@ -260,7 +259,9 @@ function makeTool(args: { root: string; snapshot?: ReportSnapshot; result?: Exec
         gateway,
         resolveWorkspaceRoot: () => args.root,
         derivations: ledger,
-        sandboxClient: sandbox.client,
+        // The composition realizes the runner over a registered workflow. The test drives the same body,
+        // with a fixed clock, thus the seam calls under test are the seam calls in production.
+        runDerivation: (input) => runDeriveTableExecBody(input, { sandboxClient: sandbox.client, now: () => Promise.resolve(0) }),
         runAuthorizer: auth.authorizer,
     });
     return { tool, gateway, sandbox, ledger, auth };
@@ -584,31 +585,16 @@ describe("a composition with no sandbox", () => {
         expect(result.outcome).toBe("unavailable");
     });
 
-    it("refuses under a callback transport, because a turn cannot await one", async () => {
+    it("derives whatever transport the client awaits under, because the container runs in a workflow", async () => {
+        // The runner is a registered workflow, thus the await is a body call under each transport. The tool
+        // reads no transport at all, and no composition refuses for one.
         const root = await makeRoot();
-        // The callback await is a workflow-body call, and a report turn is not one. The refusal comes before
-        // any container starts, thus nothing is left running that nothing can await.
-        const sandbox = makeSandbox({ root, transport: "callback", write: writesTable() });
-        const { tool, ledger } = makeTool({ root, sandbox });
+        const { tool, sandbox, ledger } = makeTool({ root });
 
-        const result = await derive(tool, {});
-
-        expect(result.outcome).toBe("unavailable");
-        if (result.outcome === "unavailable") {
-            expect(result.detail).toContain("callbacks");
-        }
-        expect(sandbox.creates).toHaveLength(0);
-        expect(ledger.records).toHaveLength(0);
-    });
-
-    it("derives under the poll transport, and under a client that states none", async () => {
-        const root = await makeRoot();
-        const polling = makeTool({ root, sandbox: makeSandbox({ root, transport: "poll", write: writesTable() }) });
-        expect((await derive(polling.tool, {})).outcome).toBe("derived");
-
-        // An absent field states nothing, thus it reads as the poll default and it refuses nothing.
-        const silent = makeTool({ root: await makeRoot() });
-        expect((await derive(silent.tool, {})).outcome).toBe("derived");
+        expect((await derive(tool, {})).outcome).toBe("derived");
+        expect(sandbox.creates).toHaveLength(1);
+        expect(sandbox.teardowns).toHaveLength(1);
+        expect(ledger.records).toHaveLength(1);
     });
 
     it("refuses a call whose scope names no report thread", async () => {

--- a/harness/src/tools/report-session/derive-table.ts
+++ b/harness/src/tools/report-session/derive-table.ts
@@ -7,7 +7,7 @@
  *
  * A session derivation is not an analysis run. It mints no run id, it registers no artifact, and it writes
  * under the session directory alone. The rails are the rails of the value tier (`tasks/extract-values.ts`):
- * the sandbox client, the identity mint, and the authorizer on every terminal path. The container is
+ * the injected exec runner, the identity mint, and the authorizer on every terminal path. The container is
  * ephemeral, and it goes away with the work.
  *
  * The container mounts the analysis tree read-only, and one write mount covers the `derived/` directory of
@@ -29,13 +29,12 @@
  * condition one time, up front, the same discipline as the eyes. A per-attempt failure would instead read as
  * a transient fault, and it would invite a repeat of a call that can never pass.
  *
- * The transport of the client is the second such bound. A derivation runs inside one live turn and not
- * inside a workflow body. The poll transport awaits with plain steps and a plain sleep, thus it settles
- * there. The callback transport awaits through `DBOS.recv`, which a workflow body alone can call, thus this
- * tool refuses up front under it rather than start a container that nothing can await.
+ * The container runs behind a seam, and never in the turn. An await of an exec is a workflow-body call
+ * under the callback transport, and a report turn is not a body. Thus the tool takes an injected runner,
+ * and a registered workflow owns the container. The tool holds no sandbox client, and it imports no DBOS.
  */
 
-import { err, ok, type Result } from "neverthrow";
+import { ok, type Result } from "neverthrow";
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
@@ -46,10 +45,8 @@ import { classifyWithinRoot, computeSha256, computeSha256File } from "../../lib/
 import { defaultErrorFields, type Logger } from "../../lib/logger.js";
 import type { ResourceSpec } from "../../config/resource-limits.js";
 import { snapshotEntry } from "../../report-model/reference-resolver.js";
-import type { SandboxClient } from "../../sandbox/client.js";
 import { generateExecutionId } from "../../sandbox/execution-id.js";
-import { mintSandboxIdentity } from "../../sandbox/identity.js";
-import type { ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
+import type { ExecResult, SubmitExecBody } from "../../sandbox/types.js";
 import type { DerivationRecord, DerivationSource, ReportSessionStateStore } from "../../state/report-session-state.js";
 import { isSafeId, reportSessionDerivedDir, toSandboxPath, type ResolveWorkspaceRoot } from "../../workspace/paths.js";
 import { defineTool, type Tool, type ToolError } from "../define-tool.js";
@@ -99,26 +96,26 @@ export interface DeriveTableToolDeps {
     readonly gateway: ReportSessionStateGateway;
     readonly resolveWorkspaceRoot: ResolveWorkspaceRoot;
     readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
-    readonly sandboxClient?: SandboxClient;
+    readonly runDerivation?: DeriveTableRunner;
     readonly runAuthorizer?: RunAuthorizer;
     readonly logger?: Logger;
 }
 
 /** The synthetic run id and step id of one derivation. Both are constants, and neither names a run row. */
-const DERIVE_RUN_LITERAL = "derive-table" as const;
-const DERIVE_STEP_LITERAL = "derive" as const;
+export const DERIVE_RUN_LITERAL = "derive-table" as const;
+export const DERIVE_STEP_LITERAL = "derive" as const;
 
 /** The provenance agent id. No agent loop runs in the container, thus this names the derivation pass. */
 const DERIVE_AGENT_ID = "table-deriver" as const;
 
 /** The exec budget of one derivation. It matches the budget of the value tier. */
-const DERIVATION_DEADLINE_MS = 300_000;
+export const DERIVATION_DEADLINE_MS = 300_000;
 
 /**
  * The container size of one derivation. A join or a pivot loads each declared input into pandas at one
  * time, thus the container needs the headroom of the value tier.
  */
-const DERIVATION_RESOURCES: ResourceSpec = { cpu: 2, memoryGb: 8 };
+export const DERIVATION_RESOURCES: ResourceSpec = { cpu: 2, memoryGb: 8 };
 
 /** The cap of the script, in bytes. A reshaping script sits far under it, and the command line carries it. */
 const SCRIPT_CAP_BYTES = 64 * 1024;
@@ -135,14 +132,8 @@ export const DERIVE_OUTPUT_ENV = "DERIVE_OUTPUT";
 /** The cap of the failure detail that the tool copies out of the standard error of the script. */
 const STDERR_TAIL_CAP = 2_000;
 
-/** The awaitExec callback. A derivation reports no live activity, thus the callback drops each event. */
-const noopEmit: ExecEmit = () => {};
-
 /** The line that the agent reads when the composition binds no sandbox rails. */
 const NO_SANDBOX_DETAIL = "the composition gives no sandbox, thus this session cannot derive a table";
-
-/** The line that the agent reads when the sandbox client awaits under a transport that a turn cannot drive. */
-const CALLBACK_TRANSPORT_DETAIL = "the sandbox of this composition reports through callbacks, which a report turn cannot await, thus it derives no table";
 
 /** One declared input, as the container reads it: the mounted path of the file, and its pinned hash. */
 export interface DerivationInputMount {
@@ -203,18 +194,12 @@ export function describeExecFailure(result: ExecResult): string | undefined {
 }
 
 /**
- * Run one derivation in an ephemeral container, and give the exec result back.
+ * The exec of one derivation, as a registered workflow reads it.
  *
- * The container mounts the analysis tree read-only, and the declared write tail is its one writable mount.
- * Thus the script reads the evidence and it writes into the `derived/` directory of the session and nowhere
- * else. The teardown runs on both paths, thus no machine outlives the call. A teardown fault reaches the log
- * alone, because the work is done.
- *
- * Each seam call is guarded, thus a fault of the sandbox becomes a short detail and the tool keeps its
- * no-throw contract.
+ * Each field is plain data, thus the value crosses the workflow boundary and it survives a replay. The
+ * paths are container paths already: the host maps them one time, before the start.
  */
-async function runDerivationExec(args: {
-    readonly client: SandboxClient;
+export interface DeriveTableExecInput {
     readonly analysisId: string;
     readonly executionId: string;
     readonly script: string;
@@ -222,51 +207,16 @@ async function runDerivationExec(args: {
     readonly workingDir: string;
     readonly inputs: readonly DerivationInputMount[];
     readonly output: string;
-    readonly logger: Logger;
-}): Promise<Result<ExecResult, string>> {
-    let sandbox: SandboxRef;
-    try {
-        sandbox = await args.client.createSandbox(
-            {
-                runId: DERIVE_RUN_LITERAL,
-                stepId: DERIVE_STEP_LITERAL,
-                analysisId: args.analysisId,
-                childWorkflowId: `${DERIVE_RUN_LITERAL}:${args.executionId}`,
-                resources: DERIVATION_RESOURCES,
-                writableTail: args.writableTail,
-            },
-            mintSandboxIdentity(DERIVE_RUN_LITERAL),
-        );
-    } catch (cause) {
-        args.logger.error("the derivation sandbox did not start", args.logger.errorFields(cause));
-        return err("the derivation sandbox did not start");
-    }
-
-    try {
-        // The tool runs inside one live turn and it never replays, thus the wall clock is the deadline.
-        const deadline = Date.now() + DERIVATION_DEADLINE_MS;
-        await args.client.submitExec(
-            sandbox,
-            buildDerivationExec({
-                script: args.script,
-                execId: args.executionId,
-                workingDir: args.workingDir,
-                inputs: args.inputs,
-                output: args.output,
-            }),
-        );
-        return ok(await args.client.awaitExec(sandbox, args.executionId, noopEmit, deadline));
-    } catch (cause) {
-        args.logger.error("the derivation exec did not complete", args.logger.errorFields(cause));
-        return err("the derivation exec did not complete");
-    } finally {
-        try {
-            await args.client.teardown(sandbox);
-        } catch (cause) {
-            args.logger.warn("the derivation sandbox did not tear down", args.logger.errorFields(cause));
-        }
-    }
 }
+
+/**
+ * Run one derivation exec and give the terminal result back.
+ *
+ * The composition realizes it over a registered workflow, thus the container lives inside a workflow body
+ * and the await is legal under each transport. A fault of the sandbox rejects the promise, and the tool
+ * turns that rejection into one short detail.
+ */
+export type DeriveTableRunner = (input: DeriveTableExecInput) => Promise<ExecResult>;
 
 /**
  * Make the derivation tool over the session-state gateway, the derivation ledger, and the sandbox rails.
@@ -276,7 +226,7 @@ async function runDerivationExec(args: {
  */
 export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTableInput, DeriveTableResult> {
     const logger = (deps.logger ?? createNoopLogger()).named("derive-table");
-    const { sandboxClient, runAuthorizer } = deps;
+    const { runDerivation, runAuthorizer } = deps;
 
     return defineTool({
         id: "derive_table",
@@ -301,15 +251,9 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
         execute: async (input, ctx): Promise<Result<DeriveTableResult, ToolError>> => {
             // The check runs before every read, thus one clear signal replaces a failure for each attempt.
             // It also narrows the two rails below, thus the exec needs no assertion.
-            if (sandboxClient === undefined || runAuthorizer === undefined) {
+            if (runDerivation === undefined || runAuthorizer === undefined) {
                 logger.warn("the composition gives no sandbox, thus no derivation can run");
                 return ok({ outcome: "unavailable", detail: NO_SANDBOX_DETAIL });
-            }
-            // The await of the callback transport is a workflow-body call, and a report turn is not one. An
-            // absent field states nothing, thus it reads as the poll default and it refuses nothing.
-            if (sandboxClient.transport === "callback") {
-                logger.warn("the sandbox client awaits through callbacks, thus no derivation can run in a turn");
-                return ok({ outcome: "unavailable", detail: CALLBACK_TRANSPORT_DETAIL });
             }
 
             const opened = await openReportThread(deps.gateway, ctx.session.scope);
@@ -401,7 +345,7 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
             let result: DeriveTableResult | undefined;
             try {
                 result = await derive({
-                    client: sandboxClient,
+                    runDerivation,
                     derivations: deps.derivations,
                     root,
                     threadId,
@@ -443,7 +387,7 @@ export function createDeriveTableTool(deps: DeriveTableToolDeps): Tool<DeriveTab
  * wrote. A clearance fault refuses the derivation, because the same doubt stands.
  */
 async function derive(args: {
-    readonly client: SandboxClient;
+    readonly runDerivation: DeriveTableRunner;
     readonly derivations: Pick<ReportSessionStateStore, "appendDerivation">;
     readonly root: string;
     readonly threadId: string;
@@ -472,8 +416,9 @@ async function derive(args: {
         }
     }
 
-    const executed = await runDerivationExec({
-        client: args.client,
+    // The path mapper refuses a stored path that escapes the root, with a throw. It runs before the try,
+    // thus that refusal stays a throw and it never reads as a fault of the container.
+    const execInput: DeriveTableExecInput = {
         analysisId: args.analysisId,
         executionId,
         script: args.script,
@@ -481,12 +426,16 @@ async function derive(args: {
         workingDir,
         inputs: args.sources.map((source) => ({ path: toSandboxPath(args.root, args.analysisId, join(args.root, source.path)), hash: source.hash })),
         output: toSandboxPath(args.root, args.analysisId, absolute),
-        logger: args.logger,
-    });
-    if (executed.isErr()) {
-        return { outcome: "exec-failed", detail: executed.error };
+    };
+
+    let executed: ExecResult;
+    try {
+        executed = await args.runDerivation(execInput);
+    } catch (cause) {
+        args.logger.error("the derivation exec did not complete", { threadId: args.threadId, ...defaultErrorFields(cause) });
+        return { outcome: "exec-failed", detail: "the derivation exec did not complete" };
     }
-    const failure = describeExecFailure(executed.value);
+    const failure = describeExecFailure(executed);
     if (failure !== undefined) {
         return { outcome: "exec-failed", detail: failure };
     }


### PR DESCRIPTION
## What & why

`derive_table` made its container in the chat turn and awaited the exec there. An await under the callback transport calls `DBOS.recv`, which a workflow body alone can call. Thus the tool read the transport off the sandbox client and refused up front, and every managed deployment derived no table.

The container now lives in a registered workflow, `derive-table-exec`. The tool holds an injected runner, it starts the workflow, and it awaits the result.

## Notes for a reviewer

- The shape copies `tasks/extract-values.ts`: a body that a unit test drives directly, a registration that closes over the construction-time deps, and a trigger that starts and awaits. One difference: the authorize and the revoke stay in the tool, because the tool already held them on every terminal path.
- No module under `tools/` imports DBOS. The tool takes a plain function.
- The body takes a checkpointed clock, and it defaults to `DBOS.now()`. A wall-clock deadline that grew on replay would shift which loop iteration crosses it. A fixed clock goes in from the unit tests, thus they drive the real body.
- `SandboxClient.transport` is gone. It was public for one reader, which this change deletes. The composition still selects the transport at `sandbox/create-sandbox.ts`.
- The rule that every caller of `awaitExec` runs inside a workflow body now sits on the interface, with the two worked examples named. Refer to #432 for the wider list of rules that no type carries.
- `openspec/specs/harness-durable-runtime/spec.md:10-20` lists which operations run as DBOS workflows. This adds one, and this pull request makes no spec change.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Sandbox:** the security model is unchanged. The mounts, the resources, the signed exec endpoints, and the identity mint are the same. The container moves from the turn into a workflow body. Nothing about its confinement moves with it.
- [x] **Provenance:** the derivation record is unchanged. The same sources, the same hashes, and the same ledger append.
