### PR TITLE
harness: obey OTEL_METRICS_EXPORTER, 60 s export, env resource, DBOS tracing behind a config flag

### DIFF
--- a/harness/openspec/specs/artifact-manifest/spec.md
+++ b/harness/openspec/specs/artifact-manifest/spec.md
@@ -117,7 +117,7 @@ before any artifact is registered or synced. For each manifest entry it SHALL
 stat the file at `{workspaceRoot}/runs/{runId}/{stepId}/{entry.path}`, bounded
 to the step root, and:
 
-- If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`, `step_id`), and emit a debug log line.
+- If the file does not exist (`ENOENT`) → drop the entry from the returned manifest, call `collector.removeRecord(path)`, increment the `cortex.artifact.reconcile.dropped` counter (tagged `agent_id`), and emit a debug log line.
 - If the path is not a regular file (a directory) → drop it the same way.
 - Otherwise → recompute SHA-256 from disk via `computeSha256File` and replace the entry's `hash` and `size` with the on-disk values.
 
@@ -136,7 +136,7 @@ dropped via `collector.dropInput` and SHALL NOT fail the step:
 - An input naming a path that is **not present** at reconcile (`ENOENT`) → dropped, logged at **warn** with the ref, its resolved host path, and `dropSite: "input-enoent"`.
 
 Every input drop SHALL increment the `cortex.artifact.reconcile.input_dropped`
-counter, tagged `agent_id`, `step_id`, and `reason` (`directory`,
+counter, tagged `agent_id` and `reason` (`directory`,
 `container-prefix`, `workspace-root`, or `missing`).
 
 An out-of-tree read is out of scope rather than drift: the analysis tree mounts

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.35.1",
+    "version": "0.35.2",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/execution/dbos-run-launcher.test.ts
+++ b/harness/src/execution/dbos-run-launcher.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The DBOS run launcher roots a run in a trace of its own. The DBOS engine is
+ * not launched: `DBOS.startWorkflow` is stubbed to record the OTel context it
+ * was invoked under, which is the context the SDK parents the workflow span on.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { context, propagation, trace, type Context } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+import { ATTR_INFLEXA_RUN_ID, createDbosRunLauncher } from "./dbos-run-launcher.js";
+
+let exporter: InMemorySpanExporter;
+let provider: NodeTracerProvider;
+let originalStartWorkflow: unknown;
+let contextAtStart: Context | undefined;
+let inputAtStart: unknown;
+
+beforeEach(async () => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+    provider.register();
+
+    const dbos = await import("@dbos-inc/dbos-sdk");
+    originalStartWorkflow ??= dbos.DBOS.startWorkflow;
+    contextAtStart = undefined;
+    inputAtStart = undefined;
+    (dbos.DBOS.startWorkflow as unknown) = () => async (input: unknown) => {
+        contextAtStart = context.active();
+        inputAtStart = input;
+        return {};
+    };
+});
+
+afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+});
+
+afterAll(async () => {
+    if (originalStartWorkflow === undefined) return;
+    const dbos = await import("@dbos-inc/dbos-sdk");
+    (dbos.DBOS.startWorkflow as unknown) = originalStartWorkflow;
+});
+
+const workflow = async (_input: { readonly planId: string }): Promise<unknown> => undefined;
+
+describe("createDbosRunLauncher", () => {
+    it("starts the workflow in a new trace, linked to the originating span", async () => {
+        const launcher = createDbosRunLauncher();
+        const tracer = trace.getTracer("test");
+        const chat = tracer.startSpan("POST /chat");
+
+        await context.with(trace.setSpan(context.active(), chat), () => launcher.launch(workflow, { workflowId: "run-1" }, { planId: "p" }));
+        chat.end();
+
+        expect(inputAtStart).toEqual({ planId: "p" });
+        const startedUnder = trace.getSpan(contextAtStart!)!.spanContext();
+        expect(startedUnder.traceId).not.toBe(chat.spanContext().traceId);
+
+        const finished = exporter.getFinishedSpans();
+        const root = finished.find((s) => s.name === "launch run")!;
+        expect(root.spanContext().spanId).toBe(startedUnder.spanId);
+        expect(root.parentSpanContext).toBeUndefined();
+        expect(root.attributes[ATTR_INFLEXA_RUN_ID]).toBe("run-1");
+        expect(root.links.map((l) => l.context)).toEqual([chat.spanContext()]);
+
+        const originating = finished.find((s) => s.name === "POST /chat")!;
+        expect(originating.attributes[ATTR_INFLEXA_RUN_ID]).toBe("run-1");
+    });
+
+    it("starts the workflow in a new trace with no link when nothing is active", async () => {
+        const launcher = createDbosRunLauncher();
+
+        await launcher.launch(workflow, { workflowId: "run-2" }, { planId: "p" });
+
+        const root = exporter.getFinishedSpans().find((s) => s.name === "launch run")!;
+        expect(trace.getSpan(contextAtStart!)!.spanContext().spanId).toBe(root.spanContext().spanId);
+        expect(root.links).toEqual([]);
+        expect(root.attributes[ATTR_INFLEXA_RUN_ID]).toBe("run-2");
+    });
+
+    it("ends the root span and rethrows when the start fails", async () => {
+        const dbos = await import("@dbos-inc/dbos-sdk");
+        (dbos.DBOS.startWorkflow as unknown) = () => async () => {
+            throw new Error("system database down");
+        };
+        const launcher = createDbosRunLauncher();
+
+        await expect(launcher.launch(workflow, { workflowId: "run-3" }, { planId: "p" })).rejects.toThrow("system database down");
+        expect(exporter.getFinishedSpans().map((s) => s.name)).toEqual(["launch run"]);
+    });
+});

--- a/harness/src/execution/dbos-run-launcher.ts
+++ b/harness/src/execution/dbos-run-launcher.ts
@@ -1,17 +1,43 @@
 /**
  * DBOS realization of the `RunLauncher` seam — the single production adapter,
- * shared by every embedder. Host-neutral: it references only DBOS, which the harness
- * already depends on, so it ships in the harness.
+ * shared by every embedder. Host-neutral: it references only DBOS and the OTel
+ * API, which the harness already depends on, so it ships in the harness.
+ *
+ * A launch detaches the run from the caller's trace. The DBOS workflow span
+ * takes the active context as its parent, and the caller is a chat request
+ * (or another short-lived operation) whose span ends in milliseconds while the
+ * run lasts hours. So the launch opens a root span of its own, runs
+ * `startWorkflow` under it, and joins the two traces by a span link back to
+ * the originating span plus `inflexa.run_id` on both sides. With no
+ * TracerProvider registered every call here is a no-op on the API's
+ * non-recording span.
  */
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
+import { context, isSpanContextValid, ROOT_CONTEXT, trace, type Link } from "@opentelemetry/api";
 
 import type { LaunchOptions, RunLauncher } from "./run-launcher.js";
+
+/** Attribute carrying the run id on the originating span and on the run's root span. */
+export const ATTR_INFLEXA_RUN_ID = "inflexa.run_id";
+
+const TRACER_NAME = "inflexa.harness.run-launcher";
 
 export function createDbosRunLauncher(): RunLauncher {
     return {
         async launch<I>(workflow: (input: I) => Promise<unknown>, opts: LaunchOptions, input: I): Promise<void> {
-            await DBOS.startWorkflow(workflow, { workflowID: opts.workflowId })(input);
+            const originating = trace.getSpan(context.active());
+            const links: Link[] = [];
+            if (originating !== undefined && isSpanContextValid(originating.spanContext())) {
+                originating.setAttribute(ATTR_INFLEXA_RUN_ID, opts.workflowId);
+                links.push({ context: originating.spanContext() });
+            }
+            const root = trace.getTracer(TRACER_NAME).startSpan("launch run", { links, attributes: { [ATTR_INFLEXA_RUN_ID]: opts.workflowId } }, ROOT_CONTEXT);
+            try {
+                await context.with(trace.setSpan(ROOT_CONTEXT, root), () => DBOS.startWorkflow(workflow, { workflowID: opts.workflowId })(input));
+            } finally {
+                root.end();
+            }
         },
     };
 }

--- a/harness/src/execution/reconcile-manifest.test.ts
+++ b/harness/src/execution/reconcile-manifest.test.ts
@@ -10,8 +10,11 @@ import { describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { metrics } from "@opentelemetry/api";
+import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
 import { createCapturingLogger } from "../__tests__/setup/logger.js";
+import { __resetReconcileMetricsForTest } from "../lib/metrics.js";
 import { ProvenanceCollector } from "../provenance/collector.js";
 import { feedExecFrame } from "../provenance/exec-frame.js";
 import { reconcileManifestWithDisk } from "./reconcile-manifest.js";
@@ -605,6 +608,51 @@ describe("reconcileManifestWithDisk — undeclared sibling reads", () => {
             expect(warns[0]!.fields).toMatchObject({ path: `/${RID}/${scratchRel}`, dropSite: "input-enoent" });
         } finally {
             await rm(sessionPath, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("reconcileManifestWithDisk — metric labels", () => {
+    test("the two reconcile counters carry agent_id (and reason), never step_id", async () => {
+        // A per-step label multiplies the series count without bound; the
+        // counters stay at one series per agent (per reason).
+        const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+        const provider = new MeterProvider({
+            readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
+        });
+        metrics.setGlobalMeterProvider(provider);
+        __resetReconcileMetricsForTest();
+
+        // A phantom manifest entry (never written) drops one manifest entry, and
+        // the absent upstream input drops one lineage input with reason `missing`.
+        const { sessionPath, root, collector, manifest } = await setup({ writeUpstream: false });
+        try {
+            manifest.push({ stepId: "de", runId: "run-001", path: "output/phantom.csv", size: 0, type: "output", hash: "" });
+            await reconcileManifestWithDisk({
+                workspaceRoot: root,
+                resourceId: RID,
+                runId: "run-001",
+                stepId: "de",
+                agentId: "agent-x",
+                manifest,
+                collector,
+            });
+
+            await provider.forceFlush();
+            const exported = exporter
+                .getMetrics()
+                .flatMap((rm) => rm.scopeMetrics)
+                .flatMap((sm) => sm.metrics);
+            const dropped = exported.find((m) => m.descriptor.name === "cortex.artifact.reconcile.dropped");
+            const inputDropped = exported.find((m) => m.descriptor.name === "cortex.artifact.reconcile.input_dropped");
+
+            expect(dropped?.dataPoints.map((p) => p.attributes)).toEqual([{ agent_id: "agent-x" }]);
+            expect(inputDropped?.dataPoints.map((p) => p.attributes)).toEqual([{ agent_id: "agent-x", reason: "missing" }]);
+        } finally {
+            await rm(sessionPath, { recursive: true, force: true });
+            await provider.shutdown();
+            metrics.disable();
+            __resetReconcileMetricsForTest();
         }
     });
 });

--- a/harness/src/execution/reconcile-manifest.ts
+++ b/harness/src/execution/reconcile-manifest.ts
@@ -27,7 +27,7 @@ import type { ProvenanceCollector } from "../provenance/collector.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
 import { classifyWithinRoot, computeSha256File, hasValidContentHash } from "../lib/fs-helpers.js";
-import { artifactReconcileDropped, lineageInputDropped } from "../lib/metrics.js";
+import { recordArtifactReconcileDropped, recordLineageInputDropped } from "../lib/metrics.js";
 
 export interface ReconcileManifestInput {
     /** Absolute host root of the analysis's workspace tree. */
@@ -98,7 +98,7 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
                 logger.debug("dropping phantom entry", { path: entry.path });
                 collector.removeRecord(entry.path);
                 droppedCount++;
-                artifactReconcileDropped.add(1, { agent_id: agentId, step_id: stepId });
+                recordArtifactReconcileDropped({ agentId });
                 continue;
             }
             throw err;
@@ -112,7 +112,7 @@ export async function reconcileManifestWithDisk(input: ReconcileManifestInput): 
             logger.debug("dropping non-file entry", { path: entry.path });
             collector.removeRecord(entry.path);
             droppedCount++;
-            artifactReconcileDropped.add(1, { agent_id: agentId, step_id: stepId });
+            recordArtifactReconcileDropped({ agentId });
             continue;
         }
 
@@ -190,14 +190,14 @@ async function fillInputHashesFromDisk(
         const containerPrefix = `/${resourceId}`;
         if (ref.path !== containerPrefix && !ref.path.startsWith(containerPrefix + "/")) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, boundSite: "container-prefix" });
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "container-prefix" });
+            recordLineageInputDropped({ agentId, reason: "container-prefix" });
             collector.dropInput(ref);
             continue;
         }
         const hostPath = path.join(resourceRoot, ref.path.slice(containerPrefix.length + 1));
         if (hostPath !== resourceRoot && !hostPath.startsWith(resourceRoot + path.sep)) {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, hostPath, boundSite: "workspace-root" });
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "workspace-root" });
+            recordLineageInputDropped({ agentId, reason: "workspace-root" });
             collector.dropInput(ref);
             continue;
         }
@@ -209,7 +209,7 @@ async function fillInputHashesFromDisk(
         // verdict (a dangling link) falls through to the ENOENT drop below.
         if ((await classifyWithinRoot(resourceRoot, hostPath)) === "escaped") {
             logger.warn("dropping out-of-tree input from lineage", { ...attestation, hostPath, boundSite: "realpath" });
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "symlink-escape" });
+            recordLineageInputDropped({ agentId, reason: "symlink-escape" });
             collector.dropInput(ref);
             continue;
         }
@@ -223,7 +223,7 @@ async function fillInputHashesFromDisk(
                 // consumed, and the count of those is how a reader tells a noisy
                 // hook from an artifact that genuinely vanished under the step.
                 logger.warn("dropping input not present at reconcile from lineage", { ...attestation, hostPath, dropSite: "input-enoent" });
-                lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "missing" });
+                recordLineageInputDropped({ agentId, reason: "missing" });
                 collector.dropInput(ref);
                 continue;
             }
@@ -237,7 +237,7 @@ async function fillInputHashesFromDisk(
             // non-file drop above. A genuinely missing FILE (ENOENT) still fails fast
             // as drift; a directory is not drift.
             logger.debug("dropping non-file input from lineage", attestation);
-            lineageInputDropped.add(1, { agent_id: agentId, step_id: stepId, reason: "directory" });
+            recordLineageInputDropped({ agentId, reason: "directory" });
             collector.dropInput(ref);
             continue;
         }

--- a/harness/src/lib/metrics.test.ts
+++ b/harness/src/lib/metrics.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The metrics API has no late-binding proxy: a meter taken before
+ * `setGlobalMeterProvider` is the no-op meter for good. The record sites of
+ * this module are imported at process start, long before the host's boot
+ * registers the provider, so the instruments must bind at record time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { metrics } from "@opentelemetry/api";
+import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, type MetricData, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+
+// Imported before any provider exists — the order the production barrel has.
+import { __resetReconcileMetricsForTest, recordArtifactReconcileDropped, recordLineageInputDropped } from "./metrics.js";
+
+let exporter: InMemoryMetricExporter;
+let provider: MeterProvider;
+
+beforeEach(() => {
+    __resetReconcileMetricsForTest();
+    exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+    provider = new MeterProvider({
+        readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
+    });
+});
+
+afterEach(async () => {
+    await provider.shutdown();
+    metrics.disable();
+    __resetReconcileMetricsForTest();
+});
+
+async function collect(): Promise<MetricData[]> {
+    await provider.forceFlush();
+    return exporter
+        .getMetrics()
+        .flatMap((rm) => rm.scopeMetrics)
+        .flatMap((sm) => sm.metrics);
+}
+
+describe("reconcile metrics", () => {
+    it("bind to a MeterProvider registered after the module was imported", async () => {
+        metrics.setGlobalMeterProvider(provider);
+
+        recordArtifactReconcileDropped({ agentId: "agent-x" });
+        recordLineageInputDropped({ agentId: "agent-x", reason: "directory" });
+
+        const exported = await collect();
+        expect(exported.map((m) => m.descriptor.name).sort()).toEqual(["cortex.artifact.reconcile.dropped", "cortex.artifact.reconcile.input_dropped"]);
+    });
+
+    it("carry agent_id and reason only", async () => {
+        metrics.setGlobalMeterProvider(provider);
+
+        recordArtifactReconcileDropped({ agentId: "agent-x" });
+        recordArtifactReconcileDropped({ agentId: "agent-x" });
+        recordLineageInputDropped({ agentId: "agent-x", reason: "missing" });
+        recordLineageInputDropped({ agentId: "agent-y", reason: "missing" });
+
+        const exported = await collect();
+        const dropped = exported.find((m) => m.descriptor.name === "cortex.artifact.reconcile.dropped")!;
+        const inputDropped = exported.find((m) => m.descriptor.name === "cortex.artifact.reconcile.input_dropped")!;
+        expect(dropped.dataPoints.map((p) => [p.attributes, p.value])).toEqual([[{ agent_id: "agent-x" }, 2]]);
+        expect(inputDropped.dataPoints.map((p) => p.attributes)).toEqual([
+            { agent_id: "agent-x", reason: "missing" },
+            { agent_id: "agent-y", reason: "missing" },
+        ]);
+    });
+});

--- a/harness/src/lib/metrics.ts
+++ b/harness/src/lib/metrics.ts
@@ -4,22 +4,59 @@
  * Instruments:
  *   - cortex.artifact.reconcile.dropped — counter for missing manifest entries
  *   - cortex.artifact.reconcile.input_dropped — counter for lineage input drops
+ *
+ * Both carry `agent_id` (about 15 values) and never a per-step or per-run
+ * identifier: a label with unbounded values multiplies the series count.
+ *
+ * Instruments are lazy so the record site binds to whichever `MeterProvider`
+ * is globally registered at first use. The metrics API has no late-binding
+ * proxy: a meter taken at module load, before `initOtel` runs, would stay
+ * on the no-op provider for the life of the process.
  */
 
-import { metrics } from "@opentelemetry/api";
+import { type Counter, metrics } from "@opentelemetry/api";
 
-const meter = metrics.getMeter("cortex");
+interface Instruments {
+    readonly artifactReconcileDropped: Counter;
+    readonly lineageInputDropped: Counter;
+}
 
-export const artifactReconcileDropped = meter.createCounter("cortex.artifact.reconcile.dropped", {
-    description:
-        "Manifest entries dropped because their on-disk file was missing at " +
-        "registration time (writes-then-deletes, renames). Tagged by agent_id, step_id.",
-});
+let instruments: Instruments | undefined;
 
-export const lineageInputDropped = meter.createCounter("cortex.artifact.reconcile.input_dropped", {
-    description:
-        "Tracked input reads dropped from lineage at reconcile because they are " +
-        "not content-attestable files of the analysis (directory reads, " +
-        "out-of-tree resolutions, paths absent at reconcile). Tagged by " +
-        "agent_id, step_id, reason.",
-});
+function getInstruments(): Instruments {
+    if (instruments === undefined) {
+        const meter = metrics.getMeter("cortex");
+        instruments = {
+            artifactReconcileDropped: meter.createCounter("cortex.artifact.reconcile.dropped", {
+                description:
+                    "Manifest entries dropped because their on-disk file was missing at " +
+                    "registration time (writes-then-deletes, renames). Tagged by agent_id.",
+            }),
+            lineageInputDropped: meter.createCounter("cortex.artifact.reconcile.input_dropped", {
+                description:
+                    "Tracked input reads dropped from lineage at reconcile because they are " +
+                    "not content-attestable files of the analysis (directory reads, " +
+                    "out-of-tree resolutions, paths absent at reconcile). Tagged by " +
+                    "agent_id, reason.",
+            }),
+        };
+    }
+    return instruments;
+}
+
+/** Record one manifest entry dropped at reconcile. */
+export function recordArtifactReconcileDropped(args: { readonly agentId: string }): void {
+    getInstruments().artifactReconcileDropped.add(1, { agent_id: args.agentId });
+}
+
+export type LineageInputDropReason = "container-prefix" | "workspace-root" | "symlink-escape" | "missing" | "directory";
+
+/** Record one tracked input read dropped from lineage at reconcile. */
+export function recordLineageInputDropped(args: { readonly agentId: string; readonly reason: LineageInputDropReason }): void {
+    getInstruments().lineageInputDropped.add(1, { agent_id: args.agentId, reason: args.reason });
+}
+
+/** Test hook — drop memoised instruments to rebind a fresh MeterProvider. */
+export function __resetReconcileMetricsForTest(): void {
+    instruments = undefined;
+}

--- a/harness/src/lib/otel.test.ts
+++ b/harness/src/lib/otel.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `initOtel` reads its export switches and its resource from the environment,
+ * the way the OTel SDK convention has it. These tests drive the init under
+ * different environments and assert on what got registered.
+ *
+ * The OTLP endpoint is a loopback HTTP server that answers 200 to every
+ * request, so the flush at reset completes at once instead of retrying a
+ * network error.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { metrics, trace } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+import {
+    __otelMeterProviderRegisteredForTest,
+    __resetOtelForTest,
+    DEFAULT_METRIC_EXPORT_INTERVAL_MS,
+    initOtel,
+    metricExportIntervalMs,
+    metricsExportDisabled,
+} from "./otel.js";
+
+let collector: Server;
+let endpoint: string;
+
+beforeAll(async () => {
+    collector = createServer((_req, res) => {
+        res.writeHead(200);
+        res.end();
+    });
+    await new Promise<void>((resolve) => collector.listen(0, "127.0.0.1", resolve));
+    endpoint = `http://127.0.0.1:${(collector.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+    await new Promise<void>((resolve) => collector.close(() => resolve()));
+});
+
+const ENV_KEYS = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_METRIC_EXPORT_INTERVAL",
+    "OTEL_SERVICE_NAME",
+    "OTEL_RESOURCE_ATTRIBUTES",
+] as const;
+
+let saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>>;
+
+beforeEach(() => {
+    saved = {};
+    for (const key of ENV_KEYS) {
+        saved[key] = process.env[key];
+        delete process.env[key];
+    }
+});
+
+afterEach(async () => {
+    await __resetOtelForTest();
+    for (const key of ENV_KEYS) {
+        const value = saved[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+});
+
+/** The resource attributes a span started on the registered provider carries. */
+function registeredResourceAttributes(): Record<string, unknown> {
+    const span = trace.getTracer("otel-test").startSpan("probe");
+    const resource = (span as unknown as ReadableSpan).resource;
+    span.end();
+    return resource.attributes;
+}
+
+describe("metricExportIntervalMs", () => {
+    it("defaults to 60 s", () => {
+        expect(metricExportIntervalMs({})).toBe(DEFAULT_METRIC_EXPORT_INTERVAL_MS);
+        expect(DEFAULT_METRIC_EXPORT_INTERVAL_MS).toBe(60_000);
+    });
+
+    it("reads OTEL_METRIC_EXPORT_INTERVAL in milliseconds", () => {
+        expect(metricExportIntervalMs({ OTEL_METRIC_EXPORT_INTERVAL: "15000" })).toBe(15_000);
+    });
+
+    it("falls back to the default on a value that is not a positive number", () => {
+        expect(metricExportIntervalMs({ OTEL_METRIC_EXPORT_INTERVAL: "soon" })).toBe(DEFAULT_METRIC_EXPORT_INTERVAL_MS);
+        expect(metricExportIntervalMs({ OTEL_METRIC_EXPORT_INTERVAL: "0" })).toBe(DEFAULT_METRIC_EXPORT_INTERVAL_MS);
+        expect(metricExportIntervalMs({ OTEL_METRIC_EXPORT_INTERVAL: "-1" })).toBe(DEFAULT_METRIC_EXPORT_INTERVAL_MS);
+        expect(metricExportIntervalMs({ OTEL_METRIC_EXPORT_INTERVAL: "" })).toBe(DEFAULT_METRIC_EXPORT_INTERVAL_MS);
+    });
+});
+
+describe("metricsExportDisabled", () => {
+    it("is true only for OTEL_METRICS_EXPORTER=none", () => {
+        expect(metricsExportDisabled({ OTEL_METRICS_EXPORTER: "none" })).toBe(true);
+        expect(metricsExportDisabled({ OTEL_METRICS_EXPORTER: "otlp" })).toBe(false);
+        expect(metricsExportDisabled({})).toBe(false);
+    });
+});
+
+describe("initOtel", () => {
+    it("registers a metric exporter when an endpoint is set", () => {
+        process.env.OTEL_EXPORTER_OTLP_ENDPOINT = endpoint;
+        initOtel();
+        expect(__otelMeterProviderRegisteredForTest()).toBe(true);
+    });
+
+    it("registers no metric exporter under OTEL_METRICS_EXPORTER=none, and instruments stay usable", () => {
+        process.env.OTEL_EXPORTER_OTLP_ENDPOINT = endpoint;
+        process.env.OTEL_METRICS_EXPORTER = "none";
+        initOtel();
+        expect(__otelMeterProviderRegisteredForTest()).toBe(false);
+        // The API's no-op provider serves the instrument — a record site never sees the switch.
+        expect(() => metrics.getMeter("otel-test").createCounter("otel.test.counter").add(1)).not.toThrow();
+        // Traces are untouched by the metrics switch.
+        const span = trace.getTracer("otel-test").startSpan("probe");
+        expect(span.spanContext().spanId).not.toBe("0000000000000000");
+        span.end();
+    });
+
+    it("registers no metric exporter without an endpoint", () => {
+        initOtel();
+        expect(__otelMeterProviderRegisteredForTest()).toBe(false);
+    });
+
+    it("puts the host's service name and version on the resource", () => {
+        initOtel({ serviceName: "cortex-test", serviceVersion: "1.2.3" });
+        expect(registeredResourceAttributes()).toMatchObject({
+            "service.name": "cortex-test",
+            "service.version": "1.2.3",
+        });
+    });
+
+    it("lets the environment override the service name and add attributes", () => {
+        process.env.OTEL_SERVICE_NAME = "cortex-from-env";
+        process.env.OTEL_RESOURCE_ATTRIBUTES = "deployment.environment.name=staging";
+        initOtel({ serviceName: "cortex-manual", serviceVersion: "1.2.3" });
+        expect(registeredResourceAttributes()).toMatchObject({
+            "service.name": "cortex-from-env",
+            "service.version": "1.2.3",
+            "deployment.environment.name": "staging",
+        });
+    });
+
+    it("defaults the service name to cortex", () => {
+        initOtel();
+        expect(registeredResourceAttributes()).toMatchObject({ "service.name": "cortex" });
+        expect(registeredResourceAttributes()).not.toHaveProperty("service.version");
+    });
+});

--- a/harness/src/lib/otel.ts
+++ b/harness/src/lib/otel.ts
@@ -1,14 +1,22 @@
 /**
  * OpenTelemetry SDK initialization — traces + metrics.
  *
- * Exported as `initOtel()` and called explicitly from index.ts to prevent
- * the bundler from tree-shaking it (side-effect-only imports get dropped).
+ * Exported as `initOtel()` and called explicitly from the host's boot sequence
+ * so the bundler cannot tree-shake it (side-effect-only imports get dropped).
  *
  * Traces: NodeTracerProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT
  *         is set.
  *
- * Metrics: MeterProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT
- *          is set. Custom Cortex metrics are defined in metrics.ts.
+ * Metrics: MeterProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT is
+ *          set and OTEL_METRICS_EXPORTER is not `none`. The export interval is
+ *          OTEL_METRIC_EXPORT_INTERVAL (ms), default 60 s. Custom Cortex
+ *          metrics are defined in metrics.ts.
+ *
+ * Resource: the host's `serviceName` / `serviceVersion` merged with the SDK
+ *           env detector (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`);
+ *           the environment wins on a conflict, so a deployment can set
+ *           `deployment.environment.name` or override the service name without
+ *           a code change. Traces and metrics share the one resource.
  *
  * Note: OTEL's instrumentation-http patches node:http but does not cover
  *        Hono's request handling or Node 22's undici-based globalThis.fetch,
@@ -16,7 +24,7 @@
  *        not currently wired.
  */
 
-import { propagation, metrics, trace } from "@opentelemetry/api";
+import { context, propagation, metrics, trace } from "@opentelemetry/api";
 
 import { createNoopLogger } from "./console-logger.js";
 import type { Logger } from "./logger.js";
@@ -26,12 +34,55 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor, type SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { resourceFromAttributes } from "@opentelemetry/resources";
-import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { detectResources, envDetector, resourceFromAttributes, type Resource } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+
+/** The SDK's own default when neither the host nor the environment says otherwise. */
+export const DEFAULT_METRIC_EXPORT_INTERVAL_MS = 60_000;
+
+export interface InitOtelOptions {
+    /** Diagnostics sink; omitted falls back to no-op. */
+    readonly logger?: Logger;
+    /** `service.name` when `OTEL_SERVICE_NAME` is unset. Default `cortex`. */
+    readonly serviceName?: string;
+    /** `service.version` — the host's package version. Omitted leaves the attribute unset. */
+    readonly serviceVersion?: string;
+}
 
 let initialized = false;
 let registeredTracerProvider: NodeTracerProvider | undefined;
 let registeredMeterProvider: MeterProvider | undefined;
+
+/**
+ * `OTEL_METRICS_EXPORTER=none` turns metric export off while the OTLP endpoint
+ * stays set for traces. Any other value (including unset) keeps the OTLP
+ * exporter, the only one the harness ships.
+ */
+export function metricsExportDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+    return env.OTEL_METRICS_EXPORTER === "none";
+}
+
+/**
+ * Export interval from `OTEL_METRIC_EXPORT_INTERVAL` (milliseconds). An unset,
+ * non-numeric, or non-positive value falls back to the 60 s default.
+ */
+export function metricExportIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
+    const raw = env.OTEL_METRIC_EXPORT_INTERVAL;
+    if (raw === undefined || raw.trim() === "") return DEFAULT_METRIC_EXPORT_INTERVAL_MS;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_METRIC_EXPORT_INTERVAL_MS;
+    return Math.floor(parsed);
+}
+
+function buildResource(options: InitOtelOptions): Resource {
+    const manual: Record<string, string> = {
+        [ATTR_SERVICE_NAME]: options.serviceName ?? "cortex",
+    };
+    if (options.serviceVersion) manual[ATTR_SERVICE_VERSION] = options.serviceVersion;
+    // `merge` gives precedence to the argument: the environment overrides the
+    // host's values, which is the OTel SDK convention for env configuration.
+    return resourceFromAttributes(manual).merge(detectResources({ detectors: [envDetector] }));
+}
 
 /**
  * Initialize the OpenTelemetry SDK. Must be called before any code that
@@ -39,15 +90,16 @@ let registeredMeterProvider: MeterProvider | undefined;
  *
  * Safe to call multiple times — only the first call has effect.
  */
