### PR TITLE
feat(harness): remove the cpu ConfigMap from the k8s backend

### DIFF
--- a/harness/openspec/specs/harness-sandbox-exec/spec.md
+++ b/harness/openspec/specs/harness-sandbox-exec/spec.md
@@ -165,33 +165,17 @@ step output so the workflow body holds it verbatim on replay.
 
 ### Requirement: The step quota is published inside the sandbox
 
-Both backends SHALL make the cpu quota of a step visible inside the sandbox.
-The backend SHALL cover `/proc/cpuinfo` and `/sys/devices/system/cpu/online`
-with files that describe `floor(cpu)` cores (minimum 1): a read-only bind mount
-on Docker, and a per-Job ConfigMap with `subPath` mounts on K8s. The ConfigMap
-SHALL carry the Job as its owner reference, thus the delete of the Job removes
-it. Teardown SHALL also delete it explicitly, for a ConfigMap that got no
-owner.
+The Docker backend SHALL make the cpu quota of a step visible inside the
+sandbox. It SHALL cover `/proc/cpuinfo` and `/sys/devices/system/cpu/online`
+with a read-only bind mount of files that describe `floor(cpu)` cores
+(minimum 1). The K8s backend SHALL NOT mount cpu files: the cluster runtime
+(gVisor with `cpu-num-from-quota` and `systemd-cgroup`) derives the guest
+core count and memory from the pod limits.
 
 Both backends SHALL inject the shared thread-limit env (`thread-env.ts`): the
 thread-pool variables at `1`, and the worker-count variables at `floor(cpu)`.
 The rationale and the exact variable set are in the docker-sandbox-provider
 spec ("The cpu quota is visible inside the container").
-
-#### Scenario: K8s cpu files ride in a Job-owned ConfigMap
-
-- **GIVEN** a K8s sandbox with resources `{ cpu: 2 }`
-- **WHEN** `sandbox.create` runs
-- **THEN** a ConfigMap named after the Job SHALL hold the `online` and `cpuinfo` files
-- **AND** its owner reference SHALL point at the Job
-- **AND** the pod SHALL mount each key with `subPath` over the kernel path
-
-#### Scenario: A ConfigMap failure fails the launch with its cause
-
-- **GIVEN** a service account without `configmaps` permissions
-- **WHEN** `sandbox.create` runs
-- **THEN** the launch SHALL fail with the `k8s.createNamespacedConfigMap` operation named
-- **AND** the created Job SHALL be cleaned up
 
 ### Requirement: submitExec is a DBOS step keyed on execId
 

--- a/harness/src/sandbox/k8s-client.test.ts
+++ b/harness/src/sandbox/k8s-client.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { BatchV1Api, CoreV1Api, V1ConfigMap, V1Job, V1Pod } from "@kubernetes/client-node";
+import type { BatchV1Api, CoreV1Api, V1Job, V1Pod } from "@kubernetes/client-node";
 
 import { createK8sSandboxOps, sanitizeLabelValue } from "./k8s-client.js";
 import { mintSandboxIdentity } from "./identity.js";
@@ -15,16 +15,9 @@ import { mintSandboxIdentity } from "./identity.js";
 const SESSION_PVC_ROOT = "/sessions";
 const resolveWorkspaceRoot = (analysisId: string) => `${SESSION_PVC_ROOT}/${analysisId}`;
 
