### PR TITLE
feat(skills): add the statistics rules from roadmap items 1, 2, 6 and 20

### DIFF
--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/.openspec.yaml
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/design.md
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/design.md
@@ -1,0 +1,65 @@
+# Design: add-statistics-rules-to-skill-packs
+
+## Context
+
+The packs are the runtime knowledge of the sandbox agents
+(`agent-skill-assignment` spec). `validateAgentSkills` reads only if each
+`SKILL.md` is readable. It never reads the prose. Thus a statistical rule
+exists only where a pack states it, and only for an agent whose roster grants
+that pack. Four rules are absent or unreachable today. The proposal names them
+with `file:line` references.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The immune agent can reach the cutpoint correction rule, and its own pack
+  states the immune-specific application.
+- The planner and the statistical-modeling pack both state the cross-step
+  feature-selection rule.
+- The bulk-transcriptomics pack refuses inferential differential expression
+  with no biological replication.
+- The statistical-modeling pack names the remedy for a violated Cox
+  proportional-hazards assumption.
+
+**Non-Goals:**
+
+- No code-enforced acceptance gate. That is roadmap item 46, parked.
+- No change to `validateAgentSkills`. Review stays the control for prose.
+- No new pack. The 20-pack inventory of `agent-skill-assignment` stays.
+
+## Decisions
+
+- **Roster grant plus a pack section, not a copy of the full rule.** The
+  immune agent gets `statistical-modeling` in `meta.skills`, thus the
+  canonical cutpoint rule and its API references become searchable. The
+  immune pack gets a short Statistics section that states the immune-specific
+  application: BH FDR over 10 to 64 score-by-condition comparisons, and the
+  corrected p-value for a cutpoint. A full copy was rejected, because a copy
+  drifts. Prompt-pack drift is the exact failure mode of roadmap item 29.
+- **The leakage rule lives in two layers.** The planner chains the steps,
+  thus the planner prompt must state the rule at plan time. The
+  statistical-modeling pack executes the modeling step, thus the pack must
+  state the same rule at execution time. One layer alone leaves a hole: a
+  plan can arrive from a prior run, and a pack rule cannot reshape a plan.
+- **The replication floor mirrors the chromatin pack wording.** The
+  chromatin pack already names a single-replicate analysis an anti-pattern
+  (`skills/chromatin-regulation/SKILL.md:126-128`). The bulk pack uses the
+  same shape: a decision-tree bound plus an anti-pattern entry. The floor is:
+  if no group has biological replication, report descriptive fold changes
+  only, and state why.
+- **The prompt Skills line is corrected in the same pass.** The immune
+  prompt names two packs, and `meta.skills` holds three. The roster edit
+  touches the file pair anyway, and the prompt-cache prefix invalidates one
+  time either way.
+
+## Risks / Trade-offs
+
+- [The roster entry and the prompt edits invalidate two prompt-cache
+  prefixes] → The cost is one cache write for each agent, one time. No
+  durable state changes.
+- [The `statistical-modeling` pack widens the search surface of the immune
+  agent] → The pack covers the survival and panel work of this agent. The
+  bulk agent roster does not change.
+- [A prose rule binds only through review] → Accepted. The spec records the
+  rule, thus a later review has a target. Code enforcement is item 46.

