### PR TITLE
fix(harness): bind the sandbox thread pools to the cpu quota

### DIFF
--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -291,6 +291,47 @@ describe("docker createSandbox — transport modes", () => {
         expect(registered).toEqual([{ runId: "run-1", stepId: "step-a", sandboxId: ref.sandboxId }]);
     });
 
+    test("the cpu request is published as the thread count of every parallel runtime", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // Without these the runtimes size their pools from the host's core count
+        // and oversubscribe the cgroup the same call sets NanoCpus on.
+        const env = envMapOf(sandboxOf(created)!);
+        expect(env.OMP_NUM_THREADS).toBe("2");
+        expect(env.OPENBLAS_NUM_THREADS).toBe("2");
+        expect(env.MC_CORES).toBe("2");
+    });
+
+    test("a fractional cpu request floors to one thread, and extraEnv overrides the derived count", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox({ ...META, resources: { cpu: 0.5, memoryGb: 1 }, extraEnv: { OMP_NUM_THREADS: "8" } }, mintSandboxIdentity("run-1"))
+        )._unsafeUnwrap();
+
+        const env = envMapOf(sandboxOf(created)!);
+        expect(env.MC_CORES).toBe("1");
+        expect(env.OMP_NUM_THREADS).toBe("8");
+    });
+
     test("a container that maps no host port is stopped, removed, and reported failed", async () => {
         const { docker, removed } = stubDocker();
         // A daemon that starts the container but publishes no port for 8765/tcp.

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -39,6 +39,7 @@ import type { Logger } from "../lib/logger.js";
 import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, sandboxWriteTail } from "./mount-plan.js";
+import { threadLimitEnv } from "./thread-env.js";
 
 /** Read the originating HTTP status off any `SandboxError` variant that carries one. */
 function statusOf(e: SandboxError): number | undefined {
@@ -329,18 +330,24 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
 
                     const image = meta.image ?? config.image;
 
+                    const spec = meta.resources;
+
                     // Poll mode never dials out and carries no CORTEX_BASE_URL; it sets the
                     // firewall flag so the root entrypoint installs the egress block before
                     // dropping to uid 1000. Callback mode is the inverse.
-                    const env = [
-                        `SANDBOX_TRANSPORT=${transport}`,
-                        `SANDBOX_CALLBACK_SECRET=${callbackSecret}`,
-                        ...(pollMode ? ["SANDBOX_EGRESS_FIREWALL=1"] : [`CORTEX_BASE_URL=${config.cortexBaseUrl}`]),
-                        ...Object.entries(plan.env).map(([k, v]) => `${k}=${v}`),
-                        ...Object.entries(meta.extraEnv ?? {}).map(([k, v]) => `${k}=${v}`),
-                    ];
+                    //
+                    // Composed as one record, not a list of `K=V`: a duplicate key in the
+                    // Env array resolves by whichever end of `environ` the reading libc
+                    // scans from, so the later spread has to be the one that wins here.
+                    const env = Object.entries({
+                        SANDBOX_TRANSPORT: transport,
+                        SANDBOX_CALLBACK_SECRET: callbackSecret,
+                        ...(pollMode ? { SANDBOX_EGRESS_FIREWALL: "1" } : { CORTEX_BASE_URL: config.cortexBaseUrl }),
+                        ...threadLimitEnv(spec),
+                        ...plan.env,
+                        ...(meta.extraEnv ?? {}),
+                    }).map(([k, v]) => `${k}=${v}`);
 
-                    const spec = meta.resources;
                     const createOpts: Docker.ContainerCreateOptions = {
                         name: sandboxId,
                         ...(config.platform !== undefined && { platform: config.platform }),

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -129,6 +129,11 @@ describe("k8s createSandbox", () => {
         expect(envMap.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
         expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1");
         expect(envMap.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
+        // The cgroup limit below is invisible to the runtimes inside it, so the
+        // same cpu request rides in as their thread count.
+        expect(envMap.OMP_NUM_THREADS).toBe("2");
+        expect(envMap.OPENBLAS_NUM_THREADS).toBe("2");
+        expect(envMap.MC_CORES).toBe("2");
 
         expect(container.workingDir).toBe("/an-1/runs/run-1/step-a");
 

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -30,6 +30,7 @@ import { ResultAsync, err, ok } from "neverthrow";
 import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, buildSessionSubPaths } from "./mount-plan.js";
+import { threadLimitEnv } from "./thread-env.js";
 import type { CreateSandboxMeta, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SandboxTransport } from "./types.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
@@ -183,25 +184,26 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
     });
 
     const transport = config.transport ?? "poll";
-    const env = [
-        { name: "SANDBOX_TRANSPORT", value: transport },
+    const spec = meta.resources;
+    // Composed as one record, not a list of `{name, value}`: a duplicate name in
+    // a container's env is resolved by the kubelet, not by this spec, so the
+    // later spread has to be the one that wins here.
+    const env = Object.entries({
+        SANDBOX_TRANSPORT: transport,
         // Poll mode never dials out, so the URL is omitted (matching the Docker
         // backend) — the pod spec itself then documents that no callback egress
         // is expected. sandbox-server neither reads nor requires it in poll mode.
-        ...(transport === "callback" ? [{ name: "CORTEX_BASE_URL", value: config.cortexBaseUrl }] : []),
-        { name: "SANDBOX_CALLBACK_SECRET", value: identity.callbackSecret },
-        ...Object.entries(plan.env).map(([name, value]) => ({ name, value })),
-        ...Object.entries(meta.extraEnv ?? {}).map(([k, v]) => ({
-            name: k,
-            value: v,
-        })),
-    ];
+        ...(transport === "callback" ? { CORTEX_BASE_URL: config.cortexBaseUrl } : {}),
+        SANDBOX_CALLBACK_SECRET: identity.callbackSecret,
+        ...threadLimitEnv(spec),
+        ...plan.env,
+        ...(meta.extraEnv ?? {}),
+    }).map(([name, value]) => ({ name, value }));
 
     // requests == limits → Guaranteed QoS and a predictable OOM bound; also
     // satisfies the namespace ResourceQuota, which rejects any pod that omits
     // requests.cpu/memory. The CPU limit can throttle a hot step, but a throttle
     // beats an eviction.
-    const spec = meta.resources;
     const quantities: Record<string, string> = {
         cpu: String(spec.cpu),
         memory: `${spec.memoryGb}Gi`,

--- a/harness/src/sandbox/thread-env.ts
+++ b/harness/src/sandbox/thread-env.ts
@@ -1,0 +1,41 @@
+/**
+ * Thread-count env for a sandbox container.
+ *
+ * The backends turn a step's `ResourceSpec` into a hard cgroup limit
+ * (`NanoCpus`/`Memory` on Docker, `limits.cpu`/`limits.memory` on K8s). A cgroup
+ * quota is invisible to the runtimes inside it: `parallel::detectCores()` and
+ * the OpenBLAS thread pool read the host's core count from `/proc`, not the
+ * quota. A step given 2 CPUs on a 12-core host therefore forks 12 workers into
+ * a cgroup sized for 2, and each fork carries its own copy of the working set
+ * until the memory limit is reached. sandbox-server shares that cgroup, so the
+ * thrash takes the exec endpoint down with the workload.
+ *
+ * The fix is to publish the quota that the cgroup already enforces, so the
+ * libraries size their pools from the same number.
+ */
+
+import type { ResourceSpec } from "../config/resource-limits.js";
+
+/**
+ * Env that binds every parallel runtime in the container to `spec.cpu`.
+ *
+ * A fractional CPU request floors to one thread, because a pool of zero is not
+ * representable and a pool of two on half a core only adds context switches.
+ *
+ * The caller places these before `plan.env` and the embedder's `extraEnv`, so a
+ * host that knows better about a particular step keeps the last word.
+ */
+export function threadLimitEnv(spec: ResourceSpec): Record<string, string> {
+    const threads = String(Math.max(1, Math.floor(spec.cpu)));
+    return {
+        // OpenMP: the R and Python numerical stacks, and the compiled code of
+        // most Bioconductor packages.
+        OMP_NUM_THREADS: threads,
+        // OpenBLAS keeps its own pool and ignores OMP_NUM_THREADS when it is
+        // built with its own threading.
+        OPENBLAS_NUM_THREADS: threads,
+        // R reads this at startup into `options(mc.cores)`, which is what
+        // `mclapply` and BiocParallel size their worker count from.
+        MC_CORES: threads,
+    };
+}


### PR DESCRIPTION
## What & why

Each sandbox backend turns the step resources into a hard limit: `NanoCpus` and
`Memory` on Docker, `requests` and `limits` on K8s. But a cgroup quota is
invisible to the runtimes inside it. `parallel::detectCores()` and the OpenBLAS
pool read the core count of the host from `/proc`, not the quota.

Thus a step with 2 CPUs on a host of 12 cores forks 12 workers into a cgroup of
2 CPUs and 8 GB. Then the memory runs out. sandbox-server shares that cgroup,
thus it does not answer `/exec` again. The container now receives the quota that
the cgroup already enforces: `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, and
`MC_CORES`, from the clamped `spec.cpu`.

Notes for the reviewer:

- Each backend composes its env from one record, not from a list. A duplicate
  key resolves at the kubelet or at the libc that reads `environ`, not in this
  code. One record makes the precedence explicit, thus the `extraEnv` of an
  embedder keeps the last word over the derived count.
- The three variables cover the R and Python stack of the image. OpenBLAS keeps
  a private pool that ignores `OMP_NUM_THREADS`, and R reads `MC_CORES` at
  startup into `options(mc.cores)`, which is what `mclapply` and BiocParallel
  size from.
- No spec states this behavior yet. `openspec/specs/docker-sandbox-provider/spec.md`
  states the `NanoCpus` and `Memory` translation only.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. The change adds three env
  values. It grants no capability, no mount, and no egress, and it does not
  change a resource limit.
- [x] **Provenance:** a prior analysis stays reproducible. But a parallel step
  now runs with fewer workers, thus a method whose result depends on the worker
  count can vary.
