### PR TITLE
feat(cli): checkpoint the step a failed `inflexa setup` stops at

### DIFF
--- a/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/.openspec.yaml
+++ b/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/proposal.md
+++ b/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`inflexa setup` asks a long questionnaire, and it holds no memory of where a run stopped. Thus
+a failure at the reference-data step or the sandbox step costs the operator every question
+before it. The machine is already provisioned up to that point.
+
+Each step is idempotent against `config.json`, so the re-run is not dangerous. It is only
+tedious, and the tedium is what makes an operator abandon a half-provisioned machine. A Windows
+install that failed at the container step is the reported case. The compose file was the fault,
+and every re-attempt re-asked the connection mode, the Postgres user, and the port.
+
+The config cannot supply the memory on its own. `explicitPostgresFields` writes nothing when
+every answer equals a default, so "the user accepted the default" and "setup never asked" are
+the same document. The wizard needs its own small record.
+
+## What Changes
+
+- **A failed run records the step it stopped at.** The record holds one step name and the
+  version of the binary that wrote it. A complete run deletes it, so the file's presence alone
+  means "the last run failed".
+- **A re-run after a failure offers to continue.** One question, ahead of the wizard's first
+  question: continue from the recorded step, or ask everything. A re-run after a SUCCESS is
+  unchanged and asks the full questionnaire, which is what a deliberate re-run is for.
+- **A step before the continue point still runs, and asks nothing.** It resolves its value
+  through the same no-prompt path a batch run takes. Thus the later steps that consume `mode`
+  and `pgConn` see no difference.
+- **The connection-mode question and the connection block are one skip unit.** The direct
+  branch has no no-prompt path, because `collectDirectConnection` can only prompt. A partial
+  skip would ask again for the endpoint, the credential, and the model.
+- **The container work is never skipped.** A continue rewrites the compose file, starts the
+  stack, and waits on Postgres as a fresh run does. Those steps read live state, not an answer.
+- **A record from another binary version resolves to "no checkpoint".** A release can add,
+  drop, or reorder a step, so an old position names a step this build cannot honor. Every other
+  read fault resolves the same way, and an unreadable record never fails a run.
+
+## Impact
+
+- Affected specs: `setup-answers`
+- Affected code: `src/modules/infra/setup.ts`, `src/lib/env.ts`
+- `env.setupStatePath` is a new channel-aware stack path, so a dev failure never redirects the
+  wizard of an installed production binary.
+- Batch resolution is untouched. A run that cannot prompt never offers, thus `--yes` and a
+  non-TTY run resolve exactly as before.
+- `infra-state-resilience` needs no change. A deleted data dir, a truncated file, and a foreign
+  schema all resolve to "no checkpoint", which is the convergence that spec already demands.

--- a/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/specs/setup-answers/spec.md
+++ b/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/specs/setup-answers/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: One answers mechanism resolves every setup question
+
+Setup SHALL define a single answers schema (`SetupAnswers`) covering every interactive decision point of the setup flow — connection mode, direct-connection facts, credential source, model, Postgres fields, resource share, embedding backend and its values, reference selection, sandbox variant, and runtime. Two front-ends populate it: value flags and the `--config` YAML file, resolved per question with the fixed precedence:
+
+```
+flag  >  config-file value  >  interactive prompt (TTY, not --yes, and not before the checkpoint)  >  default-or-error (--yes, non-TTY, or a step before the checkpoint)
+```
+
+The checkpoint supplies no value. It withdraws the prompt of a step the operator chose to continue past. That step then resolves through the same no-prompt path `--yes` uses. The full rule is below, in "A failed setup records the step it stopped at".
+
+A supplied answer SHALL skip its prompt even in an interactive run, so a partially-filled config file composes with prompts for the remaining questions. A non-TTY run SHALL resolve exactly as `--yes` does. Every persisted value SHALL flow through the same writers the interactive wizard uses — the answers layer changes where values come from, never where they go.
+
+When a MODE-CARRYING flag (`--connection`, `--embeddings`) moves a block's mode away from the file's, the file's leaves that are exclusive to the superseded mode SHALL be dropped from the merged answers and the run SHALL print a note naming each superseded key and the flag that superseded it — an announced drop, never a silent one, and never a hard failure. Mismatches within one source (flag mode against flag leaves, or file mode against file leaves) remain upfront errors: a same-source contradiction is an authoring mistake, not an override.
+
+#### Scenario: A flag overrides the config file
+
+- **WHEN** setup runs with `--config fleet.yml` (carrying `postgres.password: a`) and `--postgres-password b`
+- **THEN** the resolved answer for the Postgres password is `b`
+
+#### Scenario: A config file answers questions interactively; prompts fill the gaps
+
+- **WHEN** setup runs on a TTY without `--yes`, with a config file answering the connection and Postgres questions but not embeddings
+- **THEN** the connection and Postgres prompts are skipped, and the embedding question is still asked
+
+#### Scenario: Non-TTY resolves like --yes
+
+- **WHEN** setup runs without a TTY and without `--yes`
+- **THEN** no prompt is attempted and every question resolves through the same default-or-error path `--yes` uses
+
+#### Scenario: A mode flag supersedes the file's dependent leaves
+
+- **WHEN** `setup --yes --config fleet.yml --embeddings off` runs with the file answering `embedding: {mode: api-key, baseURL: …, model: …}`
+- **THEN** the resolved embedding answer is `off`, the run prints a note naming `embedding.baseURL` and `embedding.model` as superseded by `--embeddings off`, and setup succeeds
+
+#### Scenario: A same-source mode mismatch still fails
+
+- **WHEN** `setup --yes --embeddings off --embeddings-url https://gw.corp/v1` runs (both answers from flags)
+- **THEN** setup fails upfront naming the mismatch, exactly as an all-file mismatch does
+
+## ADDED Requirements
+
+### Requirement: A failed setup records the step it stopped at, and a re-run offers to continue
+
+`inflexa setup` MUST record the name of the step it stopped at, when a run fails after the wizard opens. A run that completes MUST delete that record. Thus the record's presence alone means "the last run failed". No list of finished steps is kept.
+
+The record MUST hold the step name and the version of the binary that wrote it. It MUST live at a channel-aware path under the data dir. Thus a dev failure never redirects the wizard of an installed production binary.
+
+A record whose version is not this binary's MUST resolve to "no checkpoint". A release can add, drop, or reorder a step, thus an old position names a step this build cannot honor. Every other read fault MUST resolve the same way: no file, unreadable bytes, invalid JSON, and a foreign schema. An unreadable record MUST never fail a run.
+
+On a run that can prompt, a record MUST produce ONE question, ahead of the wizard's first question. The two answers are "continue from the recorded step" and "ask everything". A run that cannot prompt MUST never offer. It MUST resolve exactly as it does with no record, thus `--yes` and a non-TTY run are unchanged.
+
+A step BEFORE the chosen continue point MUST still run, and it MUST NOT ask its questions. It MUST resolve its value through the same no-prompt path `--yes` uses. Thus the later steps that consume that value see no difference. A step at or after the continue point MUST ask as it does with no record.
+
+The connection-mode question and the connection block that follows it MUST be skipped as one unit. The direct branch has no no-prompt path, thus a partial skip would ask again for the endpoint, the credential, and the model.
+
+The container work MUST NOT be skipped. A continue rewrites the compose file, starts the stack, and waits on Postgres, exactly as a fresh run does. Those steps read live state, not an answer.
+
+A failed record write MUST warn, and it MUST NOT change the outcome of the run. The run already failed, and the record is an affordance for the next run.
+
+#### Scenario: A late failure records its step
+
+- **WHEN** setup fails at the reference-data step
+- **THEN** the record names that step and the version of the binary, and the run names the step back to the operator
+
+#### Scenario: A complete run leaves no record
+
+- **WHEN** setup runs to "Setup complete"
+- **THEN** no record is on disk, and the next run asks every question
+
+#### Scenario: A record from another version is ignored
+
+- **GIVEN** a record written by a different version of the binary
+- **WHEN** setup runs
+- **THEN** no continue is offered, the run proceeds as a fresh one, and a complete run deletes the record
+
+#### Scenario: A continue silences the steps before it
+
+- **GIVEN** a record naming the reference-data step
+- **WHEN** an interactive setup runs and the operator chooses to continue
+- **THEN** the connection and Postgres questions are not asked, their persisted values are resolved, and the reference-data step still asks
+
+#### Scenario: Start again asks everything
+
+- **GIVEN** a record naming the reference-data step
+- **WHEN** an interactive setup runs and the operator chooses to start again
+- **THEN** every question is asked, and a complete run deletes the record
+
+#### Scenario: A batch run never offers to continue
+
+- **GIVEN** a record naming any step
+- **WHEN** `setup --yes` runs
+- **THEN** no question is asked, every step resolves through its batch path, and the run exits as it does with no record