--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/proposal.md
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: add-statistics-rules-to-skill-packs
+
+## Why
+
+Four statistical defects sit in the skill packs and in the planner prompt. Each
+one can change a scientific conclusion. They are items 1, 2, 6 and 20 of
+`ROADMAP-2026-2027.md`, wave 1.
+
+- `skills/immune-profiling/SKILL.md:138-140` recommends an optimal cutpoint
+  with no corrected p-value. `skills/statistical-modeling/SKILL.md:155-160`
+  holds the correction rule. But the roster of the immune agent
+  (`src/agents/sandbox/immune-profiling-agent.ts:33`) does not grant that pack.
+  Thus the agent cannot reach the rule that guards it.
+- `src/prompts/planner.ts:203-208` chains a differential-expression step into a
+  biomarker-panel step. No layer states that a gene list from a full-cohort
+  contrast is already a feature selection on the same samples. The panel AUC
+  inflates, and the panel fails external validation.
+- `skills/bulk-transcriptomics/SKILL.md:21` routes `n < 3` per group to edgeR
+  QLF with no lower bound. A one-against-one design then gets p-values with no
+  inferential basis. Two sibling packs set a floor
+  (`skills/chromatin-regulation/SKILL.md:58,126-128`,
+  `skills/single-cell/SKILL.md:345-347`).
+- `skills/statistical-modeling/SKILL.md:21` demands the Cox
+  proportional-hazards check, and it stops there. No pack names the remedy for
+  a violation.
+
+## What Changes
+
+- Add a Statistics section to the immune-profiling pack. It demands BH FDR over
+  every score-by-condition comparison, and the maxstat corrected p-value for a
+  cutpoint. Amend the survival-integration lines that recommend an uncorrected
+  cutpoint.
+- Add `statistical-modeling` to the roster of the immune agent. Correct the
+  Skills line of the immune agent prompt, which also omits `single-cell`.
+- Add the two-clause leakage rule to the Translational Considerations of the
+  planner prompt, and to the statistical-modeling pack. Clause one: a feature
+  list from a supervised contrast on the same samples is already a selection.
+  Clause two: the modeling step must then select again inside cross-validation,
+  from the full feature matrix, or report the estimate as optimistic.
+- Add the replication floor to the bulk-transcriptomics decision tree and
+  anti-patterns. With no biological replication in any group, refuse
+  inferential differential expression, and report descriptive fold changes
+  only. Mirror the floor in the agent prompt summary.
+- Add the Cox failure path to the statistical-modeling pack. On a violation,
+  stratify on the covariate at fault, or add a time-varying term. Report the
+  hazard ratio as time-averaged.
+
+## Capabilities
+
+### New Capabilities
+
+- `skill-statistics-standards`: the statistical rules that the skill packs
+  state, and the roster wiring that makes each rule reachable by the agent
+  that it guards.
+
+### Modified Capabilities
+
+- `planning-enhancements`: the planner prompt states the cross-step
+  feature-selection rule beside the biomarker-evaluation guidance that it
+  already carries.
+
+## Impact
+
+- `skills/immune-profiling/SKILL.md` — a new Statistics section, amended
+  survival-integration lines.
+- `skills/statistical-modeling/SKILL.md` — the cross-step leakage clause, and
+  the Cox failure path.
+- `skills/bulk-transcriptomics/SKILL.md` — the replication floor.
+- `src/agents/sandbox/immune-profiling-agent.ts` — the roster gains
+  `statistical-modeling`.
+- `src/prompts/sandbox/immune-profiling-agent.ts` — the corrected Skills line.
+- `src/prompts/sandbox/bulk-transcriptomics-agent.ts` — the mirrored floor.
+- `src/prompts/planner.ts` — the leakage rule in Translational Considerations.
+- The roster entry and the prompt edits invalidate the prompt-cache prefix of
+  the two touched agents one time. Nothing else about the change is durable
+  state. No schema, no database column, and no DBOS step change.

--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/specs/planning-enhancements/spec.md
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/specs/planning-enhancements/spec.md
@@ -1,0 +1,19 @@
+# planning-enhancements Delta
+
+## ADDED Requirements
+
+### Requirement: The planner prompt states the cross-step feature-selection rule
+
+The Translational Considerations of the planner prompt MUST state the
+two-clause leakage rule beside the biomarker-evaluation guidance. Clause one:
+a feature list from a supervised contrast on the same samples is already a
+selection. Clause two: the modeling step MUST select again inside
+cross-validation, from the full feature matrix. If it cannot, the plan MUST
+demand that the step reports the estimate as optimistic.
+
+#### Scenario: A biomarker plan does not chain a full-cohort contrast into a panel
+
+- **WHEN** the planner writes a plan with a differential-expression step and a
+  later biomarker-panel step over the same samples
+- **THEN** the plan instructs the modeling step to select features again
+  inside cross-validation, or to report the estimate as optimistic

