### PR TITLE
fix(harness): forbid core-discovery choreography in a step description

### DIFF
--- a/harness/src/prompts/planner.ts
+++ b/harness/src/prompts/planner.ts
@@ -6,7 +6,14 @@ export function resourceEstimationSection(policy?: ResourcePolicy): string {
     const base = `Use the data context to estimate cpu and memoryGb for each step. Consider
 total file size, per-file sizes, feature x sample dimensions, and what the
 step actually does in memory. Be conservative — a 14 MB dataset does not
-need 18 GB of RAM.`;
+need 18 GB of RAM.
+
+The resources you declare are enforced by the runtime, not by the step.
+Do not put core-discovery or thread-tuning choreography into a step
+description: no cgroup reads, no nproc/detectCores() reconciliation, no
+claims about what CPU count the container reports. The runtime owns
+resource reporting; a step that benefits from parallelism relies on
+standard core detection and each library's defaults.`;
     if (!policy) {
         return `${base} If data size is unknown, default to cpu: 4, memoryGb: 8.`;
     }


### PR DESCRIPTION
## What & why

In staging analysis `01a04846` the planner wrote cgroup reads, a worker formula, and CPU-count reconciliation into the T2S1 step text. The sandbox runs under gVisor, and gVisor gives false values for those signals (quota `-1`, `nproc` 1, `/proc/cpuinfo` 2, `nproc --all` 16). The step lost turns on the mismatch and sized its workers to 2, while the pod had an enforced allocation of 8 CPUs. This change adds one rule to `resourceEstimationSection`: the planner must not put core-discovery or thread-tuning choreography into a step description, because the runtime owns resource reporting.

Notes for the reviewer:

- The briefing already withholds the `resources` block from the step agent (`prompts/briefing.ts`). This change closes the other channel, the free task text.
- Correct in-sandbox CPU reporting lands separately in platform-charts (the runsc `cpu-num-from-quota` spike). The two changes are independent, but the guidance here assumes that detection inside the sandbox is, or becomes, truthful.
- `bun run lint` reports one pre-existing `must-use-result` error in `src/providers/ai-sdk.test.ts:1378`, present on `main` and not touched here.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`). Typecheck passes. Lint has the one pre-existing error named above. Tests were not run for this prompt-string change.
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
