### PR TITLE
fix(harness): forward the libs root through the sandbox client factory

### DIFF
--- a/harness/openspec/specs/package-store/spec.md
+++ b/harness/openspec/specs/package-store/spec.md
@@ -88,7 +88,11 @@ backend whose farm rides a volume the host cannot read MUST get the proof
 from the farm resolver. There the resolver MUST answer `unavailable` when
 the lock does not parse, and the backend mounts only a resolved farm. A K8s
 configuration CAN name the host mountpoint of the libs volume, and the
-backend then proves the lock itself, through the joined path.
+backend then proves the lock itself, through the joined path. The sandbox
+client factory MUST forward that root to the backend, because an embedder
+composes through the factory and never builds the backend config itself.
+Under a fixed farm source no resolver exists, thus the forwarded root
+carries the only gate that shape can have.
 
 #### Scenario: The gate reads the lock
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.33.0",
+    "version": "0.33.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -4,7 +4,7 @@
  * transport is client-owned. Pure composition — no DBOS, no backend.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { createServer } from "node:http";
 import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -13,6 +13,7 @@ import type { Pool } from "pg";
 
 import type { AwaitExecOptions } from "./await-exec.js";
 import { composeAwaitOptions, createSandboxClient, precreateStepTree } from "./create-sandbox.js";
+import * as k8sClient from "./k8s-client.js";
 import { STEP_SUBDIRS } from "./mount-plan.js";
 import type { CreateSandboxMeta, SandboxLiveness } from "./types.js";
 
@@ -142,6 +143,42 @@ describe("precreateStepTree — step-tree access mode", () => {
         await expect(precreateStepTree(deps(undefined), { ...meta, writableTail: "../escape" })).rejects.toThrow(/Invalid writableTail/);
         await expect(precreateStepTree(deps(undefined), { ...meta, writableTail: TAIL, readOnly: true })).rejects.toThrow(/read-only sandbox cannot/);
         await expect(stat(join(root, "..", "escape"))).rejects.toThrow();
+    });
+});
+
+describe("createSandboxClient — the k8s libs root threading", () => {
+    test("libStorePvcRoot reaches the k8s ops, so the host-side lock gate can run", () => {
+        // The forward is one optional field: tsc cannot catch its absence, and
+        // under a `fixed` farm source it carries the ONLY lock gate. The spy
+        // asserts the composed backend config instead of faking a cluster,
+        // because the factory forwards no test API seams.
+        let captured: k8sClient.K8sClientConfig | null = null;
+        const spy = spyOn(k8sClient, "createK8sSandboxOps").mockImplementation((cfg) => {
+            captured = cfg;
+            // The client is never used — the test ends at the composed config.
+            return {} as unknown as ReturnType<typeof k8sClient.createK8sSandboxOps>;
+        });
+        try {
+            createSandboxClient({
+                pool: {} as unknown as Pool,
+                env: { backend: "k8s", namespace: "sandbox" },
+                cortexBaseUrl: "https://x",
+                image: "sandbox-base:latest",
+                resourceLimits: { maxCpu: 8, maxMemoryGb: 32, maxGpuCount: 0 },
+                resolveWorkspaceRoot: (id) => join("/sessions", id),
+                sessionPvc: "cortex-sessions",
+                sessionPvcRoot: "/sessions",
+                libStorePvc: "cortex-libs",
+                libStorePvcRoot: "/mnt/libs",
+                farmSource: { kind: "fixed", location: { farmPath: "farms/catalog" } },
+            });
+
+            expect(captured).not.toBeNull();
+            expect(captured!.libStorePvcRoot).toBe("/mnt/libs");
+            expect(captured!.libStorePvc).toBe("cortex-libs");
+        } finally {
+            spy.mockRestore();
+        }
     });
 });
 

--- a/harness/src/sandbox/create-sandbox.test.ts
+++ b/harness/src/sandbox/create-sandbox.test.ts
@@ -14,6 +14,7 @@ import type { Pool } from "pg";
 import type { AwaitExecOptions } from "./await-exec.js";
 import { composeAwaitOptions, createSandboxClient, precreateStepTree } from "./create-sandbox.js";
 import * as k8sClient from "./k8s-client.js";
