### PR TITLE
fix(providers): state the reasoning depth with the neutral name of the AI SDK

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.30.0",
+    "version": "0.30.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -255,7 +255,6 @@ export type {
     ChatUsage,
     ModelMessage,
     PromptCachePolicy,
-    ReasoningEffort,
     ReasoningPolicy,
 } from "./providers/types.js";
 // Prompt caching. `PromptCachePolicy` is the harness's vendor-neutral cache
@@ -266,13 +265,15 @@ export type {
 // `"off"`; the `cortex.harness.agent.cache_*_tokens` metrics show which case a
 // deployment is actually in.
 export { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "./providers/prompt-cache.js";
-// Reasoning depth. `ReasoningPolicy` is the vendor-neutral directive for how
-// deep a model reasons; a composition root sets it per run through
-// `RunAgentOptions.reasoning`. It defaults to `DEFAULT_REASONING` — adaptive
-// thinking at the `xhigh` effort — because an agent loop drives tools over many
-// iterations, and a shallow turn there wastes more calls than the deeper turn
-// costs in tokens. A host on a model with no reasoning support passes `"off"`.
-export { DEFAULT_REASONING, reasoningProviderOptions } from "./providers/reasoning.js";
+// Reasoning depth. `ReasoningPolicy` is the vendor-neutral name for how deep a
+// model reasons; a composition root sets it per run through
+// `RunAgentOptions.reasoning`. It defaults to `DEFAULT_REASONING` — `xhigh` —
+// because an agent loop drives tools over many iterations, and a shallow turn
+// there wastes more calls than the deeper turn costs in tokens. The provider
+// package resolves the name for the model that it is bound to, thus a model
+// that accepts no `xhigh` gets the nearest name that it accepts. A host on a
+// model with no reasoning support passes `"provider-default"`.
+export { DEFAULT_REASONING } from "./providers/reasoning.js";
 // Provider error channel. `ProviderError` is the value `chat`/`embed` fail
 // with; `toProviderError` is its sole constructor. Exposed so an embedder
 // realizing its own `ChatProvider`/`EmbeddingProvider` fails with the exact

--- a/harness/src/loop/prompt-cache.test.ts
+++ b/harness/src/loop/prompt-cache.test.ts
@@ -25,14 +25,6 @@ import type { AgentDefinition } from "./types.js";
 
 const ANTHROPIC_5M = { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } };
 
-/** The reasoning half of the merged bag — the default policy of `run-agent`. */
-const REASONING_XHIGH = { anthropic: { effort: "xhigh", thinking: { type: "adaptive" } }, openai: { reasoningEffort: "xhigh" } };
-
-/** The whole bag the loop attaches when both defaults are in force. */
-const MERGED_5M = {
-    anthropic: { ...ANTHROPIC_5M.anthropic, ...REASONING_XHIGH.anthropic },
-    openai: REASONING_XHIGH.openai,
-};
 
 const echoTool = defineTool({
     id: "echo",
@@ -95,7 +87,7 @@ describe("runAgent prompt-cache directive", () => {
         // 3 iterations + the forced tool-less wrap-up.
         expect(chat.calls).toHaveLength(4);
         for (const call of chat.calls) {
-            expect(call.providerOptions).toEqual(MERGED_5M);
+            expect(call.providerOptions).toEqual(ANTHROPIC_5M);
         }
 
         // The wrap-up is the call that empties the tool set — it must still carry
@@ -104,7 +96,7 @@ describe("runAgent prompt-cache directive", () => {
         const wrapUp = chat.calls.at(-1)!;
         expect(Object.keys(wrapUp.tools)).toHaveLength(0);
         expect(wrapUp.toolChoice).toBe("none");
-        expect(wrapUp.providerOptions).toEqual(MERGED_5M);
+        expect(wrapUp.providerOptions).toEqual(ANTHROPIC_5M);
     });
 
     it("sends the same directive object on every call, so the prefix stays byte-identical", async () => {
@@ -134,11 +126,38 @@ describe("runAgent prompt-cache directive", () => {
         await runAgent(agentDef(2), GO, makeSession(), opts(chat, { promptCache: "off" as PromptCachePolicy }));
 
         expect(chat.calls).toHaveLength(3);
-        // The bag is not empty — the reasoning policy still writes its own keys.
-        // What caching off means is that no cache directive rides in it.
+        // Caching off leaves no bag at all. The reasoning depth rides on its own
+        // neutral field, thus it writes no vendor key here.
         for (const call of chat.calls) {
-            expect(call.providerOptions?.["anthropic"]?.["cacheControl"]).toBeUndefined();
-            expect(call.providerOptions).toEqual(REASONING_XHIGH);
+            expect(call.providerOptions).toBeUndefined();
+            expect(call.reasoning).toBe("xhigh");
+        }
+    });
+});
+
+describe("runAgent reasoning directive", () => {
+    it("carries the neutral depth on every call, and writes no vendor key for it", async () => {
+        const chat = neverTerminating();
+
+        await runAgent(agentDef(3), GO, makeSession(), opts(chat));
+
+        expect(chat.calls).toHaveLength(4);
+        for (const call of chat.calls) {
+            expect(call.reasoning).toBe("xhigh");
+            // The vendor key is what turned the per-model table of the provider
+            // package off, thus nothing may write it again.
+            expect(call.providerOptions?.["anthropic"]?.["effort"]).toBeUndefined();
+            expect(call.providerOptions?.["openai"]).toBeUndefined();
+        }
+    });
+
+    it("honours an explicit depth from the composition root", async () => {
+        const chat = neverTerminating();
+
+        await runAgent(agentDef(2), GO, makeSession(), opts(chat, { reasoning: "low" }));
+
+        for (const call of chat.calls) {
+            expect(call.reasoning).toBe("low");
         }
     });
 });

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -24,7 +24,7 @@ import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-m
 import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
 import { classifyProviderError } from "../providers/errors.js";
 import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/prompt-cache.js";
-import { DEFAULT_REASONING, mergeProviderOptions, reasoningProviderOptions } from "../providers/reasoning.js";
+import { DEFAULT_REASONING } from "../providers/reasoning.js";
 import { resultStep } from "./run-step.js";
 import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderCapabilities, ReasoningPolicy } from "../providers/types.js";
 import { AskRejectedError, UnavailableAsk, type AskApproval, type AskRequest } from "../tools/approval/contract.js";
@@ -116,14 +116,15 @@ export interface RunAgentOptions {
     readonly promptCache?: PromptCachePolicy;
     /**
      * Reasoning policy for every LLM call this run makes. Defaults to
-     * `DEFAULT_REASONING` (adaptive thinking at `xhigh`) — an agent loop drives
-     * tools over many iterations, and a shallow turn there costs more in wasted
-     * calls than the deeper turn costs in tokens.
+     * `DEFAULT_REASONING` (`xhigh`) — an agent loop drives tools over many
+     * iterations, and a shallow turn there costs more in wasted calls than the
+     * deeper turn costs in tokens. The provider package resolves the name for
+     * the model that it is bound to.
      *
      * The policy lives here, on the run, rather than on the provider, for the
      * same reason that the cache policy does: a one-shot LLM call elsewhere has
      * its own depth needs and must not inherit the depth of a loop. A host on a
-     * model with no reasoning support passes `"off"`.
+     * model with no reasoning support passes `"provider-default"`.
      */
     readonly reasoning?: ReasoningPolicy;
     /**
@@ -234,10 +235,10 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // Resolved once, not per iteration: an identical options object across every
     // call is itself part of the cache contract — the request prefix has to be
     // byte-identical to be read back.
-    const providerOptions = mergeProviderOptions(
-        promptCacheProviderOptions(opts.promptCache ?? DEFAULT_PROMPT_CACHE),
-        reasoningProviderOptions(opts.reasoning ?? DEFAULT_REASONING),
-    );
+    const providerOptions = promptCacheProviderOptions(opts.promptCache ?? DEFAULT_PROMPT_CACHE);
+    // The depth is a neutral name, and the provider package resolves it for the
+    // model. A vendor key here would turn that resolution off.
+    const reasoning = opts.reasoning ?? DEFAULT_REASONING;
     const usage: AgentRunUsage = {};
 
     // Exactly one record per completed run — never one per iteration. That bound is
@@ -400,6 +401,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
             tools: toolDefs,
             ...(opts.toolChoice !== undefined ? { toolChoice: opts.toolChoice } : {}),
             providerOptions,
+            reasoning,
         };
         const llmStepName = formatStepName.llm(i);
         const reply = await resultStep(runStep)(llmStepName, () => provider.chat(request, session, signal));
@@ -524,7 +526,7 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // cache_write_tokens counter is what makes that waste visible.
     const wrapUpStepName = formatStepName.llm(agent.maxIterations);
     const wrapUp = await resultStep(runStep)(wrapUpStepName, () =>
-        provider.chat({ system: agent.systemPrompt, messages, tools: {}, toolChoice: "none", providerOptions }, session, signal),
+        provider.chat({ system: agent.systemPrompt, messages, tools: {}, toolChoice: "none", providerOptions, reasoning }, session, signal),
     );
     accountForCall(wrapUp, wrapUpStepName);
 

--- a/harness/src/providers/ai-sdk.ts
+++ b/harness/src/providers/ai-sdk.ts
@@ -642,6 +642,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                         // bound, because the headers of a non-streaming response arrive
                         // when the model completes.
                         providerOptions: req.providerOptions,
+                        reasoning: req.reasoning,
                     });
                 });
                 return ok(responseFromGenerate(result, { requestedModelId, servedModelId: capture.servedModelId() }));
@@ -687,6 +688,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                     // thus it feeds neither bound.
                     ...(requestTimeoutMs !== undefined ? { timeout: { firstChunkMs: requestTimeoutMs, chunkMs: requestTimeoutMs } } : {}),
                     providerOptions: req.providerOptions,
+                    reasoning: req.reasoning,
                 });
                 const iterator = result.fullStream[Symbol.asyncIterator]();
                 const first = await pullNextDelta(iterator);
@@ -846,38 +848,6 @@ function withStoreDirective(model: LanguageModelV4, store: boolean): LanguageMod
 }
 
 /**
- * Mirror the neutral reasoning effort into the namespace of an
- * OpenAI-compatible connection.
- *
- * The compatible provider reads `providerOptions[<the name of the connection>]`
- * rather than `providerOptions.openai`, and it derives that namespace from the
- * first dot-separated segment of the name. The loop cannot write that key,
- * because only this seam knows the name. Thus the middleware copies
- * `reasoningEffort` across at request time. A value that the caller already set
- * on the namespace wins, and a request with no effort passes through untouched.
- */
-function withCompatibleReasoning(model: LanguageModelV4, name: string): LanguageModelV4 {
-    const namespace = name.split(".")[0]?.trim();
-    if (namespace === undefined || namespace === "") return model;
-    return wrapLanguageModel({
-        model,
-        middleware: {
-            transformParams: async ({ params }) => {
-                const effort = params.providerOptions?.["openai"]?.["reasoningEffort"];
-                if (effort === undefined) return params;
-                return {
-                    ...params,
-                    providerOptions: {
-                        ...params.providerOptions,
-                        [namespace]: { reasoningEffort: effort, ...params.providerOptions?.[namespace] },
-                    },
-                };
-            },
-        },
-    });
-}
-
-/**
  * Realize an `AiSdkProviderConfig` into a `ChatProvider` bound to that config's
  * connection and model. The model is closed into the returned provider here (it
  * is never passed per `ChatRequest`), so N models require N provider
@@ -961,7 +931,9 @@ export function createConfiguredAiSdkProvider(deps: ConfiguredAiSdkProviderDeps)
         fetch: effectiveFetch as typeof fetch | undefined,
     });
     return createAiSdkProvider({
-        model: withCompatibleReasoning(provider.chatModel(config.model), config.name),
+        // The compatible package reads the neutral `reasoning` of the call, thus
+        // the seam needs no middleware to carry the depth into its namespace.
+        model: provider.chatModel(config.model),
         resolveBilling: deps.resolveBilling,
         capabilities: config.capabilities,
         logger: deps.logger,

--- a/harness/src/providers/reasoning.ts
+++ b/harness/src/providers/reasoning.ts
@@ -1,35 +1,18 @@
 /**
- * Reasoning policy → provider wire options.
+ * The reasoning depth of a run.
  *
- * This is the **only** place in the harness that names a vendor for reasoning
- * depth. Everything upstream — `ReasoningPolicy` and `RunAgentOptions` — speaks
- * the neutral harness concept. This module translates it one time, at the
- * provider seam, thus the loop never learns which vendor it talks to. It is the
- * sibling of `prompt-cache.ts`, and it obeys the same rules.
+ * The harness states the depth one time, on `ChatRequest.reasoning`, with the
+ * neutral names of the AI SDK. It names no vendor key. Each provider package
+ * holds the table of what its own models accept, and it maps the neutral name
+ * onto the wire. The Anthropic package also selects adaptive thinking there.
  *
- * ## Why the emitted options are safe on every provider
+ * ## Why the harness names no vendor key
  *
- * `providerOptions` of the AI SDK is a namespaced bag. Each provider reads only
- * `providerOptions[<its own name>]`, and it ignores each other key. Thus the
- * `anthropic` namespace is inert on an OpenAI model, and the `openai` namespace
- * is inert on an Anthropic model. Neither one is an error.
- *
- * ## What each namespace does
- *
- * The Anthropic namespace carries two keys, because the vendor splits the
- * concept in two:
- *
- *  - `thinking: { type: "adaptive" }` says that the model reasons, and it lets
- *    the model choose the depth for each turn. A fixed `budgetTokens` is removed
- *    on the current models, and it returns a 400 there.
- *  - `effort` says how deep the model reasons and how much it spends in total.
- *    The vendor default is `high`.
- *
- * The OpenAI namespace carries one key, `reasoningEffort`, which takes the same
- * five values. An OpenAI-compatible endpoint reads the same key, but from a
- * namespace that carries the *name of the connection* rather than `openai`. The
- * provider seam mirrors the value into that namespace, because only the seam
- * knows the name (`providers/ai-sdk.ts`).
+ * The harness wrote `providerOptions.anthropic.effort` before. A value on that
+ * key turns the per-model table of the Anthropic package off, thus the raw name
+ * reached the wire. A model that accepts `high` but not `xhigh` answered 400.
+ * The neutral field has no such hazard, because the package resolves the name
+ * for the model that it is bound to.
  *
  * ## Where the policy belongs
  *
@@ -38,46 +21,17 @@
  * depth needs, and it must not inherit the depth of an agent loop.
  */
 
-import type { ProviderOptions, ReasoningPolicy } from "./types.js";
+import type { ReasoningPolicy } from "./types.js";
 
 /**
- * The default policy: adaptive thinking at the `xhigh` effort.
+ * The default policy: the deepest name of the neutral ladder.
  *
- * `xhigh` sits between `high` and `max`. It is the vendor recommendation for
- * coding and agentic work, and each agent of the harness drives tools over many
- * iterations. `max` costs more than the remaining quality is worth for a routine
- * turn, thus it is not the default. A host that wants a cheaper loop passes a
- * lower effort, and a host on a model with no reasoning support passes `"off"`.
- */
-export const DEFAULT_REASONING: ReasoningPolicy = { effort: "xhigh" };
-
-/**
- * Translate a neutral reasoning policy into provider wire options.
+ * Each agent of the harness drives tools over many iterations. A shallow turn
+ * there wastes more calls than a deeper turn costs in tokens. The Anthropic
+ * package sends `xhigh` to a model that accepts it, and `max` to a model that
+ * does not. The OpenAI-compatible package sends the name as it is.
  *
- * Returns `undefined` for `"off"`, thus the caller can leave `providerOptions`
- * unset rather than send an empty bag.
+ * A host that wants a cheaper loop passes a lower name. A host on a model with
+ * no reasoning support passes `"provider-default"`.
  */
-export function reasoningProviderOptions(policy: ReasoningPolicy): ProviderOptions | undefined {
-    if (policy === "off") return undefined;
-    return {
-        anthropic: { effort: policy.effort, thinking: { type: "adaptive" } },
-        openai: { reasoningEffort: policy.effort },
-    };
-}
-
-/**
- * Merge two option bags one namespace at a time.
- *
- * A plain spread of the two bags drops a whole namespace when both sides carry
- * it, and the cache policy and the reasoning policy both write `anthropic`. The
- * right-hand bag wins for a key that both sides set.
- */
-export function mergeProviderOptions(left: ProviderOptions | undefined, right: ProviderOptions | undefined): ProviderOptions | undefined {
-    if (left === undefined) return right;
-    if (right === undefined) return left;
-    const merged: ProviderOptions = { ...left };
-    for (const [namespace, options] of Object.entries(right)) {
-        merged[namespace] = { ...merged[namespace], ...options };
-    }
-    return merged;
-}
+export const DEFAULT_REASONING: ReasoningPolicy = "xhigh";

--- a/harness/src/providers/types.ts
+++ b/harness/src/providers/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { FinishReason, LanguageModel, ModelMessage, ToolSet } from "ai";
+import type { LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
 import type { ResultAsync } from "neverthrow";
 
@@ -43,6 +44,11 @@ export interface ChatRequest {
     readonly tools: ToolSet;
     readonly toolChoice?: "auto" | "none" | "required" | { readonly type: "tool"; readonly toolName: string };
     readonly providerOptions?: ProviderOptions;
+    /**
+     * How deep the model reasons on this call. Absent sends no directive, thus
+     * the model applies its own default. Refer to `ReasoningPolicy`.
+     */
+    readonly reasoning?: ReasoningPolicy;
 }
 
 /**
@@ -60,15 +66,23 @@ export type PromptCachePolicy = { readonly ttl: "5m" | "1h" } | "off";
 /**
  * How deep a model reasons, in harness-neutral names.
  *
- * `{ effort }` asks the provider for that reasoning depth, and `"off"` sends no
- * reasoning directive at all. The five values are the ladder that both vendor
- * families accept. A model with no reasoning support ignores the directive
- * rather than fails on it, thus the policy is a no-op for that model. Refer to
- * `./reasoning.ts`, the single place where the harness translates this into
- * vendor wire options.
+ * This is the `reasoning` call setting of the AI SDK, and the harness passes the
+ * value through without a change. Each provider package maps the name onto its
+ * own wire shape, and each one holds the table of what its models accept. The
+ * Anthropic package selects adaptive thinking with the matching `effort`, and it
+ * lowers a level that the model does not accept. The OpenAI-compatible package
+ * sends the name as `reasoning_effort`.
+ *
+ * `"provider-default"` sends no directive, thus the model applies its own
+ * default. `"none"` asks for no reasoning. The other names are the ladder from
+ * the shallowest depth to the deepest depth.
+ *
+ * CAUTION: never write `providerOptions.anthropic.effort` or
+ * `providerOptions.openai.reasoningEffort` in place of this field. A value on
+ * either key turns the per-model table off, and the raw name then reaches the
+ * wire. A model that does not accept that name answers 400.
  */
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
-export type ReasoningPolicy = { readonly effort: ReasoningEffort } | "off";
+export type ReasoningPolicy = NonNullable<LanguageModelV4CallOptions["reasoning"]>;
 
 /**
  * Token accounting for one chat call, in harness-neutral names.


### PR DESCRIPTION
## What & why

The harness wrote `providerOptions.anthropic.effort`. A value on that key turns
the per-model table of the Anthropic package off. Thus the raw name reached the
wire, and a model that accepts no `xhigh` answered 400. `ChatRequest` now carries
the neutral `reasoning` name of the AI SDK. The provider package then resolves
the name for the model that it is bound to.

Notes for the review:

- A probe of the wire body gives `effort: "max"` with adaptive thinking for
  sonnet-4-6, and `effort: "xhigh"` with adaptive thinking for opus-4-7. The
  compatible arm gives `reasoning_effort: "xhigh"`. The package also warns when
  it lowers a name.
- The compatible-namespace middleware goes away. The compatible package reads
  the neutral name itself, thus the seam needs no mirror.
- `ReasoningEffort` and `reasoningProviderOptions` leave the public surface, and
  the `max` name goes with them. The neutral ladder stops at `xhigh`. Neither
  host reads any of the three today.
- The version is a patch, as asked. The public interface change is larger than a
  patch, thus the release is your call.
- `bun run lint`, `bun run typecheck`, and `bun test` are green (3699 pass).

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01XdXJKsGSXB2VkunLZD5eU1
