### PR TITLE
feat(harness): complete the data profile of an analysis with no input files

### DIFF
--- a/cli/src/modules/harness/dev/profile.ts
+++ b/cli/src/modules/harness/dev/profile.ts
@@ -108,6 +108,12 @@ export async function runProfile(flags: ContextFlags): Promise<void> {
         case "already_running":
             log.info("A profile run is already in progress — watching it");
             break;
+        case "completed":
+            // The analysis has no input files, so the ledger row is complete at
+            // once with no result. No workflow ran, so there is nothing to watch.
+            log.step("No input files — the profile is complete with no result");
+            outro("Done — inspect details with `inflexa profile --status`");
+            return shutdown(0);
         case "failed": {
             // The trigger claims pending/completed rows only; a failed row needs
             // the retry claim. Mirror the managed retry route: claim, then start.

--- a/cli/src/modules/harness/profile_trigger.ts
+++ b/cli/src/modules/harness/profile_trigger.ts
@@ -403,6 +403,11 @@ async function runProfileLadder(
             return { kind: "triggered", restarted: result === "restarted", materialized: true };
         case "already_running":
             return { kind: "already_running", materialized: true };
+        case "completed":
+            // The trigger completes a row at once only for an empty manifest, and the ladder settles an
+            // empty input set before it seeds. A completed profile covers the dispatched set, so the
+            // outcome is the one a completed row at parity reports.
+            return { kind: "already_profiled", materialized: true };
         case "failed":
             // A `failed` ledger row took the retry-claim route above, so reaching here means the trigger
             // itself faulted — report it so the UI surfaces it and the user can re-open or run
@@ -491,6 +496,10 @@ export async function forceReprofile(runtime: HarnessRuntime, analysis: Analysis
             return { kind: "triggered", restarted: result === "restarted", materialized: true };
         case "already_running":
             return { kind: "already_running", materialized: true };
+        case "completed":
+            // The same type obligation as the parity ladder: force settles an empty input set as `no_inputs`
+            // before it triggers, so the trigger's empty-manifest completion is not reachable here.
+            return { kind: "already_profiled", materialized: true };
         case "failed":
             // The trigger's CAS claims only pending/completed rows; a `failed` row needs the retry claim.
             // Force is deliberate, so unlike parity it resurrects a failure whose input set is unchanged.

--- a/harness/openspec/changes/complete-empty-data-profile/.openspec.yaml
+++ b/harness/openspec/changes/complete-empty-data-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/harness/openspec/changes/complete-empty-data-profile/proposal.md
+++ b/harness/openspec/changes/complete-empty-data-profile/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+An analysis with no input files has no profile state that says "done". The trigger refuses
+an unseeded analysis and an empty manifest, so the ledger row stays at `pending` or NULL. A
+consumer reads that row as "not profiled", and the user sees a profile that never starts.
+
+The body already knows the correct answer. When the workflow body receives an empty
+manifest, it completes the profile as a no-op (the data-profile-init spec). But no trigger
+can reach that path: every claim into `running` requires a seed that names files, and the
+trigger refuses an empty seed before any claim. Thus the harness holds two answers for one
+condition, and only the refusal is reachable.
+
+A profile describes files. An analysis with no files has nothing to describe, and thus its
+profile is complete at once. There is no reason to claim the row, to mint an authorization,
+or to start a workflow for zero files.
+
+## What Changes
+
+- **A new ledger operation, `completeEmptyDataProfile`.** It stamps a row `completed` with
+  no result, no error, no workflow id, and the seed `[]`. The CAS refuses a live run and a
+  row whose seed names files. The seed predicate is the negation of the claim conjunct, so
+  a claim and an empty-set completion can never both win on one row.
+- **The trigger takes the empty-set route.** When the manifest is empty and the seed names
+  no file, `triggerDataProfile` stamps the row and returns the new result `"completed"`. No
+  claim runs, and no workflow starts. An empty manifest against a seed that names files
+  stays a refusal, because the caller and the ledger diverge.
+- **The unseeded refusal narrows to a manifest that names files.** A NULL seed or `[]`
+  against a non-empty manifest still means that the caller skipped the seed.
+
+## Impact
+
+- `src/state/data-profile.ts`, `src/state/index.ts`: the new operation.
+- `src/tasks/data-profile.ts`: the trigger route and the `"completed"` result member.
+- `DataProfileTriggerResult` gains a member. An embedder with an exhaustive switch on the
+  result must add the case when it takes this version.
+- `clearDataProfile` stays. An embedder can keep the "not profiled" clear, or it can seed
+  `[]` and trigger to reach `completed`.

--- a/harness/openspec/changes/complete-empty-data-profile/specs/data-profile-rerun/spec.md
+++ b/harness/openspec/changes/complete-empty-data-profile/specs/data-profile-rerun/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: An analysis with no input files completes without a workflow
+
+`completeEmptyDataProfile(querier, analysisId)` MUST stamp a row `'completed'` with a single
+UPDATE. The guard MUST be `data_profile_status IS DISTINCT FROM 'running' AND
+(seed_input_file_ids IS NULL OR jsonb_array_length(seed_input_file_ids) = 0)`. The write MUST
+set `data_profile_started_at` and `data_profile_completed_at` to one timestamp, because no
+workflow ran. The write MUST set `data_profile_error`, `data_profile_result`, and
+`data_profile_workflow_id` to NULL. The write MUST set `seed_input_file_ids` to `[]`, so that
+the completed row names the set that it covers.
+
+The operation MUST resolve to `ok(true)` when it stamped the row. It MUST resolve to `ok(false)`
+when the guard refused the row: no such analysis, a live run, or a seed that names files. A
+refusal stays in the ok channel.
+
+The seed predicate is the negation of the claim conjunct. Thus a claim into `running` and an
+empty-set completion can never both win on one row. A seed upsert that lands between a caller's
+pre-read and the stamp is never hidden behind a finished profile.
+
+A `completed` row whose seed is `[]` MUST NOT be claimable by `tryRerunDataProfile`. A later seed
+upsert that names files makes the row claimable. Then the rerun claim MUST take it as any
+completed row.
+
+#### Scenario: A never-profiled row with no seed completes at once
+
+- **WHEN** `completeEmptyDataProfile(querier, analysisId)` is called for a row whose `data_profile_status` is NULL and whose `seed_input_file_ids` is NULL
+- **THEN** it MUST resolve to `ok(true)`
+- **AND** `data_profile_status` MUST be `'completed'`
+- **AND** `data_profile_result` and `data_profile_workflow_id` MUST be NULL
+- **AND** `seed_input_file_ids` MUST be `[]`
+- **AND** `data_profile_started_at` MUST equal `data_profile_completed_at`
+
+#### Scenario: A prior profile whose files are gone is replaced
+
+- **WHEN** `completeEmptyDataProfile` is called for a `'completed'` row with a stored `data_profile_result` and a seed of `[]`
+- **THEN** it MUST resolve to `ok(true)` and `data_profile_result` MUST be NULL
+
+#### Scenario: A live run is never stamped
+
+- **WHEN** `completeEmptyDataProfile` is called while `data_profile_status = 'running'`
+- **THEN** it MUST resolve to `ok(false)` and every profile column MUST keep its prior value
+
+#### Scenario: A seed that names files refuses the stamp
+
+- **WHEN** `completeEmptyDataProfile` is called for a row whose `seed_input_file_ids` names at least one file
+- **THEN** it MUST resolve to `ok(false)` and the row MUST be untouched
+
+#### Scenario: A completed-empty row is claimable for a rerun after a reseed
+
+- **WHEN** a seed upsert names files on a `'completed'` row whose seed was `[]`, and `tryRerunDataProfile` is then called
+- **THEN** it MUST resolve to `ok(true)` and `data_profile_status` MUST be `'running'`
+
+### Requirement: The trigger completes an analysis with no input files at once
+
+When `stagedInputs` is empty and the seed is NULL or `[]`, `triggerDataProfile` MUST call
+`completeEmptyDataProfile`. When the stamp landed, the trigger MUST return `"completed"`. The
+trigger MUST attempt no claim into `'running'`, and it MUST start no workflow. When the stamp
+refused the row and the row is `'running'`, the trigger MUST return `"already_running"`. In every
+other refusal the trigger MUST return `"failed"` and log the rejection with the analysis id.
+
+`DataProfileTriggerResult` MUST carry the member `"completed"`.
+
+#### Scenario: A never-profiled analysis with no inputs is completed
+
+- **WHEN** `triggerDataProfile` runs with an empty `stagedInputs` for an analysis whose `seed_input_file_ids` is NULL
+- **THEN** it MUST return `"completed"`
+- **AND** `data_profile_status` MUST be `'completed'` with a NULL `data_profile_result` and a seed of `[]`
+- **AND** no workflow MUST be started
+
+#### Scenario: An analysis seeded with an empty set is completed
+
+- **WHEN** `triggerDataProfile` runs with an empty `stagedInputs` for an analysis whose `seed_input_file_ids` is `[]`
+- **THEN** it MUST return `"completed"` and `data_profile_status` MUST be `'completed'`
+
+#### Scenario: An empty manifest against a live run reports the run
+
+- **WHEN** `triggerDataProfile` runs with an empty `stagedInputs` while `data_profile_status = 'running'` and the seed names no file
+- **THEN** it MUST return `"already_running"` and the row MUST be untouched
+
+#### Scenario: An empty manifest for a missing analysis row fails
+
+- **WHEN** `triggerDataProfile` runs with an empty `stagedInputs` for an analysis with no `cortex_analysis_state` row
+- **THEN** it MUST return `"failed"`
+
+## MODIFIED Requirements
+
+### Requirement: The trigger rejects an unseeded analysis before dispatch
+
+`triggerDataProfile` MUST return `"failed"` without a claim when `stagedInputs` names at least
+one file and the seed is NULL or empty. The trigger MUST log the rejection with the analysis id.
+When `stagedInputs` is empty and the seed names at least one file, the trigger MUST also return
+`"failed"` without a claim. The caller and the ledger diverge in that case. This pre-read is the
+source of the operator-facing reason. The CAS conjuncts of the claims and of the empty-set
+completion are the enforcement.
+
+#### Scenario: An unseeded analysis is refused before any claim
+
+- **WHEN** `triggerDataProfile` runs with a `stagedInputs` that names a file, for an analysis whose `seed_input_file_ids` is NULL
+- **THEN** it MUST return `"failed"`
+- **AND** the ledger row MUST be untouched (no transition to `'running'` is attempted)
+
+#### Scenario: An analysis seeded with an empty set is refused a manifest that names files
+
+- **WHEN** `triggerDataProfile` runs with a `stagedInputs` that names a file, for an analysis whose `seed_input_file_ids` is `[]`
+- **THEN** it MUST return `"failed"` and the ledger row MUST be untouched
+
+#### Scenario: An empty manifest against a seed that names files is refused
+
+- **WHEN** `triggerDataProfile` runs with an empty `stagedInputs` for an analysis whose `seed_input_file_ids` names at least one file
+- **THEN** it MUST return `"failed"` and the ledger row MUST be untouched

--- a/harness/openspec/changes/complete-empty-data-profile/tasks.md
+++ b/harness/openspec/changes/complete-empty-data-profile/tasks.md
@@ -1,0 +1,20 @@
+## 1. The ledger operation
+
+- [x] 1.1 Add `completeEmptyDataProfile` to `src/state/data-profile.ts` with the `UNSEEDED` predicate
+- [x] 1.2 Export it from `src/state/index.ts`
+
+## 2. The trigger route
+
+- [x] 2.1 Add `"completed"` to `DataProfileTriggerResult`
+- [x] 2.2 Route an empty manifest against an empty seed to `completeEmptyDataProfile`
+- [x] 2.3 Keep the refusal of an empty manifest against a seed that names files
+- [x] 2.4 Narrow the unseeded refusal to a manifest that names files
+
+## 3. Tests
+
+- [x] 3.1 `state/data-profile.test.ts`: the stamp, the three refusals, and the rerun claim after a reseed
+- [x] 3.2 `tasks/data-profile.trigger.test.ts`: the `"completed"` route, `already_running`, no row, and the narrowed refusals
+
+## 4. Specs
+
+- [x] 4.1 `data-profile-rerun`: add the empty-set completion requirements, and narrow the trigger rejection requirement

--- a/harness/src/state/data-profile.test.ts
+++ b/harness/src/state/data-profile.test.ts
@@ -5,6 +5,7 @@ import { withSchema } from "../__tests__/setup/postgres.js";
 import {
     clearDataProfile,
     completeDataProfile,
+    completeEmptyDataProfile,
     failDataProfile,
     loadDataProfileStatus,
     recordDataProfileWorkflowId,
@@ -749,5 +750,125 @@ describe("the recorded profile workflow id", () => {
         // Read raw: the public read collapses a cleared row to null, so it cannot show this.
         expect(await rawWorkflowId(pool, "a-wf-clear")).toBeNull();
         expect((await loadDataProfileStatus(pool, "a-wf-clear"))._unsafeUnwrap()).toBeNull();
+    });
+});
+
+// An analysis with no input files has nothing to profile. The empty-set completion stamps
+// the row `completed` at once, with no result and no workflow, and names the empty set as
+// its seed. The CAS refuses a live run and a row whose seed names files.
+describe("completing an analysis with no input files", () => {
+    let pool: Pool;
+    let drop: () => Promise<void>;
+
+    beforeAll(async () => {
+        const ctx = await withSchema("dp_complete_empty");
+        pool = ctx.pool;
+        drop = ctx.drop;
+    });
+
+    afterAll(async () => {
+        await drop();
+    });
+
+    /** Read the two lifecycle timestamps straight off the row. */
+    async function rawTimestamps(analysisId: string): Promise<{ startedAt: string | null; completedAt: string | null }> {
+        const res = await pool.query<{ data_profile_started_at: string | null; data_profile_completed_at: string | null }>({
+            text: "SELECT data_profile_started_at, data_profile_completed_at FROM cortex_analysis_state WHERE analysis_id = $1",
+            values: [analysisId],
+        });
+        return { startedAt: res.rows[0]?.data_profile_started_at ?? null, completedAt: res.rows[0]?.data_profile_completed_at ?? null };
+    }
+
+    it("stamps a never-profiled NULL-seed row completed, with no result and the empty seed", async () => {
+        await seedAnalysis(pool, "a-empty-null", null, null);
+
+        const stamped = (await completeEmptyDataProfile(pool, "a-empty-null"))._unsafeUnwrap();
+        expect(stamped).toBe(true);
+
+        const status = (await loadDataProfileStatus(pool, "a-empty-null"))._unsafeUnwrap();
+        expect(status?.status).toBe("completed");
+        expect(status?.result).toBeNull();
+        expect(status?.error).toBeNull();
+        expect(status?.workflowId).toBeNull();
+        expect(status?.seedInputFileIds).toEqual([]);
+
+        // No workflow ran, so the profile started and completed at one instant.
+        const stamps = await rawTimestamps("a-empty-null");
+        expect(stamps.startedAt).not.toBeNull();
+        expect(stamps.completedAt).toBe(stamps.startedAt);
+    });
+
+    it("stamps a pending row seeded with `[]`", async () => {
+        await seedAnalysis(pool, "a-empty-pending", "pending", []);
+
+        expect((await completeEmptyDataProfile(pool, "a-empty-pending"))._unsafeUnwrap()).toBe(true);
+        expect(await rawStatus(pool, "a-empty-pending")).toBe("completed");
+    });
+
+    it("replaces a prior profile whose files are gone with no result", async () => {
+        // The inputs were removed after a profile. The prior result describes files the
+        // analysis no longer has, so the empty completion replaces it.
+        await seedAnalysis(pool, "a-empty-prior", "completed", []);
+        await pool.query({
+            text: "UPDATE cortex_analysis_state SET data_profile_result = $1::jsonb, data_profile_workflow_id = 'dataprofile:a-empty-prior:old' WHERE analysis_id = $2",
+            values: [JSON.stringify(SAMPLE_RESULT), "a-empty-prior"],
+        });
+
+        expect((await completeEmptyDataProfile(pool, "a-empty-prior"))._unsafeUnwrap()).toBe(true);
+
+        const status = (await loadDataProfileStatus(pool, "a-empty-prior"))._unsafeUnwrap();
+        expect(status?.status).toBe("completed");
+        expect(status?.result).toBeNull();
+        expect(await rawWorkflowId(pool, "a-empty-prior")).toBeNull();
+    });
+
+    it("replaces a failed attempt whose files are gone", async () => {
+        await seedAnalysis(pool, "a-empty-failed", "failed", null);
+        await pool.query({
+            text: "UPDATE cortex_analysis_state SET data_profile_error = 'boom' WHERE analysis_id = $1",
+            values: ["a-empty-failed"],
+        });
+
+        expect((await completeEmptyDataProfile(pool, "a-empty-failed"))._unsafeUnwrap()).toBe(true);
+
+        const status = (await loadDataProfileStatus(pool, "a-empty-failed"))._unsafeUnwrap();
+        expect(status?.status).toBe("completed");
+        expect(status?.error).toBeNull();
+    });
+
+    it("refuses a live run and leaves the row untouched", async () => {
+        await seedAnalysis(pool, "a-empty-running", "running", []);
+
+        expect((await completeEmptyDataProfile(pool, "a-empty-running"))._unsafeUnwrap()).toBe(false);
+        expect(await rawStatus(pool, "a-empty-running")).toBe("running");
+    });
+
+    it("refuses a row whose seed names files — the caller's pre-read is not the enforcement", async () => {
+        // A seed upsert landed between a caller's read and this write. The row now names
+        // files, and a `completed` stamp would hide them behind a finished profile.
+        await seedAnalysis(pool, "a-empty-reseeded", "pending", ["file-aaa"]);
+
+        expect((await completeEmptyDataProfile(pool, "a-empty-reseeded"))._unsafeUnwrap()).toBe(false);
+        expect(await rawStatus(pool, "a-empty-reseeded")).toBe("pending");
+        const status = (await loadDataProfileStatus(pool, "a-empty-reseeded"))._unsafeUnwrap();
+        expect(status?.seedInputFileIds).toEqual(["file-aaa"]);
+    });
+
+    it("refuses an analysis with no ledger row", async () => {
+        expect((await completeEmptyDataProfile(pool, "a-empty-norow"))._unsafeUnwrap()).toBe(false);
+    });
+
+    it("is not claimable for a rerun until a later seed names files", async () => {
+        await seedAnalysis(pool, "a-empty-then-files", null, null);
+        expect((await completeEmptyDataProfile(pool, "a-empty-then-files"))._unsafeUnwrap()).toBe(true);
+
+        // `[]` is not a seed, so the rerun claim refuses the completed-empty row.
+        expect((await tryRerunDataProfile(pool, "a-empty-then-files"))._unsafeUnwrap()).toBe(false);
+        expect(await rawStatus(pool, "a-empty-then-files")).toBe("completed");
+
+        // Inputs arrive: the seed upsert names them, and the rerun claim takes the row.
+        await setSeed(pool, "a-empty-then-files", ["file-aaa"]);
+        expect((await tryRerunDataProfile(pool, "a-empty-then-files"))._unsafeUnwrap()).toBe(true);
+        expect(await rawStatus(pool, "a-empty-then-files")).toBe("running");
     });
 });

--- a/harness/src/state/data-profile.ts
+++ b/harness/src/state/data-profile.ts
@@ -74,6 +74,14 @@ export interface DataProfileStatus {
 const SEEDED = "seed_input_file_ids IS NOT NULL AND jsonb_array_length(seed_input_file_ids) > 0";
 
 /**
+ * The negation of {@link SEEDED}: the row names no input file. A NULL seed and `[]`
+ * both name zero files, and {@link completeEmptyDataProfile} treats them the same.
+ * The two predicates are disjoint, so a claim into `running` and an empty-set
+ * completion can never both win on one row.
+ */
+const UNSEEDED = "(seed_input_file_ids IS NULL OR jsonb_array_length(seed_input_file_ids) = 0)";
+
+/**
  * Try to claim a startable row into `running`. Startable means `'pending'` (seeded,
  * not yet run) or NULL (no profile: never profiled, or cleared by `clearDataProfile`).
  *
@@ -336,6 +344,56 @@ export function clearDataProfile(pool: Querier, analysisId: string): ResultAsync
                 seed_input_file_ids = NULL
             WHERE analysis_id = $1 AND data_profile_status IS DISTINCT FROM 'running'`,
             values: [analysisId],
+        });
+        return (result.rowCount ?? 0) > 0;
+    });
+}
+
+/**
+ * Stamp a row `completed` with no result, because the analysis has no input files.
+ *
+ * A profile describes files. An analysis with no files has nothing to describe, and
+ * thus the profile is complete at once: no claim into `running`, no workflow, and no
+ * sandbox. The write is a terminal write like {@link completeDataProfile}, but it starts
+ * from a settled row or an empty row, not from a `running` one. As a result
+ * `data_profile_started_at` and `data_profile_completed_at` carry the same instant, and
+ * `data_profile_workflow_id` stays NULL, because no stream is addressable (see
+ * {@link recordDataProfileWorkflowId}).
+ *
+ * The seed is written as `[]`, so the completed row names the set that it covers: the
+ * empty set. A `completed` row with a NULL seed stays forbidden (see
+ * {@link completeDataProfile}). A prior `data_profile_result` is replaced with NULL,
+ * because it describes files that the analysis no longer has. A prior `failed` row is
+ * replaced too, because the set that failed is gone.
+ *
+ * Two guards ride in the CAS:
+ * - `IS DISTINCT FROM 'running'`: a live workflow owns the row, and its terminal write
+ *   must not land on a row that this write moved. The same reason as
+ *   {@link clearDataProfile}.
+ * - {@link UNSEEDED}: the row names no file. A seed upsert that lands between a caller's
+ *   pre-read and this write makes the row a seeded, startable row. A `completed` stamp
+ *   over it would hide those files behind a finished profile. The CAS refuses that row,
+ *   and the caller reads the status again to name the cause.
+ *
+ * The rerun claim carries {@link SEEDED}, so a completed-empty row is not claimable until
+ * a later seed upsert names files. Then `tryRerunDataProfile` takes it, the same as any
+ * completed row.
+ *
+ * `ok(true)` when this call stamped the row. `ok(false)` when the guard refused it: no
+ * such analysis, a live run, or a seed that names files. A refusal stays in the ok
+ * channel, the same as the sibling CAS ops.
+ */
+export function completeEmptyDataProfile(pool: Querier, analysisId: string): ResultAsync<boolean, DbError> {
+    const now = new Date().toISOString();
+    return tryMutation("dataProfile.completeEmptyDataProfile", async () => {
+        const result = await pool.query({
+            text: `UPDATE cortex_analysis_state
+            SET data_profile_status = 'completed', data_profile_error = NULL,
+                data_profile_started_at = $1, data_profile_completed_at = $1,
+                data_profile_result = NULL, data_profile_workflow_id = NULL,
+                seed_input_file_ids = '[]'::jsonb
+            WHERE analysis_id = $2 AND data_profile_status IS DISTINCT FROM 'running' AND ${UNSEEDED}`,
+            values: [now, analysisId],
         });
         return (result.rowCount ?? 0) > 0;
     });

--- a/harness/src/state/index.ts
+++ b/harness/src/state/index.ts
@@ -62,6 +62,7 @@ export {
     expireStaleDataProfile,
     reconcileOrphanedDataProfile,
     clearDataProfile,
+    completeEmptyDataProfile,
     loadDataProfileStatus,
     loadSeedInputFileIds,
     recordDataProfileWorkflowId,

--- a/harness/src/tasks/data-profile.trigger.test.ts
+++ b/harness/src/tasks/data-profile.trigger.test.ts
@@ -41,7 +41,8 @@ function legacyStagedInput(fileId: string): StagedInput {
  * Seed a `cortex_analysis_state` row at the given `data_profile_status` (pass `null`
  * for the cleared/never-profiled state). Mirrors the helper in
  * `state/data-profile.test.ts`: it leaves `seed_input_file_ids` NULL, which is
- * exactly the unseeded state both the trigger's guard and the claim CAS refuse.
+ * exactly the unseeded state that the claim CAS refuses, and that the trigger's guard
+ * refuses when the manifest names files.
  */
 async function seedAnalysis(pool: Pool, analysisId: string, dpStatus: string | null = "pending"): Promise<void> {
     const now = new Date().toISOString();
@@ -126,14 +127,15 @@ describe("triggerDataProfile seed-first guard", () => {
         await drop();
     });
 
-    it("refuses a NULL-seed row and leaves it unclaimed", async () => {
-        // `seedAnalysis` leaves `seed_input_file_ids` NULL — the unseeded ledger.
+    it("refuses a NULL-seed row dispatched a manifest that names files, and leaves it unclaimed", async () => {
+        // `seedAnalysis` leaves `seed_input_file_ids` NULL. The manifest names a file, so
+        // the caller skipped the seed: the trigger refuses before any claim.
         await seedAnalysis(pool, "a-noseed", "pending");
 
         const result = await triggerDataProfile(tripwireDeps(pool), {
             auth: makeLocalAuth(),
             analysisId: "a-noseed",
-            stagedInputs: [],
+            stagedInputs: [stagedInput("file-aaa")],
         });
 
         expect(result).toBe("failed");
@@ -144,20 +146,84 @@ describe("triggerDataProfile seed-first guard", () => {
         expect(status?.status).toBe("pending");
     });
 
-    it("refuses an empty-seed row — `[]` names zero files, and is not a seed", async () => {
+    it("refuses an empty-seed row dispatched a manifest that names files — `[]` is not a seed", async () => {
         // `upsertAnalysis` writes NULL to mean "leave the stored seed alone", so `[]`
-        // reaches the ledger as a real value. It must be refused exactly like NULL.
+        // reaches the ledger as a real value. Against a manifest that names a file, it
+        // must be refused exactly like NULL.
         await seedAnalysis(pool, "a-emptyseed", "pending");
         await setSeed(pool, "a-emptyseed", []);
 
         const result = await triggerDataProfile(tripwireDeps(pool), {
             auth: makeLocalAuth(),
             analysisId: "a-emptyseed",
-            stagedInputs: [],
+            stagedInputs: [stagedInput("file-aaa")],
         });
 
         expect(result).toBe("failed");
         expect(await rawStatus(pool, "a-emptyseed")).toBe("pending");
+    });
+
+    it("completes a NULL-seed row dispatched an empty manifest — no input files, no workflow", async () => {
+        // The never-profiled analysis with no inputs. Nothing to profile, so the row is
+        // `completed` at once. `tripwireDeps` documents that no workflow is launched.
+        await seedAnalysis(pool, "a-empty-noseed", null);
+
+        const result = await triggerDataProfile(tripwireDeps(pool), {
+            auth: makeLocalAuth(),
+            analysisId: "a-empty-noseed",
+            stagedInputs: [],
+        });
+
+        expect(result).toBe("completed");
+        expect(await rawStatus(pool, "a-empty-noseed")).toBe("completed");
+        const status = (await loadDataProfileStatus(pool, "a-empty-noseed"))._unsafeUnwrap();
+        expect(status?.status).toBe("completed");
+        expect(status?.result).toBeNull();
+        expect(status?.workflowId).toBeNull();
+        expect(status?.seedInputFileIds).toEqual([]);
+    });
+
+    it("completes an empty-seed pending row dispatched an empty manifest", async () => {
+        // The caller seeded `[]` and forwarded an empty manifest: the two agree that the
+        // analysis has no input files.
+        await seedAnalysis(pool, "a-empty-seeded", "pending");
+        await setSeed(pool, "a-empty-seeded", []);
+
+        const result = await triggerDataProfile(tripwireDeps(pool), {
+            auth: makeLocalAuth(),
+            analysisId: "a-empty-seeded",
+            stagedInputs: [],
+        });
+
+        expect(result).toBe("completed");
+        expect(await rawStatus(pool, "a-empty-seeded")).toBe("completed");
+    });
+
+    it("reports already_running for an empty manifest against a live run", async () => {
+        // A live workflow owns the row. The empty-set stamp refuses it, and the trigger
+        // names the cause from the status instead of a bare failure.
+        await seedAnalysis(pool, "a-empty-running", "running");
+        await setSeed(pool, "a-empty-running", []);
+
+        const result = await triggerDataProfile(tripwireDeps(pool), {
+            auth: makeLocalAuth(),
+            analysisId: "a-empty-running",
+            stagedInputs: [],
+        });
+
+        expect(result).toBe("already_running");
+        expect(await rawStatus(pool, "a-empty-running")).toBe("running");
+    });
+
+    it("fails an empty manifest for an analysis with no ledger row", async () => {
+        const result = await triggerDataProfile(tripwireDeps(pool), {
+            auth: makeLocalAuth(),
+            analysisId: "a-empty-norow",
+            stagedInputs: [],
+        });
+
+        expect(result).toBe("failed");
+        expect(await rawStatus(pool, "a-empty-norow")).toBeNull();
     });
 
     it("claims a NULL-status seeded row — the cleared-then-reseeded state", async () => {

--- a/harness/src/tasks/data-profile.ts
+++ b/harness/src/tasks/data-profile.ts
@@ -64,6 +64,7 @@ import { absorbRecipe, renderAbsorbDelta, type AbsorbKind } from "./data-profile
 import { formatResolutionErrors, resolveProfileSubmission, type ProfileResolution, type ResolvedGroup } from "./data-profile-resolve.js";
 import {
     completeDataProfile,
+    completeEmptyDataProfile,
     failDataProfile,
     loadDataProfileStatus,
     loadSeedInputFileIds,
@@ -805,7 +806,16 @@ function logTerminalNoop(logger: Logger, analysisId: string, write: string): voi
     logger.warn("terminal write skipped: ledger row not running (cleared or expired concurrently)", { analysisId, write });
 }
 
-export type DataProfileTriggerResult = "started" | "restarted" | "already_running" | "failed";
+/**
+ * What the trigger did:
+ * - `"started"`: a first profile claimed the row and a workflow runs.
+ * - `"restarted"`: a re-profile claimed a `completed` row and a workflow runs.
+ * - `"already_running"`: a workflow already owns the row, and nothing new ran.
+ * - `"completed"`: the analysis has no input files, so the row is `completed` at once
+ *   with no result. No workflow ran (see {@link completeEmptyDataProfile}).
+ * - `"failed"`: the trigger refused the call or faulted, and the row is unchanged.
+ */
+export type DataProfileTriggerResult = "started" | "restarted" | "already_running" | "completed" | "failed";
 
 /**
  * Route-side deps for triggering the data-profile workflow: the ledger pool,
@@ -897,6 +907,12 @@ async function startDataProfileWorkflow(deps: DataProfileTriggerDeps, params: Da
  * row is claimed by neither: retrying a failure is a deliberate act the caller drives
  * through `tryRetryDataProfile` + `runDataProfile`.
  *
+ * An analysis with no input files takes none of the claims. An empty manifest against
+ * a seed that names no file stamps the row `completed` at once, with no result and no
+ * workflow (see {@link completeEmptyDataProfile}), and the trigger returns
+ * `"completed"`. An empty manifest against a seed that names files is a divergence
+ * between the caller and the ledger, and the trigger refuses it.
+ *
  * Returns what happened, so the caller can surface it (e.g. in the seed response).
  */
 export async function triggerDataProfile(deps: DataProfileTriggerDeps, params: DataProfileTriggerParams): Promise<DataProfileTriggerResult> {
@@ -911,18 +927,33 @@ export async function triggerDataProfile(deps: DataProfileTriggerDeps, params: D
         // `loadSeedInputFileIds`, which returns null for BOTH a missing analysis row and
         // a NULL-seed row (`loadDataProfileStatus` would hide the seed of a cleared row).
         const seeded = unwrapOrThrow(await loadSeedInputFileIds(deps.pool, analysisId));
-        if (seeded === null || seeded.length === 0) {
-            logger.error("trigger rejected: no seeded input set (missing analysis row or caller skipped seeding)");
+
+        if (params.stagedInputs.length === 0) {
+            // The trigger validates the manifest it is about to dispatch against the ledger
+            // seed. A seeded row profiled against an EMPTY manifest would claim `running` and
+            // then hit the body's empty-manifest path, and complete with a NULL result while
+            // the seed still names files. Refuse the divergence before any claim.
+            if (seeded !== null && seeded.length > 0) {
+                logger.error("trigger rejected: empty manifest dispatched against a non-empty seed", { seededCount: seeded.length });
+                return "failed";
+            }
+
+            // The analysis has no input files, so there is nothing to profile. The row is
+            // `completed` at once, with no workflow. The CAS carries the same seed
+            // predicate as this pre-read, so a seed upsert that lands in between cannot be
+            // hidden behind a finished profile: the stamp refuses, and the status read
+            // below names the cause.
+            if (unwrapOrThrow(await completeEmptyDataProfile(deps.pool, analysisId))) return "completed";
+            const current = unwrapOrThrow(await loadDataProfileStatus(deps.pool, analysisId));
+            if (current?.status === "running") return "already_running";
+            logger.error("trigger rejected: empty-set completion refused (no analysis row, or the seed now names files)");
             return "failed";
         }
 
-        // The trigger validates the ledger seed above; it must also validate the manifest
-        // it is about to dispatch. A seeded row profiled against an EMPTY manifest would
-        // claim `running` and then hit the body's empty-manifest path — completing with a
-        // NULL result while the seed still names files, an incoherence a staleness policy
-        // then loops on re-triggering. Refuse the divergence before any claim.
-        if (params.stagedInputs.length === 0) {
-            logger.error("trigger rejected: empty manifest dispatched against a non-empty seed", { seededCount: seeded.length });
+        // A non-empty manifest against a seed that names no file: the caller skipped the
+        // seed, or the analysis row is missing. Name the cause before any claim.
+        if (seeded === null || seeded.length === 0) {
+            logger.error("trigger rejected: no seeded input set (missing analysis row or caller skipped seeding)");
             return "failed";
         }
 


### PR DESCRIPTION
## What & why

An analysis with no input files had no profile state that says "done". `triggerDataProfile` refused an unseeded analysis and an empty manifest, so the ledger row stayed at `pending` or NULL, and a consumer read it as "not profiled". 

A profile describes files, and an analysis with no files has nothing to describe. Thus the profile is now complete at once: the new ledger operation `completeEmptyDataProfile` stamps the row `completed` with no result, no workflow id, and the seed `[]`. The trigger takes this route when the manifest is empty and the seed names no file, and it returns the new result `"completed"`. No claim runs, and no workflow starts.

Notes for the reviewer:

- The CAS of `completeEmptyDataProfile` carries the negation of the `SEEDED` claim conjunct. Thus a claim into `running` and this stamp can never both win on one row. A seed upsert that lands between the pre-read and the stamp is never hidden behind a finished profile.
- A `completed` row with the seed `[]` is not claimable for a rerun. A later seed upsert that names files makes it claimable, the same as any completed row.
- An empty manifest against a seed that names files stays a refusal. The unseeded refusal now applies only to a manifest that names files.
- `DataProfileTriggerResult` gains the member `"completed"`. The three exhaustive switches in the CLI carry the case. The parity ladder and the force path settle an empty set before they trigger, so they map it to `already_profiled`. The dev `inflexa profile` command reports the completion and exits. The CLI's empty-set branch still calls `clearDataProfile`, so the CLI keeps its "not profiled" route in this PR.
- The spec delta lives in `openspec/changes/complete-empty-data-profile`, and `openspec validate` passes.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01QgKBpFt9m9dZ6ebY9hAY38