-export function initOtel(injected?: Logger): void {
+export function initOtel(options: InitOtelOptions = {}): void {
     if (initialized) return;
     initialized = true;
-    const logger = (injected ?? createNoopLogger()).named("otel");
+    const logger = (options.logger ?? createNoopLogger()).named("otel");
 
     // ── W3C Trace Context propagation ──────────────────────────────────
     propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 
     const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const resource = buildResource(options);
 
     // ── Traces ─────────────────────────────────────────────────────────
     // Always register a TracerProvider so trace.getTracer() returns real spans
@@ -60,11 +112,6 @@ export function initOtel(injected?: Logger): void {
             const base = endpoint.replace(/\/+$/, "");
             spanProcessors.push(new BatchSpanProcessor(new OTLPTraceExporter({ url: `${base}/v1/traces` })));
         }
-
-        const serviceName = process.env.OTEL_SERVICE_NAME || "cortex";
-        const resource = resourceFromAttributes({
-            [ATTR_SERVICE_NAME]: serviceName,
-        });
 
         const tracerProvider = new NodeTracerProvider({
             resource,
@@ -82,22 +129,31 @@ export function initOtel(injected?: Logger): void {
         // `initTelemetry: () => {}` — its TUI owns stdout, so the banner corrupted
         // the screen and the whole of the harness's traces + metrics were switched
         // off to avoid it. At debug through the injected seam it costs nothing.
-        logger.debug("TracerProvider registered", { spanId: ctx.spanId, noop: isNoop, endpoint: endpoint ?? null, processors: spanProcessors.length });
+        logger.debug("TracerProvider registered", {
+            spanId: ctx.spanId,
+            noop: isNoop,
+            endpoint: endpoint ?? null,
+            processors: spanProcessors.length,
+            resource: resource.attributes,
+        });
         testSpan.end();
     }
 
     // ── Metrics ────────────────────────────────────────────────────────
-    if (endpoint) {
+    // With no MeterProvider registered the API's global no-op provider serves
+    // every instrument, so the record sites stay valid when export is off.
+    if (endpoint && !metricsExportDisabled()) {
         const base = endpoint.replace(/\/+$/, "");
         const metricExporter = new OTLPMetricExporter({
             url: `${base}/v1/metrics`,
         });
 
         const meterProvider = new MeterProvider({
+            resource,
             readers: [
                 new PeriodicExportingMetricReader({
                     exporter: metricExporter,
-                    exportIntervalMillis: 30_000,
+                    exportIntervalMillis: metricExportIntervalMs(),
                 }),
             ],
         });
@@ -117,4 +173,25 @@ export async function shutdownOtel(): Promise<void> {
     if (registeredTracerProvider) tasks.push(registeredTracerProvider.shutdown());
     if (registeredMeterProvider) tasks.push(registeredMeterProvider.shutdown());
     await Promise.allSettled(tasks);
+}
+
+/**
+ * Test hook: shut the providers down and unregister every global the init
+ * touched, so a test can drive `initOtel` again under a different environment.
+ * Test-only.
+ */
+export async function __resetOtelForTest(): Promise<void> {
+    await shutdownOtel();
+    registeredTracerProvider = undefined;
+    registeredMeterProvider = undefined;
+    trace.disable();
+    metrics.disable();
+    context.disable();
+    propagation.disable();
+    initialized = false;
+}
+
+/** Test hook: whether `initOtel` registered a metric-exporting MeterProvider. Test-only. */
+export function __otelMeterProviderRegisteredForTest(): boolean {
+    return registeredMeterProvider !== undefined;
 }

--- a/harness/src/runtime/dbos.test.ts
+++ b/harness/src/runtime/dbos.test.ts
@@ -10,10 +10,22 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Pool } from "pg";
 
-import { silentLogger } from "../__tests__/setup/logger.js";
-import { __resetDbosStateForTest, __setDbosStateForTest, dbosState, sweepEphemeralWorkflows, type DbosConfig } from "./dbos.js";
+import { createCapturingLogger, silentLogger } from "../__tests__/setup/logger.js";
+import { __resetDbosStateForTest, __setDbosStateForTest, dbosSdkConfig, dbosSdkLogger, dbosState, sweepEphemeralWorkflows, type DbosConfig } from "./dbos.js";
 
 const stubConfig = {} as DbosConfig;
+
+const fullConfig: DbosConfig = {
+    dbHost: "db.internal",
+    dbPort: "5432",
+    dbName: "cortex",
+    dbUser: "cortex",
+    dbPassword: "secret",
+    dbSslMode: "disable",
+    appName: "cortex",
+    adminPort: "3001",
+    executorId: "pod-1",
+};
 
 /**
  * `DBOS.shutdown` is stubbed by DIRECT property assignment, which
@@ -89,6 +101,61 @@ describe("launchDbos / shutdownDbos", () => {
         await shutdownDbos({ logger: silentLogger });
         expect(dbosState().launched).toBe(false);
         expect(stub).toHaveBeenCalled();
+    });
+});
+
+describe("dbosSdkConfig", () => {
+    it("leaves SDK tracing off unless the host turns it on", () => {
+        const sdk = dbosSdkConfig(fullConfig, silentLogger);
+        expect(sdk.tracingEnabled).toBe(false);
+        expect(sdk.otelAttributeFormat).toBe("semconv");
+        expect(sdk.enableOTLP).toBeUndefined();
+        expect(sdk.otlpTracesEndpoints).toBeUndefined();
+    });
+
+    it("passes tracingEnabled through", () => {
+        expect(dbosSdkConfig({ ...fullConfig, tracingEnabled: true }, silentLogger).tracingEnabled).toBe(true);
+    });
+
+    it("routes the SDK's own logging through the harness Logger seam", () => {
+        const logger = createCapturingLogger();
+        const sdk = dbosSdkConfig(fullConfig, logger);
+        sdk.logger!.info("Recovering 2 workflows");
+        expect(logger.records).toEqual([{ level: "info", msg: "[sdk] Recovering 2 workflows", fields: {} }]);
+    });
+});
+
+describe("dbosSdkLogger", () => {
+    it("applies the configured threshold, since the SDK does not filter a custom logger", () => {
+        const logger = createCapturingLogger();
+        const sdk = dbosSdkLogger(logger, "warn");
+        sdk.debug("d");
+        sdk.info("i");
+        sdk.warn("w");
+        sdk.error("e");
+        expect(logger.records.map((r) => r.level)).toEqual(["warn", "error"]);
+    });
+
+    it("defaults the threshold to info", () => {
+        const logger = createCapturingLogger();
+        const sdk = dbosSdkLogger(logger, undefined);
+        sdk.debug("d");
+        sdk.info("i");
+        expect(logger.records.map((r) => r.level)).toEqual(["info"]);
+    });
+
+    it("carries the stack and the operation context as fields, not in the message", () => {
+        const logger = createCapturingLogger();
+        const sdk = dbosSdkLogger(logger, "info");
+        const span = { attributes: { "dbos.operation.workflow_id": "wf-1", "dbos.operation.name": "executeAnalysis" } };
+        sdk.error("step failed", { stack: "Error: step failed\n    at x", span: span as never });
+        expect(logger.records).toHaveLength(1);
+        expect(logger.records[0]!.msg).toBe("[sdk] step failed");
+        expect(logger.records[0]!.fields).toEqual({
+            "dbos.operation.workflow_id": "wf-1",
+            "dbos.operation.name": "executeAnalysis",
+            stack: "Error: step failed\n    at x",
+        });
     });
 });
 

--- a/harness/src/runtime/dbos.ts
+++ b/harness/src/runtime/dbos.ts
@@ -13,10 +13,10 @@
  * See `openspec/changes/harness-dbos-runtime`.
  */
 
-import { DBOS } from "@dbos-inc/dbos-sdk";
+import { DBOS, type DBOSConfig, type DLogger } from "@dbos-inc/dbos-sdk";
 import type { Pool } from "pg";
 
-import type { Logger } from "../lib/logger.js";
+import type { LogFields, Logger } from "../lib/logger.js";
 import { DBOS_SYSTEM_POOL_SIZE } from "./pools.js";
 
 /**
@@ -36,12 +36,38 @@ export interface DbosConfig {
     /** Stable per-pod executor id (e.g. `process.env.HOSTNAME ?? "local-dev"`). */
     readonly executorId: string;
     /**
-     * SDK log verbosity (winston levels; the SDK's own default is `info`).
-     * Interactive embedders pass `warn` so the launch banner and migration
-     * chatter don't interleave with their own command output; the server root
-     * omits it and keeps the informative default.
+     * Least severe SDK record forwarded to the host's `Logger` (winston level
+     * names; the SDK's own default is `info`). The SDK's lines ride the
+     * harness `Logger` seam under `[dbos.sdk]`, so this threshold is applied by
+     * the bridge, not by the SDK. Interactive embedders pass `warn` so the
+     * launch banner and migration chatter stay out of their logs; the server
+     * root omits it and keeps the informative default.
      */
     readonly logLevel?: string;
+    /**
+     * Emit DBOS workflow and step spans on the globally registered
+     * TracerProvider, and run every workflow and step body under an active
+     * OTel context. Default `false`.
+     *
+     * DBOS installs nothing of its own here: with no OTLP endpoint of its own it
+     * probes the global provider and, when one is registered, emits under the
+     * instrumentation scope `dbos-tracer` through that provider's processors.
+     * A host that registers no provider (the CLI passes a no-op
+     * `initTelemetry`) must leave this off, otherwise the SDK installs its own
+     * `BasicTracerProvider` and every span is created and never exported.
+     *
+     * Attribute names follow the `dbos.*` semantic-convention layout
+     * (`otelAttributeFormat: "semconv"`).
+     *
+     * Known SDK behavior a host must plan for:
+     * - a recovered workflow starts a new root trace, with no link to the trace
+     *   of the original execution
+     * - every already-completed step re-emits a `cached=true` span on replay,
+     *   so a restart with many in-flight steps bursts spans; size
+     *   `OTEL_BSP_MAX_QUEUE_SIZE` for it
+     * - step span names embed the step, tool-use, or exec id
+     */
+    readonly tracingEnabled?: boolean;
 }
 
 /** DBOS lifecycle facts a host's readiness probe reports on. */
@@ -82,6 +108,75 @@ function systemDatabaseUrl(config: DbosConfig): string {
     return `postgresql://${user}:${password}@${host}:${port}/${database}?sslmode=${dbosSslMode(config.dbSslMode)}`;
 }
 
+/** Winston severity ranks, ascending verbosity — the scale `DbosConfig.logLevel` names. */
+const SDK_LOG_LEVEL_RANK: Readonly<Record<string, number>> = {
+    error: 0,
+    warn: 1,
+    info: 2,
+    http: 3,
+    verbose: 4,
+    debug: 5,
+    silly: 6,
+};
+
+const SDK_DEFAULT_LOG_LEVEL = "info";
+
+/**
+ * Bridge the SDK's internal logger onto the harness `Logger` seam, so the
+ * SDK's own lines (`Recovering N workflows…`, migration chatter) land in the
+ * host's sink instead of on the process console. The SDK does not filter by
+ * `logLevel` before it delegates to a custom logger, so the threshold is
+ * applied here. Records arrive as strings; an `Error` arrives as its message
+ * with the stack (and cause chain) in `metadata.stack`; inside a workflow or
+ * step body `metadata.span.attributes` carries the operation context, which
+ * rides as fields.
+ */
+export function dbosSdkLogger(logger: Logger, logLevel: string | undefined): DLogger {
+    const sink = logger.named("sdk");
+    const threshold = SDK_LOG_LEVEL_RANK[logLevel ?? SDK_DEFAULT_LOG_LEVEL] ?? SDK_LOG_LEVEL_RANK[SDK_DEFAULT_LOG_LEVEL]!;
+    const passes = (level: keyof typeof SDK_LOG_LEVEL_RANK): boolean => SDK_LOG_LEVEL_RANK[level]! <= threshold;
+    const fields = (metadata: Parameters<DLogger["error"]>[1]): LogFields | undefined => {
+        const attributes = metadata?.span?.attributes;
+        const stack = metadata?.stack;
+        if (attributes === undefined && stack === undefined) return undefined;
+        return { ...attributes, ...(stack !== undefined ? { stack } : {}) };
+    };
+    const message = (entry: unknown): string => (typeof entry === "string" ? entry : String(entry));
+    return {
+        debug: (entry, metadata) => {
+            if (passes("debug")) sink.debug(message(entry), fields(metadata));
+        },
+        info: (entry, metadata) => {
+            if (passes("info")) sink.info(message(entry), fields(metadata));
+        },
+        warn: (entry, metadata) => {
+            if (passes("warn")) sink.warn(message(entry), fields(metadata));
+        },
+        error: (entry, metadata) => {
+            if (passes("error")) sink.error(message(entry), fields(metadata));
+        },
+    };
+}
+
+/**
+ * The SDK config `launchDbos` sets. Pure over `DbosConfig`, so a test can
+ * assert on the mapping without a launch.
+ */
+export function dbosSdkConfig(config: DbosConfig, logger: Logger): DBOSConfig {
+    return {
+        name: config.appName,
+        systemDatabaseUrl: systemDatabaseUrl(config),
+        systemDatabasePoolSize: DBOS_SYSTEM_POOL_SIZE,
+        executorID: config.executorId,
+        applicationVersion: config.applicationVersion,
+        adminPort: parseInt(config.adminPort, 10),
+        logLevel: config.logLevel,
+        logger: dbosSdkLogger(logger, config.logLevel),
+        tracingEnabled: config.tracingEnabled ?? false,
+        otelAttributeFormat: "semconv",
+    };
+}
+
 /**
  * Launch DBOS. Idempotent — a second call is a no-op so tests that drive
  * the harness twice (or accidentally double-import) don't re-launch.
@@ -94,27 +189,19 @@ export async function launchDbos({ config, logger: injected }: { config: DbosCon
     if (state.launched) return;
 
     const logger = injected.named("dbos");
-    const executorID = config.executorId;
-    const adminPort = parseInt(config.adminPort, 10);
+    const sdkConfig = dbosSdkConfig(config, logger);
 
-    DBOS.setConfig({
-        name: config.appName,
-        systemDatabaseUrl: systemDatabaseUrl(config),
-        systemDatabasePoolSize: DBOS_SYSTEM_POOL_SIZE,
-        executorID,
-        applicationVersion: config.applicationVersion,
-        adminPort,
-        logLevel: config.logLevel,
-    });
+    DBOS.setConfig(sdkConfig);
 
     const start = performance.now();
     await DBOS.launch();
     state.launched = true;
     state.recoveryStarted = true;
     logger.info("launched", {
-        executorID,
+        executorID: sdkConfig.executorID,
         applicationVersion: config.applicationVersion,
-        adminPort,
+        adminPort: sdkConfig.adminPort,
+        tracingEnabled: sdkConfig.tracingEnabled,
         durationMs: Math.round(performance.now() - start),
     });
 }

--- a/harness/src/workflows/metrics.ts
+++ b/harness/src/workflows/metrics.ts
@@ -1,15 +1,10 @@
 /**
- * Workflow-side OTel metrics → Middleware.io.
+ * Workflow-side OTel metrics.
  *
- * Two signals so 3-hour runs and pause-resume cascades are observable:
  *   - cortex.workflow.parent.cancelled_children — counter, incremented once
  *     per child the fail-fast or pause cascade reaps. A baseline near 0
  *     means runs land cleanly; a spike means siblings keep colliding with
  *     a single failing step.
- *   - cortex.workflow.stream.bytes               — counter, incremented by
- *     the byte count of every UI part written onto the DBOS stream. The
- *     leading indicator for 3-hour stream growth is monotonic — a runaway
- *     emitter shows up as an unbounded slope.
  *
  * Instruments are lazy so the workflow body binds to whichever
  * `MeterProvider` is globally registered at startup.
@@ -19,7 +14,6 @@ import { type Counter, metrics } from "@opentelemetry/api";
 
 interface Instruments {
     readonly cancelledChildren: Counter;
-    readonly streamBytes: Counter;
 }
 
 let instruments: Instruments | undefined;
@@ -30,10 +24,6 @@ function getInstruments(): Instruments {
         instruments = {
             cancelledChildren: meter.createCounter("cortex.workflow.parent.cancelled_children", {
                 description: "Children cancelled by the parent's fail-fast or pause cascade",
-            }),
-            streamBytes: meter.createCounter("cortex.workflow.stream.bytes", {
-                description: "Bytes written to the parent's DBOS UI-parts stream — proxy for " + "3-hour stream growth",
-                unit: "By",
             }),
         };
     }
@@ -48,16 +38,6 @@ function getInstruments(): Instruments {
  */
 export function recordCancelledChild(args: { readonly cause: "fail_fast" | "budget_exceeded" | "external_cancel" }): void {
     getInstruments().cancelledChildren.add(1, { cause: args.cause });
-}
-
-/**
- * Record one UI-part write. `bytes` is the serialised JSON size of the
- * part as it lands on the stream; `kind` is the part `type` for
- * dashboarding. The workflow body wraps its `DBOS.writeStream` call site
- * so a single emitter records once per part.
- */
-export function recordStreamWrite(args: { readonly bytes: number; readonly kind: string }): void {
-    getInstruments().streamBytes.add(args.bytes, { kind: args.kind });
 }
 
 /** Test hook — drop memoised instruments to rebind a fresh MeterProvider. */


### PR DESCRIPTION
## What & why

- `initOtel` starts the metric exporter only when `OTEL_METRICS_EXPORTER` is not `none`. The interval comes from `OTEL_METRIC_EXPORT_INTERVAL`, default 60 s.
- The resource merges the `serviceName` and `serviceVersion` of the host with the SDK env detector, and the environment wins. The MeterProvider shares it. `initOtel` takes an options object.
- The two reconcile counters lose the unbounded `step_id` label. The dead `cortex.workflow.stream.bytes` instrument is removed.
- `DbosConfig.tracingEnabled` (default `false`) goes to `DBOS.setConfig` with `otelAttributeFormat: "semconv"`. The default is off because the CLI registers no provider.
- The SDK has a `logger` hook (`DBOSConfig.logger`). A bridge sends the SDK lines to the harness `Logger` under `[dbos.sdk]` and applies `logLevel`, because the SDK does not filter a custom logger.
- The run launcher starts a workflow under `ROOT_CONTEXT` in a short root span with a link to the originating span. Both spans carry `inflexa.run_id`.

Notes for the reviewer:

- `lib/metrics.ts` took its meter at import time, before `initOtel`. The metrics API has no late-binding proxy, so both reconcile counters were no-op instruments in production. They bind at record time now. The other five metric modules were lazy already.
- The DBOS behavior that the flag depends on is validated in `platform-charts/docs/observability/explore/round2-cortex-dbos.md`: DBOS probes the global provider, installs nothing, and emits under the scope `dbos-tracer`. A recovered workflow starts a new root trace. Each cached step re-emits a `cached=true` span on replay. Span names embed ids.
- The version bump to 0.35.2 (a patch above 0.35.1) is a separate commit.

The host must pass `tracingEnabled` from a `DBOS_TRACING` env after the pin bump to 0.35.2, pass `serviceName` and `serviceVersion` to `initOtel`, and set `OTEL_BSP_MAX_QUEUE_SIZE` and `OTEL_RESOURCE_ATTRIBUTES` in the chart. The target-assessment route calls `DBOS.startWorkflow` directly, so it gets no root span until it uses `runLauncher.launch`.

Test evidence: typecheck clean, `bun run test:full` 4251 pass, 0 fail, 18 skip. Lint reports one error in `src/providers/ai-sdk.test.ts:1378` that is present on `main`.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01XJ3U53ivPT6zGc5FL7N4vv
