### PR TITLE
fix(prompts): re-sync five sandbox agent prompts with their packs

### DIFF
--- a/harness/openspec/changes/resync-sandbox-agent-prompts/.openspec.yaml
+++ b/harness/openspec/changes/resync-sandbox-agent-prompts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/harness/openspec/changes/resync-sandbox-agent-prompts/design.md
+++ b/harness/openspec/changes/resync-sandbox-agent-prompts/design.md
@@ -1,0 +1,43 @@
+# Design: resync-sandbox-agent-prompts
+
+## Context
+
+A sandbox agent prompt summarizes its packs: the API references, the method
+recommendations, and the scope. The pack is the layer that holds the work and
+its contract (root `CLAUDE.md`, "Agent-facing content"). No validation reads
+the prose, thus a drifted summary stays green until an agent acts on it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Each of the five prompt summaries states only what its packs hold.
+- Each availability caveat of a pack survives into the prompt, or the
+  recommendation leaves the prompt.
+
+**Non-Goals:**
+
+- No pack content changes. A gap in a pack is a different change.
+- No mechanical validation of prompt-pack agreement. Review stays the
+  control, and the new requirement gives review its target.
+- No roster changes.
+
+## Decisions
+
+- **The pack wins each conflict.** The pack is the contract layer, and the
+  prompt is the mechanism layer. Example: the microbiome pack puts shotgun
+  profiling upstream by design. Thus the prompt drops MetaPhlAn and HUMAnN,
+  and the pack does not gain them.
+- **Five prompts, not three.** The roadmap counted three. A full comparison
+  found the same fault in `dna-methylation-agent.ts` and `network-agent.ts`.
+  The fix is the same mechanical pass, thus one change covers all five.
+- **The requirement lands in `agent-skill-assignment`.** That spec already
+  owns the relation between an agent and its packs. A new capability for one
+  prose rule was rejected as too small to stand alone.
+
+## Risks / Trade-offs
+
+- [Each edited prompt invalidates its prompt-cache prefix] → One cache write
+  for each of the five agents, one time.
+- [A future edit drifts again] → The new requirement gives a review target.
+  Mechanical enforcement stays out of scope, per the root `CLAUDE.md`.

