### PR TITLE
harness: drop cleanup-workflow traces and replayed step spans at the source, stable DBOS span names

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inflexa-ai/harness",
-    "version": "0.35.2",
+    "version": "0.35.3",
     "description": "Host-agnostic bioinformatics agent harness — hand-rolled agent loop, DBOS-durable workflows, sandboxed compute.",
     "license": "Apache-2.0",
     "type": "module",

--- a/harness/src/lib/otel-spans.test.ts
+++ b/harness/src/lib/otel-spans.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The span policy is exercised the way `initOtel` composes it: the sampler on
+ * a tracer provider, and the processor in front of the exporting processor.
+ * An in-memory exporter stands in for the OTLP one, so the tests assert on
+ * exactly what would leave the process. The provider is registered so that
+ * `context.with` carries a span the way DBOS's `runWithTrace` does.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { context, propagation, ROOT_CONTEXT, trace, TraceFlags, type Span as ApiSpan } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+import { submitExec } from "../sandbox/submit-exec.js";
+import type { SandboxRef } from "../sandbox/types.js";
+import {
+    ATTR_INFLEXA_EXEC_ID,
+    ATTR_INFLEXA_STEP_ID,
+    ATTR_INFLEXA_TOOL_USE_ID,
+    createHarnessSampler,
+    DbosSpanProcessor,
+    stableSpan,
+    untracedWorkflow,
+} from "./otel-spans.js";
+
+let exporter: InMemorySpanExporter;
+let provider: NodeTracerProvider;
+let untracedCounter = 0;
+
+beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+        sampler: createHarnessSampler(),
+        spanProcessors: [new DbosSpanProcessor(new SimpleSpanProcessor(exporter))],
+    });
+    provider.register();
+});
+
+afterEach(async () => {
+    await provider.shutdown();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+});
+
+function tracer() {
+    return provider.getTracer("otel-spans-test");
+}
+
+/** A fresh untraced name for each test, because the set outlives a test. */
+function freshUntraced(): string {
+    const name = `test-untraced-${++untracedCounter}`;
+    untracedWorkflow(name);
+    return name;
+}
+
+function childOf(parent: ApiSpan, name: string): ApiSpan {
+    return tracer().startSpan(name, {}, trace.setSpan(context.active(), parent));
+}
+
+/** Run `fn` under `span`, the way DBOS runs a step body under its step span. */
+function under<T>(span: ApiSpan, fn: () => T): T {
+    return context.with(trace.setSpan(context.active(), span), fn);
+}
+
+function exportedNames(): string[] {
+    return exporter.getFinishedSpans().map((s) => s.name);
+}
+
+function exportedByName(name: string): ReadableSpan {
+    const found = exporter.getFinishedSpans().find((s) => s.name === name);
+    if (found === undefined) throw new Error(`no exported span named ${name}`);
+    return found;
+}
+
+describe("createHarnessSampler", () => {
+    it("records nothing for an untraced workflow and its children", () => {
+        const name = freshUntraced();
+        const root = tracer().startSpan(name);
+        const step = childOf(root, "query-active-sandboxes");
+        const query = childOf(step, "pg.query");
+        expect(root.isRecording()).toBe(false);
+        expect(step.isRecording()).toBe(false);
+        expect(query.isRecording()).toBe(false);
+        query.end();
+        step.end();
+        root.end();
+        expect(exportedNames()).toEqual([]);
+    });
+
+    it("records every other root and its children", () => {
+        const root = tracer().startSpan("executeAnalysis");
+        const step = childOf(root, "generate-file-metadata");
+        step.end();
+        root.end();
+        expect(exportedNames()).toEqual(["generate-file-metadata", "executeAnalysis"]);
+    });
+
+    it("honours a name declared after the provider was created, from the next root span on", () => {
+        const name = `test-late-untraced-${++untracedCounter}`;
+        const before = tracer().startSpan(name);
+        expect(before.isRecording()).toBe(true);
+        before.end();
+
+        untracedWorkflow(name);
+        const after = tracer().startSpan(name);
+        expect(after.isRecording()).toBe(false);
+        after.end();
+
+        expect(exportedNames()).toEqual([name]);
+    });
+
+    it("takes the decision of a remote parent, so an untraced name under a sampled remote parent is recorded", () => {
+        const name = freshUntraced();
+        const remote = trace.setSpanContext(ROOT_CONTEXT, {
+            traceId: "0af7651916cd43dd8448eb211c80319c",
+            spanId: "b7ad6b7169203331",
+            traceFlags: TraceFlags.SAMPLED,
+            isRemote: true,
+        });
+        const span = tracer().startSpan(name, {}, remote);
+        expect(span.isRecording()).toBe(true);
+        span.end();
+        expect(exportedNames()).toEqual([name]);
+    });
+});
+
+describe("DbosSpanProcessor", () => {
+    it("drops a span that is marked cached after it started, and keeps its siblings", () => {
+        const root = tracer().startSpan("executeAnalysis");
+        const replayed = childOf(root, "generate-file-metadata");
+        const fresh = childOf(root, "generate-step-summary");
+        replayed.setAttribute("cached", true);
+        replayed.end();
+        fresh.end();
+        root.end();
+        expect(exportedNames()).toEqual(["generate-step-summary", "executeAnalysis"]);
+    });
+
+    it("keeps a span whose cached attribute is not the boolean true", () => {
+        const span = tracer().startSpan("a-step");
+        span.setAttribute("cached", "true");
+        span.end();
+        expect(exportedNames()).toEqual(["a-step"]);
+    });
+});
+
+describe("stableSpan", () => {
+    it("renames the active span that carries the DBOS name and attributes the id", () => {
+        const step = tracer().startSpan("compose-step-seed:qc-filter");
+        under(step, () => stableSpan("compose-step-seed:qc-filter", "compose-step-seed", { [ATTR_INFLEXA_STEP_ID]: "qc-filter" }));
+        step.end();
+        expect(exportedNames()).toEqual(["compose-step-seed"]);
+        expect(exportedByName("compose-step-seed").attributes).toMatchObject({ [ATTR_INFLEXA_STEP_ID]: "qc-filter" });
+    });
+
+    it("is a no-op with no active span", () => {
+        expect(() => stableSpan("tool:read_file:toolu_01AbC", "tool:read_file", { [ATTR_INFLEXA_TOOL_USE_ID]: "toolu_01AbC" })).not.toThrow();
+        expect(exportedNames()).toEqual([]);
+    });
+
+    it("is a no-op on a non-recording span", () => {
+        const name = freshUntraced();
+        const root = tracer().startSpan(name);
+        const step = childOf(root, "compose-step-seed:qc-filter");
+        expect(step.isRecording()).toBe(false);
+        expect(() => under(step, () => stableSpan("compose-step-seed:qc-filter", "compose-step-seed", { [ATTR_INFLEXA_STEP_ID]: "qc-filter" }))).not.toThrow();
+        step.end();
+        root.end();
+        expect(exportedNames()).toEqual([]);
+    });
+
+    it("leaves an active span alone when its name is not the DBOS name", () => {
+        const request = tracer().startSpan("POST /chat");
+        under(request, () => stableSpan("tool:read_file:toolu_01AbC", "tool:read_file", { [ATTR_INFLEXA_TOOL_USE_ID]: "toolu_01AbC" }));
+        request.end();
+        expect(exportedNames()).toEqual(["POST /chat"]);
+        expect(exportedByName("POST /chat").attributes).not.toHaveProperty(ATTR_INFLEXA_TOOL_USE_ID);
+    });
+});
+
+describe("a step body that calls stableSpan", () => {
+    const REF: SandboxRef = {
+        sandboxId: "sbx-1",
+        host: "127.0.0.1",
+        port: 8765,
+        backend: "docker",
+        callbackSecret: "base64:dGVzdHNlY3JldA==",
+    };
+
+    /** A `runStep` that opens a span with the DBOS step name and runs the body under it, as DBOS does. */
+    const spanStep = <T>(work: () => Promise<T>, config: { name: string }): Promise<T> => {
+        const span = tracer().startSpan(config.name);
+        return under(span, work).finally(() => span.end());
+    };
+
+    it("submitExec exports sandbox.submit-exec with the exec id as an attribute", async () => {
+        const execId = "wf-1:s-a:fn-0";
+        const accepted: typeof fetch = (async () =>
+            new Response(JSON.stringify({ execId, status: "started" }), {
+                status: 202,
+                headers: { "content-type": "application/json" },
+            })) as unknown as typeof fetch;
+
+        await submitExec(REF, { command: ["echo", "hi"], execId }, { fetch: accepted, runStep: spanStep });
+
+        expect(exportedNames()).toEqual(["sandbox.submit-exec"]);
+        expect(exportedByName("sandbox.submit-exec").attributes).toMatchObject({ [ATTR_INFLEXA_EXEC_ID]: execId });
+    });
+});