--- a/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/tasks.md
+++ b/cli/openspec/changes/archive/2026-08-20-checkpoint-failed-setup/tasks.md
@@ -1,0 +1,34 @@
+## 1. The record on disk
+
+- [x] 1.1 Add `env.setupStatePath` to `StackPaths`, `stackPaths()`, `env`, and `envDoc`
+- [x] 1.2 Name the file `setup-state.json`, and `setup-state.dev.json` on the dev channel
+- [x] 1.3 Update the two `stackPaths` expectations and the cross-channel disjoint count
+
+## 2. The step names and the read
+
+- [x] 2.1 Add `SETUP_STEPS` in wizard order, and the `SetupStep` union it yields
+- [x] 2.2 Add `setupStateSchema` with the step name and the version of the binary
+- [x] 2.3 `readSetupState` resolves every fault to `null`, and a foreign version is one of them
+- [x] 2.4 `writeSetupState` and `clearSetupState` give a `Result`, never a throw
+
+## 3. The offer and the skip
+
+- [x] 3.1 `offerContinue` asks one question ahead of `intro`, on a run that can prompt
+- [x] 3.2 `done(step)` marks a step before the continue point. `asks(step)` withdraws its prompt
+- [x] 3.3 Thread `asks(step)` through postgres, model, resources, embeddings, refs, and sandbox
+- [x] 3.4 `chooseConnectionMode` takes `canAsk` and falls back to `resolveConnectionMode`
+- [x] 3.5 Skip the connection block as one unit when the continue point is past it
+
+## 4. The write seam
+
+- [x] 4.1 Set `currentStep` at the head of each step
+- [x] 4.2 Write the record in one `finally`, gated on `process.exitCode`
+- [x] 4.3 Delete the record on the success path, and warn on a failed delete
+
+## 5. Tests
+
+- [x] 5.1 A complete run leaves no record
+- [x] 5.2 A failed step records its own name and this binary's version
+- [x] 5.3 A record from another version is ignored, and the completing run deletes it
+- [x] 5.4 A continue silences the earlier steps and still asks the checkpoint step
+- [x] 5.5 "Start again" asks every question

--- a/cli/openspec/specs/setup-answers/spec.md
+++ b/cli/openspec/specs/setup-answers/spec.md
@@ -11,8 +11,10 @@ validation probes, and idempotency. Created by archiving change non-interactive-
 Setup SHALL define a single answers schema (`SetupAnswers`) covering every interactive decision point of the setup flow — connection mode, direct-connection facts, credential source, model, Postgres fields, resource share, embedding backend and its values, reference selection, sandbox variant, and runtime. Two front-ends populate it: value flags and the `--config` YAML file, resolved per question with the fixed precedence:
 
 ```
-flag  >  config-file value  >  interactive prompt (TTY and not --yes)  >  default-or-error (--yes or non-TTY)
+flag  >  config-file value  >  interactive prompt (TTY, not --yes, and not before the checkpoint)  >  default-or-error (--yes, non-TTY, or a step before the checkpoint)
 ```
+
+The checkpoint supplies no value. It withdraws the prompt of a step the operator chose to continue past. That step then resolves through the same no-prompt path `--yes` uses. The full rule is below, in "A failed setup records the step it stopped at".
 
 A supplied answer SHALL skip its prompt even in an interactive run, so a partially-filled config file composes with prompts for the remaining questions. A non-TTY run SHALL resolve exactly as `--yes` does. Every persisted value SHALL flow through the same writers the interactive wizard uses — the answers layer changes where values come from, never where they go.
 
@@ -223,4 +225,56 @@ Every answerable question SHALL be declared exactly once, in a single table keye
 
 - **WHEN** the config file contains `postgres:` as a null or scalar block
 - **THEN** the upfront error names the `postgres` file block together with its flag spellings, not the bare key alone
