### PR TITLE
fix(harness): root a data-profile path in the frame of its reader

### DIFF
--- a/harness/src/app/data-profile-orientation.test.ts
+++ b/harness/src/app/data-profile-orientation.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "bun:test";
 import type { DataProfileResult } from "../state/data-profile.js";
 import { buildDataProfileOrientation, DATA_PROFILE_ORIENTATION_MAX_CHARS } from "./data-profile-orientation.js";
 
+/** The analysis every rendered path is rooted with. */
+const ANALYSIS_ID = "an-1";
+
 const RICH: DataProfileResult = {
     summary: "Bulk RNA-seq of rectal mucosal biopsies, 24 samples, UC vs healthy controls.",
     files: [
@@ -44,7 +47,7 @@ const LEGACY: DataProfileResult = {
 
 describe("buildDataProfileOrientation", () => {
     it("projects the dataset identity, design, concerns, and file dimensions", () => {
-        const text = buildDataProfileOrientation(RICH);
+        const text = buildDataProfileOrientation(RICH, ANALYSIS_ID);
 
         expect(text).toContain("transcriptomics / bulk-rna-seq");
         expect(text).toContain("Homo sapiens (taxon 9606)");
@@ -54,7 +57,7 @@ describe("buildDataProfileOrientation", () => {
         expect(text).toContain("Two groups (12 UC, 12 control)");
         expect(text).toContain("batch confounded with group in batch 2");
         // Dimensions ride with each file, which is the only place they appear.
-        expect(text).toContain("data/inputs/f1/counts.csv — Raw gene-level count matrix (20531 x 24, CSV)");
+        expect(text).toContain("/an-1/data/inputs/f1/counts.csv — Raw gene-level count matrix (20531 x 24, CSV)");
         expect(text).toContain("Files (2):");
     });
 
@@ -63,7 +66,7 @@ describe("buildDataProfileOrientation", () => {
             ...RICH,
             organism: { scientificName: "Mus musculus", taxonId: "10090", source: "inferred", confidence: "low", notes: "from gene ID patterns" },
         };
-        expect(buildDataProfileOrientation(guessed)).toContain("Mus musculus (taxon 10090) [low confidence]");
+        expect(buildDataProfileOrientation(guessed, ANALYSIS_ID)).toContain("Mus musculus (taxon 10090) [low confidence]");
     });
 
     it("omits fields the profiler left null or unset instead of printing empties", () => {
@@ -77,7 +80,7 @@ describe("buildDataProfileOrientation", () => {
             tissue: null,
             condition: null,
         };
-        const text = buildDataProfileOrientation(sparse);
+        const text = buildDataProfileOrientation(sparse, ANALYSIS_ID);
 
         expect(text).toContain("Dataset: transcriptomics");
         expect(text).not.toContain("tissue:");
@@ -88,7 +91,7 @@ describe("buildDataProfileOrientation", () => {
     });
 
     it("falls back to the summary for a legacy snapshot that has no structured fields", () => {
-        const text = buildDataProfileOrientation(LEGACY);
+        const text = buildDataProfileOrientation(LEGACY, ANALYSIS_ID);
 
         expect(text).toContain("Three RNA-seq count matrices and a sample sheet.");
         expect(text).toContain("data/inputs/f1/counts.csv — Raw count matrix");
@@ -106,7 +109,7 @@ describe("buildDataProfileOrientation", () => {
                 cols: 4,
             })),
         };
-        const text = buildDataProfileOrientation(many);
+        const text = buildDataProfileOrientation(many, ANALYSIS_ID);
 
         expect(text).toContain("Files (8 of 30):");
         expect(text).toContain("data/inputs/f7/counts.csv");
@@ -118,7 +121,7 @@ describe("buildDataProfileOrientation", () => {
             ...RICH,
             qualityAssessment: { concerns: ["c1", "c2", "c3", "c4", "c5"], strengths: [] },
         };
-        expect(buildDataProfileOrientation(many)).toContain("Concerns: c1; c2; c3 (+2 more)");
+        expect(buildDataProfileOrientation(many, ANALYSIS_ID)).toContain("Concerns: c1; c2; c3 (+2 more)");
     });
 
     // The bound is the whole point: this text is destined for a context window it does
@@ -147,19 +150,19 @@ describe("buildDataProfileOrientation", () => {
             qualityAssessment: { concerns: Array.from({ length: 100 }, () => "Q".repeat(1_000)), strengths: [] },
         };
 
-        expect(buildDataProfileOrientation(monstrous).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
+        expect(buildDataProfileOrientation(monstrous, ANALYSIS_ID).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
     });
 
     it("honours a caller-supplied bound", () => {
-        expect(buildDataProfileOrientation(RICH, 80).length).toBeLessThanOrEqual(80);
-        expect(buildDataProfileOrientation(RICH, 0)).toBe("");
+        expect(buildDataProfileOrientation(RICH, ANALYSIS_ID, 80).length).toBeLessThanOrEqual(80);
+        expect(buildDataProfileOrientation(RICH, ANALYSIS_ID, 0)).toBe("");
     });
 
     it("stays well under the bound for an ordinary profile", () => {
-        expect(buildDataProfileOrientation(RICH).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
+        expect(buildDataProfileOrientation(RICH, ANALYSIS_ID).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
         // A real profile should not be flirting with the cap — if it is, the projection
         // has stopped being an orientation and become a dump.
-        expect(buildDataProfileOrientation(RICH).length).toBeLessThan(800);
+        expect(buildDataProfileOrientation(RICH, ANALYSIS_ID).length).toBeLessThan(800);
     });
 });
 
@@ -193,7 +196,7 @@ describe("a dataset described by kinds", () => {
     };
 
     it("renders the kinds before the notable files", () => {
-        const text = buildDataProfileOrientation(STRUCTURED);
+        const text = buildDataProfileOrientation(STRUCTURED, ANALYSIS_ID);
         expect(text).toContain("Kinds (2, 2339 files):");
         expect(text).toContain("per-patient variant calls (1171x, VCF) — one patient's somatic variant calls");
         expect(text).toContain("Axes: patient (1171)");
@@ -201,16 +204,35 @@ describe("a dataset described by kinds", () => {
     });
 
     it("names a coverage shortfall rather than implying the kinds cover everything", () => {
-        expect(buildDataProfileOrientation(STRUCTURED)).toContain("Coverage: 2339 of 2340 files match a kind");
+        expect(buildDataProfileOrientation(STRUCTURED, ANALYSIS_ID)).toContain("Coverage: 2339 of 2340 files match a kind");
     });
 
     it("stays within the character budget on a structured profile", () => {
-        expect(buildDataProfileOrientation(STRUCTURED).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
+        expect(buildDataProfileOrientation(STRUCTURED, ANALYSIS_ID).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS);
     });
 
     it("falls back to the file list for a snapshot written before kinds existed", () => {
-        const text = buildDataProfileOrientation(RICH);
+        const text = buildDataProfileOrientation(RICH, ANALYSIS_ID);
         expect(text).not.toContain("Kinds (");
         expect(text).toContain("Files (2):");
+    });
+});
+
+describe("the frame of a rendered path", () => {
+    it("roots every file path, so none reads as relative to the agent's working directory", () => {
+        const text = buildDataProfileOrientation(RICH, ANALYSIS_ID);
+        for (const line of text.split("\n").filter((l) => l.startsWith("- data") || l.startsWith("- /"))) {
+            expect(line).toStartWith(`- /${ANALYSIS_ID}/`);
+        }
+    });
+
+    it("roots a stored path that already carries the root exactly once", () => {
+        const rooted: DataProfileResult = {
+            ...RICH,
+            files: [{ path: `/${ANALYSIS_ID}/data/inputs/f1/counts.csv`, description: "Raw count matrix" }],
+        };
+        const text = buildDataProfileOrientation(rooted, ANALYSIS_ID);
+        expect(text).toContain(`/${ANALYSIS_ID}/data/inputs/f1/counts.csv`);
+        expect(text).not.toContain(`/${ANALYSIS_ID}/${ANALYSIS_ID}`);
     });
 });

--- a/harness/src/app/data-profile-orientation.ts
+++ b/harness/src/app/data-profile-orientation.ts
@@ -13,9 +13,17 @@
  *
  * A pure function over the record — no I/O, no LLM, no pipeline. It is the whole
  * mechanism.
+ *
+ * Every path it renders is projected into the frame-independent
+ * `/{analysisId}/…` form. The record stores a path relative to the analysis
+ * root, which is the correct form to store; but a step agent resolves a relative
+ * path against its own working directory, thus the stored form names a file that
+ * does not exist there. The absolute form resolves to the same file in every
+ * frame, including the conversation agent's, so the projection is unconditional.
  */
 
 import type { DataProfileResult } from "../state/data-profile.js";
+import { toAnalysisRootPath } from "../workspace/paths.js";
 
 /** The character budget the projection guarantees it will not exceed. */
 export const DATA_PROFILE_ORIENTATION_MAX_CHARS = 1200;
@@ -91,8 +99,12 @@ function formatFileFacts(file: DataProfileResult["files"][number]): string {
  * A snapshot written before the record was widened carries none of the structured
  * fields. Rather than emit a bare file list, that case falls back to the narrative
  * summary — the one orientation a legacy row does have.
+ *
+ * `analysisId` roots each rendered file path (see the module header). It is the
+ * id of the analysis the profile belongs to, and it is what the sandbox mounts
+ * the tree at.
  */
-export function buildDataProfileOrientation(result: DataProfileResult, maxChars: number = DATA_PROFILE_ORIENTATION_MAX_CHARS): string {
+export function buildDataProfileOrientation(result: DataProfileResult, analysisId: string, maxChars: number = DATA_PROFILE_ORIENTATION_MAX_CHARS): string {
     const lines: string[] = [];
 
     const identity = [
@@ -154,7 +166,7 @@ export function buildDataProfileOrientation(result: DataProfileResult, maxChars:
         const header = shown.length < result.files.length ? `${label} (${shown.length} of ${result.files.length}):` : `${label} (${result.files.length}):`;
         lines.push(header);
         for (const file of shown) {
-            lines.push(`- ${file.path} — ${clip(file.description, MAX_FILE_DESCRIPTION_CHARS)}${formatFileFacts(file)}`);
+            lines.push(`- ${toAnalysisRootPath(analysisId, file.path)} — ${clip(file.description, MAX_FILE_DESCRIPTION_CHARS)}${formatFileFacts(file)}`);
         }
     }
 

--- a/harness/src/prompts/briefing.test.ts
+++ b/harness/src/prompts/briefing.test.ts
@@ -51,7 +51,7 @@ function handoff(overrides: Partial<UpstreamHandoff> = {}): UpstreamHandoff {
 }
 
 const WORKSPACE = {
-    analysisRoot: "/an-1",
+    analysisId: "an-1",
     workingDir: "/an-1/runs/run-1/T1S2",
 } as const;
 
@@ -117,15 +117,15 @@ describe("renderOrientation", () => {
     };
 
     it("carries the dataset identity when a profile exists", () => {
-        const rendered = renderOrientation(profile);
+        const rendered = renderOrientation(profile, "an-1");
         expect(rendered).toContain("transcriptomics");
         expect(rendered).toContain("Homo sapiens");
-        expect(rendered).toContain("data/inputs/counts.csv");
+        expect(rendered).toContain("/an-1/data/inputs/counts.csv");
     });
 
     it("omits the section cleanly when the analysis has no profile yet", () => {
-        expect(renderOrientation(null)).toBe("");
-        expect(renderOrientation(undefined)).toBe("");
+        expect(renderOrientation(null, "an-1")).toBe("");
+        expect(renderOrientation(undefined, "an-1")).toBe("");
     });
 
     it("bounds a pathological profile to the orientation budget", () => {
@@ -140,7 +140,7 @@ describe("renderOrientation", () => {
         };
         // The projection is hard-clamped; the section adds only its heading and
         // the fixed pointer at the pull-the-full-profile tool.
-        expect(renderOrientation(huge).length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS + 200);
+        expect(renderOrientation(huge, "an-1").length).toBeLessThanOrEqual(DATA_PROFILE_ORIENTATION_MAX_CHARS + 200);
     });
 });
 

--- a/harness/src/prompts/briefing.ts
+++ b/harness/src/prompts/briefing.ts
@@ -123,21 +123,35 @@ export function renderTask(step: AnalysisStep): string {
 
 // ── (2) Workspace ─────────────────────────────────────────────────────
 
-/** The two in-sandbox paths that anchor every path the agent writes or reads. */
+/**
+ * What anchors every path the agent writes or reads: the id the tree is mounted
+ * at, and the step's writable directory.
+ *
+ * The frame carries the id rather than the analysis root, because the root is
+ * `/{analysisId}` and two fields for one value can disagree. The id is also what
+ * every other path in the briefing is rooted with, thus one field serves the
+ * workspace section and the orientation alike.
+ */
 export interface WorkspaceFrame {
-    /** In-sandbox analysis root — the read-only mount of the whole analysis tree. */
-    readonly analysisRoot: string;
+    /** The analysis id. The sandbox mounts the read-only analysis tree at `/{analysisId}`. */
+    readonly analysisId: string;
     /** In-sandbox working directory — this step's writable artifact directory, and its cwd. */
     readonly workingDir: string;
 }
 
+/** The in-sandbox analysis root of a frame — the read-only mount of the whole tree. */
+export function analysisRootOf(frame: WorkspaceFrame): string {
+    return `/${frame.analysisId}`;
+}
+
 export function renderWorkspace(frame: WorkspaceFrame): string {
-    if (!frame.analysisRoot.trim() || !frame.workingDir.trim()) return "";
+    if (!frame.analysisId.trim() || !frame.workingDir.trim()) return "";
+    const analysisRoot = analysisRootOf(frame);
     return section(
         "Workspace",
         bullets([
             `Working directory (writable, your cwd): \`${frame.workingDir}\` — write outputs to \`output/\`, \`figures/\`, \`scripts/\`, \`logs/\` under it.`,
-            `Analysis root (read-only): \`${frame.analysisRoot}\` — inputs at \`${frame.analysisRoot}/data/inputs/\`, prior runs at \`${frame.analysisRoot}/runs/\`.`,
+            `Analysis root (read-only): \`${analysisRoot}\` — inputs at \`${analysisRoot}/data/inputs/\`, prior runs at \`${analysisRoot}/runs/\`.`,
         ]),
     );
 }
@@ -149,9 +163,9 @@ export function renderWorkspace(frame: WorkspaceFrame): string {
  * Absent or not-yet-profiled → `""`, and the agent falls back to its always-on
  * `inspect_data_profile` tool.
  */
-export function renderOrientation(profile: DataProfileResult | null | undefined): string {
+export function renderOrientation(profile: DataProfileResult | null | undefined, analysisId: string): string {
     if (!profile) return "";
-    const orientation = buildDataProfileOrientation(profile, DATA_PROFILE_ORIENTATION_MAX_CHARS);
+    const orientation = buildDataProfileOrientation(profile, analysisId, DATA_PROFILE_ORIENTATION_MAX_CHARS);
     if (orientation.trim().length === 0) return "";
     return section("Data orientation", `${orientation}\n\nThis is a bounded projection — call \`inspect_data_profile\` for the full profile.`);
 }
@@ -229,7 +243,12 @@ export interface StepBriefing {
  * caller's durable step replay-stable.
  */
 export function composeStepBriefing(briefing: StepBriefing): string {
-    return [renderTask(briefing.step), renderWorkspace(briefing.workspace), renderOrientation(briefing.profile), renderUpstream(briefing.upstream)]
+    return [
+        renderTask(briefing.step),
+        renderWorkspace(briefing.workspace),
+        renderOrientation(briefing.profile, briefing.workspace.analysisId),
+        renderUpstream(briefing.upstream),
+    ]
         .filter(Boolean)
         .join("\n\n");
 }

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -423,7 +423,7 @@ export async function runDataProfileBody(input: DataProfileWorkflowInput, deps: 
                 `Profile the input data for this analysis: say what the dataset IS, so planning can proceed.`,
                 ``,
                 renderWorkspace({
-                    analysisRoot: `/${analysisId}`,
+                    analysisId,
                     workingDir: toSandboxPath(workspaceRoot, analysisId, profileWritePrefix),
                 }),
                 ``,

--- a/harness/src/tools/ad-hoc-router.ts
+++ b/harness/src/tools/ad-hoc-router.ts
@@ -82,7 +82,7 @@ async function profileOrientation(pool: Pool, analysisId: string, logger: Logger
     try {
         const status = unwrapOrThrow(await loadDataProfileStatus(pool, analysisId));
         if (!status?.result) return "No persisted data-profile facts are available.";
-        return buildDataProfileOrientation(status.result, DATA_PROFILE_ORIENTATION_MAX_CHARS);
+        return buildDataProfileOrientation(status.result, analysisId, DATA_PROFILE_ORIENTATION_MAX_CHARS);
     } catch (error) {
         logger.warn("could not load data profile for ad hoc routing", { error: error instanceof Error ? error.message : String(error) });
         return "The persisted data profile could not be loaded; route from the request alone.";

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -333,7 +333,7 @@ const NO_FACTS_GUIDANCE =
  *
  * Pure — the same grounding renders the same string.
  */
-function renderDataContext(grounding: DataGrounding): string {
+function renderDataContext(grounding: DataGrounding, analysisId: string): string {
     switch (grounding.kind) {
         case "absent":
             return "";
@@ -357,7 +357,7 @@ function renderDataContext(grounding: DataGrounding): string {
                 "From this analysis's persisted data profile — the authoritative record of what the input data " +
                     "is, derived by profiling the files themselves. Nobody typed it; ground your plan in it.",
                 "",
-                buildDataProfileOrientation(grounding.result, DATA_PROFILE_ORIENTATION_MAX_CHARS),
+                buildDataProfileOrientation(grounding.result, analysisId, DATA_PROFILE_ORIENTATION_MAX_CHARS),
             ];
             if (grounding.kind === "provisional") {
                 lines.push(
@@ -1004,7 +1004,7 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 },
             );
             const grounding = classifyGrounding(profileStatus);
-            const dataContextBlock = renderDataContext(grounding);
+            const dataContextBlock = renderDataContext(grounding, analysisId);
 
             // Reference data and package availability are mandatory grounding,
             // not optional planner lookups. Read both inventories host-side before

--- a/harness/src/tools/research/inspect-data-profile.test.ts
+++ b/harness/src/tools/research/inspect-data-profile.test.ts
@@ -314,10 +314,12 @@ describe("scope: files — paged, with truncation always visible", () => {
 
         const out = await run({ scope: "files" });
         expect(out).toMatchObject({ scope: "files", page: 1, pageSize: 20, total: 2, hasMore: false });
+        // The record stores a root-relative path; the tool serves the rooted form,
+        // which resolves to the same file from any agent's working directory.
         expect(out).toMatchObject({
             files: [
                 {
-                    path: "data/inputs/f1/counts.csv",
+                    path: `/${ANALYSIS}/data/inputs/f1/counts.csv`,
                     description: "Raw count matrix",
                     dataType: "count-matrix",
                     format: "CSV",
@@ -327,7 +329,14 @@ describe("scope: files — paged, with truncation always visible", () => {
                     warnings: ["3 low-depth samples"],
                     metrics: { sparsity: 0.41 },
                 },
-                { path: "data/inputs/f2/metadata.csv", description: "Sample metadata", dataType: "clinical-metadata", format: "CSV", rows: 24, cols: 6 },
+                {
+                    path: `/${ANALYSIS}/data/inputs/f2/metadata.csv`,
+                    description: "Sample metadata",
+                    dataType: "clinical-metadata",
+                    format: "CSV",
+                    rows: 24,
+                    cols: 6,
+                },
             ],
         });
     });
@@ -343,7 +352,7 @@ describe("scope: files — paged, with truncation always visible", () => {
 
         const second = await run({ scope: "files", page: 2, pageSize: 10 });
         expect(second).toMatchObject({ page: 2, total: 25, hasMore: true });
-        expect((second as { files: { path: string }[] }).files[0]?.path).toBe("data/inputs/f10/counts.csv");
+        expect((second as { files: { path: string }[] }).files[0]?.path).toBe(`/${ANALYSIS}/data/inputs/f10/counts.csv`);
 
         // The last page holds the remainder and says so — no silent truncation anywhere.
         const third = await run({ scope: "files", page: 3, pageSize: 10 });
@@ -425,6 +434,11 @@ describe("scope: kinds", () => {
             coverage: { matched: 3510, unmatched: 3, total: 3513 },
         });
         expect((out as { kinds: unknown[] }).kinds).toHaveLength(2);
+        // A glob takes the same rooting as a file path, and its wildcard survives it.
+        expect((out as { kinds: { pathPattern: string }[] }).kinds.map((k) => k.pathPattern)).toEqual([
+            `/${ANALYSIS}/data/inputs/vcf/*.vcf.gz`,
+            `/${ANALYSIS}/data/inputs/tbi/*.tbi`,
+        ]);
     });
 
     it("reports the scope unavailable — not empty — for a pre-kinds snapshot", async () => {

--- a/harness/src/tools/research/inspect-data-profile.ts
+++ b/harness/src/tools/research/inspect-data-profile.ts
@@ -19,6 +19,12 @@
  * Lifecycle states are data variants, not errors (the `defineTool` contract): a missing,
  * in-flight, failed, or stale profile is an ordinary, expected outcome the model must be
  * able to reason about, so each returns in the ok channel.
+ *
+ * Every path it serves is projected into the frame-independent `/{analysisId}/…`
+ * form. The record stores a path relative to the analysis root, and a step agent
+ * resolves a relative path against its own working directory — thus the stored
+ * form names a file that does not exist in the frame of the caller. The same
+ * projection guards the step briefing (`app/data-profile-orientation.ts`).
  */
 
 import { ok, type Result } from "neverthrow";
@@ -28,6 +34,7 @@ import { z } from "zod";
 import { scopeResource } from "../../auth/types.js";
 import { unwrapOrThrow } from "../../lib/result.js";
 import { loadDataProfileStatus, type DataProfileFile, type DataProfileResult, type DataProfileStatus } from "../../state/index.js";
+import { toAnalysisRootPath } from "../../workspace/paths.js";
 import { defineTool, type ToolError } from "../define-tool.js";
 
 /** Per-file records returned per page when the caller names none. */
@@ -162,6 +169,22 @@ function datasetFileCount(result: DataProfileResult): number | null {
     if (result.coverage) return result.coverage.total;
     if (result.kinds && result.kinds.length > 0) return result.kinds.reduce((sum, kind) => sum + kind.count, 0);
     return null;
+}
+
+/** Serve each per-file record with a path that resolves in the frame of the caller. */
+function rootFilePaths(files: readonly DataProfileFile[], analysisId: string): DataProfileFile[] {
+    return files.map((file) => ({ ...file, path: toAnalysisRootPath(analysisId, file.path) }));
+}
+
+/**
+ * Serve each kind with a glob that resolves in the frame of the caller.
+ *
+ * A `pathPattern` is a path with a wildcard segment, thus it takes the same
+ * projection as a file path. The wildcard characters survive it: the projection
+ * only re-roots the pattern.
+ */
+function rootKindPatterns(kinds: NonNullable<DataProfileResult["kinds"]>, analysisId: string): NonNullable<DataProfileResult["kinds"]> {
+    return kinds.map((kind) => ({ ...kind, pathPattern: toAnalysisRootPath(analysisId, kind.pathPattern) }));
 }
 
 /**
@@ -347,7 +370,7 @@ export function createInspectDataProfileTool(pool: Pool) {
                     ...envelope,
                     scope: "kinds",
                     available: true,
-                    kinds: result.kinds,
+                    kinds: rootKindPatterns(result.kinds, resourceId),
                     ...(result.axes ? { axes: result.axes } : {}),
                     ...(result.coverage ? { coverage: result.coverage } : {}),
                 });
@@ -366,7 +389,7 @@ export function createInspectDataProfileTool(pool: Pool) {
                 pageSize,
                 total,
                 hasMore: start + files.length < total,
-                files,
+                files: rootFilePaths(files, resourceId),
             });
         },
     });

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -531,7 +531,7 @@ export async function composeStepSeed(args: { input: ExecuteAnalysisInput; stepI
     // through the same helpers the sandbox mount and the mutate tools use, so
     // the seed cannot disagree with the container about where anything is.
     const workspace = {
-        analysisRoot: `/${analysisId}`,
+        analysisId,
         workingDir: toSandboxPath(workspaceRoot, analysisId, stepWritePrefix({ workspaceRoot, runId, stepId })),
     };
 

--- a/harness/src/workspace/paths.test.ts
+++ b/harness/src/workspace/paths.test.ts
@@ -9,6 +9,7 @@ import {
     resolveWorkspacePath,
     stepWritePrefix,
     tailWritePrefix,
+    toAnalysisRootPath,
     toSandboxPath,
 } from "./paths.js";
 
@@ -300,5 +301,46 @@ describe("toSandboxPath", () => {
 
     it("throws when the host path escapes the workspace root", () => {
         expect(() => toSandboxPath(ROOT, ANALYSIS, resolvePath(SESSIONS, "analysis-002", "x"))).toThrow(/escapes the workspace root/);
+    });
+});
+
+describe("toAnalysisRootPath", () => {
+    it("roots a stored root-relative path", () => {
+        expect(toAnalysisRootPath(ANALYSIS, "data/inputs/x.csv")).toBe(`/${ANALYSIS}/data/inputs/x.csv`);
+        expect(toAnalysisRootPath(ANALYSIS, "")).toBe(`/${ANALYSIS}`);
+    });
+
+    it("is idempotent on a path that already carries the root", () => {
+        const rooted = `/${ANALYSIS}/data/inputs/x.csv`;
+        expect(toAnalysisRootPath(ANALYSIS, rooted)).toBe(rooted);
+        expect(toAnalysisRootPath(ANALYSIS, toAnalysisRootPath(ANALYSIS, "data/inputs/x.csv"))).toBe(rooted);
+        expect(toAnalysisRootPath(ANALYSIS, `/${ANALYSIS}`)).toBe(`/${ANALYSIS}`);
+    });
+
+    it("reads the near-misses a model writes as the same file", () => {
+        for (const written of ["/data/inputs/x.csv", "./data/inputs/x.csv", "data//inputs/x.csv", "  data/inputs/x.csv  ", "data/./inputs/x.csv"]) {
+            expect(toAnalysisRootPath(ANALYSIS, written)).toBe(`/${ANALYSIS}/data/inputs/x.csv`);
+        }
+    });
+
+    it("keeps the wildcard segments of a kind's glob", () => {
+        expect(toAnalysisRootPath(ANALYSIS, "data/inputs/vcf/*.vcf.gz")).toBe(`/${ANALYSIS}/data/inputs/vcf/*.vcf.gz`);
+    });
+
+    it("returns a path that climbs above the root unchanged, so the resolver rejects it", () => {
+        expect(toAnalysisRootPath(ANALYSIS, "../other/x.csv")).toBe("../other/x.csv");
+        expect(resolveWorkspacePath({ workspaceRoot: ROOT, analysisId: ANALYSIS, path: "../other/x.csv" }).kind).toBe("out_of_scope");
+    });
+
+    it("gives a path that resolves to the same file from inside a step frame", () => {
+        // The defect this guards: a stored root-relative path resolves against the
+        // step's working directory, which is not where the file is.
+        const stored = "data/inputs/x.csv";
+        const frameLocal = resolveWorkspacePath({ workspaceRoot: ROOT, analysisId: ANALYSIS, path: stored, workingDir: STEP_DIR });
+        expect(frameLocal.kind === "ok" && frameLocal.relative).not.toBe(stored.split("/").join(sep));
+
+        const rooted = resolveWorkspacePath({ workspaceRoot: ROOT, analysisId: ANALYSIS, path: toAnalysisRootPath(ANALYSIS, stored), workingDir: STEP_DIR });
+        expect(rooted.kind).toBe("ok");
+        if (rooted.kind === "ok") expect(rooted.relative).toBe(stored.split("/").join(sep));
     });
 });

--- a/harness/src/workspace/paths.ts
+++ b/harness/src/workspace/paths.ts
@@ -26,7 +26,7 @@
  * read-only).
  */
 
-import { relative as relativePath, resolve as resolvePath, sep } from "node:path";
+import { posix as posixPath, relative as relativePath, resolve as resolvePath, sep } from "node:path";
 
 /**
  * The workspace-root resolution seam (see the workspace-root-resolution spec).
@@ -208,7 +208,53 @@ export function toSandboxPath(workspaceRoot: string, resourceId: string, hostAbs
     if (tail === ".." || tail.startsWith("../")) {
         throw new Error(`toSandboxPath: host path escapes the workspace root: ${hostAbsPath}`);
     }
+    return joinAnalysisRoot(resourceId, tail);
+}
+
+/**
+ * Map an analysis-root-relative path to the frame-independent `/{resourceId}/…`
+ * form this module defines at the top of the file.
+ *
+ * A record that outlives one agent stores the root-relative form, because that
+ * form does not depend on where a host puts the root. But a reader always reads
+ * inside a frame, and an agent whose working directory is a step directory
+ * resolves `data/inputs/x.csv` against that step directory. Thus one stored path
+ * is correct in the store and wrong in the message. This is the projection that a
+ * renderer applies before a stored path reaches an agent.
+ *
+ * The input comes from a record and it is a POSIX path, thus it normalizes under
+ * POSIX rules. The read is tolerant of the near-misses that a model writes: a
+ * leading slash, a `./` prefix, and a doubled separator all name the same file,
+ * and a path that already carries the correct root passes through. A tail that
+ * climbs above the root is returned as it is, because such a path must fail at
+ * the resolver as `out_of_scope`. A prefix would only make it look canonical.
+ */
+export function toAnalysisRootPath(resourceId: string, path: string): string {
+    const trimmed = path.trim();
+    if (trimmed === "") return `/${resourceId}`;
+
+    // Already rooted at this analysis: normalize the tail, then attach the root again.
+    const rooted = trimmed.startsWith("/") ? stripAnalysisRoot(trimmed, resourceId) : null;
+    if (rooted !== null) return joinAnalysisRoot(resourceId, normalizeTail(rooted));
+
+    // A record holds no host path. Thus a leading slash is how a model writes the
+    // same root-relative path, and the remainder is the tail.
+    const tail = normalizeTail(trimmed.replace(/^\/+/, ""));
+    if (tail === ".." || tail.startsWith("../")) return trimmed;
+    return joinAnalysisRoot(resourceId, tail);
+}
+
+/** `/{resourceId}` plus a tail. An empty tail gives the bare root. */
+function joinAnalysisRoot(resourceId: string, tail: string): string {
     return tail === "" ? `/${resourceId}` : `/${resourceId}/${tail}`;
+}
+
+/** Collapse `.`, `..`, and a doubled separator in a POSIX tail. A bare `.` becomes empty. */
+function normalizeTail(tail: string): string {
+    if (tail === "") return "";
+    const normalized = posixPath.normalize(tail);
+    if (normalized === "." || normalized === "./") return "";
+    return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }
 
 /**


### PR DESCRIPTION
## What & why

The data profile stores each file path relative to the analysis root. That is the correct storage form, because it does not depend on where a host puts the root. But every reader reads inside a frame. A sandbox step has its step directory as its working directory, thus it resolves `data/inputs/x.csv` against that step directory, where no such file exists.

The step briefing put the stored form in front of the agent unchanged, in the same message that names the working directory. A capable model saw the mismatch and added the root. A small model copied the string, and its script then failed to find the input. Each stored path now renders in the frame-independent `/{analysisId}/…` form. That form resolves to the same file in every frame, thus the projection is unconditional.

Notes for review:

- **`toAnalysisRootPath` holds the projection** (`workspace/paths.ts`), beside the `toSandboxPath` that already owns the `/{resourceId}/…` shape. It is idempotent. It reads the near-misses of a model as the same file: a leading slash, a `./` prefix, and a doubled separator. A path that climbs above the root passes through unchanged, thus the resolver still rejects it as `out_of_scope`.
- **`WorkspaceFrame` carries the analysis id in place of the analysis root.** The root is `/{analysisId}`. Two fields for one value can disagree, and one field now serves the workspace section and the orientation alike.
- **The orientation budget stays at 1200 characters.** A rooted path costs the length of the id on each line, thus a profile with many notable files elides its tail sooner. The file header still states the true total, and the section still points at `inspect_data_profile`. Raise the budget separately if this proves tight.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
