### PR TITLE
feat(harness): block a capped-out step that persisted no output files

### DIFF
--- a/harness/openspec/changes/block-capped-out-empty-steps/.openspec.yaml
+++ b/harness/openspec/changes/block-capped-out-empty-steps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/harness/openspec/changes/block-capped-out-empty-steps/design.md
+++ b/harness/openspec/changes/block-capped-out-empty-steps/design.md
@@ -1,0 +1,59 @@
+# Design: block-capped-out-empty-steps
+
+## Context
+
+The step body reads the blocker holder at `src/workflows/sandbox-step.ts:745`,
+and it walks the artifact tree at `:799-809`, after the branch. Thus the
+branch cannot see the manifest today. The walk is wrapped in `safeRunValue`,
+and it is not a `DBOS.runStep`. The loop already returns `finishReason` and
+`hitMaxSteps`, and the mark-complete write persists them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A capped-out step with an empty manifest terminates `blocked`, and its
+  dependents do not run.
+- A step that finishes on its own initiative keeps the current contract. No
+  artifact-count inference applies to it.
+
+**Non-Goals:**
+
+- No failure taxonomy work. That is roadmap item 24.
+- No salvage of a failed step. That is roadmap item 31.
+- No deadline or budget exit. Those are roadmap items 27 and 47.
+
+## Decisions
+
+- **Hoist the walk above the blocked branch.** The predicate needs the
+  manifest, and the walk is inline, thus the hoist shifts no DBOS function
+  id. The blocker path then pays one extra directory walk, which is a
+  host-side read.
+- **Route into the existing branch, not a new one.** The capped-out empty
+  case reuses the `mark-blocked` step, the `blocked_reason` column and the
+  `data-step-blocked` part. A second terminal path would double the surface
+  that the parent and the readers must understand.
+- **The reason is deterministic prose, not model output.** The branch writes
+  a fixed reason that names the cap and the empty manifest. The summarizer
+  does not run, because the model loop is what just capped out.
+- **The predicate is `hitMaxSteps` and an empty manifest, and no blocker.**
+  An agent that called `report_blocker` keeps its own reason. A capped-out
+  step with artifacts stays `completed`, because partial output is real
+  output, and the summary reports it.
+
+## Risks / Trade-offs
+
+- [An in-flight capped-out child replays across the deploy and takes the new
+  branch] → DBOS raises a step mismatch on that narrow class. The run then
+  blocks its dependents, which is the intended correction. Accepted, and the
+  proposal marks it.
+- [A legitimate empty step that hits the cap on its last iteration blocks] →
+  Correct by contract. The deliverable of a step is its persisted files, per
+  `src/prompts/sandbox-standards.ts:141-142`.
+
+## Migration Plan
+
+- Land the spec delta and the branch in one commit.
+- No data migration. The `blocked` status and its column exist.
+- Rollback is a revert. A step that blocked under the new rule stays
+  `blocked` in the ledger, which stays a true record.

