### PR TITLE
fix(harness): give each sandbox runtime the cpu quota of its step

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.30.2",
+    "version": "0.30.3",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/sandbox/cpu-files.test.ts
+++ b/harness/src/sandbox/cpu-files.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `cpuFiles` is pure: the content of the two cpu files from a thread count and
+ * the text of a real `/proc/cpuinfo`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { cpuFiles } from "./cpu-files.js";
+
+function block(n: number): string {
+    return `processor\t: ${n}\nvendor_id\t: GenuineIntel\nmodel name\t: Test CPU\ncpu MHz\t\t: 2400.000\nflags\t\t: fpu vme\n`;
+}
+
+/** Four processor blocks in the x86 layout: a blank line after each block. */
+const HOST_CPUINFO = [0, 1, 2, 3].map((n) => `${block(n)}\n`).join("");
+
+function processorCount(cpuinfo: string): number {
+    return cpuinfo.match(/^processor\b/gm)?.length ?? 0;
+}
+
+describe("cpuFiles", () => {
+    test("two threads: online is the range 0-1 and cpuinfo keeps the first two blocks", () => {
+        const files = cpuFiles(2, HOST_CPUINFO);
+
+        expect(files.online).toBe("0-1\n");
+        expect(files.cpuinfo).toBe(`${block(0)}\n${block(1)}\n`);
+        expect(processorCount(files.cpuinfo!)).toBe(2);
+    });
+
+    test("one thread: online is `0`, as the kernel writes it for a single cpu", () => {
+        const files = cpuFiles(1, HOST_CPUINFO);
+
+        expect(files.online).toBe("0\n");
+        expect(processorCount(files.cpuinfo!)).toBe(1);
+        expect(files.cpuinfo).toStartWith("processor\t: 0\n");
+    });
+
+    test("more threads than host blocks: all blocks stay", () => {
+        const files = cpuFiles(8, HOST_CPUINFO);
+
+        expect(files.online).toBe("0-7\n");
+        expect(processorCount(files.cpuinfo!)).toBe(4);
+    });
+
+    test("a block with no processor line is not a processor", () => {
+        // An ARM kernel ends the file with a trailer that names the board.
+        const arm = `${HOST_CPUINFO}Hardware\t: Test Board\nRevision\t: 0001\n`;
+
+        const files = cpuFiles(8, arm);
+
+        expect(processorCount(files.cpuinfo!)).toBe(4);
+        expect(files.cpuinfo).not.toContain("Hardware");
+    });
+
+    test("no host cpuinfo: online only", () => {
+        const files = cpuFiles(3, undefined);
+
+        expect(files.online).toBe("0-2\n");
+        expect(files.cpuinfo).toBeUndefined();
+    });
+});

--- a/harness/src/sandbox/cpu-files.ts
+++ b/harness/src/sandbox/cpu-files.ts
@@ -8,9 +8,28 @@
  * describe the host, not the cgroup. A read-only bind of a small file over each
  * path makes both calls report the quota.
  *
- * This module makes the content of the two files. It touches no file system.
- * The Docker backend writes the content to the host and binds it.
+ * This module makes the content of the two files, and it reads the
+ * `/proc/cpuinfo` of the harness host that the content is cut from. The Docker
+ * backend writes the content to the host and binds it. The K8s backend puts
+ * the content in a ConfigMap and mounts each key with `subPath`.
  */
+
+import { readFile } from "node:fs/promises";
+
+/** The two container paths that the cpu files cover. */
+export const CPU_ONLINE_PATH = "/sys/devices/system/cpu/online";
+export const CPUINFO_PATH = "/proc/cpuinfo";
+
+/**
+ * The `/proc/cpuinfo` of the harness host, read once per process. The content
+ * does not change while the process runs. A host with no such file, for
+ * example macOS, gives `undefined`, and the caller covers only `online`.
+ */
+let hostCpuinfo: Promise<string | undefined> | undefined;
+export function readHostCpuinfoOnce(): Promise<string | undefined> {
+    hostCpuinfo ??= readFile(CPUINFO_PATH, "utf8").catch(() => undefined);
+    return hostCpuinfo;
+}
 
 export interface CpuFiles {
     /** Content of `/sys/devices/system/cpu/online`: `0` for one thread, else the range `0-<n-1>`. */

--- a/harness/src/sandbox/cpu-files.ts
+++ b/harness/src/sandbox/cpu-files.ts
@@ -1,0 +1,50 @@
+/**
+ * The two cpu files that a sandbox reads for its core count.
+ *
+ * The thread env (`thread-env.ts`) reaches each library that reads a thread
+ * count from the environment. Two base calls read a kernel file instead:
+ * `parallel::detectCores()` greps `/proc/cpuinfo`, and `os.cpu_count()` of
+ * Python 3.12 reads `/sys/devices/system/cpu/online` through glibc. Both files
+ * describe the host, not the cgroup. A read-only bind of a small file over each
+ * path makes both calls report the quota.
+ *
+ * This module makes the content of the two files. It touches no file system.
+ * The Docker backend writes the content to the host and binds it.
+ */
+
+export interface CpuFiles {
+    /** Content of `/sys/devices/system/cpu/online`: `0` for one thread, else the range `0-<n-1>`. */
+    readonly online: string;
+    /**
+     * Content of `/proc/cpuinfo`: the first n `processor` blocks of the real file
+     * of the host. `undefined` when the host gives no `/proc/cpuinfo`.
+     */
+    readonly cpuinfo: string | undefined;
+}
+
+/**
+ * Split the text of `/proc/cpuinfo` into its `processor` blocks. A blank line
+ * ends a block. A block with no `processor` line, for example the `Hardware`
+ * trailer of an ARM kernel, is not a processor and is dropped.
+ */
+function processorBlocks(cpuinfo: string): string[] {
+    return cpuinfo
+        .split(/\n\s*\n/)
+        .map((block) => block.trim())
+        .filter((block) => /^processor\b/m.test(block));
+}
+
+/**
+ * The content of the two cpu files for `threads` cpus.
+ *
+ * `threads` is a positive integer. The caller applies the same floor as
+ * `threadLimitEnv`: `Math.max(1, Math.floor(spec.cpu))`. When the host has fewer
+ * processor blocks than `threads`, all blocks stay. Each block keeps its own
+ * text, thus the `processor` numbers stay `0` to `n-1` as in the real file.
+ */
+export function cpuFiles(threads: number, hostCpuinfo: string | undefined): CpuFiles {
+    const online = `${threads === 1 ? "0" : `0-${threads - 1}`}\n`;
+    if (hostCpuinfo === undefined) return { online, cpuinfo: undefined };
+    const blocks = processorBlocks(hostCpuinfo).slice(0, threads);
+    return { online, cpuinfo: blocks.map((block) => `${block}\n\n`).join("") };
+}

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -57,6 +57,8 @@ interface CreatedContainer {
     capAdd?: string[];
     securityOpt?: string[];
     portBindings?: Record<string, Array<{ HostIp?: string; HostPort?: string }>>;
+    memory?: number;
+    memorySwap?: number;
 }
 
 interface CreateOpts {
@@ -73,6 +75,8 @@ interface CreateOpts {
         CapAdd?: string[];
         SecurityOpt?: string[];
         PortBindings?: Record<string, Array<{ HostIp?: string; HostPort?: string }>>;
+        Memory?: number;
+        MemorySwap?: number;
     };
 }
 
@@ -154,6 +158,8 @@ function stubDocker(): {
                 capAdd: opts.HostConfig?.CapAdd,
                 securityOpt: opts.HostConfig?.SecurityOpt,
                 portBindings: opts.HostConfig?.PortBindings,
+                memory: opts.HostConfig?.Memory,
+                memorySwap: opts.HostConfig?.MemorySwap,
             });
             labelsByName.set(opts.name, opts.Labels ?? {});
             return makeContainer(opts.name);
