### PR TITLE
fix(sandbox): publish the cpu quota of the container to the runtimes in it

### DIFF
--- a/images/sandbox-base/Dockerfile
+++ b/images/sandbox-base/Dockerfile
@@ -277,6 +277,10 @@ COPY --from=provtrack-builder /provtrack.so /opt/provenance/provtrack.so
 COPY images/sandbox-base/provenance/sitecustomize.py /opt/provenance/sitecustomize.py
 COPY images/sandbox-base/provenance/Rprofile.site /opt/provenance/Rprofile.site
 
+# CPU-quota shim for R. sandbox-server points R_PROFILE_USER at this file and
+# publishes the quota as INFLEXA_CPU_LIMIT; see server/cpulimit.go.
+COPY images/sandbox-base/cpu-limit.R /opt/cpu-limit.R
+
 # Default to the unprivileged workload user. Callback mode and K8s run as uid
 # 1000 throughout. Docker poll mode overrides `User` to root at create time so
 # the entrypoint can install the egress firewall, then `setpriv` drops back to

--- a/images/sandbox-base/Dockerfile
+++ b/images/sandbox-base/Dockerfile
@@ -281,6 +281,12 @@ COPY images/sandbox-base/provenance/Rprofile.site /opt/provenance/Rprofile.site
 # publishes the quota as INFLEXA_CPU_LIMIT; see server/cpulimit.go.
 COPY images/sandbox-base/cpu-limit.R /opt/cpu-limit.R
 
+# The same shim for Python. A .pth line that starts with `import` is executed by
+# the site module at interpreter start, which needs no PYTHONPATH entry and so
+# does not leak into conda's Python (see the lib-store .pth above).
+COPY images/sandbox-base/cpu-limit.py /usr/lib/python3/dist-packages/inflexa_cpu_limit.py
+RUN echo "import inflexa_cpu_limit" > /usr/lib/python3/dist-packages/inflexa-cpu-limit.pth
+
 # Default to the unprivileged workload user. Callback mode and K8s run as uid
 # 1000 throughout. Docker poll mode overrides `User` to root at create time so
 # the entrypoint can install the egress firewall, then `setpriv` drops back to

--- a/images/sandbox-base/cpu-limit.R
+++ b/images/sandbox-base/cpu-limit.R
@@ -1,0 +1,40 @@
+# CPU-quota visibility for R in Inflexa sandbox containers.
+#
+# `parallel::detectCores()` reads /sys/devices/system/cpu/online, which
+# describes the machine. A cgroup CPU quota does not change that file, and
+# neither does a cpuset, and neither does any environment value. Thus R is the
+# one runtime in this image that reports the cores of the host whatever the
+# container is limited to.
+#
+# Code that sizes a worker pool from detectCores() then forks one worker for
+# each core of the host. Each fork copies its working set, thus the forks
+# exhaust the memory limit of the container before the CPU limit throttles them.
+#
+# sandbox-server publishes the quota of the container as INFLEXA_CPU_LIMIT, and
+# this profile makes detectCores() report it. Nothing else changes here. In
+# particular `mc.cores` stays unset, because R defaults mclapply to 2 workers,
+# and that default is R's own and not a count of the host.
+#
+# Loaded before user code when R_PROFILE_USER points to this file.
+
+local({
+  n <- suppressWarnings(as.integer(Sys.getenv("INFLEXA_CPU_LIMIT", "")))
+  if (is.na(n) || n < 1L) return(invisible(NULL))
+
+  # The signature must match the one it replaces: a caller can pass either
+  # argument, and both are ignored here because the quota counts logical cores.
+  replace <- function(...) {
+    ns <- asNamespace("parallel")
+    tryCatch({
+      unlockBinding("detectCores", ns)
+      assign("detectCores", function(all.tests = FALSE, logical = TRUE) n, envir = ns)
+      lockBinding("detectCores", ns)
+    }, error = function(e) invisible(NULL))
+  }
+
+  # `parallel` is a base package that loads on demand, thus the hook covers the
+  # usual path. The direct call covers a profile that runs after something else
+  # already loaded it.
+  setHook(packageEvent("parallel", "onLoad"), replace)
+  if (isNamespaceLoaded("parallel")) replace()
+})

