### PR TITLE
chore(harness): bump the minor for the per-user ask grant

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.26.3",
+    "version": "0.27.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
## What & why

The published harness is at 0.26.3. The ask seam then gained a required `userId`
on `AskContext`. A standing grant now keys on the analysis, the user, and the
grant key. A new required field on a public interface is more than a fix. Thus
this pull request moves the minor to 0.27.0.

Notes for the review:

- The change is one line in `harness/package.json`, the same shape as the last
  bump, `fbe1d525`.
- The pin of `@inflexa-ai/harness` in the CLI stays as it is. A CLI release is a
  separate change, and it waits for this version to publish.

## Type of change

- [x] Refactor / internal change

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