--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/specs/skill-statistics-standards/spec.md
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/specs/skill-statistics-standards/spec.md
@@ -1,0 +1,94 @@
+# skill-statistics-standards Delta
+
+## ADDED Requirements
+
+### Requirement: A survival cutpoint carries the corrected p-value
+
+The immune-profiling pack MUST demand the maxstat corrected p-value for an
+optimal survival cutpoint. The pack MUST NOT recommend an optimal cutpoint
+without that correction. The nominal p-value of an optimized split has no
+meaning, and the pack MUST say so or point to the rule.
+
+#### Scenario: The pack survival guidance names the correction
+
+- **WHEN** the agent reads the survival-integration guidance of
+  `skills/immune-profiling/SKILL.md`
+- **THEN** the guidance demands the maxstat corrected p-value for a cutpoint
+- **AND** no line recommends an optimal cutpoint without the correction
+
+### Requirement: Immune score comparisons carry multiplicity control
+
+The immune-profiling pack MUST carry a Statistics section. The section MUST
+demand Benjamini-Hochberg FDR over every score-by-condition comparison,
+because one run compares 10 to 64 cell-type scores.
+
+#### Scenario: The Statistics section demands BH FDR
+
+- **WHEN** the agent reads `skills/immune-profiling/SKILL.md`
+- **THEN** a Statistics section exists
+- **AND** it demands BH FDR over every score-by-condition comparison
+
+### Requirement: The immune agent can reach the statistical rules
+
+The `meta.skills` of the immune-profiling agent MUST include
+`statistical-modeling`. The Skills line of the immune agent prompt MUST name
+the same packs as `meta.skills`.
+
+#### Scenario: The cutpoint rule is searchable by the immune agent
+
+- **WHEN** the immune agent searches its skills for cutpoint guidance
+- **THEN** the corrected-p-value rule of the statistical-modeling pack is in
+  its search surface
+
+#### Scenario: The prompt Skills line matches the roster
+
+- **WHEN** the immune agent prompt is compared with `meta.skills`
+- **THEN** the Skills line names each pack of the roster, and no other pack
+
+### Requirement: A prior supervised contrast counts as feature selection
+
+The statistical-modeling pack MUST state the two-clause leakage rule. Clause
+one: a feature list from a supervised contrast on the same samples is already
+a selection. Clause two: the modeling step MUST then select again inside
+cross-validation, from the full feature matrix. If it cannot, it MUST report
+the performance estimate as optimistic.
+
+#### Scenario: The pack states the cross-step clause
+
+- **WHEN** the agent reads the panel-development guidance of
+  `skills/statistical-modeling/SKILL.md`
+- **THEN** the guidance states that an upstream gene list from the same
+  samples is already a selection
+- **AND** it demands a new selection inside cross-validation, or an
+  "optimistic" label on the estimate
+
+### Requirement: Bulk differential expression has a replication floor
+
+The bulk-transcriptomics pack MUST refuse inferential differential expression
+when no group has biological replication. In that case the pack MUST demand
+descriptive fold changes only, with a statement of why. The decision tree and
+the anti-pattern list MUST both carry the floor. The method-selection summary
+of the bulk agent prompt MUST mirror it.
+
+#### Scenario: A one-against-one design gets no p-values
+
+- **WHEN** the agent reads the decision tree for a design with one sample in
+  each group
+- **THEN** the tree routes to descriptive fold changes only
+- **AND** the anti-pattern list names inferential differential expression
+  without replication
+
+### Requirement: A violated Cox check names its remedy
+
+The statistical-modeling pack MUST name the failure path of the Cox
+proportional-hazards check. On a violation, stratify on the covariate at
+fault, or add a time-varying term. The pack MUST demand that the hazard ratio
+is then reported as time-averaged.
+
+#### Scenario: The pack states the remedy
+
+- **WHEN** the agent reads the survival guidance of
+  `skills/statistical-modeling/SKILL.md`
+- **THEN** the guidance names stratification or a time-varying term as the
+  remedy
+- **AND** it demands the time-averaged label on the hazard ratio

