### PR TITLE
fix(sandbox-step): sync a step's bytes even when registration is rejected

### DIFF
--- a/harness/openspec/changes/fix-lineage-attestation-severity/.openspec.yaml
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/harness/openspec/changes/fix-lineage-attestation-severity/proposal.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Two production steps whose science had fully succeeded were hard-failed by their
+own bookkeeping, over one data-input file each that the step never referenced:
+
+```
+[post-step.reconcile] external registration failed for T3S2:
+  1 row(s) rejected, 51/52 local artifact(s) registered
+  runs/{run}/T3S2/data/samplesheet.csv: not referenced by any activity
+```
+
+The registry contract the fail-fast rule was written against is stricter than
+the real one. The registry returns HTTP 200 and commits per leaf and per
+activity, with no batch-wide rollback — some rows being accepted while others
+are rejected is a normal outcome, not an error — and it reports a file that no
+activity references in the same `failed[]` bucket as a genuine rejection. Such a
+row registers nothing, so it puts no bytes at risk.
+
+The throw also precedes byte sync. Both steps had 51 real artifacts registered
+with an `artifact_id` and never uploaded: the outputs were orphaned *by* the
+rule written to prevent orphaning, on exactly the case where its rationale
+inverts.
+
+## What Changes
+
+- Severity follows what a rejection puts at risk, not the fact of a rejection.
+  A rejected **output** — bytes that exist nowhere but the step tree — stays
+  terminal, and so does a rejection cascaded from a real one.
+- `failedCount` (surfaced as `externalFailed`) SHALL exclude a rejection of a
+  file no activity in the payload references. `failed[]` still carries every
+  per-path rejection, and an uncounted one SHALL be logged at warn with its path
+  and the registry's reason — not counting a rejection is never licence to drop
+  it silently.
+- Byte sync SHALL be attempted whatever registration returned, including when it
+  threw. Sync covers only the rows registration accepted (`artifact_id IS NOT
+  NULL AND file_id IS NULL`), so it uploads exactly those and reaches nothing
+  rejected. A registration error stays the surfaced cause; a sync failure that
+  follows it is logged, never substituted.
+
+## Capabilities
+
+### New Capabilities
+
+None. This narrows existing requirements in `artifact-manifest`.
+
+### Modified Capabilities
+
+- `artifact-manifest`: registry-rejection severity is per-rejection rather than
+  per-batch, and byte sync is independent of the registration outcome. The
+  content-attestation invariants are untouched — no hashless edge is registered,
+  and every surviving output is still re-hashed from disk.
+
+## Impact
+
+- `src/execution/artifact-registration.ts` — surfacing of uncounted rejections.
+- `src/workflows/sandbox-step.ts` — sync attempted on the registration-failure
+  path, registration error re-raised as the cause.
+- The managed `ArtifactRegistry` adapter — classifies rejections and excludes
+  not-referenced rows from `failedCount`.

--- a/harness/openspec/changes/fix-lineage-attestation-severity/proposal.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/proposal.md
@@ -26,9 +26,10 @@ inverts.
 - Severity follows what a rejection puts at risk, not the fact of a rejection.
   A rejected **output** — bytes that exist nowhere but the step tree — stays
   terminal, and so does a rejection cascaded from a real one.
-- `failedCount` (surfaced as `externalFailed`) SHALL exclude a rejection of a
-  file no activity in the payload references. `failed[]` still carries every
-  per-path rejection, and an uncounted one SHALL be logged at warn with its path
+- `failedCount` (surfaced as `externalFailed`) and `failed[]` SHALL both exclude
+  a rejection of a file no activity in the payload references, so the fail-fast
+  message names only what cost the step something. Such a rejection is reported
+  across the seam in `notCounted`, and `registerStepArtifacts` logs it with its path
   and the registry's reason — not counting a rejection is never licence to drop
   it silently.
 - Byte sync SHALL be attempted whatever registration returned, including when it

--- a/harness/openspec/changes/fix-lineage-attestation-severity/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/specs/artifact-manifest/spec.md
@@ -1,0 +1,121 @@
+## MODIFIED Requirements
+
+### Requirement: Registration through the ArtifactRegistry seam
+
+`registerStepArtifacts(db, registry, input, session)` SHALL: (1) build the
+`cortex_artifacts` rows from the reconciled manifest — `role = 'step_output'`,
+`path` prefixed `runs/{runId}/{stepId}/`, `file_type` from the entry's inferred
+type — and upsert them; (2) call the injected `ArtifactRegistry.register(input,
+session)`; (3) write each returned external id back via `updateArtifactId` for
+paths the local upsert owns. It SHALL return `{ localCount, externalRegistered,
+externalFailed, failureDetails }`. When the artifacts array is empty it SHALL
+return all-zero counts immediately and SHALL NOT call the registry.
+
+The registry's outcome is partial by contract — it commits per leaf and per
+activity, with no batch-wide rollback — so `registered` and `failed` arriving
+together describes a normal registration. `failed` SHALL carry every per-path
+rejection the registry reported, each with its path and the registry's reason.
+`failedCount`, surfaced as `externalFailed`, SHALL count only the **terminal**
+rejections: a rejected artifact whose bytes exist nowhere but the step tree, and
+any rejection cascaded from one — a row the registry rejected as a consequence
+of a genuine failure. A rejection of a file that no activity in the payload
+references SHALL NOT be counted, because it registers nothing and so puts no
+bytes at risk.
+
+An uncounted rejection SHALL still be surfaced: when `failedCount` is zero and
+`failed` is non-empty, `registerStepArtifacts` SHALL log a warn record naming
+each rejected path and the registry's reason for it. Not counting a rejection
+decides only that it is not worth failing a step over; it is never licence to
+drop it silently, because that record is the only place a reader can check the
+verdict against what the registry actually said.
+
+#### Scenario: Successful registration
+
+- **WHEN** `registerStepArtifacts` is called with 3 reconciled artifacts
+- **THEN** 3 rows are upserted into `cortex_artifacts`, the registry's `register` is called, returned external ids are stored via `updateArtifactId`, and the result is `{ localCount: 3, externalRegistered: 3, externalFailed: 0, failureDetails: [] }`
+
+#### Scenario: External registration partially fails
+
+- **WHEN** the registry returns some of the step's outputs in `failed`
+- **THEN** accepted artifacts get their `artifact_id` stored, rejected ones retain `artifact_id = NULL`, and `externalFailed` reflects the count of terminal rejections
+
+#### Scenario: A rejection that nothing references is surfaced, not counted
+
+- **WHEN** the registry accepts every row except a file that no activity in the payload references
+- **THEN** `failed` carries that path with the registry's reason, a warn record names the path and that reason, and `externalFailed` is `0`
+
+#### Scenario: Empty artifact list short-circuits
+
+- **WHEN** `registerStepArtifacts` is called with an empty artifacts array
+- **THEN** it returns `{ localCount: 0, externalRegistered: 0, externalFailed: 0, failureDetails: [] }` and the registry is NOT called
+
+### Requirement: Integrity stages fail-fast; enrichment stages degrade
+
+`reconcileAndRegisterStepArtifacts` SHALL reconcile, then register, and the
+sandbox-step body SHALL then `ArtifactRegistry.sync` the step's artifacts. The
+sequence is fail-fast: a non-zero `externalFailed` SHALL throw with the per-file
+failure detail, and the sandbox-step body SHALL tear down the sandbox, mark the
+step failed, and re-raise so the parent's fail-fast cascade fires.
+
+Byte sync SHALL be attempted whatever registration returned, including when
+registration threw. Sync is defined over the rows registration accepted
+(`artifact_id IS NOT NULL AND file_id IS NULL`), so attempting it after a throw
+uploads exactly those rows and reaches nothing that was rejected — whereas
+skipping it leaves every accepted artifact registered and never uploaded,
+orphaned by the very throw raised to prevent orphaning. A registration error
+SHALL remain the surfaced cause: a sync failure that follows one SHALL be logged
+with its own detail and SHALL NOT replace the registration error the step fails
+on. The OSS `createNoopArtifactRegistry` returns `externalFailed: 0` and never
+trips this.
+
+The enrichment stages — file-metadata generation, step-summary generation, and
+vector indexing — SHALL run under `safeRun`/`safeRunValue` so any single failure
+degrades without failing the step.
+
+Within the vector-index stage, degradation SHALL be per-item: each surviving
+file description and the step summary SHALL be embedded and upserted under its
+own failure boundary, so one rejected input costs only its own index entry and
+every remaining item is still attempted. Index setup (ensuring the search index
+exists and constructing the store) SHALL remain all-or-nothing — a setup failure
+degrades the whole stage. Each per-item failure SHALL be logged with the item's
+id and input text length, and when at least one item fails the stage SHALL log a
+summary carrying the counts of items indexed and items failed — a partial index
+returns fewer search hits rather than an error, so the logged counts are the
+only signal that degradation occurred.
+
+#### Scenario: An output rejection fails the step
+
+- **WHEN** `reconcileAndRegisterStepArtifacts` gets `externalFailed > 0` from registration
+- **THEN** it throws with the per-file detail and the step is marked failed
+
+#### Scenario: A rejection that orphans nothing does not fail the step
+
+- **GIVEN** a step whose outputs all registered and whose only rejection is a file no activity references
+- **WHEN** `reconcileAndRegisterStepArtifacts` runs
+- **THEN** `externalFailed` is `0`, the rejection is logged with its path and reason, and the step completes with its artifacts synced
+
+#### Scenario: Registered bytes sync even when registration throws
+
+- **GIVEN** registration that accepted most of the step's artifacts and threw on a rejected output
+- **WHEN** the sandbox-step body handles the throw
+- **THEN** `ArtifactRegistry.sync` is still attempted, the accepted rows are uploaded, and the step fails with the registration error as its cause
+
+#### Scenario: A degraded enrichment stage does not fail the step
+
+- **WHEN** vector indexing throws while indexing a step's outputs
+- **THEN** the failure is logged and swallowed and the step still completes
+
+#### Scenario: One rejected input costs only its own entry
+
+- **WHEN** embedding one file description fails while the step has other file descriptions and a summary
+- **THEN** every other file description and the summary are still embedded and upserted, and the step completes
+
+#### Scenario: Partial indexing is observable in the logs
+
+- **WHEN** at least one item fails to index while others succeed
+- **THEN** each failed item is logged with its id and text length, and a summary log reports the indexed and failed counts
+
+#### Scenario: Index setup failure degrades the whole stage
+
+- **WHEN** ensuring the search index exists fails before any item is indexed
+- **THEN** the stage logs the failure and indexes nothing, and the step still completes