-function stubApis(
-    podSequence: Array<Partial<V1Pod>>,
-    opts: { create409Times?: number; existingOwner?: string; configMap409?: boolean; configMapError?: { code: number } } = {},
-) {
+function stubApis(podSequence: Array<Partial<V1Pod>>, opts: { create409Times?: number; existingOwner?: string } = {}) {
     const createdJobs: V1Job[] = [];
     const deletedJobs: string[] = [];
-    const createdConfigMaps: V1ConfigMap[] = [];
-    const replacedConfigMaps: V1ConfigMap[] = [];
-    const deletedConfigMaps: string[] = [];
-    let configMap409 = opts.configMap409 ?? false;
     let podIdx = 0;
     let deletedError: { code: number } | null = null;
     let pending409 = opts.create409Times ?? 0;
@@ -64,23 +57,6 @@ function stubApis(
     } as unknown as BatchV1Api;
 
     const coreApi = {
-        createNamespacedConfigMap: async ({ body }: { namespace: string; body: V1ConfigMap }) => {
-            if (opts.configMapError) throw Object.assign(new Error("configmaps is forbidden"), opts.configMapError);
-            if (configMap409) {
-                configMap409 = false;
-                throw Object.assign(new Error("configmaps already exists"), { code: 409 });
-            }
-            createdConfigMaps.push(body);
-            return body;
-        },
-        readNamespacedConfigMap: async ({ name }: { namespace: string; name: string }) => ({ metadata: { name, resourceVersion: "7" } }),
-        replaceNamespacedConfigMap: async ({ body }: { namespace: string; name: string; body: V1ConfigMap }) => {
-            replacedConfigMaps.push(body);
-            return body;
-        },
-        deleteNamespacedConfigMap: async ({ name }: { namespace: string; name: string }) => {
-            deletedConfigMaps.push(name);
-        },
         listNamespacedPod: async (_args: { namespace: string; labelSelector?: string }) => {
             const pod = podSequence[Math.min(podIdx, podSequence.length - 1)];
             podIdx++;
@@ -93,9 +69,6 @@ function stubApis(
         coreApi,
         createdJobs,
         deletedJobs,
-        createdConfigMaps,
-        replacedConfigMaps,
-        deletedConfigMaps,
         setDeleteError: (err: { code: number } | null) => {
             deletedError = err;
         },
@@ -173,7 +146,7 @@ describe("k8s createSandbox", () => {
 
         const sessionVolume = podSpec.volumes!.find((v) => v.name === "session");
         expect(sessionVolume!.persistentVolumeClaim!.claimName).toBe("cortex-sessions");
-        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "libs", "refs", "cpu"]);
+        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "libs", "refs"]);
 
         const mounts = container.volumeMounts!;
         const ro = mounts.find((m) => m.name === "session" && m.mountPath === "/an-1")!;
@@ -506,7 +479,7 @@ describe("k8s createSandbox", () => {
         )._unsafeUnwrap();
 
         const podSpec = stub.createdJobs[0]!.spec!.template.spec!;
-        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session", "cpu"]);
+        expect(podSpec.volumes!.map((v) => v.name)).toEqual(["session"]);
         const mounts = podSpec.containers[0].volumeMounts!;
         expect(mounts.some((m) => m.mountPath.startsWith("/mnt"))).toBe(false);
         const env = podSpec.containers[0].env ?? [];
@@ -1061,105 +1034,5 @@ describe("k8s isAlive", () => {
             })
         )._unsafeUnwrap();
         expect(liveness).toEqual({ alive: false, oomKilled: true });
-    });
-});
-
-/** Three processor blocks, in the shape of a real `/proc/cpuinfo`. */
-const HOST_CPUINFO = [0, 1, 2].map((i) => `processor\t: ${i}\nmodel name\t: test cpu\n`).join("\n") + "\n";
-
-const RUNNING_POD = { status: { phase: "Running", podIP: "10.0.0.1" }, metadata: { name: "sbx-x-abc" } };
-
-function cpuOps(stub: ReturnType<typeof stubApis>, readHostCpuinfo: () => Promise<string | undefined>) {
-    return createK8sSandboxOps({
-        image: "sandbox-base:latest",
-        cortexBaseUrl: "https://cortex.example.com:443",
-        namespace: "sandbox",
-        sessionPvcRoot: SESSION_PVC_ROOT,
-        resolveWorkspaceRoot,
-        sessionPvc: "cortex-sessions",
-        batchApi: stub.batchApi,
-        coreApi: stub.coreApi,
-        readHostCpuinfo,
-        registerSandbox: async () => {},
-    });
-}
-
-const CPU_META = { runId: "run-1", stepId: "step-a", analysisId: "an-1", childWorkflowId: "run-1-0", resources: { cpu: 2, memoryGb: 4 } };
-
-describe("k8s cpu files", () => {
-    test("the cpu files ride in a ConfigMap owned by the Job and mount over the two kernel paths", async () => {
-        const stub = stubApis([RUNNING_POD]);
-        const ops = cpuOps(stub, async () => HOST_CPUINFO);
-
-        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
-
-        expect(stub.createdConfigMaps).toHaveLength(1);
-        const map = stub.createdConfigMaps[0]!;
-        expect(map.metadata!.name).toBe(ref.sandboxId);
-        expect(map.metadata!.ownerReferences).toEqual([{ apiVersion: "batch/v1", kind: "Job", name: ref.sandboxId, uid: "job-uid-1" }]);
-        expect(map.data!.online).toBe("0-1\n");
-        // Two of the three blocks of the host: the quota counts logical cores.
-        expect(map.data!.cpuinfo!.match(/^processor/gm)).toHaveLength(2);
-
-        const podSpec = stub.createdJobs[0]!.spec!.template.spec!;
-        expect(podSpec.volumes!.find((v) => v.name === "cpu")!.configMap!.name).toBe(ref.sandboxId);
-        const mounts = podSpec.containers[0]!.volumeMounts!.filter((m) => m.name === "cpu");
-        expect(mounts).toEqual([
-            { name: "cpu", mountPath: "/sys/devices/system/cpu/online", subPath: "online", readOnly: true },
-            { name: "cpu", mountPath: "/proc/cpuinfo", subPath: "cpuinfo", readOnly: true },
-        ]);
-    });
-
-    test("a harness host with no cpuinfo covers online only", async () => {
-        const stub = stubApis([RUNNING_POD]);
-        const ops = cpuOps(stub, async () => undefined);
-
-        (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
-
-        expect(stub.createdConfigMaps[0]!.data).toEqual({ online: "0-1\n" });
-        const mounts = stub.createdJobs[0]!.spec!.template.spec!.containers[0]!.volumeMounts!.filter((m) => m.name === "cpu");
-        expect(mounts.map((m) => m.mountPath)).toEqual(["/sys/devices/system/cpu/online"]);
-    });
-
-    test("a ConfigMap that exists already is replaced with the same data and the current owner", async () => {
-        const stub = stubApis([RUNNING_POD], { configMap409: true });
-        const ops = cpuOps(stub, async () => HOST_CPUINFO);
-
-        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
-
-        expect(stub.createdConfigMaps).toHaveLength(0);
-        expect(stub.replacedConfigMaps).toHaveLength(1);
-        const map = stub.replacedConfigMaps[0]!;
-        expect(map.metadata!.resourceVersion).toBe("7");
-        expect(map.metadata!.ownerReferences![0]!.uid).toBe("job-uid-1");
-        expect(map.metadata!.name).toBe(ref.sandboxId);
-        expect(map.data!.online).toBe("0-1\n");
-    });
-
-    test("a ConfigMap failure deletes the Job and fails the create with the real cause", async () => {
-        const stub = stubApis([RUNNING_POD], { configMapError: { code: 403 } });
-        const ops = cpuOps(stub, async () => HOST_CPUINFO);
-
-        const error = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1"))).match(
-            () => {
-                throw new Error("the create must fail");
-            },
-            (e) => e,
-        );
-
-        expect(error.type).toBe("container_create_failed");
-        expect(error.op).toBe("k8s.createNamespacedConfigMap");
-        expect(stub.deletedJobs).toHaveLength(1);
-    });
-
-    test("teardown deletes the ConfigMap with the Job", async () => {
-        const stub = stubApis([RUNNING_POD]);
-        const ops = cpuOps(stub, async () => HOST_CPUINFO);
-
-        const ref = (await ops.createSandbox(CPU_META, mintSandboxIdentity("run-1")))._unsafeUnwrap();
-        (await ops.teardown(ref))._unsafeUnwrap();
-
-        expect(stub.deletedJobs).toEqual([ref.sandboxId]);
-        expect(stub.deletedConfigMaps).toEqual([ref.sandboxId]);
     });
 });

