### PR TITLE
fix(cli): keep the retired-image hint off the setup path

### DIFF
--- a/cli/openspec/specs/lib-store-provisioning/spec.md
+++ b/cli/openspec/specs/lib-store-provisioning/spec.md
@@ -83,9 +83,11 @@ and its derived provisioner reference exists in no registry. `inflexa
 setup` and `inflexa sandbox pull` MUST delete the field, with one notice,
 thus the default image pair serves. A reference outside the retired set
 MUST stay, because a custom image is a deliberate override. When the
-engine still holds a retired variant image, setup and `inflexa sandbox
-status` MUST print one removal hint. The hint names the image, its size,
-and the remove command. Nothing removes an image without the user.
+engine still holds a retired variant image, `inflexa sandbox status`
+MUST print one removal hint. The hint names the image, its size, and the
+remove command. Nothing removes an image without the user. Setup MUST
+NOT reach the engine for the hint: setup touches the engine only through
+its probe seams, and the hint is a diagnostic of the status surface.
 
 #### Scenario: A retired override clears at setup
 

--- a/cli/src/modules/infra/setup.ts
+++ b/cli/src/modules/infra/setup.ts
@@ -808,24 +808,18 @@ async function runTransfersSetup(answered: SetupAnswers["sandbox"], canPrompt: b
     const { TRANSFER_KINDS } = await import("../../types/store.ts");
     const { inspectStoreContent, startCatalogTransfer } = await import("../libs/store_download.ts");
     const { settleTransfer } = await import("../../db/primary_mutation.ts");
-    const { migrateRetiredSandboxImageOverride, retiredImagesOnEngine } = await import("../libs/pull.ts");
-    const { selectedRuntime } = await import("../../lib/config.ts");
+    const { migrateRetiredSandboxImageOverride } = await import("../libs/pull.ts");
 
     // The migration comes before the transfers, because the transfers pull the
     // configured image — a kept retired override would pull the baked image
-    // and derive a provisioner reference that no registry holds.
+    // and derive a provisioner reference that no registry holds. The engine
+    // stays untouched here: setup reaches it only through its probe seams,
+    // and the retired-image removal hint lives on `sandbox status`, where a
+    // live engine scan belongs.
     const migrated = migrateRetiredSandboxImageOverride();
-    const lines: string[] = [];
     if (migrated !== null) {
-        lines.push(`The config named the retired image ${migrated}.`, "The override is removed, and the default sandbox-base pair serves.");
+        note(`The config named the retired image ${migrated}.\nThe override is removed, and the default sandbox-base pair serves.`, "Images");
     }
-    const rt = selectedRuntime();
-    if (rt !== null) {
-        for (const image of await retiredImagesOnEngine(rt)) {
-            lines.push(`The retired image ${image.ref} (${image.size}) stays on the engine. Run \`${rt.bin} rmi ${image.ref}\` to free the space.`);
-        }
-    }
-    if (lines.length > 0) note(lines.join("\n"), "Images");
 
     // A second setup during a live transfer reports the run and opens no
     // second consent, and it never waits.


### PR DESCRIPTION
The hint scan spawned a live `image ls` inside setup — the one engine call there that no seam covers. The batch tests stub every probe, and the live spawn blocked one test past its cap on the runner.

Setup touches the engine only through its probe seams. Thus the hint lives on `sandbox status` alone, the surface setup points a user at. Setup keeps the config migration and its notice, which is pure file work. The spec states the split.