### PR TITLE
fix(cli): the daily limit on the ask, not on the read

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -63,9 +63,10 @@ for (const signal of ["SIGTERM", "SIGHUP"] as const) {
 getLogger("main").info({ argv: process.argv.slice(2) }, "cli start");
 
 // Started BEFORE the command and read AFTER it, so the read overlaps the work a person asked for instead
-// of delaying it. It resolves from a recorded answer on all but one run a day, and it never rejects — see
-// modules/update/latest.ts for every condition that makes it "nothing to report". The TUI is not covered
-// here: it exits through its own shutdown() and asks its own question (tui/app.launch.tsx).
+// of delaying it. It reads the network at each startup, and it never rejects — see modules/update/latest.ts
+// for every condition that makes it "nothing to report". The once-a-day limit sits on the printed line
+// (modules/update/notice.ts), not on this read. The TUI is not covered here: it exits through its own
+// shutdown() and asks its own question (tui/app.launch.tsx).
 const updateRead = pendingUpdate();
 
 try {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,9 +64,9 @@ getLogger("main").info({ argv: process.argv.slice(2) }, "cli start");
 
 // Started BEFORE the command and read AFTER it, so the read overlaps the work a person asked for instead
 // of delaying it. It reads the network at each startup, and it never rejects — see modules/update/latest.ts
-// for every condition that makes it "nothing to report". The once-a-day limit sits on the printed line
-// (modules/update/notice.ts), not on this read. The TUI is not covered here: it exits through its own
-// shutdown() and asks its own question (tui/app.launch.tsx).
+// for every condition that makes it "nothing to report". The printed line shows at each run; only the ask
+// dialog of the TUI holds a once-a-day record (modules/update/notice.ts). The TUI is not covered here: it
+// exits through its own shutdown() and asks its own question (tui/app.launch.tsx).
 const updateRead = pendingUpdate();
 
 try {

--- a/cli/src/lib/env.ts
+++ b/cli/src/lib/env.ts
@@ -296,13 +296,13 @@ export const env = Object.freeze({
      */
     locksDir: join(dataDir(), "inflexa", "locks"),
     /**
-     * The record of the last release-version read: when it ran, and the newest version it saw. See
-     * src/modules/update/latest.ts, which reads it to hold the network read to once a day.
+     * The record of the last shown update ask: when it showed, and the release it named. See
+     * src/modules/update/notice.ts, which reads it to hold the ask to one time a day.
      *
      * Deliberately NOT channel-forked, unlike the stack paths above: a development build never reads for
      * a new release, so a production binary is the only writer this file can have and the two channels
-     * cannot collide here. Losing it costs one extra network read, so nothing downstream treats an
-     * unreadable file as an error.
+     * cannot collide here. Losing it costs one extra ask, so nothing downstream treats an unreadable
+     * file as an error.
      */
     updateStatePath: join(dataDir(), "inflexa", "update-state.json"),
     /**
@@ -534,7 +534,7 @@ export const envDoc: Readonly<
     updateStatePath: {
         kind: "path",
         label: "update state",
-        description: "when inflexa last read for a new release, and the newest version it saw",
+        description: "when inflexa last showed the update ask, and the release it named",
         baseVar: dataVar,
     },
     modelDir: { kind: "path", label: "models", description: "local embedding GGUF models, downloaded by `inflexa setup --embeddings`", baseVar: dataVar },

--- a/cli/src/modules/update/latest.test.ts
+++ b/cli/src/modules/update/latest.test.ts
@@ -1,9 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { describe, expect, test } from "bun:test";
 
 import pkg from "../../../package.json";
-import { env } from "../../lib/env.ts";
 import type { FetchLike } from "../../lib/download.ts";
 import { fetchLatestVersion, isNewerVersion, readNewerVersion, updateReadAllowed } from "./latest.ts";
 
@@ -11,16 +8,6 @@ import { fetchLatestVersion, isNewerVersion, readNewerVersion, updateReadAllowed
 function redirectTo(version: string): FetchLike {
     return async () => new Response(null, { status: 302, headers: { location: `https://github.com/inflexa-ai/inflexa/releases/tag/v${version}` } });
 }
-
-/** Record a read of `version` at `at`, the way a previous run would have left it. */
-function recordRead(version: string, at: number): void {
-    mkdirSync(dirname(env.updateStatePath), { recursive: true });
-    writeFileSync(env.updateStatePath, JSON.stringify({ checkedAt: at, version }));
-}
-
-afterEach(() => {
-    rmSync(env.updateStatePath, { force: true });
-});
 
 describe("isNewerVersion", () => {
     test("ranks by major, then minor, then patch", () => {
@@ -78,61 +65,22 @@ describe("updateReadAllowed", () => {
 });
 
 describe("readNewerVersion", () => {
-    test("a recorded read from within the day answers without touching the network", async () => {
-        const now = 1_000_000_000_000;
-        recordRead("99.0.0", now - 60_000);
-        const found = await readNewerVersion({
-            now,
-            fetch: () => {
-                throw new Error("the network must not be read");
-            },
-        });
-        expect(found).toBe("99.0.0");
+    test("a newer release than the running version is the answer", async () => {
+        expect(await readNewerVersion(redirectTo("99.1.0"))).toBe("99.1.0");
     });
 
-    test("a recorded read older than a day is read again", async () => {
-        const now = 1_000_000_000_000;
-        recordRead("0.0.1", now - 25 * 60 * 60 * 1000);
-        expect(await readNewerVersion({ now, fetch: redirectTo("99.1.0") })).toBe("99.1.0");
+    test("a release that is not newer is nothing to say", async () => {
+        expect(await readNewerVersion(redirectTo(pkg.version))).toBeNull();
     });
 
-    test("a read that finds nothing newer answers null and still holds the next read for a day", async () => {
-        const now = 1_000_000_000_000;
-        expect(await readNewerVersion({ now, fetch: redirectTo(pkg.version) })).toBeNull();
-
-        // The record's job is to hold the NEXT read, and that job does not depend on what this one found.
-        const later = await readNewerVersion({
-            now: now + 60_000,
-            fetch: () => {
-                throw new Error("the network must not be read");
-            },
-        });
-        expect(later).toBeNull();
+    test("a failed read is nothing to say, never a failure", async () => {
+        expect(await readNewerVersion(async () => new Response("", { status: 503 }))).toBeNull();
     });
 
-    test("a failed read answers null and records nothing, so the next run reads again", async () => {
-        const now = 1_000_000_000_000;
-        expect(
-            await readNewerVersion({
-                now,
-                fetch: async () => new Response("", { status: 503 }),
-            }),
-        ).toBeNull();
-
-        let reads = 0;
-        await readNewerVersion({
-            now: now + 60_000,
-            fetch: (...args) => {
-                reads += 1;
-                return redirectTo("99.2.0")(...args);
-            },
-        });
-        expect(reads).toBe(1);
-    });
-
-    test("an unreadable record costs one network read, never a failure", async () => {
-        mkdirSync(dirname(env.updateStatePath), { recursive: true });
-        writeFileSync(env.updateStatePath, "{ this is not json");
-        expect(await readNewerVersion({ now: 1_000_000_000_000, fetch: redirectTo("99.3.0") })).toBe("99.3.0");
+    test("the network is read at each call, so a same-day release is seen", async () => {
+        // No record holds the second call: a release that lands after the first read of the day must
+        // not wait out that day.
+        expect(await readNewerVersion(redirectTo(pkg.version))).toBeNull();
+        expect(await readNewerVersion(redirectTo("99.1.0"))).toBe("99.1.0");
     });
 });

--- a/cli/src/modules/update/latest.ts
+++ b/cli/src/modules/update/latest.ts
@@ -1,8 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
-
 import { err, ok, Result, ResultAsync } from "neverthrow";
-import { z } from "zod";
 
 import pkg from "../../../package.json";
 import { env, updateNoticeSuppressed } from "../../lib/env.ts";
@@ -18,9 +14,6 @@ export const RELEASE_REPO = "inflexa-ai/inflexa";
  * page is a plain redirect that no rate limit covers.
  */
 export const RELEASES_LATEST_URL = `https://github.com/${RELEASE_REPO}/releases/latest`;
-
-/** How long a recorded read stays good. One day, the interval `gh` and `update-notifier` settled on. */
-const READ_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * How long the read may take before it is abandoned. It is short because a command the person actually
@@ -86,40 +79,6 @@ export async function fetchLatestVersion(fetchImpl: FetchLike = fetch): Promise<
     return ok(`${version.major}.${version.minor}.${version.patch}`);
 }
 
-/** The on-disk record of the last read. `version` is the newest release that read saw, not the running one. */
-const updateStateSchema = z.object({ checkedAt: z.number(), version: z.string() });
-
-type UpdateState = z.infer<typeof updateStateSchema>;
-
-/**
- * The recorded read, or `null`. Absence is the NORMAL condition — no run has read yet — so every fault
- * resolves to `null`: no file, bad bytes, a foreign schema. The cost of an unreadable record is one extra
- * network read, never a failure.
- */
-function readState(): UpdateState | null {
-    return Result.fromThrowable(
-        () => updateStateSchema.safeParse(JSON.parse(readFileSync(env.updateStatePath, "utf8"))),
-        () => undefined,
-    )().match(
-        (parsed) => (parsed.success ? parsed.data : null),
-        () => null,
-    );
-}
-
-/** Record `version` as what the read at `now` saw. A write fault is swallowed for the reason {@link readState} gives. */
-function writeState(version: string, now: number): void {
-    Result.fromThrowable(
-        () => {
-            mkdirSync(dirname(env.updateStatePath), { recursive: true });
-            writeFileSync(env.updateStatePath, JSON.stringify({ checkedAt: now, version } satisfies UpdateState, null, 4) + "\n");
-        },
-        () => undefined,
-    )().match(
-        () => undefined,
-        () => undefined,
-    );
-}
-
 /**
  * Whether this build may look for a newer release at all. Each condition names a build that CANNOT be
  * compared against the release page, or a run that must stay quiet:
@@ -138,9 +97,10 @@ export function updateReadAllowed(compiled: boolean, development: boolean, suppr
 /**
  * The newest released version when it is later than the running one, else `null`.
  *
- * At most one network read a day, and the recorded answer serves every run in between. This is the whole
- * reason the record exists: a person runs `inflexa` many times an hour, and a network read on each of
- * them would be both slow and rude to the host.
+ * The network read runs at each call, thus at each startup. As a result a release from the same day is
+ * visible at the next start. The once-a-day limit sits on the ASK, not on this read — `claimDailyAsk` in
+ * notice.ts keeps that record. The read overlaps the command that the person asked for (src/index.ts),
+ * and READ_TIMEOUT_MS caps what it can cost.
  *
  * Never gives an error. A caller uses this to decorate a run it does not own, so a failed read must read
  * as "nothing to say" — the `infra-state-resilience` spec states the same rule for the stack state.
@@ -148,29 +108,16 @@ export function updateReadAllowed(compiled: boolean, development: boolean, suppr
  * Separate from {@link pendingUpdate} only by the gate above it. A caller in the product always wants the
  * gate, so it always calls the other one.
  */
-export async function readNewerVersion(options: { readonly fetch?: FetchLike; readonly now?: number } = {}): Promise<string | null> {
-    const now = options.now ?? Date.now();
-    const recorded = readState();
-    if (recorded !== null && now - recorded.checkedAt < READ_INTERVAL_MS) {
-        return isNewerVersion(recorded.version, pkg.version) ? recorded.version : null;
-    }
-
-    const latest = await fetchLatestVersion(options.fetch ?? fetch);
+export async function readNewerVersion(fetchImpl: FetchLike = fetch): Promise<string | null> {
+    const latest = await fetchLatestVersion(fetchImpl);
     return latest.match(
-        (version) => {
-            // Recorded even when it equals the running version: the record's job is to hold the NEXT read
-            // for a day, and that job is the same whether or not this read found anything new.
-            writeState(version, now);
-            return isNewerVersion(version, pkg.version) ? version : null;
-        },
-        // A failed read writes nothing, so the next run reads again rather than waiting out the day on an
-        // answer that never arrived.
+        (version) => (isNewerVersion(version, pkg.version) ? version : null),
         () => null,
     );
 }
 
 /** The gated read: {@link readNewerVersion} unless {@link updateReadAllowed} says this build must stay quiet. */
-export async function pendingUpdate(options: { readonly fetch?: FetchLike; readonly now?: number } = {}): Promise<string | null> {
+export async function pendingUpdate(fetchImpl: FetchLike = fetch): Promise<string | null> {
     if (!updateReadAllowed(isCompiledBinary(), env.isDevelopment, updateNoticeSuppressed())) return null;
-    return readNewerVersion(options);
+    return readNewerVersion(fetchImpl);
 }

--- a/cli/src/modules/update/notice.test.ts
+++ b/cli/src/modules/update/notice.test.ts
@@ -64,12 +64,11 @@ describe("printUpdateNotice", () => {
         expect(out).toContain("git pull");
     });
 
-    test("prints one time inside a day, and a run with no terminal does not burn the day", () => {
+    test("prints at each run, with no daily hold", () => {
+        // The line is passive, so the once-a-day record of the TUI dialog does not cover it.
         __setCompiledBinaryForTest(true);
-        // The no-terminal run shows nothing, so the ask record must stay untouched.
-        expect(captureStderr(false, () => printUpdateNotice("99.0.0"))).toBe("");
         expect(captureStderr(true, () => printUpdateNotice("99.0.0"))).toContain("99.0.0");
-        expect(captureStderr(true, () => printUpdateNotice("99.0.0"))).toBe("");
+        expect(captureStderr(true, () => printUpdateNotice("99.0.0"))).toContain("99.0.0");
     });
 });
 

--- a/cli/src/modules/update/notice.test.ts
+++ b/cli/src/modules/update/notice.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 import pkg from "../../../package.json";
+import { env } from "../../lib/env.ts";
 import { __setCompiledBinaryForTest } from "../../lib/install_context.ts";
-import { __releaseUpdateNoticeClaimForTest, claimUpdateNotice, printUpdateNotice, updateOffer } from "./notice.ts";
+import { __releaseUpdateNoticeClaimForTest, claimDailyAsk, claimUpdateNotice, printUpdateNotice, updateOffer } from "./notice.ts";
 
 const realWrite = process.stderr.write.bind(process.stderr);
 const realIsTTY = process.stderr.isTTY;
@@ -24,6 +27,7 @@ afterEach(() => {
     Object.defineProperty(process.stderr, "isTTY", { value: realIsTTY, configurable: true });
     __setCompiledBinaryForTest(null);
     __releaseUpdateNoticeClaimForTest();
+    rmSync(env.updateStatePath, { force: true });
 });
 
 describe("printUpdateNotice", () => {
@@ -58,6 +62,50 @@ describe("printUpdateNotice", () => {
         __setCompiledBinaryForTest(false);
         const out = captureStderr(true, () => printUpdateNotice("99.0.0"));
         expect(out).toContain("git pull");
+    });
+
+    test("prints one time inside a day, and a run with no terminal does not burn the day", () => {
+        __setCompiledBinaryForTest(true);
+        // The no-terminal run shows nothing, so the ask record must stay untouched.
+        expect(captureStderr(false, () => printUpdateNotice("99.0.0"))).toBe("");
+        expect(captureStderr(true, () => printUpdateNotice("99.0.0"))).toContain("99.0.0");
+        expect(captureStderr(true, () => printUpdateNotice("99.0.0"))).toBe("");
+    });
+});
+
+describe("claimDailyAsk", () => {
+    const now = 1_000_000_000_000;
+
+    test("the first ask passes, and it holds the same version for a day", () => {
+        expect(claimDailyAsk("99.0.0", now)).toBe(true);
+        expect(claimDailyAsk("99.0.0", now + 60_000)).toBe(false);
+        expect(claimDailyAsk("99.0.0", now + 25 * 60 * 60 * 1000)).toBe(true);
+    });
+
+    test("a newer release passes inside the day, so a same-day release does not wait", () => {
+        expect(claimDailyAsk("99.0.0", now)).toBe(true);
+        expect(claimDailyAsk("99.0.1", now + 60_000)).toBe(true);
+    });
+
+    test("a refused claim keeps the record, so the day counts from the shown ask", () => {
+        expect(claimDailyAsk("99.0.0", now)).toBe(true);
+        expect(claimDailyAsk("99.0.0", now + 23 * 60 * 60 * 1000)).toBe(false);
+        // 24 hours after the refused claim, but 47 after the shown one: the day ended, so it passes.
+        expect(claimDailyAsk("99.0.0", now + 47 * 60 * 60 * 1000)).toBe(true);
+    });
+
+    test("an unreadable record costs one extra ask, never a failure", () => {
+        mkdirSync(dirname(env.updateStatePath), { recursive: true });
+        writeFileSync(env.updateStatePath, "{ this is not json");
+        expect(claimDailyAsk("99.0.0", now)).toBe(true);
+    });
+
+    test("a record from the old shape reads as no record", () => {
+        // A machine that updates across this change holds `{checkedAt, version}`. That shape must cost
+        // one extra ask, not a failure and not a held ask.
+        mkdirSync(dirname(env.updateStatePath), { recursive: true });
+        writeFileSync(env.updateStatePath, JSON.stringify({ checkedAt: now - 60_000, version: "99.0.0" }));
+        expect(claimDailyAsk("99.0.0", now)).toBe(true);
     });
 });
 

--- a/cli/src/modules/update/notice.ts
+++ b/cli/src/modules/update/notice.ts
@@ -1,5 +1,68 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { Result } from "neverthrow";
+import { z } from "zod";
+
 import pkg from "../../../package.json";
+import { env } from "../../lib/env.ts";
 import { installChannel, upgradeInstruction, type InstallChannel } from "./channel.ts";
+import { isNewerVersion } from "./latest.ts";
+
+/** How long one shown ask holds the next one. One day, the interval `gh` and `update-notifier` settled on. */
+const ASK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** The on-disk record of the last shown ask. `version` is the release that the ask named. */
+const askStateSchema = z.object({ promptedAt: z.number(), version: z.string() });
+
+type AskState = z.infer<typeof askStateSchema>;
+
+/**
+ * The recorded ask, or `null`. Absence is the NORMAL condition — no run showed an ask yet — so every
+ * fault resolves to `null`: no file, bad bytes, a foreign schema. The cost of an unreadable record is
+ * one extra ask, never a failure.
+ */
+function readAskState(): AskState | null {
+    return Result.fromThrowable(
+        () => askStateSchema.safeParse(JSON.parse(readFileSync(env.updateStatePath, "utf8"))),
+        () => undefined,
+    )().match(
+        (parsed) => (parsed.success ? parsed.data : null),
+        () => null,
+    );
+}
+
+/** Record `version` as what the ask at `now` named. A write fault is swallowed for the reason {@link readAskState} gives. */
+function writeAskState(version: string, now: number): void {
+    Result.fromThrowable(
+        () => {
+            mkdirSync(dirname(env.updateStatePath), { recursive: true });
+            writeFileSync(env.updateStatePath, JSON.stringify({ promptedAt: now, version } satisfies AskState, null, 4) + "\n");
+        },
+        () => undefined,
+    )().match(
+        () => undefined,
+        () => undefined,
+    );
+}
+
+/**
+ * Whether a surface may show the ask for `version` now. A `true` also records the ask, thus the
+ * decision and the record are one step, and no caller can forget the write.
+ *
+ * A `version` newer than the recorded one passes inside the day. The read behind this runs at each
+ * startup (latest.ts), and a release from the same day must not wait behind a record about an older
+ * release.
+ *
+ * Call it only at the moment the message really shows. A claim from a run whose message a later guard
+ * drops would burn the day with nothing shown.
+ */
+export function claimDailyAsk(version: string, now: number = Date.now()): boolean {
+    const recorded = readAskState();
+    const allowed = recorded === null || isNewerVersion(version, recorded.version) || now - recorded.promptedAt >= ASK_INTERVAL_MS;
+    if (allowed) writeAskState(version, now);
+    return allowed;
+}
 
 /** What a surface with a person in front of it must do about a newer release. See {@link updateOffer}. */
 export type UpdateOffer =
@@ -48,9 +111,15 @@ export function __releaseUpdateNoticeClaimForTest(): void {
  *
  * Silent unless stderr is a terminal. A redirected stream is a file or a pipe that some other program
  * reads, and this text means nothing to it.
+ *
+ * Shown one time a day for a version ({@link claimDailyAsk}), because the person runs `inflexa` many
+ * times an hour and the same line on each run is noise.
  */
 export function printUpdateNotice(version: string | null): void {
     if (version === null || claimed || !process.stderr.isTTY) return;
+
+    // Behind the guards above, so a run whose message cannot show does not burn the day.
+    if (!claimDailyAsk(version)) return;
 
     // An installer install updates itself, so it gets the command that does that. Every other channel gets
     // the command of the tool that owns the file.

--- a/cli/src/modules/update/notice.ts
+++ b/cli/src/modules/update/notice.ts
@@ -47,15 +47,16 @@ function writeAskState(version: string, now: number): void {
 }
 
 /**
- * Whether a surface may show the ask for `version` now. A `true` also records the ask, thus the
- * decision and the record are one step, and no caller can forget the write.
+ * Whether the TUI may open the update dialog for `version` now. A `true` also records the ask, thus
+ * the decision and the record are one step, and no caller can forget the write.
  *
- * A `version` newer than the recorded one passes inside the day. The read behind this runs at each
- * startup (latest.ts), and a release from the same day must not wait behind a record about an older
- * release.
+ * Only the dialog is under this record, because a dialog interrupts. The stderr line and the TUI toast
+ * are passive, so they show at each run. A `version` newer than the recorded one passes inside the
+ * day: the read runs at each startup (latest.ts), and a same-day release must not wait behind a record
+ * about an older release.
  *
- * Call it only at the moment the message really shows. A claim from a run whose message a later guard
- * drops would burn the day with nothing shown.
+ * Call it only at the moment the dialog really opens. A claim that a later guard drops would burn the
+ * day with nothing shown.
  */
 export function claimDailyAsk(version: string, now: number = Date.now()): boolean {
     const recorded = readAskState();
@@ -112,14 +113,11 @@ export function __releaseUpdateNoticeClaimForTest(): void {
  * Silent unless stderr is a terminal. A redirected stream is a file or a pipe that some other program
  * reads, and this text means nothing to it.
  *
- * Shown one time a day for a version ({@link claimDailyAsk}), because the person runs `inflexa` many
- * times an hour and the same line on each run is noise.
+ * Shown at each run: one line on stderr does not interrupt, so it carries no daily record. The dialog
+ * of the TUI is the one surface under that record ({@link claimDailyAsk}).
  */
 export function printUpdateNotice(version: string | null): void {
     if (version === null || claimed || !process.stderr.isTTY) return;
-
-    // Behind the guards above, so a run whose message cannot show does not burn the day.
-    if (!claimDailyAsk(version)) return;
 
     // An installer install updates itself, so it gets the command that does that. Every other channel gets
     // the command of the tool that owns the file.

--- a/cli/src/modules/update/upgrade.ts
+++ b/cli/src/modules/update/upgrade.ts
@@ -10,9 +10,9 @@ import { fetchLatestVersion, isNewerVersion } from "./latest.ts";
 /**
  * `inflexa upgrade` — install the newest release, or name the command that does.
  *
- * The version read here is unconditional, and it deliberately ignores the once-a-day record that the
- * startup notice keeps (see latest.ts). A person who types this command is asking NOW, and an answer from
- * yesterday would be a wrong answer to that question.
+ * The version read here is unconditional, and its answer is not under the once-a-day ask record that the
+ * startup notice keeps (see notice.ts). A person who types this command is asking NOW, and the answer
+ * must show every time.
  */
 export async function upgrade(): Promise<void> {
     const channel = installChannel();

--- a/cli/src/tui/app.launch.tsx
+++ b/cli/src/tui/app.launch.tsx
@@ -119,14 +119,15 @@ async function renderChat(target: ChatTarget): Promise<void> {
 async function offerUpdate(): Promise<void> {
     const offer = updateOffer(await pendingUpdate(), installChannel());
     if (offer.kind === "none") return;
-    // One ask a day: the read above runs at each startup, and this claim is what keeps the dialog and
-    // the toast from opening on each launch. Claimed past the "none" gate, so only a shown message
-    // burns the day.
-    if (!claimDailyAsk(offer.version)) return;
     if (offer.kind === "tell") {
         notify({ kind: "info", text: `inflexa ${offer.version} is out. Update with: ${offer.instruction}` }, 8000, { queue: true });
         return;
     }
+
+    // One ask a day: the read above runs at each startup, and this claim is what keeps the dialog from
+    // opening on each launch. The toast above is not under the record, because a toast does not
+    // interrupt.
+    if (!claimDailyAsk(offer.version)) return;
 
     const version = offer.version;
     dialogPush(() => (

--- a/cli/src/tui/app.launch.tsx
+++ b/cli/src/tui/app.launch.tsx
@@ -23,7 +23,7 @@ import pkg from "../../package.json";
 import { applyErrorMessage, applyUpdate } from "../modules/update/apply.ts";
 import { installChannel } from "../modules/update/channel.ts";
 import { pendingUpdate } from "../modules/update/latest.ts";
-import { claimUpdateNotice, updateOffer } from "../modules/update/notice.ts";
+import { claimDailyAsk, claimUpdateNotice, updateOffer } from "../modules/update/notice.ts";
 
 // The TUI-entry layer: a thin render shim. All resolution/prompting/creation logic lives in
 // modules/analysis/launch.ts (headless, returns a ChatTarget); this file only makes the proxy
@@ -93,9 +93,9 @@ async function renderChat(target: ChatTarget): Promise<void> {
     void warmGrammars();
 
     // Offer the newest release, behind the same post-render fire-and-forget discipline as the two calls
-    // above. It reads from a recorded answer on all but one run a day, so it usually settles before the
-    // first frame; the dialog stack is module state, so a push that lands before the overlay mounts still
-    // renders once it does.
+    // above. The read goes to the network on each launch, with a short cap (modules/update/latest.ts);
+    // the dialog stack is module state, so a push that lands before the overlay mounts still renders
+    // once it does.
     void offerUpdate();
 
     // Boot the embedded harness runtime AFTER render() has the terminal (fire-and-forget, the same
@@ -119,6 +119,10 @@ async function renderChat(target: ChatTarget): Promise<void> {
 async function offerUpdate(): Promise<void> {
     const offer = updateOffer(await pendingUpdate(), installChannel());
     if (offer.kind === "none") return;
+    // One ask a day: the read above runs at each startup, and this claim is what keeps the dialog and
+    // the toast from opening on each launch. Claimed past the "none" gate, so only a shown message
+    // burns the day.
+    if (!claimDailyAsk(offer.version)) return;
     if (offer.kind === "tell") {
         notify({ kind: "info", text: `inflexa ${offer.version} is out. Update with: ${offer.instruction}` }, 8000, { queue: true });
         return;


### PR DESCRIPTION
## What & why

The CLI read the release page one time a day, and a fresh record blocked the next read. Thus a person who started inflexa before a same-day release saw nothing about that release for up to 24 hours. This change turns the shape around: the network read runs at each startup, and only the TUI ask dialog holds a once-a-day record.

Notes for the reviewer:

- `claimDailyAsk` (notice.ts) guards the dialog only. A `true` answer records the ask, thus the decision and the record are one step.
- The stderr line and the TUI toast are passive, so they show at each run with no record.
- A version that is newer than the recorded one opens the dialog inside the day, thus a second same-day release does not wait.
- The claim runs at the moment the dialog opens. A run whose dialog cannot open does not use up the day.
- The state file keeps its path, with the new `{promptedAt, version}` shape. An old `{checkedAt, version}` record fails the parse, reads as no record, and costs one extra ask.
- `inflexa upgrade` stays unconditional.

## Type of change

- [x] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
