### PR TITLE
chore: narrow the STE gate, and link the local subsystems in CI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,18 +4,6 @@
     "pr": ""
   },
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
-            "timeout": 10,
-            "statusMessage": "Reply contract"
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -32,18 +20,6 @@
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ste-check.ts\"",
-            "timeout": 15,
-            "statusMessage": "STE check"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
         "hooks": [
           {
             "type": "command",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,19 +41,21 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # A PR can change cli and harness together, and its checks must run
-      # against that pair. The npm pin cannot see an unpublished harness. Thus
-      # this step links the working-copy harness over the installed one, the
-      # same as `bun run harness:local` on a developer machine. The harness
-      # install comes first, because the link script builds the harness. A push
-      # to main keeps the npm pin: release.yml waits on the push checks as its
-      # release gate, and they must run against the harness version that the
-      # shipped binary bundles.
-      - name: Use the local harness
-        if: github.event_name == 'pull_request'
+      # A change can touch cli, harness, and prov-kernel together, and its
+      # checks must run against that set. The npm pins cannot see an
+      # unpublished harness or prov-kernel. Thus every run — pull request and
+      # push alike — links the working copies over the installed ones, the
+      # same as `bun run harness:local` and `bun run kernel:local` on a
+      # developer machine. The installs come first, because the link scripts
+      # build each package. The npm pins are proven at release time instead:
+      # release.yml installs them and runs the cli checks against that
+      # install before it ships a binary.
+      - name: Use the local harness and prov-kernel
         run: |
           bun install --frozen-lockfile --cwd ../harness
+          bun install --frozen-lockfile --cwd ../prov-kernel
           bun run harness:local
+          bun run kernel:local
 
       - name: ESLint
         run: bun run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,16 +123,26 @@ jobs:
 
       # cli pins @inflexa-ai/harness to an exact version and installs it from
       # npm, so the binary bundles the published, attested harness artifact —
-      # not a local build. The pinned version is always already on npm here:
-      # the harness bump is promoted first (release-harness.yml), and a later,
-      # separate cli change consumes it. PR checks link the local harness, but
-      # the push checks that the gate above waits on keep this same npm pin —
-      # thus a main commit whose cli wants an unpublished harness fails that
-      # gate, and it never reaches this step.
+      # not a local build. Lint/Test link the working-copy harness in every
+      # run, so this install is the first place the npm pin is exercised: an
+      # unpublished pin fails right here under the frozen lockfile.
       - name: Install cli dependencies
         if: steps.gate.outputs.release == 'true'
         working-directory: cli
         run: bun install --frozen-lockfile
+
+      # The only checks that run against the npm pin. The Lint/Test runs the
+      # gate above waited on linked the working-copy harness, so they prove
+      # the source pair, not the published artifact the binary bundles. The
+      # typecheck catches API drift between cli and the pinned harness, and
+      # the test suite catches behavior drift — either one fails the release
+      # before any tag or binary exists.
+      - name: Check the cli against the npm harness
+        if: steps.gate.outputs.release == 'true'
+        working-directory: cli
+        run: |
+          bun run typecheck
+          bun test
 
       - name: Build release binaries
         if: steps.gate.outputs.release == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,19 +42,21 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # A PR can change cli and harness together, and its checks must run
-      # against that pair. The npm pin cannot see an unpublished harness. Thus
-      # this step links the working-copy harness over the installed one, the
-      # same as `bun run harness:local` on a developer machine. The harness
-      # install comes first, because the link script builds the harness. A push
-      # to main keeps the npm pin: release.yml waits on the push checks as its
-      # release gate, and they must run against the harness version that the
-      # shipped binary bundles.
-      - name: Use the local harness
-        if: github.event_name == 'pull_request'
+      # A change can touch cli, harness, and prov-kernel together, and its
+      # checks must run against that set. The npm pins cannot see an
+      # unpublished harness or prov-kernel. Thus every run — pull request and
+      # push alike — links the working copies over the installed ones, the
+      # same as `bun run harness:local` and `bun run kernel:local` on a
+      # developer machine. The installs come first, because the link scripts
+      # build each package. The npm pins are proven at release time instead:
+      # release.yml installs them and runs the cli checks against that
+      # install before it ships a binary.
+      - name: Use the local harness and prov-kernel
         run: |
           bun install --frozen-lockfile --cwd ../harness
+          bun install --frozen-lockfile --cwd ../prov-kernel
           bun run harness:local
+          bun run kernel:local
 
       - name: Run tests
         run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,17 @@
 
 ## Language
 
-Write all text in ASD-STE100 Simplified Technical English (STE), issue 9.
+Write the git text, the GitHub text, and each document in ASD-STE100
+Simplified Technical English (STE), issue 9.
 
 Use STE in:
 
-- each message to the user
 - each commit message
+- each pull request: the title, the body, a comment, and a review
+- each GitHub issue: the title, the body, and a comment
 - each document in this project
-- each comment and each docstring in the code
+
+STE does not apply to a chat reply, or to a comment in the code.
 
 STE controls prose only. It does not control code, an identifier, a command, a
 tool name, or text that you copy from a file. Keep the copied text as it is.
@@ -311,29 +314,23 @@ realizations of the seams. An embedder never controls what the harness does.
 Design a new capability in the harness first. Then connect it from the embedder.
 Do not design a capability as a feature of the embedder.
 
-### Red CI on a change to the two subsystems
+### The harness link in CI, and the npm pin at release
 
-The `cli` jobs of `lint.yml` and `test.yml` treat the harness in two ways:
+The `cli` jobs of `lint.yml` and `test.yml` link the working-copy harness and
+the working-copy prov-kernel in every run, the same as `bun run harness:local`
+and `bun run kernel:local`. Thus a combined change is green on a pull request
+and on main. `kernel:local` also points the tsprov install of the linked
+kernel at the copy of cli, because two tsprov copies break class identity.
 
-- On a pull request, the jobs link the working-copy harness, the same as `bun
-  run harness:local`. Thus a pull request that changes `cli` and `harness`
-  together is green.
-- On a push to main, the jobs install the pinned npm version of
-  `@inflexa-ai/harness` with a frozen lockfile. `release.yml` waits on these
-  checks. Thus the release gate runs against the exact version that the binary
-  bundles.
+Only `release.yml` uses the npm pins. It installs the pinned
+`@inflexa-ai/harness` and the locked `@inflexa-ai/prov-kernel` from npm with a
+frozen lockfile. Then it runs the cli typecheck and the cli tests against that
+install. If a pin is stale, or if a pin is not on npm, the release fails
+before the tag and the binaries.
 
-As a result, when a combined change merges, the push run on main has red `cli`
-checks. The red stays until the harness version publishes and the pin bump
-lands on main. This result is correct. Do not treat it as a defect.
-
-Obey these rules:
-
-- Do not report the red CI on main as a finding.
-- Do not read the workflow files to find the cause again.
-- Do not recommend a branch split or a merge sequence.
-- The developer of the pull request controls the harness release and the version
-  change. Refer to `cli/CLAUDE.md`, "Scope: implementation only".
+Thus a cli release comes after the harness publish and after the pin bump.
+The developer of the pull request controls the harness release and the
+version change. Refer to `cli/CLAUDE.md`, "Scope: implementation only".
 
 ## Agent-facing content
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -29,6 +29,8 @@
         "format:file": "prettier --write",
         "harness:local": "cd ../harness && bun run build && bun link && cd ../cli && bun link @inflexa-ai/harness",
         "harness:remote": "rm -rf node_modules/@inflexa-ai/harness && bun install",
+        "kernel:local": "cd ../prov-kernel && bun run build && bun link && cd ../cli && bun link @inflexa-ai/prov-kernel && rm -rf ../prov-kernel/node_modules/@inflexa-ai/tsprov && ln -s \"$(pwd)/node_modules/@inflexa-ai/tsprov\" ../prov-kernel/node_modules/@inflexa-ai/tsprov",
+        "kernel:remote": "rm -rf node_modules/@inflexa-ai/prov-kernel ../prov-kernel/node_modules/@inflexa-ai/tsprov && bun install && bun install --cwd ../prov-kernel",
         "lint": "eslint .",
         "start": "bun run src/index.ts",
         "test": "bun test",


### PR DESCRIPTION
## What & why

The STE gate covered the chat reply, and the cli CI jobs used the npm pin on a push to main. Both rules made development harder. This change narrows the STE gate to the commit surface, the GitHub surface, and the markdown documents. It also links the working-copy harness and the working-copy prov-kernel in every lint run and test run.

Notes for the reviewer:

- The UserPromptSubmit and Stop hook groups are gone from `.claude/settings.json`. The Bash gate and the document gate stay.
- The push checks no longer prove the npm pin. Thus `release.yml` now runs the cli typecheck and the cli tests against the npm install, before the tag and the binaries. A stale pin fails the release there.
- `kernel:local` points the tsprov install of the linked kernel at the copy of cli. Two tsprov copies break class identity in `ProvDocument.equals`. `kernel:remote` restores the npm state.
- "Red CI on main" was a documented, correct state. The new model removes it, together with the CLAUDE.md section that explained it.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [ ] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.