--- a/harness/openspec/changes/fix-lineage-attestation-severity/specs/artifact-manifest/spec.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/specs/artifact-manifest/spec.md
@@ -13,21 +13,26 @@ return all-zero counts immediately and SHALL NOT call the registry.
 
 The registry's outcome is partial by contract — it commits per leaf and per
 activity, with no batch-wide rollback — so `registered` and `failed` arriving
-together describes a normal registration. `failed` SHALL carry every per-path
-rejection the registry reported, each with its path and the registry's reason.
-`failedCount`, surfaced as `externalFailed`, SHALL count only the **terminal**
-rejections: a rejected artifact whose bytes exist nowhere but the step tree, and
-any rejection cascaded from one — a row the registry rejected as a consequence
-of a genuine failure. A rejection of a file that no activity in the payload
-references SHALL NOT be counted, because it registers nothing and so puts no
-bytes at risk.
+together describes a normal registration. `failed`, surfaced as
+`failureDetails`, and `failedCount`, surfaced as `externalFailed`, SHALL both
+describe only the **terminal** rejections: a rejected artifact whose bytes exist
+nowhere but the step tree, and any rejection cascaded from one — a row the
+registry rejected as a consequence of a genuine failure. A rejection of a file
+that no activity in the payload references SHALL NOT appear in either, because
+it registers nothing and so puts no bytes at risk. The two move together so that
+the fail-fast message lists exactly the paths that cost the step something: a
+`failed` array padded with harmless rejections would name them, during an
+incident, in the same breath and the same format as the real ones.
 
-An uncounted rejection SHALL still be surfaced: when `failedCount` is zero and
-`failed` is non-empty, `registerStepArtifacts` SHALL log a warn record naming
-each rejected path and the registry's reason for it. Not counting a rejection
-decides only that it is not worth failing a step over; it is never licence to
-drop it silently, because that record is the only place a reader can check the
-verdict against what the registry actually said.
+A rejection the registry excludes SHALL still be reported, in `notCounted`, and
+`registerStepArtifacts` SHALL log a warn record naming each such path and the
+registry's reason for it. Excluding a rejection decides only that it is not
+worth failing a step over; it is never licence to drop it silently, because that
+record is the only place a reader can check the verdict against what the
+external system actually said. The log SHALL be emitted by
+`registerStepArtifacts` rather than left to the registry: the seam is
+implementable by an embedder, and a rejection does not get to go unrecorded
+because one implementation chose not to log it.
 
 #### Scenario: Successful registration
 
@@ -42,7 +47,7 @@ verdict against what the registry actually said.
 #### Scenario: A rejection that nothing references is surfaced, not counted
 
 - **WHEN** the registry accepts every row except a file that no activity in the payload references
-- **THEN** `failed` carries that path with the registry's reason, a warn record names the path and that reason, and `externalFailed` is `0`
+- **THEN** `notCounted` carries that path with the registry's reason, a warn record names the path and that reason, and both `externalFailed` and `failureDetails` are empty
 
 #### Scenario: Empty artifact list short-circuits
 

--- a/harness/openspec/changes/fix-lineage-attestation-severity/tasks.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Severity of a registry rejection
+
+- [ ] 1.1 Adapter: exclude a not-referenced rejection from `failedCount`, keeping it in `failed[]` with its path and reason; output and cascaded rejections stay counted.
+- [ ] 1.2 `registerStepArtifacts` — when `failedCount` is 0 and `failed` is non-empty, log one warn record naming each rejected path and the registry's reason.
+
+## 2. Byte sync independent of registration
+
+- [ ] 2.1 `sandbox-step` post-step body — attempt `ArtifactRegistry.sync` whatever registration returned, including when it threw.
+- [ ] 2.2 Keep the registration error as the surfaced cause; log a sync failure that follows one with its own detail rather than replacing the cause.
+
+## 3. Tests
+
+- [ ] 3.1 A step whose only rejection is a not-referenced file completes, with the rejection logged.
+- [ ] 3.2 An output rejection still fails the step with the per-file detail.
+- [ ] 3.3 Registration throws — sync is still called and the accepted rows upload; the step fails with the registration error.
+
+## 4. Spec
+
+- [x] 4.1 Delta on `artifact-manifest`: rejection severity follows what is at risk; uncounted rejections are surfaced; sync is attempted independently of the registration outcome.
+- [x] 4.2 Hand-rewrite the **Purpose** section the delta does not carry — it claimed every registry rejection is terminal.
+- [ ] 4.3 Archive (`openspec archive`) once the code lands; validate `--strict`.

--- a/harness/openspec/changes/fix-lineage-attestation-severity/tasks.md
+++ b/harness/openspec/changes/fix-lineage-attestation-severity/tasks.md
@@ -2,19 +2,19 @@
 
 ## 1. Severity of a registry rejection
 