--- a/images/sandbox-base/cpu-limit.py
+++ b/images/sandbox-base/cpu-limit.py
@@ -1,0 +1,51 @@
+"""CPU-quota visibility for Python in Inflexa sandbox containers.
+
+`os.cpu_count()` reports the cores of the machine. A cgroup CPU quota does not
+change it. Thus a pool that sizes itself from that number forks one worker for
+each core of the host, inside a container that has a fraction of them. Each fork
+copies its working set, thus the forks exhaust the memory limit of the container
+before the CPU limit throttles them.
+
+sandbox-server publishes the quota of the container as INFLEXA_CPU_LIMIT, and
+this module makes `os.cpu_count()` report it. `multiprocessing.cpu_count()`,
+`multiprocessing.Pool()`, and both pools of `concurrent.futures` read that one
+function at call time, thus each of them gets the quota.
+
+CPython 3.13 gives the same control through PYTHON_CPU_COUNT. This module is the
+equivalent for the 3.12 interpreter of this image.
+
+`os.sched_getaffinity` stays as it is, because it reports a set of processor
+numbers and a quota removes no processor from that set. The conda interpreter of
+the library store has its own site directory, thus this module does not reach
+it. The thread-count variables that sandbox-server publishes do reach it.
+
+The .pth file beside this module imports it at interpreter start. It does
+nothing when the variable is absent, which is the state of a container that has
+no quota.
+"""
+
+import os
+
+
+def _quota() -> int:
+    """The published quota, or 0 when there is none to publish."""
+    try:
+        limit = int(os.environ.get("INFLEXA_CPU_LIMIT", ""))
+    except ValueError:
+        return 0
+    return limit if limit >= 1 else 0
+
+
+_LIMIT = _quota()
+
+if _LIMIT:
+
+    def _cpu_count() -> int:
+        """Report the quota of the container, not the cores of the machine."""
+        return _LIMIT
+
+    os.cpu_count = _cpu_count
+    # Present from CPython 3.13. Kept in step so a later base image needs no
+    # change here.
+    if hasattr(os, "process_cpu_count"):
+        os.process_cpu_count = _cpu_count

