### PR TITLE
fix(harness): give the derivation exec an id that names its workflow

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.26.1",
+    "version": "0.26.2",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/tasks/derive-table-exec.ts
+++ b/harness/src/tasks/derive-table-exec.ts
@@ -12,10 +12,14 @@
  * The body owns the whole machine lifetime. It creates the container, submits one exec, awaits the terminal
  * result, and tears the container down on both paths. A teardown fault reaches the log alone, because the
  * work is done by then.
+ *
+ * The exec id is `${workflowId}:${stepId}:${fnId}`, the one shape that `workflowIdFromExec` parses. A
+ * callback host reads the owner workflow out of the exec id alone, thus a flat id makes the completion
+ * callback unroutable and it lands as a `400`. The pull backstop still settles such an exec, but it pays
+ * the quiet interval first.
  */
 
 import { DBOS, type WorkflowHandle } from "@dbos-inc/dbos-sdk";
-import { randomUUID } from "node:crypto";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
@@ -53,7 +57,10 @@ export interface DeriveTableExecDeps {
  */
 export async function runDeriveTableExecBody(input: DeriveTableExecInput, deps: DeriveTableExecDeps): Promise<ExecResult> {
     const logger = (deps.logger ?? createNoopLogger()).named("derive-table-exec").with({ analysisId: input.analysisId });
-    const workflowId = DBOS.workflowID ?? `${DERIVE_RUN_LITERAL}:${input.executionId}`;
+    const workflowId = DBOS.workflowID ?? deriveTableExecWorkflowId(input.executionId);
+    // One workflow submits one exec, thus the function id is a constant. The three segments are what a
+    // callback host parses to find the workflow that awaits this exec.
+    const execId = `${workflowId}:${DERIVE_STEP_LITERAL}:fn-0`;
 
     const sandbox = await deps.sandboxClient.createSandbox(
         {
@@ -75,13 +82,13 @@ export async function runDeriveTableExecBody(input: DeriveTableExecInput, deps: 
             sandbox,
             buildDerivationExec({
                 script: input.script,
-                execId: input.executionId,
+                execId,
                 workingDir: input.workingDir,
                 inputs: input.inputs,
                 output: input.output,
             }),
         );
-        return await deps.sandboxClient.awaitExec(sandbox, input.executionId, noopEmit, deadline);
+        return await deps.sandboxClient.awaitExec(sandbox, execId, noopEmit, deadline);
     } finally {
         try {
             await deps.sandboxClient.teardown(sandbox);
@@ -99,9 +106,14 @@ export function registerDeriveTableExecWorkflow(deps: DeriveTableExecDeps): (inp
     return DBOS.registerWorkflow((input: DeriveTableExecInput) => runDeriveTableExecBody(input, deps), { name: "derive-table-exec" });
 }
 
-/** The per-attempt workflow id. The execution id is unique already, and the nonce keeps a retry distinct. */
-export function deriveTableExecWorkflowId(executionId: string, nonce: string): string {
-    return `${DERIVE_RUN_LITERAL}:${executionId}:${nonce}`;
+/**
+ * The workflow id of one derivation.
+ *
+ * It carries exactly one colon, because `workflowIdFromExec` recovers the id by a strip of the last two
+ * colon-delimited segments of the exec id. The execution id is unique already, thus no nonce joins it.
+ */
+export function deriveTableExecWorkflowId(executionId: string): string {
+    return `${DERIVE_RUN_LITERAL}:${executionId}`;
 }
 
 /**
@@ -112,7 +124,7 @@ export function deriveTableExecWorkflowId(executionId: string, nonce: string): s
  */
 export async function triggerDeriveTableExec(workflow: (input: DeriveTableExecInput) => Promise<ExecResult>, input: DeriveTableExecInput): Promise<ExecResult> {
     const handle = (await DBOS.startWorkflow(workflow, {
-        workflowID: deriveTableExecWorkflowId(input.executionId, randomUUID()),
+        workflowID: deriveTableExecWorkflowId(input.executionId),
     })(input)) as WorkflowHandle<ExecResult>;
     return handle.getResult();
 }

--- a/harness/src/tools/report-session/derive-table.test.ts
+++ b/harness/src/tools/report-session/derive-table.test.ts
@@ -27,6 +27,7 @@ import type { ReportSnapshot } from "../../report-model/reference-resolver.js";
 import type { SandboxClient } from "../../sandbox/client.js";
 import type { CreateSandboxMeta, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
 import { runDeriveTableExecBody } from "../../tasks/derive-table-exec.js";
+import { workflowIdFromExec } from "../../sandbox/exec-id.js";
 import type { AppendDerivationOutcome, DerivationRecord } from "../../state/report-session-state.js";
 import { reportSessionDir } from "../../workspace/paths.js";
 import { makeToolContext } from "../__fixtures__/tool-context.js";
@@ -583,6 +584,20 @@ describe("a composition with no sandbox", () => {
         const result = (await tool.execute({ script: SCRIPT, inputs: [PINNED_PATH], output: "yield.csv" }, ctxForThread("t1")))._unsafeUnwrap();
 
         expect(result.outcome).toBe("unavailable");
+    });
+
+    it("submits an exec id that names the workflow that awaits it", async () => {
+        // A callback host reads the owner workflow out of the exec id alone. A flat id makes the completion
+        // callback unroutable, and the exec then settles on the pull backstop alone.
+        const root = await makeRoot();
+        const { tool, sandbox } = makeTool({ root });
+
+        await derive(tool, {});
+
+        const submitted = sandbox.submits[0];
+        expect(submitted).toBeDefined();
+        expect(workflowIdFromExec(submitted!.execId)).not.toBeNull();
+        expect(sandbox.creates[0]!.childWorkflowId).toBe(workflowIdFromExec(submitted!.execId));
     });
 
     it("derives whatever transport the client awaits under, because the container runs in a workflow", async () => {


### PR DESCRIPTION
## What & why

Staging ran a derivation under the callback transport. The sandbox finished its script cleanly, and the completion callback then answered `400`.

The callback host recovers the owner workflow from the exec id alone, with `workflowIdFromExec`. That function strips the last two colon-delimited segments. The derivation sent a flat id from `generateExecutionId`, thus the parse gave null and the route refused the callback.

The exec id is now `${workflowId}:${stepId}:fn-0`, the shape that the workspace mutate tools already submit.

## Notes for a reviewer

- Nothing failed in staging. The pull backstop settled the exec, and it paid the quiet interval first. That was about 30 seconds for each derivation.
- The workflow id carries exactly one colon, thus the parse recovers it whole. `sandbox/exec-id.ts:1-11` states that assumption.
- The nonce goes away. The execution id is unique already, and a deterministic workflow id replays better.
- A new case asserts that the submitted exec id parses back to the workflow id that `createSandbox` received.
- `tasks/extract-values.ts:142` mints the same flat id, and it takes the same `400` on every callback deployment. This PR leaves that alone.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Sandbox:** the security model is unchanged. The exec id is a routing key. Each body is still HMAC-signed, and the verification still happens in the workflow body.
- [x] **Provenance:** the derivation record is unchanged.