--- a/harness/src/lib/otel-spans.ts
+++ b/harness/src/lib/otel-spans.ts
@@ -1,0 +1,139 @@
+/**
+ * Span policy of the harness TracerProvider: which DBOS traces are recorded,
+ * which spans reach the exporter, and the names the exported spans carry.
+ *
+ * DBOS names a workflow span after the registered workflow and a step span
+ * after the step function, and it runs each body under its span, so every
+ * child (a step, a patched fetch, a pg query) sits under the workflow span.
+ * Three shapes of that output are noise in a trace store, and each is stopped
+ * in the process, before export, rather than in a collector downstream. The
+ * decisions live where the workflows and steps are written; this module holds
+ * the mechanism only:
+ *
+ * - A module that registers a housekeeping workflow declares it untraced with
+ *   `untracedWorkflow(name)` next to its registration. The sampler drops a
+ *   root span that carries such a name at creation, and `ParentBased`
+ *   sampling carries the decision to every child.
+ * - A replayed step re-emits its span with `cached=true`, which DBOS sets
+ *   after the span has started. A sampler cannot see that, so
+ *   `DbosSpanProcessor` drops the span at `onEnd`.
+ * - A step whose DBOS name embeds an id calls `stableSpan` as the first
+ *   statement of its body. The helper renames the active DBOS span to the
+ *   stable prefix and puts the id in an `inflexa.*` attribute. The DBOS step
+ *   name itself is untouched: DBOS compares it against the recorded name on
+ *   replay and throws `DBOSUnexpectedStepError` on a mismatch, so a rename
+ *   would break every workflow in flight across a deploy.
+ */
+
+import { trace, type Attributes, type Context } from "@opentelemetry/api";
+import {
+    ParentBasedSampler,
+    SamplingDecision,
+    type ReadableSpan,
+    type Sampler,
+    type SamplingResult,
+    type Span,
+    type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+/**
+ * Names of the DBOS workflows whose traces are not recorded. A registering
+ * module adds its own name at registration, which runs at boot inside
+ * `assembleCoreRuntime`, before `DBOS.launch` starts the first workflow. The
+ * sampler reads the set on every root span, so the set is complete before it
+ * is consulted, and a name added later applies from the next root span on.
+ */
+const untracedWorkflowNames = new Set<string>();
+
+/**
+ * Declare a registered DBOS workflow untraced: no root span for it is
+ * recorded, and no child span under it. Call it next to the
+ * `DBOS.registerWorkflow` that gives the workflow the same name.
+ */
+export function untracedWorkflow(name: string): void {
+    untracedWorkflowNames.add(name);
+}
+
+/** Root decision only: `NOT_RECORD` for an untraced workflow, `RECORD_AND_SAMPLED` for every other root. */
+class UntracedWorkflowRootSampler implements Sampler {
+    shouldSample(_context: Context, _traceId: string, spanName: string): SamplingResult {
+        return {
+            decision: untracedWorkflowNames.has(spanName) ? SamplingDecision.NOT_RECORD : SamplingDecision.RECORD_AND_SAMPLED,
+        };
+    }
+
+    toString(): string {
+        return "UntracedWorkflowRootSampler";
+    }
+}
+
+/**
+ * The sampler of the harness TracerProvider. A root span named after an
+ * untraced workflow is not recorded; every other root is. A span with a parent
+ * takes the parent's decision (the standard `ParentBased` behaviour), so a DBOS
+ * step, a fetch, or a pg span under a dropped root is dropped with it, and a
+ * remote parent (an inbound `traceparent`) is honoured as usual.
+ */
+export function createHarnessSampler(): Sampler {
+    return new ParentBasedSampler({ root: new UntracedWorkflowRootSampler() });
+}
+
+/** The plan step id a `compose-step-seed` step carries. */
+export const ATTR_INFLEXA_STEP_ID = "inflexa.step_id";
+/** The provider tool-use id of a tool step. */
+export const ATTR_INFLEXA_TOOL_USE_ID = "inflexa.tool_use_id";
+/** The exec id (`${workflowId}:${stepId}:${fnId}`) of a sandbox exec step. */
+export const ATTR_INFLEXA_EXEC_ID = "inflexa.exec_id";
+/** The 1-based attempt counter of a sandbox poll, pull, or liveness-probe step. */
+export const ATTR_INFLEXA_ATTEMPT = "inflexa.attempt";
+/** The per-item key (a ChEMBL or NCT id) of a target-assessment fan-out step. */
+export const ATTR_INFLEXA_FANOUT_KEY = "inflexa.fanout_key";
+
+/**
+ * Rename the DBOS span of the step that is running to `name` and put its id
+ * in `attributes`. Call it as the first statement of a step body whose DBOS
+ * name embeds an id, with that DBOS name as `dbosName`.
+ *
+ * DBOS runs the body under its span, so with tracing on the active span is
+ * the step span. With tracing off DBOS opens no span, and the active span, if
+ * there is one, belongs to whoever started the workflow or the chat turn. The
+ * helper therefore renames a span only when its name is `dbosName`, and it
+ * leaves a missing or non-recording span alone.
+ */
+export function stableSpan(dbosName: string, name: string, attributes: Attributes): void {
+    const span = trace.getActiveSpan();
+    if (span === undefined || !span.isRecording()) return;
+    // The API `Span` has no name accessor; the SDK span the provider hands out does.
+    if ((span as Partial<ReadableSpan>).name !== dbosName) return;
+    span.updateName(name);
+    span.setAttributes(attributes);
+}
+
+/**
+ * Sits in front of the exporting processor and forwards every span except a
+ * replayed one (`cached=true`), which it drops at `onEnd`.
+ */
+export class DbosSpanProcessor implements SpanProcessor {
+    constructor(private readonly next: SpanProcessor) {}
+
+    onStart(span: Span, parentContext: Context): void {
+        this.next.onStart(span, parentContext);
+    }
+
+    onEnding(span: Span): void {
+        this.next.onEnding?.(span);
+    }
+
+    onEnd(span: ReadableSpan): void {
+        if (span.attributes.cached === true) return;
+        this.next.onEnd(span);
+    }
+
+    forceFlush(): Promise<void> {
+        return this.next.forceFlush();
+    }
+
+    shutdown(): Promise<void> {
+        return this.next.shutdown();
+    }
+}

--- a/harness/src/lib/otel.test.ts
+++ b/harness/src/lib/otel.test.ts
@@ -22,6 +22,7 @@ import {
     metricExportIntervalMs,
     metricsExportDisabled,
 } from "./otel.js";
+import { untracedWorkflow } from "./otel-spans.js";
 
 let collector: Server;
 let endpoint: string;
@@ -148,5 +149,17 @@ describe("initOtel", () => {
         initOtel();
         expect(registeredResourceAttributes()).toMatchObject({ "service.name": "cortex" });
         expect(registeredResourceAttributes()).not.toHaveProperty("service.version");
+    });
+
+    it("installs the span policy: an untraced workflow root is not recorded, every other root is", () => {
+        untracedWorkflow("otel-test-untraced");
+        initOtel();
+        const tracer = trace.getTracer("otel-test");
+        const cleanup = tracer.startSpan("otel-test-untraced");
+        const run = tracer.startSpan("executeAnalysis");
+        expect(cleanup.isRecording()).toBe(false);
+        expect(run.isRecording()).toBe(true);
+        cleanup.end();
+        run.end();
     });
 });

