### PR TITLE
feat(harness): key a standing ask grant on the person it belongs to

### DIFF
--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -106,9 +106,8 @@ export type UIMessage = {
 const MESSAGE_CAP = 200;
 
 // The identity the ask seam keys a standing `always` grant on. One person owns a
-// local CLI install, and the CLI holds no account model, so every turn of every
-// analysis carries this one value. The harness never interprets it — a managed
-// host passes the identity of its signed-in person here instead.
+// local install, and the CLI holds no account model, so every turn carries this
+// one value.
 const LOCAL_ASK_USER_ID = "local";
 
 const [messages, setMessages] = createStore<UIMessage[]>([]);

--- a/cli/src/tui/hooks/conversation.ts
+++ b/cli/src/tui/hooks/conversation.ts
@@ -105,6 +105,12 @@ export type UIMessage = {
 // store's read imposes no ceiling of its own, so this is free to move.
 const MESSAGE_CAP = 200;
 
+// The identity the ask seam keys a standing `always` grant on. One person owns a
+// local CLI install, and the CLI holds no account model, so every turn of every
+// analysis carries this one value. The harness never interprets it — a managed
+// host passes the identity of its signed-in person here instead.
+const LOCAL_ASK_USER_ID = "local";
+
 const [messages, setMessages] = createStore<UIMessage[]>([]);
 const [streamText, setStreamText] = createSignal("");
 const [streamPartId, setStreamPartId] = createSignal<string | null>(null);
@@ -1436,7 +1442,14 @@ async function sendLocked(opts: { sessionId: string; analysisId: string; userTex
             // carrying the turn's analysis/thread, its abort signal, and its guarded emit sink, so the
             // gateway's `data-ask` emissions and its poll ride the same signal and sink as every other
             // turn event (a swap/reset that supersedes the turn drops them at `emitForTurn`).
-            ask: (req, emit) => runtime.askGateway.ask(req, { analysisId: opts.analysisId, threadId: opts.sessionId, signal: myTurn.signal, emit }),
+            ask: (req, emit) =>
+                runtime.askGateway.ask(req, {
+                    analysisId: opts.analysisId,
+                    userId: LOCAL_ASK_USER_ID,
+                    threadId: opts.sessionId,
+                    signal: myTurn.signal,
+                    emit,
+                }),
             analysisId: opts.analysisId,
             // The pg thread binds 1:1 to the session, so a plan launched here stamps its run.
             threadId: opts.sessionId,

--- a/harness/openspec/changes/scope-ask-grants-per-user/.openspec.yaml
+++ b/harness/openspec/changes/scope-ask-grants-per-user/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/harness/openspec/changes/scope-ask-grants-per-user/design.md
+++ b/harness/openspec/changes/scope-ask-grants-per-user/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`ask` (`src/tools/approval/gateway.ts`) reads a standing grant before it pauses.
+The lookup keys on `(analysis_id, grant_key)`, and `cortex_ask_grants` carries
+the same primary key. An analysis belongs to an organization, and each person
+with execute access can answer its asks. Thus one `always` blesses the future
+asks of every other person in that analysis.
+
+`AskContext` carries `analysisId`, `threadId`, `signal`, and `emit`. It carries
+no identity. The harness must not read the `auth` capability, and the managed
+credential is an opaque bearer token. Thus only the embedder can name the person.
+
+## Goals / Non-Goals
+
+- Goal: an `always` binds the person that gave it.
+- Goal: the seam stays host-agnostic. The harness takes an opaque string, and it
+  never interprets the value.
+- Non-goal: a revoke surface for a grant.
+- Non-goal: a call site. No tool calls `ctx.ask`, and this change adds none.
+- Non-goal: the cortex and lumen bind sites. They come in a later change.
+
+## Decisions
+
+- **`userId`, not `principalId`.** Nexus holds "principal" for the subject of an
+  authorization grant. The harness cannot see that model, thus a `principalId`
+  here would name a concept of a different system. `userId` is one plain word,
+  and it binds the seam to no identity model.
+- **The field is required.** An optional field gives the organization-wide grant
+  to each embedder that omits it. The weak state must not be the quiet default,
+  thus the typecheck asks the question one time at each bind site.
+- **The grant belongs to the user of the turn.** `answer(id, reply)` keeps its
+  shape, and the transaction reads `user_id` off the ask row. A grant answers
+  "do not ask me again", and the next ask goes to the user of the turn. A person
+  that answers the ask of a different person writes the grant of that person.
+  That power is bounded: the same person can already approve the one action, and
+  the grant covers one key in one analysis.
+- **The analysis stays in the key.** The primary key becomes
+  `(analysis_id, user_id, grant_key)`. The existing rule that a grant never
+  crosses an analysis holds, and the person is a narrower scope on top of it.
+- **The migration keeps each old row.** It adds `user_id` with an empty default,
+  drops the default, and then replaces the primary key. An old row cannot get a
+  person. The empty value matches no real user, thus the row is inert.
+- **`cortex_asks.user_id` is nullable, as `grant_key` is.** The additive
+  migration adds it with no backfill, and each new row writes it. The answer
+  transaction reads it with `COALESCE(user_id, '')`, thus a row that predates
+  the column can never write a grant that a real user matches.
+
+## Risks / Trade-offs
+
+- [A person answers the ask of a different person and writes that grant] → the
+  scope is one grant key in one analysis. That person already holds the power to
+  approve the action one time.
+- [An old grant stops working] → the person answers the ask one more time, and
+  the new grant carries the person. No row is deleted.
+- [No revoke surface] → a per-user grant makes a revoke more necessary. This
+  work leaves the gap as it stands, and `purge-analysis` still clears the table.
+
+## Migration Plan
+
+The DDL runs at boot inside the existing guarded block. The guard reads
+`information_schema` for the column, thus the work runs one time and each later
+boot is a no-op. A fresh database gets the shape from the `CREATE TABLE`.
+
+A rollback must revert the DDL with the code. The old code writes an insert with
+two key columns, and `user_id` carries no default after the migration.
+
+## Open Questions
+
+- A revoke route for a grant, and the surface that drives it.
+- Whether a person must see a grant that a different person recorded for them.

--- a/harness/openspec/changes/scope-ask-grants-per-user/proposal.md
+++ b/harness/openspec/changes/scope-ask-grants-per-user/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+`cortex_ask_grants` keys a standing grant on `(analysis_id, grant_key)`. An
+analysis belongs to an organization, and more than one person can work in it.
+Thus an `always` from one person auto-approves the turn of a different person,
+and that person never sees the ask. The gate exists to make a person decide. A
+grant that crosses persons removes that control.
+
+The harness cannot derive the person. It must not read the `auth` capability,
+and the credential it carries is opaque. Thus the embedder must supply the
+identity as plain data.
+
+## What Changes
+
+- `AskContext` gets a required `userId`. An embedder that omits it fails the
+  typecheck, thus the wide grant cannot be the quiet default.
+- `cortex_ask_grants` keys on `(analysis_id, user_id, grant_key)`. One grant
+  applies to one person in one analysis.
+- `cortex_asks` records `user_id`. The ledger says who each ask went to, and the
+  answer transaction reads the value back to write the grant.
+- `pending()` reports `userId`, thus a host can route an unresolved ask to the
+  correct person.
+- The CLI passes its one local identity at the bind site. No other consumer of
+  the seam is in this repository.
+
+No tool calls `ctx.ask` today. This change builds the support only, and it
+connects no tool.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tool-approval`: a standing grant belongs to one person inside the analysis,
+  not to the analysis. The ledger records the person of each request.
+
+## Impact
+
+- `src/state/init.ts` — `user_id` on both tables, and a guarded migration for
+  the new primary key.
+- `src/tools/approval/gateway.ts` — `AskContext.userId`, threaded into the row
+  and into the grant lookup.
+- `src/tools/approval/queries.ts` — `AskRow.userId`, `selectGrant` takes the
+  user, both inserts write the column, and the answer transaction keys the grant
+  on it.
+- `src/tools/approval/gateway.test.ts` — per-user grant coverage.
+- `cli/src/tui/hooks/conversation.ts` — the CLI binds its local identity.
+- Cortex and lumen give the value at their own bind sites, in a later change.

--- a/harness/openspec/changes/scope-ask-grants-per-user/specs/tool-approval/spec.md
+++ b/harness/openspec/changes/scope-ask-grants-per-user/specs/tool-approval/spec.md
@@ -1,0 +1,110 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: An always reply records an analysis-scoped standing grant`
+- TO: `### Requirement: An always reply records a standing grant for one user`
+
+## ADDED Requirements
+
+### Requirement: Each ask is raised for one user
+
+`AskContext` MUST carry a required `userId`. The value is an opaque identity
+string, and the embedder supplies it for the person that the ask goes to. The
+harness MUST NOT derive that identity, because it never reads the `auth`
+capability. The harness MUST NOT interpret the value. `ctx.ask` MUST record the
+identity on the ledger row (`cortex_asks.user_id`), and it MUST use the identity
+for the grant lookup. `pending()` MUST report the identity for each unresolved
+ask, thus a host can route an ask to the correct person.
+
+#### Scenario: The ledger row records the user of the turn
+
+- **GIVEN** an `AskContext` bound with a user id
+- **WHEN** `ctx.ask` persists its pending row
+- **THEN** the row carries that user id
+
+#### Scenario: The pending enumeration reports the user
+
+- **GIVEN** two unresolved asks raised for two different users
+- **WHEN** `pending()` is called
+- **THEN** each entry carries the user id its ask was raised for
+
+## MODIFIED Requirements
+
+### Requirement: The approval reply is a three-variant decision
+
+`AskReply` MUST be one of `once`, `always`, or `reject`, and it is never a
+boolean. `once` MUST approve the one pending invocation. `always` MUST approve
+the pending invocation, and it MUST record a standing grant for the matched
+action. That grant covers one user inside one analysis, and it lasts the
+lifecycle of the analysis (see the standing-grants requirement). `reject` MUST
+deny, and it can carry model-facing feedback text.
+
+#### Scenario: Approve-once returns and the tool proceeds
+
+- **WHEN** the user answers a pending ask with `once`
+- **THEN** `ctx.ask` returns the `once` reply and the tool proceeds with its guarded action
+
+#### Scenario: Reject carries optional feedback
+
+- **WHEN** the user answers a pending ask with `reject` and feedback text
+- **THEN** the reply carries that feedback for the model-facing denial
+
+### Requirement: An always reply records a standing grant for one user
+
+An `always` reply MUST persist a grant row (`cortex_ask_grants`) keyed by the
+analysis, the user, and the ask's grant key. The grant key is
+`AskRequest.grantKey` when the request carries one, and the `command` when it
+does not. The user is the `userId` of the `AskContext` that raised the ask, and
+not the caller that sends the answer. What the user approved as `always` MUST
+grant exactly that key and nothing broader. A tool that keys a grant more
+broadly than the displayed `command` MUST make that breadth visible in the
+request content it renders.
+
+When `ctx.ask` runs and a matching grant exists — the same analysis, the same
+user, and the same grant key — it MUST short-circuit with no pause. No prompt
+reaches a surface. The ask MUST still be recorded in `cortex_asks` as
+`resolved`, thus the ledger stays a complete audit of every approval-gated
+action. A grant MUST last for the lifecycle of its analysis, and it MUST survive
+a process restart. A grant MUST never apply to another analysis, and it MUST
+never apply to another user.
+
+#### Scenario: A matching grant auto-approves without pausing
+
+- **GIVEN** an analysis in which an earlier ask for a given grant key was answered `always`
+- **WHEN** a tool calls `ctx.ask` for the same grant key, in that analysis, for the same user
+- **THEN** `ctx.ask` returns approved without surfacing a prompt, and a `resolved` ledger row records the invocation
+
+#### Scenario: A grant does not cross users
+
+- **GIVEN** an `always` grant one user recorded in an analysis
+- **WHEN** a tool calls `ctx.ask` for the same grant key in that analysis, for a different user
+- **THEN** the ask pauses for a decision as if no grant existed
+
+#### Scenario: The grant carries the user of the ask, not the answerer
+
+- **GIVEN** a pending ask raised for user `U`
+- **WHEN** any caller answers that ask `always`
+- **THEN** the recorded grant carries `U`, and a later ask for `U` short-circuits
+
+#### Scenario: A grant matches on the grant key, not the displayed command
+
+- **GIVEN** an analysis where an ask with command `C1` and grant key `K` was answered `always`
+- **WHEN** a tool calls `ctx.ask` with a different command `C2` but the same grant key `K`, for the same user
+- **THEN** `ctx.ask` short-circuits and returns approved without surfacing a prompt
+
+#### Scenario: An absent grant key falls back to the command
+
+- **GIVEN** an ask with no `grantKey` answered `always`
+- **WHEN** a tool calls `ctx.ask` with the same `command` in that analysis, for the same user
+- **THEN** the grant short-circuits the prompt, exactly as when the grant key equals the command
+
+#### Scenario: A grant survives a process restart
+
+- **GIVEN** an analysis with a recorded `always` grant and a restarted harness process
+- **WHEN** a tool calls `ctx.ask` for the granted key, for the same user
+- **THEN** the grant still short-circuits the prompt
+
+#### Scenario: A grant does not cross analyses
+
+- **GIVEN** an `always` grant recorded in one analysis
+- **WHEN** a tool calls `ctx.ask` for the same grant key and the same user in a different analysis
+- **THEN** the ask pauses for a decision as if no grant existed

--- a/harness/openspec/changes/scope-ask-grants-per-user/tasks.md
+++ b/harness/openspec/changes/scope-ask-grants-per-user/tasks.md
@@ -1,0 +1,34 @@
+## 1. Schema
+
+- [x] 1.1 `src/state/init.ts`: `user_id` on `cortex_asks` (nullable, as `grant_key` is) and on `cortex_ask_grants`, with the primary key `(analysis_id, user_id, grant_key)`
+- [x] 1.2 `src/state/init.ts`: a guarded migration that adds `user_id` with an empty default, drops the default, and replaces the primary key
+
+## 2. The seam and its queries
+
+- [x] 2.1 `src/tools/approval/gateway.ts`: a required `userId` on `AskContext`, threaded into the row and into the grant lookup
+- [x] 2.2 `src/tools/approval/queries.ts`: `userId` on `AskRow`, written by both inserts
+- [x] 2.3 `src/tools/approval/queries.ts`: `selectGrant(querier, analysisId, userId, grantKey)`
+- [x] 2.4 `src/tools/approval/queries.ts`: the answer transaction returns `user_id` and keys the grant insert on it
+- [x] 2.5 `src/tools/approval/queries.ts`: `userId` on `PendingAsk`, selected by `selectPending`
+
+## 3. The bind site in this repository
+
+- [x] 3.1 `cli/src/tui/hooks/conversation.ts`: the CLI passes its one local identity
+
+## 4. Tests
+
+- [x] 4.1 A grant of one user does not short-circuit the ask of a different user
+- [x] 4.2 A grant of the same user short-circuits the ask, and the ledger records it `resolved`
+- [x] 4.3 An `always` answer writes the grant with the user of the ask row
+- [x] 4.4 `pending()` reports the user of each unresolved ask
+- [x] 4.5 `src/state/purge-analysis.test.ts`: the seeded grant row carries a user
+
+## 5. Verify
+
+- [x] 5.1 `bun run format:file` on each changed file in `src/`
+- [x] 5.2 `tsc -p tsconfig.json` clean in the harness
+- [x] 5.3 `bun run lint` clean
+- [x] 5.4 `bun test` green
+
+The CLI typecheck needs a build of the working-copy harness, and the `cli` job of
+the pull request links one. Thus that job covers task 3.1.

--- a/harness/src/state/init.ts
+++ b/harness/src/state/init.ts
@@ -432,10 +432,6 @@ CREATE TABLE IF NOT EXISTS cortex_working_memory (
 CREATE TABLE IF NOT EXISTS cortex_asks (
   id           TEXT PRIMARY KEY,
   analysis_id  TEXT NOT NULL,
-  -- The person that the ask goes to, as the embedder names one. The grant an
-  -- 'always' writes carries this value, thus the decision of one person never
-  -- approves the turn of a different person. Nullable only so the additive
-  -- migration can add it to an already-created table with no backfill.
   user_id      TEXT,
   thread_id    TEXT,
   title        TEXT NOT NULL,
@@ -460,12 +456,11 @@ CREATE INDEX IF NOT EXISTS idx_cortex_asks_analysis
 CREATE INDEX IF NOT EXISTS idx_cortex_asks_pending
   ON cortex_asks(status) WHERE status = 'pending';
 
--- Standing approval grants behind an 'always' reply. The key is the analysis,
--- the person the ask went to, and the ask's grant key (the displayed command when
--- the tool gave no broader key). A later ask that matches all three
--- auto-approves with no pause. A grant lives for the lifecycle of its analysis,
--- it survives a process restart, and it applies to no other analysis and to no
--- other person.
+-- Standing approval grants behind an 'always' reply — keyed by the analysis, the
+-- user, and the ask's grant key (the displayed command when the tool supplied no
+-- broader key), so a later matching ask auto-approves without pausing. Lives for
+-- the analysis lifecycle, surviving process restarts, and never applies to
+-- another analysis or another user.
 CREATE TABLE IF NOT EXISTS cortex_ask_grants (
   analysis_id  TEXT NOT NULL,
   user_id      TEXT NOT NULL,
@@ -660,17 +655,10 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                     ALTER TABLE cortex_ask_grants RENAME COLUMN command TO grant_key;
                   END IF;
                 END $$`,
-                // The person that an ask goes to. Nullable and unbackfilled, as
-                // grant_key is: every new row writes it, and an orphaned legacy pending
-                // row is swept to 'expired' before any answer reads it.
                 "ALTER TABLE cortex_asks ADD COLUMN IF NOT EXISTS user_id TEXT",
-                // A grant belongs to one person, thus the person joins the key. The
-                // guard reads information_schema, so the work runs one time and a fresh
-                // database (which the CREATE TABLE above already shapes) skips it. An
-                // existing row cannot get a person: it keeps the empty default, which
-                // matches no real identity, thus the row is inert and no row is lost.
-                // Scoped to current_schema() so parallel test schemas in the same
-                // database never trigger each other's migration.
+                // The user joins the grant key. Guarded and scoped like the rename
+                // above. An existing row keeps the empty default, which matches no real
+                // identity, so it is inert rather than deleted.
                 `DO $$ BEGIN
                   IF NOT EXISTS (
                     SELECT 1 FROM information_schema.columns

--- a/harness/src/state/init.ts
+++ b/harness/src/state/init.ts
@@ -432,6 +432,11 @@ CREATE TABLE IF NOT EXISTS cortex_working_memory (
 CREATE TABLE IF NOT EXISTS cortex_asks (
   id           TEXT PRIMARY KEY,
   analysis_id  TEXT NOT NULL,
+  -- The person that the ask goes to, as the embedder names one. The grant an
+  -- 'always' writes carries this value, thus the decision of one person never
+  -- approves the turn of a different person. Nullable only so the additive
+  -- migration can add it to an already-created table with no backfill.
+  user_id      TEXT,
   thread_id    TEXT,
   title        TEXT NOT NULL,
   command      TEXT NOT NULL,
@@ -455,16 +460,18 @@ CREATE INDEX IF NOT EXISTS idx_cortex_asks_analysis
 CREATE INDEX IF NOT EXISTS idx_cortex_asks_pending
   ON cortex_asks(status) WHERE status = 'pending';
 
--- Standing approval grants behind an 'always' reply — keyed by the analysis and
--- the ask's grant key (the displayed command when the tool supplied no broader
--- key), so a later matching ask auto-approves without pausing. Lives for the
--- analysis lifecycle, surviving process restarts, and never applies to another
--- analysis.
+-- Standing approval grants behind an 'always' reply. The key is the analysis,
+-- the person the ask went to, and the ask's grant key (the displayed command when
+-- the tool gave no broader key). A later ask that matches all three
+-- auto-approves with no pause. A grant lives for the lifecycle of its analysis,
+-- it survives a process restart, and it applies to no other analysis and to no
+-- other person.
 CREATE TABLE IF NOT EXISTS cortex_ask_grants (
   analysis_id  TEXT NOT NULL,
+  user_id      TEXT NOT NULL,
   grant_key    TEXT NOT NULL,
   created_at   TEXT NOT NULL,
-  PRIMARY KEY (analysis_id, grant_key)
+  PRIMARY KEY (analysis_id, user_id, grant_key)
 );
 `;
 
@@ -651,6 +658,28 @@ export async function initCortexState(pool: Pool, injected?: Logger): Promise<vo
                     WHERE table_schema = current_schema() AND table_name = 'cortex_ask_grants' AND column_name = 'command'
                   ) THEN
                     ALTER TABLE cortex_ask_grants RENAME COLUMN command TO grant_key;
+                  END IF;
+                END $$`,
+                // The person that an ask goes to. Nullable and unbackfilled, as
+                // grant_key is: every new row writes it, and an orphaned legacy pending
+                // row is swept to 'expired' before any answer reads it.
+                "ALTER TABLE cortex_asks ADD COLUMN IF NOT EXISTS user_id TEXT",
+                // A grant belongs to one person, thus the person joins the key. The
+                // guard reads information_schema, so the work runs one time and a fresh
+                // database (which the CREATE TABLE above already shapes) skips it. An
+                // existing row cannot get a person: it keeps the empty default, which
+                // matches no real identity, thus the row is inert and no row is lost.
+                // Scoped to current_schema() so parallel test schemas in the same
+                // database never trigger each other's migration.
+                `DO $$ BEGIN
+                  IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = current_schema() AND table_name = 'cortex_ask_grants' AND column_name = 'user_id'
+                  ) THEN
+                    ALTER TABLE cortex_ask_grants ADD COLUMN user_id TEXT NOT NULL DEFAULT '';
+                    ALTER TABLE cortex_ask_grants ALTER COLUMN user_id DROP DEFAULT;
+                    ALTER TABLE cortex_ask_grants DROP CONSTRAINT IF EXISTS cortex_ask_grants_pkey;
+                    ALTER TABLE cortex_ask_grants ADD PRIMARY KEY (analysis_id, user_id, grant_key);
                   END IF;
                 END $$`,
             ];

--- a/harness/src/state/purge-analysis.test.ts
+++ b/harness/src/state/purge-analysis.test.ts
@@ -154,12 +154,12 @@ describe("createAnalysisPurge", () => {
             values: [`plan-${analysisId}`, analysisId, now],
         });
         await rig.pool.query({
-            text: `INSERT INTO cortex_asks (id, analysis_id, title, command, grant_key, status, created_at)
-                   VALUES ($1, $2, 'run it', 'Rscript go.R', 'Rscript go.R', 'resolved', $3)`,
+            text: `INSERT INTO cortex_asks (id, analysis_id, user_id, title, command, grant_key, status, created_at)
+                   VALUES ($1, $2, 'user-1', 'run it', 'Rscript go.R', 'Rscript go.R', 'resolved', $3)`,
             values: [`ask-${analysisId}`, analysisId, now],
         });
         await rig.pool.query({
-            text: `INSERT INTO cortex_ask_grants (analysis_id, grant_key, created_at) VALUES ($1, 'Rscript go.R', $2)`,
+            text: `INSERT INTO cortex_ask_grants (analysis_id, user_id, grant_key, created_at) VALUES ($1, 'user-1', 'Rscript go.R', $2)`,
             values: [analysisId, now],
         });
 

--- a/harness/src/tools/approval/gateway.test.ts
+++ b/harness/src/tools/approval/gateway.test.ts
@@ -52,14 +52,18 @@ afterEach(async () => {
 
 const REQUEST: AskRequest = { title: "Run a command", command: "rm -rf /tmp/scratch", detail: "irreversible" };
 
+// Two people in one analysis — the case an analysis-keyed grant used to conflate.
+const USER_A = "user-A";
+const USER_B = "user-B";
+
 /** Start `ask` without awaiting, collecting its emitted `data-ask` parts. */
-function startAsk(request: AskRequest, analysisId = "analysis-A"): StartedAsk {
+function startAsk(request: AskRequest, analysisId = "analysis-A", userId = USER_A): StartedAsk {
     const controller = new AbortController();
     const parts: AskPartData[] = [];
     const emit: EmitFn = (event) => {
         if (event.type === "data-ask") parts.push((event as ChatDataPart).data as AskPartData);
     };
-    const ctx: AskContext = { analysisId, signal: controller.signal, emit };
+    const ctx: AskContext = { analysisId, userId, signal: controller.signal, emit };
     const promise = gateway.ask(request, ctx);
     controllers.push(controller);
     // A swallowing copy so a rejection the test itself awaits is not also seen as
@@ -172,17 +176,34 @@ describe("createAskGateway — answer and pending contract", () => {
         expect(await gateway.answer(idPending, { kind: "once" })).toBe("applied");
         expect(await stillPending.promise).toEqual({ kind: "once" });
     });
+
+    it("reports the user each unresolved ask was raised for", async () => {
+        const forA = startAsk(REQUEST, "analysis-A", USER_A);
+        const idA = await waitForPendingId("analysis-A");
+        const forB = startAsk({ ...REQUEST, command: "second command" }, "analysis-B", USER_B);
+        const idB = await waitForPendingId("analysis-B");
+
+        // A host reads this to route each ask to the person who can answer it.
+        const userById = new Map((await gateway.pending()).map((ask) => [ask.id, ask.userId]));
+        expect(userById.get(idA)).toBe(USER_A);
+        expect(userById.get(idB)).toBe(USER_B);
+
+        // Settle both so teardown has nothing racing the drop.
+        expect(await gateway.answer(idA, { kind: "once" })).toBe("applied");
+        expect(await gateway.answer(idB, { kind: "once" })).toBe("applied");
+        await Promise.all([forA.promise, forB.promise]);
+    });
 });
 
-// ── 5.3 — analysis-scoped standing grants ────────────────────────────
+// ── 5.3 — standing grants, per user inside one analysis ──────────────
 
 describe("createAskGateway — standing grants", () => {
     const GRANTED: AskRequest = { title: "Deploy", command: "git push --force", detail: undefined };
 
-    async function grantCount(analysisId: string, grantKey: string): Promise<number> {
+    async function grantCount(analysisId: string, grantKey: string, userId = USER_A): Promise<number> {
         const res = await pool.query({
-            text: `SELECT count(*)::int AS n FROM cortex_ask_grants WHERE analysis_id = $1 AND grant_key = $2`,
-            values: [analysisId, grantKey],
+            text: `SELECT count(*)::int AS n FROM cortex_ask_grants WHERE analysis_id = $1 AND grant_key = $2 AND user_id = $3`,
+            values: [analysisId, grantKey, userId],
         });
         return (res.rows[0] as { n: number }).n;
     }
@@ -202,7 +223,7 @@ describe("createAskGateway — standing grants", () => {
         const emit: EmitFn = (event) => {
             if (event.type === "data-ask") parts.push((event as ChatDataPart).data as AskPartData);
         };
-        const reply = await gateway.ask(GRANTED, { analysisId: "analysis-A", signal: controller.signal, emit });
+        const reply = await gateway.ask(GRANTED, { analysisId: "analysis-A", userId: USER_A, signal: controller.signal, emit });
 
         expect(reply).toEqual({ kind: "always" });
         expect(parts).toHaveLength(0);
@@ -219,7 +240,7 @@ describe("createAskGateway — standing grants", () => {
 
         const restarted = createAskGateway({ pool });
         const controller = new AbortController();
-        const reply = await restarted.ask(GRANTED, { analysisId: "analysis-A", signal: controller.signal, emit: () => {} });
+        const reply = await restarted.ask(GRANTED, { analysisId: "analysis-A", userId: USER_A, signal: controller.signal, emit: () => {} });
 
         expect(reply).toEqual({ kind: "always" });
         expect(await restarted.pending()).toHaveLength(0);
@@ -238,6 +259,44 @@ describe("createAskGateway — standing grants", () => {
 
         expect(await gateway.answer(otherId, { kind: "once" })).toBe("applied");
         expect(await other.promise).toEqual({ kind: "once" });
+    });
+
+    it("does not apply the grant of one user to another user in the same analysis", async () => {
+        const first = startAsk(GRANTED, "analysis-A", USER_A);
+        const id = await waitForPendingId("analysis-A");
+        expect(await gateway.answer(id, { kind: "always" })).toBe("applied");
+        expect(await first.promise).toEqual({ kind: "always" });
+
+        expect(await grantCount("analysis-A", GRANTED.command, USER_A)).toBe(1);
+        expect(await grantCount("analysis-A", GRANTED.command, USER_B)).toBe(0);
+
+        // The same command in the same analysis, for a different person: the ask
+        // pauses as if no grant existed. This is the whole point of the user key.
+        const other = startAsk(GRANTED, "analysis-A", USER_B);
+        const otherId = await waitForPendingId("analysis-A");
+        expect(await gateway.answer(otherId, { kind: "once" })).toBe("applied");
+        expect(await other.promise).toEqual({ kind: "once" });
+    });
+
+    it("records the grant under the user the ask was raised for", async () => {
+        // `answer` takes no identity — the ledger row is what names the person, so a
+        // decision recorded by anyone lands on the user of the paused turn.
+        const started = startAsk(GRANTED, "analysis-A", USER_B);
+        const id = await waitForPendingId("analysis-A");
+        expect(await gateway.answer(id, { kind: "always" })).toBe("applied");
+        expect(await started.promise).toEqual({ kind: "always" });
+
+        expect(await grantCount("analysis-A", GRANTED.command, USER_B)).toBe(1);
+        expect(await grantCount("analysis-A", GRANTED.command, USER_A)).toBe(0);
+
+        // The next ask of that same person short-circuits with no prompt.
+        const reply = await gateway.ask(GRANTED, {
+            analysisId: "analysis-A",
+            userId: USER_B,
+            signal: new AbortController().signal,
+            emit: () => {},
+        });
+        expect(reply).toEqual({ kind: "always" });
     });
 
     // A grant key lets a tool bless a broader class than the one command it displays.
@@ -262,7 +321,7 @@ describe("createAskGateway — standing grants", () => {
             if (event.type === "data-ask") parts.push((event as ChatDataPart).data as AskPartData);
         };
         const later: AskRequest = { title: "Write a file", command: "write_file report/b.txt", grantKey: WIDE_KEY };
-        const reply = await gateway.ask(later, { analysisId: "analysis-A", signal: new AbortController().signal, emit });
+        const reply = await gateway.ask(later, { analysisId: "analysis-A", userId: USER_A, signal: new AbortController().signal, emit });
 
         expect(reply).toEqual({ kind: "always" });
         expect(parts).toHaveLength(0);
@@ -338,7 +397,7 @@ describe("createAskGateway — sweep", () => {
     const STALE = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
 
     function pendingRow(createdAt: string): AskRow {
-        return { id: uuidv7(), analysisId: "analysis-A", threadId: null, title: "t", command: "c", detail: null, grantKey: null, createdAt };
+        return { id: uuidv7(), analysisId: "analysis-A", userId: USER_A, threadId: null, title: "t", command: "c", detail: null, grantKey: null, createdAt };
     }
 
     it("expires orphaned pending rows past the max age and returns the count swept", async () => {

--- a/harness/src/tools/approval/gateway.ts
+++ b/harness/src/tools/approval/gateway.ts
@@ -40,20 +40,12 @@ export interface AskGatewayDeps {
 
 /**
  * Per-turn context an embedder binds into the `Ask` seam. It scopes the ask to an
- * analysis/thread and to one person, carries the turn's abort `signal`, and
- * supplies the `emit` sink the `data-ask` part flows through.
+ * analysis/thread and to one user, carries the turn's abort `signal`, and supplies
+ * the `emit` sink the `data-ask` part flows through.
  */
 export interface AskContext {
     readonly analysisId: string;
-    /**
-     * The person the ask goes to, as an opaque identity the embedder names. It
-     * keys the standing grant an `always` records, thus the decision of one person
-     * never approves the turn of a different person in the same analysis.
-     *
-     * The harness cannot derive it — it never reads the `auth` capability — and it
-     * never interprets the value. It is required, because an absent identity would
-     * hand every embedder that forgot it an analysis-wide grant.
-     */
+    /** The opaque identity of the person the ask goes to. The harness never reads it. */
     readonly userId: string;
     readonly threadId?: string;
     readonly signal: AbortSignal;
@@ -97,10 +89,9 @@ export function createAskGateway(deps: AskGatewayDeps): AskGateway {
             createdAt: now,
         };
 
-        // A standing grant this person recorded for this ask's grant key — the
-        // command unless the tool supplied a broader key — short-circuits the prompt:
-        // record the invocation as `resolved` for the audit trail and return without
-        // pausing. The grant of a different person never matches here.
+        // A standing grant this user holds for this ask's grant key — the command
+        // unless the tool supplied a broader key — short-circuits the prompt: record
+        // the invocation as `resolved` for the audit trail and return without pausing.
         if (unwrapOrThrow(await selectGrant(pool, ctx.analysisId, ctx.userId, request.grantKey ?? request.command))) {
             unwrapOrThrow(await insertGrantedAsk(pool, row, now));
             return { kind: "always" };

--- a/harness/src/tools/approval/gateway.ts
+++ b/harness/src/tools/approval/gateway.ts
@@ -40,11 +40,21 @@ export interface AskGatewayDeps {
 
 /**
  * Per-turn context an embedder binds into the `Ask` seam. It scopes the ask to an
- * analysis/thread, carries the turn's abort `signal`, and supplies the `emit` sink
- * the `data-ask` part flows through.
+ * analysis/thread and to one person, carries the turn's abort `signal`, and
+ * supplies the `emit` sink the `data-ask` part flows through.
  */
 export interface AskContext {
     readonly analysisId: string;
+    /**
+     * The person the ask goes to, as an opaque identity the embedder names. It
+     * keys the standing grant an `always` records, thus the decision of one person
+     * never approves the turn of a different person in the same analysis.
+     *
+     * The harness cannot derive it — it never reads the `auth` capability — and it
+     * never interprets the value. It is required, because an absent identity would
+     * hand every embedder that forgot it an analysis-wide grant.
+     */
+    readonly userId: string;
     readonly threadId?: string;
     readonly signal: AbortSignal;
     readonly emit: EmitFn;
@@ -78,6 +88,7 @@ export function createAskGateway(deps: AskGatewayDeps): AskGateway {
         const row: AskRow = {
             id,
             analysisId: ctx.analysisId,
+            userId: ctx.userId,
             threadId: ctx.threadId ?? null,
             title: request.title,
             command: request.command,
@@ -86,10 +97,11 @@ export function createAskGateway(deps: AskGatewayDeps): AskGateway {
             createdAt: now,
         };
 
-        // A standing grant for this ask's grant key — the command unless the tool
-        // supplied a broader key — short-circuits the prompt: record the invocation as
-        // `resolved` for the audit trail and return without pausing.
-        if (unwrapOrThrow(await selectGrant(pool, ctx.analysisId, request.grantKey ?? request.command))) {
+        // A standing grant this person recorded for this ask's grant key — the
+        // command unless the tool supplied a broader key — short-circuits the prompt:
+        // record the invocation as `resolved` for the audit trail and return without
+        // pausing. The grant of a different person never matches here.
+        if (unwrapOrThrow(await selectGrant(pool, ctx.analysisId, ctx.userId, request.grantKey ?? request.command))) {
             unwrapOrThrow(await insertGrantedAsk(pool, row, now));
             return { kind: "always" };
         }

--- a/harness/src/tools/approval/queries.ts
+++ b/harness/src/tools/approval/queries.ts
@@ -27,6 +27,8 @@ export type AnswerOutcome = "applied" | "not_found" | "already_terminal";
 export interface PendingAsk {
     readonly id: string;
     readonly analysisId: string;
+    /** The person the ask went to, thus a host can route it to that person. */
+    readonly userId: string;
     readonly threadId: string | null;
     readonly title: string;
     readonly command: string;
@@ -44,6 +46,8 @@ export interface AskResolution {
 export interface AskRow {
     readonly id: string;
     readonly analysisId: string;
+    /** The person the ask goes to. An `always` keys its standing grant on this. */
+    readonly userId: string;
     readonly threadId: string | null;
     readonly title: string;
     readonly command: string;
@@ -58,9 +62,9 @@ export function insertPendingAsk(querier: Querier, row: AskRow): ResultAsync<voi
     return tryMutation("asks.insertPending", async () => {
         await querier.query({
             text: `INSERT INTO cortex_asks
-              (id, analysis_id, thread_id, title, command, detail, grant_key, status, created_at)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8)`,
-            values: [row.id, row.analysisId, row.threadId, row.title, row.command, row.detail, row.grantKey ?? row.command, row.createdAt],
+              (id, analysis_id, user_id, thread_id, title, command, detail, grant_key, status, created_at)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9)`,
+            values: [row.id, row.analysisId, row.userId, row.threadId, row.title, row.command, row.detail, row.grantKey ?? row.command, row.createdAt],
         });
     });
 }
@@ -74,11 +78,12 @@ export function insertGrantedAsk(querier: Querier, row: AskRow, resolvedAt: stri
     return tryMutation("asks.insertGranted", async () => {
         await querier.query({
             text: `INSERT INTO cortex_asks
-              (id, analysis_id, thread_id, title, command, detail, grant_key, status, reply, created_at, resolved_at)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, 'resolved', $8::jsonb, $9, $10)`,
+              (id, analysis_id, user_id, thread_id, title, command, detail, grant_key, status, reply, created_at, resolved_at)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'resolved', $9::jsonb, $10, $11)`,
             values: [
                 row.id,
                 row.analysisId,
+                row.userId,
                 row.threadId,
                 row.title,
                 row.command,
@@ -92,12 +97,12 @@ export function insertGrantedAsk(querier: Querier, row: AskRow, resolvedAt: stri
     });
 }
 
-/** Does a standing grant cover `(analysisId, grantKey)` in this analysis? */
-export function selectGrant(querier: Querier, analysisId: string, grantKey: string): ResultAsync<boolean, DbError> {
+/** Does a standing grant cover `(analysisId, userId, grantKey)` for this person? */
+export function selectGrant(querier: Querier, analysisId: string, userId: string, grantKey: string): ResultAsync<boolean, DbError> {
     return tryQuery("asks.selectGrant", async () => {
         const result = await querier.query({
-            text: `SELECT 1 FROM cortex_ask_grants WHERE analysis_id = $1 AND grant_key = $2`,
-            values: [analysisId, grantKey],
+            text: `SELECT 1 FROM cortex_ask_grants WHERE analysis_id = $1 AND user_id = $2 AND grant_key = $3`,
+            values: [analysisId, userId, grantKey],
         });
         return (result.rowCount ?? 0) > 0;
     });
@@ -133,12 +138,13 @@ export function markAborted(querier: Querier, id: string, resolvedAt: string): R
 export function selectPending(querier: Querier): ResultAsync<PendingAsk[], DbError> {
     return tryQuery("asks.selectPending", async () => {
         const result = await querier.query({
-            text: `SELECT id, analysis_id, thread_id, title, command, detail, created_at
+            text: `SELECT id, analysis_id, COALESCE(user_id, '') AS user_id, thread_id, title, command, detail, created_at
               FROM cortex_asks WHERE status = 'pending' ORDER BY created_at ASC`,
         });
         return result.rows.map((row: Record<string, unknown>) => ({
             id: row.id as string,
             analysisId: row.analysis_id as string,
+            userId: row.user_id as string,
             threadId: (row.thread_id as string | null) ?? null,
             title: row.title as string,
             command: row.command as string,
@@ -184,7 +190,7 @@ export function answerAsk(pool: Pool, id: string, reply: AskReply, now: string):
             client.query({
                 text: `UPDATE cortex_asks SET status = $1, reply = $2::jsonb, resolved_at = $3
                   WHERE id = $4 AND status = 'pending'
-                  RETURNING analysis_id, COALESCE(grant_key, command) AS grant_key`,
+                  RETURNING analysis_id, COALESCE(user_id, '') AS user_id, COALESCE(grant_key, command) AS grant_key`,
                 values: [status, JSON.stringify(reply), now, id],
             }),
         ).andThen((updated) => {
@@ -194,12 +200,16 @@ export function answerAsk(pool: Pool, id: string, reply: AskReply, now: string):
             // caveat: every insert writes grant_key (command when the tool supplied
             // none), and the COALESCE above covers any pending row that predates
             // the column — `command` is NOT NULL, so the key can never be null.
-            const granted = updated.rows[0] as { analysis_id: string; grant_key: string };
+            // `user_id` reads the same way, and its COALESCE gives the empty string
+            // for a row that predates that column. Such a row is an orphan of a dead
+            // process, and the empty identity matches no real person, thus the grant
+            // it would write can never short-circuit a live ask.
+            const granted = updated.rows[0] as { analysis_id: string; user_id: string; grant_key: string };
             return tryMutation("asks.answer:grant", async () => {
                 await client.query({
-                    text: `INSERT INTO cortex_ask_grants (analysis_id, grant_key, created_at)
-                      VALUES ($1, $2, $3) ON CONFLICT (analysis_id, grant_key) DO NOTHING`,
-                    values: [granted.analysis_id, granted.grant_key, now],
+                    text: `INSERT INTO cortex_ask_grants (analysis_id, user_id, grant_key, created_at)
+                      VALUES ($1, $2, $3, $4) ON CONFLICT (analysis_id, user_id, grant_key) DO NOTHING`,
+                    values: [granted.analysis_id, granted.user_id, granted.grant_key, now],
                 });
             }).map<AnswerOutcome>(() => "applied");
         }),

--- a/harness/src/tools/approval/queries.ts
+++ b/harness/src/tools/approval/queries.ts
@@ -27,7 +27,6 @@ export type AnswerOutcome = "applied" | "not_found" | "already_terminal";
 export interface PendingAsk {
     readonly id: string;
     readonly analysisId: string;
-    /** The person the ask went to, thus a host can route it to that person. */
     readonly userId: string;
     readonly threadId: string | null;
     readonly title: string;
@@ -46,7 +45,6 @@ export interface AskResolution {
 export interface AskRow {
     readonly id: string;
     readonly analysisId: string;
-    /** The person the ask goes to. An `always` keys its standing grant on this. */
     readonly userId: string;
     readonly threadId: string | null;
     readonly title: string;
@@ -200,10 +198,8 @@ export function answerAsk(pool: Pool, id: string, reply: AskReply, now: string):
             // caveat: every insert writes grant_key (command when the tool supplied
             // none), and the COALESCE above covers any pending row that predates
             // the column — `command` is NOT NULL, so the key can never be null.
-            // `user_id` reads the same way, and its COALESCE gives the empty string
-            // for a row that predates that column. Such a row is an orphan of a dead
-            // process, and the empty identity matches no real person, thus the grant
-            // it would write can never short-circuit a live ask.
+            // `user_id` reads the same way: its COALESCE gives the empty string for a
+            // row that predates the column, and that identity matches no real user.
             const granted = updated.rows[0] as { analysis_id: string; user_id: string; grant_key: string };
             return tryMutation("asks.answer:grant", async () => {
                 await client.query({


### PR DESCRIPTION
## What & why

A standing ask grant was keyed on the analysis and the grant key. An analysis
belongs to an organization, and each member with execute access answers its
asks. Thus one `always` blessed the future asks of every other member, and those
members never saw the ask. `AskContext` now carries a required `userId`, the ask
ledger records it, and `cortex_ask_grants` keys on
`(analysis_id, user_id, grant_key)`.

Notes for the review:

- The name is `userId`, and not `principalId`. Nexus holds "principal" for the
  subject of an authorization grant, thus that name would point at a model the
  harness cannot see.
- The field is required, not optional. An optional field would hand the wide
  grant to each embedder that omits it, and the weak state must not be the quiet
  default.
- `answer(id, reply)` keeps its shape. The grant carries the user of the ask
  row, thus the person that the next ask goes to owns it. `design.md` records
  the consequence when one person answers the ask of a different person.
- The migration keeps each old row. It adds the column with an empty default,
  drops the default, and replaces the primary key. An empty identity matches no
  real person, thus an old grant is inert and no row is lost.
- No tool calls `ctx.ask`. This change builds the support only. Cortex and lumen
  give the value at their own bind sites, in a later change.
- The CLI typecheck needs a build of the working-copy harness. The `cli` job of
  this pull request links one.

## Type of change

- [x] New feature / capability

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