+
+### Requirement: A failed setup records the step it stopped at, and a re-run offers to continue
+
+`inflexa setup` MUST record the name of the step it stopped at, when a run fails after the wizard opens. A run that completes MUST delete that record. Thus the record's presence alone means "the last run failed". No list of finished steps is kept.
+
+The record MUST hold the step name and the version of the binary that wrote it. It MUST live at a channel-aware path under the data dir. Thus a dev failure never redirects the wizard of an installed production binary.
+
+A record whose version is not this binary's MUST resolve to "no checkpoint". A release can add, drop, or reorder a step, thus an old position names a step this build cannot honor. Every other read fault MUST resolve the same way: no file, unreadable bytes, invalid JSON, and a foreign schema. An unreadable record MUST never fail a run.
+
+On a run that can prompt, a record MUST produce ONE question, ahead of the wizard's first question. The two answers are "continue from the recorded step" and "ask everything". A run that cannot prompt MUST never offer. It MUST resolve exactly as it does with no record, thus `--yes` and a non-TTY run are unchanged.
+
+A step BEFORE the chosen continue point MUST still run, and it MUST NOT ask its questions. It MUST resolve its value through the same no-prompt path `--yes` uses. Thus the later steps that consume that value see no difference. A step at or after the continue point MUST ask as it does with no record.
+
+The connection-mode question and the connection block that follows it MUST be skipped as one unit. The direct branch has no no-prompt path, thus a partial skip would ask again for the endpoint, the credential, and the model.
+
+The container work MUST NOT be skipped. A continue rewrites the compose file, starts the stack, and waits on Postgres, exactly as a fresh run does. Those steps read live state, not an answer.
+
+A failed record write MUST warn, and it MUST NOT change the outcome of the run. The run already failed, and the record is an affordance for the next run.
+
+#### Scenario: A late failure records its step
+
+- **WHEN** setup fails at the reference-data step
+- **THEN** the record names that step and the version of the binary, and the run names the step back to the operator
+
+#### Scenario: A complete run leaves no record
+
+- **WHEN** setup runs to "Setup complete"
+- **THEN** no record is on disk, and the next run asks every question
+
+#### Scenario: A record from another version is ignored
+
+- **GIVEN** a record written by a different version of the binary
+- **WHEN** setup runs
+- **THEN** no continue is offered, the run proceeds as a fresh one, and a complete run deletes the record
+
+#### Scenario: A continue silences the steps before it
+
+- **GIVEN** a record naming the reference-data step
+- **WHEN** an interactive setup runs and the operator chooses to continue
+- **THEN** the connection and Postgres questions are not asked, their persisted values are resolved, and the reference-data step still asks
+
+#### Scenario: Start again asks everything
+
+- **GIVEN** a record naming the reference-data step
+- **WHEN** an interactive setup runs and the operator chooses to start again
+- **THEN** every question is asked, and a complete run deletes the record
+
+#### Scenario: A batch run never offers to continue
+
+- **GIVEN** a record naming any step
+- **WHEN** `setup --yes` runs
+- **THEN** no question is asked, every step resolves through its batch path, and the run exits as it does with no record
 

--- a/cli/src/lib/env.test.ts
+++ b/cli/src/lib/env.test.ts
@@ -128,6 +128,7 @@ describe("stackPaths", () => {
             cliproxyAuthDir: join(base, "inflexa", "cliproxy", "auth"),
             postgresDataDir: join(base, "inflexa", "postgres"),
             composeFilePath: join(base, "inflexa", "docker-compose.yml"),
+            setupStatePath: join(base, "inflexa", "setup-state.json"),
         });
     });
 
@@ -137,17 +138,19 @@ describe("stackPaths", () => {
             cliproxyAuthDir: join(base, "inflexa", "cliproxy-dev", "auth"),
             postgresDataDir: join(base, "inflexa", "postgres-dev"),
             composeFilePath: join(base, "inflexa", "docker-compose.dev.yml"),
+            setupStatePath: join(base, "inflexa", "setup-state.dev.json"),
         });
     });
 
     test("no stack path is shared across channels — the whole mount/compose surface is disjoint", () => {
         const prod = Object.values(stackPaths(base, "production"));
         const dev = Object.values(stackPaths(base, "development"));
-        // Every prod path is absent from the dev set (and vice versa), and the union is 8 distinct paths:
+        // Every prod path is absent from the dev set (and vice versa), and the union is 10 distinct paths:
         // a single shared entry would re-open a collision (shared PGDATA, one build rewriting the other's
-        // compose file, or — worst — a shared proxy credential dir the OAuth rotation would corrupt).
+        // compose file, a dev failure that redirects the wizard of an installed binary, or — worst — a
+        // shared proxy credential dir the OAuth rotation would corrupt).
         for (const p of prod) expect(dev).not.toContain(p);
-        expect(new Set([...prod, ...dev]).size).toBe(8);
+        expect(new Set([...prod, ...dev]).size).toBe(10);
     });
 });
 

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -222,7 +222,7 @@ export function isReservedPostgresPort(port: number): boolean {
     return reservedPostgresPorts.includes(port);
 }
 
-/** The four host-side stack paths that must not be shared across build channels. See {@link stackPaths}. */
+/** The five host-side stack paths that must not be shared across build channels. See {@link stackPaths}. */
 export type StackPaths = {
     /** CLIProxyAPI config file, bind-mounted into the proxy container. */
     readonly cliproxyConfigPath: string;
@@ -232,6 +232,12 @@ export type StackPaths = {
     readonly postgresDataDir: string;
     /** Generated Docker Compose file orchestrating the stack. */
     readonly composeFilePath: string;
+    /**
+     * Where a failed `inflexa setup` records the step it stopped at, so the next run can offer to
+     * continue there. Channel-aware with the rest: a dev run's failure must never redirect the wizard of
+     * an installed production binary, whose step list can differ.
+     */
+    readonly setupStatePath: string;
 };
 
 /**
@@ -244,11 +250,13 @@ export function stackPaths(dataDirBase: string, channel: string | undefined): St
     const proxyDir = dev ? "cliproxy-dev" : "cliproxy";
     const postgresDir = dev ? "postgres-dev" : "postgres";
     const composeFile = dev ? "docker-compose.dev.yml" : "docker-compose.yml";
+    const setupStateFile = dev ? "setup-state.dev.json" : "setup-state.json";
     return {
         cliproxyConfigPath: join(dataDirBase, "inflexa", proxyDir, "config.yaml"),
         cliproxyAuthDir: join(dataDirBase, "inflexa", proxyDir, "auth"),
         postgresDataDir: join(dataDirBase, "inflexa", postgresDir),
         composeFilePath: join(dataDirBase, "inflexa", composeFile),
+        setupStatePath: join(dataDirBase, "inflexa", setupStateFile),
     };
 }
 
@@ -333,6 +341,12 @@ export const env = Object.freeze({
      * run; the launch-time gate generates it if missing.
      */
     composeFilePath: stackDirs.composeFilePath,
+    /**
+     * The checkpoint of a failed `inflexa setup` — the name of the step that stopped, plus the version
+     * of the binary that wrote it. A complete run deletes the file, thus its presence alone means "the
+     * last run failed". See src/modules/infra/setup.ts.
+     */
+    setupStatePath: stackDirs.setupStatePath,
     configPath: join(configDir(), "inflexa", "config.json"),
     authPath: join(configDir(), "inflexa", "auth.json"),
     provKeyPath: join(configDir(), "inflexa", "prov_key.json"),
@@ -548,6 +562,12 @@ export const envDoc: Readonly<
         kind: "path",
         label: "compose file",
         description: "Docker Compose file orchestrating the proxy and Postgres containers",
+        baseVar: dataVar,
+    },
+    setupStatePath: {
+        kind: "path",
+        label: "setup checkpoint",
+        description: "the step a failed `inflexa setup` stopped at; deleted when a run completes",
         baseVar: dataVar,
     },
     configPath: { kind: "path", label: "config", description: "settings (telemetry consent)", baseVar: configVar },