--- a/harness/openspec/changes/add-statistics-rules-to-skill-packs/tasks.md
+++ b/harness/openspec/changes/add-statistics-rules-to-skill-packs/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: add-statistics-rules-to-skill-packs
+
+## 1. Immune profiling (roadmap item 1)
+
+- [x] 1.1 Add a Statistics section to `skills/immune-profiling/SKILL.md`. Demand BH FDR over every score-by-condition comparison, and the maxstat corrected p-value for a cutpoint.
+- [x] 1.2 Amend the survival-integration lines of the pack. Remove the uncorrected "median split or optimal cutpoint" recommendation.
+- [x] 1.3 Add `statistical-modeling` to `skills` in `src/agents/sandbox/immune-profiling-agent.ts`.
+- [x] 1.4 Correct the Skills line of `src/prompts/sandbox/immune-profiling-agent.ts` so that it names each pack of `meta.skills`.
+
+## 2. Cross-step feature-selection leakage (roadmap item 2)
+
+- [x] 2.1 Add the two-clause leakage rule to the Translational Considerations of `src/prompts/planner.ts`, beside the biomarker-evaluation point.
+- [x] 2.2 Add the cross-step clause to the panel-development guidance of `skills/statistical-modeling/SKILL.md`.
+
+## 3. Replication floor for bulk differential expression (roadmap item 6)
+
+- [x] 3.1 Add the floor to the decision tree of `skills/bulk-transcriptomics/SKILL.md`. With no biological replication in any group, descriptive fold changes only.
+- [x] 3.2 Add the floor to the anti-pattern list of the pack. Mirror the wording of `skills/chromatin-regulation/SKILL.md`.
+- [x] 3.3 Mirror the floor in the method-selection summary of `src/prompts/sandbox/bulk-transcriptomics-agent.ts`.
+
+## 4. Cox proportional-hazards failure path (roadmap item 20)
+
+- [x] 4.1 Add the failure path to `skills/statistical-modeling/SKILL.md`. On a violation, stratify or add a time-varying term, and report the hazard ratio as time-averaged.
+
+## 5. Verify
+
+- [x] 5.1 Run `npx tsc --noEmit` in `harness/` and make sure that it is clean.
+- [x] 5.2 Run `bun test src/agents/sandbox/` and make sure that the skill validation passes.
+- [x] 5.3 Run `bun run format:file` on the changed `src/` files.
+- [x] 5.4 Read each edited pack section against the delta spec, one requirement at a time.

--- a/harness/src/agents/sandbox/immune-profiling-agent.ts
+++ b/harness/src/agents/sandbox/immune-profiling-agent.ts
@@ -30,7 +30,9 @@ export const meta: AgentMeta = {
     // `single-cell` carries the scirpy reference, which is the route from 10x
     // VDJ / AIRR files to called clonotypes — the input every repertoire metric
     // in `immune-profiling` assumes it already has.
-    skills: ["immune-profiling", "single-cell", "shared/omics-general"],
+    // `statistical-modeling` carries the survival-cutpoint correction and the
+    // multiplicity rules that the immune-clinical correlation work demands.
+    skills: ["immune-profiling", "single-cell", "statistical-modeling", "shared/omics-general"],
     tools: [...BASE_SANDBOX_TOOLS, "pubmed", "searchGene", "lookupAnnotation", "searchInteractions", "searchGeoDatasets", "opentargets"],
 };
 

--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -205,7 +205,12 @@ safety, toxicity, or treatment outcomes:
    statistical-modeling step for biomarker panel construction with
    proper cross-validation. Distinguish predictive (treatment x marker
    interaction) from prognostic (outcome association) modeling — these
-   require different designs.
+   require different designs. A feature list from a supervised contrast
+   on the same samples (for example, differentially expressed genes) is
+   already a feature selection. The modeling step must select again
+   inside cross-validation, from the full feature matrix. If it cannot,
+   it must report the performance estimate as optimistic. State this
+   constraint in the description of the modeling step.
 
 3. **Include safety assessment steps.** If compounds, targets, or
    genetic variants are central to the analysis, include steps that

--- a/harness/src/prompts/sandbox/bulk-transcriptomics-agent.ts
+++ b/harness/src/prompts/sandbox/bulk-transcriptomics-agent.ts
@@ -21,7 +21,9 @@ limma/voom, sva. Check contrast syntax there before writing it.
 - **Raw counts, simple design, n=3-50 per group** — PyDESeq2 (default).
 - **Raw counts, complex design (interactions, >2 factors)** — DESeq2 via rpy2.
 - **Raw counts, n > 50 per group** — limma-voom via rpy2 (scales better).