--- a/harness/src/lib/otel.ts
+++ b/harness/src/lib/otel.ts
@@ -5,7 +5,12 @@
  * so the bundler cannot tree-shake it (side-effect-only imports get dropped).
  *
  * Traces: NodeTracerProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT
- *         is set.
+ *         is set. The provider carries the span policy of otel-spans.ts: the
+ *         root span of a workflow declared with `untracedWorkflow` is not
+ *         recorded (and its children with it), a replayed `cached=true` span
+ *         is dropped before export, and a step body that calls `stableSpan`
+ *         is exported under a stable name with its id in an `inflexa.*`
+ *         attribute.
  *
  * Metrics: MeterProvider exports to OTLP when OTEL_EXPORTER_OTLP_ENDPOINT is
  *          set and OTEL_METRICS_EXPORTER is not `none`. The export interval is
@@ -28,6 +33,7 @@ import { context, propagation, metrics, trace } from "@opentelemetry/api";
 
 import { createNoopLogger } from "./console-logger.js";
 import type { Logger } from "./logger.js";
+import { createHarnessSampler, DbosSpanProcessor } from "./otel-spans.js";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
@@ -110,11 +116,12 @@ export function initOtel(options: InitOtelOptions = {}): void {
 
         if (endpoint) {
             const base = endpoint.replace(/\/+$/, "");
-            spanProcessors.push(new BatchSpanProcessor(new OTLPTraceExporter({ url: `${base}/v1/traces` })));
+            spanProcessors.push(new DbosSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter({ url: `${base}/v1/traces` }))));
         }
 
         const tracerProvider = new NodeTracerProvider({
             resource,
+            sampler: createHarnessSampler(),
             spanProcessors,
         });
         tracerProvider.register();

