### PR TITLE
fix(harness): keep XML text nodes as strings, and fail an empty review report

### DIFF
--- a/harness/src/literature/sources/pubmed.ts
+++ b/harness/src/literature/sources/pubmed.ts
@@ -84,6 +84,10 @@ const xmlParser = new XMLParser({
     attributeNamePrefix: "@_",
     isArray: (name) => ["PubmedArticle", "Author", "MeshHeading", "AbstractText", "sec", "p", "record"].includes(name),
     textNodeName: "#text",
+    // Each consumer reads a text node as a string. Without this option the
+    // parser turns a numeric text node into a number, and a year-only PubDate
+    // then crashes the year extraction in `parseEsummary`.
+    parseTagValue: false,
 });
 
 interface DocSumItem {

--- a/harness/src/tools/bio/pubmed.test.ts
+++ b/harness/src/tools/bio/pubmed.test.ts
@@ -49,6 +49,29 @@ const ESUMMARY_XML = `<?xml version="1.0"?>
   </DocSum>
 </eSummaryResult>`;
 
+// An electronic-only or ahead-of-print record can carry a bare year in PubDate.
+// The parser must keep that value as text. A numeric parse of it crashed the
+// year extraction, and one such record discarded the whole result set.
+const YEAR_ONLY_ESUMMARY_XML = `<?xml version="1.0"?>
+<eSummaryResult>
+  <DocSum>
+    <Id>12345678</Id>
+    <Item Name="PubDate" Type="Date">2021 Mar 15</Item>
+    <Item Name="Source" Type="String">Nature</Item>
+    <Item Name="AuthorList" Type="List">
+      <Item Name="Author" Type="String">Smith J</Item>
+    </Item>
+    <Item Name="Title" Type="String">BRCA1 and drug resistance</Item>
+    <Item Name="FullJournalName" Type="String">Nature Reviews Cancer</Item>
+  </DocSum>
+  <DocSum>
+    <Id>40000001</Id>
+    <Item Name="PubDate" Type="Date">2026</Item>
+    <Item Name="Source" Type="String">Nat Rev Drug Discov</Item>
+    <Item Name="Title" Type="String">Ahead-of-print record</Item>
+  </DocSum>
+</eSummaryResult>`;
+
 const EFETCH_XML = `<?xml version="1.0"?>
 <PubmedArticleSet>
   <PubmedArticle>
@@ -147,6 +170,36 @@ describe("pubmed — action 'search'", () => {
         expect(explicit[0]!.searchParams.get("mindate")).toBe("2020/01/01");
         expect(explicit[0]!.searchParams.get("maxdate")).toBe("2021/12/31");
         expect(explicit[0]!.searchParams.get("datetype")).toBe("pdat");
+    });
+
+    it("returns every summary when one record carries a year-only PubDate", async () => {
+        stubNcbi((url) => {
+            if (url.pathname.endsWith("esearch.fcgi")) return json({ esearchresult: { idlist: ["12345678", "40000001"], count: "2" } });
+            return xml(YEAR_ONLY_ESUMMARY_XML);
+        });
+
+        const { ctx } = makeToolContext();
+        const result = (await tool.execute({ action: "search", query: "Bender A[Author]" }, ctx))._unsafeUnwrap();
+
+        expect(result).toEqual({
+            totalFound: 2,
+            results: [
+                {
+                    pmid: "12345678",
+                    title: "BRCA1 and drug resistance",
+                    journal: "Nature Reviews Cancer",
+                    year: "2021",
+                    authors: "Smith J",
+                },
+                {
+                    pmid: "40000001",
+                    title: "Ahead-of-print record",
+                    journal: "Nat Rev Drug Discov",
+                    year: "2026",
+                    authors: "",
+                },
+            ],
+        });
     });
 
     it("returns an empty results list when nothing matches (does not throw, and does not call esummary)", async () => {

--- a/harness/src/tools/research/literature-reviewer.test.ts
+++ b/harness/src/tools/research/literature-reviewer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { makeSession } from "../../providers/__fixtures__/session.js";
 import { makeMessage, scriptedProvider, textBlock } from "../../loop/__fixtures__/scripted-provider.js";
+import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { ToolContext } from "../define-tool.js";
 import { createLiteratureReviewerTool } from "./literature-reviewer.js";
 import { unusedCitationResolver } from "../../citations/__fixtures__/resolver.js";
@@ -60,6 +61,28 @@ describe("literatureReviewer sub-agent tool", () => {
 
         // The child transcript is not exposed — only the report leaves the tool.
         expect(Object.keys(result)).toEqual(["report"]);
+    });
+
+    it("returns an error, not an empty report, when the child run ends without a final text", async () => {
+        // A terminal reply with no text block ends the child loop, and the
+        // transcript then holds no report. The tool must surface that as an
+        // error that names the finish reason, not as `ok({ report: "" })`.
+        const provider = scriptedProvider([makeMessage([], "end_turn")]);
+        const tool = createLiteratureReviewerTool({
+            provider,
+            model: "claude-test",
+            bioKeys: { drugbank: "", disgenet: "", epaCcte: "" },
+            citationResolver: unusedCitationResolver,
+        });
+
+        const { ctx } = makeToolContext();
+        const outcome = await tool.execute({ brief: "Investigate BRCA1." }, ctx);
+
+        expect(outcome.isErr()).toBe(true);
+        const error = outcome._unsafeUnwrapErr();
+        expect(error.error).toContain("no report");
+        expect(error.error).toContain("stop");
+        expect(error.retryable).toBe(true);
     });
 
     it("distinguishes citation discovery from verification without collapsing uncertainty", () => {

--- a/harness/src/tools/research/literature-reviewer.ts
+++ b/harness/src/tools/research/literature-reviewer.ts
@@ -15,7 +15,7 @@
  * so the child never replays).
  */
 
-import { ok } from "neverthrow";
+import { err, ok } from "neverthrow";
 import { z } from "zod";
 
 import { finalText, runAgent } from "../../loop/run-agent.js";
@@ -100,7 +100,7 @@ export function createLiteratureReviewerTool(deps: LiteratureReviewerDeps): Tool
         }),
         describeCall: "none",
         execute: async ({ brief }, ctx) => {
-            const { messages: transcript } = await runAgent(agent, [{ role: "user", content: brief }], forSubAgent(ctx.session, AGENT_ID), {
+            const { messages: transcript, finish } = await runAgent(agent, [{ role: "user", content: brief }], forSubAgent(ctx.session, AGENT_ID), {
                 provider: deps.provider,
                 signal: ctx.signal,
                 emit: ctx.emit,
@@ -112,7 +112,15 @@ export function createLiteratureReviewerTool(deps: LiteratureReviewerDeps): Tool
                 // same frame, same call path, same loop-local step names.
                 invocationId: ctx.invocationId,
             });
-            return ok({ report: finalText(transcript) });
+            const report = finalText(transcript);
+            // A child run can end with no final text. Examples are a terminal
+            // reply with no text block, and a capped-out run whose wrap-up is
+            // empty. An ok result with an empty report hides that failure, so
+            // the tool returns an error that names the finish reason.
+            if (report.trim() === "") {
+                return err({ error: `The literature reviewer gave no report (finish reason: ${finish.reason}). Retry, or narrow the brief.`, retryable: true });
+            }
+            return ok({ report });
         },
     });
 }


### PR DESCRIPTION
## What & why

A PubMed search crashed when the result window held a record with a year-only publication date. The esummary parser kept the default `parseTagValue` of fast-xml-parser, and that turned the date into a number. The year extraction in `parseEsummary` then threw, and one bad record discarded the whole result set. Recent electronic-only records carry such dates, thus a date sort or a wide result window made the `search` action fail. The parser now keeps each text node as a string.

The `literature_reviewer` tool hid a related failure. A child run that ended with no final text returned `ok({ report: "" })`, and nothing signaled it. The tool now returns an error that names the finish reason.

Notes for the reviewer:

- The parser option applies to every E-utilities parse function. Each consumer already coerces an attribute-bearing node with `String(...)`, thus no output shape changes.
- The Postgres-backed suites did not run locally, because this machine has no local Postgres. The touched suites, lint, and typecheck are green.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
