### PR TITLE
fix(harness): decode a JSON-encoded string in validate_synthesis

### DIFF
--- a/harness/src/execution/run-synthesis.test.ts
+++ b/harness/src/execution/run-synthesis.test.ts
@@ -237,6 +237,49 @@ describe("validate_synthesis inner tool", () => {
         expect(holder.outcome).toBeNull();
     });
 
+    it("decodes a candidate that arrives as a JSON-encoded string", async () => {
+        const { validate, holder } = __buildInnerToolsForTest({
+            knownStepIds: new Set(["T1S1"]),
+            runId: RUN_ID,
+        });
+
+        const plain = (await validate.execute({ synthesis: JSON.stringify(validSynthesisPayload()) }, makeToolCtx()))._unsafeUnwrap() as {
+            valid: boolean;
+            issues: unknown[];
+        };
+        const fenced = (
+            await validate.execute({ synthesis: "```json\n" + JSON.stringify(validSynthesisPayload()) + "\n```" }, makeToolCtx())
+        )._unsafeUnwrap() as {
+            valid: boolean;
+            issues: unknown[];
+        };
+
+        expect(plain.valid).toBe(true);
+        expect(plain.issues).toHaveLength(0);
+        expect(fenced.valid).toBe(true);
+        expect(fenced.issues).toHaveLength(0);
+        expect(holder.outcome).toBeNull();
+    });
+
+    it("reports the issues of the synthesis inside a JSON-encoded string", async () => {
+        const { validate } = __buildInnerToolsForTest({
+            knownStepIds: new Set(["T1S1"]),
+            runId: RUN_ID,
+        });
+
+        const result = (
+            await validate.execute({ synthesis: JSON.stringify({ ...validSynthesisPayload(), runId: "other-run" }) }, makeToolCtx())
+        )._unsafeUnwrap() as {
+            valid: false;
+            issues: { path: string; code: string; message: string }[];
+        };
+
+        expect(result.valid).toBe(false);
+        expect(result.issues).toHaveLength(1);
+        expect(result.issues[0]?.path).toBe("synthesis.runId");
+        expect(result.issues[0]?.code).toBe("semantic");
+    });
+
     it("reports schema issues on a malformed candidate instead of rejecting it", async () => {
         const { validate, holder } = __buildInnerToolsForTest({
             knownStepIds: new Set(["T1S1"]),

--- a/harness/src/execution/run-synthesis.ts
+++ b/harness/src/execution/run-synthesis.ts
@@ -46,6 +46,7 @@ import { synthesisAgentPrompt } from "../prompts/synthesis-agent.js";
 import { composeSystemPrompt } from "../agents/system-prompt.js";
 import type { StepSummary } from "../schemas/step-summary.js";
 import { runDir } from "../workspace/paths.js";
+import { decodeObjectString } from "../lib/zod-issues.js";
 
 import { runToTerminal } from "../loop/run-to-terminal.js";
 import { passthroughStep } from "../loop/run-step.js";
@@ -338,17 +339,21 @@ function buildValidateTool(ctx: InnerToolContext): Tool {
             "field-by-field synthesis schema is the arg schema of " +
             "submit_synthesis — this tool deliberately does not restate it. " +
             "Non-terminal: call as often as needed to iterate toward a clean " +
-            "synthesis, then submit_synthesis.",
+            "synthesis, then submit_synthesis. A candidate that arrives as a " +
+            "JSON-encoded string is decoded before the checks run, so the " +
+            "result describes the synthesis inside the string.",
         // Deliberately permissive: a structurally-invalid candidate must reach
         // `execute` so the model gets a structured {valid:false, issues} result —
         // including semantic issues — instead of a bare Zod rejection at the loop's
         // input boundary. `execute` re-parses against RunSynthesisSchema itself.
+        // The permissive schema also means the loop's string repair never runs
+        // here, so `execute` decodes a JSON-encoded string itself.
         inputSchema: z.object({
             synthesis: z.unknown().describe("The candidate synthesis, in any shape. Field-by-field schema: see submit_synthesis."),
         }),
         describeCall: "none",
         execute: async (input) => {
-            const result = fullyValidate(input.synthesis, ctx);
+            const result = fullyValidate(decodeObjectString(input.synthesis), ctx);
             return ok(result.valid ? { valid: true as const, issues: [] as ValidationIssue[] } : { valid: false as const, issues: result.issues });
         },
     });

--- a/harness/src/lib/zod-issues.ts
+++ b/harness/src/lib/zod-issues.ts
@@ -143,6 +143,19 @@ export function repairToolInput(input: unknown, error: z.ZodError): unknown | un
 }
 
 /**
+ * Decode a value that a model sent as a JSON-encoded object string, with or
+ * without a wrapper artifact. The decoded object is returned when the string
+ * parses to one. Each other value comes back as it is, thus a caller can apply
+ * this to an argument of any type. This is the repair that `repairToolInput`
+ * applies at the loop boundary, for a tool whose schema accepts the string.
+ */
+export function decodeObjectString(value: unknown): unknown {
+    if (typeof value !== "string" || value.length > MAX_REPAIRABLE_STRING_LENGTH) return value;
+    const parsed = parseAs(value, "object") ?? parseAs(stripWrappers(value).text, "object");
+    return parsed === undefined ? value : parsed.value;
+}
+
+/**
  * The measurement of a string that broke its maximum length, or `undefined` for
  * any other issue.
  *


### PR DESCRIPTION
## What & why

`validate_synthesis` now decodes a candidate that arrives as a JSON-encoded string, and then validates the object inside. Run `d2fae219` in staging ended with a synthesis of `"test"` in the overview and the conclusions. The DBOS event stream of the run shows the cause. The synthesizer sent a complete and valid synthesis to `validate_synthesis` as a JSON string, four times. The tool takes `z.unknown()`, thus the string repair of the loop never runs for it, and the validator answered "expected object, received string" each time. The model then sent a `"test"` probe to `submit_synthesis` as an object, and that terminal call ended the loop with the placeholder.

Notes for the reviewer:

- The decode uses the same `parseAs` and `stripWrappers` rules as `repairToolInput`, through the new `decodeObjectString` in `zod-issues.ts`. Thus the validator sees the same value that the loop boundary of `submit_synthesis` would repair.
- The validator does not report the string encoding as an issue. An issue keeps `valid: false`, and that is the loop that the model could not exit. The string is harmless at `submit_synthesis`, because the loop repairs it there.
- `bun run lint` reports one pre-existing error in `src/providers/ai-sdk.test.ts:1378`, from `bbab2825` on main. The three changed files lint clean.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01TeyxgEQc9g2Wti3H4LVx2Y