--- a/harness/openspec/changes/block-capped-out-empty-steps/proposal.md
+++ b/harness/openspec/changes/block-capped-out-empty-steps/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: block-capped-out-empty-steps
+
+## Why
+
+A sandbox step that hits its iteration cap with no deliverables goes green.
+`src/workflows/sandbox-step.ts:905-919` writes `status: "completed"`
+unconditionally, and it carries `hitMaxSteps` as metadata only. An agent that
+burns 50 iterations against a broken container thus reports success. The
+post-step pipeline registers an empty manifest, and the parent schedules the
+dependents on nothing. A dependent then improvises, and the signed PROV chain
+attests the improvisation.
+
+This contradicts the stated contract at
+`src/prompts/sandbox-standards.ts:141-142`: the deliverable of a step is its
+persisted files. This is roadmap item 3, wave 1.
+
+## What Changes
+
+- Hoist the `walkStepArtifacts` call above the blocked branch. The call is
+  inline, not a `DBOS.runStep`, thus the hoist shifts no function id.
+- Route the capped-out empty case into the blocked branch. A step with
+  `hitMaxSteps` and an empty manifest terminates `blocked`, with a
+  deterministic reason. The `blocked` status, the `blocked_reason` column and
+  the `data-step-blocked` part all exist (`src/state/init.ts:112,567`).
+- **BREAKING** for one narrow replay class: an in-flight capped-out child
+  that replays across the deploy takes the new branch. Its recorded step
+  sequence no longer matches, and DBOS raises a step mismatch. A run that
+  went green now blocks its dependents. That is the intended change.
+- The rule is narrow. A step that finishes on its own initiative with no
+  files and no blocker stays `completed`. Only the capped-out empty case
+  blocks.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `harness-sandbox-agents`: the no-inference requirement narrows. A capped-out
+  step with an empty manifest is `blocked`. A step that finished on its own
+  stays exempt from artifact-count inference.
+
+## Impact
+
+- `src/workflows/sandbox-step.ts` — the hoist and the routed branch.
+- `openspec/specs/harness-sandbox-agents/spec.md` — the narrowed requirement.
+- No schema change, no new column, no new `DBOS.runStep`.
+- Dependent runs: a plan whose capped-out step now blocks does not schedule
+  the dependents of that step. That is the correction, not a regression.

--- a/harness/openspec/changes/block-capped-out-empty-steps/specs/harness-sandbox-agents/spec.md
+++ b/harness/openspec/changes/block-capped-out-empty-steps/specs/harness-sandbox-agents/spec.md
@@ -1,0 +1,52 @@
+# harness-sandbox-agents Delta
+
+## MODIFIED Requirements
+
+### Requirement: Step agents declare inability via report_blocker, not output inference
+
+A step agent SHALL get a terminal `report_blocker({ reason })` tool whenever a
+blocker cell is supplied; there SHALL be no `submit`/`done` tool, because a
+step's deliverable is its persisted files. Calling `report_blocker` SHALL record
+`{ kind: "blocker", reason }` into the per-run holder the workflow body reads
+after `runAgent`. `blocked` SHALL be a distinct terminal step status — separate
+from `failed` and `completed` — carrying the reason to the
+`cortex_step_executions.blocked_reason` column, a `data-step-blocked` run-event
+part, and the step return. The parent scheduler SHALL treat a blocker exactly
+like a step failure: only the blocked step's transitive dependents become
+unreachable, while in-flight siblings and independent ready steps continue
+(see the harness-durable-runtime capability). The harness SHALL NOT infer
+failure from output/artifact counts for a step that finished on its own
+initiative: a legitimately-empty step (no files, no blocker, clean finish
+before the iteration cap) SHALL stay `completed`.
+
+The exception is narrow. If the loop hits its iteration cap, the artifact
+manifest is empty, and no blocker exists, the step MUST terminate `blocked`.
+The reason MUST be deterministic, and it MUST name the cap and the empty
+manifest. A capped-out step with artifacts stays `completed`, because partial
+output is real output.
+
+#### Scenario: Blocker yields a distinct blocked status
+
+- **GIVEN** a step agent that calls `report_blocker({ reason })` and stops
+- **WHEN** the workflow body reads the blocker holder after the loop
+- **THEN** the step SHALL terminate with status `blocked`, persisting the reason to `blocked_reason` and emitting a `data-step-blocked` part
+- **AND** in-flight siblings SHALL NOT be cancelled; only the blocked step's transitive dependents are never dispatched
+
+#### Scenario: Empty step is not auto-failed
+
+- **GIVEN** a step that writes no artifacts, calls no blocker, and ends cleanly before its iteration cap
+- **WHEN** the step terminates
+- **THEN** its status SHALL be `completed` (with `artifactCount: 0`), not failed or blocked
+
+#### Scenario: Capped-out step with no deliverables is blocked
+
+- **GIVEN** a step whose loop hits the iteration cap, with an empty artifact manifest and no blocker
+- **WHEN** the workflow body reads the manifest after the loop
+- **THEN** the step MUST terminate `blocked`, with a deterministic reason in `blocked_reason` and a `data-step-blocked` part
+- **AND** the transitive dependents of the step are never dispatched
+
+#### Scenario: Capped-out step with artifacts stays completed
+
+- **GIVEN** a step whose loop hits the iteration cap, with a non-empty artifact manifest
+- **WHEN** the step terminates
+- **THEN** its status SHALL be `completed`, with `hitMaxSteps` persisted