--- a/harness/src/loop/run-agent.ts
+++ b/harness/src/loop/run-agent.ts
@@ -19,6 +19,7 @@ import type { UsageRecorder } from "../billing/usage-recorder.js";
 import { stripNulCharacters } from "../input-sanitization.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { ATTR_INFLEXA_TOOL_USE_ID, stableSpan } from "../lib/otel-spans.js";
 import { hintForZodIssue, repairToolInput } from "../lib/zod-issues.js";
 import { markInterruptedMessage, syntheticUserMessage } from "../memory/ai-sdk-message-storage.js";
 import { stripUnansweredToolCalls } from "../memory/tool-call-integrity.js";
@@ -218,7 +219,13 @@ export async function runAgent(agent: AgentDefinition, initial: readonly LoopMes
         session,
         signal,
         emit,
-        runStep: (name, fn) => runStep(`${formatStepName.tool(tu.toolName, tu.toolCallId)}:${name}`, fn),
+        runStep: (name, fn) => {
+            const stepName = `${formatStepName.tool(tu.toolName, tu.toolCallId)}:${name}`;
+            return runStep(stepName, () => {
+                stableSpan(stepName, `tool:${tu.toolName}:${name}`, { [ATTR_INFLEXA_TOOL_USE_ID]: tu.toolCallId });
+                return fn();
+            });
+        },
         ask,
         turnUsage,
     });
