### PR TITLE
test(cli): give the sandboxStatus runtime probe a real timeout

### DIFF
--- a/cli/src/modules/libs/pull.test.ts
+++ b/cli/src/modules/libs/pull.test.ts
@@ -24,24 +24,42 @@ afterEach(() => {
     rmSync(env.configPath, { force: true });
 });
 
+/**
+ * The runtime resolution below spawns `docker` and `podman`, and the cost of that is the machine's, not
+ * the code's. It measures about 3.6 s on a developer machine, which sits close enough to Bun's 5-second
+ * default to cross it on a loaded CI runner — the whole test then reads as a failure of a change that
+ * touched nothing near it.
+ *
+ * The cap is raised rather than the probe stubbed. A stub would run in milliseconds, but the real seam is
+ * exactly what this case exists to exercise: that `firstReadyRuntime` resolves WITHOUT pinning. A stub
+ * would leave that claim untested and the test green, which is worse than slow.
+ *
+ * 30 s is about eight times the measured cost, and it still fails fast if a probe truly hangs.
+ */
+const RUNTIME_PROBE_TIMEOUT_MS = 30_000;
+
 describe("sandboxStatus — read-only, never pins", () => {
-    test("does not write the runtime config key when none is selected", async () => {
-        // No runtime selected: status must inspect against a detected ready runtime
-        // (or report unknown when none is) while leaving config untouched.
-        mkdirSync(dirname(env.configPath), { recursive: true });
-        writeFileSync(env.configPath, JSON.stringify({ telemetry: false }));
+    test(
+        "does not write the runtime config key when none is selected",
+        async () => {
+            // No runtime selected: status must inspect against a detected ready runtime
+            // (or report unknown when none is) while leaving config untouched.
+            mkdirSync(dirname(env.configPath), { recursive: true });
+            writeFileSync(env.configPath, JSON.stringify({ telemetry: false }));
 
-        // sandboxStatus prints its report to stdout; silence it for the test run.
-        const originalLog = console.log;
-        console.log = (): void => {};
-        try {
-            await sandboxStatus();
-        } finally {
-            console.log = originalLog;
-        }
+            // sandboxStatus prints its report to stdout; silence it for the test run.
+            const originalLog = console.log;
+            console.log = (): void => {};
+            try {
+                await sandboxStatus();
+            } finally {
+                console.log = originalLog;
+            }
 
-        expect(readConfig().runtime).toBeUndefined();
-    });
+            expect(readConfig().runtime).toBeUndefined();
+        },
+        RUNTIME_PROBE_TIMEOUT_MS,
+    );
 });
 
 describe("isMovingTag — decides when a present image must still be re-pulled", () => {


### PR DESCRIPTION
## What & why

`sandboxStatus` spawns `docker` and `podman` to resolve a runtime, which measures about 3.6 s here against Bun's 5-second default. A loaded CI runner crosses that cap. The case then fails, and it names a change that touched nothing near it. That is what it did on PR #443, whose failing commit only changed a comment. This gives that one case a 30-second cap.

Notes for the reviewer:

- **The cap is raised, and the probe is not stubbed.** A stub would run in milliseconds. The real seam is what the case exists to exercise: `firstReadyRuntime` resolves and does not pin (`cli/src/modules/libs/pull.ts:243`). A stub would leave that claim untested and the test green.
- **30 s is about eight times the measured cost.** It still fails fast if a probe truly hangs, which is the only thing the default cap protects.
- **Nothing in `pull.ts` changes.** The diff is the test file alone, and its body is unchanged apart from the indent that the new argument list requires.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