@@ -289,6 +295,70 @@ describe("docker createSandbox — transport modes", () => {
             `${refsRoot}:/mnt/refs:ro`,
         ]);
         expect(registered).toEqual([{ runId: "run-1", stepId: "step-a", sandboxId: ref.sandboxId }]);
+    });
+
+    test("the cpu request is published as the thread count of each parallel library", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // Without these the libraries size their pools from the core count of the
+        // host and oversubscribe the cgroup that the same call sets NanoCpus on.
+        const env = envMapOf(sandboxOf(created)!);
+        expect(env.OMP_NUM_THREADS).toBe("2");
+        expect(env.OPENBLAS_NUM_THREADS).toBe("2");
+        expect(env.BIOCPARALLEL_WORKER_NUMBER).toBe("2");
+        expect(env.LOKY_MAX_CPU_COUNT).toBe("2");
+        // R defaults mclapply to 2 workers. A value here raises the fork count.
+        expect(env.MC_CORES).toBeUndefined();
+    });
+
+    test("a fractional cpu request floors to one thread, and extraEnv overrides the derived count", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (
+            await ops.createSandbox({ ...META, resources: { cpu: 0.5, memoryGb: 1 }, extraEnv: { OMP_NUM_THREADS: "8" } }, mintSandboxIdentity("run-1"))
+        )._unsafeUnwrap();
+
+        const env = envMapOf(sandboxOf(created)!);
+        expect(env.OPENBLAS_NUM_THREADS).toBe("1");
+        expect(env.OMP_NUM_THREADS).toBe("8");
+    });
+
+    test("the container gets no swap: MemorySwap equals Memory", async () => {
+        const { docker, created } = stubDocker();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // With swap a fork storm thrashes instead of an OOM kill, and
+        // sandbox-server in the same cgroup stops to answer /exec.
+        const sandbox = sandboxOf(created)!;
+        expect(sandbox.memory).toBe(4 * 1024 ** 3);
+        expect(sandbox.memorySwap).toBe(4 * 1024 ** 3);
     });
 
     test("a container that maps no host port is stopped, removed, and reported failed", async () => {

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
 import { createCapturingLogger } from "../__tests__/setup/logger.js";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Docker from "dockerode";
@@ -32,14 +32,21 @@ async function writeCompleteStore(root: string, version: string): Promise<void> 
 // `refStorePath` is, at createSandbox time, a real (non-symlink) directory, so a bare
 // temp dir already models a usable store.
 let refsRoot: string;
+// A real parent of a workspace root. The Docker client writes the cpu files of a
+// sandbox into `<parent>/.cpu/<sandboxId>/`, and it makes `.cpu` only when the
+// parent exists. The `/sessions` root of the other tests is not on disk, thus
+// those sandboxes get no cpu binds and their exact bind lists stay short.
+let wsRoot: string;
 beforeEach(async () => {
     libRoot = await mkdtemp(join(tmpdir(), "harness-libstore-"));
     await writeCompleteStore(libRoot, "2026.07.04-abc");
     refsRoot = await mkdtemp(join(tmpdir(), "harness-refstore-"));
+    wsRoot = await mkdtemp(join(tmpdir(), "harness-workspace-"));
 });
 afterEach(async () => {
     await rm(libRoot, { recursive: true, force: true });
     await rm(refsRoot, { recursive: true, force: true });
+    await rm(wsRoot, { recursive: true, force: true });
 });
 
 interface CreatedContainer {
@@ -361,6 +368,85 @@ describe("docker createSandbox — transport modes", () => {
         expect(sandbox.memorySwap).toBe(4 * 1024 ** 3);
     });
 
+    test("the cpu files are bound over the online list and /proc/cpuinfo, and teardown removes them", async () => {
+        const { docker, created } = stubDocker();
+        const hostCpuinfo = [0, 1, 2, 3].map((n) => `processor\t: ${n}\nmodel name\t: Test CPU\n\n`).join("");
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join(wsRoot, id),
+            readHostCpuinfo: async () => hostCpuinfo,
+            docker,
+            fetch: okFetch,
+            registerSandbox: async () => {},
+        });
+
+        const ref = (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // `parallel::detectCores()` greps /proc/cpuinfo and `os.cpu_count()` reads
+        // the online list. Both files describe the host, thus a small file over
+        // each path is the only way to make them report the quota.
+        const cpuDir = join(wsRoot, ".cpu", ref.sandboxId);
+        const sandbox = sandboxOf(created)!;
+        expect(sandbox.binds).toEqual([
+            `${wsRoot}/an-1:/an-1:ro`,
+            `${wsRoot}/an-1/runs/run-1/step-a:/an-1/runs/run-1/step-a:rw`,
+            `${cpuDir}/online:/sys/devices/system/cpu/online:ro`,
+            `${cpuDir}/cpuinfo:/proc/cpuinfo:ro`,
+        ]);
+        expect(await readFile(join(cpuDir, "online"), "utf8")).toBe("0-1\n");
+        // The first two processor blocks of the host, and no other.
+        expect(await readFile(join(cpuDir, "cpuinfo"), "utf8")).toBe("processor\t: 0\nmodel name\t: Test CPU\n\nprocessor\t: 1\nmodel name\t: Test CPU\n\n");
+
+        (await ops.teardown(ref))._unsafeUnwrap();
+        expect(existsSync(cpuDir)).toBe(false);
+    });
+
+    test("a host with no /proc/cpuinfo binds the online file only", async () => {
+        const { docker, created } = stubDocker();
+        const logger = createCapturingLogger();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join(wsRoot, id),
+            readHostCpuinfo: async () => undefined,
+            docker,
+            fetch: okFetch,
+            logger,
+            registerSandbox: async () => {},
+        });
+
+        const ref = (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        const binds = sandboxOf(created)!.binds;
+        expect(binds).toContain(`${join(wsRoot, ".cpu", ref.sandboxId, "online")}:/sys/devices/system/cpu/online:ro`);
+        expect(binds.some((b) => b.endsWith(":/proc/cpuinfo:ro"))).toBe(false);
+        expect(logger.records.some((r) => r.level === "debug" && r.msg.includes("no host /proc/cpuinfo"))).toBe(true);
+    });
+
+    test("a workspace root with no parent on disk gets no cpu binds and a warning", async () => {
+        const { docker, created } = stubDocker();
+        const logger = createCapturingLogger();
+        const ops = createDockerSandboxOps({
+            image: "sandbox-base:latest",
+            cortexBaseUrl: "https://x",
+            resolveWorkspaceRoot: (id) => join(wsRoot, "absent", id),
+            readHostCpuinfo: async () => "processor\t: 0\n\n",
+            docker,
+            fetch: okFetch,
+            logger,
+            registerSandbox: async () => {},
+        });
+
+        (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        // The sandbox still starts: the thread env limits each library, and only
+        // the two base calls report the host.
+        expect(sandboxOf(created)!.binds.some((b) => b.includes(".cpu"))).toBe(false);
+        expect(existsSync(join(wsRoot, "absent"))).toBe(false);
+        expect(logger.records.some((r) => r.level === "warn" && r.msg.includes("cpu files not written"))).toBe(true);
+    });
+
     test("a container that maps no host port is stopped, removed, and reported failed", async () => {
         const { docker, removed } = stubDocker();
         // A daemon that starts the container but publishes no port for 8765/tcp.
@@ -563,7 +649,7 @@ describe("docker createSandbox — mounts and platform", () => {
         const ops = createDockerSandboxOps({
             image: "sandbox-base:latest",
             cortexBaseUrl: "https://x",
-            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            resolveWorkspaceRoot: (id) => join(wsRoot, id),
             libStorePath: libRoot,
             docker,
             fetch: okFetch,
@@ -629,7 +715,7 @@ describe("docker createSandbox — ref store re-check", () => {
         const ops = createDockerSandboxOps({
             image: "sandbox-base:latest",
             cortexBaseUrl: "https://x",
-            resolveWorkspaceRoot: (id) => join("/sessions", id),
+            resolveWorkspaceRoot: (id) => join(wsRoot, id),
             refStorePath: missing,
             docker,
             fetch: okFetch,

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -7,6 +7,15 @@
  * `/mnt/libs` / `/mnt/refs` when their host paths are configured. Container
  * paths and lib-store env come from the shared mount plan (`mount-plan.ts`).
  *
+ * ## The cpu files
+ *
+ * Two more binds put a small file over `/sys/devices/system/cpu/online` and
+ * over `/proc/cpuinfo` (`cpu-files.ts`). Each file describes `spec.cpu` cpus,
+ * not the host. The host side of each bind is a file under
+ * `<parent of the workspace root>/.cpu/<sandboxId>/`, thus outside the tree
+ * that the sandbox sees. `teardown` removes the directory when this process
+ * wrote it. A directory from an earlier process stays.
+ *
  * ## Transport and confinement
  *
  * The container joins the default bridge and publishes sandbox-server's port to
@@ -30,7 +39,8 @@
  */
 
 import { existsSync, lstatSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import Docker from "dockerode";
 import { ResultAsync, err, ok, type Result } from "neverthrow";
 
@@ -39,6 +49,7 @@ import type { Logger } from "../lib/logger.js";
 import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, sandboxWriteTail } from "./mount-plan.js";
+import { cpuFiles } from "./cpu-files.js";
 import { threadLimitEnv } from "./thread-env.js";
 
 /** Read the originating HTTP status off any `SandboxError` variant that carries one. */
@@ -70,6 +81,12 @@ const MANAGED_BY_VALUE = "cortex";
 const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
+
+/** The two container paths that the cpu files cover. */
+const CPU_ONLINE_PATH = "/sys/devices/system/cpu/online";
+const CPUINFO_PATH = "/proc/cpuinfo";
+/** The directory next to the workspace root that holds the cpu files of each sandbox. */
+const CPU_FILES_DIR = ".cpu";
 
 export interface DockerClientConfig {
     image: string;
@@ -106,6 +123,12 @@ export interface DockerClientConfig {
     docker?: Docker;
     /** Injected for tests so `/health` polling can be stubbed. */
     fetch?: typeof fetch;
+    /**
+     * Injected for tests so the `/proc/cpuinfo` of the host can be stubbed. The
+     * default reads the file once per process. `undefined` means that the host
+     * has no such file, for example macOS.
+     */
+    readHostCpuinfo?: () => Promise<string | undefined>;
     /**
      * Optional logger so a lib-store degradation (a configured store whose `current`
      * vanished or went incomplete by sandbox-create time) is observable instead of a
@@ -156,6 +179,54 @@ function refStoreUsable(refStorePath: string): boolean {
         return lstatSync(refStorePath).isDirectory();
     } catch {
         return false;
+    }
+}
+
+/**
+ * The `/proc/cpuinfo` of the harness host, read once per process. The content
+ * does not change while the process runs. A host with no such file, for
+ * example macOS, gives `undefined`, and the caller binds only `online`.
+ */
+let hostCpuinfo: Promise<string | undefined> | undefined;
+function readHostCpuinfoOnce(): Promise<string | undefined> {
+    hostCpuinfo ??= readFile(CPUINFO_PATH, "utf8").catch(() => undefined);
+    return hostCpuinfo;
+}
+
+/**
+ * Write the cpu files of one sandbox into `dir` and return their binds.
+ *
+ * The directory `.cpu` is made with no `recursive` option on purpose. The
+ * parent of the workspace root must exist already. Thus a root that is not on
+ * disk gives no directory at an unexpected place, and the sandbox starts with
+ * no cpu files. The failure is a degradation, not an error: the thread env
+ * still limits each library, but `detectCores()` and `os.cpu_count()` report
+ * the host.
+ */
+async function writeCpuFiles(
+    dir: string,
+    files: { readonly online: string; readonly cpuinfo: string | undefined },
+    logger: Logger,
+    sandboxId: string,
+): Promise<string[]> {
+    const ignoreExists = (cause: NodeJS.ErrnoException): void => {
+        if (cause.code !== "EEXIST") throw cause;
+    };
+    try {
+        await mkdir(dirname(dir)).catch(ignoreExists);
+        await mkdir(dir).catch(ignoreExists);
+        const online = join(dir, "online");
+        await writeFile(online, files.online);
+        const binds = [`${online}:${CPU_ONLINE_PATH}:ro`];
+        if (files.cpuinfo !== undefined) {
+            const cpuinfo = join(dir, "cpuinfo");
+            await writeFile(cpuinfo, files.cpuinfo);
+            binds.push(`${cpuinfo}:${CPUINFO_PATH}:ro`);
+        }
+        return binds;
+    } catch (cause) {
+        logger.warn("cpu files not written — the sandbox reports the cores of the host", { sandboxId, dir, cause });
+        return [];
     }
 }
 
@@ -273,6 +344,9 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
     const fetchImpl = config.fetch ?? fetch;
     const transport: SandboxTransport = config.transport ?? "poll";
     const pollMode = transport === "poll";
+    const readHostCpuinfo = config.readHostCpuinfo ?? readHostCpuinfoOnce;
+    /** The cpu directory of each sandbox that this process wrote, for `teardown`. */
+    const cpuDirs = new Map<string, string>();
 
     return {
         createSandbox(meta, identity) {
@@ -311,6 +385,17 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                     // a crafted tail cannot escape the resolved root into the container. The
                     // tail is the step directory, or the one the caller declared.
                     const write = sandboxWriteTail(meta);
+                    // The same floor as `threadLimitEnv`: a fractional cpu request is one cpu.
+                    const threads = Math.max(1, Math.floor(meta.resources.cpu));
+                    const cpuinfo = await readHostCpuinfo();
+                    if (cpuinfo === undefined) {
+                        logger.debug("no host /proc/cpuinfo — the sandbox gets the online file only", { sandboxId });
+                    }
+                    // Next to the workspace root, not under it: the root is bound read-only
+                    // at `/{analysisId}`, and a file under it is visible in the sandbox.
+                    const cpuDir = join(dirname(hostTreePath), CPU_FILES_DIR, sandboxId);
+                    const cpuBinds = await writeCpuFiles(cpuDir, cpuFiles(threads, cpuinfo), logger, sandboxId);
+                    if (cpuBinds.length > 0) cpuDirs.set(sandboxId, cpuDir);
                     const binds = [
                         `${hostTreePath}:${plan.readonlyTreePath}:ro`,
                         ...(write && plan.writableStepPath
@@ -318,6 +403,7 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                             : []),
                         ...(libsMounted && config.libStorePath ? [`${config.libStorePath}:${plan.libsPath}:ro`] : []),
                         ...(refsMounted && config.refStorePath ? [`${config.refStorePath}:${plan.refsPath}:ro`] : []),
+                        ...cpuBinds,
                     ];
 
                     const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
@@ -429,11 +515,11 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
         },
 
         teardown(ref) {
-            return removeContainerIgnoreMissing(docker, ref.sandboxId);
+            return teardownSandbox(ref.sandboxId);
         },
 
         teardownById(sandboxId) {
-            return removeContainerIgnoreMissing(docker, sandboxId);
+            return teardownSandbox(sandboxId);
         },
 
         listManagedSandboxes() {
@@ -471,6 +557,22 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
 
         isAliveById,
     };
+
+    /**
+     * Remove the container, then the cpu files that this process wrote for it.
+     * A failure of the file removal does not fail the teardown: the container is
+     * gone, and a stale small directory is not a risk to a later sandbox.
+     */
+    function teardownSandbox(sandboxId: string): ResultAsync<void, SandboxError> {
+        return removeContainerIgnoreMissing(docker, sandboxId).map(async () => {
+            const cpuDir = cpuDirs.get(sandboxId);
+            if (cpuDir === undefined) return;
+            cpuDirs.delete(sandboxId);
+            await rm(cpuDir, { recursive: true, force: true }).catch((cause: unknown) => {
+                logger.debug("cpu files not removed", { sandboxId, cpuDir, cause });
+            });
+        });
+    }
 
     function isAliveById(sandboxId: string): ResultAsync<SandboxLiveness, SandboxError> {
         return trySandbox(

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -39,6 +39,7 @@ import type { Logger } from "../lib/logger.js";
 import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, sandboxWriteTail } from "./mount-plan.js";
+import { threadLimitEnv } from "./thread-env.js";
 
 /** Read the originating HTTP status off any `SandboxError` variant that carries one. */
 function statusOf(e: SandboxError): number | undefined {
@@ -329,18 +330,24 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
 
                     const image = meta.image ?? config.image;
 
+                    const spec = meta.resources;
+
                     // Poll mode never dials out and carries no CORTEX_BASE_URL; it sets the
                     // firewall flag so the root entrypoint installs the egress block before
                     // dropping to uid 1000. Callback mode is the inverse.
-                    const env = [
-                        `SANDBOX_TRANSPORT=${transport}`,
-                        `SANDBOX_CALLBACK_SECRET=${callbackSecret}`,
-                        ...(pollMode ? ["SANDBOX_EGRESS_FIREWALL=1"] : [`CORTEX_BASE_URL=${config.cortexBaseUrl}`]),
-                        ...Object.entries(plan.env).map(([k, v]) => `${k}=${v}`),
-                        ...Object.entries(meta.extraEnv ?? {}).map(([k, v]) => `${k}=${v}`),
-                    ];
+                    //
+                    // Composed as one record, not as a list of `K=V`. A duplicate key in
+                    // the Env array resolves at the libc that scans `environ`, thus the
+                    // later spread must win here, not there.
+                    const env = Object.entries({
+                        SANDBOX_TRANSPORT: transport,
+                        SANDBOX_CALLBACK_SECRET: callbackSecret,
+                        ...(pollMode ? { SANDBOX_EGRESS_FIREWALL: "1" } : { CORTEX_BASE_URL: config.cortexBaseUrl }),
+                        ...threadLimitEnv(spec),
+                        ...plan.env,
+                        ...(meta.extraEnv ?? {}),
+                    }).map(([k, v]) => `${k}=${v}`);
 
-                    const spec = meta.resources;
                     const createOpts: Docker.ContainerCreateOptions = {
                         name: sandboxId,
                         ...(config.platform !== undefined && { platform: config.platform }),
@@ -375,6 +382,11 @@ export function createDockerSandboxOps(config: DockerClientConfig): {
                             SecurityOpt: ["no-new-privileges"],
                             NanoCpus: Math.round(spec.cpu * 1e9),
                             Memory: spec.memoryGb * 1024 ** 3,
+                            // `Memory` alone lets the container swap as much again. A fork
+                            // storm then thrashes for minutes, and sandbox-server stops to
+                            // answer. With no swap the OOM killer removes the largest fork in
+                            // seconds, and sandbox-server survives. K8s runs with no swap.
+                            MemorySwap: spec.memoryGb * 1024 ** 3,
                             AutoRemove: false,
                         },
                     };

--- a/harness/src/sandbox/docker-client.ts
+++ b/harness/src/sandbox/docker-client.ts
@@ -39,7 +39,7 @@
  */
 
 import { existsSync, lstatSync, statSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import Docker from "dockerode";
 import { ResultAsync, err, ok, type Result } from "neverthrow";
@@ -49,7 +49,7 @@ import type { Logger } from "../lib/logger.js";
 import { tailWritePrefix, type ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, sandboxWriteTail } from "./mount-plan.js";
-import { cpuFiles } from "./cpu-files.js";
+import { CPU_ONLINE_PATH, CPUINFO_PATH, cpuFiles, readHostCpuinfoOnce } from "./cpu-files.js";
 import { threadLimitEnv } from "./thread-env.js";
 
 /** Read the originating HTTP status off any `SandboxError` variant that carries one. */
@@ -82,9 +82,6 @@ const OWNER_WORKFLOW_LABEL = "cortex/owner-workflow-id";
 const RUN_ID_LABEL = "cortex/run-id";
 const STEP_ID_LABEL = "cortex/step-id";
 
-/** The two container paths that the cpu files cover. */
-const CPU_ONLINE_PATH = "/sys/devices/system/cpu/online";
-const CPUINFO_PATH = "/proc/cpuinfo";
 /** The directory next to the workspace root that holds the cpu files of each sandbox. */
 const CPU_FILES_DIR = ".cpu";
 
@@ -180,17 +177,6 @@ function refStoreUsable(refStorePath: string): boolean {
     } catch {
         return false;
     }
-}
-
-/**
- * The `/proc/cpuinfo` of the harness host, read once per process. The content
- * does not change while the process runs. A host with no such file, for
- * example macOS, gives `undefined`, and the caller binds only `online`.
- */
-let hostCpuinfo: Promise<string | undefined> | undefined;
-function readHostCpuinfoOnce(): Promise<string | undefined> {
-    hostCpuinfo ??= readFile(CPUINFO_PATH, "utf8").catch(() => undefined);
-    return hostCpuinfo;
 }
 
 /**

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -129,6 +129,12 @@ describe("k8s createSandbox", () => {
         expect(envMap.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
         expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1");
         expect(envMap.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
+        // The cgroup limit below is invisible to the libraries inside it, thus
+        // the same cpu request rides in as their thread count.
+        expect(envMap.OMP_NUM_THREADS).toBe("2");
+        expect(envMap.OPENBLAS_NUM_THREADS).toBe("2");
+        expect(envMap.BIOCPARALLEL_WORKER_NUMBER).toBe("2");
+        expect(envMap.MC_CORES).toBeUndefined();
 
         expect(container.workingDir).toBe("/an-1/runs/run-1/step-a");
 

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { BatchV1Api, CoreV1Api, V1Job, V1Pod } from "@kubernetes/client-node";
+import type { BatchV1Api, CoreV1Api, V1ConfigMap, V1Job, V1Pod } from "@kubernetes/client-node";
 
 import { createK8sSandboxOps, sanitizeLabelValue } from "./k8s-client.js";
 import { mintSandboxIdentity } from "./identity.js";
@@ -15,9 +15,16 @@ import { mintSandboxIdentity } from "./identity.js";
 const SESSION_PVC_ROOT = "/sessions";
 const resolveWorkspaceRoot = (analysisId: string) => `${SESSION_PVC_ROOT}/${analysisId}`;
 
-function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string } = {}) {
+function stubApis(
+    podSequence: Array<Partial<V1Pod>>,
+    opts: { create409Times?: number; existingOwner?: string; configMap409?: boolean; configMapError?: { code: number } } = {},
+) {
     const createdJobs: V1Job[] = [];
     const deletedJobs: string[] = [];
+    const createdConfigMaps: V1ConfigMap[] = [];
+    const replacedConfigMaps: V1ConfigMap[] = [];
+    const deletedConfigMaps: string[] = [];
+    let configMap409 = opts.configMap409 ?? false;
     let podIdx = 0;
     let deletedError: { code: number } | null = null;
     let pending409 = opts.create409Times ?? 0;
@@ -36,6 +43,7 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
                 throw err;
             }
             createdJobs.push(body);
+            return { metadata: { name: body.metadata?.name, uid: "job-uid-1" } };
         },
         deleteNamespacedJob: async ({ name }: { namespace: string; name: string }) => {
             if (deletedError) throw deletedError;
@@ -51,11 +59,28 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
                 err.code = 404;
                 throw err;
             }
-            return { metadata: { name, annotations: { "cortex/owner-workflow-id": existingOwner } } };
+            return { metadata: { name, uid: "job-uid-existing", annotations: { "cortex/owner-workflow-id": existingOwner } } };
         },
     } as unknown as BatchV1Api;
 
     const coreApi = {
+        createNamespacedConfigMap: async ({ body }: { namespace: string; body: V1ConfigMap }) => {
+            if (opts.configMapError) throw Object.assign(new Error("configmaps is forbidden"), opts.configMapError);
+            if (configMap409) {
+                configMap409 = false;
+                throw Object.assign(new Error("configmaps already exists"), { code: 409 });
+            }
+            createdConfigMaps.push(body);
+            return body;
+        },
+        readNamespacedConfigMap: async ({ name }: { namespace: string; name: string }) => ({ metadata: { name, resourceVersion: "7" } }),
+        replaceNamespacedConfigMap: async ({ body }: { namespace: string; name: string; body: V1ConfigMap }) => {
+            replacedConfigMaps.push(body);
+            return body;
+        },
+        deleteNamespacedConfigMap: async ({ name }: { namespace: string; name: string }) => {
+            deletedConfigMaps.push(name);
+        },
         listNamespacedPod: async (_args: { namespace: string; labelSelector?: string }) => {
             const pod = podSequence[Math.min(podIdx, podSequence.length - 1)];
             podIdx++;
@@ -68,6 +93,9 @@ function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: n
         coreApi,
         createdJobs,
         deletedJobs,
+        createdConfigMaps,
+        replacedConfigMaps,
+        deletedConfigMaps,
         setDeleteError: (err: { code: number } | null) => {
             deletedError = err;
         },
@@ -145,7 +173,7 @@ describe("k8s createSandbox", () => {
 
         const sessionVolume = podSpec.volumes!.find((v) => v.name === "session");
         expect(sessionVolume!.persistentVolumeClaim!.claimName).toBe("cortex-sessions");
-        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "libs", "refs"]);
+        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "libs", "refs", "cpu"]);
 
         const mounts = container.volumeMounts!;
         const ro = mounts.find((m) => m.name === "session" && m.mountPath === "/an-1")!;
@@ -478,7 +506,7 @@ describe("k8s createSandbox", () => {
         )._unsafeUnwrap();
 
         const podSpec = stub.createdJobs[0]!.spec!.template.spec!;
-        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session"]);
+        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "cpu"]);
         const mounts = podSpec.containers[0].volumeMounts!;
         expect(mounts.some((m) => m.mountPath.startsWith("/mnt"))).toBe(false);
         const env = podSpec.containers[0].env ?? [];
@@ -1033,5 +1061,105 @@ describe("k8s isAlive", () => {
             })
         )._unsafeUnwrap();
         expect(liveness).toEqual({ alive: false, oomKilled: true });
+    });
+});
+
+/** Three processor blocks, in the shape of a real `/proc/cpuinfo`. */
+const HOST_CPUINFO = [0, 1, 2].map((i) => `processor\t: ${i}\nmodel name\t: test cpu\n`).join("\n") + "\n";
+
+const RUNNING_POD = { status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "sbx-x-abc" } };
+
+function cpuOps(stub: ReturnType<typeof stubApis>, readHostCpuinfo: () => Promise<string | undefined>) {
+    return createK8sSandboxOps({
+        image: "sandbox-base:latest",
+        cortexBaseUrl: "https://cortex.example.com:443",
+        namespace: "sandbox",
+        sessionPvcRoot: SESSION_PVC_ROOT,
+        resolveWorkspaceRoot,
+        sessionPvc: "cortex-sessions",
+        batchApi: stub.batchApi,
+        coreApi: stub.coreApi,
+        readHostCpuinfo,
+        registerSandbox: async () => {},
+    });
+}
+
+const CPU_META = { runId: "run-1", stepId: "step-a", analysisId: "an-1", childWorkflowId: "run-1-0", resources: { cpu: 2, memoryGb: 4 } };
+
+describe("k8s cpu files", () => {
+    test("the cpu files ride in a ConfigMap owned by the Job and mount over the two kernel paths", async () => {
+        const stub = stubApis([RUNNING_POD]);
+        const ops = cpuOps(stub, async () => HOST_CPUINFO);
+
+        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(stub.createdConfigMaps).toHaveLength(1);
+        const map = stub.createdConfigMaps[0]!;
+        expect(map.metadata!.name).toBe(ref.sandboxId);
+        expect(map.metadata!.ownerReferences).toEqual([{ apiVersion: "batch/v1", kind: "Job", name: ref.sandboxId, uid: "job-uid-1" }]);
+        expect(map.data!.online).toBe("0-1\n");
+        // Two of the three blocks of the host: the quota counts logical cores.
+        expect(map.data!.cpuinfo!.match(/^processor/gm)).toHaveLength(2);
+
+        const podSpec = stub.createdJobs[0]!.spec!.template.spec!;
+        expect(podSpec.volumes!.find((v) => v.name === "cpu")!.configMap!.name).toBe(ref.sandboxId);
+        const mounts = podSpec.containers[0]!.volumeMounts!.filter((m) => m.name === "cpu");
+        expect(mounts).toEqual([
+            { name: "cpu", mountPath: "/sys/devices/system/cpu/online", subPath: "online", readOnly: true },
+            { name: "cpu", mountPath: "/proc/cpuinfo", subPath: "cpuinfo", readOnly: true },
+        ]);
+    });
+
+    test("a harness host with no cpuinfo covers online only", async () => {
+        const stub = stubApis([RUNNING_POD]);
+        const ops = cpuOps(stub, async () => undefined);
+
+        (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(stub.createdConfigMaps[0]!.data).toEqual({ online: "0-1\n" });
+        const mounts = stub.createdJobs[0]!.spec!.template.spec!.containers[0]!.volumeMounts!.filter((m) => m.name === "cpu");
+        expect(mounts.map((m) => m.mountPath)).toEqual(["/sys/devices/system/cpu/online"]);
+    });
+
+    test("a ConfigMap that exists already is replaced with the same data and the current owner", async () => {
+        const stub = stubApis([RUNNING_POD], { configMap409: true });
+        const ops = cpuOps(stub, async () => HOST_CPUINFO);
+
+        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+
+        expect(stub.createdConfigMaps).toHaveLength(0);
+        expect(stub.replacedConfigMaps).toHaveLength(1);
+        const map = stub.replacedConfigMaps[0]!;
+        expect(map.metadata!.resourceVersion).toBe("7");
+        expect(map.metadata!.ownerReferences![0]!.uid).toBe("job-uid-1");
+        expect(map.metadata!.name).toBe(ref.sandboxId);
+        expect(map.data!.online).toBe("0-1\n");
+    });
+
+    test("a ConfigMap failure deletes the Job and fails the create with the real cause", async () => {
+        const stub = stubApis([RUNNING_POD], { configMapError: { code: 403 } });
+        const ops = cpuOps(stub, async () => HOST_CPUINFO);
+
+        const error = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1"))).match(
+            () => {
+                throw new Error("the create must fail");
+            },
+            (e) => e,
+        );
+
+        expect(error.type).toBe("container_create_failed");
+        expect(error.op).toBe("k8s.createNamespacedConfigMap");
+        expect(stub.deletedJobs).toHaveLength(1);
+    });
+
+    test("teardown deletes the ConfigMap with the Job", async () => {
+        const stub = stubApis([RUNNING_POD]);
+        const ops = cpuOps(stub, async () => HOST_CPUINFO);
+
+        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
+        (await ops.teardown(ref))._unsafeUnwrap();
+
+        expect(stub.deletedJobs).toEqual([ref.sandboxId]);
+        expect(stub.deletedConfigMaps).toEqual([ref.sandboxId]);
     });
 });

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -30,6 +30,7 @@ import { ResultAsync, err, ok } from "neverthrow";
 import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, buildSessionSubPaths } from "./mount-plan.js";
+import { threadLimitEnv } from "./thread-env.js";
 import type { CreateSandboxMeta, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SandboxTransport } from "./types.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
@@ -183,25 +184,26 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
     });
 
     const transport = config.transport ?? "poll";
-    const env = [
-        { name: "SANDBOX_TRANSPORT", value: transport },
+    const spec = meta.resources;
+    // Composed as one record, not as a list of `{name, value}`. A duplicate name
+    // in the env of a container resolves at the kubelet, thus the later spread
+    // must win here, not there.
+    const env = Object.entries({
+        SANDBOX_TRANSPORT: transport,
         // Poll mode never dials out, so the URL is omitted (matching the Docker
         // backend) — the pod spec itself then documents that no callback egress
         // is expected. sandbox-server neither reads nor requires it in poll mode.
-        ...(transport === "callback" ? [{ name: "CORTEX_BASE_URL", value: config.cortexBaseUrl }] : []),
-        { name: "SANDBOX_CALLBACK_SECRET", value: identity.callbackSecret },
-        ...Object.entries(plan.env).map(([name, value]) => ({ name, value })),
-        ...Object.entries(meta.extraEnv ?? {}).map(([k, v]) => ({
-            name: k,
-            value: v,
-        })),
-    ];
+        ...(transport === "callback" ? { CORTEX_BASE_URL: config.cortexBaseUrl } : {}),
+        SANDBOX_CALLBACK_SECRET: identity.callbackSecret,
+        ...threadLimitEnv(spec),
+        ...plan.env,
+        ...(meta.extraEnv ?? {}),
+    }).map(([name, value]) => ({ name, value }));
 
     // requests == limits → Guaranteed QoS and a predictable OOM bound; also
     // satisfies the namespace ResourceQuota, which rejects any pod that omits
     // requests.cpu/memory. The CPU limit can throttle a hot step, but a throttle
     // beats an eviction.
-    const spec = meta.resources;
     const quantities: Record<string, string> = {
         cpu: String(spec.cpu),
         memory: `${spec.memoryGb}Gi`,

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -18,6 +18,7 @@ import {
     BatchV1Api,
     CoreV1Api,
     KubeConfig,
+    type V1ConfigMap,
     type V1Job,
     type V1ObjectMeta,
     type V1PodSpec,
@@ -31,6 +32,7 @@ import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, buildSessionSubPaths } from "./mount-plan.js";
 import { threadLimitEnv } from "./thread-env.js";
+import { CPU_ONLINE_PATH, CPUINFO_PATH, type CpuFiles, cpuFiles, readHostCpuinfoOnce } from "./cpu-files.js";
 import type { CreateSandboxMeta, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SandboxTransport } from "./types.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
@@ -43,6 +45,8 @@ function statusOf(e: SandboxError): number | undefined {
 const SESSION_VOLUME_NAME = "session";
 const LIBS_VOLUME_NAME = "libs";
 const REFS_VOLUME_NAME = "refs";
+/** The ConfigMap volume that holds the two cpu files of the sandbox (`cpu-files.ts`). */
+const CPU_VOLUME_NAME = "cpu";
 
 const SANDBOX_SERVER_PORT = 8765;
 const POD_READY_TIMEOUT_MS = 5 * 60_000;
@@ -116,10 +120,33 @@ export interface K8sClientConfig {
     tolerations?: V1Toleration[];
     /** RuntimeClass for runtime isolation (e.g. `gvisor`). Omit for the default runtime. */
     runtimeClassName?: string;
+    /**
+     * The `/proc/cpuinfo` text that the cpu ConfigMap of each Job is cut from.
+     * Defaults to the file of the host of this process, read once. Injected for tests.
+     */
+    readHostCpuinfo?: () => Promise<string | undefined>;
     /** Injected for tests. */
     batchApi?: BatchV1Api;
     coreApi?: CoreV1Api;
     registerSandbox: (meta: CreateSandboxMeta, ref: SandboxRef) => Promise<void>;
+}
+
+function deleteConfigMapIgnoreMissing(coreApi: CoreV1Api, namespace: string, name: string): ResultAsync<void, SandboxError> {
+    return trySandbox(
+        async () => {
+            await coreApi.deleteNamespacedConfigMap({ namespace, name });
+        },
+        (status, cause) => ({
+            type: "teardown_failed",
+            op: "k8s.teardown",
+            sandboxId: name,
+            status,
+            cause,
+        }),
+    ).orElse((e) =>
+        // A 404 means the owner reference removed it with the Job already.
+        statusOf(e) === 404 ? ok(undefined) : err(e),
+    );
 }
 
 function deleteJobIgnoreMissing(batchApi: BatchV1Api, namespace: string, name: string): ResultAsync<void, SandboxError> {
@@ -176,7 +203,13 @@ function workspaceSubPathFor(config: K8sClientConfig, analysisId: string): strin
     return posix;
 }
 
-function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity): V1Job {
+/** Which of the two kernel paths the cpu ConfigMap of a Job covers. */
+interface CpuMount {
+    /** `false` on a harness host with no `/proc/cpuinfo`: the pod then covers `online` only. */
+    hasCpuinfo: boolean;
+}
+
+function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity, cpu: CpuMount): V1Job {
     const { sandboxId } = identity;
     const plan = buildMountPlan(meta, {
         libs: !!config.libStorePvc,
@@ -261,6 +294,17 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
             mountPath: plan.refsPath,
             readOnly: true,
         });
+    }
+
+    // The cpu files ride in a ConfigMap named after the Job (`ensureCpuConfigMap`).
+    // A `subPath` mount of one key over one kernel path is accepted by the API
+    // server, the kubelet, and gVisor. Under gVisor the sandbox sees no cgroup
+    // at all, thus these two files are the only source of the quota for
+    // `parallel::detectCores()` and `os.cpu_count()`.
+    volumes.push({ name: CPU_VOLUME_NAME, configMap: { name: sandboxId } });
+    volumeMounts.push({ name: CPU_VOLUME_NAME, mountPath: CPU_ONLINE_PATH, subPath: "online", readOnly: true });
+    if (cpu.hasCpuinfo) {
+        volumeMounts.push({ name: CPU_VOLUME_NAME, mountPath: CPUINFO_PATH, subPath: "cpuinfo", readOnly: true });
     }
 
     const podSpec: V1PodSpec = {
@@ -460,6 +504,9 @@ function waitForJobGone(batchApi: BatchV1Api, namespace: string, name: string): 
  * means an (astronomically rare) name collision with a *different* step —
  * adopting its pod would HMAC-fail every callback, and deleting its Job would
  * kill a live sibling. Refuse loudly instead.
+ *
+ * The result is the uid of the Job that the pod belongs to, for the owner
+ * reference of the cpu ConfigMap.
  */
 function createOrAdoptJob(
     batchApi: BatchV1Api,
@@ -468,7 +515,7 @@ function createOrAdoptJob(
     sandboxId: string,
     ownerWorkflowId: string,
     job: V1Job,
-): ResultAsync<void, SandboxError> {
+): ResultAsync<string | undefined, SandboxError> {
     const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
         type: "container_create_failed",
         op: "k8s.createNamespacedJob",
@@ -479,7 +526,7 @@ function createOrAdoptJob(
     return new ResultAsync(
         (async () => {
             const created = await trySandbox(() => batchApi.createNamespacedJob({ namespace, body: job }), createFailed);
-            if (created.isOk()) return ok(undefined);
+            if (created.isOk()) return ok(created.value?.metadata?.uid);
             if (statusOf(created.error) !== 409) return err(created.error);
 
             const existingRead = await trySandbox(() => batchApi.readNamespacedJob({ namespace, name: sandboxId }), createFailed);
@@ -503,7 +550,77 @@ function createOrAdoptJob(
                 if (gone.isErr()) return err(gone.error);
                 const recreated = await trySandbox(() => batchApi.createNamespacedJob({ namespace, body: job }), createFailed);
                 if (recreated.isErr()) return err(recreated.error);
+                return ok(recreated.value?.metadata?.uid);
             }
+            return ok(existingRead.value.metadata?.uid);
+        })(),
+    );
+}
+
+/**
+ * Make the cpu ConfigMap of a Job, or bring an existing one up to date.
+ *
+ * The ConfigMap comes after the Job, because the Job is its owner. Thus the
+ * TTL of the Job and a Foreground delete both remove the ConfigMap with it.
+ * The pod waits at its mount until the ConfigMap exists, and that wait is
+ * shorter than the schedule of the pod.
+ *
+ * A `409 AlreadyExists` is the recovery re-run of the spawn step, or a
+ * ConfigMap whose prior owner Job is not yet collected. Both cases get the
+ * same data and the current owner through a replace.
+ */
+function ensureCpuConfigMap(
+    coreApi: CoreV1Api,
+    namespace: string,
+    sandboxId: string,
+    jobUid: string | undefined,
+    files: CpuFiles,
+): ResultAsync<void, SandboxError> {
+    const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
+        type: "container_create_failed",
+        op: "k8s.createNamespacedConfigMap",
+        sandboxId,
+        status,
+        cause,
+    });
+    const body: V1ConfigMap = {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: {
+            name: sandboxId,
+            namespace,
+            labels: {
+                [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
+                role: "sandbox",
+                "cortex/sandbox-id": sandboxId,
+            },
+            ...(jobUid !== undefined && {
+                ownerReferences: [{ apiVersion: "batch/v1", kind: "Job", name: sandboxId, uid: jobUid }],
+            }),
+        },
+        data: {
+            online: files.online,
+            ...(files.cpuinfo !== undefined && { cpuinfo: files.cpuinfo }),
+        },
+    };
+    return new ResultAsync(
+        (async () => {
+            const created = await trySandbox(() => coreApi.createNamespacedConfigMap({ namespace, body }), createFailed);
+            if (created.isOk()) return ok(undefined);
+            if (statusOf(created.error) !== 409) return err(created.error);
+
+            const existing = await trySandbox(() => coreApi.readNamespacedConfigMap({ namespace, name: sandboxId }), createFailed);
+            if (existing.isErr()) return err(existing.error);
+            const replaced = await trySandbox(
+                () =>
+                    coreApi.replaceNamespacedConfigMap({
+                        namespace,
+                        name: sandboxId,
+                        body: { ...body, metadata: { ...body.metadata, resourceVersion: existing.value.metadata?.resourceVersion } },
+                    }),
+                createFailed,
+            );
+            if (replaced.isErr()) return err(replaced.error);
             return ok(undefined);
         })(),
     );
@@ -518,16 +635,29 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
     listManagedSandboxes(): ResultAsync<ManagedSandbox[], SandboxError>;
 } {
     const { batchApi, coreApi } = config.batchApi && config.coreApi ? { batchApi: config.batchApi, coreApi: config.coreApi } : buildKubeApi();
+    const readHostCpuinfo = config.readHostCpuinfo ?? readHostCpuinfoOnce;
 
     return {
         createSandbox(meta, identity) {
             return new ResultAsync(
                 (async () => {
                     const { sandboxId } = identity;
-                    const job = buildJobSpec(meta, config, identity);
+                    // The same floor as `threadLimitEnv`: a fraction of a core still
+                    // keeps one thread busy, and a count of zero is not representable.
+                    const threads = Math.max(1, Math.floor(meta.resources.cpu));
+                    const files = cpuFiles(threads, await readHostCpuinfo());
+                    const job = buildJobSpec(meta, config, identity, { hasCpuinfo: files.cpuinfo !== undefined });
 
                     const adopted = await createOrAdoptJob(batchApi, coreApi, config.namespace, sandboxId, meta.childWorkflowId, job);
                     if (adopted.isErr()) return err(adopted.error);
+
+                    const cpuMap = await ensureCpuConfigMap(coreApi, config.namespace, sandboxId, adopted.value, files);
+                    if (cpuMap.isErr()) {
+                        // A pod whose ConfigMap never comes stays at ContainerCreating
+                        // until the ready wait expires. Fail now, with the real cause.
+                        await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
+                        return err(cpuMap.error);
+                    }
 
                     // A Job whose pod never schedules (quota rejection, no nodes, spot
                     // reclaim) is reaped by neither backoffLimit (an admission rejection
@@ -555,23 +685,29 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                             }),
                         );
                         if (registered.isErr()) {
-                            await cleanupFailedJob(batchApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
+                            await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
                             return err(registered.error);
                         }
                         return ok(ref);
                     }
-                    await cleanupFailedJob(batchApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
+                    await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
                     return err(ready.error);
                 })(),
             );
         },
 
+        // The owner reference removes the cpu ConfigMap with the Job. The explicit
+        // delete covers a ConfigMap that got no owner, and it is a no-op on 404.
         teardown(ref) {
-            return deleteJobIgnoreMissing(batchApi, config.namespace, ref.sandboxId);
+            return deleteJobIgnoreMissing(batchApi, config.namespace, ref.sandboxId).andThen(() =>
+                deleteConfigMapIgnoreMissing(coreApi, config.namespace, ref.sandboxId),
+            );
         },
 
         teardownById(sandboxId) {
-            return deleteJobIgnoreMissing(batchApi, config.namespace, sandboxId);
+            return deleteJobIgnoreMissing(batchApi, config.namespace, sandboxId).andThen(() =>
+                deleteConfigMapIgnoreMissing(coreApi, config.namespace, sandboxId),
+            );
         },
 
         listManagedSandboxes() {
@@ -650,9 +786,13 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
  * matters; a delete error here is logged and swallowed so it never masks the
  * create error returned to the caller.
  */
-async function cleanupFailedJob(batchApi: BatchV1Api, namespace: string, sandboxId: string, logger: Logger): Promise<void> {
+async function cleanupFailedJob(batchApi: BatchV1Api, coreApi: CoreV1Api, namespace: string, sandboxId: string, logger: Logger): Promise<void> {
     const deleted = await deleteJobIgnoreMissing(batchApi, namespace, sandboxId);
     if (deleted.isErr()) {
         logger.named("k8s-client").error("failed to delete Job after startup failure", { sandboxId, err: deleted.error });
+    }
+    const deletedMap = await deleteConfigMapIgnoreMissing(coreApi, namespace, sandboxId);
+    if (deletedMap.isErr()) {
+        logger.named("k8s-client").error("failed to delete cpu ConfigMap after startup failure", { sandboxId, err: deletedMap.error });
     }
 }

--- a/harness/src/sandbox/thread-env.ts
+++ b/harness/src/sandbox/thread-env.ts
@@ -1,0 +1,52 @@
+/**
+ * Thread-count env for a sandbox container.
+ *
+ * Each backend turns the `ResourceSpec` of a step into a hard cgroup limit:
+ * `NanoCpus` and `Memory` on Docker, `limits.cpu` and `limits.memory` on K8s. A
+ * cgroup quota is invisible to most runtimes inside it. `parallel::detectCores()`
+ * greps `/proc/cpuinfo`, and `os.cpu_count()` reads
+ * `/sys/devices/system/cpu/online`. Both files describe the host. Thus a step
+ * with 2 CPUs on a host of 12 cores forks 12 workers into a cgroup of 2 CPUs,
+ * and each fork copies its working set until the memory limit stops it.
+ *
+ * The env below publishes the quota to each library that reads a thread count
+ * from the environment. `parallelly::availableCores()` and `joblib.cpu_count()`
+ * read the cgroup quota on their own, thus they need no value here.
+ *
+ * `MC_CORES` is absent on purpose. R defaults `mclapply` to 2 workers, not to
+ * the core count. A value there raises the fork count instead of a decrease.
+ */
+
+import type { ResourceSpec } from "../config/resource-limits.js";
+
+/**
+ * Env that binds each parallel library in the container to `spec.cpu`.
+ *
+ * A fractional CPU request floors to one thread. A pool of zero is not
+ * representable, and two threads on half a core only add context switches.
+ *
+ * The caller puts these before `plan.env` and before the `extraEnv` of the
+ * embedder, thus a host that knows more about a step keeps the last word.
+ */
+export function threadLimitEnv(spec: ResourceSpec): Record<string, string> {
+    const threads = String(Math.max(1, Math.floor(spec.cpu)));
+    return {
+        // OpenMP: the compiled code of R and Python packages.
+        OMP_NUM_THREADS: threads,
+        // OpenBLAS keeps a private pool. A pthread build reads this name first.
+        OPENBLAS_NUM_THREADS: threads,
+        // MKL reads this name before OMP_NUM_THREADS.
+        MKL_NUM_THREADS: threads,
+        // BiocParallel sizes `bpparam()` from this name. DESeq2 `parallel=TRUE`
+        // and the other Bioconductor packages size their workers from `bpparam()`.
+        BIOCPARALLEL_WORKER_NUMBER: threads,
+        // data.table defaults to half of the host cores.
+        R_DATATABLE_NUM_THREADS: threads,
+        // The Python numerical stack.
+        NUMBA_NUM_THREADS: threads,
+        NUMEXPR_MAX_THREADS: threads,
+        LOKY_MAX_CPU_COUNT: threads,
+        POLARS_MAX_THREADS: threads,
+        RAYON_NUM_THREADS: threads,
+    };
+}


### PR DESCRIPTION
## What & why

Each backend turns the step resources into a hard cgroup limit, but the limit is invisible to the runtimes inside it. `parallel::detectCores()` greps `/proc/cpuinfo`, and `os.cpu_count()` reads `/sys/devices/system/cpu/online`. Both describe the host. Thus a step with 2 CPUs on a host of 12 cores forks 12 workers into a cgroup of 8 GB, and the forks exhaust the memory. On Docker, `Memory` alone lets the container swap as much again, thus the storm thrashes for minutes and sandbox-server stops to answer `/exec`.

The harness now does three things at launch, on both backends. It publishes the quota as the thread count of each library that reads one from the environment (`thread-env.ts`). It covers the two kernel files with the quota (`cpu-files.ts`: a bind mount on Docker, a ConfigMap with `subPath` mounts on K8s). On Docker it sets `MemorySwap` equal to `Memory`.

Replaces #469.

Notes for the reviewer:

- On Docker, through `submitExec`: `detectCores()` 2, `os.cpu_count()` 2, no swap inside the cgroup, and a fork storm of 6 workers ends with an OOM kill in 15 s instead of a hang. On staging EKS under gVisor, the sandbox sees no cgroup at all by default. The env covers the libraries that read it. The `subPath` mount over the two files gives the quota to each runtime and each library default (pydeseq2, xgboost, WGCNA, `mp.Pool()`).
- `MC_CORES` stays unset. R defaults `mclapply` to 2 workers, and a value there raises the fork count.
- The K8s service account of the harness must have `create`, `get`, `update`, and `delete` on `configmaps` in the sandbox namespace. That is a platform-charts change, and it must land before the pin bump. A missing permission fails the launch at once, with the cause.
- The `cpuinfo` blocks describe the harness host, not the node.
- No spec states this behavior yet. `openspec/specs/docker-sandbox-provider/spec.md` states the `NanoCpus` and `Memory` translation only.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. The change adds env values, two read-only files over two kernel paths, and a swap limit. It grants no capability, no mount of host data, and no egress, and it lowers no resource limit.
- [x] **Provenance:** an earlier analysis stays reproducible. But a parallel step now runs with fewer workers, thus a method whose result depends on the worker count can vary.

https://claude.ai/code/session_01Ji4x1TwcZRuKJvtvpFgWbE