--- a/images/sandbox-base/server/cpulimit.go
+++ b/images/sandbox-base/server/cpulimit.go
@@ -1,0 +1,147 @@
+package main
+
+// CPU-quota visibility for spawned commands.
+//
+// The harness gives each container a hard CPU quota (`NanoCpus` on Docker,
+// `limits.cpu` on K8s). A cgroup quota is invisible to the runtimes inside it:
+// `/proc` and `/sys` still describe the machine, so `nproc`, `os.cpu_count()`,
+// and `parallel::detectCores()` all report the cores of the host. A thread pool
+// or a worker pool that sizes itself from that number oversubscribes the quota,
+// and a forked pool exhausts the memory limit of the container long before the
+// CPU limit throttles it.
+//
+// This file reads the quota that the container itself is under, and publishes
+// it to each command. The value comes from the cgroup, not from the request
+// that made the container, thus it can never disagree with what the kernel
+// enforces. A container with no quota publishes nothing and keeps the defaults
+// of the machine.
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	cgroupV2CPUMax    = "/sys/fs/cgroup/cpu.max"
+	cgroupV1CPUQuota  = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	cgroupV1CPUPeriod = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+	// R profile that makes `parallel::detectCores()` report the quota. R reads
+	// /sys/devices/system/cpu/online, which no quota and no cpuset changes, so
+	// R is the one runtime that an environment value alone cannot reach.
+	cpuLimitRProfilePath = "/opt/cpu-limit.R"
+
+	envCPULimit     = "INFLEXA_CPU_LIMIT"
+	envRProfileUser = "R_PROFILE_USER"
+)
+
+// cpuLimitVars are the thread-pool controls whose own default comes from the
+// core count of the machine. Each one is a ceiling, thus a value at the quota
+// never oversubscribes.
+//
+// MC_CORES is deliberately absent. R defaults `mclapply` to 2 workers, not to
+// the core count, so a value here would raise the fork count instead of lowering
+// it — and the forks are what exhaust the memory of the container.
+var cpuLimitVars = []string{
+	"OMP_NUM_THREADS",
+	"OPENBLAS_NUM_THREADS",
+	"MKL_NUM_THREADS",
+	"NUMEXPR_NUM_THREADS",
+	"NUMBA_NUM_THREADS",
+	"POLARS_MAX_THREADS",
+	"RAYON_NUM_THREADS",
+	"R_DATATABLE_NUM_THREADS",
+}
+
+// cpuQuota is the whole-core ceiling of this container, or 0 when it has none.
+// Read once: the quota of a running container does not change. It is a variable
+// so that a test can state a quota that the machine it runs on does not have.
+var cpuQuota func() int = sync.OnceValue(readCPUQuota)
+
+// readCPUQuota reads the CPU quota of this container from its cgroup. It
+// returns 0 when there is no quota, which is also what a host with neither
+// cgroup layout gives.
+func readCPUQuota() int {
+	if n, ok := cpuQuotaV2(cgroupV2CPUMax); ok {
+		return n
+	}
+	if n, ok := cpuQuotaV1(cgroupV1CPUQuota, cgroupV1CPUPeriod); ok {
+		return n
+	}
+	return 0
+}
+
+// cpuQuotaV2 parses the cgroup v2 `cpu.max` file, whose two fields are the
+// quota and the period in microseconds. An unlimited container writes `max` in
+// the first field.
+func cpuQuotaV2(path string) (int, bool) {
+	fields := strings.Fields(readTrimmed(path))
+	if len(fields) < 2 || fields[0] == "max" {
+		return 0, false
+	}
+	return quotaCores(fields[0], fields[1])
+}
+
+// cpuQuotaV1 parses the two cgroup v1 files. An unlimited container writes -1
+// as its quota.
+func cpuQuotaV1(quotaPath, periodPath string) (int, bool) {
+	return quotaCores(readTrimmed(quotaPath), readTrimmed(periodPath))
+}
+
+// quotaCores converts a quota and a period in microseconds into whole cores. It
+// rounds up: a fractional quota still keeps one thread busy, and a pool of zero
+// is not representable.
+func quotaCores(quota, period string) (int, bool) {
+	q, err := strconv.Atoi(quota)
+	if err != nil || q <= 0 {
+		return 0, false
+	}
+	p, err := strconv.Atoi(period)
+	if err != nil || p <= 0 {
+		return 0, false
+	}
+	return (q + p - 1) / p, true
+}
+
+func readTrimmed(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// cpuLimitEnv returns the environment entries that publish the quota to one
+// command. It sets a name only when base leaves it unset, thus a value that the
+// embedder put on the container, and a value that the request carries, both keep
+// the last word over this default.
+func cpuLimitEnv(base []string, quota int) []string {
+	if quota < 1 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(base))
+	for _, kv := range base {
+		if name, _, ok := strings.Cut(kv, "="); ok {
+			set[name] = struct{}{}
+		}
+	}
+	value := strconv.Itoa(quota)
+	out := make([]string, 0, len(cpuLimitVars)+2)
+	add := func(name, v string) {
+		if _, ok := set[name]; !ok {
+			out = append(out, name+"="+v)
+		}
+	}
+	for _, name := range cpuLimitVars {
+		add(name, value)
+	}
+	// The R profile reads this name. Nothing else in the image derives the
+	// quota, so the two can not disagree.
+	add(envCPULimit, value)
+	if fileExists(cpuLimitRProfilePath) {
+		add(envRProfileUser, cpuLimitRProfilePath)
+	}
+	return out
+}