-- **Raw counts, n < 3 per group** — edgeR QLF via rpy2.
+- **Raw counts, n = 2 per group** — edgeR QLF via rpy2.
+- **No biological replication in any group (1 vs 1)** — no inferential
+  DE. Report descriptive log2 fold changes only, and state why.
 - **Pre-normalized (TPM, FPKM, log-CPM, microarray intensities)** — limma
   via rpy2.
 - **Raw microarray CEL** — out of scope: reading them needs a per-design

--- a/harness/src/prompts/sandbox/immune-profiling-agent.ts
+++ b/harness/src/prompts/sandbox/immune-profiling-agent.ts
@@ -8,11 +8,15 @@ with immunedeconv (R via rpy2), decoupler, gseapy, and scanpy.
 
 ## Skills
 
-Your skills: \`immune-profiling\`, \`shared/omics-general\`.
+Your skills: \`immune-profiling\`, \`single-cell\`, \`statistical-modeling\`,
+\`shared/omics-general\`.
 
 \`immune-profiling\` carries the deconvolution API patterns (immunedeconv,
 MCP-counter), immune signature gene lists (TIS, IFN-g, CYT, exhaustion),
-checkpoint panels, and TCR/BCR diversity metrics.
+checkpoint panels, and TCR/BCR diversity metrics. \`single-cell\` carries the
+scirpy route from 10x VDJ / AIRR files to called clonotypes.
+\`statistical-modeling\` carries the survival-cutpoint correction and the
+multiplicity rules for score-by-condition comparisons.
 
 ## Core Capabilities
 

--- a/skills/bulk-transcriptomics/SKILL.md
+++ b/skills/bulk-transcriptomics/SKILL.md
@@ -18,7 +18,10 @@ Input data?
 ├── Raw integer counts (RNA-seq)
 │   ├── Simple design (2 conditions, no interaction terms)
 │   │   ├── n >= 3 per group, n <= 50 per group → PyDESeq2 (Python, default)
-│   │   ├── n < 3 per group → edgeR QLF via rpy2 (better small-sample performance)
+│   │   ├── n = 2 per group → edgeR QLF via rpy2 (better small-sample performance)
+│   │   ├── No biological replication in any group (1 vs 1) → NO inferential DE.
+│   │   │     Report descriptive log2 fold changes only, and state why
+│   │   │     (see Anti-Patterns)
 │   │   └── n > 50 per group → limma-voom via rpy2 (faster, scales well)
 │   ├── Complex design (interaction terms, >2 factors, nested)
 │   │   ├── Standard factorial/interaction → DESeq2 via rpy2 (full formula support)
@@ -69,6 +72,7 @@ Input data?
 
 ## Anti-Patterns
 
+- **Inferential DE without biological replication**: With one sample per group, there is no within-group variance to estimate. The edgeR statistics assume replication — a 1 vs 1 run produces confident-looking p-values with no inferential basis. Refuse the test. Report descriptive log2 fold changes only, state that no replication exists, and name the design that supports inference (n >= 2 per group, n >= 3 preferred).
 - **DESeq2/PyDESeq2 on TPM/FPKM**: These methods model raw counts with a negative binomial distribution. Normalized values break the statistical model and produce invalid results.
 - **Wrong contrast syntax**: PyDESeq2 uses `["factor", "numerator", "denominator"]`. DESeq2 via rpy2 uses `c("factor", "numerator", "denominator")`. Mixing them up silently returns wrong comparisons.
 - **Skipping normalization check**: Always verify library sizes are not wildly different before DE. Extreme outliers can dominate results.

--- a/skills/immune-profiling/SKILL.md
+++ b/skills/immune-profiling/SKILL.md
@@ -136,8 +136,10 @@ When DE results are available from upstream steps:
 
 ### With Survival / Clinical Outcomes
 - Stratify patients by immune cell proportions or signature scores
-- Kaplan-Meier by high/low immune infiltration (median split or
-  optimal cutpoint)
+- Kaplan-Meier by high/low immune infiltration. A median split is a
+  pre-specified split, and it demands no cutpoint correction. An
+  optimal cutpoint demands the maxstat corrected p-value — see
+  Statistics below.
 - Multivariate Cox including immune scores alongside clinical
   covariates
 
@@ -145,6 +147,22 @@ When DE results are available from upstream steps:
 - Compare immune profiles between responders and non-responders
 - Test whether baseline immune state predicts treatment response
 - Assess on-treatment immune modulation (paired pre/post)
+
+## Statistics
+
+- **Multiplicity over immune scores**: One run yields 10 to 64
+  cell-type or signature scores. Correct every score-by-condition
+  comparison (t-test, Wilcoxon, correlation) with Benjamini-Hochberg
+  FDR across the full set of scores. Report q-values, not raw
+  p-values.
+- **Survival cutpoints**: The nominal log-rank p-value of an optimal
+  cutpoint has no meaning — the scan over candidate cutpoints
+  inflates it. Report the maxstat corrected p-value. The
+  `statistical-modeling` skill carries the full rule and the
+  `surv_cutpoint` API pattern.
+- **Cox models**: Include clinical covariates. Do a check of the
+  proportional-hazards assumption, and apply the failure path that
+  the `statistical-modeling` skill states.
 
 ## References
 
@@ -170,3 +188,7 @@ When DE results are available from upstream steps:
   macrophages, and MDSCs are immunosuppressive
 - Score immune signatures without checking that the signature genes
   are actually expressed in the dataset
+- Report the nominal p-value of an optimized survival cutpoint — only
+  the maxstat corrected p-value has meaning
+- Compare immune scores across conditions without BH FDR over the
+  full score set

--- a/skills/statistical-modeling/SKILL.md
+++ b/skills/statistical-modeling/SKILL.md
@@ -19,6 +19,9 @@ Choose the method based on your outcome type and analytical goal:
   - `lifelines.KaplanMeierFitter` for survival curves, `logrank_test()` for group comparison.
 - **Multivariate (adjust for covariates)**
   - `lifelines.CoxPHFitter` for Cox proportional hazards regression. Check PH assumption with `check_assumptions()`.
+    If the check fails, stratify on the covariate at fault (`strata=[...]`), or add a
+    time-varying term. Then report the hazard ratio as time-averaged, not as a
+    constant effect.
 - **ML-based survival (non-linear, high-dimensional)**
   - `scikit-survival.RandomSurvivalForest` for non-linear survival prediction.
   - `scikit-survival.GradientBoostingSurvivalAnalysis` for best predictive performance.
@@ -189,6 +192,12 @@ Feature selection belongs **inside** the cross-validation loop, not before it â€
 selecting over all samples first is the most common leak in panel development
 and reliably adds several AUC points that do not survive external validation.
 See `references/scikit-learn-api.md` for the nested-CV construction.
+
+The rule spans steps. A gene list from an upstream differential-expression
+step on the same samples is already a selection over all samples. Build the
+panel from the full feature matrix, and select again inside cross-validation.
+If only the pre-selected list is available, report the performance estimate
+as optimistic, and say why.
 
 ### ROC Analysis
 


### PR DESCRIPTION
## What & why

This lands roadmap items 1, 2, 6 and 20 — the wave-1 statistics rules. Four rules were absent or unreachable, and each gap can change a scientific conclusion. The immune pack recommended an uncorrected optimal cutpoint, and the immune agent could not reach the correction rule. No layer stated that a full-cohort contrast is already a feature selection. The bulk pack routed a 1 vs 1 design to inferential differential expression. The statistical-modeling pack named no remedy for a violated Cox assumption.

Notes for the reviewer:

- The OpenSpec change `add-statistics-rules-to-skill-packs` carries the proposal, the design, the delta specs and the tasks. Read the delta specs first.
- The immune roster gains `statistical-modeling`. The prompt edits invalidate the prompt-cache prefix of the immune agent and the bulk agent one time.
- No runtime change. The diff touches three packs, three prompts and one roster array.
- No new tests. The edits are prose, and the existing skill-validation suite covers the roster.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [x] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. This change does not touch the sandbox.
- [x] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