--- a/harness/openspec/changes/block-capped-out-empty-steps/tasks.md
+++ b/harness/openspec/changes/block-capped-out-empty-steps/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: block-capped-out-empty-steps
+
+## 1. The branch
+
+- [x] 1.1 Hoist the `walkStepArtifacts` call in `src/workflows/sandbox-step.ts` above the blocked branch. Keep it inline, and keep the `safeRunValue` wrap.
+- [x] 1.2 Extend the branch predicate: enter it on a blocker outcome, or on `hitMaxSteps` with an empty manifest.
+- [x] 1.3 Write a deterministic reason for the capped-out case. Name the cap and the empty manifest.
+- [x] 1.4 Keep the blocker reason for a step that called `report_blocker`. The blocker outcome wins over the capped-out reason.
+- [x] 1.5 Make sure that the completed path does not walk a second time. Pass the hoisted manifest into the post-step stages.
+
+## 2. Tests
+
+- [x] 2.1 A capped-out step with an empty manifest terminates `blocked`, with the deterministic reason in `blocked_reason`.
+- [x] 2.2 A capped-out step with artifacts terminates `completed`, with `hitMaxSteps` persisted.
+- [x] 2.3 A clean empty step with no blocker terminates `completed`.
+- [x] 2.4 A blocker outcome keeps its own reason when the step also capped out.
+- [x] 2.5 The parent does not dispatch the dependents of the blocked step.
+
+## 3. Verify
+
+- [x] 3.1 Run `npx tsc --noEmit` in `harness/` and make sure that it is clean.
+- [x] 3.2 Run `bun test src/workflows/` against the DBOS test rig.
+- [x] 3.3 Run `bun run format:file` on the changed `src/` files.
+- [x] 3.4 Read the delta spec against the branch, one scenario at a time.

--- a/harness/src/workflows/sandbox-step.test.ts
+++ b/harness/src/workflows/sandbox-step.test.ts
@@ -22,8 +22,9 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, mock, test } fro
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { okAsync } from "neverthrow";
+import { ok, okAsync } from "neverthrow";
 import type { Pool } from "pg";
+import { z } from "zod";
 import { CortexChatPartSchema } from "@inflexa-ai/harness/contracts/schemas/chat-parts.js";
 import { isReconciling, type CortexChatPartType } from "@inflexa-ai/harness/contracts/part-registry.js";
 
@@ -36,7 +37,9 @@ import type { SandboxClient } from "../sandbox/client.js";
 import type { CreateSandboxMeta, SandboxRef } from "../sandbox/types.js";
 import type { ArtifactRegistry, ArtifactSyncInput } from "../execution/artifact-registry.js";
 import type { WorkspaceFilesystem } from "../workspace/filesystem.js";
-import { createLineageCollector, runSandboxStepBody, type SandboxStepDeps, type SandboxStepInput } from "./sandbox-step.js";
+import { makeMessage, scriptedProvider, textBlock, toolUseBlock } from "../loop/__fixtures__/scripted-provider.js";
+import { defineTool } from "../tools/define-tool.js";
+import { CAPPED_OUT_EMPTY_REASON, createLineageCollector, runSandboxStepBody, type SandboxStepDeps, type SandboxStepInput } from "./sandbox-step.js";
 
 const RUN = "run-9";
 
