### PR TITLE
feat(harness): reachable research tools, a grounded planner, and one reasoning depth

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/agents/conversation-agent.test.ts
+++ b/harness/src/agents/conversation-agent.test.ts
@@ -50,7 +50,7 @@ describe("createConversationAgent", () => {
         const agent = buildAgent();
         expect(agent.id).toBe(CONVERSATION_AGENT_ID);
         expect(agent.model).toBe("anthropic/claude-opus-4-7");
-        expect(agent.maxIterations).toBe(50);
+        expect(agent.maxIterations).toBe(200);
     });
 
     // Provisioning is decided in conversation: an embedder may give this agent a way to
@@ -105,7 +105,6 @@ describe("createConversationAgent", () => {
             "resolve_citation",
             "comptox",
             "generate_plan",
-            "literature_reviewer",
             "generate_analogy_report",
             "workspace_search",
             "read_file",

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -54,13 +54,7 @@ import {
 import { createNcbiTools, createChemDbTools, type BioToolKeys } from "../tools/bio/keys.js";
 
 // Dependency-bearing tool factories.
-import {
-    createGeneratePlanTool,
-    createLiteratureReviewerTool,
-    createInspectRunTool,
-    createInspectDataProfileTool,
-    createGenerateAnalogyReportTool,
-} from "../tools/research/index.js";
+import { createGeneratePlanTool, createInspectRunTool, createInspectDataProfileTool, createGenerateAnalogyReportTool } from "../tools/research/index.js";
 import {
     createFileStatTool,
     createGrepTool,
@@ -88,7 +82,7 @@ import { createResolveCitationTool } from "../tools/research/resolve-citation.js
 export const CONVERSATION_AGENT_ID = "conversation-agent" as const;
 
 /** Runaway guard — heavy tool-driving turns need generous headroom. */
-const CONVERSATION_MAX_ITERATIONS = 50;
+const CONVERSATION_MAX_ITERATIONS = 200;
 
 /**
  * The shared dependencies the composition root explodes apart. The environment
@@ -280,8 +274,6 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         showUserTool,
         createShowPlanTool(pool),
         showFileTool,
-        // Batch literature/biology research (sub-agent as a loop-driving tool).
-        createLiteratureReviewerTool({ provider, model, bioKeys, citationResolver, usageRecorder }),
         // Cross-domain analogy generation (sub-agent as a loop-driving tool).
         createGenerateAnalogyReportTool({ provider, model, bioKeys, usageRecorder }),
         // Workspace semantic search + raw read/grep over the read seam.

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -246,6 +246,7 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
             pool,
             resourcePolicy,
             usageRecorder,
+            bioKeys,
             ...(refStorePath ? { refStorePath } : {}),
             ...(packagesFile ? { packagesFile } : {}),
             ...(deps.logger ? { logger: deps.logger } : {}),

--- a/harness/src/agents/conversation-agent.ts
+++ b/harness/src/agents/conversation-agent.ts
@@ -54,7 +54,14 @@ import {
 import { createNcbiTools, createChemDbTools, type BioToolKeys } from "../tools/bio/keys.js";
 
 // Dependency-bearing tool factories.
-import { createGeneratePlanTool, createInspectRunTool, createInspectDataProfileTool, createGenerateAnalogyReportTool } from "../tools/research/index.js";
+import {
+    createGeneratePlanTool,
+    createInspectRunTool,
+    createInspectDataProfileTool,
+    createGenerateAnalogyReportTool,
+    createSearchSemanticScholarTool,
+    searchArxivTool,
+} from "../tools/research/index.js";
 import {
     createFileStatTool,
     createGrepTool,
@@ -208,6 +215,10 @@ export function createConversationAgent(deps: ConversationAgentDeps): AgentDefin
         ncbi.pubmed,
         // Verification of one caller-supplied citation (distinct from discovery).
         createResolveCitationTool(citationResolver),
+        // Literature outside PubMed. A question about a method, a model or a
+        // preprint has no MEDLINE record, thus PubMed alone cannot answer it.
+        createSearchSemanticScholarTool({ ...(bioKeys.semanticScholar === undefined ? {} : { apiKey: bioKeys.semanticScholar }) }),
+        searchArxivTool,
         // ChEMBL (compounds / drug / mechanism / bioactivity / targets behind one action).
         chemblTool,
         // PubChem (compound / crossrefs / assays behind one action).

--- a/harness/src/agents/report-session-agent.test.ts
+++ b/harness/src/agents/report-session-agent.test.ts
@@ -65,7 +65,7 @@ describe("createReportSessionAgent", () => {
         expect(agent.model).toBe("anthropic/claude-opus-4-8");
         // A full session drives more small tool calls than a conversation turn,
         // thus the cap matches the report runner (REPORT_AGENT_MAX_STEPS).
-        expect(agent.maxIterations).toBe(75);
+        expect(agent.maxIterations).toBe(200);
     });
 
     test("holds the analysis read surface", () => {

--- a/harness/src/agents/report-session-agent.ts
+++ b/harness/src/agents/report-session-agent.ts
@@ -65,7 +65,7 @@ export const REPORT_SESSION_AGENT_ID = "report-session" as const;
  * look, record — drives more small tool calls than a conversation turn, thus it
  * gets the headroom of the report runner (REPORT_AGENT_MAX_STEPS).
  */
-const REPORT_SESSION_MAX_ITERATIONS = 75;
+const REPORT_SESSION_MAX_ITERATIONS = 200;
 
 /**
  * The shared dependencies of the report agent. The gateway binds the per-session

--- a/harness/src/agents/sandbox/catalog.test.ts
+++ b/harness/src/agents/sandbox/catalog.test.ts
@@ -5,7 +5,7 @@ import { bulkTranscriptomicsAgentPrompt } from "../../prompts/sandbox/bulk-trans
 import { dataProfilerPrompt } from "../../prompts/sandbox/data-profiler.js";
 
 import { makeFakeSandboxAgentDeps } from "./__fixtures__/deps.js";
-import { createSandboxAgents, SANDBOX_AGENT_META } from "./index.js";
+import { createSandboxAgents, SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS, SANDBOX_AGENT_META } from "./index.js";
 
 describe("createSandboxAgents", () => {
     const deps = makeFakeSandboxAgentDeps();
@@ -88,8 +88,13 @@ describe("createSandboxAgents", () => {
         expect(agents["data-profiler"]!.systemPrompt.includes(dataProfilerPrompt.trim())).toBe(true);
     });
 
-    it("network-agent has the per-meta defaultMaxSteps override (35)", () => {
-        expect(agents["network-agent"]!.maxIterations).toBe(35);
+    it("every agent takes the shared default cap — no per-agent override", () => {
+        for (const [id, meta] of Object.entries(SANDBOX_AGENT_META)) {
+            expect(meta.defaultMaxSteps, id).toBeUndefined();
+        }
+        for (const [id, def] of Object.entries(agents)) {
+            expect(def.maxIterations, id).toBe(SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS);
+        }
     });
 
     it("non-plannable agents flagged in meta carry plannable=false", () => {

--- a/harness/src/agents/sandbox/data-profiler.ts
+++ b/harness/src/agents/sandbox/data-profiler.ts
@@ -19,7 +19,6 @@ export const meta: AgentMeta = {
     // differently. Declared rather than bolted on, so the resolved roster stays
     // `meta.tools` plus the always-on set.
     tools: [...BASE_SANDBOX_TOOLS, "scanInputs"],
-    defaultMaxSteps: 85,
     plannable: false,
 };
 

--- a/harness/src/agents/sandbox/network-agent.ts
+++ b/harness/src/agents/sandbox/network-agent.ts
@@ -13,7 +13,6 @@ export const meta: AgentMeta = {
     suitableFor: ["expression-matrices", "correlation-matrices", "general-omics"],
     skills: ["network-regulatory", "shared/omics-general"],
     tools: [...BASE_SANDBOX_TOOLS, "pubmed", "searchGene", "lookupAnnotation", "searchInteractions"],
-    defaultMaxSteps: 35,
 };
 
 export function createNetworkAgent(deps: SandboxAgentDeps): AgentDefinition {

--- a/harness/src/agents/sandbox/types.ts
+++ b/harness/src/agents/sandbox/types.ts
@@ -69,4 +69,4 @@ export interface AgentMeta {
 }
 
 /** Default runaway-guard for sandbox agents. */
-export const SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS = 50;
+export const SANDBOX_AGENT_DEFAULT_MAX_ITERATIONS = 200;

--- a/harness/src/config/resource-limits.ts
+++ b/harness/src/config/resource-limits.ts
@@ -47,7 +47,7 @@ export type ResourcePolicy = z.infer<typeof ResourcePolicySchema>;
 /** Default LLM-turn budget for a sandbox agent step. Covers simple,
  *  standard, and complex analyses — extra headroom on simple steps is
  *  cheaper than truncating complex ones. */
-export const DEFAULT_SANDBOX_MAX_STEPS = 75;
+export const DEFAULT_SANDBOX_MAX_STEPS = 200;
 
 // ── Error ───────────────────────────────────────────────────────────
 

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -255,6 +255,8 @@ export type {
     ChatUsage,
     ModelMessage,
     PromptCachePolicy,
+    ReasoningEffort,
+    ReasoningPolicy,
 } from "./providers/types.js";
 // Prompt caching. `PromptCachePolicy` is the harness's vendor-neutral cache
 // directive; a composition root sets it per run via `RunAgentOptions.promptCache`
@@ -264,6 +266,13 @@ export type {
 // `"off"`; the `cortex.harness.agent.cache_*_tokens` metrics show which case a
 // deployment is actually in.
 export { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "./providers/prompt-cache.js";
+// Reasoning depth. `ReasoningPolicy` is the vendor-neutral directive for how
+// deep a model reasons; a composition root sets it per run through
+// `RunAgentOptions.reasoning`. It defaults to `DEFAULT_REASONING` — adaptive
+// thinking at the `xhigh` effort — because an agent loop drives tools over many
+// iterations, and a shallow turn there wastes more calls than the deeper turn
+// costs in tokens. A host on a model with no reasoning support passes `"off"`.
+export { DEFAULT_REASONING, reasoningProviderOptions } from "./providers/reasoning.js";
 // Provider error channel. `ProviderError` is the value `chat`/`embed` fail
 // with; `toProviderError` is its sole constructor. Exposed so an embedder
 // realizing its own `ChatProvider`/`EmbeddingProvider` fails with the exact

--- a/harness/src/loop/prompt-cache.test.ts
+++ b/harness/src/loop/prompt-cache.test.ts
@@ -25,6 +25,15 @@ import type { AgentDefinition } from "./types.js";
 
 const ANTHROPIC_5M = { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } };
 
+/** The reasoning half of the merged bag — the default policy of `run-agent`. */
+const REASONING_XHIGH = { anthropic: { effort: "xhigh", thinking: { type: "adaptive" } }, openai: { reasoningEffort: "xhigh" } };
+
+/** The whole bag the loop attaches when both defaults are in force. */
+const MERGED_5M = {
+    anthropic: { ...ANTHROPIC_5M.anthropic, ...REASONING_XHIGH.anthropic },
+    openai: REASONING_XHIGH.openai,
+};
+
 const echoTool = defineTool({
     id: "echo",
     description: "A no-op tool.",
@@ -86,7 +95,7 @@ describe("runAgent prompt-cache directive", () => {
         // 3 iterations + the forced tool-less wrap-up.
         expect(chat.calls).toHaveLength(4);
         for (const call of chat.calls) {
-            expect(call.providerOptions).toEqual(ANTHROPIC_5M);
+            expect(call.providerOptions).toEqual(MERGED_5M);
         }
 
         // The wrap-up is the call that empties the tool set — it must still carry
@@ -95,7 +104,7 @@ describe("runAgent prompt-cache directive", () => {
         const wrapUp = chat.calls.at(-1)!;
         expect(Object.keys(wrapUp.tools)).toHaveLength(0);
         expect(wrapUp.toolChoice).toBe("none");
-        expect(wrapUp.providerOptions).toEqual(ANTHROPIC_5M);
+        expect(wrapUp.providerOptions).toEqual(MERGED_5M);
     });
 
     it("sends the same directive object on every call, so the prefix stays byte-identical", async () => {
@@ -115,7 +124,7 @@ describe("runAgent prompt-cache directive", () => {
         await runAgent(agentDef(2), GO, makeSession(), opts(chat, { promptCache: { ttl: "1h" } }));
 
         for (const call of chat.calls) {
-            expect(call.providerOptions).toEqual({ anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } } });
+            expect(call.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual({ type: "ephemeral", ttl: "1h" });
         }
     });
 
@@ -125,8 +134,11 @@ describe("runAgent prompt-cache directive", () => {
         await runAgent(agentDef(2), GO, makeSession(), opts(chat, { promptCache: "off" as PromptCachePolicy }));
 
         expect(chat.calls).toHaveLength(3);
+        // The bag is not empty — the reasoning policy still writes its own keys.
+        // What caching off means is that no cache directive rides in it.
         for (const call of chat.calls) {
-            expect(call.providerOptions).toBeUndefined();
+            expect(call.providerOptions?.["anthropic"]?.["cacheControl"]).toBeUndefined();
+            expect(call.providerOptions).toEqual(REASONING_XHIGH);
         }
     });
 });

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -24,8 +24,9 @@ import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-m
 import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
 import { classifyProviderError } from "../providers/errors.js";
 import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/prompt-cache.js";
+import { DEFAULT_REASONING, mergeProviderOptions, reasoningProviderOptions } from "../providers/reasoning.js";
 import { resultStep } from "./run-step.js";
-import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderCapabilities } from "../providers/types.js";
+import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderCapabilities, ReasoningPolicy } from "../providers/types.js";
 import { AskRejectedError, UnavailableAsk, type AskApproval, type AskRequest } from "../tools/approval/contract.js";
 import { isToolError, readToolResultImages, type Tool, type ToolContext, type ToolResultImage } from "../tools/define-tool.js";
 import { addChatUsage, hasReportedUsage, recordAgentRun, type AgentRunUsage } from "./metrics.js";
@@ -113,6 +114,18 @@ export interface RunAgentOptions {
      * cache-write premium for a cache nothing ever reads back.
      */
     readonly promptCache?: PromptCachePolicy;
+    /**
+     * Reasoning policy for every LLM call this run makes. Defaults to
+     * `DEFAULT_REASONING` (adaptive thinking at `xhigh`) — an agent loop drives
+     * tools over many iterations, and a shallow turn there costs more in wasted
+     * calls than the deeper turn costs in tokens.
+     *
+     * The policy lives here, on the run, rather than on the provider, for the
+     * same reason that the cache policy does: a one-shot LLM call elsewhere has
+     * its own depth needs and must not inherit the depth of a loop. A host on a
+     * model with no reasoning support passes `"off"`.
+     */
+    readonly reasoning?: ReasoningPolicy;
     /**
      * Diagnostic sink for the run's own lifecycle. Optional because `runAgent` is
      * called from tools, workflow bodies, and test rigs alike — silence is the
@@ -221,7 +234,10 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // Resolved once, not per iteration: an identical options object across every
     // call is itself part of the cache contract — the request prefix has to be
     // byte-identical to be read back.
-    const providerOptions = promptCacheProviderOptions(opts.promptCache ?? DEFAULT_PROMPT_CACHE);
+    const providerOptions = mergeProviderOptions(
+        promptCacheProviderOptions(opts.promptCache ?? DEFAULT_PROMPT_CACHE),
+        reasoningProviderOptions(opts.reasoning ?? DEFAULT_REASONING),
+    );
     const usage: AgentRunUsage = {};
 
     // Exactly one record per completed run — never one per iteration. That bound is

--- a/harness/src/prompts/SOUL.ts
+++ b/harness/src/prompts/SOUL.ts
@@ -54,6 +54,14 @@ Reproducibility over improvisation.
 Signal over storytelling.
 Honesty over polish.
 
+## How you write
+
+Lead with the conclusion. Put it first, then the evidence for it.
+
+Keep a caveat that changes a decision. Cut a caveat that only shows care.
+
+Do not make a bullet list of the same content to look shorter.
+
 ## Guardrails
 
 Refuse to fabricate scientific results.
@@ -179,9 +187,18 @@ Each session may begin with limited memory. Project files, notes, outputs, and c
 When a request is in scope:
 - answer directly
 - be precise
-- show reasoning clearly
+- give the reasoning that changes the conclusion, and no more
 - state uncertainty explicitly
 - propose the next useful step when relevant
+
+Text is not your only channel. A card, a plan, a table, a figure, and a file
+each reach the user on their own.
+
+- Do not restate what a rendered part already shows the user.
+- Write about a rendered part only to steer: which part matters, and what
+  comes next.
+- If you have nothing to add to what the user can already see, say so in one
+  line.
 
 When a request is out of scope:
 - say you are Inflexa

--- a/harness/src/prompts/SOUL.ts
+++ b/harness/src/prompts/SOUL.ts
@@ -58,8 +58,6 @@ Honesty over polish.
 
 Lead with the conclusion. Put it first, then the evidence for it.
 
-Keep a caveat that changes a decision. Cut a caveat that only shows care.
-
 Do not make a bullet list of the same content to look shorter.
 
 ## Guardrails
@@ -199,6 +197,7 @@ each reach the user on their own.
   comes next.
 - If you have nothing to add to what the user can already see, say so in one
   line.
+- Keep a caveat that changes a decision. Cut a caveat that only shows care.
 
 When a request is out of scope:
 - say you are Inflexa

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -185,10 +185,10 @@ targets, biomarkers, patient stratification, safety signals):
 
 ## Literature & Biology Investigation
 
-You run every literature and biology investigation yourself, with your own
-bio-lookup tools. There is no research sub-agent to delegate to. Each call
-you make streams to the user, so they see the evidence accumulate and can
-redirect you mid-investigation.
+Your bio-lookup tools are how you answer a biology question. Reach for them
+freely and often — a lookup is cheap next to any computation, and each call
+streams to the user, so they watch the evidence accumulate and can redirect
+you mid-investigation.
 
 **A quick answer** is one or two calls:
 - "What does BRCA1 do?" → \`search_gene\`
@@ -196,10 +196,13 @@ redirect you mid-investigation.
 - "Any papers on EGFR in AD?" → \`pubmed\`
 
 **A systematic investigation** (3+ targets, evidence profiles, novelty
-grading) is the same tools driven wider. Work one target at a time and
-say what you found before you move to the next — a batch of silent calls
-followed by one wall of text is the failure mode to avoid. Where the
-targets are independent, issue the calls together rather than in series.
+grading) is the same tools driven wider. Issue independent lookups together
+rather than in series, and report what each target gave you as you go.
+
+Every tool names the corpora it searches and the identifiers it accepts.
+Read that before you conclude a database holds nothing on a question — the
+entry point is usually a different tool, not a dead end. When a tool does
+report nothing, say so plainly and continue with what the others gave you.
 
 Ground every claim in a record you actually retrieved. Verify a citation
 a user hands you with \`resolve_citation\` — that is verification, not

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -143,9 +143,9 @@ To interpret results:
 3. **Read step summaries for detail** — when the synthesis references a finding,
    read the corresponding step's \`summary.md\` for the full evidence basis
    (metrics, methods, quality assessment).
-4. **Dig deeper on specific findings** — for follow-up questions, use bio-lookup
-   tools directly or delegate to \`literature_reviewer\` for additional investigation
-   beyond what the synthesis already covers.
+4. **Dig deeper on specific findings** — for follow-up questions, use your
+   bio-lookup tools directly to investigate beyond what the synthesis
+   already covers.
 
 Group findings by biological theme (e.g., immune response, metabolic
 changes) rather than by analysis step. Clearly separate well-supported
@@ -185,21 +185,25 @@ targets, biomarkers, patient stratification, safety signals):
 
 ## Literature & Biology Investigation
 
-You have bio-lookup tools for quick lookups AND a \`literature_reviewer\`
-agent for deep batch investigation. Route appropriately:
+You run every literature and biology investigation yourself, with your own
+bio-lookup tools. There is no research sub-agent to delegate to. Each call
+you make streams to the user, so they see the evidence accumulate and can
+redirect you mid-investigation.
 
-**Handle directly** (1-2 targets, quick answer):
+**A quick answer** is one or two calls:
 - "What does BRCA1 do?" → \`search_gene\`
 - "What pathways involve TP53?" → \`lookup_annotation\`
 - "Any papers on EGFR in AD?" → \`pubmed\`
 
-**Delegate to \`literature_reviewer\`** (3+ targets, systematic investigation):
-- "Investigate these top DE genes against literature"
-- "Build evidence profiles for these enriched pathways"
-- "Validate these findings — are they novel or established?"
+**A systematic investigation** (3+ targets, evidence profiles, novelty
+grading) is the same tools driven wider. Work one target at a time and
+say what you found before you move to the next — a batch of silent calls
+followed by one wall of text is the failure mode to avoid. Where the
+targets are independent, issue the calls together rather than in series.
 
-It returns a structured evidence report. Use it to ground your hypotheses,
-grade evidence, or present validated findings.
+Ground every claim in a record you actually retrieved. Verify a citation
+a user hands you with \`resolve_citation\` — that is verification, not
+discovery.
 
 ### Which bio database to enter from
 
@@ -234,22 +238,19 @@ as one continuous thought process. Do not skip phases.
 - If refining prior hypotheses, read them from conversation context.
 
 ### 2. Investigate — Cross-Reference with Biology
-Delegate to the \`literature_reviewer\` with the genes, pathways, and
-features you identified in orientation. Include fold changes, condition
-names, and what you need to know. The reviewer systematically investigates
-each target and returns structured evidence.
-
-For quick follow-ups on specific targets during ideation, use your
-own bio-lookup tools directly.
+Investigate the genes, pathways, and features you identified in
+orientation, with your own bio-lookup tools. Carry the fold changes and
+the condition names into what you look up, and work through the targets
+one at a time.
 
 The goal: distinguish what's novel from what's established, and find
 biological mechanisms that explain observed data patterns.
 
-Two complementary tools serve hypothesis exploration: the
-\`literature_reviewer\` for in-domain biology evidence (used here), and
-\`generate_analogy_report\` for cross-domain inspiration (used in the
-Ideate step below). Treat them as a pair — biology evidence anchors
-hypotheses to reality, analogies broaden the candidate space.
+Two things serve hypothesis exploration: your own bio-lookup tools for
+in-domain biology evidence (used here), and \`generate_analogy_report\`
+for cross-domain inspiration (used in the Ideate step below). Treat them
+as a pair — biology evidence anchors hypotheses to reality, analogies
+broaden the candidate space.
 
 ### 3. Ideate — Generate Candidate Hypotheses
 Each hypothesis must be:

--- a/harness/src/prompts/conversation.ts
+++ b/harness/src/prompts/conversation.ts
@@ -35,18 +35,10 @@ Re-orient only when:
 
 Route by what you are asking for:
 
-1. **What the dataset IS** → \`inspect_data_profile\`. The authoritative record:
-   domain, organism, tissue, condition, experimental design, caveats, the file
-   census, and — under \`scope:'groups'\` — the groups the files fall into and the
-   dimensions that vary across them. There is no data-profile file — this tool is
-   the only way to read it. Do not go looking for one, and do not re-derive these
+1. **What the dataset IS** → \`inspect_data_profile\`. Do not re-derive these
    facts by reading the raw inputs.
-2. **Which files exist** → \`workspace_search\`. Semantic search over the indexed
-   workspace; it returns ranked paths with descriptions and metadata, not
-   contents. Groups and dimensions are indexed; most individual input files are
-   not, so reach them through their group and \`list_files\`.
-3. **What is inside a file** → \`read_file\` (or \`list_files\`) on a path a search
-   returned.
+2. **Which files exist** → \`workspace_search\`, then \`list_files\`.
+3. **What is inside a file** → \`read_file\` on a path a search returned.
 
 Do not start with filesystem exploration for general data questions.
 Do not tell the user you cannot access their files — you can.
@@ -118,30 +110,25 @@ stop polling and tell the user it is still running. Never loop on
 ## Interpreting Results
 
 After a run completes, the workflow automatically produces two types of output:
-- **Step summaries** (\`summary.md\` per step) — computational findings,
-  method choices, quality assessment. Pure facts, no literature.
-- **Run synthesis** (\`synthesis.json\` at run level) — integrated
-  interpretation of the run: conclusions, selective key findings
-  (novel/contradicted/high-impact only), biological themes, limitations,
-  and literature references with PMIDs. Produced only when the run had
-  summaries to integrate and hit no blocker — \`synthesis.json\` exists
-  for that run alone; a skipped or failed synthesis writes no file.
+- **A step summary**, one for each step — computational findings, method
+  choices, quality assessment. Pure facts, no literature.
+- **A run synthesis**, one for the run — the integrated interpretation:
+  conclusions, selective key findings, biological themes, limitations, and
+  literature references. A run produces one only when it had summaries to
+  integrate and it hit no blocker.
 
 To interpret results:
 
 1. **Check whether the run produced a synthesis** — \`inspect_run({ runId })\`
-   reports the run's \`synthesisStatus\` and gives a \`synthesisPath\` only when it
-   is \`produced\`. When the run produced a synthesis,
-   \`workspace_search("synthesis conclusions interpretation")\` also finds
-   \`synthesis.json\` — that integrated interpretation, with conclusions and
-   literature grounding, is your primary source. When synthesis was skipped or
-   failed, no synthesis file exists — fall back to the per-step \`summary.md\`
-   files as your source and integrate the findings yourself.
+   reports the \`synthesisStatus\` of the run, and it gives a \`synthesisPath\`
+   only when that status is \`produced\`. The synthesis is your primary source
+   when it exists. When it was skipped or failed, read the step summaries and
+   integrate the findings yourself.
 2. **Read the synthesis** — when present, it has conclusions (the "so what"),
    selective key findings graded by novelty, biological themes, and
    explicit limitations with key references.
 3. **Read step summaries for detail** — when the synthesis references a finding,
-   read the corresponding step's \`summary.md\` for the full evidence basis
+   read the summary of that step for the full evidence basis
    (metrics, methods, quality assessment).
 4. **Dig deeper on specific findings** — for follow-up questions, use your
    bio-lookup tools directly to investigate beyond what the synthesis
@@ -208,24 +195,9 @@ Ground every claim in a record you actually retrieved. Verify a citation
 a user hands you with \`resolve_citation\` — that is verification, not
 discovery.
 
-### Which bio database to enter from
-
-Each tool states its own contract; these are the comparisons no single one
-can make:
-
-- **Target assessment** → \`opentargets({action:"target"})\` first: one call returns
-  genetic evidence, tractability, and the drug landscape, already scored. De-risk
-  from there with \`target_safety\` and \`gene_preclinical_profile\`. Reach for
-  \`gene_disease_evidence\` when you need the underlying records rather than the
-  scores — the individual SNPs, GDA scores and variant classifications.
-- **Compounds** → ChEMBL (\`chembl({action:"compounds"})\`) for curated potency, mechanism,
-  and approved drugs. \`pubchem({action:"compound"})\` when ChEMBL misses it — then
-  bridge back to curated data with \`pubchem({action:"crossrefs"})\`.
-- **Safety** → \`target_safety\` is mechanism-based (the target);
-  \`search_faers\` is post-market (a specific marketed drug). EPA CTX for
-  environmental and industrial chemicals.
-
-All of these are lightweight API calls — never spin up a sandbox for a lookup.
+Each tool names the corpora it searches and the identifiers it takes, and it
+says which tool to prefer over it. Read that rather than a list here. All of
+them are lightweight API calls — never start a sandbox for a lookup.
 
 ## Hypothesis Exploration
 
@@ -243,8 +215,7 @@ as one continuous thought process. Do not skip phases.
 ### 2. Investigate — Cross-Reference with Biology
 Investigate the genes, pathways, and features you identified in
 orientation, with your own bio-lookup tools. Carry the fold changes and
-the condition names into what you look up, and work through the targets
-one at a time.
+the condition names into what you look up.
 
 The goal: distinguish what's novel from what's established, and find
 biological mechanisms that explain observed data patterns.
@@ -410,9 +381,6 @@ Instead:
 
 - Keep responses concise and data-driven.
 - When the user's intent is ambiguous, ask a brief clarifying question.
-- Use bio-lookup tools to provide biological context for key findings,
-  but keep tool usage focused — look up the most important genes and
-  pathways, not every result.
 - When results conflict, present both sides rather than choosing one.
 - Present hypotheses in a clear, structured format with ID, claim,
   rationale, test design, expected outcomes, and priority.

--- a/harness/src/prompts/execute-analysis/step-summary.ts
+++ b/harness/src/prompts/execute-analysis/step-summary.ts
@@ -23,6 +23,10 @@ Write a markdown summary that covers:
 - limitations of the analysis
 
 Use markdown headings and bullets freely — there is no fixed schema.
+
+A later agent reads this file, not a person, and no card carries its content.
+Thus write each number and each caveat in full. Lead each section with its
+result, but never drop a fact to make the document shorter.
 Report only numbers that exist in a persisted artifact. Do not fabricate
 results and do not report a number that appears only in command stdout.
 

--- a/harness/src/prompts/execute-analysis/step-summary.ts
+++ b/harness/src/prompts/execute-analysis/step-summary.ts
@@ -23,10 +23,6 @@ Write a markdown summary that covers:
 - limitations of the analysis
 
 Use markdown headings and bullets freely — there is no fixed schema.
-
-A later agent reads this file, not a person, and no card carries its content.
-Thus write each number and each caveat in full. Lead each section with its
-result, but never drop a fact to make the document shorter.
 Report only numbers that exist in a persisted artifact. Do not fabricate
 results and do not report a number that appears only in command stdout.
 

--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -34,7 +34,8 @@ export function plannerPrompt(agentCatalog: string, resourcePolicy?: ResourcePol
 You are a bioinformatics analysis planner. Your ONLY job is to produce a
 structured analysis plan (DAG of steps) given a data context and research
 question. You do NOT interact with the user, search the workspace, or
-execute anything. You receive all context you need as input.
+execute anything. Your seed is authoritative for this dataset. Your search
+tools cover what the seed does not hold.
 
 ## CRITICAL — Read This First
 
@@ -72,8 +73,7 @@ terminal tool call. No exceptions.
 ## Search Before You Draft — When It Pays
 
 You hold read-only search tools. None of them writes and none of them
-computes, so the only cost of a call is the wait. Use that budget on the
-gaps the seed leaves, not on what the seed already told you.
+computes. Reach for one whenever it would sharpen the plan.
 
 **Search when:**
 - The assay, the platform, or the organism is one whose standard pipeline
@@ -92,15 +92,16 @@ gaps the seed leaves, not on what the seed already told you.
   \`query_docs\`. The package inventory in your seed says what is
   importable; it does not say what the API offers.
 
-**Do NOT search when:**
-- The data profile, the reference inventory, or the package inventory in
-  your seed already answers it. Re-deriving what you were handed wastes
-  the user's wait.
-- The question is routine for a design you recognize. A standard
-  differential-expression plan needs no literature call.
-- A search failed once. An empty result is a real answer — record what you
-  found, draft the plan you can defend, and state the gap in the plan's own
-  rationale.
+**The one thing not to search for:** what your seed already answers. Do not
+re-derive the data profile, the reference census, or the package census that
+you were handed.
+
+**When a search comes back empty**, rephrase it once, or try one sibling
+corpus. If that is also empty, record the gap in the rationale of the plan
+and continue. An empty result is a real answer.
+
+If an inventory block in your seed reports that its lookup failed, absence
+in it proves nothing. Call the matching tool.
 
 What a search may change: the choice of method, the order of steps, a
 threshold, a package, or a reference. What it must never change: the fact
@@ -134,8 +135,9 @@ before relying on it.
   it against whatever the environment actually holds.
 - Match the organism to the dataset. A step that silently uses a human resource
   on mouse data produces confident, meaningless numbers.
-- Check before you commit a step to a reference, and treat what you find as the
-  environment's current state — not a guarantee it is still there at run time.
+- Check before you commit a step to a reference. The census in your seed answers
+  most of it, and \`list_available_refs\` narrows to one collection. Treat what you
+  find as the current state of the environment, not a guarantee for run time.
 - **When a reference the analysis genuinely cannot proceed without is absent,
   do not plan around it — stop and ask.** Call \`request_clarification\`, naming
   what is needed in terms of what the data IS and which step needs it. Provisioning
@@ -153,7 +155,8 @@ run time. A step that leans on an absent library is a guaranteed failure discove
 only once the run reaches it, which is the most expensive moment to learn it.
 
 - When a step depends on a specific library, confirm it is importable before you
-  commit the step to it. Checking a handful of names is one cheap call.
+  commit the step to it. The census in your seed answers most names, and
+  \`list_available_packages\` answers the rest.
 - Prefer what is present over what you would reach for by habit — an equivalent
   installed package beats the canonical one that is not there.
 - When nothing installed can do the step's work, treat it exactly as you would an

--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -52,9 +52,9 @@ your work is discarded and the user sees nothing. Every session MUST end
 with exactly one call to \`submit_plan\`, \`request_clarification\`, or
 \`report_blocker\`.
 
-Your very first action must be either \`submit_plan\`
-or \`request_clarification\` / \`report_blocker\` (if you cannot draft one).
-Do NOT respond with text before any tool call.
+You may call the search tools below before you draft. Every session still
+ends with exactly one terminal call. Do NOT respond with text before any
+tool call.
 
 ## Canonical Flow
 
@@ -65,8 +65,47 @@ every field it declares.
 fix the specific fields, and call \`submit_plan\` again →
 \`accepted: true\`. STOP.
 
-Typical run: 2–4 tool calls total. Every run ends with ONE terminal
-tool call. No exceptions.
+Typical run: 2–4 tool calls when the seed already answers the question,
+plus the searches you needed when it did not. Every run ends with ONE
+terminal tool call. No exceptions.
+
+## Search Before You Draft — When It Pays
+
+You hold read-only search tools. None of them writes and none of them
+computes, so the only cost of a call is the wait. Use that budget on the
+gaps the seed leaves, not on what the seed already told you.
+
+**Search when:**
+- The assay, the platform, or the organism is one whose standard pipeline
+  you are not sure of → \`search_geo_datasets\` for comparable public
+  studies (their design, platform, and sample counts), then \`pubmed\` for
+  the method those studies cite.
+- The research question names a method, a statistic, or a correction you
+  cannot pin down → \`search_semantic_scholar\` and \`search_arxiv\`. The
+  first ranks method papers best; the second holds statistics and
+  machine-learning work that is not indexed in PubMed.
+- A step would reproduce something that already exists as a pipeline →
+  \`search_github_repos\`. An approach someone published as running code is
+  a better step than one you invent.
+- You are about to name a function of a staged package and you are not
+  certain of its signature or that it exists → \`resolve_library_id\`, then
+  \`query_docs\`. The package inventory in your seed says what is
+  importable; it does not say what the API offers.
+
+**Do NOT search when:**
+- The data profile, the reference inventory, or the package inventory in
+  your seed already answers it. Re-deriving what you were handed wastes
+  the user's wait.
+- The question is routine for a design you recognize. A standard
+  differential-expression plan needs no literature call.
+- A search failed once. An empty result is a real answer — record what you
+  found, draft the plan you can defend, and state the gap in the plan's own
+  rationale.
+
+What a search may change: the choice of method, the order of steps, a
+threshold, a package, or a reference. What it must never change: the fact
+that every step you write runs on this dataset. A published design is
+evidence, not a substitute for the profile you were handed.
 
 ## Do NOT
 - Respond with plain text (even to explain the plan — the user never sees it).

--- a/harness/src/providers/ai-sdk.ts
+++ b/harness/src/providers/ai-sdk.ts
@@ -846,6 +846,38 @@ function withStoreDirective(model: LanguageModelV4, store: boolean): LanguageMod
 }
 
 /**
+ * Mirror the neutral reasoning effort into the namespace of an
+ * OpenAI-compatible connection.
+ *
+ * The compatible provider reads `providerOptions[<the name of the connection>]`
+ * rather than `providerOptions.openai`, and it derives that namespace from the
+ * first dot-separated segment of the name. The loop cannot write that key,
+ * because only this seam knows the name. Thus the middleware copies
+ * `reasoningEffort` across at request time. A value that the caller already set
+ * on the namespace wins, and a request with no effort passes through untouched.
+ */
+function withCompatibleReasoning(model: LanguageModelV4, name: string): LanguageModelV4 {
+    const namespace = name.split(".")[0]?.trim();
+    if (namespace === undefined || namespace === "") return model;
+    return wrapLanguageModel({
+        model,
+        middleware: {
+            transformParams: async ({ params }) => {
+                const effort = params.providerOptions?.["openai"]?.["reasoningEffort"];
+                if (effort === undefined) return params;
+                return {
+                    ...params,
+                    providerOptions: {
+                        ...params.providerOptions,
+                        [namespace]: { reasoningEffort: effort, ...params.providerOptions?.[namespace] },
+                    },
+                };
+            },
+        },
+    });
+}
+
+/**
  * Realize an `AiSdkProviderConfig` into a `ChatProvider` bound to that config's
  * connection and model. The model is closed into the returned provider here (it
  * is never passed per `ChatRequest`), so N models require N provider
@@ -929,7 +961,7 @@ export function createConfiguredAiSdkProvider(deps: ConfiguredAiSdkProviderDeps)
         fetch: effectiveFetch as typeof fetch | undefined,
     });
     return createAiSdkProvider({
-        model: provider.chatModel(config.model),
+        model: withCompatibleReasoning(provider.chatModel(config.model), config.name),
         resolveBilling: deps.resolveBilling,
         capabilities: config.capabilities,
         logger: deps.logger,

--- a/harness/src/providers/reasoning.ts
+++ b/harness/src/providers/reasoning.ts
@@ -1,0 +1,83 @@
+/**
+ * Reasoning policy → provider wire options.
+ *
+ * This is the **only** place in the harness that names a vendor for reasoning
+ * depth. Everything upstream — `ReasoningPolicy` and `RunAgentOptions` — speaks
+ * the neutral harness concept. This module translates it one time, at the
+ * provider seam, thus the loop never learns which vendor it talks to. It is the
+ * sibling of `prompt-cache.ts`, and it obeys the same rules.
+ *
+ * ## Why the emitted options are safe on every provider
+ *
+ * `providerOptions` of the AI SDK is a namespaced bag. Each provider reads only
+ * `providerOptions[<its own name>]`, and it ignores each other key. Thus the
+ * `anthropic` namespace is inert on an OpenAI model, and the `openai` namespace
+ * is inert on an Anthropic model. Neither one is an error.
+ *
+ * ## What each namespace does
+ *
+ * The Anthropic namespace carries two keys, because the vendor splits the
+ * concept in two:
+ *
+ *  - `thinking: { type: "adaptive" }` says that the model reasons, and it lets
+ *    the model choose the depth for each turn. A fixed `budgetTokens` is removed
+ *    on the current models, and it returns a 400 there.
+ *  - `effort` says how deep the model reasons and how much it spends in total.
+ *    The vendor default is `high`.
+ *
+ * The OpenAI namespace carries one key, `reasoningEffort`, which takes the same
+ * five values. An OpenAI-compatible endpoint reads the same key, but from a
+ * namespace that carries the *name of the connection* rather than `openai`. The
+ * provider seam mirrors the value into that namespace, because only the seam
+ * knows the name (`providers/ai-sdk.ts`).
+ *
+ * ## Where the policy belongs
+ *
+ * The policy rides on the run, not on the provider, for the same reason that the
+ * cache policy does. A one-shot LLM call elsewhere in the harness has its own
+ * depth needs, and it must not inherit the depth of an agent loop.
+ */
+
+import type { ProviderOptions, ReasoningPolicy } from "./types.js";
+
+/**
+ * The default policy: adaptive thinking at the `xhigh` effort.
+ *
+ * `xhigh` sits between `high` and `max`. It is the vendor recommendation for
+ * coding and agentic work, and each agent of the harness drives tools over many
+ * iterations. `max` costs more than the remaining quality is worth for a routine
+ * turn, thus it is not the default. A host that wants a cheaper loop passes a
+ * lower effort, and a host on a model with no reasoning support passes `"off"`.
+ */
+export const DEFAULT_REASONING: ReasoningPolicy = { effort: "xhigh" };
+
+/**
+ * Translate a neutral reasoning policy into provider wire options.
+ *
+ * Returns `undefined` for `"off"`, thus the caller can leave `providerOptions`
+ * unset rather than send an empty bag.
+ */
+export function reasoningProviderOptions(policy: ReasoningPolicy): ProviderOptions | undefined {
+    if (policy === "off") return undefined;
+    return {
+        anthropic: { effort: policy.effort, thinking: { type: "adaptive" } },
+        openai: { reasoningEffort: policy.effort },
+    };
+}
+
+/**
+ * Merge two option bags one namespace at a time.
+ *
+ * A plain spread of the two bags drops a whole namespace when both sides carry
+ * it, and the cache policy and the reasoning policy both write `anthropic`. The
+ * right-hand bag wins for a key that both sides set.
+ */
+export function mergeProviderOptions(left: ProviderOptions | undefined, right: ProviderOptions | undefined): ProviderOptions | undefined {
+    if (left === undefined) return right;
+    if (right === undefined) return left;
+    const merged: ProviderOptions = { ...left };
+    for (const [namespace, options] of Object.entries(right)) {
+        merged[namespace] = { ...merged[namespace], ...options };
+    }
+    return merged;
+}

--- a/harness/src/providers/types.ts
+++ b/harness/src/providers/types.ts
@@ -58,6 +58,19 @@ export interface ChatRequest {
 export type PromptCachePolicy = { readonly ttl: "5m" | "1h" } | "off";
 
 /**
+ * How deep a model reasons, in harness-neutral names.
+ *
+ * `{ effort }` asks the provider for that reasoning depth, and `"off"` sends no
+ * reasoning directive at all. The five values are the ladder that both vendor
+ * families accept. A model with no reasoning support ignores the directive
+ * rather than fails on it, thus the policy is a no-op for that model. Refer to
+ * `./reasoning.ts`, the single place where the harness translates this into
+ * vendor wire options.
+ */
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningPolicy = { readonly effort: ReasoningEffort } | "off";
+
+/**
  * Token accounting for one chat call, in harness-neutral names.
  *
  * `inputTokens` is the *total* billed prefix — cached and uncached alike — so a

--- a/harness/src/tools/bio/bio-lookup.test.ts
+++ b/harness/src/tools/bio/bio-lookup.test.ts
@@ -9,6 +9,10 @@ afterEach(() => {
     globalThis.fetch = realFetch;
 });
 
+function json(body: unknown): Response {
+    return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
 function stubFetch(response: () => Response): void {
     globalThis.fetch = (async () => response()) as unknown as typeof fetch;
 }
@@ -37,7 +41,7 @@ describe("searchGene (bio-lookup family)", () => {
         const result = (
             await searchGeneTool.execute(
                 {
-                    symbols: ["BRCA1"],
+                    identifiers: ["BRCA1"],
                     species: "homo_sapiens",
                     expand: false,
                 },
@@ -57,7 +61,7 @@ describe("searchGene (bio-lookup family)", () => {
         const result = (
             await searchGeneTool.execute(
                 {
-                    symbols: ["NOTAGENE"],
+                    identifiers: ["NOTAGENE"],
                     species: "homo_sapiens",
                     expand: false,
                 },
@@ -73,6 +77,55 @@ describe("searchGene (bio-lookup family)", () => {
         stubFetch(() => new Response("upstream down", { status: 500 }));
 
         const { ctx } = makeToolContext();
-        await expect(searchGeneTool.execute({ symbols: ["BRCA1"], species: "homo_sapiens", expand: false }, ctx)).rejects.toThrow();
+        await expect(searchGeneTool.execute({ identifiers: ["BRCA1"], species: "homo_sapiens", expand: false }, ctx)).rejects.toThrow();
+    });
+
+    it("resolves an Ensembl gene ID to its approved symbol before it reaches Ensembl", async () => {
+        const seen: string[] = [];
+        globalThis.fetch = (async (input: unknown) => {
+            const url = String(input);
+            seen.push(url);
+            if (url.includes("genenames.org")) {
+                return json({
+                    response: {
+                        docs: [
+                            {
+                                symbol: "TP53",
+                                name: "tumor protein p53",
+                                hgnc_id: "HGNC:11998",
+                                ensembl_gene_id: "ENSG00000141510",
+                                uniprot_ids: ["P04637"],
+                            },
+                        ],
+                    },
+                });
+            }
+            if (url.includes("uniprot.org")) {
+                return json({ results: [{ primaryAccession: "P04637", genes: [{ geneName: { value: "TP53" } }] }] });
+            }
+            if (url.includes("ebi.ac.uk/chembl")) return json({ targets: [] });
+            return json({ id: "ENSG00000141510", display_name: "TP53", biotype: "protein_coding" });
+        }) as unknown as typeof fetch;
+
+        const { ctx } = makeToolContext();
+        const result = (await searchGeneTool.execute({ identifiers: ["ENSG00000141510"], species: "homo_sapiens" }, ctx))._unsafeUnwrap();
+
+        expect(result.resolvedFrom).toEqual([{ input: "ENSG00000141510", symbol: "TP53" }]);
+        expect(result.genes[0]!.symbol).toBe("TP53");
+        expect(seen.some((u) => u.includes("/lookup/symbol/homo_sapiens/TP53"))).toBe(true);
+    });
+
+    it("reports an identifier that anchors on no human gene as notFound, not an error", async () => {
+        globalThis.fetch = (async (input: unknown) => {
+            const url = String(input);
+            if (url.includes("ensembl.org")) return json({ id: "", display_name: "" });
+            return json({});
+        }) as unknown as typeof fetch;
+
+        const { ctx } = makeToolContext();
+        const result = (await searchGeneTool.execute({ identifiers: ["CHEMBL99999999"], species: "homo_sapiens" }, ctx))._unsafeUnwrap();
+
+        expect(result.notFound).toEqual(["CHEMBL99999999"]);
+        expect(result.genes).toEqual([]);
     });
 });

--- a/harness/src/tools/bio/bio-lookup.test.ts
+++ b/harness/src/tools/bio/bio-lookup.test.ts
@@ -85,7 +85,8 @@ describe("searchGene (bio-lookup family)", () => {
         globalThis.fetch = (async (input: unknown) => {
             const url = String(input);
             seen.push(url);
-            if (url.includes("genenames.org")) {
+            const { hostname, pathname } = new URL(url);
+            if (hostname === "rest.genenames.org") {
                 return json({
                     response: {
                         docs: [
@@ -100,10 +101,10 @@ describe("searchGene (bio-lookup family)", () => {
                     },
                 });
             }
-            if (url.includes("uniprot.org")) {
+            if (hostname === "rest.uniprot.org") {
                 return json({ results: [{ primaryAccession: "P04637", genes: [{ geneName: { value: "TP53" } }] }] });
             }
-            if (url.includes("ebi.ac.uk/chembl")) return json({ targets: [] });
+            if (hostname === "www.ebi.ac.uk" && pathname.startsWith("/chembl")) return json({ targets: [] });
             return json({ id: "ENSG00000141510", display_name: "TP53", biotype: "protein_coding" });
         }) as unknown as typeof fetch;
 
@@ -118,7 +119,7 @@ describe("searchGene (bio-lookup family)", () => {
     it("reports an identifier that anchors on no human gene as notFound, not an error", async () => {
         globalThis.fetch = (async (input: unknown) => {
             const url = String(input);
-            if (url.includes("ensembl.org")) return json({ id: "", display_name: "" });
+            if (new URL(url).hostname === "rest.ensembl.org") return json({ id: "", display_name: "" });
             return json({});
         }) as unknown as typeof fetch;
 

--- a/harness/src/tools/bio/chembl-tool.test.ts
+++ b/harness/src/tools/bio/chembl-tool.test.ts
@@ -319,6 +319,15 @@ describe("chembl — action: bioactivity", () => {
         expect(requestedUrls[0]).not.toContain("standard_type=");
     });
 
+    it("indexes the assay side for idType='assay'", async () => {
+        stubRoutes([["/activity.json", ACTIVITY_ROWS]]);
+
+        const activities = resultKey(await callChembl({ action: "bioactivity", chemblId: "CHEMBL829584", idType: "assay" }), "activities");
+
+        expect(activities[0]!.assayChemblId).toBe("CHEMBL829584");
+        expect(requestedUrls[0]).toContain("/activity.json?assay_chembl_id=CHEMBL829584&limit=25");
+    });
+
     it("returns an empty activities list when ChEMBL responds 404 (not is_error)", async () => {
         stubStatus(404, "not found");
 

--- a/harness/src/tools/bio/chembl.ts
+++ b/harness/src/tools/bio/chembl.ts
@@ -51,7 +51,9 @@ const inputSchema = z
                     "(INHIBITOR, AGONIST, …), targetChemblId + targetName, moleculeChemblId. Curated mainly for clinical/approved molecules, so tool " +
                     "compounds often have none.\n" +
                     "'bioactivity' (chemblId + idType) — measured activity rows: the curated, QUOTABLE potency. → standardType, standardValue + " +
-                    "standardUnits, pchemblValue (normalized -log10), assayChemblId, assayType, compoundChemblId, targetChemblId.\n" +
+                    "standardUnits, pchemblValue (normalized -log10), assayChemblId, assayType, compoundChemblId, targetChemblId. With idType='assay' " +
+                    "it reads ONE assay back by the assayChemblId that an earlier bioactivity row carried — every measurement made under the same " +
+                    "protocol, which is how you compare compounds on like terms.\n" +
                     "'targets' (query) — resolve a gene symbol or protein name to a ChEMBL target, producing the ID that bioactivity (idType='target') " +
                     "and compounds (searchType='target') need. → targetChemblId, preferredName, targetType, organism, geneNames. Check `organism`: the " +
                     "top hit for a human symbol may be a non-human ortholog.",
@@ -77,15 +79,15 @@ const inputSchema = z
             .min(1)
             .optional()
             .describe(
-                "Required for 'mechanism' and 'bioactivity'. A molecule ID ('CHEMBL25' = aspirin), or — for bioactivity with idType='target' — a target " +
-                    "ID ('CHEMBL203' = EGFR). 'mechanism' takes a molecule ID only.",
+                "Required for 'mechanism' and 'bioactivity'. A molecule ID ('CHEMBL25' = aspirin), or — for bioactivity — a target ID ('CHEMBL203' = " +
+                    "EGFR) with idType='target', or an assay ID ('CHEMBL1217643') with idType='assay'. 'mechanism' takes a molecule ID only.",
             ),
         idType: z
-            .enum(["compound", "target"])
+            .enum(["compound", "target", "assay"])
             .optional()
             .describe(
-                "Required for 'bioactivity' — which side of the activity table `chemblId` indexes. 'compound': everything that molecule was assayed " +
-                    "against. 'target': every compound assayed against that target.",
+                "Required for 'bioactivity' — which column of the activity table `chemblId` indexes. 'compound': everything that molecule was assayed " +
+                    "against. 'target': every compound assayed against that target. 'assay': every measurement made under that one assay protocol.",
             ),
         activityType: z
             .string()
@@ -138,10 +140,13 @@ export type ChemblOutput =
 export const chemblTool = defineTool({
     id: "chembl",
     description:
-        "ChEMBL — the manually curated database of drug-like bioactives (~2.4M compounds), the targets they were measured against, their mechanisms and " +
-        "their approval status. Five lookups; pick with `action`, which gives each one's params and return fields.\n" +
-        "IDs are resolved, never guessed: a `chemblId` comes from a prior action='compounds'/'drug' (molecules) or action='targets' (targets), or from " +
-        "pubchem action='crossrefs'. A compound or gene name is not a ChEMBL ID.\n" +
+        "ChEMBL — the manually curated database of drug-like bioactives of EMBL-EBI (~2.4M compounds), the targets they were measured against, their " +
+        "mechanisms and their approval status. Five lookups; pick with `action`, which gives each one's params and return fields.\n" +
+        "ACCEPTED IDENTIFIERS: free text for 'compounds', 'drug' and 'targets' — a compound name ('imatinib'), an indication ('melanoma'), a gene symbol " +
+        "('EGFR') or a SMILES string. A ChEMBL ID for 'mechanism' and 'bioactivity' — a molecule ID ('CHEMBL25'), a target ID ('CHEMBL203') or an assay " +
+        "ID ('CHEMBL1217643'), named by `idType`.\n" +
+        "IDs are resolved, never guessed: a `chemblId` comes from a prior action='compounds'/'drug' (molecules), action='targets' (targets), the " +
+        "assayChemblId of a bioactivity row (assays), or pubchem action='crossrefs'. A compound or gene name is not a ChEMBL ID.\n" +
         "Being curated, ChEMBL is what you quote from: prefer action='bioactivity' over pubchem action='assays' for any number you will cite, and resolve " +
         "compounds here first. If ChEMBL misses the compound, resolve it via pubchem action='compound' and bridge back with pubchem action='crossrefs'.\n" +
         "An empty array is valid no-data, not an error — do not retry the same call.",

--- a/harness/src/tools/bio/comptox.ts
+++ b/harness/src/tools/bio/comptox.ts
@@ -142,9 +142,13 @@ export function createComptoxTool(deps: { apiKey: string }) {
     return defineTool({
         id: "comptox",
         description:
-            "EPA's CompTox (CTX) chemical-safety databases — four datasets behind `dataset`: 'toxcast' (in-vitro HTS bioactivity), 'hazard' (in-vivo: " +
+            "The CompTox Chemicals Dashboard (CTX) of the U.S. Environmental Protection Agency — the chemical-safety corpus that holds ToxCast, ToxValDB, " +
+            "the genotoxicity and cancer summaries, and the SEEM exposure predictions. Four datasets behind `dataset`: 'toxcast' (in-vitro HTS " +
+            "bioactivity), 'hazard' (in-vivo: " +
             "NOAEL/LOAEL/LD50, genotoxicity, cancer), 'chemical' (identity + physicochemical/ADMET), 'exposure' (SEEM predictions, toxicokinetics, uses, " +
             "products). See `dataset` for what each returns; all four resolve `query` to a DTXSID first.\n" +
+            "ACCEPTED IDENTIFIERS: a DTXSID ('DTXSID7020182') used directly, or a CASRN ('80-05-7'), a chemical name ('bisphenol A') or — for dataset " +
+            "'chemical' — an InChIKey, each resolved by EXACT match.\n" +
             "Requires EPA_CCTE_API_KEY — a missing key fails terminally: do NOT retry, tell the user the key needs configuring and proceed without EPA data.\n" +
             "found: false means the query did not resolve to a chemical; a present-but-empty section is likewise valid no-data. Do not retry either.\n" +
             "This is environmental/industrial-chemical data: for drug-like compounds prefer PubChem or ChEMBL — dataset 'chemical' returns " +

--- a/harness/src/tools/bio/drug-gene-interactions.ts
+++ b/harness/src/tools/bio/drug-gene-interactions.ts
@@ -174,8 +174,11 @@ export function createDrugGeneInteractionsTool(deps: { drugbankApiKey: string; l
     return defineTool({
         id: "drug_gene_interactions",
         description:
-            "Drug↔gene interactions across DGIdb, DrugBank and PharmGKB, in one call — 'what drugs hit these genes?' and 'what genes does this drug act " +
-            "on?'. See `direction` and `sources` for the modes.\n" +
+            "Drug↔gene interactions across DGIdb (the Drug Gene Interaction Database), DrugBank and PharmGKB, in one call — 'what drugs hit these " +
+            "genes?' and 'what genes does this drug act on?'. See `direction` and `sources` for the modes.\n" +
+            "ACCEPTED IDENTIFIERS: a HUGO gene symbol ('EGFR') for direction 'gene_to_drugs'; a drug name ('imatinib'), a DrugBank ID ('DB00619') or a " +
+            "DGIdb concept ID for 'drug_to_genes'. A brand name and a non-HUGO symbol match nothing — resolve the symbol with search_gene and the brand " +
+            "name with search_faers({action:'label'}) first.\n" +
             "It answers whether an interaction is KNOWN, by whom, and of what type. For quotable POTENCY (IC50/Ki) use chembl({action:'bioactivity'}) instead.\n" +
             "Verbose fields (`includeAttributes`, `includeDrugRecord`) are off by default — both cost a lot of context and are rarely what the question needs.\n" +
             "ALWAYS read `perSource` before concluding an interaction is unknown: 'no_data' means that corpus has nothing; 'unavailable' means it could " +

--- a/harness/src/tools/bio/gene-disease-evidence.test.ts
+++ b/harness/src/tools/bio/gene-disease-evidence.test.ts
@@ -227,4 +227,48 @@ describe("geneDiseaseEvidence — fan-out", () => {
     it("rejects a limit above the per-source ceiling at the schema boundary", async () => {
         await expect(tool.inputSchema.parseAsync({ query: "PCSK9", queryType: "gene", limit: 999 })).rejects.toThrow();
     });
+
+    it("keeps cbioportal out of the default set — it scans every curated study", async () => {
+        stubFetch((url) => {
+            if (url.includes("disgenet")) return json([]);
+            if (url.includes("esearch")) return json({ esearchresult: { idlist: [], count: "0" } });
+            return json({ _embedded: { singleNucleotidePolymorphisms: [] } });
+        });
+
+        const { ctx } = makeToolContext();
+        const result = (await tool.execute({ query: "PCSK9", queryType: "gene" }, ctx))._unsafeUnwrap();
+
+        expect(result.perSource.map((s) => s.source)).not.toContain("cbioportal");
+    });
+
+    it("reads one GWAS study back by its accession, and marks the other corpora not_applicable", async () => {
+        const seen: string[] = [];
+        stubFetch((url) => {
+            seen.push(url);
+            return json({ _embedded: { associations: [GWAS_ASSOCIATION] }, page: { totalElements: 1 } });
+        });
+
+        const { ctx } = makeToolContext();
+        const result = (await tool.execute({ query: "GCST000392", queryType: "gwas_study" }, ctx))._unsafeUnwrap();
+
+        expect(seen[0]).toContain("/studies/GCST000392/associations");
+        expect(outcome(result.perSource, "gwas")).toMatchObject({ status: "ok", returned: 1 });
+        expect(result.perSource.filter((s) => s.status === "not_applicable")).toHaveLength(0);
+        expect(result.disgenet).toBeUndefined();
+    });
+
+    it("reads one ClinVar record back by its accession, and reports the corpora that cannot", async () => {
+        const seen: string[] = [];
+        stubFetch((url) => {
+            seen.push(url);
+            return json({ esearchresult: { idlist: [], count: "0" } });
+        });
+
+        const { ctx } = makeToolContext();
+        const result = (await tool.execute({ query: "VCV000012345", queryType: "clinvar_accession", sources: ["clinvar", "gwas"] }, ctx))._unsafeUnwrap();
+
+        expect(seen.every((u) => u.includes("eutils"))).toBe(true);
+        expect(outcome(result.perSource, "clinvar")).toMatchObject({ status: "no_data" });
+        expect(outcome(result.perSource, "gwas")).toMatchObject({ status: "not_applicable" });
+    });
 });

--- a/harness/src/tools/bio/gene-disease-evidence.ts
+++ b/harness/src/tools/bio/gene-disease-evidence.ts
@@ -1,8 +1,8 @@
 /**
- * geneDiseaseEvidence — one tool over the three gene↔disease evidence corpora:
- * the NHGRI-EBI GWAS Catalog, DisGeNET, and NCBI ClinVar.
+ * geneDiseaseEvidence — one tool over the four gene↔disease evidence corpora:
+ * the NHGRI-EBI GWAS Catalog, DisGeNET, NCBI ClinVar, and cBioPortal.
  *
- * These were three tools with the same input skeleton (`query` + a
+ * The first three were three tools with the same input skeleton (`query` + a
  * gene/disease/variant discriminator + a strength threshold + `limit`)
  * answering the same question — what genetic evidence links this gene to this
  * disease or trait. Picking between them was never a routing decision an agent
@@ -10,25 +10,35 @@
  * defaults to all of them. `search_pathway`'s `source: kegg | reactome | both`
  * is the same shape.
  *
+ * cBioPortal joins them as the somatic half of the same question, and it is the
+ * one source that is NOT in the default set: it scans every curated study, thus
+ * it costs several large requests that a routine gene query must not pay.
+ *
  * Each source runs independently and reports its own outcome in `perSource`: a
  * missing DisGeNET key or a GWAS Catalog outage degrades that one corpus to
- * `unavailable` instead of failing a call the other two could have answered.
+ * `unavailable` instead of failing a call the others could have answered.
  *
  * The input is a flat object with a `queryType` discriminator — not a
  * `z.discriminatedUnion`, which `defineTool` rejects (model tool calling needs
- * a top-level `"type":"object"`).
+ * a top-level `"type":"object"`). A `queryType` that only one corpus can serve
+ * — an accession of that corpus — marks the others `not_applicable` rather
+ * than sending them a query they cannot read.
  */
 
 import { ok } from "neverthrow";
 import { z } from "zod";
 
 import { defineTool } from "../define-tool.js";
+import { getSomaticMutationFrequencies, type MutationFrequency } from "../lib/cbioportal-client.js";
 import { filterInformative, searchClinvar, type ClinicalSignificance, type ClinvarVariant } from "../lib/clinvar-client.js";
 import { searchDisgenet, type Gda } from "../lib/disgenet-client.js";
-import { searchGwasCatalog, type GwasAssociation } from "../lib/gwas-catalog-client.js";
+import { searchGwasCatalog, type GwasAssociation, type GwasSearchType } from "../lib/gwas-catalog-client.js";
 
-const SOURCES = ["gwas", "disgenet", "clinvar"] as const;
+const SOURCES = ["gwas", "disgenet", "clinvar", "cbioportal"] as const;
 type Source = (typeof SOURCES)[number];
+
+const QUERY_TYPES = ["gene", "disease", "variant", "gwas_study", "clinvar_accession"] as const;
+type QueryType = (typeof QUERY_TYPES)[number];
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
@@ -47,34 +57,72 @@ interface SourceOutcome {
     detail?: string;
 }
 
-/** DisGeNET has no variant-level lookup; the other two do. */
-function applicableSources(queryType: "gene" | "disease" | "variant"): Source[] {
-    return queryType === "variant" ? ["gwas", "clinvar"] : [...SOURCES];
+/** Which query types each corpus can read. An accession is readable by one corpus only. */
+const SOURCE_QUERY_TYPES: Record<Source, readonly QueryType[]> = {
+    gwas: ["gene", "disease", "variant", "gwas_study"],
+    disgenet: ["gene", "disease"],
+    clinvar: ["gene", "disease", "variant", "clinvar_accession"],
+    cbioportal: ["gene"],
+};
+
+/**
+ * cBioPortal stays out of the default set. It scans every curated study, thus
+ * a caller opts into it by naming it in `sources`.
+ */
+const OPT_IN_SOURCES: readonly Source[] = ["cbioportal"];
+
+function applicableSources(queryType: QueryType): Source[] {
+    return SOURCES.filter((source) => SOURCE_QUERY_TYPES[source].includes(queryType));
 }
+
+/** The corpora a call queries when it names none. */
+function defaultSources(queryType: QueryType): Source[] {
+    return applicableSources(queryType).filter((source) => !OPT_IN_SOURCES.includes(source));
+}
+
+/**
+ * The GWAS Catalog name for each query type it serves. `clinvar_accession` is
+ * absent because `applicableSources` never selects the GWAS Catalog for it.
+ */
+const GWAS_SEARCH_TYPES: Partial<Record<QueryType, GwasSearchType>> = {
+    gene: "gene",
+    disease: "trait",
+    variant: "variant",
+    gwas_study: "study",
+};
 
 const inputSchema = z.object({
     query: z
         .string()
         .min(1)
         .describe(
-            "The entity, matching `queryType`. gene: a HUGO symbol ('PCSK9'); DisGeNET also takes an Entrez ID. disease: a disease or trait name " +
-                "('LDL cholesterol'); DisGeNET also takes a UMLS CUI ('C0006142'). variant: a dbSNP rsID ('rs11591147').",
+            "The entity, matching `queryType`. gene: a HUGO symbol ('PCSK9'); DisGeNET also takes an Entrez ID, and cBioPortal takes the symbol " +
+                "directly. disease: a disease or trait name ('LDL cholesterol'); DisGeNET also takes a UMLS CUI ('C0006142'). variant: a dbSNP rsID " +
+                "('rs11591147'). gwas_study: a GWAS Catalog study accession ('GCST000392'). clinvar_accession: a ClinVar accession ('VCV000012345', " +
+                "'RCV000009910') or a bare variation ID.",
         ),
     queryType: z
-        .enum(["gene", "disease", "variant"])
+        .enum(QUERY_TYPES)
         .describe(
             "'gene' — the diseases/traits associated with a gene. 'disease' — the genes associated with a disease or trait (the GWAS Catalog calls it a " +
-                "trait; this value covers both). 'variant' — one rsID; DisGeNET is skipped, having no variant-level lookup.",
+                "trait; this value covers both). 'variant' — one rsID; DisGeNET is skipped, having no variant-level lookup. 'gwas_study' — every " +
+                "association reported by ONE GWAS Catalog study, read back from the studyAccession that a gwas record carries; GWAS Catalog only. " +
+                "'clinvar_accession' — one ClinVar record, read back from the accession that a clinvar record carries; ClinVar only.",
         ),
     sources: z
         .array(z.enum(SOURCES))
         .min(1)
         .optional()
         .describe(
-            "Corpora to query in parallel. Default ALL applicable — they carry different evidence types, and disagreement between them is itself informative. " +
-                "'gwas': population SNP-trait associations with effect sizes and p-values (common-variant / MR support). " +
+            "Corpora to query in parallel. Default ALL applicable EXCEPT cbioportal — they carry different evidence types, and disagreement between them " +
+                "is itself informative. " +
+                "'gwas': the NHGRI-EBI GWAS Catalog — population SNP-trait associations with effect sizes and p-values (common-variant / MR support). " +
                 "'disgenet': curated + text-mined gene-disease associations scored 0–1, broadest coverage; needs DISGENET_API_KEY. " +
-                "'clinvar': clinically classified germline variants — pathogenicity and review status; rare/Mendelian rather than common-variant.",
+                "'clinvar': NCBI ClinVar — clinically classified germline variants, pathogenicity and review status; rare/Mendelian rather than " +
+                "common-variant. " +
+                "'cbioportal': the somatic half — how often the gene is mutated in each cancer type across every curated cBioPortal study, as " +
+                "cancerTypeName, mutatedSamples/totalSamples, frequency and the contributing studies. OPT IN by naming it: it scans every study, so it is " +
+                "several seconds slower than the rest, and it applies to queryType 'gene' only.",
         ),
     limit: z
         .number()
@@ -108,11 +156,12 @@ const inputSchema = z.object({
 
 interface GeneDiseaseEvidenceOutput {
     query: string;
-    queryType: "gene" | "disease" | "variant";
+    queryType: QueryType;
     perSource: SourceOutcome[];
     gwas?: GwasAssociation[];
     disgenet?: Gda[];
     clinvar?: ClinvarVariant[];
+    cbioportal?: MutationFrequency[];
 }
 
 /**
@@ -150,18 +199,22 @@ export function createGeneDiseaseEvidenceTool(deps: { ncbiApiKey?: string; disge
     return defineTool({
         id: "gene_disease_evidence",
         description:
-            "Genetic evidence linking a gene to a disease or trait, across the GWAS Catalog, DisGeNET and ClinVar in one call — 'is there human genetic " +
-            "support for this target in this indication?'. See `sources` for what each corpus carries.\n" +
+            "Genetic evidence linking a gene to a disease or trait, across the NHGRI-EBI GWAS Catalog, DisGeNET, NCBI ClinVar and cBioPortal in one call " +
+            "— 'is there human genetic support for this target in this indication?'. See `sources` for what each corpus carries.\n" +
             "For the integrated, pre-scored view prefer opentargets({action:'target'}) FIRST — it folds genetic association together with tractability " +
-            "and the drug landscape. Reach here for the underlying records: actual SNPs, effect sizes, scores and pathogenicity calls with their studies and PMIDs.\n" +
+            "and the drug landscape. Reach here for the underlying records: actual SNPs, effect sizes, scores, pathogenicity calls and somatic mutation " +
+            "frequencies with their studies and PMIDs.\n" +
+            "ACCEPTED IDENTIFIERS, each named by its `queryType`: a HUGO gene symbol or an Entrez ID ('PCSK9', '5008'); a disease or trait name or a UMLS " +
+            "CUI ('LDL cholesterol', 'C0006142'); a dbSNP rsID ('rs11591147'); a GWAS Catalog study accession ('GCST000392'); and a ClinVar accession " +
+            "('VCV000012345'). The last two read one record back by the accession that an earlier result of this same tool reported.\n" +
             "ALWAYS read `perSource` before concluding anything is absent. 'no_data' means that corpus genuinely has nothing; 'unavailable' means it " +
-            "could not be reached (a missing DISGENET_API_KEY lands here — tell the user and proceed with the other two); 'not_applicable' means that " +
+            "could not be reached (a missing DISGENET_API_KEY lands here — tell the user and proceed with the others); 'not_applicable' means that " +
             "corpus has no lookup for this queryType. Only 'no_data' is evidence of absence, and none is worth retrying unchanged.",
         inputSchema,
         describeCall: "none",
         execute: async (input) => {
             const applicable = applicableSources(input.queryType);
-            const requested = input.sources ?? applicable;
+            const requested = input.sources ?? defaultSources(input.queryType);
             const selected = requested.filter((s) => applicable.includes(s));
             const limit = input.limit ?? DEFAULT_LIMIT;
 
@@ -178,10 +231,10 @@ export function createGeneDiseaseEvidenceTool(deps: { ncbiApiKey?: string; disge
                     })),
             };
 
-            const [gwas, disgenet, clinvar] = await Promise.all([
+            const [gwas, disgenet, clinvar, cbioportal] = await Promise.all([
                 selected.includes("gwas")
                     ? runSource<GwasAssociation>("gwas", async () => {
-                          const searchType = input.queryType === "gene" ? "gene" : input.queryType === "disease" ? "trait" : "variant";
+                          const searchType = GWAS_SEARCH_TYPES[input.queryType]!;
                           const res = await searchGwasCatalog(input.query, searchType, {
                               limit,
                               ...(input.pValueThreshold !== undefined ? { pValueThreshold: input.pValueThreshold } : {}),
@@ -210,6 +263,12 @@ export function createGeneDiseaseEvidenceTool(deps: { ncbiApiKey?: string; disge
                           return { records: variants, totalFound: res.totalFound };
                       })
                     : null,
+                selected.includes("cbioportal")
+                    ? runSource<MutationFrequency>("cbioportal", async () => {
+                          const res = await getSomaticMutationFrequencies(input.query);
+                          return { records: res.rows.slice(0, limit), totalFound: res.rows.length };
+                      })
+                    : null,
             ]);
 
             if (gwas) {
@@ -223,6 +282,10 @@ export function createGeneDiseaseEvidenceTool(deps: { ncbiApiKey?: string; disge
             if (clinvar) {
                 output.perSource.push(clinvar.outcome);
                 output.clinvar = clinvar.records;
+            }
+            if (cbioportal) {
+                output.perSource.push(cbioportal.outcome);
+                output.cbioportal = cbioportal.records;
             }
 
             return ok(output);

--- a/harness/src/tools/bio/gene-preclinical-profile.ts
+++ b/harness/src/tools/bio/gene-preclinical-profile.ts
@@ -1,17 +1,20 @@
 /**
- * genePreclinicalProfile — the in-vivo preclinical picture of one gene: where
- * it is expressed at baseline (Bgee) and what removing it does to a mouse
- * (IMPC), behind one `include`.
+ * genePreclinicalProfile — the in-vivo picture of one gene: where it is
+ * expressed at baseline (Bgee), what removing it does to a mouse (IMPC), and
+ * what people who carry variation in it present with (Monarch, HPO), behind
+ * one `include`.
  *
- * The two halves share an input exactly — ONE human gene symbol, with the
- * per-species orthologs resolved internally — and answer one question between
- * them: is this target expressed where it needs to act, and is a model organism
- * a fair surrogate for it. They were two tools that were called as a pair.
+ * The three halves share an input exactly — ONE human gene symbol, with the
+ * per-species orthologs and the gene curie resolved internally — and answer one
+ * question between them: is this target expressed where it needs to act, is a
+ * model organism a fair surrogate for it, and what does losing it do to a
+ * person. The first two were two tools that were called as a pair.
  *
- * Neither source caps its own output: Bgee returns every annotated tissue per
- * species and IMPC every significant phenotype term, so both halves are trimmed
- * here rather than in the clients — the target-assessment collectors read the
- * same clients and legitimately want full fidelity for the dossier.
+ * No source caps its own output: Bgee returns every annotated tissue per
+ * species, IMPC every significant phenotype term, and Monarch every curated
+ * HPO annotation, so each half is trimmed here rather than in the clients — the
+ * target-assessment collectors read the same clients and legitimately want full
+ * fidelity for the dossier.
  */
 
 import { ok } from "neverthrow";
@@ -19,7 +22,9 @@ import { z } from "zod";
 
 import { defineTool } from "../define-tool.js";
 import { SUPPORTED_SPECIES, getMultiSpeciesExpression, type ExpressionRank, type SupportedSpecies, type TissueRow } from "../lib/bgee-client.js";
+import { resolveTarget } from "../lib/identifier-resolver.js";
 import { getKoPhenotypeProfile, type MpTerm, type ViabilityCall, type ViabilityCategory } from "../lib/impc-client.js";
+import { getGenePhenotypeProfile, type MonarchPhenotypeAssociation } from "../lib/monarch-client.js";
 
 /** Ordered weakest → strongest so `minRank` can be a numeric floor. */
 const RANK_ORDER: Record<ExpressionRank, number> = { absent: 0, low: 1, medium: 2, high: 3 };
@@ -46,6 +51,23 @@ interface ExpressionHalf {
     notFound: string[];
 }
 
+/**
+ * One curated human phenotype. The HPO ancestor closure of the source record
+ * is dropped here: it exists so a dossier collector can resolve an organ system
+ * by identifier, and it runs to hundreds of ids that a reader never uses.
+ */
+type HumanPhenotypeTerm = Omit<MonarchPhenotypeAssociation, "ancestorIds">;
+
+interface HumanPhenotypeHalf {
+    /** The curie Monarch was queried by, e.g. `HGNC:1100`; null when the symbol did not anchor on HGNC. */
+    geneCurie: string | null;
+    hpoTerms: HumanPhenotypeTerm[];
+    /** Curated HPO annotations before `phenotypeLimit`. */
+    phenotypeCount: number;
+    /** True when `phenotypeLimit` trimmed `hpoTerms`; `phenotypeCount` is the real total. */
+    phenotypesTrimmed: boolean;
+}
+
 interface KnockoutHalf {
     mouseMarkerSymbol: string | null;
     mgiAccessionId: string | null;
@@ -68,12 +90,14 @@ const inputSchema = z.object({
                 "orthologs are resolved for you.",
         ),
     include: z
-        .array(z.enum(["expression", "knockout"]))
+        .array(z.enum(["expression", "knockout", "phenotypes"]))
         .min(1)
         .optional()
         .describe(
-            "Default BOTH — two sides of one judgement, one request each. 'expression': Bgee baseline (healthy, untreated) expression per species and " +
-                "tissue. 'knockout': IMPC mouse loss-of-function phenotype.",
+            "Default ['expression','knockout'] — two sides of one judgement, one request each. 'expression': Bgee baseline (healthy, untreated) " +
+                "expression per species and tissue. 'knockout': IMPC mouse loss-of-function phenotype. 'phenotypes': the HUMAN counterpart — the curated " +
+                "HPO phenotypes that Monarch attributes to variation in this gene, from HPOA, OMIM and Orphanet, each with its PMIDs and the disease it " +
+                "was annotated under. Ask for it explicitly, and pair it with 'knockout' when the question is whether the mouse recapitulates the person.",
         ),
     species: z
         .array(z.enum(SUPPORTED_SPECIES))
@@ -107,8 +131,9 @@ const inputSchema = z.object({
         .max(200)
         .optional()
         .describe(
-            `'knockout' only. Max MP phenotype terms, best p-value first (default ${DEFAULTS.phenotypeLimit}, max 200). \`phenotypeCount\` gives the ` +
-                "true total; `organSystems` is never trimmed, so the top-line picture survives.",
+            `'knockout' and 'phenotypes'. Max phenotype terms per half — MP terms best p-value first, HPO terms in curation order (default ` +
+                `${DEFAULTS.phenotypeLimit}, max 200). Each half reports its own \`phenotypeCount\` for the true total; \`organSystems\` is never ` +
+                "trimmed, so the top-line knockout picture survives.",
         ),
 });
 
@@ -116,6 +141,7 @@ type PreclinicalOutput = {
     geneSymbol: string;
     expression?: ExpressionHalf;
     knockout?: KnockoutHalf;
+    phenotypes?: HumanPhenotypeHalf;
 };
 
 function boundExpression(raw: Awaited<ReturnType<typeof getMultiSpeciesExpression>>, minRank: ExpressionRank, tissueLimit: number): ExpressionHalf {
@@ -152,26 +178,56 @@ function boundKnockout(raw: Awaited<ReturnType<typeof getKoPhenotypeProfile>>, p
     };
 }
 
+/**
+ * Anchor the symbol on HGNC and read the curated human phenotypes. A symbol
+ * that anchors on no HGNC id gives a null curie and an empty term list, which
+ * is absence and not a failure.
+ */
+async function fetchHumanPhenotypes(geneSymbol: string, phenotypeLimit: number): Promise<HumanPhenotypeHalf> {
+    let geneCurie: string | null;
+    try {
+        geneCurie = (await resolveTarget(geneSymbol)).ids.hgnc;
+    } catch {
+        geneCurie = null;
+    }
+    if (!geneCurie) return { geneCurie: null, hpoTerms: [], phenotypeCount: 0, phenotypesTrimmed: false };
+
+    const profile = await getGenePhenotypeProfile(geneCurie);
+    return {
+        geneCurie: profile.geneCurie,
+        hpoTerms: profile.phenotypes.slice(0, phenotypeLimit).map(({ ancestorIds: _ancestorIds, ...term }) => term),
+        phenotypeCount: profile.phenotypes.length,
+        phenotypesTrimmed: profile.phenotypes.length > phenotypeLimit,
+    };
+}
+
 export const genePreclinicalProfileTool = defineTool({
     id: "gene_preclinical_profile",
     description:
-        "The in-vivo preclinical profile of ONE human gene — baseline expression (Bgee) and mouse-knockout phenotype (IMPC) in one call. Answers " +
-        "tissue-of-action ('where does this target act?'), model-organism suitability ('is the mouse a fair surrogate?') and essentiality ('what happens " +
-        "when this gene is lost?').\n" +
+        "The in-vivo profile of ONE human gene across three corpora in one call — baseline expression from Bgee, the mouse-knockout phenotype from IMPC " +
+        "(the International Mouse Phenotyping Consortium), and the curated human phenotypes from the Monarch Initiative (HPO terms sourced from HPOA, " +
+        "OMIM and Orphanet). Answers tissue-of-action ('where does this target act?'), model-organism suitability ('is the mouse a fair surrogate?'), " +
+        "essentiality ('what happens when this gene is lost?') and the human read-out ('what do people carrying variation in it present with?').\n" +
         "Expression is BASELINE (healthy, untreated) only — differential expression between conditions is the analysis pipeline's job, never this tool.\n" +
+        "ACCEPTED IDENTIFIERS: one HUMAN gene symbol, e.g. 'BRCA1'. The ENSG, the per-species orthologs and the HGNC curie are resolved for you; an " +
+        "Ensembl ID, a mouse symbol and an MGI ID are not accepted here — put those through search_gene first.\n" +
         "Output is trimmed by default (see `minRank`, `tissueLimit`, `phenotypeLimit`); the accompanying counts distinguish a trimmed list from a sparse one.\n" +
         "SPARSE OUTPUT IS VALID NO-DATA, not an error — do not retry. A null humanEnsemblId means the symbol did not resolve; a null mouseMarkerSymbol " +
-        "with no phenotype terms means the gene has not been IMPC-phenotyped, which is common.",
+        "with no phenotype terms means the gene has not been IMPC-phenotyped, which is common; an empty hpoTerms list means Monarch curates no human " +
+        "phenotype for the gene, and a null geneCurie means the symbol anchored on no HGNC id.",
     inputSchema,
     describeCall: "none",
     execute: async ({ geneSymbol, include, species, minRank, tissueLimit, phenotypeLimit }) => {
         const halves = include ?? ["expression", "knockout"];
         const wantExpression = halves.includes("expression");
         const wantKnockout = halves.includes("knockout");
+        const wantPhenotypes = halves.includes("phenotypes");
+        const termLimit = phenotypeLimit ?? DEFAULTS.phenotypeLimit;
 
-        const [expressionRaw, knockoutRaw] = await Promise.all([
+        const [expressionRaw, knockoutRaw, phenotypesHalf] = await Promise.all([
             wantExpression ? getMultiSpeciesExpression(geneSymbol, [...(species ?? DEFAULT_SPECIES)]) : Promise.resolve(null),
             wantKnockout ? getKoPhenotypeProfile(geneSymbol) : Promise.resolve(null),
+            wantPhenotypes ? fetchHumanPhenotypes(geneSymbol, termLimit) : Promise.resolve(null),
         ]);
 
         const output: PreclinicalOutput = { geneSymbol };
@@ -179,7 +235,10 @@ export const genePreclinicalProfileTool = defineTool({
             output.expression = boundExpression(expressionRaw, minRank ?? DEFAULTS.minRank, tissueLimit ?? DEFAULTS.tissueLimit);
         }
         if (knockoutRaw) {
-            output.knockout = boundKnockout(knockoutRaw, phenotypeLimit ?? DEFAULTS.phenotypeLimit);
+            output.knockout = boundKnockout(knockoutRaw, termLimit);
+        }
+        if (phenotypesHalf) {
+            output.phenotypes = phenotypesHalf;
         }
         return ok(output);
     },

--- a/harness/src/tools/bio/lookup-annotation.ts
+++ b/harness/src/tools/bio/lookup-annotation.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 
 import { defineTool, type ToolError } from "../define-tool.js";
 import { apiFetchValidated, describeApiError } from "../lib/api-utils.js";
-import { searchPathways, type Pathway } from "../lib/pathway-client.js";
+import { getPathwayById, searchPathways, type Pathway } from "../lib/pathway-client.js";
 
 const QUICKGO_BASE = "https://www.ebi.ac.uk/QuickGO/services";
 const HEADERS = { Accept: "application/json" };
@@ -102,15 +102,24 @@ const inputSchema = z
             .describe(
                 "'go' — Gene Ontology via QuickGO (EBI); needs ONE of goId, query, or geneProductId. Returns terms[] { id, name, definition, aspect } " +
                     "and/or annotations[] { geneProductId, goId, goName, aspect, evidenceCode, qualifier }. " +
-                    "'kegg' / 'reactome' — one pathway database; needs query. 'pathways' — both, in parallel; needs query. " +
-                    "Returns pathways[] { id, name, source, url, genes? }.",
+                    "'kegg' / 'reactome' — one pathway database; needs query or pathwayId. 'pathways' — both, in parallel; needs query or pathwayId. " +
+                    "Returns pathways[] { id, name, source, url, description?, genes? }.",
             ),
         query: z
             .string()
             .min(1)
             .optional()
             .describe(
-                "Free-text term. Required for the pathway vocabularies ('apoptosis', 'MAPK signaling'); for 'go' it is one of the three accepted inputs.",
+                "Free-text term. Required for the pathway vocabularies ('apoptosis', 'MAPK signaling') unless pathwayId is given; for 'go' it is one of " +
+                    "the three accepted inputs.",
+            ),
+        pathwayId: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+                "Pathway vocabularies only. ONE pathway identifier, read back exactly as a search returned it — a Reactome stable ID ('R-HSA-109581') " +
+                    "or a KEGG pathway ID ('hsa04010'). The prefix picks the database, so `vocabulary` and `organism` are ignored for it.",
             ),
         goId: z
             .string()
@@ -135,9 +144,13 @@ const inputSchema = z
             .optional()
             .describe(`Max records per vocabulary queried (default ${DEFAULT_LIMIT}, max 100); with 'pathways' it applies to KEGG and Reactome separately.`),
     })
-    .refine((d) => d.vocabulary === "go" || (d.query !== undefined && d.query.trim().length > 0), {
-        message: "query is required for vocabulary 'kegg', 'reactome' and 'pathways' — the pathway term to search for",
+    .refine((d) => d.vocabulary === "go" || (d.query !== undefined && d.query.trim().length > 0) || (d.pathwayId !== undefined && d.pathwayId.length > 0), {
+        message: "vocabulary 'kegg', 'reactome' and 'pathways' need query (the pathway term to search for) or pathwayId (one 'R-HSA-…' or 'hsa…' identifier)",
         path: ["query"],
+    })
+    .refine((d) => d.vocabulary !== "go" || d.pathwayId === undefined, {
+        message: "pathwayId belongs to the pathway vocabularies — vocabulary 'go' takes goId instead",
+        path: ["pathwayId"],
     })
     .refine((d) => d.vocabulary !== "go" || d.goId !== undefined || d.query !== undefined || d.geneProductId !== undefined, {
         message: "vocabulary 'go' needs at least one of goId (term by ID), query (free-text term search), or geneProductId (a protein's annotations)",
@@ -157,17 +170,34 @@ type AnnotationOutput = { terms?: GoTerm[]; annotations?: GoAnnotation[] } | { p
 export const lookupAnnotationTool = defineTool({
     id: "lookup_annotation",
     description:
-        "Functional annotation for a gene, protein or term — Gene Ontology (QuickGO) and the pathway databases (KEGG, Reactome) behind one `vocabulary`. " +
-        "Names what a gene is known to do, resolves a GO or pathway identifier, or finds the pathways a term belongs to.\n" +
+        "Functional annotation for a gene, protein or term — the Gene Ontology (through EBI QuickGO) and the pathway databases KEGG and Reactome, behind " +
+        "one `vocabulary`. Names what a gene is known to do, resolves a GO or pathway identifier, or finds the pathways a term belongs to.\n" +
+        "ACCEPTED IDENTIFIERS: a GO term ID ('GO:0008150'), a UniProt accession for a protein's annotations ('P04637'), an NCBI Taxon ID ('9606'), a " +
+        "Reactome stable ID ('R-HSA-109581'), a KEGG pathway ID ('hsa04010'), and free text for any of the vocabularies ('apoptosis').\n" +
         "This is annotation LOOKUP, not enrichment: to test whether a gene SET is over-represented in GO/KEGG/Reactome terms use " +
         "search_interactions({action:'enrichment'}), which does the statistics.\n" +
-        "An empty terms / annotations / pathways array is valid no-data — do not retry the same input.",
+        "An empty terms / annotations / pathways array is valid no-data — report it and continue, do not retry the same input. An empty pathways array " +
+        "for a pathwayId means neither database holds that identifier.",
     inputSchema,
     describeCall: "none",
-    execute: async ({ vocabulary, query, goId, geneProductId, taxonId, organism, includeGenes, limit }): Promise<Result<AnnotationOutput, ToolError>> => {
+    execute: async ({
+        vocabulary,
+        query,
+        pathwayId,
+        goId,
+        geneProductId,
+        taxonId,
+        organism,
+        includeGenes,
+        limit,
+    }): Promise<Result<AnnotationOutput, ToolError>> => {
         const cap = limit ?? DEFAULT_LIMIT;
 
         if (vocabulary !== "go") {
+            if (pathwayId) {
+                const pathway = await getPathwayById(pathwayId);
+                return ok({ pathways: pathway ? [pathway] : [] });
+            }
             const pathways = await searchPathways(query!, {
                 source: vocabulary === "pathways" ? "both" : vocabulary,
                 organism: organism ?? "hsa",

--- a/harness/src/tools/bio/opentargets.test.ts
+++ b/harness/src/tools/bio/opentargets.test.ts
@@ -201,6 +201,44 @@ describe("opentargets — action 'disease'", () => {
     });
 });
 
+describe("opentargets — action 'resolve_disease'", () => {
+    it("turns a plain disease name into the ids the 'disease' action accepts", async () => {
+        const seen = stubOpenTargets(() =>
+            gqlResponse({
+                search: {
+                    total: 2,
+                    hits: [
+                        { id: "MONDO_0005148", name: "type 2 diabetes mellitus", description: "A type of diabetes mellitus." },
+                        { id: "EFO_0004541", name: "HbA1c measurement", description: null },
+                    ],
+                },
+            }),
+        );
+
+        const { ctx } = makeToolContext();
+        const result = (await openTargetsTool.execute({ action: "resolve_disease", diseaseName: "type 2 diabetes", limit: 5 }, ctx))._unsafeUnwrap();
+
+        expect(seen[0]!.operation).toBe("DiseaseSearch");
+        expect(seen[0]!.variables).toMatchObject({ queryString: "type 2 diabetes", size: 5 });
+        expect(result).toEqual({
+            totalFound: 2,
+            candidates: [
+                { id: "MONDO_0005148", name: "type 2 diabetes mellitus", description: "A type of diabetes mellitus." },
+                { id: "EFO_0004541", name: "HbA1c measurement", description: null },
+            ],
+        });
+    });
+
+    it("returns an empty candidate list for a name that matches no disease", async () => {
+        stubOpenTargets(() => gqlResponse({ search: { total: 0, hits: [] } }));
+
+        const { ctx } = makeToolContext();
+        const result = (await openTargetsTool.execute({ action: "resolve_disease", diseaseName: "not a disease" }, ctx))._unsafeUnwrap();
+
+        expect(result).toEqual({ totalFound: 0, candidates: [] });
+    });
+});
+
 describe("opentargets — input validation", () => {
     it("emits a flat object schema whose only required field is the discriminator", () => {
         expect(openTargetsTool.jsonSchema.type).toBe("object");
@@ -226,6 +264,21 @@ describe("opentargets — input validation", () => {
 
     it("rejects a 'target' whose ensemblId is blank", () => {
         expect(openTargetsTool.inputSchema.safeParse({ action: "target", ensemblId: "  " }).success).toBe(false);
+    });
+
+    it("rejects 'resolve_disease' with no diseaseName", () => {
+        const parsed = openTargetsTool.inputSchema.safeParse({ action: "resolve_disease" });
+
+        expect(parsed.success).toBe(false);
+        const message = parsed.success ? "" : parsed.error.issues.map((i) => i.message).join(" ");
+        expect(message).toContain("diseaseName is required");
+    });
+
+    it("points a missing efoId at the resolver rather than leaving the caller stuck", () => {
+        const parsed = openTargetsTool.inputSchema.safeParse({ action: "disease" });
+
+        const message = parsed.success ? "" : parsed.error.issues.map((i) => i.message).join(" ");
+        expect(message).toContain("resolve_disease");
     });
 
     it("rejects 'disease' with no efoId, naming the identifier it needs", () => {

--- a/harness/src/tools/bio/opentargets.ts
+++ b/harness/src/tools/bio/opentargets.ts
@@ -17,29 +17,53 @@
  * gene ID or an EFO disease ID, and a gene symbol silently returns an empty
  * result rather than an error. Naming the two identifiers apart is what makes
  * that contract visible at the call site.
+ *
+ * `resolve_disease` closes that contract. It takes the plain disease name a
+ * user supplies and returns the disease ids of the same corpus, thus the
+ * caller never has to know an ontology id before it can ask a question.
  */
 
 import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
 import { defineTool, type ToolError } from "../define-tool.js";
-import { searchDiseaseAssociations, searchTargetAssociations, type Association, type TargetInfo } from "../lib/opentargets-client.js";
+import {
+    searchDiseaseAssociations,
+    searchDiseases,
+    searchTargetAssociations,
+    type Association,
+    type DiseaseCandidate,
+    type TargetInfo,
+} from "../lib/opentargets-client.js";
 
 const DEFAULT_LIMIT = 10;
 
 const inputSchema = z
     .object({
         action: z
-            .enum(["target", "disease"])
+            .enum(["target", "disease", "resolve_disease"])
             .describe(
                 "'target' (needs ensemblId) — the diseases associated with the gene: targetInfo (approvedSymbol, approvedName, " +
                     "tractability across small molecule / antibody / other modalities) plus associations[], each with an overall score and " +
                     "its per-datatype breakdown — genetic association, known drug, literature, animal model, somatic mutation. " +
                     "'disease' (needs efoId) — the targets ranked for that disease; each association carries targetId/targetSymbol/targetName " +
-                    "and the same score breakdown.",
+                    "and the same score breakdown. " +
+                    "'resolve_disease' (needs diseaseName) — the disease-name resolver: a plain name ('type 2 diabetes', 'asthma') comes back as " +
+                    "candidates[] { id, name, description }, best match first. Take the id of the row whose name you meant and pass it as efoId.",
             ),
         ensemblId: z.string().optional().describe("Ensembl gene ID, e.g. ENSG00000141510 (TP53). Required for action 'target'."),
-        efoId: z.string().optional().describe("EFO disease ID, e.g. EFO_0000311. Required for action 'disease'."),
+        efoId: z
+            .string()
+            .optional()
+            .describe(
+                "Open Targets disease ID, e.g. EFO_0000311, MONDO_0005148 or HP_0001250. Required for action 'disease'. Get one from " +
+                    "action 'resolve_disease', or from the diseaseId of an action 'target' association.",
+            ),
+        diseaseName: z
+            .string()
+            .min(1)
+            .optional()
+            .describe("Required for action 'resolve_disease'. A plain disease or trait name, e.g. 'type 2 diabetes'. No ontology id, no synonym list."),
         limit: z
             .number()
             .int()
@@ -48,7 +72,8 @@ const inputSchema = z
             .optional()
             .describe(
                 `Max associations to return (default ${DEFAULT_LIMIT}, max 100), ordered by DESCENDING association score. The default is the top ` +
-                    `${DEFAULT_LIMIT}, which is where the evidence is; raise it only when you are surveying the long tail rather than ranking.`,
+                    `${DEFAULT_LIMIT}, which is where the evidence is; raise it only when you are surveying the long tail rather than ranking. ` +
+                    "For action 'resolve_disease' it caps the candidate rows instead.",
             ),
     })
     .refine((d) => d.action !== "target" || (d.ensemblId !== undefined && d.ensemblId.trim().length > 0), {
@@ -58,22 +83,33 @@ const inputSchema = z
         path: ["ensemblId"],
     })
     .refine((d) => d.action !== "disease" || (d.efoId !== undefined && d.efoId.trim().length > 0), {
-        message: "efoId is required when action is 'disease' — Open Targets accepts only EFO disease IDs (e.g. EFO_0000311), never free-text disease names.",
+        message:
+            "efoId is required when action is 'disease' — Open Targets accepts only a disease ID (e.g. EFO_0000311), never a free-text disease name. " +
+            "Call action='resolve_disease' with the name to get the ID, then retry.",
         path: ["efoId"],
+    })
+    .refine((d) => d.action !== "resolve_disease" || (d.diseaseName !== undefined && d.diseaseName.trim().length > 0), {
+        message: "diseaseName is required when action is 'resolve_disease' — the plain disease or trait name to resolve.",
+        path: ["diseaseName"],
     });
 
-type OpenTargetsOutput = { targetInfo: TargetInfo | null; associations: Association[] } | { associations: Association[] };
+type OpenTargetsOutput =
+    { targetInfo: TargetInfo | null; associations: Association[] } | { associations: Association[] } | { totalFound: number; candidates: DiseaseCandidate[] };
 
 export const openTargetsTool = defineTool({
     id: "opentargets",
     description:
-        "Query the Open Targets Platform — the preferred FIRST call for target assessment, since one 'target' query yields the genetic evidence, " +
-        "tractability, and drug landscape together, already scored and ranked. See the action parameter for what each mode needs and returns.\n" +
-        "It is the integrated view; the underlying records live elsewhere. For the raw genetic evidence (individual SNPs, effect sizes, GDA scores, " +
-        "variant pathogenicity) use gene_disease_evidence. For this target's mechanism-based safety liabilities use target_safety.\n" +
-        "IDENTIFIERS ONLY: it accepts an Ensembl gene ID (action 'target') or an EFO disease ID (action 'disease'). A bare gene symbol or a free-text " +
-        "disease name silently returns an EMPTY result rather than an error — resolve a symbol to its ENSG id with search_gene first.\n" +
-        "NO-DATA IS FINAL — do not retry the same id. Empty associations mean no evidence, or an unresolvable id.",
+        "Query the Open Targets Platform — the integrated target-disease evidence corpus of EMBL-EBI, GSK and their partners — the preferred FIRST call " +
+        "for target assessment, since one 'target' query yields the genetic evidence, tractability, and drug landscape together, already scored and " +
+        "ranked. See the action parameter for what each mode needs and returns.\n" +
+        "It is the integrated view; the underlying records live elsewhere. For the raw genetic evidence (individual SNPs from the GWAS Catalog, DisGeNET " +
+        "GDA scores, ClinVar variant pathogenicity) use gene_disease_evidence. For this target's mechanism-based safety liabilities use target_safety.\n" +
+        "ACCEPTED IDENTIFIERS: an Ensembl gene ID for action 'target' (ENSG00000141510); an Open Targets disease ID for action 'disease' — EFO " +
+        "(EFO_0000311), MONDO (MONDO_0005148) or HP (HP_0001250), because Open Targets keys a disease on EFO and EFO imports the other two; and a plain " +
+        "disease NAME for action 'resolve_disease' ('type 2 diabetes'), which is how you obtain that disease ID. A bare gene symbol is NOT accepted by " +
+        "action 'target' and silently returns an empty result — resolve it to its ENSG id with search_gene first.\n" +
+        "NO-DATA IS FINAL — do not retry the same id. Empty associations mean no evidence, or an id the platform does not hold. An empty candidates " +
+        "list means the name matched no disease: rephrase it, do not invent an id.",
     inputSchema,
     describeCall: "none",
     execute: async (input): Promise<Result<OpenTargetsOutput, ToolError>> => {
@@ -86,6 +122,10 @@ export const openTargetsTool = defineTool({
             case "disease": {
                 const associations = await searchDiseaseAssociations(input.efoId!, limit);
                 return ok({ associations });
+            }
+            case "resolve_disease": {
+                const { total, candidates } = await searchDiseases(input.diseaseName!, limit);
+                return ok({ totalFound: total, candidates });
             }
         }
     },

--- a/harness/src/tools/bio/preclinical.test.ts
+++ b/harness/src/tools/bio/preclinical.test.ts
@@ -119,6 +119,88 @@ describe("genePreclinicalProfile — knockout half", () => {
     });
 });
 
+describe("genePreclinicalProfile — human phenotype half", () => {
+    /** Anchor the symbol on HGNC, then serve Monarch's HPO annotations for that curie. */
+    const PHENOTYPE_ROUTES: Array<[string, () => Response]> = [
+        ["genenames.org", () => geneDocs([{ symbol: "BRCA1", name: "BRCA1 DNA repair associated", hgnc_id: "HGNC:1100", uniprot_ids: ["P38398"] }])],
+        ["uniprot.org", () => json({ results: [{ primaryAccession: "P38398", genes: [{ geneName: { value: "BRCA1" } }] }] })],
+        ["ebi.ac.uk/chembl", () => json({ targets: [] })],
+        ["rest.ensembl.org", () => json({ id: "ENSG00000012048" })],
+        [
+            "monarchinitiative.org",
+            () =>
+                json({
+                    items: [
+                        {
+                            subject_taxon: "NCBITaxon:9606",
+                            object: "HP:0003002",
+                            object_label: "Breast carcinoma",
+                            object_closure: ["HP:0000001", "HP:0002664"],
+                            publications: ["PMID:12345678"],
+                            disease_context_qualifier: "MONDO:0007254",
+                            has_percentage: 60,
+                        },
+                        { subject_taxon: "NCBITaxon:10090", object: "MP:0001392", object_label: "a mouse term" },
+                    ],
+                }),
+        ],
+    ];
+
+    it("returns the curated human phenotypes, without the ancestor closure", async () => {
+        stubFetch(PHENOTYPE_ROUTES);
+
+        const { ctx } = makeToolContext();
+        const result = (await genePreclinicalProfileTool.execute({ geneSymbol: "BRCA1", include: ["phenotypes"] }, ctx))._unsafeUnwrap();
+
+        expect(result.phenotypes!.geneCurie).toBe("HGNC:1100");
+        expect(result.phenotypes!.phenotypeCount).toBe(1);
+        expect(result.phenotypes!.hpoTerms[0]).toEqual({
+            hpoId: "HP:0003002",
+            label: "Breast carcinoma",
+            publications: ["PMID:12345678"],
+            diseaseContext: "MONDO:0007254",
+            frequencyPercent: 60,
+            primaryKnowledgeSource: null,
+        });
+        expect(result.expression).toBeUndefined();
+        expect(result.knockout).toBeUndefined();
+    });
+
+    it("reports a symbol that anchors on no HGNC id as a null curie, not an error", async () => {
+        stubFetch([
+            ["genenames.org", () => geneDocs([])],
+            ["uniprot.org", () => json({ results: [] })],
+            ["ebi.ac.uk/chembl", () => json({ targets: [] })],
+            ["rest.ensembl.org", () => json({ id: "" })],
+        ]);
+
+        const { ctx } = makeToolContext();
+        const result = (await genePreclinicalProfileTool.execute({ geneSymbol: "NOTAGENE", include: ["phenotypes"] }, ctx))._unsafeUnwrap();
+
+        expect(result.phenotypes).toEqual({ geneCurie: null, hpoTerms: [], phenotypeCount: 0, phenotypesTrimmed: false });
+    });
+
+    it("stays out of the default include set", async () => {
+        const seen: string[] = [];
+        globalThis.fetch = (async (url: string | URL) => {
+            const u = String(url);
+            seen.push(u);
+            if (u.includes("ensembl")) return json({ id: "ENSG00000012048" });
+            if (u.includes("bgee")) return json({ data: { calls: [] } });
+            for (const [needle, make] of IMPC_ROUTES) {
+                if (u.includes(needle)) return make();
+            }
+            return new Response("unrouted", { status: 404 });
+        }) as typeof fetch;
+
+        const { ctx } = makeToolContext();
+        const result = (await genePreclinicalProfileTool.execute({ geneSymbol: "BRCA1" }, ctx))._unsafeUnwrap();
+
+        expect(result.phenotypes).toBeUndefined();
+        expect(seen.some((u) => u.includes("monarchinitiative.org"))).toBe(false);
+    });
+});
+
 describe("genePreclinicalProfile — both halves", () => {
     it("fetches expression and knockout together by default", async () => {
         const seen: string[] = [];

--- a/harness/src/tools/bio/preclinical.test.ts
+++ b/harness/src/tools/bio/preclinical.test.ts
@@ -197,7 +197,7 @@ describe("genePreclinicalProfile — human phenotype half", () => {
         const result = (await genePreclinicalProfileTool.execute({ geneSymbol: "BRCA1" }, ctx))._unsafeUnwrap();
 
         expect(result.phenotypes).toBeUndefined();
-        expect(seen.some((u) => u.includes("monarchinitiative.org"))).toBe(false);
+        expect(seen.some((u) => new URL(u).hostname === "api-v3.monarchinitiative.org")).toBe(false);
     });
 });
 

--- a/harness/src/tools/bio/pubchem.ts
+++ b/harness/src/tools/bio/pubchem.ts
@@ -93,8 +93,11 @@ type PubchemOutput = { results: PubChemCompound[] } | { crossRefs: PubChemCrossR
 export const pubchemTool = defineTool({
     id: "pubchem",
     description:
-        "Query PubChem (110M+ compounds) — pick the lookup with `action`: 'compound' (resolve an identifier), 'crossrefs' (external registry ids for a CID), 'assays' (bioassay screening " +
-        "summaries for a CID). See `action` for what each returns. " +
+        "Query PubChem — the open chemical database of the NCBI, with over 110M compounds and their BioAssay screening records. Pick the lookup with " +
+        "`action`: 'compound' (resolve an identifier), 'crossrefs' (external registry ids for a CID), 'assays' (bioassay screening summaries for a CID). " +
+        "See `action` for what each returns. " +
+        "ACCEPTED IDENTIFIERS: for 'compound', the form named by `searchBy` — a chemical name ('aspirin'), a SMILES string, an InChI, an InChIKey " +
+        "('BSYNRYMUTXBXSQ-UHFFFAOYSA-N') or a numeric CID ('2244'). 'crossrefs' and 'assays' take the numeric CID only. " +
         "Reach for PubChem when ChEMBL misses the compound — it covers metabolites, vendor chemicals, food additives and environmental compounds that ChEMBL does not. " +
         "PubChem carries no curated mechanism or potency data, so resolve broadly HERE and then bridge OUT: action 'compound' to get the cid, action 'crossrefs' to take its ChEMBL ID, " +
         "then chembl action='mechanism' / 'bioactivity' there for curated activity data. " +

--- a/harness/src/tools/bio/pubmed.ts
+++ b/harness/src/tools/bio/pubmed.ts
@@ -148,12 +148,18 @@ export function createPubMedTool(deps: { ncbiApiKey?: string }) {
     return defineTool({
         id: "pubmed",
         description:
-            "Search and read the biomedical literature via PubMed / PubMed Central (NCBI E-utilities). The three actions form a chain " +
-            "— search, then details on the relevant hits, then fulltext; see the action parameter for what each needs and returns. Read " +
+            "Search and read the biomedical literature in PubMed and PubMed Central — the MEDLINE citation index and the open-access full-text archive of " +
+            "the U.S. National Library of Medicine, through the NCBI E-utilities. The three actions form a chain " +
+            "— search, then details on the relevant hits, then fulltext; see the action parameter for what each needs and returns.\n" +
+            "ACCEPTED IDENTIFIERS: an Entrez free-text query with optional field tags for 'search' ('PCSK9[Title] AND 2020:2024[dp]'); PMIDs for " +
+            "'details' ('34567890'); and a PMID or a PMC ID for 'fulltext' ('PMC7096066'). For literature outside MEDLINE — a method, a model, a " +
+            "preprint — use search_semantic_scholar or search_arxiv instead.\n" +
+            "Read " +
             "fulltext sparingly — only where the 'details' abstract is not enough, and only for articles that have a pmcId (open-access). " +
             "A full article is larger than everything else this tool returns combined, so it comes back trimmed to a character budget: take the " +
             "`outline` from the first call and re-request the specific `sections` you need rather than raising maxChars. " +
-            "available: false is an expected outcome, not an error — do not retry it.",
+            "An empty result set and available: false are expected outcomes, not errors — an article with no PMC record simply has no open full text. " +
+            "Report it and continue, do not retry it.",
         inputSchema,
         // One tool, three jobs. The action alone would still render three
         // different searches identically, so each action names its own subject:

--- a/harness/src/tools/bio/search-clinical-trials.ts
+++ b/harness/src/tools/bio/search-clinical-trials.ts
@@ -1,58 +1,111 @@
 /**
- * searchClinicalTrials — search ClinicalTrials.gov for clinical trials.
+ * searchClinicalTrials — search ClinicalTrials.gov for clinical trials, and
+ * read one study back by the NCT id that a search returns.
+ *
+ * The input is a flat object with an `action` discriminator — not a
+ * `z.discriminatedUnion`, which `defineTool` rejects (model tool calling needs
+ * a top-level `"type":"object"`). `action` defaults to 'search', thus the
+ * common call stays a query and nothing more.
  */
 
-import { ok } from "neverthrow";
+import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
-import { defineTool } from "../define-tool.js";
-import { searchTrials } from "../lib/clinical-trials-client.js";
+import { defineTool, type ToolError } from "../define-tool.js";
+import { getTrialDetails, searchTrials, type ClinicalTrial, type TrialDetails } from "../lib/clinical-trials-client.js";
 
 /** briefSummary preview length when `includeSummaries` is off. */
 const SUMMARY_PREVIEW_CHARS = 300;
 
+/** A listed trial keeps the full record, or the preview shape that trims it. */
+type TrialListRow = ClinicalTrial | (Omit<ClinicalTrial, "detailedDescription"> & { summaryTruncated: boolean });
+
+/** One result shape per action — the key names the records it carries. */
+type ClinicalTrialsOutput = { trial: TrialDetails | null } | { totalFound: number; trials: TrialListRow[] };
+
 export const searchClinicalTrialsTool = defineTool({
     id: "search_clinical_trials",
     description:
-        "Search ClinicalTrials.gov to map the clinical development landscape for a target, drug, or indication — what is being tried, at what phase, by whom, and what stopped. " +
-        "Returns totalFound plus per trial: NCT ID, title, status, phase, conditions, interventions, enrollment, start and completion dates, sponsor, whyStopped " +
-        "(the termination reason, when there is one) and a briefSummary preview — set includeSummaries for the full protocol prose. " +
-        "`query` is free text matched across the whole study record, so a gene symbol, a drug name, a condition, or an NCT ID all work. " +
-        "`phase` and `status` are optional server-side filters — omit them to see the full landscape; totalFound reports the true match count even when it exceeds the page returned. " +
-        "An empty trials array is a valid 'nothing matched' (often an over-narrow filter) — do not retry the identical query.",
-    inputSchema: z.object({
-        query: z.string().describe("Free-text search term: condition name, drug/intervention name, gene symbol, or an NCT ID."),
-        phase: z
-            .enum(["EARLY_PHASE1", "PHASE1", "PHASE2", "PHASE3", "PHASE4"])
-            .optional()
-            .describe(
-                "Optional exact phase filter. Omit for all phases (observational and expanded-access studies carry no phase and are excluded when this is set).",
-            ),
-        status: z
-            .enum(["RECRUITING", "ACTIVE_NOT_RECRUITING", "COMPLETED", "NOT_YET_RECRUITING"])
-            .optional()
-            .describe(
-                "Optional recruitment-status filter. Omit for all statuses — note TERMINATED/WITHDRAWN trials are not selectable here and appear only in an unfiltered search.",
-            ),
-        limit: z
-            .number()
-            .int()
-            .min(1)
-            .max(50)
-            .default(10)
-            .describe("Max trials to return (default 10, max 50). totalFound reports the true match count regardless."),
-        includeSummaries: z
-            .boolean()
-            .default(false)
-            .describe(
-                "Default FALSE — briefSummary comes back as a 300-character preview and detailedDescription is omitted, which is enough to map a " +
-                    "landscape. Set true for the full protocol prose, and narrow `limit` when you do: a full summary runs to several thousand characters " +
-                    "per trial.",
-            ),
-    }),
+        "Search ClinicalTrials.gov — the trial registry of the U.S. National Library of Medicine, which holds interventional and observational studies " +
+        "worldwide — to map the clinical development landscape for a target, drug, or indication: what is being tried, at what phase, by whom, and what " +
+        "stopped.\n" +
+        "action 'search' (the default) returns totalFound plus per trial: NCT ID, title, status, phase, conditions, interventions, enrollment, start and " +
+        "completion dates, sponsor, whyStopped (the termination reason, when there is one) and a briefSummary preview — set includeSummaries for the full " +
+        "protocol prose.\n" +
+        "action 'details' takes ONE nctId and returns that study in full: the same trial record plus outcomes[] (each primary/secondary/other outcome " +
+        "measure with its numeric effect where the sponsor posted results) and the reported adverse events with their per-arm counts. This is how you " +
+        "read a result, as opposed to finding a trial.\n" +
+        "ACCEPTED IDENTIFIERS: `query` is free text matched across the whole study record, so a gene symbol ('KRAS'), a drug or brand name ('imatinib', " +
+        "'Gleevec'), a condition ('melanoma') or an NCT ID ('NCT00000102') all work. `nctId` takes one NCT ID and nothing else.\n" +
+        "`phase` and `status` are optional server-side filters — omit them to see the full landscape; totalFound reports the true match count even when it " +
+        "exceeds the page returned.\n" +
+        "ABSENCE IS NORMAL. An empty trials array is a valid 'nothing matched' (often an over-narrow filter) and a null trial from 'details' means the " +
+        "registry holds no such NCT ID — report it and move on, do not retry the identical call. A trial with no posted results carries empty outcomes " +
+        "and adverse events, which means unreported, never zero.",
+    inputSchema: z
+        .object({
+            action: z
+                .enum(["search", "details"])
+                .default("search")
+                .describe("'search' (default) — find trials with `query`. 'details' — read one trial, with its outcomes and adverse events, by `nctId`."),
+            query: z.string().optional().describe("Required for 'search'. Free-text search term: condition name, drug/brand name, gene symbol, or an NCT ID."),
+            nctId: z
+                .string()
+                .optional()
+                .describe("Required for 'details'. One ClinicalTrials.gov registry ID, e.g. 'NCT00000102' — exactly as the nctId field of a search result."),
+            phase: z
+                .enum(["EARLY_PHASE1", "PHASE1", "PHASE2", "PHASE3", "PHASE4"])
+                .optional()
+                .describe(
+                    "'search' only. Optional exact phase filter. Omit for all phases (observational and expanded-access studies carry no phase and are " +
+                        "excluded when this is set).",
+                ),
+            status: z
+                .enum(["RECRUITING", "ACTIVE_NOT_RECRUITING", "COMPLETED", "NOT_YET_RECRUITING", "TERMINATED", "WITHDRAWN", "SUSPENDED"])
+                .optional()
+                .describe(
+                    "'search' only. Optional recruitment-status filter. Omit for all statuses. TERMINATED (stopped early), WITHDRAWN (stopped before " +
+                        "enrollment) and SUSPENDED are the attrition record — filter on one of them to ask what failed, and read whyStopped for the reason.",
+                ),
+            limit: z
+                .number()
+                .int()
+                .min(1)
+                .max(50)
+                .default(10)
+                .describe("'search' only. Max trials to return (default 10, max 50). totalFound reports the true match count regardless."),
+            includeSummaries: z
+                .boolean()
+                .default(false)
+                .describe(
+                    "'search' only. Default FALSE — briefSummary comes back as a 300-character preview and detailedDescription is omitted, which is enough " +
+                        "to map a landscape. Set true for the full protocol prose, and narrow `limit` when you do: a full summary runs to several thousand " +
+                        "characters per trial.",
+                ),
+        })
+        .refine((d) => d.action === "details" || (d.query !== undefined && d.query.trim().length > 0), {
+            message: "query is required when action is 'search' — the free text to match across the study records.",
+            path: ["query"],
+        })
+        .refine((d) => d.action !== "details" || (d.nctId !== undefined && d.nctId.trim().length > 0), {
+            message: "nctId is required when action is 'details' — one NCT ID, e.g. 'NCT00000102'. Find one with action 'search'.",
+            path: ["nctId"],
+        }),
     describeCall: "none",
-    execute: async ({ query, phase, status, limit = 10, includeSummaries = false }) => {
-        const result = await searchTrials(query, { phase, status, limit });
+    execute: async ({
+        action = "search",
+        query,
+        nctId,
+        phase,
+        status,
+        limit = 10,
+        includeSummaries = false,
+    }): Promise<Result<ClinicalTrialsOutput, ToolError>> => {
+        if (action === "details") {
+            return ok({ trial: await getTrialDetails(nctId!) });
+        }
+
+        const result = await searchTrials(query!, { phase, status, limit });
         const trials = includeSummaries
             ? result.trials
             : result.trials.map(({ detailedDescription: _detailedDescription, ...trial }) => ({

--- a/harness/src/tools/bio/search-faers.ts
+++ b/harness/src/tools/bio/search-faers.ts
@@ -1,40 +1,110 @@
 /**
- * searchFaers — search FDA FAERS for adverse event reports for a drug.
+ * searchFaers — one tool over the two openFDA drug corpora: the FAERS
+ * spontaneous adverse-event reports and the Structured Product Labels.
+ *
+ * The three actions answer one question between them — what is known about
+ * the post-market safety of this molecule. `adverse_events` ranks the reported
+ * reactions, `seriousness` counts the outcome flags behind them, and `label`
+ * gives the regulatory answer: the boxed warning, the Section 5 warnings, and
+ * whether a REMS program constrains the drug.
+ *
+ * The input is a flat object with an `action` discriminator — not a
+ * `z.discriminatedUnion`, which `defineTool` rejects (model tool calling needs
+ * a top-level `"type":"object"`).
  */
 
-import { ok } from "neverthrow";
+import { ok, type Result } from "neverthrow";
 import { z } from "zod";
 
-import { defineTool } from "../define-tool.js";
-import { getFaersByDrug } from "../lib/openfda-client.js";
+import { defineTool, type ToolError } from "../define-tool.js";
+import {
+    getDrugLabelActions,
+    getFaersByDrug,
+    getFaersSeriousness,
+    type AdverseEventCount,
+    type DrugLabelAction,
+    type SeriousnessProfile,
+} from "../lib/openfda-client.js";
+
+/** `label` returns whole prose sections, so its ceiling is far below the others. */
+const LABEL_MAX_LIMIT = 10;
+const LABEL_DEFAULT_LIMIT = 3;
+
+/** One result shape per action — the key names the records it carries. */
+type FaersOutput =
+    { totalReports: number | undefined; adverseEvents: AdverseEventCount[] } | { seriousness: SeriousnessProfile | null } | { labels: DrugLabelAction[] };
 
 export const searchFaersTool = defineTool({
     id: "search_faers",
     description:
-        "Search FDA FAERS for post-market adverse-event reports on one marketed drug — the real-world safety signal for a specific molecule. " +
-        "Returns totalReports and adverseEvents[]: { reaction (MedDRA preferred term), count }, most-reported first. " +
-        "These are spontaneous report counts, NOT incidence rates: there is no denominator and reporting is heavily biased, so use them to rank signals, never to state a rate. " +
-        "Matching is on the openFDA GENERIC name only — 'imatinib' works, the brand name 'Gleevec' does not. For mechanism-based liabilities of a TARGET (rather than a marketed drug), use target_safety. " +
-        "An empty adverseEvents array is valid no-data (drug absent from FAERS under that generic name) — do not retry.",
-    inputSchema: z.object({
-        drugName: z.string().describe("Generic (INN) drug name, e.g. 'imatinib', 'pembrolizumab'. Brand names do not match."),
-        limit: z
-            .number()
-            .int()
-            .min(1)
-            .max(100)
-            .default(15)
-            .describe(
-                "Max distinct adverse-reaction terms to return, most-reported first (default 15, max 100). totalReports covers the whole drug regardless.",
-            ),
-        serious: z.boolean().default(false).describe("When true, count only reports flagged serious (death, hospitalization, life-threatening, disabling)."),
-    }),
+        "openFDA — the post-market drug record of the U.S. Food and Drug Administration, across two corpora: FAERS (the FDA Adverse Event Reporting " +
+        "System, spontaneous reports) and the Structured Product Labels (the approved prescribing information, served through DailyMed). Three lookups; " +
+        "pick with `action`.\n" +
+        "'adverse_events' (default) — totalReports and adverseEvents[] { reaction (MedDRA preferred term), count }, most-reported first. These are " +
+        "spontaneous report COUNTS, not incidence rates: there is no denominator and reporting is heavily biased, so use them to rank signals, never to " +
+        "state a rate.\n" +
+        "'seriousness' — the outcome breakdown behind those reports: totalReports plus fatalCount, hospitalizationCount, lifeThreateningCount, " +
+        "disablingCount, congenitalAnomalyCount and otherSeriousCount. This is how you tell a common nuisance reaction from a lethal one; the same " +
+        "no-denominator caveat holds.\n" +
+        "'label' — the regulatory position on the drug: boxedWarning text, the Section 5 warningsAndCautions excerpt, a REMS indicator, the brand and " +
+        "generic names, the application number, the label effective date and a citable DailyMed URL. This is the only action that carries an official " +
+        "warning rather than a report count.\n" +
+        "ACCEPTED IDENTIFIERS: a drug name in `drugName`. 'adverse_events' and 'seriousness' match the openFDA GENERIC name only — 'imatinib' works, the " +
+        "brand name 'Gleevec' does not. 'label' matches the generic OR the brand name, so a brand name goes in there and the genericName field of each " +
+        "row gives you the generic to use for the other two actions.\n" +
+        "For mechanism-based liabilities of a TARGET (rather than a marketed drug), use target_safety; for a chemical's toxicology use comptox.\n" +
+        "ABSENCE IS NORMAL: an empty adverseEvents array, a null seriousness, or an empty labels array means the drug is absent from that corpus under " +
+        "that name — say so and continue, do not retry the same name.",
+    inputSchema: z
+        .object({
+            action: z
+                .enum(["adverse_events", "seriousness", "label"])
+                .default("adverse_events")
+                .describe(
+                    "'adverse_events' (default) — the ranked reaction terms. 'seriousness' — the outcome-flag breakdown for the same reports. 'label' — " +
+                        "the FDA label: boxed warning, Section 5 warnings and REMS.",
+                ),
+            drugName: z
+                .string()
+                .min(1)
+                .describe(
+                    "The drug name. Generic (INN) for 'adverse_events' and 'seriousness', e.g. 'imatinib' or 'pembrolizumab' — a brand name matches " +
+                        "nothing there. 'label' also accepts a brand name, e.g. 'Gleevec'.",
+                ),
+            limit: z
+                .number()
+                .int()
+                .min(1)
+                .max(100)
+                .optional()
+                .describe(
+                    `'adverse_events': max distinct adverse-reaction terms to return, most-reported first (default 15, max 100); totalReports covers the ` +
+                        `whole drug regardless. 'label': max label versions, newest first (default ${LABEL_DEFAULT_LIMIT}, max ${LABEL_MAX_LIMIT}) — a ` +
+                        `boxed warning runs to thousands of characters, so raise it only to trace how a warning changed. Ignored by 'seriousness'.`,
+                ),
+            serious: z
+                .boolean()
+                .default(false)
+                .describe(
+                    "'adverse_events' only. When true, count only reports flagged serious (death, hospitalization, life-threatening, disabling). For the " +
+                        "breakdown of WHICH serious outcome, use action 'seriousness' instead.",
+                ),
+        })
+        .refine((d) => d.action !== "label" || d.limit === undefined || d.limit <= LABEL_MAX_LIMIT, {
+            message: `limit is capped at ${LABEL_MAX_LIMIT} for action 'label' — each label version carries whole prose sections`,
+            path: ["limit"],
+        }),
     describeCall: "none",
-    execute: async ({ drugName, limit = 15, serious = false }) => {
-        const result = await getFaersByDrug(drugName, { limit, serious });
-        return ok({
-            totalReports: result.totalReports,
-            adverseEvents: result.adverseEvents,
-        });
+    execute: async ({ action = "adverse_events", drugName, limit, serious = false }): Promise<Result<FaersOutput, ToolError>> => {
+        switch (action) {
+            case "seriousness":
+                return ok({ seriousness: await getFaersSeriousness(drugName) });
+            case "label":
+                return ok({ labels: await getDrugLabelActions(drugName, { limit: limit ?? LABEL_DEFAULT_LIMIT }) });
+            case "adverse_events": {
+                const result = await getFaersByDrug(drugName, { limit: limit ?? 15, serious });
+                return ok({ totalReports: result.totalReports, adverseEvents: result.adverseEvents });
+            }
+        }
     },
 });

--- a/harness/src/tools/bio/search-gene.ts
+++ b/harness/src/tools/bio/search-gene.ts
@@ -1,36 +1,103 @@
 /**
- * searchGene — look up gene information via the Ensembl REST API.
+ * searchGene — resolve gene identifiers against the Ensembl REST API.
+ *
+ * Ensembl itself keys only on a symbol (`/lookup/symbol`), which makes an
+ * ENSG, a UniProt accession, a ChEMBL target id or an HGNC id unusable as
+ * input. That is the identifier a user pastes, so this tool takes it: an
+ * input that is not a plain symbol goes through `resolveTarget`, which anchors
+ * it on HGNC and UniProt, and the approved symbol it returns is what reaches
+ * Ensembl. `resolvedFrom` reports each such translation, thus the caller can
+ * see which input became which symbol.
  */
 
 import { ok } from "neverthrow";
 import { z } from "zod";
 
 import { defineTool } from "../define-tool.js";
-import { lookupGenes } from "../lib/ensembl-client.js";
+import { lookupGenes, type GeneInfo } from "../lib/ensembl-client.js";
+import { resolveTarget } from "../lib/identifier-resolver.js";
 
 /**
- * How many symbols a detail names before it switches to a count plus a sample.
- * Eight symbols of typical length stay well inside the emit-site cap, so the
- * listed form is never the thing that trips it.
+ * How many identifiers a detail names before it switches to a count plus a
+ * sample. Eight identifiers of typical length stay well inside the emit-site
+ * cap, so the listed form is never the thing that trips it.
  */
-const SYMBOLS_LISTED_IN_FULL = 8;
+const IDENTIFIERS_LISTED_IN_FULL = 8;
+
+/**
+ * The identifier spaces that Ensembl cannot key on. Anything that matches none
+ * of them is treated as a symbol and goes straight to Ensembl.
+ */
+const NON_SYMBOL_PATTERNS = [/^ENSG\d{11}$/, /^HGNC:\d+$/, /^CHEMBL\d+$/, /^[A-Z][0-9][A-Z0-9]{3}[0-9](-\d+)?$/];
+
+function isSymbol(identifier: string): boolean {
+    return !NON_SYMBOL_PATTERNS.some((pattern) => pattern.test(identifier));
+}
+
+/** One input that was not a symbol, beside the approved symbol it became. */
+interface ResolvedIdentifier {
+    input: string;
+    symbol: string;
+}
 
 export const searchGeneTool = defineTool({
     id: "search_gene",
     description:
-        "Resolve gene symbols against Ensembl — the identifier step other tools depend on. Per symbol: Ensembl gene ID (ENSG…), coordinates, strand, " +
-        "biotype, assembly, description; plus notFound[]. Gene-level only — no transcripts or exons. Batch up to 200 symbols per call. " +
-        "notFound is valid no-data (deprecated, aliased or mistyped symbol, or wrong species) — do not retry unchanged.",
+        "Resolve gene identifiers against Ensembl — the identifier step other tools depend on. Per gene: Ensembl gene ID (ENSG…), coordinates, strand, " +
+        "biotype, assembly, description; plus resolvedFrom[] and notFound[]. Gene-level only — no transcripts or exons. Batch up to 200 identifiers per " +
+        "call.\n" +
+        "ACCEPTED IDENTIFIERS, mixed freely in one call: a HUGO gene symbol ('BRCA1'), an Ensembl gene ID ('ENSG00000012048'), an HGNC ID ('HGNC:1100'), " +
+        "a UniProt accession ('P38398') and a ChEMBL target ID ('CHEMBL5619'). An input that is not a symbol is anchored on the HGNC and UniProt " +
+        "registries first, and the approved symbol it yields is reported in resolvedFrom[] — that anchoring is human, so a non-symbol input with a " +
+        "non-human `species` looks the ortholog up by the human approved symbol.\n" +
+        "notFound is valid no-data (a deprecated, aliased or mistyped identifier, or one this species has no gene for) — report it and continue, do not " +
+        "retry unchanged.",
     inputSchema: z.object({
-        symbols: z.array(z.string()).min(1).max(200).describe("Gene symbols to look up (e.g. ['BRCA1', 'TP53'])"),
+        identifiers: z
+            .array(z.string())
+            .min(1)
+            .max(200)
+            .describe("Gene identifiers to look up, mixed freely (e.g. ['BRCA1', 'ENSG00000141510', 'P38398', 'HGNC:1100', 'CHEMBL5619'])"),
         species: z.string().default("homo_sapiens").describe("Species name (e.g. 'homo_sapiens', 'mus_musculus')"),
     }),
-    // The symbols are the call. A large batch is summarized here rather than
+    // The identifiers are the call. A large batch is summarized here rather than
     // left to the emit-site cap: that cap cuts at a character, so a 200-symbol
     // join arrives ending in `TP5` — a fragment that reads as a real symbol and
     // says nothing about how many were dropped. The count leads, so a batch is
     // legible as a batch even when the sample after it is itself trimmed.
-    describeCall: ({ symbols }) =>
-        symbols.length <= SYMBOLS_LISTED_IN_FULL ? symbols.join(", ") : `${symbols.length} genes: ${symbols.slice(0, SYMBOLS_LISTED_IN_FULL).join(", ")}, …`,
-    execute: async ({ symbols, species }) => ok(await lookupGenes(symbols, { species })),
+    describeCall: ({ identifiers }) =>
+        identifiers.length <= IDENTIFIERS_LISTED_IN_FULL
+            ? identifiers.join(", ")
+            : `${identifiers.length} genes: ${identifiers.slice(0, IDENTIFIERS_LISTED_IN_FULL).join(", ")}, …`,
+    execute: async ({ identifiers, species }) => {
+        const symbols: string[] = [];
+        const resolvedFrom: ResolvedIdentifier[] = [];
+        const notFound: string[] = [];
+
+        for (const identifier of identifiers) {
+            const trimmed = identifier.trim();
+            if (isSymbol(trimmed)) {
+                symbols.push(trimmed);
+                continue;
+            }
+            // `resolveTarget` throws when it can anchor the input on no human
+            // gene. That is absence, so it becomes a notFound row.
+            try {
+                const resolved = await resolveTarget(trimmed);
+                resolvedFrom.push({ input: trimmed, symbol: resolved.geneSymbol });
+                symbols.push(resolved.geneSymbol);
+            } catch {
+                notFound.push(trimmed);
+            }
+        }
+
+        const genes: GeneInfo[] = [];
+        if (symbols.length > 0) {
+            const lookup = await lookupGenes(symbols, { species });
+            genes.push(...lookup.genes);
+            notFound.push(...lookup.notFound);
+        }
+
+        return ok({ genes, resolvedFrom, notFound });
+    },
 });

--- a/harness/src/tools/bio/search-geo-datasets.ts
+++ b/harness/src/tools/bio/search-geo-datasets.ts
@@ -47,7 +47,10 @@ const GeoEsummaryResponseSchema = z.object({
 export const searchGeoDatasetsTool = defineTool({
     id: "search_geo_datasets",
     description:
-        "Search NCBI GEO for public gene-expression datasets by disease, tissue, or experimental condition — use it to find external validation cohorts or to cite published data. " +
+        "Search the NCBI Gene Expression Omnibus (GEO) — the public functional-genomics repository of the U.S. National Library of Medicine — for " +
+        "gene-expression datasets by disease, tissue, or experimental condition. Use it to find external validation cohorts or to cite published data. " +
+        "ACCEPTED IDENTIFIERS: an Entrez free-text query with optional field tags ('breast cancer RNA-seq'), a GEO accession ('GSE12345', 'GDS1234'), and " +
+        "an organism scientific name ('Homo sapiens') in `organism`. " +
         "Returns totalFound plus datasets[]: { accession (GSE…/GDS…), title, summary (truncated to 300 chars), platform, sampleCount, organism, pubmedIds }. " +
         "HARD CAVEAT: this tool returns metadata only, and sandbox containers have no network — never plan an in-sandbox step that downloads a GEO dataset. " +
         "Bringing the data itself in is a capability of the surrounding environment, not of this tool: consult the tools you actually have rather than assuming it is possible or that it is not. " +

--- a/harness/src/tools/bio/search-interactions.ts
+++ b/harness/src/tools/bio/search-interactions.ts
@@ -16,13 +16,17 @@ type InteractionsOutput =
 export const searchInteractionsTool = defineTool({
     id: "search_interactions",
     description:
-        "Query STRING DB for protein-protein interactions and gene-set functional enrichment. " +
+        "Query the STRING database — the protein-protein association network of EMBL, which folds experimental, database, co-expression and text-mined " +
+        "evidence into one confidence score — for interactions and gene-set functional enrichment. " +
         "'partners' — the one-hop interaction partners of the input proteins, score-sorted: 'what else does this protein work with?'. " +
         "'network' — the interactions AMONG the input proteins only, no new nodes: 'is my gene set actually connected?'. " +
         "'enrichment' — statistical over-representation of GO, KEGG, Reactome and Pfam terms in the input set, FDR-sorted: the enrichment TEST, as " +
         "opposed to lookup_annotation, which just reads a vocabulary. " +
+        "ACCEPTED IDENTIFIERS: STRING resolves each one itself, so a HUGO gene symbol ('TP53'), a UniProt accession ('P04637'), an Ensembl protein ID " +
+        "('ENSP00000269305') and a full protein name all work, mixed in one call. `species` takes an NCBI Taxonomy ID (9606 = human).\n" +
         "`limit` applies to all three actions and defaults small: a network over N proteins grows with N² edges. `totalEdges` / `totalTerms` give the " +
-        "pre-trim counts. An empty result is valid no-data (unconnected set, no enriched term, unresolvable identifiers) — do not retry.",
+        "pre-trim counts. An empty result is valid no-data (unconnected set, no enriched term, unresolvable identifiers) — report it and continue, do " +
+        "not retry.",
     inputSchema: z.object({
         identifiers: z.array(z.string()).min(1).max(100).describe("Protein/gene identifiers (e.g. ['TP53', 'BRCA1'])"),
         species: z.number().int().default(9606).describe("NCBI Taxonomy ID (9606 = human, 10090 = mouse)"),

--- a/harness/src/tools/bio/target-safety.ts
+++ b/harness/src/tools/bio/target-safety.ts
@@ -133,8 +133,9 @@ export const targetSafetyTool = defineTool({
     id: "target_safety",
     description:
         "TARGET-level, mechanism-based safety liability — the curated secondary-pharmacology panel and Open Targets' curated liabilities in one call. " +
-        "Judges what engaging a target is likely to do to an organ system, before any specific molecule exists. Identifiers may be gene symbols, ChEMBL " +
-        "target IDs, UniProt accessions or Ensembl gene IDs, mixed.\n" +
+        "Judges what engaging a target is likely to do to an organ system, before any specific molecule exists.\n" +
+        "ACCEPTED IDENTIFIERS, mixed freely in one call: a HUGO gene symbol ('HERG', 'KCNH2'), a ChEMBL target ID ('CHEMBL240'), a UniProt accession " +
+        "('Q12809') and an Ensembl gene ID ('ENSG00000055118').\n" +
         "This is the safety of the TARGET, not of a drug. For a marketed molecule's post-market adverse events use search_faers; for a chemical's " +
         "toxicology use comptox; for what removing the gene does in vivo use gene_preclinical_profile.\n" +
         "ABSENCE IS NOT SAFETY. The panel is finite and hand-curated, so no match means only 'not on the panel'; an empty Open Targets liability list " +

--- a/harness/src/tools/bio/translational-medicine.test.ts
+++ b/harness/src/tools/bio/translational-medicine.test.ts
@@ -77,4 +77,58 @@ describe("searchClinicalTrials (translational-medicine family)", () => {
         const { ctx } = makeToolContext();
         await expect(searchClinicalTrialsTool.execute({ query: "imatinib", phase: undefined, status: undefined, limit: 20 }, ctx)).rejects.toThrow();
     });
+
+    it("selects the attrition statuses the registry serves", () => {
+        for (const status of ["TERMINATED", "WITHDRAWN", "SUSPENDED"]) {
+            expect(searchClinicalTrialsTool.inputSchema.safeParse({ query: "imatinib", status }).success).toBe(true);
+        }
+    });
+});
+
+describe("searchClinicalTrials — action 'details'", () => {
+    it("reads one study back by its NCT id, with its outcomes and adverse events", async () => {
+        const seen: string[] = [];
+        globalThis.fetch = (async (input: unknown) => {
+            seen.push(String(input));
+            return trialsResponse({
+                protocolSection: {
+                    identificationModule: { nctId: "NCT01234567", briefTitle: "A Study of Imatinib in CML" },
+                    statusModule: { overallStatus: "TERMINATED", whyStopped: "Slow accrual" },
+                    outcomesModule: { primaryOutcomes: [{ measure: "Overall survival", timeFrame: "24 months" }] },
+                },
+                resultsSection: {
+                    adverseEventsModule: {
+                        eventGroups: [{ id: "EG000", title: "Imatinib" }],
+                        seriousEvents: [{ term: "Neutropenia", organSystem: "Blood", stats: [{ groupId: "EG000", numAffected: 3, numAtRisk: 40 }] }],
+                    },
+                },
+            });
+        }) as unknown as typeof fetch;
+
+        const { ctx } = makeToolContext();
+        const result = (await searchClinicalTrialsTool.execute({ action: "details", nctId: "NCT01234567" }, ctx))._unsafeUnwrap();
+
+        expect(seen[0]).toContain("/studies/NCT01234567");
+        expect(result.trial!.trial.nctId).toBe("NCT01234567");
+        expect(result.trial!.whyStopped).toBe("Slow accrual");
+        expect(result.trial!.outcomes[0]!.measure).toBe("Overall survival");
+        expect(result.trial!.adverseEvents[0]).toMatchObject({ term: "Neutropenia", serious: true });
+    });
+
+    it("returns a null trial for an NCT id the registry does not hold (not is_error)", async () => {
+        stubFetch(() => new Response("not found", { status: 404 }));
+
+        const { ctx } = makeToolContext();
+        const result = (await searchClinicalTrialsTool.execute({ action: "details", nctId: "NCT99999999" }, ctx))._unsafeUnwrap();
+
+        expect(result.trial).toBeNull();
+    });
+
+    it("rejects 'details' with no nctId at the schema boundary", () => {
+        const parsed = searchClinicalTrialsTool.inputSchema.safeParse({ action: "details" });
+
+        expect(parsed.success).toBe(false);
+        const message = parsed.success ? "" : parsed.error.issues.map((i) => i.message).join(" ");
+        expect(message).toContain("nctId is required");
+    });
 });

--- a/harness/src/tools/describe-call.test.ts
+++ b/harness/src/tools/describe-call.test.ts
@@ -106,17 +106,17 @@ describe("describeCall — conversation roster", () => {
         expect(describeCall(tool, { action: "fulltext", pmcId: "PMC1234567" })).toBe("fulltext PMC1234567");
     });
 
-    it("search_gene names the symbols", () => {
-        expect(describeCall(searchGeneTool, { symbols: ["BRCA1", "TP53"], species: "homo_sapiens" })).toBe("BRCA1, TP53");
+    it("search_gene names the identifiers", () => {
+        expect(describeCall(searchGeneTool, { identifiers: ["BRCA1", "ENSG00000141510"], species: "homo_sapiens" })).toBe("BRCA1, ENSG00000141510");
     });
 
     // A batch this size joins to well over the 120-character cap. Left to the cap, the string
     // arrives ending mid-symbol — a fragment that reads as a real gene and says nothing about how
     // many were dropped. The count leads instead, so the sample after it can be trimmed harmlessly.
     it("search_gene counts a large batch rather than letting the cap sever a symbol", () => {
-        const symbols = Array.from({ length: 60 }, (_, i) => `GENE${i}`);
+        const identifiers = Array.from({ length: 60 }, (_, i) => `GENE${i}`);
 
-        const detail = describeCall(searchGeneTool, { symbols, species: "homo_sapiens" });
+        const detail = describeCall(searchGeneTool, { identifiers, species: "homo_sapiens" });
 
         expect(detail).toBe("60 genes: GENE0, GENE1, GENE2, GENE3, GENE4, GENE5, GENE6, GENE7, …");
         expect(normalizeDetail(detail)).toBe(detail);

--- a/harness/src/tools/lib/cbioportal-client.ts
+++ b/harness/src/tools/lib/cbioportal-client.ts
@@ -61,6 +61,8 @@ const RawCancerStudySchema = z.object({
     cancerType: z.object({ name: z.string().optional(), cancerTypeId: z.string().optional() }).optional(),
     name: z.string().optional(),
     description: z.string().optional(),
+    /** The denominator of a study. The sample-list SUMMARY projection carries no count. */
+    allSampleCount: z.number().optional(),
 });
 type RawCancerStudy = z.infer<typeof RawCancerStudySchema>;
 
@@ -69,6 +71,22 @@ async function listStudies(): Promise<RawCancerStudy[]> {
     const res = await apiFetchValidated(url, z.array(RawCancerStudySchema), { headers: HEADERS });
     if (res.isErr()) throw new Error(describeApiError(res.error));
     return res.value ?? [];
+}
+
+/**
+ * The cancer-type vocabulary, keyed by its id. The study SUMMARY projection
+ * carries the id alone, thus a row would otherwise report `esca` where it must
+ * report `Esophageal Adenocarcinoma`.
+ */
+async function cancerTypeNames(): Promise<Map<string, string>> {
+    const url = `${CBIOPORTAL_BASE}/cancer-types?pageSize=10000`;
+    const res = await apiFetchValidated(url, z.array(z.object({ cancerTypeId: z.string().optional(), name: z.string().optional() })), { headers: HEADERS });
+    const names = new Map<string, string>();
+    if (res.isErr()) return names;
+    for (const row of res.value ?? []) {
+        if (row.cancerTypeId && row.name) names.set(row.cancerTypeId, row.name);
+    }
+    return names;
 }
 
 async function listAllSampleLists(): Promise<RawSampleList[]> {
@@ -128,7 +146,7 @@ export async function getSomaticMutationFrequencies(
     const entrezGeneId = await resolveEntrezId(geneSymbol);
     if (entrezGeneId == null) return { entrezGeneId: null, rows: [] };
 
-    const [studies, profiles, sampleLists] = await Promise.all([listStudies(), listMutationProfiles(), listAllSampleLists()]);
+    const [studies, profiles, sampleLists, typeNames] = await Promise.all([listStudies(), listMutationProfiles(), listAllSampleLists(), cancerTypeNames()]);
 
     const allSampleListByStudy = new Map<string, RawSampleList>();
     for (const sl of sampleLists) {
@@ -155,11 +173,11 @@ export async function getSomaticMutationFrequencies(
 
     const byCancerType = new Map<string, { name: string; total: number; mutated: number; studies: Set<string> }>();
     for (const studyId of studiesWithMutations) {
-        const sl = allSampleListByStudy.get(studyId);
-        if (!sl?.sampleCount) continue;
         const study = studyById.get(studyId);
+        const sampleCount = study?.allSampleCount ?? 0;
+        if (sampleCount === 0) continue;
         const cancerTypeId = study?.cancerType?.cancerTypeId ?? study?.cancerTypeId ?? "unknown";
-        const cancerTypeName = study?.cancerType?.name ?? cancerTypeId;
+        const cancerTypeName = study?.cancerType?.name ?? typeNames.get(cancerTypeId) ?? cancerTypeId;
         if (!byCancerType.has(cancerTypeId)) {
             byCancerType.set(cancerTypeId, {
                 name: cancerTypeName,
@@ -169,7 +187,7 @@ export async function getSomaticMutationFrequencies(
             });
         }
         const bucket = byCancerType.get(cancerTypeId)!;
-        bucket.total += sl.sampleCount;
+        bucket.total += sampleCount;
         bucket.mutated += mutatedStudySamples.get(studyId)?.size ?? 0;
         bucket.studies.add(studyId);
     }

--- a/harness/src/tools/lib/chembl-client.ts
+++ b/harness/src/tools/lib/chembl-client.ts
@@ -335,13 +335,22 @@ export async function searchTargets(query: string, limit = 25): Promise<ChemblTa
     return (res.value.targets ?? []).map(mapTarget);
 }
 
+/** Which column of the ChEMBL activity table the supplied id indexes. */
+export type BioactivityIdType = "compound" | "target" | "assay";
+
+const ACTIVITY_ID_FIELD: Record<BioactivityIdType, string> = {
+    compound: "molecule_chembl_id",
+    target: "target_chembl_id",
+    assay: "assay_chembl_id",
+};
+
 export async function getBioactivity(
     chemblId: string,
-    type: "compound" | "target",
+    type: BioactivityIdType,
     options: { activityType?: string; limit?: number } = {},
 ): Promise<ChemblActivity[]> {
     const limit = options.limit ?? 500;
-    const idParam = type === "compound" ? `molecule_chembl_id=${encodeURIComponent(chemblId)}` : `target_chembl_id=${encodeURIComponent(chemblId)}`;
+    const idParam = `${ACTIVITY_ID_FIELD[type]}=${encodeURIComponent(chemblId)}`;
     let url = `${CHEMBL_BASE}/activity.json?${idParam}&limit=${limit}`;
     if (options.activityType) {
         url += `&standard_type=${encodeURIComponent(options.activityType)}`;

--- a/harness/src/tools/lib/gwas-catalog-client.ts
+++ b/harness/src/tools/lib/gwas-catalog-client.ts
@@ -1,9 +1,10 @@
 /**
  * Pure async client functions for the NHGRI-EBI GWAS Catalog REST API.
  *
- * Public, no key required. Three search paths: by gene (SNP-by-gene lookup then
- * per-SNP associations), by trait (EFO trait search then its associations), and
- * by variant (direct rsID associations).
+ * Public, no key required. Four search paths: by gene (SNP-by-gene lookup then
+ * per-SNP associations), by trait (EFO trait search then its associations), by
+ * variant (direct rsID associations), and by study (the associations of one
+ * GCST study accession).
  */
 
 import { z } from "zod";
@@ -27,7 +28,7 @@ export interface GwasAssociation {
     sampleSize: string;
 }
 
-export type GwasSearchType = "gene" | "trait" | "variant";
+export type GwasSearchType = "gene" | "trait" | "variant" | "study";
 
 // GWAS Catalog raw wire shapes (HAL+JSON), validated at the fetch boundary.
 // Every field is optional because the API omits absent values; leaf strings
@@ -55,10 +56,10 @@ const RawGwasAssociationSchema = z.object({
     study: RawGwasStudySchema.optional(),
     pvalueMantissa: z.number().optional(),
     pvalueExponent: z.number().optional(),
-    riskFrequency: z.string().optional(),
+    riskFrequency: z.string().nullable().optional(),
     orPerCopyNum: z.number().nullable().optional(),
     betaNum: z.number().nullable().optional(),
-    range: z.string().optional(),
+    range: z.string().nullable().optional(),
 });
 type RawGwasAssociation = z.infer<typeof RawGwasAssociationSchema>;
 
@@ -160,6 +161,11 @@ export async function searchGwasCatalog(
     if (searchType === "variant") {
         const rsId = query.startsWith("rs") ? query : `rs${query}`;
         associationsUrl = `${GWAS_BASE}/singleNucleotidePolymorphisms/${rsId}/associations?projection=associationBySnp`;
+    } else if (searchType === "study") {
+        // The study endpoint keys on the accession alone. The projection nests
+        // the study record on each association, thus `mapAssociation` reads the
+        // accession, the PubMed id and the sample size without a second request.
+        associationsUrl = `${GWAS_BASE}/studies/${encodeURIComponent(query)}/associations?projection=associationByStudy&size=${limit}`;
     } else {
         const traitRes = await apiFetchValidated(
             `${GWAS_BASE}/efoTraits/search/findBySearchQuery?query=${encodeURIComponent(query)}`,
@@ -177,7 +183,12 @@ export async function searchGwasCatalog(
     }
 
     const res = await apiFetchValidated(associationsUrl, GwasEmbeddedSchema, { headers: GWAS_HEADERS });
-    if (res.isErr()) throw new Error(describeApiError(res.error));
+    if (res.isErr()) {
+        // An accession or an rsID that the catalog does not hold is absence, not
+        // a failure, thus it returns an empty record set.
+        if (res.error.type === "http_status" && res.error.status === 404) return { totalFound: 0, associations: [] };
+        throw new Error(describeApiError(res.error));
+    }
 
     const rawAssocs = res.value?._embedded?.associations ?? [];
     const totalFound = res.value?.page?.totalElements ?? rawAssocs.length;

--- a/harness/src/tools/lib/openfda-client.ts
+++ b/harness/src/tools/lib/openfda-client.ts
@@ -79,10 +79,17 @@ function escapeQueryPhrase(value: string): string {
     return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+/**
+ * A boolean operator is separated by a space, never by a literal `+`. The whole
+ * search string goes through `encodeURIComponent`, which turns a `+` into
+ * `%2B`. openFDA then reads that as a character of the term and matches
+ * nothing, but it reads `%20` as the separator that it is.
+ */
+
 function buildSearch(drugName: string, serious: boolean): string {
     const escaped = escapeQueryPhrase(drugName);
     let search = `patient.drug.openfda.generic_name:"${escaped}"`;
-    if (serious) search += "+AND+serious:1";
+    if (serious) search += " AND serious:1";
     return search;
 }
 
@@ -142,7 +149,7 @@ export async function getFaersSeriousness(drugName: string): Promise<Seriousness
     }
 
     async function countWith(field: string): Promise<number> {
-        const q = `${search}+AND+${field}:1`;
+        const q = `${search} AND ${field}:1`;
         const url = `${OPENFDA_BASE}?search=${encodeURIComponent(q)}&limit=1`;
         const res = await apiFetchValidated(url, FaersMetaResponseSchema);
         if (res.isErr()) return 0;
@@ -228,15 +235,17 @@ const OpenFdaLabelResponseSchema = z.object({
 });
 
 /**
- * Fetch FDA Structured Product Label entries by generic drug name. Returns
- * the most recent N labels (sorted by effective_time desc); each row carries
- * the boxed-warning text, the Section 5 warnings_and_cautions excerpt, and a
- * REMS indicator. Returns [] on 404 / no match.
+ * Fetch FDA Structured Product Label entries by drug name. The name matches
+ * the generic name or the brand name, thus a caller that holds only a brand
+ * name reads the generic name back off each row. Returns the most recent N
+ * labels (sorted by effective_time desc). Each row carries the boxed-warning
+ * text, the Section 5 warnings_and_cautions excerpt, and a REMS indicator.
+ * Returns [] on 404 / no match.
  */
-export async function getDrugLabelActions(genericName: string, options: { limit?: number } = {}): Promise<DrugLabelAction[]> {
+export async function getDrugLabelActions(drugName: string, options: { limit?: number } = {}): Promise<DrugLabelAction[]> {
     const limit = options.limit ?? 5;
-    const escaped = escapeQueryPhrase(genericName);
-    const search = `openfda.generic_name:"${escaped}"`;
+    const escaped = escapeQueryPhrase(drugName);
+    const search = `(openfda.generic_name:"${escaped}" OR openfda.brand_name:"${escaped}")`;
     const url = `${OPENFDA_LABEL_BASE}?search=${encodeURIComponent(search)}` + `&sort=effective_time:desc&limit=${limit}`;
     const res = await apiFetchValidated(url, OpenFdaLabelResponseSchema);
     if (res.isErr()) {

--- a/harness/src/tools/lib/opentargets-client.ts
+++ b/harness/src/tools/lib/opentargets-client.ts
@@ -45,6 +45,18 @@ export interface SafetyLiability {
     source: string;
 }
 
+/**
+ * One disease or trait that Open Targets holds, as the free-text resolver
+ * returns it. The `id` is the identifier that `searchDiseaseAssociations`
+ * accepts. Open Targets keys a disease on the EFO ontology, which imports
+ * MONDO, Orphanet and HP, thus an id can read `EFO_…`, `MONDO_…` or `HP_…`.
+ */
+export interface DiseaseCandidate {
+    id: string;
+    name: string;
+    description: string | null;
+}
+
 export interface BaselineExpressionEntry {
     tissueId: string;
     tissueLabel: string;
@@ -94,6 +106,19 @@ const DISEASE_QUERY = `
             score
           }
         }
+      }
+    }
+  }
+`;
+
+const DISEASE_SEARCH_QUERY = `
+  query DiseaseSearch($queryString: String!, $size: Int!) {
+    search(queryString: $queryString, entityNames: ["disease"], page: { size: $size, index: 0 }) {
+      total
+      hits {
+        id
+        name
+        description
       }
     }
   }
@@ -199,6 +224,25 @@ const DiseaseAssociationsDataSchema = z.object({
                         .nullable()
                         .optional(),
                 })
+                .optional(),
+        })
+        .nullable()
+        .optional(),
+});
+
+const DiseaseSearchDataSchema = z.object({
+    search: z
+        .object({
+            total: z.number().nullable().optional(),
+            hits: z
+                .array(
+                    z.object({
+                        id: z.string(),
+                        name: z.string().nullable().optional(),
+                        description: z.string().nullable().optional(),
+                    }),
+                )
+                .nullable()
                 .optional(),
         })
         .nullable()
@@ -321,6 +365,25 @@ export async function searchDiseaseAssociations(efoId: string, limit = 25): Prom
         somaticMutationScore: extractDatatype(row.datatypeScores ?? [], "somatic_mutation"),
         literaturePmids: [],
     }));
+}
+
+/**
+ * Resolve a free-text disease or trait name to the disease ids that
+ * `searchDiseaseAssociations` accepts. A name that matches nothing gives an
+ * empty candidate list, which is a normal outcome and not an error.
+ */
+export async function searchDiseases(query: string, limit = 10): Promise<{ total: number; candidates: DiseaseCandidate[] }> {
+    const data = await gqlFetch(DISEASE_SEARCH_QUERY, { queryString: query, size: limit }, DiseaseSearchDataSchema);
+
+    const hits = data.search?.hits ?? [];
+    return {
+        total: data.search?.total ?? hits.length,
+        candidates: hits.map((hit) => ({
+            id: hit.id,
+            name: hit.name ?? "",
+            description: hit.description ?? null,
+        })),
+    };
 }
 
 /** Fetch known safety liabilities for a target. */

--- a/harness/src/tools/lib/pathway-client.ts
+++ b/harness/src/tools/lib/pathway-client.ts
@@ -9,7 +9,11 @@ import { z } from "zod";
 import { apiFetch, apiFetchValidated, parseTSV } from "./api-utils.js";
 
 const KEGG_BASE = "https://rest.kegg.jp";
-const REACTOME_BASE = "https://reactome.org/ContentService";
+// The ContentService of the primary host answers 404 on each path. The release
+// host serves the same API, and a probe of `search/query`, `data/query/{stId}`
+// and `data/participants/{stId}` returned 200 on it. The web pages that a result
+// links to stay on the primary host, thus only the API base moves.
+const REACTOME_BASE = "https://release.reactome.org/ContentService";
 
 export function stripHtmlAndCollapseWs(s: string): string {
     // Strip tags to a fixpoint: a single pass can leave a `<…>` behind when

--- a/harness/src/tools/lib/pathway-client.ts
+++ b/harness/src/tools/lib/pathway-client.ts
@@ -63,6 +63,13 @@ const ReactomeSearchResponseSchema = z.object({
 /** Participant list — `searchReactome` reads `displayName` per participant. */
 const ReactomeParticipantsSchema = z.array(z.object({ displayName: z.string().optional() }));
 
+/** One Reactome event record, as `/data/query/{stId}` serves it. */
+const ReactomeEntrySchema = z.object({
+    stId: z.string().optional(),
+    displayName: z.string().optional(),
+    summation: z.array(z.object({ text: z.string().optional() })).optional(),
+});
+
 /** Participant list — `getPathwayMemberships` reads `refEntities` per participant. */
 const ReactomeParticipantEntitiesSchema = z.array(
     z.object({
@@ -162,6 +169,64 @@ export async function searchPathways(query: string, options: PathwaySearchOption
     }
     const results = await Promise.all(tasks);
     return results.flat();
+}
+
+/** A Reactome stable identifier, for example `R-HSA-109581`. */
+const REACTOME_ID_RE = /^R-[A-Z]{3}-\d+(\.\d+)?$/;
+
+/** A KEGG pathway identifier, for example `hsa04010` or `map04010`. */
+const KEGG_ID_RE = /^[a-z]{3,4}\d{5}$/;
+
+/** Read one field out of a KEGG flat-file record. */
+function keggField(record: string, field: string): string | null {
+    const match = new RegExp(`^${field}\\s+(.*)$`, "m").exec(record);
+    return match?.[1]?.trim() || null;
+}
+
+async function getKeggPathway(id: string): Promise<Pathway | null> {
+    const res = await apiFetch<string>(`${KEGG_BASE}/get/${encodeURIComponent(id)}`, { parseAs: "text" });
+    if (res.isErr()) return null;
+    const record = res.value;
+    const name = keggField(record, "NAME");
+    if (!name) return null;
+    const description = keggField(record, "DESCRIPTION");
+    return {
+        id,
+        name,
+        source: "kegg",
+        ...(description ? { description } : {}),
+        url: `https://www.kegg.jp/pathway/${id}`,
+    };
+}
+
+async function getReactomePathway(id: string): Promise<Pathway | null> {
+    const res = await apiFetchValidated(`${REACTOME_BASE}/data/query/${encodeURIComponent(id)}`, ReactomeEntrySchema, {
+        headers: { Accept: "application/json" },
+    });
+    if (res.isErr()) return null;
+    const entry = res.value;
+    const stId = entry.stId ?? id;
+    const description = entry.summation?.map((s) => s.text ?? "").find((text) => text.length > 0);
+    return {
+        id: stId,
+        name: stripHtmlAndCollapseWs(entry.displayName ?? ""),
+        source: "reactome",
+        ...(description ? { description: stripHtmlAndCollapseWs(description) } : {}),
+        url: `https://reactome.org/content/detail/${stId}`,
+    };
+}
+
+/**
+ * Read one pathway by its own identifier. The prefix of the identifier picks
+ * the database, thus the caller passes the id back exactly as a search
+ * returned it. An identifier that neither database holds gives null, which is
+ * absence and not a failure.
+ */
+export async function getPathwayById(id: string): Promise<Pathway | null> {
+    const trimmed = id.trim();
+    if (REACTOME_ID_RE.test(trimmed)) return getReactomePathway(trimmed);
+    if (KEGG_ID_RE.test(trimmed)) return getKeggPathway(trimmed);
+    return null;
 }
 
 /** Pathway memberships for a gene symbol — used directly by §3.7 collector. */

--- a/harness/src/tools/research/context7-docs.ts
+++ b/harness/src/tools/research/context7-docs.ts
@@ -31,7 +31,7 @@ const Context7DocsResponseSchema = z.object({ content: z.string().optional() });
 export const resolveLibraryIdTool = defineTool({
     id: "resolve_library_id",
     description:
-        "Resolve a package name (e.g., 'scanpy', 'DESeq2', 'scikit-learn') to a Context7 library ID. Call this BEFORE queryDocs to get the library ID needed for documentation lookup. Returns matching libraries ranked by relevance.",
+        "Resolve a package name (e.g., 'scanpy', 'DESeq2', 'scikit-learn') to a Context7 library ID. Call this BEFORE `query_docs` to get the library ID needed for documentation lookup. Returns matching libraries ranked by relevance.",
     inputSchema: z.object({
         libraryName: z.string().describe("Package or library name to search for (e.g., 'scanpy', 'pysam', 'lifelines')."),
         query: z.string().describe("What you need help with — used to rank results by relevance (e.g., 'how to run differential expression')."),
@@ -62,9 +62,9 @@ export const resolveLibraryIdTool = defineTool({
 export const queryDocsTool = defineTool({
     id: "query_docs",
     description:
-        "Query up-to-date documentation and code examples for a library. You must call resolve-library-id first to get the libraryId. Use this to verify function signatures, parameters, and usage patterns before writing code.",
+        "Query up-to-date documentation and code examples for a library. You must call `resolve_library_id` first to get the libraryId. Use this to verify function signatures, parameters, and usage patterns before writing code.",
     inputSchema: z.object({
-        libraryId: z.string().describe("Context7 library ID from resolve-library-id (e.g., '/scverse/scanpy')."),
+        libraryId: z.string().describe("Context7 library ID from `resolve_library_id` (for example '/scverse/scanpy')."),
         query: z.string().describe("Specific question about the library (e.g., 'rank_genes_groups function parameters and usage')."),
     }),
     describeCall: "none",

--- a/harness/src/tools/research/generate-analogy-report.ts
+++ b/harness/src/tools/research/generate-analogy-report.ts
@@ -217,8 +217,8 @@ export function createGenerateAnalogyReportTool(deps: GenerateAnalogyReportDeps)
             "stuck', 'brainstorm ideas', 'are there precedents outside biology'. The " +
             "trigger is exploratory INTENT, not the words 'analogy' or 'cross-domain' " +
             "— users rarely name it, so infer it and reach for the tool proactively.\n" +
-            "NOT for: in-domain literature review (use `literature_reviewer` or " +
-            "`pubmed`), single-gene factual lookup (use `search_gene`), or " +
+            "NOT for: in-domain literature review (use `pubmed` and the other " +
+            "bio-lookup tools), single-gene factual lookup (use `search_gene`), or " +
             "execution-mode turns where the user just wants the next step done. It " +
             "drives a multi-step research sub-agent over live literature search, so " +
             "it is slow — never spend it on a fact you could look up.\n" +

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -224,8 +224,11 @@ describe("generatePlan loop-driving tool", () => {
             toolContext(),
         );
 
-        expect(Object.keys(provider.calls[0]!.tools)).not.toContain("list_available_refs");
-        expect(Object.keys(provider.calls[0]!.tools)).toEqual(expect.arrayContaining(["submit_plan", "request_clarification", "report_blocker"]));
+        expect(Object.keys(provider.calls[0]!.tools)).toEqual(
+            expect.arrayContaining(["submit_plan", "request_clarification", "report_blocker", "list_available_refs"]),
+        );
+        // The census still rides in the seed. The tool is for the narrow second
+        // look, thus the planner never has to call one to learn what is staged.
         expect(transcript(provider)).toContain("/mnt/refs/managed/collectri-human/2.0/CollecTRI_regulons.csv");
         // The planner sees the same meaning-bearing labels a sandbox agent does.
         expect(transcript(provider)).toContain("regulon");

--- a/harness/src/tools/research/generate-plan.test.ts
+++ b/harness/src/tools/research/generate-plan.test.ts
@@ -14,6 +14,9 @@ import type { DataProfileResult } from "../../state/index.js";
 import type { Tool, ToolContext } from "../define-tool.js";
 import { createGeneratePlanTool } from "./generate-plan.js";
 
+/** The key slice the search tools of the planner take. An empty key keeps every tool constructible offline. */
+const TEST_BIO_KEYS = { drugbank: "", disgenet: "", epaCcte: "" };
+
 /** A ToolContext whose session scopes the tool to `analysisId` — where it reads the profile from. */
 function toolContext(analysisId = "analysis-001"): ToolContext {
     return {
@@ -155,7 +158,7 @@ describe("generatePlan loop-driving tool", () => {
 
     /** Rebuild the tool per test — the provider is the only thing that varies. */
     function toolFor(provider: ScriptedProvider): Tool {
-        return createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool });
+        return createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, bioKeys: TEST_BIO_KEYS });
     }
 
     // ── Outcome shaping ──────────────────────────────────────────────
@@ -216,7 +219,10 @@ describe("generatePlan loop-driving tool", () => {
         await writeFile(join(root, "managed", "collectri-human", "2.0", "CollecTRI_regulons.csv"), "source,target");
 
         const provider = refsProbe();
-        await createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, refStorePath: root }).execute(INPUT, toolContext());
+        await createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, refStorePath: root, bioKeys: TEST_BIO_KEYS }).execute(
+            INPUT,
+            toolContext(),
+        );
 
         expect(Object.keys(provider.calls[0]!.tools)).not.toContain("list_available_refs");
         expect(Object.keys(provider.calls[0]!.tools)).toEqual(expect.arrayContaining(["submit_plan", "request_clarification", "report_blocker"]));
@@ -266,7 +272,8 @@ describe("generatePlan loop-driving tool", () => {
 
     describe("data context", () => {
         it("takes no dataset field from the caller at all", () => {
-            const schema = createGeneratePlanTool({ conversation: { provider: scriptedProvider([]), model: "claude-test" }, pool }).jsonSchema as {
+            const schema = createGeneratePlanTool({ conversation: { provider: scriptedProvider([]), model: "claude-test" }, pool, bioKeys: TEST_BIO_KEYS })
+                .jsonSchema as {
                 properties: Record<string, unknown>;
                 required?: string[];
             };
@@ -433,7 +440,7 @@ describe("generatePlan loop-driving tool", () => {
     describe("outcome records", () => {
         function loggedToolFor(provider: ScriptedProvider): { tool: Tool; logger: CapturingLogger } {
             const logger = createCapturingLogger();
-            return { tool: createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, logger }), logger };
+            return { tool: createGeneratePlanTool({ conversation: { provider, model: "claude-test" }, pool, logger, bioKeys: TEST_BIO_KEYS }), logger };
         }
 
         /** The one per-invocation outcome record, failing loudly if there is not exactly one. */
@@ -501,7 +508,12 @@ describe("generatePlan loop-driving tool", () => {
             const cancelled = createCapturingLogger();
             const aborted = new AbortController();
             aborted.abort();
-            await createGeneratePlanTool({ conversation: { provider: scriptedProvider([]), model: "claude-test" }, pool, logger: cancelled }).execute(INPUT, {
+            await createGeneratePlanTool({
+                conversation: { provider: scriptedProvider([]), model: "claude-test" },
+                pool,
+                logger: cancelled,
+                bioKeys: TEST_BIO_KEYS,
+            }).execute(INPUT, {
                 ...toolContext(),
                 signal: aborted.signal,
             });

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -41,6 +41,12 @@ import type { EnvironmentStorePaths } from "../../config/environment-stores.js";
 import { createListAvailablePackagesTool } from "../sandbox/list-available-packages.js";
 import { createListAvailableRefsTool } from "../sandbox/list-available-refs.js";
 import { createReportBlockerToolFor } from "../sandbox/report-blocker.js";
+import { searchGeoDatasetsTool } from "../bio/search-geo-datasets.js";
+import { createNcbiTools, type BioToolKeys } from "../bio/keys.js";
+import { queryDocsTool, resolveLibraryIdTool } from "./context7-docs.js";
+import { searchArxivTool } from "./search-arxiv.js";
+import { createSearchGithubReposTool } from "./search-github-repos.js";
+import { createSearchSemanticScholarTool } from "./search-semantic-scholar.js";
 
 import { DATA_PROFILE_ORIENTATION_MAX_CHARS, buildDataProfileOrientation } from "../../app/data-profile-orientation.js";
 import { DEFAULT_SANDBOX_MAX_STEPS, type ResourcePolicy } from "../../config/resource-limits.js";
@@ -60,10 +66,16 @@ import { insertPlan, loadDataProfileStatus, loadPlan, type DataProfileResult, ty
 const PLANNER_AGENT_ID = "planner";
 
 /**
- * Budget for the planner's internal loop: one draft/submit attempt plus
- * correction retries and headroom.
+ * Budget for the planner's internal loop: a bounded research phase, one
+ * draft/submit attempt, correction retries, and headroom.
+ *
+ * The planner holds search tools, thus a plan against an unfamiliar assay or an
+ * unfamiliar method costs some lookups before the draft. A well-grounded plan
+ * still costs two or three calls, because the prompt gates the research phase on
+ * what the seed does not already answer. The wall-clock guard, not this number,
+ * is what bounds the worst case.
  */
-const PLANNER_MAX_ITERATIONS = 13;
+const PLANNER_MAX_ITERATIONS = 40;
 
 /** Wall-clock guard for a single plan-generation invocation. */
 const PLAN_TIMEOUT_MS = 600_000;
@@ -85,7 +97,7 @@ const MAX_LOGGED_ISSUE_CHARS = 240;
 const MAX_LOGGED_REJECTIONS = 6;
 /** Excerpt of the planner's last words — the one artifact that explains a run ending on prose. */
 const MAX_LOGGED_PROSE_CHARS = 800;
-/** Tool-call trace length. The planner's whole budget is ~16 turns, so this rarely truncates. */
+/** Tool-call trace length. The planner's whole budget is ~43 turns, so this rarely truncates. */
 const MAX_LOGGED_TOOL_CALLS = 48;
 
 /** Trim to `max`, marking the cut so a truncated value never reads as a complete one. */
@@ -873,11 +885,46 @@ export interface GeneratePlanDeps extends EnvironmentStorePaths {
     readonly logger?: Logger;
     /** LLM usage-accounting seam for the planner loop; omitted falls back to the no-op recorder. */
     readonly usageRecorder?: UsageRecorder;
+    /** API keys for the search tools the planner uses to ground a plan. */
+    readonly bioKeys: BioToolKeys;
+}
+
+/**
+ * The search tools of the planner — built one time, not per invocation.
+ *
+ * The set answers the two questions that a seed cannot. "What did a study of
+ * this kind do before?" reaches the public dataset records and the literature.
+ * "What does this package actually give me?" reaches the developer docs. The
+ * planner reads its reference and package inventories from the seed, thus the
+ * docs pair is what turns a package name into a real function.
+ *
+ * A tool here never writes and never computes. Thus the worst outcome of a
+ * needless call is latency, and the prompt is what bounds that.
+ */
+function buildPlannerSearchTools(bioKeys: BioToolKeys): Tool[] {
+    const ncbi = createNcbiTools(bioKeys);
+    return [
+        // Comparable public studies — the design, the platform, and the sample
+        // count that a plan for the same assay must answer to.
+        searchGeoDatasetsTool,
+        // Prior methods, in three corpora that do not overlap: the biomedical
+        // literature, the statistics and machine-learning preprints, and the
+        // cross-field index that ranks a method paper best.
+        ncbi.pubmed,
+        searchArxivTool,
+        createSearchSemanticScholarTool({ ...(bioKeys.semanticScholar === undefined ? {} : { apiKey: bioKeys.semanticScholar }) }),
+        // The same approach as running code — a pipeline that someone published.
+        createSearchGithubReposTool({ githubToken: bioKeys.github }),
+        // The API of a staged package, so a step names a function that exists.
+        resolveLibraryIdTool,
+        queryDocsTool,
+    ];
 }
 
 /** Build the `generate_plan` tool bound to its provider and pool. */
 export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
     const baseLogger = (deps.logger ?? createNoopLogger()).named("generate-plan");
+    const searchTools = buildPlannerSearchTools(deps.bioKeys);
     return defineTool({
         id: "generate_plan",
         description:
@@ -1071,7 +1118,10 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),
                 model: deps.conversation.model,
-                tools: innerTools.terminal,
+                // The search tools come first, and the terminal tools come last.
+                // The order is the order of the prompt, and it is stable across
+                // every invocation, thus the cached request prefix holds.
+                tools: [...searchTools, ...innerTools.terminal],
                 maxIterations: PLANNER_MAX_ITERATIONS,
             };
 

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -902,7 +902,8 @@ export interface GeneratePlanDeps extends EnvironmentStorePaths {
  * A tool here never writes and never computes. Thus the worst outcome of a
  * needless call is latency, and the prompt is what bounds that.
  */
-function buildPlannerSearchTools(bioKeys: BioToolKeys): Tool[] {
+function buildPlannerSearchTools(deps: GeneratePlanDeps): Tool[] {
+    const bioKeys = deps.bioKeys;
     const ncbi = createNcbiTools(bioKeys);
     return [
         // Comparable public studies — the design, the platform, and the sample
@@ -919,6 +920,12 @@ function buildPlannerSearchTools(bioKeys: BioToolKeys): Tool[] {
         // The API of a staged package, so a step names a function that exists.
         resolveLibraryIdTool,
         queryDocsTool,
+        // The environment itself. The seed already carries a rendered census of
+        // both stores. These two tools are for the narrow second look: one
+        // collection of the reference store, or one package name that a step is
+        // about to import.
+        createListAvailableRefsTool(deps.refStorePath === undefined ? {} : { refStorePath: deps.refStorePath }),
+        createListAvailablePackagesTool(deps.packagesFile === undefined ? {} : { packagesFile: deps.packagesFile }),
     ];
 }
 
@@ -1118,7 +1125,7 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
             // dep, thus the tool must stay constructible from an empty bag. The tool
             // definitions are identical across invocations, thus the request prefix
             // that the cache keys on does not move.
-            const searchTools = buildPlannerSearchTools(deps.bioKeys);
+            const searchTools = buildPlannerSearchTools(deps);
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -66,16 +66,17 @@ import { insertPlan, loadDataProfileStatus, loadPlan, type DataProfileResult, ty
 const PLANNER_AGENT_ID = "planner";
 
 /**
- * Budget for the planner's internal loop: a bounded research phase, one
- * draft/submit attempt, correction retries, and headroom.
+ * Budget for the planner's internal loop: the research phase, one draft/submit
+ * attempt, correction retries, and headroom.
  *
- * The planner holds search tools, thus a plan against an unfamiliar assay or an
- * unfamiliar method costs some lookups before the draft. A well-grounded plan
+ * The number is deliberately far above what a plan costs. A well-grounded plan
  * still costs two or three calls, because the prompt gates the research phase on
- * what the seed does not already answer. The wall-clock guard, not this number,
- * is what bounds the worst case.
+ * what the seed does not already answer. What the ceiling must never do is stop
+ * a planner that is searching correctly. A capped run takes the forced wrap-up
+ * path and submits the plan that it had, not the plan that it was building.
+ * Thus the wall-clock guard, not this number, is what bounds the worst case.
  */
-const PLANNER_MAX_ITERATIONS = 40;
+const PLANNER_MAX_ITERATIONS = 200;
 
 /** Wall-clock guard for a single plan-generation invocation. */
 const PLAN_TIMEOUT_MS = 600_000;
@@ -97,7 +98,7 @@ const MAX_LOGGED_ISSUE_CHARS = 240;
 const MAX_LOGGED_REJECTIONS = 6;
 /** Excerpt of the planner's last words — the one artifact that explains a run ending on prose. */
 const MAX_LOGGED_PROSE_CHARS = 800;
-/** Tool-call trace length. The planner's whole budget is ~43 turns, so this rarely truncates. */
+/** Tool-call trace length. A long research phase passes it, and `toolCallsTruncated` marks the record when it does. */
 const MAX_LOGGED_TOOL_CALLS = 48;
 
 /** Trim to `max`, marking the cut so a truncated value never reads as a complete one. */

--- a/harness/src/tools/research/generate-plan.ts
+++ b/harness/src/tools/research/generate-plan.ts
@@ -925,7 +925,6 @@ function buildPlannerSearchTools(bioKeys: BioToolKeys): Tool[] {
 /** Build the `generate_plan` tool bound to its provider and pool. */
 export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
     const baseLogger = (deps.logger ?? createNoopLogger()).named("generate-plan");
-    const searchTools = buildPlannerSearchTools(deps.bioKeys);
     return defineTool({
         id: "generate_plan",
         description:
@@ -1115,6 +1114,11 @@ export function createGeneratePlanTool(deps: GeneratePlanDeps): Tool {
                 parentPlanId: input.parentPlanId ?? null,
             };
             const innerTools = buildInnerTools(holder, trace, persistCtx, deps.pool, deps.resourcePolicy, logger);
+            // Built here rather than at construction: a `describeCall` hook reads no
+            // dep, thus the tool must stay constructible from an empty bag. The tool
+            // definitions are identical across invocations, thus the request prefix
+            // that the cache keys on does not move.
+            const searchTools = buildPlannerSearchTools(deps.bioKeys);
             const planner: AgentDefinition = {
                 id: PLANNER_AGENT_ID,
                 systemPrompt: composeSystemPrompt(plannerInstructions(deps.resourcePolicy)),

--- a/harness/src/tools/research/resolve-citation.ts
+++ b/harness/src/tools/research/resolve-citation.ts
@@ -7,10 +7,15 @@ export function createResolveCitationTool(resolver: CitationResolver): Tool {
     return defineTool({
         id: "resolve_citation",
         description:
-            "Verify one supplied citation against applicable bibliographic authorities. " +
-            "Use this for 'does this reference exist and does its metadata agree?', not for topical literature discovery. " +
+            "Verify one supplied citation against the applicable bibliographic authorities — the DOI registry, Crossref, PubMed, arXiv and Semantic " +
+            "Scholar — and report where they agree. " +
+            "Use this for 'does this reference exist and does its metadata agree?', not for topical literature discovery: pubmed, " +
+            "search_semantic_scholar and search_arxiv are the discovery tools.\n" +
+            "ACCEPTED IDENTIFIERS: a DOI ('10.1038/nature12373'), a PMID ('23945592'), an arXiv ID ('2301.00001'), or raw bibliographic text. Each " +
+            "authority that the input cannot address is marked not_applicable rather than queried.\n" +
             "Returns source-labelled records, field comparisons, conflicts, coverage, and one of verified, metadata_mismatch, " +
-            "not_found, unverifiable, or inconclusive. Source failure never becomes not_found.",
+            "not_found, unverifiable, or inconclusive. Source failure never becomes not_found — an unreachable authority reports unavailable, and " +
+            "not_found means the authorities that answered hold no such record.",
         inputSchema: CitationInputSchema,
         describeCall: ({ citation }) => `verify ${citation}`,
         execute: async (input, ctx) => ok(await resolver.resolveOne(input, { signal: ctx.signal })),

--- a/harness/src/tools/research/search-arxiv.ts
+++ b/harness/src/tools/research/search-arxiv.ts
@@ -15,9 +15,14 @@ const source = createArxivSource({ maxRetries: 3, retryDelayMs: 1_000, timeoutMs
 export const searchArxivTool = defineTool({
     id: "search_arxiv",
     description:
-        "Search arXiv for preprints in ML, physics, math, control theory, " +
-        "economics, and related quantitative fields. Returns id, title, " +
-        "abstract, authors, publication date, arXiv categories, and URLs.",
+        "Search arXiv — the open preprint server of Cornell University — for work in machine learning, physics, math, quantitative biology, control " +
+        "theory, economics and the related quantitative fields. Returns id, title, abstract, authors, publication date, arXiv categories, and URLs.\n" +
+        "It carries PREPRINTS, thus a paper here may not be peer reviewed, and it is where a method appears months before a journal holds it. For the " +
+        "clinical and biomedical literature use pubmed, which indexes MEDLINE; for cross-domain coverage of any field use search_semantic_scholar.\n" +
+        "ACCEPTED IDENTIFIERS: free text in `query`, and arXiv category codes in `categories` ('cs.LG', 'q-bio.GN', 'math.OC'). An arXiv ID " +
+        "('2301.00001') also matches as free text.\n" +
+        "ABSENCE IS NORMAL: an empty papers array means arXiv holds nothing for the query, and `success: false` with an `error` string means the service " +
+        "could not be reached. Report either one and continue, do not retry unchanged.",
     inputSchema: z.object({
         query: z.string().describe('Free-text query. Example: "adaptive control feedback stabilization".'),
         categories: z

--- a/harness/src/tools/research/search-semantic-scholar.ts
+++ b/harness/src/tools/research/search-semantic-scholar.ts
@@ -22,10 +22,16 @@ export function createSearchSemanticScholarTool(options: { readonly apiKey?: str
     return defineTool({
         id: "search_semantic_scholar",
         description:
-            "Search Semantic Scholar for academic papers across all sciences " +
-            "(biology, ML, physics, math, economics, engineering, etc.). Returns " +
-            "paper id, title, abstract, year, venue, citation count, authors, and " +
-            "external IDs (DOI, ArXiv). Best for cross-domain analogical search.",
+            "Search Semantic Scholar — the cross-disciplinary literature corpus of the Allen Institute for AI, which indexes over 200M papers across " +
+            "biology, medicine, machine learning, physics, math, economics and engineering. Returns paper id, title, abstract, year, venue, citation " +
+            "count, authors, and external IDs (DOI, arXiv). Its citation counts are what rank a field by influence, and its breadth is what makes it the " +
+            "tool for a cross-domain analogical search.\n" +
+            "For the clinical and biomedical literature alone, pubmed indexes MEDLINE more precisely; for preprints in the quantitative fields use " +
+            "search_arxiv.\n" +
+            "ACCEPTED IDENTIFIERS: free text in `query`. A DOI or an arXiv ID also matches as free text, and each result carries its DOI and arXiv ID " +
+            "back for a citation.\n" +
+            "ABSENCE IS NORMAL: an empty papers array means the corpus holds nothing for the query, and `success: false` with an `error` string means the " +
+            "service could not be reached (its unkeyed rate limit lands here). Report either one and continue, do not retry unchanged.",
         inputSchema: z.object({
             query: z
                 .string()


### PR DESCRIPTION
## What & why

The conversation agent could not answer a question that named an identifier. It held a research sub-agent that gave it no tool it did not already hold, and reaching for that sub-agent spent tokens without an answer. The planner drafted every plan from its seed and guessed past a gap. This branch closes each of those, and it sets the reasoning depth for every loop.

Reviewer notes:

- **A required dep is new.** `GeneratePlanDeps` now takes `bioKeys`. An embedder that builds `createGeneratePlanTool` at its own composition root must pass it.
- **Every loop now sends a reasoning directive.** `providers/reasoning.ts` is the one place that names a vendor for depth, and it defaults to adaptive thinking at `xhigh`. It is inert on a model with no reasoning support. A host that wants the old behavior passes `reasoning: "off"` per run.
- **Turn budgets moved to 200** for the conversation agent, each sandbox step agent, the report session, and the planner. The two per-agent step overrides are gone, thus each step agent takes the shared default.
- **`literature_reviewer` left the conversation roster only.** The synthesis agent still holds it, because a workflow body has no user to stream to.
- **One API base moved.** `reactome.org/ContentService` answers 404 on each path that the client calls. `release.reactome.org` answers 200 on all three. A linked web page stays on the primary host.
- **Two suite-wide tests time out under load** (`production-resolver`, `derive-table`). Both fail the same way on the branch point, thus neither is new.

## Type of change

- [x] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [ ] This PR is focused on a single logical change.

https://claude.ai/code/session_014Y416Vj3ctDkL1ZqsuNfRz
