### PR TITLE
fix(cli): watch the liveness of a download, and drop its deadlines

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.27.0",
+        "@inflexa-ai/harness": "0.28.1",
         "@inflexa-ai/prov-kernel": "^0.5.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",
@@ -168,7 +168,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.27.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.38", "@ai-sdk/openai": "^4.0.39", "@ai-sdk/openai-compatible": "^3.0.30", "@ai-sdk/provider": "^4.0.7", "@ai-sdk/provider-utils": "5.0.27", "@anthropic-ai/sdk": "^0.116.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@fontsource-variable/space-grotesk": "5.1.1", "@fontsource/ibm-plex-mono": "5.1.1", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ag-grid-community": "36.1.0", "ai": "^7.0.61", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "echarts": "5.5.1", "fast-xml-parser": "^5.10.1", "hono": "^4.12.34", "hyparquet": "^1.28.1", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "openai": "^7.4.0", "p-queue": "^9.3.3", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-8m0zWgRgb2MQN5CMVYs5r2IeaeyouXAfi60F0EJw4owUeMlif74kWbTraL7YRXeB+7X09JSMCmM0/sxsEdwoUQ=="],
+    "@inflexa-ai/harness": ["@inflexa-ai/harness@0.28.1", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.38", "@ai-sdk/openai": "^4.0.39", "@ai-sdk/openai-compatible": "^3.0.30", "@ai-sdk/provider": "^4.0.7", "@ai-sdk/provider-utils": "5.0.27", "@anthropic-ai/sdk": "^0.116.0", "@dbos-inc/dbos-sdk": "^4.23.6", "@fontsource-variable/space-grotesk": "5.1.1", "@fontsource/ibm-plex-mono": "5.1.1", "@kubernetes/client-node": "^1.4.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.9.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "@opentelemetry/semantic-conventions": "^1.43.0", "ag-grid-community": "36.1.0", "ai": "^7.0.61", "cheerio": "^1.2.0", "dockerode": "^4.0.12", "echarts": "5.5.1", "fast-xml-parser": "^5.10.1", "hono": "^4.12.34", "hyparquet": "^1.28.1", "js-tiktoken": "^1.0.21", "mime": "^4.1.0", "nanoid": "^5.1.16", "neverthrow": "^8.2.0", "openai": "^7.4.0", "p-queue": "^9.3.3", "pdf-parse": "^2.4.5", "pg": "^8.22.0", "puppeteer-core": "^23.11.1", "zod": "^4.4.3" } }, "sha512-JT/YBZxtTYL2MrNg+Y9QIS6PSfERsw8/jMfNQ0NQaSe4kkcbPhzEPdEKZ9XTNdCWy0l9pLliv/giCAN23hbh3Q=="],
 
     "@inflexa-ai/prov-kernel": ["@inflexa-ai/prov-kernel@0.5.0", "", { "dependencies": { "neverthrow": "^8.2.0", "zod": "^4.4.3" }, "peerDependencies": { "@inflexa-ai/tsprov": "^0.5.1" } }, "sha512-kbNYe8WwYH8TQk/F4hjmdIJpZv7nuucbgk3zSZ/fpF8FApbqsUcJKHV6PdgUUecopEYjQ7n/g97opkhLpKCUGA=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inflexa",
-    "version": "0.17.0",
+    "version": "0.17.1",
     "description": "Local-first AI agent for reproducible biological data analysis",
     "keywords": [
         "bioinformatics",
@@ -38,7 +38,7 @@
     "dependencies": {
         "@clack/core": "1.4.3",
         "@clack/prompts": "^1.7.0",
-        "@inflexa-ai/harness": "0.27.0",
+        "@inflexa-ai/harness": "0.28.1",
         "@inflexa-ai/prov-kernel": "^0.5.0",
         "@inflexa-ai/tsprov": "0.5.1",
         "@opentelemetry/api": "^1.9.1",

--- a/cli/src/cli/agent_policy.ts
+++ b/cli/src/cli/agent_policy.ts
@@ -15,9 +15,37 @@ import type { Command } from "commander";
  *   which is grantable per analysis. The prompt is the security boundary here.
  * - `blocked` — never runs, not even with approval; the mandatory `reason` is handed
  *   verbatim to the model so it can explain to the user why and stop retrying.
+ *
+ * A runnable kind can also carry {@link TransferTrait}.
  */
 export type AgentPolicy =
-    { readonly kind: "auto"; readonly safeFlags: readonly string[] } | { readonly kind: "approval" } | { readonly kind: "blocked"; readonly reason: string };
+    | ({ readonly kind: "auto"; readonly safeFlags: readonly string[] } & TransferTrait)
+    | ({ readonly kind: "approval" } & TransferTrait)
+    | { readonly kind: "blocked"; readonly reason: string };
+
+/**
+ * The trait a runnable command carries when its work is a transfer from an upstream publisher —
+ * `refs download` and `geo download` today. The tool then runs it with NO deadline of its own, and the
+ * approval prompt states that.
+ *
+ * A transfer has no honest deadline to declare here. Its size is a 2 GB artifact over whatever link the
+ * user has, so a ceiling generous enough to spare an honest run also spares a dead one; and a bound on
+ * silence stops the honest run first, because a captured transfer prints one line for each file and one
+ * file is minutes of quiet. Liveness is decided where the bytes are instead — `downloadToFile` in
+ * `lib/download.ts` watches its own body and ends a transfer that stops moving, within
+ * `LIVENESS_WINDOW_MS`. A second bound out here could only ever be the wrong one.
+ *
+ * The trait is deliberately not a `kind`: what may run the command, and how long it may take, are
+ * different questions, and folding them together would make a fourth kind that means "approval, but".
+ */
+export type TransferTrait = {
+    readonly transfer?: true;
+};
+
+/** Whether `policy` marks a transfer — see {@link TransferTrait}. A `blocked` command never runs, thus it never carries one. */
+export function isTransferPolicy(policy: AgentPolicy | undefined): boolean {
+    return policy !== undefined && policy.kind !== "blocked" && policy.transfer === true;
+}
 
 /**
  * The policy store, keyed on the `Command` INSTANCE rather than its path string.

--- a/cli/src/cli/agent_policy_tree.test.ts
+++ b/cli/src/cli/agent_policy_tree.test.ts
@@ -29,10 +29,16 @@ function runReport(channel: "development" | "production"): PolicyRow[] {
     return JSON.parse(proc.stdout.toString()) as PolicyRow[];
 }
 
-/** Compact each row to its audit value: `auto(flag,flag)` for auto, otherwise the bare kind. */
+/**
+ * Compact each row to its audit value: `auto(flag,flag)` for auto, otherwise the bare kind, and `+transfer`
+ * on either when the command runs with no deadline of the tool's own.
+ */
 function policyTable(rows: readonly PolicyRow[]): Record<string, string> {
     const out: Record<string, string> = {};
-    for (const row of rows) out[row.grantKey] = row.kind === "auto" ? `auto(${(row.safeFlags ?? []).join(",")})` : String(row.kind);
+    for (const row of rows) {
+        const kind = row.kind === "auto" ? `auto(${(row.safeFlags ?? []).join(",")})` : String(row.kind);
+        out[row.grantKey] = row.transfer ? `${kind}+transfer` : kind;
+    }
     return out;
 }
 
@@ -47,7 +53,7 @@ const EXPECTED_DEV_OFF: Record<string, string> = {
     "inflexa auth whoami": "auto()",
     "inflexa config": "blocked",
     "inflexa down": "blocked",
-    "inflexa geo download": "approval",
+    "inflexa geo download": "approval+transfer",
     "inflexa inputs add": "blocked",
     "inflexa inputs ls": "auto(analysis)",
     "inflexa inputs remove": "blocked",
@@ -61,7 +67,7 @@ const EXPECTED_DEV_OFF: Record<string, string> = {
     "inflexa prov verify": "auto()",
     "inflexa prov verify-file": "auto()",
     "inflexa prune": "approval",
-    "inflexa refs download": "approval",
+    "inflexa refs download": "approval+transfer",
     "inflexa refs list": "auto(urls,json)",
     "inflexa refs path": "auto()",
     "inflexa refs verify": "auto(json)",
@@ -91,7 +97,7 @@ const EXPECTED_DEV_ON: Record<string, string> = {
     "inflexa chat": "blocked",
     "inflexa config": "blocked",
     "inflexa down": "blocked",
-    "inflexa geo download": "approval",
+    "inflexa geo download": "approval+transfer",
     "inflexa inputs add": "blocked",
     "inflexa inputs ls": "auto(analysis)",
     "inflexa inputs remove": "blocked",
@@ -106,7 +112,7 @@ const EXPECTED_DEV_ON: Record<string, string> = {
     "inflexa prov verify": "auto()",
     "inflexa prov verify-file": "auto()",
     "inflexa prune": "approval",
-    "inflexa refs download": "approval",
+    "inflexa refs download": "approval+transfer",
     "inflexa refs list": "auto(urls,json)",
     "inflexa refs path": "auto()",
     "inflexa refs verify": "auto(json)",

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -521,7 +521,9 @@ export function buildProgram(): Command {
             // the flag could only ever have failed — `--analysis` is the way to name a target.
             .option("--analysis <id|name>", "Operate on a specific analysis")
             .option("--max-size <size>", "Override the per-Series download ceiling (e.g. 500MB, 64GB)"),
-        { kind: "approval" },
+        // A transfer: a Series is gigabytes over NCBI's link, so the agent's tool gives it no deadline and
+        // the downloader ends it when the bytes stop. `--max-size` bounds the SIZE, never the time.
+        { kind: "approval", transfer: true },
         async (gse: string, options: { analysis?: string; maxSize?: string }) => {
             const { runGeoDownload } = await import("../modules/geo/download.ts");
             await runGeoDownload(gse, { analysis: options.analysis }, options.maxSize);
@@ -729,7 +731,9 @@ export function buildProgram(): Command {
             .argument("[ids...]", "Catalog dataset ids (interactive selection when omitted)")
             .option("--yes", "Skip the download confirmation")
             .option("--force", "Re-fetch even when already installed — repairs damage and refreshes mutable upstreams"),
-        { kind: "approval" },
+        // A transfer: one catalog artifact reaches 2 GB, and the captured readout prints a line for each
+        // file that lands, so the whole of a large one is quiet. The downloader watches the bytes instead.
+        { kind: "approval", transfer: true },
         async (ids: string[], options: { yes?: boolean; force?: boolean }) => {
             const { runRefsDownload } = await import("../modules/refs/commands.ts");
             await runRefsDownload(ids, options);

--- a/cli/src/lib/download.test.ts
+++ b/cli/src/lib/download.test.ts
@@ -21,6 +21,11 @@ function sha(body: string): string {
     return createHash("sha256").update(body).digest("hex");
 }
 
+/** Local rather than `Promise.sleep`: the global extensions load from the CLI entry point, which a test process never runs. */
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** Offline upstream: serves `body`, optionally as an error status, a post-redirect url, or with a content-length header. */
 function serve(
     body: string,
@@ -110,6 +115,53 @@ describe("downloadToFile", () => {
         expect(result.isOk()).toBe(true);
         expect(readFileSync(dest, "utf8")).toBe("payload");
         expect(cancelled).toBe(1);
+    });
+
+    test("ends a body that stops moving as stalled, and writes nothing", async () => {
+        // The failure the watch exists for: the socket is open, the promise is pending, and the upstream
+        // sent one chunk and then died. Nothing but the gap between chunks can tell this from slow work.
+        const dest = join(root(), "out.bin");
+        const stream = new ReadableStream({
+            start: (c) => c.enqueue(new TextEncoder().encode("first")),
+        });
+        const result = await downloadToFile(URL_OK, dest, { fetch: async () => new Response(stream), livenessWindowMs: 40 });
+        expect(result._unsafeUnwrapErr().type).toBe("stalled");
+        expect(existsSync(dest)).toBe(false);
+    });
+
+    test("runs past the window for as long as bytes keep arriving", async () => {
+        // The half that a wall-clock deadline gets wrong: this transfer outlives its own window twice over
+        // and is healthy throughout, which is exactly the multi-gigabyte download the bound must not cut.
+        const dest = join(root(), "out.bin");
+        const stream = new ReadableStream({
+            async start(c) {
+                for (const part of ["a", "b", "c", "d", "e"]) {
+                    await sleep(20);
+                    c.enqueue(new TextEncoder().encode(part));
+                }
+                c.close();
+            },
+        });
+        const result = await downloadToFile(URL_OK, dest, { fetch: async () => new Response(stream), livenessWindowMs: 50 });
+        expect(result.isOk()).toBe(true);
+        expect(readFileSync(dest, "utf8")).toBe("abcde");
+    });
+
+    test("ends a request that never answers as stalled, and spends no further attempt on it", async () => {
+        // An expired window is the upstream's whole allowance, so the retry schedule stops rather than
+        // spending three more windows on a host that has already said nothing for one.
+        let calls = 0;
+        const result = await downloadToFile(URL_OK, join(root(), "out.bin"), {
+            retry: { attempts: 3, baseMs: 0, shouldRetry: () => true },
+            livenessWindowMs: 40,
+            fetch: async (_input, init) =>
+                new Promise<Response>((_resolve, reject) => {
+                    calls += 1;
+                    init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+                }),
+        });
+        expect(result._unsafeUnwrapErr().type).toBe("stalled");
+        expect(calls).toBe(1);
     });
 
     test("a progress observer throw never aborts the transfer", async () => {

--- a/cli/src/lib/download.ts
+++ b/cli/src/lib/download.ts
@@ -14,11 +14,19 @@ export type DownloadProgress =
     | { readonly type: "bytes"; readonly bytes: number }
     | { readonly type: "completed"; readonly bytes: number };
 
-/** Why a download failed. `http_failed`/`insecure_redirect` are transport faults; `io_failed` is a local fs/stream fault. */
+/**
+ * Why a download failed. `http_failed`/`insecure_redirect` are transport faults; `io_failed` is a local
+ * fs/stream fault; `stalled` is a transfer that stopped moving bytes (see {@link LIVENESS_WINDOW_MS}).
+ *
+ * `stalled` is its own variant rather than one more `io_failed`, because the two want different
+ * remedies: a full disk wants space, and a dead connection wants another attempt. A caller that folded
+ * them together would report the wrong one to the user.
+ */
 export type DownloadError =
     | { readonly type: "http_failed"; readonly message: string; readonly cause?: unknown }
     | { readonly type: "insecure_redirect"; readonly message: string }
-    | { readonly type: "io_failed"; readonly message: string; readonly cause?: unknown };
+    | { readonly type: "io_failed"; readonly message: string; readonly cause?: unknown }
+    | { readonly type: "stalled"; readonly message: string };
 
 /** The injectable fetch seam — production passes nothing (global `fetch`), tests inject a stub. */
 export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
@@ -52,6 +60,11 @@ export type DownloadToFileOptions = {
      * it also uses to mean "nothing here". Only the caller knows which of the two it is talking to.
      */
     readonly retry?: DownloadRetry;
+    /**
+     * Window of silence that ends the transfer, in milliseconds; omitted means {@link LIVENESS_WINDOW_MS}.
+     * A test passes a small value, and production passes none.
+     */
+    readonly livenessWindowMs?: number;
 };
 
 /**
@@ -70,6 +83,72 @@ export function declaredContentLength(response: Response): number | undefined {
     if (raw === null) return undefined;
     const parsed = Number(raw);
     return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * How long a transfer may receive no bytes before it counts as dead.
+ *
+ * A transfer has no honest wall-clock limit: a 2 GB artifact on a slow link is healthy work for half an
+ * hour, and a ceiling generous enough to spare it would also spare a socket that died an hour ago.
+ * Silence separates the two, because bytes arrive only while the upstream is really there. Two minutes
+ * is long enough for a publisher that stalls under load, and short enough that a dead connection does
+ * not hold the command for the rest of the day.
+ */
+export const LIVENESS_WINDOW_MS = 120_000;
+
+/**
+ * A liveness watch over one transfer.
+ *
+ * Give `signal` to the request and to the body: the watch aborts both when the window passes with no
+ * report of progress. Call `alive` for each sign of progress, and the window starts again. `expired`
+ * tells the caller that the watch ended the transfer, and not the upstream — the one fact an abort
+ * cannot carry by itself. Call `close` on each exit, or the timer outlives the transfer.
+ */
+export type LivenessWatch = {
+    readonly signal: AbortSignal;
+    /** The window this watch holds, in milliseconds. Carried so an error message can state it. */
+    readonly windowMs: number;
+    readonly alive: () => void;
+    readonly expired: () => boolean;
+    readonly close: () => void;
+};
+
+/**
+ * Make a liveness watch with a window of `windowMs`.
+ *
+ * The timer is unref'd, thus a stalled transfer never holds the process open by itself. The open socket
+ * does that for as long as it lives, which is the correct owner of the wait.
+ */
+export function createLivenessWatch(windowMs: number = LIVENESS_WINDOW_MS): LivenessWatch {
+    const controller = new AbortController();
+    let fired = false;
+    let closed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const arm = (): void => {
+        timer = setTimeout(() => {
+            fired = true;
+            controller.abort();
+        }, windowMs);
+        timer.unref();
+    };
+    arm();
+    return {
+        signal: controller.signal,
+        windowMs,
+        // A watch that fired stays fired: the abort is already out, the transfer is already ending, and
+        // a late chunk from a socket that still drains must not present a dead transfer as a live one.
+        alive: () => {
+            if (closed || fired) return;
+            if (timer !== undefined) clearTimeout(timer);
+            arm();
+        },
+        expired: () => fired,
+        close: () => {
+            closed = true;
+            if (timer !== undefined) clearTimeout(timer);
+            timer = undefined;
+        },
+    };
 }
 
 /** The default schedule: ask once and believe the answer. Named so the retry loop reads the same either way. */
@@ -98,9 +177,27 @@ function reportProgress(onProgress: ((event: DownloadProgress) => void) | undefi
  *
  * Retries only the initial request, and only on the caller's schedule ({@link DownloadToFileOptions.retry}).
  * A body that truncates mid-stream is never restarted, for the same reason it never resumes.
+ *
+ * Bounded by liveness, never by the clock: one {@link LivenessWatch} covers the request and the body, so
+ * a transfer lives for as long as bytes keep arriving and ends as `stalled` when they stop. The watch is
+ * owned here rather than inside the transfer, so it closes on every exit, including a thrown one.
  */
 export async function downloadToFile(url: string, dest: string, options: DownloadToFileOptions = {}): Promise<Result<DownloadedFile, DownloadError>> {
+    const watch = createLivenessWatch(options.livenessWindowMs ?? LIVENESS_WINDOW_MS);
+    try {
+        return await transferToFile(url, dest, options, watch);
+    } finally {
+        watch.close();
+    }
+}
+
+/** One transfer under the liveness watch that {@link downloadToFile} owns. */
+async function transferToFile(url: string, dest: string, options: DownloadToFileOptions, watch: LivenessWatch): Promise<Result<DownloadedFile, DownloadError>> {
     const doFetch = options.fetch ?? fetch;
+    const stalled = (): DownloadError => ({
+        type: "stalled",
+        message: `No data arrived from ${url} for ${Math.round(watch.windowMs / 1000)}s.`,
+    });
     const partPath = `${dest}.part`;
     // Preparing the destination and reaching the upstream are separated so each reports as what it
     // is: a full disk and an unreachable host are different problems with different remedies, and
@@ -116,14 +213,20 @@ export async function downloadToFile(url: string, dest: string, options: Downloa
     let lastCause: unknown;
     for (let attempt = 0; attempt < retry.attempts; attempt += 1) {
         if (attempt > 0 && retry.baseMs > 0) await Promise.sleep(retry.baseMs * 2 ** (attempt - 1));
+        // Each attempt starts the window again, so the backoff between two attempts never counts against
+        // the upstream: waiting on our own schedule is not the upstream going quiet.
+        watch.alive();
         let attempted: Response;
         try {
-            attempted = await doFetch(url, {});
+            attempted = await doFetch(url, { signal: watch.signal });
         } catch (cause) {
             // A transport fault retries on the same schedule as a shed status: in the moment, neither is
-            // distinguishable from an upstream that will answer on the next try.
+            // distinguishable from an upstream that will answer on the next try. An expired watch is the
+            // exception — the upstream already had its window, so more attempts would only spend more of
+            // it against a host that says nothing.
             lastCause = cause;
             response = undefined;
+            if (watch.expired()) break;
             continue;
         }
         response = attempted;
@@ -132,7 +235,7 @@ export async function downloadToFile(url: string, dest: string, options: Downloa
         // abandoned one would hold the connection the imminent retry needs.
         await attempted.body?.cancel().catch(() => undefined);
     }
-    if (response === undefined) return err({ type: "http_failed", message: `Could not reach ${url}.`, cause: lastCause });
+    if (response === undefined) return err(watch.expired() ? stalled() : { type: "http_failed", message: `Could not reach ${url}.`, cause: lastCause });
 
     if (!response.ok || response.body === null) {
         // A rejected response still owns its socket until the body is drained or cancelled, exactly
@@ -154,11 +257,15 @@ export async function downloadToFile(url: string, dest: string, options: Downloa
         // would compete with it for the stream's mode, while an inline stage keeps backpressure intact.
         const counter = new Transform({
             transform(chunk: Buffer, _encoding, callback) {
+                // The one place that knows the upstream is still there. Every other signal — a socket
+                // that is open, a promise that is pending — holds just as true for a connection that
+                // died mid-body, which is the failure this watch exists to end.
+                watch.alive();
                 reportProgress(options.onProgress, { type: "bytes", bytes: chunk.length });
                 callback(null, chunk);
             },
         });
-        await pipeline(Readable.fromWeb(response.body), counter, createWriteStream(partPath, { flags: "w" }));
+        await pipeline(Readable.fromWeb(response.body), counter, createWriteStream(partPath, { flags: "w" }), { signal: watch.signal });
         const written = (await stat(partPath)).size;
         const digest = await sha256File(partPath);
         if (digest.isErr()) return err({ type: "io_failed", message: `Could not hash the download of ${url}.`, cause: digest.error.cause });
@@ -166,6 +273,8 @@ export async function downloadToFile(url: string, dest: string, options: Downloa
         reportProgress(options.onProgress, { type: "completed", bytes: written });
         return ok({ bytes: written, sha256: digest.value });
     } catch (cause) {
-        return err({ type: "io_failed", message: `Could not write ${dest}.`, cause });
+        // The abort the watch raised surfaces here as a rejected pipeline, and it is not a local write
+        // fault: reporting it as one would send the user after disk space for a dead connection.
+        return err(watch.expired() ? stalled() : { type: "io_failed", message: `Could not write ${dest}.`, cause });
     }
 }

--- a/cli/src/modules/geo/download.ts
+++ b/cli/src/modules/geo/download.ts
@@ -53,6 +53,10 @@ export function describeGeoDownloadError(error: GeoDownloadError, accession: str
         case "http_failed":
         case "io_failed":
             return `Downloading ${accession} failed: ${error.message}\nNothing was downloaded.`;
+        // Its own arm rather than one more transport fault: a stall is the one failure here that the
+        // same command can clear on its own, so the line ends with the remedy instead of a full stop.
+        case "stalled":
+            return `Downloading ${accession} stopped: ${error.message}\nNothing was downloaded — re-run to start again.`;
     }
 }
 

--- a/cli/src/modules/harness/inflexa_classify.test.ts
+++ b/cli/src/modules/harness/inflexa_classify.test.ts
@@ -33,7 +33,7 @@ describe("classifyInflexaArgv — action", () => {
             argv,
             path: ["inflexa", "refs", "download"],
             grantKey: "inflexa refs download",
-            policy: { kind: "approval" },
+            policy: { kind: "approval", transfer: true },
             // `--yes` is explicitly set; the positional dataset id contributes nothing.
             setOptions: ["yes"],
         });
@@ -49,7 +49,7 @@ describe("classifyInflexaArgv — action", () => {
             argv,
             path: ["inflexa", "refs", "download"],
             grantKey: "inflexa refs download",
-            policy: { kind: "approval" },
+            policy: { kind: "approval", transfer: true },
             setOptions: [],
         });
     });
@@ -116,7 +116,7 @@ describe("classifyInflexaArgv — defensive tokenization", () => {
             argv: ["refs", "download", "reactome-pathways", "--yes"],
             path: ["inflexa", "refs", "download"],
             grantKey: "inflexa refs download",
-            policy: { kind: "approval" },
+            policy: { kind: "approval", transfer: true },
             setOptions: ["yes"],
         });
     });
@@ -144,7 +144,7 @@ describe("classifyInflexaArgv — policy + setOptions", () => {
     test("an approval command's verdict carries the approval policy", async () => {
         const result = await classifyInflexaArgv(["refs", "download", "reactome-pathways", "--yes"]);
         if (result.kind !== "action") throw new Error("expected action");
-        expect(result.policy).toEqual({ kind: "approval" });
+        expect(result.policy).toEqual({ kind: "approval", transfer: true });
     });
 
     test("an auto command's verdict carries the auto policy and its safeFlags", async () => {

--- a/cli/src/modules/harness/inflexa_tool.test.ts
+++ b/cli/src/modules/harness/inflexa_tool.test.ts
@@ -126,9 +126,8 @@ describe("run_inflexa — execute", () => {
         // Neither key is present: a download outlives any ceiling worth setting, and it is silent for the
         // whole of one large file, so either bound could only ever cut an honest transfer short.
         expect(sub.bounds[0]).toEqual({});
-        // What the user consents to that the argv line cannot show, plus the one condition that ends it.
+        // What the user consents to that the argv line cannot show, and nothing about the mechanism.
         expect(ask.calls[0]?.detail).toContain("no time limit");
-        expect(ask.calls[0]?.detail).toContain("2 minutes");
     });
 
     test("a command that is not a transfer keeps both of the tool's bounds and says nothing about them", async () => {

--- a/cli/src/modules/harness/inflexa_tool.test.ts
+++ b/cli/src/modules/harness/inflexa_tool.test.ts
@@ -7,7 +7,15 @@ import { describe, expect, test } from "bun:test";
 
 import type { AgentPolicy } from "../../cli/agent_policy.ts";
 import { reportAgentPolicies } from "../../test_support/agent_policy_report.ts";
-import { createRunInflexaTool, decideAction, resolveInvocation, spawnInflexa, type RunSubprocess, type SubprocessResult } from "./inflexa_tool.ts";
+import {
+    createRunInflexaTool,
+    decideAction,
+    resolveInvocation,
+    spawnInflexa,
+    type RunSubprocess,
+    type SpawnBounds,
+    type SubprocessResult,
+} from "./inflexa_tool.ts";
 
 // A canned subprocess outcome; overridden per-test for the timeout/cancel/truncation cases.
 const OK_RESULT: SubprocessResult = { exitCode: 0, stdout: "hello", stderr: "", endedBy: "exit" };
@@ -17,15 +25,18 @@ function recordingSubprocess(result: SubprocessResult = OK_RESULT): {
     fn: RunSubprocess;
     calls: (readonly string[])[];
     cwds: (string | undefined)[];
+    bounds: SpawnBounds[];
 } {
     const calls: (readonly string[])[] = [];
     const cwds: (string | undefined)[] = [];
-    const fn: RunSubprocess = (cmd, cwd, _signal) => {
+    const bounds: SpawnBounds[] = [];
+    const fn: RunSubprocess = (cmd, cwd, _signal, spawnBounds) => {
         calls.push(cmd);
         cwds.push(cwd);
+        bounds.push(spawnBounds);
         return Promise.resolve(result);
     };
-    return { fn, calls, cwds };
+    return { fn, calls, cwds, bounds };
 }
 
 /** An `ask` seam that records its requests and resolves with a fixed approval. */
@@ -103,6 +114,33 @@ describe("run_inflexa — execute", () => {
         expect(ask.calls[0]?.grantKey).toBe("inflexa refs download");
         expect(sub.calls.length).toBe(1);
         expect(result.status).toBe("ran");
+    });
+
+    test("a transfer command runs under neither bound, and its approval states that", async () => {
+        const sub = recordingSubprocess();
+        const ask = recordingAsk({ kind: "once" });
+        const tool = makeTool(sub.fn);
+
+        await tool.execute({ argv: ["refs", "download", "x", "--yes"] }, makeCtx(ask.fn));
+
+        // Neither key is present: a download outlives any ceiling worth setting, and it is silent for the
+        // whole of one large file, so either bound could only ever cut an honest transfer short.
+        expect(sub.bounds[0]).toEqual({});
+        // What the user consents to that the argv line cannot show, plus the one condition that ends it.
+        expect(ask.calls[0]?.detail).toContain("no time limit");
+        expect(ask.calls[0]?.detail).toContain("2 minutes");
+    });
+
+    test("a command that is not a transfer keeps both of the tool's bounds and says nothing about them", async () => {
+        const sub = recordingSubprocess();
+        const ask = recordingAsk({ kind: "once" });
+        const tool = makeTool(sub.fn);
+
+        await tool.execute({ argv: ["status"] }, makeCtx(ask.fn));
+
+        expect(sub.bounds[0]?.timeoutMs).toBeGreaterThan(0);
+        expect(sub.bounds[0]?.idleTimeoutMs).toBeGreaterThan(0);
+        expect(ask.calls[0]?.detail).not.toContain("no time limit");
     });
 
     test("a packed single-string argv displays and spawns the SAME tokenized argv", async () => {

--- a/cli/src/modules/harness/inflexa_tool.ts
+++ b/cli/src/modules/harness/inflexa_tool.ts
@@ -27,8 +27,9 @@ import type { Command } from "commander";
 import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
-import { type AgentPolicy, getAgentPolicy } from "../../cli/agent_policy.ts";
+import { type AgentPolicy, getAgentPolicy, isTransferPolicy } from "../../cli/agent_policy.ts";
 import { buildProgram } from "../../cli/index.ts";
+import { LIVENESS_WINDOW_MS } from "../../lib/download.ts";
 import { env } from "../../lib/env.ts";
 import { anchorPathForAnalysisId } from "../analysis/output.ts";
 import { classifyInflexaArgv, toEffectiveArgv } from "./inflexa_classify.ts";
@@ -45,6 +46,10 @@ const MAX_OUTPUT_CHARS = 60_000;
  * hung command hold the turn for just as long. Measuring the gap between output separates the two —
  * a command that is still reporting is still working, however long it takes, and one that has said
  * nothing for two minutes is not coming back.
+ *
+ * A transfer is the case where even that reading fails, because a captured download is legitimately
+ * silent for the whole of one large file. Such a command carries `TransferTrait` and runs under neither
+ * bound; its liveness is watched over the arriving bytes instead.
  */
 const DEFAULT_IDLE_TIMEOUT_MS = 120_000;
 
@@ -72,6 +77,15 @@ const FLUSH_GRACE_MS = 1_000;
  * hold `exited` open forever and the timeout would bound nothing.
  */
 const KILL_GRACE_MS = 2_000;
+
+/**
+ * What the approval prompt of a transfer command says before the standing-grant sentence.
+ *
+ * The user consents to a run with no deadline, which the argv line does not show, thus the prompt must
+ * say it. The window comes from the downloader itself, so the number the user reads is the number that
+ * ends the run.
+ */
+const TRANSFER_DETAIL = `This command downloads data. It has no time limit, and it stops when no data arrives for ${Math.round(LIVENESS_WINDOW_MS / 60_000)} minutes. `;
 
 /**
  * What the tool should do with a classified `action` verdict, decided purely from
@@ -148,8 +162,15 @@ export type RunInflexaResult =
  */
 export type SubprocessResult = { readonly exitCode: number; readonly stdout: string; readonly stderr: string; readonly endedBy: "exit" | "timeout" | "cancel" };
 
-/** The subprocess seam — injectable so tests assert on the composed argv and working directory without spawning a real process. */
-export type RunSubprocess = (cmd: readonly string[], cwd: string | undefined, signal: AbortSignal) => Promise<SubprocessResult>;
+/**
+ * The subprocess seam — injectable so tests assert on the composed argv and working directory without
+ * spawning a real process.
+ *
+ * `bounds` rides the call rather than the construction, because the deadlines belong to the COMMAND and
+ * not to the tool: a transfer runs unbounded while every other command keeps the tool's own two bounds,
+ * and one tool instance serves both.
+ */
+export type RunSubprocess = (cmd: readonly string[], cwd: string | undefined, signal: AbortSignal, bounds: SpawnBounds) => Promise<SubprocessResult>;
 
 /**
  * Locate the folder an analysis lives in — injectable so tests need no database.
@@ -253,8 +274,12 @@ function collectCapped(
 
 /** Injectable process bounds for {@link spawnInflexa}; graces default to the real values, shrinkable in tests. */
 export interface SpawnBounds {
-    /** Absolute ceiling on the run, however chatty the child is. */
-    readonly timeoutMs: number;
+    /**
+     * Absolute ceiling on the run, however chatty the child is. Omitted means no ceiling, and then only
+     * `idleTimeoutMs` and the caller's own signal can end the child — the shape a transfer command runs
+     * under, where the downloader holds the liveness bound instead (see `TransferTrait`).
+     */
+    readonly timeoutMs?: number;
     /** Longest the child may produce NO output before it is abandoned. Omitted means only `timeoutMs` bounds it. */
     readonly idleTimeoutMs?: number;
     readonly flushGraceMs?: number;
@@ -263,10 +288,12 @@ export interface SpawnBounds {
 
 /**
  * The real subprocess wrapper: spawn `cmd`, capture stdout/stderr memory-bounded,
- * and bound the run by `timeoutMs` and, when given, by how long it stays silent
- * (`idleTimeoutMs`, rearmed on every chunk either stream produces — so a command
- * that reports progress runs as long as it needs, while a wedged one still dies
- * promptly). The deadlines and the caller's `signal` (chat
+ * and bound the run by each bound `bounds` gives — `timeoutMs` for the whole run,
+ * and `idleTimeoutMs` for how long it stays silent (rearmed on every chunk either
+ * stream produces — so a command that reports progress runs as long as it needs,
+ * while a wedged one still dies promptly). Both are optional, and a `bounds` that
+ * gives neither leaves the caller's `signal` as the only stop — which is what a
+ * transfer command runs under. The deadlines and the caller's `signal` (chat
  * disconnect / turn abort) are merged — either aborts the child — and `endedBy`
  * reports which one fired (timeout wins a tie: the deadline elapsed either way),
  * so a user cancel is never mislabelled a timeout or a completed run.
@@ -299,7 +326,7 @@ export async function spawnInflexa(cmd: readonly string[], signal: AbortSignal, 
     // firing into an abort nobody reads. Ordering is what closes that, so nothing between here and
     // the clears on the exit path may throw; the deadline controller is built above because
     // `Bun.spawn` needs its signal, but a controller with no timer costs nothing if the spawn fails.
-    const totalTimer = setTimeout(expire, timeoutMs);
+    const totalTimer: ReturnType<typeof setTimeout> | null = timeoutMs === undefined ? null : setTimeout(expire, timeoutMs);
     let idleTimer: ReturnType<typeof setTimeout> | null = idleTimeoutMs === undefined ? null : setTimeout(expire, idleTimeoutMs);
     // Latched once the child is reaped, because output outlives it: the pipes are still read
     // during the flush grace below, and a chunk arriving there would otherwise rearm the idle
@@ -328,7 +355,7 @@ export async function spawnInflexa(cmd: readonly string[], signal: AbortSignal, 
     const stderr = collectCapped(proc.stderr, budget, noteActivity);
     const exitCode = await proc.exited;
     settled = true;
-    clearTimeout(totalTimer);
+    if (totalTimer !== null) clearTimeout(totalTimer);
     if (idleTimer !== null) clearTimeout(idleTimer);
     if (killTimer !== null) clearTimeout(killTimer);
     // The child is reaped; a LATER abort of the caller's long-lived turn signal
@@ -407,7 +434,7 @@ export function createRunInflexaTool(deps: RunInflexaToolDeps = {}) {
     const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const idleTimeoutMs = deps.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
     const resolveAnalysisFolder: ResolveAnalysisFolder = deps.resolveAnalysisFolder ?? ((analysisId) => anchorPathForAnalysisId(analysisId) ?? undefined);
-    const runSubprocess: RunSubprocess = deps.runSubprocess ?? ((cmd, cwd, signal) => spawnInflexa(cmd, signal, { timeoutMs, idleTimeoutMs }, cwd));
+    const runSubprocess: RunSubprocess = deps.runSubprocess ?? ((cmd, cwd, signal, bounds) => spawnInflexa(cmd, signal, bounds, cwd));
 
     return defineTool({
         id: "run_inflexa",
@@ -456,6 +483,10 @@ export function createRunInflexaTool(deps: RunInflexaToolDeps = {}) {
             // A rejected argv never reaches a process or a prompt — report it and let the model correct itself.
             if (c.kind === "malformed") return ok({ status: "invalid", message: c.message });
 
+            // Read once, and used twice: it decides the bounds the child runs under, and it decides what
+            // the approval says about them. Introspection (`--help`) carries no policy and is never one.
+            const transfer = c.kind === "action" && isTransferPolicy(c.policy);
+
             if (c.kind === "action") {
                 // The registration-declared policy is the floor. `decideAction` runs it before any
                 // grant/ask interaction, so a `blocked` command (or an unclassified one, fail-closed)
@@ -470,7 +501,10 @@ export function createRunInflexaTool(deps: RunInflexaToolDeps = {}) {
                         // executes, nothing hidden. Spaced elements render quoted so the word
                         // boundaries the user reads are the word boundaries that spawn.
                         command: ["inflexa", ...c.argv.map(displayArgvElement)].join(" "),
-                        detail: 'Approving "always" lets this inflexa subcommand run again in this analysis without asking each time.',
+                        // The caveat leads, because it is what this approval buys that the argv line does not
+                        // show: consent to a run with no deadline. It states the one condition that ends
+                        // such a run, so "no time limit" cannot read as "no way out".
+                        detail: `${transfer ? TRANSFER_DETAIL : ""}Approving "always" lets this inflexa subcommand run again in this analysis without asking each time.`,
                         // Trade-off accepted here: the standing grant keys on the bare subcommand PATH, not this exact
                         // argv, so an "always" on a benign `inflexa X` also blesses a later, more dangerous flag variant
                         // (`inflexa X --destructive`) of the same subcommand without a fresh prompt. That is tolerable
@@ -500,7 +534,9 @@ export function createRunInflexaTool(deps: RunInflexaToolDeps = {}) {
             // child then inherits this process's directory.
             const scope = ctx.session.scope;
             const cwd = scope.kind === "analysis" ? resolveAnalysisFolder(scope.analysisId) : undefined;
-            const r = await runSubprocess(cmd, cwd, ctx.signal);
+            // A transfer runs with neither bound: `downloadToFile` ends it when the bytes stop, and a
+            // second deadline out here could only ever cut an honest download short (see `TransferTrait`).
+            const r = await runSubprocess(cmd, cwd, ctx.signal, transfer ? {} : { timeoutMs, idleTimeoutMs });
             // truncateOutput re-bounds here because the seam is injectable: the real
             // spawn already caps at source, but the contract must hold for any seam.
             if (r.endedBy === "timeout") return ok({ status: "timed_out", stdout: truncateOutput(r.stdout), stderr: truncateOutput(r.stderr) });

--- a/cli/src/modules/harness/inflexa_tool.ts
+++ b/cli/src/modules/harness/inflexa_tool.ts
@@ -29,7 +29,6 @@ import { z } from "zod";
 
 import { type AgentPolicy, getAgentPolicy, isTransferPolicy } from "../../cli/agent_policy.ts";
 import { buildProgram } from "../../cli/index.ts";
-import { LIVENESS_WINDOW_MS } from "../../lib/download.ts";
 import { env } from "../../lib/env.ts";
 import { anchorPathForAnalysisId } from "../analysis/output.ts";
 import { classifyInflexaArgv, toEffectiveArgv } from "./inflexa_classify.ts";
@@ -82,10 +81,11 @@ const KILL_GRACE_MS = 2_000;
  * What the approval prompt of a transfer command says before the standing-grant sentence.
  *
  * The user consents to a run with no deadline, which the argv line does not show, thus the prompt must
- * say it. The window comes from the downloader itself, so the number the user reads is the number that
- * ends the run.
+ * say it. It says only that. How the run ends is the downloader's mechanism, and a prompt that recited
+ * it would ask the user to hold a number they can act on in no way, and would go stale the day the
+ * mechanism changes.
  */
-const TRANSFER_DETAIL = `This command downloads data. It has no time limit, and it stops when no data arrives for ${Math.round(LIVENESS_WINDOW_MS / 60_000)} minutes. `;
+const TRANSFER_DETAIL = "This command downloads data. It has no time limit. ";
 
 /**
  * What the tool should do with a classified `action` verdict, decided purely from

--- a/cli/src/test_support/agent_policy_report.ts
+++ b/cli/src/test_support/agent_policy_report.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 
-import { getAgentPolicy } from "../cli/agent_policy.ts";
+import { getAgentPolicy, isTransferPolicy } from "../cli/agent_policy.ts";
 import { buildProgram } from "../cli/index.ts";
 
 /**
@@ -18,6 +18,8 @@ export type PolicyRow = {
     readonly kind: "auto" | "approval" | "blocked" | null;
     /** The `auto` policy's safe flags, else `null` — the set that must be a subset of {@link declaredOptions}. */
     readonly safeFlags: readonly string[] | null;
+    /** Whether the policy marks a transfer — the command the tool runs with no deadline of its own. */
+    readonly transfer: boolean;
     /** Every declared option's canonical attributeName on this command. */
     readonly declaredOptions: readonly string[];
 };
@@ -44,6 +46,7 @@ function walk(command: Command, path: readonly string[], rows: PolicyRow[]): voi
             hasPolicy: policy !== undefined,
             kind: policy?.kind ?? null,
             safeFlags: policy?.kind === "auto" ? [...policy.safeFlags] : null,
+            transfer: isTransferPolicy(policy),
             declaredOptions: command.options.map((option) => option.attributeName()),
         });
     }


### PR DESCRIPTION
## What & why

The `run_inflexa` tool gave each command one idle bound of 120 s and one ceiling of 30 minutes. A download obeys neither honestly. One catalog artifact reaches 2 GB, and the captured readout prints a line only for each file that lands. Thus the whole of one large file is quiet, and the idle bound stopped a healthy transfer at 2 minutes.

Liveness now sits in the downloader, where the bytes are. `downloadToFile` holds one watch over the request and the body. Each chunk starts the window again. A window that passes with no chunk aborts both, and gives the new `stalled` error. A command whose work is a transfer declares `transfer: true` in its agent policy, and the tool then runs it under neither bound.

## Notes for the reviewer

- **The trait is the scope of the removal.** `refs download` and `geo download` carry it today. Each other command keeps both bounds, thus a wedged command still dies promptly.
- **One boolean drives two things.** It picks the spawn bounds, and it picks the approval text. Thus an unbounded run and a prompt that says "no time limit" cannot disagree.
- **The trait proves no liveness.** Nothing checks that a command marked `transfer` really downloads through `downloadToFile`. The audit line `approval+transfer` is what puts that in front of a reviewer.
- **The watch cancels, and it never exits.** It returns `err({ type: "stalled" })`, and each caller reports it on its own error path.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_014NTXPXMty4kXxvm6LcZzaH