@@ -558,5 +561,135 @@ describe("sandbox-step lineage attestation", () => {
         const failure = stepFailure(logger);
         expect(failure?.errorClass).toBe("lineage_attestation");
         expect(failure?.err).toContain(SYNC_FAILURE);
+    });
+});
+
+// ── capped-out steps with no deliverables route to blocked ───────────
+
+/**
+ * The narrow rule (see the harness-sandbox-agents spec): a loop that spent its
+ * whole iteration budget and persisted nothing terminates `blocked` with a
+ * deterministic reason, so its dependents never run against an empty manifest.
+ * A blocker outcome keeps its own reason, a capped-out step with artifacts
+ * stays `completed`, and a clean empty finish stays `completed`.
+ */
+describe("sandbox-step capped-out empty manifest", () => {
+    /**
+     * A pool that records every query's bind values, so the ledger write is
+     * assertable. `updateStepExecution` calls `query({ text, values })` (the
+     * config form) while other writers use `query(text, params)` — record both.
+     */
+    function makeRecordingPool(): { pool: Pool; values: unknown[] } {
+        const values: unknown[] = [];
+        const pool = {
+            query: async (arg: unknown, params?: unknown[]) => {
+                if (typeof arg === "object" && arg !== null && "values" in arg) {
+                    values.push(...((arg as { values?: unknown[] }).values ?? []));
+                }
+                values.push(...(params ?? []));
+                return { rows: [], rowCount: 0 };
+            },
+        } as unknown as Pool;
+        return { pool, values };
+    }
+
+    /**
+     * Deps whose loop caps out: a one-iteration agent with one `echo` tool, and
+     * a provider whose first reply is a tool call. The wrap-up call (and every
+     * post-step producer call after it) gets a plain "done", so the loop ends
+     * with `finish.cappedOut: true` and `reason: "max_iterations"`.
+     */
+    function cappedOutDeps(args: { blockerReason?: string } = {}): { deps: SandboxStepDeps; values: unknown[] } {
+        const { pool, values } = makeRecordingPool();
+        const provider = scriptedProvider((i) =>
+            i === 0 ? makeMessage([toolUseBlock("tu-1", "echo", { label: "x" })], "tool_use") : makeMessage([textBlock("done")], "end_turn"),
+        );
+        const deps: SandboxStepDeps = {
+            ...usageStepDeps(undefined),
+            pool,
+            provider,
+            buildAgent: ({ blockerHolder }) => ({
+                id: USAGE_AGENT_ID,
+                systemPrompt: "you are a test step agent",
+                model: STEP_MODEL_ID,
+                tools: [
+                    defineTool({
+                        id: "echo",
+                        description: "Echo the label back.",
+                        inputSchema: z.object({ label: z.string() }),
+                        describeCall: "none",
+                        execute: async ({ label }) => {
+                            if (args.blockerReason !== undefined) {
+                                blockerHolder.outcome = { kind: "blocker", reason: args.blockerReason };
+                            }
+                            return ok({ label });
+                        },
+                    }),
+                ],
+                maxIterations: 1,
+            }),
+        };
+        return { deps, values };
+    }
+
+    function blockedParts(parts: ReadonlyArray<Record<string, unknown>>): Array<Record<string, unknown>> {
+        return parts.filter((p) => p.type === "data-step-blocked");
+    }
+
+    it("terminates blocked with the deterministic reason when the cap hits an empty manifest", async () => {
+        const { deps, values } = cappedOutDeps();
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("blocked");
+        expect(result.error).toBe(CAPPED_OUT_EMPTY_REASON);
+        expect(result.finishReason).toBe("max_iterations");
+        // The ledger write carries the reason (error + blocked_reason) and the cap.
+        expect(values).toContain("blocked");
+        expect(values.filter((v) => v === CAPPED_OUT_EMPTY_REASON).length).toBe(2);
+        const emitted = blockedParts(dbosState.emittedParts);
+        expect(emitted.length).toBe(1);
+        expect(emitted[0]!.reason).toBe(CAPPED_OUT_EMPTY_REASON);
+    });
+
+    it("stays completed when the capped-out step persisted artifacts", async () => {
+        const dir = join(workspaceRoot, "runs", USAGE_RUN_ID, USAGE_STEP_ID, "output");
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "result.csv"), "gene,count\nTP53,7\n");
+        const { deps, values } = cappedOutDeps();
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(result.finishReason).toBe("max_iterations");
+        expect(values).toContain("completed");
+        // hit_max_steps binds as 1 on the mark-complete write.
+        expect(values).toContain(1);
+        expect(blockedParts(dbosState.emittedParts)).toEqual([]);
+    });
+
+    it("stays completed on a clean empty finish under the cap", async () => {
+        // The pre-existing contract: no files, no blocker, and a stop before the
+        // cap is a legitimately-empty step, and no artifact-count inference runs.
+        const { pool, values } = makeRecordingPool();
+        const deps: SandboxStepDeps = { ...usageStepDeps(undefined), pool };
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("complete");
+        expect(values).toContain("completed");
+        expect(blockedParts(dbosState.emittedParts)).toEqual([]);
+    });
+
+    it("keeps the blocker's own reason when the step also capped out", async () => {
+        const { deps } = cappedOutDeps({ blockerReason: "the input has no batch column" });
+
+        const result = await runSandboxStepBody(usageStepInput(), deps);
+
+        expect(result.status).toBe("blocked");
+        expect(result.error).toBe("the input has no batch column");
+        const emitted = blockedParts(dbosState.emittedParts);
+        expect(emitted.length).toBe(1);
+        expect(emitted[0]!.reason).toBe("the input has no batch column");
     });
 });