--- a/images/sandbox-base/server/cpulimit_test.go
+++ b/images/sandbox-base/server/cpulimit_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func TestCPUQuotaV2(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    int
+		wantOK  bool
+	}{
+		{"two cores", "200000 100000\n", 2, true},
+		{"a fraction rounds up", "150000 100000\n", 2, true},
+		{"half a core still gets one thread", "50000 100000\n", 1, true},
+		{"unlimited", "max 100000\n", 0, false},
+		{"one field", "200000\n", 0, false},
+		{"not a number", "lots 100000\n", 0, false},
+		{"zero period", "200000 0\n", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := cpuQuotaV2(writeFile(t, "cpu.max", c.content))
+			if got != c.want || ok != c.wantOK {
+				t.Fatalf("got (%d, %v), want (%d, %v)", got, ok, c.want, c.wantOK)
+			}
+		})
+	}
+}
+
+func TestCPUQuotaV1(t *testing.T) {
+	period := writeFile(t, "cpu.cfs_period_us", "100000\n")
+
+	quota := writeFile(t, "cpu.cfs_quota_us", "400000\n")
+	if got, ok := cpuQuotaV1(quota, period); got != 4 || !ok {
+		t.Fatalf("got (%d, %v), want (4, true)", got, ok)
+	}
+
+	unlimited := writeFile(t, "cpu.cfs_quota_us", "-1\n")
+	if got, ok := cpuQuotaV1(unlimited, period); got != 0 || ok {
+		t.Fatalf("got (%d, %v), want (0, false)", got, ok)
+	}
+}
+
+func TestReadCPUQuotaWithoutCgroupFiles(t *testing.T) {
+	// A host with neither layout is indistinguishable from an unlimited one, and
+	// both must publish nothing rather than a guess.
+	if got := readCPUQuota(); got < 0 {
+		t.Fatalf("got %d, want 0 or a positive quota", got)
+	}
+}
+
+func envMap(entries []string) map[string]string {
+	out := make(map[string]string, len(entries))
+	for _, kv := range entries {
+		if name, value, ok := strings.Cut(kv, "="); ok {
+			out[name] = value
+		}
+	}
+	return out
+}
+
+func TestCPULimitEnvPublishesTheQuota(t *testing.T) {
+	env := envMap(cpuLimitEnv([]string{"PATH=/usr/bin"}, 3))
+
+	for _, name := range cpuLimitVars {
+		if env[name] != "3" {
+			t.Fatalf("%s = %q, want \"3\"", name, env[name])
+		}
+	}
+	if env[envCPULimit] != "3" {
+		t.Fatalf("%s = %q, want \"3\"", envCPULimit, env[envCPULimit])
+	}
+}
+
+func TestCPULimitEnvOmitsMCCores(t *testing.T) {
+	// R defaults mclapply to 2 workers. Publishing the quota here would raise the
+	// fork count, which is the opposite of what this file is for.
+	if slices.Contains(cpuLimitVars, "MC_CORES") {
+		t.Fatal("MC_CORES must not be published: it raises R's default fork count")
+	}
+	if _, found := envMap(cpuLimitEnv(nil, 8))["MC_CORES"]; found {
+		t.Fatal("MC_CORES must not be published")
+	}
+}
+
+func TestCPULimitEnvIsSilentWithoutAQuota(t *testing.T) {
+	if got := cpuLimitEnv([]string{"PATH=/usr/bin"}, 0); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestCPULimitEnvKeepsAValueThatIsAlreadySet(t *testing.T) {
+	env := envMap(cpuLimitEnv([]string{"OMP_NUM_THREADS=1", "PATH=/usr/bin"}, 4))
+
+	if _, found := env["OMP_NUM_THREADS"]; found {
+		t.Fatal("a name the container already sets must not be published again")
+	}
+	if env["OPENBLAS_NUM_THREADS"] != "4" {
+		t.Fatalf("the other names must still be published, got %q", env["OPENBLAS_NUM_THREADS"])
+	}
+}
+
+func TestBuildCommandLetsTheRequestOverrideTheQuota(t *testing.T) {
+	// The machine that runs this test has its own quota, or none, so the wiring
+	// is exercised against a stated one.
+	restore := cpuQuota
+	cpuQuota = func() int { return 4 }
+	t.Cleanup(func() { cpuQuota = restore })
+
+	cmd := buildCommand(context.Background(), execSubmitRequest{
+		Command: []string{"true"},
+		Env:     map[string]string{"OMP_NUM_THREADS": "1"},
+	})
+	env := envMap(cmd.Env)
+
+	if env["OMP_NUM_THREADS"] != "1" {
+		t.Fatalf("the request must win, got %q", env["OMP_NUM_THREADS"])
+	}
+	if env["OPENBLAS_NUM_THREADS"] != "4" {
+		t.Fatalf("the quota must reach the names the request leaves alone, got %q", env["OPENBLAS_NUM_THREADS"])
+	}
+	if env[envCPULimit] != "4" {
+		t.Fatalf("%s = %q, want \"4\"", envCPULimit, env[envCPULimit])
+	}
+}

--- a/images/sandbox-base/server/executor.go
+++ b/images/sandbox-base/server/executor.go
@@ -510,6 +510,9 @@ func buildCommand(ctx context.Context, req execSubmitRequest) *exec.Cmd {
 		cmd.Dir = req.Cwd
 	}
 	cmd.Env = sanitizedEnviron()
+	// Before req.Env: the quota is a default that a caller with better knowledge
+	// of one command overrides, not a mandate.
+	cmd.Env = append(cmd.Env, cpuLimitEnv(cmd.Env, cpuQuota())...)
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}