-- [ ] 1.1 Adapter: exclude a not-referenced rejection from `failedCount`, keeping it in `failed[]` with its path and reason; output and cascaded rejections stay counted.
-- [ ] 1.2 `registerStepArtifacts` — when `failedCount` is 0 and `failed` is non-empty, log one warn record naming each rejected path and the registry's reason.
+- [ ] 1.1 (cortex, inflexa-ai/cortex#347) Adapter: exclude a not-referenced rejection from `failedCount` and `failed[]`, reporting it in `notCounted` with its path and reason; output and cascaded rejections stay counted.
+- [x] 1.2 `registerStepArtifacts` — log one warn record naming each `notCounted` path and the registry's reason.
 
 ## 2. Byte sync independent of registration
 
-- [ ] 2.1 `sandbox-step` post-step body — attempt `ArtifactRegistry.sync` whatever registration returned, including when it threw.
-- [ ] 2.2 Keep the registration error as the surfaced cause; log a sync failure that follows one with its own detail rather than replacing the cause.
+- [x] 2.1 `sandbox-step` post-step body — attempt `ArtifactRegistry.sync` whatever registration returned, including when it threw.
+- [x] 2.2 Keep the registration error as the surfaced cause; log a sync failure that follows one with its own detail rather than replacing the cause.
 
 ## 3. Tests
 
-- [ ] 3.1 A step whose only rejection is a not-referenced file completes, with the rejection logged.
-- [ ] 3.2 An output rejection still fails the step with the per-file detail.
-- [ ] 3.3 Registration throws — sync is still called and the accepted rows upload; the step fails with the registration error.
+- [x] 3.1 A step whose only rejection is a not-referenced file completes, with the rejection logged.
+- [x] 3.2 An output rejection still fails the step with the per-file detail.
+- [x] 3.3 Registration throws — sync is still called and the accepted rows upload; the step fails with the registration error.
 
 ## 4. Spec
 

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -31,8 +31,17 @@ mount does not establish that — it bounds what *this* step writes, while every
 sibling has its own directory mounted read-write over the same host inodes and
 mutates it freely. This makes the registered hash equal `sha256sum` of
 the bytes the sync target receives at upload time. The reconcile/register/sync
-stages are pulled out of the best-effort net: a registry rejection is
-**terminal** — it fails the step loudly rather than orphaning real outputs green.
+stages are pulled out of the best-effort net, and inside that net **severity
+follows what a rejection puts at risk**. An external registry commits per leaf
+and per activity rather than per batch, so a result carrying accepted and
+rejected rows together is an ordinary outcome, not an error. A rejected
+**output** orphans bytes that exist nowhere but the step tree, so it is
+**terminal** — it fails the step loudly rather than finishing green — and so is
+any rejection cascaded from a real one. A rejection of a file that no activity
+references registers nothing, so it orphans nothing: it is logged with its path
+and reason, and the step continues. Byte sync is attempted whatever registration
+returned, because it uploads exactly the rows registration accepted, while a
+registration error remains the cause the step fails on.
 
 A ref that cannot be hashed is dropped from lineage, whatever put it out of
 reach: a **directory** (e.g. `ls` of a mount), a read **resolving outside the
@@ -212,6 +221,24 @@ paths the local upsert owns. It SHALL return `{ localCount, externalRegistered,
 externalFailed, failureDetails }`. When the artifacts array is empty it SHALL
 return all-zero counts immediately and SHALL NOT call the registry.
 
+The registry's outcome is partial by contract — it commits per leaf and per
+activity, with no batch-wide rollback — so `registered` and `failed` arriving
+together describes a normal registration. `failed` SHALL carry every per-path
+rejection the registry reported, each with its path and the registry's reason.
+`failedCount`, surfaced as `externalFailed`, SHALL count only the **terminal**
+rejections: a rejected artifact whose bytes exist nowhere but the step tree, and
+any rejection cascaded from one — a row the registry rejected as a consequence
+of a genuine failure. A rejection of a file that no activity in the payload
+references SHALL NOT be counted, because it registers nothing and so puts no
+bytes at risk.
+
+An uncounted rejection SHALL still be surfaced: when `failedCount` is zero and
+`failed` is non-empty, `registerStepArtifacts` SHALL log a warn record naming
+each rejected path and the registry's reason for it. Not counting a rejection
+decides only that it is not worth failing a step over; it is never licence to
+drop it silently, because that record is the only place a reader can check the
+verdict against what the registry actually said.
+
 #### Scenario: Successful registration
 
 - **WHEN** `registerStepArtifacts` is called with 3 reconciled artifacts
@@ -219,8 +246,13 @@ return all-zero counts immediately and SHALL NOT call the registry.
 
 #### Scenario: External registration partially fails
 
-- **WHEN** the registry returns some entries in `failed`
-- **THEN** accepted artifacts get their `artifact_id` stored, rejected ones retain `artifact_id = NULL`, and `externalFailed` reflects the rejection count
+- **WHEN** the registry returns some of the step's outputs in `failed`
+- **THEN** accepted artifacts get their `artifact_id` stored, rejected ones retain `artifact_id = NULL`, and `externalFailed` reflects the count of terminal rejections
+
+#### Scenario: A rejection that nothing references is surfaced, not counted
+
+- **WHEN** the registry accepts every row except a file that no activity in the payload references
+- **THEN** `failed` carries that path with the registry's reason, a warn record names the path and that reason, and `externalFailed` is `0`
 
 #### Scenario: Empty artifact list short-circuits
 
@@ -229,15 +261,26 @@ return all-zero counts immediately and SHALL NOT call the registry.
 
 ### Requirement: Integrity stages fail-fast; enrichment stages degrade
 
-`reconcileAndRegisterStepArtifacts` SHALL reconcile, then register, then
-`ArtifactRegistry.sync` the step's artifacts, and SHALL treat the whole sequence
-as fail-fast: a non-zero `externalFailed` SHALL throw with the
-per-file failure detail, and the sandbox-step body SHALL tear down the sandbox,
-mark the step failed, and re-raise so the parent's fail-fast cascade fires. The
-OSS `createNoopArtifactRegistry` returns `externalFailed: 0` and never trips
-this. The enrichment stages — file-metadata generation, step-summary generation,
-and vector indexing — SHALL run under `safeRun`/`safeRunValue` so any single
-failure degrades without failing the step.
+`reconcileAndRegisterStepArtifacts` SHALL reconcile, then register, and the
+sandbox-step body SHALL then `ArtifactRegistry.sync` the step's artifacts. The
+sequence is fail-fast: a non-zero `externalFailed` SHALL throw with the per-file
+failure detail, and the sandbox-step body SHALL tear down the sandbox, mark the
+step failed, and re-raise so the parent's fail-fast cascade fires.
+
+Byte sync SHALL be attempted whatever registration returned, including when
+registration threw. Sync is defined over the rows registration accepted
+(`artifact_id IS NOT NULL AND file_id IS NULL`), so attempting it after a throw
+uploads exactly those rows and reaches nothing that was rejected — whereas
+skipping it leaves every accepted artifact registered and never uploaded,
+orphaned by the very throw raised to prevent orphaning. A registration error
+SHALL remain the surfaced cause: a sync failure that follows one SHALL be logged
+with its own detail and SHALL NOT replace the registration error the step fails
+on. The OSS `createNoopArtifactRegistry` returns `externalFailed: 0` and never
+trips this.
+
+The enrichment stages — file-metadata generation, step-summary generation, and
+vector indexing — SHALL run under `safeRun`/`safeRunValue` so any single failure
+degrades without failing the step.
 
 Within the vector-index stage, degradation SHALL be per-item: each surviving
 file description and the step summary SHALL be embedded and upserted under its
@@ -250,10 +293,22 @@ summary carrying the counts of items indexed and items failed — a partial inde
 returns fewer search hits rather than an error, so the logged counts are the
 only signal that degradation occurred.
 
-#### Scenario: Registry rejection fails the step
+#### Scenario: An output rejection fails the step
 
 - **WHEN** `reconcileAndRegisterStepArtifacts` gets `externalFailed > 0` from registration
 - **THEN** it throws with the per-file detail and the step is marked failed
+
+#### Scenario: A rejection that orphans nothing does not fail the step
+
+- **GIVEN** a step whose outputs all registered and whose only rejection is a file no activity references
+- **WHEN** `reconcileAndRegisterStepArtifacts` runs
+- **THEN** `externalFailed` is `0`, the rejection is logged with its path and reason, and the step completes with its artifacts synced
+
+#### Scenario: Registered bytes sync even when registration throws
+
+- **GIVEN** registration that accepted most of the step's artifacts and threw on a rejected output
+- **WHEN** the sandbox-step body handles the throw
+- **THEN** `ArtifactRegistry.sync` is still attempted, the accepted rows are uploaded, and the step fails with the registration error as its cause
 
 #### Scenario: A degraded enrichment stage does not fail the step
 

--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -223,21 +223,26 @@ return all-zero counts immediately and SHALL NOT call the registry.
 
 The registry's outcome is partial by contract — it commits per leaf and per
 activity, with no batch-wide rollback — so `registered` and `failed` arriving
-together describes a normal registration. `failed` SHALL carry every per-path
-rejection the registry reported, each with its path and the registry's reason.
-`failedCount`, surfaced as `externalFailed`, SHALL count only the **terminal**
-rejections: a rejected artifact whose bytes exist nowhere but the step tree, and
-any rejection cascaded from one — a row the registry rejected as a consequence
-of a genuine failure. A rejection of a file that no activity in the payload
-references SHALL NOT be counted, because it registers nothing and so puts no
-bytes at risk.
+together describes a normal registration. `failed`, surfaced as
+`failureDetails`, and `failedCount`, surfaced as `externalFailed`, SHALL both
+describe only the **terminal** rejections: a rejected artifact whose bytes exist
+nowhere but the step tree, and any rejection cascaded from one — a row the
+registry rejected as a consequence of a genuine failure. A rejection of a file
+that no activity in the payload references SHALL NOT appear in either, because
+it registers nothing and so puts no bytes at risk. The two move together so that
+the fail-fast message lists exactly the paths that cost the step something: a
+`failed` array padded with harmless rejections would name them, during an
+incident, in the same breath and the same format as the real ones.
 
-An uncounted rejection SHALL still be surfaced: when `failedCount` is zero and
-`failed` is non-empty, `registerStepArtifacts` SHALL log a warn record naming
-each rejected path and the registry's reason for it. Not counting a rejection
-decides only that it is not worth failing a step over; it is never licence to
-drop it silently, because that record is the only place a reader can check the
-verdict against what the registry actually said.
+A rejection the registry excludes SHALL still be reported, in `notCounted`, and
+`registerStepArtifacts` SHALL log a warn record naming each such path and the
+registry's reason for it. Excluding a rejection decides only that it is not
+worth failing a step over; it is never licence to drop it silently, because that
+record is the only place a reader can check the verdict against what the
+external system actually said. The log SHALL be emitted by
+`registerStepArtifacts` rather than left to the registry: the seam is
+implementable by an embedder, and a rejection does not get to go unrecorded
+because one implementation chose not to log it.
 
 #### Scenario: Successful registration
 
@@ -252,7 +257,7 @@ verdict against what the registry actually said.
 #### Scenario: A rejection that nothing references is surfaced, not counted
 
 - **WHEN** the registry accepts every row except a file that no activity in the payload references
-- **THEN** `failed` carries that path with the registry's reason, a warn record names the path and that reason, and `externalFailed` is `0`
+- **THEN** `notCounted` carries that path with the registry's reason, a warn record names the path and that reason, and both `externalFailed` and `failureDetails` are empty
 
 #### Scenario: Empty artifact list short-circuits
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/execution/artifact-registration.test.ts
+++ b/harness/src/execution/artifact-registration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `registerStepArtifacts` — a registry's severity verdict is recorded, not trusted.
+ *
+ * A registry may keep a rejection out of `failed`/`failedCount` when it was
+ * never attempted and no bytes are at risk. That judgement is the registry's to
+ * make; the record of it is not. The seam is implementable by an embedder, so
+ * the harness logs whatever comes back in `notCounted` rather than leaving the
+ * only account of a rejection to whichever implementation happens to be wired.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Pool } from "pg";
+
+import { createCapturingLogger } from "../__tests__/setup/logger.js";
+import type { AgentSession } from "../auth/types.js";
+import { ProvenanceCollector } from "../provenance/collector.js";
+import type { ArtifactManifestEntry } from "../schemas/artifact-manifest.js";
+import { registerStepArtifacts } from "./artifact-registration.js";
+import type { ArtifactRegistry, ExternalRegistrationResult } from "./artifact-registry.js";
+
+const RID = "an-1";
+const RUN = "run-1";
+const STEP = "s1";
+const OUT = `runs/${RUN}/${STEP}/output/out.csv`;
+const HASH = `sha256:${"a".repeat(64)}`;
+
+/** Every write this module makes is fire-and-forget SQL, and none of it is read back. */
+const stubDb = (): Pool => ({ query: async () => ({ rows: [], rowCount: 0 }) }) as unknown as Pool;
+
+const manifest = (): ArtifactManifestEntry[] => [
+    { stepId: STEP, runId: RUN, path: "output/out.csv", size: 40, type: "output", hash: HASH },
+];
+
+const registryReturning = (result: ExternalRegistrationResult): ArtifactRegistry =>
+    ({ register: async () => result, sync: async () => {} }) as unknown as ArtifactRegistry;
+
+const run = async (result: ExternalRegistrationResult) => {
+    const logger = createCapturingLogger();
+    const registration = await registerStepArtifacts(
+        stubDb(),
+        registryReturning(result),
+        { resourceId: RID, runId: RUN, stepId: STEP, artifacts: manifest(), collector: new ProvenanceCollector({ stepId: STEP, runId: RUN }) },
+        {} as AgentSession,
+        logger,
+    );
+    const rejectionWarnings = logger.records.filter(
+        (r) => r.level === "warn" && r.msg.includes("excluded from the failure count"),
+    );
+    return { registration, rejectionWarnings };
+};
+
+const accepted = { registered: [{ path: OUT, externalId: "a-1" }], failed: [], failedCount: 0 };
+
+describe("registerStepArtifacts — uncounted rejections", () => {
+    it("logs a rejection the registry excluded, without failing the step over it", async () => {
+        const { registration, rejectionWarnings } = await run({
+            ...accepted,
+            notCounted: [{ path: "data/unused.csv", error: "ArtifactNotReferencedError" }],
+        });
+
+        // The step's verdict is untouched: nothing was attempted, so nothing is at risk.
+        expect(registration.externalFailed).toBe(0);
+        expect(registration.failureDetails).toEqual([]);
+        expect(registration.externalRegistered).toBe(1);
+
+        // ...but the rejection is on the record, with enough to check the verdict
+        // against what the external system actually said.
+        expect(rejectionWarnings).toHaveLength(1);
+        expect(rejectionWarnings[0]!.fields.rejected).toEqual([
+            { path: "data/unused.csv", error: "ArtifactNotReferencedError" },
+        ]);
+        // Bound context, so the line is attributable without reading around it.
+        expect(rejectionWarnings[0]!.fields).toMatchObject({ runId: RUN, stepId: STEP });
+    });
+
+    it("says nothing when the registry excluded nothing", async () => {
+        const { rejectionWarnings } = await run(accepted);
+        expect(rejectionWarnings).toEqual([]);
+    });
+
+    it("treats an empty exclusion list as nothing to say", async () => {
+        const { rejectionWarnings } = await run({ ...accepted, notCounted: [] });
+        expect(rejectionWarnings).toEqual([]);
+    });
+
+    it("leaves a terminal rejection counted and detailed, alongside an excluded one", async () => {
+        const { registration, rejectionWarnings } = await run({
+            registered: [],
+            failed: [{ path: OUT, error: "leaf transaction rolled back" }],
+            failedCount: 1,
+            notCounted: [{ path: "data/unused.csv", error: "ArtifactNotReferencedError" }],
+        });
+
+        // The fail-fast message is built from `failureDetails`, so the harmless
+        // rejection must not appear there next to the one that cost the step.
+        expect(registration.externalFailed).toBe(1);
+        expect(registration.failureDetails).toEqual([{ path: OUT, error: "leaf transaction rolled back" }]);
+        expect(rejectionWarnings).toHaveLength(1);
+    });
+});

