### PR TITLE
release harness 0.34.0

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.33.1",
+    "version": "0.34.0",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
## What & why

Bump the harness version to 0.34.0. When the bump lands on main, `release-harness.yml` publishes the package to npm. The release ships the host-side file-tool writes, the `write-file` session event, and the flattened `file_written` support from #491. The published 0.33.x versions came from main before that merge, and thus they do not hold those changes.

The bump is a minor bump, not a patch. The file-tool collector record now carries `invocationId` in place of `timestamp`, and the session-event union gains a member. A consumer that reads those shapes must move with the version.

After the publish, the cortex pin moves from 0.32.0 to 0.34.0, and inflexa-ai/cortex#361 goes green.

## Type of change

- [ ] Bug fix
- [ ] New feature / capability
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [ ] Tests added or updated for the change.
- [ ] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01VeVK4jKZ8hMPXhB5RBPgFT
