### PR TITLE
fix(providers): drive every model call on the streaming wire

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.30.1",
+    "version": "0.30.2",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/loop/prompt-cache.test.ts
+++ b/harness/src/loop/prompt-cache.test.ts
@@ -25,7 +25,6 @@ import type { AgentDefinition } from "./types.js";
 
 const ANTHROPIC_5M = { anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } } };
 
-
 const echoTool = defineTool({
     id: "echo",
     description: "A no-op tool.",
@@ -271,29 +270,24 @@ describe("runAgent cache-token metrics", () => {
 // ── The openai-compatible no-op ─────────────────────────────────────
 
 /**
- * A canned OpenAI chat-completions response. `prompt_tokens_details.cached_tokens`
+ * A canned OpenAI chat-completions stream. `prompt_tokens_details.cached_tokens`
  * is the OpenAI-family cache-read report — the provider normalizes it onto the
  * same neutral field the Anthropic provider uses.
  */
 function cannedOpenAiFetch(seen: Record<string, unknown>[]): typeof fetch {
     return (async (_input: string | URL | Request, init?: RequestInit) => {
         seen.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
-        return new Response(
-            JSON.stringify({
-                id: "chatcmpl-1",
-                object: "chat.completion",
-                created: 1_700_000_000,
-                model: "local-model",
-                choices: [{ index: 0, message: { role: "assistant", content: "done" }, finish_reason: "stop" }],
-                usage: {
-                    prompt_tokens: 100,
-                    completion_tokens: 7,
-                    total_tokens: 107,
-                    prompt_tokens_details: { cached_tokens: 80 },
-                },
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-        );
+        const base = { id: "chatcmpl-1", object: "chat.completion.chunk", created: 1_700_000_000, model: "local-model" };
+        const body = [
+            `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: { role: "assistant", content: "done" }, finish_reason: null }] })}\n\n`,
+            `data: ${JSON.stringify({
+                ...base,
+                choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                usage: { prompt_tokens: 100, completion_tokens: 7, total_tokens: 107, prompt_tokens_details: { cached_tokens: 80 } },
+            })}\n\n`,
+            "data: [DONE]\n\n",
+        ].join("");
+        return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
     }) as typeof fetch;
 }
 

--- a/harness/src/providers/ai-sdk.openai-arm.test.ts
+++ b/harness/src/providers/ai-sdk.openai-arm.test.ts
@@ -70,20 +70,6 @@ const RESPONSES_USAGE = {
     output_tokens_details: { reasoning_tokens: 64 },
 };
 
-/** A complete Responses reply that carries one assistant text item. */
-function responsesJson(text: string): Response {
-    return new Response(
-        JSON.stringify({
-            id: "resp_test_1",
-            created_at: 1_700_000_000,
-            model: MODEL,
-            output: [{ type: "message", role: "assistant", id: "msg_test_1", content: [{ type: "output_text", text, annotations: [] }] }],
-            usage: RESPONSES_USAGE,
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-    );
-}
-
 /** One event of the Responses event stream. */
 function sseEvent(event: object): string {
     return `data: ${JSON.stringify(event)}\n\n`;
@@ -101,18 +87,14 @@ function responsesSse(deltas: readonly string[]): Response {
     return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
 }
 
-/** A chat-completions reply. The Responses path of the package cannot read it. */
-function chatCompletionsJson(text: string): Response {
+/** A Responses event stream that reports a failure instead of a turn. */
+function responsesErrorSse(message: string): Response {
     return new Response(
-        JSON.stringify({
-            id: "chatcmpl_test_1",
-            object: "chat.completion",
-            created: 1_700_000_000,
-            model: MODEL,
-            choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }],
-            usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
+        [
+            sseEvent({ type: "response.created", response: { id: "resp_test_1", created_at: 1_700_000_000, model: MODEL } }),
+            sseEvent({ type: "error", code: "server_error", message, sequence_number: 1 }),
+        ].join(""),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
     );
 }
 
@@ -162,7 +144,7 @@ describe("openai arm usage", () => {
     it("lands the cached and the reasoning counts of the Responses wire on the neutral fields", async () => {
         // The arm owns no usage mapping. The package normalizes the two nested
         // wire counts, and the shared runtime copies them onto `ChatUsage`.
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch), resolveBilling: async () => ({}) });
 
         const reply = (await provider.chat(request, makeSession()))._unsafeUnwrap();
@@ -198,11 +180,11 @@ describe("openai arm stream", () => {
     });
 });
 
-describe("openai arm wire mismatch", () => {
-    it("surfaces a classified provider error for a chat-completions body", async () => {
-        // The arm binds the Responses path. A backend that answers with the other
-        // dialect fails loud on the error channel, and it never reads as a turn.
-        const cap = capturingFetch(() => chatCompletionsJson("Hello, world"));
+describe("openai arm stream failure", () => {
+    it("surfaces a classified provider error for an error event", async () => {
+        // A backend that reports a failure mid-stream fails loud on the error
+        // channel, and it never reads as an empty turn.
+        const cap = capturingFetch(() => responsesErrorSse("upstream exploded"));
         const provider = createConfiguredAiSdkProvider({
             config: openaiArm(cap.fetch, { maxRetries: 0 }),
             resolveBilling: async () => ({}),
@@ -213,8 +195,7 @@ describe("openai arm wire mismatch", () => {
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error.type).toBe("provider");
-            expect(result.error.retryable).toBe(false);
-            expect(result.error.message).toContain("Invalid JSON response");
+            expect(result.error.message).toContain("upstream exploded");
         }
     });
 });
@@ -223,7 +204,7 @@ describe("openai arm store directive", () => {
     it("sends store false when the config declares no value", async () => {
         // An unset value lets the server keep the response, and it makes the
         // package emit an item reference for a round-tripped item.
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(request, makeSession());
@@ -233,7 +214,7 @@ describe("openai arm store directive", () => {
     });
 
     it("sends store true when the config declares it", async () => {
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch, { store: true }), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(request, makeSession());
@@ -246,7 +227,7 @@ describe("openai arm store directive", () => {
         // The cache namespace of a different vendor is inert on this wire, thus
         // the `user` key carries the proof: the merge adds, and it does not
         // replace.
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(
@@ -268,7 +249,7 @@ describe("openai arm output ceiling", () => {
         // The package puts a ceiling on the wire as it is. A shared default above
         // the cap of the model fails each call, thus the arm sends none and the
         // server holds the reply at the cap.
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(request, makeSession());
@@ -278,7 +259,7 @@ describe("openai arm output ceiling", () => {
     });
 
     it("sends the ceiling that the config names", async () => {
-        const cap = capturingFetch(() => responsesJson("Hello, world"));
+        const cap = capturingFetch(() => responsesSse(["Hello, world"]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch, { maxOutputTokens: 4_096 }), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(request, makeSession());
@@ -293,7 +274,7 @@ describe("openai arm encrypted reasoning", () => {
         // The stateless path of the package captures the blob in the
         // provider-scoped options of a reasoning part. A later turn hands the
         // same history back, and the blob must reach the wire again.
-        const cap = capturingFetch(() => responsesJson("The second answer."));
+        const cap = capturingFetch(() => responsesSse(["The second answer."]));
         const provider = createConfiguredAiSdkProvider({ config: openaiArm(cap.fetch), resolveBilling: async () => ({}) });
 
         const result = await provider.chat(

--- a/harness/src/providers/ai-sdk.request-timeout.test.ts
+++ b/harness/src/providers/ai-sdk.request-timeout.test.ts
@@ -12,10 +12,12 @@ const request: ChatRequest = {
     tools: {},
 };
 
-/** A minimal OpenAI-compatible chat completion that the SDK parses to `"ok"`. */
-const OK_COMPLETION = JSON.stringify({
-    choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
-});
+/** A minimal OpenAI-compatible completion stream that the SDK parses to `"ok"`. */
+const OK_COMPLETION = [
+    `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "local-model", choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }] })}\n\n`,
+    `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "local-model", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+    "data: [DONE]\n\n",
+].join("");
 
 /** Build an OpenAI-compatible config over a fake fetch, with the guard fields set per test. */
 function openAiConfig(fetch: FetchLike, opts: { requestTimeoutMs?: number; maxRetries?: number } = {}): AiSdkProviderConfig {
@@ -31,9 +33,9 @@ function openAiConfig(fetch: FetchLike, opts: { requestTimeoutMs?: number; maxRe
     };
 }
 
-/** A JSON response with headers ready at once. */
-function jsonResponse(body: string): Response {
-    return new Response(body, { status: 200, headers: { "content-type": "application/json" } });
+/** An event-stream response with headers ready at once. */
+function sseResponse(body: string): Response {
+    return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
 }
 
 /**
@@ -85,7 +87,7 @@ function fetchWithSteadyBody(body: string, chunks: number, gapMs: number): Fetch
                 );
             },
         });
-        return Promise.resolve(new Response(stream, { status: 200, headers: { "content-type": "application/json" } }));
+        return Promise.resolve(new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } }));
     };
 }
 
@@ -146,7 +148,7 @@ describe("request-timeout guard", () => {
         const fetch: FetchLike = (input, init) => {
             calls += 1;
             if (calls === 1) return fetchThatNeverStarts()(input, init);
-            return Promise.resolve(jsonResponse(OK_COMPLETION));
+            return Promise.resolve(sseResponse(OK_COMPLETION));
         };
         const provider = createConfiguredAiSdkProvider({
             config: openAiConfig(fetch, { requestTimeoutMs: 30 }),
@@ -253,7 +255,7 @@ describe("request-timeout transport lift", () => {
         const inits: (RequestInit | undefined)[] = [];
         const wrapped = wrapFetchWithRequestTimeout((_input, init) => {
             inits.push(init);
-            return Promise.resolve(jsonResponse(OK_COMPLETION));
+            return Promise.resolve(sseResponse(OK_COMPLETION));
         }, 10_000);
 
         await wrapped("http://models.local/v1", { method: "POST" });
@@ -269,7 +271,7 @@ describe("request-timeout transport lift", () => {
         const provider = createConfiguredAiSdkProvider({
             config: openAiConfig((_input, init) => {
                 inits.push(init);
-                return Promise.resolve(jsonResponse(OK_COMPLETION));
+                return Promise.resolve(sseResponse(OK_COMPLETION));
             }),
             resolveBilling: async () => ({}),
         });

--- a/harness/src/providers/ai-sdk.test.ts
+++ b/harness/src/providers/ai-sdk.test.ts
@@ -19,6 +19,8 @@ import {
     RETRY_MAX_DELAY_MS,
     RETRY_MAX_RETRIES,
 } from "./ai-sdk.js";
+import { createNoopLogger } from "../lib/console-logger.js";
+import type { LogFields, Logger } from "../lib/logger.js";
 import { isProviderError } from "./errors.js";
 import type { ChatRequest } from "./types.js";
 
@@ -53,6 +55,47 @@ function streamResult(deltas: readonly string[]): LanguageModelV4StreamResult {
     };
 }
 
+/**
+ * Replay a generate-shaped double as a stream. Both provider entry points drive
+ * the same wire, so one fixture has to reach `doStream` as well: the parts carry
+ * the same content, identity, finish reason and usage the generate result holds.
+ * A rejecting `impl` rejects here too, which is what the retry tests need.
+ */
+function streamFromGenerate(
+    impl: (options: LanguageModelV4CallOptions) => Promise<LanguageModelV4GenerateResult>,
+): (options: LanguageModelV4CallOptions) => Promise<LanguageModelV4StreamResult> {
+    return async (options) => {
+        const generated = await impl(options);
+        return {
+            stream: new ReadableStream({
+                start(controller) {
+                    controller.enqueue({ type: "stream-start", warnings: generated.warnings });
+                    const modelId = generated.response?.modelId;
+                    if (modelId !== undefined) controller.enqueue({ type: "response-metadata", modelId });
+                    let seq = 0;
+                    for (const content of generated.content) {
+                        if (content.type === "text") {
+                            const id = `txt-${(seq += 1)}`;
+                            controller.enqueue({ type: "text-start", id });
+                            controller.enqueue({ type: "text-delta", id, delta: content.text });
+                            controller.enqueue({ type: "text-end", id });
+                            continue;
+                        }
+                        if (content.type === "tool-call") controller.enqueue(content);
+                    }
+                    controller.enqueue({
+                        type: "finish",
+                        finishReason: generated.finishReason,
+                        usage: generated.usage,
+                        ...(generated.providerMetadata !== undefined ? { providerMetadata: generated.providerMetadata } : {}),
+                    });
+                    controller.close();
+                },
+            }),
+        };
+    };
+}
+
 function fakeModel(
     impl: (options: LanguageModelV4CallOptions) => Promise<LanguageModelV4GenerateResult>,
     streamImpl?: (options: LanguageModelV4CallOptions) => Promise<LanguageModelV4StreamResult>,
@@ -63,11 +106,7 @@ function fakeModel(
         modelId: "fake-model",
         supportedUrls: {},
         doGenerate: impl,
-        doStream:
-            streamImpl ??
-            (async () => {
-                throw new Error("streaming is not used in these tests");
-            }),
+        doStream: streamImpl ?? streamFromGenerate(impl),
     };
 }
 
@@ -169,7 +208,10 @@ describe("createAiSdkProvider", () => {
 
         expect(result.isOk()).toBe(true);
         expect(result._unsafeUnwrap().message).toEqual({ role: "assistant", content: [{ type: "text", text: "done" }] });
-        expect(calls[0]!.headers).toMatchObject({
+        // A header name is case-insensitive on the wire, thus the assertion folds
+        // the case rather than pinning the spelling the SDK happens to forward.
+        const sent = Object.fromEntries(Object.entries(calls[0]!.headers ?? {}).map(([name, value]) => [name.toLowerCase(), value]));
+        expect(sent).toMatchObject({
             "x-billing-context": "bc-test",
             "x-billing-virtual-key": "vk-test",
         });
@@ -1229,5 +1271,116 @@ describe("model identity", () => {
         if (done?.type !== "done") throw new Error(`expected a terminal done event, got ${done?.type}`);
         expect(done.response.requestedModelId).toBe("fake-model");
         expect(done.response.servedModelId).toBe("fake-model-20260101");
+    });
+});
+
+describe("stream error parts", () => {
+    /** A stream that opens, then reports `error` the way a mid-turn failure does. */
+    function erroringStream(error: unknown): () => Promise<LanguageModelV4StreamResult> {
+        return async () => ({
+            stream: new ReadableStream({
+                start(controller) {
+                    controller.enqueue({ type: "stream-start", warnings: [] });
+                    controller.enqueue({ type: "error", error });
+                    controller.close();
+                },
+            }),
+        });
+    }
+
+    it("fails the call rather than returning the empty turn the parts describe", async () => {
+        const provider = createAiSdkProvider({
+            model: fakeModel(async () => okResult("unused"), erroringStream(new Error("upstream exploded"))),
+            resolveBilling: async () => ({}),
+            maxRetries: 0,
+        });
+
+        const result = await provider.chat(request, makeSession());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.type).toBe("provider");
+            expect(result.error.message).toContain("upstream exploded");
+        }
+    });
+
+    it("classifies a named condition by the status it stands for, thus overload stays retryable", async () => {
+        const provider = createAiSdkProvider({
+            model: fakeModel(async () => okResult("unused"), erroringStream({ type: "overloaded_error", message: "Overloaded" })),
+            resolveBilling: async () => ({}),
+            maxRetries: 0,
+        });
+
+        const result = await provider.chat(request, makeSession());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.retryable).toBe(true);
+            // The bare payload reaches the message as its own text, never as
+            // `[object Object]`.
+            expect(result.error.message).toContain("Overloaded");
+            expect(result.error.message).toContain("529");
+        }
+    });
+});
+
+describe("failure logging", () => {
+    /** A logger that keeps the records emitted at `error`. */
+    function recordingLogger(): { logger: Logger; errors: { msg: string; fields?: LogFields }[] } {
+        const errors: { msg: string; fields?: LogFields }[] = [];
+        const base = createNoopLogger();
+        const logger: Logger = {
+            ...base,
+            error: (msg, fields) => {
+                errors.push(fields === undefined ? { msg } : { msg, fields });
+            },
+            with: () => logger,
+            named: () => logger,
+            errorFields: (err) => ({ error: err instanceof Error ? err.message : String(err) }),
+        };
+        return { logger, errors };
+    }
+
+    it("records a call the envelope gave up on, thus the operator sees what the reply says", async () => {
+        const { logger, errors } = recordingLogger();
+        const provider = createAiSdkProvider({
+            model: fakeModel(async () => {
+                throw Object.assign(new Error("payment required"), { status: 402 });
+            }),
+            resolveBilling: async () => ({}),
+            maxRetries: 0,
+            logger,
+        });
+
+        const result = await provider.chat(request, makeSession());
+
+        expect(result.isErr()).toBe(true);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]!.msg).toBe("provider call failed");
+        expect(errors[0]!.fields).toMatchObject({ kind: "budget", retryable: false, error: "payment required" });
+    });
+
+    it("leaves a caller abort unrecorded, because a cancellation is not a failure", async () => {
+        const { logger, errors } = recordingLogger();
+        const controller = new AbortController();
+        const provider = createAiSdkProvider({
+            model: fakeModel(async () => {
+                controller.abort();
+                throw controller.signal.reason;
+            }),
+            resolveBilling: async () => ({}),
+            maxRetries: 0,
+            logger,
+        });
+
+        let threw = false;
+        try {
+            await provider.chat(request, makeSession(), controller.signal);
+        } catch {
+            threw = true;
+        }
+
+        expect(threw).toBe(true);
+        expect(errors).toHaveLength(0);
     });
 });

--- a/harness/src/providers/ai-sdk.ts
+++ b/harness/src/providers/ai-sdk.ts
@@ -1,5 +1,4 @@
 import {
-    generateText,
     streamText,
     wrapLanguageModel,
     type FinishReason,
@@ -454,10 +453,10 @@ interface ServedModelCapture {
 
 /**
  * Capture the served model id at the raw model boundary, because that is the
- * only place it is still distinguishable from the requested one: `generateText`
- * and `streamText` both coalesce an unreported response model id to the bound
- * model's own id, so reading `result.response.modelId` would silently republish
- * the requested id as an endpoint's claim. A middleware sees the provider's
+ * only place it is still distinguishable from the requested one: `streamText`
+ * coalesces an unreported response model id to the bound model's own id, so
+ * reading `result.response.modelId` would silently republish the requested id
+ * as an endpoint's claim. A middleware sees the provider's
  * result before that fallback applies, so "reported nothing" stays absent.
  *
  * Built per call, never per provider: one provider instance serves concurrent
@@ -513,20 +512,6 @@ function responseFromMessages(input: {
     return { message, finishReason, rawFinishReason, usage, requestedModelId, servedModelId };
 }
 
-function responseFromGenerate(
-    result: Awaited<ReturnType<typeof generateText>>,
-    identity: { readonly requestedModelId?: string; readonly servedModelId?: string },
-): ChatResponse {
-    return responseFromMessages({
-        messages: result.responseMessages,
-        fallbackText: result.text,
-        finishReason: result.finishReason,
-        rawFinishReason: result.rawFinishReason,
-        usage: result.usage,
-        ...identity,
-    });
-}
-
 /**
  * Drop empty text parts — and messages left with no content at all — before
  * the wire call. The Anthropic Messages API rejects any request containing an
@@ -558,9 +543,15 @@ function sanitizeMessages(messages: readonly ModelMessage[]): ModelMessage[] {
  *
  * `delta` carries the text of one content part. `aborted` marks the `abort`
  * part, which the SDK emits when the chunk bound or the caller signal stops the
- * stream. `end` marks a stream that closed with no further text.
+ * stream. `failed` marks the `error` part, which the SDK emits for a wire
+ * failure that reaches it mid-stream. `end` marks a stream that closed with no
+ * further text.
  */
-type StreamPull = { readonly kind: "delta"; readonly text: string } | { readonly kind: "aborted"; readonly reason?: string } | { readonly kind: "end" };
+type StreamPull =
+    | { readonly kind: "delta"; readonly text: string }
+    | { readonly kind: "aborted"; readonly reason?: string }
+    | { readonly kind: "failed"; readonly error: unknown }
+    | { readonly kind: "end" };
 
 /**
  * Advance the SDK stream to the next text delta.
@@ -576,8 +567,54 @@ async function pullNextDelta(iterator: AsyncIterator<TextStreamPart<ToolSet>>): 
         const part = next.value;
         if (part.type === "text-delta") return { kind: "delta", text: part.text };
         if (part.type === "abort") return { kind: "aborted", reason: part.reason };
+        // The SDK reports a wire failure as a part, not as a rejection, and it
+        // then closes the stream. Skipping it would turn a failed call into an
+        // empty assistant turn that the loop reads as a real answer.
+        if (part.type === "error") return { kind: "failed", error: part.error };
     }
     return { kind: "end" };
+}
+
+/**
+ * The HTTP status that each Anthropic stream error type stands for.
+ *
+ * A provider names a mid-stream failure in the payload, not in the status line:
+ * a stream that carries `overloaded_error` reports the condition that a 529
+ * names on the non-streaming wire. The classifier reads the status alone, thus
+ * the part has to reach it as an error that names one, or the same condition
+ * would classify one way on `chat` and another way on `chatStream`.
+ */
+const STREAM_ERROR_STATUS: Readonly<Record<string, number>> = {
+    invalid_request_error: 400,
+    authentication_error: 401,
+    permission_error: 403,
+    not_found_error: 404,
+    request_too_large: 413,
+    rate_limit_error: 429,
+    timeout_error: 408,
+    api_error: 500,
+    overloaded_error: 529,
+};
+
+/**
+ * The failure that an `error` part of the SDK stream stands for.
+ *
+ * The part carries whatever the provider put on the wire, and that is often a
+ * bare object rather than an `Error`. Left as it is, it reaches the message as
+ * `[object Object]` and reaches the classifier with no status at all.
+ */
+function streamPartFailure(error: unknown): unknown {
+    if (error instanceof Error) return error;
+    if (typeof error !== "object" || error === null) return new Error(String(error));
+    const reported = error as { readonly type?: unknown; readonly message?: unknown };
+    const type = typeof reported.type === "string" ? reported.type : undefined;
+    const message = typeof reported.message === "string" ? reported.message : undefined;
+    const failure = new Error(message ?? type ?? "The provider reported a stream error.", { cause: error });
+    const status = type === undefined ? undefined : STREAM_ERROR_STATUS[type];
+    // `extractStatus` walks the chain for this field, thus the named condition
+    // classifies the same way it would from a status line.
+    if (status !== undefined) Object.assign(failure, { status });
+    return failure;
 }
 
 /**
@@ -615,16 +652,47 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
     const requestedModelId = requestedModelIdOf(deps.model);
     routeSdkWarningsTo(logger);
 
+    /**
+     * Record a call that the envelope gave up on.
+     *
+     * The envelope reports one attempt at `debug`, thus a deployment that runs
+     * at `info` keeps no trace of a call that exhausted its retries: the reply
+     * carries the failure to the user and the operator sees nothing. This is the
+     * one record that names the outcome.
+     */
+    function logFailure(session: AgentSession, failure: ProviderError, thrown: unknown): void {
+        logger.error("provider call failed", {
+            workload: workloadOf(session),
+            kind: failure.type,
+            retryable: failure.retryable,
+            ...logger.errorFields(thrown),
+        });
+    }
+
     function chat(req: ChatRequest, session: AgentSession, signal?: AbortSignal): ResultAsync<ChatResponse, ProviderError> {
         const run = async (): Promise<Result<ChatResponse, ProviderError>> => {
             const retry = createRetry(signal, logger, maxRetries);
             const capture = captureServedModelId(deps.model);
             try {
-                const result = await retry(async () => {
+                const collected = await retry(async () => {
                     // Attribution headers are time-limited; resolving them inside the
                     // retried closure keeps them fresh across a multi-minute window.
                     const headers = await resolveBillingHeaders(deps.resolveBilling, session);
-                    return generateText({
+                    // The call streams on the wire and collapses below.
+                    //
+                    // A non-streaming turn sends no header until the model completes,
+                    // thus the `headersTimeout` of the host HTTP client bounds the whole
+                    // generation. No option of the SDK lifts that bound, because it sits
+                    // under the fetch. Node defaults the field to 300s, and a turn near
+                    // 18k output tokens reaches it, while `DEFAULT_MAX_OUTPUT_TOKENS`
+                    // asks for up to 64k. A cut turn then costs twice: the envelope
+                    // starts the same generation again from zero.
+                    //
+                    // Anthropic states the rule for its own SDKs: a large `max_tokens`
+                    // makes streaming necessary, to prevent an HTTP timeout. Thus a
+                    // ceiling this size streams whether or not a consumer wants the
+                    // deltas, and `chatStream` stays the seam that forwards them.
+                    const result = streamText({
                         model: capture.model,
                         system: req.system,
                         messages: sanitizeMessages(req.messages),
@@ -637,18 +705,51 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                         maxRetries: 0,
                         headers,
                         abortSignal: signal,
-                        // No SDK timeout rides here. `chunkMs` bounds a stream only,
-                        // thus it is inert on this call. The fetch guard is the full
-                        // bound, because the headers of a non-streaming response arrive
-                        // when the model completes.
+                        // `firstChunkMs` bounds the wait for the first content chunk,
+                        // and `chunkMs` bounds each later gap. Thus each silent interval
+                        // carries the one configured bound, and a turn that writes
+                        // steadily runs as long as it needs.
+                        ...(requestTimeoutMs !== undefined ? { timeout: { firstChunkMs: requestTimeoutMs, chunkMs: requestTimeoutMs } } : {}),
                         providerOptions: req.providerOptions,
                         reasoning: req.reasoning,
                     });
+                    // The drain sits inside the retried closure, thus a failure at any
+                    // point of the stream re-runs the whole attempt and the envelope
+                    // keeps its whole-call scope. No delta reaches a consumer here —
+                    // `chatStream` is the seam that forwards them.
+                    const iterator = result.fullStream[Symbol.asyncIterator]();
+                    let text = "";
+                    for (let pull = await pullNextDelta(iterator); pull.kind !== "end"; pull = await pullNextDelta(iterator)) {
+                        // A caller abort rides out as the reason of its own signal, thus
+                        // it stays a cancellation and reaches the caller as a throw.
+                        if (pull.kind === "aborted") throw abortedStreamFailure(signal, pull.reason, requestTimeoutMs);
+                        if (pull.kind === "failed") throw streamPartFailure(pull.error);
+                        text += pull.text;
+                    }
+                    // These promises settle only once the stream is fully drained, thus
+                    // the loop above must reach its end before this point.
+                    return {
+                        messages: await result.responseMessages,
+                        fallbackText: text,
+                        finishReason: await result.finishReason,
+                        rawFinishReason: await result.rawFinishReason,
+                        usage: await result.usage,
+                    };
                 });
-                return ok(responseFromGenerate(result, { requestedModelId, servedModelId: capture.servedModelId() }));
+                return ok(
+                    responseFromMessages({
+                        ...collected,
+                        requestedModelId,
+                        // Read after the drain: the metadata chunk that carries the
+                        // served id reaches the capture only as the stream is consumed.
+                        servedModelId: capture.servedModelId(),
+                    }),
+                );
             } catch (e) {
                 if (isAbortError(e) || signal?.aborted) throw e;
-                return err(toProviderError(unwrapForClassification(e), workloadOf(session)));
+                const failure = toProviderError(unwrapForClassification(e), workloadOf(session));
+                logFailure(session, failure, e);
+                return err(failure);
             }
         };
         return new ResultAsync(run());
@@ -696,6 +797,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                 // throw carries the sentinel, thus the envelope gives the attempt a
                 // fresh window under the retry policy of a connection error.
                 if (first.kind === "aborted") throw abortedStreamFailure(signal, first.reason, requestTimeoutMs);
+                if (first.kind === "failed") throw streamPartFailure(first.error);
                 if (first.kind === "end") {
                     // A doStream promise rejection — the shape a real connection
                     // failure takes — does NOT surface at this first pull: streamText
@@ -742,6 +844,7 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
                 // partial text that arrived before it. The catch below builds the
                 // terminal `ProviderError` from the throwable.
                 if (pull.kind === "aborted") throw abortedStreamFailure(signal, pull.reason, requestTimeoutMs);
+                if (pull.kind === "failed") throw streamPartFailure(pull.error);
                 text += pull.text;
                 yield { type: "text-delta", text: pull.text };
             }
@@ -759,7 +862,9 @@ export function createAiSdkProvider(deps: AiSdkProviderDeps): ChatProvider {
             yield { type: "done", response };
         } catch (e) {
             if (isAbortError(e) || signal?.aborted) throw e;
-            throw toProviderError(unwrapForClassification(e), workloadOf(session));
+            const failure = toProviderError(unwrapForClassification(e), workloadOf(session));
+            logFailure(session, failure, e);
+            throw failure;
         }
     }
 

--- a/harness/src/providers/configured-provider.barrel.test.ts
+++ b/harness/src/providers/configured-provider.barrel.test.ts
@@ -6,52 +6,53 @@ import type { AiSdkProviderConfig, ChatRequest, ConfiguredAiSdkProviderDeps } fr
 import { makeSession } from "./__fixtures__/session.js";
 import type { FetchLike } from "./types.js";
 
-function anthropicJson(text: string, model: string): Response {
-    return new Response(
-        JSON.stringify({
-            id: "msg_test_1",
-            type: "message",
-            role: "assistant",
-            model,
-            content: [{ type: "text", text }],
-            stop_reason: "end_turn",
-            stop_sequence: null,
-            usage: {
-                input_tokens: 12,
-                output_tokens: 3,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
-            },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-    );
+/** One `text/event-stream` body: each arm of the provider reads the wire as SSE. */
+function sse(events: readonly string[]): Response {
+    return new Response(events.map((event) => `${event}\n\n`).join(""), {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+    });
 }
 
-function openaiJson(text: string, model: string): Response {
-    return new Response(
-        JSON.stringify({
-            id: "chatcmpl_test_1",
-            object: "chat.completion",
-            created: 1_700_000_000,
-            model,
-            choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }],
+function anthropicSse(text: string, model: string): Response {
+    const usage = { input_tokens: 12, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
+    return sse([
+        `event: message_start\ndata: ${JSON.stringify({
+            type: "message_start",
+            message: { id: "msg_test_1", type: "message", role: "assistant", model, content: [], stop_reason: null, stop_sequence: null, usage },
+        })}`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } })}`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+    ]);
+}
+
+function openaiSse(text: string, model: string): Response {
+    const base = { id: "chatcmpl_test_1", object: "chat.completion.chunk", created: 1_700_000_000, model };
+    return sse([
+        `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: { role: "assistant", content: text }, finish_reason: null }] })}`,
+        `data: ${JSON.stringify({
+            ...base,
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
             usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-    );
+        })}`,
+        "data: [DONE]",
+    ]);
 }
 
-function responsesJson(text: string, model: string): Response {
-    return new Response(
-        JSON.stringify({
-            id: "resp_test_1",
-            created_at: 1_700_000_000,
-            model,
-            output: [{ type: "message", role: "assistant", id: "msg_test_1", content: [{ type: "output_text", text, annotations: [] }] }],
-            usage: { input_tokens: 12, output_tokens: 3 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-    );
+function responsesSse(text: string, model: string): Response {
+    const item = { type: "message", id: "msg_test_1", role: "assistant", content: [{ type: "output_text", text, annotations: [] }] };
+    const response = { id: "resp_test_1", created_at: 1_700_000_000, model, usage: { input_tokens: 12, output_tokens: 3 } };
+    return sse([
+        `data: ${JSON.stringify({ type: "response.created", response: { ...response, output: [] } })}`,
+        `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { ...item, content: [] } })}`,
+        `data: ${JSON.stringify({ type: "response.output_text.delta", item_id: "msg_test_1", output_index: 0, content_index: 0, delta: text })}`,
+        `data: ${JSON.stringify({ type: "response.output_text.done", item_id: "msg_test_1", output_index: 0, content_index: 0, text })}`,
+        `data: ${JSON.stringify({ type: "response.output_item.done", output_index: 0, item })}`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { ...response, output: [item] } })}`,
+    ]);
 }
 
 /**
@@ -77,7 +78,7 @@ const request: ChatRequest = {
 
 describe("provider configuration front door", () => {
     it("constructs a working anthropic ChatProvider from the package root", async () => {
-        const cap = capturingFetch(anthropicJson);
+        const cap = capturingFetch(anthropicSse);
         const config: AiSdkProviderConfig = {
             kind: "anthropic",
             baseURL: "http://models.local/anthropic",
@@ -99,7 +100,7 @@ describe("provider configuration front door", () => {
     });
 
     it("constructs a working openai-compatible ChatProvider from the package root", async () => {
-        const cap = capturingFetch(openaiJson);
+        const cap = capturingFetch(openaiSse);
         const config: AiSdkProviderConfig = {
             kind: "openai-compatible",
             name: "self-hosted",
@@ -121,7 +122,7 @@ describe("provider configuration front door", () => {
     });
 
     it("constructs a working openai ChatProvider from the package root", async () => {
-        const cap = capturingFetch(responsesJson);
+        const cap = capturingFetch(responsesSse);
         const config: AiSdkProviderConfig = {
             kind: "openai",
             apiKey: "test-key",
@@ -142,7 +143,7 @@ describe("provider configuration front door", () => {
     });
 
     it("builds two provider instances over one connection, each carrying its own bound model", async () => {
-        const cap = capturingFetch(openaiJson);
+        const cap = capturingFetch(openaiSse);
         const connection = {
             kind: "openai-compatible" as const,
             name: "shared-endpoint",
@@ -193,27 +194,27 @@ describe("output-token ceiling", () => {
     it("sends the default ceiling for a model the SDK's capability table does not know", async () => {
         // The regression: an unrecognized id takes the SDK's 4096 fallback when
         // nothing names a ceiling, truncating plan-sized tool calls mid-payload.
-        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-99-future"))).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+        expect(await wireMaxTokens(anthropicSse, anthropicModel("claude-opus-99-future"))).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
     });
 
     it("lets the SDK clamp the default down to a known model's real limit", async () => {
         // What makes a high default safe: it never reaches a model the SDK knows
         // to have a smaller ceiling.
-        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-4-1"))).toBe(32_000);
+        expect(await wireMaxTokens(anthropicSse, anthropicModel("claude-opus-4-1"))).toBe(32_000);
     });
 
     it("recognizes claude-opus-5, clamping an over-large ceiling to its real limit", async () => {
         // Guards the dependency floor: before @ai-sdk/anthropic 4.0.20 this id was
         // unknown, so it took the 4096 fallback and skipped the clamp — 200000 would
         // ride out verbatim instead of landing on the model's real 128k.
-        expect(await wireMaxTokens(anthropicJson, anthropicModel("claude-opus-5", 200_000))).toBe(128_000);
+        expect(await wireMaxTokens(anthropicSse, anthropicModel("claude-opus-5", 200_000))).toBe(128_000);
     });
 
     it("honours a per-config override on the openai-compatible arm", async () => {
         // The escape hatch for servers that validate prompt + max_tokens against a
         // small context window.
         expect(
-            await wireMaxTokens(openaiJson, (fetch) => ({
+            await wireMaxTokens(openaiSse, (fetch) => ({
                 kind: "openai-compatible",
                 name: "self-hosted",
                 baseURL: "http://models.local/v1",


### PR DESCRIPTION
`chat` sent a non-streaming request, and a non-streaming reply carries no header until the model completes. Thus the `headersTimeout` of the host HTTP client bounded the whole generation, and no option of the AI SDK lifts that bound. Node defaults the field to 300s, while `DEFAULT_MAX_OUTPUT_TOKENS` asks for up to 64,000 output tokens. `chat` now drives `streamText` and collapses the stream into the same `ChatResponse`.

Notes for the review:

- **The response contract does not move.** Both entry points already built the reply with `responseFromMessages`, thus `ChatResponse` comes out identical. The drain sits inside the retried closure, so the envelope keeps its whole-call scope, and a client abort still reaches the caller as a throw.
- **Two defects came with the new wire, and this change repairs them.** The SDK reports a mid-stream failure as an `error` part that the pull skipped, thus a failed call returned an empty assistant turn. A provider also names a mid-stream condition in the payload, not in the status line. Thus an `overloaded_error` classified as not retryable, against the 529 it stands for.
- **A failed call is now logged.** The envelope reports an attempt at `debug` only. Thus a deployment at `info` kept no trace of a failure that the user saw.
- **One behavior is deliberately given up.** A 200 reply whose body is not an event stream now reads as an empty turn rather than an error. A gateway answers with an event stream or with an HTTP error status, thus the case has no realistic wire.
- **The version is a patch bump**, 0.30.1 to 0.30.2. No consumer needs a change.

Measured on one production data profile: the first attempt wrote 30,915 output tokens in 515s, the client cut it at 302s, and the retry wrote the answer in 263s.

https://claude.ai/code/session_01Sep8Hbp8yYerd8bm5adrh9