### PR DESCRIPTION
## What & why

The harness gives each container a hard CPU quota. A cgroup quota is invisible
to the runtimes inside it, because `/proc` and `/sys` still describe the
machine. Thus `nproc`, `os.cpu_count()`, and `parallel::detectCores()` all
report the cores of the host under any quota.

Code that sizes a worker pool from that number forks one worker for each core of
the host. Each fork copies its working set. Thus the forks exhaust the memory
limit of the container before the CPU limit throttles them, and the workload
takes sandbox-server down with it.

sandbox-server now reads the quota of the cgroup that it is in, and it publishes
that number to each command. The value comes from the kernel, not from the
request that made the container, thus the two can never disagree.

Notes for the reviewer:

- An environment value alone reaches neither language. `detectCores()` reads
  `/sys/devices/system/cpu/online`, and `os.cpu_count()` reads the machine. Thus
  the image carries one shim for each: an R profile on `R_PROFILE_USER`, and a
  Python module that a `.pth` line imports.
- `MC_CORES` and `options(mc.cores)` stay unset. R defaults `mclapply` to 2
  workers, and that default is R's own, not a count of the host. A value there
  would raise the fork count.
- Each published name is a default. A value on the container, and a value in the
  exec request, both keep the last word over it.
- Under a quota of 2 CPUs a probe of the image gives 2 for `detectCores()`, for
  `mclapply` with `mc.cores = detectCores()`, for `os.cpu_count()`, and for
  `mp.Pool()`. With no quota the same probe gives the numbers of the host.
- `go vet` and `go test ./...` pass in `images/sandbox-base/server`. The two
  shim files have no CI coverage, and the probe above is the only record of
  them.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally. This change touches no TypeScript, so the Go suite of the image is what ran.
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. The change adds two read-only
  shim files and some environment names. It grants no capability, no mount, and
  no egress, and it changes no resource limit.
- [x] **Provenance:** the provenance hooks are untouched. The R shim rides on
  `R_PROFILE_USER`, and the provenance profile keeps `R_PROFILE`. A probe of the
  image shows that both profiles load. But a parallel step now runs with fewer
  workers, thus a method whose result depends on the worker count can vary.
