### PR TITLE
feat(sandbox): bound exec streams at the producer, carry a digest not the body

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.27.0",
+    "version": "0.28.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/sandbox/await-exec.ts
+++ b/harness/src/sandbox/await-exec.ts
@@ -57,6 +57,7 @@
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 
+import { digestBody } from "./digest.js";
 import { signCallback, verifyCallback } from "./hmac.js";
 import { createEscalationPolicy, probeLiveness, syntheticFailureReason, syntheticFailureResult } from "./liveness.js";
 import {
@@ -322,13 +323,16 @@ export async function awaitExecCallback(
         }
 
         // Verify against the exact bytes sandbox-server signed. The route
-        // preserves them as `payloadRaw`; the JSON.stringify fallback exists
-        // only for messages persisted before that field was added — re-
-        // serializing diverges from Go's HTML-escaping encoder.
-        const bodyBytes = Buffer.from(msg.payloadRaw ?? JSON.stringify(msg.payload), "utf8");
+        // reduces them to `payloadDigest` at ingress — the signature covers that
+        // digest, so it is all verification needs and the message never carries
+        // a second copy of the body. `payloadRaw` is the superseded form, and
+        // the JSON.stringify fallback covers messages persisted before either
+        // field existed — re-serializing diverges from Go's HTML-escaping
+        // encoder, so it is a last resort, not a normal path.
+        const bodyDigest = msg.payloadDigest ?? digestBody(Buffer.from(msg.payloadRaw ?? JSON.stringify(msg.payload), "utf8"));
         const result = verifyCallback({
             execId,
-            body: bodyBytes,
+            bodyDigest,
             signature: msg.signature,
             timestamp: msg.timestamp,
             secret: callbackSecret,

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -24,6 +24,7 @@ import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.j
 import { tryMutation } from "../lib/db-result.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { clearSandboxRef, setSandboxRef } from "../state/index.js";
+import { capExecStreams, EXEC_STREAM_BYTE_CAP } from "../tools/workspace/result-bounds.js";
 import { awaitExec, type AwaitExecOptions } from "./await-exec.js";
 import type { SandboxClient } from "./client.js";
 import { createDockerSandboxOps } from "./docker-client.js";
@@ -57,6 +58,13 @@ export interface CreateSandboxClientConfig {
     transport?: SandboxTransport;
     /** Default sandbox-base image when the workflow doesn't override per-step. */
     image: string;
+    /**
+     * Per-stream retention budget sent with every exec, so the sandbox drops
+     * output past it instead of shipping it. Defaults to `EXEC_STREAM_BYTE_CAP`,
+     * the same value the host truncates to on receipt — sending more than the
+     * host will keep buys nothing.
+     */
+    execStreamByteCap?: number;
     /** Cluster resource ceilings; every sandbox request is clamped to these. */
     resourceLimits: ResourceLimits;
     /** K8s namespace; only used by the k8s backend. */
@@ -264,8 +272,21 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
             const resources = clampResources(meta.resources, config.resourceLimits);
             return unwrapOrThrow(await ops.createSandbox({ ...meta, resources }, identity));
         },
-        submitExec: async (ref, body) => submitExec(ref, body, config.submitDeps),
-        awaitExec: (ref, execId, emit, deadline) => awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),
+        submitExec: async (ref, body) =>
+            submitExec(ref, body, {
+                ...config.submitDeps,
+                execStreamByteCap: config.submitDeps?.execStreamByteCap ?? config.execStreamByteCap,
+            }),
+        // The one place an ExecResult crosses from the wire into the process, so
+        // the cap lands here rather than at each consumer. Every downstream use —
+        // tool results, workflow return values, durable step outputs — is bounded
+        // by construction, including against a sandbox image that predates the
+        // retention budget and still returns whole streams.
+        awaitExec: async (ref, execId, emit, deadline) =>
+            capExecStreams(
+                await awaitExec(ref, execId, emit, deadline, composeAwaitOptions(config.awaitOptions, transport, isAlive)),
+                config.execStreamByteCap ?? EXEC_STREAM_BYTE_CAP,
+            ),
         isAlive,
         isAliveById: async (sandboxId) => unwrapOrThrow(await ops.isAliveById(sandboxId)),
         teardown,

--- a/harness/src/sandbox/digest.ts
+++ b/harness/src/sandbox/digest.ts
@@ -1,0 +1,19 @@
+/**
+ * Body digest for sandbox callbacks.
+ *
+ * The callback signature is taken over the hex SHA-256 of the POSTed body
+ * rather than over the body itself, so the digest is a value the ingress can
+ * compute and forward while the bytes themselves are dropped — verification
+ * downstream needs nothing more.
+ *
+ * This lives apart from `hmac.ts` on purpose. Hashing carries no secret and
+ * decides nothing, so the route that only forwards can depend on it without
+ * taking on the verification machinery it is required to stay clear of.
+ */
+
+import { createHash } from "node:crypto";
+
+/** Hex SHA-256 of the POSTed bytes — the value the callback signature covers. */
+export function digestBody(input: Buffer | string): string {
+    return createHash("sha256").update(input).digest("hex");
+}

--- a/harness/src/sandbox/hmac.ts
+++ b/harness/src/sandbox/hmac.ts
@@ -15,12 +15,22 @@
  * neither of which should keep a 3-hour sandbox burning.
  */
 
-import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { digestBody } from "./digest.js";
 
 export interface VerifyCallbackInput {
     execId: string;
-    /** The bytes the sandbox-server POSTed. The dumb route preserves them. */
-    body: Buffer | string;
+    /**
+     * The bytes the sandbox-server POSTed. Supply this or `bodyDigest`.
+     *
+     * The signature covers the hex SHA-256 of the body, never the body itself,
+     * so a caller that has already hashed the bytes can verify from the digest
+     * alone — which is what keeps a large payload from being carried twice.
+     */
+    body?: Buffer | string;
+    /** Hex SHA-256 of the POSTed bytes. Takes precedence over `body`. */
+    bodyDigest?: string;
     /** `X-Sandbox-Signature` value (lowercase hex). */
     signature: string | null;
     /** `X-Sandbox-Timestamp` value (unix seconds). */
@@ -49,7 +59,7 @@ function decodeSecret(secret: string): Buffer {
 }
 
 function sha256Hex(input: Buffer | string): string {
-    return createHash("sha256").update(input).digest("hex");
+    return digestBody(input);
 }
 
 /**
@@ -66,8 +76,13 @@ export function verifyCallback(input: VerifyCallbackInput): VerifyResult {
         return { valid: false, reason: "missing" };
     }
 
+    const digest = input.bodyDigest ?? (input.body !== undefined ? sha256Hex(input.body) : undefined);
+    if (digest === undefined) {
+        return { valid: false, reason: "missing" };
+    }
+
     const secretBytes = decodeSecret(input.secret);
-    const message = `${input.execId}:${input.timestamp}:${sha256Hex(input.body)}`;
+    const message = `${input.execId}:${input.timestamp}:${digest}`;
     const expected = createHmac("sha256", secretBytes).update(message).digest("hex");
 
     const provided = input.signature;

--- a/harness/src/sandbox/submit-exec.test.ts
+++ b/harness/src/sandbox/submit-exec.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { EXEC_STREAM_BYTE_CAP } from "../tools/workspace/result-bounds.js";
 import { verifyCallback } from "./hmac.js";
 import { submitExec } from "./submit-exec.js";
 import type { SandboxRef } from "./types.js";
@@ -56,7 +57,33 @@ describe("submitExec", () => {
         expect(JSON.parse(calls[0]!.init!.body as string)).toEqual({
             command: ["echo", "hi"],
             execId: "wf-1:s-a:fn-0",
+            stdoutByteCap: EXEC_STREAM_BYTE_CAP,
+            stderrByteCap: EXEC_STREAM_BYTE_CAP,
         });
+    });
+
+    test("sends the configured retention budget instead of the default when given one", async () => {
+        const { fn, calls } = fetchResponding([{ status: 202, body: { execId: "wf-1:s-a:fn-0", status: "started" } }]);
+
+        await submitExec(REF, { command: ["echo", "hi"], execId: "wf-1:s-a:fn-0" }, { fetch: fn, runStep: (w) => w(), execStreamByteCap: 1234 });
+
+        const body = JSON.parse(calls[0]!.init!.body as string) as Record<string, unknown>;
+        expect(body.stdoutByteCap).toBe(1234);
+        expect(body.stderrByteCap).toBe(1234);
+    });
+
+    test("an explicit per-body cap wins over the configured default", async () => {
+        const { fn, calls } = fetchResponding([{ status: 202, body: { execId: "wf-1:s-a:fn-0", status: "started" } }]);
+
+        await submitExec(
+            REF,
+            { command: ["echo", "hi"], execId: "wf-1:s-a:fn-0", stdoutByteCap: 7, stderrByteCap: 9 },
+            { fetch: fn, runStep: (w) => w(), execStreamByteCap: 1234 },
+        );
+
+        const body = JSON.parse(calls[0]!.init!.body as string) as Record<string, unknown>;
+        expect(body.stdoutByteCap).toBe(7);
+        expect(body.stderrByteCap).toBe(9);
     });
 
     test("signs the exact bytes it POSTs, so sandbox-server's inbound check passes", async () => {

--- a/harness/src/sandbox/submit-exec.ts
+++ b/harness/src/sandbox/submit-exec.ts
@@ -19,6 +19,7 @@
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 
+import { EXEC_STREAM_BYTE_CAP } from "../tools/workspace/result-bounds.js";
 import { signCallback } from "./hmac.js";
 import type { SandboxRef, SubmitExecBody } from "./types.js";
 
@@ -27,6 +28,11 @@ export interface SubmitExecDeps {
     fetch?: typeof fetch;
     /** Injected for tests. Defaults to `DBOS.runStep`. */
     runStep?: <T>(fn: () => Promise<T>, config: { name: string }) => Promise<T>;
+    /**
+     * Per-stream retention budget to send when the body does not carry one.
+     * Defaults to `EXEC_STREAM_BYTE_CAP`.
+     */
+    execStreamByteCap?: number;
 }
 
 const SUBMIT_HTTP_TIMEOUT_MS = 30_000;
@@ -76,7 +82,16 @@ export async function submitExec(ref: SandboxRef, body: SubmitExecBody, deps: Su
     const fetchImpl = deps.fetch ?? fetch;
     const runStep = deps.runStep ?? (<T>(fn: () => Promise<T>, c: { name: string }) => DBOS.runStep(fn, c));
 
-    await runStep(() => postExec(fetchImpl, ref, body), {
+    // Every exec in the process funnels through here, so this is where the
+    // retention budget is attached rather than at each of the callers that build
+    // a body. Applied before signing, since the signature covers these bytes.
+    const capped: SubmitExecBody = {
+        ...body,
+        stdoutByteCap: body.stdoutByteCap ?? deps.execStreamByteCap ?? EXEC_STREAM_BYTE_CAP,
+        stderrByteCap: body.stderrByteCap ?? deps.execStreamByteCap ?? EXEC_STREAM_BYTE_CAP,
+    };
+
+    await runStep(() => postExec(fetchImpl, ref, capped), {
         name: `sandbox.submit-exec.${body.execId}`,
     });
 }

--- a/harness/src/sandbox/types.ts
+++ b/harness/src/sandbox/types.ts
@@ -111,6 +111,19 @@ export const ExecResultSchema = z.object({
     stderr: z.string().default(""),
     durationMs: z.number().nullable(),
     timedOut: z.boolean().default(false),
+    /**
+     * Set when sandbox-server dropped output past the per-stream cap it was
+     * given. The total is what the command actually produced, which is what
+     * separates "printed nothing" from "printed more than we kept" — without it
+     * a capped stream and an empty one are indistinguishable downstream.
+     *
+     * Optional because a sandbox image that pre-dates the cap omits both, and
+     * because the watchdog's synthetic failures carry neither.
+     */
+    stdoutTruncated: z.boolean().optional(),
+    stderrTruncated: z.boolean().optional(),
+    stdoutTotalBytes: z.number().int().nonnegative().optional(),
+    stderrTotalBytes: z.number().int().nonnegative().optional(),
     /** Set when the watchdog synthesises a completion for a dead sandbox. */
     syntheticFailure: z
         .object({
@@ -131,15 +144,21 @@ export type ExecResult = z.infer<typeof ExecResultSchema>;
  * a non-null `signature` and `timestamp`; the in-process watchdog uses a
  * `null` signature + a `synthetic-failure` payload (see `await-exec.ts`).
  *
- * `payloadRaw` is the exact bytes sandbox-server POSTed — sandbox-server's
- * HMAC signs the raw body, and Go's `encoding/json` HTML-escapes `<`, `>`,
- * `&` by default, so verifying against a JS re-serialization of the parsed
- * payload would diverge for any output containing those characters
- * (common in bioinformatics: FASTA headers, shell stderr, command pipelines).
- * Optional only for back-compat with messages that pre-date this field.
+ * `payloadDigest` is the hex SHA-256 of the exact bytes sandbox-server POSTed.
+ * The HMAC signs that digest rather than the body itself, so the digest is all
+ * verification needs — and carrying it instead of the bytes keeps the message
+ * from holding a second copy of a payload that can be arbitrarily large.
+ * Re-serializing the parsed payload would not do: Go's `encoding/json`
+ * HTML-escapes `<`, `>`, `&` by default, so a JS re-serialization diverges for
+ * any output containing those characters (common in bioinformatics: FASTA
+ * headers, shell stderr, command pipelines).
+ *
+ * `payloadRaw` is the superseded form, kept optional so messages already in
+ * flight or persisted still verify.
  */
 export const ExecEventMessageSchema = z.object({
     payload: z.unknown(),
+    payloadDigest: z.string().optional(),
     payloadRaw: z.string().optional(),
     signature: z.string().nullable(),
     timestamp: z.number().int().nullable(),
@@ -213,6 +232,14 @@ export interface SubmitExecBody {
     cwd?: string;
     env?: Record<string, string>;
     timeoutSeconds?: number;
+    /**
+     * Per-stream retention budget for the sandbox. Omitting them leaves the
+     * sandbox unbounded, which is how a server that pre-dates the fields
+     * behaves; the host caps on receipt regardless, so the difference is how
+     * many bytes cross the wire, not what the caller ends up with.
+     */
+    stdoutByteCap?: number;
+    stderrByteCap?: number;
 }
 
 /** Step-meta passed to `createSandbox` — what the registry row needs. */

--- a/harness/src/tools/workspace/execute-command.test.ts
+++ b/harness/src/tools/workspace/execute-command.test.ts
@@ -4,6 +4,7 @@ import { makeToolContext } from "../__fixtures__/tool-context.js";
 import type { SandboxClient } from "../../sandbox/client.js";
 import type { CreateSandboxMeta, ExecEmit, ExecResult, SandboxRef, SubmitExecBody } from "../../sandbox/types.js";
 import { createExecuteCommandTool } from "./execute-command.js";
+import { EXEC_STREAM_BYTE_CAP } from "./result-bounds.js";
 
 const DEFAULT_CWD = "/analysis-001/runs/run-abc/step1";
 
@@ -173,7 +174,10 @@ describe("execute_command tool", () => {
     });
 
     it("truncates oversize stdout while leaving exit/duration/timedOut intact", async () => {
-        const big = "x".repeat(9000);
+        // Derived from the cap, not a literal: a fixed size silently stops being
+        // oversize the moment the cap is raised, and the test then asserts
+        // truncation of something that was never truncated.
+        const big = "x".repeat(EXEC_STREAM_BYTE_CAP + 1000);
         const client = makeFakeClient({
             result: {
                 execId: "",

--- a/harness/src/tools/workspace/result-bounds.test.ts
+++ b/harness/src/tools/workspace/result-bounds.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import type { ExecResult } from "../../sandbox/types.js";
-import { EXEC_STREAM_BYTE_CAP, boundExecResult } from "./result-bounds.js";
+import { EXEC_STREAM_BYTE_CAP, boundExecResult, capExecStreams } from "./result-bounds.js";
 
 function baseResult(over: Partial<ExecResult> = {}): ExecResult {
     return {
@@ -78,5 +78,67 @@ describe("boundExecResult", () => {
     it("omits syntheticFailure when not present", () => {
         const r = boundExecResult(baseResult());
         expect("syntheticFailure" in r).toBe(false);
+    });
+});
+
+describe("boundExecResult with producer-side truncation", () => {
+    it("reports the sandbox's total rather than the length of what survived", () => {
+        // The sandbox kept 100 bytes of a 9 MB stream, so the retained slice is
+        // well under the cap — its length is not the number to report.
+        const r = boundExecResult(
+            baseResult({
+                stdout: "y".repeat(100),
+                stdoutTruncated: true,
+                stdoutTotalBytes: 9_000_000,
+            }),
+        );
+        expect(r.stdoutTruncated).toBe(true);
+        expect(r.stdoutTotalLength).toBe(9_000_000);
+    });
+
+    it("stays truncated when both the producer and the host cut", () => {
+        const big = "z".repeat(EXEC_STREAM_BYTE_CAP + 1);
+        const r = boundExecResult(baseResult({ stderr: big, stderrTruncated: true, stderrTotalBytes: 5_000_000 }));
+        expect(r.stderrTruncated).toBe(true);
+        expect(r.stderrTotalLength).toBe(5_000_000);
+        expect(Buffer.byteLength(r.stderr, "utf8")).toBeLessThanOrEqual(EXEC_STREAM_BYTE_CAP);
+    });
+
+    it("falls back to the local measurement when the sandbox reports no total", () => {
+        const big = "q".repeat(EXEC_STREAM_BYTE_CAP + 10);
+        const r = boundExecResult(baseResult({ stdout: big }));
+        expect(r.stdoutTruncated).toBe(true);
+        expect(r.stdoutTotalLength).toBe(EXEC_STREAM_BYTE_CAP + 10);
+    });
+});
+
+describe("capExecStreams", () => {
+    it("returns the input unchanged when nothing needs cutting", () => {
+        const input = baseResult({ stdout: "small", stderr: "" });
+        expect(capExecStreams(input)).toBe(input);
+    });
+
+    it("cuts oversize streams while keeping the ExecResult shape", () => {
+        const big = "x".repeat(EXEC_STREAM_BYTE_CAP + 500);
+        const r = capExecStreams(baseResult({ stdout: big, execId: "wf1:step1:7", exitCode: 2 }));
+        expect(Buffer.byteLength(r.stdout, "utf8")).toBeLessThanOrEqual(EXEC_STREAM_BYTE_CAP);
+        expect(r.stdoutTruncated).toBe(true);
+        expect(r.stdoutTotalBytes).toBe(EXEC_STREAM_BYTE_CAP + 500);
+        // Shape and discriminants survive — this value is forwarded onward.
+        expect(r.execId).toBe("wf1:step1:7");
+        expect(r.exitCode).toBe(2);
+    });
+
+    it("keeps the sandbox's own total when it already truncated", () => {
+        const r = capExecStreams(baseResult({ stdout: "kept", stdoutTruncated: true, stdoutTotalBytes: 400_000_000 }));
+        expect(r.stdoutTotalBytes).toBe(400_000_000);
+    });
+
+    it("never ends a cut stream in a replacement character", () => {
+        // A cap landing mid-sequence would otherwise decode to U+FFFD.
+        const snowmen = "☃".repeat(EXEC_STREAM_BYTE_CAP);
+        const r = capExecStreams(baseResult({ stdout: snowmen }));
+        expect(r.stdout.endsWith("�")).toBe(false);
+        expect(Buffer.byteLength(r.stdout, "utf8")).toBeLessThanOrEqual(EXEC_STREAM_BYTE_CAP);
     });
 });

--- a/harness/src/tools/workspace/result-bounds.ts
+++ b/harness/src/tools/workspace/result-bounds.ts
@@ -8,18 +8,42 @@
  * The cap is well below the loop's overall result budget so a chatty
  * command cannot blow the context window even when stdout AND stderr both
  * cap out at the limit.
+ *
+ * The same value is sent to the sandbox as a retention budget, so the bytes are
+ * dropped at the producer and never cross the wire. Capping here as well is not
+ * redundant: a sandbox image that pre-dates the budget returns the whole stream,
+ * and this is the boundary that keeps it out of the process either way.
  */
 
 import type { ExecResult } from "../../sandbox/types.js";
 
-/** Per-stream cap. 8 KiB — multi-KB but well under the loop result budget. */
-export const EXEC_STREAM_BYTE_CAP = 8 * 1024;
+/** Per-stream cap. 32 KiB — roomy for real output, well under the loop result budget. */
+export const EXEC_STREAM_BYTE_CAP = 32 * 1024;
 
 export interface BoundedStream {
     readonly content: string;
     readonly truncated: boolean;
     readonly totalLength: number;
     readonly returnedBytes: number;
+}
+
+/**
+ * Decode `buf` as UTF-8, dropping a trailing partial sequence rather than
+ * letting it decode to U+FFFD. Only the last few bytes can be partial, so the
+ * scan is bounded by the maximum UTF-8 sequence length.
+ */
+function trimPartialSequence(buf: Buffer): string {
+    const MAX_UTF8_SEQUENCE = 4;
+    for (let drop = 0; drop < MAX_UTF8_SEQUENCE && drop < buf.length; drop++) {
+        const candidate = buf.subarray(0, buf.length - drop);
+        const decoded = candidate.toString("utf8");
+        if (!decoded.endsWith("�")) {
+            return decoded;
+        }
+    }
+    // A stream that genuinely ends in U+FFFD is returned as-is; dropping more
+    // would start eating real characters.
+    return buf.toString("utf8");
 }
 
 export interface BoundedExecResult {
@@ -41,8 +65,15 @@ function boundStream(stream: string, cap: number = EXEC_STREAM_BYTE_CAP): Bounde
     if (totalLength <= cap) {
         return { content: stream, truncated: false, totalLength, returnedBytes: totalLength };
     }
-    const buf = Buffer.from(stream, "utf8").subarray(0, cap);
-    const content = buf.toString("utf8");
+    // Slice the string before encoding. Encoding first allocates a Buffer the
+    // size of the whole stream in order to keep `cap` bytes of it, which makes
+    // the function that exists to bound a stream the largest allocation on the
+    // path. One UTF-16 code unit encodes to at most 3 UTF-8 bytes, so `cap`
+    // units always cover `cap` bytes and the encode stays bounded.
+    const buf = Buffer.from(stream.slice(0, cap), "utf8").subarray(0, cap);
+    // The byte cut can land mid-sequence, and decoding that directly ends the
+    // content in U+FFFD. Trim back to the last whole character instead.
+    const content = trimPartialSequence(buf);
     return {
         content,
         truncated: true,
@@ -52,10 +83,40 @@ function boundStream(stream: string, cap: number = EXEC_STREAM_BYTE_CAP): Bounde
 }
 
 /**
+ * Bound an `ExecResult`'s streams while keeping its shape.
+ *
+ * `boundExecResult` produces the tool-facing form; this is for the boundaries
+ * that have to forward an `ExecResult` onward — notably a workflow return value,
+ * which DBOS serializes into its durable step output. Returns the input
+ * unchanged when nothing needed cutting, so the common path allocates nothing.
+ */
+export function capExecStreams(result: ExecResult, cap: number = EXEC_STREAM_BYTE_CAP): ExecResult {
+    const out = boundStream(result.stdout, cap);
+    const err = boundStream(result.stderr, cap);
+    if (!out.truncated && !err.truncated) {
+        return result;
+    }
+    return {
+        ...result,
+        stdout: out.content,
+        stderr: err.content,
+        stdoutTruncated: out.truncated || (result.stdoutTruncated ?? false),
+        stderrTruncated: err.truncated || (result.stderrTruncated ?? false),
+        stdoutTotalBytes: result.stdoutTotalBytes ?? out.totalLength,
+        stderrTotalBytes: result.stderrTotalBytes ?? err.totalLength,
+    };
+}
+
+/**
  * Apply per-stream truncation to an `ExecResult`. `exitCode`, `durationMs`,
  * `timedOut`, and `syntheticFailure` pass through unchanged regardless of
  * stream truncation — the discriminants the loop and the model rely on are
  * preserved.
+ *
+ * When the sandbox already truncated at the producer, what arrives here is the
+ * retained slice, not the stream — so its length is the wrong number to report.
+ * The sandbox's own totals win where present, and truncation is the union of the
+ * two cuts: either side having dropped bytes makes the result truncated.
  */
 export function boundExecResult(result: ExecResult, cap: number = EXEC_STREAM_BYTE_CAP): BoundedExecResult {
     const outStream = boundStream(result.stdout, cap);
@@ -65,10 +126,10 @@ export function boundExecResult(result: ExecResult, cap: number = EXEC_STREAM_BY
         exitCode: result.exitCode,
         stdout: outStream.content,
         stderr: errStream.content,
-        stdoutTruncated: outStream.truncated,
-        stderrTruncated: errStream.truncated,
-        stdoutTotalLength: outStream.totalLength,
-        stderrTotalLength: errStream.totalLength,
+        stdoutTruncated: outStream.truncated || (result.stdoutTruncated ?? false),
+        stderrTruncated: errStream.truncated || (result.stderrTruncated ?? false),
+        stdoutTotalLength: result.stdoutTotalBytes ?? outStream.totalLength,
+        stderrTotalLength: result.stderrTotalBytes ?? errStream.totalLength,
         durationMs: result.durationMs,
         timedOut: result.timedOut,
         ...(result.syntheticFailure ? { syntheticFailure: result.syntheticFailure } : {}),

--- a/images/sandbox-base/server/capturing_builder_test.go
+++ b/images/sandbox-base/server/capturing_builder_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCapturingBuilderUnboundedWhenCapZero(t *testing.T) {
+	b := &capturingBuilder{}
+	if _, err := b.Write([]byte(strings.Repeat("x", 5000))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := len(b.String()); got != 5000 {
+		t.Fatalf("retained %d bytes, want 5000", got)
+	}
+	if b.truncated() {
+		t.Fatal("uncapped builder reported truncation")
+	}
+	if got := b.totalBytes(); got != 5000 {
+		t.Fatalf("totalBytes = %d, want 5000", got)
+	}
+}
+
+func TestCapturingBuilderRetainsOnlyUpToCap(t *testing.T) {
+	b := &capturingBuilder{byteCap: 100}
+	for i := 0; i < 10; i++ {
+		if _, err := b.Write([]byte(strings.Repeat("y", 50))); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	if got := len(b.String()); got != 100 {
+		t.Fatalf("retained %d bytes, want 100", got)
+	}
+	if !b.truncated() {
+		t.Fatal("expected truncation")
+	}
+	// The true size survives even though the bytes did not — that is what tells a
+	// caller the command printed 500 bytes rather than 100.
+	if got := b.totalBytes(); got != 500 {
+		t.Fatalf("totalBytes = %d, want 500", got)
+	}
+}
+
+// A short write must not be reported as truncated just because a cap is set.
+func TestCapturingBuilderUnderCapIsNotTruncated(t *testing.T) {
+	b := &capturingBuilder{byteCap: 100}
+	if _, err := b.Write([]byte("short")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if b.truncated() {
+		t.Fatal("under-cap write reported truncation")
+	}
+	if got := b.String(); got != "short" {
+		t.Fatalf("String() = %q, want %q", got, "short")
+	}
+}
+
+// Write reports the full length as accepted so the pipe reader never sees a
+// short write once the retention budget is spent.
+func TestCapturingBuilderWriteReportsFullLength(t *testing.T) {
+	b := &capturingBuilder{byteCap: 4}
+	n, err := b.Write([]byte("abcdefgh"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != 8 {
+		t.Fatalf("Write returned %d, want 8", n)
+	}
+}
+
+// Capping lands on a byte boundary, which can fall mid-rune. The retained string
+// must still be valid UTF-8 rather than ending in a replacement character.
+func TestCapturingBuilderTrimsPartialRune(t *testing.T) {
+	// "☃" is 3 bytes; a cap of 4 keeps one whole snowman plus one stray byte.
+	b := &capturingBuilder{byteCap: 4}
+	if _, err := b.Write([]byte("☃☃")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := b.String()
+	if !utf8.ValidString(got) {
+		t.Fatalf("String() = %q, which is not valid UTF-8", got)
+	}
+	if got != "☃" {
+		t.Fatalf("String() = %q, want %q", got, "☃")
+	}
+}
+
+func TestCapturingBuilderConcurrentWrites(t *testing.T) {
+	b := &capturingBuilder{byteCap: 256}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 64; j++ {
+				_, _ = b.Write([]byte("z"))
+			}
+		}()
+	}
+	wg.Wait()
+	if got := b.totalBytes(); got != 16*64 {
+		t.Fatalf("totalBytes = %d, want %d", got, 16*64)
+	}
+	if got := len(b.String()); got != 256 {
+		t.Fatalf("retained %d bytes, want 256", got)
+	}
+}

--- a/images/sandbox-base/server/exectable.go
+++ b/images/sandbox-base/server/exectable.go
@@ -26,11 +26,15 @@ const completedEntryTTL = time.Hour
 const eventRingCapacity = 256
 
 type execResult struct {
-	ExitCode   int    `json:"exitCode"`
-	Stdout     string `json:"stdout"`
-	Stderr     string `json:"stderr"`
-	DurationMs int64  `json:"durationMs"`
-	TimedOut   bool   `json:"timedOut,omitempty"`
+	ExitCode         int    `json:"exitCode"`
+	Stdout           string `json:"stdout"`
+	Stderr           string `json:"stderr"`
+	StdoutTruncated  bool   `json:"stdoutTruncated,omitempty"`
+	StderrTruncated  bool   `json:"stderrTruncated,omitempty"`
+	StdoutTotalBytes int64  `json:"stdoutTotalBytes,omitempty"`
+	StderrTotalBytes int64  `json:"stderrTotalBytes,omitempty"`
+	DurationMs       int64  `json:"durationMs"`
+	TimedOut         bool   `json:"timedOut,omitempty"`
 }
 
 // ringEvent is one buffered progress event: the exact event-payload bytes plus

--- a/images/sandbox-base/server/executor.go
+++ b/images/sandbox-base/server/executor.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 // maxExecBodyBytes caps how much of a POST /exec body the server will buffer.
@@ -27,12 +28,18 @@ import (
 const maxExecBodyBytes = 16 << 20
 
 // execSubmitRequest is the new submit-and-return body for POST /exec.
+// StdoutByteCap/StderrByteCap bound how much of each stream is retained and
+// returned. Absent or 0 means unbounded, which is what a host that predates the
+// field sends — the host caps on receipt either way, so an old host talking to a
+// new server behaves exactly as before.
 type execSubmitRequest struct {
 	Command        []string          `json:"command"`
 	ExecID         string            `json:"execId"`
 	Cwd            string            `json:"cwd,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 	TimeoutSeconds int               `json:"timeoutSeconds,omitempty"`
+	StdoutByteCap  int               `json:"stdoutByteCap,omitempty"`
+	StderrByteCap  int               `json:"stderrByteCap,omitempty"`
 }
 
 type execSubmitResponse struct {
@@ -51,13 +58,17 @@ type eventPayload struct {
 
 // completionPayload is the body POSTed to /sandbox/:execId/complete.
 type completionPayload struct {
-	ExecID     string             `json:"execId"`
-	ExitCode   int                `json:"exitCode"`
-	Stdout     string             `json:"stdout"`
-	Stderr     string             `json:"stderr"`
-	DurationMs int64              `json:"durationMs"`
-	TimedOut   bool               `json:"timedOut,omitempty"`
-	Provenance *provenancePayload `json:"provenance,omitempty"`
+	ExecID           string             `json:"execId"`
+	ExitCode         int                `json:"exitCode"`
+	Stdout           string             `json:"stdout"`
+	Stderr           string             `json:"stderr"`
+	StdoutTruncated  bool               `json:"stdoutTruncated,omitempty"`
+	StderrTruncated  bool               `json:"stderrTruncated,omitempty"`
+	StdoutTotalBytes int64              `json:"stdoutTotalBytes,omitempty"`
+	StderrTotalBytes int64              `json:"stderrTotalBytes,omitempty"`
+	DurationMs       int64              `json:"durationMs"`
+	TimedOut         bool               `json:"timedOut,omitempty"`
+	Provenance       *provenancePayload `json:"provenance,omitempty"`
 }
 
 type provenancePayload struct {
@@ -201,8 +212,8 @@ func (e *executor) run(req execSubmitRequest, traceID string) {
 
 	stderrBuf := newStderrRingBuffer()
 	var stderrBufMu sync.Mutex
-	stdoutBuilder := &capturingBuilder{}
-	stderrBuilder := &capturingBuilder{}
+	stdoutBuilder := &capturingBuilder{byteCap: req.StdoutByteCap}
+	stderrBuilder := &capturingBuilder{byteCap: req.StderrByteCap}
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -243,17 +254,25 @@ func (e *executor) run(req execSubmitRequest, traceID string) {
 
 	stdout := stdoutBuilder.String()
 	stderr := stderrBuilder.String()
+	stdoutTruncated := stdoutBuilder.truncated()
+	stderrTruncated := stderrBuilder.truncated()
+	stdoutTotal := stdoutBuilder.totalBytes()
+	stderrTotal := stderrBuilder.totalBytes()
 
 	status := execStatusCompleted
 	if exitCode != 0 {
 		status = execStatusFailed
 	}
 	e.table.complete(req.ExecID, status, &execResult{
-		ExitCode:   exitCode,
-		Stdout:     stdout,
-		Stderr:     stderr,
-		DurationMs: durationMs,
-		TimedOut:   timedOut,
+		ExitCode:         exitCode,
+		Stdout:           stdout,
+		Stderr:           stderr,
+		StdoutTruncated:  stdoutTruncated,
+		StderrTruncated:  stderrTruncated,
+		StdoutTotalBytes: stdoutTotal,
+		StderrTotalBytes: stderrTotal,
+		DurationMs:       durationMs,
+		TimedOut:         timedOut,
 	})
 
 	now := nowRFC3339()
@@ -274,13 +293,17 @@ func (e *executor) run(req execSubmitRequest, traceID string) {
 	}
 
 	e.postCompletion(req.ExecID, completionPayload{
-		ExecID:     req.ExecID,
-		ExitCode:   exitCode,
-		Stdout:     stdout,
-		Stderr:     stderr,
-		DurationMs: durationMs,
-		TimedOut:   timedOut,
-		Provenance: prov,
+		ExecID:           req.ExecID,
+		ExitCode:         exitCode,
+		Stdout:           stdout,
+		Stderr:           stderr,
+		StdoutTruncated:  stdoutTruncated,
+		StderrTruncated:  stderrTruncated,
+		StdoutTotalBytes: stdoutTotal,
+		StderrTotalBytes: stderrTotal,
+		DurationMs:       durationMs,
+		TimedOut:         timedOut,
+		Provenance:       prov,
 	})
 }
 
@@ -494,21 +517,74 @@ func buildCommand(ctx context.Context, req execSubmitRequest) *exec.Cmd {
 }
 
 // capturingBuilder is a goroutine-safe in-memory accumulator for stdout/stderr.
+//
+// Retention is bounded by byteCap: bytes past it are counted and dropped rather
+// than buffered, so a command that writes a whole dataset to stdout costs the
+// cap rather than the dataset. total keeps the true size, which is what lets a
+// caller tell "printed nothing" apart from "printed more than we kept". A
+// byteCap of 0 retains everything.
 type capturingBuilder struct {
-	mu  sync.Mutex
-	buf strings.Builder
+	mu      sync.Mutex
+	buf     strings.Builder
+	byteCap int
+	total   int64
 }
 
 func (c *capturingBuilder) Write(p []byte) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.buf.Write(p)
+	written := len(p)
+	c.total += int64(written)
+	if c.byteCap <= 0 {
+		return c.buf.Write(p)
+	}
+	if room := c.byteCap - c.buf.Len(); room > 0 {
+		if len(p) > room {
+			p = p[:room]
+		}
+		if _, err := c.buf.Write(p); err != nil {
+			return 0, err
+		}
+	}
+	// Report the whole write as accepted. A short count with no error is an
+	// io.Writer contract violation that surfaces in callers as io.ErrShortWrite,
+	// and the pipe reader is not the party that fails when retention runs out.
+	return written, nil
 }
 
 func (c *capturingBuilder) String() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.buf.String()
+	return trimPartialRune(c.buf.String())
+}
+
+// totalBytes is what the command produced, retained or not.
+func (c *capturingBuilder) totalBytes() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total
+}
+
+// truncated reports whether anything was dropped.
+func (c *capturingBuilder) truncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.byteCap > 0 && c.total > int64(c.buf.Len())
+}
+
+// trimPartialRune drops a trailing partial UTF-8 sequence. The cap lands on a
+// byte boundary, which can fall mid-rune; the remainder would otherwise reach
+// the host as U+FFFD.
+func trimPartialRune(s string) string {
+	if s == "" || utf8.ValidString(s) {
+		return s
+	}
+	for i := len(s) - 1; i >= 0 && i > len(s)-utf8.UTFMax-1; i-- {
+		if utf8.RuneStart(s[i]) && utf8.ValidString(s[:i]) {
+			return s[:i]
+		}
+	}
+	return s
 }
 
 // capturePipe reads a sub-process pipe line-by-line into builder, emits the


### PR DESCRIPTION
## Why

A sandbox command's stdout and stderr were retained in full by sandbox-server, POSTed in full, and cut only once they reached the tool result — 8 KiB of a stream that had already crossed the wire and been serialized. The cap that existed protected the model's context, not the transport, so a command that printed a dataset cost the whole dataset everywhere upstream of the one place that bounded it.

`boundExecResult` also had exactly two call sites. Every other `ExecResult` consumer — including a workflow return value that DBOS serializes into `operation_outputs` — saw the raw value.

## What changes

**The producer drops what nobody will read.** `capturingBuilder` takes a byte cap; bytes past it are counted and discarded rather than buffered. The true total travels beside the retained slice, so "printed nothing" stays distinguishable from "printed more than we kept".

The cap rides per exec on `SubmitExecBody` rather than sandbox pod env — a sandbox outlives many execs, so pod env would freeze the value at creation, and it would leak into user commands through `sanitizedEnviron`. Go decodes without `DisallowUnknownFields`, so this is invisible to older images.

**The envelope stops carrying the body twice.** It held the payload parsed *and* raw, so serializing it materialized the payload twice over. The raw copy existed for verification — but the signature never covered the raw bytes. Both sides sign `execId:timestamp:sha256hex(body)`, so forwarding the 64-character digest is byte-exact and constant-size regardless of what the command printed. `payloadRaw` stays optional for one release so envelopes already in flight or persisted still verify.

**The cap moves to the seam.** `capExecStreams` bounds an `ExecResult` while keeping its shape, applied in `createSandboxClient` — the one place a result crosses from wire into process. Every consumer downstream is bounded by construction rather than by remembering to call something.

**`boundStream` stops being the biggest allocation on the path.** It encoded the entire stream into a Buffer before slicing 8 KiB off the front. It now slices first, and trims a trailing partial UTF-8 sequence rather than emitting U+FFFD.

**`digestBody` lives in its own module.** Hashing carries no secret and decides nothing, so a route required to stay a dumb forwarder can depend on it without taking on verification machinery. A structural test in cortex asserts exactly that, and it should keep passing.

Default per-stream cap: 8 KiB → 32 KiB. Output beyond it was already discarded before the model saw it; what changes is that it is discarded before it is copied.

## Compatibility

| Direction | Behaviour |
|-|-|
| New host → old sandbox | field ignored; host-side cap still applies — correct, no bandwidth saving |
| Old host → new sandbox | cap absent = 0 = unbounded — unchanged |

No flag day in either direction.

## Verification

- `go build`, `go vet`, full Go suite pass; new `capturing_builder_test.go` covers cap/no-cap, the true total, the `io.Writer` contract, partial-rune trimming, and concurrent writes
- `tsc --noEmit` clean; full harness suite passes (`bun test`)
- New TS tests cover producer-side totals winning over local measurement, `capExecStreams` shape preservation, and the retention budget reaching the wire
- `prettier` and `eslint` clean on touched files; `gofmt` clean on touched files (`callback.go`/`treediff.go` deviations are pre-existing on `main`)

One test caught a real bug during development: `Write` returned the truncated length, a short write with no error, which callers surface as `io.ErrShortWrite`.

## Sequencing

Cortex depends on this via a published `@inflexa-ai/harness`, so this merges and releases first. The cortex PR needs `payloadDigest`, `sandbox/digest.js`, and `execStreamByteCap` on `CreateSandboxClientConfig`.

https://claude.ai/code/session_01382sMb9hFogpSroVmCj4pF