--- a/harness/src/execution/artifact-registration.ts
+++ b/harness/src/execution/artifact-registration.ts
@@ -80,6 +80,16 @@ export async function registerStepArtifacts(
     const localPaths = new Set(localEntries.map((e) => e.path));
     const result = await registry.register(input, session);
 
+    // The registry excluded these from `failed` by its own severity judgement, so
+    // this is their only record. Logged here rather than left to the registry:
+    // the seam is implementable by an embedder, and a rejection does not get to
+    // go unrecorded because one implementation chose not to log it.
+    if (result.notCounted && result.notCounted.length > 0) {
+        log.warn("registry rejections excluded from the failure count", {
+            rejected: result.notCounted.map((f) => ({ path: f.path, error: f.error })),
+        });
+    }
+
     let externalRegistered = 0;
     for (const reg of result.registered) {
         // Skip files the registry also returned that we didn't upsert locally

--- a/harness/src/execution/artifact-registry.ts
+++ b/harness/src/execution/artifact-registry.ts
@@ -62,6 +62,17 @@ export interface ExternalRegistrationResult {
      * back a whole batch (`failed` then carries one summary entry).
      */
     failedCount: number;
+    /**
+     * Rejections the registry judged non-terminal and deliberately kept out of
+     * `failed`/`failedCount`: rows it never attempted, so nothing registered and
+     * no bytes are at risk. Reported rather than dropped — excluding a rejection
+     * decides only that it is not worth failing a step over, never that it goes
+     * unrecorded. Keeping them out of `failed` is what lets the fail-fast message
+     * list only the paths that actually cost the step something; surfacing them
+     * here is what keeps the registry's verdict checkable against what the
+     * external system actually said.
+     */
+    notCounted?: ReadonlyArray<{ path: string; error: string }>;
 }
 
 export interface ArtifactRegistry {

--- a/harness/src/execution/post-step-pipeline.ts
+++ b/harness/src/execution/post-step-pipeline.ts
@@ -141,10 +141,12 @@ export async function generateStepSummaryAndWrite(
 /**
  * Reconcile the manifest against disk (drop phantoms, rehash) and register the
  * survivors with the local ledger + the injected `ArtifactRegistry`. Fail-fast
- * (see the artifact-manifest spec): a non-zero `externalFailed` is a persistent rejection that
- * orphans real outputs, so it throws with the per-file detail (the OSS
- * filesystem registry returns `externalFailed: 0`, so it never trips). Returns
- * the reconciled manifest.
+ * (see the artifact-manifest spec): `externalFailed` counts only the terminal
+ * rejections — a rejected output whose bytes exist nowhere but the step tree,
+ * plus anything rejected as a consequence of one — so a non-zero count means
+ * real outputs went unregistered, and it throws with the per-file detail (the
+ * OSS filesystem registry returns `externalFailed: 0`, so it never trips).
+ * Returns the reconciled manifest.
  */
 export async function reconcileAndRegisterStepArtifacts(
     deps: PostStepPipelineDeps,
@@ -180,12 +182,19 @@ export async function reconcileAndRegisterStepArtifacts(
         deps.logger,
     );
     if (reg.externalFailed > 0) {
-        const wholeActivityFailed = reg.externalRegistered === 0;
+        // The registry commits per leaf and per activity, so accepted and rejected
+        // rows arriving together is ordinary and `externalRegistered` is what
+        // genuinely landed. Zero of it means this batch registered nothing at all:
+        // no row carries an `artifact_id`, so the byte-sync that follows selects
+        // none of them and every output stays local-only. That reads as a payload-
+        // or credential-shaped rejection rather than a per-file one, so it rides on
+        // the message and as its own field.
+        const noneRegistered = reg.externalRegistered === 0;
         const detail = reg.failureDetails.map((f) => `${f.path}: ${f.error}`).join("\n  ");
         const msg =
             `[post-step.reconcile] external registration failed for ${input.stepId}: ` +
-            `${reg.externalFailed} row(s) rejected, ${reg.externalRegistered}/${reg.localCount} local artifact(s) registered` +
-            (wholeActivityFailed ? " (WHOLE ACTIVITY ROLLED BACK — outputs orphaned)" : "") +
+            `${reg.externalFailed} terminal rejection(s), ${reg.externalRegistered}/${reg.localCount} local artifact(s) registered` +
+            (noneRegistered ? " (nothing in this batch registered)" : "") +
             (detail ? `\n  ${detail}` : "");
         // Logged as fields as well as thrown: the throw reaches `failStep` as one
         // opaque string, so the per-path rejections are only queryable from here.
@@ -197,7 +206,7 @@ export async function reconcileAndRegisterStepArtifacts(
             externalFailed: reg.externalFailed,
             externalRegistered: reg.externalRegistered,
             localCount: reg.localCount,
-            wholeActivityFailed,
+            noneRegistered,
             failures: reg.failureDetails,
         });
         throw new Error(msg);

--- a/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
+++ b/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
@@ -221,20 +221,43 @@ const registrationRejectionMirror = DBOS.registerWorkflow(
     { name: "registration-rejection-mirror" },
 );
 
-// ── 10.13 — idempotent sync (no replay re-fire) ─────────────────────────
+// ── 10.13 — a replayed sync moves no bytes ──────────────────────────────
 
-let idempotentSyncCalls = 0;
-let idempotentSyncArgs: string[] = [];
+/** One `cortex_artifacts` row, cut down to the columns the sync selection reads. */
+interface LedgerRow {
+    path: string;
+    role: string;
+    artifactId: string | null;
+    fileId: string | null;
+}
+
+let syncLedger: LedgerRow[] = [];
+let syncCalls = 0;
+/** Rows uploaded by each `syncStepArtifacts` invocation, in call order. */
+let syncUploads: number[] = [];
+
+/**
+ * Stands in for `deps.artifactRegistry.sync`, over the selection the harness
+ * hands it: `queryUnsyncedStepArtifacts` returns step-output rows with
+ * `artifact_id IS NOT NULL AND file_id IS NULL`. A row is therefore in the
+ * queue only until an upload stamps it with a `file_id`; a row the registry
+ * rejected never enters it at all, having no `artifact_id`.
+ */
+async function syncStepArtifacts(): Promise<void> {
+    syncCalls += 1;
+    const unsynced = syncLedger.filter((r) => r.role === "step_output" && r.artifactId !== null && r.fileId === null);
+    for (const row of unsynced) row.fileId = `file-${row.path}`;
+    syncUploads.push(unsynced.length);
+}
 
 const idempotentSyncMirror = DBOS.registerWorkflow(
-    async (input: { stepId: string }): Promise<{ syncCalls: number; tail: string }> => {
-        await DBOS.runStep(
-            async () => {
-                idempotentSyncCalls += 1;
-                idempotentSyncArgs.push(input.stepId);
-            },
-            { name: "post-step.sync" },
-        );
+    async (): Promise<{ uploads: number[]; tail: string }> => {
+        // A bare await, as in `sandbox-step`: the sync takes no DBOS function id,
+        // so replay re-executes it rather than replaying a cached result. What
+        // keeps the second pass from re-uploading is the selection it runs over —
+        // the first pass gave every row it uploaded a `file_id`, and a row
+        // carrying one is no longer unsynced.
+        await syncStepArtifacts();
 
         // Unconditional cancel — see threeStepMirror's note on DBOS's
         // determinism requirement for step sequences across replay.
@@ -242,7 +265,7 @@ const idempotentSyncMirror = DBOS.registerWorkflow(
 
         const tail = await DBOS.runStep(async () => "tail-ok", { name: "post-step.tail" });
 
-        return { syncCalls: idempotentSyncCalls, tail };
+        return { uploads: [...syncUploads], tail };
     },
     { name: "idempotent-sync-mirror" },
 );
@@ -392,31 +415,49 @@ describe("Integration test 10.13 — per-step sync (registration rejection + ide
         expect(steps?.map((s) => s.name)).toEqual(["mark-failed-attestation"]);
     });
 
-    it("sync is NOT re-fired on DBOS recovery (cached step result returns)", async () => {
-        idempotentSyncCalls = 0;
-        idempotentSyncArgs = [];
+    it("a replayed sync re-runs and uploads nothing — the unsynced selection skips rows that already carry a file_id", async () => {
+        syncCalls = 0;
+        syncUploads = [];
+        syncLedger = [
+            { path: "output/results.csv", role: "step_output", artifactId: "art-1", fileId: null },
+            { path: "figures/volcano.png", role: "step_output", artifactId: "art-2", fileId: null },
+            // Rejected by the registry: no `artifact_id`, so never selected.
+            { path: "logs/run.log", role: "step_output", artifactId: null, fileId: null },
+            // A data input, born-synced — outside the step-output selection.
+            { path: "data/expr.csv", role: "input", artifactId: "art-0", fileId: "file-0" },
+        ];
 
         const wfId = rig.nextWorkflowId("sync-idem-");
 
         const handle1 = await DBOS.startWorkflow(idempotentSyncMirror, {
             workflowID: wfId,
-        })({ stepId: "step-A" });
+        })();
         handle1.getResult().catch(() => {});
         const status1 = await waitForTerminal(wfId);
         expect(status1?.status).toBe("CANCELLED");
 
-        expect(idempotentSyncCalls).toBe(1);
-        expect(idempotentSyncArgs).toEqual(["step-A"]);
+        expect(syncCalls).toBe(1);
+        expect(syncUploads).toEqual([2]);
 
-        const handle2 = await DBOS.resumeWorkflow<{ syncCalls: number; tail: string }>(wfId);
+        const handle2 = await DBOS.resumeWorkflow<{ uploads: number[]; tail: string }>(wfId);
         const result = await handle2.getResult();
 
-        // Sync's closure did NOT run on replay — counter still 1, args
-        // array still has only the original invocation.
-        expect(idempotentSyncCalls).toBe(1);
-        expect(idempotentSyncArgs).toEqual(["step-A"]);
+        // The bare await DOES re-run on replay — it holds no cached result to
+        // return — and the load-bearing assertion is that it moves no bytes:
+        // both registered rows were stamped with a `file_id` on the first pass.
+        expect(syncCalls).toBe(2);
+        expect(result.uploads).toEqual([2, 0]);
+
+        // The rejected row is still byteless and the born-synced input untouched.
+        expect(syncLedger.find((r) => r.path === "logs/run.log")?.fileId).toBeNull();
+        expect(syncLedger.find((r) => r.path === "data/expr.csv")?.fileId).toBe("file-0");
         expect(result.tail).toBe("tail-ok");
-        expect(result.syncCalls).toBe(1);
+
+        // No checkpoint is spent on the sync: it never appears in the recorded
+        // step list, so the body's function-ID sequence is what it would be
+        // without it.
+        const steps = await DBOS.listWorkflowSteps(wfId);
+        expect(steps?.map((s) => s.name)).not.toContain("post-step.sync");
 
         const status2 = await DBOS.getWorkflowStatus(wfId);
         expect(status2?.status).toBe("SUCCESS");

--- a/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
+++ b/harness/src/workflows/__tests__/dbos/workflow-replay.test.ts
@@ -6,9 +6,10 @@
  *    before `generateFileMetadata` runs. Verify: cached LLM result returns
  *    on replay (no re-issued API call), next `durableStep` runs forward."
  *
- * Test 10.13 — per-step sync, non-fatal + idempotent on recovery:
- *   "Runs inline in the child; failure logged as warning, step still
- *    reports complete; idempotent on DBOS recovery."
+ * Test 10.13 — per-step sync, sequenced after registration + idempotent:
+ *   "Runs inline in the child; a registration rejection still attempts it and
+ *    its own failure is logged as a warning rather than displacing the
+ *    registration error; idempotent on DBOS recovery."
  *
  * Pattern — DBOS-determinism-safe chaos:
  *
@@ -166,40 +167,58 @@ const threeStepMirror = DBOS.registerWorkflow(
     { name: "three-step-mirror" },
 );
 
-// ── 10.13 — non-fatal sync (safeRun swallows throw) ────────────────────
+// ── 10.13 — sync attempted after a registration rejection ───────────────
 
-let nonFatalSyncCalls = 0;
-let nonFatalPostSyncCalls = 0;
+const REGISTRATION_REJECTION = "external registration failed: 1 row(s) rejected";
+const SYNC_UNREACHABLE = "artifact store reachability lost";
 
-const nonFatalSyncMirror = DBOS.registerWorkflow(
-    async (): Promise<{ syncCalls: number; postSyncCalls: number }> => {
-        // Mirror of `deps.artifactRegistry.sync(...)` wrapped by the body's
-        // fail-fast try/catch.
-        // In production, `safeRun` swallows any throw and the body proceeds.
+let rejectionRegisterCalls = 0;
+let rejectionSyncCalls = 0;
+let rejectionMarkFailedCalls = 0;
+
+/** Stands in for `deps.artifactRegistry.sync`, which throws on a persistent failure. */
+async function unreachableSync(): Promise<void> {
+    rejectionSyncCalls += 1;
+    throw new Error(SYNC_UNREACHABLE);
+}
+
+const registrationRejectionMirror = DBOS.registerWorkflow(
+    async (): Promise<never> => {
+        // Mirror of `sandbox-step`'s lineage-attestation block. Registration and
+        // the byte-sync are sequenced independently: a registration rejection
+        // still attempts the sync (otherwise the rows that DID register are left
+        // with `artifact_id` set and `file_id` NULL — bytes never uploaded), a
+        // throw from that sync is warn-logged and swallowed, and the REGISTRATION
+        // error is what fails the step.
+        //
+        // Neither operation is `DBOS.runStep`-wrapped in the body, so neither is
+        // mirrored as one here. `failStep`'s `mark-failed-attestation` is the
+        // block's only checkpoint, and the test below reads the recorded step
+        // list to assert the added sync attempt took no function id.
         try {
+            rejectionRegisterCalls += 1;
+            throw new Error(REGISTRATION_REJECTION);
+        } catch (registrationErr) {
+            try {
+                await unreachableSync();
+            } catch (syncErr) {
+                // This body mirrors `sandbox-step`'s; keep it on the seam so the mirror
+                // stays faithful (and silent) rather than printing during the run.
+                silentLogger
+                    .named("mirror")
+                    .named("post-step.sync")
+                    .warn("failed after a registration rejection (non-fatal)", silentLogger.errorFields(syncErr));
+            }
             await DBOS.runStep(
                 async () => {
-                    nonFatalSyncCalls += 1;
-                    throw new Error("artifact store reachability lost");
+                    rejectionMarkFailedCalls += 1;
                 },
-                { name: "post-step.sync" },
+                { name: "mark-failed-attestation" },
             );
-        } catch (err) {
-            // This body mirrors `sandbox-step`'s; keep it on the seam so the mirror
-            // stays faithful (and silent) rather than printing during the run.
-            silentLogger.named("mirror").warn("post-step.sync failed (non-fatal)", silentLogger.errorFields(err));
+            throw registrationErr;
         }
-
-        await DBOS.runStep(
-            async () => {
-                nonFatalPostSyncCalls += 1;
-            },
-            { name: "post-step.vector-index" },
-        );
-
-        return { syncCalls: nonFatalSyncCalls, postSyncCalls: nonFatalPostSyncCalls };
     },
-    { name: "non-fatal-sync-mirror" },
+    { name: "registration-rejection-mirror" },
 );
 
 // ── 10.13 — idempotent sync (no replay re-fire) ─────────────────────────
@@ -342,25 +361,35 @@ describe("Integration test 10.6 — chaos recovery", () => {
     });
 });
 
-describe("Integration test 10.13 — per-step sync (non-fatal + idempotent)", () => {
-    it("sync failure is logged but the workflow still reaches SUCCESS", async () => {
-        nonFatalSyncCalls = 0;
-        nonFatalPostSyncCalls = 0;
+describe("Integration test 10.13 — per-step sync (registration rejection + idempotent)", () => {
+    it("a registration rejection still attempts the sync, and is the error the workflow fails with", async () => {
+        rejectionRegisterCalls = 0;
+        rejectionSyncCalls = 0;
+        rejectionMarkFailedCalls = 0;
 
-        const wfId = rig.nextWorkflowId("sync-fail-");
-        const handle = await DBOS.startWorkflow(nonFatalSyncMirror, {
+        const wfId = rig.nextWorkflowId("reg-reject-");
+        const handle = await DBOS.startWorkflow(registrationRejectionMirror, {
             workflowID: wfId,
         })();
+        handle.getResult().catch(() => {});
+        const status = await waitForTerminal(wfId);
 
-        const result = await handle.getResult();
+        expect(status?.status).toBe("ERROR");
+        expect(rejectionRegisterCalls).toBe(1);
+        // The load-bearing assertion: registration throwing does not skip the
+        // byte-sync. Skipping it is what strands rows registered-but-byteless.
+        expect(rejectionSyncCalls).toBe(1);
+        expect(rejectionMarkFailedCalls).toBe(1);
 
-        expect(nonFatalSyncCalls).toBe(1);
-        expect(result.syncCalls).toBe(1);
-        expect(nonFatalPostSyncCalls).toBe(1);
-        expect(result.postSyncCalls).toBe(1);
+        // The sync's own failure does not displace the registration rejection.
+        const err = status?.error as Error | undefined;
+        expect(err?.message).toContain(REGISTRATION_REJECTION);
+        expect(err?.message).not.toContain(SYNC_UNREACHABLE);
 
-        const status = await DBOS.getWorkflowStatus(wfId);
-        expect(status?.status).toBe("SUCCESS");
+        // The sync attempt is a bare await, so it takes no DBOS function id: the
+        // block's checkpoint sequence is what it would be without it.
+        const steps = await DBOS.listWorkflowSteps(wfId);
+        expect(steps?.map((s) => s.name)).toEqual(["mark-failed-attestation"]);
     });
 
     it("sync is NOT re-fired on DBOS recovery (cached step result returns)", async () => {

--- a/harness/src/workflows/sandbox-step.test.ts
+++ b/harness/src/workflows/sandbox-step.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { okAsync } from "neverthrow";
@@ -29,12 +29,12 @@ import { isReconciling, type CortexChatPartType } from "@inflexa-ai/harness/cont
 
 import { makeLocalAuth } from "../auth/local-auth-context.js";
 import type { RunSession } from "../auth/types.js";
-import { silentLogger } from "../__tests__/setup/logger.js";
+import { createCapturingLogger, silentLogger, type CapturingLogger } from "../__tests__/setup/logger.js";
 import { classifyReadPath } from "../provenance/collector.js";
 import type { AgentChat, ChatResponse, ChatUsage, EmbeddingProvider } from "../providers/types.js";
 import type { SandboxClient } from "../sandbox/client.js";
 import type { CreateSandboxMeta, SandboxRef } from "../sandbox/types.js";
-import type { ArtifactRegistry } from "../execution/artifact-registry.js";
+import type { ArtifactRegistry, ArtifactSyncInput } from "../execution/artifact-registry.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
 import { createLineageCollector, runSandboxStepBody, type SandboxStepDeps, type SandboxStepInput } from "./sandbox-step.js";
 
@@ -427,5 +427,136 @@ describe("sandbox-step pod labels", () => {
 
         expect(result.status).toBe("complete");
         expect(spawns[0]!.podLabels).toBeUndefined();
+    });
+});
+
+// ── lineage attestation: registration and byte-sync ──────────────────
+
+/**
+ * The two operations behind `data-step-activity: persisting`. Registration
+ * assigns each artifact its external id; the sync uploads the bytes those ids
+ * point at. They are sequenced independently in the body because a rejected
+ * registration that skipped the sync leaves the rows that DID register with an
+ * `artifact_id` and no `file_id` — an orphan the step's own fail-fast exists to
+ * prevent.
+ */
+describe("sandbox-step lineage attestation", () => {
+    const REGISTRY_REJECTION = "provenance registry rejected the payload";
+    const SYNC_FAILURE = "artifact store reachability lost";
+    /** The generic phrase `failStep` scrubs a lineage failure down to. */
+    const SCRUBBED = "Step results could not be finalized.";
+
+    /**
+     * A real file under the step's write prefix, so the artifact walk yields a
+     * non-empty manifest and registration is actually reached — an empty manifest
+     * short-circuits before the registry is ever called.
+     */
+    async function seedStepOutput(): Promise<void> {
+        const dir = join(workspaceRoot, "runs", USAGE_RUN_ID, USAGE_STEP_ID, "output");
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "result.csv"), "gene,count\nTP53,7\n");
+    }
+
+    interface AttestationProbe {
+        readonly deps: SandboxStepDeps;
+        /** Every `sync` call, in order. */
+        readonly syncCalls: ArtifactSyncInput[];
+        /** `"register"` / `"sync"` in invocation order. */
+        readonly order: string[];
+    }
+
+    function attestationDeps(args: { logger?: SandboxStepDeps["logger"]; rejectRegistration: boolean; syncThrows: boolean }): AttestationProbe {
+        const syncCalls: ArtifactSyncInput[] = [];
+        const order: string[] = [];
+        const artifactRegistry: ArtifactRegistry = {
+            register: async (registration) => {
+                order.push("register");
+                if (!args.rejectRegistration) return { registered: [], failed: [], failedCount: 0 };
+                return {
+                    registered: [],
+                    failed: [{ path: `runs/${registration.runId}/${registration.stepId}/output/result.csv`, error: REGISTRY_REJECTION }],
+                    failedCount: 1,
+                };
+            },
+            sync: async (syncInput) => {
+                order.push("sync");
+                syncCalls.push(syncInput);
+                if (args.syncThrows) throw new Error(SYNC_FAILURE);
+            },
+        };
+        return {
+            deps: { ...usageStepDeps(undefined), ...(args.logger ? { logger: args.logger } : {}), artifactRegistry },
+            syncCalls,
+            order,
+        };
+    }
+
+    const SYNC_INPUT: ArtifactSyncInput = { resourceId: ANALYSIS_ID, runId: USAGE_RUN_ID, stepId: USAGE_STEP_ID };
+
+    /** The `step failure` record — the only account of why a scrubbed step died. */
+    function stepFailure(logger: CapturingLogger): { errorClass: unknown; err: string } | undefined {
+        const rec = logger.records.find((r) => r.msg.endsWith("step failure"));
+        return rec ? { errorClass: rec.fields.errorClass, err: String(rec.fields.err) } : undefined;
+    }
+
+    it("uploads the bytes even when registration is rejected", async () => {
+        // The regression this guards: a rejected registration used to abort the
+        // block before the sync, stranding every row that DID register with an
+        // `artifact_id` and a NULL `file_id`.
+        await seedStepOutput();
+        const { deps, syncCalls, order } = attestationDeps({ rejectRegistration: true, syncThrows: false });
+
+        await expect(runSandboxStepBody(usageStepInput(), deps)).rejects.toThrow(SCRUBBED);
+
+        expect(syncCalls).toEqual([SYNC_INPUT]);
+        expect(order).toEqual(["register", "sync"]);
+    });
+
+    it("records the registration rejection as the cause, not the sync failure that followed it", async () => {
+        // The sync attempt must not be able to displace the error that actually
+        // failed the step — the thrown message is scrubbed, so this record is the
+        // only thing an operator can diagnose from.
+        await seedStepOutput();
+        const logger = createCapturingLogger();
+        const { deps, syncCalls } = attestationDeps({ logger, rejectRegistration: true, syncThrows: true });
+
+        await expect(runSandboxStepBody(usageStepInput(), deps)).rejects.toThrow(SCRUBBED);
+
+        expect(syncCalls).toEqual([SYNC_INPUT]);
+        const failure = stepFailure(logger);
+        expect(failure?.errorClass).toBe("lineage_attestation");
+        expect(failure?.err).toContain(REGISTRY_REJECTION);
+        expect(failure?.err).not.toContain(SYNC_FAILURE);
+
+        // The swallowed sync failure is still reported, under its own stage name.
+        const syncWarn = logger.records.find((r) => r.msg.includes("post-step.sync"));
+        expect(syncWarn?.level).toBe("warn");
+        expect(String(syncWarn?.fields.err)).toContain(SYNC_FAILURE);
+    });
+
+    it("registers then syncs once and completes when both succeed", async () => {
+        await seedStepOutput();
+        const { deps, syncCalls, order } = attestationDeps({ rejectRegistration: false, syncThrows: false });
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(order).toEqual(["register", "sync"]);
+        expect(syncCalls).toEqual([SYNC_INPUT]);
+    });
+
+    it("still fails the step when registration succeeds and the sync does not", async () => {
+        // Fail-fast on the success arm is unchanged: bytes that never landed are
+        // the same orphan, and the step must not finish green.
+        await seedStepOutput();
+        const logger = createCapturingLogger();
+        const { deps, syncCalls } = attestationDeps({ logger, rejectRegistration: false, syncThrows: true });
+
+        await expect(runSandboxStepBody(usageStepInput(), deps)).rejects.toThrow(SCRUBBED);
+
+        expect(syncCalls).toEqual([SYNC_INPUT]);
+        const failure = stepFailure(logger);
+        expect(failure?.errorClass).toBe("lineage_attestation");
+        expect(failure?.err).toContain(SYNC_FAILURE);
     });
 });

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -836,12 +836,16 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
     // outputs, so it fails the step loudly instead of finishing green. Transient
     // managed-root errors are already retried in the client, so anything thrown here is
     // persistent — tear down, mark failed, and re-raise so the parent's fail-fast
-    // cascade fires (mirrors the agent-loop failure path).
+    // cascade fires (mirrors the agent-loop failure path). The two operations are
+    // sequenced independently: byte-sync is attempted on both arms, so a rejected
+    // registration still uploads the bytes of whatever DID register.
     await emitActivity("persisting", "Registering artifacts");
-    let reconciledManifest: readonly ArtifactManifestEntry[];
-    try {
-        reconciledManifest = await reconcileAndRegisterStepArtifacts(deps, postCtx, manifest);
-        await deps.artifactRegistry.sync(
+    // A bare call, deliberately not `DBOS.runStep`-wrapped: it is reachable from
+    // two arms below, and a checkpointed step reached from a conditional arm
+    // would shift the body's function-ID sequence between the two paths (see the
+    // harness-durable-runtime spec).
+    const syncStepArtifacts = (): Promise<void> =>
+        deps.artifactRegistry.sync(
             {
                 resourceId: input.analysisId,
                 runId: input.runId,
@@ -849,6 +853,30 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
             },
             session,
         );
+    let reconciledManifest: readonly ArtifactManifestEntry[];
+    try {
+        reconciledManifest = await reconcileAndRegisterStepArtifacts(deps, postCtx, manifest);
+    } catch (registrationErr) {
+        // Registration and byte-sync are independent, and a registry rejection is
+        // partial: the rows that DID register carry `artifact_id` with `file_id`
+        // still NULL, which is exactly what `queryUnsyncedStepArtifacts` selects.
+        // Syncing anyway uploads their bytes (rows that never registered are not
+        // selected, so this stays idempotent under re-execution); skipping it is
+        // what strands them registered-but-byteless.
+        try {
+            await syncStepArtifacts();
+        } catch (syncErr) {
+            // A cancellation is control-flow, not a sync failure — re-raise it
+            // verbatim, as every other stage in this body does. Any real failure
+            // is swallowed so it cannot displace the registration rejection as the
+            // step's cause; this record is the only account of it.
+            if (syncErr instanceof DBOSErrors.DBOSWorkflowCancelledError) throw syncErr;
+            logger.named("post-step.sync").warn("failed after a registration rejection (non-fatal)", logger.errorFields(syncErr));
+        }
+        throw await failStep("lineage_attestation", registrationErr);
+    }
+    try {
+        await syncStepArtifacts();
     } catch (err) {
         throw await failStep("lineage_attestation", err);
     }


### PR DESCRIPTION
Two prod steps whose science had fully completed were hard-failed during post-step artifact registration, each over a single **unused data-input file**. `reconcileAndRegisterStepArtifacts` threw, and `syncStepArtifacts` was the next statement in the same `try` — so 51 artifacts that Nexus had already accepted into the ledger never had their bytes uploaded. Rows carried an `artifact_id` and a null `file_id`: referenced in the ledger, unreadable from it. The fail-fast produced exactly the orphaning it exists to prevent.

## Changes

**`sandbox-step.ts` — sync moved into the rejection path.** When registration throws, the workflow now attempts byte-sync *before* `failStep`, in its own inner try/catch. A sync failure is logged and swallowed: the registration error is the one that reaches the caller, so the diagnostic the operator sees is still the real cause. `DBOSWorkflowCancelledError` is re-raised rather than swallowed — a cancelled workflow must stay cancelled, and it can surface from the same `await`.

The call stays a bare `await`, not a fresh `runStep`. On replay the checkpoint is already recorded, so this re-runs and uploads nothing.

**A rejection the registry excludes is reported, not dropped.** `ExternalRegistrationResult` gains `notCounted`: rejections the registry judged non-terminal and kept out of `failed`/`failedCount`. `registerStepArtifacts` logs them at warn with path and reason.

`failed` and `failedCount` deliberately move together. Padding `failed` with harmless rejections would list them, during an incident, in the same breath and the same format as the ones that actually cost the step its bytes — so the fail-fast message names only the latter, and `notCounted` carries the rest. The log lives here rather than in the registry because the seam is implementable by an embedder: a rejection does not get to go unrecorded because one implementation chose not to log it.

**`post-step-pipeline.ts` — a zero-registration batch is described accurately.** `wholeActivityFailed` claimed activity-level failure whenever `registered.length === 0`, which is also what a batch of pure rejections looks like. Renamed `noneRegistered`, and the message now says "nothing in this batch registered". "N row(s) rejected" became "N terminal rejection(s)".

## Notes for review

- Patch bump to **0.28.1** — `ExternalRegistrationResult` gains an optional field, and no existing implementation or caller changes shape: a registry that omits it stays conformant and the log simply has nothing to say. Rebased onto `main` (0.28.0, exec-stream caps); no conflicts beyond the version line.
- `idempotentSyncMirror` in the replay test was asserting the opposite of the real behaviour (that replay skips sync). It re-runs and uploads nothing; the test now asserts that. It was passing for the wrong reason before.
- `wholeActivityFailed` → `noneRegistered` is a structured-log field rename; any saved query on the old name goes silent.

Pairs with inflexa-ai/cortex#347, which stops the unused input from being counted at all and returns `notCounted`. 0.28.1 is published and cortex#347 is already pinned to it, so the two can land in either order. Together: cortex stops manufacturing the rejection, the harness stops one from costing a step its bytes. **The 63 already-stranded artifacts have been recovered.**

## Verification

`npx tsc --noEmit` clean · full `bun test` in `harness/` → **3416 pass, 6 skip, 0 fail** across 227 files, including 4 new tests for the `notCounted` log. Re-run after the rebase.

https://claude.ai/code/session_019bjmgTZSvqfSazfAF7SKhW