+import { createNoopLogger } from "../lib/console-logger.js";
 import { STEP_SUBDIRS } from "./mount-plan.js";
 import type { CreateSandboxMeta, SandboxLiveness } from "./types.js";
 
@@ -152,6 +153,7 @@ describe("createSandboxClient — the k8s libs root threading", () => {
         // under a `fixed` farm source it carries the ONLY lock gate. The spy
         // asserts the composed backend config instead of faking a cluster,
         // because the factory forwards no test API seams.
+        const logger = createNoopLogger();
         let captured: k8sClient.K8sClientConfig | null = null;
         const spy = spyOn(k8sClient, "createK8sSandboxOps").mockImplementation((cfg) => {
             captured = cfg;
@@ -171,11 +173,15 @@ describe("createSandboxClient — the k8s libs root threading", () => {
                 libStorePvc: "cortex-libs",
                 libStorePvcRoot: "/mnt/libs",
                 farmSource: { kind: "fixed", location: { farmPath: "farms/catalog" } },
+                logger,
             });
 
             expect(captured).not.toBeNull();
             expect(captured!.libStorePvcRoot).toBe("/mnt/libs");
             expect(captured!.libStorePvc).toBe("cortex-libs");
+            // The same reference, not a copy: the lock-gate warning must reach
+            // the embedder's sink, never the no-op fallback.
+            expect(captured!.logger).toBe(logger);
         } finally {
             spy.mockRestore();
         }

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -236,6 +236,10 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
                   nodeSelector: config.nodeSelector,
                   tolerations: config.tolerations,
                   runtimeClassName: config.runtimeClassName,
+                  // Without the forward, every k8s-client diagnostic — the lock-gate
+                  // warning included — lands in the no-op fallback, and a degraded
+                  // sandbox mounts silently.
+                  logger: config.logger,
                   registerSandbox,
               })
             : createDockerSandboxOps({

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -126,6 +126,15 @@ export interface CreateSandboxClientConfig {
     sessionPvcRoot?: string;
     /** K8s: PVC claim mounted read-only at `/mnt/libs`. */
     libStorePvc?: string;
+    /**
+     * K8s: absolute mountpoint of `libStorePvc` on this process's filesystem,
+     * for a host that mounts the same volume. With it set, the backend proves
+     * the `inflexa.lock` of the resolved farm before the mount. Under a
+     * `fixed` farm source no resolver exists, thus this root carries the only
+     * lock gate that shape can have. Without it, the proof duty stays whole
+     * on the farm resolver.
+     */
+    libStorePvcRoot?: string;
     /** K8s: PVC claim mounted read-only at `/mnt/refs`. */
     refStorePvc?: string;
     /** K8s: node selector pinning sandbox pods to the dedicated agent pool. */
@@ -220,6 +229,7 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
                   sessionPvcRoot: config.sessionPvcRoot,
                   resolveWorkspaceRoot: config.resolveWorkspaceRoot,
                   libStorePvc: config.libStorePvc,
+                  libStorePvcRoot: config.libStorePvcRoot,
                   farmSource: config.farmSource,
                   toolchainSource: config.toolchainSource,
                   refStorePvc: config.refStorePvc,

--- a/harness/src/sandbox/create-sandbox.ts
+++ b/harness/src/sandbox/create-sandbox.ts
@@ -236,9 +236,6 @@ export function createSandboxClient(config: CreateSandboxClientConfig): SandboxC
                   nodeSelector: config.nodeSelector,
                   tolerations: config.tolerations,
                   runtimeClassName: config.runtimeClassName,
-                  // Without the forward, every k8s-client diagnostic — the lock-gate
-                  // warning included — lands in the no-op fallback, and a degraded
-                  // sandbox mounts silently.
                   logger: config.logger,
                   registerSandbox,
               })


### PR DESCRIPTION
The K8s backend proves the `inflexa.lock` of a farm through the host mountpoint of the libs volume. The factory did not forward that root, and an embedder composes only through the factory. Thus the gate was unreachable for every embedder. Under a fixed farm source no resolver exists, and the forwarded root carries the only gate that shape has.

A spy test pins the forward, because the field is optional and tsc cannot miss it for a caller.