@@ -770,14 +777,16 @@ async function dispatchTools(
     await Promise.all(
         stepTools.map(({ tu, idx }) => {
             const startedAt = performance.now();
-            return runStep(toolStepName(tu.toolName, tu.toolCallId), () => dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding)).then(
-                (settled: DispatchedCall | ToolResultPart) => {
-                    durations[idx] = elapsedMs(startedAt);
-                    const dispatched = readDispatchedStep(settled);
-                    results[idx] = dispatched.result;
-                    if (dispatched.detail !== undefined) resultDetails[idx] = dispatched.detail;
-                },
-            );
+            const stepName = toolStepName(tu.toolName, tu.toolCallId);
+            return runStep(stepName, () => {
+                stableSpan(stepName, `tool:${tu.toolName}`, { [ATTR_INFLEXA_TOOL_USE_ID]: tu.toolCallId });
+                return dispatchTool(tu, toolsById, toolCtx(tu), isFatalLoopError, encoding);
+            }).then((settled: DispatchedCall | ToolResultPart) => {
+                durations[idx] = elapsedMs(startedAt);
+                const dispatched = readDispatchedStep(settled);
+                results[idx] = dispatched.result;
+                if (dispatched.detail !== undefined) resultDetails[idx] = dispatched.detail;
+            });
         }),
     );
 

--- a/harness/src/runtime/dbos.ts
+++ b/harness/src/runtime/dbos.ts
@@ -59,13 +59,14 @@ export interface DbosConfig {
      * Attribute names follow the `dbos.*` semantic-convention layout
      * (`otelAttributeFormat: "semconv"`).
      *
-     * Known SDK behavior a host must plan for:
-     * - a recovered workflow starts a new root trace, with no link to the trace
-     *   of the original execution
-     * - every already-completed step re-emits a `cached=true` span on replay,
-     *   so a restart with many in-flight steps bursts spans; size
-     *   `OTEL_BSP_MAX_QUEUE_SIZE` for it
-     * - step span names embed the step, tool-use, or exec id
+     * The harness TracerProvider shapes what the SDK emits (`lib/otel-spans.ts`):
+     * a workflow declared with `untracedWorkflow` is not recorded, a replayed
+     * `cached=true` span is dropped before export, and a step body that calls
+     * `stableSpan` is exported under a stable name with its id in an
+     * `inflexa.*` attribute. The step name DBOS records is unchanged.
+     *
+     * Known SDK behavior a host must plan for: a recovered workflow starts a
+     * new root trace, with no link to the trace of the original execution.
      */
     readonly tracingEnabled?: boolean;
 }

--- a/harness/src/sandbox/await-exec.ts
+++ b/harness/src/sandbox/await-exec.ts
@@ -57,6 +57,7 @@
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 
+import { ATTR_INFLEXA_ATTEMPT, ATTR_INFLEXA_EXEC_ID, stableSpan } from "../lib/otel-spans.js";
 import { digestBody } from "./digest.js";
 import { signCallback, verifyCallback } from "./hmac.js";
 import { createEscalationPolicy, probeLiveness, syntheticFailureReason, syntheticFailureResult } from "./liveness.js";
