### PR TITLE
feat(harness): default the sandbox thread pools to one thread

### DIFF
--- a/harness/openspec/specs/docker-sandbox-provider/spec.md
+++ b/harness/openspec/specs/docker-sandbox-provider/spec.md
@@ -259,6 +259,47 @@ container `HostConfig`: `NanoCpus` set to `round(cpu * 1e9)` and `Memory` set to
 - **WHEN** the Docker container is created
 - **THEN** the `HostConfig` has no `DeviceRequests` entry
 
+### Requirement: The cpu quota is visible inside the container
+
+A cgroup quota is invisible to the runtimes inside it. `parallel::detectCores()`
+greps `/proc/cpuinfo`, and `os.cpu_count()` reads
+`/sys/devices/system/cpu/online`, and the two files describe the host. Thus the
+Docker backend SHALL bind-mount two host-written files, read-only, over the two
+paths. The files describe `floor(cpu)` cores (minimum 1): an `online` file with
+`0-{n-1}`, and a `cpuinfo` file with the first `n` processor blocks of the
+host's `/proc/cpuinfo`, when that file is readable. The backend SHALL also set
+`MemorySwap` equal to `Memory`, thus a memory storm ends in an OOM kill and not
+in a swap thrash.
+
+The backend SHALL inject the shared thread-limit env (`thread-env.ts`). Each
+thread-pool variable (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`,
+`MKL_NUM_THREADS`, `R_DATATABLE_NUM_THREADS`, `NUMBA_NUM_THREADS`,
+`NUMEXPR_MAX_THREADS`, `POLARS_MAX_THREADS`, `RAYON_NUM_THREADS`) SHALL be `1`.
+Each worker-count variable (`BIOCPARALLEL_WORKER_NUMBER`, `LOKY_MAX_CPU_COUNT`)
+SHALL be `floor(cpu)` (minimum 1). A fork copies the thread-pool size of its
+parent, thus a pool at the quota runs `workers * quota` threads. One thread for
+each pool is the safe default, and the agent raises it per command through the
+exec `env`. `MC_CORES` SHALL NOT be set. `plan.env` and `extraEnv` SHALL
+override these defaults.
+
+#### Scenario: Core-count calls report the quota
+
+- **GIVEN** resources `{ cpu: 2 }` on a 12-core host
+- **WHEN** the container runs `parallel::detectCores()` or `os.cpu_count()`
+- **THEN** both report `2`
+
+#### Scenario: Thread pools default to one thread
+
+- **GIVEN** resources `{ cpu: 2 }`
+- **WHEN** the container is created
+- **THEN** the env has `OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `BIOCPARALLEL_WORKER_NUMBER=2`, and no `MC_CORES`
+
+#### Scenario: No swap
+
+- **GIVEN** resources `{ memoryGb: 1 }`
+- **WHEN** the container is created
+- **THEN** `MemorySwap` equals `Memory`
+
 ### Requirement: Sandbox containers labeled for managed-sweep cleanup
 
 Sandbox containers created by the Docker backend SHALL carry the labels

--- a/harness/openspec/specs/harness-sandbox-exec/spec.md
+++ b/harness/openspec/specs/harness-sandbox-exec/spec.md
@@ -163,6 +163,36 @@ step output so the workflow body holds it verbatim on replay.
 - **THEN** it SHALL adopt that machine under the step-1 identity
 - **AND** SHALL NOT create a second machine
 
+### Requirement: The step quota is published inside the sandbox
+
+Both backends SHALL make the cpu quota of a step visible inside the sandbox.
+The backend SHALL cover `/proc/cpuinfo` and `/sys/devices/system/cpu/online`
+with files that describe `floor(cpu)` cores (minimum 1): a read-only bind mount
+on Docker, and a per-Job ConfigMap with `subPath` mounts on K8s. The ConfigMap
+SHALL carry the Job as its owner reference, thus the delete of the Job removes
+it. Teardown SHALL also delete it explicitly, for a ConfigMap that got no
+owner.
+
+Both backends SHALL inject the shared thread-limit env (`thread-env.ts`): the
+thread-pool variables at `1`, and the worker-count variables at `floor(cpu)`.
+The rationale and the exact variable set are in the docker-sandbox-provider
+spec ("The cpu quota is visible inside the container").
+
+#### Scenario: K8s cpu files ride in a Job-owned ConfigMap
+
+- **GIVEN** a K8s sandbox with resources `{ cpu: 2 }`
+- **WHEN** `sandbox.create` runs
+- **THEN** a ConfigMap named after the Job SHALL hold the `online` and `cpuinfo` files
+- **AND** its owner reference SHALL point at the Job
+- **AND** the pod SHALL mount each key with `subPath` over the kernel path
+
+#### Scenario: A ConfigMap failure fails the launch with its cause
+
+- **GIVEN** a service account without `configmaps` permissions
+- **WHEN** `sandbox.create` runs
+- **THEN** the launch SHALL fail with the `k8s.createNamespacedConfigMap` operation named
+- **AND** the created Job SHALL be cleaned up
+
 ### Requirement: submitExec is a DBOS step keyed on execId
 
 `submitExec(ref, body)` SHALL run as a DBOS step named

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/prompts/briefing.test.ts
+++ b/harness/src/prompts/briefing.test.ts
@@ -239,6 +239,19 @@ describe("composeStepBriefing", () => {
         expect(seed).toContain("/an-1");
     });
 
+    it("renders the resource budget and the workers-times-threads rule", () => {
+        const seed = composeStepBriefing({ step: fullyPopulatedStep(), workspace: WORKSPACE, profile: null, upstream: [] });
+        expect(seed).toContain("Resources (hard limits)");
+        expect(seed).toContain("workers × threads-per-worker");
+    });
+
+    it("omits the resources section for a historical step that carries none", () => {
+        const step = { ...fullyPopulatedStep(), resources: undefined };
+        const seed = composeStepBriefing({ step, workspace: WORKSPACE, profile: null, upstream: [] });
+        expect(seed).not.toContain("Resources (hard limits)");
+        expect(seed).not.toMatch(/\n{3,}/);
+    });
+
     it("is byte-identical when recomposed from the same data (replay stability)", () => {
         const briefing = {
             step: fullyPopulatedStep(),

--- a/harness/src/prompts/briefing.ts
+++ b/harness/src/prompts/briefing.ts
@@ -173,9 +173,9 @@ export function renderResources(resources: AnalysisStep["resources"]): string {
     const cores = Math.max(1, Math.floor(resources.cpu));
     const items = [
         `CPU: ${resources.cpu} ${resources.cpu === 1 ? "core" : "cores"} (hard quota). Memory: ${resources.memoryGb} GB (hard limit — exceeding it kills the process).`,
-        `Core-count calls (\`parallel::detectCores()\`, \`os.cpu_count()\`) report this quota — trust them for worker counts.`,
+        `Core-count calls (\`parallel::detectCores()\`, \`os.cpu_count()\`) report this quota — worker counts sized from them are already right, nothing to raise.`,
         `BLAS/OpenMP thread pools default to **1 thread** (\`OMP_NUM_THREADS\` etc.). For a thread-parallel single-process step, raise them per command via \`execute_command\`'s \`env\`, up to ${cores}.`,
-        `Keep workers × threads-per-worker ≤ ${cores}. Raise one, never both.`,
+        `The one rule: workers × threads-per-worker must stay ≤ ${cores}. A mix is fine while the product holds.`,
     ];
     if (resources.gpu) items.push(`GPU: ${resources.gpu.count}.`);
     return section("Resources (hard limits)", bullets(items));

--- a/harness/src/prompts/briefing.ts
+++ b/harness/src/prompts/briefing.ts
@@ -55,7 +55,9 @@ export const STEP_TASK_FIELDS = [
  * threaded separately through the workflow input, execution knobs, and result
  * fields populated after the step runs. `depends_on` is not rendered here
  * because the dependencies appear as {@link renderUpstream} blocks — with their
- * results — rather than as bare ids.
+ * results — rather than as bare ids. `resources` renders as its own
+ * {@link renderResources} section, because the budget is an execution bound,
+ * not a task instruction.
  */
 export const STEP_NON_TASK_FIELDS = [
     "id",
@@ -156,6 +158,29 @@ export function renderWorkspace(frame: WorkspaceFrame): string {
     );
 }
 
+// ── (2b) Resources ────────────────────────────────────────────────────
+
+/**
+ * The cpu and memory budget of the step, with the one rule that keeps a
+ * parallel workload inside it. The mounted cpu files make `detectCores()` and
+ * `os.cpu_count()` report the quota, thus the fork count is right by default.
+ * The thread pools default to one thread (see `sandbox/thread-env.ts`), and
+ * only the agent knows when a step is thread-parallel. Thus the briefing names
+ * the budget and the rule, and the agent raises a pool per command.
+ */
+export function renderResources(resources: AnalysisStep["resources"]): string {
+    if (!resources) return "";
+    const cores = Math.max(1, Math.floor(resources.cpu));
+    const items = [
+        `CPU: ${resources.cpu} ${resources.cpu === 1 ? "core" : "cores"} (hard quota). Memory: ${resources.memoryGb} GB (hard limit — exceeding it kills the process).`,
+        `Core-count calls (\`parallel::detectCores()\`, \`os.cpu_count()\`) report this quota — trust them for worker counts.`,
+        `BLAS/OpenMP thread pools default to **1 thread** (\`OMP_NUM_THREADS\` etc.). For a thread-parallel single-process step, raise them per command via \`execute_command\`'s \`env\`, up to ${cores}.`,
+        `Keep workers × threads-per-worker ≤ ${cores}. Raise one, never both.`,
+    ];
+    if (resources.gpu) items.push(`GPU: ${resources.gpu.count}.`);
+    return section("Resources (hard limits)", bullets(items));
+}
+
 // ── (3) Data orientation ──────────────────────────────────────────────
 
 /**
@@ -246,6 +271,7 @@ export function composeStepBriefing(briefing: StepBriefing): string {
     return [
         renderTask(briefing.step),
         renderWorkspace(briefing.workspace),
+        renderResources(briefing.step.resources),
         renderOrientation(briefing.profile, briefing.workspace.analysisId),
         renderUpstream(briefing.upstream),
     ]

--- a/harness/src/prompts/sandbox-standards.ts
+++ b/harness/src/prompts/sandbox-standards.ts
@@ -146,12 +146,13 @@ BLAS/OpenMP thread pools default to **1 thread** (\`OMP_NUM_THREADS\`,
 \`OPENBLAS_NUM_THREADS\`, \`MKL_NUM_THREADS\`, …). A forked worker inherits its
 parent's pool size, so this default is what keeps \`mclapply\` /
 \`multiprocessing\` from running workers × threads on a quota sized for one of
-them. The rule: **workers × threads-per-worker must not exceed the quota —
-raise one, never both.**
+them. The rule: **workers × threads-per-worker must not exceed the quota.** A
+mix is fine while the product stays inside it.
 
 - **Fork/worker parallelism** (\`mclapply\`, \`BiocParallel\`, \`joblib\`,
-  \`multiprocessing\`): size the workers from the quota and leave the thread
-  defaults alone.
+  \`multiprocessing\`): size the workers from the reported core count and leave
+  the thread defaults alone — there is nothing to raise. \`joblib\` also
+  divides its own thread budget across its workers; do not manage it.
 - **Thread parallelism** (one process: xgboost, WGCNA, data.table, polars, a
   single large BLAS fit): raise the thread variables for that command through
   \`execute_command\`'s \`env\`, e.g.

--- a/harness/src/prompts/sandbox-standards.ts
+++ b/harness/src/prompts/sandbox-standards.ts
@@ -136,6 +136,32 @@ up front.
   \`AnnotationHub\` — they all reach for the network and will fail. Load from an
   inventory path instead. Do NOT download data or install packages at runtime.
 
+## CPU Budget and Parallelism
+
+Your briefing names this step's CPU quota and memory limit. The container's
+core-count calls (\`parallel::detectCores()\`, \`os.cpu_count()\`) report the
+quota, so worker counts sized from them are safe.
+
+BLAS/OpenMP thread pools default to **1 thread** (\`OMP_NUM_THREADS\`,
+\`OPENBLAS_NUM_THREADS\`, \`MKL_NUM_THREADS\`, …). A forked worker inherits its
+parent's pool size, so this default is what keeps \`mclapply\` /
+\`multiprocessing\` from running workers × threads on a quota sized for one of
+them. The rule: **workers × threads-per-worker must not exceed the quota —
+raise one, never both.**
+
+- **Fork/worker parallelism** (\`mclapply\`, \`BiocParallel\`, \`joblib\`,
+  \`multiprocessing\`): size the workers from the quota and leave the thread
+  defaults alone.
+- **Thread parallelism** (one process: xgboost, WGCNA, data.table, polars, a
+  single large BLAS fit): raise the thread variables for that command through
+  \`execute_command\`'s \`env\`, e.g.
+  \`env: { "OMP_NUM_THREADS": "4", "OPENBLAS_NUM_THREADS": "4" }\` on a 4-CPU
+  quota.
+
+Exceeding the quota does not kill the step — the cgroup throttles it — but an
+oversubscribed step runs slower and can starve the exec server that runs your
+commands.
+
 ## Output Contract — Persisted Files Are the Deliverable
 
 This is a hard requirement, not a convention. **Your deliverable is persisted

--- a/harness/src/sandbox/docker-client.test.ts
+++ b/harness/src/sandbox/docker-client.test.ts
@@ -304,7 +304,7 @@ describe("docker createSandbox — transport modes", () => {
         expect(registered).toEqual([{ runId: "run-1", stepId: "step-a", sandboxId: ref.sandboxId }]);
     });
 
-    test("the cpu request is published as the thread count of each parallel library", async () => {
+    test("the thread pools default to one thread and the worker counts to the cpu request", async () => {
         const { docker, created } = stubDocker();
         const ops = createDockerSandboxOps({
             image: "sandbox-base:latest",
@@ -317,18 +317,19 @@ describe("docker createSandbox — transport modes", () => {
 
         (await ops.createSandbox(META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
 
-        // Without these the libraries size their pools from the core count of the
-        // host and oversubscribe the cgroup that the same call sets NanoCpus on.
+        // A fork copies the pool size of its parent, thus a pool at the quota
+        // runs workers * quota threads. One thread per pool is the safe
+        // default, and the agent raises it per command through the exec env.
         const env = envMapOf(sandboxOf(created)!);
-        expect(env.OMP_NUM_THREADS).toBe("2");
-        expect(env.OPENBLAS_NUM_THREADS).toBe("2");
+        expect(env.OMP_NUM_THREADS).toBe("1");
+        expect(env.OPENBLAS_NUM_THREADS).toBe("1");
         expect(env.BIOCPARALLEL_WORKER_NUMBER).toBe("2");
         expect(env.LOKY_MAX_CPU_COUNT).toBe("2");
         // R defaults mclapply to 2 workers. A value here raises the fork count.
         expect(env.MC_CORES).toBeUndefined();
     });
 
-    test("a fractional cpu request floors to one thread, and extraEnv overrides the derived count", async () => {
+    test("a fractional cpu request floors to one worker, and extraEnv overrides the defaults", async () => {
         const { docker, created } = stubDocker();
         const ops = createDockerSandboxOps({
             image: "sandbox-base:latest",
@@ -344,6 +345,7 @@ describe("docker createSandbox — transport modes", () => {
         )._unsafeUnwrap();
 
         const env = envMapOf(sandboxOf(created)!);
+        expect(env.BIOCPARALLEL_WORKER_NUMBER).toBe("1");
         expect(env.OPENBLAS_NUM_THREADS).toBe("1");
         expect(env.OMP_NUM_THREADS).toBe("8");
     });

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -157,10 +157,10 @@ describe("k8s createSandbox", () => {
         expect(envMap.SANDBOX_CALLBACK_SECRET).toBe(ref.callbackSecret);
         expect(envMap.PROVENANCE_WATCH_DIRS).toBe("/an-1");
         expect(envMap.R_LIBS_SITE).toContain("/mnt/libs/current/r/");
-        // The cgroup limit below is invisible to the libraries inside it, thus
-        // the same cpu request rides in as their thread count.
-        expect(envMap.OMP_NUM_THREADS).toBe("2");
-        expect(envMap.OPENBLAS_NUM_THREADS).toBe("2");
+        // The thread pools default to one thread, and the worker counts follow
+        // the cpu request. The agent raises a pool per command.
+        expect(envMap.OMP_NUM_THREADS).toBe("1");
+        expect(envMap.OPENBLAS_NUM_THREADS).toBe("1");
         expect(envMap.BIOCPARALLEL_WORKER_NUMBER).toBe("2");
         expect(envMap.MC_CORES).toBeUndefined();
 

--- a/harness/src/sandbox/thread-env.ts
+++ b/harness/src/sandbox/thread-env.ts
@@ -2,16 +2,22 @@
  * Thread-count env for a sandbox container.
  *
  * Each backend turns the `ResourceSpec` of a step into a hard cgroup limit:
- * `NanoCpus` and `Memory` on Docker, `limits.cpu` and `limits.memory` on K8s. A
- * cgroup quota is invisible to most runtimes inside it. `parallel::detectCores()`
- * greps `/proc/cpuinfo`, and `os.cpu_count()` reads
- * `/sys/devices/system/cpu/online`. Both files describe the host. Thus a step
- * with 2 CPUs on a host of 12 cores forks 12 workers into a cgroup of 2 CPUs,
- * and each fork copies its working set until the memory limit stops it.
+ * `NanoCpus` and `Memory` on Docker, `limits.cpu` and `limits.memory` on K8s.
+ * The mounted cpu files show the quota to `parallel::detectCores()` and to
+ * `os.cpu_count()`. Thus the fork count of a step follows the quota by default.
  *
- * The env below publishes the quota to each library that reads a thread count
- * from the environment. `parallelly::availableCores()` and `joblib.cpu_count()`
- * read the cgroup quota on their own, thus they need no value here.
+ * The thread pools get a different default. A fork copies the pool size of its
+ * parent, and no R runtime divides it. Thus a pool at the quota turns into
+ * `workers * quota` threads inside one cgroup. The env below pins each pool to
+ * one thread, which is the convention of Snakemake and of the HPC sites. A
+ * thread-parallel step raises the value per command, through the `env`
+ * parameter of `execute_command`. The rule for the agent is one line: workers
+ * times threads must not go above the quota.
+ *
+ * The two worker-count names stay at the quota. They cap process workers, not
+ * threads, and a worker with one thread is safe at each count up to the quota.
+ * joblib divides its own budget by its worker count, and a value of one in
+ * `OMP_NUM_THREADS` gives each of its workers one thread as well.
  *
  * `MC_CORES` is absent on purpose. R defaults `mclapply` to 2 workers, not to
  * the core count. A value there raises the fork count instead of a decrease.
@@ -20,33 +26,38 @@
 import type { ResourceSpec } from "../config/resource-limits.js";
 
 /**
- * Env that binds each parallel library in the container to `spec.cpu`.
+ * Env that makes each parallel library in the container safe under `spec.cpu`.
  *
- * A fractional CPU request floors to one thread. A pool of zero is not
- * representable, and two threads on half a core only add context switches.
+ * A fractional CPU request floors to one worker. A pool of zero is not
+ * representable, and two workers on half a core only add context switches.
  *
  * The caller puts these before `plan.env` and before the `extraEnv` of the
  * embedder, thus a host that knows more about a step keeps the last word.
  */
 export function threadLimitEnv(spec: ResourceSpec): Record<string, string> {
-    const threads = String(Math.max(1, Math.floor(spec.cpu)));
+    const workers = String(Math.max(1, Math.floor(spec.cpu)));
     return {
+        // Thread pools: one thread each. The agent raises a value per command.
         // OpenMP: the compiled code of R and Python packages.
-        OMP_NUM_THREADS: threads,
+        OMP_NUM_THREADS: "1",
         // OpenBLAS keeps a private pool. A pthread build reads this name first.
-        OPENBLAS_NUM_THREADS: threads,
+        OPENBLAS_NUM_THREADS: "1",
         // MKL reads this name before OMP_NUM_THREADS.
-        MKL_NUM_THREADS: threads,
+        MKL_NUM_THREADS: "1",
+        // data.table defaults to half of the visible cores.
+        R_DATATABLE_NUM_THREADS: "1",
+        // The Python numerical stack.
+        NUMBA_NUM_THREADS: "1",
+        NUMEXPR_MAX_THREADS: "1",
+        POLARS_MAX_THREADS: "1",
+        RAYON_NUM_THREADS: "1",
+        // Worker counts: the quota.
         // BiocParallel sizes `bpparam()` from this name. DESeq2 `parallel=TRUE`
         // and the other Bioconductor packages size their workers from `bpparam()`.
-        BIOCPARALLEL_WORKER_NUMBER: threads,
-        // data.table defaults to half of the host cores.
-        R_DATATABLE_NUM_THREADS: threads,
-        // The Python numerical stack.
-        NUMBA_NUM_THREADS: threads,
-        NUMEXPR_MAX_THREADS: threads,
-        LOKY_MAX_CPU_COUNT: threads,
-        POLARS_MAX_THREADS: threads,
-        RAYON_NUM_THREADS: threads,
+        // `parallelly::availableCores()` reads it too, and under gVisor, where no
+        // cgroup is visible, it is the only bound that library sees.
+        BIOCPARALLEL_WORKER_NUMBER: workers,
+        // loky caps its worker default at this name.
+        LOKY_MAX_CPU_COUNT: workers,
     };
 }

--- a/skills/bulk-transcriptomics/references/deseq2-rpy2-api.md
+++ b/skills/bulk-transcriptomics/references/deseq2-rpy2-api.md
@@ -89,9 +89,10 @@ dds = deseq2.DESeq(dds)                          # test="Wald", fitType="paramet
 # Likelihood ratio test (for multi-level factors, time series)
 dds = deseq2.DESeq(dds, test="LRT", reduced=Formula("~ 1"))
 
-# With parallelization
+# With parallelization — size the workers from the quota, not from a fixed count
 biocparallel = importr("BiocParallel")
-dds = deseq2.DESeq(dds, parallel=True, BPPARAM=biocparallel.MulticoreParam(4))
+workers = biocparallel.multicoreWorkers()  # sized from the CPU quota of the step
+dds = deseq2.DESeq(dds, parallel=True, BPPARAM=biocparallel.MulticoreParam(workers))
 ```
 
 ## Extracting Results

--- a/skills/cheminformatics/references/datamol-api.md
+++ b/skills/cheminformatics/references/datamol-api.md
@@ -288,7 +288,7 @@ fps_array = np.array(fps)
 
 - `dm.parallelized()` uses joblib. RDKit `Mol` objects *are* picklable, so passing mol objects works -- but pickling large mol lists costs more than passing SMILES strings and re-parsing in the worker, so SMILES is usually faster.
 - Note that `dm.parallelized()` defaults to `n_jobs=-1`; pass `n_jobs=1` to run serially.
-- `n_jobs=-1` uses all CPUs. In sandbox environments, check available cores first.
+- `n_jobs=-1` resolves to the visible core count, which equals the CPU quota of the step. Each joblib worker keeps one thread, thus the default is safe.
 - For small datasets (<1K), parallelization overhead may exceed the benefit. Use serial processing instead.
 
 ## Complete Standardization + Profiling Workflow

--- a/skills/cheminformatics/references/gseapy-connectivity.md
+++ b/skills/cheminformatics/references/gseapy-connectivity.md
@@ -213,3 +213,5 @@ def score_drug_panel(query_up, query_down, drug_signatures,
   top hits with 1000.
 - Results are in `res2d` (DataFrame), not `results` (dict). Always
   use `.res2d` for consistent access.
+- `prerank` takes `threads=` (default 4). Size it from the visible
+  cores, which report the CPU quota of the step.

--- a/skills/cheminformatics/references/rdkit-core.md
+++ b/skills/cheminformatics/references/rdkit-core.md
@@ -295,8 +295,11 @@ result = AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
 # Optimize geometry with MMFF
 AllChem.MMFFOptimizeMolecule(mol, maxIters=500)
 
-# Multiple conformers
-cids = AllChem.EmbedMultipleConfs(mol, numConfs=50, params=AllChem.ETKDGv3())
+# Multiple conformers. The embedding is thread-parallel: numThreads = 0 uses
+# all visible cores, and the visible count equals the CPU quota of the step.
+params = AllChem.ETKDGv3()
+params.numThreads = 0
+cids = AllChem.EmbedMultipleConfs(mol, numConfs=50, params=params)
 # Optimize each. Returns one (not_converged, energy) tuple per
 # conformer, in conformer order: results[i] belongs to cids[i].
 results = AllChem.MMFFOptimizeMoleculeConfs(mol, maxIters=500)

--- a/skills/dna-methylation/references/epidish-api.md
+++ b/skills/dna-methylation/references/epidish-api.md
@@ -339,7 +339,7 @@ celldmc_out <- CellDMC(
   cov.mod = cov_matrix,
   adjPMethod = "fdr",
   adjPThresh = 0.05,
-  mc.cores = 4
+  mc.cores = parallel::detectCores()  # forked workers — detectCores() reports the CPU quota of the step
 )
 
 # 3. Identify cell-type-specific DMPs

--- a/skills/drug-repurposing/references/repurposing-methods.md
+++ b/skills/drug-repurposing/references/repurposing-methods.md
@@ -77,6 +77,8 @@ def connectivity_score_prerank(disease_signature, drug_gene_sets,
 
     rnk = disease_signature.set_index("gene")["rank_metric"]
 
+    # gseapy defaults to 4 threads. Size threads= from the visible cores,
+    # which report the CPU quota of the step.
     result = gseapy.prerank(
         rnk=rnk,
         gene_sets=drug_gene_sets,

--- a/skills/immune-profiling/references/immune-signatures.md
+++ b/skills/immune-profiling/references/immune-signatures.md
@@ -165,6 +165,8 @@ def score_signatures_ssgsea(expression_df, signatures_dict):
     DataFrame
         Signatures (rows) x Samples (columns) with NES scores.
     """
+    import os
+
     import gseapy
 
     result = gseapy.ssgsea(
@@ -173,6 +175,7 @@ def score_signatures_ssgsea(expression_df, signatures_dict):
         outdir=None,
         no_plot=True,
         min_size=3,
+        threads=os.cpu_count() or 4,  # gseapy defaults to 4 — size from the visible cores
     )
     return result.res2d.pivot(
         index="Term", columns="Name", values="NES",

--- a/skills/metabolomics/references/xcms-api.md
+++ b/skills/metabolomics/references/xcms-api.md
@@ -90,7 +90,10 @@ cwp <- CentWaveParam(
   integrate = 1L
 )
 
-# Run peak detection across all samples
+# Run peak detection across all samples.
+# findChromPeaks, adjustRtime, and fillChromPeaks fork BiocParallel workers from
+# the default bpparam(), which is sized from the CPU quota of the step. Pass
+# BPPARAM only to reduce the workers. Leave the thread limits at their default.
 xdata <- findChromPeaks(raw_data, param = cwp)
 
 # Inspect results

--- a/skills/microbiome/references/dada2-api.md
+++ b/skills/microbiome/references/dada2-api.md
@@ -56,11 +56,15 @@ out <- filterAndTrim(
   minLen = 20,               # integer — discard reads shorter than this after trimming
   rm.phix = TRUE,            # logical — remove PhiX spike-in reads
   compress = TRUE,           # logical — gzip output files
-  multithread = TRUE,        # logical | integer — use multiple threads (TRUE = all cores)
+  multithread = TRUE,        # logical | integer — use multiple threads (TRUE = all visible cores)
   verbose = TRUE
 )
 # Returns: matrix with columns "reads.in" and "reads.out", one row per sample
 ```
+
+Parallelism: `multithread = TRUE` sizes from the visible core count, and that
+count equals the CPU quota of the step. Keep it on. Do not wrap a multithreaded
+DADA2 call in forked workers on top of it.
 
 ### Choosing truncLen
 

--- a/skills/microbiome/references/maaslin2-api.md
+++ b/skills/microbiome/references/maaslin2-api.md
@@ -59,7 +59,7 @@ result <- Maaslin2(
   plot_heatmap = TRUE,           # logical — generate heatmap of significant associations
   plot_scatter = TRUE,           # logical — generate scatter plots for significant pairs
   heatmap_first_n = 50,          # int — top N associations to show in heatmap
-  cores = 1                      # int — number of parallel threads
+  cores = 1                      # int — forked workers (not threads) — size from detectCores(), which reports the CPU quota
 )
 ```
 

--- a/skills/network-regulatory/SKILL.md
+++ b/skills/network-regulatory/SKILL.md
@@ -19,6 +19,9 @@ Choose the method based on your data type and analytical goal:
    - Soft-thresholding power is chosen inside `findModules()`; call
      `WGCNA.pickSoftThreshold()` directly only to inspect the fit table. The
      scale-free fit cut is `RsquaredCut`, default 0.9.
+   - PyWGCNA is thread-parallel. Give the one process the full CPU budget of
+     the step: raise the thread limit for that command. Do not add forked
+     workers on top of it.
 
 2. **Co-expression from single-cell data**
    - Aggregate to **pseudobulk** first (per cluster or per sample), then apply PyWGCNA.

--- a/skills/network-regulatory/references/pywgcna-api.md
+++ b/skills/network-regulatory/references/pywgcna-api.md
@@ -58,6 +58,8 @@ Filter to top variable genes before WGCNA to manage memory and noise.
 ```python
 # CRITICAL: Filter to top variable genes before WGCNA
 # PyWGCNA can be very slow/memory-hungry with >5000 genes
+# PyWGCNA is thread-parallel. Raise the thread limit for this command to the
+# full CPU budget of the step, and do not add forked workers.
 n_top = 5000
 gene_var = expr_df.var(axis=0).sort_values(ascending=False)
 top_genes = gene_var.head(n_top).index.tolist()

--- a/skills/pkpd-clinical-response/references/population-pk-nlme.md
+++ b/skills/pkpd-clinical-response/references/population-pk-nlme.md
@@ -47,6 +47,9 @@ fit <- nlmixr2(one.cmt, theo_sd, est = "saem",
                control = saemControl(nBurn = 200, nEm = 300, print = 0))
 ```
 
+- SAEM estimation is thread-parallel (OpenMP), and the thread limit of the
+  process defaults to 1 in the sandbox. Raise the thread limit for the
+  estimation command to the full CPU budget of the step.
 - Parameters are estimated on the log scale and exponentiated in `model({})`, so
   they stay positive and IIV is lognormal — the standard PK parameterisation.
 - `linCmt()` picks the closed-form linear model implied by the parameter names

--- a/skills/proteomics/references/msstats-rpy2-api.md
+++ b/skills/proteomics/references/msstats-rpy2-api.md
@@ -279,7 +279,7 @@ msstats.dataProcessPlots(processed, type="ProfilePlot", address="output/profile_
 
 ## Version Notes
 
-- MSstats >= 4.10 (Bioconductor 3.20+): uses `data.table` internally for performance.
+- MSstats >= 4.10 (Bioconductor 3.20+): uses `data.table` internally for performance. The thread limit of the process defaults to 1 in the sandbox. For a large `dataProcess` run, raise the thread limit for that command to the full CPU budget of the step.
 - MSstatsTMT >= 2.10: supports `moderated=TRUE` for empirical Bayes in `groupComparisonTMT`.
 - Converter functions vary by version -- check available converters with `dir(msstats)`.
 - `groupComparison` contrast matrix column names must match `Condition` values exactly.

--- a/skills/single-cell/references/pertpy-api.md
+++ b/skills/single-cell/references/pertpy-api.md
@@ -50,7 +50,7 @@ adata_loaded = ag.load(
 adata_result, results = ag.predict(
     adata_loaded,
     random_state=42,
-    n_threads=4,
+    n_threads=4,  # size from os.cpu_count(), which reports the CPU quota of the step
 )
 
 # Sort cell types by responsiveness

--- a/skills/spatial-omics/references/spatialdata-api.md
+++ b/skills/spatial-omics/references/spatialdata-api.md
@@ -301,7 +301,7 @@ sc.tl.leiden(adata, resolution=0.5, key_added="clusters")
 # Spatial analysis with squidpy
 sq.gr.spatial_neighbors(adata, coord_type="generic", n_neighs=10)
 sq.gr.nhood_enrichment(adata, cluster_key="clusters")
-sq.gr.spatial_autocorr(adata, mode="moran", n_jobs=4)
+sq.gr.spatial_autocorr(adata, mode="moran", n_jobs=4)  # size n_jobs from os.cpu_count()
 ```
 
 ## Gotchas

--- a/skills/spatial-omics/references/squidpy-api.md
+++ b/skills/spatial-omics/references/squidpy-api.md
@@ -98,7 +98,7 @@ sq.gr.spatial_autocorr(
     mode="moran",              # "moran" or "geary"
     genes=None,                # list of genes to test (None = all in .var)
     n_perms=100,               # permutations for p-value (None = analytical)
-    n_jobs=4                   # parallel jobs
+    n_jobs=4                   # parallel jobs — size from os.cpu_count(), which reports the CPU quota
 )
 # Results stored in adata.uns['moranI'] (DataFrame):
 #   columns: I, pval_norm, var_norm, pval_z_sim, pval_sim, var_sim

--- a/skills/statistical-modeling/SKILL.md
+++ b/skills/statistical-modeling/SKILL.md
@@ -34,6 +34,7 @@ Escalate complexity only when simpler models underperform:
 - **Start**: `sklearn.LogisticRegression` (interpretable, baseline).
 - **If non-linear patterns**: `sklearn.RandomForestClassifier` (handles interactions, feature importance built in).
 - **If maximum performance needed**: `xgboost.XGBClassifier` (gradient boosting, tunable).
+  - xgboost is thread-parallel: raise the thread limit for the training command to the full CPU budget of the step. Do not run it under forked workers (for example joblib) at the same time.
 - **Metric**: Use **AUC-ROC** as primary metric. For imbalanced classes, also report **AUPRC** (precision-recall). Never use accuracy alone on imbalanced data.
 
 ### 3. Regression (predict continuous outcome)

--- a/skills/statistical-modeling/references/scikit-learn-api.md
+++ b/skills/statistical-modeling/references/scikit-learn-api.md
@@ -253,5 +253,5 @@ perm_imp = permutation_importance(pipe, X_test, y_test, n_repeats=10, random_sta
 - `roc_auc_score` requires probability scores (`predict_proba`), not class labels.
 - `feature_importances_` (impurity-based) can be biased toward high-cardinality features; prefer `permutation_importance`.
 - Set `max_iter` on `LogisticRegression` (default 100 often insufficient).
-- `n_jobs=-1` uses all CPU cores -- set explicitly in resource-constrained environments.
+- `n_jobs=-1` resolves to the visible core count, which equals the CPU quota of the step. Each worker keeps one BLAS thread. Keep workers × threads inside the quota.
 - `GridSearchCV` refits on full training set by default (`refit=True`); access via `.best_estimator_`.

--- a/skills/statistical-modeling/references/xgboost-api.md
+++ b/skills/statistical-modeling/references/xgboost-api.md
@@ -199,3 +199,4 @@ loaded_bst = xgb.Booster(model_file='model.ubj')
 - `feature_importances_` uses 'gain' by default in sklearn API. Use `xgb.plot_importance(model, importance_type='weight')` for split count.
 - Cross-validation with early stopping requires manual fold splitting (sklearn's `cross_val_score` does not pass `eval_set` per fold).
 - `predict_proba` returns shape `(n_samples, n_classes)`. For binary, positive-class probabilities are at index 1.
+- Threading: xgboost obeys the thread limit of the process, and that limit defaults to 1 in the sandbox. For a single fit, raise the thread limit for that command to the full CPU budget. Keep it at 1 when a forked search (`GridSearchCV`, `cross_val_score` with `n_jobs`) wraps the estimator.


### PR DESCRIPTION
## What & why

PR #472 set the ten thread env names to the cpu quota. A fork copies the thread-pool size of its parent, and no R runtime divides it. Thus a step with 8 forked workers on a quota of 8 ran 64 threads, and sandbox-server starved. The value at the quota also disabled the own worker split of joblib.

The thread pools (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, and the rest) now default to `1`. The worker-count names (`BIOCPARALLEL_WORKER_NUMBER`, `LOKY_MAX_CPU_COUNT`) stay at the quota. The mounted cpu files still give the quota to `detectCores()` and `os.cpu_count()`, thus the fork count is correct by default.

The briefing now renders the step resources with the one rule: workers times threads must not go above the quota. The sandbox prompt tells the agent to raise a pool per command through the `env` of `execute_command`. A survey pass over all 20 skills added one library-specific line where the new defaults change behavior: thread-parallel methods (xgboost, PyWGCNA, MSstats/data.table, nlmixr2 SAEM, RDKit conformers, DADA2), worker knobs with hardcoded counts (MulticoreParam, mc.cores, n_jobs, gseapy threads), and one stale `n_jobs=-1` warning.

This is the industry convention. Snakemake sets the same names to `threads` with a default of 1. Biowulf, CSC, TACC, and FASRC default R to one thread. No runtime splits at fork time, and joblib under a value of 1 stays safe.

Notes for the reviewer:

- The safe default costs speed in one case: a thread-parallel step whose agent does not raise the pools runs on one core. The briefing and the prompt carry the rule against that.
- The `lint` failure in `src/providers/ai-sdk.test.ts` is on main and is not part of this change.
- The two sandbox specs now state the quota publication, the cpu files, and the swap limit.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits obey [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO.
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [ ] **Methods:** the method is stated, relevant literature cited where appropriate, and tool/library versions are pinned.
- [x] **Sandbox:** the security model is preserved. The change alters env defaults only. It grants no capability and no egress, and it lowers no resource limit.
- [x] **Provenance:** an earlier analysis stays reproducible. But a step that relied on the implicit thread count can now run with one thread, thus its wall time can grow.

https://claude.ai/code/session_01Ji4x1TwcZRuKJvtvpFgWbE
