### PR TITLE
fix(harness): place the cache breakpoint on the last message

### DIFF
--- a/harness/bun.lock
+++ b/harness/bun.lock
@@ -45,6 +45,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@ai-sdk/amazon-bedrock": "^5.0.74",
         "@eslint/js": "^10.0.1",
         "@types/bun": "latest",
         "@types/dockerode": "^3.3.47",
@@ -74,6 +75,8 @@
     "uuid": "^11.1.1",
   },
   "packages": {
+    "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@5.0.74", "", { "dependencies": { "@ai-sdk/anthropic": "4.0.49", "@ai-sdk/openai": "4.0.58", "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36", "@smithy/eventstream-codec": "^4.3.3", "@smithy/util-utf8": "^4.3.3", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-upkwfmjqpz6KA+dfbqU5OfnIvgmC5QAVddddJqTXpG5dNiHXYDG/KDxOArDlYlZH6kjAK4q7zCAIRYUpgVsHOQ=="],
+
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.38", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-esbTb5jq/37dloBJzld3CpYCZskiDWGcI4O8kzst9J/0Km4by7cgQXLTB/gGdjXxBsyjPQUeotVqqRRIrx2zew=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.49", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qdSUr4FAN7e+MHBdVzkmbGMtpf7XQdQp1AgMI3jV0QPmld/4k4QbR7mXRQgjUsPeIfAwBzMPMPziHAPP1tXRwg=="],
@@ -222,6 +225,14 @@
 
     "@sidvind/better-ajv-errors": ["@sidvind/better-ajv-errors@7.0.0", "", { "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A=="],
 
+    "@smithy/core": ["@smithy/core@3.33.3", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "tslib": "^2.6.2" } }, "sha512-u4EAkaviMcQYlorFSnxFUgF/Dnbgiu2TzGmqOU4h3CL4MbvrYyNCXpFkcBwvAEU11EvspKX2zzS2uX7q+43VdQ=="],
+
+    "@smithy/types": ["@smithy/types@4.18.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "tslib": "^2.6.2" } }, "sha512-7wNWV7SugHpcMA7uzEawJNpE0GrasXM7a9E+1+Wm6NxVuDClESac/AKt+G7jMZNUz5vBLWqKlqVV7Sv7AtUr6Q=="],
+
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -327,6 +338,8 @@
     "async-lock": ["async-lock@1.4.1", "", {}, "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
@@ -946,6 +959,14 @@
 
     "zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
 
+    "@ai-sdk/amazon-bedrock/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.49", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-fzy2sLrs3vNsliIgx65fuovsa6a7OTXd6DllKUgLuVmPyqLnvoZCv9NlKgq+krzDzSxLb9d0zTaJJpsjBVLNyA=="],
+
+    "@ai-sdk/amazon-bedrock/@ai-sdk/openai": ["@ai-sdk/openai@4.0.58", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oO3vH0e8lhN3OrANukokI2rvUJV+RVwTwJ2y+eSK+IiKlauFza2Yyl/7hjErqkjOt/eMOobhNijo+CFsFt8T+g=="],
+
+    "@ai-sdk/amazon-bedrock/@ai-sdk/provider": ["@ai-sdk/provider@4.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A=="],
+
+    "@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.36", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.29.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
@@ -987,6 +1008,14 @@
     "@opentelemetry/sdk-logs/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@sidvind/better-ajv-errors/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@smithy/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@smithy/eventstream-codec/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@smithy/types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@smithy/util-utf8/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@types/docker-modem/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/.openspec.yaml
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/design.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The cache keys on an exact prefix. The render order is tools, then system, then
+messages. Thus one breakpoint at the end of the messages caches the whole prefix.
+The request-level directive and the message-level directive cache the same bytes.
+Only the placement differs.
+
+## Decision
+
+### Place the breakpoint on the last message
+
+A block marker is countable. Each hop between the harness and the endpoint can
+read it, trim it, and reason about it. A top-level field is countable only by the
+endpoint.
+
+This makes the harness safe against the class of defect, not against one version
+of one proxy. The proxy budget is now correct, because the proxy sees every
+breakpoint that the request holds.
+
+### Roll the breakpoint forward, and do not pin it
+
+The loop appends the reply of the model and the results of its tools on each
+iteration. A breakpoint on the last message advances with them, and iteration N+1
+reads back what iteration N wrote.
+
+A pinned breakpoint at the end of the stable prefix looks attractive, because the
+tail of a turn changes on each turn. But a pinned breakpoint makes each iteration
+send the whole tool transcript uncached. A long tool loop is the case that
+caching exists for, thus the rolling placement wins.
+
+### Return a copy of the transcript
+
+The loop pushes each new message onto the array that the caller gave it, and the
+host writes that array to the thread store. A directive written into the array
+goes into the store, and it comes back on each later turn. The count then grows
+by one per turn until the endpoint refuses the request.
+
+### Remove a directive that a stored message carries
+
+`memory/ai-sdk-message-storage.ts` reads `cache_control` off a stored block. Thus
+a row that an older build wrote can arrive with a directive already on it. Such a
+directive spends a breakpoint that the harness did not budget. The placement
+function removes each one, thus the invariant holds against the store as well as
+against the loop.
+
+### Move back past a thinking block
+
+The Anthropic provider resolves a message-level directive onto the last content
+part of the message. A thinking block cannot carry `cache_control`. The provider
+drops the directive there, and it reports no error. The result is a silent cache
+miss on each call after it. The server-side placement moved back for us before,
+thus the function moves back too.
+
+## Risks / Trade-offs
+
+- The placement is now the responsibility of the harness. A future provider that
+  changes which block can carry a marker breaks it silently. The unit tests pin
+  the two known cases: a thinking block, and an empty content array.
+- `promptCacheProviderOptions` stays in the barrel. An embedder can still attach
+  it to a request and keep the defect. The alternative removes a public export
+  and breaks an embedder that uses it correctly. The doc comment carries the
+  warning instead.
+
+## Verification
+
+A live rig proved both halves. It ran CLIProxyAPI v7.2.148 with cloaking forced
+on, against a mock endpoint that counts breakpoints and enforces the limit of
+four:
+
+- The request placement fails on turn 2, turn 3, and turn 4 with the HTTP 400.
+  Turn 1 passes. Each failing request carries 5 breakpoints.
+- The message placement passes on each turn, with 3 or 4 breakpoints.
+
+Real chats through the CLI proxy against Anthropic passed on each turn. They
+reported cache reads of 2050 and 2059 tokens after the first turn.

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/proposal.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/proposal.md
@@ -33,6 +33,14 @@ three markers to it. Each turn after the first fails.
 - `runAgent` places the breakpoint on each call, and no longer sets
   `ChatRequest.providerOptions`. The breakpoint rides the last message, and the
   transcript grows with each iteration.
+- The marker goes into the namespace of each vendor that takes an explicit
+  breakpoint: `anthropic.cacheControl` and `bedrock.cachePoint`. A provider reads
+  only its own namespace. Thus the pair is inert for the other vendor, and the
+  placement needs no idea which one serves the call.
+- `@ai-sdk/amazon-bedrock` becomes a dev dependency. The code imports nothing
+  from it. One unit test renders the marker through the real Bedrock provider.
+  That package exports no type for `cachePoint`, and it passes the value to AWS
+  as it is.
 
 ## Capabilities
 

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/proposal.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The loop put the cache directive on the request. The Anthropic provider then
+emits a top-level `cache_control` field, and the server places the breakpoint.
+That field is invisible to an intermediary, because an intermediary counts
+blocks.
+
+CLIProxyAPI is the intermediary that the CLI uses on the Claude OAuth path. It
+adds up to four block markers of its own, and it trims them to the Anthropic
+limit of four by that blind count. The top-level field made the total five. The
+endpoint refused the request:
+
+```
+HTTP 400 A maximum of 4 blocks with cache_control may be provided. Found 5.
+```
+
+The refusal is not retryable, and the next turn makes the same shape again. Thus
+the thread stops. The first turn of a thread passes, because the proxy adds only
+three markers to it. Each turn after the first fails.
+
+## What Changes
+
+- `withPromptCacheBreakpoint(messages, policy)` places the directive on the last
+  message that can carry it. A block marker is countable, thus each hop trims
+  correctly.
+- The function removes the directive from each other message. One request holds
+  one breakpoint.
+- The function returns a copy. The caller keeps the transcript, and a host writes
+  that transcript to a store. A directive in the store comes back on each later
+  turn.
+- The placement moves back past a message that ends with a thinking block. Such a
+  block cannot carry a directive, and the provider drops it without an error.
+- `runAgent` places the breakpoint on each call, and no longer sets
+  `ChatRequest.providerOptions`. The breakpoint rides the last message, and the
+  transcript grows with each iteration.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `harness-providers`: the placement of the cache directive moves from the
+  request to the last message, and the module gains the placement function.
+- `harness-agent-loop`: the loop places the breakpoint per call instead of
+  sending one options object per run.
+
+## Impact
+
+- `src/providers/prompt-cache.ts` — adds `withPromptCacheBreakpoint`.
+- `src/loop/run-agent.ts` — both chat call sites place the breakpoint.
+- `src/index.ts` — the barrel exports the placement function.
+- `src/loop/prompt-cache.test.ts` — covers the placement and its edge cases.
+- `src/providers/integration/anthropic-caching.integration.test.ts` — builds the
+  request the loop now builds.
+- An embedder that calls `promptCacheProviderOptions` and attaches the result to
+  a `ChatRequest` keeps the defect. The doc comment names the correct site.

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-agent-loop/spec.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-agent-loop/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: The loop caches its prompt prefix by default
+
+`RunAgentOptions` MUST accept an optional `promptCache: PromptCachePolicy`. It
+MUST default to `DEFAULT_PROMPT_CACHE` (`{ ttl: "5m" }`) when the caller supplies
+none. A host whose endpoint ignores cache directives, or charges badly for them,
+MUST be able to pass `"off"`.
+
+The loop MUST resolve the policy ONCE per run. An identical policy across every
+call is part of the cache contract, because the prefix must be byte-identical to
+be read back.
+
+The loop MUST place the breakpoint with `withPromptCacheBreakpoint` on each call,
+and MUST NOT set `ChatRequest.providerOptions` for the cache. The breakpoint rides
+the last message, and the transcript grows with each iteration. Thus the loop
+re-derives the placement per call.
+
+The placement MUST roll forward with the transcript. Each iteration appends the
+reply of the model and the results of its tools. The next call then reads back
+what the last call wrote. A breakpoint pinned before the tool messages makes each
+iteration send the whole tool transcript uncached.
+
+The forced wrap-up call MUST also carry a breakpoint. That call empties the tool
+set, thus it reads nothing back and rewrites the prefix. The write is pure waste,
+and the cache-write counter is what makes the waste visible.
+
+#### Scenario: A run with no policy still caches
+
+- **WHEN** `runAgent` is invoked with no `promptCache`
+- **THEN** every LLM call it makes MUST carry the 5-minute cache directive on its last message
+
+#### Scenario: No call carries a request-level directive
+
+- **WHEN** `runAgent` makes any LLM call
+- **THEN** `ChatRequest.providerOptions` MUST be unset, because a request-level directive is a breakpoint that an intermediary cannot count
+
+#### Scenario: The breakpoint rolls forward across iterations
+
+- **GIVEN** a run whose model calls a tool on each iteration
+- **WHEN** the loop makes each call
+- **THEN** the marked message index MUST grow from one call to the next
+
+#### Scenario: The transcript the run returns is unmarked
+
+- **WHEN** `runAgent` completes
+- **THEN** no message of `AgentRunResult.messages` MUST carry a cache directive, because a host writes that array to a thread store
+
+#### Scenario: A host opts out
+
+- **WHEN** `runAgent` is invoked with `promptCache: "off"`
+- **THEN** no LLM call it makes MUST carry a cache directive, on a message or on the request

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-providers/spec.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-providers/spec.md
@@ -9,8 +9,19 @@ cache directive at all.
 
 `providers/prompt-cache.ts` MUST be the ONLY place in the harness that names a
 vendor for caching. `promptCacheProviderOptions(policy)` MUST return `undefined`
-for `"off"`. For each other policy it MUST return one `cacheControl` directive in
-the namespace of the provider.
+for `"off"`. For each other policy it MUST return one directive for each vendor
+that takes an explicit breakpoint, each in the namespace of that vendor:
+`anthropic.cacheControl` and `bedrock.cachePoint`. Both directives MUST carry the
+ttl of the policy.
+
+A provider reads only its own namespace, thus the directive of one vendor is
+inert on another. As a result the placement never learns which vendor serves the
+call. A vendor that caches without a marker gets none: the OpenAI family caches
+prefixes server-side and exposes no breakpoint, and Gemini caches implicitly.
+
+The two shapes differ in more than the name. Anthropic marks the last content
+block of the message. Bedrock appends a `cachePoint` block after it. Both land at
+the same position of the prefix.
 
 `withPromptCacheBreakpoint(messages, policy)` MUST place that directive, and it
 MUST be the only writer of one. It MUST put the directive on the LAST message that
@@ -51,10 +62,22 @@ OpenAI-compatible family does server-side prefix caching, unprompted.
 - **WHEN** `promptCacheProviderOptions("off")` is called
 - **THEN** it MUST return `undefined`, and the request MUST carry no `providerOptions`
 
-#### Scenario: A ttl policy emits one namespaced cache directive
+#### Scenario: A ttl policy emits one directive for each marker vendor
 
 - **WHEN** `promptCacheProviderOptions({ ttl: "1h" })` is called
-- **THEN** it MUST return a single provider-namespaced `cacheControl` directive that carries that ttl
+- **THEN** it MUST return `anthropic.cacheControl` and `bedrock.cachePoint`, and each one MUST carry that ttl
+
+#### Scenario: The bedrock marker reaches the wire in the shape of that vendor
+
+- **GIVEN** a transcript that `withPromptCacheBreakpoint` marked with a ttl policy
+- **WHEN** the Bedrock provider renders the request
+- **THEN** a `cachePoint` block MUST come after the content of the last message, and it MUST carry the ttl
+
+#### Scenario: A marker of another vendor is removed from an earlier message
+
+- **GIVEN** a transcript whose first message carries a `bedrock.cachePoint` directive
+- **WHEN** `withPromptCacheBreakpoint` is called with a ttl policy
+- **THEN** the first message MUST lose that directive, because the one-breakpoint invariant holds per vendor
 
 #### Scenario: The breakpoint goes on the last message
 

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-providers/spec.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/specs/harness-providers/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Prompt caching is a vendor-neutral policy translated at one site
+
+The harness MUST express prompt caching as `PromptCachePolicy`. A value of
+`{ ttl: "5m" | "1h" }` caches the request prefix for that lifetime. The prefix is
+the tools, the system prompt, and the message history. A value of `"off"` sends no
+cache directive at all.
+
+`providers/prompt-cache.ts` MUST be the ONLY place in the harness that names a
+vendor for caching. `promptCacheProviderOptions(policy)` MUST return `undefined`
+for `"off"`. For each other policy it MUST return one `cacheControl` directive in
+the namespace of the provider.
+
+`withPromptCacheBreakpoint(messages, policy)` MUST place that directive, and it
+MUST be the only writer of one. It MUST put the directive on the LAST message that
+can carry it. It MUST remove the directive from each other message, thus a request
+holds exactly one breakpoint. It MUST return a copy of the messages.
+
+The harness MUST NOT attach the directive to a `ChatRequest`. A request-level
+directive reaches the wire as a top-level `cache_control` field. An intermediary
+counts blocks, thus it cannot see that field.
+
+CLIProxyAPI adds its own block markers, and it trims them to the Anthropic limit
+of four by that count. A top-level field then makes the total five, and the
+endpoint answers HTTP 400. The refusal is not retryable, and the next turn builds
+the same shape. Thus the thread stops.
+
+A copy is necessary because the caller keeps the transcript. A host writes that
+transcript to a thread store. A directive in the store comes back on each later
+turn, and the count grows by one per turn.
+
+The removal is necessary because `memory/ai-sdk-message-storage.ts` reads
+`cache_control` off a stored block. Thus a row from an older build can arrive with
+a directive on it. That directive spends a breakpoint that the harness did not
+budget.
+
+A message that ends with a thinking block cannot carry the directive. The provider
+drops it there and reports no error, thus each later call misses the cache.
+`withPromptCacheBreakpoint` MUST move back to the last message that can carry the
+directive. It MUST place none when no message can carry one.
+
+The emitted options MUST be safe on every provider. AI SDK `providerOptions` is a
+namespaced bag, and each provider reads only its own key from it. Thus a directive
+for one vendor is inert on another, and it is not an error. A vendor that caches
+automatically needs no directive, thus the policy is a no-op for it. The
+OpenAI-compatible family does server-side prefix caching, unprompted.
+
+#### Scenario: An off policy sends no directive
+
+- **WHEN** `promptCacheProviderOptions("off")` is called
+- **THEN** it MUST return `undefined`, and the request MUST carry no `providerOptions`
+
+#### Scenario: A ttl policy emits one namespaced cache directive
+
+- **WHEN** `promptCacheProviderOptions({ ttl: "1h" })` is called
+- **THEN** it MUST return a single provider-namespaced `cacheControl` directive that carries that ttl
+
+#### Scenario: The breakpoint goes on the last message
+
+- **GIVEN** a transcript of three messages and a ttl policy
+- **WHEN** `withPromptCacheBreakpoint` is called
+- **THEN** only the third message MUST carry the directive
+
+#### Scenario: A directive on an earlier message is removed
+
+- **GIVEN** a transcript whose first message came from the store with a directive on it
+- **WHEN** `withPromptCacheBreakpoint` is called with a ttl policy
+- **THEN** the result MUST hold one directive, on the last message, and the first message MUST keep its other provider keys
+
+#### Scenario: The placement moves back past a thinking block
+
+- **GIVEN** a transcript whose last message is an assistant turn that ends with a thinking block
+- **WHEN** `withPromptCacheBreakpoint` is called with a ttl policy
+- **THEN** the directive MUST go on the message before it
+
+#### Scenario: The transcript of the caller stays unmarked
+
+- **GIVEN** a transcript that a host later writes to a thread store
+- **WHEN** `withPromptCacheBreakpoint` is called
+- **THEN** it MUST return a copy, and no message of the input MUST carry a directive
+
+#### Scenario: An off policy strips a stored directive
+
+- **GIVEN** a transcript whose first message came from the store with a directive on it
+- **WHEN** `withPromptCacheBreakpoint` is called with `"off"`
+- **THEN** the result MUST hold no directive at all
+
+#### Scenario: The directive is inert on a provider that did not ask for it
+
+- **GIVEN** a request that carries a cache directive in the namespace of one provider
+- **WHEN** it is sent to an OpenAI-compatible model
+- **THEN** the model MUST ignore the foreign namespace and the call MUST succeed

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/tasks.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/tasks.md
@@ -1,3 +1,9 @@
+## 0. Vendors
+
+- [x] 0.1 Add `@ai-sdk/amazon-bedrock` as a dev dependency of the harness
+- [x] 0.2 Emit `bedrock.cachePoint` beside `anthropic.cacheControl`, each with the ttl of the policy
+- [x] 0.3 Bind the emitted shapes with `satisfies`, thus a renamed key breaks the build
+
 ## 1. Placement
 
 - [x] 1.1 Add `withPromptCacheBreakpoint(messages, policy)` to `src/providers/prompt-cache.ts`
@@ -18,6 +24,8 @@
 - [x] 3.2 Loop tests for the per-call placement, the roll-forward, and the unmarked result
 - [x] 3.3 A regression test that no call carries a request-level directive
 - [x] 3.4 Point the Anthropic caching integration test at the new placement
+- [x] 3.5 Render the bedrock marker through the real provider, and assert the `cachePoint` block and its ttl
+- [x] 3.6 Assert that the strip covers a stale marker of any vendor namespace
 
 ## 4. Verify
 

--- a/harness/openspec/changes/place-cache-breakpoint-on-last-message/tasks.md
+++ b/harness/openspec/changes/place-cache-breakpoint-on-last-message/tasks.md
@@ -1,0 +1,27 @@
+## 1. Placement
+
+- [x] 1.1 Add `withPromptCacheBreakpoint(messages, policy)` to `src/providers/prompt-cache.ts`
+- [x] 1.2 Put the directive on the last message that can carry it, and remove it from each other message
+- [x] 1.3 Move back past a message that ends with a thinking block, and past an empty content array
+- [x] 1.4 Return a copy, thus the transcript of the caller stays unmarked
+
+## 2. Loop
+
+- [x] 2.1 Resolve the policy once per run in `src/loop/run-agent.ts`
+- [x] 2.2 Place the breakpoint on each iteration and on the wrap-up call
+- [x] 2.3 Stop setting `ChatRequest.providerOptions` for the cache
+- [x] 2.4 Export the placement function from `src/index.ts`
+
+## 3. Tests
+
+- [x] 3.1 Unit tests for the placement, the strip, the copy, the walk-back, and the off policy
+- [x] 3.2 Loop tests for the per-call placement, the roll-forward, and the unmarked result
+- [x] 3.3 A regression test that no call carries a request-level directive
+- [x] 3.4 Point the Anthropic caching integration test at the new placement
+
+## 4. Verify
+
+- [x] 4.1 `npx tsc -p tsconfig.json --noEmit` clean
+- [x] 4.2 `bun test` green (4225 pass, 0 fail)
+- [x] 4.3 A live rig with CLIProxyAPI v7.2.148 refuses the old placement and accepts the new one
+- [x] 4.4 Real chats through the CLI proxy pass, and they report cache reads

--- a/harness/package.json
+++ b/harness/package.json
@@ -94,6 +94,7 @@
         "uuid": "^11.1.1"
     },
     "devDependencies": {
+        "@ai-sdk/amazon-bedrock": "^5.0.74",
         "@eslint/js": "^10.0.1",
         "@types/bun": "latest",
         "@types/dockerode": "^3.3.47",

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -274,8 +274,12 @@ export type {
 // re-sends its prefix every iteration and breaks even immediately). Hosts whose
 // endpoint ignores cache directives — notably the Claude Max OAuth path — pass
 // `"off"`; the `cortex.harness.agent.cache_*_tokens` metrics show which case a
-// deployment is actually in.
-export { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "./providers/prompt-cache.js";
+// deployment is actually in. `withPromptCacheBreakpoint` is the placement: it
+// puts the ONE marker of a request on its last message, where every hop upstream
+// can count it. Never attach `promptCacheProviderOptions` to a request itself —
+// that emits a top-level field an intermediary cannot see, and a proxy that trims
+// to Anthropic's cap of four breakpoints then sends five.
+export { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions, withPromptCacheBreakpoint } from "./providers/prompt-cache.js";
 // Reasoning depth. `ReasoningPolicy` is the vendor-neutral name for how deep a
 // model reasons; a composition root sets it per run through
 // `RunAgentOptions.reasoning`. It defaults to `DEFAULT_REASONING` — `xhigh` —

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -276,9 +276,11 @@ export type {
 // `"off"`; the `cortex.harness.agent.cache_*_tokens` metrics show which case a
 // deployment is actually in. `withPromptCacheBreakpoint` is the placement: it
 // puts the ONE marker of a request on its last message, where every hop upstream
-// can count it. Never attach `promptCacheProviderOptions` to a request itself —
-// that emits a top-level field an intermediary cannot see, and a proxy that trims
-// to Anthropic's cap of four breakpoints then sends five.
+// can count it, in the namespace of each vendor that needs an explicit
+// breakpoint (Anthropic and Bedrock; the OpenAI family and Gemini cache without
+// one). Never attach `promptCacheProviderOptions` to a request itself — that
+// emits a top-level field an intermediary cannot see, and a proxy that trims to
+// Anthropic's cap of four breakpoints then sends five.
 export { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions, withPromptCacheBreakpoint } from "./providers/prompt-cache.js";
 // Reasoning depth. `ReasoningPolicy` is the vendor-neutral name for how deep a
 // model reasons; a composition root sets it per run through

--- a/harness/src/loop/prompt-cache.test.ts
+++ b/harness/src/loop/prompt-cache.test.ts
@@ -14,8 +14,8 @@ import { z } from "zod";
 
 import { makeSession } from "../providers/__fixtures__/session.js";
 import { createConfiguredAiSdkProvider } from "../providers/ai-sdk.js";
-import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/prompt-cache.js";
-import type { PromptCachePolicy } from "../providers/types.js";
+import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions, withPromptCacheBreakpoint } from "../providers/prompt-cache.js";
+import type { ModelMessage, PromptCachePolicy } from "../providers/types.js";
 import { defineTool } from "../tools/define-tool.js";
 import { makeMessage, scriptedProvider, type ScriptedProvider, textBlock, toolUseBlock } from "./__fixtures__/scripted-provider.js";
 import { __resetMetricsForTest } from "./metrics.js";
@@ -77,8 +77,113 @@ describe("promptCacheProviderOptions", () => {
     });
 });
 
+// ── Breakpoint placement ────────────────────────────────────────────
+//
+// The marker has to ride a MESSAGE, never the request: a request-level directive
+// reaches the wire as a top-level `cache_control` field, and an intermediary that
+// counts blocks to stay under Anthropic's cap of four cannot see one. These
+// assert the placement itself, because the failure it prevents is a
+// non-retryable 400 that wedges a whole thread.
+
+/** Every message index carrying a cache marker. */
+function breakpointsOf(messages: readonly ModelMessage[]): number[] {
+    return messages.flatMap((m, i) => (m.providerOptions?.["anthropic"]?.["cacheControl"] === undefined ? [] : [i]));
+}
+
+const userText = (text: string): ModelMessage => ({ role: "user", content: [{ type: "text", text }] });
+const assistantText = (text: string): ModelMessage => ({ role: "assistant", content: [{ type: "text", text }] });
+/** An assistant turn that ends in a thinking block — a block that cannot carry a marker. */
+const assistantThinking = (): ModelMessage => ({
+    role: "assistant",
+    content: [
+        { type: "text", text: "answering" },
+        { type: "reasoning", text: "deliberating", providerOptions: { anthropic: { signature: "sig-1" } } },
+    ],
+});
+
+describe("withPromptCacheBreakpoint", () => {
+    it("places exactly one breakpoint, on the last message", () => {
+        const marked = withPromptCacheBreakpoint([userText("a"), assistantText("b"), userText("c")], DEFAULT_PROMPT_CACHE);
+
+        expect(breakpointsOf(marked)).toEqual([2]);
+        expect(marked[2]?.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual({ type: "ephemeral", ttl: "5m" });
+    });
+
+    it("carries an explicit ttl onto the message", () => {
+        const marked = withPromptCacheBreakpoint([userText("a")], { ttl: "1h" });
+
+        expect(marked[0]?.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual({ type: "ephemeral", ttl: "1h" });
+    });
+
+    it("never mutates the caller's array or its messages", () => {
+        const transcript = [userText("a"), userText("b")];
+        const snapshot = structuredClone(transcript);
+
+        const marked = withPromptCacheBreakpoint(transcript, DEFAULT_PROMPT_CACHE);
+
+        // The transcript is what the loop keeps appending to and the host later
+        // persists. A marker written into it would ride into the stored thread and
+        // come back on every later turn, one more breakpoint per turn.
+        expect(transcript).toEqual(snapshot);
+        expect(breakpointsOf(transcript)).toEqual([]);
+        expect(marked[1]).not.toBe(transcript[1]);
+    });
+
+    it("walks back past an assistant turn that ends in a thinking block", () => {
+        // The provider drops a marker on a thinking block: no error, no breakpoint,
+        // and a silent miss on every call after it.
+        const marked = withPromptCacheBreakpoint([userText("a"), assistantThinking()], DEFAULT_PROMPT_CACHE);
+
+        expect(breakpointsOf(marked)).toEqual([0]);
+    });
+
+    it("skips a message with no content to host the marker", () => {
+        const empty: ModelMessage = { role: "user", content: [] };
+
+        expect(breakpointsOf(withPromptCacheBreakpoint([userText("a"), empty], DEFAULT_PROMPT_CACHE))).toEqual([0]);
+        expect(breakpointsOf(withPromptCacheBreakpoint([{ role: "user", content: "" }, empty], DEFAULT_PROMPT_CACHE))).toEqual([]);
+    });
+
+    it("strips a stale marker a stored message carried in, leaving exactly one", () => {
+        // `memory/ai-sdk-message-storage.ts` reads `cache_control` back off a stored
+        // block, so a row an older build wrote can arrive already marked. Left in
+        // place it spends a breakpoint slot the harness never budgeted.
+        const stale: ModelMessage = { ...userText("old"), providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } } };
+
+        expect(breakpointsOf(withPromptCacheBreakpoint([stale, userText("new")], DEFAULT_PROMPT_CACHE))).toEqual([1]);
+    });
+
+    it("keeps the other provider keys of a message it strips", () => {
+        const stale: ModelMessage = {
+            ...assistantText("old"),
+            providerOptions: { anthropic: { cacheControl: { type: "ephemeral" }, signature: "sig-2" }, openai: { store: true } },
+        };
+
+        const marked = withPromptCacheBreakpoint([stale, userText("new")], DEFAULT_PROMPT_CACHE);
+
+        expect(marked[0]?.providerOptions).toEqual({ anthropic: { signature: "sig-2" }, openai: { store: true } });
+    });
+
+    it("places nothing when caching is off, and strips what a stored message carried", () => {
+        const stale: ModelMessage = { ...userText("old"), providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } } };
+
+        const marked = withPromptCacheBreakpoint([stale, userText("new")], "off" as PromptCachePolicy);
+
+        expect(breakpointsOf(marked)).toEqual([]);
+        // The namespace held nothing else, thus it goes with the marker.
+        expect(marked[0]?.providerOptions).toEqual({});
+    });
+
+    it("returns the array itself when there is nothing to place and nothing to strip", () => {
+        const transcript = [userText("a")];
+
+        expect(withPromptCacheBreakpoint(transcript, "off" as PromptCachePolicy)).toBe(transcript);
+        expect(withPromptCacheBreakpoint([], DEFAULT_PROMPT_CACHE)).toEqual([]);
+    });
+});
+
 describe("runAgent prompt-cache directive", () => {
-    it("attaches the default 5m directive to every iteration, the wrap-up included", async () => {
+    it("marks the last message on every iteration, the wrap-up included", async () => {
         const chat = neverTerminating();
 
         await runAgent(agentDef(3), GO, makeSession(), opts(chat));
@@ -86,27 +191,53 @@ describe("runAgent prompt-cache directive", () => {
         // 3 iterations + the forced tool-less wrap-up.
         expect(chat.calls).toHaveLength(4);
         for (const call of chat.calls) {
-            expect(call.providerOptions).toEqual(ANTHROPIC_5M);
+            expect(breakpointsOf(call.messages)).toEqual([call.messages.length - 1]);
+            expect(call.messages.at(-1)?.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual(ANTHROPIC_5M.anthropic.cacheControl);
         }
 
-        // The wrap-up is the call that empties the tool set — it must still carry
-        // the directive (its write is the one the cache_write_tokens metric exposes
+        // The wrap-up is the call that empties the tool set — it must still place
+        // the breakpoint (its write is the one the cache_write_tokens metric exposes
         // as waste).
         const wrapUp = chat.calls.at(-1)!;
         expect(Object.keys(wrapUp.tools)).toHaveLength(0);
         expect(wrapUp.toolChoice).toBe("none");
-        expect(wrapUp.providerOptions).toEqual(ANTHROPIC_5M);
+        expect(breakpointsOf(wrapUp.messages)).toHaveLength(1);
     });
 
-    it("sends the same directive object on every call, so the prefix stays byte-identical", async () => {
+    it("writes no request-level directive on any call", async () => {
         const chat = neverTerminating();
 
         await runAgent(agentDef(3), GO, makeSession(), opts(chat));
 
-        const first = chat.calls[0]!.providerOptions;
+        // The regression guard. A request-level bag reaches Anthropic as a top-level
+        // `cache_control`, which is a breakpoint no intermediary can count —
+        // CLIProxyAPI then trims its own markers to four and sends five.
         for (const call of chat.calls) {
-            expect(call.providerOptions).toBe(first);
+            expect(call.providerOptions).toBeUndefined();
         }
+    });
+
+    it("rolls the breakpoint forward as the transcript grows", async () => {
+        const chat = neverTerminating();
+
+        await runAgent(agentDef(3), GO, makeSession(), opts(chat));
+
+        // Each iteration appends the assistant reply and its tool results, and the
+        // breakpoint advances with them: a pinned one would re-process the whole
+        // tool transcript uncached on every iteration.
+        const marked = chat.calls.map((call) => breakpointsOf(call.messages)[0]!);
+        for (let i = 1; i < marked.length; i++) {
+            expect(marked[i]!).toBeGreaterThan(marked[i - 1]!);
+        }
+    });
+
+    it("leaves the transcript it returns unmarked", async () => {
+        const chat = neverTerminating();
+
+        const result = await runAgent(agentDef(3), GO, makeSession(), opts(chat));
+
+        // The host persists this array. A marker in it would be stored and replayed.
+        expect(breakpointsOf(result.messages)).toEqual([]);
     });
 
     it("honours an explicit 1h policy from the composition root", async () => {
@@ -115,7 +246,7 @@ describe("runAgent prompt-cache directive", () => {
         await runAgent(agentDef(2), GO, makeSession(), opts(chat, { promptCache: { ttl: "1h" } }));
 
         for (const call of chat.calls) {
-            expect(call.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual({ type: "ephemeral", ttl: "1h" });
+            expect(call.messages.at(-1)?.providerOptions?.["anthropic"]?.["cacheControl"]).toEqual({ type: "ephemeral", ttl: "1h" });
         }
     });
 
@@ -125,9 +256,10 @@ describe("runAgent prompt-cache directive", () => {
         await runAgent(agentDef(2), GO, makeSession(), opts(chat, { promptCache: "off" as PromptCachePolicy }));
 
         expect(chat.calls).toHaveLength(3);
-        // Caching off leaves no bag at all. The reasoning depth rides on its own
-        // neutral field, thus it writes no vendor key here.
+        // Caching off leaves no marker anywhere and no bag at all. The reasoning
+        // depth rides on its own neutral field, thus it writes no vendor key here.
         for (const call of chat.calls) {
+            expect(breakpointsOf(call.messages)).toEqual([]);
             expect(call.providerOptions).toBeUndefined();
             expect(call.reasoning).toBe("xhigh");
         }

--- a/harness/src/loop/prompt-cache.test.ts
+++ b/harness/src/loop/prompt-cache.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+import { generateText } from "ai";
 import { metrics } from "@opentelemetry/api";
 import { AggregationTemporality, InMemoryMetricExporter, MeterProvider, type MetricData, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { ok } from "neverthrow";
@@ -61,14 +63,21 @@ function neverTerminating(): ScriptedProvider {
 }
 
 describe("promptCacheProviderOptions", () => {
-    it("defaults to the 5m ephemeral policy", () => {
+    it("marks every vendor that takes an explicit breakpoint", () => {
         expect(DEFAULT_PROMPT_CACHE).toEqual({ ttl: "5m" });
-        expect(promptCacheProviderOptions(DEFAULT_PROMPT_CACHE)).toEqual(ANTHROPIC_5M);
+        // Both namespaces ride together: a provider reads only its own key, so
+        // the pair costs nothing to whichever one is not serving the call and the
+        // placement never has to know which vendor it is talking to.
+        expect(promptCacheProviderOptions(DEFAULT_PROMPT_CACHE)).toEqual({
+            ...ANTHROPIC_5M,
+            bedrock: { cachePoint: { type: "default", ttl: "5m" } },
+        });
     });
 
-    it("carries the requested ttl through", () => {
+    it("carries the requested ttl through to each vendor", () => {
         expect(promptCacheProviderOptions({ ttl: "1h" })).toEqual({
             anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
+            bedrock: { cachePoint: { type: "default", ttl: "1h" } },
         });
     });
 
@@ -151,6 +160,18 @@ describe("withPromptCacheBreakpoint", () => {
         const stale: ModelMessage = { ...userText("old"), providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } } };
 
         expect(breakpointsOf(withPromptCacheBreakpoint([stale, userText("new")], DEFAULT_PROMPT_CACHE))).toEqual([1]);
+    });
+
+    it("strips a stale marker in ANY vendor namespace, not only anthropic", () => {
+        // The one-breakpoint invariant is per vendor. A bedrock marker left on an
+        // earlier message spends a Bedrock cache point the harness never budgeted,
+        // and Anthropic's own count would never notice.
+        const stale: ModelMessage = { ...userText("old"), providerOptions: { bedrock: { cachePoint: { type: "default" } } } };
+
+        const marked = withPromptCacheBreakpoint([stale, userText("new")], DEFAULT_PROMPT_CACHE);
+
+        expect(marked[0]?.providerOptions).toEqual({});
+        expect(marked[1]?.providerOptions?.["bedrock"]?.["cachePoint"]).toEqual({ type: "default", ttl: "5m" });
     });
 
     it("keeps the other provider keys of a message it strips", () => {
@@ -446,10 +467,11 @@ describe("prompt caching against an openai-compatible provider", () => {
         expect(result.finish.cappedOut).toBe(false);
 
         // And it never reached the wire — `providerOptions` is a client-side
-        // namespaced bag, so nothing anthropic-shaped appears in the request body.
+        // namespaced bag, so no vendor cache marker appears in the request body.
         expect(bodies).toHaveLength(1);
         expect(JSON.stringify(bodies[0])).not.toContain("cache_control");
         expect(JSON.stringify(bodies[0])).not.toContain("cacheControl");
+        expect(JSON.stringify(bodies[0])).not.toContain("cachePoint");
     });
 
     it("reports openai-family cached tokens on the same neutral usage field", async () => {
@@ -474,5 +496,64 @@ describe("prompt caching against an openai-compatible provider", () => {
         });
         // That family bills no separate cache write.
         expect(reply.usage?.cacheCreationInputTokens).toBeUndefined();
+    });
+});
+
+// ── The Bedrock marker, rendered by the real provider ───────────────
+//
+// The one placement carries a marker for both vendors that need one. Anthropic
+// and Bedrock disagree on more than spelling — Anthropic marks the last content
+// block of the message, Bedrock appends a `cachePoint` block after it — so the
+// only honest check is what the provider actually renders. `@ai-sdk/amazon-bedrock`
+// exports no type for the `cachePoint` value and forwards it to AWS verbatim,
+// thus a wrong shape here would reach the wire unchecked and nothing upstream
+// would catch it.
+
+/** A canned Bedrock Converse response — enough for the provider to parse a reply. */
+function cannedBedrockFetch(seen: Record<string, unknown>[]): typeof fetch {
+    return (async (_input: string | URL | Request, init?: RequestInit) => {
+        seen.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+            JSON.stringify({
+                output: { message: { role: "assistant", content: [{ text: "ok" }] } },
+                stopReason: "end_turn",
+                usage: { inputTokens: 10, outputTokens: 3, totalTokens: 13 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        );
+    }) as typeof fetch;
+}
+
+describe("the bedrock marker on the wire", () => {
+    /** The content blocks Bedrock renders for the last message of the request. */
+    async function lastMessageBlocks(policy: PromptCachePolicy): Promise<Record<string, unknown>[]> {
+        const bodies: Record<string, unknown>[] = [];
+        const bedrock = createAmazonBedrock({ region: "us-east-1", apiKey: "test-key", fetch: cannedBedrockFetch(bodies) });
+
+        await generateText({
+            model: bedrock("anthropic.claude-sonnet-5"),
+            messages: [...withPromptCacheBreakpoint([userText("first"), assistantText("second"), userText("third")], policy)],
+        });
+
+        const messages = (bodies[0]?.["messages"] ?? []) as { content: Record<string, unknown>[] }[];
+        return messages.at(-1)?.content ?? [];
+    }
+
+    it("appends a cachePoint block after the last message, carrying the ttl", async () => {
+        const blocks = await lastMessageBlocks(DEFAULT_PROMPT_CACHE);
+
+        // Appended AFTER the text, not merged into it — that is Bedrock's shape.
+        expect(blocks.at(-1)).toEqual({ cachePoint: { type: "default", ttl: "5m" } });
+        expect(blocks.at(-2)).toEqual({ text: "third" });
+    });
+
+    it("carries an explicit 1h ttl", async () => {
+        expect((await lastMessageBlocks({ ttl: "1h" })).at(-1)).toEqual({ cachePoint: { type: "default", ttl: "1h" } });
+    });
+
+    it("renders no cachePoint at all when caching is off", async () => {
+        const blocks = await lastMessageBlocks("off" as PromptCachePolicy);
+
+        expect(blocks.some((b) => "cachePoint" in b)).toBe(false);
     });
 });

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -23,7 +23,7 @@ import { hintForZodIssue, repairToolInput } from "../lib/zod-issues.js";
 import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-message-storage.js";
 import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
 import { classifyProviderError } from "../providers/errors.js";
-import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../providers/prompt-cache.js";
+import { DEFAULT_PROMPT_CACHE, withPromptCacheBreakpoint } from "../providers/prompt-cache.js";
 import { DEFAULT_REASONING } from "../providers/reasoning.js";
 import { resultStep } from "./run-step.js";
 import type { AgentChat, ChatRequest, ChatResponse, PromptCachePolicy, ProviderCapabilities, ReasoningPolicy } from "../providers/types.js";
@@ -232,10 +232,11 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     let toolCallCount = 0;
     let toolErrorCount = 0;
 
-    // Resolved once, not per iteration: an identical options object across every
-    // call is itself part of the cache contract — the request prefix has to be
-    // byte-identical to be read back.
-    const providerOptions = promptCacheProviderOptions(opts.promptCache ?? DEFAULT_PROMPT_CACHE);
+    // Resolved once, not per iteration: an identical policy across every call is
+    // itself part of the cache contract — the request prefix has to be
+    // byte-identical to be read back. The breakpoint it places is re-derived per
+    // call, because it rides the last message and the transcript grows.
+    const promptCache = opts.promptCache ?? DEFAULT_PROMPT_CACHE;
     // The depth is a neutral name, and the provider package resolves it for the
     // model. A vendor key here would turn that resolution off.
     const reasoning = opts.reasoning ?? DEFAULT_REASONING;
@@ -397,10 +398,9 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         iterations = i + 1;
         const request: ChatRequest = {
             system: agent.systemPrompt,
-            messages,
+            messages: withPromptCacheBreakpoint(messages, promptCache),
             tools: toolDefs,
             ...(opts.toolChoice !== undefined ? { toolChoice: opts.toolChoice } : {}),
-            providerOptions,
             reasoning,
         };
         const llmStepName = formatStepName.llm(i);
@@ -521,12 +521,16 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
     // Cache defeater (known; not fixed here). Emptying the tool set changes the
     // very front of the request prefix — tool definitions are cached ahead of
     // system and history — so this call reads *nothing* back from the cache and
-    // rewrites the whole prefix from scratch. It still carries the cache options
+    // rewrites the whole prefix from scratch. It still places the breakpoint
     // because it is the one call whose write is pure waste, and the
     // cache_write_tokens counter is what makes that waste visible.
     const wrapUpStepName = formatStepName.llm(agent.maxIterations);
     const wrapUp = await resultStep(runStep)(wrapUpStepName, () =>
-        provider.chat({ system: agent.systemPrompt, messages, tools: {}, toolChoice: "none", providerOptions, reasoning }, session, signal),
+        provider.chat(
+            { system: agent.systemPrompt, messages: withPromptCacheBreakpoint(messages, promptCache), tools: {}, toolChoice: "none", reasoning },
+            session,
+            signal,
+        ),
     );
     accountForCall(wrapUp, wrapUpStepName);
 

--- a/harness/src/providers/integration/anthropic-caching.integration.test.ts
+++ b/harness/src/providers/integration/anthropic-caching.integration.test.ts
@@ -2,9 +2,9 @@
  * Integration test — Anthropic prompt caching through the real provider seam.
  *
  * Proves the whole chain end to end against a live endpoint: the harness's
- * neutral `PromptCachePolicy` → the `anthropic.cacheControl` wire option →
- * a served cache read → `ChatResponse.usage.cacheReadInputTokens`. If any link
- * breaks, the second identical request reports a zero cache read.
+ * neutral `PromptCachePolicy` → the `anthropic.cacheControl` marker on the last
+ * message → a served cache read → `ChatResponse.usage.cacheReadInputTokens`. If
+ * any link breaks, the second identical request reports a zero cache read.
  *
  * ## Caching is a NO-OP on the Claude Max OAuth path — read this first
  *
@@ -29,7 +29,7 @@ import { jsonSchema, tool as aiTool } from "ai";
 
 import { makeSession } from "../__fixtures__/session.js";
 import { createConfiguredAiSdkProvider } from "../ai-sdk.js";
-import { DEFAULT_PROMPT_CACHE, promptCacheProviderOptions } from "../prompt-cache.js";
+import { DEFAULT_PROMPT_CACHE, withPromptCacheBreakpoint } from "../prompt-cache.js";
 import type { ChatRequest } from "../types.js";
 
 const API_KEY = process.env.ANTHROPIC_API_KEY;
@@ -48,10 +48,13 @@ const LARGE_SYSTEM = Array.from(
 
 /**
  * The request the loop builds: a `system` string, an AI SDK `ToolSet`, and the
- * cache directive as request-level `providerOptions`. The provider emits a
- * single top-level `cache_control` from it and the server places the breakpoint
- * on the last cacheable block, so tools + system are cached without the harness
- * hand-marking blocks.
+ * cache breakpoint placed on the LAST MESSAGE, exactly as `runAgent` places it.
+ * One breakpoint at the end of the messages caches the whole prefix, because the
+ * cache keys on a prefix and the render order is tools → system → messages.
+ *
+ * The placement is the part under test as much as the caching is: the marker has
+ * to be a per-block one that an intermediary can count, never the request-level
+ * directive that reaches the wire as a top-level `cache_control` field.
  *
  * Byte-identical across both calls — that is the whole point: the prefix must
  * not shift or nothing is read back.
@@ -68,8 +71,7 @@ const CACHED_REQUEST: ChatRequest = {
             }),
         }),
     },
-    messages: [{ role: "user", content: "Reply with the single word: ok" }],
-    providerOptions: promptCacheProviderOptions(DEFAULT_PROMPT_CACHE),
+    messages: withPromptCacheBreakpoint([{ role: "user", content: "Reply with the single word: ok" }], DEFAULT_PROMPT_CACHE),
 };
 
 describe.skipIf(!API_KEY)("Anthropic prompt caching", () => {

--- a/harness/src/providers/integration/anthropic-caching.integration.test.ts
+++ b/harness/src/providers/integration/anthropic-caching.integration.test.ts
@@ -6,19 +6,22 @@
  * message → a served cache read → `ChatResponse.usage.cacheReadInputTokens`. If
  * any link breaks, the second identical request reports a zero cache read.
  *
- * ## Caching is a NO-OP on the Claude Max OAuth path — read this first
+ * ## Why this is gated on a direct API key — read this first
  *
- * The Claude Max OAuth path does not honour cache directives, and the OSS CLI
- * defaults to routing through a local CLIProxyAPI on exactly that path. Caching
- * therefore engages only against a **direct API key or a gateway** — which is
- * what this test uses, and why it is gated on a real `ANTHROPIC_API_KEY` rather
- * than on whatever the CLI happens to be wired to.
+ * A direct API key or a gateway is the only endpoint where a cache read proves
+ * that OUR breakpoint works. The OSS CLI routes through a local CLIProxyAPI on
+ * the Claude OAuth path, and that proxy places breakpoints of its own while it
+ * cloaks the request. Caching does engage there — but it engages with
+ * `promptCache: "off"` too, so a read there attributes nothing.
  *
- * This is not a footnote: it is the single most likely reason a deployment sees
- * no cache benefit, and it is precisely what the new
- * `cortex.harness.agent.cache_read_tokens` metric exposes at runtime — a
+ * Hence the `ANTHROPIC_API_KEY` gate rather than whatever the CLI happens to be
+ * wired to. Nothing injects markers on this path, so a served read is the
+ * placement in this module working, end to end.
+ *
+ * At runtime the same distinction applies to
+ * `cortex.harness.agent.cache_read_tokens`: against a direct endpoint a
  * flat-zero read counter beside a non-zero write counter is the signature of an
- * endpoint that is billing for cache writes and serving no reads.
+ * endpoint billing for cache writes and serving no reads.
  *
  * Gated on `ANTHROPIC_API_KEY`; skipped otherwise. `ANTHROPIC_BASE_URL`
  * optionally points at a gateway instead of the public API.

--- a/harness/src/providers/prompt-cache.ts
+++ b/harness/src/providers/prompt-cache.ts
@@ -39,6 +39,30 @@
  * A marker on a message block is counted, trimmed, and reasoned about by every
  * hop. Keep it there. {@link withPromptCacheBreakpoint} is the only writer.
  *
+ * ## Which vendors need a marker at all
+ *
+ * Only two of them, and both take it on a message:
+ *
+ *  - **Anthropic** — `anthropic.cacheControl`. Fully opt-in: no marker, no
+ *    caching, at full price.
+ *  - **Amazon Bedrock** — `bedrock.cachePoint`. Also fully opt-in.
+ *
+ * The OpenAI family caches prefixes server-side, unprompted, and exposes no
+ * breakpoint to place (`promptCacheKey` and `promptCacheRetention` are request
+ * settings for affinity and retention, not placement — a separate concern from
+ * this policy). Gemini caches implicitly by default, and its explicit mode is a
+ * cache RESOURCE created out of band and referenced by name, which is not a
+ * marker and does not fit a ttl policy.
+ *
+ * So both markers ride together on the one chosen message. A provider reads only
+ * its own namespace, thus the pair is free to whichever vendor is not serving
+ * the call, and the placement never learns which one that is.
+ *
+ * The asymmetry worth remembering: under-marking silently costs money, while
+ * over-marking hard-fails. Anthropic answers 400 past four breakpoints, and the
+ * legacy Bedrock integration answers 400 on a top-level `cache_control`. Every
+ * failure in this area comes from asking for too much.
+ *
  * ## Cache defeaters — what silently kills the hit rate
  *
  * The cache keys on an *exact prefix*. Anything that perturbs the head of the
@@ -83,6 +107,8 @@
  * of an endpoint billing for writes and serving no reads.
  */
 
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
+
 import type { ModelMessage, PromptCachePolicy, ProviderOptions } from "./types.js";
 
 /**
@@ -100,10 +126,38 @@ import type { ModelMessage, PromptCachePolicy, ProviderOptions } from "./types.j
 export const DEFAULT_PROMPT_CACHE: PromptCachePolicy = { ttl: "5m" };
 
 /**
+ * Amazon Bedrock's cache marker, from the Converse API's `CachePointBlock`:
+ * `type` is required and its only valid value is `default`; `ttl` is optional
+ * and accepts exactly `5m` or `1h`, the same pair `PromptCachePolicy` offers.
+ *
+ * Declared here rather than imported because `@ai-sdk/amazon-bedrock` exports no
+ * type for it — `BedrockProviderOptions` covers the request-level options only,
+ * and the provider passes a `cachePoint` value through to AWS verbatim. Thus a
+ * wrong shape here reaches the wire unchecked, and this declaration is the only
+ * guard. Refer to the CachePointBlock page of the Bedrock API reference.
+ */
+interface BedrockCacheOptions {
+    readonly cachePoint: { readonly type: "default"; readonly ttl?: "5m" | "1h" };
+}
+
+/**
  * Translate a neutral cache policy into provider wire options.
  *
  * Returns `undefined` for `"off"` so the caller can leave the bag entirely unset
  * rather than sending an empty one.
+ *
+ * Both vendors that take an explicit marker get one, in their own namespace. A
+ * provider reads only its own key, so the pair costs nothing to whichever one is
+ * not serving the call, and the placement needs no idea which vendor it is
+ * talking to. The two shapes differ in more than spelling: Anthropic marks the
+ * last content block of the message, while Bedrock appends a `cachePoint` block
+ * after it. Both end up at the same position in the prefix.
+ *
+ * The `satisfies` clauses are the point of naming the vendor types at all. This
+ * bag is a `Record<string, JSONObject>`, thus nothing here is checked by
+ * default, and a renamed key would compile and silently stop caching —
+ * `cacheControl` has already been renamed once, and the provider still accepts
+ * `cache_control` as its alias.
  *
  * CAUTION: this is the marker's VALUE, not its placement. Attaching it to a
  * `ChatRequest` emits the invisible top-level field the module header warns
@@ -111,15 +165,23 @@ export const DEFAULT_PROMPT_CACHE: PromptCachePolicy = { ttl: "5m" };
  */
 export function promptCacheProviderOptions(policy: PromptCachePolicy): ProviderOptions | undefined {
     if (policy === "off") return undefined;
-    return { anthropic: { cacheControl: { type: "ephemeral", ttl: policy.ttl } } };
+    const anthropic = { cacheControl: { type: "ephemeral", ttl: policy.ttl } } satisfies AnthropicProviderOptions;
+    const bedrock = { cachePoint: { type: "default", ttl: policy.ttl } } satisfies BedrockCacheOptions;
+    return { anthropic, bedrock };
 }
 
 /**
- * The `anthropic` namespace key that carries the marker. Named once so the
- * writer and the stripper cannot drift apart.
+ * Every namespace that can carry a breakpoint, and the key it carries it under.
+ *
+ * The writer and the stripper both read this list, thus they cannot drift apart,
+ * and the one-breakpoint invariant covers each vendor rather than only the one
+ * that happens to be serving the call. `@ai-sdk/amazon-bedrock` reads either
+ * `bedrock` or `amazonBedrock`; its own documentation uses `bedrock`.
  */
-const CACHE_CONTROL_KEY = "cacheControl";
-const ANTHROPIC = "anthropic";
+const BREAKPOINT_SITES: readonly (readonly [namespace: string, key: string])[] = [
+    ["anthropic", "cacheControl"],
+    ["bedrock", "cachePoint"],
+];
 
 /**
  * Whether a message can HOST the breakpoint — that is, whether the marker put on
@@ -154,31 +216,34 @@ function lastHostIndex(messages: readonly ModelMessage[]): number {
     return -1;
 }
 
-/** Whether this message already carries a cache marker in the anthropic namespace. */
+/** Whether this message already carries a cache marker in ANY breakpoint namespace. */
 function carriesBreakpoint(message: ModelMessage): boolean {
-    return message.providerOptions?.[ANTHROPIC]?.[CACHE_CONTROL_KEY] !== undefined;
+    return BREAKPOINT_SITES.some(([namespace, key]) => message.providerOptions?.[namespace]?.[key] !== undefined);
 }
 
-/** The same message with the marker added to its anthropic namespace. */
+/** The same message with each namespace of `options` merged into its own bag. */
 function withBreakpoint<M extends ModelMessage>(message: M, options: ProviderOptions): M {
-    return {
-        ...message,
-        providerOptions: {
-            ...message.providerOptions,
-            [ANTHROPIC]: { ...message.providerOptions?.[ANTHROPIC], ...options[ANTHROPIC] },
-        },
-    };
+    const merged: Record<string, Record<string, unknown>> = { ...message.providerOptions };
+    for (const [namespace] of BREAKPOINT_SITES) {
+        const marker = options[namespace];
+        if (marker === undefined) continue;
+        merged[namespace] = { ...message.providerOptions?.[namespace], ...marker };
+    }
+    return { ...message, providerOptions: merged as NonNullable<M["providerOptions"]> };
 }
 
-/** The same message with the marker removed, and the namespace dropped when it held nothing else. */
+/** The same message with every marker removed, and each namespace dropped when it held nothing else. */
 function withoutBreakpoint<M extends ModelMessage>(message: M): M {
     if (!carriesBreakpoint(message)) return message;
-    const { [CACHE_CONTROL_KEY]: _dropped, ...rest } = message.providerOptions?.[ANTHROPIC] ?? {};
-    const { [ANTHROPIC]: _namespace, ...others } = message.providerOptions ?? {};
-    return {
-        ...message,
-        providerOptions: Object.keys(rest).length === 0 ? others : { ...others, [ANTHROPIC]: rest },
-    };
+    const remaining: Record<string, Record<string, unknown>> = { ...message.providerOptions };
+    for (const [namespace, key] of BREAKPOINT_SITES) {
+        const bag = remaining[namespace];
+        if (bag?.[key] === undefined) continue;
+        const { [key]: _dropped, ...rest } = bag;
+        if (Object.keys(rest).length === 0) delete remaining[namespace];
+        else remaining[namespace] = rest;
+    }
+    return { ...message, providerOptions: remaining as NonNullable<M["providerOptions"]> };
 }
 
 /**

--- a/harness/src/providers/prompt-cache.ts
+++ b/harness/src/providers/prompt-cache.ts
@@ -15,12 +15,29 @@
  * error — on an OpenAI-compatible model, which is exactly what we want: that
  * family does automatic server-side prefix caching and needs no directive.
  *
- * ## What the Anthropic namespace does
+ * ## What the Anthropic namespace does, and where the marker must go
  *
- * A request-level `cacheControl` makes the provider emit a single top-level
- * `cache_control` marker; the server then places the breakpoint on the last
- * cacheable block, so the whole prefix (tools → system → history) is cached
- * without the harness hand-placing per-block markers.
+ * The options go on the LAST MESSAGE of the request, never on the request
+ * itself. Both placements cache the same bytes — one breakpoint at the end of
+ * the messages covers the whole prefix (tools → system → history), because the
+ * cache keys on a prefix — but only the message placement survives an
+ * intermediary.
+ *
+ * A REQUEST-level `cacheControl` makes the provider emit a top-level
+ * `cache_control` field instead of a per-block marker, and the server then
+ * places the breakpoint itself. That is one fewer thing for the harness to get
+ * right, and it is why this module used to do it. It is also invisible: an
+ * intermediary that counts breakpoints to stay under Anthropic's cap of four
+ * counts BLOCKS, so a top-level field is a breakpoint nothing on the way
+ * upstream can see. CLIProxyAPI — what the OSS CLI routes through on the Claude
+ * OAuth path — injects up to four block markers of its own and trims to four by
+ * that blind count, so the harness's invisible fifth breakpoint made every
+ * request past a thread's first turn fail with `A maximum of 4 blocks with
+ * cache_control may be provided. Found 5.` (HTTP 400, non-retryable — the thread
+ * is wedged, because the next turn rebuilds the same shape).
+ *
+ * A marker on a message block is counted, trimmed, and reasoned about by every
+ * hop. Keep it there. {@link withPromptCacheBreakpoint} is the only writer.
  *
  * ## Cache defeaters — what silently kills the hit rate
  *
@@ -52,7 +69,7 @@
  * `cache_read_tokens` counter is the symptom.
  */
 
-import type { PromptCachePolicy, ProviderOptions } from "./types.js";
+import type { ModelMessage, PromptCachePolicy, ProviderOptions } from "./types.js";
 
 /**
  * The default policy: cache with the 5-minute TTL.
@@ -71,10 +88,110 @@ export const DEFAULT_PROMPT_CACHE: PromptCachePolicy = { ttl: "5m" };
 /**
  * Translate a neutral cache policy into provider wire options.
  *
- * Returns `undefined` for `"off"` so the caller can leave `providerOptions`
- * entirely unset rather than sending an empty bag.
+ * Returns `undefined` for `"off"` so the caller can leave the bag entirely unset
+ * rather than sending an empty one.
+ *
+ * CAUTION: this is the marker's VALUE, not its placement. Attaching it to a
+ * `ChatRequest` emits the invisible top-level field the module header warns
+ * about. Place it with {@link withPromptCacheBreakpoint}.
  */
 export function promptCacheProviderOptions(policy: PromptCachePolicy): ProviderOptions | undefined {
     if (policy === "off") return undefined;
     return { anthropic: { cacheControl: { type: "ephemeral", ttl: policy.ttl } } };
+}
+
+/**
+ * The `anthropic` namespace key that carries the marker. Named once so the
+ * writer and the stripper cannot drift apart.
+ */
+const CACHE_CONTROL_KEY = "cacheControl";
+const ANTHROPIC = "anthropic";
+
+/**
+ * Whether a message can HOST the breakpoint — that is, whether the marker put on
+ * it actually reaches the wire.
+ *
+ * The Anthropic provider resolves a message-level marker onto the message's last
+ * content part. A thinking block cannot carry `cache_control`, so a marker on an
+ * assistant message that ends in one is dropped by the provider: no error, no
+ * breakpoint, and a silent cache miss on every call after it. Walking back past
+ * such a message is what the server-side placement did for us before, so this
+ * keeps the behaviour rather than introducing a new failure mode.
+ *
+ * An empty content array hosts nothing either — there is no last part to mark.
+ * The content is read as `unknown` because the four message roles carry four
+ * different part unions and this predicate cares about exactly one field.
+ */
+function canHostBreakpoint(message: ModelMessage): boolean {
+    const content: unknown = message.content;
+    if (typeof content === "string") return content.length > 0;
+    if (!Array.isArray(content)) return false;
+    const last: unknown = content.at(-1);
+    if (typeof last !== "object" || last === null) return false;
+    return (last as { readonly type?: unknown }).type !== "reasoning";
+}
+
+/** The index of the last message that can host the breakpoint, or `-1` when none can. */
+function lastHostIndex(messages: readonly ModelMessage[]): number {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        if (message !== undefined && canHostBreakpoint(message)) return i;
+    }
+    return -1;
+}
+
+/** Whether this message already carries a cache marker in the anthropic namespace. */
+function carriesBreakpoint(message: ModelMessage): boolean {
+    return message.providerOptions?.[ANTHROPIC]?.[CACHE_CONTROL_KEY] !== undefined;
+}
+
+/** The same message with the marker added to its anthropic namespace. */
+function withBreakpoint<M extends ModelMessage>(message: M, options: ProviderOptions): M {
+    return {
+        ...message,
+        providerOptions: {
+            ...message.providerOptions,
+            [ANTHROPIC]: { ...message.providerOptions?.[ANTHROPIC], ...options[ANTHROPIC] },
+        },
+    };
+}
+
+/** The same message with the marker removed, and the namespace dropped when it held nothing else. */
+function withoutBreakpoint<M extends ModelMessage>(message: M): M {
+    if (!carriesBreakpoint(message)) return message;
+    const { [CACHE_CONTROL_KEY]: _dropped, ...rest } = message.providerOptions?.[ANTHROPIC] ?? {};
+    const { [ANTHROPIC]: _namespace, ...others } = message.providerOptions ?? {};
+    return {
+        ...message,
+        providerOptions: Object.keys(rest).length === 0 ? others : { ...others, [ANTHROPIC]: rest },
+    };
+}
+
+/**
+ * Place the request's ONE cache breakpoint, on the last message that can host it.
+ *
+ * Returns a copy — the caller's array is the transcript the loop keeps pushing
+ * onto and the host later persists, and a marker written into it would ride into
+ * the stored thread and come back on every later turn, one more breakpoint per
+ * turn until the request is refused. Only the request-shaped copy carries one.
+ *
+ * The placement is deliberately ROLLING, not pinned to the end of the stable
+ * prefix: within one run the loop appends an assistant reply and its tool results
+ * on every iteration, and a breakpoint that advances with them lets iteration N+1
+ * read back everything iteration N wrote. A pinned breakpoint would re-process
+ * the whole tool transcript uncached on every iteration, which is the opposite of
+ * what an agent loop needs.
+ *
+ * A marker already on any other message is REMOVED — the invariant is exactly one
+ * breakpoint per request, and a stored message that carries one from an older
+ * build (`memory/ai-sdk-message-storage.ts` reads `cache_control` back off a
+ * stored block) would otherwise spend a slot that the harness never budgeted.
+ * `"off"` strips and places nothing, so turning caching off really does send no
+ * directive at all.
+ */
+export function withPromptCacheBreakpoint<M extends ModelMessage>(messages: readonly M[], policy: PromptCachePolicy): readonly M[] {
+    const options = promptCacheProviderOptions(policy);
+    const target = options === undefined ? -1 : lastHostIndex(messages);
+    if (target < 0 && !messages.some(carriesBreakpoint)) return messages;
+    return messages.map((message, index) => (index === target && options !== undefined ? withBreakpoint(message, options) : withoutBreakpoint(message)));
 }

--- a/harness/src/providers/prompt-cache.ts
+++ b/harness/src/providers/prompt-cache.ts
@@ -60,13 +60,27 @@
  * `prompts/briefing.ts`). Keep it that way — one interpolated id or path there
  * makes every step's ~20k-char prefix unique.
  *
- * ## Where caching is a no-op regardless
+ * ## What the cache-token metrics do and do not prove
  *
- * The Claude Max OAuth path does not honour cache directives, and the OSS CLI
- * defaults to routing through a local CLIProxyAPI on exactly that path. Caching
- * only engages against a direct API key or a gateway. The cache-token metrics
- * (`loop/metrics.ts`) are what tell the two apart at runtime — a flat-zero
- * `cache_read_tokens` counter is the symptom.
+ * Caching DOES engage on the Claude OAuth path the OSS CLI routes through a
+ * local CLIProxyAPI: measured, 2050-2151 cache-read tokens on the turns after
+ * the first. An earlier note here claimed that path ignores cache directives
+ * outright. It does not.
+ *
+ * But a read there is not evidence that OUR breakpoint earned it. While cloaking
+ * — which is what that path does — the proxy places breakpoints of its own on
+ * the system block, the first user message, the system message it relocates, and
+ * the last message. Those cache the prefix whatever the harness sends: with
+ * `promptCache: "off"` and no marker of ours on the wire, a repeat request still
+ * read 1902 tokens back.
+ *
+ * So on that path `cache_read_tokens` (`loop/metrics.ts`) reports whether the
+ * deployment gets caching at all, which is what the counter is for. It does not
+ * attribute the read, and it cannot tell a working harness breakpoint from a
+ * proxy that is quietly doing the work. Against a direct API key or a gateway,
+ * where nothing injects markers, the counter does mean exactly that — and a
+ * flat-zero read counter beside a non-zero write counter is still the signature
+ * of an endpoint billing for writes and serving no reads.
  */
 
 import type { ModelMessage, PromptCachePolicy, ProviderOptions } from "./types.js";


### PR DESCRIPTION
## What & why

The loop put its prompt-cache directive on the request. The Anthropic provider emits such a directive as a top-level `cache_control` field, and the server then places the breakpoint. That field is invisible to an intermediary, because an intermediary counts blocks.

CLIProxyAPI is the intermediary that the CLI uses on the Claude OAuth path. It injects up to four block markers of its own. It then trims them to the Anthropic limit of four by that blind count. Thus the top-level field made the total five, and the endpoint answered HTTP 400. The refusal is not retryable, and the next turn builds the same shape. Thus the thread stops.

`withPromptCacheBreakpoint` now places the one marker on the last message that can carry it, where each hop can count it. It marks each vendor that needs an explicit breakpoint: Anthropic and Bedrock.

## Notes for the reviewer

- **The scope is wider than one proxy version.** The bump from v7.2.90 to v7.2.148 exposed the defect. The top-level field was always uncountable, thus the budget of any intermediary is now correct.
- **The placement rolls forward, and it is not pinned.** A pinned breakpoint makes each iteration of a tool loop send the whole tool transcript uncached.
- **Both upstreams document this.** The AI SDK documents the message placement and not the request placement. Anthropic documents that an automatic breakpoint takes one of the four slots.
- **Bedrock rides along.** It is the other vendor that caches only when asked, and it takes the marker on a message too. `@ai-sdk/amazon-bedrock` is a dev dependency only, and the code imports nothing from it.
- **One note changes with it.** A measurement shows caching does engage through the CLI proxy, which the module denied.
- `src/providers/ai-sdk.test.ts:1378` fails lint on `main` already. This branch does not touch that file.