--- a/cli/src/modules/infra/setup.test.ts
+++ b/cli/src/modules/infra/setup.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { REFERENCE_DATA_CATALOG } from "@inflexa-ai/harness";
+import pkg from "../../../package.json";
 import { ok, err } from "neverthrow";
 import {
     adoptedConnection,
@@ -2339,5 +2340,138 @@ describe("setup() — batch orchestration", () => {
                 entry.effect(observe());
             });
         }
+    });
+
+    describe("the checkpoint of a failed run", () => {
+        beforeEach(() => {
+            assertTestSandbox(env.setupStatePath);
+            rmSync(env.setupStatePath, { force: true });
+        });
+
+        afterEach(() => {
+            rmSync(env.setupStatePath, { force: true });
+        });
+
+        test("a complete run leaves no checkpoint, so the next run asks everything", async () => {
+            await runSetup(batch({}));
+
+            expect(process.exitCode).toBe(0);
+            expect(existsSync(env.setupStatePath)).toBe(false);
+        });
+
+        test("a failed step records its own name and the version that wrote it", async () => {
+            refsStep.mockImplementation(async () => err({ type: "download_failed" as const, message: "the mirror refused" }));
+
+            const output = await runSetup(batch({}));
+
+            expect(process.exitCode).toBe(1);
+            expect(JSON.parse(readFileSync(env.setupStatePath, "utf8"))).toEqual({ step: "refs", version: pkg.version });
+            // The step that failed is named back to the operator, because the record is only useful if
+            // they know a re-run will act on it.
+            expect(output).toContain('continue from the "refs" step');
+        });
+
+        test("a record from another binary version is ignored, and the completing run deletes it", async () => {
+            mkdirSync(dirname(env.setupStatePath), { recursive: true });
+            writeFileSync(env.setupStatePath, JSON.stringify({ step: "refs", version: "0.0.0-not-this-build" }));
+
+            await runSetup(batch({}));
+
+            // A foreign record names a position THIS build cannot honor, so the run proceeds normally —
+            // and completing it clears the file rather than leaving the stale record for the next run.
+            expect(process.exitCode).toBe(0);
+            expect(existsSync(env.setupStatePath)).toBe(false);
+        });
+    });
+
+    describe("a checkpoint continue silences only the steps before it", () => {
+        let wasTTY: boolean | undefined;
+        let prompts: string[];
+        let selects: string[];
+        let continueChoice: "continue" | "restart";
+
+        const CONTINUE_QUESTION = "Continue from there?";
+
+        beforeEach(() => {
+            assertTestSandbox(env.setupStatePath);
+            rmSync(env.setupStatePath, { force: true });
+            wasTTY = process.stdin.isTTY;
+            Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+            prompts = [];
+            selects = [];
+            continueChoice = "continue";
+            spies.push(
+                spyOn(cliPrompts, "promptText").mockImplementation(async (message: string, opts?: { defaultValue?: string }) => {
+                    prompts.push(message);
+                    return opts?.defaultValue ?? "openai";
+                }),
+                spyOn(cliPrompts, "promptTextOptional").mockImplementation(async (message: string) => {
+                    prompts.push(message);
+                    return null;
+                }),
+                spyOn(cliPrompts, "select").mockImplementation(async (message: string, options: { value: string; label: string }[]) => {
+                    selects.push(message);
+                    // Only the continue offer is steered per test; every other select takes its first
+                    // option, which is each one's documented default.
+                    return message.includes(CONTINUE_QUESTION) ? continueChoice : options[0]!.value;
+                }),
+                spyOn(sandboxPullModule, "sandboxPull").mockImplementation(async () => ok({ type: "declined" as const })),
+                spyOn(compose, "composeAvailable").mockImplementation(async () => true),
+                spyOn(compose, "writeComposeFile").mockImplementation(() => ok(undefined)),
+            );
+            globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 404 }))) as unknown as typeof fetch;
+        });
+
+        afterEach(() => {
+            Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+            rmSync(env.setupStatePath, { force: true });
+        });
+
+        /** Write the checkpoint this build would honor, at `step`. */
+        function checkpointAt(step: string): void {
+            mkdirSync(dirname(env.setupStatePath), { recursive: true });
+            writeFileSync(env.setupStatePath, JSON.stringify({ step, version: pkg.version }));
+        }
+
+        /** An interactive invocation with the Postgres step on, so its prompts are observable. */
+        const interactiveRun = { auth: false, start: false, force: false, postgres: true, flags: {} } as const;
+
+        function asked(messages: readonly string[], fragment: string): boolean {
+            return messages.some((message) => message.includes(fragment));
+        }
+
+        test("a `refs` checkpoint resolves the earlier steps in silence and still asks the refs step", async () => {
+            // Stand in for what the failed run persisted, so a silenced Postgres step has a value to resolve.
+            writeConfig({ ...readConfig(), postgres: { user: "fleet" } })._unsafeUnwrap();
+            checkpointAt("refs");
+
+            await runSetup(interactiveRun);
+
+            expect(process.exitCode).toBe(0);
+            expect(asked(selects, CONTINUE_QUESTION)).toBe(true);
+            // Every step before the checkpoint resolved without a question.
+            expect(asked(selects, "How should inflexa reach models?")).toBe(false);
+            expect(asked(prompts, "Username")).toBe(false);
+            expect(asked(prompts, "Port")).toBe(false);
+            // The checkpoint step itself still asks — a continue starts AT the step that failed.
+            expect(refsStep.mock.calls.at(-1)![0].interactive).toBe(true);
+            // A silenced step resolves what the failed run persisted, and writes nothing new.
+            expect(readConfig().postgres).toEqual({ user: "fleet" });
+            // The completed run cleared the record.
+            expect(existsSync(env.setupStatePath)).toBe(false);
+        });
+
+        test("start again asks every question, and the record is gone either way", async () => {
+            checkpointAt("refs");
+            continueChoice = "restart";
+
+            await runSetup(interactiveRun);
+
+            expect(process.exitCode).toBe(0);
+            expect(asked(selects, "How should inflexa reach models?")).toBe(true);
+            expect(asked(prompts, "Username")).toBe(true);
+            expect(asked(prompts, "Port")).toBe(true);
+            expect(existsSync(env.setupStatePath)).toBe(false);
+        });
     });
 });

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -1,12 +1,23 @@
 import { readdir, readFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+
+import pkg from "../../../package.json";
 
 import { intro, outro, log, note, spinner as clackSpinner } from "@clack/prompts";
-import { type Result, ok, err } from "neverthrow";
+import { Result, ok, err } from "neverthrow";
 import { z } from "zod";
-import { ensureRuntime, readConfig, resolvePostgresConfig, selectedRuntime, writeConfig, type ConfigError, type ModelAuthConfig } from "../../lib/config.ts";
+import {
+    ensureRuntime,
+    readConfig,
+    resolveConnectionMode,
+    resolvePostgresConfig,
+    selectedRuntime,
+    writeConfig,
+    type ConfigError,
+    type ModelAuthConfig,
+} from "../../lib/config.ts";
 import { ensureReady, firstReadyRuntime, runtimeIds, runtimes, ContainerRuntimeError, type ContainerRuntime } from "../../lib/container.ts";
 import {
     anthropicAuthTokenSet,
@@ -107,6 +118,93 @@ type SetupOptions = {
      */
     flags?: SetupAnswerFlags;
 };
+
+// --- the setup checkpoint --------------------------------------------------
+//
+// The wizard below asks a long questionnaire, and a failure at a late step used to cost the operator the
+// whole questionnaire again. The checkpoint gives the wizard one memory: the name of the step that
+// stopped.
+//
+// It marks a FAILED run only, and a complete run deletes the record. Thus a deliberate re-run after a
+// success keeps the full questionnaire, which is what a re-run is for, while a re-run after a failure
+// offers to continue. This is why the file holds no "these steps are done" list — such a list would make
+// every later re-run partial.
+
+/**
+ * The ordered step names of {@link setup}. The order IS the wizard's order, and the index of a name in
+ * this list is what "before the checkpoint" means. A name belongs here when a failure at a LATER step
+ * must not make the operator answer that step again.
+ */
+const SETUP_STEPS = ["connection", "auth", "postgres", "model", "resources", "embeddings", "refs", "sandbox"] as const;
+
+/** One step of the {@link setup} wizard. See {@link SETUP_STEPS}. */
+type SetupStep = (typeof SETUP_STEPS)[number];
+
+/**
+ * The on-disk record. `version` is the version of the binary that wrote it: a release can add, drop, or
+ * reorder a step name, so a record from a different build names a position THIS build cannot honor.
+ */
+const setupStateSchema = z.object({ step: z.enum(SETUP_STEPS), version: z.string() });
+
+/**
+ * The step the last failed run stopped at, or `null`. Absence is the NORMAL condition — a complete run
+ * deletes the file — so every fault resolves to `null` rather than to an error: no file, unreadable
+ * bytes, invalid JSON, a foreign schema, and a record from another binary version all mean the same
+ * thing here. A checkpoint that cannot be read costs one questionnaire, which is the state this feature
+ * improves on, and never a failed setup.
+ */
+function readSetupState(): SetupStep | null {
+    return Result.fromThrowable(
+        () => setupStateSchema.safeParse(JSON.parse(readFileSync(env.setupStatePath, "utf8"))),
+        () => undefined,
+    )().match(
+        (parsed) => (parsed.success && parsed.data.version === pkg.version ? parsed.data.step : null),
+        () => null,
+    );
+}
+
+/** The one fault a checkpoint write or delete can carry. Narrow by design: the caller only warns. */
+type SetupStateError = { type: "io_failed"; cause: unknown };
+
+/**
+ * Record `step` as the point a failed run stopped at. The write is never fatal to the caller — the run
+ * has already failed, and the record is an affordance for the NEXT run — so this gives the fault back
+ * rather than acting on it.
+ */
+function writeSetupState(step: SetupStep): Result<void, SetupStateError> {
+    return Result.fromThrowable(
+        () => {
+            mkdirSync(dirname(env.setupStatePath), { recursive: true });
+            writeFileSync(env.setupStatePath, JSON.stringify({ step, version: pkg.version }, null, 4) + "\n");
+        },
+        (cause): SetupStateError => ({ type: "io_failed", cause }),
+    )();
+}
+
+/**
+ * Delete the checkpoint, which is what marks the run complete. `force` makes the absent-file case a
+ * no-op, and that is the usual case: most runs never wrote a record.
+ */
+function clearSetupState(): Result<void, SetupStateError> {
+    return Result.fromThrowable(
+        () => rmSync(env.setupStatePath, { force: true }),
+        (cause): SetupStateError => ({ type: "io_failed", cause }),
+    )();
+}
+
+/**
+ * Ask whether to continue from `step`. Gives the step to continue from, or `null` to ask everything.
+ * This is the FIRST question of the run, ahead of `intro`, because its answer decides which of the
+ * questions after it are asked at all.
+ */
+async function offerContinue(step: SetupStep): Promise<SetupStep | null> {
+    log.warn(`The last setup run stopped at the "${step}" step.`);
+    const chosen = await select("Continue from there?", [
+        { value: "continue", label: `Continue from "${step}" — keep the answers before it` },
+        { value: "restart", label: "Start again — ask every question" },
+    ]);
+    return chosen === "continue" ? step : null;
+}
 
 export async function setup(options: SetupOptions): Promise<void> {
     // "Never prompt" is one fact, not two: `--yes` and a missing terminal withdraw the terminal
@@ -215,13 +313,36 @@ export async function setup(options: SetupOptions): Promise<void> {
     }
     const rt = readyResult.value;
 
+    // The checkpoint of a failed earlier run, and the operator's answer about it. Read AFTER the answer
+    // set validates and the runtime probes, because a run that dies there provisions nothing and so has no
+    // step to continue from. A run that cannot prompt never offers: `continueFrom` stays null, every
+    // predicate below resolves exactly as it did before this feature, and batch behavior is unchanged.
+    const failedAt = readSetupState();
+    const continueFrom = failedAt !== null && canPrompt ? await offerContinue(failedAt) : null;
+
+    /** True when `step` sits BEFORE the checkpoint the operator chose to continue from. */
+    const done = (step: SetupStep): boolean => continueFrom !== null && SETUP_STEPS.indexOf(step) < SETUP_STEPS.indexOf(continueFrom);
+
+    /**
+     * Whether `step` may ask its questions. A done step still RUNS — it resolves its value in silence,
+     * through the same no-prompt path a batch run already takes — so the later steps that consume that
+     * value see no difference. That existing path is what keeps this change small.
+     */
+    const asks = (step: SetupStep): boolean => canPrompt && !done(step);
+
     intro("inflexa setup");
+
+    // The single write seam of the checkpoint. The try below leaves through many error returns and one
+    // throw, and a mark at each of them would drift the first time a return is added. One variable, set at
+    // the head of each step, plus one write in the `finally`, covers all of them — and `process.exitCode`
+    // is the signal every one of those returns already sets.
+    let currentStep: SetupStep = "connection";
 
     try {
         // The connection mode is the ONE question whose batch default the resolver applies early and
         // whose interactive default it deliberately does NOT — applying it would pre-empt the wizard's
         // first prompt. So an unresolved mode here means exactly "an interactive run still has to ask".
-        const mode = await chooseConnectionMode(connectionMode);
+        const mode = await chooseConnectionMode(connectionMode, asks("connection"));
 
         // `--provider` wears the vocabulary of the connection mode (design D4), so its check can only run
         // once the mode is known — under batch that is upfront in the resolver, on an interactive run it
@@ -275,7 +396,15 @@ export async function setup(options: SetupOptions): Promise<void> {
             }
         }
 
-        if (mode === "cliproxy") {
+        currentStep = "auth";
+        // Both halves of the mode block write their result to config, so a continue past it reads what the
+        // failed run already persisted. The cliproxy half would be harmless to repeat (the proxy config
+        // heals, and an existing credential skips the login), but the direct half has NO silent path —
+        // `collectDirectConnection` can only prompt — so skipping the block as a unit is the only way to
+        // keep a continue from asking for the endpoint, the credential, and the model a second time.
+        if (done("auth")) {
+            log.info(`Keeping the ${mode} model connection that the last run saved.`);
+        } else if (mode === "cliproxy") {
             // --- proxy config ---
             const writeResult = await writeProxyConfig();
             if (writeResult.isErr()) {
@@ -496,12 +625,13 @@ export async function setup(options: SetupOptions): Promise<void> {
             }
         }
 
+        currentStep = "postgres";
         // --- postgres config ---
         // Postgres is provisioned in BOTH modes; only the compose file's service set differs (the mode
         // drops or keeps the proxy service — see generateComposeFile).
         let pgConn: PostgresConnection;
         if (options.postgres) {
-            const resolvedPostgres = await promptPostgresConfig(answers.postgres, canPrompt);
+            const resolvedPostgres = await promptPostgresConfig(answers.postgres, asks("postgres"));
             if (resolvedPostgres.isErr()) {
                 log.error(
                     `The answered Postgres configuration could not be saved: ${resolvedPostgres.error.type}.\n` +
@@ -571,6 +701,7 @@ export async function setup(options: SetupOptions): Promise<void> {
             pgConn = resolvePostgresConfig();
         }
 
+        currentStep = "model";
         // --- default chat model ---
         // Cliproxy only, and only after the compose step above started the proxy, so the live `/models`
         // list and the accessibility sweep can answer. Nothing here WAITS on the proxy's port bind (the
@@ -578,13 +709,14 @@ export async function setup(options: SetupOptions): Promise<void> {
         // gracefully, which is fine because it is optional and must never fail setup. An ANSWERED model
         // is a pin (no select); an unanswered one offers a preselected Auto default plus the account's
         // accessible models, and under batch keeps Auto semantics by writing nothing.
-        const cliproxyModel = await runDefaultModelSetup(mode, answers.connection?.model, batch, validate);
+        const cliproxyModel = await runDefaultModelSetup(mode, answers.connection?.model, !asks("model"), validate);
         if (cliproxyModel.isErr()) {
             log.error(cliproxyModel.error.message);
             process.exitCode = 1;
             return;
         }
 
+        currentStep = "resources";
         // --- analysis resource allowance ---
         // Collects the machine budget for the harness's resource policy — the
         // total share of this host analyses may use; per-step ceilings are
@@ -592,7 +724,7 @@ export async function setup(options: SetupOptions): Promise<void> {
         // share persists the machine-relative absolutes without the prompt; a run
         // that can neither ask nor read an answer skips entirely — the resolved
         // default (half the detected machine) applies unpersisted.
-        const resourceAllowance = await promptResourceConfig(answers.resources?.sharePct, canPrompt);
+        const resourceAllowance = await promptResourceConfig(answers.resources?.sharePct, asks("resources"));
         if (resourceAllowance.isErr()) {
             log.error(
                 `The answered resource allowance could not be saved: ${resourceAllowance.error.type}.\n` +
@@ -602,6 +734,7 @@ export async function setup(options: SetupOptions): Promise<void> {
             return;
         }
 
+        currentStep = "embeddings";
         // --- embeddings ---
         // The spec-bound position for the INTERACTIVE embedding question — after auth
         // + postgres, before "Setup complete". The clack select offers
@@ -612,7 +745,7 @@ export async function setup(options: SetupOptions): Promise<void> {
         // See modules/embedding/setup.ts.
         if (!embeddingModeAnswered) {
             const { runEmbeddingSetup } = await import("../embedding/setup.ts");
-            const embedResult = await runEmbeddingSetup(canPrompt, embeddingAnswers);
+            const embedResult = await runEmbeddingSetup(asks("embeddings"), embeddingAnswers);
             if (embedResult.isErr()) {
                 log.error(`Embedding setup: ${embedResult.error.message}`);
                 process.exitCode = 1;
@@ -620,6 +753,7 @@ export async function setup(options: SetupOptions): Promise<void> {
             }
         }
 
+        currentStep = "refs";
         // --- reference data ---
         // The setup offer and `inflexa refs download` share one handler. Creating the public
         // store/user namespace is deliberate here; no passive runtime path creates it.
@@ -627,8 +761,8 @@ export async function setup(options: SetupOptions): Promise<void> {
         const selection = referenceSelectionOf(answers.refs);
         const refsResult = await runReferenceSetup({
             // A selection is its own consent, so the only thing left to decide is whether the step may
-            // ask: a terminal that batch mode has not withdrawn.
-            interactive: canPrompt,
+            // ask: a terminal that neither batch mode nor the checkpoint has withdrawn.
+            interactive: asks("refs"),
             ...(selection === undefined ? {} : { selection }),
         });
         if (refsResult.isErr()) {
@@ -637,12 +771,21 @@ export async function setup(options: SetupOptions): Promise<void> {
             return;
         }
 
+        currentStep = "sandbox";
         // --- sandbox image ---
         // Provision the sandbox image through the SAME handler as
         // `inflexa sandbox pull` (design: one dogfooded path). A pull failure warns
         // and continues — the image is an offer here, not a hard prerequisite
         // (`inflexa profile` pulls it on demand if still missing).
-        await runSandboxImageSetup(answers.sandbox, canPrompt);
+        await runSandboxImageSetup(answers.sandbox, asks("sandbox"));
+
+        // Deleting the record IS the mark of a complete run: the next run then finds no checkpoint and
+        // asks everything, which is what a deliberate re-run is for. A failed delete leaves a stale record,
+        // whose only cost is one offer to continue on the next run, so it warns rather than failing here.
+        clearSetupState().match(
+            () => undefined,
+            () => log.warn(`Could not clear the setup checkpoint at ${env.setupStatePath}. The next run may offer to continue from a finished step.`),
+        );
 
         // Re-read rather than tracking "did THIS run configure embeddings": the closing hint is about the
         // MACHINE's state, and a backend left by the interactive picker above — or by an earlier run, which
@@ -653,6 +796,13 @@ export async function setup(options: SetupOptions): Promise<void> {
     } catch (error) {
         log.error(`Setup failed unexpectedly: ${error}`);
         process.exitCode = 1;
+    } finally {
+        if (process.exitCode === 1) {
+            writeSetupState(currentStep).match(
+                () => log.info(`Re-run \`inflexa setup\` to continue from the "${currentStep}" step.`),
+                () => log.warn("Could not record the setup checkpoint, so the next run asks every question again."),
+            );
+        }
     }
 }
 
@@ -1277,10 +1427,14 @@ const ANTHROPIC_AUTH_TOKEN_VAR = "ANTHROPIC_AUTH_TOKEN";
  * / `connection.mode` answer, or the `cliproxy` default it applies under batch), else an interactive
  * select. The mode value is validated in exactly one place — the answers schema — so this takes it
  * pre-narrowed rather than re-parsing a string a second front-end already checked.
+ *
+ * `canAsk` is false when a checkpoint continue has already passed this step. The persisted mode
+ * (`resolveConnectionMode`) is then the right answer, because the earlier run wrote it — and its
+ * `cliproxy` fallback matches what a terminal-less run resolved to before this parameter existed.
  */
-async function chooseConnectionMode(answered: ConnectionMode | undefined): Promise<ConnectionMode> {
+async function chooseConnectionMode(answered: ConnectionMode | undefined, canAsk: boolean): Promise<ConnectionMode> {
     if (answered) return answered;
-    if (!process.stdin.isTTY) return "cliproxy";
+    if (!canAsk) return resolveConnectionMode();
     const chosen = await select("How should inflexa reach models?", [
         { value: "cliproxy", label: "Managed local proxy (CLIProxyAPI) — default" },
         { value: "direct", label: "Direct endpoint (your own provider)" },

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -121,37 +121,23 @@ type SetupOptions = {
 
 // --- the setup checkpoint --------------------------------------------------
 //
-// The wizard below asks a long questionnaire, and a failure at a late step used to cost the operator the
-// whole questionnaire again. The checkpoint gives the wizard one memory: the name of the step that
-// stopped.
-//
-// It marks a FAILED run only, and a complete run deletes the record. Thus a deliberate re-run after a
-// success keeps the full questionnaire, which is what a re-run is for, while a re-run after a failure
-// offers to continue. This is why the file holds no "these steps are done" list — such a list would make
-// every later re-run partial.
+// A failed run records the step it stopped at, and a complete run deletes the record. So the file's
+// presence alone means "the last run failed": a re-run after a success keeps the full questionnaire,
+// which is what a re-run is for, and only a re-run after a failure offers to continue. A "these steps
+// are done" list would instead make every later re-run partial.
 
-/**
- * The ordered step names of {@link setup}. The order IS the wizard's order, and the index of a name in
- * this list is what "before the checkpoint" means. A name belongs here when a failure at a LATER step
- * must not make the operator answer that step again.
- */
+/** The step names in wizard order — the index of a name is what "before the checkpoint" means. */
 const SETUP_STEPS = ["connection", "auth", "postgres", "model", "resources", "embeddings", "refs", "sandbox"] as const;
 
-/** One step of the {@link setup} wizard. See {@link SETUP_STEPS}. */
 type SetupStep = (typeof SETUP_STEPS)[number];
 
-/**
- * The on-disk record. `version` is the version of the binary that wrote it: a release can add, drop, or
- * reorder a step name, so a record from a different build names a position THIS build cannot honor.
- */
+/** `version` guards the step name: a release can add, drop, or reorder one, and old positions then lie. */
 const setupStateSchema = z.object({ step: z.enum(SETUP_STEPS), version: z.string() });
 
 /**
- * The step the last failed run stopped at, or `null`. Absence is the NORMAL condition — a complete run
- * deletes the file — so every fault resolves to `null` rather than to an error: no file, unreadable
- * bytes, invalid JSON, a foreign schema, and a record from another binary version all mean the same
- * thing here. A checkpoint that cannot be read costs one questionnaire, which is the state this feature
- * improves on, and never a failed setup.
+ * The step the last failed run stopped at, or `null`. Absence is the NORMAL condition, so every fault —
+ * no file, bad bytes, a foreign schema, another binary version — resolves to `null` rather than to an
+ * error. An unreadable checkpoint costs one questionnaire, never a failed setup.
  */
 function readSetupState(): SetupStep | null {
     return Result.fromThrowable(
@@ -163,13 +149,11 @@ function readSetupState(): SetupStep | null {
     );
 }
 
-/** The one fault a checkpoint write or delete can carry. Narrow by design: the caller only warns. */
 type SetupStateError = { type: "io_failed"; cause: unknown };
 
 /**
- * Record `step` as the point a failed run stopped at. The write is never fatal to the caller — the run
- * has already failed, and the record is an affordance for the NEXT run — so this gives the fault back
- * rather than acting on it.
+ * Record `step` as the point a failed run stopped at. The fault rides back out because the run has
+ * already failed: the record is an affordance for the NEXT run, so losing it is never fatal here.
  */
 function writeSetupState(step: SetupStep): Result<void, SetupStateError> {
     return Result.fromThrowable(
@@ -181,10 +165,7 @@ function writeSetupState(step: SetupStep): Result<void, SetupStateError> {
     )();
 }
 
-/**
- * Delete the checkpoint, which is what marks the run complete. `force` makes the absent-file case a
- * no-op, and that is the usual case: most runs never wrote a record.
- */
+/** Delete the checkpoint — the mark of a complete run. `force` because most runs wrote no record. */
 function clearSetupState(): Result<void, SetupStateError> {
     return Result.fromThrowable(
         () => rmSync(env.setupStatePath, { force: true }),
@@ -193,9 +174,8 @@ function clearSetupState(): Result<void, SetupStateError> {
 }
 
 /**
- * Ask whether to continue from `step`. Gives the step to continue from, or `null` to ask everything.
- * This is the FIRST question of the run, ahead of `intro`, because its answer decides which of the
- * questions after it are asked at all.
+ * Ask whether to continue from `step`, or `null` to ask everything. It is the FIRST question of the run
+ * because its answer decides which of the questions after it are asked at all.
  */
 async function offerContinue(step: SetupStep): Promise<SetupStep | null> {
     log.warn(`The last setup run stopped at the "${step}" step.`);
@@ -313,10 +293,9 @@ export async function setup(options: SetupOptions): Promise<void> {
     }
     const rt = readyResult.value;
 
-    // The checkpoint of a failed earlier run, and the operator's answer about it. Read AFTER the answer
-    // set validates and the runtime probes, because a run that dies there provisions nothing and so has no
-    // step to continue from. A run that cannot prompt never offers: `continueFrom` stays null, every
-    // predicate below resolves exactly as it did before this feature, and batch behavior is unchanged.
+    // Read after the answers validate and the runtime probes: a run that dies there provisions nothing,
+    // so it has no step to continue from. A run that cannot prompt never offers, which is what leaves
+    // batch behavior unchanged.
     const failedAt = readSetupState();
     const continueFrom = failedAt !== null && canPrompt ? await offerContinue(failedAt) : null;
 
@@ -324,18 +303,15 @@ export async function setup(options: SetupOptions): Promise<void> {
     const done = (step: SetupStep): boolean => continueFrom !== null && SETUP_STEPS.indexOf(step) < SETUP_STEPS.indexOf(continueFrom);
 
     /**
-     * Whether `step` may ask its questions. A done step still RUNS — it resolves its value in silence,
-     * through the same no-prompt path a batch run already takes — so the later steps that consume that
-     * value see no difference. That existing path is what keeps this change small.
+     * Whether `step` may ask its questions. A done step still RUNS, through the same no-prompt path a
+     * batch run takes, so the later steps that consume its value see no difference.
      */
     const asks = (step: SetupStep): boolean => canPrompt && !done(step);
 
     intro("inflexa setup");
 
-    // The single write seam of the checkpoint. The try below leaves through many error returns and one
-    // throw, and a mark at each of them would drift the first time a return is added. One variable, set at
-    // the head of each step, plus one write in the `finally`, covers all of them — and `process.exitCode`
-    // is the signal every one of those returns already sets.
+    // The try below leaves through many error returns and one throw. One variable set at the head of each
+    // step, plus one write in the `finally`, covers all of them, so a new return needs no new mark.
     let currentStep: SetupStep = "connection";
 
     try {
@@ -397,11 +373,9 @@ export async function setup(options: SetupOptions): Promise<void> {
         }
 
         currentStep = "auth";
-        // Both halves of the mode block write their result to config, so a continue past it reads what the
-        // failed run already persisted. The cliproxy half would be harmless to repeat (the proxy config
-        // heals, and an existing credential skips the login), but the direct half has NO silent path —
-        // `collectDirectConnection` can only prompt — so skipping the block as a unit is the only way to
-        // keep a continue from asking for the endpoint, the credential, and the model a second time.
+        // Skipped as a UNIT: both halves persist their result to config, and the direct half has no silent
+        // path — `collectDirectConnection` can only prompt — so a partial skip would ask for the endpoint,
+        // the credential, and the model a second time.
         if (done("auth")) {
             log.info(`Keeping the ${mode} model connection that the last run saved.`);
         } else if (mode === "cliproxy") {
@@ -779,9 +753,7 @@ export async function setup(options: SetupOptions): Promise<void> {
         // (`inflexa profile` pulls it on demand if still missing).
         await runSandboxImageSetup(answers.sandbox, asks("sandbox"));
 
-        // Deleting the record IS the mark of a complete run: the next run then finds no checkpoint and
-        // asks everything, which is what a deliberate re-run is for. A failed delete leaves a stale record,
-        // whose only cost is one offer to continue on the next run, so it warns rather than failing here.
+        // A failed delete leaves a stale record, whose only cost is one offer to continue on the next run.
         clearSetupState().match(
             () => undefined,
             () => log.warn(`Could not clear the setup checkpoint at ${env.setupStatePath}. The next run may offer to continue from a finished step.`),

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -293,9 +293,15 @@ export async function setup(options: SetupOptions): Promise<void> {
     }
     const rt = readyResult.value;
 
-    // Read after the answers validate and the runtime probes: a run that dies there provisions nothing,
-    // so it has no step to continue from. A run that cannot prompt never offers, which is what leaves
-    // batch behavior unchanged.
+    // Read after the answers validate, the answered-embedding gate, and the runtime probes. Each of those
+    // sits outside the `try` that writes a checkpoint, so a run that dies in one records nothing.
+    //
+    // Only the embedding gate can provision before it fails: `--embeddings local` downloads a model and a
+    // runtime first. It stays uncovered anyway, because that gate fires only on an ANSWERED mode. An
+    // answered mode is a batch run, and a batch run never reaches the offer below, so no run could read
+    // the record it wrote.
+    //
+    // A run that cannot prompt never offers, which is what leaves batch behavior unchanged.
     const failedAt = readSetupState();
     const continueFrom = failedAt !== null && canPrompt ? await offerContinue(failedAt) : null;
 


### PR DESCRIPTION
## What & why

A failed `inflexa setup` restarted the whole questionnaire. Each step is idempotent against `config.json`, but the wizard held no memory of where it stopped, thus the operator answered every question again. `setup()` now records the name of the step that stopped, plus the version of the binary that wrote it. A complete run deletes the record, thus the file alone means "the last run failed": a re-run after a success keeps the full questionnaire, and a re-run after a failure offers to continue from that step.

Notes for the reviewer:

- **A skipped step still runs.** `asks(step)` (`cli/src/modules/infra/setup.ts:331`) only withdraws the prompt. The step resolves its value through the no-prompt path it already had for a batch run. As a result the later steps that consume `mode` and `pgConn` see no difference, and batch behavior is unchanged.
- **One write seam.** The `finally` at `cli/src/modules/infra/setup.ts:799` covers every error return and the unexpected throw, because `process.exitCode` is the signal each of those returns already sets. A new return needs no new mark.
- **The mode block is skipped as a unit** on a continue past it. Its direct half has no silent path, thus a partial skip would ask for the endpoint and the credential a second time.
- **`env.setupStatePath` is channel-aware** with the rest of the stack paths. A dev failure must never redirect the wizard of an installed production binary, whose step list can differ. A record from another version resolves to "no checkpoint".
- **No OpenSpec proposal yet.** The `cli` spec tree does not describe this behavior.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
