### PR TITLE
refactor(release): give the product metadata one source in cli/package.json

### DIFF
--- a/.github/homebrew/inflexa.rb.tmpl
+++ b/.github/homebrew/inflexa.rb.tmpl
@@ -7,8 +7,8 @@
 # (Bun itself is tap-only for the same reason), so a self-owned tap with a
 # binary-download formula is the standard channel — same model as oven-sh/bun.
 class Inflexa < Formula
-  desc "Local-first AI agent for reproducible biological data analysis"
-  homepage "https://github.com/inflexa-ai/inflexa"
+  desc "{{DESCRIPTION}}"
+  homepage "{{HOMEPAGE}}"
   # Explicit rather than scanned from the URL: the asset basenames end in
   # arch tokens (arm64, x64) that Homebrew's version detection could latch
   # onto, and the pinned value keeps livecheck comparisons exact.

--- a/.github/homebrew/render.sh
+++ b/.github/homebrew/render.sh
@@ -25,6 +25,35 @@ if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
   exit 1
 fi
 
+# cli/package.json is the one source of the product metadata, the same as it
+# is for the version (see .github/citation/sync.sh). .github/npm/assemble.ts
+# reads the same file for the npm packages. Edit the metadata there, not in
+# the template.
+manifest="$(dirname "$0")/../../cli/package.json"
+desc=$(jq -r '.description // ""' "$manifest")
+homepage=$(jq -r '.homepage // ""' "$manifest")
+
+if [ -z "$desc" ] || [ -z "$homepage" ]; then
+  echo "error: $manifest must give a description and a homepage" >&2
+  exit 1
+fi
+
+# Both values land inside a double-quoted Ruby string and inside a sed
+# program below. A quote, a backslash, or a line break breaks one of the two,
+# thus reject such a value before the splice.
+case "$desc$homepage" in
+  *'"'* | *'\'* | *$'\n'*)
+    echo "error: description and homepage in $manifest must hold no quote, backslash, or line break" >&2
+    exit 1
+    ;;
+esac
+
+# & and the | delimiter stay special in a sed replacement.
+esc_desc=${desc//&/\\&}
+esc_desc=${esc_desc//|/\\|}
+esc_homepage=${homepage//&/\\&}
+esc_homepage=${esc_homepage//|/\\|}
+
 sum_of() {
   local sha
   sha=$(awk -v name="$1" '$2 == name { print $1 }' "$assets/SHA256SUMS")
@@ -40,6 +69,8 @@ notices_sha=$(shasum -a 256 "$assets/THIRD-PARTY-NOTICES.txt" | awk '{ print $1 
 rendered=$(
   sed \
     -e "s/{{VERSION}}/$version/g" \
+    -e "s|{{DESCRIPTION}}|$esc_desc|g" \
+    -e "s|{{HOMEPAGE}}|$esc_homepage|g" \
     -e "s/{{SHA_DARWIN_ARM64}}/$(sum_of inflexa-darwin-arm64)/g" \
     -e "s/{{SHA_DARWIN_X64}}/$(sum_of inflexa-darwin-x64)/g" \
     -e "s/{{SHA_LINUX_X64}}/$(sum_of inflexa-linux-x64)/g" \

--- a/.github/npm/assemble.ts
+++ b/.github/npm/assemble.ts
@@ -19,27 +19,31 @@ import { createHash } from "node:crypto";
 import { chmodSync, cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const DESCRIPTION = "Local-first AI agent for reproducible biological data analysis";
 const REPO_URL = "https://github.com/inflexa-ai/inflexa";
-const HOMEPAGE_URL = "https://inflexa.ai";
 
+// cli/package.json is the one source of the product metadata, the same as it
+// is for the version (see .github/citation/sync.sh). That manifest is private
+// and thus never reaches npm, so the three fields are copied here into the
+// manifests that npm does receive. .github/homebrew/render.sh reads the same
+// file for the formula. Edit the metadata there, not here.
+const CLI_MANIFEST = join(import.meta.dir, "..", "..", "cli", "package.json");
+const cli = JSON.parse(readFileSync(CLI_MANIFEST, "utf8")) as {
+    description?: string;
+    homepage?: string;
+    keywords?: string[];
+};
+
+const DESCRIPTION = cli.description;
+const HOMEPAGE_URL = cli.homepage;
 // Only the wrapper carries the keywords: the five platform packages are
-// install-gated binary carriers, and the same terms on each of them puts five
+// install-gated binary carriers, and the same terms on each of them put five
 // near-identical results into one npm search.
-const KEYWORDS = [
-    "bioinformatics",
-    "computational-biology",
-    "ai-agent",
-    "agentic-ai",
-    "genomics",
-    "multi-omics",
-    "rna-seq",
-    "single-cell",
-    "reproducible-research",
-    "provenance",
-    "local-first",
-    "llm",
-];
+const KEYWORDS = cli.keywords;
+
+if (!DESCRIPTION || !HOMEPAGE_URL || !KEYWORDS?.length) {
+    console.error(`error: ${CLI_MANIFEST} must give a description, a homepage, and at least one keyword`);
+    process.exit(1);
+}
 
 type Platform = {
     /** npm naming: process.platform-process.arch, the launcher's lookup key. */

--- a/.github/npm/assemble.ts
+++ b/.github/npm/assemble.ts
@@ -21,6 +21,25 @@ import { join } from "node:path";
 
 const DESCRIPTION = "Local-first AI agent for reproducible biological data analysis";
 const REPO_URL = "https://github.com/inflexa-ai/inflexa";
+const HOMEPAGE_URL = "https://inflexa.ai";
+
+// Only the wrapper carries the keywords: the five platform packages are
+// install-gated binary carriers, and the same terms on each of them puts five
+// near-identical results into one npm search.
+const KEYWORDS = [
+    "bioinformatics",
+    "computational-biology",
+    "ai-agent",
+    "agentic-ai",
+    "genomics",
+    "multi-omics",
+    "rna-seq",
+    "single-cell",
+    "reproducible-research",
+    "provenance",
+    "local-first",
+    "llm",
+];
 
 type Platform = {
     /** npm naming: process.platform-process.arch, the launcher's lookup key. */
@@ -70,7 +89,7 @@ for (const line of readFileSync(join(assetsDir, "SHA256SUMS"), "utf8").split("\n
 
 const shared = {
     license: "Apache-2.0",
-    homepage: REPO_URL,
+    homepage: HOMEPAGE_URL,
     repository: { type: "git", url: `git+${REPO_URL}.git` },
     publishConfig: { access: "public", registry: "https://registry.npmjs.org" },
 };
@@ -132,6 +151,7 @@ writeFileSync(
             name: "@inflexa-ai/inflexa",
             version,
             description: DESCRIPTION,
+            keywords: KEYWORDS,
             ...shared,
             bin: { inflexa: "bin/inflexa.js" },
             files: ["bin", "postinstall.js"],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,22 @@
 {
     "name": "inflexa",
     "version": "0.16.1",
+    "description": "Local-first AI agent for reproducible biological data analysis",
+    "keywords": [
+        "bioinformatics",
+        "computational-biology",
+        "ai-agent",
+        "agentic-ai",
+        "genomics",
+        "multi-omics",
+        "rna-seq",
+        "single-cell",
+        "reproducible-research",
+        "provenance",
+        "local-first",
+        "llm"
+    ],
+    "homepage": "https://inflexa.ai",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## What & why

The npm packages of the CLI carried no keywords, and their `homepage` pointed at the repository. This PR adds the keywords and sets the homepage to `https://inflexa.ai`. It also gives the three metadata fields one source. Before, the description lived in two files in two languages, and the two homepages disagreed. Thus one edit asked for two changes, and a reader could not know which file to open. `cli/package.json` already owns the product version, so the metadata now takes the same route.

Notes for the review:

- `cli/package.json` stays private and never publishes itself. The two release scripts copy the fields into the artifacts that npm and Homebrew receive. Each script stops the release with a named error if a field is absent.
- The keywords go on the wrapper package only. The five platform packages carry one binary each. The same terms on all of them would put five near-identical results in one npm search.
- `render.sh` splices both values into a Ruby string and into a sed program. Thus it rejects an empty value, a quote, a backslash, and a line break first. It also escapes `&` and the `|` delimiter.
- The metadata reaches the registry and the tap at the next `Release npm` run and `Homebrew tap` run. Those runs build the artifacts.

I ran both scripts against fake release assets, with the fields present and with one absent. I read the rendered manifests and the formula.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`). No source file of a subsystem changed, and this worktree has no installed dependencies.
- [ ] Tests added or updated for the change. The two release scripts have no suite.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.