--- a/harness/src/sandbox/k8s-client.ts
+++ b/harness/src/sandbox/k8s-client.ts
@@ -18,7 +18,6 @@ import {
     BatchV1Api,
     CoreV1Api,
     KubeConfig,
-    type V1ConfigMap,
     type V1Job,
     type V1ObjectMeta,
     type V1PodSpec,
@@ -32,7 +31,6 @@ import type { ResolveWorkspaceRoot } from "../workspace/paths.js";
 import { type SandboxError, trySandbox } from "./sandbox-error.js";
 import { buildMountPlan, buildSessionSubPaths } from "./mount-plan.js";
 import { threadLimitEnv } from "./thread-env.js";
-import { CPU_ONLINE_PATH, CPUINFO_PATH, type CpuFiles, cpuFiles, readHostCpuinfoOnce } from "./cpu-files.js";
 import type { CreateSandboxMeta, ManagedSandbox, SandboxIdentity, SandboxLiveness, SandboxRef, SandboxTransport } from "./types.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
@@ -45,8 +43,6 @@ function statusOf(e: SandboxError): number | undefined {
 const SESSION_VOLUME_NAME = "session";
 const LIBS_VOLUME_NAME = "libs";
 const REFS_VOLUME_NAME = "refs";
-/** The ConfigMap volume that holds the two cpu files of the sandbox (`cpu-files.ts`). */
-const CPU_VOLUME_NAME = "cpu";
 
 const SANDBOX_SERVER_PORT = 8765;
 const POD_READY_TIMEOUT_MS = 5 * 60_000;
@@ -120,33 +116,10 @@ export interface K8sClientConfig {
     tolerations?: V1Toleration[];
     /** RuntimeClass for runtime isolation (e.g. `gvisor`). Omit for the default runtime. */
     runtimeClassName?: string;
-    /**
-     * The `/proc/cpuinfo` text that the cpu ConfigMap of each Job is cut from.
-     * Defaults to the file of the host of this process, read once. Injected for tests.
-     */
-    readHostCpuinfo?: () => Promise<string | undefined>;
     /** Injected for tests. */
     batchApi?: BatchV1Api;
     coreApi?: CoreV1Api;
     registerSandbox: (meta: CreateSandboxMeta, ref: SandboxRef) => Promise<void>;
-}
-
-function deleteConfigMapIgnoreMissing(coreApi: CoreV1Api, namespace: string, name: string): ResultAsync<void, SandboxError> {
-    return trySandbox(
-        async () => {
-            await coreApi.deleteNamespacedConfigMap({ namespace, name });
-        },
-        (status, cause) => ({
-            type: "teardown_failed",
-            op: "k8s.teardown",
-            sandboxId: name,
-            status,
-            cause,
-        }),
-    ).orElse((e) =>
-        // A 404 means the owner reference removed it with the Job already.
-        statusOf(e) === 404 ? ok(undefined) : err(e),
-    );
 }
 
 function deleteJobIgnoreMissing(batchApi: BatchV1Api, namespace: string, name: string): ResultAsync<void, SandboxError> {
@@ -203,13 +176,7 @@ function workspaceSubPathFor(config: K8sClientConfig, analysisId: string): strin
     return posix;
 }
 
-/** Which of the two kernel paths the cpu ConfigMap of a Job covers. */
-interface CpuMount {
-    /** `false` on a harness host with no `/proc/cpuinfo`: the pod then covers `online` only. */
-    hasCpuinfo: boolean;
-}
-
-function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity, cpu: CpuMount): V1Job {
+function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity: SandboxIdentity): V1Job {
     const { sandboxId } = identity;
     const plan = buildMountPlan(meta, {
         libs: !!config.libStorePvc,
@@ -294,17 +261,6 @@ function buildJobSpec(meta: CreateSandboxMeta, config: K8sClientConfig, identity
             mountPath: plan.refsPath,
             readOnly: true,
         });
-    }
-
-    // The cpu files ride in a ConfigMap named after the Job (`ensureCpuConfigMap`).
-    // A `subPath` mount of one key over one kernel path is accepted by the API
-    // server, the kubelet, and gVisor. Under gVisor the sandbox sees no cgroup
-    // at all, thus these two files are the only source of the quota for
-    // `parallel::detectCores()` and `os.cpu_count()`.
-    volumes.push({ name: CPU_VOLUME_NAME, configMap: { name: sandboxId } });
-    volumeMounts.push({ name: CPU_VOLUME_NAME, mountPath: CPU_ONLINE_PATH, subPath: "online", readOnly: true });
-    if (cpu.hasCpuinfo) {
-        volumeMounts.push({ name: CPU_VOLUME_NAME, mountPath: CPUINFO_PATH, subPath: "cpuinfo", readOnly: true });
     }
 
     const podSpec: V1PodSpec = {
@@ -504,9 +460,6 @@ function waitForJobGone(batchApi: BatchV1Api, namespace: string, name: string): 
  * means an (astronomically rare) name collision with a *different* step —
  * adopting its pod would HMAC-fail every callback, and deleting its Job would
  * kill a live sibling. Refuse loudly instead.
- *
- * The result is the uid of the Job that the pod belongs to, for the owner
- * reference of the cpu ConfigMap.
  */
 function createOrAdoptJob(
     batchApi: BatchV1Api,
@@ -515,7 +468,7 @@ function createOrAdoptJob(
     sandboxId: string,
     ownerWorkflowId: string,
     job: V1Job,
-): ResultAsync<string | undefined, SandboxError> {
+): ResultAsync<void, SandboxError> {
     const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
         type: "container_create_failed",
         op: "k8s.createNamespacedJob",
@@ -526,7 +479,7 @@ function createOrAdoptJob(
     return new ResultAsync(
         (async () => {
             const created = await trySandbox(() => batchApi.createNamespacedJob({ namespace, body: job }), createFailed);
-            if (created.isOk()) return ok(created.value?.metadata?.uid);
+            if (created.isOk()) return ok(undefined);
             if (statusOf(created.error) !== 409) return err(created.error);
 
             const existingRead = await trySandbox(() => batchApi.readNamespacedJob({ namespace, name: sandboxId }), createFailed);
@@ -550,77 +503,8 @@ function createOrAdoptJob(
                 if (gone.isErr()) return err(gone.error);
                 const recreated = await trySandbox(() => batchApi.createNamespacedJob({ namespace, body: job }), createFailed);
                 if (recreated.isErr()) return err(recreated.error);
-                return ok(recreated.value?.metadata?.uid);
+                return ok(undefined);
             }
-            return ok(existingRead.value.metadata?.uid);
-        })(),
-    );
-}
-
-/**
- * Make the cpu ConfigMap of a Job, or bring an existing one up to date.
- *
- * The ConfigMap comes after the Job, because the Job is its owner. Thus the
- * TTL of the Job and a Foreground delete both remove the ConfigMap with it.
- * The pod waits at its mount until the ConfigMap exists, and that wait is
- * shorter than the schedule of the pod.
- *
- * A `409 AlreadyExists` is the recovery re-run of the spawn step, or a
- * ConfigMap whose prior owner Job is not yet collected. Both cases get the
- * same data and the current owner through a replace.
- */
-function ensureCpuConfigMap(
-    coreApi: CoreV1Api,
-    namespace: string,
-    sandboxId: string,
-    jobUid: string | undefined,
-    files: CpuFiles,
-): ResultAsync<void, SandboxError> {
-    const createFailed = (status: number | undefined, cause: unknown): SandboxError => ({
-        type: "container_create_failed",
-        op: "k8s.createNamespacedConfigMap",
-        sandboxId,
-        status,
-        cause,
-    });
-    const body: V1ConfigMap = {
-        apiVersion: "v1",
-        kind: "ConfigMap",
-        metadata: {
-            name: sandboxId,
-            namespace,
-            labels: {
-                [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
-                role: "sandbox",
-                "cortex/sandbox-id": sandboxId,
-            },
-            ...(jobUid !== undefined && {
-                ownerReferences: [{ apiVersion: "batch/v1", kind: "Job", name: sandboxId, uid: jobUid }],
-            }),
-        },
-        data: {
-            online: files.online,
-            ...(files.cpuinfo !== undefined && { cpuinfo: files.cpuinfo }),
-        },
-    };
-    return new ResultAsync(
-        (async () => {
-            const created = await trySandbox(() => coreApi.createNamespacedConfigMap({ namespace, body }), createFailed);
-            if (created.isOk()) return ok(undefined);
-            if (statusOf(created.error) !== 409) return err(created.error);
-
-            const existing = await trySandbox(() => coreApi.readNamespacedConfigMap({ namespace, name: sandboxId }), createFailed);
-            if (existing.isErr()) return err(existing.error);
-            const replaced = await trySandbox(
-                () =>
-                    coreApi.replaceNamespacedConfigMap({
-                        namespace,
-                        name: sandboxId,
-                        body: { ...body, metadata: { ...body.metadata, resourceVersion: existing.value.metadata?.resourceVersion } },
-                    }),
-                createFailed,
-            );
-            if (replaced.isErr()) return err(replaced.error);
             return ok(undefined);
         })(),
     );
@@ -635,29 +519,16 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
     listManagedSandboxes(): ResultAsync<ManagedSandbox[], SandboxError>;
 } {
     const { batchApi, coreApi } = config.batchApi && config.coreApi ? { batchApi: config.batchApi, coreApi: config.coreApi } : buildKubeApi();
-    const readHostCpuinfo = config.readHostCpuinfo ?? readHostCpuinfoOnce;
 
     return {
         createSandbox(meta, identity) {
             return new ResultAsync(
                 (async () => {
                     const { sandboxId } = identity;
-                    // The same floor as `threadLimitEnv`: a fraction of a core still
-                    // keeps one thread busy, and a count of zero is not representable.
-                    const threads = Math.max(1, Math.floor(meta.resources.cpu));
-                    const files = cpuFiles(threads, await readHostCpuinfo());
-                    const job = buildJobSpec(meta, config, identity, { hasCpuinfo: files.cpuinfo !== undefined });
+                    const job = buildJobSpec(meta, config, identity);
 
                     const adopted = await createOrAdoptJob(batchApi, coreApi, config.namespace, sandboxId, meta.childWorkflowId, job);
                     if (adopted.isErr()) return err(adopted.error);
-
-                    const cpuMap = await ensureCpuConfigMap(coreApi, config.namespace, sandboxId, adopted.value, files);
-                    if (cpuMap.isErr()) {
-                        // A pod whose ConfigMap never comes stays at ContainerCreating
-                        // until the ready wait expires. Fail now, with the real cause.
-                        await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
-                        return err(cpuMap.error);
-                    }
 
                     // A Job whose pod never schedules (quota rejection, no nodes, spot
                     // reclaim) is reaped by neither backoffLimit (an admission rejection
@@ -685,29 +556,23 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
                             }),
                         );
                         if (registered.isErr()) {
-                            await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
+                            await cleanupFailedJob(batchApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
                             return err(registered.error);
                         }
                         return ok(ref);
                     }
-                    await cleanupFailedJob(batchApi, coreApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
+                    await cleanupFailedJob(batchApi, config.namespace, sandboxId, config.logger ?? createNoopLogger());
                     return err(ready.error);
                 })(),
             );
         },
 
-        // The owner reference removes the cpu ConfigMap with the Job. The explicit
-        // delete covers a ConfigMap that got no owner, and it is a no-op on 404.
         teardown(ref) {
-            return deleteJobIgnoreMissing(batchApi, config.namespace, ref.sandboxId).andThen(() =>
-                deleteConfigMapIgnoreMissing(coreApi, config.namespace, ref.sandboxId),
-            );
+            return deleteJobIgnoreMissing(batchApi, config.namespace, ref.sandboxId);
         },
 
         teardownById(sandboxId) {
-            return deleteJobIgnoreMissing(batchApi, config.namespace, sandboxId).andThen(() =>
-                deleteConfigMapIgnoreMissing(coreApi, config.namespace, sandboxId),
-            );
+            return deleteJobIgnoreMissing(batchApi, config.namespace, sandboxId);
         },
 
         listManagedSandboxes() {
@@ -786,13 +651,9 @@ export function createK8sSandboxOps(config: K8sClientConfig): {
  * matters; a delete error here is logged and swallowed so it never masks the
  * create error returned to the caller.
  */
-async function cleanupFailedJob(batchApi: BatchV1Api, coreApi: CoreV1Api, namespace: string, sandboxId: string, logger: Logger): Promise<void> {
+async function cleanupFailedJob(batchApi: BatchV1Api, namespace: string, sandboxId: string, logger: Logger): Promise<void> {
     const deleted = await deleteJobIgnoreMissing(batchApi, namespace, sandboxId);
     if (deleted.isErr()) {
         logger.named("k8s-client").error("failed to delete Job after startup failure", { sandboxId, err: deleted.error });
-    }
-    const deletedMap = await deleteConfigMapIgnoreMissing(coreApi, namespace, sandboxId);
-    if (deletedMap.isErr()) {
-        logger.named("k8s-client").error("failed to delete cpu ConfigMap after startup failure", { sandboxId, err: deletedMap.error });
     }
 }


### PR DESCRIPTION
## What & why

The k8s backend put the cpu files of each sandbox Job in a per-Job ConfigMap. It mounted the `online` and `cpuinfo` keys with `subPath` over the two kernel paths (#472). The cluster runtime now makes that redundant: the gvisor-installer sets `cpu-num-from-quota` and `systemd-cgroup` in runsc.toml (platform-charts#70), and runsc then derives the guest core count and the guest memory from the pod limits. A staging probe after that merge saw nproc 4 and MemTotal 1 GiB for limits of cpu 4 and memory 1Gi. This change removes the ConfigMap path from `k8s-client.ts`, with its tests and the spec passage.

Notes for the reviewer:

- The Docker backend keeps its bind of the cpu files, because runc shows the host `/proc/cpuinfo` to the container.
- `thread-env.ts` stays in both backends. It pins each pool to one thread, and a correct core count does not remove that concern.
- The `configmaps` RBAC grant in platform-charts becomes dead after this lands. A separate platform-charts PR reverts it.
- `K8sClientConfig` loses the `readHostCpuinfo` field. The cortex embedder does not pass it, so no embedder change is necessary.
- `bun run lint` reports one pre-existing `must-use-result` error in `src/providers/ai-sdk.test.ts:1378`, present on `main` and not touched here.

## Type of change

- [x] Refactor / internal change
- [x] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally. Typecheck passes. The sandbox suites pass (71 tests). Lint has the one pre-existing error named above.
- [x] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow Conventional Commits.
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

## For analytical method / sandbox / provenance changes

- [x] **Sandbox:** the security model is preserved. The change removes a mount and an API surface, and it adds nothing.