@@ -269,9 +270,14 @@ export async function awaitExecCallback(
     /** Ask the sandbox directly. Returns null when the exec has not finished. */
     const pull = async (): Promise<ExecResult | null> => {
         pullAttempt += 1;
-        const pulled = await runStep(() => pullExecResult(fetchImpl, ref, execId), {
-            name: `sandbox.pull-exec-result.${execId}.${pullAttempt}`,
-        });
+        const pullStepName = `sandbox.pull-exec-result.${execId}.${pullAttempt}`;
+        const pulled = await runStep(
+            () => {
+                stableSpan(pullStepName, "sandbox.pull-exec-result", { [ATTR_INFLEXA_EXEC_ID]: execId, [ATTR_INFLEXA_ATTEMPT]: pullAttempt });
+                return pullExecResult(fetchImpl, ref, execId);
+            },
+            { name: pullStepName },
+        );
         if (pulled.kind !== "completed") return null;
 
         // Identical treatment to a pushed completion: the bytes were signed by
@@ -447,9 +453,14 @@ export async function awaitExecPoll(ref: SandboxRef, execId: string, emit: ExecE
 
     while (true) {
         pollAttempt += 1;
-        const polled = await runStep(() => pollExecOnce(fetchImpl, ref, execId, cursor), {
-            name: `sandbox.poll-exec-result.${execId}.${pollAttempt}`,
-        });
+        const pollStepName = `sandbox.poll-exec-result.${execId}.${pollAttempt}`;
+        const polled = await runStep(
+            () => {
+                stableSpan(pollStepName, "sandbox.poll-exec-result", { [ATTR_INFLEXA_EXEC_ID]: execId, [ATTR_INFLEXA_ATTEMPT]: pollAttempt });
+                return pollExecOnce(fetchImpl, ref, execId, cursor);
+            },
+            { name: pollStepName },
+        );
 
         if (polled.kind === "ok") {
             // Identical treatment to a pushed completion: the bytes were signed by
@@ -494,9 +505,14 @@ export async function awaitExecPoll(ref: SandboxRef, execId: string, emit: ExecE
 
         if (isAlive && escalation.onPoll(polled.kind === "ok" ? "ok" : "unavailable")) {
             probeAttempt += 1;
-            const verdict = await runStep(() => probeLiveness(isAlive, ref), {
-                name: `sandbox.probe-liveness.${execId}.${probeAttempt}`,
-            });
+            const probeStepName = `sandbox.probe-liveness.${execId}.${probeAttempt}`;
+            const verdict = await runStep(
+                () => {
+                    stableSpan(probeStepName, "sandbox.probe-liveness", { [ATTR_INFLEXA_EXEC_ID]: execId, [ATTR_INFLEXA_ATTEMPT]: probeAttempt });
+                    return probeLiveness(isAlive, ref);
+                },
+                { name: probeStepName },
+            );
             // Only an observably dead machine fails the exec — the result lives
             // in that machine and nowhere else, so it is unrecoverable and the
             // synthetic failure races nothing. `alive` (live-but-slow exec,

--- a/harness/src/sandbox/notification-sweep.ts
+++ b/harness/src/sandbox/notification-sweep.ts
@@ -22,8 +22,10 @@ import { DBOS } from "@dbos-inc/dbos-sdk";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { untracedWorkflow } from "../lib/otel-spans.js";
 
 const SWEEP_CRON = "0 */5 * * * *";
+const SWEEP_WORKFLOW = "dbos-notifications-sweep";
 const DELETE_BATCH_LIMIT = 10_000;
 
 export interface SweepDeps {
@@ -93,10 +95,11 @@ export function registerNotificationSweep(deps: RegisterNotificationSweepDeps): 
         async () => {
             await sweepStaleNotifications({ deleteStale, logger: deps.logger });
         },
-        { name: "dbos-notifications-sweep" },
+        { name: SWEEP_WORKFLOW },
     );
+    untracedWorkflow(SWEEP_WORKFLOW);
     DBOS.registerScheduled(sweep, {
-        name: "dbos-notifications-sweep",
+        name: SWEEP_WORKFLOW,
         crontab: SWEEP_CRON,
     });
 }

--- a/harness/src/sandbox/reaper.ts
+++ b/harness/src/sandbox/reaper.ts
@@ -25,12 +25,14 @@ import type { Pool } from "pg";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { untracedWorkflow } from "../lib/otel-spans.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { reconcileReapedSandbox } from "../state/active-sandboxes.js";
 import type { SandboxClient } from "./client.js";
 import type { ManagedSandbox } from "./types.js";
 
 const REAPER_CRON = "0 */5 * * * *";
+const REAPER_WORKFLOW = "sandbox-reaper";
 const DEFAULT_GRACE_MS = 10 * 60_000;
 
 /**
@@ -207,11 +209,12 @@ export function registerSandboxReaper(deps: RegisterReaperDeps): void {
                 { name: "sandbox-reaper-sweep" },
             );
         },
-        { name: "sandbox-reaper" },
+        { name: REAPER_WORKFLOW },
     );
+    untracedWorkflow(REAPER_WORKFLOW);
 
     DBOS.registerScheduled(reaper, {
-        name: "sandbox-reaper",
+        name: REAPER_WORKFLOW,
         crontab: REAPER_CRON,
     });
 }

--- a/harness/src/sandbox/submit-exec.ts
+++ b/harness/src/sandbox/submit-exec.ts
@@ -19,6 +19,7 @@
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 
+import { ATTR_INFLEXA_EXEC_ID, stableSpan } from "../lib/otel-spans.js";
 import { EXEC_STREAM_BYTE_CAP } from "../tools/workspace/result-bounds.js";
 import { signCallback } from "./hmac.js";
 import type { SandboxRef, SubmitExecBody } from "./types.js";
@@ -91,7 +92,12 @@ export async function submitExec(ref: SandboxRef, body: SubmitExecBody, deps: Su
         stderrByteCap: body.stderrByteCap ?? deps.execStreamByteCap ?? EXEC_STREAM_BYTE_CAP,
     };
 
-    await runStep(() => postExec(fetchImpl, ref, capped), {
-        name: `sandbox.submit-exec.${body.execId}`,
-    });
+    const stepName = `sandbox.submit-exec.${body.execId}`;
+    await runStep(
+        () => {
+            stableSpan(stepName, "sandbox.submit-exec", { [ATTR_INFLEXA_EXEC_ID]: body.execId });
+            return postExec(fetchImpl, ref, capped);
+        },
+        { name: stepName },
+    );
 }

--- a/harness/src/sandbox/watchdog.ts
+++ b/harness/src/sandbox/watchdog.ts
@@ -25,6 +25,7 @@ import type { ResultAsync } from "neverthrow";
 
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { untracedWorkflow } from "../lib/otel-spans.js";
 import type { DbError } from "../lib/db-result.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import type { ActiveSandboxRow } from "../state/index.js";
@@ -35,6 +36,8 @@ import type { ExecEventMessage, ExecResult, SandboxLiveness, SandboxRef } from "
 
 export const SHARD_COUNT = 8;
 const WATCHDOG_CRON = "*/60 * * * * *";
+const WATCHDOG_PARENT_WORKFLOW = "sandbox-watchdog-parent";
+const WATCHDOG_SHARD_WORKFLOW = "sandbox-watchdog-shard";
 
 /** Stable hash → shard mapping, exported for tests. */
 export function shardIndex(sandboxId: string, shardCount = SHARD_COUNT): number {
@@ -178,8 +181,9 @@ export function registerWatchdog(deps: WatchdogDeps): void {
                 logger: deps.logger,
             });
         },
-        { name: "sandbox-watchdog-shard" },
+        { name: WATCHDOG_SHARD_WORKFLOW },
     );
+    untracedWorkflow(WATCHDOG_SHARD_WORKFLOW);
 
     // The scheduled target must itself be a registered workflow — DBOS's
     // scheduler loop skips (and errors on) any `@scheduled` function that lacks
@@ -197,11 +201,12 @@ export function registerWatchdog(deps: WatchdogDeps): void {
                 await DBOS.startWorkflow(childCheckShard)(shard);
             }
         },
-        { name: "sandbox-watchdog-parent" },
+        { name: WATCHDOG_PARENT_WORKFLOW },
     );
+    untracedWorkflow(WATCHDOG_PARENT_WORKFLOW);
 
     DBOS.registerScheduled(watchdogParent, {
-        name: "sandbox-watchdog-parent",
+        name: WATCHDOG_PARENT_WORKFLOW,
         crontab: WATCHDOG_CRON,
     });
 }

--- a/harness/src/workflows/execute-analysis.ts
+++ b/harness/src/workflows/execute-analysis.ts
@@ -70,6 +70,7 @@ import type { RunSession } from "../auth/types.js";
 import type { RunAuthorization, RunAuthorizer } from "../execution/run-authorizer.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { ATTR_INFLEXA_STEP_ID, stableSpan } from "../lib/otel-spans.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import type { CitationResolver } from "../citations/types.js";
 import { unwrapOrThrow } from "../lib/result.js";
@@ -1148,7 +1149,14 @@ async function runSchedulerLoop(args: SchedulerLoopArgs): Promise<SchedulerLoopO
             // `completed`, so this is the first (and only) moment their results
             // can be named. Checkpointed so a replay re-dispatches the child
             // with a byte-identical prompt instead of re-reading the DB/disk.
-            const prompt = await DBOS.runStep(() => composeStepSeed({ input, stepId, runId, deps }), { name: `compose-step-seed:${stepId}` });
+            const seedStepName = `compose-step-seed:${stepId}`;
+            const prompt = await DBOS.runStep(
+                () => {
+                    stableSpan(seedStepName, "compose-step-seed", { [ATTR_INFLEXA_STEP_ID]: stepId });
+                    return composeStepSeed({ input, stepId, runId, deps });
+                },
+                { name: seedStepName },
+            );
             const baseChildInput = buildChildInput({
                 input,
                 stepId,

--- a/harness/src/workflows/execute-target-assessment.ts
+++ b/harness/src/workflows/execute-target-assessment.ts
@@ -43,6 +43,7 @@ import { forSubAgent } from "../auth/types.js";
 import type { RunAuthorization, RunAuthorizer } from "../execution/run-authorizer.js";
 import { createNoopLogger } from "../lib/console-logger.js";
 import type { Logger } from "../lib/logger.js";
+import { ATTR_INFLEXA_FANOUT_KEY, stableSpan } from "../lib/otel-spans.js";
 import type { UsageRecorder } from "../billing/usage-recorder.js";
 import { unwrapOrThrow } from "../lib/result.js";
 import { durableStep } from "../loop/run-step.js";
@@ -440,11 +441,17 @@ export async function runExecuteTargetAssessmentBody(
             fn: (item: TItem) => Promise<FanoutEnvelope<TOut>>,
         ): Promise<Array<FanoutEnvelope<TOut>>> {
             return Promise.all(
-                items.map((item) =>
-                    DBOS.runStep(() => fn(item), {
-                        name: `ta-fanout:${stepKindForName}:${keyOf(item)}`,
-                    }).catch((err: unknown) => wrapCollectorThrow(err) as FanoutEnvelope<TOut>),
-                ),
+                items.map((item) => {
+                    const key = keyOf(item);
+                    const stepName = `ta-fanout:${stepKindForName}:${key}`;
+                    return DBOS.runStep(
+                        () => {
+                            stableSpan(stepName, `ta-fanout:${stepKindForName}`, { [ATTR_INFLEXA_FANOUT_KEY]: key });
+                            return fn(item);
+                        },
+                        { name: stepName },
+                    ).catch((err: unknown) => wrapCollectorThrow(err) as FanoutEnvelope<TOut>);
+                }),
             );
         }
 


### PR DESCRIPTION
## What & why

`initOtel` puts a span policy on the harness TracerProvider (`harness/src/lib/otel-spans.ts`). Three kinds of DBOS trace noise stop in the process, before export. A collector sees a span only after the process paid for it, so a filter there saves nothing at the source. The decisions live where the workflows and steps are written, and the module holds the mechanism. `DbosConfig.tracingEnabled` keeps its default `false`, and there is no new configuration option.

- **Untraced workflows, declared at registration.** Each housekeeping module calls `untracedWorkflow(name)` next to its `DBOS.registerWorkflow`: `sandbox-watchdog-parent` and `sandbox-watchdog-shard` (`sandbox/watchdog.ts`), `sandbox-reaper` (`sandbox/reaper.ts`), `dbos-notifications-sweep` (`sandbox/notification-sweep.ts`). A `ParentBased` sampler does not record a root span with a declared name, and each child (a DBOS step, a fetch, a pg span) takes the decision of its parent. A remote parent keeps the standard `ParentBased` behavior. Registration runs at boot, before the first workflow, so the set is complete when the sampler reads it, and a test covers a name added later.
- **Replayed spans dropped.** `DbosSpanProcessor` sits in front of the `BatchSpanProcessor` and drops a span with `cached=true` at `onEnd`. DBOS sets that attribute after the span starts, so a sampler cannot see it.
- **Stable names, set in the step body.** `stableSpan(dbosName, name, attributes)` renames the active DBOS span and adds the id attribute. It acts only when the active span is recording and carries `dbosName`, so with tracing off a span of the host is never touched. Call sites:
  - `loop/run-agent.ts`: a tool step becomes `tool:<toolName>` and a tool sub-step `tool:<toolName>:<inner>`, with `inflexa.tool_use_id`. The `salvage:` and `ta-investigate:critique:` formatters flow through the same dispatch, so one call covers them.
  - `workflows/execute-analysis.ts`: `compose-step-seed`, `inflexa.step_id`.
  - `sandbox/submit-exec.ts`: `sandbox.submit-exec`, `inflexa.exec_id`.
  - `sandbox/await-exec.ts`: `sandbox.pull-exec-result`, `sandbox.poll-exec-result`, `sandbox.probe-liveness`, with `inflexa.exec_id` and `inflexa.attempt`.
  - `workflows/execute-target-assessment.ts`: `ta-fanout:<kind>`, `inflexa.fanout_key`.

Notes for the reviewer:

- The DBOS step names are unchanged. DBOS compares the recorded step name on replay and throws `DBOSUnexpectedStepError` on a mismatch (`@dbos-inc/dbos-sdk@4.23.6`, `dist/src/dbos-executor.js:503-504`, and `:655-656` in `runInternalStep`). A rename would break each workflow in flight across a deploy.
- `llm:<i>` and `llm-<i>` keep the iteration counter, because it is not an id. `ta-collector:<id>` keeps its collector id, because the manifest is a fixed set.
- The version bump to 0.35.3 is a separate commit.

Gates: `tsc --noEmit` clean. `bun run test:full` 4263 pass, 0 fail, 18 skip. `eslint .` reports one error in `src/providers/ai-sdk.test.ts:1378` that is present on `main`.

## Type of change

- [ ] Bug fix
- [x] New feature / capability
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Analytical method, sandbox, or provenance change (gets extra scrutiny — see below)

## Checklist

- [x] Lint, typecheck, and tests pass locally (`bun run lint`, `bun run typecheck`, `bun test`).
- [x] Tests added or updated for the change.
- [x] Documentation updated if user-facing behavior changed.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are **signed off** for the DCO (`git commit -s`).
- [x] This PR is focused on a single logical change.

https://claude.ai/code/session_01XJ3U53ivPT6zGc5FL7N4vv