--- a/harness/openspec/changes/resync-sandbox-agent-prompts/proposal.md
+++ b/harness/openspec/changes/resync-sandbox-agent-prompts/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: resync-sandbox-agent-prompts
+
+## Why
+
+Some sandbox agent prompts claim pack content that the pack does not hold, or
+they recommend a tool that the pack names as unavailable. `validateAgentSkills`
+never reads the prose, thus the drift stays green until an agent acts on it.
+This is roadmap item 29, wave 1. The roadmap names three prompts. A full
+comparison of each prompt against its packs found five:
+
+- `src/prompts/sandbox/microbiome-agent.ts:23-24` claims API references for
+  MetaPhlAn, HUMAnN and PICRUSt2. `skills/microbiome/` holds none of them,
+  and `SKILL.md:55` puts shotgun profiling out of scope. The prompt at
+  `:84-85` recommends SparCC and propr, which `SKILL.md:144` says are not
+  installed.
+- `src/prompts/sandbox/metabolomics-agent.ts:13` claims CAMERA and limma
+  references that the pack does not hold, and it omits pymzml, which the pack
+  holds. The prompt at `:30-31` demands pathway mapping without the hedge of
+  `SKILL.md:94`, and `:54-55` makes the enrichment figure unconditional.
+- `src/prompts/sandbox/spatial-omics-agent.ts:29-31` recommends
+  `sq.gr.ligrec`, which `skills/spatial-omics/SKILL.md:109-112` marks as
+  unavailable and tells the agent to report as a blocker.
+- `src/prompts/sandbox/dna-methylation-agent.ts:13-14` claims dmrseq and SVA
+  references that the pack does not hold, and the prompt does not carry the
+  IDAT-pipeline constraint of `skills/dna-methylation/SKILL.md:12-25`.
+- `src/prompts/sandbox/network-agent.ts:13-14` claims an OmniPath reference
+  that lives in a different pack. The prompt at `:26-27` asserts a pre-staged
+  parquet file. `SKILL.md:47-50` says that the file must resolve from the
+  inventory.
+
+The result is an agent that imports an absent package, calls an unavailable
+function, or promises a figure it cannot make. Each failure burns iterations,
+and a silent substitution is worse.
+
+## What Changes
+
+- Re-sync the five prompt summaries against their packs. The pack is the
+  ground truth in each conflict.
+- Remove each claim of a reference that no pack of the roster holds.
+- Carry each availability caveat of the pack into the prompt, or drop the
+  recommendation from the prompt.
+- Align the scope lines of the prompt with the scope of the pack.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-skill-assignment`: a new requirement binds a prompt summary to its
+  packs. A prompt must not claim content that no pack of its roster holds.
+
+## Impact
+
+- `src/prompts/sandbox/microbiome-agent.ts`
+- `src/prompts/sandbox/metabolomics-agent.ts`
+- `src/prompts/sandbox/spatial-omics-agent.ts`
+- `src/prompts/sandbox/dna-methylation-agent.ts`
+- `src/prompts/sandbox/network-agent.ts`
+- Each edited prompt invalidates its own prompt-cache prefix one time. No
+  pack changes, no roster changes, no schema changes.

--- a/harness/openspec/changes/resync-sandbox-agent-prompts/specs/agent-skill-assignment/spec.md
+++ b/harness/openspec/changes/resync-sandbox-agent-prompts/specs/agent-skill-assignment/spec.md
@@ -1,0 +1,28 @@
+# agent-skill-assignment Delta
+
+## ADDED Requirements
+
+### Requirement: A prompt summary matches the packs of its roster
+
+A sandbox agent prompt MUST NOT claim an API reference that no pack of its
+roster holds. If a pack names a package or a function as unavailable, the prompt MUST NOT
+recommend it without the caveat of the pack. It MUST NOT put work in scope that a pack of its roster puts out of
+scope. In each conflict, the pack is the ground truth.
+
+#### Scenario: A reference claim resolves to a pack file
+
+- **WHEN** a prompt names an API reference topic for one of its packs
+- **THEN** a reference file for that topic exists in that pack
+
+#### Scenario: An unavailable tool keeps its caveat
+
+- **GIVEN** a pack that names a package or a function as unavailable
+- **WHEN** the prompt of an agent with that pack mentions it
+- **THEN** the prompt carries the caveat of the pack, or it does not mention
+  the item
+
+#### Scenario: The prompt scope follows the pack scope
+
+- **GIVEN** a pack that puts a task out of scope
+- **WHEN** the prompt of an agent with that pack describes its capabilities
+- **THEN** the prompt does not present that task as in scope

--- a/harness/openspec/changes/resync-sandbox-agent-prompts/tasks.md
+++ b/harness/openspec/changes/resync-sandbox-agent-prompts/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: resync-sandbox-agent-prompts
+
+## 1. Microbiome prompt
+
+- [x] 1.1 Remove the MetaPhlAn, HUMAnN and PICRUSt2 reference claims at `src/prompts/sandbox/microbiome-agent.ts:23-24`.
+- [x] 1.2 Align the shotgun lines at `:28-31` and `:45-46` with the pack scope. The entry point is a profiled table.
+- [x] 1.3 Replace the SparCC and propr recommendation at `:84-85` with the CLR computation note of `skills/microbiome/SKILL.md:144`.
+
+## 2. Metabolomics prompt
+
+- [x] 2.1 Correct the reference list at `src/prompts/sandbox/metabolomics-agent.ts:13` to XCMS, matchms and pymzml.
+- [x] 2.2 Add the pathway-mapping hedge of `skills/metabolomics/SKILL.md:94` to the capability at `:30-31`.
+- [x] 2.3 Make the pathway-enrichment figure at `:54-55` conditional on a resolved metabolite-set file.
+
+## 3. Spatial omics prompt
+
+- [x] 3.1 Mark `sq.gr.ligrec` at `src/prompts/sandbox/spatial-omics-agent.ts:29-31` as unavailable, per `skills/spatial-omics/SKILL.md:109-112`. Report a blocker, do not substitute.
+
+## 4. DNA methylation prompt
+
+- [x] 4.1 Correct the reference claims at `src/prompts/sandbox/dna-methylation-agent.ts:13-14`. The pack holds minfi, champ, dmrcate, epidish and methylclock only.
+- [x] 4.2 Carry the IDAT-pipeline constraint of `skills/dna-methylation/SKILL.md:12-25` into the prompt workflow lines.
+- [x] 4.3 Align the Bismark line at `:23` with the pack. Alignment and extraction happen upstream.
+
+## 5. Network prompt
+
+- [x] 5.1 Correct the reference claims at `src/prompts/sandbox/network-agent.ts:13-14`. The OmniPath reference lives in a different pack.
+- [x] 5.2 Replace the pre-staged-parquet assertion at `:26-27` with the resolve-from-inventory rule of `skills/network-regulatory/SKILL.md:47-50`.
+
+## 6. Verify
+
+- [x] 6.1 Run `npx tsc --noEmit` in `harness/` and make sure that it is clean.
+- [x] 6.2 Run `bun run format:file` on the five changed prompt files.
+- [x] 6.3 Read each prompt against its packs, one claim at a time, per the new requirement.

--- a/harness/src/prompts/sandbox/dna-methylation-agent.ts
+++ b/harness/src/prompts/sandbox/dna-methylation-agent.ts
@@ -10,27 +10,33 @@ between beta-values (for reporting) and M-values (for statistics).
 
 Your skills: \`dna-methylation\`, \`shared/omics-general\`.
 
-API references in \`dna-methylation\`: minfi, ChAMP, DMRcate, dmrseq,
-methylclock, SVA, EpiDISH.
+API references in \`dna-methylation\`: minfi, ChAMP, DMRcate, EpiDISH,
+methylclock.
 
 ## Method Selection (Summary)
 
-- **Array processing** — minfi (preferred for flexibility), ChAMP (for
-  rapid automated analysis). Noob normalization is the default and
-  returns beta-values. Convert to M-values via logit transformation
-  (\`M = log2(beta / (1 - beta))\`) for downstream statistics.
-  Verify array annotation — wrong manifest silently corrupts.
-- **Bisulfite-seq** — Bismark for alignment and extraction. Coverage
-  filter: >=5× (WGBS) or >=10× (RRBS). Do NOT deduplicate RRBS data.
+- **Array processing** — the Illumina manifest and annotation packages
+  are not staged here, and there is no network to install them. Thus
+  the IDAT-to-betas pipeline (minfi, ChAMP) cannot run unless the
+  package loads — confirm that before you build around it, and report
+  the blocker if it does not. A beta or M-value matrix that arrives
+  processed still supports DMP testing, deconvolution, clocks, and
+  EWAS — report by CpG ID when annotation is missing. Convert to
+  M-values via logit transformation (\`M = log2(beta / (1 - beta))\`)
+  for downstream statistics.
+- **Bisulfite-seq** — the entry point is a per-CpG coverage/methylation
+  matrix. Alignment and methylation extraction happen upstream — if
+  you get raw FASTQ, say so and stop. Coverage filter: >=5× (WGBS) or
+  >=10× (RRBS).
 - **DMP analysis** — limma on M-values. Filter: padj < 0.05 AND
   \`abs(delta_beta) > 0.05\`. Report delta-beta for interpretation.
 - **DMR detection** — DMRcate for array data (kernel smoothing on limma
   results); dmrseq for bisulfite-seq (models spatial CpG correlation).
 - **Methylation clocks** — methylclock package. Verify all required
   CpGs are present on the platform before running.
-- **Cell deconvolution** — ALWAYS run for blood samples.
-  \`minfi::estimateCellCounts()\` or EpiDISH. Include proportions as
-  covariates in DMP/EWAS models.
+- **Cell deconvolution** — ALWAYS run for blood samples. EpiDISH on a
+  beta matrix (\`minfi::estimateCellCounts()\` needs the unstaged array
+  annotation). Include proportions as covariates in DMP/EWAS models.
 - **EWAS** — limma with covariates (age, sex, cell proportions, SVA
   surrogate variables). BH FDR correction.
 

--- a/harness/src/prompts/sandbox/metabolomics-agent.ts
+++ b/harness/src/prompts/sandbox/metabolomics-agent.ts
@@ -10,7 +10,7 @@ visualizations from mass spectrometry data.
 
 Your skills: \`metabolomics\`, \`shared/omics-general\`.
 
-API references in \`metabolomics\`: XCMS, CAMERA, matchms, limma.
+API references in \`metabolomics\`: XCMS, matchms, pymzml.
 
 ## Method Selection (Summary)
 
@@ -27,8 +27,11 @@ API references in \`metabolomics\`: XCMS, CAMERA, matchms, limma.
 - **Lipidomics** — lipid class normalization for within-class
   comparisons. LIPID MAPS nomenclature. Analyze chain length and
   saturation patterns.
-- **Pathway mapping** — map annotated metabolites to KEGG compound IDs,
-  run hypergeometric enrichment on metabolite sets.
+- **Pathway mapping** — needs a metabolite-set reference that is often
+  not provisioned, and the KEGG APIs are unreachable. Check the
+  reference inventory first. Run enrichment only with a locally
+  resolved metabolite-set file. If none exists, report it and stop at
+  the annotated, statistically-tested feature table.
 
 ## Domain Standards
 
@@ -52,7 +55,8 @@ API references in \`metabolomics\`: XCMS, CAMERA, matchms, limma.
 - **Feature intensity heatmaps** — top significant features, samples
   clustered by group, z-scored intensities.
 - **Pathway enrichment bar plots** — enriched pathways ranked by
-  p-value.
+  p-value. Only when a metabolite-set reference resolved (see Pathway
+  mapping) — otherwise omit, and say why.
 
 ## Domain Anti-Patterns
 

--- a/harness/src/prompts/sandbox/microbiome-agent.ts
+++ b/harness/src/prompts/sandbox/microbiome-agent.ts
@@ -21,14 +21,16 @@ Compositionality awareness governs every statistical decision you make.
 Your skills: \`microbiome\`, \`shared/omics-general\`.
 
 API references in \`microbiome\`: DADA2, phyloseq, vegan, ANCOM-BC2, ALDEx2,
-MaAsLin2, MetaPhlAn, HUMAnN, PICRUSt2.
+MaAsLin2, biom-format.
 
 ## Method Selection (Summary)
 
 - **Amplicon processing** — DADA2 for ASV inference. SILVA 138.1 for
   16S, UNITE for ITS. Always inspect error rate plots.
-- **Shotgun profiling** — MetaPhlAn 4 for taxonomy, HUMAnN 3 for
-  function.
+- **Shotgun data** — the entry point is a profiled table. Taxonomic
+  and functional profiling of shotgun FASTQ happens upstream. If you
+  get raw shotgun reads, say so and stop. Profiler output is relative
+  abundance — carry the compositional methods through.
 - **Data handling** — phyloseq for ASV table + taxonomy + metadata +
   tree.
 - **Alpha diversity** — Shannon, Simpson, Chao1, Faith's PD via
@@ -42,8 +44,10 @@ MaAsLin2, MetaPhlAn, HUMAnN, PICRUSt2.
   - Default (single timepoint, n >= 10/group) → ANCOM-BC2 (bias-corrected)
   - n < 10/group → ALDEx2 (Bayesian CLR, robust with small samples)
   - Longitudinal/repeated measures → MaAsLin2 (mixed effects)
-- **Functional profiling** — HUMAnN 3 for shotgun. PICRUSt2 for 16S
-  (flag as "predicted"). Apply same compositional methods.
+- **Functional analysis** — import a functional abundance table (gene
+  families, pathways) handed from upstream into pandas, and run
+  differential pathway analysis with the same compositional methods.
+  Flag results from a 16S prediction tool as "predicted".
 - **Rarefaction** — prefer NOT to rarefy. Modern DA methods handle
   unequal library sizes. If needed for alpha diversity, rarefy to
   minimum depth and report rarefaction curves.
@@ -82,7 +86,9 @@ MaAsLin2, MetaPhlAn, HUMAnN, PICRUSt2.
 - DESeq2 or edgeR for differential abundance — elevated false-positive
   rate on zero-inflated compositional microbiome data.
 - Pearson/Spearman correlation on relative abundances. Produces
-  spurious negative correlations. Use SparCC or proportionality (propr).
+  spurious negative correlations. SparCC and propr are not installed
+  here — CLR-transform the counts and correlate the CLR values, or
+  compute rho proportionality in numpy, per the \`microbiome\` skill.
 - Rarefying before differential abundance testing. DA methods handle
   library size internally.
 - Reporting taxa assigned with low bootstrap confidence (<70%).

--- a/harness/src/prompts/sandbox/network-agent.ts
+++ b/harness/src/prompts/sandbox/network-agent.ts
@@ -10,8 +10,8 @@ produced by upstream modality agents.
 
 Your skills: \`network-regulatory\`, \`shared/omics-general\`.
 
-API references in \`network-regulatory\`: PyWGCNA, decoupler TF activity,
-networkx/igraph, leidenalg, OmniPath.
+API references in \`network-regulatory\`: PyWGCNA, decoupler, networkx,
+igraph.
 
 ## Method Selection (Summary)
 
@@ -23,9 +23,11 @@ networkx/igraph, leidenalg, OmniPath.
 - **TF activity (fast, per-cell)** — decoupler with CollecTRI via
   \`run_ulm()\` or \`run_mlm()\`. Faster than pySCENIC when regulon
   discovery is not the goal.
-- **PPI network** — OmniPath interactions from pre-staged parquet
-  (physical, regulatory, signalling). Build with networkx or igraph.
-  Filter by confidence as needed.
+- **PPI network** — the STRING and OmniPath web APIs are unreachable.
+  A PPI network comes from an interaction file resolved from the
+  reference inventory. If none is provisioned, say so, and scope the
+  analysis to what is. Build with networkx or igraph. Filter by
+  confidence as needed.
 - **Community detection** — Leiden via igraph or leidenalg.
 - **Hub genes** — combine betweenness centrality, degree centrality, and
   module membership (kME). Validate against known biology.
@@ -42,7 +44,8 @@ networkx/igraph, leidenalg, OmniPath.
 - Log-transform expression before correlations. Pearson on raw counts
   is dominated by high-count genes.
 - decoupler: use CollecTRI (not DoRothEA) for TF regulons, PROGENy for
-  pathways. Load from pre-staged parquet via \`pd.read_parquet()\`.
+  pathways. Resolve the network file from the reference inventory —
+  never assume a staged path.
 - Save processed networks and module assignments as AnnData when
   meaningful.
 

--- a/harness/src/prompts/sandbox/spatial-omics-agent.ts
+++ b/harness/src/prompts/sandbox/spatial-omics-agent.ts
@@ -27,8 +27,10 @@ API references in \`spatial-omics\`: squidpy, spatialdata, cell2location.
 - **Spatially variable genes** — Moran's I via
   \`sq.gr.spatial_autocorr(adata, mode="moran")\`. Always FDR-correct.
 - **Niche analysis** — neighborhood enrichment
-  (\`sq.gr.nhood_enrichment\`), co-occurrence (\`sq.gr.co_occurrence\`),
-  spatially-constrained ligand-receptor (\`sq.gr.ligrec\`).
+  (\`sq.gr.nhood_enrichment\`), co-occurrence (\`sq.gr.co_occurrence\`).
+  \`sq.gr.ligrec\` cannot run here — its package is missing, and its
+  interaction database needs network access. Report the blocker, and
+  do not substitute another analysis silently.
 - **SpatialData** — for complex experiments with multiple sections or
   coordinate transformations. Otherwise AnnData with
   \`.obsm["spatial"]\` suffices.


### PR DESCRIPTION
## What & why

This lands roadmap item 29, wave 1. Five sandbox agent prompts claimed pack content that the pack does not hold, or they recommended a tool that the pack names as unavailable. No validation reads the prose, thus the drift stays green until an agent imports an absent package or calls an unavailable function. Each failure burns iterations, and a silent substitution is worse. The pack is the ground truth in each conflict, and the prompts now state only what their packs hold.

Notes for the reviewer:

- The roadmap counted three drifted prompts. A full comparison of every prompt against its packs found five: microbiome, metabolomics, spatial-omics, dna-methylation, and network.
- The OpenSpec change `resync-sandbox-agent-prompts` carries the proposal, the design, the delta spec and the tasks. The delta spec adds one requirement to `agent-skill-assignment`: a prompt summary must match the packs of its roster.
- Each edited prompt invalidates its own prompt-cache prefix one time. No pack changes, no roster changes, no runtime changes.
- No new tests. The edits are prose inside five prompt constants.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. This change does not touch the sandbox.
- [x] **Provenance:** prior analyses remain reproducible (or the expected variance is documented).