--- a/harness/src/workflows/sandbox-step.ts
+++ b/harness/src/workflows/sandbox-step.ts
@@ -132,6 +132,13 @@ export interface SandboxStepInput {
  */
 export const DEFAULT_STEP_TIMEOUT_SECONDS = 3600;
 
+/**
+ * Deterministic `blocked_reason` for a loop that spent every iteration and
+ * persisted no output files (see the harness-sandbox-agents spec). Fixed prose,
+ * never model output — the summarizer does not run on this path.
+ */
+export const CAPPED_OUT_EMPTY_REASON = "The step hit its iteration cap with no output files persisted.";
+
 export type SandboxStepStatus = "complete" | "failed" | "canceled" | "blocked";
 
 /**
@@ -738,12 +745,35 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
         });
     }
 
+    // Manifest walk, hoisted above the blocked branch so the capped-out
+    // predicate can read it. The call is inline (not `DBOS.runStep`-wrapped),
+    // so the hoist shifts no function id (see the harness-durable-runtime spec).
+    const manifest = await safeRunValue(
+        logger,
+        () =>
+            walkStepArtifacts({
+                writePrefix,
+                stepId: input.stepId,
+                runId: input.runId,
+            }),
+        "post-step.walk",
+        [] as readonly ArtifactManifestEntry[],
+    );
+
     // Blocker (see the harness-sandbox-agents spec): the agent declared it cannot fulfil the step. A
     // blocked step has no deliverables — skip the artifact post-step pipeline,
     // mark `blocked` (carrying the reason), emit the blocked part, and return a
     // terminal-failure status so the parent's fail-fast cascade fires.
+    //
+    // The capped-out empty case routes into the same branch: a loop that spent
+    // every iteration and persisted nothing has no deliverables, and a green
+    // status would attest an empty step. A blocker outcome keeps its own
+    // reason. A capped-out step WITH artifacts stays on the completed path,
+    // because partial output is real output.
     const blockerOutcome = blockerHolder.outcome;
-    if (blockerOutcome) {
+    const cappedOutEmpty = hitMaxSteps && manifest.length === 0;
+    if (blockerOutcome || cappedOutEmpty) {
+        const blockedReason = blockerOutcome?.reason ?? CAPPED_OUT_EMPTY_REASON;
         await tryTeardown(logger, deps, sandbox);
         const durationMs = (await DBOS.now()) - startedAt;
         await DBOS.runStep(
@@ -752,8 +782,8 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
                     await updateStepExecution(deps.pool, input.runId, input.stepId, {
                         status: "blocked",
                         durationMs,
-                        error: blockerOutcome.reason,
-                        blockedReason: blockerOutcome.reason,
+                        error: blockedReason,
+                        blockedReason,
                         attempts: 1,
                         lastErrorClass: "blocked",
                         finishReason,
@@ -769,22 +799,22 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
             runId: input.runId,
             stepId: input.stepId,
             agentId: input.agentId,
-            reason: blockerOutcome.reason,
+            reason: blockedReason,
         });
         await emitActivity("failed", "Step blocked");
         return {
             status: "blocked",
             durationMs,
             finishReason,
-            error: blockerOutcome.reason,
+            error: blockedReason,
             ...(stepUsage ? { usage: stepUsage } : {}),
         };
     }
 
-    // (4-8) post-step — the body is the explicit composition: walk the artifact
-    // tree once, then thread each stage's typed output into the next. Helpers
-    // run inline (not `DBOS.runStep`-wrapped), so a replay re-executes this
-    // section. Each helper is best-effort (`safeRun*` logs + degrades) so a
+    // (4-8) post-step — the body is the explicit composition: the manifest from
+    // the single walk above threads each stage's typed output into the next.
+    // Helpers run inline (not `DBOS.runStep`-wrapped), so a replay re-executes
+    // this section. Each helper is best-effort (`safeRun*` logs + degrades) so a
     // single failure never fails the step.
     const postCtx: PostStepContext = {
         input,
@@ -796,17 +826,6 @@ export async function runSandboxStepBody(input: SandboxStepInput, deps: SandboxS
     };
 
     await emitActivity("generating-metadata", "Describing output files");
-    const manifest = await safeRunValue(
-        logger,
-        () =>
-            walkStepArtifacts({
-                writePrefix,
-                stepId: input.stepId,
-                runId: input.runId,
-            }),
-        "post-step.walk",
-        [] as readonly ArtifactManifestEntry[],
-    );
     // The two post-step LLM producers are wrapped in `DBOS.runStep` so their
     // outputs are checkpointed (see the harness-durable-runtime spec): the conditional terminal emits they
     // gate (`data-step-summary`, file-tree) stay replay-stable and the billed


### PR DESCRIPTION
## What & why

This lands roadmap item 3, the last wave-1 change. A sandbox step that hit its iteration cap with no persisted files went green. The post-step pipeline registered an empty manifest, and the parent scheduled the dependents on nothing. A dependent then improvised, and the signed PROV chain attested the improvisation, against the contract that the deliverable of a step is its persisted files. The step now terminates `blocked`, with a deterministic reason, and its dependents never run.

Notes for the reviewer:

- The rule is narrow. A blocker outcome keeps its own reason. A capped-out step with artifacts stays `completed`, because partial output is real output. A clean empty finish under the cap stays `completed`, and no artifact-count inference runs on it.
- The manifest walk moved above the blocked branch. The call is inline, not a `DBOS.runStep`, thus the hoist shifts no function id.
- **Replay hazard, intended.** An in-flight capped-out child that replays across this deploy takes the new branch, and DBOS raises a step mismatch on that narrow class. A run that went green now blocks its dependents, which is the correction.
- The OpenSpec change `block-capped-out-empty-steps` carries the proposal, the design, the delta spec on `harness-sandbox-agents`, and the tasks.
- The parent-side isolation of a blocked step has existing coverage in `execute-analysis.test.ts` ("blocked isolation").

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. This change does not touch the sandbox.
- [x] **Provenance:** prior analyses remain reproducible (or the expected variance is documented). The PROV chain no longer attests an empty capped-out step as a success.
